### PR TITLE
Default interactive GJC to tmux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
 - Changed `gjc team` startup to use tmux worker panes backed by dedicated detached git worktrees by default, while keeping `--worktree` as a backward-compatible launch override.
 - Constrained the visible GJC utility surface to the retained workflow/runtime endpoints and four bundled task agents, with MCP, arbitrary skill, plugin, extension, marketplace, and custom discovery surfaces quarantined from default public use.
 - Changed web search provider credential lookup to use the shared `AuthStorage` pipeline (`getApiKey`/`getOAuthAccess`) for API-key and OAuth auth instead of direct `AgentStorage` access

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -228,6 +228,8 @@ export function getExtraHelpText(): string {
   GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
   GJC_PLAN_MODEL              - Override planning model (see --plan)
   GJC_NO_PTY                  - Disable PTY-based interactive bash execution
+  GJC_LAUNCH_POLICY           - Launch policy for interactive startup: auto, tmux, or direct
+  GJC_TMUX_SESSION            - tmux session name for default interactive startup (default: gajae_code)
 
   For complete environment variable reference, see:
   ${chalk.dim("docs/environment-variables.md")}

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -6,6 +6,7 @@ import { THINKING_EFFORTS } from "@gajae-code/ai";
 import { APP_NAME } from "@gajae-code/utils";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
+import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
 
@@ -138,6 +139,7 @@ export default class Index extends Command {
 	async run(): Promise<void> {
 		const { args } = prepareAcpTerminalAuthArgs(this.argv);
 		const parsed = parseArgs(args);
+		if (launchDefaultTmuxIfNeeded({ parsed, rawArgs: args })) return;
 		await runRootCommand(parsed, args);
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,0 +1,163 @@
+import * as path from "node:path";
+import type { Args } from "../cli/args";
+
+export const GJC_DEFAULT_TMUX_SESSION = "gajae_code";
+export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
+export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
+export const GJC_TMUX_COMMAND_ENV = "GJC_TMUX_COMMAND";
+
+type LaunchPolicy = "auto" | "direct" | "tmux";
+
+interface TtyState {
+	stdin: boolean;
+	stdout: boolean;
+}
+
+export interface TmuxLaunchContext {
+	parsed: Args;
+	rawArgs: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	argv?: string[];
+	execPath?: string;
+	platform?: NodeJS.Platform;
+	tty?: TtyState;
+	spawnSync?: TmuxSpawnSync;
+	tmuxAvailable?: boolean;
+}
+
+export interface TmuxSpawnResult {
+	exitCode: number | null;
+	signalCode?: string | null;
+	stderr?: string;
+}
+
+export type TmuxSpawnSync = (command: string, args: string[], options: TmuxSpawnOptions) => TmuxSpawnResult;
+
+export interface TmuxSpawnOptions {
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+	stdin: "inherit";
+	stdout: "inherit";
+	stderr: "inherit";
+}
+
+export interface TmuxLaunchPlan {
+	tmuxCommand: string;
+	sessionName: string;
+	cwd: string;
+	innerCommand: string;
+	newSessionArgs: string[];
+	attachSessionArgs: string[];
+}
+
+interface CommandResolutionContext {
+	cwd: string;
+	argv: string[];
+	execPath: string;
+}
+
+function parseLaunchPolicy(env: NodeJS.ProcessEnv): LaunchPolicy {
+	const raw = env[GJC_LAUNCH_POLICY_ENV]?.trim().toLowerCase();
+	if (raw === "direct" || raw === "tmux" || raw === "auto") return raw;
+	if (env.GJC_NO_TMUX === "1" || env.GJC_NO_TMUX === "true") return "direct";
+	return "auto";
+}
+
+function isInteractiveRootLaunch(parsed: Args, tty: TtyState): boolean {
+	return (
+		tty.stdin &&
+		tty.stdout &&
+		!parsed.help &&
+		!parsed.version &&
+		!parsed.print &&
+		parsed.mode === undefined &&
+		parsed.export === undefined &&
+		parsed.listModels === undefined
+	);
+}
+
+function shellQuote(value: string): string {
+	if (value.length === 0) return "''";
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function resolveCurrentGjcCommand(context: CommandResolutionContext): string[] {
+	const entrypoint = context.argv[1];
+	if (!entrypoint) return ["gjc"];
+	const resolvedEntrypoint = path.isAbsolute(entrypoint) ? entrypoint : path.resolve(context.cwd, entrypoint);
+	if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs")) {
+		return [context.execPath, resolvedEntrypoint];
+	}
+	return [resolvedEntrypoint];
+}
+
+function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
+	const command = resolveCurrentGjcCommand(context);
+	const quoted = [...command, ...rawArgs].map(shellQuote).join(" ");
+	return `exec env ${GJC_TMUX_LAUNCHED_ENV}=1 ${quoted}`;
+}
+
+export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaunchPlan | undefined {
+	const env = context.env ?? process.env;
+	const policy = parseLaunchPolicy(env);
+	if (policy === "direct") return undefined;
+	if (env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return undefined;
+	const platform = context.platform ?? process.platform;
+	if (platform === "win32") return undefined;
+	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
+	if (policy === "auto" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
+	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, { stdin: true, stdout: true })) return undefined;
+
+	const cwd = context.cwd ?? process.cwd();
+	const sessionName = env.GJC_TMUX_SESSION?.trim() || GJC_DEFAULT_TMUX_SESSION;
+	const tmuxCommand = env[GJC_TMUX_COMMAND_ENV]?.trim() || "tmux";
+	const tmuxAvailable = context.tmuxAvailable ?? Bun.which(tmuxCommand) !== null;
+	if (!tmuxAvailable) return undefined;
+	const innerCommand = buildInnerCommand(
+		{
+			cwd,
+			argv: context.argv ?? process.argv,
+			execPath: context.execPath ?? process.execPath,
+		},
+		context.rawArgs,
+	);
+	return {
+		tmuxCommand,
+		sessionName,
+		cwd,
+		innerCommand,
+		newSessionArgs: ["new-session", "-s", sessionName, "-c", cwd, innerCommand],
+		attachSessionArgs: ["attach-session", "-t", sessionName],
+	};
+}
+
+function defaultSpawnSync(command: string, args: string[], options: TmuxSpawnOptions): TmuxSpawnResult {
+	const result = Bun.spawnSync({
+		cmd: [command, ...args],
+		cwd: options.cwd,
+		env: options.env,
+		stdin: options.stdin,
+		stdout: options.stdout,
+		stderr: options.stderr,
+	});
+	return { exitCode: result.exitCode, signalCode: result.signalCode };
+}
+
+export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
+	const plan = buildDefaultTmuxLaunchPlan(context);
+	if (!plan) return false;
+	const env = context.env ?? process.env;
+	const spawnSync = context.spawnSync ?? defaultSpawnSync;
+	const options: TmuxSpawnOptions = {
+		cwd: plan.cwd,
+		env,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	};
+	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);
+	if (created.exitCode === 0) return true;
+	const attached = spawnSync(plan.tmuxCommand, plan.attachSessionArgs, options);
+	return attached.exitCode === 0;
+}

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import type { Args } from "@gajae-code/coding-agent/cli/args";
+import {
+	buildDefaultTmuxLaunchPlan,
+	GJC_DEFAULT_TMUX_SESSION,
+	GJC_TMUX_LAUNCHED_ENV,
+	launchDefaultTmuxIfNeeded,
+	type TmuxSpawnOptions,
+} from "@gajae-code/coding-agent/gjc-runtime/launch-tmux";
+
+function args(overrides: Partial<Args> = {}): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		...overrides,
+	};
+}
+
+const interactiveTty = { stdin: true, stdout: true };
+
+describe("default GJC tmux launch", () => {
+	it("plans an interactive root launch inside the gajae_code tmux session", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"] }),
+			rawArgs: ["hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan?.sessionName).toBe(GJC_DEFAULT_TMUX_SESSION);
+		expect(plan?.tmuxCommand).toBe("tmux");
+		expect(plan?.newSessionArgs.slice(0, 5)).toEqual(["new-session", "-s", "gajae_code", "-c", "/repo"]);
+		expect(plan?.innerCommand).toContain(`${GJC_TMUX_LAUNCHED_ENV}=1`);
+		expect(plan?.innerCommand).toContain("'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' 'hello world'");
+	});
+
+	it("does not wrap non-interactive or already wrapped launches", () => {
+		const common = {
+			rawArgs: [],
+			cwd: "/repo",
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin" as const,
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		};
+
+		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args({ print: true }), env: {} })).toBeUndefined();
+		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args({ mode: "json" }), env: {} })).toBeUndefined();
+		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args(), env: { TMUX: "/tmp/tmux" } })).toBeUndefined();
+		expect(
+			buildDefaultTmuxLaunchPlan({ ...common, parsed: args(), env: { [GJC_TMUX_LAUNCHED_ENV]: "1" } }),
+		).toBeUndefined();
+	});
+
+	it("attaches an existing gajae_code session when creation fails", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args(),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: calls.length === 1 ? 1 : 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls).toHaveLength(2);
+		expect(calls[0].args[0]).toBe("new-session");
+		expect(calls[1].args).toEqual(["attach-session", "-t", "gajae_code"]);
+	});
+
+	it("falls through to direct launch when tmux is unavailable", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args(),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: false,
+		});
+
+		expect(plan).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- wrap default interactive `gjc` startup in a `gajae_code` tmux session when tmux and TTYs are available
- keep non-interactive, RPC/ACP, export, model listing, and already-wrapped launches direct
- add focused launch planning tests and document launch policy env vars

## Tests
- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`
- `bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/src/commands/launch.ts packages/coding-agent/src/cli/args.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/CHANGELOG.md`
- `git diff --check`

## Notes
- No issues created.
- Direct CLI version smoke was attempted but local `pi_natives.darwin-arm64.node` is not built in this worktree.