### PR TITLE
Make terminal UI identity GJC-native

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
 - Changed `gjc team` startup to use tmux worker panes backed by dedicated detached git worktrees by default, while keeping `--worktree` as a backward-compatible launch override.
 - Constrained the visible GJC utility surface to the retained workflow/runtime endpoints and four bundled task agents, with MCP, arbitrary skill, plugin, extension, marketplace, and custom discovery surfaces quarantined from default public use.
+- Redesigned the interactive TUI chrome with GJC-native operator/gajae turns, a forge-style welcome surface, and compact cwd/pulse indicators tuned for terminal coding-agent ergonomics.
 - Changed web search provider credential lookup to use the shared `AuthStorage` pipeline (`getApiKey`/`getOAuthAccess`) for API-key and OAuth auth instead of direct `AgentStorage` access
 - Changed the `codex` web search provider display label from `Codex` to `OpenAI`
 - Updated `anthropic` and `openai`/`gemini` web search option descriptions to reflect their native `web_search`/OAuth requirements

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -61,7 +61,8 @@ export const TAB_METADATA: Record<SettingTab, { label: string; icon: `tab.${stri
 
 /** Status line segment identifiers */
 export type StatusLineSegmentId =
-	| "pi"
+	| "gajae"
+	| "pi" // legacy custom alias; public presets use gajae
 	| "model"
 	| "mode"
 	| "path"

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -16,6 +16,12 @@ export class AssistantMessageComponent extends Container {
 	#usageInfo?: Usage;
 	#convertedKittyImages = new Map<string, ImageContent>();
 	#kittyConversionsInFlight = new Set<string>();
+	#responseHeader = new Text(
+		`${theme.fg("border", "▌")} ${theme.bold(theme.fg("statusLineModel", "gajae"))} ${theme.fg("dim", "reply")}`,
+		1,
+		0,
+	);
+	#responseFooter = new Text(theme.fg("border", "▔"), 1, 0);
 
 	constructor(
 		message?: AssistantMessage,
@@ -143,6 +149,7 @@ export class AssistantMessageComponent extends Container {
 
 		if (hasVisibleContent) {
 			this.#contentContainer.addChild(new Spacer(1));
+			this.#contentContainer.addChild(this.#responseHeader);
 		}
 
 		// Render content in order
@@ -181,6 +188,9 @@ export class AssistantMessageComponent extends Container {
 		}
 
 		this.#renderToolImages();
+		if (hasVisibleContent) {
+			this.#contentContainer.addChild(this.#responseFooter);
+		}
 		// Check if aborted - show after partial content
 		// But only if there are no tool calls (tool execution components will show the error)
 		const hasToolCalls = message.content.some(c => c.type === "toolCall");

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -58,8 +58,16 @@ export class BashExecutionComponent extends Container {
 		this.#contentContainer = contentContainer;
 		this.#loader = loader;
 
-		// Command header
-		this.#headerText = new Text(theme.fg(colorKey, theme.bold(`$ ${command}`)), 1, 0);
+		// Command header: terse shell rail, no extra render work on streaming chunks.
+		const shellLabel = excludeFromContext ? "shell · no context" : "shell";
+		this.#headerText = new Text(
+			`${theme.fg(colorKey, theme.bold(shellLabel))} ${theme.fg("dim", "·")} ${theme.fg(
+				colorKey,
+				theme.bold(`$ ${command}`),
+			)}`,
+			1,
+			0,
+		);
 		this.#contentContainer.addChild(this.#headerText);
 		this.#contentContainer.addChild(this.#loader);
 	}

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -3,7 +3,7 @@
  * Shares the same kernel session as the agent's eval tool.
  */
 
-import { Container, type Loader, Text, type TUI } from "@gajae-code/tui";
+import { Container, type Loader, padding, Text, type TUI, visibleWidth } from "@gajae-code/tui";
 import { sanitizeText } from "@gajae-code/utils";
 import { highlightCode, theme } from "../../modes/theme/theme";
 import type { TruncationMeta } from "../../tools/output-meta";
@@ -29,14 +29,20 @@ export class EvalExecutionComponent extends Container {
 	#truncation?: TruncationMeta;
 	#expanded = false;
 	#contentContainer: Container;
+	#headerText: Text;
 
 	#highlightLang(): "python" | "javascript" {
 		return this.language === "js" ? "javascript" : "python";
 	}
 
 	#formatHeader(colorKey: ExecutionColorKey): Text {
-		const prompt = theme.fg(colorKey, theme.bold(">>>"));
-		const continuation = theme.fg(colorKey, "    ");
+		const modeLabel = this.language === "js" ? "node" : "python";
+		const promptMarker = `${modeLabel} · >>> `;
+		const prompt = `${theme.fg(colorKey, theme.bold(modeLabel))} ${theme.fg("dim", "·")} ${theme.fg(
+			colorKey,
+			theme.bold(">>>"),
+		)}`;
+		const continuation = padding(visibleWidth(promptMarker));
 		const codeLines = highlightCode(this.code, this.#highlightLang());
 		const headerLines = codeLines.map((line, index) =>
 			index === 0 ? `${prompt} ${line}` : `${continuation}${line}`,
@@ -56,8 +62,9 @@ export class EvalExecutionComponent extends Container {
 		const { contentContainer, loader } = buildExecutionFrame(this, ui, colorKey);
 		this.#contentContainer = contentContainer;
 		this.#loader = loader;
+		this.#headerText = this.#formatHeader(colorKey);
 
-		this.#contentContainer.addChild(this.#formatHeader(colorKey));
+		this.#contentContainer.addChild(this.#headerText);
 		this.#contentContainer.addChild(this.#loader);
 	}
 
@@ -109,8 +116,7 @@ export class EvalExecutionComponent extends Container {
 
 		this.#contentContainer.clear();
 
-		const colorKey: ExecutionColorKey = this.excludeFromContext ? "dim" : "pythonMode";
-		this.#contentContainer.addChild(this.#formatHeader(colorKey));
+		this.#contentContainer.addChild(this.#headerText);
 
 		if (availableLines.length > 0) {
 			if (this.#expanded) {

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -207,38 +207,38 @@ export class FooterComponent implements Component {
 			}
 		}
 
+		const workspacePrefix = `${theme.fg("border", "◆")} ${theme.bold(theme.fg("statusLinePath", "cwd"))} `;
+		const telemetryPrefix = `${theme.fg("border", "◇")} ${theme.bold(theme.fg("statusLineContext", "pulse"))} `;
+		const workspaceWidth = Math.max(1, width - visibleWidth(workspacePrefix));
+		const telemetryWidth = Math.max(1, width - visibleWidth(telemetryPrefix));
+
 		let statsLeftWidth = visibleWidth(statsLeft);
 		const rightSideWidth = visibleWidth(rightSide);
 
-		// If statsLeft is too wide, truncate it
-		if (statsLeftWidth > width) {
-			// Truncate statsLeft to fit width (no room for right side)
-			const plainStatsLeft = statsLeft.replace(/\x1b\[[0-9;]*m/g, "");
-			statsLeft = `${plainStatsLeft.substring(0, width - 1)}…`;
+		// If statsLeft is too wide, truncate it to the post-prefix telemetry budget.
+		if (statsLeftWidth > telemetryWidth) {
+			statsLeft = truncateToWidth(statsLeft, telemetryWidth);
 			statsLeftWidth = visibleWidth(statsLeft);
 		}
 
-		// Calculate available space for padding (minimum 2 spaces between stats and model)
+		// Calculate available space for padding (minimum 2 spaces between stats and model).
 		const minPadding = 2;
 		const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
 
 		let statsLine: string;
-		if (totalNeeded <= width) {
-			// Both fit - add padding to right-align model
-			const pad = padding(width - statsLeftWidth - rightSideWidth);
+		if (totalNeeded <= telemetryWidth) {
+			// Both fit - add padding to right-align model inside the post-prefix budget.
+			const pad = padding(telemetryWidth - statsLeftWidth - rightSideWidth);
 			statsLine = statsLeft + pad + rightSide;
 		} else {
-			// Need to truncate right side
-			const availableForRight = width - statsLeftWidth - minPadding;
+			// Need to truncate right side inside the post-prefix budget.
+			const availableForRight = telemetryWidth - statsLeftWidth - minPadding;
 			if (availableForRight > 3) {
-				// Truncate to fit (strip ANSI codes for length calculation, then truncate raw string)
-				const plainRightSide = rightSide.replace(/\x1b\[[0-9;]*m/g, "");
-				const truncatedPlain = plainRightSide.substring(0, availableForRight);
-				// For simplicity, just use plain truncated version (loses color, but fits)
-				const pad = padding(width - statsLeftWidth - truncatedPlain.length);
-				statsLine = statsLeft + pad + truncatedPlain;
+				const truncatedRight = truncateToWidth(rightSide, availableForRight);
+				const pad = padding(telemetryWidth - statsLeftWidth - visibleWidth(truncatedRight));
+				statsLine = statsLeft + pad + truncatedRight;
 			} else {
-				// Not enough space for right side at all
+				// Not enough space for right side at all.
 				statsLine = statsLeft;
 			}
 		}
@@ -250,7 +250,10 @@ export class FooterComponent implements Component {
 		const remainder = statsLine.slice(statsLeft.length); // padding + rightSide
 		const dimRemainder = theme.fg("dim", remainder);
 
-		const lines = [theme.fg("dim", pwd), dimStatsLeft + dimRemainder];
+		const lines = [
+			truncateToWidth(`${workspacePrefix}${theme.fg("dim", truncateToWidth(pwd, workspaceWidth))}`, width),
+			truncateToWidth(`${telemetryPrefix}${dimStatsLeft}${dimRemainder}`, width),
+		];
 
 		// Add extension statuses on a single line, sorted by key alphabetically
 		if (this.#extensionStatuses.size > 0) {

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -2,12 +2,12 @@ import type { PresetDef, StatusLinePreset } from "./types";
 
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
-		leftSegments: ["model", "mode", "path", "git", "pr", "context_pct", "cost"],
-		rightSegments: ["session_name"],
+		leftSegments: ["model", "mode", "git", "pr", "path"],
+		rightSegments: ["session_name", "token_rate", "context_pct", "cost"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
-			path: { abbreviate: true, maxLength: 40, stripWorkPrefix: true },
+			path: { abbreviate: true, maxLength: 32, stripWorkPrefix: true },
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 		},
 	},
@@ -33,7 +33,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	},
 
 	full: {
-		leftSegments: ["pi", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
+		leftSegments: ["gajae", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
 		rightSegments: [
 			"session_name",
 			"token_in",
@@ -56,7 +56,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	nerd: {
 		// Full preset with all Nerd Font icons
-		leftSegments: ["pi", "hostname", "model", "mode", "path", "git", "pr", "session", "subagents"],
+		leftSegments: ["gajae", "hostname", "model", "mode", "path", "git", "pr", "session", "subagents"],
 		rightSegments: [
 			"session_name",
 			"token_in",

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -63,11 +63,18 @@ function classifyProjectDir(pwd: string): { scratch: boolean; relative: string |
 // Segment Implementations
 // ═══════════════════════════════════════════════════════════════════════════
 
-const piSegment: StatusLineSegment = {
+const gajaeSegment: StatusLineSegment = {
+	id: "gajae",
+	render(_ctx) {
+		return { content: theme.fg("accent", "GJC"), visible: true };
+	},
+};
+
+// Legacy custom-config alias only. Public presets must use `gajae`.
+const legacyPiSegment: StatusLineSegment = {
 	id: "pi",
 	render(_ctx) {
-		const content = theme.icon.pi ? `${theme.icon.pi} ` : "";
-		return { content: theme.fg("accent", content), visible: true };
+		return gajaeSegment.render(_ctx);
 	},
 };
 
@@ -517,7 +524,8 @@ const usageSegment: StatusLineSegment = {
 // ═══════════════════════════════════════════════════════════════════════════
 
 export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
-	pi: piSegment,
+	gajae: gajaeSegment,
+	pi: legacyPiSegment,
 	model: modelSegment,
 	mode: modeSegment,
 	path: pathSegment,

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,4 +1,4 @@
-import { Container, Markdown, Spacer } from "@gajae-code/tui";
+import { type Component, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers
@@ -17,22 +17,42 @@ export class UserMessageComponent extends Container {
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => theme.fg("userMessageText", value);
 		this.addChild(new Spacer(1));
+		const label = synthetic ? "replay" : "operator";
 		this.addChild(
-			new Markdown(text, 1, 1, getMarkdownTheme(), {
-				bgColor,
-				color,
-			}),
+			new Text(
+				`${theme.fg("borderAccent", "▸")} ${theme.bold(theme.fg("accent", label))} ${theme.fg("dim", "input")}`,
+				1,
+				0,
+			),
 		);
+		this.addChild(new PromptZoneMarkdown(text, bgColor, color));
+		this.addChild(new Text(theme.fg("borderAccent", "▔"), 1, 0));
+	}
+}
+
+class PromptZoneMarkdown implements Component {
+	#markdown: Markdown;
+
+	constructor(text: string, bgColor: (value: string) => string, color: (value: string) => string) {
+		this.#markdown = new Markdown(text, 1, 1, getMarkdownTheme(), {
+			bgColor,
+			color,
+		});
 	}
 
-	override render(width: number): string[] {
-		const lines = super.render(width);
+	invalidate(): void {
+		this.#markdown.invalidate();
+	}
+
+	render(width: number): string[] {
+		const lines = this.#markdown.render(width);
 		if (lines.length === 0) {
 			return lines;
 		}
 
-		lines[0] = OSC133_ZONE_START + lines[0];
-		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
-		return lines;
+		const zoned = [...lines];
+		zoned[0] = OSC133_ZONE_START + zoned[0];
+		zoned[zoned.length - 1] = `${zoned[zoned.length - 1]}${OSC133_ZONE_END}${OSC133_ZONE_FINAL}`;
+		return zoned;
 	}
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -1,6 +1,6 @@
 import { type Component, padding, TERMINAL, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { APP_NAME } from "@gajae-code/utils";
-import { theme } from "../../modes/theme/theme";
+import { type ThemeColor, theme } from "../../modes/theme/theme";
 
 export interface RecentSession {
 	name: string;
@@ -14,11 +14,12 @@ export interface LspServerInfo {
 }
 
 /**
- * Premium welcome screen with red-claw GJC mark and two-column layout.
+ * GJC-native launch surface with compact command affordances, project
+ * signals, and a claw/talon mark without copying another agent shell.
  */
 export class WelcomeComponent implements Component {
 	#animStart: number | null = null;
-	#animTimer: ReturnType<typeof setInterval> | null = null;
+	#animTimer: NodeJS.Timeout | null = null;
 
 	constructor(
 		private readonly version: string,
@@ -78,13 +79,16 @@ export class WelcomeComponent implements Component {
 		}
 		const dualContentWidth = boxWidth - 3; // 3 = │ + │ + │
 		const preferredLeftCol = 26;
-		const minLeftCol = 12; // red-claw logo width
+		const minLeftCol = 16; // claw mark plus GJC identity labels
 		const minRightCol = 20;
+		const modelPill = this.#pill(theme.icon.model || "model", this.modelName, "statusLineModel");
+		const providerPill = this.#pill(theme.icon.package || "provider", this.providerName, "statusLinePath");
 		const leftMinContentWidth = Math.max(
 			minLeftCol,
-			visibleWidth("Welcome back!"),
-			visibleWidth(this.modelName),
-			visibleWidth(this.providerName),
+			visibleWidth("Gajae forge"),
+			visibleWidth("shape · act · prove"),
+			visibleWidth(modelPill),
+			visibleWidth(providerPill),
 		);
 		const desiredLeftCol = Math.min(preferredLeftCol, Math.max(minLeftCol, Math.floor(dualContentWidth * 0.35)));
 		const dualLeftCol =
@@ -102,12 +106,13 @@ export class WelcomeComponent implements Component {
 		// Left column - centered content
 		const leftLines = [
 			"",
-			this.#centerText(theme.bold("Welcome back!"), leftCol),
+			this.#centerText(theme.bold(theme.fg("accent", "Gajae forge")), leftCol),
+			this.#centerText(theme.fg("dim", "shape · act · prove"), leftCol),
 			"",
 			...logoColored.map(l => this.#centerText(l, leftCol)),
 			"",
-			this.#centerText(theme.fg("muted", this.modelName), leftCol),
-			this.#centerText(theme.fg("borderMuted", this.providerName), leftCol),
+			this.#centerText(modelPill, leftCol),
+			this.#centerText(providerPill, leftCol),
 		];
 
 		// Right column separator
@@ -117,7 +122,7 @@ export class WelcomeComponent implements Component {
 		// Recent sessions content
 		const sessionLines: string[] = [];
 		if (this.recentSessions.length === 0) {
-			sessionLines.push(` ${theme.fg("dim", "No recent sessions")}`);
+			sessionLines.push(` ${theme.fg("dim", "No saved trails")}`);
 		} else {
 			// Reserve width for the bullet prefix (" • ") and the trailing " (timeAgo)"
 			// so the relative time is never the part that gets truncated. The name
@@ -155,17 +160,25 @@ export class WelcomeComponent implements Component {
 
 		// Right column
 		const rightLines = [
-			` ${theme.bold(theme.fg("accent", "Tips"))}`,
-			` ${theme.fg("dim", "?")}${theme.fg("muted", " for keyboard shortcuts")}`,
-			` ${theme.fg("dim", "#")}${theme.fg("muted", " for prompt actions")}`,
-			` ${theme.fg("dim", "/")}${theme.fg("muted", " for commands")}`,
-			` ${theme.fg("dim", "!")}${theme.fg("muted", " to run bash")}`,
-			` ${theme.fg("dim", "$")}${theme.fg("muted", " to run python")}`,
+			` ${theme.bold(theme.fg("accent", "Flow keys"))}`,
+			` ${theme.fg("dim", "/")}${theme.fg("muted", " commands")} ${theme.fg("dim", "·")} ${theme.fg(
+				"dim",
+				"#",
+			)}${theme.fg("muted", " actions")}`,
+			` ${theme.fg("dim", "!")}${theme.fg("muted", " shell")} ${theme.fg("dim", "·")} ${theme.fg("dim", "$")}${theme.fg(
+				"muted",
+				" python",
+			)}`,
+			` ${theme.fg("dim", "?")}${theme.fg("muted", " keymap")} ${theme.fg("dim", "·")} ${theme.fg(
+				"dim",
+				"ctrl+l",
+			)}${theme.fg("muted", " model")}`,
+			` ${theme.fg("dim", "shift+tab")}${theme.fg("muted", " reasoning")}`,
 			separator,
-			` ${theme.bold(theme.fg("accent", "LSP Servers"))}`,
+			` ${theme.bold(theme.fg("accent", "Project pulse"))}`,
 			...lspLines,
 			separator,
-			` ${theme.bold(theme.fg("accent", "Recent sessions"))}`,
+			` ${theme.bold(theme.fg("accent", "Session trail"))}`,
 			...sessionLines,
 			"",
 		];
@@ -182,7 +195,7 @@ export class WelcomeComponent implements Component {
 		const lines: string[] = [];
 
 		// Top border with embedded title
-		const title = ` ${APP_NAME} v${this.version} `;
+		const title = ` ${APP_NAME} v${this.version} · GJC forge `;
 		const titlePrefixRaw = hChar.repeat(3);
 		const titleStyled = theme.fg("dim", titlePrefixRaw) + theme.fg("muted", title);
 		const titleVisLen = visibleWidth(titlePrefixRaw) + visibleWidth(title);
@@ -226,29 +239,20 @@ export class WelcomeComponent implements Component {
 		return padding(leftPad) + text + padding(rightPad);
 	}
 
-	/** Fit string to exact width with ANSI-aware truncation/padding */
+	/** Fit string to exact width with native ANSI/wide-glyph truncation and padding. */
 	#fitToWidth(str: string, width: number): string {
 		const visLen = visibleWidth(str);
 		if (visLen > width) {
-			const ellipsis = "…";
-			const ellipsisWidth = visibleWidth(ellipsis);
-			const maxWidth = Math.max(0, width - ellipsisWidth);
-			let truncated = "";
-			let currentWidth = 0;
-			let inEscape = false;
-			for (const char of str) {
-				if (char === "\x1b") inEscape = true;
-				if (inEscape) {
-					truncated += char;
-					if (char === "m") inEscape = false;
-				} else if (currentWidth < maxWidth) {
-					truncated += char;
-					currentWidth++;
-				}
-			}
-			return `${truncated}${ellipsis}`;
+			return truncateToWidth(str, width, null, true);
 		}
 		return str + padding(width - visLen);
+	}
+
+	#pill(icon: string, text: string, color: ThemeColor): string {
+		return `${theme.fg("borderMuted", "[")} ${theme.fg(color, icon)} ${theme.fg("muted", text)} ${theme.fg(
+			"borderMuted",
+			"]",
+		)}`;
 	}
 
 	/** Pick the logo frame for the current intro phase, or the resting frame. */
@@ -272,7 +276,7 @@ export class WelcomeComponent implements Component {
 }
 
 // biome-ignore format: preserve ASCII art layout
-const RED_CLAW_LOGO = ["╭─╮    ╭─╮", "╰─╲╭──╮╱─╯", "  │●  ●│  ", "  ╰╮▔▔╭╯  ", "   ╰──╯   "];
+const RED_CLAW_LOGO = ["  ╭╮  ╭╮  ╭╮ ", " ╭╯│ ╭╯│ ╭╯│ ", "╭╯ ╰─╯ ╰─╯ ╰╮", "╰╮  ╭───╮  ╭╯", " ╰──╯   ╰──╯ "];
 
 /** Multi-stop palette for the red-claw diagonal gradient. */
 const GRADIENT_STOPS: ReadonlyArray<readonly [number, number, number]> = [

--- a/packages/coding-agent/test/gjc-ui-redesign.test.ts
+++ b/packages/coding-agent/test/gjc-ui-redesign.test.ts
@@ -43,12 +43,15 @@ describe("GJC red-claw redesign defaults", () => {
 		expect(new Set([colors.accent, colors.error, colors.warning, colors.toolDiffRemoved]).size).toBe(4);
 	});
 
-	it("removes Pi identity and powerline separators from the default-visible status line", () => {
+	it("keeps public status presets on the GJC identity", () => {
 		expect(SETTINGS_SCHEMA["statusLine.separator"].default).toBe("slash");
 		expect(STATUS_LINE_PRESETS.default.leftSegments).not.toContain("pi");
 		expect(STATUS_LINE_PRESETS.default.separator).toBe("slash");
-		expect(STATUS_LINE_PRESETS.full.leftSegments).toContain("pi");
-		expect(STATUS_LINE_PRESETS.nerd.leftSegments).toContain("pi");
+		expect(STATUS_LINE_PRESETS.full.leftSegments).toContain("gajae");
+		expect(STATUS_LINE_PRESETS.nerd.leftSegments).toContain("gajae");
+		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
+			expect(preset.leftSegments, name).not.toContain("pi");
+		}
 	});
 
 	it("brands HTML session exports as GJC without changing transcript role support", () => {

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -1,0 +1,178 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { BashExecutionComponent } from "@gajae-code/coding-agent/modes/components/bash-execution";
+import { EvalExecutionComponent } from "@gajae-code/coding-agent/modes/components/eval-execution";
+import { FooterComponent } from "@gajae-code/coding-agent/modes/components/footer";
+import { STATUS_LINE_PRESETS } from "@gajae-code/coding-agent/modes/components/status-line/presets";
+import { UserMessageComponent } from "@gajae-code/coding-agent/modes/components/user-message";
+import { WelcomeComponent } from "@gajae-code/coding-agent/modes/components/welcome";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { type TUI, visibleWidth } from "@gajae-code/tui";
+
+function createFooterSession(): AgentSession {
+	return {
+		state: {
+			model: { id: "very-long-model-name-for-footer-budget", contextWindow: 200_000 },
+		},
+		sessionManager: {
+			getEntries: () => [
+				{
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: {
+							input: 1234,
+							output: 567,
+							cacheRead: 89,
+							cacheWrite: 12,
+							cost: { total: 0.123 },
+							premiumRequests: 0,
+						},
+					},
+				},
+			],
+		},
+		getContextUsage: () => ({ contextWindow: 200_000, percent: 42.5 }),
+		modelRegistry: { isUsingOAuth: () => false },
+	} as unknown as AgentSession;
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+});
+
+describe("redesigned interactive shell chrome", () => {
+	it("renders distinct GJC-native user and assistant turns", () => {
+		const user = Bun.stripANSI(new UserMessageComponent("hello").render(80).join("\n"));
+		const assistant = Bun.stripANSI(
+			new AssistantMessageComponent(createAssistantMessage("hi")).render(80).join("\n"),
+		);
+
+		expect(user).toContain("operator input");
+		expect(assistant).toContain("gajae reply");
+		expect(user).not.toContain("you submitted");
+		expect(assistant).not.toContain("agent response");
+	});
+
+	it("keeps the GJC forge launch surface responsive", () => {
+		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai");
+		const lines = component.render(54);
+		const rendered = Bun.stripANSI(lines.join("\n"));
+
+		expect(rendered).toContain("Gajae forge");
+		expect(rendered).toContain("╭╮  ╭╮  ╭╮");
+		expect(rendered).not.toContain("●");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(54);
+		}
+	});
+
+	it("renders execution rails without breaking output caps", () => {
+		const ui = { requestRender: () => {} } as unknown as TUI;
+		const bash = new BashExecutionComponent("printf ready", ui, false);
+		bash.setComplete(0, false, { output: Array.from({ length: 160 }, (_, i) => `line-${i}`).join("\n") });
+		const bashRendered = Bun.stripANSI(bash.render(80).join("\n"));
+
+		expect(bashRendered).toContain("shell · $ printf");
+		expect(bashRendered).toContain("ctrl+o to expand");
+		expect(bashRendered).not.toContain("line-0\n");
+		for (const line of bash.render(80)) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(80);
+		}
+	});
+
+	it("keeps eval execution headers compact and mode-labeled", () => {
+		const ui = { requestRender: () => {} } as unknown as TUI;
+		const py = new EvalExecutionComponent("print('ready')", ui, false, "python");
+		const js = new EvalExecutionComponent("1 + 1", ui, false, "js");
+
+		expect(Bun.stripANSI(py.render(80).join("\n"))).toContain("python · >>>");
+		expect(Bun.stripANSI(js.render(80).join("\n"))).toContain("node · >>>");
+	});
+
+	it("keeps eval continuation aligned for multiline code", () => {
+		const ui = { requestRender: () => {} } as unknown as TUI;
+		const py = new EvalExecutionComponent("print('a')\nprint('b')", ui, false, "python");
+		const stripped = Bun.stripANSI(py.render(80).join("\n"));
+
+		expect(stripped).toContain("python · >>> print('a')");
+		expect(stripped).toContain("          print('b')");
+	});
+
+	it("keeps OSC 133 prompt markers scoped to the message body", () => {
+		const rendered = new UserMessageComponent("hello").render(80);
+
+		expect(rendered[0]).not.toContain("\x1b]133;A\x07");
+		expect(rendered[1]).not.toContain("\x1b]133;A\x07");
+		expect(rendered[2]).toContain("\x1b]133;A\x07");
+		expect(rendered[rendered.length - 2]).toContain("\x1b]133;B\x07\x1b]133;C\x07");
+		expect(rendered[rendered.length - 1]).not.toContain("\x1b]133;B\x07");
+	});
+
+	it("budgets footer prefixes before truncating pulse", () => {
+		const footer = new FooterComponent(createFooterSession());
+		const lines = footer.render(72);
+		const rendered = Bun.stripANSI(lines.join("\n"));
+
+		expect(rendered).toContain("cwd");
+		expect(rendered).toContain("pulse");
+		expect(rendered).toContain("very-long-mod");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(72);
+		}
+	});
+
+	it("keeps public status presets on the GJC identity", () => {
+		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
+			expect(preset.leftSegments, name).not.toContain("pi");
+		}
+
+		expect(STATUS_LINE_PRESETS.full.leftSegments).toContain("gajae");
+		expect(STATUS_LINE_PRESETS.nerd.leftSegments).toContain("gajae");
+	});
+
+	it("keeps the default status preset dense and pulse-forward", () => {
+		expect(STATUS_LINE_PRESETS.default.leftSegments).toEqual(["model", "mode", "git", "pr", "path"]);
+		expect(STATUS_LINE_PRESETS.default.rightSegments).toEqual(["session_name", "token_rate", "context_pct", "cost"]);
+		expect(STATUS_LINE_PRESETS.default.segmentOptions?.path?.maxLength).toBe(32);
+	});
+
+	it("keeps forge launch rendering on the bounded-work path", () => {
+		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai", [
+			{ name: "very-long-session-name".repeat(10), timeAgo: "2h" },
+		]);
+		const first = component.render(96);
+		const second = component.render(96);
+
+		expect(first).toHaveLength(second.length);
+		expect(first.join("\n")).toBe(second.join("\n"));
+		for (const line of first) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(96);
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -94,7 +94,7 @@ describe("status line session accent", () => {
 		const component = new StatusLineComponent(createStatusLineSession("Named session"));
 		component.updateSettings({
 			preset: "custom",
-			leftSegments: ["pi"],
+			leftSegments: ["gajae"],
 			rightSegments: ["session_name"],
 			separator: "powerline-thin",
 			sessionAccent,

--- a/scripts/verify-gjc-ui-redesign.ts
+++ b/scripts/verify-gjc-ui-redesign.ts
@@ -74,6 +74,10 @@ async function verifyStatusDefaults(): Promise<GateResult> {
 	const fullStart = presets.indexOf("full:");
 	const defaultBlock = defaultStart >= 0 && minimalStart > defaultStart ? presets.slice(defaultStart, minimalStart) : "";
 	const compactBlock = compactStart >= 0 && fullStart > compactStart ? presets.slice(compactStart, fullStart) : "";
+	const leftSegmentsByPreset = parsePresetLeftSegments(presets);
+	const publicPresetUsesPi = Object.entries(leftSegmentsByPreset).filter(([, segments]) => segments.includes("pi"));
+	const fullUsesGajae = leftSegmentsByPreset.full?.includes("gajae") === true;
+	const nerdUsesGajae = leftSegmentsByPreset.nerd?.includes("gajae") === true;
 	return {
 		name: "default-visible status line identity",
 		passed:
@@ -81,13 +85,30 @@ async function verifyStatusDefaults(): Promise<GateResult> {
 			!defaultBlock.includes('"pi"') &&
 			compactBlock.includes('separator: "slash"') &&
 			presets.includes('full: {') &&
-			presets.includes('leftSegments: ["pi", "hostname"'),
+			fullUsesGajae &&
+			nerdUsesGajae &&
+			publicPresetUsesPi.length === 0,
 		details: [
 			`default separator slash: ${defaultBlock.includes('separator: "slash"')}`,
 			`default pi segment absent: ${!defaultBlock.includes('"pi"')}`,
-			`full/nerd opt-in pi retained: ${presets.includes('leftSegments: ["pi", "hostname"')}`,
+			`full GJC identity present: ${fullUsesGajae}`,
+			`nerd GJC identity present: ${nerdUsesGajae}`,
+			`public pi preset absent: ${publicPresetUsesPi.length === 0}${
+				publicPresetUsesPi.length > 0 ? ` (${publicPresetUsesPi.map(([name]) => name).join(", ")})` : ""
+			}`,
 		],
 	};
+}
+
+function parsePresetLeftSegments(source: string): Record<string, string[]> {
+	const result: Record<string, string[]> = {};
+	const presetRegex = /\n\t([a-z_]+): \{[\s\S]*?leftSegments: \[([^\]]*)\]/g;
+	for (const match of source.matchAll(presetRegex)) {
+		const [, name, rawSegments] = match;
+		if (!name || !rawSegments) continue;
+		result[name] = [...rawSegments.matchAll(/"([^"]+)"/g)].map(segmentMatch => segmentMatch[1]).filter(Boolean);
+	}
+	return result;
 }
 
 async function verifyExportBranding(): Promise<GateResult> {


### PR DESCRIPTION
## Summary
- replaces the borrowed-looking shell chrome with GJC-native forge/operator/gajae/cwd/pulse surfaces
- keeps the startup icon as an abstract claw/talon mark, not a character
- moves public status-line identity to `gajae` while retaining `pi` only as a legacy custom-config alias
- strengthens regression coverage for prompt OSC boundaries, bounded rendering, public preset identity, and redesign verification gates

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/gjc-ui-redesign.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/bash-execution-sixel.test.ts packages/coding-agent/test/status-line-context-cache.test.ts packages/coding-agent/test/status-line-overflow.test.ts`
- `bun run check:gjc-ui`
- `git diff --check`

## Review
- Code reviewer: APPROVE, 0 issues
- Architect: CLEAR, performance and OSC boundaries acceptable
