### PR TITLE
Give GJC its own resilient shell surface

### DIFF
--- a/.gjc/skills/deep-interview/SKILL.md
+++ b/.gjc/skills/deep-interview/SKILL.md
@@ -60,7 +60,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 ## Native Plugin Invocation Guard (Issue #3030)
 
-If this raw bundled skill is loaded by GJC's native skill loader through `/gajae-code:deep-interview` or `Skill("gajae-code:deep-interview")`, do not treat that path as permission to skip rendered GJC setup. The user-facing preferred invocation is `/deep-interview`; do not recommend or advertise `/gajae-code:deep-interview` as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
+If this raw bundled skill is loaded by GJC's native skill loader through `/gajae-code:deep-interview` or `Skill("gajae-code:deep-interview")`, do not treat that path as permission to skip rendered GJC setup. The user-facing invocation is `/skill:deep-interview`; do not recommend or advertise `/deep-interview` or `/gajae-code:deep-interview` as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
 
 ## Phase 0: Resolve Ambiguity Threshold (blocking prerequisite)
 
@@ -710,7 +710,7 @@ Optional settings in `.gjc/settings.json`:
 
 ## Resume
 
-If interrupted, run `/deep-interview` again. The skill reads state from `.gjc/state/deep-interview-state.json` and resumes from the last cgjcleted round.
+If interrupted, run `/skill:deep-interview` again. The skill reads state from `.gjc/state/deep-interview-state.json` and resumes from the last cgjcleted round.
 
 ## Integration with Staged execution
 
@@ -722,18 +722,18 @@ Staged execution: "Your request is quite open-ended. Would you like to run a dee
   [Yes, interview first] [No, expand directly]
 ```
 
-If the user chooses interview, execution invokes `/deep-interview`. When the interview cgjcletes and the user selects "Execute with team", the spec becomes Phase 0 output and execution continues from Phase 1 (Planning).
+If the user chooses interview, execution invokes `/skill:deep-interview`. When the interview cgjcletes and the user selects "Execute with team", the spec becomes Phase 0 output and execution continues from Phase 1 (Planning).
 
 ## Approval-Gated Pipeline: deep-interview → ralplan → pending approval
 
 The recommended refinement path chains clarity and feasibility gates, then stops for explicit execution approval:
 
 ```
-/deep-interview "vague idea"
+/skill:deep-interview "vague idea"
   → Socratic Q&A until ambiguity ≤ <resolvedThresholdPercent>
   → Spec written to .gjc/specs/deep-interview-{slug}.md
   → User explicitly selects "Refine with ralplan consensus"
-  → /ralplan --consensus --direct (spec as input, skip interview)
+  → /skill:ralplan --consensus --direct (spec as input, skip interview)
     → Planner creates implementation plan from spec
     → Architect reviews for architectural soundness
     → Critic validates quality and testability

--- a/.gjc/skills/ralplan/SKILL.md
+++ b/.gjc/skills/ralplan/SKILL.md
@@ -138,5 +138,5 @@ The gate auto-passes when it detects **any** concrete signal. You do not need al
 |-------|----------|
 | Gate fires on a well-specified prgjct | Add a file reference, function name, or issue number to anchor the request |
 | Want to bypass the gate | Prefix with `force:` or `!` (e.g., `force: team fix it`) |
-| Gate does not fire on a vague prgjct | The gate only catches prgjcts with <=15 effective words and no concrete anchors; add more detail or use `/ralplan` explicitly |
+| Gate does not fire on a vague prgjct | The gate only catches prgjcts with <=15 effective words and no concrete anchors; add more detail or use `/skill:ralplan` explicitly |
 | Redirected to ralplan but want execution | Use the structured approval option or explicitly say which execution skill should proceed; `just do it` / `skip planning` alone only ends planning with a `pending approval` artifact |

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/agent": {
       "name": "@gajae-code/agent-core",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "dependencies": {
         "@gajae-code/ai": "catalog:",
         "@gajae-code/natives": "catalog:",
@@ -30,7 +30,7 @@
     },
     "packages/ai": {
       "name": "@gajae-code/ai",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -48,7 +48,7 @@
     },
     "packages/coding-agent": {
       "name": "@gajae-code/coding-agent",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "bin": {
         "gjc": "src/cli.ts",
       },
@@ -83,7 +83,7 @@
     },
     "packages/natives": {
       "name": "@gajae-code/natives",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "devDependencies": {
         "@napi-rs/cli": "catalog:",
         "@types/bun": "catalog:",
@@ -91,7 +91,7 @@
     },
     "packages/stats": {
       "name": "@gajae-code/stats",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "bin": {
         "gjc-stats": "./src/index.ts",
       },
@@ -116,7 +116,7 @@
     },
     "packages/swarm-extension": {
       "name": "@gajae-code/swarm-extension",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "bin": {
         "gjc-swarm": "src/cli.ts",
       },
@@ -132,7 +132,7 @@
     },
     "packages/tui": {
       "name": "@gajae-code/tui",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "dependencies": {
         "@gajae-code/natives": "catalog:",
         "@gajae-code/utils": "catalog:",
@@ -172,7 +172,7 @@
     },
     "packages/utils": {
       "name": "@gajae-code/utils",
-      "version": "15.3.2",
+      "version": "0.1.0",
       "dependencies": {
         "@gajae-code/natives": "catalog:",
         "beautiful-mermaid": "catalog:",
@@ -184,7 +184,7 @@
         "@types/bun": "catalog:",
       },
     },
-    "python/robomp/web": {
+    "python/robogjc/web": {
       "name": "robogjc-web",
       "version": "0.1.0",
       "dependencies": {
@@ -1129,7 +1129,7 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "robogjc-web": ["robogjc-web@workspace:python/robomp/web"],
+    "robogjc-web": ["robogjc-web@workspace:python/robogjc/web"],
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
 - Changed `gjc team` startup to use tmux worker panes backed by dedicated detached git worktrees by default, while keeping `--worktree` as a backward-compatible launch override.
 - Constrained the visible GJC utility surface to the retained workflow/runtime endpoints and four bundled task agents, with MCP, arbitrary skill, plugin, extension, marketplace, and custom discovery surfaces quarantined from default public use.
-- Redesigned the interactive TUI chrome with GJC-native operator/gajae turns, a forge-style welcome surface, and compact cwd/pulse indicators tuned for terminal coding-agent ergonomics.
+- Redesigned the interactive TUI chrome with a minimal opencode-style prompt composer, simple user/gajae transcript labels, a forge-style welcome surface, and compact cwd/pulse indicators tuned for terminal coding-agent ergonomics.
 - Changed web search provider credential lookup to use the shared `AuthStorage` pipeline (`getApiKey`/`getOAuthAccess`) for API-key and OAuth auth instead of direct `AgentStorage` access
 - Changed the `codex` web search provider display label from `Codex` to `OpenAI`
 - Updated `anthropic` and `openai`/`gemini` web search option descriptions to reflect their native `web_search`/OAuth requirements

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2427,7 +2427,7 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.enableSkillCommands": {
 		type: "boolean",
-		default: false,
+		default: true,
 	},
 
 	"skills.enableCodexUser": { type: "boolean", default: false },

--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getAgentDir, isEnoent } from "@gajae-code/utils";
+import { getAgentDir, isEnoent, parseFrontmatter } from "@gajae-code/utils";
 import deepInterviewAgent from "./gjc/agents/deep-interview.md" with { type: "text" };
 import ralplanAgent from "./gjc/agents/ralplan.md" with { type: "text" };
 import teamAgent from "./gjc/agents/team.md" with { type: "text" };
@@ -12,6 +12,15 @@ import ultragoalSkill from "./gjc/skills/ultragoal/SKILL.md" with { type: "text"
 export const DEFAULT_GJC_DEFINITION_NAMES = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
 export type DefaultGjcDefinitionName = (typeof DEFAULT_GJC_DEFINITION_NAMES)[number];
 export type DefaultGjcDefinitionKind = "agent" | "skill";
+export type EmbeddedDefaultGjcSkill = {
+	name: DefaultGjcDefinitionName;
+	description: string;
+	filePath: string;
+	baseDir: string;
+	source: "bundled:default";
+	hide?: boolean;
+	content: string;
+};
 export type DefaultGjcInstallStatus = "different" | "matching" | "missing" | "skipped" | "written";
 
 export interface DefaultGjcDefinition {
@@ -63,6 +72,30 @@ const DEFAULT_GJC_DEFINITIONS: readonly DefaultGjcDefinition[] = [
 
 export function getDefaultGjcDefinitions(): readonly DefaultGjcDefinition[] {
 	return DEFAULT_GJC_DEFINITIONS;
+}
+
+export function getDefaultGjcAgentDefinitions(): readonly DefaultGjcDefinition[] {
+	return DEFAULT_GJC_DEFINITIONS.filter(definition => definition.kind === "agent");
+}
+
+export function getEmbeddedDefaultGjcSkills(): EmbeddedDefaultGjcSkill[] {
+	return DEFAULT_GJC_DEFINITIONS.filter(definition => definition.kind === "skill").map(definition => {
+		const { frontmatter } = parseFrontmatter(definition.content, {
+			source: `embedded:gjc/${definition.relativePath}`,
+			level: "warn",
+		});
+		const description =
+			typeof frontmatter.description === "string" ? frontmatter.description : `GJC ${definition.name} workflow`;
+		return {
+			name: definition.name,
+			description,
+			filePath: `embedded:gjc/${definition.relativePath}`,
+			baseDir: `embedded:gjc/skills/${definition.name}`,
+			source: "bundled:default",
+			hide: frontmatter.hide === true,
+			content: definition.content,
+		};
+	});
 }
 
 export async function installDefaultGjcDefinitions(

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -60,7 +60,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 ## Native Plugin Invocation Guard (Issue #3030)
 
-If this raw bundled skill is loaded by GJC's native skill loader through `/gajae-code:deep-interview` or `Skill("gajae-code:deep-interview")`, do not treat that path as permission to skip rendered GJC setup. The user-facing preferred invocation is `/deep-interview`; do not recommend or advertise `/gajae-code:deep-interview` as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
+If this raw bundled skill is loaded by GJC's native skill loader through `/gajae-code:deep-interview` or `Skill("gajae-code:deep-interview")`, do not treat that path as permission to skip rendered GJC setup. The user-facing invocation is `/skill:deep-interview`; do not recommend or advertise `/deep-interview` or `/gajae-code:deep-interview` as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
 
 ## Phase 0: Resolve Ambiguity Threshold (blocking prerequisite)
 
@@ -710,7 +710,7 @@ Optional settings in `.gjc/settings.json`:
 
 ## Resume
 
-If interrupted, run `/deep-interview` again. The skill reads state from `.gjc/state/deep-interview-state.json` and resumes from the last completed round.
+If interrupted, run `/skill:deep-interview` again. The skill reads state from `.gjc/state/deep-interview-state.json` and resumes from the last completed round.
 
 ## Integration with Staged execution
 
@@ -722,18 +722,18 @@ Staged execution: "Your request is quite open-ended. Would you like to run a dee
   [Yes, interview first] [No, expand directly]
 ```
 
-If the user chooses interview, execution invokes `/deep-interview`. When the interview completes and the user selects "Execute with team", the spec becomes Phase 0 output and execution continues from Phase 1 (Planning).
+If the user chooses interview, execution invokes `/skill:deep-interview`. When the interview completes and the user selects "Execute with team", the spec becomes Phase 0 output and execution continues from Phase 1 (Planning).
 
 ## Approval-Gated Pipeline: deep-interview → ralplan → pending approval
 
 The recommended refinement path chains clarity and feasibility gates, then stops for explicit execution approval:
 
 ```
-/deep-interview "vague idea"
+/skill:deep-interview "vague idea"
   → Socratic Q&A until ambiguity ≤ <resolvedThresholdPercent>
   → Spec written to .gjc/specs/deep-interview-{slug}.md
   → User explicitly selects "Refine with ralplan consensus"
-  → /ralplan --consensus --direct (spec as input, skip interview)
+  → /skill:ralplan --consensus --direct (spec as input, skip interview)
     → Planner creates implementation plan from spec
     → Architect reviews for architectural soundness
     → Critic validates quality and testability

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -138,5 +138,5 @@ The gate auto-passes when it detects **any** concrete signal. You do not need al
 |-------|----------|
 | Gate fires on a well-specified prompt | Add a file reference, function name, or issue number to anchor the request |
 | Want to bypass the gate | Prefix with `force:` or `!` (e.g., `force: team fix it`) |
-| Gate does not fire on a vague prompt | The gate only catches prompts with <=15 effective words and no concrete anchors; add more detail or use `/ralplan` explicitly |
+| Gate does not fire on a vague prompt | The gate only catches prompts with <=15 effective words and no concrete anchors; add more detail or use `/skill:ralplan` explicitly |
 | Redirected to ralplan but want execution | Use the structured approval option or explicitly say which execution skill should proceed; `just do it` / `skip planning` alone only ends planning with a `pending approval` artifact |

--- a/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
+++ b/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
@@ -16,7 +16,7 @@
  */
 import type { SkillsSettings } from "../../config/settings";
 import type { CustomCommandSource, LoadedCustomCommand } from "../custom-commands";
-import { getSkillSlashCommandName, type Skill } from "../skills";
+import { getSkillSlashCommandNames, type Skill } from "../skills";
 import type { SlashCommandInfo, SlashCommandLocation } from "../slash-commands";
 import type { ExtensionRunner } from "./runner";
 
@@ -54,12 +54,14 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 	if (session.skillsSettings?.enableSkillCommands) {
 		for (const skill of session.skills) {
 			if (skill.hide === true) continue;
-			out.push({
-				name: getSkillSlashCommandName(skill),
-				description: skill.description || undefined,
-				source: "skill",
-				path: skill.filePath,
-			});
+			for (const name of getSkillSlashCommandNames(skill)) {
+				out.push({
+					name,
+					description: skill.description || undefined,
+					source: "skill",
+					path: skill.filePath,
+				});
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -16,12 +16,14 @@ export interface Skill {
 	source: string;
 	/**
 	 * When `true`, the skill is loaded and reachable via `skill://<name>` and
-	 * (when enabled) `/skill:<name>`, but is excluded from the rendered system
-	 * prompt's `<skills>` listing.
+	 * skill slash aliases, but is excluded from the rendered system prompt's
+	 * `<skills>` listing.
 	 */
 	hide?: boolean;
 	/** Source metadata for display */
 	_source?: SourceMeta;
+	/** Embedded SKILL.md content for bundled defaults that survive .gjc deletion. */
+	content?: string;
 }
 
 export interface SkillWarning {
@@ -282,11 +284,48 @@ export function getSkillSlashCommandName(skill: Pick<Skill, "name">): string {
 	return `skill:${skill.name}`;
 }
 
+export function isNamespacedSkillSlashCommandName(commandName: string): boolean {
+	return commandName.startsWith("skill:");
+}
+
+export function getSkillSlashCommandNames(skill: Pick<Skill, "name">): string[] {
+	return [getSkillSlashCommandName(skill)];
+}
+
+export function isSkillSlashCommandName(commandName: string, skill: Pick<Skill, "name">): boolean {
+	return commandName === getSkillSlashCommandName(skill);
+}
+
+export interface ResolvedSkillSlashCommand {
+	name: string;
+	description: string;
+	skill: Skill;
+}
+
+export function resolveSkillSlashCommands(
+	skills: readonly Skill[],
+	_reservedDirectCommandNames: ReadonlySet<string>,
+): ResolvedSkillSlashCommand[] {
+	const commands: ResolvedSkillSlashCommand[] = [];
+	const claimedNames = new Set<string>();
+	for (const skill of skills) {
+		if (skill.hide === true) continue;
+		for (const name of getSkillSlashCommandNames(skill)) {
+			if (claimedNames.has(name)) {
+				continue;
+			}
+			claimedNames.add(name);
+			commands.push({ name, description: skill.description, skill });
+		}
+	}
+	return commands;
+}
+
 export async function buildSkillPromptMessage(
-	skill: Pick<Skill, "name" | "filePath">,
+	skill: Pick<Skill, "name" | "filePath" | "content">,
 	args: string,
 ): Promise<BuiltSkillPromptMessage> {
-	const content = await Bun.file(skill.filePath).text();
+	const content = typeof skill.content === "string" ? skill.content : await Bun.file(skill.filePath).text();
 	const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
 	const metaLines = [`Skill: ${skill.filePath}`];
 	const trimmedArgs = args.trim();

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -58,6 +58,9 @@ export class SkillProtocolHandler implements ProtocolHandler {
 		const hasRelativePath = urlPath && urlPath !== "/" && urlPath !== "";
 
 		if (hasRelativePath) {
+			if (skill.baseDir.startsWith("embedded:")) {
+				throw new Error(`Embedded skill ${skill.name} does not include relative file assets`);
+			}
 			const relativePath = decodeURIComponent(urlPath.slice(1));
 			validateRelativePath(relativePath);
 			targetPath = path.join(skill.baseDir, relativePath);
@@ -69,6 +72,17 @@ export class SkillProtocolHandler implements ProtocolHandler {
 			}
 		} else {
 			targetPath = skill.filePath;
+		}
+
+		if (typeof skill.content === "string" && !hasRelativePath) {
+			return {
+				url: url.href,
+				content: skill.content,
+				contentType: "text/markdown",
+				size: Buffer.byteLength(skill.content, "utf-8"),
+				sourcePath: targetPath,
+				notes: [],
+			};
 		}
 
 		const file = Bun.file(targetPath);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -642,8 +642,6 @@ async function buildSessionOptions(
 		options.enableLsp = false;
 	}
 
-	options.skills = [];
-
 	// Rules
 	if (parsed.noRules) {
 		options.rules = [];

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -50,7 +50,12 @@ import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../
 import type { ExtensionUIContext, ExtensionUIDialogOptions } from "../../extensibility/extensions";
 import { runExtensionCompact } from "../../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
-import { buildSkillPromptMessage, getSkillSlashCommandName } from "../../extensibility/skills";
+import {
+	buildSkillPromptMessage,
+	getSkillSlashCommandNames,
+	isNamespacedSkillSlashCommandName,
+	isSkillSlashCommandName,
+} from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
@@ -641,8 +646,10 @@ export class AcpAgent implements Agent {
 	}
 
 	async #runPromptOrCommand(record: ManagedSessionRecord, text: string, images: AgentImageContent[]): Promise<void> {
-		const skillResult = await this.#tryRunSkillCommand(record, text);
-		if (skillResult) {
+		// Namespaced skill commands cannot collide with ACP builtins; handle
+		// them before builtin dispatch. Bare `/name` aliases are intentionally
+		// not skill commands.
+		if (text.startsWith("/skill:") && (await this.#tryRunSkillCommand(record, text))) {
 			return;
 		}
 
@@ -686,11 +693,19 @@ export class AcpAgent implements Agent {
 			return;
 		}
 
+		if (await this.#tryRunSkillCommand(record, text, { directAliasMayCollide: false })) {
+			return;
+		}
+
 		await record.session.prompt(text, { images });
 	}
 
-	async #tryRunSkillCommand(record: ManagedSessionRecord, text: string): Promise<boolean> {
-		if (!text.startsWith("/skill:")) {
+	async #tryRunSkillCommand(
+		record: ManagedSessionRecord,
+		text: string,
+		options: { directAliasMayCollide?: boolean } = {},
+	): Promise<boolean> {
+		if (!text.startsWith("/")) {
 			return false;
 		}
 		if (!record.session.skillsSettings?.enableSkillCommands) {
@@ -699,8 +714,14 @@ export class AcpAgent implements Agent {
 		const spaceIndex = text.indexOf(" ");
 		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
 		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skillName = commandName.slice("skill:".length);
-		const skill = record.session.skills.find(candidate => candidate.name === skillName);
+		if (
+			!isNamespacedSkillSlashCommandName(commandName) &&
+			options.directAliasMayCollide !== true &&
+			(await this.#directSkillAliasCollides(record, commandName))
+		) {
+			return false;
+		}
+		const skill = record.session.skills.find(candidate => isSkillSlashCommandName(commandName, candidate));
 		if (!skill || skill.hide === true) {
 			return false;
 		}
@@ -713,6 +734,14 @@ export class AcpAgent implements Agent {
 			attribution: "user",
 		});
 		return true;
+	}
+
+	async #directSkillAliasCollides(record: ManagedSessionRecord, commandName: string): Promise<boolean> {
+		if (record.session.customCommands.some(command => command.command.name === commandName)) {
+			return true;
+		}
+		const fileCommands = await loadSlashCommands({ cwd: record.session.sessionManager.getCwd() });
+		return fileCommands.some(command => command.name === commandName);
 	}
 
 	async cancel(params: { sessionId: string }): Promise<void> {
@@ -1396,23 +1425,10 @@ export class AcpAgent implements Agent {
 			commands.push(command);
 		};
 
-		// Advertise in the order dispatch resolves them: ACP builtins first
-		// (so core commands like `/model`, `/mcp`, `/todo` cannot be shadowed),
-		// then skills, then custom/user commands, then file-based slash
-		// commands. `appendCommand` dedupes by name so earlier entries win.
+		// Advertise builtins first, then custom/user commands, then file-based
+		// slash commands, then namespaced `/skill:<name>` skills.
 		for (const command of ACP_BUILTIN_SLASH_COMMANDS) {
 			appendCommand(command);
-		}
-
-		if (session.skillsSettings?.enableSkillCommands) {
-			for (const skill of session.skills) {
-				if (skill.hide === true) continue;
-				appendCommand({
-					name: getSkillSlashCommandName(skill),
-					description: skill.description || `Run ${skill.name} skill`,
-					input: { hint: "arguments" },
-				});
-			}
 		}
 
 		for (const command of session.customCommands) {
@@ -1428,6 +1444,19 @@ export class AcpAgent implements Agent {
 				name: command.name,
 				description: command.description,
 			});
+		}
+
+		if (session.skillsSettings?.enableSkillCommands) {
+			for (const skill of session.skills) {
+				if (skill.hide === true) continue;
+				for (const name of getSkillSlashCommandNames(skill)) {
+					appendCommand({
+						name,
+						description: skill.description || `Run ${skill.name} skill`,
+						input: { hint: "arguments" },
+					});
+				}
+			}
 		}
 
 		return commands;

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -16,12 +16,7 @@ export class AssistantMessageComponent extends Container {
 	#usageInfo?: Usage;
 	#convertedKittyImages = new Map<string, ImageContent>();
 	#kittyConversionsInFlight = new Set<string>();
-	#responseHeader = new Text(
-		`${theme.fg("border", "▌")} ${theme.bold(theme.fg("statusLineModel", "gajae"))} ${theme.fg("dim", "reply")}`,
-		1,
-		0,
-	);
-	#responseFooter = new Text(theme.fg("border", "▔"), 1, 0);
+	#responseHeader = new Text(theme.bold(theme.fg("statusLineModel", "gajae")), 1, 0);
 
 	constructor(
 		message?: AssistantMessage,
@@ -188,9 +183,6 @@ export class AssistantMessageComponent extends Container {
 		}
 
 		this.#renderToolImages();
-		if (hasVisibleContent) {
-			this.#contentContainer.addChild(this.#responseFooter);
-		}
 		// Check if aborted - show after partial content
 		// But only if there are no tool calls (tool execution components will show the error)
 		const hasToolCalls = message.content.some(c => c.type === "toolCall");

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -779,16 +779,21 @@ export class StatusLineComponent implements Component {
 	}
 
 	render(width: number): string[] {
-		// Only render hook statuses - main status is in editor's top border
-		const showHooks = this.#settings.showHookStatus ?? true;
-		if (!showHooks || this.#hookStatuses.size === 0) {
-			return [];
+		const lines: string[] = [];
+		const statusLine = this.#buildStatusLine(width);
+		if (statusLine) {
+			lines.push(truncateToWidth(statusLine, width));
 		}
 
-		const sortedStatuses = Array.from(this.#hookStatuses.entries())
-			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([, text]) => sanitizeStatusText(text));
-		const hookLine = sortedStatuses.join(" ");
-		return [truncateToWidth(hookLine, width)];
+		const showHooks = this.#settings.showHookStatus ?? true;
+		if (showHooks && this.#hookStatuses.size > 0) {
+			const sortedStatuses = Array.from(this.#hookStatuses.entries())
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([, text]) => sanitizeStatusText(text));
+			const hookLine = sortedStatuses.join(" ");
+			lines.push(truncateToWidth(hookLine, width));
+		}
+
+		return lines;
 	}
 }

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -17,16 +17,9 @@ export class UserMessageComponent extends Container {
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => theme.fg("userMessageText", value);
 		this.addChild(new Spacer(1));
-		const label = synthetic ? "replay" : "operator";
-		this.addChild(
-			new Text(
-				`${theme.fg("borderAccent", "▸")} ${theme.bold(theme.fg("accent", label))} ${theme.fg("dim", "input")}`,
-				1,
-				0,
-			),
-		);
+		const label = synthetic ? "replay" : "user";
+		this.addChild(new Text(theme.bold(theme.fg("accent", label)), 1, 0));
 		this.addChild(new PromptZoneMarkdown(text, bgColor, color));
-		this.addChild(new Text(theme.fg("borderAccent", "▔"), 1, 0));
 	}
 }
 

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -78,13 +78,15 @@ export class WelcomeComponent implements Component {
 			return [];
 		}
 		const dualContentWidth = boxWidth - 3; // 3 = │ + │ + │
-		const preferredLeftCol = 26;
-		const minLeftCol = 16; // claw mark plus GJC identity labels
+		const preferredLeftCol = 36;
+		const minLeftCol = 18; // claw mark plus GJC identity labels
 		const minRightCol = 20;
 		const modelPill = this.#pill(theme.icon.model || "model", this.modelName, "statusLineModel");
 		const providerPill = this.#pill(theme.icon.package || "provider", this.providerName, "statusLinePath");
+		const logoMinWidth = Math.max(...RED_CLAW_LOGO.map(line => visibleWidth(line)));
 		const leftMinContentWidth = Math.max(
 			minLeftCol,
+			logoMinWidth,
 			visibleWidth("Gajae forge"),
 			visibleWidth("shape · act · prove"),
 			visibleWidth(modelPill),
@@ -276,7 +278,14 @@ export class WelcomeComponent implements Component {
 }
 
 // biome-ignore format: preserve ASCII art layout
-const RED_CLAW_LOGO = ["  ╭╮  ╭╮  ╭╮ ", " ╭╯│ ╭╯│ ╭╯│ ", "╭╯ ╰─╯ ╰─╯ ╰╮", "╰╮  ╭───╮  ╭╯", " ╰──╯   ╰──╯ "];
+const RED_CLAW_LOGO = [
+	"╭────────────────╮        ╭────────╮",
+	"╰──────╮      ╭──╯     ╭──╯  ╭─────╯",
+	"       ╰──────╯    ╭───╯  ╭──╯      ",
+	"       ╭──────╮    ╰───╮  ╰──╮      ",
+	"╭──────╯      ╰──╮     ╰──╮  ╰─────╮",
+	"╰────────────────╯        ╰────────╯",
+];
 
 /** Multi-stop palette for the red-claw diagonal gradient. */
 const GRADIENT_STOPS: ReadonlyArray<readonly [number, number, number]> = [

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,6 +3,7 @@ import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import type { AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import { buildSkillPromptMessage } from "../../extensibility/skills";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
@@ -408,7 +409,7 @@ export class InputController {
 	}
 
 	/**
-	 * Dispatch a `/skill:<name> [args]` invocation through `promptCustomMessage`
+	 * Dispatch a skill slash invocation (`/skill:<name>`) through `promptCustomMessage`
 	 * using the supplied `streamingBehavior`. Returns true if the text was a
 	 * recognised skill command and was dispatched. A failure to load the skill
 	 * file is surfaced via `showError` but still returns true — the editor was
@@ -421,29 +422,17 @@ export class InputController {
 	 * ignores it.
 	 */
 	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		if (!text.startsWith("/skill:")) return false;
+		if (!text.startsWith("/")) return false;
 		const spaceIndex = text.indexOf(" ");
 		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
 		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skillPath = this.ctx.skillCommands?.get(commandName);
-		if (!skillPath) return false;
+		const skill = this.ctx.skillCommands?.get(commandName);
+		if (!skill) return false;
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
 		try {
-			const content = await Bun.file(skillPath).text();
-			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-			const metaLines = [`Skill: ${skillPath}`];
-			if (args) {
-				metaLines.push(`User: ${args}`);
-			}
-			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-			const skillName = commandName.slice("skill:".length);
-			const details: SkillPromptDetails = {
-				name: skillName || commandName,
-				path: skillPath,
-				args: args || undefined,
-				lineCount: body ? body.split("\n").length : 0,
-			};
+			const built = await buildSkillPromptMessage(skill, args);
+			const details: SkillPromptDetails = built.details;
 			// When the agent is streaming, register the compact slash-form text as
 			// the pending-display twin BEFORE dispatching the CustomMessage. The
 			// returned tag is embedded in details so AgentSession.#handleAgentEvent
@@ -456,7 +445,7 @@ export class InputController {
 			await this.ctx.session.promptCustomMessage(
 				{
 					customType: SKILL_PROMPT_MESSAGE_TYPE,
-					content: message,
+					content: built.message,
 					display: true,
 					details,
 					attribution: "user",

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -37,6 +37,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
+import { resolveSkillSlashCommands, type Skill } from "../extensibility/skills";
 import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
@@ -115,6 +116,12 @@ const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	mid: "muted",
 	high: "borderAccent",
 };
+
+function configureDefaultComposerChrome(editor: CustomEditor): void {
+	editor.setBorderVisible(false);
+	editor.setPromptGutter(`${theme.fg("accent", "›")} `);
+	editor.setPaddingX(1);
+}
 
 interface WorkingMessageAccent {
 	main: string;
@@ -277,10 +284,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	lastStatusSpacer: Spacer | undefined = undefined;
 	lastStatusText: Text | undefined = undefined;
 	fileSlashCommands: Set<string> = new Set();
-	skillCommands: Map<string, string> = new Map();
+	skillCommands: Map<string, Skill> = new Map();
 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
 
-	#pendingSlashCommands: SlashCommand[] = [];
+	#baseSlashCommands: SlashCommand[] = [];
+	#baseReservedSlashCommandNames: Set<string> = new Set();
 	#cleanupUnsubscribe?: () => void;
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
@@ -353,6 +361,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.todoContainer = new Container();
 		this.btwContainer = new Container();
 		this.editor = new CustomEditor(getEditorTheme());
+		configureDefaultComposerChrome(this.editor);
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
 		this.editor.onAutocompleteCancel = () => {
@@ -398,19 +407,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			description: `${loaded.command.description} (${loaded.source})`,
 		}));
 
-		// Build skill commands from session.skills (if enabled)
-		const skillCommandList: SlashCommand[] = [];
-		if (settings.get("skills.enableSkillCommands")) {
-			for (const skill of this.session.skills) {
-				if (skill.hide === true) continue;
-				const commandName = `skill:${skill.name}`;
-				this.skillCommands.set(commandName, skill.filePath);
-				skillCommandList.push({ name: commandName, description: skill.description });
-			}
-		}
-
-		// Store pending commands for init() where file commands are loaded async
-		this.#pendingSlashCommands = [...BUILTIN_SLASH_COMMANDS, ...hookCommands, ...customCommands, ...skillCommandList];
+		this.#baseSlashCommands = [...BUILTIN_SLASH_COMMANDS, ...hookCommands, ...customCommands];
+		this.#baseReservedSlashCommandNames = new Set(this.#baseSlashCommands.map(command => command.name));
+		this.#rebuildSkillSlashCommands();
 
 		this.#uiHelpers = new UiHelpers(this);
 		this.#btwController = new BtwController(this);
@@ -498,7 +497,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.statusContainer);
 		this.ui.addChild(this.todoContainer);
 		this.ui.addChild(this.btwContainer);
-		this.ui.addChild(this.statusLine); // Only renders hook statuses (main status in editor border)
+		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer stays borderless.
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);
@@ -560,6 +559,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Set up theme file watcher
 		onThemeChange(() => {
 			clearRenderCache();
+			configureDefaultComposerChrome(this.editor);
 			this.ui.invalidate();
 			this.updateEditorBorderColor();
 			this.ui.requestRender();
@@ -586,17 +586,36 @@ export class InteractiveMode implements InteractiveModeContext {
 	async refreshSlashCommandState(cwd?: string): Promise<void> {
 		const basePath = cwd ?? this.sessionManager.getCwd();
 		const fileCommands = await loadSlashCommands({ cwd: basePath });
-		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
+		const fileCommandNames = new Set(fileCommands.map(cmd => cmd.name));
+		this.fileSlashCommands = fileCommandNames;
 		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => ({
 			name: cmd.name,
 			description: cmd.description,
 		}));
+		const skillCommands = this.#rebuildSkillSlashCommands(fileCommandNames);
+		const slashCommands = [...this.#baseSlashCommands, ...skillCommands];
 		const autocompleteProvider = this.#inputController.createAutocompleteProvider(
-			[...this.#pendingSlashCommands, ...fileSlashCommands],
+			[...slashCommands, ...fileSlashCommands],
 			basePath,
 		);
 		this.editor.setAutocompleteProvider(autocompleteProvider);
 		this.session.setSlashCommands(fileCommands);
+	}
+
+	#rebuildSkillSlashCommands(fileCommandNames: ReadonlySet<string> = new Set()): SlashCommand[] {
+		this.skillCommands.clear();
+		if (!settings.get("skills.enableSkillCommands")) {
+			return [];
+		}
+		const reservedDirectCommandNames = new Set([
+			...this.#baseReservedSlashCommandNames,
+			...Array.from(fileCommandNames),
+		]);
+		const resolvedCommands = resolveSkillSlashCommands(this.session.skills, reservedDirectCommandNames);
+		for (const command of resolvedCommands) {
+			this.skillCommands.set(command.name, command.skill);
+		}
+		return resolvedCommands.map(command => ({ name: command.name, description: command.description }));
 	}
 
 	async getUserInput(): Promise<SubmittedUserInput> {
@@ -921,9 +940,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	updateEditorTopBorder(): void {
-		const availableWidth = this.editor.getTopBorderAvailableWidth(this.ui.terminal.columns);
-		const topBorder = this.statusLine.getTopBorder(availableWidth);
-		this.editor.setTopBorder(topBorder);
+		// The opencode-style composer is intentionally borderless. Keep status-line
+		// rendering out of the input area so the prompt remains a simple gutter + body.
+		this.editor.setTopBorder(undefined);
 	}
 
 	rebuildChatFromMessages(): void {
@@ -2063,6 +2082,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			? factory(this.ui, getEditorTheme(), this.keybindings)
 			: new CustomEditor(getEditorTheme());
 
+		configureDefaultComposerChrome(nextEditor);
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
 		nextEditor.onAutocompleteCancel = () => {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -11,6 +11,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
+import type { Skill } from "../extensibility/skills";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { MCPManager } from "../runtime-mcp";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
@@ -124,7 +125,7 @@ export interface InteractiveModeContext {
 	lastStatusSpacer: Spacer | undefined;
 	lastStatusText: Text | undefined;
 	fileSlashCommands: Set<string>;
-	skillCommands: Map<string, string>;
+	skillCommands: Map<string, Skill>;
 	oauthManualInput: OAuthManualInputManager;
 	todoPhases: TodoPhase[];
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -46,6 +46,7 @@ import { Settings, type SkillsSettings } from "./config/settings";
 import { CursorExecHandlers } from "./cursor";
 import "./discovery";
 import { resolveConfigValue } from "./config/resolve-config-value";
+import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
 import { initializeWithSettings } from "./discovery";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
 import { TtsrManager } from "./export/ttsr";
@@ -64,7 +65,7 @@ import {
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
 import { ExtensionRuntime } from "./extensibility/extensions/loader";
-import { type Skill, type SkillWarning, setActiveSkills } from "./extensibility/skills";
+import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "./extensibility/skills";
 import type { FileSlashCommand } from "./extensibility/slash-commands";
 import type { HindsightSessionState } from "./hindsight/state";
 import { LocalProtocolHandler, type LocalProtocolOptions } from "./internal-urls";
@@ -253,7 +254,7 @@ export interface CreateAgentSessionOptions {
 	/** Shared event bus for tool/extension communication. Default: creates new bus. */
 	eventBus?: EventBus;
 
-	/** Skills. Default: discovered from multiple locations */
+	/** Skills. Default: bundled GJC defaults, plus filesystem skills when enabled */
 	skills?: Skill[];
 	/** Rules. Default: discovered from multiple locations */
 	rules?: Rule[];
@@ -762,6 +763,17 @@ function buildMCPPromptCommands(manager: MCPManager): LoadedCustomCommand[] {
  * });
  * ```
  */
+
+function withEmbeddedDefaultGjcSkills(skills: Skill[]): Skill[] {
+	const byName = new Map(skills.map(skill => [skill.name, skill]));
+	for (const defaultSkill of getEmbeddedDefaultGjcSkills()) {
+		if (!byName.has(defaultSkill.name)) {
+			byName.set(defaultSkill.name, defaultSkill);
+		}
+	}
+	return [...byName.values()];
+}
+
 export async function createAgentSession(options: CreateAgentSessionOptions = {}): Promise<CreateAgentSessionResult> {
 	const cwd = options.cwd ?? getProjectDir();
 	const agentDir = options.agentDir ?? getDefaultAgentDir();
@@ -967,10 +979,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	let skills: Skill[];
 	let skillWarnings: SkillWarning[];
 	if (options.skills !== undefined) {
-		skills = options.skills;
+		// The four public GJC workflow skills are a product invariant, not
+		// ordinary filesystem-discovered skills. Keep them available even for
+		// explicit SDK skill lists so startup and command routing survive
+		// accidental `.gjc` deletion or overzealous caller filtering.
+		skills = withEmbeddedDefaultGjcSkills(options.skills);
 		skillWarnings = [];
+	} else if (settings.get("skills.enabled")) {
+		const skillsResult = await logger.time("loadSkills", loadSkills, {
+			...settings.getGroup("skills"),
+			cwd,
+			disabledExtensions: settings.get("disabledExtensions"),
+		});
+		skills = withEmbeddedDefaultGjcSkills(skillsResult.skills);
+		skillWarnings = skillsResult.warnings;
 	} else {
-		skills = [];
+		// GJC's four public workflow skills are bundled into the binary so the
+		// default workflow surface survives accidental .gjc deletion. Arbitrary
+		// filesystem skill discovery remains gated by skills.enabled above.
+		skills = getEmbeddedDefaultGjcSkills();
 		skillWarnings = [];
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4646,7 +4646,7 @@ export class AgentSession {
 		return this.#skillsSettings;
 	}
 
-	/** Skills loaded by SDK (empty if --no-skills or skills: [] was passed) */
+	/** Skills loaded by SDK (always includes bundled GJC workflow defaults unless explicitly overridden by SDK callers) */
 	get skills(): readonly Skill[] {
 		return this.#skills;
 	}

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -5,6 +5,7 @@
  */
 import { Effort } from "@gajae-code/ai";
 import { parseFrontmatter, prompt } from "@gajae-code/utils";
+import { getDefaultGjcAgentDefinitions } from "../defaults/gjc-defaults";
 import { parseAgentFields } from "../discovery/helpers";
 import exploreMd from "../prompts/agents/explore.md" with { type: "text" };
 // Embed agent markdown files at build time
@@ -118,9 +119,13 @@ export function loadBundledAgents(): AgentDefinition[] {
 	if (bundledAgentsCache !== null) {
 		return bundledAgentsCache;
 	}
-	bundledAgentsCache = EMBEDDED_AGENT_DEFS.map(def =>
+	const defaultAgents = getDefaultGjcAgentDefinitions().map(definition =>
+		parseAgent(`embedded:gjc/${definition.relativePath}`, definition.content, "bundled"),
+	);
+	const utilityAgents = EMBEDDED_AGENT_DEFS.map(def =>
 		parseAgent(`embedded:${def.fileName}`, buildAgentContent(def), "bundled"),
 	);
+	bundledAgentsCache = [...defaultAgents, ...utilityAgents];
 	return bundledAgentsCache;
 }
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1059,11 +1059,7 @@ describe("ACP agent", () => {
 				source: "test",
 			},
 		];
-		await harness.agent.prompt({
-			sessionId: created.sessionId,
-			messageId: "00000000-0000-4000-8000-000000000004",
-			prompt: [{ type: "text", text: "/reload-plugins" }],
-		} as PromptRequest);
+		await waitForBootstrapGuard();
 
 		const commandUpdates = harness.updates.filter(
 			update =>
@@ -1077,6 +1073,7 @@ describe("ACP agent", () => {
 		expect(names).toContain("fast");
 		expect(names).toContain("force");
 		expect(names).toContain("skill:sample");
+		expect(names).not.toContain("sample");
 		expect(names).not.toContain("settings");
 		expect(names).not.toContain("copy");
 		expect(names).not.toContain("plan");
@@ -1126,6 +1123,23 @@ describe("ACP agent", () => {
 		expect(session.customMessages[0]!.content).toContain("# Sample\nDo work.");
 		expect(session.customMessages[0]!.content).toContain(`Skill: ${skillPath}`);
 		expect(session.customMessages[0]!.content).toContain("User: extra context");
+
+		session.customMessages = [];
+		session.skills.push({
+			name: "fast",
+			description: "Colliding skill",
+			filePath: skillPath,
+			baseDir: skillDir,
+			source: "test",
+		});
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000002",
+			prompt: [{ type: "text", text: "/fast" }],
+		} as PromptRequest);
+
+		expect(session.customMessages).toEqual([]);
+		expect(session.fastMode).toBe(true);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -7,6 +7,8 @@ import {
 	getDefaultGjcDefinitions,
 	installDefaultGjcDefinitions,
 } from "@gajae-code/coding-agent/defaults/gjc-defaults";
+import { loadSkills } from "@gajae-code/coding-agent/extensibility/skills";
+import { discoverAgents } from "@gajae-code/coding-agent/task/discovery";
 
 const tempRoots: string[] = [];
 
@@ -37,6 +39,43 @@ describe("default GJC definitions", () => {
 		expect(agents).toEqual(expected);
 		expect(definitions).toHaveLength(8);
 		expect(definitions.every(definition => definition.content.includes(definition.name))).toBe(true);
+	});
+
+	it("keeps the four default agents bundled when project .gjc is absent", async () => {
+		const repoRoot = await makeTempRoot();
+		const agents = await discoverAgents(repoRoot, repoRoot);
+		const expected = [...DEFAULT_GJC_DEFINITION_NAMES].sort();
+		const bundledDefaults = agents.agents
+			.filter(agent => agent.source === "bundled" && expected.includes(agent.name as (typeof expected)[number]))
+			.map(agent => agent.name)
+			.sort();
+
+		expect(bundledDefaults).toEqual(expected);
+		expect(agents.projectAgentsDir).toBeNull();
+	});
+
+	it("makes installed project definitions discoverable by GJC skill and agent loaders", async () => {
+		const repoRoot = await makeTempRoot();
+		const projectGjcRoot = path.join(repoRoot, ".gjc");
+		await installDefaultGjcDefinitions({ targetRoot: projectGjcRoot });
+
+		const skills = await loadSkills({
+			cwd: repoRoot,
+			enabled: true,
+			enablePiProject: true,
+			enablePiUser: false,
+		});
+		const agents = await discoverAgents(repoRoot, repoRoot);
+		const expected = [...DEFAULT_GJC_DEFINITION_NAMES].sort();
+
+		expect(skills.skills.map(skill => skill.name).sort()).toEqual(expected);
+		expect(
+			agents.agents
+				.filter(agent => agent.source === "project")
+				.map(agent => agent.name)
+				.sort(),
+		).toEqual(expected);
+		expect(agents.projectAgentsDir).toBe(path.join(projectGjcRoot, "agents"));
 	});
 
 	it("installs bundled definitions without overwriting local edits unless forced", async () => {

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -23,6 +23,8 @@ import { Agent } from "@gajae-code/agent-core";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { getEmbeddedDefaultGjcSkills } from "@gajae-code/coding-agent/defaults/gjc-defaults";
+import { resolveSkillSlashCommands, type Skill } from "@gajae-code/coding-agent/extensibility/skills";
 import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
 import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -56,7 +58,7 @@ type StubEditor = {
 	onSubmit?: (text: string) => Promise<void>;
 };
 
-function createStubInputControllerContext(opts: { skillCommands: Map<string, string>; isStreaming: boolean }) {
+function createStubInputControllerContext(opts: { skillCommands: Map<string, Skill>; isStreaming: boolean }) {
 	let editorText = "";
 	const editor: StubEditor = {
 		setText(text) {
@@ -70,7 +72,9 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 	const enqueueCustomMessageDisplay = vi.fn((_text: string, _mode: "steer" | "followUp") => "sk-test-0");
 	// Annotate parameters so `mock.calls[N]` is typed as a tuple (not `[]`) and
 	// `message` carries required skill prompt details for assertion below.
-	const promptCustomMessage = vi.fn(async (_message: { details: SkillPromptDetails }, _options?: unknown) => {});
+	const promptCustomMessage = vi.fn(
+		async (_message: { content: string; details: SkillPromptDetails }, _options?: unknown) => {},
+	);
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
@@ -106,12 +110,26 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
 	let tempDir: TempDir;
-	let skillCommands: Map<string, string>;
+	let skillCommands: Map<string, Skill>;
 
 	beforeEach(() => {
 		tempDir = TempDir.createSync("@pi-skill-queue-stub-");
 		const skillPath = writeSkillFile(tempDir.path(), "test-skill", "Do the thing.");
-		skillCommands = new Map<string, string>([["skill:test-skill", skillPath]]);
+		skillCommands = new Map<string, Skill>([
+			[
+				"skill:test-skill",
+				{
+					name: "test-skill",
+					description: "Test skill",
+					filePath: skillPath,
+					baseDir: tempDir.path(),
+					source: "test",
+				},
+			],
+		]);
+		const skill = skillCommands.get("skill:test-skill");
+		if (!skill) throw new Error("expected test skill");
+		skillCommands.set("test-skill", skill);
 	});
 
 	afterEach(() => {
@@ -166,6 +184,29 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(messageArg.details.__pendingDisplayTag).toBe("sk-test-0");
 	});
 
+	it("E3b: embedded default skill command does not require .gjc on disk", async () => {
+		const embedded = getEmbeddedDefaultGjcSkills().find(skill => skill.name === "deep-interview");
+		if (!embedded) throw new Error("expected embedded deep-interview skill");
+		const { ctx, editor, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands: new Map<string, Skill>([["skill:deep-interview", embedded]]),
+			isStreaming: false,
+		});
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:deep-interview clarify this");
+		await editor.onSubmit?.("/skill:deep-interview clarify this");
+
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		const firstCall = promptCustomMessage.mock.calls[0];
+		expect(firstCall).toBeDefined();
+		if (!firstCall) throw new Error("expected promptCustomMessage to be called");
+		const messageArg = firstCall[0];
+		expect(messageArg.content).toContain("Deep Interview");
+		expect(messageArg.details.path).toBe("embedded:gjc/skills/deep-interview/SKILL.md");
+		expect(ctx.showError).not.toHaveBeenCalled();
+	});
+
 	it("E3: not streaming -> enqueueCustomMessageDisplay NOT called and tag absent", async () => {
 		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage } = createStubInputControllerContext({
 			skillCommands,
@@ -185,6 +226,24 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		}
 		const messageArg = firstCall[0];
 		expect(messageArg.details.__pendingDisplayTag).toBeUndefined();
+	});
+});
+
+describe("skill slash command resolution", () => {
+	it("enables namespaced skill commands by default", () => {
+		expect(Settings.isolated().get("skills.enableSkillCommands")).toBe(true);
+	});
+
+	it("exposes only namespaced skill commands", () => {
+		const deepInterview = getEmbeddedDefaultGjcSkills().find(skill => skill.name === "deep-interview");
+		if (!deepInterview) throw new Error("expected embedded deep-interview skill");
+
+		const withFileCollision = resolveSkillSlashCommands([deepInterview], new Set(["deep-interview"]));
+		expect(withFileCollision.map(command => command.name)).toEqual(["skill:deep-interview"]);
+
+		const afterCollisionRemoved = resolveSkillSlashCommands([deepInterview], new Set());
+		expect(afterCollisionRemoved.map(command => command.name)).toEqual(["skill:deep-interview"]);
+		expect(afterCollisionRemoved.every(command => command.skill === deepInterview)).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -3,21 +3,34 @@ import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
 import { BashExecutionComponent } from "@gajae-code/coding-agent/modes/components/bash-execution";
+import { CustomEditor } from "@gajae-code/coding-agent/modes/components/custom-editor";
 import { EvalExecutionComponent } from "@gajae-code/coding-agent/modes/components/eval-execution";
 import { FooterComponent } from "@gajae-code/coding-agent/modes/components/footer";
 import { STATUS_LINE_PRESETS } from "@gajae-code/coding-agent/modes/components/status-line/presets";
 import { UserMessageComponent } from "@gajae-code/coding-agent/modes/components/user-message";
 import { WelcomeComponent } from "@gajae-code/coding-agent/modes/components/welcome";
-import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getEditorTheme, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { type TUI, visibleWidth } from "@gajae-code/tui";
+import { StatusLineComponent } from "../../../src/modes/components/status-line";
 
 function createFooterSession(): AgentSession {
 	return {
 		state: {
+			messages: [],
 			model: { id: "very-long-model-name-for-footer-budget", contextWindow: 200_000 },
 		},
 		sessionManager: {
+			getSessionName: () => "forge-session",
+			getSessionId: () => "session-123456",
+			getUsageStatistics: () => ({
+				input: 1234,
+				output: 567,
+				cacheRead: 89,
+				cacheWrite: 12,
+				premiumRequests: 0,
+				cost: 0.123,
+			}),
 			getEntries: () => [
 				{
 					type: "message",
@@ -36,6 +49,9 @@ function createFooterSession(): AgentSession {
 			],
 		},
 		getContextUsage: () => ({ contextWindow: 200_000, percent: 42.5 }),
+		getGoalModeState: () => undefined,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		isFastModeActive: () => false,
 		modelRegistry: { isUsingOAuth: () => false },
 	} as unknown as AgentSession;
 }
@@ -67,16 +83,19 @@ beforeAll(async () => {
 });
 
 describe("redesigned interactive shell chrome", () => {
-	it("renders distinct GJC-native user and assistant turns", () => {
+	it("renders opencode-style minimal user and gajae turns", () => {
 		const user = Bun.stripANSI(new UserMessageComponent("hello").render(80).join("\n"));
 		const assistant = Bun.stripANSI(
 			new AssistantMessageComponent(createAssistantMessage("hi")).render(80).join("\n"),
 		);
 
-		expect(user).toContain("operator input");
-		expect(assistant).toContain("gajae reply");
-		expect(user).not.toContain("you submitted");
-		expect(assistant).not.toContain("agent response");
+		expect(user).toContain("user");
+		expect(assistant).toContain("gajae");
+		expect(user).not.toContain("operator input");
+		expect(assistant).not.toContain("assistant");
+		expect(assistant).not.toContain("gajae reply");
+		expect(user).not.toContain("▸");
+		expect(assistant).not.toContain("▌");
 	});
 
 	it("keeps the GJC forge launch surface responsive", () => {
@@ -85,11 +104,44 @@ describe("redesigned interactive shell chrome", () => {
 		const rendered = Bun.stripANSI(lines.join("\n"));
 
 		expect(rendered).toContain("Gajae forge");
-		expect(rendered).toContain("╭╮  ╭╮  ╭╮");
+		expect(rendered).toContain("╭────────────────╮        ╭────────╮");
+		expect(rendered).toContain("╰────────────────╯        ╰────────╯");
 		expect(rendered).not.toContain("●");
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(54);
 		}
+	});
+
+	it("renders the live composer as a borderless opencode-style prompt", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setBorderVisible(false);
+		editor.setPromptGutter("› ");
+		editor.setPaddingX(1);
+		editor.setText("draft");
+
+		const rendered = Bun.stripANSI(editor.render(40).join("\n"));
+
+		expect(rendered).toContain("› draft");
+		expect(rendered).not.toContain("╭");
+		expect(rendered).not.toContain("╰");
+	});
+
+	it("renders the main status rail outside the borderless composer", () => {
+		const statusLine = new StatusLineComponent(createFooterSession());
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setBorderVisible(false);
+		editor.setPromptGutter("› ");
+		editor.setPaddingX(1);
+		editor.setText("draft");
+
+		const statusRendered = Bun.stripANSI(statusLine.render(140).join("\n"));
+		const editorRendered = Bun.stripANSI(editor.render(140).join("\n"));
+
+		expect(statusRendered).toContain("very-long-model-name-for-footer-budget");
+		expect(statusRendered).toContain("forge-session");
+		expect(editorRendered).toContain("› draft");
+		expect(editorRendered).not.toContain("very-long-model-name-for-footer-budget");
+		expect(editorRendered).not.toContain("╭");
 	});
 
 	it("renders execution rails without breaking output caps", () => {
@@ -130,8 +182,7 @@ describe("redesigned interactive shell chrome", () => {
 		expect(rendered[0]).not.toContain("\x1b]133;A\x07");
 		expect(rendered[1]).not.toContain("\x1b]133;A\x07");
 		expect(rendered[2]).toContain("\x1b]133;A\x07");
-		expect(rendered[rendered.length - 2]).toContain("\x1b]133;B\x07\x1b]133;C\x07");
-		expect(rendered[rendered.length - 1]).not.toContain("\x1b]133;B\x07");
+		expect(rendered[rendered.length - 1]).toContain("\x1b]133;B\x07\x1b]133;C\x07");
 	});
 
 	it("budgets footer prefixes before truncating pulse", () => {

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { DEFAULT_GJC_DEFINITION_NAMES } from "@gajae-code/coding-agent/defaults/gjc-defaults";
 import type { Skill } from "@gajae-code/coding-agent/sdk";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
@@ -69,6 +70,20 @@ Loaded via symbolic link.
 
 	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
 
+	it("loads embedded default GJC workflow skills even when .gjc is absent and arbitrary skill discovery is disabled", async () => {
+		fs.rmSync(path.join(tempDir, ".gjc"), { recursive: true, force: true });
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "skills.enabled": false }),
+		});
+		const expected = [...DEFAULT_GJC_DEFINITION_NAMES].sort();
+
+		expect(session.skills.map(skill => skill.name).sort()).toEqual(expected);
+		expect(session.skills.every(skill => skill.filePath.startsWith("embedded:gjc/skills/"))).toBe(true);
+	});
+
 	it("should discover skills by default and expose them on session.skills", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
@@ -107,22 +122,20 @@ Loaded via symbolic link.
 
 		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
 	});
-	it("should have empty skills when options.skills is empty array (--no-skills)", async () => {
+	it("keeps bundled GJC workflow skills even when options.skills is empty", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
 			sessionManager: SessionManager.inMemory(),
-			skills: [], // Explicitly empty - like --no-skills
+			skills: [],
 			settings: createIsolatedSkillsSettings(),
 		});
 
-		// session.skills should be empty
-		expect(session.skills).toEqual([]);
-		// No warnings since we didn't discover
+		expect(session.skills.map(skill => skill.name).sort()).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
 		expect(session.skillWarnings).toEqual([]);
 	});
 
-	it("should use provided skills when options.skills is explicitly set", async () => {
+	it("should use provided skills plus bundled GJC workflow skills when options.skills is explicitly set", async () => {
 		const customSkill: Skill = {
 			name: "custom-skill",
 			description: "A custom skill",
@@ -139,9 +152,10 @@ Loaded via symbolic link.
 			settings: createIsolatedSkillsSettings(),
 		});
 
-		// session.skills should contain only the provided skill
-		expect(session.skills).toEqual([customSkill]);
-		// No warnings since we didn't discover
+		expect(session.skills).toContainEqual(customSkill);
+		for (const name of DEFAULT_GJC_DEFINITION_NAMES) {
+			expect(session.skills.some(skill => skill.name === name)).toBe(true);
+		}
 		expect(session.skillWarnings).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary
- redesign GJC shell chrome with user/gajae turns, borderless opencode-style composer, and horizontal claw launch mark
- embed the four default GJC workflow skills/agents so they survive .gjc deletion
- enable namespaced skill commands by default and expose only /skill:<name> workflow invocation

## Verification
- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/sdk-skills.test.ts
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict
- git diff --check