### PR TITLE
Wire GJC native skill-state hooks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Wired GJC native UserPromptSubmit/Stop skill-state hooks, including `gjc setup hooks`, so public workflow keywords activate `.gjc/state`, active skill state can block premature Stop events, and active Ultragoal sessions remind steering prompts to use `gjc ultragoal steer`.
 - Fixed legacy Pi plugin import remapping and stale GJC config-path tests so rebranded `.gjc` discovery contracts pass while preserving legacy compatibility.
 - Fixed web search OAuth-backed providers (including Codex and Gemini) to use broker-managed token retrieval and account metadata, avoiding direct token-store refresh behavior that could cause search authentication failures
 - Updated Tavily missing-credential feedback to prompt users to configure an API-key provider setting instead of referencing `agent.db` directly

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -30,6 +30,7 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 process.title = APP_NAME;
 
 const commands: CommandEntry[] = [
+	{ name: "codex-native-hook", load: () => import("./commands/codex-native-hook").then(m => m.default) },
 	{ name: "question", load: () => import("./commands/question").then(m => m.default) },
 	{ name: "state", load: () => import("./commands/state").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -8,9 +8,14 @@ import { $which, APP_NAME, getPythonEnvDir } from "@gajae-code/utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { installDefaultGjcDefinitions } from "../defaults/gjc-defaults";
+import {
+	getDefaultCodexHooksPath,
+	mergeGjcManagedCodexHooksConfig,
+	readGjcManagedCodexHooksStatus,
+} from "../hooks/codex-native-hooks-config";
 import { theme } from "../modes/theme/theme";
 
-export type SetupComponent = "defaults" | "python" | "stt";
+export type SetupComponent = "defaults" | "hooks" | "python" | "stt";
 
 export interface SetupCommandArgs {
 	component: SetupComponent;
@@ -21,7 +26,7 @@ export interface SetupCommandArgs {
 	};
 }
 
-const VALID_COMPONENTS: SetupComponent[] = ["defaults", "python", "stt"];
+const VALID_COMPONENTS: SetupComponent[] = ["defaults", "hooks", "python", "stt"];
 
 const MANAGED_PYTHON_ENV = getPythonEnvDir();
 
@@ -118,6 +123,9 @@ export async function runSetupCommand(cmd: SetupCommandArgs): Promise<void> {
 		case "defaults":
 			await handleDefaultsSetup(cmd.flags);
 			break;
+		case "hooks":
+			await handleHooksSetup(cmd.flags);
+			break;
 		case "python":
 			await handlePythonSetup(cmd.flags);
 			break;
@@ -125,6 +133,42 @@ export async function runSetupCommand(cmd: SetupCommandArgs): Promise<void> {
 			await handleSttSetup(cmd.flags);
 			break;
 	}
+}
+
+async function handleHooksSetup(flags: { json?: boolean; check?: boolean }): Promise<void> {
+	const hooksPath = getDefaultCodexHooksPath();
+	const existingContent = await Bun.file(hooksPath).text().catch(() => null);
+	const status = readGjcManagedCodexHooksStatus(existingContent, hooksPath);
+
+	if (flags.check) {
+		if (flags.json) {
+			process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+			if (!status.installed) process.exit(1);
+			return;
+		}
+		if (!status.installed) {
+			process.stderr.write(`${chalk.red(`${theme.status.error} GJC native Codex hooks are not fully installed`)}\n`);
+			process.stderr.write(`${chalk.dim(`Target: ${hooksPath}`)}\n`);
+			process.stderr.write(`${chalk.dim(`Missing events: ${status.missingEvents.join(", ")}`)}\n`);
+			process.exit(1);
+		}
+		process.stdout.write(`${chalk.green(`${theme.status.success} GJC native Codex hooks are installed`)}\n`);
+		process.stdout.write(`${chalk.dim(`Target: ${hooksPath}`)}\n`);
+		return;
+	}
+
+	const merged = mergeGjcManagedCodexHooksConfig(existingContent);
+	await Bun.write(hooksPath, merged.content);
+	const installed = readGjcManagedCodexHooksStatus(merged.content, hooksPath);
+
+	if (flags.json) {
+		process.stdout.write(`${JSON.stringify({ ...installed, changed: merged.changed }, null, 2)}\n`);
+		return;
+	}
+
+	process.stdout.write(`${chalk.green(`${theme.status.success} GJC native Codex hooks installed`)}\n`);
+	process.stdout.write(`${chalk.dim(`Target: ${hooksPath}`)}\n`);
+	process.stdout.write(`${chalk.dim(`Managed events: UserPromptSubmit, Stop; changed: ${merged.changed ? "yes" : "no"}`)}\n`);
 }
 
 async function handleDefaultsSetup(flags: { json?: boolean; check?: boolean; force?: boolean }): Promise<void> {
@@ -253,6 +297,7 @@ ${chalk.bold("Usage:")}
 
 ${chalk.bold("Components:")}
   defaults  Install bundled GJC default skills and agents
+  hooks     Install GJC native Codex UserPromptSubmit/Stop skill-state hooks
   python    Verify a Python 3 interpreter is reachable for code execution
   stt       Install speech-to-text dependencies (openai-whisper, recording tools)
 
@@ -264,6 +309,8 @@ ${chalk.bold("Options:")}
 ${chalk.bold("Examples:")}
   ${APP_NAME} setup defaults         Install bundled GJC defaults
   ${APP_NAME} setup defaults --check Check bundled GJC defaults are installed
+  ${APP_NAME} setup hooks            Install native Codex skill-state hooks
+  ${APP_NAME} setup hooks --check    Check native Codex skill-state hooks
   ${APP_NAME} setup python           Install Python execution dependencies
   ${APP_NAME} setup stt              Install speech-to-text dependencies
   ${APP_NAME} setup stt --check      Check if STT dependencies are available

--- a/packages/coding-agent/src/commands/codex-native-hook.ts
+++ b/packages/coding-agent/src/commands/codex-native-hook.ts
@@ -1,0 +1,11 @@
+import { Command } from "@gajae-code/utils/cli";
+import { runGjcNativeSkillHookCli } from "../hooks/native-skill-hook";
+
+export default class CodexNativeHook extends Command {
+	static description = "Run GJC native UserPromptSubmit/Stop skill-state hook";
+	static strict = false;
+
+	async run(): Promise<void> {
+		await runGjcNativeSkillHookCli();
+	}
+}

--- a/packages/coding-agent/src/commands/setup.ts
+++ b/packages/coding-agent/src/commands/setup.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags, renderCommandHelp } from "@gajae-code/utils/cli";
 import { runSetupCommand, type SetupCommandArgs, type SetupComponent } from "../cli/setup-cli";
 import { initTheme } from "../modes/theme/theme";
 
-const COMPONENTS: SetupComponent[] = ["defaults", "python", "stt"];
+const COMPONENTS: SetupComponent[] = ["defaults", "hooks", "python", "stt"];
 
 export default class Setup extends Command {
 	static description = "Install dependencies for optional features";

--- a/packages/coding-agent/src/hooks/codex-native-hooks-config.ts
+++ b/packages/coding-agent/src/hooks/codex-native-hooks-config.ts
@@ -1,0 +1,143 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const GJC_MANAGED_CODEX_HOOK_EVENTS = ["UserPromptSubmit", "Stop"] as const;
+
+export type GjcManagedCodexHookEvent = (typeof GJC_MANAGED_CODEX_HOOK_EVENTS)[number];
+
+type JsonObject = Record<string, unknown>;
+
+export interface CodexCommandHook {
+	type: "command";
+	command: string;
+	statusMessage?: string;
+	timeout?: number;
+}
+
+export interface CodexHookEntry {
+	hooks: CodexCommandHook[];
+}
+
+export interface GjcManagedCodexHooksConfig {
+	hooks: Record<GjcManagedCodexHookEvent, CodexHookEntry[]>;
+}
+
+export interface MergeGjcManagedCodexHooksResult {
+	content: string;
+	changed: boolean;
+	managedHookCount: number;
+}
+
+export interface GjcCodexHooksStatus {
+	hooksPath: string;
+	installed: boolean;
+	missingEvents: GjcManagedCodexHookEvent[];
+	managedHookCount: number;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeHooksRoot(parsed: unknown): JsonObject {
+	if (!isJsonObject(parsed)) return {};
+	return structuredClone(parsed);
+}
+
+function normalizeHooksMap(root: JsonObject): Record<string, unknown> {
+	if (isJsonObject(root.hooks)) return root.hooks;
+	const hooks: Record<string, unknown> = {};
+	root.hooks = hooks;
+	return hooks;
+}
+
+function commandIsGjcManaged(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	return /\bgjc(?:\.exe)?\b/.test(value) && /\bcodex-native-hook\b/.test(value);
+}
+
+function entryContainsGjcManagedHook(value: unknown): boolean {
+	if (!isJsonObject(value) || !Array.isArray(value.hooks)) return false;
+	return value.hooks.some(hook => isJsonObject(hook) && commandIsGjcManaged(hook.command));
+}
+
+function managedCommand(): string {
+	return "gjc codex-native-hook";
+}
+
+function managedEntry(event: GjcManagedCodexHookEvent): CodexHookEntry {
+	const hook: CodexCommandHook = {
+		type: "command",
+		command: managedCommand(),
+		statusMessage: "GJC skill state",
+		...(event === "Stop" ? { timeout: 30 } : {}),
+	};
+	return { hooks: [hook] };
+}
+
+export function buildGjcManagedCodexHooksConfig(): GjcManagedCodexHooksConfig {
+	return {
+		hooks: {
+			UserPromptSubmit: [managedEntry("UserPromptSubmit")],
+			Stop: [managedEntry("Stop")],
+		},
+	};
+}
+
+export function getDefaultCodexHooksPath(homeDir = os.homedir()): string {
+	return path.join(homeDir, ".codex", "hooks.json");
+}
+
+export function mergeGjcManagedCodexHooksConfig(existingContent: string | null): MergeGjcManagedCodexHooksResult {
+	let root = normalizeHooksRoot(null);
+	if (existingContent?.trim()) {
+		try {
+			root = normalizeHooksRoot(JSON.parse(existingContent) as unknown);
+		} catch {
+			root = normalizeHooksRoot(null);
+		}
+	}
+
+	const hooks = normalizeHooksMap(root);
+	const managed = buildGjcManagedCodexHooksConfig();
+	let managedHookCount = 0;
+
+	for (const event of GJC_MANAGED_CODEX_HOOK_EVENTS) {
+		const existingEntries = Array.isArray(hooks[event]) ? hooks[event] : [];
+		const userEntries = existingEntries.filter(entry => !entryContainsGjcManagedHook(entry));
+		const nextEntries = [...managed.hooks[event], ...userEntries];
+		managedHookCount += managed.hooks[event].length;
+		hooks[event] = nextEntries;
+	}
+
+	const content = `${JSON.stringify(root, null, 2)}\n`;
+	return { content, changed: content !== (existingContent ?? ""), managedHookCount };
+}
+
+export function readGjcManagedCodexHooksStatus(content: string | null, hooksPath: string): GjcCodexHooksStatus {
+	const missingEvents: GjcManagedCodexHookEvent[] = [];
+	let managedHookCount = 0;
+	let hooks: Record<string, unknown> = {};
+	if (content?.trim()) {
+		try {
+			const root = normalizeHooksRoot(JSON.parse(content) as unknown);
+			hooks = isJsonObject(root.hooks) ? root.hooks : {};
+		} catch {
+			hooks = {};
+		}
+	}
+
+	for (const event of GJC_MANAGED_CODEX_HOOK_EVENTS) {
+		const entries = Array.isArray(hooks[event]) ? hooks[event] : [];
+		const eventManagedCount = entries.filter(entryContainsGjcManagedHook).length;
+		managedHookCount += eventManagedCount;
+		if (eventManagedCount === 0) missingEvents.push(event);
+	}
+
+	return {
+		hooksPath,
+		installed: missingEvents.length === 0,
+		missingEvents,
+		managedHookCount,
+	};
+}

--- a/packages/coding-agent/src/hooks/native-skill-hook.ts
+++ b/packages/coding-agent/src/hooks/native-skill-hook.ts
@@ -1,0 +1,160 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import * as path from "node:path";
+import {
+	buildActiveUltragoalPromptContext,
+	buildSkillActivationAdditionalContext,
+	buildSkillStopOutput,
+	recordSkillActivation,
+} from "./skill-state";
+
+export type GjcNativeHookEventName = "UserPromptSubmit" | "Stop";
+
+export interface GjcNativeHookDispatchResult {
+	hookEventName: GjcNativeHookEventName | null;
+	outputJson: Record<string, unknown> | null;
+}
+
+type HookPayload = Record<string, unknown>;
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function readHookEventName(payload: HookPayload): GjcNativeHookEventName | null {
+	const raw = safeString(payload.hook_event_name ?? payload.hookEventName ?? payload.event ?? payload.name).trim();
+	return raw === "UserPromptSubmit" || raw === "Stop" ? raw : null;
+}
+
+function readPromptText(payload: HookPayload): string {
+	return safeString(payload.prompt ?? payload.user_prompt ?? payload.userPrompt).trim();
+}
+
+function readSessionId(payload: HookPayload): string | undefined {
+	return safeString(payload.session_id ?? payload.sessionId).trim() || undefined;
+}
+
+function readThreadId(payload: HookPayload): string | undefined {
+	return safeString(payload.thread_id ?? payload.threadId).trim() || undefined;
+}
+
+function readTurnId(payload: HookPayload): string | undefined {
+	return safeString(payload.turn_id ?? payload.turnId).trim() || undefined;
+}
+
+export async function dispatchGjcNativeSkillHook(
+	payload: HookPayload,
+	options: { cwd?: string; stateDir?: string } = {},
+): Promise<GjcNativeHookDispatchResult> {
+	const hookEventName = readHookEventName(payload);
+	const cwd = (options.cwd ?? safeString(payload.cwd).trim()) || process.cwd();
+	if (hookEventName === "UserPromptSubmit") {
+		const prompt = readPromptText(payload);
+		const skillState = prompt
+			? await recordSkillActivation({
+					cwd,
+					text: prompt,
+					sessionId: readSessionId(payload),
+					threadId: readThreadId(payload),
+					turnId: readTurnId(payload),
+					stateDir: options.stateDir,
+				})
+			: null;
+		const activeUltragoalContext = skillState
+			? null
+			: await buildActiveUltragoalPromptContext({
+					cwd,
+					sessionId: readSessionId(payload),
+					threadId: readThreadId(payload),
+					stateDir: options.stateDir,
+				});
+		return {
+			hookEventName,
+			outputJson: skillState || activeUltragoalContext
+				? {
+						hookSpecificOutput: {
+							hookEventName,
+							additionalContext: skillState
+								? buildSkillActivationAdditionalContext(skillState)
+								: activeUltragoalContext,
+						},
+					}
+				: null,
+		};
+	}
+
+	if (hookEventName === "Stop") {
+		return {
+			hookEventName,
+			outputJson: await buildSkillStopOutput({
+				cwd,
+				sessionId: readSessionId(payload),
+				threadId: readThreadId(payload),
+				stateDir: options.stateDir,
+			}),
+		};
+	}
+
+	return { hookEventName, outputJson: null };
+}
+
+async function readStdinJson(): Promise<{ payload: HookPayload; parseError: Error | null }> {
+	const chunks: Uint8Array[] = [];
+	for await (const chunk of Bun.stdin.stream()) {
+		chunks.push(chunk);
+	}
+	const raw = Buffer.concat(chunks).toString("utf-8").trim();
+	if (!raw) return { payload: {}, parseError: null };
+	try {
+		return { payload: JSON.parse(raw) as HookPayload, parseError: null };
+	} catch (error) {
+		return { payload: {}, parseError: error instanceof Error ? error : new Error(String(error)) };
+	}
+}
+
+async function logHookError(cwd: string, type: string, error: unknown): Promise<void> {
+	const logsDir = path.join(cwd, ".gjc", "logs");
+	await mkdir(logsDir, { recursive: true }).catch(() => {});
+	await appendFile(
+		path.join(logsDir, `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`),
+		`${JSON.stringify({ timestamp: new Date().toISOString(), type, error: error instanceof Error ? error.message : String(error) })}\n`,
+	).catch(() => {});
+}
+
+export async function runGjcNativeSkillHookCli(): Promise<void> {
+	const { payload, parseError } = await readStdinJson();
+	if (parseError) {
+		await logHookError(process.cwd(), "native_hook_stdin_parse_error", parseError);
+		process.stdout.write(`${JSON.stringify({
+			decision: "block",
+			reason: "GJC native hook received malformed JSON input.",
+			hookSpecificOutput: {
+				hookEventName: "Unknown",
+				additionalContext: `stdin JSON parsing failed inside gjc codex-native-hook: ${parseError.message}`,
+			},
+		})}\n`);
+		return;
+	}
+
+	try {
+		const result = await dispatchGjcNativeSkillHook(payload);
+		if (result.outputJson) {
+			process.stdout.write(`${JSON.stringify(result.outputJson)}\n`);
+		} else if (result.hookEventName === "Stop") {
+			process.stdout.write("{}\n");
+		}
+	} catch (error) {
+		const cwd = safeString(payload.cwd).trim() || process.cwd();
+		await logHookError(cwd, "native_hook_dispatch_error", error);
+		if (readHookEventName(payload) === "Stop") {
+			const detail = error instanceof Error ? error.message : String(error);
+			process.stdout.write(`${JSON.stringify({
+				decision: "block",
+				reason: "GJC native Stop hook failed before normal continuation handling.",
+				stopReason: "gjc_native_stop_dispatch_failure",
+				systemMessage: `GJC native Stop hook failed before normal continuation handling. Failure: ${detail}`,
+			})}\n`);
+		} else {
+			process.exitCode = 1;
+		}
+	}
+}

--- a/packages/coding-agent/src/hooks/skill-keywords.ts
+++ b/packages/coding-agent/src/hooks/skill-keywords.ts
@@ -1,0 +1,86 @@
+export interface SkillKeywordDefinition {
+	keyword: string;
+	skill: GjcWorkflowSkill;
+	priority: number;
+	guidance: string;
+}
+
+export const GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
+
+export type GjcWorkflowSkill = (typeof GJC_WORKFLOW_SKILLS)[number];
+
+export const GJC_SKILL_KEYWORD_DEFINITIONS: readonly SkillKeywordDefinition[] = [
+	{
+		keyword: "$deep-interview",
+		skill: "deep-interview",
+		priority: 8,
+		guidance: "Activate GJC deep-interview requirements workflow",
+	},
+	{
+		keyword: "deep interview",
+		skill: "deep-interview",
+		priority: 8,
+		guidance: "Activate GJC deep-interview requirements workflow",
+	},
+	{
+		keyword: "interview me",
+		skill: "deep-interview",
+		priority: 8,
+		guidance: "Activate GJC deep-interview requirements workflow",
+	},
+	{
+		keyword: "don't assume",
+		skill: "deep-interview",
+		priority: 8,
+		guidance: "Activate GJC deep-interview requirements workflow",
+	},
+	{
+		keyword: "$ralplan",
+		skill: "ralplan",
+		priority: 9,
+		guidance: "Activate GJC ralplan planning workflow",
+	},
+	{
+		keyword: "consensus plan",
+		skill: "ralplan",
+		priority: 9,
+		guidance: "Activate GJC ralplan planning workflow",
+	},
+	{
+		keyword: "$ultragoal",
+		skill: "ultragoal",
+		priority: 8,
+		guidance: "Activate GJC ultragoal durable goal workflow",
+	},
+	{
+		keyword: "ultragoal",
+		skill: "ultragoal",
+		priority: 8,
+		guidance: "Activate GJC ultragoal durable goal workflow",
+	},
+	{
+		keyword: "$team",
+		skill: "team",
+		priority: 8,
+		guidance: "Activate GJC team workflow",
+	},
+	{
+		keyword: "coordinated team",
+		skill: "team",
+		priority: 8,
+		guidance: "Activate GJC team workflow",
+	},
+] as const;
+
+export function isGjcWorkflowSkill(value: string): value is GjcWorkflowSkill {
+	return (GJC_WORKFLOW_SKILLS as readonly string[]).includes(value);
+}
+
+export function compareSkillKeywordMatches(
+	a: { priority: number; keyword: string },
+	b: { priority: number; keyword: string },
+): number {
+	if (b.priority !== a.priority) return b.priority - a.priority;
+	if (b.keyword.length !== a.keyword.length) return b.keyword.length - a.keyword.length;
+	return a.keyword.localeCompare(b.keyword);
+}

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -1,0 +1,342 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	GJC_SKILL_KEYWORD_DEFINITIONS,
+	compareSkillKeywordMatches,
+	isGjcWorkflowSkill,
+	type GjcWorkflowSkill,
+} from "./skill-keywords";
+
+export const GJC_STATE_DIR = ".gjc/state";
+export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
+
+export interface SkillKeywordMatch {
+	keyword: string;
+	skill: GjcWorkflowSkill;
+	priority: number;
+}
+
+export interface SkillActiveEntry {
+	skill: GjcWorkflowSkill;
+	phase?: string;
+	active?: boolean;
+	activated_at?: string;
+	updated_at?: string;
+	session_id?: string;
+	thread_id?: string;
+	turn_id?: string;
+}
+
+export interface SkillActiveState {
+	version: number;
+	active: boolean;
+	skill: GjcWorkflowSkill;
+	keyword: string;
+	phase: string;
+	activated_at: string;
+	updated_at: string;
+	source: "gjc-skill-state-hook";
+	session_id?: string;
+	thread_id?: string;
+	turn_id?: string;
+	initialized_mode?: GjcWorkflowSkill;
+	initialized_state_path?: string;
+	active_skills: SkillActiveEntry[];
+}
+
+export interface ModeState {
+	active?: boolean;
+	current_phase?: string;
+	skill?: string;
+	session_id?: string;
+	thread_id?: string;
+	cwd?: string;
+	updated_at?: string;
+	[key: string]: unknown;
+}
+
+export interface RecordSkillActivationInput {
+	cwd: string;
+	text: string;
+	sessionId?: string;
+	threadId?: string;
+	turnId?: string;
+	nowIso?: string;
+	stateDir?: string;
+}
+
+export interface StopHookInput {
+	cwd: string;
+	sessionId?: string;
+	threadId?: string;
+	stateDir?: string;
+}
+
+export interface UserPromptSubmitStateInput {
+	cwd: string;
+	sessionId?: string;
+	threadId?: string;
+	stateDir?: string;
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isWordChar(value: string | undefined): boolean {
+	return Boolean(value && /[a-z0-9_]/i.test(value));
+}
+
+function keywordToPattern(keyword: string): RegExp {
+	const escaped = escapeRegex(keyword);
+	const prefix = isWordChar(keyword[0]) ? "(?<![A-Za-z0-9_])" : "";
+	const suffix = isWordChar(keyword[keyword.length - 1]) ? "(?![A-Za-z0-9_])" : "";
+	return new RegExp(`${prefix}${escaped}${suffix}`, "i");
+}
+
+const KEYWORD_PATTERNS = GJC_SKILL_KEYWORD_DEFINITIONS.map(definition => ({
+	...definition,
+	pattern: keywordToPattern(definition.keyword),
+}));
+
+function parseExplicitSkillInvocations(text: string): { matches: SkillKeywordMatch[]; sawExplicitLikeInvocation: boolean } {
+	const matches: SkillKeywordMatch[] = [];
+	let sawExplicitLikeInvocation = false;
+	const explicitPattern = /\$((?:gjc:)?[a-z][a-z0-9-]*)/gi;
+	const seenSkills = new Set<string>();
+	let match: RegExpExecArray | null;
+	while ((match = explicitPattern.exec(text)) !== null) {
+		sawExplicitLikeInvocation = true;
+		const token = match[1] ?? "";
+		const normalized = token.startsWith("gjc:") ? token.slice(4) : token;
+		if (!isGjcWorkflowSkill(normalized) || seenSkills.has(normalized)) continue;
+		seenSkills.add(normalized);
+		matches.push({
+			keyword: match[0],
+			skill: normalized,
+			priority: GJC_SKILL_KEYWORD_DEFINITIONS.find(definition => definition.skill === normalized)?.priority ?? 0,
+		});
+	}
+	return { matches, sawExplicitLikeInvocation };
+}
+
+export function detectSkillKeywords(text: string): SkillKeywordMatch[] {
+	const explicit = parseExplicitSkillInvocations(text);
+	if (explicit.matches.length > 0) return explicit.matches;
+	if (explicit.sawExplicitLikeInvocation) return [];
+
+	const implicit: SkillKeywordMatch[] = [];
+	for (const definition of KEYWORD_PATTERNS) {
+		const match = text.match(definition.pattern);
+		if (!match) continue;
+		implicit.push({ keyword: match[0], skill: definition.skill, priority: definition.priority });
+	}
+
+	const merged: SkillKeywordMatch[] = [];
+	for (const item of implicit.sort(compareSkillKeywordMatches)) {
+		if (merged.some(existing => existing.skill === item.skill)) continue;
+		merged.push(item);
+	}
+	return merged;
+}
+
+export function detectPrimarySkillKeyword(text: string): SkillKeywordMatch | null {
+	return detectSkillKeywords(text)[0] ?? null;
+}
+
+export function resolveGjcStateDir(cwd: string, stateDir?: string): string {
+	return stateDir ? path.resolve(cwd, stateDir) : path.join(cwd, GJC_STATE_DIR);
+}
+
+function initialPhaseForSkill(skill: GjcWorkflowSkill): string {
+	if (skill === "deep-interview") return "interviewing";
+	if (skill === "ultragoal") return "goal-planning";
+	return "planning";
+}
+
+function modeStateFileName(skill: GjcWorkflowSkill): string {
+	return `${skill}-state.json`;
+}
+
+function modeStatePath(stateDir: string, skill: GjcWorkflowSkill, sessionId?: string): string {
+	if (sessionId) return path.join(stateDir, "sessions", sessionId, modeStateFileName(skill));
+	return path.join(stateDir, modeStateFileName(skill));
+}
+
+function skillStatePath(stateDir: string, sessionId?: string): string {
+	if (sessionId) return path.join(stateDir, "sessions", sessionId, SKILL_ACTIVE_STATE_FILE);
+	return path.join(stateDir, SKILL_ACTIVE_STATE_FILE);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+	try {
+		const raw = await Bun.file(filePath).text();
+		return JSON.parse(raw) as T;
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return null;
+		return null;
+	}
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function entryMatchesContext(entry: SkillActiveEntry, state: SkillActiveState, sessionId?: string, threadId?: string): boolean {
+	const entrySessionId = entry.session_id ?? state.session_id;
+	const entryThreadId = entry.thread_id ?? state.thread_id;
+	if (sessionId && entrySessionId && entrySessionId !== sessionId) return false;
+	if (threadId && entryThreadId && entryThreadId !== threadId) return false;
+	return true;
+}
+
+function listActiveSkills(state: SkillActiveState | null): SkillActiveEntry[] {
+	if (!state?.active) return [];
+	return state.active_skills.filter(entry => entry.active !== false);
+}
+
+export async function readVisibleSkillActiveState(
+	cwd: string,
+	sessionId?: string,
+	stateDir?: string,
+): Promise<SkillActiveState | null> {
+	const resolvedStateDir = resolveGjcStateDir(cwd, stateDir);
+	if (sessionId) {
+		const sessionState = await readJsonFile<SkillActiveState>(skillStatePath(resolvedStateDir, sessionId));
+		if (sessionState) return sessionState;
+	}
+	return await readJsonFile<SkillActiveState>(skillStatePath(resolvedStateDir));
+}
+
+export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
+	const match = detectPrimarySkillKeyword(input.text);
+	if (!match) return null;
+
+	const resolvedStateDir = resolveGjcStateDir(input.cwd, input.stateDir);
+	const nowIso = input.nowIso ?? new Date().toISOString();
+	const phase = initialPhaseForSkill(match.skill);
+	const initializedStatePath = modeStatePath(resolvedStateDir, match.skill, input.sessionId);
+	const entry: SkillActiveEntry = {
+		skill: match.skill,
+		phase,
+		active: true,
+		activated_at: nowIso,
+		updated_at: nowIso,
+		...(input.sessionId ? { session_id: input.sessionId } : {}),
+		...(input.threadId ? { thread_id: input.threadId } : {}),
+		...(input.turnId ? { turn_id: input.turnId } : {}),
+	};
+	const state: SkillActiveState = {
+		version: 1,
+		active: true,
+		skill: match.skill,
+		keyword: match.keyword,
+		phase,
+		activated_at: nowIso,
+		updated_at: nowIso,
+		source: "gjc-skill-state-hook",
+		...(input.sessionId ? { session_id: input.sessionId } : {}),
+		...(input.threadId ? { thread_id: input.threadId } : {}),
+		...(input.turnId ? { turn_id: input.turnId } : {}),
+		initialized_mode: match.skill,
+		initialized_state_path: initializedStatePath,
+		active_skills: [entry],
+	};
+	const modeState: ModeState = {
+		active: true,
+		current_phase: phase,
+		skill: match.skill,
+		cwd: input.cwd,
+		updated_at: nowIso,
+		...(input.sessionId ? { session_id: input.sessionId } : {}),
+		...(input.threadId ? { thread_id: input.threadId } : {}),
+		...(input.turnId ? { turn_id: input.turnId } : {}),
+	};
+
+	await writeJsonFile(initializedStatePath, modeState);
+	await writeJsonFile(skillStatePath(resolvedStateDir, input.sessionId), state);
+	if (!input.sessionId) return state;
+	await writeJsonFile(skillStatePath(resolvedStateDir), state);
+	return state;
+}
+
+function isTerminalModeState(state: ModeState | null): boolean {
+	if (!state || state.active !== true) return true;
+	const phase = String(state.current_phase ?? "").trim().toLowerCase();
+	return ["complete", "completed", "failed", "cancelled", "canceled", "inactive"].includes(phase);
+}
+
+async function readVisibleModeState(
+	cwd: string,
+	skill: GjcWorkflowSkill,
+	sessionId?: string,
+	stateDir?: string,
+): Promise<{ state: ModeState; statePath: string } | null> {
+	const resolvedStateDir = resolveGjcStateDir(cwd, stateDir);
+	if (sessionId) {
+		const sessionStatePath = modeStatePath(resolvedStateDir, skill, sessionId);
+		const sessionState = await readJsonFile<ModeState>(sessionStatePath);
+		if (sessionState) return { state: sessionState, statePath: sessionStatePath };
+	}
+	const rootStatePath = modeStatePath(resolvedStateDir, skill);
+	const rootState = await readJsonFile<ModeState>(rootStatePath);
+	if (!rootState) return null;
+	return { state: rootState, statePath: rootStatePath };
+}
+
+function stateMatchesContext(state: ModeState, sessionId?: string, threadId?: string): boolean {
+	if (sessionId && state.session_id && state.session_id !== sessionId) return false;
+	if (threadId && state.thread_id && state.thread_id !== threadId) return false;
+	return true;
+}
+
+export async function buildActiveUltragoalPromptContext(input: UserPromptSubmitStateInput): Promise<string | null> {
+	const visibleModeState = await readVisibleModeState(input.cwd, "ultragoal", input.sessionId, input.stateDir);
+	if (!visibleModeState) return null;
+	if (isTerminalModeState(visibleModeState.state)) return null;
+	if (!stateMatchesContext(visibleModeState.state, input.sessionId, input.threadId)) return null;
+
+	const phase = String(visibleModeState.state.current_phase ?? "active");
+	return `Ultragoal is active (phase: ${phase}; state: ${visibleModeState.statePath}). If the user prompt is a steering request, use \`gjc ultragoal steer\` to add or steer subgoals. Normal prose should not mutate Ultragoal state.`;
+}
+
+export async function buildSkillStopOutput(input: StopHookInput): Promise<Record<string, unknown> | null> {
+	const resolvedStateDir = resolveGjcStateDir(input.cwd, input.stateDir);
+	const skillState = await readVisibleSkillActiveState(input.cwd, input.sessionId, input.stateDir);
+	const activeEntries = listActiveSkills(skillState).filter(entry => (
+		skillState ? entryMatchesContext(entry, skillState, input.sessionId, input.threadId) : false
+	));
+	if (!skillState || activeEntries.length === 0) return null;
+
+	for (const entry of activeEntries) {
+		const modeState = await readJsonFile<ModeState>(modeStatePath(resolvedStateDir, entry.skill, input.sessionId));
+		if (isTerminalModeState(modeState)) continue;
+		const phase = String(modeState?.current_phase ?? entry.phase ?? skillState.phase ?? "active");
+		const statePath = modeStatePath(resolvedStateDir, entry.skill, input.sessionId);
+		const systemMessage = `GJC skill "${entry.skill}" is still active (phase: ${phase}; state: ${statePath}). Continue or explicitly finish/cancel the skill before stopping.`;
+		return {
+			decision: "block",
+			reason: systemMessage,
+			stopReason: `gjc_skill_${entry.skill.replace(/-/g, "_")}_${phase.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`,
+			systemMessage,
+		};
+	}
+
+	return null;
+}
+
+export function buildSkillActivationAdditionalContext(state: SkillActiveState): string {
+	return [
+		`GJC native UserPromptSubmit detected workflow keyword "${state.keyword}" -> ${state.skill}.`,
+		state.initialized_mode && state.initialized_state_path
+			? `skill: ${state.initialized_mode} activated and initial state initialized at ${state.initialized_state_path}; use \`gjc state write/read/clear --input '<json>' --json\` for runtime state updates when the private GJC runtime endpoint is available.`
+			: null,
+		state.skill === "ultragoal"
+			? "Ultragoal is active. If the user prompt is a steering request, use `gjc ultragoal steer` to add or steer subgoals."
+			: null,
+		"Follow AGENTS.md routing and preserve GJC workflow transition and planning-safety rules.",
+	]
+		.filter((value): value is string => Boolean(value))
+		.join(" ");
+}

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	mergeGjcManagedCodexHooksConfig,
+	readGjcManagedCodexHooksStatus,
+} from "../src/hooks/codex-native-hooks-config";
+import { dispatchGjcNativeSkillHook } from "../src/hooks/native-skill-hook";
+import { detectSkillKeywords, readVisibleSkillActiveState } from "../src/hooks/skill-state";
+
+describe("GJC native skill-state hooks", () => {
+	let tempDir: string | undefined;
+
+	afterEach(async () => {
+		if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	});
+
+	async function cwd(): Promise<string> {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-hooks-"));
+		return tempDir;
+	}
+
+	it("detects only the public GJC workflow skill surface", () => {
+		expect(detectSkillKeywords("$deep-interview then $team").map(match => match.skill)).toEqual([
+			"deep-interview",
+			"team",
+		]);
+		expect(detectSkillKeywords("$autopilot deep interview")).toEqual([]);
+		expect(detectSkillKeywords("please run a consensus plan")[0]?.skill).toBe("ralplan");
+	});
+
+	it("UserPromptSubmit persists session-scoped skill-active and mode state", async () => {
+		const root = await cwd();
+		const result = await dispatchGjcNativeSkillHook({
+			hook_event_name: "UserPromptSubmit",
+			prompt: "$deep-interview clarify this feature",
+			cwd: root,
+			session_id: "session-1",
+			thread_id: "thread-1",
+			turn_id: "turn-1",
+		});
+
+		expect(result.hookEventName).toBe("UserPromptSubmit");
+		expect(result.outputJson?.hookSpecificOutput).toMatchObject({ hookEventName: "UserPromptSubmit" });
+		const state = await readVisibleSkillActiveState(root, "session-1");
+		expect(state).toMatchObject({
+			active: true,
+			skill: "deep-interview",
+			keyword: "$deep-interview",
+			session_id: "session-1",
+			initialized_mode: "deep-interview",
+		});
+		expect(state?.initialized_state_path).toBe(path.join(root, ".gjc", "state", "sessions", "session-1", "deep-interview-state.json"));
+		const modeState = await Bun.file(state?.initialized_state_path ?? "").json();
+		expect(modeState).toMatchObject({ active: true, current_phase: "interviewing", session_id: "session-1" });
+	});
+
+	it("Stop blocks while matching skill state is active and allows terminal mode state", async () => {
+		const root = await cwd();
+		await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "$ralplan plan this",
+			cwd: root,
+			sessionId: "session-2",
+			threadId: "thread-2",
+		});
+
+		const blocked = await dispatchGjcNativeSkillHook({
+			hookEventName: "Stop",
+			cwd: root,
+			sessionId: "session-2",
+			threadId: "thread-2",
+		});
+		expect(blocked.outputJson).toMatchObject({ decision: "block", stopReason: "gjc_skill_ralplan_planning" });
+
+		await Bun.write(
+			path.join(root, ".gjc", "state", "sessions", "session-2", "ralplan-state.json"),
+			JSON.stringify({ active: false, current_phase: "complete", session_id: "session-2" }),
+		);
+		const allowed = await dispatchGjcNativeSkillHook({
+			hookEventName: "Stop",
+			cwd: root,
+			sessionId: "session-2",
+			threadId: "thread-2",
+		});
+		expect(allowed.outputJson).toBeNull();
+	});
+
+	it("UserPromptSubmit reminds active Ultragoal sessions to use ultragoal steer", async () => {
+		const root = await cwd();
+		await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "$ultragoal plan this",
+			cwd: root,
+			sessionId: "session-ultra",
+			threadId: "thread-ultra",
+		});
+
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "Add a blocker-resolution subgoal based on the failed smoke test",
+			cwd: root,
+			sessionId: "session-ultra",
+			threadId: "thread-ultra",
+		});
+
+		expect(result.outputJson?.hookSpecificOutput).toMatchObject({ hookEventName: "UserPromptSubmit" });
+		const context = String(
+			(result.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ?? "",
+		);
+		expect(context).toContain("Ultragoal is active");
+		expect(context).toContain("gjc ultragoal steer");
+		expect(context).toContain("add or steer subgoals");
+	});
+
+	it("UserPromptSubmit includes steer guidance when activating Ultragoal", async () => {
+		const root = await cwd();
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "$ultragoal plan this",
+			cwd: root,
+			sessionId: "session-ultra-start",
+			threadId: "thread-ultra-start",
+		});
+		const context = String(
+			(result.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ?? "",
+		);
+		expect(context).toContain("Ultragoal is active");
+		expect(context).toContain("gjc ultragoal steer");
+	});
+
+	it("merges managed Codex UserPromptSubmit/Stop hooks without dropping user hooks", () => {
+		const existing = JSON.stringify({
+			hooks: {
+				UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo user-prompt" }] }],
+				Stop: [
+					{ hooks: [{ type: "command", command: "gjc codex-native-hook" }] },
+					{ hooks: [{ type: "command", command: "echo user-stop" }] },
+				],
+			},
+		});
+
+		const merged = mergeGjcManagedCodexHooksConfig(existing);
+		const parsed = JSON.parse(merged.content) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+
+		expect(parsed.hooks.UserPromptSubmit?.flatMap(entry => entry.hooks.map(hook => hook.command))).toEqual([
+			"gjc codex-native-hook",
+			"echo user-prompt",
+		]);
+		expect(parsed.hooks.Stop?.flatMap(entry => entry.hooks.map(hook => hook.command))).toEqual([
+			"gjc codex-native-hook",
+			"echo user-stop",
+		]);
+		expect(readGjcManagedCodexHooksStatus(merged.content, "/tmp/hooks.json")).toMatchObject({
+			installed: true,
+			missingEvents: [],
+			managedHookCount: 2,
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add GJC native UserPromptSubmit/Stop skill-state hook dispatch for the four public workflows
- add `gjc setup hooks` to merge managed Codex hooks without dropping user hooks
- add Ultragoal active-state steering guidance for UserPromptSubmit prompts

## Tests
- `bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts`
- `bunx biome check packages/coding-agent/src/hooks/skill-keywords.ts packages/coding-agent/src/hooks/skill-state.ts packages/coding-agent/src/hooks/native-skill-hook.ts packages/coding-agent/src/hooks/codex-native-hooks-config.ts packages/coding-agent/src/commands/codex-native-hook.ts packages/coding-agent/src/commands/setup.ts packages/coding-agent/src/cli/setup-cli.ts packages/coding-agent/src/cli.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts`
- `git diff --check`

## Not tested
- `bun --cwd=packages/coding-agent run check:types` (local environment missing `tsgo`)