### PR TITLE
Surface GJC workflow skill state in the TUI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a native in-TUI skill HUD rail backed by `.gjc/state/skill-active-state.json`, so active GJC workflow skills are visible without a separate tmux pane.
 - Added a native `gjc team` runtime that writes GJC-scoped state, mailboxes, task lifecycle files, and telemetry without delegating to an external `omx` binary
 - Added `codex` and `gemini` to the web search provider settings so users can configure OpenAI and Gemini web search directly from provider selection
 - Added OpenAI (`codex`) and Gemini web search options with updated setup descriptions for `omp /login openai-codex` and Gemini OAuth login

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -523,6 +523,11 @@ export const SETTINGS_SCHEMA = {
 		default: false,
 	},
 
+	"statusLine.showSkillHud": {
+		type: "boolean",
+		default: true,
+	},
+
 	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentId[] },
 
 	"statusLine.rightSegments": { type: "array", default: [] as StatusLineSegmentId[] },
@@ -2878,6 +2883,7 @@ export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
 	showHookStatus: boolean;
+	showSkillHud: boolean;
 	leftSegments: StatusLineSegmentId[];
 	rightSegments: StatusLineSegmentId[];
 	segmentOptions: Record<string, unknown>;

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -1,0 +1,47 @@
+import type { SkillActiveEntry } from "../../../skill-state/active-state";
+
+const ANSI_RESET_FG = "\x1b[39m";
+const ANSI_RESET_BOLD = "\x1b[22m";
+const ANSI_BORDER = "\x1b[90m";
+const ANSI_ACCENT = "\x1b[36m";
+const ANSI_DIM = "\x1b[2m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function visibleWidth(text: string): number {
+	return text.replace(ANSI_PATTERN, "").length;
+}
+
+function truncateToWidth(text: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+	if (visibleWidth(text) <= maxWidth) return text;
+	const plain = text.replace(ANSI_PATTERN, "");
+	if (maxWidth === 1) return "…";
+	return `${plain.slice(0, maxWidth - 1)}…`;
+}
+
+function sanitizeHudPart(value: string | undefined): string {
+	return (value ?? "")
+		.replace(ANSI_PATTERN, "")
+		.replace(/[\r\n\t]+/g, " ")
+		.trim();
+}
+
+function compareEntries(a: SkillActiveEntry, b: SkillActiveEntry): number {
+	return a.skill.localeCompare(b.skill) || (a.phase ?? "").localeCompare(b.phase ?? "");
+}
+
+export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
+	const active = entries.filter(entry => entry.active !== false && sanitizeHudPart(entry.skill)).sort(compareEntries);
+	if (active.length === 0 || width <= 0) return null;
+	const body = active
+		.map(entry => {
+			const skill = sanitizeHudPart(entry.skill);
+			const phase = sanitizeHudPart(entry.phase);
+			return phase ? `${skill}:${phase}` : skill;
+		})
+		.join(" + ");
+	const prefix = `${ANSI_BORDER}◆${ANSI_RESET_FG} ${ANSI_BOLD}${ANSI_ACCENT}hud${ANSI_RESET_FG}${ANSI_RESET_BOLD} `;
+	const budget = Math.max(1, width - visibleWidth(prefix));
+	return truncateToWidth(`${prefix}${ANSI_DIM}${truncateToWidth(body, budget)}${ANSI_RESET_BOLD}`, width);
+}

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -8,10 +8,12 @@ import { settings } from "../../config/settings";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
+import { readVisibleSkillActiveState, type SkillActiveEntry } from "../../skill-state/active-state";
 import * as git from "../../utils/git";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../utils/session-color";
 import { sanitizeStatusText } from "../shared";
 import { computeNonMessageTokens } from "../utils/context-usage";
+import { renderSkillHudBar } from "./skill-hud/render";
 import {
 	canReuseCachedPr,
 	createPrCacheContext,
@@ -37,6 +39,7 @@ export interface StatusLineSettings {
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
 	showHookStatus?: boolean;
+	showSkillHud?: boolean;
 	sessionAccent?: boolean;
 }
 
@@ -154,6 +157,9 @@ export class StatusLineComponent implements Component {
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#loopModeStatus: { enabled: boolean } | null = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
+	#skillHudEntries: SkillActiveEntry[] = [];
+	#skillHudLastFetch = 0;
+	#skillHudInFlight = false;
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
@@ -197,6 +203,7 @@ export class StatusLineComponent implements Component {
 			rightSegments: settings.get("statusLine.rightSegments"),
 			separator: settings.get("statusLine.separator"),
 			showHookStatus: settings.get("statusLine.showHookStatus"),
+			showSkillHud: settings.get("statusLine.showSkillHud"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 		};
@@ -228,6 +235,11 @@ export class StatusLineComponent implements Component {
 
 	setGoalModeStatus(status: { enabled: boolean; paused: boolean } | undefined): void {
 		this.#goalModeStatus = status ?? null;
+	}
+
+	setSkillHudEntriesForTest(entries: SkillActiveEntry[]): void {
+		this.#skillHudEntries = entries;
+		this.#skillHudLastFetch = Date.now();
 	}
 
 	setHookStatus(key: string, text: string | undefined): void {
@@ -420,6 +432,28 @@ export class StatusLineComponent implements Component {
 		}
 
 		return null;
+	}
+
+	#refreshSkillHudInBackground(): void {
+		if (this.#settings.showSkillHud === false) return;
+		const now = Date.now();
+		if (this.#skillHudInFlight || now - this.#skillHudLastFetch < 1000) return;
+		const getCwd = this.session.sessionManager?.getCwd;
+		const getSessionId = this.session.sessionManager?.getSessionId;
+		const cwd = typeof getCwd === "function" ? getCwd.call(this.session.sessionManager) : getProjectDir();
+		const sessionId = typeof getSessionId === "function" ? getSessionId.call(this.session.sessionManager) : undefined;
+		this.#skillHudInFlight = true;
+		void readVisibleSkillActiveState(cwd, sessionId)
+			.then(state => {
+				this.#skillHudEntries = state?.active_skills ?? [];
+			})
+			.catch(() => {
+				this.#skillHudEntries = [];
+			})
+			.finally(() => {
+				this.#skillHudLastFetch = Date.now();
+				this.#skillHudInFlight = false;
+			});
 	}
 
 	/**
@@ -780,6 +814,12 @@ export class StatusLineComponent implements Component {
 
 	render(width: number): string[] {
 		const lines: string[] = [];
+		this.#refreshSkillHudInBackground();
+		const skillHud = this.#settings.showSkillHud === false ? null : renderSkillHudBar(this.#skillHudEntries, width);
+		if (skillHud) {
+			lines.push(skillHud);
+		}
+
 		const statusLine = this.#buildStatusLine(width);
 		if (statusLine) {
 			lines.push(truncateToWidth(statusLine, width));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -165,6 +165,7 @@ import {
 	selectDiscoverableMCPToolNamesByServer,
 } from "../runtime-mcp/discoverable-tool-metadata";
 import { deobfuscateSessionContext, type SecretObfuscator } from "../secrets/obfuscator";
+import { isCanonicalGjcWorkflowSkill, syncSkillActiveState } from "../skill-state/active-state";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import { resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
 import {
@@ -196,6 +197,7 @@ import {
 	type PythonExecutionMessage,
 	readPendingDisplayTag,
 	SILENT_ABORT_MARKER,
+	SKILL_PROMPT_MESSAGE_TYPE,
 } from "./messages";
 import { formatSessionDumpText } from "./session-dump-format";
 import type {
@@ -839,6 +841,7 @@ export class AgentSession {
 	#mcpPromptCommands: LoadedCustomCommand[] = [];
 
 	#skillsSettings: SkillsSettings | undefined;
+	#activeSkillState: { skill: string; sessionId?: string } | undefined;
 
 	// Model registry for API key resolution
 	#modelRegistry: ModelRegistry;
@@ -1746,6 +1749,17 @@ export class AgentSession {
 					cacheWrite: usage.cacheWrite,
 				},
 			});
+			if (this.#activeSkillState) {
+				await syncSkillActiveState({
+					cwd: this.sessionManager.getCwd(),
+					skill: this.#activeSkillState.skill,
+					active: false,
+					phase: "complete",
+					sessionId: this.#activeSkillState.sessionId,
+					source: "skill-prompt",
+				}).catch(() => {});
+				this.#activeSkillState = undefined;
+			}
 			const fallbackAssistant = [...event.messages]
 				.reverse()
 				.find((message): message is AssistantMessage => message.role === "assistant");
@@ -3991,6 +4005,28 @@ export class AgentSession {
 		}
 	}
 
+	async #syncSkillPromptActiveState(
+		message: Pick<CustomMessage<unknown>, "customType" | "details">,
+		active: boolean,
+	): Promise<void> {
+		if (message.customType !== SKILL_PROMPT_MESSAGE_TYPE) return;
+		const details = message.details;
+		if (!details || typeof details !== "object") return;
+		const name = (details as { name?: unknown }).name;
+		if (typeof name !== "string" || !isCanonicalGjcWorkflowSkill(name)) return;
+		const cwd = this.sessionManager.getCwd();
+		const sessionId = this.sessionManager.getSessionId();
+		await syncSkillActiveState({
+			cwd,
+			skill: name,
+			active,
+			phase: active ? "running" : "complete",
+			sessionId,
+			source: "skill-prompt",
+		});
+		this.#activeSkillState = active ? { skill: name, sessionId } : undefined;
+	}
+
 	async promptCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice">,
@@ -4021,7 +4057,12 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 
-		await this.#promptWithMessage(customMessage, textContent, options);
+		await this.#syncSkillPromptActiveState(customMessage, true).catch(() => {});
+		try {
+			await this.#promptWithMessage(customMessage, textContent, options);
+		} finally {
+			await this.#syncSkillPromptActiveState(customMessage, false).catch(() => {});
+		}
 	}
 
 	async #promptWithMessage(

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -1,0 +1,254 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
+
+export const CANONICAL_GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
+
+export type CanonicalGjcWorkflowSkill = (typeof CANONICAL_GJC_WORKFLOW_SKILLS)[number];
+
+export interface SkillActiveEntry {
+	skill: string;
+	phase?: string;
+	active?: boolean;
+	activated_at?: string;
+	updated_at?: string;
+	session_id?: string;
+	thread_id?: string;
+	turn_id?: string;
+}
+
+export interface SkillActiveState {
+	version?: number;
+	active?: boolean;
+	skill?: string;
+	keyword?: string;
+	phase?: string;
+	activated_at?: string;
+	updated_at?: string;
+	source?: string;
+	session_id?: string;
+	thread_id?: string;
+	turn_id?: string;
+	active_skills?: SkillActiveEntry[];
+	[key: string]: unknown;
+}
+
+export interface SkillActiveStatePaths {
+	rootPath: string;
+	sessionPath?: string;
+}
+
+export interface SyncSkillActiveStateOptions {
+	cwd: string;
+	skill: string;
+	active: boolean;
+	phase?: string;
+	sessionId?: string;
+	threadId?: string;
+	turnId?: string;
+	nowIso?: string;
+	source?: string;
+}
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function entryKey(entry: Pick<SkillActiveEntry, "skill" | "session_id">): string {
+	return `${entry.skill}::${safeString(entry.session_id).trim()}`;
+}
+
+function normalizeEntry(raw: unknown): SkillActiveEntry | null {
+	if (!raw || typeof raw !== "object") return null;
+	const record = raw as Record<string, unknown>;
+	const skill = safeString(record.skill).trim();
+	if (!skill) return null;
+	return {
+		...record,
+		skill,
+		phase: safeString(record.phase).trim() || undefined,
+		active: record.active !== false,
+		activated_at: safeString(record.activated_at).trim() || undefined,
+		updated_at: safeString(record.updated_at).trim() || undefined,
+		session_id: safeString(record.session_id).trim() || undefined,
+		thread_id: safeString(record.thread_id).trim() || undefined,
+		turn_id: safeString(record.turn_id).trim() || undefined,
+	};
+}
+
+export function isCanonicalGjcWorkflowSkill(skill: string): skill is CanonicalGjcWorkflowSkill {
+	return (CANONICAL_GJC_WORKFLOW_SKILLS as readonly string[]).includes(skill);
+}
+
+export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
+	if (!raw || typeof raw !== "object") return [];
+	const state = raw as SkillActiveState;
+	const deduped = new Map<string, SkillActiveEntry>();
+
+	if (Array.isArray(state.active_skills)) {
+		for (const candidate of state.active_skills) {
+			const normalized = normalizeEntry(candidate);
+			if (!normalized || normalized.active === false) continue;
+			deduped.set(entryKey(normalized), normalized);
+		}
+	}
+
+	const topLevelSkill = safeString(state.skill).trim();
+	if (deduped.size === 0 && state.active === true && topLevelSkill) {
+		const entry: SkillActiveEntry = {
+			skill: topLevelSkill,
+			phase: safeString(state.phase).trim() || undefined,
+			active: true,
+			activated_at: safeString(state.activated_at).trim() || undefined,
+			updated_at: safeString(state.updated_at).trim() || undefined,
+			session_id: safeString(state.session_id).trim() || undefined,
+			thread_id: safeString(state.thread_id).trim() || undefined,
+			turn_id: safeString(state.turn_id).trim() || undefined,
+		};
+		deduped.set(entryKey(entry), entry);
+	}
+
+	return [...deduped.values()];
+}
+
+export function normalizeSkillActiveState(raw: unknown): SkillActiveState | null {
+	if (!raw || typeof raw !== "object") return null;
+	const state = raw as SkillActiveState;
+	const activeSkills = listActiveSkills(state);
+	const primary = activeSkills.find(entry => entry.skill === safeString(state.skill).trim()) ?? activeSkills[0];
+	const skill = safeString(state.skill).trim() || primary?.skill || "";
+	if (!skill && activeSkills.length === 0) return null;
+	return {
+		...state,
+		version: typeof state.version === "number" ? state.version : 1,
+		active: typeof state.active === "boolean" ? state.active : activeSkills.length > 0,
+		skill,
+		keyword: safeString(state.keyword).trim(),
+		phase: safeString(state.phase).trim() || primary?.phase || "",
+		activated_at: safeString(state.activated_at).trim() || primary?.activated_at || "",
+		updated_at: safeString(state.updated_at).trim() || primary?.updated_at || "",
+		source: safeString(state.source).trim() || undefined,
+		session_id: safeString(state.session_id).trim() || primary?.session_id || undefined,
+		thread_id: safeString(state.thread_id).trim() || primary?.thread_id || undefined,
+		turn_id: safeString(state.turn_id).trim() || primary?.turn_id || undefined,
+		active_skills: activeSkills.length > 0 ? activeSkills : [],
+	};
+}
+
+export function getSkillActiveStatePaths(cwd: string, sessionId?: string): SkillActiveStatePaths {
+	const stateDir = path.join(cwd, ".gjc", "state");
+	const rootPath = path.join(stateDir, SKILL_ACTIVE_STATE_FILE);
+	const normalizedSessionId = safeString(sessionId).trim();
+	if (!normalizedSessionId) return { rootPath };
+	return {
+		rootPath,
+		sessionPath: path.join(stateDir, "sessions", normalizedSessionId, SKILL_ACTIVE_STATE_FILE),
+	};
+}
+
+async function readStateFile(filePath: string): Promise<SkillActiveState | null> {
+	try {
+		return normalizeSkillActiveState(JSON.parse(await Bun.file(filePath).text()));
+	} catch {
+		return null;
+	}
+}
+
+function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
+	const normalizedSessionId = safeString(sessionId).trim();
+	if (!normalizedSessionId) return entries;
+	return entries.filter(entry => {
+		const entrySessionId = safeString(entry.session_id).trim();
+		return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
+	});
+}
+
+function mergeVisibleEntries(
+	sessionState: SkillActiveState | null,
+	rootState: SkillActiveState | null,
+	sessionId?: string,
+): SkillActiveEntry[] {
+	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId);
+	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
+	for (const entry of listActiveSkills(sessionState)) {
+		merged.set(entryKey(entry), entry);
+	}
+	return [...merged.values()];
+}
+
+export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {
+	const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+	const [rootState, sessionState] = await Promise.all([
+		readStateFile(rootPath),
+		sessionPath ? readStateFile(sessionPath) : Promise.resolve(null),
+	]);
+	const activeSkills = mergeVisibleEntries(sessionState, rootState, sessionId);
+	if (activeSkills.length === 0) return null;
+	const primary = activeSkills[0];
+	return {
+		...(rootState ?? {}),
+		...(sessionState ?? {}),
+		version: 1,
+		active: true,
+		skill: primary?.skill ?? "",
+		phase: primary?.phase ?? "",
+		session_id: safeString(sessionId).trim() || primary?.session_id,
+		active_skills: activeSkills,
+	};
+}
+
+async function writeStateFile(filePath: string, state: SkillActiveState): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await Bun.write(filePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function upsertEntry(entries: SkillActiveEntry[], entry: SkillActiveEntry, active: boolean): SkillActiveEntry[] {
+	const key = entryKey(entry);
+	const retained = entries.filter(candidate => entryKey(candidate) !== key);
+	return active ? [...retained, entry] : retained;
+}
+
+export async function syncSkillActiveState(options: SyncSkillActiveStateOptions): Promise<void> {
+	const nowIso = options.nowIso ?? new Date().toISOString();
+	const entry: SkillActiveEntry = {
+		skill: options.skill,
+		phase: options.phase,
+		active: options.active,
+		activated_at: nowIso,
+		updated_at: nowIso,
+		session_id: options.sessionId,
+		thread_id: options.threadId,
+		turn_id: options.turnId,
+	};
+	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, options.sessionId);
+	const rootState = (await readStateFile(rootPath)) ?? { version: 1, active_skills: [] };
+	const rootEntries = upsertEntry(listActiveSkills(rootState), entry, options.active);
+	const nextRoot: SkillActiveState = {
+		...rootState,
+		version: 1,
+		active: rootEntries.length > 0,
+		skill: rootEntries[0]?.skill ?? "",
+		phase: rootEntries[0]?.phase ?? "",
+		updated_at: nowIso,
+		source: options.source,
+		active_skills: rootEntries,
+	};
+	await writeStateFile(rootPath, nextRoot);
+
+	if (!sessionPath) return;
+	const sessionState = (await readStateFile(sessionPath)) ?? { version: 1, active_skills: [] };
+	const sessionEntries = upsertEntry(listActiveSkills(sessionState), entry, options.active);
+	const nextSession: SkillActiveState = {
+		...sessionState,
+		version: 1,
+		active: sessionEntries.length > 0,
+		skill: sessionEntries[0]?.skill ?? "",
+		phase: sessionEntries[0]?.phase ?? "",
+		session_id: options.sessionId,
+		updated_at: nowIso,
+		source: options.source,
+		active_skills: sessionEntries,
+	};
+	await writeStateFile(sessionPath, nextSession);
+}

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	CANONICAL_GJC_WORKFLOW_SKILLS,
+	getSkillActiveStatePaths,
+	listActiveSkills,
+	normalizeSkillActiveState,
+	readVisibleSkillActiveState,
+	syncSkillActiveState,
+} from "../src/skill-state/active-state";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-active-"));
+	try {
+		await fn(cwd);
+	} finally {
+		await fs.rm(cwd, { recursive: true, force: true });
+	}
+}
+
+describe("GJC skill-active state", () => {
+	it("normalizes legacy top-level active state into active skills", () => {
+		const state = normalizeSkillActiveState({ active: true, skill: "deep-interview", phase: "intent-first" });
+		expect(state?.active_skills).toEqual([
+			expect.objectContaining({ skill: "deep-interview", phase: "intent-first", active: true }),
+		]);
+	});
+
+	it("ignores inactive and blank entries while deduping by skill and session", () => {
+		const active = listActiveSkills({
+			active_skills: [
+				{ skill: "", active: true },
+				{ skill: "team", active: false },
+				{ skill: "ralplan", phase: "draft", session_id: "sess-a" },
+				{ skill: "ralplan", phase: "review", session_id: "sess-a" },
+				{ skill: "ralplan", phase: "root" },
+			],
+		});
+		expect(active).toEqual([
+			expect.objectContaining({ skill: "ralplan", phase: "review", session_id: "sess-a" }),
+			expect.objectContaining({ skill: "ralplan", phase: "root" }),
+		]);
+	});
+
+	it("writes root and session copies under .gjc/state", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({
+				cwd,
+				skill: "team",
+				phase: "running",
+				active: true,
+				sessionId: "sess-a",
+				nowIso: "2026-05-27T00:00:00.000Z",
+			});
+
+			const paths = getSkillActiveStatePaths(cwd, "sess-a");
+			expect(await fs.readFile(paths.rootPath, "utf8")).toContain("team");
+			expect(paths.sessionPath).toBeDefined();
+			expect(await fs.readFile(paths.sessionPath ?? "", "utf8")).toContain("running");
+		});
+	});
+
+	it("filters root fallback entries to the current session", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({ cwd, skill: "team", active: true, phase: "running", sessionId: "sess-a" });
+			await syncSkillActiveState({
+				cwd,
+				skill: "deep-interview",
+				active: true,
+				phase: "intent",
+				sessionId: "sess-b",
+			});
+
+			const visible = await readVisibleSkillActiveState(cwd, "sess-b");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["deep-interview"]);
+		});
+	});
+
+	it("clears only the matching session entry", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({ cwd, skill: "team", active: true, sessionId: "sess-a" });
+			await syncSkillActiveState({ cwd, skill: "team", active: true, sessionId: "sess-b" });
+			await syncSkillActiveState({ cwd, skill: "team", active: false, sessionId: "sess-a" });
+
+			const sessionA = await readVisibleSkillActiveState(cwd, "sess-a");
+			const sessionB = await readVisibleSkillActiveState(cwd, "sess-b");
+			expect(sessionA).toBeNull();
+			expect(sessionB?.active_skills?.map(entry => entry.session_id)).toEqual(["sess-b"]);
+		});
+	});
+
+	it("keeps the canonical GJC workflow skill set intentionally small", () => {
+		expect(CANONICAL_GJC_WORKFLOW_SKILLS).toEqual(["deep-interview", "ralplan", "ultragoal", "team"]);
+	});
+});

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { renderSkillHudBar } from "../src/modes/components/skill-hud/render";
+import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
+
+function visibleWidth(text: string): number {
+	return Bun.stripANSI(text).length;
+}
+
+describe("skill HUD bar renderer", () => {
+	it("omits the bar when no active skills exist", () => {
+		expect(renderSkillHudBar([], 80)).toBeNull();
+	});
+
+	it("renders active skill and phase compactly", () => {
+		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "deep-interview", phase: "intent-first" }], 80) ?? "");
+		expect(rendered).toContain("hud");
+		expect(rendered).toContain("deep-interview:intent-first");
+	});
+
+	it("sanitizes dynamic text and truncates to width", () => {
+		const rendered = renderSkillHudBar(
+			[{ skill: "team\n\u001b[31mred", phase: "running\twith-a-very-long-phase-name" }],
+			30,
+		);
+		expect(rendered).not.toBeNull();
+		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\n");
+		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\t");
+		expect(visibleWidth(rendered ?? "")).toBeLessThanOrEqual(30);
+	});
+
+	it("is included as a native status-line rail without changing preset segments", () => {
+		expect(STATUS_LINE_PRESETS.default.leftSegments).toEqual(["model", "mode", "git", "pr", "path"]);
+		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "team", phase: "running" }], 100) ?? "");
+		expect(rendered).toContain("hud team:running");
+	});
+
+	it("omits inactive entries so statusLine.showSkillHud can gate the rail", () => {
+		expect(renderSkillHudBar([{ skill: "team", phase: "running", active: false }], 100)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- add .gjc-rooted skill-active state helpers for the four default GJC workflow skills
- render active skill state as a native in-TUI HUD rail without a tmux pane or new workflow surface
- sync skill prompt lifecycle state and add focused state/render regression tests

## Verification
- bun test packages/coding-agent/test/skill-active-state.test.ts packages/coding-agent/test/skill-hud-bar.test.ts
- bun --cwd=packages/coding-agent run check

## Review
- AI slop cleanup: PASS (bounded changed-file pass; fallbacks classified as grounded non-fatal UI/state fail-safes)
- Code review: LGTM / APPROVE (0 critical/high/medium/low issues; architectural status CLEAR)
