### PR TITLE
Make tmux opt-in and seed ultragoal goal mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
+- Changed interactive `gjc` startup to launch tmux only when `--tmux` is provided, with direct startup as the default.
 - Changed `gjc team` startup to use tmux worker panes backed by dedicated detached git worktrees by default, while keeping `--worktree` as a backward-compatible launch override.
 - Constrained the visible GJC utility surface to the retained workflow/runtime endpoints and four bundled task agents, with MCP, arbitrary skill, plugin, extension, marketplace, and custom discovery surfaces quarantined from default public use.
 - Redesigned the interactive TUI chrome with a minimal opencode-style prompt composer, simple user/gajae transcript labels, a forge-style welcome surface, and compact cwd/pulse indicators tuned for terminal coding-agent ergonomics.
@@ -28,6 +28,7 @@
 ### Fixed
 
 - Wired GJC native UserPromptSubmit/Stop skill-state hooks, including `gjc setup hooks`, so public workflow keywords activate `.gjc/state`, active skill state can block premature Stop events, and active Ultragoal sessions remind steering prompts to use `gjc ultragoal steer`.
+- Fixed `gjc ultragoal create-goals` to seed GJC goal mode runtime state automatically, avoiding a separate manual `/goal` setup step.
 - Fixed legacy Pi plugin import remapping and stale GJC config-path tests so rebranded `.gjc` discovery contracts pass while preserving legacy compatibility.
 - Fixed web search OAuth-backed providers (including Codex and Gemini) to use broker-managed token retrieval and account metadata, avoiding direct token-store refresh behavior that could cause search authentication failures
 - Updated Tavily missing-credential feedback to prompt users to configure an API-key provider setting instead of referencing `agent.db` directly

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -35,6 +35,7 @@ export interface Args {
 	noTools?: boolean;
 	noLsp?: boolean;
 	noPty?: boolean;
+	tmux?: boolean;
 	/** Retained for runtime/test compatibility; extension loading flags are no longer parsed. */
 	hooks?: string[];
 	extensions?: string[];
@@ -125,6 +126,8 @@ export function parseArgs(args: string[]): Args {
 			result.noLsp = true;
 		} else if (arg === "--no-pty") {
 			result.noPty = true;
+		} else if (arg === "--tmux") {
+			result.tmux = true;
 		} else if (arg === "--tools" && i + 1 < args.length) {
 			const toolNames = args[++i]
 				.split(",")
@@ -228,7 +231,8 @@ export function getExtraHelpText(): string {
   GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
   GJC_PLAN_MODEL              - Override planning model (see --plan)
   GJC_NO_PTY                  - Disable PTY-based interactive bash execution
-  GJC_LAUNCH_POLICY           - Launch policy for interactive startup: auto, tmux, or direct
+  --tmux                       - Launch interactive startup inside tmux
+  GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
   GJC_TMUX_SESSION            - tmux session name for default interactive startup (default: gajae_code)
 
   For complete environment variable reference, see:

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -84,6 +84,9 @@ export default class Index extends Command {
 		"no-pty": Flags.boolean({
 			description: "Disable PTY-based interactive bash execution",
 		}),
+		tmux: Flags.boolean({
+			description: "Launch interactive startup inside tmux",
+		}),
 		tools: Flags.string({
 			description: "Comma-separated list of tools to enable (default: all)",
 		}),

--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -1,5 +1,10 @@
 import { Command } from "@gajae-code/utils/cli";
-import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
+import {
+	isUltragoalCreateGoalsInvocation,
+	readUltragoalCodexObjective,
+	writePendingGoalModeRequest,
+} from "../gjc-runtime/goal-mode-request";
+import { runGjcRuntimeBridge } from "./gjc-runtime-bridge";
 
 export default class Ultragoal extends Command {
 	static description = "Run private GJC Ultragoal workflow commands";
@@ -7,6 +12,14 @@ export default class Ultragoal extends Command {
 	static examples = ["$ gjc ultragoal status --json"];
 
 	async run(): Promise<void> {
-		await runBridgedRuntimeEndpoint("ultragoal", this.argv);
+		const shouldActivateGoalMode = isUltragoalCreateGoalsInvocation(this.argv);
+		const result = runGjcRuntimeBridge("ultragoal", this.argv);
+		if (result.error) process.stderr.write(`${result.error}\n`);
+		process.exitCode = result.status;
+		if (result.status !== 0 || !shouldActivateGoalMode) return;
+
+		const cwd = process.cwd();
+		const { objective, goalsPath } = await readUltragoalCodexObjective(cwd);
+		await writePendingGoalModeRequest({ cwd, objective, goalsPath });
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -1,0 +1,117 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+export const GJC_SESSION_FILE_ENV = "GJC_SESSION_FILE";
+export const GJC_SESSION_ID_ENV = "GJC_SESSION_ID";
+export const GJC_SESSION_CWD_ENV = "GJC_SESSION_CWD";
+
+const REQUEST_VERSION = 1;
+const DEFAULT_ULTRAGOAL_OBJECTIVE =
+	"Complete the durable ultragoal plan in .gjc/ultragoal/goals.json, including later accepted/appended stories, under the original brief constraints; use .gjc/ultragoal/ledger.jsonl as the audit trail.";
+
+export interface PendingGoalModeRequest {
+	version: typeof REQUEST_VERSION;
+	kind: "goal_mode_request";
+	source: "ultragoal";
+	objective: string;
+	createdAt: string;
+	goalsPath?: string;
+}
+
+interface UltragoalPlanShape {
+	codexObjective?: unknown;
+}
+
+function isEnoent(error: unknown): boolean {
+	return (
+		typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT"
+	);
+}
+
+function requestPath(cwd: string): string {
+	return path.join(cwd, ".gjc", "state", "goal-mode-request.json");
+}
+
+function ultragoalGoalsPath(cwd: string): string {
+	return path.join(cwd, ".gjc", "ultragoal", "goals.json");
+}
+
+function isCreateGoalsArg(value: string): boolean {
+	return value === "create-goals" || value === "create";
+}
+
+export function isUltragoalCreateGoalsInvocation(args: readonly string[]): boolean {
+	const command = args.find(arg => !arg.startsWith("-"));
+	return command !== undefined && isCreateGoalsArg(command);
+}
+
+export async function readUltragoalCodexObjective(cwd: string): Promise<{ objective: string; goalsPath: string }> {
+	const goalsPath = ultragoalGoalsPath(cwd);
+	try {
+		const plan = (await Bun.file(goalsPath).json()) as UltragoalPlanShape;
+		const objective = typeof plan.codexObjective === "string" ? plan.codexObjective.trim() : "";
+		return { objective: objective || DEFAULT_ULTRAGOAL_OBJECTIVE, goalsPath };
+	} catch (error) {
+		if (isEnoent(error)) {
+			return { objective: DEFAULT_ULTRAGOAL_OBJECTIVE, goalsPath };
+		}
+		throw error;
+	}
+}
+
+export async function writePendingGoalModeRequest(input: {
+	cwd: string;
+	objective: string;
+	goalsPath?: string;
+}): Promise<PendingGoalModeRequest> {
+	const objective = input.objective.trim();
+	if (!objective) throw new Error("goal objective is required");
+	const request: PendingGoalModeRequest = {
+		version: REQUEST_VERSION,
+		kind: "goal_mode_request",
+		source: "ultragoal",
+		objective,
+		createdAt: new Date().toISOString(),
+		goalsPath: input.goalsPath,
+	};
+	const filePath = requestPath(input.cwd);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await Bun.write(filePath, `${JSON.stringify(request, null, 2)}\n`);
+	return request;
+}
+
+export async function consumePendingGoalModeRequest(cwd: string): Promise<PendingGoalModeRequest | null> {
+	const filePath = requestPath(cwd);
+	let raw: unknown;
+	try {
+		raw = await Bun.file(filePath).json();
+	} catch (error) {
+		if (isEnoent(error)) return null;
+		throw error;
+	}
+	const candidate = raw as Partial<PendingGoalModeRequest>;
+	if (
+		candidate.version !== REQUEST_VERSION ||
+		candidate.kind !== "goal_mode_request" ||
+		candidate.source !== "ultragoal" ||
+		typeof candidate.objective !== "string" ||
+		candidate.objective.trim().length === 0
+	) {
+		return null;
+	}
+	await fs.unlink(filePath).catch(error => {
+		if (!isEnoent(error)) throw error;
+	});
+	return { ...candidate, objective: candidate.objective.trim() } as PendingGoalModeRequest;
+}
+
+export function buildGjcRuntimeSessionEnv(input: {
+	sessionFile?: string | null;
+	sessionId?: string | null;
+	cwd?: string | null;
+}): Record<string, string> {
+	const env: Record<string, string> = {};
+	if (input.sessionFile) env[GJC_SESSION_FILE_ENV] = input.sessionFile;
+	if (input.sessionId) env[GJC_SESSION_ID_ENV] = input.sessionId;
+	if (input.cwd) env[GJC_SESSION_CWD_ENV] = input.cwd;
+	return env;
+}

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -6,7 +6,7 @@ export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_COMMAND_ENV = "GJC_TMUX_COMMAND";
 
-type LaunchPolicy = "auto" | "direct" | "tmux";
+type LaunchPolicy = "direct" | "tmux";
 
 interface TtyState {
 	stdin: boolean;
@@ -59,9 +59,9 @@ interface CommandResolutionContext {
 
 function parseLaunchPolicy(env: NodeJS.ProcessEnv): LaunchPolicy {
 	const raw = env[GJC_LAUNCH_POLICY_ENV]?.trim().toLowerCase();
-	if (raw === "direct" || raw === "tmux" || raw === "auto") return raw;
+	if (raw === "direct" || raw === "tmux") return raw;
 	if (env.GJC_NO_TMUX === "1" || env.GJC_NO_TMUX === "true") return "direct";
-	return "auto";
+	return "tmux";
 }
 
 function isInteractiveRootLaunch(parsed: Args, tty: TtyState): boolean {
@@ -101,13 +101,12 @@ function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[])
 export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaunchPlan | undefined {
 	const env = context.env ?? process.env;
 	const policy = parseLaunchPolicy(env);
-	if (policy === "direct") return undefined;
+	if (!context.parsed.tmux || policy === "direct") return undefined;
 	if (env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return undefined;
 	const platform = context.platform ?? process.platform;
 	if (platform === "win32") return undefined;
 	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
-	if (policy === "auto" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
-	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, { stdin: true, stdout: true })) return undefined;
+	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
 
 	const cwd = context.cwd ?? process.cwd();
 	const sessionName = env.GJC_TMUX_SESSION?.trim() || GJC_DEFAULT_TMUX_SESSION;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -39,6 +39,7 @@ import type {
 import type { CompactOptions } from "../extensibility/extensions/types";
 import { resolveSkillSlashCommands, type Skill } from "../extensibility/skills";
 import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slash-commands";
+import { consumePendingGoalModeRequest } from "../gjc-runtime/goal-mode-request";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
@@ -1122,6 +1123,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				await this.#exitGoalMode({ reason: "dropped", silent: true });
 				return;
 			}
+			if (event.state?.enabled === true && !this.#goalModePreviousTools) {
+				this.#goalModePreviousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+			}
 			this.goalModeEnabled = event.state?.enabled === true;
 			this.goalModePaused = event.state?.enabled !== true && event.state?.goal?.status === "paused";
 			if (!event.state?.enabled) {
@@ -1217,6 +1221,12 @@ export class InteractiveMode implements InteractiveModeContext {
 				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
 			}
 			this.#updateGoalModeStatus();
+			return;
+		}
+		const pendingGoal = goalEnabled ? await consumePendingGoalModeRequest(this.sessionManager.getCwd()) : null;
+		if (pendingGoal) {
+			await this.#enterGoalMode({ objective: pendingGoal.objective, silent: true });
+			this.#scheduleGoalContinuation();
 			return;
 		}
 		if (!this.session.settings.get("plan.enabled")) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -137,6 +137,7 @@ import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
+import { buildGjcRuntimeSessionEnv, consumePendingGoalModeRequest } from "../gjc-runtime/goal-mode-request";
 import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
@@ -1483,6 +1484,9 @@ export class AgentSession {
 				await this.#goalRuntime.onGoalToolCompleted();
 			} else {
 				await this.#goalRuntime.onToolCompleted(event.toolName);
+			}
+			if (event.toolName === "bash" && !event.isError) {
+				await this.#activatePendingGjcGoalModeRequest();
 			}
 		}
 		if (event.type === "tool_execution_end" && event.toolName === "yield" && !event.isError) {
@@ -3794,6 +3798,25 @@ export class AgentSession {
 			},
 			options ? { deliverAs: options.deliverAs } : undefined,
 		);
+	}
+
+	async #activatePendingGjcGoalModeRequest(): Promise<boolean> {
+		if (!this.settings.get("goal.enabled")) return false;
+		const currentState = this.getGoalModeState();
+		if (currentState?.goal && currentState.goal.status !== "complete" && currentState.goal.status !== "dropped") {
+			return false;
+		}
+		const pendingGoal = await consumePendingGoalModeRequest(this.sessionManager.getCwd());
+		if (!pendingGoal) return false;
+
+		const previousTools = this.getActiveToolNames().filter(name => name !== "goal");
+		const goalTools = [...new Set([...previousTools, "goal"])];
+		await this.#goalRuntime.createGoal({ objective: pendingGoal.objective });
+		await this.setActiveToolsByName(goalTools);
+		if (this.isStreaming) {
+			await this.sendGoalModeContext({ deliverAs: "steer" });
+		}
+		return true;
 	}
 
 	resolveRoleModel(role: string): Model | undefined {
@@ -7330,6 +7353,9 @@ export class AgentSession {
 			});
 			if (hookResult?.result) {
 				this.recordBashResult(command, hookResult.result, options);
+				if (hookResult.result.exitCode === 0 && !hookResult.result.cancelled) {
+					await this.#activatePendingGjcGoalModeRequest();
+				}
 				return hookResult.result;
 			}
 		}
@@ -7343,10 +7369,18 @@ export class AgentSession {
 				signal: abortController.signal,
 				sessionKey: this.sessionId,
 				timeout: clampTimeout("bash") * 1000,
+				env: buildGjcRuntimeSessionEnv({
+					sessionFile: this.sessionManager.getSessionFile(),
+					sessionId: this.sessionId,
+					cwd,
+				}),
 				onMinimizedSave: originalText => this.#saveBashOriginalArtifact(originalText),
 			});
 
 			this.recordBashResult(command, result, options);
+			if (result.exitCode === 0 && !result.cancelled) {
+				await this.#activatePendingGjcGoalModeRequest();
+			}
 			return result;
 		} finally {
 			this.#bashAbortControllers.delete(abortController);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -7,6 +7,7 @@ import * as z from "zod/v4";
 import { AsyncJobManager } from "../async";
 import { type BashResult, executeBash } from "../exec/bash-executor";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { buildGjcRuntimeSessionEnv } from "../gjc-runtime/goal-mode-request";
 import { InternalUrlRouter } from "../internal-urls";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { highlightCode, type Theme } from "../modes/theme/theme";
@@ -518,7 +519,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			},
 		};
 		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
-		const resolvedEnv = env
+		const expandedEnv = env
 			? Object.fromEntries(
 					await Promise.all(
 						Object.entries(env).map(async ([key, value]) => [
@@ -532,6 +533,14 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					),
 				)
 			: undefined;
+		const resolvedEnv = {
+			...buildGjcRuntimeSessionEnv({
+				sessionFile: this.session.getSessionFile(),
+				sessionId: this.session.getSessionId?.(),
+				cwd: this.session.cwd,
+			}),
+			...expandedEnv,
+		};
 
 		// Resolve protocol URLs (agent://, artifact://, etc.) in extracted cwd.
 		if (cwd?.includes("://") || cwd?.includes("local:/")) {

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	consumePendingGoalModeRequest,
+	isUltragoalCreateGoalsInvocation,
+	readUltragoalCodexObjective,
+	writePendingGoalModeRequest,
+} from "@gajae-code/coding-agent/gjc-runtime/goal-mode-request";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-goal-mode-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("GJC ultragoal goal mode request", () => {
+	it("detects create-goals invocations without matching flags", () => {
+		expect(isUltragoalCreateGoalsInvocation(["create-goals", "--brief", "ship it"])).toBe(true);
+		expect(isUltragoalCreateGoalsInvocation(["create", "--brief", "ship it"])).toBe(true);
+		expect(isUltragoalCreateGoalsInvocation(["--json", "status"])).toBe(false);
+		expect(isUltragoalCreateGoalsInvocation(["--create-goals"])).toBe(false);
+		expect(isUltragoalCreateGoalsInvocation(["status", "--filter", "create-goals"])).toBe(false);
+	});
+
+	it("reads codexObjective from the generated ultragoal plan", async () => {
+		const root = await tempDir();
+		const goalsPath = path.join(root, ".gjc", "ultragoal", "goals.json");
+		await fs.mkdir(path.dirname(goalsPath), { recursive: true });
+		await Bun.write(goalsPath, JSON.stringify({ codexObjective: "Complete .gjc/ultragoal/goals.json" }));
+
+		const result = await readUltragoalCodexObjective(root);
+
+		expect(result.objective).toBe("Complete .gjc/ultragoal/goals.json");
+		expect(result.goalsPath).toBe(goalsPath);
+	});
+
+	it("writes and consumes a pending runtime goal mode request", async () => {
+		const root = await tempDir();
+		await writePendingGoalModeRequest({ cwd: root, objective: "Complete ultragoal", goalsPath: "goals.json" });
+
+		const request = await consumePendingGoalModeRequest(root);
+		const consumedAgain = await consumePendingGoalModeRequest(root);
+
+		expect(request?.objective).toBe("Complete ultragoal");
+		expect(request?.source).toBe("ultragoal");
+		expect(consumedAgain).toBeNull();
+	});
+
+	it("surfaces corrupt pending request json", async () => {
+		const root = await tempDir();
+		const requestPath = path.join(root, ".gjc", "state", "goal-mode-request.json");
+		await fs.mkdir(path.dirname(requestPath), { recursive: true });
+		await Bun.write(requestPath, "{");
+
+		await expect(consumePendingGoalModeRequest(root)).rejects.toThrow(SyntaxError);
+	});
+
+	it("surfaces corrupt ultragoal goals json", async () => {
+		const root = await tempDir();
+		const goalsPath = path.join(root, ".gjc", "ultragoal", "goals.json");
+		await fs.mkdir(path.dirname(goalsPath), { recursive: true });
+		await Bun.write(goalsPath, "{");
+
+		await expect(readUltragoalCodexObjective(root)).rejects.toThrow(SyntaxError);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -20,10 +20,26 @@ function args(overrides: Partial<Args> = {}): Args {
 const interactiveTty = { stdin: true, stdout: true };
 
 describe("default GJC tmux launch", () => {
-	it("plans an interactive root launch inside the gajae_code tmux session", () => {
+	it("does not plan tmux for interactive root launch without --tmux", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"] }),
 			rawArgs: ["hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan).toBeUndefined();
+	});
+
+	it("plans an interactive --tmux root launch inside the gajae_code tmux session", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
 			cwd: "/repo",
 			env: {},
 			argv: ["bun", "packages/coding-agent/src/cli.ts"],
@@ -37,7 +53,9 @@ describe("default GJC tmux launch", () => {
 		expect(plan?.tmuxCommand).toBe("tmux");
 		expect(plan?.newSessionArgs.slice(0, 5)).toEqual(["new-session", "-s", "gajae_code", "-c", "/repo"]);
 		expect(plan?.innerCommand).toContain(`${GJC_TMUX_LAUNCHED_ENV}=1`);
-		expect(plan?.innerCommand).toContain("'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' 'hello world'");
+		expect(plan?.innerCommand).toContain(
+			"'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' '--tmux' 'hello world'",
+		);
 	});
 
 	it("does not wrap non-interactive or already wrapped launches", () => {
@@ -53,16 +71,22 @@ describe("default GJC tmux launch", () => {
 
 		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args({ print: true }), env: {} })).toBeUndefined();
 		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args({ mode: "json" }), env: {} })).toBeUndefined();
-		expect(buildDefaultTmuxLaunchPlan({ ...common, parsed: args(), env: { TMUX: "/tmp/tmux" } })).toBeUndefined();
 		expect(
-			buildDefaultTmuxLaunchPlan({ ...common, parsed: args(), env: { [GJC_TMUX_LAUNCHED_ENV]: "1" } }),
+			buildDefaultTmuxLaunchPlan({ ...common, parsed: args({ tmux: true }), env: { TMUX: "/tmp/tmux" } }),
+		).toBeUndefined();
+		expect(
+			buildDefaultTmuxLaunchPlan({
+				...common,
+				parsed: args({ tmux: true }),
+				env: { [GJC_TMUX_LAUNCHED_ENV]: "1" },
+			}),
 		).toBeUndefined();
 	});
 
 	it("attaches an existing gajae_code session when creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args(),
+			parsed: args({ tmux: true }),
 			rawArgs: [],
 			cwd: "/repo",
 			env: {},
@@ -85,7 +109,7 @@ describe("default GJC tmux launch", () => {
 
 	it("falls through to direct launch when tmux is unavailable", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
-			parsed: args(),
+			parsed: args({ tmux: true }),
 			rawArgs: [],
 			cwd: "/repo",
 			env: {},


### PR DESCRIPTION
## Summary
- make interactive `gjc` start directly by default and require `--tmux` for tmux wrapping
- seed a pending goal-mode request after successful `gjc ultragoal create-goals`
- activate pending ultragoal goals through the live parent `GoalRuntime`/`SessionManager` path after successful bash completion, with durable startup restore fallback

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts`
- `bun run check:ts`
- independent code-reviewer LGTM
- independent architect LGTM

## Notes
- No raw session JSONL `mode_change` mutation is used; activation stays under `GoalRuntime` ownership.
- Private end-to-end GJC ultragoal runtime bridge was not available in this worktree, so coverage is at the public bridge/request/session-integration boundaries.
