### PR TITLE
Stabilize multiplexer rendering without scrollback replay

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -129,7 +129,13 @@ function isTermuxSession(): boolean {
 }
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
-const isMultiplexer = Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+function isMultiplexerSession(): boolean {
+	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+}
+
+function useLegacyMultiplexerFullRender(): boolean {
+	return $flag("PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER");
+}
 
 /**
  * Options for overlay positioning and sizing.
@@ -1063,7 +1069,7 @@ export class TUI extends Container {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
-			if (clear) buffer += isMultiplexer ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
+			if (clear) buffer += isMultiplexerSession() ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				// Lines were pre-terminated/normalized by #applyLineResets; image
@@ -1083,6 +1089,61 @@ export class TUI extends Container {
 				this.#maxLinesRendered = Math.max(this.#maxLinesRendered, newLines.length);
 			}
 			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+			this.#previousLines = newLines;
+			this.#previousWidth = width;
+			this.#previousHeight = height;
+		};
+
+		const multiplexerViewportRepaint = (reason: string): void => {
+			this.#fullRedrawCount += 1;
+			const nextViewportTop = Math.max(0, newLines.length - height);
+			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
+			let buffer = "\x1b[?2026h";
+			if (currentScreenRow > 0) {
+				buffer += `\x1b[${currentScreenRow}A`;
+			}
+			buffer += "\r";
+			for (let screenRow = 0; screenRow < height; screenRow++) {
+				if (screenRow > 0) buffer += "\r\n";
+				buffer += "\x1b[2K";
+				const lineIndex = nextViewportTop + screenRow;
+				if (lineIndex >= newLines.length) continue;
+				const line = newLines[lineIndex];
+				const isImage = TERMINAL.isImageLine(line);
+				if (!isImage && visibleWidth(line) > width) {
+					let truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
+					truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
+					buffer += truncatedLine;
+				} else {
+					buffer += line;
+				}
+			}
+
+			const finalPhysicalRow = nextViewportTop + Math.max(0, height - 1);
+			let cursorSeq = "\x1b[?25l";
+			let cursorToRow = finalPhysicalRow;
+			if (cursorPos && cursorPos.row >= nextViewportTop && cursorPos.row < nextViewportTop + height) {
+				const cursor = this.#cursorControlSequence(cursorPos, newLines.length, finalPhysicalRow);
+				cursorSeq = cursor.seq;
+				cursorToRow = cursor.toRow;
+			}
+			this.#hardwareCursorRow = cursorToRow;
+			buffer += cursorSeq;
+			buffer += "\x1b[?2026l";
+			this.terminal.write(buffer);
+
+			if ($flag("PI_DEBUG_REDRAW")) {
+				const logPath = getDebugLogPath();
+				const msg = `[${new Date().toISOString()}] multiplexerViewportRepaint: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
+				fs.appendFileSync(logPath, msg);
+			}
+			// In multiplexers this deliberately prioritizes the live viewport over
+			// historical scrollback repair. After offscreen changes, #previousLines
+			// tracks the desired logical transcript, not every byte emitted into the
+			// multiplexer scrollback.
+			this.#cursorRow = Math.max(0, newLines.length - 1);
+			this.#maxLinesRendered = newLines.length;
+			this.#viewportTopRow = nextViewportTop;
 			this.#previousLines = newLines;
 			this.#previousWidth = width;
 			this.#previousHeight = height;
@@ -1113,10 +1174,16 @@ export class TUI extends Container {
 		// Height changes normally need a full re-render to keep the visible viewport aligned,
 		// but Termux changes height when the software keyboard shows or hides.
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
-		if (heightChanged && !isTermuxSession() && !isMultiplexer) {
-			logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
-			fullRender(true);
-			return;
+		if (heightChanged) {
+			if (isMultiplexerSession() && !useLegacyMultiplexerFullRender()) {
+				multiplexerViewportRepaint(`terminal height changed (${this.#previousHeight} -> ${height})`);
+				return;
+			}
+			if (!isTermuxSession() && !isMultiplexerSession()) {
+				logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
+				fullRender(true);
+				return;
+			}
 		}
 
 		// Content shrunk below the previous render and no overlays - re-render to clear empty rows
@@ -1173,7 +1240,11 @@ export class TUI extends Container {
 				const extraLines = this.#previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					if (isMultiplexerSession() && !useLegacyMultiplexerFullRender()) {
+						multiplexerViewportRepaint(`extraLines > height (${extraLines} > ${height})`);
+					} else {
+						fullRender(true);
+					}
 					return;
 				}
 				const clearStartOffset = newLines.length > 0 && extraLines > 0 ? 1 : 0;
@@ -1208,7 +1279,11 @@ export class TUI extends Container {
 		// scrollback ends up consistent with the new transcript state.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
+			if (isMultiplexerSession() && !useLegacyMultiplexerFullRender()) {
+				multiplexerViewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+			} else {
+				fullRender(true);
+			}
 			return;
 		}
 

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { type Component, CURSOR_MARKER, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
@@ -88,6 +88,45 @@ async function flushRender(term: VirtualTerminal): Promise<void> {
 }
 
 describe("TUI overlays", () => {
+	let previousTmux: string | undefined;
+	let previousSty: string | undefined;
+	let previousZellij: string | undefined;
+	let previousLegacyFullRender: string | undefined;
+
+	beforeEach(() => {
+		previousTmux = Bun.env.TMUX;
+		previousSty = Bun.env.STY;
+		previousZellij = Bun.env.ZELLIJ;
+		previousLegacyFullRender = Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+		delete Bun.env.TMUX;
+		delete Bun.env.STY;
+		delete Bun.env.ZELLIJ;
+		delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+	});
+
+	afterEach(() => {
+		if (previousTmux === undefined) {
+			delete Bun.env.TMUX;
+		} else {
+			Bun.env.TMUX = previousTmux;
+		}
+		if (previousSty === undefined) {
+			delete Bun.env.STY;
+		} else {
+			Bun.env.STY = previousSty;
+		}
+		if (previousZellij === undefined) {
+			delete Bun.env.ZELLIJ;
+		} else {
+			Bun.env.ZELLIJ = previousZellij;
+		}
+		if (previousLegacyFullRender === undefined) {
+			delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+		} else {
+			Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER = previousLegacyFullRender;
+		}
+	});
+
 	it("does not scroll the terminal when an overlay is shown with a large historical working area", async () => {
 		const term = new VirtualTerminal(80, 24);
 		const tui = new TUI(term);

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -44,9 +44,21 @@ function countMatches(lines: string[], pattern: RegExp): number {
 
 describe("TUI terminal-state regressions", () => {
 	let monotonicNow = 0;
+	let previousTmux: string | undefined;
+	let previousSty: string | undefined;
+	let previousZellij: string | undefined;
+	let previousLegacyFullRender: string | undefined;
 	// Keep TUI's 16ms render throttle deterministic without sleeping a real frame per render.
 
 	beforeEach(() => {
+		previousTmux = Bun.env.TMUX;
+		previousSty = Bun.env.STY;
+		previousZellij = Bun.env.ZELLIJ;
+		previousLegacyFullRender = Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+		delete Bun.env.TMUX;
+		delete Bun.env.STY;
+		delete Bun.env.ZELLIJ;
+		delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
 		monotonicNow = 0;
 		vi.spyOn(performance, "now").mockImplementation(() => {
 			monotonicNow += 20;
@@ -56,6 +68,26 @@ describe("TUI terminal-state regressions", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		if (previousTmux === undefined) {
+			delete Bun.env.TMUX;
+		} else {
+			Bun.env.TMUX = previousTmux;
+		}
+		if (previousSty === undefined) {
+			delete Bun.env.STY;
+		} else {
+			Bun.env.STY = previousSty;
+		}
+		if (previousZellij === undefined) {
+			delete Bun.env.ZELLIJ;
+		} else {
+			Bun.env.ZELLIJ = previousZellij;
+		}
+		if (previousLegacyFullRender === undefined) {
+			delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+		} else {
+			Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER = previousLegacyFullRender;
+		}
 	});
 
 	describe("cursor + differential stability", () => {
@@ -623,6 +655,107 @@ describe("TUI terminal-state regressions", () => {
 	});
 
 	describe("scrollback integrity", () => {
+		it("repaints only the visible viewport for offscreen changes in tmux", async () => {
+			Bun.env.TMUX = "1";
+			delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const lines = rows("line-", 80);
+			const component = new MutableLinesComponent(lines);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const before = visible(term);
+
+				term.clearWriteLog();
+				const nextLines = [...lines];
+				nextLines[0] = "updated-offscreen-header";
+				component.setLines(nextLines);
+				tui.requestRender();
+				await settle(term);
+
+				expect(visible(term)).toEqual(before);
+				const writes = term.getWriteLog().join("");
+				expect(writes).not.toContain("\x1b[3J");
+				expect(writes).not.toContain("\x1b[2J");
+				expect(writes).not.toContain("updated-offscreen-header");
+				expect(writes).toContain("line-79");
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("keeps a legacy full-render kill switch for multiplexer viewport repaint", async () => {
+			Bun.env.TMUX = "1";
+			Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER = "1";
+
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const lines = rows("line-", 80);
+			const component = new MutableLinesComponent(lines);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				term.clearWriteLog();
+				const nextLines = [...lines];
+				nextLines[0] = "updated-offscreen-header";
+				component.setLines(nextLines);
+				tui.requestRender();
+				await settle(term);
+
+				const writes = term.getWriteLog().join("");
+				expect(writes).toContain("\x1b[2J\x1b[H");
+				expect(writes).not.toContain("\x1b[3J");
+				expect(writes).toContain("updated-offscreen-header");
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("refreshes newly visible rows after a tmux height increase", async () => {
+			Bun.env.TMUX = "1";
+			delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const lines = rows("line-", 80);
+			const component = new MutableLinesComponent(lines);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const nextLines = [...lines];
+				nextLines[70] = "UPDATED-70";
+				component.setLines(nextLines);
+				tui.requestRender();
+				await settle(term);
+				expect(visible(term).join("\n")).not.toContain("UPDATED-70");
+
+				term.clearWriteLog();
+				term.resize(32, 12);
+				await settle(term);
+
+				const viewport = visible(term).join("\n");
+				expect(viewport).toContain("UPDATED-70");
+				expect(viewport).not.toContain("line-70");
+				const writes = term.getWriteLog().join("");
+				expect(writes).not.toContain("\x1b[3J");
+				expect(writes).not.toContain("\x1b[2J");
+				expect(writes).not.toContain("line-0");
+				expect(writes).toContain("UPDATED-70");
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("overflow content appears once across buffer without duplicate row IDs", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);
@@ -838,9 +971,11 @@ describe("TUI terminal-state regressions", () => {
 
 		function getWrites(term: VirtualTerminal): string[] {
 			const writes: string[] = [];
+			const originalWrite = term.write.bind(term);
 			const spy = vi.spyOn(term, "write");
 			spy.mockImplementation((data: string) => {
 				writes.push(data);
+				originalWrite(data);
 			});
 			return writes;
 		}

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -12,6 +12,7 @@ export class VirtualTerminal implements Terminal {
 	private xterm: XtermTerminalType;
 	private inputHandler?: (data: string) => void;
 	private resizeHandler?: () => void;
+	#writeLog: string[] = [];
 	private _columns: number;
 	private _rows: number;
 
@@ -48,7 +49,16 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	write(data: string): void {
+		this.#writeLog.push(data);
 		this.xterm.write(data);
+	}
+
+	getWriteLog(): string[] {
+		return [...this.#writeLog];
+	}
+
+	clearWriteLog(): void {
+		this.#writeLog = [];
 	}
 
 	get columns(): number {


### PR DESCRIPTION
## Summary
- add a tmux/multiplexer viewport-only repaint path for offscreen and height-change redraws
- avoid scrollback-clearing `3J` and full offscreen transcript replay in the tmux acceptance path
- add write-log regression coverage for tmux viewport stability, height growth, and legacy kill switch behavior

## Validation
- `git diff --check`
- `bun test packages/tui/test/render-regressions.test.ts`
- `bun --cwd=packages/tui run test`
- `bun --cwd=packages/tui run check`
- Independent code-reviewer: APPROVE
- Independent architect: CLEAR

## Notes
- `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` preserves the older multiplexer full-render fallback if needed.
- Not tested in a live interactive tmux pane; covered with deterministic xterm-based emitted-byte regressions.
