### PR TITLE
Harden skill HUD state lifecycle and path boundaries

### DIFF
--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -153,6 +153,10 @@ export function resolveGjcStateDir(cwd: string, stateDir?: string): string {
 	return stateDir ? path.resolve(cwd, stateDir) : path.join(cwd, GJC_STATE_DIR);
 }
 
+function encodeStatePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
 function initialPhaseForSkill(skill: GjcWorkflowSkill): string {
 	if (skill === "deep-interview") return "interviewing";
 	if (skill === "ultragoal") return "goal-planning";
@@ -164,12 +168,12 @@ function modeStateFileName(skill: GjcWorkflowSkill): string {
 }
 
 function modeStatePath(stateDir: string, skill: GjcWorkflowSkill, sessionId?: string): string {
-	if (sessionId) return path.join(stateDir, "sessions", sessionId, modeStateFileName(skill));
+	if (sessionId) return path.join(stateDir, "sessions", encodeStatePathSegment(sessionId), modeStateFileName(skill));
 	return path.join(stateDir, modeStateFileName(skill));
 }
 
 function skillStatePath(stateDir: string, sessionId?: string): string {
-	if (sessionId) return path.join(stateDir, "sessions", sessionId, SKILL_ACTIVE_STATE_FILE);
+	if (sessionId) return path.join(stateDir, "sessions", encodeStatePathSegment(sessionId), SKILL_ACTIVE_STATE_FILE);
 	return path.join(stateDir, SKILL_ACTIVE_STATE_FILE);
 }
 

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -210,7 +210,7 @@ export class StatusLineComponent implements Component {
 	}
 
 	updateSettings(settings: StatusLineSettings): void {
-		this.#settings = settings;
+		this.#settings = { ...this.#settings, ...settings };
 	}
 
 	setAutoCompactEnabled(enabled: boolean): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1407,6 +1407,7 @@ export class AgentSession {
 					}
 				}
 			}
+			await this.#syncSkillPromptActiveStateSafely(event.message, true);
 		}
 
 		// Plan-mode → compaction transition: stamp `SILENT_ABORT_MARKER` on the
@@ -1754,15 +1755,14 @@ export class AgentSession {
 				},
 			});
 			if (this.#activeSkillState) {
-				await syncSkillActiveState({
-					cwd: this.sessionManager.getCwd(),
-					skill: this.#activeSkillState.skill,
-					active: false,
-					phase: "complete",
-					sessionId: this.#activeSkillState.sessionId,
-					source: "skill-prompt",
-				}).catch(() => {});
-				this.#activeSkillState = undefined;
+				const { skill, sessionId } = this.#activeSkillState;
+				await this.#syncSkillPromptActiveStateSafely(
+					{ customType: SKILL_PROMPT_MESSAGE_TYPE, details: { name: skill } },
+					false,
+				);
+				if (this.#activeSkillState?.skill === skill && this.#activeSkillState.sessionId === sessionId) {
+					this.#activeSkillState = undefined;
+				}
 			}
 			const fallbackAssistant = [...event.messages]
 				.reverse()
@@ -4050,6 +4050,19 @@ export class AgentSession {
 		this.#activeSkillState = active ? { skill: name, sessionId } : undefined;
 	}
 
+	async #syncSkillPromptActiveStateSafely(
+		message: Pick<CustomMessage<unknown>, "customType" | "details">,
+		active: boolean,
+	): Promise<void> {
+		try {
+			await this.#syncSkillPromptActiveState(message, active);
+		} catch {
+			// Skill HUD state is observational; a filesystem write failure must not
+			// interrupt the prompt turn it is visualizing. The native Stop hook still
+			// performs authoritative workflow blocking from persisted state.
+		}
+	}
+
 	async promptCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice">,
@@ -4080,11 +4093,11 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 
-		await this.#syncSkillPromptActiveState(customMessage, true).catch(() => {});
+		await this.#syncSkillPromptActiveStateSafely(customMessage, true);
 		try {
 			await this.#promptWithMessage(customMessage, textContent, options);
 		} finally {
-			await this.#syncSkillPromptActiveState(customMessage, false).catch(() => {});
+			await this.#syncSkillPromptActiveStateSafely(customMessage, false);
 		}
 	}
 
@@ -4496,6 +4509,7 @@ export class AgentSession {
 
 		const prependMessages = queuedMessages.slice(0, -1);
 		const textContent = this.#getCustomMessageTextContent(message);
+		await this.#syncSkillPromptActiveStateSafely(message, true);
 		try {
 			await this.#promptWithMessage(message, textContent, {
 				prependMessages,
@@ -4504,6 +4518,8 @@ export class AgentSession {
 		} catch (error) {
 			this.#pendingNextTurnMessages = [...queuedMessages, ...this.#pendingNextTurnMessages];
 			throw error;
+		} finally {
+			await this.#syncSkillPromptActiveStateSafely(message, false);
 		}
 	}
 
@@ -4575,7 +4591,12 @@ export class AgentSession {
 					this.#queueHiddenNextTurnMessage(appMessage, false);
 					return;
 				}
-				await this.agent.prompt(appMessage);
+				await this.#syncSkillPromptActiveStateSafely(appMessage, true);
+				try {
+					await this.agent.prompt(appMessage);
+				} finally {
+					await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+				}
 				return;
 			}
 			this.agent.appendMessage(appMessage);
@@ -4594,7 +4615,12 @@ export class AgentSession {
 				this.#queueHiddenNextTurnMessage(appMessage, false);
 				return;
 			}
-			await this.agent.prompt(appMessage);
+			await this.#syncSkillPromptActiveStateSafely(appMessage, true);
+			try {
+				await this.agent.prompt(appMessage);
+			} finally {
+				await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+			}
 			return;
 		}
 

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
+export const SKILL_ACTIVE_STALE_MS = 24 * 60 * 60 * 1000;
 
 export const CANONICAL_GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
 
@@ -55,8 +56,23 @@ function safeString(value: unknown): string {
 	return typeof value === "string" ? value : "";
 }
 
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
 function entryKey(entry: Pick<SkillActiveEntry, "skill" | "session_id">): string {
 	return `${entry.skill}::${safeString(entry.session_id).trim()}`;
+}
+
+function timestampMs(value: string | undefined): number | null {
+	if (!value) return null;
+	const ms = Date.parse(value);
+	return Number.isFinite(ms) ? ms : null;
+}
+
+function isFreshEntry(entry: SkillActiveEntry, nowMs = Date.now()): boolean {
+	const ms = timestampMs(entry.updated_at) ?? timestampMs(entry.activated_at);
+	return ms === null || nowMs - ms <= SKILL_ACTIVE_STALE_MS;
 }
 
 function normalizeEntry(raw: unknown): SkillActiveEntry | null {
@@ -143,7 +159,7 @@ export function getSkillActiveStatePaths(cwd: string, sessionId?: string): Skill
 	if (!normalizedSessionId) return { rootPath };
 	return {
 		rootPath,
-		sessionPath: path.join(stateDir, "sessions", normalizedSessionId, SKILL_ACTIVE_STATE_FILE),
+		sessionPath: path.join(stateDir, "sessions", encodePathSegment(normalizedSessionId), SKILL_ACTIVE_STATE_FILE),
 	};
 }
 
@@ -169,9 +185,11 @@ function mergeVisibleEntries(
 	rootState: SkillActiveState | null,
 	sessionId?: string,
 ): SkillActiveEntry[] {
-	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId);
+	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId).filter(entry =>
+		isFreshEntry(entry),
+	);
 	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of listActiveSkills(sessionState)) {
+	for (const entry of listActiveSkills(sessionState).filter(entry => isFreshEntry(entry))) {
 		merged.set(entryKey(entry), entry);
 	}
 	return [...merged.values()];

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -59,6 +59,27 @@ describe("GJC native skill-state hooks", () => {
 		expect(modeState).toMatchObject({ active: true, current_phase: "interviewing", session_id: "session-1" });
 	});
 
+	it("encodes hook session ids before writing skill and mode state paths", async () => {
+		const root = await cwd();
+		await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "$team coordinate this",
+			cwd: root,
+			sessionId: "../../../escape",
+			threadId: "thread-safe",
+		});
+
+		const encodedSession = "%2E%2E%2F%2E%2E%2F%2E%2E%2Fescape";
+		const state = await readVisibleSkillActiveState(root, "../../../escape");
+		expect(state?.initialized_state_path).toBe(
+			path.join(root, ".gjc", "state", "sessions", encodedSession, "team-state.json"),
+		);
+		expect(
+			await fs.stat(path.join(root, ".gjc", "state", "sessions", encodedSession, "skill-active-state.json")),
+		).toBeDefined();
+		await expect(fs.stat(path.join(root, ".gjc", "escape"))).rejects.toThrow();
+	});
+
 	it("Stop blocks while matching skill state is active and allows terminal mode state", async () => {
 		const root = await cwd();
 		await dispatchGjcNativeSkillHook({

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -62,6 +62,15 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
+	it("encodes session ids before using them as state path segments", async () => {
+		await withTempCwd(async cwd => {
+			const paths = getSkillActiveStatePaths(cwd, "../escape/session");
+			expect(paths.sessionPath).toBe(
+				path.join(cwd, ".gjc", "state", "sessions", "%2E%2E%2Fescape%2Fsession", "skill-active-state.json"),
+			);
+		});
+	});
+
 	it("filters root fallback entries to the current session", async () => {
 		await withTempCwd(async cwd => {
 			await syncSkillActiveState({ cwd, skill: "team", active: true, phase: "running", sessionId: "sess-a" });
@@ -88,6 +97,20 @@ describe("GJC skill-active state", () => {
 			const sessionB = await readVisibleSkillActiveState(cwd, "sess-b");
 			expect(sessionA).toBeNull();
 			expect(sessionB?.active_skills?.map(entry => entry.session_id)).toEqual(["sess-b"]);
+		});
+	});
+
+	it("suppresses stale visible entries left by crashed sessions", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({
+				cwd,
+				skill: "team",
+				active: true,
+				sessionId: "sess-old",
+				nowIso: "2000-01-01T00:00:00.000Z",
+			});
+
+			expect(await readVisibleSkillActiveState(cwd, "sess-old")).toBeNull();
 		});
 	});
 


### PR DESCRIPTION
## Summary\n- encode skill-state session paths before writing root/session HUD and hook state\n- make skill prompt HUD activation message-scoped for queued/deferred/streaming delivery\n- preserve status-line preset settings while keeping HUD state observational\n\n## Verification\n- bun test packages/coding-agent/test/skill-active-state.test.ts packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts\n- bun --cwd=packages/coding-agent run check\n- bun scripts/check-visible-definitions.ts\n- bun scripts/verify-g002-gates.ts\n- git diff --check origin/dev\n\n## Independent review\n- code-reviewer: APPROVE; no blockers\n- architect: CLEAR; no blockers\n\nFollow-up to PR #16 review hardening.