### PR TITLE
Fix Korean IME cursor drift

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -26,7 +26,19 @@ const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 
 function sanitizeLoadedText(text: string): string {
 	// Normalize CRLF/CR → LF, then strip C0 control chars except \n.
-	return replaceTabs(text.replace(/\r\n?/g, "\n")).replace(/[\x00-\x09\x0b-\x1f]/g, "");
+	return replaceTabs(text.replace(/\r\n?/g, "\n"))
+		.replace(/[\x00-\x09\x0b-\x1f]/g, "")
+		.normalize("NFC");
+}
+
+function insertTextNfcAt(line: string, cursorCol: number, text: string): { line: string; cursorCol: number } {
+	const before = line.slice(0, cursorCol);
+	const after = line.slice(cursorCol);
+	const beforeWithInsert = (before + text).normalize("NFC");
+	return {
+		line: (beforeWithInsert + after).normalize("NFC"),
+		cursorCol: beforeWithInsert.length,
+	};
 }
 
 const segmenter = getSegmenter();
@@ -1466,11 +1478,10 @@ export class Editor implements Component, Focusable {
 		this.#recordUndoState();
 
 		const line = this.#state.lines[this.#state.cursorLine] || "";
-		const before = line.slice(0, this.#state.cursorCol);
-		const after = line.slice(this.#state.cursorCol);
+		const inserted = insertTextNfcAt(line, this.#state.cursorCol, text);
 
-		this.#state.lines[this.#state.cursorLine] = before + text + after;
-		this.#setCursorCol(this.#state.cursorCol + text.length);
+		this.#state.lines[this.#state.cursorLine] = inserted.line;
+		this.#setCursorCol(inserted.cursorCol);
 
 		if (this.onChange) {
 			this.onChange(this.getText());
@@ -1484,12 +1495,10 @@ export class Editor implements Component, Focusable {
 		this.#recordUndoState();
 
 		const line = this.#state.lines[this.#state.cursorLine] || "";
+		const inserted = insertTextNfcAt(line, this.#state.cursorCol, char);
 
-		const before = line.slice(0, this.#state.cursorCol);
-		const after = line.slice(this.#state.cursorCol);
-
-		this.#state.lines[this.#state.cursorLine] = before + char + after;
-		this.#setCursorCol(this.#state.cursorCol + char.length);
+		this.#state.lines[this.#state.cursorLine] = inserted.line;
+		this.#setCursorCol(inserted.cursorCol);
 
 		if (this.onChange) {
 			this.onChange(this.getText());
@@ -1939,15 +1948,14 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 		this.#recordUndoState();
 
-		const normalized = text.replace(/\r\n?/g, "\n");
+		const normalized = text.replace(/\r\n?/g, "\n").normalize("NFC");
 		const lines = normalized.split("\n");
 
 		if (lines.length === 1) {
 			const line = this.#state.lines[this.#state.cursorLine] || "";
-			const before = line.slice(0, this.#state.cursorCol);
-			const after = line.slice(this.#state.cursorCol);
-			this.#state.lines[this.#state.cursorLine] = before + normalized + after;
-			this.#setCursorCol(this.#state.cursorCol + normalized.length);
+			const inserted = insertTextNfcAt(line, this.#state.cursorCol, normalized);
+			this.#state.lines[this.#state.cursorLine] = inserted.line;
+			this.#setCursorCol(inserted.cursorCol);
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
@@ -1958,11 +1966,12 @@ export class Editor implements Component, Focusable {
 				newLines.push(this.#state.lines[i] || "");
 			}
 
-			newLines.push(beforeCursor + (lines[0] || ""));
+			newLines.push((beforeCursor + (lines[0] || "")).normalize("NFC"));
 			for (let i = 1; i < lines.length - 1; i++) {
 				newLines.push(lines[i] || "");
 			}
-			newLines.push((lines[lines.length - 1] || "") + afterCursor);
+			const finalLineBeforeAfter = (lines[lines.length - 1] || "").normalize("NFC");
+			newLines.push((finalLineBeforeAfter + afterCursor).normalize("NFC"));
 
 			for (let i = this.#state.cursorLine + 1; i < this.#state.lines.length; i++) {
 				newLines.push(this.#state.lines[i] || "");
@@ -1970,7 +1979,7 @@ export class Editor implements Component, Focusable {
 
 			this.#state.lines = newLines;
 			this.#state.cursorLine += lines.length - 1;
-			this.#setCursorCol((lines[lines.length - 1] || "").length);
+			this.#setCursorCol(finalLineBeforeAfter.length);
 		}
 
 		if (this.onChange) {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -20,7 +20,15 @@ interface InputState {
 	value: string;
 	cursor: number;
 }
-
+function insertTextNfcAt(value: string, cursor: number, text: string): { value: string; cursor: number } {
+	const before = value.slice(0, cursor);
+	const after = value.slice(cursor);
+	const beforeWithInsert = (before + text).normalize("NFC");
+	return {
+		value: (beforeWithInsert + after).normalize("NFC"),
+		cursor: beforeWithInsert.length,
+	};
+}
 /**
  * Input component - single-line text input with horizontal scrolling
  */
@@ -48,8 +56,9 @@ export class Input implements Component, Focusable {
 	}
 
 	setValue(value: string): void {
-		this.#value = value;
-		this.#cursor = Math.min(this.#cursor, value.length);
+		const normalized = value.normalize("NFC");
+		this.#value = normalized;
+		this.#cursor = Math.min(this.#cursor, normalized.length);
 	}
 
 	handleInput(data: string): void {
@@ -186,8 +195,9 @@ export class Input implements Component, Focusable {
 		}
 		this.#lastAction = "type-word";
 
-		this.#value = this.#value.slice(0, this.#cursor) + text + this.#value.slice(this.#cursor);
-		this.#cursor += text.length;
+		const inserted = insertTextNfcAt(this.#value, this.#cursor, text);
+		this.#value = inserted.value;
+		this.#cursor = inserted.cursor;
 	}
 
 	#handleBackspace(): void {
@@ -300,8 +310,9 @@ export class Input implements Component, Focusable {
 		}
 
 		this.#pushUndo();
-		this.#value = this.#value.slice(0, this.#cursor) + text + this.#value.slice(this.#cursor);
-		this.#cursor += text.length;
+		const inserted = insertTextNfcAt(this.#value, this.#cursor, text);
+		this.#value = inserted.value;
+		this.#cursor = inserted.cursor;
 		this.#lastAction = "yank";
 	}
 
@@ -318,8 +329,9 @@ export class Input implements Component, Focusable {
 
 		this.#killRing.rotate();
 		const text = this.#killRing.peek() ?? "";
-		this.#value = this.#value.slice(0, this.#cursor) + text + this.#value.slice(this.#cursor);
-		this.#cursor += text.length;
+		const inserted = insertTextNfcAt(this.#value, this.#cursor, text);
+		this.#value = inserted.value;
+		this.#cursor = inserted.cursor;
 		this.#lastAction = "yank";
 	}
 
@@ -374,8 +386,9 @@ export class Input implements Component, Focusable {
 		);
 
 		// Insert at cursor position
-		this.#value = this.#value.slice(0, this.#cursor) + cleanText + this.#value.slice(this.#cursor);
-		this.#cursor += cleanText.length;
+		const inserted = insertTextNfcAt(this.#value, this.#cursor, cleanText);
+		this.#value = inserted.value;
+		this.#cursor = inserted.cursor;
 	}
 
 	invalidate(): void {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -90,7 +90,10 @@ const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 export function getSegmenter(): Intl.Segmenter {
 	return segmenter;
 }
-
+function normalizeForWidth(str: string): string {
+	const normalized = str.normalize("NFC");
+	return normalized === str ? str : normalized;
+}
 export function visibleWidthRaw(str: string): number {
 	if (!str) {
 		return 0;
@@ -127,7 +130,7 @@ export function visibleWidthRaw(str: string): number {
 	if (isPureAscii) {
 		return str.length + tabLength;
 	}
-	return Bun.stringWidth(str) - jamoOvercount + tabLength;
+	return Bun.stringWidth(normalizeForWidth(str)) - jamoOvercount + tabLength;
 }
 
 /**

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -690,6 +690,40 @@ describe("Editor component", () => {
 			// Last line has cursor (|) which we need to strip
 			expect(contentLines[1]?.replace("|", "")).toBe("ト"); // 1 char = 2 columns (+ cursor + padding)
 		});
+		it("normalizes typed NFD Hangul so backspace removes one visible syllable", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			for (const char of "한") {
+				editor.handleInput(char);
+			}
+
+			expect(editor.getText()).toBe("한");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+
+			editor.handleInput("\x7f");
+
+			expect(editor.getText()).toBe("");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+		});
+
+		it("places terminal cursor after typed NFD Hangul at the NFC cell width", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setBorderVisible(false);
+			editor.setPromptGutter("> ");
+			editor.setUseTerminalCursor(true);
+			editor.focused = true;
+
+			for (const char of "한글") {
+				editor.handleInput(char);
+			}
+
+			const [line] = editor.render(20);
+			const markerIndex = line!.indexOf(CURSOR_MARKER);
+
+			expect(editor.getText()).toBe("한글");
+			expect(markerIndex).toBeGreaterThanOrEqual(0);
+			expect(visibleWidth(line!.slice(0, markerIndex))).toBe(2 + visibleWidth("한글"));
+		});
 
 		it("handles mixed ASCII and wide characters in wrapping", () => {
 			const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -197,6 +197,19 @@ describe("Input component", () => {
 		// Stored value must be NFC — no more NFD characters in the buffer.
 		expect(input.getValue()).toBe(nfcPath);
 	});
+	it("normalizes typed NFD Korean so backspace removes one visible syllable", () => {
+		const input = new Input();
+
+		for (const char of "한") {
+			input.handleInput(char);
+		}
+
+		expect(input.getValue()).toBe("한");
+
+		input.handleInput("\x7f");
+
+		expect(input.getValue()).toBe("");
+	});
 
 	it("NFC paste: cursor column matches visible cells (no displacement)", () => {
 		// Regression guard for the "cursor floats past the filename" bug.

--- a/packages/tui/test/visible-width-jamo.test.ts
+++ b/packages/tui/test/visible-width-jamo.test.ts
@@ -62,6 +62,14 @@ describe("visibleWidth — Hangul Compatibility Jamo correction", () => {
 		expect(visibleWidth("\uac00")).toBe(2); // 가
 		expect(visibleWidth("\ud7a3")).toBe(2); // 힣
 	});
+	it("conjoining jamo sequences use NFC terminal width", () => {
+		// Some macOS input paths deliver Hangul syllables as conjoining jamo
+		// (NFD). Terminals render them as the composed syllable, so width must
+		// match NFC or the hardware cursor drifts one cell per syllable.
+		expect(visibleWidth("하")).toBe(2);
+		expect(visibleWidth("한")).toBe(2);
+		expect(visibleWidth("한글")).toBe(4);
+	});
 
 	it("mixed ASCII + syllable + jamo strings add correctly", () => {
 		// a (1) + 안 (2) + ㅂ (1) + b (1) = 5


### PR DESCRIPTION
## Summary
- Normalize typed Korean NFD/conjoining-jamo text to NFC in TUI editor/input buffers
- Calculate visible width for conjoining-jamo sequences using NFC terminal width
- Add regression tests for Korean IME cursor placement and backspace behavior

## Verification
- bun test packages/tui/test/visible-width-jamo.test.ts packages/tui/test/editor.test.ts packages/tui/test/input.test.ts
- bun run check:ts