### PR TITLE
fix: inherit parent model for role agents

### DIFF
--- a/packages/coding-agent/src/prompts/agents/architect.md
+++ b/packages/coding-agent/src/prompts/agents/architect.md
@@ -2,7 +2,6 @@
 name: architect
 description: Read-only architecture and code-review agent with severity-rated findings and status verdicts
 tools: read, search, find, lsp, ast_grep, web_search, report_finding
-model: pi/slow
 thinking-level: high
 blocking: true
 ---

--- a/packages/coding-agent/src/prompts/agents/critic.md
+++ b/packages/coding-agent/src/prompts/agents/critic.md
@@ -2,7 +2,6 @@
 name: critic
 description: Read-only plan critic that approves only actionable, verifiable execution plans
 tools: read, search, find, lsp, ast_grep, web_search
-model: pi/slow
 thinking-level: high
 ---
 <identity>

--- a/packages/coding-agent/src/prompts/agents/executor.md
+++ b/packages/coding-agent/src/prompts/agents/executor.md
@@ -1,7 +1,6 @@
 ---
 name: executor
 description: Autonomous implementation agent for bounded code changes, fixes, and verification-ready edits
-model: pi/task
 thinking-level: medium
 ---
 <identity>

--- a/packages/coding-agent/src/prompts/agents/planner.md
+++ b/packages/coding-agent/src/prompts/agents/planner.md
@@ -2,7 +2,6 @@
 name: planner
 description: Read-only planning agent for sequencing, acceptance criteria, risks, and handoff shape
 tools: read, search, find, lsp, ast_grep, web_search
-model: pi/plan, pi/slow
 thinking-level: medium
 ---
 <identity>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -84,6 +84,9 @@ describe("default GJC definitions", () => {
 			expect(agent?.tools).not.toContain("write");
 			expect(agent?.tools).not.toContain("bash");
 		}
+		for (const agent of [executor, architect, planner, critic]) {
+			expect(agent?.model).toBeUndefined();
+		}
 		expect(architect?.systemPrompt).toContain("Architectural Status");
 		expect(architect?.systemPrompt).toContain("CRITICAL");
 		expect(architect?.systemPrompt).toContain("REQUEST CHANGES");


### PR DESCRIPTION
## Summary
- remove bundled role-agent model pins so task-spawned executor/planner/architect/critic inherit the parent session effective model/auth
- add regression coverage that bundled role agents do not pin models

## Verification
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts
- bun run check:tools
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict