### PR TITLE
Fix ultragoal goal autoset for active GJC sessions

### DIFF
--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -1,7 +1,9 @@
 import { Command } from "@gajae-code/utils/cli";
 import {
+	GJC_SESSION_FILE_ENV,
 	isUltragoalCreateGoalsInvocation,
 	readUltragoalCodexObjective,
+	writeCurrentSessionGoalModeState,
 	writePendingGoalModeRequest,
 } from "../gjc-runtime/goal-mode-request";
 import { runGjcRuntimeBridge } from "./gjc-runtime-bridge";
@@ -20,6 +22,12 @@ export default class Ultragoal extends Command {
 
 		const cwd = process.cwd();
 		const { objective, goalsPath } = await readUltragoalCodexObjective(cwd);
-		await writePendingGoalModeRequest({ cwd, objective, goalsPath });
+		const sessionWrite = await writeCurrentSessionGoalModeState({
+			sessionFile: process.env[GJC_SESSION_FILE_ENV],
+			objective,
+		});
+		if (sessionWrite.status !== "existing_goal") {
+			await writePendingGoalModeRequest({ cwd, objective, goalsPath });
+		}
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -1,5 +1,14 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { Snowflake } from "@gajae-code/utils";
+import type { Goal, GoalModeState } from "../goals/state";
+import {
+	buildSessionContext,
+	loadEntriesFromFile,
+	type ModeChangeEntry,
+	type SessionEntry,
+} from "../session/session-manager";
+
 export const GJC_SESSION_FILE_ENV = "GJC_SESSION_FILE";
 export const GJC_SESSION_ID_ENV = "GJC_SESSION_ID";
 export const GJC_SESSION_CWD_ENV = "GJC_SESSION_CWD";
@@ -16,6 +25,11 @@ export interface PendingGoalModeRequest {
 	createdAt: string;
 	goalsPath?: string;
 }
+
+export type CurrentSessionGoalModeWriteResult =
+	| { status: "unavailable"; reason: "missing_session_file" | "empty_session_file" }
+	| { status: "existing_goal"; goal: Goal }
+	| { status: "updated"; goal: Goal; sessionFile: string };
 
 interface UltragoalPlanShape {
 	codexObjective?: unknown;
@@ -77,6 +91,87 @@ export async function writePendingGoalModeRequest(input: {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await Bun.write(filePath, `${JSON.stringify(request, null, 2)}\n`);
 	return request;
+}
+
+function goalFromModeData(modeData: Record<string, unknown> | undefined): Goal | null {
+	const candidate = modeData?.goal;
+	if (typeof candidate !== "object" || candidate === null) return null;
+	const goal = candidate as Partial<Goal>;
+	if (
+		typeof goal.id !== "string" ||
+		typeof goal.objective !== "string" ||
+		typeof goal.status !== "string" ||
+		typeof goal.tokensUsed !== "number" ||
+		typeof goal.timeUsedSeconds !== "number" ||
+		typeof goal.createdAt !== "number" ||
+		typeof goal.updatedAt !== "number"
+	) {
+		return null;
+	}
+	if (!["active", "paused", "budget-limited", "complete", "dropped"].includes(goal.status)) {
+		return null;
+	}
+	return goal as Goal;
+}
+
+function isNonTerminalGoal(goal: Goal | null): goal is Goal {
+	return goal !== null && goal.status !== "complete" && goal.status !== "dropped";
+}
+
+function createGoalModeState(objective: string): GoalModeState {
+	const now = Date.now();
+	const goal: Goal = {
+		id: String(Snowflake.next()),
+		objective,
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: now,
+		updatedAt: now,
+	};
+	return { enabled: true, mode: "active", goal };
+}
+
+function nextSessionEntryId(entries: readonly SessionEntry[]): string {
+	const existing = new Set(entries.map(entry => entry.id));
+	for (let index = 0; index < 100; index++) {
+		const id = crypto.randomUUID().slice(-8);
+		if (!existing.has(id)) return id;
+	}
+	return String(Snowflake.next());
+}
+
+export async function writeCurrentSessionGoalModeState(input: {
+	sessionFile?: string | null;
+	objective: string;
+}): Promise<CurrentSessionGoalModeWriteResult> {
+	const sessionFile = input.sessionFile?.trim();
+	if (!sessionFile) return { status: "unavailable", reason: "missing_session_file" };
+
+	const objective = input.objective.trim();
+	if (!objective) throw new Error("goal objective is required");
+
+	const fileEntries = await loadEntriesFromFile(sessionFile);
+	const entries = fileEntries.filter((entry): entry is SessionEntry => entry.type !== "session");
+	if (fileEntries.length === 0) return { status: "unavailable", reason: "empty_session_file" };
+
+	const context = buildSessionContext(entries);
+	const existingGoal = goalFromModeData(context.modeData);
+	if ((context.mode === "goal" || context.mode === "goal_paused") && isNonTerminalGoal(existingGoal)) {
+		return { status: "existing_goal", goal: existingGoal };
+	}
+
+	const state = createGoalModeState(objective);
+	const entry: ModeChangeEntry = {
+		type: "mode_change",
+		id: nextSessionEntryId(entries),
+		parentId: entries.at(-1)?.id ?? null,
+		timestamp: new Date().toISOString(),
+		mode: "goal",
+		data: { goal: state.goal },
+	};
+	await fs.appendFile(sessionFile, `${JSON.stringify(entry)}\n`);
+	return { status: "updated", goal: state.goal, sessionFile };
 }
 
 export async function consumePendingGoalModeRequest(cwd: string): Promise<PendingGoalModeRequest | null> {

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -5,8 +5,14 @@ import {
 	consumePendingGoalModeRequest,
 	isUltragoalCreateGoalsInvocation,
 	readUltragoalCodexObjective,
+	writeCurrentSessionGoalModeState,
 	writePendingGoalModeRequest,
 } from "@gajae-code/coding-agent/gjc-runtime/goal-mode-request";
+import {
+	buildSessionContext,
+	loadEntriesFromFile,
+	type SessionEntry,
+} from "@gajae-code/coding-agent/session/session-manager";
 
 const tempRoots: string[] = [];
 
@@ -51,6 +57,83 @@ describe("GJC ultragoal goal mode request", () => {
 		expect(request?.objective).toBe("Complete ultragoal");
 		expect(request?.source).toBe("ultragoal");
 		expect(consumedAgain).toBeNull();
+	});
+
+	it("writes goal mode state into the current session file", async () => {
+		const root = await tempDir();
+		const sessionFile = path.join(root, "session.jsonl");
+		const timestamp = new Date().toISOString();
+		await Bun.write(
+			sessionFile,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "session-1", timestamp, cwd: root }),
+				JSON.stringify({
+					type: "message",
+					id: "user-1",
+					parentId: null,
+					timestamp,
+					message: { role: "user", content: [{ type: "text", text: "start ultragoal" }] },
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const result = await writeCurrentSessionGoalModeState({
+			sessionFile,
+			objective: "Complete generated ultragoal plan",
+		});
+		const entries = (await loadEntriesFromFile(sessionFile)).filter(
+			(entry): entry is SessionEntry => entry.type !== "session",
+		);
+		const context = buildSessionContext(entries);
+
+		expect(result.status).toBe("updated");
+		expect(context.mode).toBe("goal");
+		expect(context.modeData?.goal).toMatchObject({
+			objective: "Complete generated ultragoal plan",
+			status: "active",
+			tokensUsed: 0,
+		});
+	});
+
+	it("does not overwrite an existing active session goal", async () => {
+		const root = await tempDir();
+		const sessionFile = path.join(root, "session.jsonl");
+		const timestamp = new Date().toISOString();
+		const existingGoal = {
+			id: "goal-1",
+			objective: "Existing goal",
+			status: "active" as const,
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: 1,
+			updatedAt: 1,
+		};
+		await Bun.write(
+			sessionFile,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "session-1", timestamp, cwd: root }),
+				JSON.stringify({
+					type: "mode_change",
+					id: "mode-1",
+					parentId: null,
+					timestamp,
+					mode: "goal",
+					data: { goal: existingGoal },
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const before = await Bun.file(sessionFile).text();
+		const result = await writeCurrentSessionGoalModeState({
+			sessionFile,
+			objective: "New ultragoal objective",
+		});
+		const after = await Bun.file(sessionFile).text();
+
+		expect(result).toEqual({ status: "existing_goal", goal: existingGoal });
+		expect(after).toBe(before);
 	});
 
 	it("surfaces corrupt pending request json", async () => {


### PR DESCRIPTION
## Summary
- Persist successful `gjc ultragoal create-goals` activation into the current GJC session file when `GJC_SESSION_FILE` is available.
- Keep the existing pending goal-mode request handoff so the active runtime can still consume and enable goal tooling.
- Avoid overwriting existing nonterminal goal-mode state.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts packages/coding-agent/test/gjc-runtime-bridge.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Fake-runtime CLI smoke with `GJC_SESSION_FILE` and `GJC_RUNTIME_BINARY`

## Notes
- This does not reimplement the private Ultragoal runtime endpoint; it fixes the GJC-owned goal-mode session seeding around successful runtime delegation.