### PR TITLE
Keep IRC available for detached subagents

### DIFF
--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -11,7 +11,7 @@ import { GoalTool } from "../goals/tools/goal-tool";
 import type { HindsightSessionState } from "../hindsight/state";
 import { LspTool } from "../lsp";
 import type { PlanModeState } from "../plan-mode/state";
-import { type AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import type { AgentRegistry } from "../registry/agent-registry";
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
@@ -460,9 +460,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
 		if (name === "irc") {
 			if (!session.settings.get("irc.enabled")) return false;
-			// Main agent only needs `irc` when subagents may run concurrently (async).
-			// In sync mode main blocks on `task`, so peer messaging from main is dead weight.
-			if (!session.settings.get("async.enabled") && session.getAgentId?.() === MAIN_AGENT_ID) return false;
+			// Task subagents now detach regardless of async.enabled, so the main agent
+			// may need IRC coordination whenever IRC itself is enabled.
 			return true;
 		}
 		if (name === "recipe") return session.settings.get("recipe.enabled");

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Settings } from "../../src/config/settings";
+import { AgentRegistry, MAIN_AGENT_ID } from "../../src/registry/agent-registry";
 import type { ToolSession } from "../../src/tools/index";
 import {
 	AskTool,
@@ -76,6 +77,19 @@ describe("BUILTIN_TOOLS public factory map", () => {
 
 		expect(tools.some(tool => tool.name === "job")).toBe(true);
 		expect(tools.some(tool => tool.name === "subagent")).toBe(true);
+	});
+
+	it("keeps IRC available for main-agent coordination when detached subagents run with async disabled", async () => {
+		const session = {
+			...toolSession,
+			agentRegistry: new AgentRegistry(),
+			getAgentId: () => MAIN_AGENT_ID,
+			settings: Settings.isolated({ "async.enabled": false, "irc.enabled": true }),
+		};
+
+		const tools = await createTools(session, ["irc"]);
+
+		expect(tools.some(tool => tool.name === "irc")).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary\n- keeps the IRC tool available whenever irc.enabled is true, even if async.enabled is false\n- adds regression coverage for detached subagent coordination with async disabled\n- merges current dev before validation\n\n## Verification\n- bun test packages/coding-agent/test/tool-discovery/initial-tools.test.ts packages/coding-agent/test/tools/subagent.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts\n- bun --cwd=packages/coding-agent run check\n- bun --cwd=packages/coding-agent run build && ./packages/coding-agent/dist/gjc --version && ./packages/coding-agent/dist/gjc --smoke-test\n\n## Notes\nFollow-up to PR #24 after architecture review found a stale async.enabled IRC gate.