### PR TITLE
Fix GJC worktree launch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixed
 
+- Fixed root `gjc --worktree` / `gjc -w` startup so the launch command actually creates and enters the sibling `<repo>.gajae-code-worktrees/<branch-slug>` git worktree before starting the session, using collision-resistant branch slugs and avoiding worktree side effects for help/version launches.
 - Wired GJC native UserPromptSubmit/Stop skill-state hooks, including `gjc setup hooks`, so public workflow keywords activate `.gjc/state`, active skill state can block premature Stop events, and active Ultragoal sessions remind steering prompts to use `gjc ultragoal steer`.
 - Fixed `gjc ultragoal create-goals` to seed GJC goal mode runtime state automatically, avoiding a separate manual `/goal` setup step.
 - Fixed legacy Pi plugin import remapping and stale GJC config-path tests so rebranded `.gjc` discovery contracts pass while preserving legacy compatibility.

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -3,10 +3,11 @@
  */
 
 import { THINKING_EFFORTS } from "@gajae-code/ai";
-import { APP_NAME } from "@gajae-code/utils";
+import { APP_NAME, setProjectDir } from "@gajae-code/utils";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
 import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
+import { prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
 
@@ -132,6 +133,7 @@ export default class Index extends Command {
 		`# Include files in initial message\n  ${APP_NAME} @prompt.md @image.png "What color is the sky?"`,
 		`# Non-interactive mode (process and exit)\n  ${APP_NAME} -p "List all .ts files in src/"`,
 		`# Continue previous session\n  ${APP_NAME} --continue "What did we discuss?"`,
+		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,
@@ -141,8 +143,19 @@ export default class Index extends Command {
 
 	async run(): Promise<void> {
 		const { args } = prepareAcpTerminalAuthArgs(this.argv);
-		const parsed = parseArgs(args);
-		if (launchDefaultTmuxIfNeeded({ parsed, rawArgs: args })) return;
-		await runRootCommand(parsed, args);
+		const parsed = parseArgs([...args]);
+		if (parsed.help || parsed.version) {
+			await runRootCommand(parsed, args);
+			return;
+		}
+
+		const launch = prepareLaunchWorktree(process.cwd(), args);
+		if (launch.worktree.enabled) {
+			process.chdir(launch.cwd);
+			setProjectDir(launch.cwd);
+		}
+		const launchParsed = parseArgs(launch.args);
+		if (launchDefaultTmuxIfNeeded({ parsed: launchParsed, rawArgs: launch.args, cwd: launch.cwd })) return;
+		await runRootCommand(launchParsed, launch.args);
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -49,12 +50,20 @@ function tryRunGit(cwd: string, args: string[]): string | null {
 }
 
 function sanitizePathToken(value: string): string {
-	const normalized = value
+	const readable = value
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/-+/g, "-")
 		.replace(/^-|-$/g, "");
-	return normalized || "default";
+	const prefix = readable || "default";
+	const digest = crypto.createHash("sha256").update(value).digest("hex").slice(0, 8);
+	return `${prefix}-${digest}`;
+}
+
+function resolveSourceBranchSlug(repoRoot: string, baseRef: string): string {
+	const branch = tryRunGit(repoRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+	if (branch) return sanitizePathToken(branch);
+	return `head-${baseRef.slice(0, 12)}`;
 }
 
 function branchExists(repoRoot: string, branchName: string): boolean {
@@ -146,13 +155,7 @@ export function parseLaunchWorktreeMode(args: string[]): ParsedLaunchWorktreeMod
 			continue;
 		}
 		if (arg === "-w") {
-			const next = args[index + 1];
-			if (typeof next === "string" && next.length > 0 && !next.startsWith("-") && !next.includes(":")) {
-				mode = { enabled: true, detached: false, name: next };
-				index += 1;
-			} else {
-				mode = { enabled: true, detached: true, name: null };
-			}
+			mode = { enabled: true, detached: true, name: null };
 			continue;
 		}
 		if (arg.startsWith("--worktree=")) {
@@ -180,10 +183,9 @@ export function planLaunchWorktree(
 	const baseRef = runGit(repoRoot, ["rev-parse", "HEAD"]);
 	const branchName = mode.detached ? null : mode.name;
 	if (branchName) validateBranchName(repoRoot, branchName);
-	const bucket = `${path.basename(repoRoot)}.gjc-worktrees`;
-	const worktreePath = mode.detached
-		? path.join(path.dirname(repoRoot), bucket, "launch-detached")
-		: path.join(path.dirname(repoRoot), bucket, `launch-${sanitizePathToken(mode.name)}`);
+	const bucket = `${path.basename(repoRoot)}.gajae-code-worktrees`;
+	const worktreeSlug = mode.detached ? resolveSourceBranchSlug(repoRoot, baseRef) : sanitizePathToken(mode.name);
+	const worktreePath = path.join(path.dirname(repoRoot), bucket, worktreeSlug);
 	return { enabled: true, repoRoot, worktreePath, detached: mode.detached, baseRef, branchName };
 }
 

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -19,6 +20,17 @@ function run(command: string, args: string[], cwd: string): string {
 	throw new Error(result.stderr.toString().trim() || `${command} ${args.join(" ")} failed`);
 }
 
+function testSlug(value: string): string {
+	const readable = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+	const prefix = readable || "default";
+	const digest = crypto.createHash("sha256").update(value).digest("hex").slice(0, 8);
+	return `${prefix}-${digest}`;
+}
+
 async function createRepo(prefix: string): Promise<string> {
 	const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 	cleanupRoots.push(root);
@@ -33,13 +45,14 @@ async function createRepo(prefix: string): Promise<string> {
 
 afterEach(async () => {
 	for (const root of cleanupRoots.splice(0)) {
-		const bucket = path.join(path.dirname(root), `${path.basename(root)}.gjc-worktrees`);
-		Bun.spawnSync(["git", "worktree", "remove", "--force", path.join(bucket, "launch-detached")], {
+		const bucket = path.join(path.dirname(root), `${path.basename(root)}.gajae-code-worktrees`);
+		const branchSlug = testSlug(run("git", ["branch", "--show-current"], root));
+		Bun.spawnSync(["git", "worktree", "remove", "--force", path.join(bucket, branchSlug)], {
 			cwd: root,
 			stdout: "ignore",
 			stderr: "ignore",
 		});
-		Bun.spawnSync(["git", "worktree", "remove", "--force", path.join(bucket, "launch-feature-demo")], {
+		Bun.spawnSync(["git", "worktree", "remove", "--force", path.join(bucket, "feature-demo")], {
 			cwd: root,
 			stdout: "ignore",
 			stderr: "ignore",
@@ -64,7 +77,11 @@ describe("default launch worktrees", () => {
 			mode: { enabled: true, detached: false, name: "feature/demo" },
 			remainingArgs: ["hello"],
 		});
-		expect(parseLaunchWorktreeMode(["-w", "feature/demo", "hello"])).toEqual({
+		expect(parseLaunchWorktreeMode(["-w", "hello"])).toEqual({
+			mode: { enabled: true, detached: true, name: null },
+			remainingArgs: ["hello"],
+		});
+		expect(parseLaunchWorktreeMode(["-w=feature/demo", "hello"])).toEqual({
 			mode: { enabled: true, detached: false, name: "feature/demo" },
 			remainingArgs: ["hello"],
 		});
@@ -75,7 +92,8 @@ describe("default launch worktrees", () => {
 		await fs.mkdir(path.join(repo, "node_modules"));
 
 		const first = prepareLaunchWorktree(repo, ["--worktree", "hello"]);
-		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gjc-worktrees`, "launch-detached");
+		const branchSlug = testSlug(run("git", ["branch", "--show-current"], repo));
+		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`, branchSlug);
 
 		expect(await fs.realpath(first.cwd)).toBe(await fs.realpath(expectedPath));
 		expect(first.args).toEqual(["hello"]);
@@ -121,17 +139,43 @@ describe("default launch worktrees", () => {
 		const repo = await createRepo("gjc-launch-named-worktree-");
 		const planned = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });
 		const ensured = ensureLaunchWorktree(planned);
-		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gjc-worktrees`, "launch-feature-demo");
+		const expectedPath = path.join(
+			path.dirname(repo),
+			`${path.basename(repo)}.gajae-code-worktrees`,
+			testSlug("feature/demo"),
+		);
 
 		expect(ensured.enabled && (await fs.realpath(ensured.worktreePath))).toBe(await fs.realpath(expectedPath));
 		expect(ensured.enabled && ensured.branchName).toBe("feature/demo");
 		expect(run("git", ["branch", "--show-current"], expectedPath)).toBe("feature/demo");
 	});
 
-	it("uses the source repo and launch worktree in generated tmux session names", async () => {
+	it("keeps launch worktree slugs collision-resistant for similar branch names", async () => {
+		const repo = await createRepo("gjc-launch-collision-worktree-");
+		const slashPlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });
+		const dashPlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature-demo" });
+		const casePlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "Feature" });
+		const lowerPlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature" });
+		const unicodePlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "é" });
+		const asciiPlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "e9" });
+
+		expect(slashPlan.enabled && slashPlan.worktreePath.endsWith(testSlug("feature/demo"))).toBe(true);
+		expect(dashPlan.enabled && dashPlan.worktreePath.endsWith(testSlug("feature-demo"))).toBe(true);
+		expect(slashPlan.enabled && dashPlan.enabled && slashPlan.worktreePath).not.toBe(
+			dashPlan.enabled && dashPlan.worktreePath,
+		);
+		expect(casePlan.enabled && lowerPlan.enabled && casePlan.worktreePath).not.toBe(
+			lowerPlan.enabled && lowerPlan.worktreePath,
+		);
+		expect(unicodePlan.enabled && asciiPlan.enabled && unicodePlan.worktreePath).not.toBe(
+			asciiPlan.enabled && asciiPlan.worktreePath,
+		);
+	});
+
+	it("uses the launch worktree as the generated tmux cwd", async () => {
 		const repo = await createRepo("gjc-session-worktree-");
 		const launch = prepareLaunchWorktree(repo, ["--worktree"]);
-		const parsed = { messages: [], fileArgs: [], unknownFlags: new Map() } satisfies Args;
+		const parsed = { messages: [], fileArgs: [], unknownFlags: new Map(), tmux: true } satisfies Args;
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed,
 			rawArgs: launch.args,
@@ -144,7 +188,7 @@ describe("default launch worktrees", () => {
 			tmuxAvailable: true,
 		});
 
-		expect(plan?.sessionName).toContain(`${path.basename(repo).toLowerCase()}-launch-detached-head`);
+		expect(plan?.cwd).toBe(launch.cwd);
 		expect(plan?.newSessionArgs).toContain(launch.cwd);
 	});
 });


### PR DESCRIPTION
## Summary
- wire root `gjc --worktree` / `gjc -w` launch through worktree preparation before session startup
- create/reuse sibling `<repo>.gajae-code-worktrees/<branch-slug>` directories and start from that cwd
- make branch slugs readable but collision-resistant; keep help/version side-effect free

## Verification
- `bun run --cwd packages/coding-agent check`
- `bun test packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- live `prepareLaunchWorktree` smoke with a temporary git repo created a real sibling `.gajae-code-worktrees/main-0d6e4079` worktree and stripped args to `["hello"]`

## Review
- code-reviewer: APPROVE
- architect: CLEAR

## Note
- Full source CLI smoke was not run because local native addon build was terminated by SIGKILL in this environment.