### PR TITLE
fix Korean jamo terminal width rendering

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -380,15 +380,6 @@ const fn ascii_cell_width_u16(u: u16, tab_width: usize) -> usize {
 
 #[inline]
 fn char_width_corrected(c: char) -> Option<usize> {
-	// Hangul Compatibility Jamo U+3131..=U+318E render as a single cell in
-	// the terminals we ship to (Ghostty, Terminal.app, iTerm2) even though
-	// UAX#11 classifies them as Wide. Mirrors the TS-side correction in
-	// packages/tui/src/utils.ts (visibleWidth). U+318F is reserved and
-	// intentionally excluded.
-	let cp = c as u32;
-	if (0x3131..=0x318e).contains(&cp) {
-		return Some(1);
-	}
 	UnicodeWidthChar::width(c)
 }
 
@@ -404,9 +395,9 @@ fn grapheme_width_str(g: &str, tab_width: usize) -> usize {
 	if it.next().is_none() {
 		return char_width_corrected(c0).unwrap_or(0);
 	}
-	// Multi-char grapheme: sum per-char corrected widths so the jamo
-	// override applies even inside combining clusters. Matches what
-	// UnicodeWidthStr would compute, minus the UAX#11 jamo bias.
+	// Multi-char grapheme: sum per-char widths. Conjoining Hangul jamo are
+	// kept in grapheme clusters by unicode-segmentation, and their summed
+	// width matches the NFC syllable width terminals render.
 	g.chars()
 		.map(|c| char_width_corrected(c).unwrap_or(0))
 		.sum()

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1029,6 +1029,15 @@ export class TUI extends Container {
 		}
 		return lines;
 	}
+	#truncateLinesToWidth(lines: string[], width: number): string[] {
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			if (TERMINAL.isImageLine(line) || visibleWidth(line) <= width) continue;
+			const truncated = truncateToWidth(line, width, Ellipsis.Omit);
+			lines[i] = truncated + (truncated.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
+		}
+		return lines;
+	}
 
 	#doRender(): void {
 		if (this.#stopped) return;
@@ -1059,6 +1068,7 @@ export class TUI extends Container {
 		// because the marker is embedded mid-line, and before any diff/full render
 		// path so cache comparisons stay byte-accurate.
 		newLines = this.#applyLineResets(newLines);
+		newLines = this.#truncateLinesToWidth(newLines, width);
 
 		// Width changed - need full re-render (line wrapping changes)
 		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -103,34 +103,18 @@ export function visibleWidthRaw(str: string): number {
 	let tabLength = 0;
 	const tabWidth = getDefaultTabWidth();
 	let isPureAscii = true;
-	let jamoOvercount = 0;
 	for (let i = 0; i < str.length; i++) {
 		const code = str.charCodeAt(i);
 		if (code === 9) {
 			tabLength += tabWidth;
 		} else if (code < 0x20 || code > 0x7e) {
 			isPureAscii = false;
-			// Hangul Compatibility Jamo (U+3131..U+318E) is EAW=W per UAX#11,
-			// so `Bun.stringWidth` returns 2 for each — but every macOS
-			// terminal we ship to (Ghostty, Terminal.app, iTerm2) renders
-			// them as a single cell in monospace fonts. Without this
-			// correction every jamo a Korean IME emits during composition
-			// adds 1 cell of drift to `#extractCursorPosition`, displacing
-			// the hardware cursor (and therefore the IME candidate window)
-			// `N_jamo` cells past the visible glyph. Hangul Syllables
-			// (U+AC00..U+D7A3, e.g. `안`) are correctly 2 cells in both Bun
-			// and the terminal — leave those alone. The Halfwidth Hangul
-			// block (U+FFA0..U+FFDC) is already Narrow in Bun, so no
-			// correction needed there.
-			if (code >= 0x3131 && code <= 0x318e) {
-				jamoOvercount++;
-			}
 		}
 	}
 	if (isPureAscii) {
 		return str.length + tabLength;
 	}
-	return Bun.stringWidth(normalizeForWidth(str)) - jamoOvercount + tabLength;
+	return Bun.stringWidth(normalizeForWidth(str)) + tabLength;
 }
 
 /**

--- a/packages/tui/test/ime-jamo-cursor.test.ts
+++ b/packages/tui/test/ime-jamo-cursor.test.ts
@@ -1,34 +1,9 @@
 /**
- * Regression guard for Korean IME cursor positioning in the Input
- * component.
+ * Regression guard for Korean IME cursor positioning in the Input component.
  *
- * Background: macOS Korean IME (2-bul keyboard) emits Hangul Compatibility
- * Jamo (U+3131..U+318E) during composition. Before commit 79e3170c6 the
- * Input.render() computed `cursorCols = visibleWidth(value.slice(0,
- * cursorIndex))` and `Bun.stringWidth` returned 2 for each jamo (per UAX
- * #11 EAW=W), while every macOS terminal renders them as 1 cell.
- *
- * The user-visible bug was a GROWING horizontal gap between the typed
- * jamo and the IME candidate window — every additional jamo doubled the
- * offset because `cursorCols` was N×2 instead of N×1. With 14 jamo typed,
- * the gap was ~14 cells.
- *
- * After the JS-side width correction, `cursorCols` is N×1. The Rust
- * `pi-natives` `sliceWithWidth` still treats jamo as 2 cells (binary
- * package; follow-up), so the cursor marker placement in `Input.render()`
- * has a residual ≤1-cell-per-jamo offset — but the user-visible "growing
- * gap" is gone because the JS-side `cursorCols` no longer doubles.
- *
- * What this test guards:
- *   - The cursor column for a value containing N jamo is **bounded above
- *     by `PROMPT_WIDTH + N`** (the correct cell count after the fix).
- *     Before the fix it would have been ~`PROMPT_WIDTH + 2N`, which is
- *     what the test catches.
- *   - Pure-ASCII and Hangul-syllable baselines are unchanged.
- *
- * What this test does NOT guard:
- *   - The Rust-side `sliceWithWidth` jamo discrepancy. Tracked as a
- *     follow-up; will tighten this test once the Rust crate is rebuilt.
+ * Compatibility jamo (U+3131..U+318E) are terminal-wide glyphs, so the cursor
+ * column should advance by two cells per typed jamo. Conjoining jamo input is
+ * normalized to NFC elsewhere; this test covers the compatibility-jamo path.
  */
 import { describe, expect, it } from "bun:test";
 import { CURSOR_MARKER } from "@gajae-code/tui";
@@ -57,7 +32,7 @@ function cursorColAfterTyping(text: string, width = 80): number {
 
 const PROMPT_WIDTH = 2; // "> "
 
-describe("Input cursor column does not grow at 2× per jamo", () => {
+describe("Input cursor column tracks compatibility jamo width", () => {
 	it("ASCII baseline: cursor lands exactly after the typed text", () => {
 		expect(cursorColAfterTyping("hello")).toBe(PROMPT_WIDTH + 5);
 	});
@@ -66,26 +41,20 @@ describe("Input cursor column does not grow at 2× per jamo", () => {
 		expect(cursorColAfterTyping("안녕")).toBe(PROMPT_WIDTH + 4);
 	});
 
-	it("single jamo: cursor column is at most `PROMPT_WIDTH + 1`", () => {
-		// Before fix: PROMPT_WIDTH + 2 = 4. After fix: ≤ 3.
-		expect(cursorColAfterTyping("ㅁ")).toBeLessThanOrEqual(PROMPT_WIDTH + 1);
+	it("single compatibility jamo advances by 2 cells", () => {
+		expect(cursorColAfterTyping("ㅁ")).toBe(PROMPT_WIDTH + 2);
 	});
 
-	it("8 consecutive jamo: cursor column is at most `PROMPT_WIDTH + 8`", () => {
-		// Before fix: PROMPT_WIDTH + 16 = 18. After fix: ≤ 10.
-		expect(cursorColAfterTyping("ㅁㄴㅁㄴㅇㅂㄴㅂ")).toBeLessThanOrEqual(PROMPT_WIDTH + 8);
+	it("8 consecutive compatibility jamo advance by 16 cells", () => {
+		expect(cursorColAfterTyping("ㅁㄴㅁㄴㅇㅂㄴㅂ")).toBe(PROMPT_WIDTH + 16);
 	});
 
-	it("20 consecutive jamo: cursor column is at most `PROMPT_WIDTH + 20`", () => {
-		// Before fix: PROMPT_WIDTH + 40 = 42 (catastrophic gap). After fix: ≤ 22.
+	it("20 consecutive compatibility jamo advance by 40 cells", () => {
 		const jamo = "ㅁㄴㄷㅂㅈㅎㅋㅌㄱㄹ".repeat(2);
-		expect(cursorColAfterTyping(jamo)).toBeLessThanOrEqual(PROMPT_WIDTH + 20);
+		expect(cursorColAfterTyping(jamo, 120)).toBe(PROMPT_WIDTH + 40);
 	});
 
-	it("cursor column grows by ≤1 per typed jamo (not 2)", () => {
-		// The regression: each typed jamo would advance cursor by 2 columns
-		// instead of 1, doubling the offset every keystroke. Assert the
-		// per-step delta never exceeds 1.
+	it("cursor column grows by 2 per typed compatibility jamo", () => {
 		const input = new Input();
 		(input as unknown as { focused: boolean }).focused = true;
 		const jamo = "ㅁㄴㅇㅂㅈㅎㅋㅌㄷㄹ";
@@ -96,7 +65,7 @@ describe("Input cursor column does not grow at 2× per jamo", () => {
 			const markerIdx = line.indexOf(CURSOR_MARKER);
 			const col = visibleWidth(line.slice(0, markerIdx));
 			const delta = col - prevCol;
-			expect(delta).toBeLessThanOrEqual(1);
+			expect(delta).toBe(2);
 			prevCol = col;
 		}
 	});

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type Component, TUI } from "@gajae-code/tui";
+import { visibleWidth } from "@gajae-code/tui/utils";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class MutableLinesComponent implements Component {
@@ -232,6 +233,24 @@ describe("TUI terminal-state regressions", () => {
 				expect(viewport[0]!.length).toBeLessThanOrEqual(16);
 				expect(viewport[1]!.length).toBeLessThanOrEqual(16);
 				expect(viewport[2]?.trim()).toBe("");
+			} finally {
+				tui.stop();
+			}
+		});
+		it("truncates compatibility jamo before the terminal can auto-wrap them", async () => {
+			const term = new VirtualTerminal(10, 6);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(["ㅁ".repeat(20)]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const viewport = visible(term);
+				expect(viewport[0]).toBe("ㅁ".repeat(5));
+				expect(visibleWidth(viewport[0]!)).toBe(10);
+				expect(viewport[1]?.trim()).toBe("");
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/visible-width-jamo.test.ts
+++ b/packages/tui/test/visible-width-jamo.test.ts
@@ -1,54 +1,45 @@
 /**
- * Regression guard for the Hangul Compatibility Jamo width correction in
- * `visibleWidthRaw`.
+ * Regression guard for Hangul terminal width handling.
  *
- * `Bun.stringWidth` (and the underlying UAX#11 EAW tables) classify Hangul
- * Compatibility Jamo (U+3131..U+318E) as Wide (2 cells), but every macOS
- * terminal we ship to (Ghostty, Terminal.app, iTerm2) actually renders them
- * as a single cell. Without the correction, `#extractCursorPosition` doubles
- * the column count for every jamo emitted by a Korean IME during
- * composition, displacing the hardware cursor (and therefore the IME
- * candidate window) `N_jamo` cells past the actual glyph.
+ * Hangul Compatibility Jamo (U+3131..U+318E, e.g. `ㅁ`) are East Asian Wide
+ * and xterm-compatible terminals render them as 2 cells. Undercounting them
+ * lets the TUI write lines it believes fit while the terminal auto-wraps the
+ * row, producing the diagonal/pyramid Korean rendering failure.
  *
- * Hangul Syllables (U+AC00..U+D7A3, e.g. `안`) are correctly 2 cells in both
- * Bun and the terminal — make sure the fix did NOT regress that. The
- * Halfwidth Hangul block (U+FFA0..U+FFDC) is already classified as Narrow
- * by Bun, so it does not appear in the correction and the test below is a
- * regression sanity check.
+ * Conjoining jamo sequences (U+1100..U+11FF, e.g. `한`) are different:
+ * terminals render each grapheme cluster like its NFC syllable, so width
+ * measurement must normalize those sequences before calling Bun.stringWidth.
  */
 import { describe, expect, it } from "bun:test";
 import { Ellipsis, sliceWithWidth, truncateToWidth, visibleWidth } from "@gajae-code/tui/utils";
 
-describe("visibleWidth — Hangul Compatibility Jamo correction", () => {
-	it("single compatibility jamo is 1 cell (not 2)", () => {
+describe("visibleWidth — Hangul width parity", () => {
+	it("single compatibility jamo is 2 cells", () => {
 		// U+3141 HANGUL LETTER MIEUM
-		expect(visibleWidth("ㅁ")).toBe(1);
+		expect(visibleWidth("ㅁ")).toBe(2);
 		// U+3134 HANGUL LETTER NIEUN
-		expect(visibleWidth("ㄴ")).toBe(1);
+		expect(visibleWidth("ㄴ")).toBe(2);
 		// U+3147 HANGUL LETTER IEUNG
-		expect(visibleWidth("ㅇ")).toBe(1);
+		expect(visibleWidth("ㅇ")).toBe(2);
 		// U+3142 HANGUL LETTER PIEUP
-		expect(visibleWidth("ㅂ")).toBe(1);
+		expect(visibleWidth("ㅂ")).toBe(2);
 		// U+3148 HANGUL LETTER JIEUJ
-		expect(visibleWidth("ㅈ")).toBe(1);
+		expect(visibleWidth("ㅈ")).toBe(2);
 	});
 
-	it("range edges U+3131 and U+318E are corrected", () => {
+	it("range edges U+3131 and U+318E are wide", () => {
 		// U+3131 HANGUL LETTER KIYEOK — first jamo in the block
-		expect(visibleWidth("\u3131")).toBe(1);
+		expect(visibleWidth("\u3131")).toBe(2);
 		// U+318E HANGUL LETTER ARAEAE — last jamo in the block
-		expect(visibleWidth("\u318e")).toBe(1);
+		expect(visibleWidth("\u318e")).toBe(2);
 	});
 
-	it("U+3164 HANGUL FILLER (inside the corrected range) is 1 cell", () => {
-		// Often emitted by IME for empty-syllable placeholders.
-		expect(visibleWidth("\u3164")).toBe(1);
+	it("U+3164 HANGUL FILLER is 2 cells", () => {
+		expect(visibleWidth("\u3164")).toBe(2);
 	});
 
-	it("string of 8 consecutive jamo is 8 cells, not 16", () => {
-		// Matches the user-typed sequence in the v2 screen recording —
-		// before the fix this returned 16 and produced an 8-cell gap.
-		expect(visibleWidth("ㅁㄴㅁㄴㅇㅂㄴㅂ")).toBe(8);
+	it("string of 8 consecutive compatibility jamo is 16 cells", () => {
+		expect(visibleWidth("ㅁㄴㅁㄴㅇㅂㄴㅂ")).toBe(16);
 	});
 
 	it("Hangul Syllables (U+AC00..U+D7A3) stay at 2 cells", () => {
@@ -62,6 +53,7 @@ describe("visibleWidth — Hangul Compatibility Jamo correction", () => {
 		expect(visibleWidth("\uac00")).toBe(2); // 가
 		expect(visibleWidth("\ud7a3")).toBe(2); // 힣
 	});
+
 	it("conjoining jamo sequences use NFC terminal width", () => {
 		// Some macOS input paths deliver Hangul syllables as conjoining jamo
 		// (NFD). Terminals render them as the composed syllable, so width must
@@ -72,10 +64,10 @@ describe("visibleWidth — Hangul Compatibility Jamo correction", () => {
 	});
 
 	it("mixed ASCII + syllable + jamo strings add correctly", () => {
-		// a (1) + 안 (2) + ㅂ (1) + b (1) = 5
-		expect(visibleWidth("a안ㅂb")).toBe(5);
-		// 11 ASCII letters + 1 syllable + 4 jamo = 11 + 2 + 4 = 17
-		expect(visibleWidth("hello world안ㅁㄴㅇㅂ")).toBe(11 + 2 + 4);
+		// a (1) + 안 (2) + ㅂ (2) + b (1) = 6
+		expect(visibleWidth("a안ㅂb")).toBe(6);
+		// 11 ASCII letters + 1 syllable + 4 jamo = 11 + 2 + 8 = 21
+		expect(visibleWidth("hello world안ㅁㄴㅇㅂ")).toBe(11 + 2 + 8);
 	});
 
 	it("does not regress ASCII fast path or empty input", () => {
@@ -103,35 +95,23 @@ describe("visibleWidth — Hangul Compatibility Jamo correction", () => {
 	});
 });
 
-describe("native text helpers — Hangul Compatibility Jamo correction", () => {
-	// These exercise the Rust-side `char_width_corrected` wrapper in
-	// crates/pi-natives/src/text.rs. They will fail until the native
-	// binding is rebuilt (`bun run build:native`); CI rebuilds natives so
-	// they pass there. Mirrors the TS-side range U+3131..=U+318E.
-
-	it("sliceWithWidth treats jamo as 1 cell per character", () => {
-		// 8 jamo at 1 cell each must fit fully in an 8-cell slice
-		// (pre-fix: native counted 2 cells/jamo and returned 4 chars).
+describe("native text helpers — Hangul Compatibility Jamo width parity", () => {
+	it("sliceWithWidth treats jamo as 2 cells per character", () => {
 		const input = "ㅁ".repeat(8);
 		const { text, width } = sliceWithWidth(input, 0, 8, true);
-		expect(text).toBe(input);
+		expect(text).toBe("ㅁ".repeat(4));
 		expect(width).toBe(8);
 	});
 
-	it("truncateToWidth keeps 8 jamo within an 8-cell budget", () => {
-		// Pre-fix: native truncated to 4 jamo because each was 2 cells.
+	it("truncateToWidth keeps 4 jamo within an 8-cell budget", () => {
 		const result = truncateToWidth("ㅁ".repeat(20), 8, Ellipsis.Omit);
-		// Strip any trailing pad to count jamo content.
 		const jamo = result.replaceAll(/[^\u3131-\u318E]/g, "");
-		expect(jamo.length).toBe(8);
+		expect(jamo.length).toBe(4);
 	});
 
 	it("native and TS visibleWidth agree on a jamo run", () => {
-		// Cross-layer parity guard: without the native fix, the TS path
-		// (Bun.stringWidth + manual correction) and the native path
-		// (unicode_width) disagreed by a factor of 2.
 		const input = "ㅁㄴㅇㅂㅈㄷㄱㅅ";
-		expect(visibleWidth(input)).toBe(8);
+		expect(visibleWidth(input)).toBe(16);
 		expect(sliceWithWidth(input, 0, 8, true).width).toBe(8);
 	});
 });


### PR DESCRIPTION
## Summary
- restore compatibility jamo width parity with xterm-compatible terminals
- truncate over-wide TUI render lines immediately after line resets to prevent terminal auto-wrap artifacts
- update Korean width and render regression coverage

## Verification
- bun test packages/tui/test/visible-width-jamo.test.ts packages/tui/test/ime-jamo-cursor.test.ts packages/tui/test/render-regressions.test.ts
- bun test packages/tui/test
- bun run check:ts