### PR TITLE
Fix named launch worktree args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Fixed
 
 - Fixed root `gjc --worktree` / `gjc -w` startup so the launch command actually creates and enters the sibling `<repo>.gajae-code-worktrees/<branch-slug>` git worktree before starting the session, using collision-resistant branch slugs and avoiding worktree side effects for help/version launches.
+- Fixed root `gjc --worktree <branch>` / `gjc -w <branch>` parsing so named branch worktrees create their own `<branch-slug>` directory instead of reusing the dirty detached worktree for the current branch.
 - Wired GJC native UserPromptSubmit/Stop skill-state hooks, including `gjc setup hooks`, so public workflow keywords activate `.gjc/state`, active skill state can block premature Stop events, and active Ultragoal sessions remind steering prompts to use `gjc ultragoal steer`.
 - Fixed `gjc ultragoal create-goals` to seed GJC goal mode runtime state automatically, avoiding a separate manual `/goal` setup step.
 - Fixed legacy Pi plugin import remapping and stale GJC config-path tests so rebranded `.gjc` discovery contracts pass while preserving legacy compatibility.

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -144,18 +144,26 @@ function isWorktreeDirty(worktreePath: string): boolean {
 	return runGit(worktreePath, ["status", "--porcelain"]).length > 0;
 }
 
+function resolveOptionalWorktreeName(args: string[], index: number): { name: string | null; nextIndex: number } {
+	const next = args[index + 1];
+	if (!next) return { name: null, nextIndex: index };
+	if (next === "--") return { name: null, nextIndex: index + 1 };
+	if (next.startsWith("-")) return { name: null, nextIndex: index };
+	return { name: next.trim() || null, nextIndex: index + 1 };
+}
+
 export function parseLaunchWorktreeMode(args: string[]): ParsedLaunchWorktreeMode {
 	let mode: GjcLaunchWorktreeMode = { enabled: false };
 	const remainingArgs: string[] = [];
 
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index] ?? "";
-		if (arg === "--worktree") {
-			mode = { enabled: true, detached: true, name: null };
-			continue;
-		}
-		if (arg === "-w") {
-			mode = { enabled: true, detached: true, name: null };
+		if (arg === "--worktree" || arg === "-w") {
+			const parsed = resolveOptionalWorktreeName(args, index);
+			mode = parsed.name
+				? { enabled: true, detached: false, name: parsed.name }
+				: { enabled: true, detached: true, name: null };
+			index = parsed.nextIndex;
 			continue;
 		}
 		if (arg.startsWith("--worktree=")) {

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -64,7 +64,11 @@ afterEach(async () => {
 
 describe("default launch worktrees", () => {
 	it("parses and strips launch worktree flags", () => {
-		expect(parseLaunchWorktreeMode(["--worktree", "hello"])).toEqual({
+		expect(parseLaunchWorktreeMode(["--worktree", "feature/demo", "hello"])).toEqual({
+			mode: { enabled: true, detached: false, name: "feature/demo" },
+			remainingArgs: ["hello"],
+		});
+		expect(parseLaunchWorktreeMode(["--worktree", "--", "hello"])).toEqual({
 			mode: { enabled: true, detached: true, name: null },
 			remainingArgs: ["hello"],
 		});
@@ -77,7 +81,11 @@ describe("default launch worktrees", () => {
 			mode: { enabled: true, detached: false, name: "feature/demo" },
 			remainingArgs: ["hello"],
 		});
-		expect(parseLaunchWorktreeMode(["-w", "hello"])).toEqual({
+		expect(parseLaunchWorktreeMode(["-w", "feature/demo", "hello"])).toEqual({
+			mode: { enabled: true, detached: false, name: "feature/demo" },
+			remainingArgs: ["hello"],
+		});
+		expect(parseLaunchWorktreeMode(["-w", "--", "hello"])).toEqual({
 			mode: { enabled: true, detached: true, name: null },
 			remainingArgs: ["hello"],
 		});
@@ -91,7 +99,7 @@ describe("default launch worktrees", () => {
 		const repo = await createRepo("gjc-launch-worktree-");
 		await fs.mkdir(path.join(repo, "node_modules"));
 
-		const first = prepareLaunchWorktree(repo, ["--worktree", "hello"]);
+		const first = prepareLaunchWorktree(repo, ["--worktree", "--", "hello"]);
 		const branchSlug = testSlug(run("git", ["branch", "--show-current"], repo));
 		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`, branchSlug);
 
@@ -133,6 +141,24 @@ describe("default launch worktrees", () => {
 		run("git", ["commit", "-m", "next"], repo);
 
 		expect(() => prepareLaunchWorktree(repo, ["--worktree"])).toThrow(/worktree_dirty:/);
+	});
+
+	it("creates named worktrees without reusing a dirty detached source-branch worktree", async () => {
+		const repo = await createRepo("gjc-launch-dirty-detached-named-worktree-");
+		const detached = prepareLaunchWorktree(repo, ["--worktree"]);
+		expect(detached.worktree.enabled && detached.worktree.created).toBe(true);
+		await Bun.write(path.join(detached.cwd, "dirty.txt"), "dirty\n");
+
+		const named = prepareLaunchWorktree(repo, ["--worktree", "feat/hud-ui-alignment"]);
+		const expectedPath = path.join(
+			path.dirname(repo),
+			`${path.basename(repo)}.gajae-code-worktrees`,
+			testSlug("feat/hud-ui-alignment"),
+		);
+
+		expect(await fs.realpath(named.cwd)).toBe(await fs.realpath(expectedPath));
+		expect(named.worktree.enabled && named.worktree.branchName).toBe("feat/hud-ui-alignment");
+		expect(run("git", ["branch", "--show-current"], named.cwd)).toBe("feat/hud-ui-alignment");
 	});
 
 	it("creates named launch worktrees from reusable branch names", async () => {


### PR DESCRIPTION
## Summary\n- consume the optional branch token for root `gjc --worktree <branch>` / `gjc -w <branch>` launches\n- preserve detached current-branch mode with `--worktree -- <prompt>` when an initial prompt is needed\n- add regression coverage for a dirty detached source-branch worktree plus a named branch launch\n\n## Verification\n- `git diff --check`\n- `bun test packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`\n- `bun run --cwd packages/coding-agent check`\n- live helper smoke: dirty detached worktree then `--worktree feat/hud-ui-alignment` creates `.gajae-code-worktrees/feat-hud-ui-alignment-7b990845` on branch `feat/hud-ui-alignment`\n