### PR TITLE
Support chained skill invocation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Changed normal `task` subagent launches to return immediately as detached background work while keeping generic `job` controls available.
 - Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
+- Changed `/skill:<name>` handling so canonical skill invocations can be chained in one prompt across interactive and ACP sessions, with autocomplete-only `/name` and `/skill-name` normalization back to the public canonical form.
 - Changed interactive `gjc` startup to launch tmux only when `--tmux` is provided, with direct startup as the default.
 - Changed `gjc team` to split the current tmux leader window into one GJC worker pane, reject multi-worker starts, and clean up worker panes without killing the leader session.
 - Changed GJC default definitions so workflow skills remain source-bundled while repo-visible `.gjc` default artifacts are no longer the source of truth; updated system and Ultragoal guidance to use role-agent delegation and ralplan-first planning when needed.

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -302,6 +302,52 @@ export interface ResolvedSkillSlashCommand {
 	skill: Skill;
 }
 
+export interface ParsedSkillInvocation {
+	commandName: string;
+	args: string;
+	skill: Skill;
+}
+
+interface SkillTokenMatch {
+	index: number;
+	end: number;
+	commandName: string;
+	skill: Skill;
+}
+
+export function parseSkillInvocations(
+	text: string,
+	skillsByCommandName: ReadonlyMap<string, Skill>,
+): ParsedSkillInvocation[] {
+	const trimmedText = text.trim();
+	if (!trimmedText.startsWith("/")) return [];
+	const canonicalSkillCommandPattern = /(^|\s)\/(skill:[^\s]+)/g;
+	const matches: SkillTokenMatch[] = [];
+	for (const match of trimmedText.matchAll(canonicalSkillCommandPattern)) {
+		const commandName = match[2];
+		if (!commandName) continue;
+		const skill = skillsByCommandName.get(commandName);
+		if (!skill) continue;
+		const leading = match[1] ?? "";
+		const index = (match.index ?? 0) + leading.length;
+		matches.push({
+			index,
+			end: index + commandName.length + 1,
+			commandName,
+			skill,
+		});
+	}
+	if (matches.length === 0 || matches[0]?.index !== 0) return [];
+	return matches.map((match, index) => {
+		const next = matches[index + 1];
+		return {
+			commandName: match.commandName,
+			args: trimmedText.slice(match.end, next?.index).trim(),
+			skill: match.skill,
+		};
+	});
+}
+
 export function resolveSkillSlashCommands(
 	skills: readonly Skill[],
 	_reservedDirectCommandNames: ReadonlySet<string>,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -55,6 +55,7 @@ import {
 	getSkillSlashCommandNames,
 	isNamespacedSkillSlashCommandName,
 	isSkillSlashCommandName,
+	parseSkillInvocations,
 } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
@@ -710,6 +711,37 @@ export class AcpAgent implements Agent {
 		}
 		if (!record.session.skillsSettings?.enableSkillCommands) {
 			return false;
+		}
+		const skillsByCommandName = new Map(
+			record.session.skills
+				.filter(skill => skill.hide !== true)
+				.flatMap(skill => getSkillSlashCommandNames(skill).map(commandName => [commandName, skill] as const)),
+		);
+		const invocations = parseSkillInvocations(text, skillsByCommandName);
+		if (invocations.length > 0) {
+			for (let index = 0; index < invocations.length; index += 1) {
+				const invocation = invocations[index];
+				if (!invocation) continue;
+				const built = await buildSkillPromptMessage(invocation.skill, invocation.args);
+				if (index === invocations.length - 1) {
+					await record.session.promptCustomMessage({
+						customType: SKILL_PROMPT_MESSAGE_TYPE,
+						content: built.message,
+						display: true,
+						details: built.details,
+						attribution: "user",
+					});
+				} else {
+					await record.session.sendCustomMessage({
+						customType: SKILL_PROMPT_MESSAGE_TYPE,
+						content: built.message,
+						display: true,
+						details: built.details,
+						attribution: "user",
+					});
+				}
+			}
+			return true;
 		}
 		const spaceIndex = text.indexOf(" ");
 		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,7 +3,7 @@ import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import type { AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
-import { buildSkillPromptMessage } from "../../extensibility/skills";
+import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
@@ -409,9 +409,9 @@ export class InputController {
 	}
 
 	/**
-	 * Dispatch a skill slash invocation (`/skill:<name>`) through `promptCustomMessage`
+	 * Dispatch skill slash invocation(s) (`/skill:<name>`) through custom messages
 	 * using the supplied `streamingBehavior`. Returns true if the text was a
-	 * recognised skill command and was dispatched. A failure to load the skill
+	 * recognised skill command chain and was dispatched. A failure to load a skill
 	 * file is surfaced via `showError` but still returns true — the editor was
 	 * already cleared on the success path, so falling through to plain-text
 	 * handling at that point would double-submit. Returns false when the text
@@ -423,35 +423,48 @@ export class InputController {
 	 */
 	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
 		if (!text.startsWith("/")) return false;
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-		const skill = this.ctx.skillCommands?.get(commandName);
-		if (!skill) return false;
+		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
+		if (invocations.length === 0) return false;
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
 		try {
-			const built = await buildSkillPromptMessage(skill, args);
-			const details: SkillPromptDetails = built.details;
-			// When the agent is streaming, register the compact slash-form text as
-			// the pending-display twin BEFORE dispatching the CustomMessage. The
-			// returned tag is embedded in details so AgentSession.#handleAgentEvent
-			// can remove the matching display entry when the agent consumes this
-			// message (mirrors the user-message dequeue path).
-			if (this.ctx.session.isStreaming) {
-				const tag = this.ctx.session.enqueueCustomMessageDisplay(text, streamingBehavior);
-				details.__pendingDisplayTag = tag;
+			for (let index = 0; index < invocations.length; index += 1) {
+				const invocation = invocations[index];
+				if (!invocation) continue;
+				const built = await buildSkillPromptMessage(invocation.skill, invocation.args);
+				const details: SkillPromptDetails = built.details;
+				const displayText = `/${invocation.commandName}${invocation.args ? ` ${invocation.args}` : ""}`;
+				// When the agent is streaming, register a compact slash-form text as
+				// the pending-display twin BEFORE dispatching the CustomMessage. The
+				// returned tag is embedded in details so AgentSession.#handleAgentEvent
+				// can remove the matching display entry when the agent consumes this
+				// message (mirrors the user-message dequeue path).
+				if (this.ctx.session.isStreaming) {
+					const tag = this.ctx.session.enqueueCustomMessageDisplay(displayText, streamingBehavior);
+					details.__pendingDisplayTag = tag;
+				}
+				const isLast = index === invocations.length - 1;
+				if (!this.ctx.session.isStreaming && !isLast) {
+					await this.ctx.session.sendCustomMessage({
+						customType: SKILL_PROMPT_MESSAGE_TYPE,
+						content: built.message,
+						display: true,
+						details,
+						attribution: "user",
+					});
+					continue;
+				}
+				await this.ctx.session.promptCustomMessage(
+					{
+						customType: SKILL_PROMPT_MESSAGE_TYPE,
+						content: built.message,
+						display: true,
+						details,
+						attribution: "user",
+					},
+					{ streamingBehavior },
+				);
 			}
-			await this.ctx.session.promptCustomMessage(
-				{
-					customType: SKILL_PROMPT_MESSAGE_TYPE,
-					content: built.message,
-					display: true,
-					details,
-					attribution: "user",
-				},
-				{ streamingBehavior },
-			);
 			if (this.ctx.session.isStreaming) {
 				this.ctx.updatePendingMessagesDisplay();
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -22,6 +22,10 @@ interface PromptActionAutocompleteItem extends AutocompleteItem {
 	execute: (prefix: string) => void;
 }
 
+interface SkillCommandAutocompleteItem extends AutocompleteItem {
+	normalizedSkillCommand: true;
+}
+
 interface PromptActionAutocompleteOptions {
 	commands: SlashCommand[];
 	basePath: string;
@@ -76,6 +80,10 @@ function isPromptActionItem(item: AutocompleteItem): item is PromptActionAutocom
 	return "actionId" in item && "execute" in item && typeof item.execute === "function";
 }
 
+function isSkillCommandAutocompleteItem(item: AutocompleteItem): item is SkillCommandAutocompleteItem {
+	return "normalizedSkillCommand" in item && item.normalizedSkillCommand === true;
+}
+
 function getPromptActionPrefix(textBeforeCursor: string): string | null {
 	const hashIndex = textBeforeCursor.lastIndexOf("#");
 	if (hashIndex === -1) return null;
@@ -88,13 +96,25 @@ function getPromptActionPrefix(textBeforeCursor: string): string | null {
 	return textBeforeCursor.slice(hashIndex);
 }
 
+function getSlashTokenPrefix(textBeforeCursor: string): string | null {
+	const slashIndex = textBeforeCursor.lastIndexOf("/");
+	if (slashIndex === -1) return null;
+	const beforeSlash = textBeforeCursor.slice(0, slashIndex);
+	if (beforeSlash && !/\s$/.test(beforeSlash)) return null;
+	const token = textBeforeCursor.slice(slashIndex);
+	if (/[\s]/.test(token)) return null;
+	return token;
+}
+
 export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	#baseProvider: CombinedAutocompleteProvider;
 	#actions: PromptActionDefinition[];
+	#commands: SlashCommand[];
 
 	constructor(commands: SlashCommand[], basePath: string, actions: PromptActionDefinition[]) {
 		this.#baseProvider = new CombinedAutocompleteProvider(commands, basePath);
 		this.#actions = actions;
+		this.#commands = commands;
 	}
 
 	async getSuggestions(
@@ -127,6 +147,9 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 				return { items, prefix: promptActionPrefix };
 			}
 		}
+
+		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
+		if (skillCommandSuggestions) return skillCommandSuggestions;
 
 		if (!isSettingsInitialized() || settings.get("emojiAutocomplete")) {
 			const emojiSuggestions = getEmojiSuggestions(textBeforeCursor);
@@ -173,6 +196,18 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		if (isEmojiPrefix(prefix)) {
 			return applyEmojiCompletion(lines, cursorLine, cursorCol, item, prefix);
 		}
+		if (prefix.startsWith("/") && isSkillCommandAutocompleteItem(item)) {
+			const currentLine = lines[cursorLine] || "";
+			const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
+			const afterCursor = currentLine.slice(cursorCol);
+			const newLines = [...lines];
+			newLines[cursorLine] = `${beforePrefix}/${item.value} ${afterCursor}`;
+			return {
+				lines: newLines,
+				cursorLine,
+				cursorCol: beforePrefix.length + item.value.length + 2,
+			};
+		}
 		return this.#baseProvider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
 	}
 
@@ -180,11 +215,73 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		return this.#baseProvider.getInlineHint?.(lines, cursorLine, cursorCol) ?? null;
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
+		if (skillCommandSuggestions) return skillCommandSuggestions;
 		return this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null;
 	}
 	trySyncInlineReplace(textBeforeCursor: string): { replaceLen: number; insert: string } | null {
 		if (isSettingsInitialized() && !settings.get("emojiAutocomplete")) return null;
 		return tryEmojiInlineReplace(textBeforeCursor);
+	}
+
+	#getSkillCommandSuggestions(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		const prefix = getSlashTokenPrefix(textBeforeCursor);
+		if (!prefix) return null;
+		const query = prefix.slice(1).toLowerCase();
+		if (query.length === 0) return null;
+		const normalizedQuery = query.startsWith("skill-") ? `skill:${query.slice("skill-".length)}` : query;
+		const exactNonSkillCommand = this.#commands.some(
+			command => command.name === query && !command.name.startsWith("skill:"),
+		);
+		if (exactNonSkillCommand) {
+			const command = this.#commands.find(
+				candidate => candidate.name === query && !candidate.name.startsWith("skill:"),
+			);
+			if (command) {
+				return {
+					items: [{ value: command.name, label: command.name, description: command.description }],
+					prefix,
+				};
+			}
+		}
+		const items = this.#commands
+			.filter(command => command.name.startsWith("skill:"))
+			.map(command => {
+				const skillName = command.name.slice("skill:".length);
+				if (exactNonSkillCommand && query === skillName.toLowerCase()) return null;
+				const searchTargets = [
+					command.name,
+					`skill-${skillName}`,
+					...(exactNonSkillCommand ? [] : [skillName]),
+					command.description ?? "",
+				].map(target => target.toLowerCase());
+				if (
+					!searchTargets.some(target => fuzzyMatch(normalizedQuery, target) || target.includes(normalizedQuery))
+				) {
+					return null;
+				}
+				const bestScore = Math.max(
+					...searchTargets.map(target =>
+						fuzzyMatch(normalizedQuery, target)
+							? fuzzyScore(normalizedQuery, target)
+							: target.includes(normalizedQuery)
+								? 60
+								: 0,
+					),
+				);
+				return {
+					value: command.name,
+					label: command.name,
+					description: command.description,
+					normalizedSkillCommand: true,
+					score: bestScore,
+				} satisfies SkillCommandAutocompleteItem & { score: number };
+			})
+			.filter(item => item !== null)
+			.sort((a, b) => b.score - a.score)
+			.map(({ score: _score, ...item }) => item);
+		if (items.length === 0) return null;
+		return { items, prefix };
 	}
 }
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -105,6 +105,9 @@ class FakeAgentSession {
 	waitForIdleCalls = 0;
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
+	sendCustomMessage = async (message: { customType: string; content: string; details?: unknown }): Promise<void> => {
+		this.customMessages.push(message);
+	};
 	#listeners = new Set<(event: AgentSessionEvent) => void>();
 
 	constructor(
@@ -306,8 +309,6 @@ class FakeAgentSession {
 		this.forcedToolChoice = toolName;
 	}
 
-	async sendCustomMessage(_message: string, _options?: unknown): Promise<void> {}
-
 	async sendUserMessage(_content: string, _options?: unknown): Promise<void> {}
 
 	async compact(_instructions?: string, _options?: unknown): Promise<void> {}
@@ -440,6 +441,20 @@ async function createHarness(): Promise<AgentHarness> {
  */
 async function waitForBootstrapGuard(): Promise<void> {
 	await Bun.sleep(ACP_BOOTSTRAP_RACE_GUARD_MS + 30);
+}
+
+async function waitForAvailableCommandsUpdate(harness: AgentHarness, sessionId: string): Promise<void> {
+	const deadline = Date.now() + ACP_BOOTSTRAP_RACE_GUARD_MS + 500;
+	while (Date.now() < deadline) {
+		if (
+			harness.updates.some(
+				update => update.sessionId === sessionId && update.update.sessionUpdate === "available_commands_update",
+			)
+		) {
+			return;
+		}
+		await Bun.sleep(10);
+	}
 }
 
 describe("ACP agent", () => {
@@ -1059,7 +1074,7 @@ describe("ACP agent", () => {
 				source: "test",
 			},
 		];
-		await waitForBootstrapGuard();
+		await waitForAvailableCommandsUpdate(harness, created.sessionId);
 
 		const commandUpdates = harness.updates.filter(
 			update =>
@@ -1140,6 +1155,43 @@ describe("ACP agent", () => {
 
 		expect(session.customMessages).toEqual([]);
 		expect(session.fastMode).toBe(true);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("executes chained ACP skill commands in source order", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const sampleDir = path.join(harness.cwdA, ".skills", "sample");
+		const samplePath = path.join(sampleDir, "SKILL.md");
+		const secondDir = path.join(harness.cwdA, ".skills", "second");
+		const secondPath = path.join(secondDir, "SKILL.md");
+		await fs.promises.mkdir(sampleDir, { recursive: true });
+		await fs.promises.mkdir(secondDir, { recursive: true });
+		await fs.promises.writeFile(samplePath, "---\ndescription: Sample skill\n---\n# Sample\nDo work.\n");
+		await fs.promises.writeFile(secondPath, "---\ndescription: Second skill\n---\n# Second\nDo second work.\n");
+		session.skills = [
+			{ name: "sample", description: "Sample skill", filePath: samplePath, baseDir: sampleDir, source: "test" },
+			{ name: "second", description: "Second skill", filePath: secondPath, baseDir: secondDir, source: "test" },
+		];
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000003",
+			prompt: [{ type: "text", text: "/skill:sample first /skill:second next args" }],
+		} as PromptRequest);
+
+		expect(session.promptCalls).toEqual([]);
+		expect(session.customMessages.map(message => message.content.match(/User: .*/)?.[0] ?? message.content)).toEqual([
+			"User: first",
+			"User: next args",
+		]);
+		expect(session.customMessages[0]!.content).toContain("# Sample\nDo work.");
+		expect(session.customMessages[0]!.content).toContain("User: first");
+		expect(session.customMessages[1]!.content).toContain("# Second\nDo second work.");
+		expect(session.customMessages[1]!.content).toContain("User: next args");
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -75,6 +75,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, Ski
 	const promptCustomMessage = vi.fn(
 		async (_message: { content: string; details: SkillPromptDetails }, _options?: unknown) => {},
 	);
+	const sendCustomMessage = vi.fn(async (_message: { content: string; details: SkillPromptDetails }) => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
@@ -90,6 +91,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, Ski
 			isEvalRunning: false,
 			extensionRunner: undefined,
 			enqueueCustomMessageDisplay,
+			sendCustomMessage,
 			promptCustomMessage,
 		},
 		showError,
@@ -105,7 +107,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, Ski
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage };
+	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, sendCustomMessage };
 }
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
@@ -226,6 +228,33 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		}
 		const messageArg = firstCall[0];
 		expect(messageArg.details.__pendingDisplayTag).toBeUndefined();
+	});
+
+	it("dispatches chained canonical skill commands in order while idle", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, editor, sendCustomMessage, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill alpha /skill:second-skill beta gamma");
+		await editor.onSubmit?.("/skill:test-skill alpha /skill:second-skill beta gamma");
+
+		expect(sendCustomMessage).toHaveBeenCalledTimes(1);
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		expect(sendCustomMessage.mock.calls[0]?.[0].content).toContain("Do the thing.");
+		expect(sendCustomMessage.mock.calls[0]?.[0].content).toContain("User: alpha");
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("Do the second thing.");
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("User: beta gamma");
 	});
 });
 

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import type { KeybindingsManager } from "../src/config/keybindings";
+import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
+
+function createProvider() {
+	return createPromptActionAutocompleteProvider({
+		commands: [
+			{ name: "fast", description: "Built-in fast mode" },
+			{ name: "skill:deep-interview", description: "Deep interview" },
+			{ name: "skill:fast", description: "Colliding skill" },
+		],
+		basePath: "/tmp",
+		keybindings: { getKeys: () => [] } as unknown as KeybindingsManager,
+		copyCurrentLine: () => {},
+		copyPrompt: () => {},
+		undo: () => {},
+		moveCursorToMessageEnd: () => {},
+		moveCursorToMessageStart: () => {},
+		moveCursorToLineStart: () => {},
+		moveCursorToLineEnd: () => {},
+	});
+}
+
+describe("prompt action skill autocomplete", () => {
+	it("normalizes direct skill-name typing to the canonical skill command", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.getSuggestions(["/deep"], 0, 5);
+		expect(suggestions?.prefix).toBe("/deep");
+		expect(suggestions?.items[0]?.value).toBe("skill:deep-interview");
+		const applied = provider.applyCompletion(["/deep"], 0, 5, suggestions!.items[0]!, suggestions!.prefix);
+		expect(applied.lines[0]).toBe("/skill:deep-interview ");
+	});
+
+	it("normalizes slash-skill-name typing at intermediate positions", async () => {
+		const provider = createProvider();
+		const line = "/skill:deep-interview first /skill-deep";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		expect(suggestions?.prefix).toBe("/skill-deep");
+		expect(suggestions?.items[0]?.value).toBe("skill:deep-interview");
+		const applied = provider.applyCompletion([line], 0, line.length, suggestions!.items[0]!, suggestions!.prefix);
+		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
+	});
+
+	it("does not let direct-name normalization shadow an exact non-skill command", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.getSuggestions(["/fast"], 0, 5);
+		expect(suggestions?.items.some(item => item.value === "skill:fast")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -4,7 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type Skill as CapabilitySkill, skillCapability } from "@gajae-code/coding-agent/capability/skill";
 import { getCapability } from "@gajae-code/coding-agent/discovery";
-import { loadSkills, loadSkillsFromDir, type Skill } from "@gajae-code/coding-agent/extensibility/skills";
+import {
+	loadSkills,
+	loadSkillsFromDir,
+	parseSkillInvocations,
+	type Skill,
+} from "@gajae-code/coding-agent/extensibility/skills";
 
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
 const collisionFixturesDir = path.resolve(import.meta.dirname, "fixtures/skills-collision");
@@ -18,6 +23,39 @@ const expectedFixtureSkillOrder: string[] = [
 	"unknown-field",
 	"valid-skill",
 ];
+
+function makeSkill(name: string): Skill {
+	return {
+		name,
+		description: `${name} description`,
+		filePath: `/tmp/${name}/SKILL.md`,
+		baseDir: `/tmp/${name}`,
+		source: "test",
+	};
+}
+
+describe("parseSkillInvocations", () => {
+	const alpha = makeSkill("alpha");
+	const beta = makeSkill("beta");
+	const skillsByCommandName = new Map([
+		["skill:alpha", alpha],
+		["skill:beta", beta],
+		["alpha", alpha],
+	]);
+
+	it("splits chained canonical skill invocations without treating args as commands", () => {
+		expect(parseSkillInvocations("/skill:alpha first /skill:beta second /not-a-skill", skillsByCommandName)).toEqual([
+			{ commandName: "skill:alpha", args: "first", skill: alpha },
+			{ commandName: "skill:beta", args: "second /not-a-skill", skill: beta },
+		]);
+	});
+
+	it("requires the prompt to start with a recognized canonical skill command", () => {
+		expect(parseSkillInvocations("normal text /skill:alpha later", skillsByCommandName)).toEqual([]);
+		expect(parseSkillInvocations("/alpha autocomplete alias is not invocation", skillsByCommandName)).toEqual([]);
+		expect(parseSkillInvocations("/skill:unknown /skill:alpha later", skillsByCommandName)).toEqual([]);
+	});
+});
 
 describe("skills", () => {
 	describe("loadSkillsFromDir", () => {


### PR DESCRIPTION
## Summary\n- allow canonical /skill:<name> commands to be chained in one interactive prompt\n- add ACP parity for chained skill prompts\n- add autocomplete-only /name and /skill-name normalization back to canonical /skill:<name> without advertising new aliases\n\n## Validation\n- bun test packages/coding-agent/test/skills.test.ts -t "parseSkillInvocations"\n- bun test packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts packages/coding-agent/test/acp-agent.test.ts -t "skill|autocomplete|executes chained ACP"\n- bun --cwd=packages/coding-agent run check\n- bun scripts/check-visible-definitions.ts\n- bun scripts/verify-g002-gates.ts\n- bun scripts/rebrand-inventory.ts --strict\n- bun test packages/coding-agent/test/default-gjc-definitions.test.ts\n\n## UltraQA\n- Focused adversarial matrix recorded locally in .omx/ultraqa/multi-skill-invocation-report.md\n- Full package test probe is not green in this worktree/environment; failures are unrelated to changed skill/ACP/autocomplete behavior.