### PR TITLE
Fix GJC team 50/50 tmux layout

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -138,7 +138,7 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
    - `.gjc/state/team/<team>/tasks/task-001.json`
    - `.gjc/state/team/<team>/mailboxes/worker-01.json`
 4. Resolve the worker command from `GJC_TEAM_WORKER_COMMAND` or the active `gjc` entrypoint.
-5. Split the current tmux window into one worker pane with `split-window -h` from the leader pane.
+5. Split the current tmux window into one right-side worker pane with `split-window -h -p 50` from the leader pane, then normalize the window with `select-layout even-horizontal` for a 50/50 leader-left/worker-right layout.
 6. Launch the worker with:
    - `GJC_TEAM_NAME=<team>`
    - `GJC_TEAM_WORKER_ID=worker-01`
@@ -149,8 +149,8 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 
 Important:
 
-- Leader remains in the existing pane.
-- The worker pane is an independent full GJC worker CLI session.
+- Leader remains in the existing left pane.
+- The worker pane is an independent full GJC worker CLI session on the right side of a 50/50 left-right split.
 - The worker may run in a dedicated git worktree (`gjc team --worktree[=<name>]`) while sharing the team state root.
 - `shutdown` kills only the recorded worker pane after confirming it still belongs to the stored tmux target and is not the leader pane. It never kills the tmux session.
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -484,6 +484,8 @@ async function startTmuxSession(config: GjcTeamConfig, dir: string, dryRun: bool
 				config.tmux_command,
 				"split-window",
 				"-h",
+				"-p",
+				"50",
 				"-t",
 				config.leader.pane_id,
 				"-d",
@@ -503,7 +505,7 @@ async function startTmuxSession(config: GjcTeamConfig, dir: string, dryRun: bool
 		const paneId = split.stdout.toString().trim().split(/\r?\n/)[0]?.trim() ?? "";
 		if (!paneId.startsWith("%")) throw new Error(`tmux_split_missing_pane:${config.tmux_target}:${worker.id}`);
 		rollbackPaneIds.push(paneId);
-		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "main-vertical"], {
+		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "even-horizontal"], {
 			stdout: "ignore",
 			stderr: "ignore",
 		});

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -211,8 +211,9 @@ describe("native gjc team runtime", () => {
 		}
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
-		expect(tmuxLog).toContain("split-window -h -t %1 -d -P -F #{pane_id}");
-		expect(tmuxLog).toContain("select-layout -t test-session:0 main-vertical");
+		expect(tmuxLog).toContain("split-window -h -p 50 -t %1 -d -P -F #{pane_id}");
+		expect(tmuxLog).toContain("select-layout -t test-session:0 even-horizontal");
+		expect(tmuxLog).not.toContain("select-layout -t test-session:0 main-vertical");
 		expect(tmuxLog).not.toContain("new-session");
 		expect(tmuxLog).not.toContain("kill-session");
 	});


### PR DESCRIPTION
## Summary
- make `gjc team` split the leader window at 50% with the worker on the right
- replace the biased `main-vertical` layout with `even-horizontal`
- update regression expectations and team skill docs for leader-left / worker-right behavior

## LGTM
- Code review: APPROVE
- Architecture review: CLEAR

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `git diff --check`

Not tested: live manual tmux visual smoke against an attached real GJC worker pane.