### PR TITLE
Recover interactive aborts that refuse to drain

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Agent.forceAbort()` so hosts can recover from provider/tool aborts that ignore cooperative cancellation without clearing conversation history.
+
 ## [15.3.0] - 2026-05-25
 ### Fixed
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -286,6 +286,8 @@ export class Agent {
 	#cursorOnToolResult?: CursorToolResultHandler;
 	#runningPrompt?: Promise<void>;
 	#resolveRunningPrompt?: () => void;
+	#runSequence = 0;
+	#activeRunId?: number;
 	#kimiApiFormat?: "openai" | "anthropic";
 	#preferWebsockets?: boolean;
 	#transformToolCallArguments?: (args: Record<string, unknown>, toolName: string) => Record<string, unknown>;
@@ -607,6 +609,119 @@ export class Agent {
 		this.#emit(event);
 	}
 
+	createExternalEventEmitterForCurrentRun(): ((event: AgentEvent) => void) | undefined {
+		const runId = this.#activeRunId;
+		if (runId === undefined) return undefined;
+		return (event: AgentEvent) => {
+			if (this.#activeRunId !== runId) return;
+			this.emitExternalEvent(event);
+		};
+	}
+
+	#assertActiveRun(runId: number): void {
+		if (this.#activeRunId !== runId) {
+			throw new Error("Ignoring Cursor exec callback from an inactive agent run.");
+		}
+	}
+
+	#cursorExecHandlersForRun(runId: number): CursorExecHandlers | undefined {
+		const source = this.#cursorExecHandlers;
+		if (!source) return undefined;
+
+		const guarded: CursorExecHandlers = {};
+		const read = source.read;
+		if (read) {
+			guarded.read = async args => {
+				this.#assertActiveRun(runId);
+				const result = await read(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const ls = source.ls;
+		if (ls) {
+			guarded.ls = async args => {
+				this.#assertActiveRun(runId);
+				const result = await ls(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const grep = source.grep;
+		if (grep) {
+			guarded.grep = async args => {
+				this.#assertActiveRun(runId);
+				const result = await grep(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const write = source.write;
+		if (write) {
+			guarded.write = async args => {
+				this.#assertActiveRun(runId);
+				const result = await write(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const deleteHandler = source.delete;
+		if (deleteHandler) {
+			guarded.delete = async args => {
+				this.#assertActiveRun(runId);
+				const result = await deleteHandler(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const shell = source.shell;
+		if (shell) {
+			guarded.shell = async args => {
+				this.#assertActiveRun(runId);
+				const result = await shell(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const shellStream = source.shellStream;
+		if (shellStream) {
+			guarded.shellStream = async (args, callbacks) => {
+				this.#assertActiveRun(runId);
+				const result = await shellStream(args, callbacks);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const diagnostics = source.diagnostics;
+		if (diagnostics) {
+			guarded.diagnostics = async args => {
+				this.#assertActiveRun(runId);
+				const result = await diagnostics(args);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const mcp = source.mcp;
+		if (mcp) {
+			guarded.mcp = async call => {
+				this.#assertActiveRun(runId);
+				const result = await mcp(call);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		const onToolResult = source.onToolResult;
+		if (onToolResult) {
+			guarded.onToolResult = async message => {
+				this.#assertActiveRun(runId);
+				const result = await onToolResult(message);
+				this.#assertActiveRun(runId);
+				return result;
+			};
+		}
+		return guarded;
+	}
+
 	// State mutators
 	setSystemPrompt(v: string[]) {
 		this.#state.systemPrompt = v;
@@ -753,6 +868,32 @@ export class Agent {
 		this.#abortController?.abort();
 	}
 
+	/**
+	 * Force the current run out of the busy/streaming state when cooperative abort
+	 * did not drain. The abandoned provider/tool stream may still settle later, so
+	 * #runLoop guards every state mutation with a run id.
+	 */
+	forceAbort(reason = "Force aborted"): boolean {
+		const hadActiveRun = this.#runningPrompt !== undefined || this.#state.isStreaming;
+		if (!hadActiveRun) return false;
+
+		this.#abortController?.abort(reason);
+		this.#activeRunId = undefined;
+		this.#state.isStreaming = false;
+		this.#state.streamMessage = null;
+		this.#state.pendingToolCalls = new Set<string>();
+		this.#abortController = undefined;
+		this.#cursorToolResultBuffer = [];
+
+		const resolve = this.#resolveRunningPrompt;
+		this.#runningPrompt = undefined;
+		this.#resolveRunningPrompt = undefined;
+		resolve?.();
+
+		this.#emit({ type: "agent_end", messages: [] });
+		return true;
+	}
+
 	waitForIdle(): Promise<void> {
 		return this.#runningPrompt ?? Promise.resolve();
 	}
@@ -862,7 +1003,10 @@ export class Agent {
 		this.#runningPrompt = promise;
 		this.#resolveRunningPrompt = resolve;
 
-		this.#abortController = new AbortController();
+		const runId = ++this.#runSequence;
+		this.#activeRunId = runId;
+		const abortController = new AbortController();
+		this.#abortController = abortController;
 		this.#state.isStreaming = true;
 		this.#state.streamMessage = null;
 		this.#state.error = undefined;
@@ -882,9 +1026,15 @@ export class Agent {
 			this.#cursorExecHandlers || this.#cursorOnToolResult
 				? async (message: ToolResultMessage) => {
 						let finalMessage = message;
+						if (this.#activeRunId !== runId) {
+							return finalMessage;
+						}
 						if (this.#cursorOnToolResult) {
 							try {
 								const updated = await this.#cursorOnToolResult(message);
+								if (this.#activeRunId !== runId) {
+									return finalMessage;
+								}
 								if (updated) {
 									finalMessage = updated;
 								}
@@ -902,6 +1052,7 @@ export class Agent {
 
 		const getToolChoice = () =>
 			this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
+		const cursorExecHandlers = this.#cursorExecHandlersForRun(runId);
 
 		const config: AgentLoopConfig = {
 			model,
@@ -928,6 +1079,7 @@ export class Agent {
 			onPayload: this.#onPayload,
 			onResponse: this.#onResponse,
 			onSseEvent: this.#onSseEvent,
+			signal: abortController.signal,
 			getApiKey: this.getApiKey,
 			getToolContext: this.#getToolContext,
 			syncContextBeforeModelCall: async context => {
@@ -937,26 +1089,66 @@ export class Agent {
 				context.systemPrompt = this.#state.systemPrompt;
 				context.tools = this.#state.tools;
 			},
-			cursorExecHandlers: this.#cursorExecHandlers,
+			cursorExecHandlers,
 			cursorOnToolResult,
 			transformToolCallArguments: this.#transformToolCallArguments,
 			intentTracing: this.#intentTracing,
 			appendOnlyContext: this.#appendOnlyContext,
-			beforeToolCall: this.beforeToolCall ? (ctx, signal) => this.beforeToolCall?.(ctx, signal) : undefined,
-			afterToolCall: this.afterToolCall ? (ctx, signal) => this.afterToolCall?.(ctx, signal) : undefined,
-			onAssistantMessageEvent: this.#onAssistantMessageEvent,
+			beforeToolCall: this.beforeToolCall
+				? async (ctx, signal) => {
+						if (this.#activeRunId !== runId) return undefined;
+						const result = await this.beforeToolCall?.(ctx, signal);
+						if (this.#activeRunId !== runId) return undefined;
+						return result;
+					}
+				: undefined,
+			afterToolCall: this.afterToolCall
+				? async (ctx, signal) => {
+						if (this.#activeRunId !== runId) return undefined;
+						const result = await this.afterToolCall?.(ctx, signal);
+						if (this.#activeRunId !== runId) return undefined;
+						return result;
+					}
+				: undefined,
+			onAssistantMessageEvent: this.#onAssistantMessageEvent
+				? (message, event) => {
+						if (this.#activeRunId !== runId) return;
+						this.#onAssistantMessageEvent?.(message, event);
+					}
+				: undefined,
 			onHarmonyLeak: this.#onHarmonyLeak,
 			getToolChoice,
 			getReasoning: () => this.#state.thinkingLevel,
 			getSteeringMessages: async () => {
+				if (this.#activeRunId !== runId) {
+					return [];
+				}
 				if (skipInitialSteeringPoll) {
 					skipInitialSteeringPoll = false;
 					return [];
 				}
-				return this.#dequeueSteeringMessages();
+				const queued = this.#dequeueSteeringMessages();
+				if (this.#activeRunId !== runId) {
+					this.#steeringQueue = [...queued, ...this.#steeringQueue];
+					return [];
+				}
+				return queued;
 			},
-			getFollowUpMessages: async () => this.#dequeueFollowUpMessages(),
-			onBeforeYield: () => this.#onBeforeYield?.(),
+			getFollowUpMessages: async () => {
+				if (this.#activeRunId !== runId) {
+					return [];
+				}
+				const queued = this.#dequeueFollowUpMessages();
+				if (this.#activeRunId !== runId) {
+					this.#followUpQueue = [...queued, ...this.#followUpQueue];
+					return [];
+				}
+				return queued;
+			},
+			onBeforeYield: async () => {
+				if (this.#activeRunId !== runId) return;
+				await this.#onBeforeYield?.();
+			},
 			telemetry: this.#telemetry,
 		};
 
@@ -964,10 +1156,14 @@ export class Agent {
 
 		try {
 			const stream = messages
-				? agentLoop(messages, context, config, this.#abortController.signal, this.streamFn)
-				: agentLoopContinue(context, config, this.#abortController.signal, this.streamFn);
+				? agentLoop(messages, context, config, abortController.signal, this.streamFn)
+				: agentLoopContinue(context, config, abortController.signal, this.streamFn);
 
 			for await (const event of stream) {
+				if (this.#activeRunId !== runId) {
+					break;
+				}
+
 				// Update internal state based on events
 				switch (event.type) {
 					case "message_start":
@@ -1022,6 +1218,10 @@ export class Agent {
 				this.#emit(event);
 			}
 
+			if (this.#activeRunId !== runId) {
+				return;
+			}
+
 			// Handle any remaining partial message
 			if (partial && partial.role === "assistant" && Array.isArray(partial.content) && partial.content.length > 0) {
 				const onlyEmpty = !partial.content.some(
@@ -1033,12 +1233,16 @@ export class Agent {
 				if (!onlyEmpty) {
 					this.appendMessage(partial);
 				} else {
-					if (this.#abortController?.signal.aborted) {
+					if (abortController.signal.aborted) {
 						throw new Error("Request was aborted");
 					}
 				}
 			}
 		} catch (err: any) {
+			if (this.#activeRunId !== runId) {
+				return;
+			}
+
 			const errorMsg: AgentMessage = {
 				role: "assistant",
 				content: [{ type: "text", text: "" }],
@@ -1053,7 +1257,7 @@ export class Agent {
 					totalTokens: 0,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 				},
-				stopReason: this.#abortController?.signal.aborted ? "aborted" : "error",
+				stopReason: abortController.signal.aborted ? "aborted" : "error",
 				errorMessage: err?.message || String(err),
 				timestamp: Date.now(),
 			} as AgentMessage;
@@ -1062,13 +1266,16 @@ export class Agent {
 			this.#state.error = err?.message || String(err);
 			this.#emit({ type: "agent_end", messages: [errorMsg] });
 		} finally {
-			this.#state.isStreaming = false;
-			this.#state.streamMessage = null;
-			this.#state.pendingToolCalls = new Set<string>();
-			this.#abortController = undefined;
-			this.#resolveRunningPrompt?.();
-			this.#runningPrompt = undefined;
-			this.#resolveRunningPrompt = undefined;
+			if (this.#activeRunId === runId) {
+				this.#state.isStreaming = false;
+				this.#state.streamMessage = null;
+				this.#state.pendingToolCalls = new Set<string>();
+				this.#abortController = undefined;
+				this.#activeRunId = undefined;
+				this.#resolveRunningPrompt?.();
+				this.#runningPrompt = undefined;
+				this.#resolveRunningPrompt = undefined;
+			}
 		}
 	}
 

--- a/packages/agent/test/agent-force-abort.test.ts
+++ b/packages/agent/test/agent-force-abort.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "bun:test";
+import { Agent, type StreamFn } from "@gajae-code/agent-core";
+import type { CursorExecHandlers, SimpleStreamOptions } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { createAssistantMessage } from "./helpers";
+
+async function waitForStreaming(agent: Agent): Promise<void> {
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (agent.state.isStreaming) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Agent did not enter streaming state");
+}
+
+async function waitForCapturedCursorHandlers(
+	getHandlers: () => CursorExecHandlers | undefined,
+): Promise<CursorExecHandlers> {
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		const handlers = getHandlers();
+		if (handlers) return handlers;
+		await Bun.sleep(5);
+	}
+	throw new Error("Cursor handlers were not captured");
+}
+
+describe("Agent.forceAbort", () => {
+	it("recovers busy state when stream creation never resolves", async () => {
+		const model = createMockModel({ responses: [{ content: ["after hung create"] }] });
+		let callCount = 0;
+		const { promise: neverStream } = Promise.withResolvers<AssistantMessageEventStream>();
+		const streamFn: StreamFn = (selectedModel, context, options) => {
+			callCount += 1;
+			if (callCount === 1) return neverStream;
+			return model.stream(selectedModel, context, options);
+		};
+		const agent = new Agent({
+			initialState: { model: model.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn,
+		});
+
+		void agent.prompt("hang before stream");
+		await waitForStreaming(agent);
+
+		expect(agent.forceAbort("test timeout")).toBe(true);
+		await agent.waitForIdle();
+		expect(agent.state.isStreaming).toBe(false);
+
+		await expect(agent.prompt("next")).resolves.toBeUndefined();
+		expect(model.calls).toHaveLength(1);
+	});
+
+	it("forces an ignored abort back to idle and accepts a following prompt", async () => {
+		const model = createMockModel({ responses: [{ content: ["after force"] }] });
+		const hangingStream = new AssistantMessageEventStream();
+		let callCount = 0;
+		const streamFn: StreamFn = (selectedModel, context, options) => {
+			callCount += 1;
+			if (callCount === 1) return hangingStream;
+			return model.stream(selectedModel, context, options);
+		};
+		const agent = new Agent({
+			initialState: { model: model.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn,
+		});
+
+		const firstPrompt = agent.prompt("hang");
+		await waitForStreaming(agent);
+
+		expect(agent.forceAbort("test timeout")).toBe(true);
+		await agent.waitForIdle();
+		expect(agent.state.isStreaming).toBe(false);
+
+		await expect(firstPrompt).resolves.toBeUndefined();
+		await expect(agent.prompt("next")).resolves.toBeUndefined();
+		expect(agent.state.isStreaming).toBe(false);
+		expect(model.calls).toHaveLength(1);
+	});
+
+	it("ignores stale events from the force-aborted run after a new prompt starts", async () => {
+		const model = createMockModel();
+		const firstStream = new AssistantMessageEventStream();
+		const secondStream = new AssistantMessageEventStream();
+		let callCount = 0;
+		const streamFn: StreamFn = () => {
+			callCount += 1;
+			return callCount === 1 ? firstStream : secondStream;
+		};
+		const agent = new Agent({
+			initialState: { model: model.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn,
+		});
+
+		const firstPrompt = agent.prompt("first");
+		await waitForStreaming(agent);
+		const firstRunExternalEmitter = agent.createExternalEventEmitterForCurrentRun();
+		expect(agent.forceAbort("test timeout")).toBe(true);
+		await expect(firstPrompt).resolves.toBeUndefined();
+
+		const secondPrompt = agent.prompt("second");
+		await waitForStreaming(agent);
+
+		firstRunExternalEmitter?.({
+			type: "message_end",
+			message: createAssistantMessage([{ type: "text", text: "stale-external" }]),
+		});
+		firstStream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "stale" }]),
+		});
+		await Bun.sleep(10);
+		expect(agent.state.isStreaming).toBe(true);
+
+		secondStream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "fresh" }]),
+		});
+		await expect(secondPrompt).resolves.toBeUndefined();
+
+		expect(agent.state.isStreaming).toBe(false);
+		const assistantTexts = agent.state.messages
+			.filter(message => message.role === "assistant")
+			.flatMap(message => message.content)
+			.filter(content => content.type === "text")
+			.map(content => content.text);
+		expect(assistantTexts).toEqual(["fresh"]);
+	});
+
+	it("ignores late Cursor exec calls captured by a force-aborted run", async () => {
+		const model = createMockModel();
+		const firstStream = new AssistantMessageEventStream();
+		const secondStream = new AssistantMessageEventStream();
+		let firstRunCursorHandlers: CursorExecHandlers | undefined;
+		let callCount = 0;
+		const streamFn: StreamFn = (_selectedModel, _context, options?: SimpleStreamOptions) => {
+			callCount += 1;
+			if (callCount === 1) {
+				firstRunCursorHandlers = options?.cursorExecHandlers;
+				return firstStream;
+			}
+			return secondStream;
+		};
+		const emittedToolCallIds: string[] = [];
+		const agent = new Agent({
+			initialState: { model: model.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			cursorExecHandlers: {
+				read: async args => {
+					agent.emitExternalEvent({
+						type: "tool_execution_start",
+						toolCallId: args.toolCallId,
+						toolName: "read",
+						args: { path: args.path },
+					});
+					return {
+						role: "toolResult",
+						toolCallId: args.toolCallId,
+						toolName: "read",
+						content: [{ type: "text", text: "stale read" }],
+						isError: false,
+						timestamp: Date.now(),
+					};
+				},
+			},
+			streamFn,
+		});
+		agent.subscribe(event => {
+			if (event.type === "tool_execution_start") {
+				emittedToolCallIds.push(event.toolCallId);
+			}
+		});
+
+		const firstPrompt = agent.prompt("first");
+		await waitForStreaming(agent);
+		const staleCursorHandlers = await waitForCapturedCursorHandlers(() => firstRunCursorHandlers);
+		expect(staleCursorHandlers.read).toBeDefined();
+		expect(agent.forceAbort("test timeout")).toBe(true);
+		await expect(firstPrompt).resolves.toBeUndefined();
+
+		const secondPrompt = agent.prompt("second");
+		await waitForStreaming(agent);
+		const staleReadArgs = {
+			$typeName: "agent.v1.ReadArgs",
+			path: "stale.txt",
+			toolCallId: "old-call",
+		} as Parameters<NonNullable<CursorExecHandlers["read"]>>[0];
+		await expect(staleCursorHandlers.read?.(staleReadArgs)).rejects.toThrow("inactive agent run");
+		expect(emittedToolCallIds).toEqual([]);
+
+		secondStream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "fresh" }]),
+		});
+		await expect(secondPrompt).resolves.toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### Fixed
 
 - Made `gjc ultragoal` run natively without requiring `GJC_RUNTIME_BINARY`, while preserving active goal state across interrupted turns.
+- Fixed interactive Escape/interrupt recovery so abort cleanup is bounded and forces the session back to idle when a provider stream, tool, or post-turn task ignores cooperative cancellation.
 - Fixed root `gjc --worktree` / `gjc -w` startup so the launch command actually creates and enters the sibling `<repo>.gajae-code-worktrees/<branch-slug>` git worktree before starting the session, using collision-resistant branch slugs and avoiding worktree side effects for help/version launches.
 - Fixed root `gjc --worktree <branch>` / `gjc -w <branch>` parsing so named branch worktrees create their own `<branch-slug>` directory instead of reusing the dirty detached worktree for the current branch.
 - Wired GJC native UserPromptSubmit/Stop skill-state hooks, including `gjc setup hooks`, so public workflow keywords activate `.gjc/state`, active skill state can block premature Stop events, and active Ultragoal sessions remind steering prompts to use `gjc ultragoal steer`.

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -21,6 +21,7 @@ interface CursorExecBridgeOptions {
 	tools: Map<string, AgentTool>;
 	getToolContext?: () => AgentToolContext | undefined;
 	emitEvent?: (event: AgentEvent) => void;
+	createEventEmitter?: () => ((event: AgentEvent) => void) | undefined;
 }
 
 function createToolResultMessage(
@@ -162,23 +163,30 @@ function formatMcpToolErrorMessage(toolName: string, availableTools: string[]): 
 export class CursorExecHandlers implements ICursorExecHandlers {
 	constructor(private options: CursorExecBridgeOptions) {}
 
+	#optionsForCall(): CursorExecBridgeOptions {
+		return {
+			...this.options,
+			emitEvent: this.options.createEventEmitter ? this.options.createEventEmitter() : this.options.emitEvent,
+		};
+	}
+
 	async read(args: Parameters<NonNullable<ICursorExecHandlers["read"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
-		const toolResultMessage = await executeTool(this.options, "read", toolCallId, { path: args.path });
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "read", toolCallId, { path: args.path });
 		return toolResultMessage;
 	}
 
 	async ls(args: Parameters<NonNullable<ICursorExecHandlers["ls"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
 		// Redirect ls to read tool, which handles directories
-		const toolResultMessage = await executeTool(this.options, "read", toolCallId, { path: args.path });
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "read", toolCallId, { path: args.path });
 		return toolResultMessage;
 	}
 
 	async grep(args: Parameters<NonNullable<ICursorExecHandlers["grep"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
 		const searchPath = args.glob ? `${args.path || "."}/${args.glob}` : args.path || ".";
-		const toolResultMessage = await executeTool(this.options, "search", toolCallId, {
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "search", toolCallId, {
 			pattern: args.pattern,
 			paths: [searchPath],
 			i: args.caseInsensitive || undefined,
@@ -189,7 +197,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	async write(args: Parameters<NonNullable<ICursorExecHandlers["write"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
 		const content = args.fileText ?? new TextDecoder().decode(args.fileBytes ?? new Uint8Array());
-		const toolResultMessage = await executeTool(this.options, "write", toolCallId, {
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "write", toolCallId, {
 			path: args.path,
 			content,
 		});
@@ -198,14 +206,14 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 
 	async delete(args: Parameters<NonNullable<ICursorExecHandlers["delete"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
-		const toolResultMessage = await executeDelete(this.options, args.path, toolCallId);
+		const toolResultMessage = await executeDelete(this.#optionsForCall(), args.path, toolCallId);
 		return toolResultMessage;
 	}
 
 	async shell(args: Parameters<NonNullable<ICursorExecHandlers["shell"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
 		const timeoutSeconds = args.timeout && args.timeout > 0 ? args.timeout : undefined;
-		const toolResultMessage = await executeTool(this.options, "bash", toolCallId, {
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "bash", toolCallId, {
 			command: args.command,
 			cwd: args.workingDirectory || undefined,
 			timeout: timeoutSeconds,
@@ -217,9 +225,10 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		args: Parameters<NonNullable<ICursorExecHandlers["shellStream"]>>[0],
 		callbacks: CursorShellStreamCallbacks,
 	) {
+		const options = this.#optionsForCall();
 		const toolCallId = decodeToolCallId(args.toolCallId);
 		const toolName = "bash";
-		const tool = this.options.tools.get(toolName);
+		const tool = options.tools.get(toolName);
 		if (!tool) {
 			const result = buildToolErrorResult(`Tool "${toolName}" not available`);
 			return createToolResultMessage(toolCallId, toolName, result, true);
@@ -232,7 +241,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			timeout: timeoutSeconds,
 		};
 
-		this.options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: toolArgs });
+		options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: toolArgs });
 
 		let result: AgentToolResult<unknown>;
 		let isError = false;
@@ -252,7 +261,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 				content: [{ type: "text" as const, text: sanitizedRawText }],
 				details: partialResult.details,
 			};
-			this.options.emitEvent?.({
+			options.emitEvent?.({
 				type: "tool_execution_update",
 				toolCallId,
 				toolName,
@@ -277,7 +286,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		};
 
 		try {
-			result = await tool.execute(toolCallId, toolArgs, undefined, onUpdate, this.options.getToolContext?.());
+			result = await tool.execute(toolCallId, toolArgs, undefined, onUpdate, options.getToolContext?.());
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			result = buildToolErrorResult(message);
@@ -303,7 +312,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			content: result.content.map(c => (c.type === "text" ? { ...c, text: sanitizeText(c.text) } : c)),
 			details: result.details,
 		};
-		this.options.emitEvent?.({
+		options.emitEvent?.({
 			type: "tool_execution_end",
 			toolCallId,
 			toolName,
@@ -315,7 +324,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 
 	async diagnostics(args: Parameters<NonNullable<ICursorExecHandlers["diagnostics"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
-		const toolResultMessage = await executeTool(this.options, "lsp", toolCallId, {
+		const toolResultMessage = await executeTool(this.#optionsForCall(), "lsp", toolCallId, {
 			action: "diagnostics",
 			file: args.path,
 		});
@@ -323,18 +332,19 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	}
 
 	async mcp(call: CursorMcpCall) {
+		const options = this.#optionsForCall();
 		const toolName = call.toolName || call.name;
 		const toolCallId = decodeToolCallId(call.toolCallId);
-		const tool = this.options.tools.get(toolName);
+		const tool = options.tools.get(toolName);
 		if (!tool) {
-			const availableTools = Array.from(this.options.tools.keys()).filter(name => name.startsWith("mcp__"));
+			const availableTools = Array.from(options.tools.keys()).filter(name => name.startsWith("mcp__"));
 			const message = formatMcpToolErrorMessage(toolName, availableTools);
 			const result = buildToolErrorResult(message);
 			return createToolResultMessage(toolCallId, toolName, result, true);
 		}
 
 		const args = Object.keys(call.args ?? {}).length > 0 ? call.args : decodeMcpArgs(call.rawArgs ?? {});
-		const toolResultMessage = await executeTool(this.options, toolName, toolCallId, args);
+		const toolResultMessage = await executeTool(options, toolName, toolCallId, args);
 		return toolResultMessage;
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -21,12 +21,18 @@ interface Expandable {
 	setExpanded(expanded: boolean): void;
 }
 
+const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
+
+	#abortInteractive(): Promise<void> {
+		return this.ctx.session.abort({ timeoutMs: INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS });
+	}
 
 	setupKeyHandlers(): void {
 		this.ctx.editor.setActionKeys("app.interrupt", this.ctx.keybindings.getKeys("app.interrupt"));
@@ -48,7 +54,7 @@ export class InputController {
 			if (this.ctx.loopModeEnabled) {
 				this.ctx.pauseLoop();
 				if (this.ctx.session.isStreaming) {
-					void this.ctx.session.abort();
+					void this.#abortInteractive();
 				} else {
 					this.ctx.cancelPendingSubmission();
 				}
@@ -75,7 +81,7 @@ export class InputController {
 				this.ctx.isPythonMode = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isStreaming) {
-				void this.ctx.session.abort();
+				void this.#abortInteractive();
 			} else if (!this.ctx.editor.getText().trim()) {
 				// Double-interrupt with empty editor triggers /tree, /branch, or nothing based on setting
 				const action = settings.get("doubleEscapeAction");
@@ -193,7 +199,7 @@ export class InputController {
 			// Empty submit while streaming with queued messages: flush queues immediately
 			if (!text && this.ctx.session.isStreaming && this.ctx.session.queuedMessageCount > 0) {
 				// Abort current stream and let queued messages be processed
-				await this.ctx.session.abort();
+				await this.#abortInteractive();
 				return;
 			}
 
@@ -522,7 +528,7 @@ export class InputController {
 		if (allQueued.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();
 			if (options?.abort) {
-				this.ctx.session.abort();
+				void this.#abortInteractive();
 			}
 			return 0;
 		}
@@ -532,7 +538,7 @@ export class InputController {
 		this.ctx.editor.setText(combinedText);
 		this.ctx.updatePendingMessagesDisplay();
 		if (options?.abort) {
-			this.ctx.session.abort();
+			void this.#abortInteractive();
 		}
 		return allQueued.length;
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,6 +112,8 @@ import {
 import type { CompactionQueuedMessage, InteractiveModeContext, SubmittedUserInput, TodoItem, TodoPhase } from "./types";
 import { UiHelpers } from "./utils/ui-helpers";
 
+const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
 	mid: "muted",
@@ -1937,7 +1939,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// plan) while the popup is showing. The event listener fires asynchronously
 		// (agent's #emit is fire-and-forget), so without this the model sees
 		// "Plan ready for approval." and immediately re-invokes `resolve` in a loop.
-		await this.session.abort();
+		await this.session.abort({ timeoutMs: INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS });
 
 		const planFilePath = details.planFilePath || this.planModePlanFilePath || (await this.#getPlanFilePath());
 		this.planModePlanFilePath = planFilePath;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1458,6 +1458,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: toolRegistry,
 			getToolContext: () => toolContextStore.getContext(),
 			emitEvent: event => cursorEventEmitter?.(event),
+			createEventEmitter: () => agent.createExternalEventEmitterForCurrentRun(),
 		});
 
 		const repeatToolDescriptions = settings.get("repeatToolDescriptions");

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1097,8 +1097,9 @@ export class AgentSession {
 				message,
 				assistantMessageEvent,
 			};
+			const generation = this.#promptGeneration;
 			this.#preCacheStreamingEditFile(event);
-			this.#maybeAbortStreamingEdit(event);
+			this.#maybeAbortStreamingEdit(event, generation);
 		});
 		// Per-tool TTSR reminders are folded into the matched tool's result via this hook.
 		this.agent.afterToolCall = ctx => this.#ttsrAfterToolCall(ctx);
@@ -1614,7 +1615,7 @@ export class AgentSession {
 			event.type === "message_update" &&
 			(event.assistantMessageEvent.type === "toolcall_end" || event.assistantMessageEvent.type === "toolcall_delta")
 		) {
-			this.#maybeAbortStreamingEdit(event);
+			this.#maybeAbortStreamingEdit(event, this.#promptGeneration);
 		}
 
 		// Handle session persistence
@@ -1969,6 +1970,15 @@ export class AgentSession {
 			this.#resolvePostPromptTasks();
 		}
 	}
+
+	#abandonPostPromptTasks(): void {
+		this.#postPromptTasksAbortController.abort();
+		this.#postPromptTasksAbortController = new AbortController();
+		this.#postPromptTasks.clear();
+		this.#resolveTtsrResume();
+		this.#resolvePostPromptTasks();
+	}
+
 	/**
 	 * Wait for retry, TTSR resume, and any background continuation to settle.
 	 * Loops because a TTSR continuation can trigger a retry (or vice-versa),
@@ -2437,7 +2447,7 @@ export class AgentSession {
 		};
 	}
 
-	#maybeAbortStreamingEdit(event: AgentEvent): void {
+	#maybeAbortStreamingEdit(event: AgentEvent, generation: number): void {
 		if (!this.settings.get("edit.streamingAbort")) return;
 		if (this.#streamingEditAbortTriggered) return;
 		if (event.type !== "message_update") return;
@@ -2495,15 +2505,16 @@ export class AgentSession {
 				return;
 			}
 			if (assistantEvent.type === "toolcall_delta") return;
-			void this.#checkRemovedLinesAsync(toolCall.id, path, resolvedPath, removedLines);
+			void this.#checkRemovedLinesAsync(generation, toolCall.id, path, resolvedPath, removedLines);
 			return;
 		}
 
 		if (assistantEvent.type === "toolcall_delta") return;
-		void this.#checkPreviewPatchAsync(toolCall.id, path, rename, normalizedDiff);
+		void this.#checkPreviewPatchAsync(generation, toolCall.id, path, rename, normalizedDiff);
 	}
 
 	async #checkRemovedLinesAsync(
+		generation: number,
 		toolCallId: string,
 		path: string,
 		resolvedPath: string,
@@ -2512,6 +2523,7 @@ export class AgentSession {
 		if (this.#streamingEditAbortTriggered) return;
 		try {
 			const { text } = stripBom(await Bun.file(resolvedPath).text());
+			if (this.#promptGeneration !== generation) return;
 			const normalizedContent = normalizeToLF(text);
 			const missing = removedLines.find(line => !normalizedContent.includes(normalizeToLF(line)));
 			if (missing) {
@@ -2533,6 +2545,7 @@ export class AgentSession {
 	}
 
 	async #checkPreviewPatchAsync(
+		generation: number,
 		toolCallId: string,
 		path: string,
 		rename: string | undefined,
@@ -2549,6 +2562,7 @@ export class AgentSession {
 				},
 			);
 		} catch (error) {
+			if (this.#promptGeneration !== generation) return;
 			if (error instanceof ParseError) return;
 			this.#streamingEditAbortTriggered = true;
 			logger.warn("Streaming edit aborted due to patch preview failure", {
@@ -4784,7 +4798,7 @@ export class AgentSession {
 	/**
 	 * Abort current operation and wait for agent to become idle.
 	 */
-	async abort(options?: { goalReason?: "interrupted" | "internal" }): Promise<void> {
+	async abort(options?: { goalReason?: "interrupted" | "internal"; timeoutMs?: number }): Promise<void> {
 		this.abortRetry();
 		this.#promptGeneration++;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
@@ -4794,8 +4808,31 @@ export class AgentSession {
 		this.abortEval();
 		const postPromptDrain = this.#cancelPostPromptTasks();
 		this.agent.abort();
-		await postPromptDrain;
-		await this.agent.waitForIdle();
+		const cleanup = Promise.all([postPromptDrain, this.agent.waitForIdle()]).then(
+			() => ({ type: "settled" as const }),
+			(error: unknown) => ({ type: "error" as const, error }),
+		);
+		cleanup.catch(() => {});
+		const timeoutMs = options?.timeoutMs;
+		if (timeoutMs !== undefined && timeoutMs > 0) {
+			const outcome = await Promise.race([cleanup, Bun.sleep(timeoutMs).then(() => ({ type: "timeout" as const }))]);
+			if (outcome.type === "timeout") {
+				this.#abandonPostPromptTasks();
+				this.agent.forceAbort("Abort cleanup timed out");
+				this.emitNotice(
+					"warning",
+					"Abort cleanup timed out; forced session recovery. The previous provider stream or tool may still be unwinding in the background.",
+					"abort",
+				);
+			} else if (outcome.type === "error") {
+				throw outcome.error;
+			}
+		} else {
+			const outcome = await cleanup;
+			if (outcome.type === "error") {
+				throw outcome.error;
+			}
+		}
 		await this.#goalRuntime.onTaskAborted({ reason: options?.goalReason ?? "interrupted" });
 		// Clear prompt-in-flight state: waitForIdle resolves when the agent loop's finally
 		// block runs, but nested prompt setup/finalizers may still be unwinding. Without this,

--- a/packages/coding-agent/test/agent-session-abort-timeout.test.ts
+++ b/packages/coding-agent/test/agent-session-abort-timeout.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+describe("AgentSession abort timeout", () => {
+	let tempDir: TempDir | undefined;
+	let authStorage: AuthStorage | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		authStorage?.close();
+		authStorage = undefined;
+		tempDir?.removeSync();
+		tempDir = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("bounds abort cleanup when the underlying agent never becomes idle", async () => {
+		tempDir = TempDir.createSync("@gjc-abort-timeout-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic model to exist");
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+
+		const forcedAbort = vi.spyOn(agent, "forceAbort");
+		vi.spyOn(agent, "waitForIdle").mockImplementation(() => new Promise<void>(() => {}));
+
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice") notices.push(event.message);
+		});
+
+		await session.abort({ timeoutMs: 10 });
+
+		expect(forcedAbort).toHaveBeenCalledTimes(1);
+		expect(session.isStreaming).toBe(false);
+		expect(notices.some(message => message.includes("Abort cleanup timed out"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- add `Agent.forceAbort()` plus run-id fencing for stale provider, Cursor exec, and run-scoped callbacks
- bound interactive abort cleanup with a 5s timeout and force recovery notice when cooperative abort stalls
- abandon stuck post-prompt task tracking on timeout and guard streaming-edit async abort finalizers by prompt generation

## Verification
- `bun test packages/agent/test/agent-force-abort.test.ts packages/coding-agent/test/agent-session-abort-timeout.test.ts packages/coding-agent/test/agent-session-silent-abort.test.ts`
- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `./packages/coding-agent/dist/gjc --version && ./packages/coding-agent/dist/gjc --smoke-test`
- UltraQA targeted abort rerun x2

## Review
- Code-reviewer: APPROVE
- Architect: WATCH (merge acceptable; follow-up warning to keep future external emitters on run-fenced wrappers)
