### PR TITLE
Restore loop slash command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Removed
 
-- Removed approved non-critical slash-command handlers for loop, plan, share, browser, copy, todo, changelog, context, branch, fork, handoff, force, and quit while keeping provider setup/login/logout/model selection and SSH intact.
+- Removed approved non-critical slash-command handlers for plan, share, browser, copy, todo, changelog, context, branch, fork, handoff, force, and quit while keeping /loop, provider setup/login/logout/model selection, and SSH intact.
 - Removed redundant model-selector role assignment options for smol, slow, vision, plan, designer, commit, task, and custom roles so selection uses one canonical default model.
 - Removed obvious non-critical plugin, marketplace, extension, and reload-plugin slash-command handlers from the built-in registry while preserving ambiguous slash-command utilities for a later approval pass.
 - Removed the auto-QA grievance reporting feature, including the `report_tool_issue` tool, `gjc grievances` command, auto-QA settings/env flags, sharing consent prompt, bundled push endpoint, and persistent install ID correlation path.

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -112,6 +112,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "loop",
+		description:
+			"Toggle loop mode. While enabled, the next prompt you send re-submits after every yield. Esc cancels the current iteration; /loop again to disable.",
+		inlineHint: "[count|duration]",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.handleLoopCommand(command.args);
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "goal",
 		description: "Toggle goal mode (persistent autonomous objective for this session)",
 		subcommands: [

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -309,7 +309,7 @@ describe("ACP builtin slash commands", () => {
 
 	// TUI-only and dropped commands fall through as false
 	it("TUI-only and dropped commands return false (fall through to model)", async () => {
-		const removedCommands = [
+		const fallthroughCommands = [
 			"/login",
 			"/logout",
 			"/resume",
@@ -334,7 +334,7 @@ describe("ACP builtin slash commands", () => {
 			"/handoff",
 			"/fork",
 		];
-		for (const cmd of removedCommands) {
+		for (const cmd of fallthroughCommands) {
 			const { runtime } = createRuntime();
 			const result = await executeAcpBuiltinSlashCommand(cmd, runtime);
 			expect(result).toBe(false);

--- a/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
+++ b/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
@@ -32,7 +32,6 @@ describe("GJC utility extensibility quarantine", () => {
 			"marketplace",
 			"plugins",
 			"reload-plugins",
-			"loop",
 			"plan",
 			"share",
 			"browser",
@@ -48,6 +47,7 @@ describe("GJC utility extensibility quarantine", () => {
 		]) {
 			expect(registry).not.toContain(`name: "${removedCommand}"`);
 		}
+		expect(registry).toContain(`name: "loop"`);
 		expect(registry).toContain(`name: "ssh"`);
 		expect(registry).toContain(`name: "provider"`);
 		expect(await Bun.file(srcPath("slash-commands", "helpers", "marketplace-manager.ts")).exists()).toBe(false);


### PR DESCRIPTION
## Summary
- restore the TUI `/loop` slash command because its removal was a mistake
- keep the other approved slash-command removals intact
- update tests and changelog so `/loop` is preserved going forward

## Verification
- `bun test packages/coding-agent/test/loop-limit.test.ts packages/coding-agent/test/utility-extensibility-quarantine.test.ts packages/coding-agent/test/acp-builtins.test.ts`
- `bun check`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
