### PR TITLE
Add Codex-compatible goal tools

### DIFF
--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -5,7 +5,10 @@ import { formatNumber, prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
+import createGoalDescription from "../../prompts/tools/create-goal.md" with { type: "text" };
+import getGoalDescription from "../../prompts/tools/get-goal.md" with { type: "text" };
 import goalDescription from "../../prompts/tools/goal.md" with { type: "text" };
+import updateGoalDescription from "../../prompts/tools/update-goal.md" with { type: "text" };
 import { formatDuration } from "../../slash-commands/helpers/format";
 import type { ToolSession } from "../../tools";
 import { formatErrorMessage, TRUNCATE_LENGTHS } from "../../tools/render-utils";
@@ -20,7 +23,21 @@ const goalSchema = z.object({
 	token_budget: z.number().int().describe("token budget").optional(),
 });
 
+const getGoalSchema = z.object({});
+
+const createGoalSchema = z.object({
+	objective: z.string().describe("goal objective"),
+	token_budget: z.number().int().describe("token budget").optional(),
+});
+
+const updateGoalSchema = z.object({
+	status: z.enum(["complete", "dropped"]).describe("new goal status"),
+});
+
 export type GoalToolInput = z.infer<typeof goalSchema>;
+export type GetGoalToolInput = z.infer<typeof getGoalSchema>;
+export type CreateGoalToolInput = z.infer<typeof createGoalSchema>;
+export type UpdateGoalToolInput = z.infer<typeof updateGoalSchema>;
 
 export interface GoalToolResponse {
 	goal: Goal | null;
@@ -43,7 +60,10 @@ export function buildGoalToolResponse(
 	};
 }
 
-function validateCreateParams(params: GoalToolInput): { objective: string; tokenBudget?: number } {
+function validateCreateParams(params: { objective?: string; token_budget?: number }): {
+	objective: string;
+	tokenBudget?: number;
+} {
 	const objective = params.objective?.trim();
 	if (!objective) {
 		throw new ToolError("objective is required when op=create");
@@ -53,6 +73,34 @@ function validateCreateParams(params: GoalToolInput): { objective: string; token
 		throw new ToolError("token_budget must be a positive integer when provided");
 	}
 	return { objective, tokenBudget };
+}
+
+function renderGoalToolResponse(response: GoalToolResponse): string {
+	if (!response.goal) return "No active goal.";
+
+	let text = `Goal: ${response.goal.objective}\nStatus: ${response.goal.status}\nTokens: ${response.goal.tokensUsed} used`;
+	if (response.goal.tokenBudget !== undefined) {
+		text += ` / ${response.goal.tokenBudget} budget`;
+	}
+	if (response.remainingTokens !== null) {
+		text += `\nRemaining tokens: ${response.remainingTokens}`;
+	}
+	if (response.completionBudgetReport) {
+		text += `\n\n${response.completionBudgetReport}`;
+	}
+	return text;
+}
+
+function buildGoalToolResult(op: GoalToolDetails["op"], response: GoalToolResponse): AgentToolResult<GoalToolDetails> {
+	return {
+		content: [{ type: "text", text: renderGoalToolResponse(response) }],
+		details: {
+			op,
+			goal: response.goal,
+			remainingTokens: response.remainingTokens,
+			completionBudgetReport: response.completionBudgetReport,
+		},
+	};
 }
 
 export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
@@ -97,30 +145,106 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 			const completed = await runtime.completeGoalFromTool();
 			response = buildGoalToolResponse(completed, { includeCompletionReport: true });
 		}
-		let text: string;
-		if (response.goal) {
-			text = `Goal: ${response.goal.objective}\nStatus: ${response.goal.status}\nTokens: ${response.goal.tokensUsed} used`;
-			if (response.goal.tokenBudget !== undefined) {
-				text += ` / ${response.goal.tokenBudget} budget`;
-			}
-			if (response.remainingTokens !== null) {
-				text += `\nRemaining tokens: ${response.remainingTokens}`;
-			}
-			if (response.completionBudgetReport) {
-				text += `\n\n${response.completionBudgetReport}`;
-			}
-		} else {
-			text = "No active goal.";
+		return buildGoalToolResult(params.op, response);
+	}
+}
+
+export class GetGoalTool implements AgentTool<typeof getGoalSchema, GoalToolDetails> {
+	readonly name = "get_goal";
+	readonly label = "Get Goal";
+	readonly description = prompt.render(getGoalDescription);
+	readonly parameters = getGoalSchema;
+	readonly strict = true;
+	readonly intent = "omit" as const;
+	readonly #session: ToolSession;
+
+	static createIf(session: ToolSession): GetGoalTool | null {
+		return session.getGoalModeState || session.getGoalRuntime ? new GetGoalTool(session) : null;
+	}
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	async execute(
+		_toolCallId: string,
+		_params: GetGoalToolInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<GoalToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<GoalToolDetails>> {
+		const state = this.#session.getGoalModeState?.();
+		return buildGoalToolResult("get", buildGoalToolResponse(state?.goal ?? null));
+	}
+}
+
+export class CreateGoalTool implements AgentTool<typeof createGoalSchema, GoalToolDetails> {
+	readonly name = "create_goal";
+	readonly label = "Create Goal";
+	readonly description = prompt.render(createGoalDescription);
+	readonly parameters = createGoalSchema;
+	readonly strict = true;
+	readonly intent = "omit" as const;
+	readonly #session: ToolSession;
+
+	static createIf(session: ToolSession): CreateGoalTool | null {
+		return session.getGoalRuntime ? new CreateGoalTool(session) : null;
+	}
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: CreateGoalToolInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<GoalToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<GoalToolDetails>> {
+		const runtime = this.#session.getGoalRuntime?.();
+		if (!runtime) {
+			throw new ToolError("Goal mode is not active.");
 		}
-		return {
-			content: [{ type: "text", text }],
-			details: {
-				op: params.op,
-				goal: response.goal,
-				remainingTokens: response.remainingTokens,
-				completionBudgetReport: response.completionBudgetReport,
-			},
-		};
+		const created = await runtime.createGoal(validateCreateParams(params));
+		return buildGoalToolResult("create", buildGoalToolResponse(created.goal));
+	}
+}
+
+export class UpdateGoalTool implements AgentTool<typeof updateGoalSchema, GoalToolDetails> {
+	readonly name = "update_goal";
+	readonly label = "Update Goal";
+	readonly description = prompt.render(updateGoalDescription);
+	readonly parameters = updateGoalSchema;
+	readonly strict = true;
+	readonly intent = "omit" as const;
+	readonly #session: ToolSession;
+
+	static createIf(session: ToolSession): UpdateGoalTool | null {
+		return session.getGoalRuntime ? new UpdateGoalTool(session) : null;
+	}
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: UpdateGoalToolInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<GoalToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<GoalToolDetails>> {
+		const runtime = this.#session.getGoalRuntime?.();
+		if (!runtime) {
+			throw new ToolError("Goal mode is not active.");
+		}
+		if (params.status === "dropped") {
+			const dropped = await runtime.dropGoal();
+			return buildGoalToolResult("drop", buildGoalToolResponse(dropped ?? null));
+		}
+		const completed = await runtime.completeGoalFromTool();
+		return buildGoalToolResult("complete", buildGoalToolResponse(completed, { includeCompletionReport: true }));
 	}
 }
 

--- a/packages/coding-agent/src/prompts/tools/create-goal.md
+++ b/packages/coding-agent/src/prompts/tools/create-goal.md
@@ -1,0 +1,3 @@
+Create a new goal-mode objective for the current session.
+
+Requires `objective`; optional `token_budget` must be a positive integer. Use only when `get_goal` reports no different active or paused goal.

--- a/packages/coding-agent/src/prompts/tools/get-goal.md
+++ b/packages/coding-agent/src/prompts/tools/get-goal.md
@@ -1,0 +1,3 @@
+Return the current goal-mode state.
+
+Use this before creating or completing a goal. It returns the active or paused goal when one exists, including status, usage, and remaining token budget.

--- a/packages/coding-agent/src/prompts/tools/update-goal.md
+++ b/packages/coding-agent/src/prompts/tools/update-goal.md
@@ -1,0 +1,3 @@
+Update the current goal-mode objective status.
+
+Use `status: "complete"` only after the goal is actually finished and verified. Use `status: "dropped"` only when intentionally abandoning the current goal.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1413,6 +1413,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		for (const tool of builtinTools) {
 			toolRegistry.set(tool.name, tool);
 		}
+		const goalStateToolNames = ["get_goal", "create_goal", "update_goal"] as const;
+		if (settings.get("goal.enabled")) {
+			for (const name of goalStateToolNames) {
+				if (toolRegistry.has(name)) continue;
+				const goalStateTool = await logger.time(`createTools:${name}:session`, HIDDEN_TOOLS[name], toolSession);
+				if (goalStateTool) {
+					toolRegistry.set(goalStateTool.name, wrapToolWithMetaNotice(goalStateTool));
+				}
+			}
+		}
 		if (!toolRegistry.has("goal") && settings.get("goal.enabled")) {
 			const goalTool = await logger.time("createTools:goal:session", HIDDEN_TOOLS.goal, toolSession);
 			if (goalTool) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -7,7 +7,7 @@ import { EditTool } from "../edit";
 import { checkPythonKernelAvailability } from "../eval/py/kernel";
 import type { Skill } from "../extensibility/skills";
 import type { GoalModeState, GoalRuntime } from "../goals";
-import { GoalTool } from "../goals/tools/goal-tool";
+import { CreateGoalTool, GetGoalTool, GoalTool, UpdateGoalTool } from "../goals/tools/goal-tool";
 import type { HindsightSessionState } from "../hindsight/state";
 import { LspTool } from "../lsp";
 import type { PlanModeState } from "../plan-mode/state";
@@ -310,11 +310,16 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	reflect: HindsightReflectTool.createIf,
 };
 
+const GOAL_MODE_TOOL_NAMES = ["get_goal", "create_goal", "update_goal"] as const;
+
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	yield: s => new YieldTool(s),
 	report_finding: () => reportFindingTool,
 	resolve: s => new ResolveTool(s),
 	goal: s => new GoalTool(s),
+	get_goal: GetGoalTool.createIf,
+	create_goal: CreateGoalTool.createIf,
+	update_goal: UpdateGoalTool.createIf,
 };
 
 export type ToolName = keyof typeof BUILTIN_TOOLS;
@@ -365,8 +370,14 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		toolNames && toolNames.length > 0 ? [...new Set(toolNames.map(name => name.toLowerCase()))] : undefined;
 	const goalEnabled = session.settings.get("goal.enabled");
 	const goalModeActive = goalEnabled && session.getGoalModeState?.()?.enabled === true;
+	const goalStateToolNames = [...GOAL_MODE_TOOL_NAMES];
 	if (goalModeActive && requestedTools && !requestedTools.includes("goal")) {
 		requestedTools = [...requestedTools, "goal"];
+	}
+	if (goalEnabled && requestedTools) {
+		for (const name of goalStateToolNames) {
+			if (!requestedTools.includes(name)) requestedTools.push(name);
+		}
 	}
 	const backends = resolveEvalBackends(session);
 	const allowPython = backends.python;
@@ -440,6 +451,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	const allTools: Record<string, ToolFactory> = { ...BUILTIN_TOOLS, ...HIDDEN_TOOLS };
 	const isToolAllowed = (name: string) => {
 		if (name === "goal") return goalEnabled && goalModeActive;
+		if (goalStateToolNames.includes(name as (typeof GOAL_MODE_TOOL_NAMES)[number])) return goalEnabled;
 		if (name === "lsp") return enableLsp && session.settings.get("lsp.enabled");
 		if (name === "bash") return true;
 		if (name === "eval") return allowEval;
@@ -488,6 +500,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 						.filter(([name]) => isToolAllowed(name))
 						.map(([name, factory]) => [name, factory] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOLS.yield]] as const) : []),
+					...(goalEnabled ? goalStateToolNames.map(name => [name, HIDDEN_TOOLS[name]] as const) : []),
 					...(goalModeActive ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
 				];
 

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -128,6 +128,7 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModePaused).toBe(true);
 		expect(harness.session.getGoalModeState()?.goal.status).toBe("paused");
 		expect(await toolNamesFor(harness)).not.toContain("goal");
+		expect(await toolNamesFor(harness)).toEqual(expect.arrayContaining(["get_goal", "create_goal", "update_goal"]));
 	});
 
 	it("replaces the active goal via /goal set", async () => {

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import { completionBudgetReport, GoalRuntime } from "@gajae-code/coding-agent/goals/runtime";
 import type { Goal, GoalModeState, GoalTokenUsage } from "@gajae-code/coding-agent/goals/state";
-import { GoalTool } from "@gajae-code/coding-agent/goals/tools/goal-tool";
+import { CreateGoalTool, GetGoalTool, GoalTool, UpdateGoalTool } from "@gajae-code/coding-agent/goals/tools/goal-tool";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 
 function createUsage(overrides: Partial<GoalTokenUsage> = {}): GoalTokenUsage {
@@ -302,5 +302,62 @@ describe("GoalTool", () => {
 		expect(result.details?.op).toBe("drop");
 		expect(result.details?.goal?.status).toBe("dropped");
 		expect(harness.getState()).toBeUndefined();
+	});
+
+	it("exposes Codex-compatible get_goal/create_goal/update_goal tools", async () => {
+		const harness = createRuntimeHarness();
+		const session = createToolSession({
+			getGoalRuntime: () => harness.runtime,
+			getGoalModeState: () => harness.getState(),
+		});
+
+		const created = await new CreateGoalTool(session).execute("call-create-goal", {
+			objective: "  Ship ultragoal lifecycle  ",
+			token_budget: 20,
+		});
+		expect(created.details).toMatchObject({
+			op: "create",
+			goal: { objective: "Ship ultragoal lifecycle", status: "active", tokenBudget: 20 },
+			remainingTokens: 20,
+		});
+
+		const fetched = await new GetGoalTool(session).execute("call-get-goal", {});
+		expect(fetched.details).toMatchObject({
+			op: "get",
+			goal: { objective: "Ship ultragoal lifecycle", status: "active", tokenBudget: 20 },
+			remainingTokens: 20,
+		});
+
+		const completed = await new UpdateGoalTool(session).execute("call-update-goal", { status: "complete" });
+		expect(completed.details).toMatchObject({
+			op: "complete",
+			goal: { objective: "Ship ultragoal lifecycle", status: "complete", tokenBudget: 20 },
+			remainingTokens: 20,
+		});
+		expect(completed.details?.completionBudgetReport).toBe(
+			"Goal achieved. Report final budget usage to the user: tokens used: 0 of 20.",
+		);
+		expect(harness.getState()?.enabled).toBe(false);
+	});
+
+	it("shares the same session goal state between legacy goal and Codex-compatible tools", async () => {
+		const harness = createRuntimeHarness();
+		const session = createToolSession({
+			getGoalRuntime: () => harness.runtime,
+			getGoalModeState: () => harness.getState(),
+		});
+
+		await new GoalTool(session).execute("call-legacy-create", {
+			op: "create",
+			objective: "Shared state",
+		});
+		const fetchedByNamedTool = await new GetGoalTool(session).execute("call-get-goal", {});
+		expect(fetchedByNamedTool.details?.goal?.objective).toBe("Shared state");
+		expect(fetchedByNamedTool.details?.goal?.status).toBe("active");
+
+		await new UpdateGoalTool(session).execute("call-update-goal", { status: "complete" });
+		const fetchedByLegacyTool = await new GoalTool(session).execute("call-legacy-get", { op: "get" });
+		expect(fetchedByLegacyTool.details?.goal?.objective).toBe("Shared state");
+		expect(fetchedByLegacyTool.details?.goal?.status).toBe("complete");
 	});
 });


### PR DESCRIPTION
## Summary
- add get_goal, create_goal, and update_goal wrappers over the existing goal runtime
- expose named goal tools when goal mode is enabled while preserving legacy goal tool behavior
- add regression coverage for named tools and shared state with /goal

## Verification
- bun test packages/coding-agent/test/goals/goal-tool.test.ts packages/coding-agent/test/goals/goal-mode-integration.test.ts
- bun run --cwd packages/coding-agent check