### PR TITLE
Rebrand ultragoal goal tooling to GJC

### DIFF
--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -2,7 +2,7 @@ import { Command } from "@gajae-code/utils/cli";
 import {
 	GJC_SESSION_FILE_ENV,
 	isUltragoalCreateGoalsInvocation,
-	readUltragoalCodexObjective,
+	readUltragoalGjcObjective,
 	writeCurrentSessionGoalModeState,
 	writePendingGoalModeRequest,
 } from "../gjc-runtime/goal-mode-request";
@@ -22,7 +22,7 @@ export default class Ultragoal extends Command {
 		if (result.status !== 0 || !shouldActivateGoalMode) return;
 
 		const cwd = process.cwd();
-		const { objective, goalsPath } = await readUltragoalCodexObjective(cwd);
+		const { objective, goalsPath } = await readUltragoalGjcObjective(cwd);
 		const sessionWrite = await writeCurrentSessionGoalModeState({
 			sessionFile: process.env[GJC_SESSION_FILE_ENV],
 			objective,

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -63,9 +63,9 @@ must be rejected instead of silently coerced.
 
 ### Team + Ultragoal bridge
 
-Use `$ultragoal` for durable leader-owned goal/ledger tracking and `$team` for one visible tmux execution lane. When Team is launched with an active `.gjc/ultragoal/goals.json`, worker task/status context may include leader-owned Ultragoal context: `.gjc/ultragoal/goals.json`, `.gjc/ultragoal/ledger.jsonl`, the active goal id, Codex goal mode, and the `fresh_leader_get_goal_required` checkpoint policy.
+Use `$ultragoal` for durable leader-owned goal/ledger tracking and `$team` for one visible tmux execution lane. When Team is launched with an active `.gjc/ultragoal/goals.json`, worker task/status context may include leader-owned Ultragoal context: `.gjc/ultragoal/goals.json`, `.gjc/ultragoal/ledger.jsonl`, the active goal id, GJC goal mode, and the `fresh_leader_get_goal_required` checkpoint policy.
 
-Workers provide task status and verification evidence only. They do not own Ultragoal goal state, create worker ledgers, mutate `.gjc/ultragoal`, auto-launch Team from Ultragoal, or perform hidden Codex goal mutation. The leader uses terminal Team evidence plus a fresh `get_goal` snapshot to run `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/ultragoal and <id>>" --codex-goal-json <fresh-get_goal-json-or-path>`.
+Workers provide task status and verification evidence only. They do not own Ultragoal goal state, create worker ledgers, mutate `.gjc/ultragoal`, auto-launch Team from Ultragoal, or perform hidden GJC goal mutation. The leader uses terminal Team evidence plus a fresh `get_goal` snapshot to run `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/ultragoal and <id>>" --gjc-goal-json <fresh-get_goal-json-or-path>`.
 
 ### Worker command override
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -1,23 +1,50 @@
 ---
 name: ultragoal
-description: Create and execute durable repo-native multi-goal plans over Codex goal mode artifacts.
+description: Create and execute durable repo-native multi-goal plans over GJC goal mode artifacts.
 
 source: "forked from upstream ultragoal skill and rebranded for GJC"
 ---
 
 # Ultragoal Workflow
 
-Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over Codex `/goal`.
+Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over GJC goal mode.
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.gjc/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while GJC tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI so the previous completed aggregate goal does not block or confuse the next `create_goal`.
+`ultragoal` turns a brief into repo-native artifacts and then drives a GJC goal safely through the named goal tools: `get_goal`, `create_goal`, and `update_goal`. New plans default to a stable pointer-style aggregate GJC goal for the whole durable plan in `.gjc/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while GJC tracks G001/G002 story progress in the ledger. Ultragoal does not call `/goal clear`; before multiple sequential ultragoal runs in one session/thread, manually run `/goal clear` in the UI so the previous completed aggregate goal does not block or confuse the next `create_goal`.
 
 - `.gjc/ultragoal/brief.md`
 - `.gjc/ultragoal/goals.json`
 - `.gjc/ultragoal/ledger.jsonl` (checkpoint and structured steering audit events)
 
-Existing aggregate plans with the legacy enumerated objective are migrated to the stable pointer objective on read, persisted to `goals.json`, retained in `codexObjectiveAliases` for already-active hidden Codex goal reconciliation, and audited with an `aggregate_objective_migrated` ledger entry.
+Existing aggregate plans with the legacy enumerated objective are migrated to the stable pointer objective on read, persisted to `goals.json`, retained in `gjcObjectiveAliases` for already-active hidden goal reconciliation, and audited with an `aggregate_objective_migrated` ledger entry.
+
+## Always-used command examples
+
+Use these exact `gjc ultragoal` commands before spending tool calls rediscovering syntax:
+
+```sh
+gjc ultragoal status
+gjc ultragoal status --json
+gjc ultragoal create-goals --brief "<brief>"
+gjc ultragoal create-goals --brief-file <path>
+gjc ultragoal complete-goals
+gjc ultragoal complete-goals --retry-failed
+gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get-goal-json-or-path>
+gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"
+gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --gjc-goal-json <active-get-goal-json-or-path>
+```
+
+Use these exact goal-tool calls for the inline goal state:
+
+```json
+get_goal({})
+create_goal({"objective":"<printed aggregate or per-story objective>"})
+update_goal({"status":"complete"})
+```
+
+`get_goal`, `create_goal`, and `update_goal` share the same session goal state as `/goal`; prefer these named tools inside Ultragoal because they produce JSON snapshots for ledger reconciliation.
+
 
 ## Create goals
 
@@ -25,7 +52,7 @@ Existing aggregate plans with the legacy enumerated objective are migrated to th
    - `gjc ultragoal create-goals --brief "<brief>"`
    - `gjc ultragoal create-goals --brief-file <path>`
    - `cat <brief> | gjc ultragoal create-goals --from-stdin`
-   - `gjc ultragoal create-goals --codex-goal-mode per-story --brief "<brief>"` only when one Codex goal context per story is explicitly preferred
+   - `gjc ultragoal create-goals --gjc-goal-mode per-story --brief "<brief>"` only when one GJC goal context per story is explicitly preferred
 2. Inspect `.gjc/ultragoal/goals.json` and refine if needed.
 
 ## Complete goals
@@ -34,17 +61,17 @@ Loop until `gjc ultragoal status` reports all goals complete:
 
 1. Run `gjc ultragoal complete-goals`.
 2. Read the printed handoff.
-3. Call `get_goal`.
-4. If no active Codex goal exists, call `create_goal` with the printed payload. In aggregate mode, if the same aggregate Codex objective is already active, continue the current GJC story without creating a new Codex goal.
+3. Call `get_goal({})`.
+4. If no active GJC goal exists, call `create_goal({"objective":"<printed payload objective>"})` with the printed payload. In aggregate mode, if the same aggregate objective is already active, continue the current GJC story without creating a new GJC goal.
 5. Complete the current GJC story only.
 6. Run a completion audit against the story objective and real artifacts/tests.
-7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({status: "complete"})` only after that gate is clean, then call `get_goal` again for a fresh `complete` snapshot.
-8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--codex-goal-json`; final clean checkpoints also require `--quality-gate-json`:
-   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
+7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal({})` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({"status":"complete"})` only after that gate is clean, then call `get_goal({})` again for a fresh `complete` snapshot.
+8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--gjc-goal-json`; final clean checkpoints also require `--quality-gate-json`:
+   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
 9. If blocked or failed, checkpoint failure:
    `gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
 10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
-   `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
+   `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy GJC goal blocks create_goal in this thread>" --gjc-goal-json <get_goal-json-or-path>`
 11. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
 
 ## Dynamic steering
@@ -69,7 +96,7 @@ gjc ultragoal steer --directive-json ./steering.json --json
 
 Steering invariants:
 
-- Do not edit the aggregate Codex objective, original brief constraints, quality gates, or completion status. The aggregate objective is a stable pointer to `.gjc/ultragoal/goals.json` and `.gjc/ultragoal/ledger.jsonl`, not an enumeration of initial goal ids.
+- Do not edit the aggregate goal objective, original brief constraints, quality gates, or completion status. The aggregate objective is a stable pointer to `.gjc/ultragoal/goals.json` and `.gjc/ultragoal/ledger.jsonl`, not an enumeration of initial goal ids.
 - Do not hard-delete goals, auto-complete work, weaken verification, or silently mutate `.gjc/ultragoal`.
 - Accepted and rejected attempts append structured audit entries to `.gjc/ultragoal/ledger.jsonl`.
 - Superseded goals remain in `goals.json` with steering metadata and are skipped for scheduling.
@@ -98,10 +125,10 @@ Use ultragoal and team together for a durable Ultragoal story that benefits from
 The leader checkpoints Ultragoal from Team evidence with a fresh `get_goal` snapshot:
 
 ```sh
-gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/ultragoal and <id>>" --codex-goal-json <fresh-get_goal-json-or-path>
+gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/ultragoal and <id>>" --gjc-goal-json <fresh-get_goal-json-or-path>
 ```
 
-Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden Codex goal mutation.
+Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden goal mutation.
 
 ## Mandatory final cleanup and review gate
 
@@ -114,15 +141,15 @@ The final ultragoal story is not complete until the active agent has run the fin
 5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
 
    ```sh
-   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
+   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --gjc-goal-json <active-get-goal-json-or-path>
    ```
 
-   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `gjc ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the GJC goal active, and lets `gjc ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available GJC goal context because the old per-story GJC goal remains active/incomplete.
 
-6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+6. If review is clean, call `update_goal({"status":"complete"})`, call `get_goal({})`, and checkpoint with a structured final gate:
 
    ```sh
-   gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
+   gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --gjc-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
    ```
 
 `--quality-gate-json` must include:
@@ -137,11 +164,11 @@ The final ultragoal story is not complete until the active agent has run the fin
 
 ## Constraints
 
-- The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
-- Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
-- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
+- The shell command cannot directly invoke interactive `/goal`; it emits a model-facing handoff for the active GJC agent.
+- Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; use only the named goal-tool surface: `get_goal`, `create_goal`, and `update_goal`.
+- After a completed aggregate ultragoal run, clear the goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
-- In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.
-- Completion checkpoints require read-only Codex snapshot reconciliation: pass fresh `get_goal` JSON/path with `--codex-goal-json`; shell commands and hooks must not mutate Codex goal state.
+- In aggregate mode, intermediate story checkpoints require a matching `active` GJC goal snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.
+- Completion checkpoints require read-only goal snapshot reconciliation: pass fresh `get_goal` JSON/path with `--gjc-goal-json`; shell commands and hooks must not mutate goal state.
 - Treat `ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -32,7 +32,7 @@ export type CurrentSessionGoalModeWriteResult =
 	| { status: "updated"; goal: Goal; sessionFile: string };
 
 interface UltragoalPlanShape {
-	codexObjective?: unknown;
+	gjcObjective?: unknown;
 }
 
 function isEnoent(error: unknown): boolean {
@@ -58,11 +58,11 @@ export function isUltragoalCreateGoalsInvocation(args: readonly string[]): boole
 	return command !== undefined && isCreateGoalsArg(command);
 }
 
-export async function readUltragoalCodexObjective(cwd: string): Promise<{ objective: string; goalsPath: string }> {
+export async function readUltragoalGjcObjective(cwd: string): Promise<{ objective: string; goalsPath: string }> {
 	const goalsPath = ultragoalGoalsPath(cwd);
 	try {
 		const plan = (await Bun.file(goalsPath).json()) as UltragoalPlanShape;
-		const objective = typeof plan.codexObjective === "string" ? plan.codexObjective.trim() : "";
+		const objective = typeof plan.gjcObjective === "string" ? plan.gjcObjective.trim() : "";
 		return { objective: objective || DEFAULT_ULTRAGOAL_OBJECTIVE, goalsPath };
 	} catch (error) {
 		if (isEnoent(error)) {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 
-export type UltragoalCodexGoalMode = "aggregate" | "per-story";
+export type UltragoalGjcGoalMode = "aggregate" | "per-story";
 export type UltragoalGoalStatus =
 	| "pending"
 	| "active"
@@ -28,9 +28,9 @@ export interface UltragoalGoal {
 export interface UltragoalPlan {
 	version: 1;
 	brief: string;
-	codexGoalMode: UltragoalCodexGoalMode;
-	codexObjective: string;
-	codexObjectiveAliases?: string[];
+	gjcGoalMode: UltragoalGjcGoalMode;
+	gjcObjective: string;
+	gjcObjectiveAliases?: string[];
 	goals: UltragoalGoal[];
 	createdAt: string;
 	updatedAt: string;
@@ -47,7 +47,7 @@ export interface UltragoalStatusSummary {
 	exists: boolean;
 	status: "missing" | "pending" | "active" | "complete" | "blocked" | "failed";
 	paths: UltragoalPaths;
-	codexObjective?: string;
+	gjcObjective?: string;
 	currentGoal?: UltragoalGoal;
 	counts: Record<UltragoalGoalStatus, number>;
 	goals: UltragoalGoal[];
@@ -136,8 +136,8 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 	const brief = nonEmptyString(record.brief) ?? "";
 	const createdAt = nonEmptyString(record.createdAt) ?? new Date().toISOString();
 	const updatedAt = nonEmptyString(record.updatedAt) ?? createdAt;
-	const codexGoalMode = record.codexGoalMode === "per-story" ? "per-story" : "aggregate";
-	const codexObjective = nonEmptyString(record.codexObjective) ?? DEFAULT_ULTRAGOAL_OBJECTIVE;
+	const gjcGoalMode = record.gjcGoalMode === "per-story" ? "per-story" : "aggregate";
+	const gjcObjective = nonEmptyString(record.gjcObjective) ?? DEFAULT_ULTRAGOAL_OBJECTIVE;
 	const rawGoals = Array.isArray(record.goals) ? record.goals : [];
 	const goals: UltragoalGoal[] = rawGoals.map((item, index) => {
 		const goalRecord = typeof item === "object" && item !== null ? (item as JsonObject) : {};
@@ -161,17 +161,17 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 					: undefined,
 		};
 	});
-	const aliases = Array.isArray(record.codexObjectiveAliases)
-		? record.codexObjectiveAliases.filter(
+	const aliases = Array.isArray(record.gjcObjectiveAliases)
+		? record.gjcObjectiveAliases.filter(
 				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: undefined;
 	return {
 		version: 1,
 		brief,
-		codexGoalMode,
-		codexObjective,
-		codexObjectiveAliases: aliases,
+		gjcGoalMode,
+		gjcObjective,
+		gjcObjectiveAliases: aliases,
 		goals,
 		createdAt,
 		updatedAt,
@@ -216,7 +216,7 @@ export async function getUltragoalStatus(cwd: string): Promise<UltragoalStatusSu
 		exists: true,
 		status,
 		paths,
-		codexObjective: plan.codexObjective,
+		gjcObjective: plan.gjcObjective,
 		currentGoal,
 		counts,
 		goals: plan.goals,
@@ -235,7 +235,7 @@ function titleFromBrief(brief: string): string {
 export async function createUltragoalPlan(input: {
 	cwd: string;
 	brief: string;
-	codexGoalMode?: UltragoalCodexGoalMode;
+	gjcGoalMode?: UltragoalGjcGoalMode;
 }): Promise<UltragoalPlan> {
 	const brief = input.brief.trim();
 	if (!brief) throw new Error("ultragoal brief is required");
@@ -243,8 +243,8 @@ export async function createUltragoalPlan(input: {
 	const plan: UltragoalPlan = {
 		version: 1,
 		brief,
-		codexGoalMode: input.codexGoalMode ?? "aggregate",
-		codexObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
+		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
+		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
 		goals: [
 			{
 				id: "G001",
@@ -309,7 +309,7 @@ export async function checkpointUltragoalGoal(input: {
 	goalId: string;
 	status: UltragoalGoalStatus;
 	evidence: string;
-	codexGoalJson?: string;
+	gjcGoalJson?: string;
 	qualityGateJson?: string;
 }): Promise<UltragoalPlan> {
 	const plan = await readUltragoalPlan(input.cwd);
@@ -330,7 +330,7 @@ export async function checkpointUltragoalGoal(input: {
 		goalId: goal.id,
 		status: input.status,
 		evidence,
-		codexGoalJson: input.codexGoalJson ? await readStructuredValue(input.cwd, input.codexGoalJson) : undefined,
+		gjcGoalJson: input.gjcGoalJson ? await readStructuredValue(input.cwd, input.gjcGoalJson) : undefined,
 		qualityGateJson: input.qualityGateJson ? await readStructuredValue(input.cwd, input.qualityGateJson) : undefined,
 	});
 	return plan;
@@ -382,7 +382,7 @@ export async function recordUltragoalReviewBlockers(input: {
 	title: string;
 	objective: string;
 	evidence: string;
-	codexGoalJson?: string;
+	gjcGoalJson?: string;
 }): Promise<UltragoalPlan> {
 	const objective = input.objective.trim();
 	if (!objective) throw new Error("record-review-blockers --objective is required");
@@ -391,7 +391,7 @@ export async function recordUltragoalReviewBlockers(input: {
 		goalId: input.goalId,
 		status: "review_blocked",
 		evidence: input.evidence,
-		codexGoalJson: input.codexGoalJson,
+		gjcGoalJson: input.gjcGoalJson,
 	});
 	const now = new Date().toISOString();
 	const nextId = `G${String(plan.goals.length + 1).padStart(3, "0")}`;
@@ -423,11 +423,11 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 const FLAGS_WITH_VALUES = new Set([
 	"--brief",
 	"--brief-file",
-	"--codex-goal-mode",
+	"--gjc-goal-mode",
 	"--goal-id",
 	"--status",
 	"--evidence",
-	"--codex-goal-json",
+	"--gjc-goal-json",
 	"--quality-gate-json",
 	"--kind",
 	"--title",
@@ -479,8 +479,8 @@ function renderCompleteHandoff(
 	return [
 		`Ultragoal handoff: ${result.goal.id} — ${result.goal.title}`,
 		`Objective: ${result.goal.objective}`,
-		`Codex objective: ${result.plan.codexObjective}`,
-		"Call get_goal; create_goal only if no active Codex goal exists, then complete this OMX story and checkpoint it.",
+		`GJC objective: ${result.plan.gjcObjective}`,
+		"Call get_goal({}); create_goal only if no active GJC goal exists, then complete this GJC story and checkpoint it.",
 		"",
 	].join("\n");
 }
@@ -494,8 +494,8 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 				return { status: 0, stdout: renderStatus(await getUltragoalStatus(cwd), json) };
 			case "create":
 			case "create-goals": {
-				const mode = flagValue(args, "--codex-goal-mode") === "per-story" ? "per-story" : "aggregate";
-				const plan = await createUltragoalPlan({ cwd, brief: await readBrief(cwd, args), codexGoalMode: mode });
+				const mode = flagValue(args, "--gjc-goal-mode") === "per-story" ? "per-story" : "aggregate";
+				const plan = await createUltragoalPlan({ cwd, brief: await readBrief(cwd, args), gjcGoalMode: mode });
 				return {
 					status: 0,
 					createdPlan: true,
@@ -521,7 +521,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					goalId,
 					status,
 					evidence,
-					codexGoalJson: flagValue(args, "--codex-goal-json"),
+					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 					qualityGateJson: flagValue(args, "--quality-gate-json"),
 				});
 				return {
@@ -551,7 +551,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					title: flagValue(args, "--title") ?? "Resolve final code-review blockers",
 					objective: flagValue(args, "--objective") ?? "",
 					evidence: flagValue(args, "--evidence") ?? "",
-					codexGoalJson: flagValue(args, "--codex-goal-json"),
+					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 				});
 				return { status: 0, stdout: json ? `${JSON.stringify(plan, null, 2)}\n` : "Recorded review blockers.\n" };
 			}

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import {
 	consumePendingGoalModeRequest,
 	isUltragoalCreateGoalsInvocation,
-	readUltragoalCodexObjective,
+	readUltragoalGjcObjective,
 	writeCurrentSessionGoalModeState,
 	writePendingGoalModeRequest,
 } from "@gajae-code/coding-agent/gjc-runtime/goal-mode-request";
@@ -35,13 +35,13 @@ describe("GJC ultragoal goal mode request", () => {
 		expect(isUltragoalCreateGoalsInvocation(["status", "--filter", "create-goals"])).toBe(false);
 	});
 
-	it("reads codexObjective from the generated ultragoal plan", async () => {
+	it("reads gjcObjective from the generated ultragoal plan", async () => {
 		const root = await tempDir();
 		const goalsPath = path.join(root, ".gjc", "ultragoal", "goals.json");
 		await fs.mkdir(path.dirname(goalsPath), { recursive: true });
-		await Bun.write(goalsPath, JSON.stringify({ codexObjective: "Complete .gjc/ultragoal/goals.json" }));
+		await Bun.write(goalsPath, JSON.stringify({ gjcObjective: "Complete .gjc/ultragoal/goals.json" }));
 
-		const result = await readUltragoalCodexObjective(root);
+		const result = await readUltragoalGjcObjective(root);
 
 		expect(result.objective).toBe("Complete .gjc/ultragoal/goals.json");
 		expect(result.goalsPath).toBe(goalsPath);
@@ -151,6 +151,6 @@ describe("GJC ultragoal goal mode request", () => {
 		await fs.mkdir(path.dirname(goalsPath), { recursive: true });
 		await Bun.write(goalsPath, "{");
 
-		await expect(readUltragoalCodexObjective(root)).rejects.toThrow(SyntaxError);
+		await expect(readUltragoalGjcObjective(root)).rejects.toThrow(SyntaxError);
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -42,8 +42,8 @@ describe("native GJC ultragoal runtime", () => {
 		const goalsRaw = await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).text();
 		const ledgerRaw = await Bun.file(path.join(root, ".gjc", "ultragoal", "ledger.jsonl")).text();
 
-		expect(plan.codexGoalMode).toBe("aggregate");
-		expect(plan.codexObjective).toContain(".gjc/ultragoal/goals.json");
+		expect(plan.gjcGoalMode).toBe("aggregate");
+		expect(plan.gjcObjective).toContain(".gjc/ultragoal/goals.json");
 		expect(plan.goals).toHaveLength(1);
 		expect(plan.goals[0]).toMatchObject({ id: "G001", status: "pending" });
 		expect(goalsRaw).toContain("Fix native ultragoal status");
@@ -61,7 +61,7 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			codexGoalJson: JSON.stringify({ goal: { status: "complete" } }),
+			gjcGoalJson: JSON.stringify({ goal: { status: "complete" } }),
 			qualityGateJson: JSON.stringify({ verification: { status: "passed" } }),
 		});
 		const status = await getUltragoalStatus(root);


### PR DESCRIPTION
## Summary
- update Ultragoal and Team skill guidance to use GJC goal wording and the named get_goal/create_goal/update_goal tools
- add always-used gjc ultragoal command examples with --gjc-goal-* flags
- rename native ultragoal runtime fields and flags from old goal wording to GJC goal wording

## Verification
- bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts
- bun run --cwd packages/coding-agent check
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict