### PR TITLE
Restore GJC team multi-worker parity

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Restored `gjc team` multi-worker OMX-parity orchestration with current-window worker panes, GJC-scoped state/API semantics, and `N:agent-type` launches.
+
 ### Added
 
 - Added a detached `subagent` control tool for task subagents, with list, inspect, await-with-timeout, and cancel actions.
@@ -19,7 +23,6 @@
 - Changed default interactive `gjc` startup to enter a `gajae_code` tmux session before launching the Gajae Code TUI, with non-interactive modes continuing to run directly.
 - Changed `/skill:<name>` handling so canonical skill invocations can be chained in one prompt across interactive and ACP sessions, with autocomplete-only `/name` and `/skill-name` normalization back to the public canonical form.
 - Changed interactive `gjc` startup to launch tmux only when `--tmux` is provided, with direct startup as the default.
-- Changed `gjc team` to split the current tmux leader window into one GJC worker pane, reject multi-worker starts, and clean up worker panes without killing the leader session.
 - Changed GJC default definitions so workflow skills remain source-bundled while repo-visible `.gjc` default artifacts are no longer the source of truth; updated system and Ultragoal guidance to use role-agent delegation and ralplan-first planning when needed.
 - Changed bare `gjc setup` to install the normal default workflow skills, while keeping hooks, provider, Python, and speech-to-text setup as explicit optional components.
 - Changed `gjc team` startup to use tmux worker panes backed by dedicated detached git worktrees by default, while keeping `--worktree` as a backward-compatible launch override.

--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -1,13 +1,11 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import {
-	claimGjcTeamTask,
-	type GjcTeamTaskStatus,
+	executeGjcTeamApiOperation,
 	listGjcTeams,
 	parseTeamLaunchArgs,
 	readGjcTeamSnapshot,
 	shutdownGjcTeam,
 	startGjcTeam,
-	transitionGjcTeamTask,
 } from "../gjc-runtime/team-runtime";
 
 function writeJson(value: unknown): void {
@@ -28,15 +26,6 @@ function parseInputFlag(argv: string[]): Record<string, unknown> {
 	return parsed as Record<string, unknown>;
 }
 
-function stringField(input: Record<string, unknown>, name: string): string {
-	const value = input[name];
-	return typeof value === "string" ? value.trim() : "";
-}
-
-function isTaskStatus(value: string): value is GjcTeamTaskStatus {
-	return ["pending", "in_progress", "complete", "failed", "blocked"].includes(value);
-}
-
 export default class Team extends Command {
 	static description = "Run native GJC tmux team orchestration commands";
 	static strict = false;
@@ -54,9 +43,9 @@ export default class Team extends Command {
 	};
 
 	static examples = [
-		'gjc team executor "Implement the approved plan"',
+		'gjc team 3:executor "Implement the approved plan"',
 		"gjc team status <team-name> --json",
-		'gjc team api claim-task --input \'{"team_name":"demo","worker_id":"worker-01"}\' --json',
+		'gjc team api claim-task --input \'{"team_name":"demo","worker_id":"worker-1"}\' --json',
 		"gjc team shutdown <team-name>",
 	];
 
@@ -108,23 +97,19 @@ export default class Team extends Command {
 
 		if (action === "api") {
 			const [operation] = rest;
+			if (!operation || operation === "--help" || operation === "help") {
+				writeText([
+					"Supported operations:",
+					"send-message broadcast mailbox-list mailbox-mark-delivered mailbox-mark-notified",
+					"create-task read-task list-tasks update-task claim-task transition-task-status release-task-claim",
+					"read-config read-manifest read-worker-status read-worker-heartbeat update-worker-heartbeat write-worker-inbox write-worker-identity",
+					"append-event read-events await-event write-shutdown-request read-shutdown-ack read-monitor-snapshot write-monitor-snapshot read-task-approval write-task-approval",
+				]);
+				return;
+			}
 			const input = parseInputFlag(rest);
-			const teamName = stringField(input, "team_name") || stringField(input, "teamName");
-			if (!teamName) throw new Error("missing_team_name");
-			if (operation === "claim-task") {
-				const workerId = stringField(input, "worker_id") || stringField(input, "workerId") || "worker-01";
-				writeJson(await claimGjcTeamTask(teamName, workerId));
-				return;
-			}
-			if (operation === "transition-task") {
-				const taskId = stringField(input, "task_id") || stringField(input, "taskId");
-				const status = stringField(input, "status");
-				if (!taskId) throw new Error("missing_task_id");
-				if (!isTaskStatus(status)) throw new Error(`invalid_task_status:${status}`);
-				writeJson({ ok: true, task: await transitionGjcTeamTask(teamName, taskId, status) });
-				return;
-			}
-			throw new Error(`unknown_team_api_operation:${operation ?? ""}`);
+			writeJson(await executeGjcTeamApiOperation(operation, input));
+			return;
 		}
 
 		const startArgs = action === "start" ? rest : this.argv;

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: team
-description: One coordinated GJC worker session using current-tmux split-pane orchestration
+description: Multi-worker GJC tmux team orchestration
 
 source: "forked from upstream team skill and rebranded for GJC"
 ---
 
 # Team Skill
 
-`$team` is the tmux-based single-worker execution mode for GJC. It starts one real GJC worker CLI session by splitting the current tmux leader window and coordinates it through `.gjc/state/team/...` files plus CLI team interop (`gjc team api ...`) and state files.
+`$team` is the tmux-based multi-worker execution mode for GJC. It starts real GJC worker CLI sessions by splitting the current tmux leader window and coordinates them through `.gjc/state/team/...` files plus CLI team interop (`gjc team api ...`) and state files.
 
 This skill is operationally sensitive. Treat it as an operator workflow, not a generic prompt pattern. In GJC App or plain outside-tmux sessions, do not present `$team` / `gjc team` as directly available; launch GJC CLI from shell first, or stay on the nearest app-safe surface until the user explicitly wants the tmux runtime.
 
 ## Team vs Native Subagents
 
 - Use **GJC native subagents** for bounded, in-session parallelism where one leader thread can fan out a few independent subtasks and wait for them directly.
-- Use **`gjc team`** when you need one durable visible tmux worker, shared task state, worker mailbox files, worktrees, explicit lifecycle control, or long-running execution that must survive beyond one local reasoning burst.
+- Use **`gjc team`** when you need durable visible tmux workers, shared task state, worker mailbox files, worktrees, explicit lifecycle control, or long-running execution that must survive beyond one local reasoning burst.
 - Native subagents can complement team execution, but they do **not** replace the tmux team runtime's stateful coordination contract.
 
 ## What This Skill Must Do
@@ -37,13 +37,13 @@ If `gjc team` is unavailable, stop with a hard error.
 ## Invocation Contract
 
 ```bash
-gjc team [agent-type] "<task description>"
+gjc team [N:agent-type] "<task description>"
 ```
 
 Examples:
 
 ```bash
-gjc team executor "analyze feature X and report flaws"
+gjc team 3:executor "analyze feature X and report flaws"
 gjc team "debug flaky integration tests"
 gjc team "ship end-to-end fix with verification"
 ```
@@ -51,10 +51,8 @@ gjc team "ship end-to-end fix with verification"
 ### Team-first launch contract
 
 `gjc team ...` is now the canonical launch path for coordinated execution.
-Team mode should carry one visible worker delivery/verification lane without
-requiring a separate linked execution loop up front. GJC team intentionally does
-not support multi-teammate mode; explicit `N:agent-type` values greater than one
-must be rejected instead of silently coerced.
+Team mode should carry visible worker delivery/verification lanes without
+requiring a separate linked execution loop up front. GJC team supports OMX-style multi-worker mode; explicit `N:agent-type` values select worker count and shared role.
 
 - **Canonical launch:** use plain `gjc team ...` / `$team ...` for the coordinated worker.
 - **Verification ownership:** keep one lane focused on tests, regression coverage, and evidence before shutdown.
@@ -63,13 +61,13 @@ must be rejected instead of silently coerced.
 
 ### Team + Ultragoal bridge
 
-Use `$ultragoal` for durable leader-owned goal/ledger tracking and `$team` for one visible tmux execution lane. When Team is launched with an active `.gjc/ultragoal/goals.json`, worker task/status context may include leader-owned Ultragoal context: `.gjc/ultragoal/goals.json`, `.gjc/ultragoal/ledger.jsonl`, the active goal id, GJC goal mode, and the `fresh_leader_get_goal_required` checkpoint policy.
+Use `$ultragoal` for durable leader-owned goal/ledger tracking and `$team` for parallel visible tmux execution lanes. When Team is launched with an active `.gjc/ultragoal/goals.json`, worker task/status context may include leader-owned Ultragoal context: `.gjc/ultragoal/goals.json`, `.gjc/ultragoal/ledger.jsonl`, the active goal id, GJC goal mode, and the `fresh_leader_get_goal_required` checkpoint policy.
 
 Workers provide task status and verification evidence only. They do not own Ultragoal goal state, create worker ledgers, mutate `.gjc/ultragoal`, auto-launch Team from Ultragoal, or perform hidden GJC goal mutation. The leader uses terminal Team evidence plus a fresh `get_goal` snapshot to run `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/ultragoal and <id>>" --gjc-goal-json <fresh-get_goal-json-or-path>`.
 
 ### Worker command override
 
-Important: GJC team supports exactly one worker. Use `agent-type` (for example `executor`) to select the worker role prompt; `N:agent-type` values greater than one are unsupported.
+Important: `N:agent-type` (for example `3:executor`) selects the worker count and role prompt. Plain `gjc team "task"` defaults to 3 executor workers; `gjc team 1:executor "task"` is the explicit single-worker form.
 
 To launch the worker with a specific GJC-compatible command, use `GJC_TEAM_WORKER_COMMAND`:
 
@@ -120,7 +118,7 @@ For simple read-only brownfield lookups during intake, follow active session gui
 When `$team` is used as a follow-up mode from ralplan, carry forward the approved plan's explicit **available-agent-types roster** and convert it into concrete staffing guidance before launch:
 
 - keep worker-role choices inside the known roster
-- state that GJC team launches exactly one worker and choose the single best role
+- state that GJC team launches the requested worker count and role allocation
 - state the suggested reasoning level for each lane when available
 - explain why each lane exists (delivery, verification, specialist support)
 - include an explicit launch hint (`gjc team "<task>"` / `$team "<task>"`) for the coordinated worker run; mention `$ultragoal` as the default durable follow-up/ledger path; mention a later separate Single-owner execution follow-up only when explicitly requested or genuinely needed as a fallback
@@ -130,18 +128,18 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 
 `gjc team` currently performs:
 
-1. Parse args (`agent-type`, task) and reject worker counts greater than one.
+1. Parse args (`N`, `agent-type`, task), default to 3 workers, and cap workers at 20.
 2. Non-dry-run: detect the current tmux leader context with `display-message -p "#S:#I #{pane_id}"` before creating state or worktrees.
 3. Initialize team state:
    - `.gjc/state/team/<team>/config.json`
    - `.gjc/state/team/<team>/manifest.v2.json`
-   - `.gjc/state/team/<team>/tasks/task-001.json`
-   - `.gjc/state/team/<team>/mailboxes/worker-01.json`
+   - `.gjc/state/team/<team>/tasks/task-1.json`
+   - `.gjc/state/team/<team>/mailbox/worker-1.json`
 4. Resolve the worker command from `GJC_TEAM_WORKER_COMMAND` or the active `gjc` entrypoint.
-5. Split the current tmux window into one right-side worker pane with `split-window -h -p 50` from the leader pane, then normalize the window with `select-layout even-horizontal` for a 50/50 leader-left/worker-right layout.
+5. Split the current tmux window like OMX team: worker 1 is split horizontally to the right of the leader, workers 2..N are vertically stacked in the right column, then `select-layout main-vertical` and `main-pane-width` keep leader-left/worker-right at roughly 50/50.
 6. Launch the worker with:
    - `GJC_TEAM_NAME=<team>`
-   - `GJC_TEAM_WORKER_ID=worker-01`
+   - `GJC_TEAM_WORKER_ID=worker-1`
    - `GJC_TEAM_STATE_ROOT=<leader-cwd>/.gjc/state/team`
    - optional `GJC_TEAM_WORKTREE_PATH=<path>` when worktree mode is active
 7. Store pane/target evidence in config/manifest/snapshot: `tmux_session`, `tmux_session_name`, `tmux_target`, leader pane id, and worker pane id.
@@ -150,7 +148,7 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 Important:
 
 - Leader remains in the existing left pane.
-- The worker pane is an independent full GJC worker CLI session on the right side of a 50/50 left-right split.
+- Worker panes are independent full GJC worker CLI sessions on the right side of a leader-left/worker-right split.
 - The worker may run in a dedicated git worktree (`gjc team --worktree[=<name>]`) while sharing the team state root.
 - `shutdown` kills only the recorded worker pane after confirming it still belongs to the stored tmux target and is not the leader pane. It never kills the tmux session.
 
@@ -197,9 +195,9 @@ Semantics:
 
 ### Control Plane
 
-- Current tmux leader window and exactly one worker pane.
+- Current tmux leader window and one or more worker panes.
 - `gjc team` lifecycle commands.
-- `gjc team api claim-task` and `gjc team api transition-task`.
+- `gjc team api claim-task` and `gjc team api transition-task-status`.
 
 ### Data Plane
 
@@ -208,27 +206,30 @@ Semantics:
 - `.gjc/state/team/<team>/phase.json`
 - `.gjc/state/team/<team>/events.jsonl`
 - `.gjc/state/team/<team>/telemetry.jsonl`
-- `.gjc/state/team/<team>/tasks/task-001.json`
-- `.gjc/state/team/<team>/mailboxes/worker-01.json`
+- `.gjc/state/team/<team>/tasks/task-1.json`
+- `.gjc/state/team/<team>/mailbox/worker-1.json`
 
 ## Team Mutation Interop (CLI-first)
 
 Use `gjc team api` for machine-readable task lifecycle operations.
 
 ```bash
-gjc team api claim-task --input '{"team_name":"my-team","worker_id":"worker-01"}' --json
-gjc team api transition-task --input '{"team_name":"my-team","task_id":"task-001","status":"complete"}' --json
+gjc team api claim-task --input '{"team_name":"my-team","worker_id":"worker-1"}' --json
+gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","claim_token":"<claim-token>"}' --json
 ```
 
-Supported operations today:
+Canonical worker lifecycle operations:
 
 - `claim-task`
-- `transition-task`
+- `transition-task-status`
+- `release-task-claim`
+
+OMX-parity interop operations are also available for mailbox, worker heartbeat/status, events, monitor snapshots, approvals, and shutdown request/ack flows; run `gjc team api --help` for the full operation list.
 
 Worker protocol:
 
 - Claim pending work with `claim-task`.
-- Transition the task to `complete`, `failed`, or `blocked` with `transition-task`.
+- Transition the task to `completed`, `failed`, or `blocked` with `transition-task-status`.
 - Record implementation/verification evidence in normal task output and state files; do not assume a separate leader confirmation mailbox or queue exists.
 
 ## Environment Knobs
@@ -262,8 +263,8 @@ Use only after checking `gjc team status <team>` and state evidence:
 
 1. Inspect team files:
    - `.gjc/state/team/<team>/config.json`
-   - `.gjc/state/team/<team>/tasks/task-001.json`
-   - `.gjc/state/team/<team>/mailboxes/worker-01.json`
+   - `.gjc/state/team/<team>/tasks/task-1.json`
+   - `.gjc/state/team/<team>/mailbox/worker-1.json`
 2. Capture pane tail to confirm current worker state:
    - `tmux capture-pane -t %<worker-pane> -p -S -120`
    - If a larger-tail read or bounded summary would help, prefer explicit opt-in inspection via `gjc sparkshell --tmux-pane %<worker-pane> --tail-lines 400` before improvising extra tmux commands.
@@ -312,7 +313,7 @@ When operating this skill, provide concrete progress evidence:
 
 1. Team started line (`Team started: <name>`)
 2. tmux target and worker pane id
-3. task state from `gjc team status <team>` or `.gjc/state/team/<team>/tasks/task-001.json`
+3. task state from `gjc team status <team>` or `.gjc/state/team/<team>/tasks/task-1.json`
 4. shutdown outcome (`phase=complete`, worker status `stopped`) when the run is terminal
 
 Do not claim success without file/pane evidence.

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1,7 +1,13 @@
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+
 export type GjcTeamPhase = "starting" | "running" | "complete" | "failed" | "cancelled";
-export type GjcTeamTaskStatus = "pending" | "in_progress" | "complete" | "failed" | "blocked";
+export type GjcTeamTaskStatus = "pending" | "blocked" | "in_progress" | "completed" | "failed";
+export type GjcWorkerStatusState = "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown";
+
+export const GJC_TEAM_DEFAULT_WORKERS = 3;
+export const GJC_TEAM_MAX_WORKERS = 20;
 
 export interface GjcTeamLeader {
 	session_id: string;
@@ -11,26 +17,47 @@ export interface GjcTeamLeader {
 
 export interface GjcTeamWorker {
 	id: string;
+	name: string;
+	index: number;
 	agent_type: string;
+	role: string;
 	pane_id?: string;
 	status: "starting" | "idle" | "busy" | "stopped";
 	last_heartbeat: string;
+	assigned_tasks: string[];
 	worktree_repo_root?: string;
 	worktree_path?: string;
 	worktree_branch?: string | null;
 	worktree_detached?: boolean;
 	worktree_created?: boolean;
 	worktree_base_ref?: string;
+	team_state_root?: string;
+}
+
+export interface GjcTeamTaskClaim {
+	owner: string;
+	token: string;
+	leased_until: string;
 }
 
 export interface GjcTeamTask {
 	id: string;
+	subject: string;
+	description: string;
 	title: string;
 	objective: string;
 	status: GjcTeamTaskStatus;
 	assignee?: string;
+	owner?: string;
+	result?: string;
+	error?: string;
+	blocked_by?: string[];
+	depends_on?: string[];
+	version: number;
+	claim?: GjcTeamTaskClaim;
 	created_at: string;
 	updated_at: string;
+	completed_at?: string;
 }
 
 export type GjcTeamWorktreeMode =
@@ -45,6 +72,7 @@ export interface GjcTeamConfig {
 	task: string;
 	agent_type: string;
 	worker_count: number;
+	max_workers: number;
 	state_root: string;
 	worker_command: string;
 	tmux_command: string;
@@ -53,6 +81,8 @@ export interface GjcTeamConfig {
 	tmux_target: string;
 	workspace_mode: "direct" | "worktree";
 	leader: GjcTeamLeader;
+	leader_cwd: string;
+	team_state_root: string;
 	workers: GjcTeamWorker[];
 	created_at: string;
 	updated_at: string;
@@ -87,35 +117,103 @@ export interface GjcTeamApiClaimResult {
 	ok: boolean;
 	task?: GjcTeamTask;
 	worker_id?: string;
+	claim_token?: string;
 	reason?: string;
+}
+
+export interface GjcTeamMailboxMessage {
+	message_id: string;
+	from_worker: string;
+	to_worker: string;
+	body: string;
+	created_at: string;
+	delivered_at?: string;
+	notified_at?: string;
 }
 
 interface FsError {
 	code?: string;
 }
-
-function isEnoent(error: unknown): error is FsError {
-	return typeof error === "object" && error !== null && "code" in error && (error as FsError).code === "ENOENT";
-}
-
-interface GjcTeamEvent {
-	ts: string;
-	type: string;
-	message: string;
-	data?: Record<string, unknown>;
-}
-
 interface GjcTmuxLeaderContext {
 	sessionName: string;
 	windowIndex: string;
 	leaderPaneId: string;
 	target: string;
 }
+interface GjcTeamEvent {
+	event_id: string;
+	ts: string;
+	type: string;
+	worker?: string;
+	task_id?: string;
+	message?: string;
+	data?: Record<string, unknown>;
+}
+interface WorkerStatusFile {
+	state: GjcWorkerStatusState;
+	current_task_id?: string;
+	reason?: string;
+	updated_at: string;
+}
+interface WorkerHeartbeatFile {
+	pid: number;
+	last_turn_at: string;
+	turn_count: number;
+	alive: boolean;
+}
+
+function isGjcTeamTaskStatus(value: string): value is GjcTeamTaskStatus {
+	return ["pending", "blocked", "in_progress", "completed", "failed"].includes(value);
+}
+
+function parseGjcTeamTaskStatus(value: unknown, allowLegacyComplete = false): GjcTeamTaskStatus {
+	const raw = typeof value === "string" ? value.trim() : "";
+	if (allowLegacyComplete && raw === "complete") return "completed";
+	if (isGjcTeamTaskStatus(raw)) return raw;
+	throw new Error(`invalid_task_status:${raw}`);
+}
+
+export const GJC_TEAM_API_OPERATIONS = [
+	"send-message",
+	"broadcast",
+	"mailbox-list",
+	"mailbox-mark-delivered",
+	"mailbox-mark-notified",
+	"create-task",
+	"read-task",
+	"list-tasks",
+	"update-task",
+	"claim-task",
+	"transition-task-status",
+	"transition-task",
+	"release-task-claim",
+	"read-config",
+	"read-manifest",
+	"read-worker-status",
+	"read-worker-heartbeat",
+	"update-worker-heartbeat",
+	"write-worker-inbox",
+	"write-worker-identity",
+	"append-event",
+	"read-events",
+	"await-event",
+	"write-shutdown-request",
+	"read-shutdown-ack",
+	"read-monitor-snapshot",
+	"write-monitor-snapshot",
+	"read-task-approval",
+	"write-task-approval",
+] as const;
 
 function now(): string {
 	return new Date().toISOString();
 }
-
+function isEnoent(error: unknown): error is FsError {
+	return typeof error === "object" && error !== null && "code" in error && (error as FsError).code === "ENOENT";
+}
+function isEexist(error: unknown): error is FsError {
+	return typeof error === "object" && error !== null && "code" in error && (error as FsError).code === "EEXIST";
+}
 function sanitizeName(value: string): string {
 	const sanitized = value
 		.toLowerCase()
@@ -126,11 +224,9 @@ function sanitizeName(value: string): string {
 		.replace(/-$/, "");
 	return sanitized || "team";
 }
-
 function shortHash(value: string): string {
 	return Bun.hash(value).toString(16).slice(0, 8).padStart(8, "0");
 }
-
 function makeTeamName(task: string, env: NodeJS.ProcessEnv): string {
 	const basis = [task, env.GJC_SESSION_ID, env.CODEX_SESSION_ID, env.TMUX_PANE, env.TMUX, now()]
 		.filter(Boolean)
@@ -138,15 +234,26 @@ function makeTeamName(task: string, env: NodeJS.ProcessEnv): string {
 	const prefix = sanitizeName(task).slice(0, 30).replace(/-$/, "") || "team";
 	return `${prefix}-${shortHash(basis)}`;
 }
+function teamDir(stateRoot: string, teamName: string): string {
+	return path.join(stateRoot, sanitizeName(teamName));
+}
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+function taskPath(dir: string, taskId: string): string {
+	return path.join(dir, "tasks", `${taskId}.json`);
+}
+function mailboxPath(dir: string, worker: string): string {
+	return path.join(dir, "mailbox", `${worker}.json`);
+}
+function workerDir(dir: string, worker: string): string {
+	return path.join(dir, "workers", worker);
+}
 
 export function resolveGjcTeamStateRoot(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
 	const explicit = env.GJC_TEAM_STATE_ROOT?.trim();
 	if (explicit) return path.resolve(cwd, explicit);
 	return path.join(cwd, ".gjc", "state", "team");
-}
-
-function teamDir(stateRoot: string, teamName: string): string {
-	return path.join(stateRoot, teamName);
 }
 
 async function readJsonFile<T>(filePath: string): Promise<T | null> {
@@ -157,66 +264,79 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 		throw error;
 	}
 }
-
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
-
 async function appendJsonl(filePath: string, value: unknown): Promise<void> {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await fs.appendFile(filePath, `${JSON.stringify(value)}\n`, "utf-8");
 }
-
-async function appendEvent(dir: string, event: Omit<GjcTeamEvent, "ts">): Promise<void> {
-	await appendJsonl(path.join(dir, "events.jsonl"), { ts: now(), ...event });
+async function appendEvent(dir: string, event: Omit<GjcTeamEvent, "ts" | "event_id">): Promise<GjcTeamEvent> {
+	const full = { event_id: `evt-${Date.now()}-${Math.random().toString(16).slice(2)}`, ts: now(), ...event };
+	await appendJsonl(path.join(dir, "events.jsonl"), full);
+	return full;
 }
-
-async function appendTelemetry(dir: string, event: Omit<GjcTeamEvent, "ts">): Promise<void> {
+async function appendTelemetry(
+	dir: string,
+	event: { type: string; message: string; data?: Record<string, unknown> },
+): Promise<void> {
 	await appendJsonl(path.join(dir, "telemetry.jsonl"), { ts: now(), ...event });
 }
-
 async function readConfig(dir: string): Promise<GjcTeamConfig> {
 	const config = await readJsonFile<GjcTeamConfig>(path.join(dir, "config.json"));
 	if (!config) throw new Error(`team_config_not_found:${dir}`);
-	const legacyTmuxSession = config.tmux_session ?? "";
-	const tmuxTarget = config.tmux_target ?? legacyTmuxSession;
-	const tmuxSessionName = config.tmux_session_name ?? legacyTmuxSession.split(":")[0] ?? legacyTmuxSession;
+	const tmuxSessionName = config.tmux_session_name ?? config.tmux_session?.split(":")[0] ?? "";
 	return {
 		...config,
+		max_workers: config.max_workers ?? GJC_TEAM_MAX_WORKERS,
 		tmux_command: config.tmux_command ?? resolveGjcTmuxCommand(),
 		tmux_session: tmuxSessionName,
 		tmux_session_name: tmuxSessionName,
-		tmux_target: tmuxTarget,
+		tmux_target: config.tmux_target ?? config.tmux_session ?? tmuxSessionName,
+		leader_cwd: config.leader_cwd ?? config.leader.cwd,
+		team_state_root: config.team_state_root ?? config.state_root,
 	};
 }
-
 async function readPhase(dir: string): Promise<GjcTeamPhase> {
 	const phase = await readJsonFile<{ current_phase?: GjcTeamPhase }>(path.join(dir, "phase.json"));
 	return phase?.current_phase ?? "running";
 }
-
 async function writePhase(dir: string, phase: GjcTeamPhase): Promise<void> {
 	await writeJsonFile(path.join(dir, "phase.json"), { current_phase: phase, updated_at: now() });
 }
 
+function normalizeTask(raw: GjcTeamTask): GjcTeamTask {
+	const status = raw.status === ("complete" as GjcTeamTaskStatus) ? "completed" : raw.status;
+	return {
+		...raw,
+		status,
+		subject: raw.subject ?? raw.title,
+		description: raw.description ?? raw.objective,
+		title: raw.title ?? raw.subject,
+		objective: raw.objective ?? raw.description,
+		version: raw.version ?? 1,
+	};
+}
 async function readTasks(dir: string): Promise<GjcTeamTask[]> {
-	const tasksDir = path.join(dir, "tasks");
 	try {
-		const entries = await fs.readdir(tasksDir, { withFileTypes: true });
+		const entries = await fs.readdir(path.join(dir, "tasks"), { withFileTypes: true });
 		const tasks = await Promise.all(
 			entries
 				.filter(entry => entry.isFile() && entry.name.endsWith(".json"))
-				.map(entry => readJsonFile<GjcTeamTask>(path.join(tasksDir, entry.name))),
+				.map(entry => readJsonFile<GjcTeamTask>(path.join(dir, "tasks", entry.name))),
 		);
-		return tasks.filter((task): task is GjcTeamTask => task != null).sort((a, b) => a.id.localeCompare(b.id));
+		return tasks
+			.filter((task): task is GjcTeamTask => task != null)
+			.map(normalizeTask)
+			.sort((a, b) => a.id.localeCompare(b.id));
 	} catch (error) {
 		if (isEnoent(error)) return [];
 		throw error;
 	}
 }
-
 async function writeTask(dir: string, task: GjcTeamTask): Promise<void> {
-	await writeJsonFile(path.join(dir, "tasks", `${task.id}.json`), task);
+	await writeJsonFile(taskPath(dir, task.id), normalizeTask(task));
 }
 
 async function findTeamDir(
@@ -225,51 +345,46 @@ async function findTeamDir(
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
 	const root = resolveGjcTeamStateRoot(cwd, env);
-	const exact = teamDir(root, sanitizeName(teamName));
-	const exactConfig = await readJsonFile<GjcTeamConfig>(path.join(exact, "config.json"));
-	if (exactConfig) return exact;
-
+	const exact = teamDir(root, teamName);
+	if (await readJsonFile<GjcTeamConfig>(path.join(exact, "config.json"))) return exact;
 	const candidates = await listGjcTeams(cwd, env);
-	const matches = candidates.filter(candidate => {
-		const input = sanitizeName(teamName);
-		return candidate.team_name === input || sanitizeName(candidate.display_name) === input;
-	});
+	const input = sanitizeName(teamName);
+	const matches = candidates.filter(
+		candidate => candidate.team_name === input || sanitizeName(candidate.display_name) === input,
+	);
 	if (matches.length === 1) return matches[0].state_dir;
 	if (matches.length > 1)
 		throw new Error(`ambiguous_team_name:${teamName}:${matches.map(match => match.team_name).join(",")}`);
 	throw new Error(`team_not_found:${teamName}`);
 }
-
-function buildWorkers(count: number, agentType: string): GjcTeamWorker[] {
-	return Array.from({ length: count }, (_, index) => ({
-		id: `worker-${String(index + 1).padStart(2, "0")}`,
-		agent_type: agentType,
-		status: "starting",
-		last_heartbeat: now(),
-	}));
+function buildWorkers(count: number, agentType: string, stateRoot?: string): GjcTeamWorker[] {
+	return Array.from({ length: count }, (_, index) => {
+		const id = `worker-${index + 1}`;
+		return {
+			id,
+			name: id,
+			index: index + 1,
+			agent_type: agentType,
+			role: agentType,
+			status: "starting",
+			last_heartbeat: now(),
+			assigned_tasks: [],
+			team_state_root: stateRoot,
+		};
+	});
 }
-
 function sanitizePathToken(value: string): string {
-	const sanitized = value
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/-+/g, "-")
-		.replace(/^-|-$/g, "");
-	return sanitized || "default";
+	return sanitizeName(value) || "default";
 }
-
 function runGit(cwd: string, args: string[]): string {
 	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
 	if (result.exitCode === 0) return result.stdout.toString().trim();
-	const stderr = result.stderr.toString().trim();
-	throw new Error(stderr || `git ${args.join(" ")} failed`);
+	throw new Error(result.stderr.toString().trim() || `git ${args.join(" ")} failed`);
 }
-
 function tryRunGit(cwd: string, args: string[]): string | null {
 	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
 	return result.exitCode === 0 ? result.stdout.toString().trim() : null;
 }
-
 function isGitRepository(cwd: string): boolean {
 	return tryRunGit(cwd, ["rev-parse", "--show-toplevel"]) != null;
 }
@@ -277,7 +392,6 @@ function isGitRepository(cwd: string): boolean {
 function parseWorktreeMode(args: string[]): { mode: GjcTeamWorktreeMode; remainingArgs: string[] } {
 	let mode: GjcTeamWorktreeMode = { enabled: false };
 	const remainingArgs: string[] = [];
-
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index] ?? "";
 		if (arg === "--worktree" || arg === "-w") {
@@ -285,9 +399,7 @@ function parseWorktreeMode(args: string[]): { mode: GjcTeamWorktreeMode; remaini
 			if (typeof next === "string" && next.length > 0 && !next.startsWith("-") && !next.includes(":")) {
 				mode = { enabled: true, detached: false, name: next };
 				index += 1;
-			} else {
-				mode = { enabled: true, detached: true, name: null };
-			}
+			} else mode = { enabled: true, detached: true, name: null };
 			continue;
 		}
 		if (arg.startsWith("--worktree=")) {
@@ -302,32 +414,26 @@ function parseWorktreeMode(args: string[]): { mode: GjcTeamWorktreeMode; remaini
 		}
 		remainingArgs.push(arg);
 	}
-
 	return { mode, remainingArgs };
 }
-
 function resolveDefaultWorktreeMode(mode?: GjcTeamWorktreeMode): GjcTeamWorktreeMode {
-	if (mode?.enabled) return mode;
-	return { enabled: true, detached: true, name: null };
+	return mode?.enabled ? mode : { enabled: true, detached: true, name: null };
 }
-
 function branchExists(repoRoot: string, branchName: string): boolean {
-	const result = Bun.spawnSync(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], {
-		cwd: repoRoot,
-		stdout: "ignore",
-		stderr: "ignore",
-	});
-	return result.exitCode === 0;
+	return (
+		Bun.spawnSync(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], {
+			cwd: repoRoot,
+			stdout: "ignore",
+			stderr: "ignore",
+		}).exitCode === 0
+	);
 }
-
 function worktreeIsDirty(worktreePath: string): boolean {
 	return runGit(worktreePath, ["status", "--porcelain"]).trim().length > 0;
 }
-
 function worktreeHead(worktreePath: string): string {
 	return runGit(worktreePath, ["rev-parse", "HEAD"]);
 }
-
 async function pathExists(filePath: string): Promise<boolean> {
 	try {
 		await fs.access(filePath);
@@ -337,18 +443,13 @@ async function pathExists(filePath: string): Promise<boolean> {
 		throw error;
 	}
 }
-
 function findWorktreePath(repoRoot: string, worktreePath: string): string | null {
 	const raw = runGit(repoRoot, ["worktree", "list", "--porcelain"]);
 	const resolved = path.resolve(worktreePath);
-	for (const line of raw.split(/\r?\n/)) {
-		if (!line.startsWith("worktree ")) continue;
-		const candidate = path.resolve(line.slice("worktree ".length));
-		if (candidate === resolved) return candidate;
-	}
+	for (const line of raw.split(/\r?\n/))
+		if (line.startsWith("worktree ") && path.resolve(line.slice("worktree ".length)) === resolved) return resolved;
 	return null;
 }
-
 async function ensureWorkerWorktree(
 	cwd: string,
 	dir: string,
@@ -358,34 +459,28 @@ async function ensureWorkerWorktree(
 ): Promise<GjcTeamWorker> {
 	if (!mode.enabled) return worker;
 	if (!isGitRepository(cwd)) throw new Error(`team_worktree_requires_git_repo:${cwd}`);
-
 	const repoRoot = runGit(cwd, ["rev-parse", "--show-toplevel"]);
 	const baseRef = runGit(repoRoot, ["rev-parse", "HEAD"]);
 	const worktreePath = path.join(dir, "worktrees", worker.id);
 	const existing = findWorktreePath(repoRoot, worktreePath);
 	let created = false;
-	let branchName: string | null = null;
-
-	if (!mode.detached) {
-		branchName = `${mode.name}/${sanitizePathToken(teamName)}/${sanitizePathToken(worker.id)}`;
-	}
-
+	const branchName = mode.detached
+		? null
+		: `${mode.name}/${sanitizePathToken(teamName)}/${sanitizePathToken(worker.id)}`;
 	if (existing) {
 		if (worktreeIsDirty(worktreePath)) throw new Error(`worktree_dirty:${worktreePath}`);
 		if (mode.detached && worktreeHead(worktreePath) !== baseRef) throw new Error(`worktree_stale:${worktreePath}`);
 	} else {
 		if (await pathExists(worktreePath)) throw new Error(`worktree_path_conflict:${worktreePath}`);
 		await fs.mkdir(path.dirname(worktreePath), { recursive: true });
-		const branchAlreadyExists = branchName ? branchExists(repoRoot, branchName) : false;
 		const args = mode.detached
 			? ["worktree", "add", "--detach", worktreePath, baseRef]
-			: branchAlreadyExists
+			: branchExists(repoRoot, branchName ?? "")
 				? ["worktree", "add", worktreePath, branchName ?? ""]
 				: ["worktree", "add", "-b", branchName ?? "", worktreePath, baseRef];
 		runGit(repoRoot, args);
 		created = true;
 	}
-
 	return {
 		...worker,
 		worktree_repo_root: repoRoot,
@@ -397,44 +492,31 @@ async function ensureWorkerWorktree(
 	};
 }
 
-function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 export function resolveGjcTmuxCommand(env: NodeJS.ProcessEnv = process.env): string {
 	return env.GJC_TEAM_TMUX_COMMAND?.trim() || "tmux";
 }
-
 function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEnv): GjcTmuxLeaderContext {
 	const paneTarget = env.TMUX_PANE?.trim();
 	const args = paneTarget
 		? ["display-message", "-p", "-t", paneTarget, "#S:#I #{pane_id}"]
 		: ["display-message", "-p", "#S:#I #{pane_id}"];
 	const result = Bun.spawnSync([tmuxCommand, ...args], { stdout: "pipe", stderr: "pipe" });
-	if (result.exitCode !== 0) {
-		const stderr = result.stderr.toString().trim();
-		throw new Error(stderr || "team_requires_current_tmux_context");
-	}
-	const stdout = result.stdout.toString().trim();
-	const [sessionAndWindow = "", leaderPaneId = ""] = stdout.split(/\s+/);
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString().trim() || "team_requires_current_tmux_context");
+	const [sessionAndWindow = "", leaderPaneId = ""] = result.stdout.toString().trim().split(/\s+/);
 	const [sessionName = "", windowIndex = ""] = sessionAndWindow.split(":");
-	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%")) {
-		throw new Error(`invalid_tmux_context:${stdout}`);
-	}
+	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%"))
+		throw new Error(`invalid_tmux_context:${result.stdout.toString().trim()}`);
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
-
 export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
 	const explicit = env.GJC_TEAM_WORKER_COMMAND?.trim();
 	if (explicit) return explicit;
-
 	const entrypoint = process.argv[1];
 	if (entrypoint?.endsWith(".ts"))
 		return `${shellQuote(process.execPath)} ${shellQuote(path.resolve(cwd, entrypoint))}`;
 	if (entrypoint && path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
 	return "gjc";
 }
-
 function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): string {
 	const workspace = worker.worktree_path
 		? `Worker worktree: ${worker.worktree_path}.`
@@ -442,91 +524,110 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 	const prompt = [
 		`You are ${worker.id} in gjc team ${config.team_name}.`,
 		`Team state root: ${config.state_root}.`,
-		`Team command: ${config.worker_command}.`,
 		workspace,
 		`Task: ${config.task}`,
-		`Use ${config.worker_command} team api claim-task/transition-task with this worker id, record evidence, and do not expose private support workflows as public definitions.`,
+		`Use gjc team api claim-task/transition-task-status with this worker id, record evidence, and do not mutate leader-owned goal state.`,
 	].join("\n");
 	const env = [
+		`GJC_TEAM_WORKER=${shellQuote(`${config.team_name}/${worker.id}`)}`,
+		`GJC_TEAM_INTERNAL_WORKER=${shellQuote(`${config.team_name}/${worker.id}`)}`,
 		`GJC_TEAM_NAME=${shellQuote(config.team_name)}`,
 		`GJC_TEAM_WORKER_ID=${shellQuote(worker.id)}`,
 		`GJC_TEAM_STATE_ROOT=${shellQuote(config.state_root)}`,
+		`GJC_TEAM_LEADER_CWD=${shellQuote(config.leader.cwd)}`,
+		`GJC_TEAM_DISPLAY_NAME=${shellQuote(config.display_name)}`,
 		...(worker.worktree_path ? [`GJC_TEAM_WORKTREE_PATH=${shellQuote(worker.worktree_path)}`] : []),
 	];
 	return `${env.join(" ")} ${config.worker_command} ${shellQuote(prompt)}`;
 }
-
-function buildInitialTasks(task: string): GjcTeamTask[] {
-	return [
-		{
-			id: "task-001",
-			title: "Execute team brief",
-			objective: task,
-			status: "pending",
-			created_at: now(),
-			updated_at: now(),
-		},
-	];
+function buildInitialTasks(task: string, workers: GjcTeamWorker[]): GjcTeamTask[] {
+	return workers.map(worker => ({
+		id: `task-${worker.index}`,
+		subject: `Execute team brief (${worker.id})`,
+		description: task,
+		title: `Execute team brief (${worker.id})`,
+		objective: task,
+		status: "pending",
+		owner: worker.id,
+		version: 1,
+		created_at: now(),
+		updated_at: now(),
+	}));
 }
 
 async function startTmuxSession(config: GjcTeamConfig, dir: string, dryRun: boolean): Promise<GjcTeamWorker[]> {
-	if (dryRun)
-		return config.workers.map(worker => ({
-			...worker,
-			pane_id: `%dry-run-${worker.id}`,
-		}));
-	const [worker] = config.workers;
-	if (!worker) return config.workers;
+	if (dryRun) return config.workers.map(worker => ({ ...worker, pane_id: `%dry-run-${worker.id}` }));
 	const rollbackPaneIds: string[] = [];
 	try {
-		const split = Bun.spawnSync(
-			[
-				config.tmux_command,
-				"split-window",
-				"-h",
-				"-p",
-				"50",
-				"-t",
-				config.leader.pane_id,
-				"-d",
-				"-P",
-				"-F",
-				"#{pane_id}",
-				"-c",
-				worker.worktree_path ?? config.leader.cwd,
-				buildWorkerCommand(config, worker),
-			],
-			{ stdout: "pipe", stderr: "pipe" },
-		);
-		if (split.exitCode !== 0) {
-			const stderr = split.stderr.toString().trim();
-			throw new Error(stderr || `tmux_split_failed:${config.tmux_target}:${worker.id}`);
+		const workers: GjcTeamWorker[] = [];
+		let rightStackRootPaneId: string | null = null;
+		for (const worker of config.workers) {
+			const splitDirection: string = worker.index === 1 ? "-h" : "-v";
+			const splitTarget: string =
+				worker.index === 1 ? config.leader.pane_id : (rightStackRootPaneId ?? config.leader.pane_id);
+			const split: Bun.SyncSubprocess<"pipe", "pipe"> = Bun.spawnSync(
+				[
+					config.tmux_command,
+					"split-window",
+					splitDirection,
+					"-t",
+					splitTarget,
+					"-d",
+					"-P",
+					"-F",
+					"#{pane_id}",
+					"-c",
+					worker.worktree_path ?? config.leader.cwd,
+					buildWorkerCommand(config, worker),
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			if (split.exitCode !== 0)
+				throw new Error(split.stderr.toString().trim() || `tmux_split_failed:${config.tmux_target}:${worker.id}`);
+			const paneId: string = split.stdout.toString().trim().split(/\r?\n/)[0]?.trim() ?? "";
+			if (!paneId.startsWith("%")) throw new Error(`tmux_split_missing_pane:${config.tmux_target}:${worker.id}`);
+			rollbackPaneIds.push(paneId);
+			if (worker.index === 1) rightStackRootPaneId = paneId;
+			workers.push({ ...worker, pane_id: paneId });
 		}
-		const paneId = split.stdout.toString().trim().split(/\r?\n/)[0]?.trim() ?? "";
-		if (!paneId.startsWith("%")) throw new Error(`tmux_split_missing_pane:${config.tmux_target}:${worker.id}`);
-		rollbackPaneIds.push(paneId);
-		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "even-horizontal"], {
+		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "main-vertical"], {
 			stdout: "ignore",
 			stderr: "ignore",
 		});
-		const workers = [{ ...worker, pane_id: paneId }];
-		await appendTelemetry(dir, {
-			type: "tmux_started",
-			message: "Started gjc team worker pane in current tmux window",
-			data: { tmux_target: config.tmux_target, panes: workers.map(candidate => candidate.pane_id).filter(Boolean) },
-		});
-		return workers;
-	} catch (error) {
-		for (const paneId of rollbackPaneIds) {
-			Bun.spawnSync([config.tmux_command, "kill-pane", "-t", paneId], {
+		const widthResult = Bun.spawnSync(
+			[config.tmux_command, "display-message", "-p", "-t", config.tmux_target, "#{window_width}"],
+			{ stdout: "pipe", stderr: "ignore" },
+		);
+		const width = Number.parseInt(widthResult.stdout.toString().trim(), 10);
+		if (Number.isFinite(width) && width >= 40) {
+			Bun.spawnSync(
+				[
+					config.tmux_command,
+					"set-window-option",
+					"-t",
+					config.tmux_target,
+					"main-pane-width",
+					String(Math.floor(width / 2)),
+				],
+				{ stdout: "ignore", stderr: "ignore" },
+			);
+			Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "main-vertical"], {
 				stdout: "ignore",
 				stderr: "ignore",
 			});
 		}
+		await appendTelemetry(dir, {
+			type: "tmux_started",
+			message: "Started gjc team worker panes in current tmux window",
+			data: { tmux_target: config.tmux_target, panes: workers.map(worker => worker.pane_id).filter(Boolean) },
+		});
+		return workers;
+	} catch (error) {
+		for (const paneId of rollbackPaneIds)
+			Bun.spawnSync([config.tmux_command, "kill-pane", "-t", paneId], { stdout: "ignore", stderr: "ignore" });
 		throw error;
 	}
 }
-
 function paneBelongsToTeamTarget(config: GjcTeamConfig, paneId: string): boolean {
 	if (paneId === config.leader.pane_id) return false;
 	const result = Bun.spawnSync([config.tmux_command, "display-message", "-p", "-t", paneId, "#S:#I #{pane_id}"], {
@@ -534,50 +635,58 @@ function paneBelongsToTeamTarget(config: GjcTeamConfig, paneId: string): boolean
 		stderr: "ignore",
 	});
 	if (result.exitCode !== 0) return false;
-	const stdout = result.stdout.toString().trim();
-	const [target = "", detectedPaneId = ""] = stdout.split(/\s+/);
+	const [target = "", detectedPaneId = ""] = result.stdout.toString().trim().split(/\s+/);
 	return target === config.tmux_target && detectedPaneId === paneId;
 }
-
 function killWorkerPanes(config: GjcTeamConfig): void {
-	for (const worker of config.workers) {
-		if (!worker.pane_id?.startsWith("%")) continue;
-		if (!paneBelongsToTeamTarget(config, worker.pane_id)) continue;
-		Bun.spawnSync([config.tmux_command, "kill-pane", "-t", worker.pane_id], {
-			stdout: "ignore",
-			stderr: "ignore",
-		});
-	}
+	for (const worker of config.workers)
+		if (worker.pane_id?.startsWith("%") && paneBelongsToTeamTarget(config, worker.pane_id))
+			Bun.spawnSync([config.tmux_command, "kill-pane", "-t", worker.pane_id], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
 }
-
 async function rollbackCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
-	for (const worker of workers.filter(worker => worker.worktree_created).reverse()) {
-		if (!worker.worktree_repo_root || !worker.worktree_path) continue;
-		Bun.spawnSync(["git", "worktree", "remove", "--force", worker.worktree_path], {
-			cwd: worker.worktree_repo_root,
-			stdout: "ignore",
-			stderr: "ignore",
-		});
-	}
+	for (const worker of workers.filter(worker => worker.worktree_created).reverse())
+		if (worker.worktree_repo_root && worker.worktree_path)
+			Bun.spawnSync(["git", "worktree", "remove", "--force", worker.worktree_path], {
+				cwd: worker.worktree_repo_root,
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+}
+async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
+	for (const worker of workers.filter(worker => worker.worktree_created).reverse())
+		if (worker.worktree_repo_root && worker.worktree_path && !worktreeIsDirty(worker.worktree_path))
+			Bun.spawnSync(["git", "worktree", "remove", worker.worktree_path], {
+				cwd: worker.worktree_repo_root,
+				stdout: "ignore",
+				stderr: "ignore",
+			});
 }
 
-async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
-	for (const worker of workers.filter(worker => worker.worktree_created).reverse()) {
-		if (!worker.worktree_repo_root || !worker.worktree_path) continue;
-		if (worktreeIsDirty(worker.worktree_path)) continue;
-		Bun.spawnSync(["git", "worktree", "remove", worker.worktree_path], {
-			cwd: worker.worktree_repo_root,
-			stdout: "ignore",
-			stderr: "ignore",
+async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promise<void> {
+	for (const folder of ["tasks", "claims", "mailbox", "dispatch", "approvals", "workers"])
+		await fs.mkdir(path.join(dir, folder), { recursive: true });
+	for (const worker of workers) {
+		await fs.mkdir(workerDir(dir, worker.id), { recursive: true });
+		await writeJsonFile(mailboxPath(dir, worker.id), { messages: [] });
+		await writeJsonFile(path.join(workerDir(dir, worker.id), "status.json"), { state: "idle", updated_at: now() });
+		await writeJsonFile(path.join(workerDir(dir, worker.id), "heartbeat.json"), {
+			pid: 0,
+			last_turn_at: now(),
+			turn_count: 0,
+			alive: true,
 		});
 	}
+	await writeJsonFile(mailboxPath(dir, "leader-fixed"), { messages: [] });
 }
 
 export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTeamSnapshot> {
 	const cwd = options.cwd ?? process.cwd();
 	const env = options.env ?? process.env;
-	if (options.workerCount !== 1)
-		throw new Error(`unsupported_team_worker_count:${options.workerCount}:gjc_team_supports_one_worker`);
+	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > GJC_TEAM_MAX_WORKERS)
+		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
 	const stateRoot = resolveGjcTeamStateRoot(cwd, env);
 	const teamName = sanitizeName(options.teamName ?? makeTeamName(options.task, env));
 	const displayName = sanitizeName(options.teamName ?? options.task).slice(0, 30) || teamName;
@@ -588,12 +697,11 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const tmuxContext = options.dryRun
 		? { sessionName: "dry-run", windowIndex: "0", leaderPaneId: "%dry-run-leader", target: "dry-run:0" }
 		: readCurrentTmuxLeaderContext(tmuxCommand, env);
-	const initialWorkers = buildWorkers(options.workerCount, options.agentType);
+	const initialWorkers = buildWorkers(options.workerCount, options.agentType, stateRoot);
 	const workers: GjcTeamWorker[] = [];
 	try {
-		for (const worker of initialWorkers) {
+		for (const worker of initialWorkers)
 			workers.push(options.dryRun ? worker : await ensureWorkerWorktree(cwd, dir, teamName, worker, worktreeMode));
-		}
 	} catch (error) {
 		await rollbackCreatedWorktrees(workers);
 		throw error;
@@ -605,6 +713,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		task: options.task,
 		agent_type: options.agentType,
 		worker_count: options.workerCount,
+		max_workers: GJC_TEAM_MAX_WORKERS,
 		state_root: stateRoot,
 		worker_command: resolveGjcWorkerCommand(cwd, env),
 		tmux_command: tmuxCommand,
@@ -612,18 +721,14 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		tmux_session_name: tmuxContext.sessionName,
 		tmux_target: tmuxContext.target,
 		workspace_mode: worktreeMode.enabled ? "worktree" : "direct",
-		leader: {
-			session_id: env.GJC_SESSION_ID ?? env.CODEX_SESSION_ID ?? "",
-			pane_id: tmuxContext.leaderPaneId,
-			cwd,
-		},
+		leader: { session_id: env.GJC_SESSION_ID ?? env.CODEX_SESSION_ID ?? "", pane_id: tmuxContext.leaderPaneId, cwd },
+		leader_cwd: cwd,
+		team_state_root: stateRoot,
 		workers,
 		created_at: createdAt,
 		updated_at: createdAt,
 	};
-
-	await fs.mkdir(path.join(dir, "tasks"), { recursive: true });
-	await fs.mkdir(path.join(dir, "mailboxes"), { recursive: true });
+	await initializeStateDirs(dir, config.workers);
 	await writeJsonFile(path.join(dir, "config.json"), config);
 	await writeJsonFile(path.join(dir, "manifest.v2.json"), {
 		version: 2,
@@ -642,10 +747,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		updated_at: createdAt,
 	});
 	await writePhase(dir, "starting");
-	for (const task of buildInitialTasks(options.task)) await writeTask(dir, task);
-	for (const worker of config.workers) {
-		await writeJsonFile(path.join(dir, "mailboxes", `${worker.id}.json`), { messages: [] });
-	}
+	for (const task of buildInitialTasks(options.task, config.workers)) await writeTask(dir, task);
 	await appendEvent(dir, {
 		type: "team_started",
 		message: "Started native gjc team runtime",
@@ -690,10 +792,10 @@ export async function readGjcTeamSnapshot(
 	const tasks = await readTasks(dir);
 	const taskCounts: Record<GjcTeamTaskStatus, number> = {
 		pending: 0,
-		in_progress: 0,
-		complete: 0,
-		failed: 0,
 		blocked: 0,
+		in_progress: 0,
+		completed: 0,
+		failed: 0,
 	};
 	for (const task of tasks) taskCounts[task.status] += 1;
 	return {
@@ -710,7 +812,6 @@ export async function readGjcTeamSnapshot(
 		updated_at: config.updated_at,
 	};
 }
-
 export async function listGjcTeams(
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
@@ -729,7 +830,6 @@ export async function listGjcTeams(
 		throw error;
 	}
 }
-
 export async function shutdownGjcTeam(
 	teamName: string,
 	cwd = process.cwd(),
@@ -751,60 +851,621 @@ export async function shutdownGjcTeam(
 	return readGjcTeamSnapshot(config.team_name, cwd, env);
 }
 
+export async function listGjcTeamTasks(
+	teamName: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamTask[]> {
+	return readTasks(await findTeamDir(teamName, cwd, env));
+}
+export async function readGjcTeamTask(
+	teamName: string,
+	taskId: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamTask> {
+	const task = (await listGjcTeamTasks(teamName, cwd, env)).find(candidate => candidate.id === taskId);
+	if (!task) throw new Error(`task_not_found:${taskId}`);
+	return task;
+}
+export async function createGjcTeamTask(
+	teamName: string,
+	subject: string,
+	description: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamTask> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const config = await readConfig(dir);
+	const tasks = await readTasks(dir);
+	const next = tasks.length + 1;
+	const task: GjcTeamTask = {
+		id: `task-${next}`,
+		subject,
+		description,
+		title: subject,
+		objective: description,
+		status: "pending",
+		version: 1,
+		created_at: now(),
+		updated_at: now(),
+	};
+	await writeTask(dir, task);
+	config.updated_at = now();
+	await writeJsonFile(path.join(dir, "config.json"), config);
+	await appendEvent(dir, { type: "task_created", task_id: task.id, message: subject });
+	return task;
+}
+export async function updateGjcTeamTask(
+	teamName: string,
+	taskId: string,
+	updates: Partial<Pick<GjcTeamTask, "subject" | "description" | "blocked_by" | "depends_on">>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamTask> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const task = await readGjcTeamTask(teamName, taskId, cwd, env);
+	const updated = normalizeTask({
+		...task,
+		...updates,
+		title: updates.subject ?? task.title,
+		objective: updates.description ?? task.objective,
+		version: task.version + 1,
+		updated_at: now(),
+	});
+	await writeTask(dir, updated);
+	await appendEvent(dir, { type: "task_updated", task_id: taskId, message: updated.subject });
+	return updated;
+}
 export async function claimGjcTeamTask(
 	teamName: string,
 	workerId: string,
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
+	taskId?: string,
 ): Promise<GjcTeamApiClaimResult> {
 	const dir = await findTeamDir(teamName, cwd, env);
 	const tasks = await readTasks(dir);
-	const task = tasks.find(candidate => candidate.status === "pending");
+	const task = taskId
+		? tasks.find(candidate => candidate.id === taskId)
+		: tasks.find(candidate => candidate.status === "pending" && (!candidate.owner || candidate.owner === workerId));
 	if (!task) return { ok: false, reason: "no_pending_task" };
-	const updated: GjcTeamTask = { ...task, status: "in_progress", assignee: workerId, updated_at: now() };
-	await writeTask(dir, updated);
+	if (task.status !== "pending") return { ok: false, reason: `task_not_pending:${task.id}` };
+	const token = randomUUID();
+	const claim: GjcTeamTaskClaim = {
+		owner: workerId,
+		token,
+		leased_until: new Date(Date.now() + 30 * 60_000).toISOString(),
+	};
+	const claimPath = path.join(dir, "claims", `${task.id}.json`);
+	await fs.mkdir(path.dirname(claimPath), { recursive: true });
+	let claimFile: fs.FileHandle | undefined;
+	try {
+		claimFile = await fs.open(claimPath, "wx");
+		await claimFile.writeFile(`${JSON.stringify(claim, null, 2)}\n`, "utf-8");
+	} catch (error) {
+		if (isEexist(error)) return { ok: false, reason: `task_already_claimed:${task.id}` };
+		throw error;
+	} finally {
+		await claimFile?.close();
+	}
+	const current = await readGjcTeamTask(teamName, task.id, cwd, env);
+	if (current.status !== "pending") {
+		await fs.rm(claimPath, { force: true });
+		return { ok: false, reason: `task_not_pending:${task.id}` };
+	}
+	const updated: GjcTeamTask = {
+		...current,
+		status: "in_progress",
+		assignee: workerId,
+		owner: workerId,
+		claim,
+		version: current.version + 1,
+		updated_at: now(),
+	};
+	try {
+		await writeTask(dir, updated);
+	} catch (error) {
+		await fs.rm(claimPath, { force: true });
+		throw error;
+	}
 	await appendEvent(dir, {
 		type: "task_claimed",
+		task_id: updated.id,
+		worker: workerId,
 		message: "Worker claimed task",
-		data: { task_id: updated.id, worker_id: workerId },
 	});
-	return { ok: true, task: updated, worker_id: workerId };
+	return { ok: true, task: updated, worker_id: workerId, claim_token: token };
 }
-
-export async function transitionGjcTeamTask(
+export async function transitionGjcTeamTaskStatus(
 	teamName: string,
 	taskId: string,
 	status: GjcTeamTaskStatus,
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
+	claimToken?: string,
 ): Promise<GjcTeamTask> {
 	const dir = await findTeamDir(teamName, cwd, env);
-	const tasks = await readTasks(dir);
-	const task = tasks.find(candidate => candidate.id === taskId);
-	if (!task) throw new Error(`task_not_found:${taskId}`);
-	const updated: GjcTeamTask = { ...task, status, updated_at: now() };
+	const task = await readGjcTeamTask(teamName, taskId, cwd, env);
+	if (status === "pending") throw new Error(`invalid_task_transition:${taskId}:pending_requires_release`);
+	if (task.status === "completed" || task.status === "failed") throw new Error(`task_terminal:${taskId}`);
+	if (!task.claim) throw new Error(`claim_token_required:${taskId}`);
+	if (!claimToken) throw new Error(`claim_token_required:${taskId}`);
+	if (task.claim.token !== claimToken) throw new Error(`claim_token_mismatch:${taskId}`);
+	const terminal = status === "completed" || status === "failed";
+	const updated: GjcTeamTask = {
+		...task,
+		status,
+		claim: terminal ? undefined : task.claim,
+		version: task.version + 1,
+		updated_at: now(),
+		...(terminal ? { completed_at: now() } : {}),
+	};
 	await writeTask(dir, updated);
+	if (terminal) await fs.rm(path.join(dir, "claims", `${taskId}.json`), { force: true });
 	await appendEvent(dir, {
 		type: "task_transitioned",
+		task_id: taskId,
 		message: "Task status changed",
-		data: { task_id: taskId, status },
+		data: { status },
 	});
 	return updated;
+}
+export async function transitionGjcTeamTask(
+	teamName: string,
+	taskId: string,
+	status: GjcTeamTaskStatus | "complete",
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+	claimToken?: string,
+): Promise<GjcTeamTask> {
+	return transitionGjcTeamTaskStatus(teamName, taskId, parseGjcTeamTaskStatus(status, true), cwd, env, claimToken);
+}
+export async function releaseGjcTeamTaskClaim(
+	teamName: string,
+	taskId: string,
+	claimToken: string,
+	workerId: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamTask> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const task = await readGjcTeamTask(teamName, taskId, cwd, env);
+	if (!task.claim || task.claim.token !== claimToken || task.claim.owner !== workerId)
+		throw new Error(`claim_token_mismatch:${taskId}`);
+	const updated: GjcTeamTask = {
+		...task,
+		status: "pending",
+		assignee: undefined,
+		claim: undefined,
+		version: task.version + 1,
+		updated_at: now(),
+	};
+	await writeTask(dir, updated);
+	await fs.rm(path.join(dir, "claims", `${taskId}.json`), { force: true });
+	await appendEvent(dir, {
+		type: "task_claim_released",
+		task_id: taskId,
+		worker: workerId,
+		message: "Task claim released",
+	});
+	return updated;
+}
+
+async function readMailbox(dir: string, worker: string): Promise<{ messages: GjcTeamMailboxMessage[] }> {
+	return (await readJsonFile<{ messages: GjcTeamMailboxMessage[] }>(mailboxPath(dir, worker))) ?? { messages: [] };
+}
+async function writeMailbox(
+	dir: string,
+	worker: string,
+	mailbox: { messages: GjcTeamMailboxMessage[] },
+): Promise<void> {
+	await writeJsonFile(mailboxPath(dir, worker), mailbox);
+}
+export async function sendGjcTeamMessage(
+	teamName: string,
+	fromWorker: string,
+	toWorker: string,
+	body: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamMailboxMessage> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const message = {
+		message_id: `msg-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		from_worker: fromWorker,
+		to_worker: toWorker,
+		body,
+		created_at: now(),
+	};
+	const mailbox = await readMailbox(dir, toWorker);
+	mailbox.messages.push(message);
+	await writeMailbox(dir, toWorker, mailbox);
+	await appendEvent(dir, { type: "message_sent", worker: fromWorker, message: body });
+	return message;
+}
+export async function broadcastGjcTeamMessage(
+	teamName: string,
+	fromWorker: string,
+	body: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamMailboxMessage[]> {
+	const config = await readConfig(await findTeamDir(teamName, cwd, env));
+	return Promise.all(
+		config.workers.map(worker => sendGjcTeamMessage(teamName, fromWorker, worker.id, body, cwd, env)),
+	);
+}
+export async function listGjcTeamMailbox(
+	teamName: string,
+	worker: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamMailboxMessage[]> {
+	return (await readMailbox(await findTeamDir(teamName, cwd, env), worker)).messages;
+}
+export async function markGjcTeamMailboxMessage(
+	teamName: string,
+	worker: string,
+	messageId: string,
+	field: "delivered_at" | "notified_at",
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamMailboxMessage> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const mailbox = await readMailbox(dir, worker);
+	const index = mailbox.messages.findIndex(message => message.message_id === messageId);
+	if (index < 0) throw new Error(`message_not_found:${messageId}`);
+	mailbox.messages[index] = { ...mailbox.messages[index], [field]: now() };
+	await writeMailbox(dir, worker, mailbox);
+	return mailbox.messages[index];
+}
+export async function readGjcWorkerStatus(
+	teamName: string,
+	worker: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<WorkerStatusFile> {
+	return (
+		(await readJsonFile<WorkerStatusFile>(
+			path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "status.json"),
+		)) ?? { state: "unknown", updated_at: now() }
+	);
+}
+export async function readGjcWorkerHeartbeat(
+	teamName: string,
+	worker: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<WorkerHeartbeatFile | null> {
+	return readJsonFile<WorkerHeartbeatFile>(
+		path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "heartbeat.json"),
+	);
+}
+export async function updateGjcWorkerHeartbeat(
+	teamName: string,
+	worker: string,
+	heartbeat: WorkerHeartbeatFile,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<WorkerHeartbeatFile> {
+	const value = { ...heartbeat, last_turn_at: heartbeat.last_turn_at || now() };
+	await writeJsonFile(path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "heartbeat.json"), value);
+	return value;
+}
+export async function writeGjcWorkerInbox(
+	teamName: string,
+	worker: string,
+	content: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<{ path: string }> {
+	const filePath = path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "inbox.md");
+	await Bun.write(filePath, content);
+	return { path: filePath };
+}
+export async function writeGjcWorkerIdentity(
+	teamName: string,
+	worker: GjcTeamWorker,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamWorker> {
+	await writeJsonFile(path.join(workerDir(await findTeamDir(teamName, cwd, env), worker.id), "identity.json"), worker);
+	return worker;
+}
+export async function readGjcTeamEvents(
+	teamName: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamEvent[]> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	try {
+		const text = await Bun.file(path.join(dir, "events.jsonl")).text();
+		return text
+			.split(/\r?\n/)
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as GjcTeamEvent);
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw error;
+	}
+}
+export async function appendGjcTeamEvent(
+	teamName: string,
+	type: string,
+	worker = "leader-fixed",
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamEvent> {
+	return appendEvent(await findTeamDir(teamName, cwd, env), { type, worker });
+}
+export async function awaitGjcTeamEvent(
+	teamName: string,
+	_timeoutMs = 0,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<{ status: "event" | "timeout"; event?: GjcTeamEvent }> {
+	const events = await readGjcTeamEvents(teamName, cwd, env);
+	const event = events.at(-1);
+	return event ? { status: "event", event } : { status: "timeout" };
+}
+export async function writeGjcMonitorSnapshot(
+	teamName: string,
+	snapshot: unknown,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<unknown> {
+	await writeJsonFile(path.join(await findTeamDir(teamName, cwd, env), "monitor-snapshot.json"), snapshot);
+	return snapshot;
+}
+export async function readGjcMonitorSnapshot(
+	teamName: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<unknown> {
+	return readJsonFile<unknown>(path.join(await findTeamDir(teamName, cwd, env), "monitor-snapshot.json"));
+}
+export async function writeGjcTaskApproval(
+	teamName: string,
+	taskId: string,
+	approval: Record<string, unknown>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, unknown>> {
+	await writeJsonFile(path.join(await findTeamDir(teamName, cwd, env), "approvals", `${taskId}.json`), approval);
+	return approval;
+}
+export async function readGjcTaskApproval(
+	teamName: string,
+	taskId: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, unknown> | null> {
+	return readJsonFile<Record<string, unknown>>(
+		path.join(await findTeamDir(teamName, cwd, env), "approvals", `${taskId}.json`),
+	);
+}
+export async function writeGjcShutdownRequest(
+	teamName: string,
+	worker: string,
+	requestedBy: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, unknown>> {
+	const value = { worker, requested_by: requestedBy, requested_at: now() };
+	await writeJsonFile(
+		path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "shutdown-request.json"),
+		value,
+	);
+	return value;
+}
+export async function readGjcShutdownAck(
+	teamName: string,
+	worker: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<Record<string, unknown> | null> {
+	return readJsonFile<Record<string, unknown>>(
+		path.join(workerDir(await findTeamDir(teamName, cwd, env), worker), "shutdown-ack.json"),
+	);
+}
+
+export async function executeGjcTeamApiOperation(
+	operation: string,
+	input: Record<string, unknown>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<unknown> {
+	const teamName = String(input.team_name ?? input.teamName ?? "").trim();
+	if (!teamName) throw new Error("missing_team_name");
+	const worker = String(input.worker ?? input.worker_id ?? input.workerId ?? "worker-1");
+	switch (operation) {
+		case "list-tasks":
+			return { tasks: await listGjcTeamTasks(teamName, cwd, env) };
+		case "read-task":
+			return { task: await readGjcTeamTask(teamName, String(input.task_id ?? input.taskId), cwd, env) };
+		case "create-task":
+			return {
+				task: await createGjcTeamTask(
+					teamName,
+					String(input.subject ?? "Task"),
+					String(input.description ?? ""),
+					cwd,
+					env,
+				),
+			};
+		case "update-task":
+			return {
+				task: await updateGjcTeamTask(
+					teamName,
+					String(input.task_id ?? input.taskId),
+					{
+						subject: typeof input.subject === "string" ? input.subject : undefined,
+						description: typeof input.description === "string" ? input.description : undefined,
+					},
+					cwd,
+					env,
+				),
+			};
+		case "claim-task":
+			return claimGjcTeamTask(
+				teamName,
+				worker,
+				cwd,
+				env,
+				typeof input.task_id === "string" ? input.task_id : undefined,
+			);
+		case "transition-task":
+		case "transition-task-status":
+			return {
+				ok: true,
+				task: await transitionGjcTeamTaskStatus(
+					teamName,
+					String(input.task_id ?? input.taskId),
+					parseGjcTeamTaskStatus(input.to ?? input.status),
+					cwd,
+					env,
+					typeof input.claim_token === "string" ? input.claim_token : undefined,
+				),
+			};
+		case "release-task-claim":
+			return {
+				ok: true,
+				task: await releaseGjcTeamTaskClaim(
+					teamName,
+					String(input.task_id),
+					String(input.claim_token),
+					worker,
+					cwd,
+					env,
+				),
+			};
+		case "send-message":
+			return {
+				message: await sendGjcTeamMessage(
+					teamName,
+					String(input.from_worker),
+					String(input.to_worker),
+					String(input.body),
+					cwd,
+					env,
+				),
+			};
+		case "broadcast":
+			return {
+				messages: await broadcastGjcTeamMessage(teamName, String(input.from_worker), String(input.body), cwd, env),
+			};
+		case "mailbox-list":
+			return { messages: await listGjcTeamMailbox(teamName, worker, cwd, env) };
+		case "mailbox-mark-delivered":
+			return {
+				message: await markGjcTeamMailboxMessage(
+					teamName,
+					worker,
+					String(input.message_id),
+					"delivered_at",
+					cwd,
+					env,
+				),
+			};
+		case "mailbox-mark-notified":
+			return {
+				message: await markGjcTeamMailboxMessage(
+					teamName,
+					worker,
+					String(input.message_id),
+					"notified_at",
+					cwd,
+					env,
+				),
+			};
+		case "read-config":
+			return await readConfig(await findTeamDir(teamName, cwd, env));
+		case "read-manifest":
+			return readJsonFile(path.join(await findTeamDir(teamName, cwd, env), "manifest.v2.json"));
+		case "read-worker-status":
+			return readGjcWorkerStatus(teamName, worker, cwd, env);
+		case "read-worker-heartbeat":
+			return readGjcWorkerHeartbeat(teamName, worker, cwd, env);
+		case "update-worker-heartbeat":
+			return updateGjcWorkerHeartbeat(
+				teamName,
+				worker,
+				{
+					pid: Number(input.pid ?? 0),
+					last_turn_at: now(),
+					turn_count: Number(input.turn_count ?? 0),
+					alive: Boolean(input.alive ?? true),
+				},
+				cwd,
+				env,
+			);
+		case "write-worker-inbox":
+			return writeGjcWorkerInbox(teamName, worker, String(input.content ?? ""), cwd, env);
+		case "write-worker-identity":
+			return writeGjcWorkerIdentity(
+				teamName,
+				{
+					id: worker,
+					name: worker,
+					index: Number(input.index ?? 1),
+					agent_type: String(input.role ?? "executor"),
+					role: String(input.role ?? "executor"),
+					status: "idle",
+					last_heartbeat: now(),
+					assigned_tasks: Array.isArray(input.assigned_tasks) ? input.assigned_tasks.map(String) : [],
+				},
+				cwd,
+				env,
+			);
+		case "append-event":
+			return appendGjcTeamEvent(teamName, String(input.type ?? "event"), worker, cwd, env);
+		case "read-events":
+			return { events: await readGjcTeamEvents(teamName, cwd, env) };
+		case "await-event":
+			return awaitGjcTeamEvent(teamName, Number(input.timeout_ms ?? 0), cwd, env);
+		case "write-monitor-snapshot":
+			return writeGjcMonitorSnapshot(teamName, input.snapshot ?? {}, cwd, env);
+		case "read-monitor-snapshot":
+			return readGjcMonitorSnapshot(teamName, cwd, env);
+		case "write-task-approval":
+			return writeGjcTaskApproval(teamName, String(input.task_id), input, cwd, env);
+		case "read-task-approval":
+			return readGjcTaskApproval(teamName, String(input.task_id), cwd, env);
+		case "write-shutdown-request":
+			return writeGjcShutdownRequest(teamName, worker, String(input.requested_by ?? "leader-fixed"), cwd, env);
+		case "read-shutdown-ack":
+			return readGjcShutdownAck(teamName, worker, cwd, env);
+		default:
+			throw new Error(`unknown_team_api_operation:${operation}`);
+	}
 }
 
 export function parseTeamLaunchArgs(argv: string[]): GjcTeamStartOptions {
 	const parsedWorktree = parseWorktreeMode(argv);
 	const positionals = parsedWorktree.remainingArgs.filter(arg => !arg.startsWith("--"));
 	const dryRun = argv.includes("--dry-run");
-	const spec = positionals[0] ?? "1:executor";
-	const specMatch = spec.match(/^(?:(\d+):)?([a-zA-Z][a-zA-Z0-9_-]*)$/);
-	const workerCount = specMatch?.[1] ? Number.parseInt(specMatch[1], 10) : 1;
-	const agentType = specMatch?.[2] ?? "executor";
-	const task = positionals
-		.slice(specMatch ? 1 : 0)
-		.join(" ")
-		.trim();
+	let workerCount = GJC_TEAM_DEFAULT_WORKERS;
+	let agentType = "executor";
+	let taskStartIndex = 0;
+	const first = positionals[0] ?? "";
+	const countRole = first.match(/^(\d+):([a-zA-Z][a-zA-Z0-9_-]*)$/);
+	const countOnly = first.match(/^(\d+)$/);
+	const roleOnly = first.match(/^([a-zA-Z][a-zA-Z0-9_-]*)$/);
+	if (countRole) {
+		workerCount = Number.parseInt(countRole[1] ?? "", 10);
+		agentType = countRole[2] ?? "executor";
+		taskStartIndex = 1;
+	} else if (countOnly) {
+		workerCount = Number.parseInt(countOnly[1] ?? "", 10);
+		taskStartIndex = 1;
+	} else if (roleOnly && positionals.length > 1) {
+		agentType = roleOnly[1] ?? "executor";
+		taskStartIndex = 1;
+	}
+	const task = positionals.slice(taskStartIndex).join(" ").trim();
 	if (!task) throw new Error("missing_team_task");
-	if (workerCount !== 1) throw new Error(`unsupported_team_worker_count:${workerCount}:gjc_team_supports_one_worker`);
+	if (!Number.isInteger(workerCount) || workerCount < 1 || workerCount > GJC_TEAM_MAX_WORKERS)
+		throw new Error(`invalid_team_worker_count:${workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
 	return { workerCount, agentType, task, dryRun, worktreeMode: resolveDefaultWorktreeMode(parsedWorktree.mode) };
 }

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	claimGjcTeamTask,
+	executeGjcTeamApiOperation,
 	listGjcTeams,
 	parseTeamLaunchArgs,
 	readGjcTeamSnapshot,
@@ -119,7 +120,7 @@ describe("native gjc team runtime", () => {
 		expect(snapshot.task_counts.pending).toBe(1);
 		expect(snapshot.workers).toHaveLength(1);
 		expect(snapshot.tmux_target).toBe("dry-run:0");
-		expect(snapshot.workers[0]?.pane_id).toBe("%dry-run-worker-01");
+		expect(snapshot.workers[0]?.pane_id).toBe("%dry-run-worker-1");
 
 		const telemetry = await Bun.file(path.join(snapshot.state_dir, "telemetry.jsonl")).text();
 		expect(telemetry).toContain("Native gjc team runtime initialized");
@@ -150,13 +151,14 @@ describe("native gjc team runtime", () => {
 	it("parses team starts with automatic detached worktrees and legacy --worktree stripping", () => {
 		const defaultStart = parseTeamLaunchArgs(["executor", "build", "feature"]);
 		expect(defaultStart.worktreeMode).toEqual({ enabled: true, detached: true, name: null });
-		expect(defaultStart.workerCount).toBe(1);
+		expect(defaultStart.workerCount).toBe(3);
 		expect(defaultStart.task).toBe("build feature");
 
-		expect(() => parseTeamLaunchArgs(["2:executor", "build", "feature"])).toThrow(/unsupported_team_worker_count/);
-		expect(() => parseTeamLaunchArgs(["--worktree", "3:debugger", "fix", "bug"])).toThrow(
-			/unsupported_team_worker_count/,
-		);
+		const multi = parseTeamLaunchArgs(["2:executor", "build", "feature"]);
+		expect(multi.workerCount).toBe(2);
+		expect(multi.agentType).toBe("executor");
+		const worktreeMulti = parseTeamLaunchArgs(["--worktree", "3:debugger", "fix", "bug"]);
+		expect(worktreeMulti.workerCount).toBe(3);
 
 		const explicitDetached = parseTeamLaunchArgs(["--worktree", "1:debugger", "fix", "bug"]);
 		expect(explicitDetached.worktreeMode).toEqual({ enabled: true, detached: true, name: null });
@@ -211,32 +213,32 @@ describe("native gjc team runtime", () => {
 		}
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
-		expect(tmuxLog).toContain("split-window -h -p 50 -t %1 -d -P -F #{pane_id}");
-		expect(tmuxLog).toContain("select-layout -t test-session:0 even-horizontal");
-		expect(tmuxLog).not.toContain("select-layout -t test-session:0 main-vertical");
+		expect(tmuxLog).toContain("split-window -h -t %1 -d -P -F #{pane_id}");
+		expect(tmuxLog).toContain("select-layout -t test-session:0 main-vertical");
+		expect(tmuxLog).not.toContain("new-session");
 		expect(tmuxLog).not.toContain("new-session");
 		expect(tmuxLog).not.toContain("kill-session");
 	});
 
-	it("rejects unsupported runtime worker counts before tmux or state mutation", async () => {
+	it("starts multiple runtime workers before tmux state mutation", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
 
-		await expect(
-			startGjcTeam({
-				workerCount: 2,
-				agentType: "executor",
-				task: "Reject multi worker",
-				teamName: "reject-team",
-				cwd: cleanupRoot,
-				env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
-			}),
-		).rejects.toThrow(/unsupported_team_worker_count/);
+		const snapshot = await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Start multi worker",
+			teamName: "multi-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
 
-		expect(await Bun.file(path.join(cleanupRoot, "tmux.log")).exists()).toBe(false);
-		expect(
-			await Bun.file(path.join(cleanupRoot, ".gjc", "state", "team", "reject-team", "config.json")).exists(),
-		).toBe(false);
+		expect(snapshot.workers).toHaveLength(2);
+		expect(snapshot.workers.map(worker => worker.id)).toEqual(["worker-1", "worker-2"]);
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("split-window -h -t %1");
+		expect(tmuxLog).toContain("split-window -v -t %2");
+		expect(tmuxLog).not.toContain("new-session");
 	});
 
 	it("fails outside current tmux before creating team state or worktrees", async () => {
@@ -259,7 +261,7 @@ describe("native gjc team runtime", () => {
 		);
 		expect(
 			await Bun.file(
-				path.join(cleanupRoot, ".gjc", "state", "team", "fail-team", "worktrees", "worker-01", ".git"),
+				path.join(cleanupRoot, ".gjc", "state", "team", "fail-team", "worktrees", "worker-1", ".git"),
 			).exists(),
 		).toBe(false);
 	});
@@ -285,7 +287,7 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).not.toContain("kill-session");
 		await expect(
 			Bun.file(
-				path.join(cleanupRoot, ".gjc", "state", "team", "split-fail-team", "worktrees", "worker-01", ".git"),
+				path.join(cleanupRoot, ".gjc", "state", "team", "split-fail-team", "worktrees", "worker-1", ".git"),
 			).text(),
 		).rejects.toThrow();
 	});
@@ -303,13 +305,13 @@ describe("native gjc team runtime", () => {
 			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
 		});
 
-		expect(snapshot.workers[0]?.worktree_branch).toBe("feature/demo/named-team/worker-01");
+		expect(snapshot.workers[0]?.worktree_branch).toBe("feature/demo/named-team/worker-1");
 		expect(snapshot.workers[0]?.worktree_detached).toBe(false);
 		expect(
 			Bun.spawnSync(["git", "branch", "--show-current"], { cwd: snapshot.workers[0]?.worktree_path, stdout: "pipe" })
 				.stdout.toString()
 				.trim(),
-		).toBe("feature/demo/named-team/worker-01");
+		).toBe("feature/demo/named-team/worker-1");
 	});
 
 	it("removes clean created worker worktrees on normal shutdown", async () => {
@@ -396,18 +398,235 @@ describe("native gjc team runtime", () => {
 			env: { PATH: "" },
 		});
 
-		const claim = await claimGjcTeamTask("life-team", "worker-01", cleanupRoot, { PATH: "" });
+		await expect(
+			transitionGjcTeamTask("life-team", "task-1", "completed", cleanupRoot, { PATH: "" }),
+		).rejects.toThrow("claim_token_required:task-1");
+
+		const claim = await claimGjcTeamTask("life-team", "worker-1", cleanupRoot, { PATH: "" });
 		expect(claim.ok).toBe(true);
+		await expect(
+			transitionGjcTeamTask("life-team", "task-1", "completed", cleanupRoot, { PATH: "" }),
+		).rejects.toThrow("claim_token_required:task-1");
+		await expect(
+			transitionGjcTeamTask("life-team", "task-1", "pending", cleanupRoot, { PATH: "" }, claim.claim_token),
+		).rejects.toThrow("invalid_task_transition:task-1:pending_requires_release");
 		expect(claim.task?.status).toBe("in_progress");
-		const task = await transitionGjcTeamTask("life-team", "task-001", "complete", cleanupRoot, { PATH: "" });
-		expect(task.status).toBe("complete");
+		const task = await transitionGjcTeamTask(
+			"life-team",
+			"task-1",
+			"completed",
+			cleanupRoot,
+			{ PATH: "" },
+			claim.claim_token,
+		);
+		expect(task.status).toBe("completed");
+		expect(task.claim).toBeUndefined();
+		expect(
+			await Bun.file(path.join(cleanupRoot, ".gjc", "state", "team", "life-team", "claims", "task-1.json")).exists(),
+		).toBe(false);
+		await expect(
+			executeGjcTeamApiOperation(
+				"release-task-claim",
+				{ team_name: "life-team", task_id: "task-1", worker: "worker-1", claim_token: claim.claim_token },
+				cleanupRoot,
+				{ PATH: "" },
+			),
+		).rejects.toThrow(/task_terminal|claim_token_mismatch/);
+		await expect(
+			executeGjcTeamApiOperation(
+				"transition-task-status",
+				{ team_name: "life-team", task_id: "task-1", to: "pending" },
+				cleanupRoot,
+				{ PATH: "" },
+			),
+		).rejects.toThrow("invalid_task_transition:task-1:pending_requires_release");
+		const reclaim = await claimGjcTeamTask("life-team", "worker-1", cleanupRoot, { PATH: "" }, "task-1");
+		expect(reclaim.ok).toBe(false);
+		expect(reclaim.reason).toBe("task_not_pending:task-1");
 
 		const status = await readGjcTeamSnapshot("life-team", cleanupRoot, { PATH: "" });
-		expect(status.task_counts.complete).toBe(1);
+		expect(status.task_counts.completed).toBe(1);
 		expect(await listGjcTeams(cleanupRoot, { PATH: "" })).toHaveLength(1);
 
 		const stopped = await shutdownGjcTeam("life-team", cleanupRoot, { PATH: "" });
 		expect(stopped.phase).toBe("complete");
 		expect(stopped.workers[0]?.status).toBe("stopped");
+	});
+
+	it("allows only one worker to claim a task under concurrent claim attempts", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Claim once",
+			teamName: "claim-race-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+
+		const claims = await Promise.all([
+			claimGjcTeamTask("claim-race-team", "worker-1", cleanupRoot, { PATH: "" }, "task-1"),
+			claimGjcTeamTask("claim-race-team", "worker-2", cleanupRoot, { PATH: "" }, "task-1"),
+		]);
+
+		expect(claims.filter(claim => claim.ok)).toHaveLength(1);
+		expect(claims.filter(claim => !claim.ok)).toHaveLength(1);
+		expect(claims.find(claim => !claim.ok)?.reason).toMatch(/task_already_claimed:task-1|task_not_pending:task-1/);
+		const status = await readGjcTeamSnapshot("claim-race-team", cleanupRoot, { PATH: "" });
+		expect(status.task_counts.in_progress).toBe(1);
+	});
+
+	it("supports OMX-parity behavioral API operations", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "API parity",
+			teamName: "api-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+
+		const created = (await executeGjcTeamApiOperation(
+			"create-task",
+			{ team_name: "api-team", subject: "Extra", description: "Extra work" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { task: { id: string } };
+		const read = (await executeGjcTeamApiOperation(
+			"read-task",
+			{ team_name: "api-team", task_id: created.task.id },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { task: { subject: string } };
+		expect(read.task.subject).toBe("Extra");
+		await executeGjcTeamApiOperation(
+			"update-task",
+			{ team_name: "api-team", task_id: created.task.id, subject: "Updated" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const claim = (await executeGjcTeamApiOperation(
+			"claim-task",
+			{ team_name: "api-team", task_id: created.task.id, worker: "worker-1" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { claim_token: string };
+		await executeGjcTeamApiOperation(
+			"release-task-claim",
+			{ team_name: "api-team", task_id: created.task.id, worker: "worker-1", claim_token: claim.claim_token },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const claimed = (await executeGjcTeamApiOperation(
+			"claim-task",
+			{ team_name: "api-team", task_id: created.task.id, worker: "worker-1" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { claim_token: string };
+		await executeGjcTeamApiOperation(
+			"transition-task-status",
+			{ team_name: "api-team", task_id: created.task.id, to: "completed", claim_token: claimed.claim_token },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+
+		const message = (await executeGjcTeamApiOperation(
+			"send-message",
+			{ team_name: "api-team", from_worker: "worker-1", to_worker: "worker-2", body: "hello" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { message: { message_id: string } };
+		await executeGjcTeamApiOperation(
+			"mailbox-mark-delivered",
+			{ team_name: "api-team", worker: "worker-2", message_id: message.message.message_id },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		await executeGjcTeamApiOperation(
+			"mailbox-mark-notified",
+			{ team_name: "api-team", worker: "worker-2", message_id: message.message.message_id },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const mailbox = (await executeGjcTeamApiOperation(
+			"mailbox-list",
+			{ team_name: "api-team", worker: "worker-2" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { messages: Array<{ delivered_at?: string; notified_at?: string }> };
+		expect(mailbox.messages[0]?.delivered_at).toBeTruthy();
+		expect(mailbox.messages[0]?.notified_at).toBeTruthy();
+
+		await executeGjcTeamApiOperation(
+			"write-worker-inbox",
+			{ team_name: "api-team", worker: "worker-1", content: "# Inbox" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		await executeGjcTeamApiOperation(
+			"write-worker-identity",
+			{ team_name: "api-team", worker: "worker-1", index: 1, role: "executor" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		await executeGjcTeamApiOperation(
+			"update-worker-heartbeat",
+			{ team_name: "api-team", worker: "worker-1", pid: 123, turn_count: 2, alive: true },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const heartbeat = (await executeGjcTeamApiOperation(
+			"read-worker-heartbeat",
+			{ team_name: "api-team", worker: "worker-1" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { pid: number };
+		expect(heartbeat.pid).toBe(123);
+
+		await executeGjcTeamApiOperation(
+			"append-event",
+			{ team_name: "api-team", type: "custom", worker: "worker-1" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const awaited = (await executeGjcTeamApiOperation("await-event", { team_name: "api-team" }, cleanupRoot, {
+			PATH: "",
+		})) as { status: string };
+		expect(awaited.status).toBe("event");
+		await executeGjcTeamApiOperation(
+			"write-monitor-snapshot",
+			{ team_name: "api-team", snapshot: { ok: true } },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const monitor = (await executeGjcTeamApiOperation(
+			"read-monitor-snapshot",
+			{ team_name: "api-team" },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { ok: boolean };
+		expect(monitor.ok).toBe(true);
+		await executeGjcTeamApiOperation(
+			"write-task-approval",
+			{ team_name: "api-team", task_id: created.task.id, status: "approved", reviewer: "leader" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		const approval = (await executeGjcTeamApiOperation(
+			"read-task-approval",
+			{ team_name: "api-team", task_id: created.task.id },
+			cleanupRoot,
+			{ PATH: "" },
+		)) as { status: string };
+		expect(approval.status).toBe("approved");
+		await executeGjcTeamApiOperation(
+			"write-shutdown-request",
+			{ team_name: "api-team", worker: "worker-1", requested_by: "leader-fixed" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- Restore `gjc team` to OMX-like multi-worker orchestration with `N:agent-type` launches.
- Split the current tmux window instead of creating a new session: leader stays left, workers stack on the right.
- Expand GJC-scoped team state/API/task/mailbox/worker lifecycle semantics while keeping `.gjc` and `GJC_` namespaces.
- Harden task lifecycle safety with claim-token enforcement, atomic concurrent claims, terminal immutability, and release-only pending transitions.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` (14 pass, 101 expects)
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `git diff --check`

## Review
- Code-reviewer: APPROVE
- Architect: CLEAR

## Notes
- Rebased onto latest `origin/dev` immediately before commit/PR.
- Not tested: live interactive multi-pane GJC worker run against a real model CLI.
