### PR TITLE
Expose named goal tools to agents

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1418,7 +1418,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (settings.get("goal.enabled")) {
 			for (const name of goalStateToolNames) {
 				if (toolRegistry.has(name)) continue;
-				const goalStateTool = await logger.time(`createTools:${name}:session`, HIDDEN_TOOLS[name], toolSession);
+				const goalStateTool = await logger.time(`createTools:${name}:session`, BUILTIN_TOOLS[name], toolSession);
 				if (goalStateTool) {
 					toolRegistry.set(goalStateTool.name, wrapToolWithMetaNotice(goalStateTool));
 				}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -308,6 +308,9 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	retain: HindsightRetainTool.createIf,
 	recall: HindsightRecallTool.createIf,
 	reflect: HindsightReflectTool.createIf,
+	get_goal: GetGoalTool.createIf,
+	create_goal: CreateGoalTool.createIf,
+	update_goal: UpdateGoalTool.createIf,
 };
 
 const GOAL_MODE_TOOL_NAMES = ["get_goal", "create_goal", "update_goal"] as const;
@@ -317,9 +320,6 @@ export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	report_finding: () => reportFindingTool,
 	resolve: s => new ResolveTool(s),
 	goal: s => new GoalTool(s),
-	get_goal: GetGoalTool.createIf,
-	create_goal: CreateGoalTool.createIf,
-	update_goal: UpdateGoalTool.createIf,
 };
 
 export type ToolName = keyof typeof BUILTIN_TOOLS;
@@ -500,7 +500,6 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 						.filter(([name]) => isToolAllowed(name))
 						.map(([name, factory]) => [name, factory] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOLS.yield]] as const) : []),
-					...(goalEnabled ? goalStateToolNames.map(name => [name, HIDDEN_TOOLS[name]] as const) : []),
 					...(goalModeActive ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
 				];
 

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@gajae-code/coding-agent/config/settings";
-import { createTools, HIDDEN_TOOLS, type ToolSession } from "@gajae-code/coding-agent/tools";
+import { BUILTIN_TOOLS, createTools, HIDDEN_TOOLS, type ToolSession } from "@gajae-code/coding-agent/tools";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 
@@ -267,11 +267,13 @@ describe("createTools", () => {
 				"goal.enabled": true,
 			}),
 			getGoalModeState: () => createActiveGoalState(),
+			getGoalRuntime: () =>
+				({}) as NonNullable<ToolSession["getGoalRuntime"]> extends () => infer Runtime ? Runtime : never,
 		});
 		const tools = await createTools(session, ["read"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "goal", "resolve"]);
+		expect(names).toEqual(["read", "goal", "get_goal", "create_goal", "update_goal", "resolve"]);
 	});
 
 	it("includes search_tool_bm25 when MCP tool discovery is enabled and executable", async () => {
@@ -287,7 +289,8 @@ describe("createTools", () => {
 		expect(names).toContain("search_tool_bm25");
 	});
 
-	it("HIDDEN_TOOLS contains review tools and goal", () => {
+	it("exposes named goal tools as builtins and keeps legacy goal hidden", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["goal", "report_finding", "resolve", "yield"]);
+		expect(Object.keys(BUILTIN_TOOLS)).toEqual(expect.arrayContaining(["get_goal", "create_goal", "update_goal"]));
 	});
 });


### PR DESCRIPTION
## Summary
- move get_goal, create_goal, and update_goal into the builtin tool registry so they are exposed as agent-callable tools
- keep the legacy aggregate goal tool hidden and active-goal-only
- update SDK fallback registration and tool-registry regression coverage

## Verification
- bun test packages/coding-agent/test/tools/index.test.ts packages/coding-agent/test/goals/goal-mode-integration.test.ts packages/coding-agent/test/provider-schema-compatibility.test.ts packages/coding-agent/test/schema-validation.test.ts
- bun run --cwd packages/coding-agent check