### PR TITLE
Expose legacy goal tool to agents

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1414,7 +1414,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		for (const tool of builtinTools) {
 			toolRegistry.set(tool.name, tool);
 		}
-		const goalStateToolNames = ["get_goal", "create_goal", "update_goal"] as const;
+		const goalStateToolNames = ["goal", "get_goal", "create_goal", "update_goal"] as const;
 		if (settings.get("goal.enabled")) {
 			for (const name of goalStateToolNames) {
 				if (toolRegistry.has(name)) continue;
@@ -1422,12 +1422,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (goalStateTool) {
 					toolRegistry.set(goalStateTool.name, wrapToolWithMetaNotice(goalStateTool));
 				}
-			}
-		}
-		if (!toolRegistry.has("goal") && settings.get("goal.enabled")) {
-			const goalTool = await logger.time("createTools:goal:session", HIDDEN_TOOLS.goal, toolSession);
-			if (goalTool) {
-				toolRegistry.set(goalTool.name, wrapToolWithMetaNotice(goalTool));
 			}
 		}
 		for (const tool of wrappedExtensionTools) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -308,6 +308,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	retain: HindsightRetainTool.createIf,
 	recall: HindsightRecallTool.createIf,
 	reflect: HindsightReflectTool.createIf,
+	goal: s => new GoalTool(s),
 	get_goal: GetGoalTool.createIf,
 	create_goal: CreateGoalTool.createIf,
 	update_goal: UpdateGoalTool.createIf,
@@ -319,7 +320,6 @@ export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	yield: s => new YieldTool(s),
 	report_finding: () => reportFindingTool,
 	resolve: s => new ResolveTool(s),
-	goal: s => new GoalTool(s),
 };
 
 export type ToolName = keyof typeof BUILTIN_TOOLS;
@@ -369,9 +369,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	let requestedTools =
 		toolNames && toolNames.length > 0 ? [...new Set(toolNames.map(name => name.toLowerCase()))] : undefined;
 	const goalEnabled = session.settings.get("goal.enabled");
-	const goalModeActive = goalEnabled && session.getGoalModeState?.()?.enabled === true;
 	const goalStateToolNames = [...GOAL_MODE_TOOL_NAMES];
-	if (goalModeActive && requestedTools && !requestedTools.includes("goal")) {
+	if (goalEnabled && session.getGoalRuntime !== undefined && requestedTools && !requestedTools.includes("goal")) {
 		requestedTools = [...requestedTools, "goal"];
 	}
 	if (goalEnabled && requestedTools) {
@@ -450,7 +449,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 
 	const allTools: Record<string, ToolFactory> = { ...BUILTIN_TOOLS, ...HIDDEN_TOOLS };
 	const isToolAllowed = (name: string) => {
-		if (name === "goal") return goalEnabled && goalModeActive;
+		if (name === "goal") return goalEnabled && session.getGoalRuntime !== undefined;
 		if (goalStateToolNames.includes(name as (typeof GOAL_MODE_TOOL_NAMES)[number])) return goalEnabled;
 		if (name === "lsp") return enableLsp && session.settings.get("lsp.enabled");
 		if (name === "bash") return true;
@@ -500,7 +499,6 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 						.filter(([name]) => isToolAllowed(name))
 						.map(([name, factory]) => [name, factory] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOLS.yield]] as const) : []),
-					...(goalModeActive ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
 				];
 
 	const baseResults = await Promise.all(

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -112,8 +112,10 @@ describe("InteractiveMode goal mode integration", () => {
 		await harness.cleanup();
 	});
 
-	it("toggles goal tool exposure when goal mode enters and pauses", async () => {
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+	it("keeps goal tools exposed across inactive, active, and paused states", async () => {
+		expect(await toolNamesFor(harness)).toEqual(
+			expect.arrayContaining(["goal", "get_goal", "create_goal", "update_goal"]),
+		);
 
 		await harness.mode.handleGoalModeCommand("Ship the release");
 
@@ -127,8 +129,9 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModeEnabled).toBe(false);
 		expect(harness.mode.goalModePaused).toBe(true);
 		expect(harness.session.getGoalModeState()?.goal.status).toBe("paused");
-		expect(await toolNamesFor(harness)).not.toContain("goal");
-		expect(await toolNamesFor(harness)).toEqual(expect.arrayContaining(["get_goal", "create_goal", "update_goal"]));
+		expect(await toolNamesFor(harness)).toEqual(
+			expect.arrayContaining(["goal", "get_goal", "create_goal", "update_goal"]),
+		);
 	});
 
 	it("replaces the active goal via /goal set", async () => {
@@ -256,12 +259,11 @@ describe("InteractiveMode goal mode integration", () => {
 		);
 		expect(completionText).toContain("Goal achieved. Report final budget usage to the user: tokens used: 0 of 50.");
 		expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
-		// Per fix #1: completeGoalFromTool clears state.enabled so subsequent createTools
-		// calls (e.g. mid-turn refreshes) no longer advertise the goal tool. The model's
-		// existing toolset for the in-flight turn is unaffected — what we care about here
-		// is that the next createTools observation reflects the deactivation.
+		// Goal tools stay exposed after completion so the next turn can inspect or create the next goal.
 		expect(harness.session.getGoalModeState()?.enabled).toBe(false);
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+		expect(await toolNamesFor(harness)).toEqual(
+			expect.arrayContaining(["goal", "get_goal", "create_goal", "update_goal"]),
+		);
 
 		const nextTurn = harness.mode.getUserInput();
 		// getUserInput observes mode === "exiting" and awaits #exitGoalMode before
@@ -272,7 +274,9 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModeEnabled).toBe(false);
 		expect(harness.mode.goalModePaused).toBe(false);
 		expect(harness.session.getGoalModeState()).toBeUndefined();
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+		expect(await toolNamesFor(harness)).toEqual(
+			expect.arrayContaining(["goal", "get_goal", "create_goal", "update_goal"]),
+		);
 		expect(appendCustomEntry).toHaveBeenCalledWith(
 			"goal-completed",
 			expect.objectContaining({

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -261,12 +261,26 @@ describe("createTools", () => {
 		const requestedTools = await createTools(session, ["read"]);
 		expect(requestedTools.map(t => t.name)).toEqual(["read", "resolve"]);
 	});
-	it("auto-includes goal when goal mode is active", async () => {
+	it("auto-includes goal tools when goal mode is enabled", async () => {
 		const session = createTestSession({
 			settings: createSettingsWithOverrides({
 				"goal.enabled": true,
 			}),
 			getGoalModeState: () => createActiveGoalState(),
+			getGoalRuntime: () =>
+				({}) as NonNullable<ToolSession["getGoalRuntime"]> extends () => infer Runtime ? Runtime : never,
+		});
+		const tools = await createTools(session, ["read"]);
+		const names = tools.map(t => t.name);
+
+		expect(names).toEqual(["read", "goal", "get_goal", "create_goal", "update_goal", "resolve"]);
+	});
+
+	it("exposes legacy goal even when no goal is active", async () => {
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({
+				"goal.enabled": true,
+			}),
 			getGoalRuntime: () =>
 				({}) as NonNullable<ToolSession["getGoalRuntime"]> extends () => infer Runtime ? Runtime : never,
 		});
@@ -289,8 +303,10 @@ describe("createTools", () => {
 		expect(names).toContain("search_tool_bm25");
 	});
 
-	it("exposes named goal tools as builtins and keeps legacy goal hidden", () => {
-		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["goal", "report_finding", "resolve", "yield"]);
-		expect(Object.keys(BUILTIN_TOOLS)).toEqual(expect.arrayContaining(["get_goal", "create_goal", "update_goal"]));
+	it("exposes all goal tools as builtins", () => {
+		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["report_finding", "resolve", "yield"]);
+		expect(Object.keys(BUILTIN_TOOLS)).toEqual(
+			expect.arrayContaining(["goal", "get_goal", "create_goal", "update_goal"]),
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- expose the legacy goal tool as a builtin agent-callable tool when goal mode is enabled
- keep get_goal, create_goal, and update_goal exposed alongside it
- update tool exposure tests for inactive, active, paused, and completed goal states

## Verification
- bun test packages/coding-agent/test/tools/index.test.ts packages/coding-agent/test/goals/goal-mode-integration.test.ts packages/coding-agent/test/provider-schema-compatibility.test.ts packages/coding-agent/test/schema-validation.test.ts
- bun run --cwd packages/coding-agent check