### PR TITLE
Fix ultragoal native goal activation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Fixed
 
+- Fixed `gjc ultragoal create-goals` native goal activation so live sessions receive a pending reconciliation request even when the session file already contains an active goal.
 - Made `gjc ultragoal` run natively without requiring `GJC_RUNTIME_BINARY`, while preserving active goal state across interrupted turns.
 - Fixed interactive Escape/interrupt recovery so abort cleanup is bounded and forces the session back to idle when a provider stream, tool, or post-turn task ignores cooperative cancellation.
 - Fixed root `gjc --worktree` / `gjc -w` startup so the launch command actually creates and enters the sibling `<repo>.gajae-code-worktrees/<branch-slug>` git worktree before starting the session, using collision-resistant branch slugs and avoiding worktree side effects for help/version launches.

--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -23,12 +23,10 @@ export default class Ultragoal extends Command {
 
 		const cwd = process.cwd();
 		const { objective, goalsPath } = await readUltragoalGjcObjective(cwd);
-		const sessionWrite = await writeCurrentSessionGoalModeState({
+		await writeCurrentSessionGoalModeState({
 			sessionFile: process.env[GJC_SESSION_FILE_ENV],
 			objective,
 		});
-		if (sessionWrite.status !== "existing_goal") {
-			await writePendingGoalModeRequest({ cwd, objective, goalsPath });
-		}
+		await writePendingGoalModeRequest({ cwd, objective, goalsPath });
 	}
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3816,12 +3816,12 @@ export class AgentSession {
 
 	async #activatePendingGjcGoalModeRequest(): Promise<boolean> {
 		if (!this.settings.get("goal.enabled")) return false;
+		const pendingGoal = await consumePendingGoalModeRequest(this.sessionManager.getCwd());
+		if (!pendingGoal) return false;
 		const currentState = this.getGoalModeState();
 		if (currentState?.goal && currentState.goal.status !== "complete" && currentState.goal.status !== "dropped") {
 			return false;
 		}
-		const pendingGoal = await consumePendingGoalModeRequest(this.sessionManager.getCwd());
-		if (!pendingGoal) return false;
 
 		const previousTools = this.getActiveToolNames().filter(name => name !== "goal");
 		const goalTools = [...new Set([...previousTools, "goal"])];

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	consumePendingGoalModeRequest,
+	GJC_SESSION_FILE_ENV,
 	isUltragoalCreateGoalsInvocation,
 	readUltragoalGjcObjective,
 	writeCurrentSessionGoalModeState,
@@ -134,6 +135,53 @@ describe("GJC ultragoal goal mode request", () => {
 
 		expect(result).toEqual({ status: "existing_goal", goal: existingGoal });
 		expect(after).toBe(before);
+	});
+
+	it("queues a pending activation request even when the session file already has an active goal", async () => {
+		const root = await tempDir();
+		const sessionFile = path.join(root, "session.jsonl");
+		const timestamp = new Date().toISOString();
+		const existingGoal = {
+			id: "goal-1",
+			objective: "Existing goal",
+			status: "active",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			createdAt: 1,
+			updatedAt: 1,
+		};
+		await Bun.write(
+			sessionFile,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "session-1", timestamp, cwd: root }),
+				JSON.stringify({
+					type: "mode_change",
+					id: "mode-1",
+					parentId: null,
+					timestamp,
+					mode: "goal",
+					data: { goal: existingGoal },
+				}),
+				"",
+			].join("\n"),
+		);
+
+		const cliPath = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+		const result = Bun.spawnSync(["bun", cliPath, "ultragoal", "create-goals", "--brief", "Ship native goal"], {
+			cwd: root,
+			env: { ...process.env, [GJC_SESSION_FILE_ENV]: sessionFile },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		expect(result.exitCode, result.stderr.toString()).toBe(0);
+		const pending = await consumePendingGoalModeRequest(root);
+		expect(pending?.objective).toContain(".gjc/ultragoal/goals.json");
+		const entries = (await loadEntriesFromFile(sessionFile)).filter(
+			(entry): entry is SessionEntry => entry.type !== "session",
+		);
+		const context = buildSessionContext(entries);
+		expect(context.modeData?.goal).toMatchObject(existingGoal);
 	});
 
 	it("surfaces corrupt pending request json", async () => {


### PR DESCRIPTION
## Summary
- Always queues the Ultragoal pending goal-mode reconciliation request after successful `gjc ultragoal create-goals`.
- Consumes pending reconciliation requests before the live-session active-goal guard so stale requests do not linger.
- Adds a regression test for the persisted-session-existing-goal case that previously skipped pending activation.

## Why
`writeCurrentSessionGoalModeState()` can see an active goal in the session JSONL and return `existing_goal`, but the running TUI/session may still not have that goal in memory. The previous CLI branch skipped the pending request in that case, leaving native `get_goal` unset from the live session’s perspective.

## Validation
- `bun --cwd=packages/coding-agent test test/gjc-runtime/goal-mode-request.test.ts test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`

## Notes
- Built local native addon first because the test environment lacked `packages/natives/native/pi_natives.darwin-arm64.node`.
