### PR TITLE
Clarify subagent await timeout cancellation doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ Use the smallest workflow that satisfies the request:
 
 Do not execute implementation from `deep-interview` or `ralplan` unless the user explicitly approves execution. Planning artifacts must remain `pending approval` until that approval exists.
 
+Subagent await timeouts are observation windows, not failure signals. Do not cancel a subagent merely because `subagent await` timed out; inspect/list, continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+
 ## Repository focus
 
 This repo contains multiple packages, but `packages/coding-agent/` is the primary product surface. Unless otherwise specified, assume work refers to that package.

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -177,6 +177,7 @@ Artifacts and side channels:
 - Background work / cancellation
   - Parent abort stops scheduling new work, aborts active child sessions, and marks unscheduled tasks as skipped.
   - Async jobs keep their own cancellation via `AsyncJobManager`.
+  - Await timeouts are observation windows only: they do not stop, fail, or make a subagent stale. Inspect/list and continue work; cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
 ## Limits & Caps
 - Per-subagent output truncation: `MAX_OUTPUT_BYTES = 500_000` and `MAX_OUTPUT_LINES = 5000` in `packages/coding-agent/src/task/types.ts`. Full raw output is still written to `<id>.md` before truncation is returned to the caller.

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -114,6 +114,8 @@ Ultragoal execution should use GJC's bundled role-agent roster when a durable st
 - Use `architect` for read-only architecture and code-review lanes, including `CLEAR` / `WATCH` / `BLOCK` status.
 - Use `critic` for read-only plan or handoff critique before execution proceeds.
 
+When delegating with native subagents, an await timeout only limits the leader's wait. It is not subagent failure evidence and must not be used as a cancellation reason; inspect or continue independent work, and cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+
 If an Ultragoal request has no approved plan or consensus artifact, run `ralplan` first and preserve its PRD, test spec, role roster, and verification guidance in the Ultragoal ledger. Do not silently substitute ad-hoc execution for missing planning.
 
 The Ultragoal leader owns `.gjc/ultragoal/goals.json` and `.gjc/ultragoal/ledger.jsonl`. Role agents return implementation/review evidence; they do not checkpoint Ultragoal or mutate goal state.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -173,7 +173,7 @@ Delegate by default for multi-file changes, refactors, new features, tests, and 
 <detached-subagents>
 - Normal `{{toolRefs.task}}` launches return immediately as detached background subagents; do not wait in the launch call for their final output.
 {{#has tools "subagent"}}- Use `{{toolRefs.subagent}}` to list, inspect, await with `timeout_ms`, or cancel detached task subagents.{{/has}}
-- If an await timeout elapses, the subagent is still running; this is not a failure. Inspect progress, continue independent work, and cancel only when the subagent is no longer needed or unrecoverably wrong.
+- If an await timeout elapses, the subagent is still running; this is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 {{#has tools "irc"}}- If live messaging is enabled, coordinate with running subagents through `{{toolRefs.irc}}`; cancellation is not a message channel.{{/has}}
 {{#has tools "job"}}- `{{toolRefs.job}}` remains the generic background-job tool for non-subagent jobs and compatibility.{{/has}}
 </detached-subagents>

--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -13,9 +13,9 @@ Inspect selected subagents by `ids`; omit `ids` to inspect current running subag
 ## `action: "await"`
 Wait for selected subagents by `ids`; omit `ids` to wait for current running subagents.
 - Always set `timeout_ms` when the result is not immediately required forever.
-- If the timeout elapses, the subagent is still running. This is not a failure.
-- On timeout, inspect progress, keep doing independent work, and cancel only if the subagent is no longer needed or is unrecoverably wrong.
+- Await timeout only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
+- On timeout, inspect progress and keep doing independent work. Never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
 ## `action: "cancel"`
 Stop selected running subagents by `ids`.
-- Use only when the subagent is no longer needed, has gone off-track, or is unrecoverably stuck.
+- Use only when the subagent has actually failed, gone off-track, or become unrecoverably stuck; an await timeout alone is never a cancellation reason.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -3,11 +3,11 @@ Launches subagents to parallelize workflows.
 - Results are delivered automatically when complete.
 - The tool result lists the assigned task ids (e.g. `0-AuthLoader`) — those are the live agent ids.
 {{#if ircEnabled}}
-- Coordinate with running tasks via `irc` using those ids. `subagent` cancel terminates a task and **cannot carry a message** — only use it for stalled/abandoned work.
-- If genuinely blocked on completion, wait with `subagent` action `await` and a timeout; otherwise keep working.
+- Coordinate with running tasks via `irc` using those ids. `subagent` cancel terminates a task and **cannot carry a message** — never cancel because an await timed out; cancel only when the task has actually failed, gone off-track, or become unrecoverably wrong.
+- If genuinely blocked on completion, wait with `subagent` action `await` and a timeout; timeout only bounds your wait and does not stop or fail the subagent.
 {{else}}
-- If genuinely blocked on completion, wait with `subagent` action `await` and a timeout; otherwise keep working.
-- Use `subagent` action `inspect` or `list` to snapshot manager state; `cancel` only when a task is no longer needed or unrecoverably stuck.
+- If genuinely blocked on completion, wait with `subagent` action `await` and a timeout; timeout only bounds your wait and does not stop or fail the subagent.
+- Use `subagent` action `inspect` or `list` to snapshot manager state; `cancel` only when a task has actually failed, gone off-track, or become unrecoverably wrong.
 {{/if}}
 
 {{#if ircEnabled}}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -550,8 +550,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			})
 			.join("\n");
 		const coordinationHint = ircEnabled
-			? ` DM these ids via \`irc\` to coordinate while they run. Use \`subagent\` to list, inspect, await with a timeout, or cancel only when no longer needed or unrecoverably stuck; \`job\` remains available for generic background jobs.`
-			: ` Use \`subagent\` to list, inspect, await with a timeout, or cancel only when no longer needed or unrecoverably stuck; \`job\` remains available for generic background jobs.`;
+			? ` DM these ids via \`irc\` to coordinate while they run. Use \`subagent\` to list, inspect, or await with a timeout; a timeout only bounds your wait and is never a cancellation reason. Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; \`job\` remains available for generic background jobs.`
+			: ` Use \`subagent\` to list, inspect, or await with a timeout; a timeout only bounds your wait and is never a cancellation reason. Cancel only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; \`job\` remains available for generic background jobs.`;
 
 		return {
 			content: [

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -271,7 +271,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const subagent = job.metadata?.subagent;
 		const runningTimeoutGuidance =
 			timedOut && job.status === "running"
-				? "Still running after the await timeout; this is not a failure. Inspect progress, continue independent work, and cancel only if no longer needed or unrecoverably wrong."
+				? "Still running after the await timeout; timeout only bounded this wait and is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong."
 				: undefined;
 		return {
 			id: subagent?.id ?? job.id,

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -162,6 +162,8 @@ Project executor override body.
 		expect(systemPrompt).toContain("committed repo-visible `.gjc` defaults are not the source of truth");
 		expect(ultragoal).toContain("run `ralplan` first");
 		expect(ultragoal).toContain("Role agents return implementation/review evidence");
+		expect(ultragoal).toContain("await timeout only limits the leader's wait");
+		expect(ultragoal).toContain("must not be used as a cancellation reason");
 	});
 
 	it("installs bundled workflow skill definitions without overwriting local edits unless forced", async () => {

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -218,6 +218,7 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain("Normal `task` launches return immediately as detached background subagents");
 		expect(rendered).toContain("Use `subagent` to list, inspect, await with `timeout_ms`, or cancel");
 		expect(rendered).toContain("If an await timeout elapses, the subagent is still running; this is not a failure.");
+		expect(rendered).toContain("never cancel just because an await timed out");
 		expect(rendered).toContain("`job` remains the generic background-job tool");
 	});
 

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -139,7 +139,8 @@ describe("SubagentTool", () => {
 		expect(result.details?.subagents[0]?.status).toBe("running");
 		expect(guidance).toContain("Still running");
 		expect(guidance).toContain("not a failure");
-		expect(guidance).toContain("cancel only if no longer needed");
+		expect(guidance).toContain("never cancel just because an await timed out");
+		expect(guidance).toContain("cancel only if the subagent has actually failed");
 		expect(guidance).not.toContain("steer");
 		expect(guidance).not.toContain("shutdown");
 		await manager.dispose({ timeoutMs: 100 });


### PR DESCRIPTION
## Summary
- make system/tool/runtime guidance explicit that subagent await timeouts are only observation windows
- add Ultragoal delegation doctrine and docs coverage for the same rule
- lock prompt/runtime wording with focused tests

## Verification
- bun test packages/coding-agent/test/system-prompt-templates.test.ts packages/coding-agent/test/tools/subagent.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts
- bun test packages/coding-agent/test/tools/task-simple-mode.test.ts packages/coding-agent/test/task/executor-subagent-reminders.test.ts
- bunx biome check AGENTS.md docs/tools/task.md packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md packages/coding-agent/src/prompts/system/system-prompt.md packages/coding-agent/src/prompts/tools/subagent.md packages/coding-agent/src/prompts/tools/task.md packages/coding-agent/src/task/index.ts packages/coding-agent/src/tools/subagent.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/system-prompt-templates.test.ts packages/coding-agent/test/tools/subagent.test.ts
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts