### PR TITLE
Address subagent timeout review findings

### DIFF
--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -18,4 +18,4 @@ Wait for selected subagents by `ids`; omit `ids` to wait for current running sub
 
 ## `action: "cancel"`
 Stop selected running subagents by `ids`.
-- Use only when the subagent has actually failed, gone off-track, or become unrecoverably stuck; an await timeout alone is never a cancellation reason.
+- Use only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; an await timeout alone is never a cancellation reason.

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -164,6 +164,9 @@ Project executor override body.
 		expect(ultragoal).toContain("Role agents return implementation/review evidence");
 		expect(ultragoal).toContain("await timeout only limits the leader's wait");
 		expect(ultragoal).toContain("must not be used as a cancellation reason");
+		expect(ultragoal).toContain("the subagent has actually failed");
+		expect(ultragoal).toContain("gone off-track");
+		expect(ultragoal).toContain("become unrecoverably wrong");
 	});
 
 	it("installs bundled workflow skill definitions without overwriting local edits unless forced", async () => {

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -143,15 +143,26 @@ describe("SubagentTool", () => {
 		expect(guidance).toContain("cancel only if the subagent has actually failed");
 		expect(guidance).not.toContain("steer");
 		expect(guidance).not.toContain("shutdown");
+
+		await Bun.sleep(80);
+		const completed = await tool.execute("subagent-await-completed", {
+			action: "await",
+			ids: ["0-Slow"],
+			timeout_ms: 100,
+		});
+
+		expect(completed.details?.subagents[0]?.status).toBe("completed");
+		expect(completed.details?.subagents[0]?.resultText).toContain("slow result");
+		expect(manager.getJob("job-slow")?.status).toBe("completed");
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
-	it("cancel stops a selected running subagent by subagent id", async () => {
+	it("cancel stops a selected known-bad running subagent by subagent id", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
 		manager.register(
 			"task",
-			"cancel subagent",
+			"known-bad cancel subagent",
 			async ({ signal }) => {
 				while (!signal.aborted) await Bun.sleep(5);
 				throw new Error("cancelled");


### PR DESCRIPTION
## Summary
- align subagent cancel guidance with the exact failed/off-track/unrecoverably-wrong doctrine
- add lifecycle coverage proving an await timeout leaves the subagent later deliverable
- strengthen Ultragoal prompt assertions for the allowed cancellation boundary

## Architect review
- Initial recovery review found WATCH/COMMENT issues in PR #50 follow-up areas
- Follow-up architect review returned CLEAR / APPROVE with no findings

## Verification
- bun test packages/coding-agent/test/system-prompt-templates.test.ts packages/coding-agent/test/tools/subagent.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts packages/coding-agent/test/task/executor-subagent-reminders.test.ts
- bunx biome check packages/coding-agent/src/prompts/tools/subagent.md packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/tools/subagent.test.ts