### PR TITLE
Add unscoped gajae-code install package

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -83,6 +83,10 @@
 		"CHANGELOG.md"
 	],
 	"exports": {
+		"./cli": {
+			"types": "./src/cli.ts",
+			"import": "./src/cli.ts"
+		},
 		".": {
 			"types": "./src/index.ts",
 			"import": "./src/index.ts"

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -135,7 +135,7 @@ async function executeGoalOperation(session: ToolSession, params: GoalToolInput)
 export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 	readonly name = "goal";
 	readonly label = "Goal";
-	readonly loadMode = "essential";
+	readonly loadMode = "essential" as const;
 	readonly description = prompt.render(goalDescription);
 	readonly parameters = goalSchema;
 	readonly strict = true;
@@ -161,7 +161,7 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 export class GetGoalTool implements AgentTool<typeof getGoalSchema, GoalToolDetails> {
 	readonly name = "get_goal";
 	readonly label = "Get Goal";
-	readonly loadMode = "essential";
+	readonly loadMode = "essential" as const;
 	readonly description = prompt.render(getGoalDescription);
 	readonly parameters = getGoalSchema;
 	readonly strict = true;
@@ -191,7 +191,7 @@ export class GetGoalTool implements AgentTool<typeof getGoalSchema, GoalToolDeta
 export class CreateGoalTool implements AgentTool<typeof createGoalSchema, GoalToolDetails> {
 	readonly name = "create_goal";
 	readonly label = "Create Goal";
-	readonly loadMode = "essential";
+	readonly loadMode = "essential" as const;
 	readonly description = prompt.render(createGoalDescription);
 	readonly parameters = createGoalSchema;
 	readonly strict = true;
@@ -225,7 +225,7 @@ export class CreateGoalTool implements AgentTool<typeof createGoalSchema, GoalTo
 export class UpdateGoalTool implements AgentTool<typeof updateGoalSchema, GoalToolDetails> {
 	readonly name = "update_goal";
 	readonly label = "Update Goal";
-	readonly loadMode = "essential";
+	readonly loadMode = "essential" as const;
 	readonly description = prompt.render(updateGoalDescription);
 	readonly parameters = updateGoalSchema;
 	readonly strict = true;

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -106,6 +106,34 @@ const GH_PR_CHECKOUT_FIELDS = [
 	"title",
 	"url",
 ];
+
+const PR_CHECKOUT_BRANCH_CONFIG = {
+	headRef: "gjcPrHeadRef",
+	url: "gjcPrUrl",
+	isCrossRepository: "gjcPrIsCrossRepository",
+	maintainerCanModify: "gjcPrMaintainerCanModify",
+} as const;
+
+const LEGACY_PR_CHECKOUT_BRANCH_CONFIG = {
+	headRef: "ompPrHeadRef",
+	url: "ompPrUrl",
+	isCrossRepository: "ompPrIsCrossRepository",
+	maintainerCanModify: "ompPrMaintainerCanModify",
+} as const;
+
+type PrCheckoutBranchConfigKey = keyof typeof PR_CHECKOUT_BRANCH_CONFIG;
+
+async function getPrCheckoutBranchConfig(
+	repoRoot: string,
+	localBranch: string,
+	key: PrCheckoutBranchConfigKey,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	return (
+		(await git.config.getBranch(repoRoot, localBranch, PR_CHECKOUT_BRANCH_CONFIG[key], signal)) ??
+		(await git.config.getBranch(repoRoot, localBranch, LEGACY_PR_CHECKOUT_BRANCH_CONFIG[key], signal))
+	);
+}
 // /search/<endpoint> API response shapes (subset). Used when projecting raw
 // REST results into the normalized `GhSearch*Result` shapes the formatters
 // consume. We talk to the API directly because `gh search prs`/`issues`
@@ -1023,21 +1051,21 @@ async function resolvePrBranchPushTarget(
 	maintainerCanModify?: boolean;
 	isCrossRepository: boolean;
 }> {
-	const headRef = await git.config.getBranch(repoRoot, localBranch, "ompPrHeadRef", signal);
+	const headRef = await getPrCheckoutBranchConfig(repoRoot, localBranch, "headRef", signal);
 	if (!headRef) {
 		throw new ToolError(`branch ${localBranch} has no PR push metadata; check it out via op: pr_checkout first`);
 	}
 
 	const pushRemote = await git.config.getBranch(repoRoot, localBranch, "pushRemote", signal);
 	const remote = await git.config.getBranch(repoRoot, localBranch, "remote", signal);
-	const prUrl = await git.config.getBranch(repoRoot, localBranch, "ompPrUrl", signal);
-	const maintainerCanModifyValue = await git.config.getBranch(
+	const prUrl = await getPrCheckoutBranchConfig(repoRoot, localBranch, "url", signal);
+	const maintainerCanModifyValue = await getPrCheckoutBranchConfig(
 		repoRoot,
 		localBranch,
-		"ompPrMaintainerCanModify",
+		"maintainerCanModify",
 		signal,
 	);
-	const isCrossRepositoryValue = await git.config.getBranch(repoRoot, localBranch, "ompPrIsCrossRepository", signal);
+	const isCrossRepositoryValue = await getPrCheckoutBranchConfig(repoRoot, localBranch, "isCrossRepository", signal);
 
 	const remoteName = pushRemote ?? remote;
 	if (!remoteName) {
@@ -2989,19 +3017,19 @@ async function checkoutPullRequest(
 			await git.config.setBranch(repoRoot, localBranch, "remote", remote.name, signal);
 			await git.config.setBranch(repoRoot, localBranch, "merge", `refs/heads/${headRefName}`, signal);
 			await git.config.setBranch(repoRoot, localBranch, "pushRemote", remote.name, signal);
-			await git.config.setBranch(repoRoot, localBranch, "ompPrHeadRef", headRefName, signal);
-			await git.config.setBranch(repoRoot, localBranch, "ompPrUrl", data.url ?? "", signal);
+			await git.config.setBranch(repoRoot, localBranch, PR_CHECKOUT_BRANCH_CONFIG.headRef, headRefName, signal);
+			await git.config.setBranch(repoRoot, localBranch, PR_CHECKOUT_BRANCH_CONFIG.url, data.url ?? "", signal);
 			await git.config.setBranch(
 				repoRoot,
 				localBranch,
-				"ompPrIsCrossRepository",
+				PR_CHECKOUT_BRANCH_CONFIG.isCrossRepository,
 				String(Boolean(data.isCrossRepository)),
 				signal,
 			);
 			await git.config.setBranch(
 				repoRoot,
 				localBranch,
-				"ompPrMaintainerCanModify",
+				PR_CHECKOUT_BRANCH_CONFIG.maintainerCanModify,
 				String(Boolean(data.maintainerCanModify)),
 				signal,
 			);

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -26,6 +26,7 @@ const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	gjc: true,
 	pr: true,
 	rule: true,
+	skill: true,
 };
 const INTERNAL_URL_SCHEME_RE = /^([a-z][a-z0-9+.-]*):\/\//i;
 const NARROW_NO_BREAK_SPACE = "\u202F";

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Settings } from "../../src/config/settings";
+import { type GoalModeState, GoalRuntime } from "../../src/goals";
 import { AgentRegistry, MAIN_AGENT_ID } from "../../src/registry/agent-registry";
 import type { ToolSession } from "../../src/tools/index";
 import {
@@ -33,6 +34,31 @@ const allToolsSettings = Settings.isolated({
 	"todo.enabled": true,
 	"memory.backend": "hindsight",
 	"tools.discoveryMode": "all",
+	"goal.enabled": true,
+});
+
+const activeGoalState: GoalModeState = {
+	enabled: true,
+	mode: "active",
+	goal: {
+		id: "goal-1",
+		objective: "Verify tool metadata",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 1,
+		updatedAt: 1,
+	},
+};
+
+const goalRuntime = new GoalRuntime({
+	getState: () => activeGoalState,
+	setState: () => {},
+	getCurrentUsage: () => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }),
+	emit: () => {},
+	persist: () => {},
+	sendHiddenMessage: async () => {},
+	now: () => 1,
 });
 
 const toolSession: ToolSession = {
@@ -44,6 +70,8 @@ const toolSession: ToolSession = {
 	isToolDiscoveryEnabled: () => true,
 	getSelectedDiscoveredToolNames: () => [],
 	activateDiscoveredTools: async names => names,
+	getGoalModeState: () => activeGoalState,
+	getGoalRuntime: () => goalRuntime,
 };
 
 async function getToolMetadata(): Promise<Map<string, { loadMode?: string; summary?: string }>> {

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -78,6 +78,8 @@ describe("BashTool head/tail stripping", () => {
 	function createBashToolWithStrip(stripEnabled: boolean): BashTool {
 		const session = {
 			cwd: process.cwd(),
+			getSessionFile: () => null,
+			getSessionId: () => undefined,
 			settings: {
 				get(key: string) {
 					if (key === "bashInterceptor.enabled") return false;

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -888,6 +888,37 @@ describe("github tool", () => {
 		}
 	});
 
+	it("pushes PR branches using legacy checkout metadata from pre-rebrand branches", async () => {
+		const fixture = await createPrFixture();
+		try {
+			runGit(fixture.repoRoot, ["branch", "pr-123", fixture.headRefOid]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.remote", "forksrc"]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.pushRemote", "forksrc"]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.merge", `refs/heads/${fixture.headRefName}`]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.ompPrHeadRef", fixture.headRefName]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.ompPrUrl", "https://github.com/base/repo/pull/123"]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.ompPrIsCrossRepository", "true"]);
+			runGit(fixture.repoRoot, ["config", "branch.pr-123.ompPrMaintainerCanModify", "true"]);
+			const pushSpy = vi.spyOn(git, "push").mockResolvedValue(undefined);
+
+			const tool = new GithubTool(createSession(fixture.repoRoot));
+			const result = await tool.execute("pr-push", { op: "pr_push", branch: "pr-123" });
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+			expect(text).toContain("# Pushed Pull Request Branch");
+			expect(text).toContain("PR: https://github.com/base/repo/pull/123");
+			expect(pushSpy).toHaveBeenCalledWith(
+				fixture.repoRoot,
+				expect.objectContaining({
+					remote: "forksrc",
+					refspec: `refs/heads/pr-123:refs/heads/${fixture.headRefName}`,
+				}),
+			);
+		} finally {
+			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+		}
+	});
+
 	it("exposes a flat op-based schema without legacy run_watch parameters", () => {
 		const tool = new GithubTool(createSession());
 		const wire = z.toJSONSchema(tool.parameters, { target: "draft-2020-12" }) as Record<string, unknown>;

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -187,9 +187,14 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 
 	if (fullWorkspace) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
+		addNativeBuild(tasks);
 		add(tasks, "root-test", "Root workspace TypeScript tests", ["bun", "run", "test:ts"]);
 	} else if (!ciOnly) {
-		for (const workspacePackage of expandWithDependents(touchedPackages, packages)) {
+		const affectedPackages = expandWithDependents(touchedPackages, packages);
+		if (affectedPackages.some(workspacePackage => workspacePackage.manifest.scripts?.test)) {
+			addNativeBuild(tasks);
+		}
+		for (const workspacePackage of affectedPackages) {
 			if (workspacePackage.manifest.scripts?.check) {
 				add(tasks, `check:${workspacePackage.name}`, `Check ${workspacePackage.name}`, ["bun", "--cwd", workspacePackage.dir, "run", "check"]);
 			}
@@ -232,6 +237,11 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 	}
 
 	return Array.from(tasks.values());
+}
+
+
+function addNativeBuild(tasks: Map<string, Task>): void {
+	add(tasks, "native-linux-x64", "Build linux x64 native addons", ["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
 }
 
 function add(tasks: Map<string, Task>, key: string, description: string, command: readonly string[]): void {

--- a/scripts/install-tests/tarball.dockerfile
+++ b/scripts/install-tests/tarball.dockerfile
@@ -68,7 +68,7 @@ RUN cat > /repo/scripts/publish-local.sh <<'SCRIPT'
 set -e
 
 REGISTRY="http://localhost:4873"
-PACKAGES=(utils natives ai agent tui stats coding-agent)
+PACKAGES=(utils natives ai agent tui stats coding-agent gajae-code)
 
 # Build version map from all package.json files
 declare -A VERSION_MAP
@@ -127,7 +127,7 @@ RUN verdaccio --config /root/.config/verdaccio/config.yaml &>/dev/null & \
 WORKDIR /test
 RUN verdaccio --config /root/.config/verdaccio/config.yaml &>/dev/null & \
     sleep 3 && \
-    bun add @gajae-code/coding-agent --registry http://localhost:4873 && \
+    bun add gajae-code --registry http://localhost:4873 && \
     pkill -f verdaccio
 
 # Verify the installed package works

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+interface PackageManifest {
+	name: string;
+	version: string;
+	bin?: Record<string, string>;
+	dependencies?: Record<string, string>;
+	private?: boolean;
+}
+
+const repoRoot = path.join(import.meta.dir, "..");
+
+async function readManifest(relativePath: string): Promise<PackageManifest> {
+	return (await Bun.file(path.join(repoRoot, relativePath, "package.json")).json()) as PackageManifest;
+}
+
+describe("unscoped gajae-code package publication", () => {
+	test("manifest exposes gjc and depends on the scoped CLI package", async () => {
+		const aliasManifest = await readManifest("packages/gajae-code");
+		const codingAgentManifest = await readManifest("packages/coding-agent");
+
+		expect(aliasManifest.private).toBeUndefined();
+		expect(aliasManifest.name).toBe("gajae-code");
+		expect(aliasManifest.version).toBe(codingAgentManifest.version);
+		expect(aliasManifest.bin).toEqual({ gjc: "bin/gjc.js" });
+		expect(aliasManifest.dependencies?.["@gajae-code/coding-agent"]).toBe("catalog:");
+	});
+
+	test("release publish order publishes the alias after its scoped dependency", async () => {
+		const releaseScript = await Bun.file(path.join(repoRoot, "scripts/ci-release-publish.ts")).text();
+		const codingAgentIndex = releaseScript.indexOf('dir: "packages/coding-agent"');
+		const aliasIndex = releaseScript.indexOf('dir: "packages/gajae-code"');
+
+		expect(codingAgentIndex).toBeGreaterThan(-1);
+		expect(aliasIndex).toBeGreaterThan(codingAgentIndex);
+	});
+});


### PR DESCRIPTION
## Summary
- add an unscoped \ workspace package that exposes the \ bin and depends on \
- publish the alias package after the scoped CLI package in release CI
- update install docs and tarball install smoke tests for \bun add v1.3.14 (0d9b296a)

## Verification
- \bun test v1.3.14 (0d9b296a)
- \
- \bun install v1.3.14 (0d9b296a)
Generated src/internal-urls/docs-index.generated.ts (74 docs)

Checked 416 installs across 534 packages (no changes) [737.00ms]
