### PR TITLE
Port GJC team worker integration parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For a package-by-package map, see [`docs/codebase-overview.md`](docs/codebase-ov
 
 ## Inspirations and lineage
 
-Gajae-Code builds on lessons from a small family of agent harnesses while keeping the public GJC surface intentionally focused. Historical attribution is kept in [`NOTICE.md`](NOTICE.md).
+Gajae-Code's default dark TUI identity is the GJC red-claw theme. It builds on lessons from a small family of agent harnesses while keeping the public GJC surface intentionally focused. Historical attribution is kept in [`NOTICE.md`](NOTICE.md).
 
 ## License
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Restored `gjc team` multi-worker GJC-team parity orchestration with current-window worker panes, GJC-scoped state/API semantics, and `N:agent-type` launches.
+- Ported GJC team worker-worktree integration parity so `status`/`resume` auto-checkpoint dirty workers, merge or cherry-pick worker commits, cross-rebase idle workers, and record conflicts under `.gjc` integration artifacts.
+- Restored `gjc team` multi-worker OMX-parity orchestration with current-window worker panes, GJC-scoped state/API semantics, and `N:agent-type` launches.
 
 ### Added
 

--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -2,8 +2,8 @@ import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import {
 	executeGjcTeamApiOperation,
 	listGjcTeams,
+	monitorGjcTeam,
 	parseTeamLaunchArgs,
-	readGjcTeamSnapshot,
 	shutdownGjcTeam,
 	startGjcTeam,
 } from "../gjc-runtime/team-runtime";
@@ -68,7 +68,7 @@ export default class Team extends Command {
 		if (action === "status" || action === "resume") {
 			const teamName = rest.find(arg => !arg.startsWith("--"));
 			if (!teamName) throw new Error("missing_team_name");
-			const snapshot = await readGjcTeamSnapshot(teamName);
+			const snapshot = await monitorGjcTeam(teamName);
 			if (json) {
 				writeJson(snapshot);
 				return;

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -142,8 +142,14 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
    - `GJC_TEAM_WORKER_ID=worker-1`
    - `GJC_TEAM_STATE_ROOT=<leader-cwd>/.gjc/state/team`
    - optional `GJC_TEAM_WORKTREE_PATH=<path>` when worktree mode is active
-7. Store pane/target evidence in config/manifest/snapshot: `tmux_session`, `tmux_session_name`, `tmux_target`, leader pane id, and worker pane id.
-8. Return control to the leader; follow-up uses `status`, `resume`, `shutdown`, and `gjc team api`.
+7. Automatically integrate worker worktree commits during leader monitoring:
+   - dirty worker worktrees are auto-checkpointed before integration
+   - clean-ahead worker history is merged into the leader with a runtime merge commit
+   - diverged worker history is cherry-picked into the leader
+   - idle/done/failed worker worktrees are cross-rebased onto the updated leader after integration; working workers are skipped
+   - conflicts are aborted, recorded, and reported to the leader mailbox without falsely advancing `last_integrated_head`
+8. Store pane/target/integration evidence in config/manifest/snapshot: `tmux_session`, `tmux_session_name`, `tmux_target`, leader pane id, worker pane ids, and `integration_by_worker`.
+9. Return control to the leader; follow-up uses `status`, `resume`, `shutdown`, and `gjc team api`.
 
 Important:
 
@@ -187,8 +193,10 @@ gjc team shutdown <team-name>
 
 Semantics:
 
-- `status`: reads team snapshot (task counts, worker state, tmux target/pane evidence).
-- `resume`: reads the same live team snapshot for reconnect/inspection flows.
+- `status`: mutating monitor path; reads team snapshot and applies pending worker worktree integration before returning task counts, worker state, tmux target/pane evidence, and `integration_by_worker`.
+- `resume`: mutating monitor path; performs the same integration-aware live snapshot for reconnect/inspection flows.
+- `list`: pure read path; lists known teams without integrating worker commits.
+- API/read-only snapshot operations are pure unless explicitly documented as a monitor/status path.
 - `shutdown`: kills the recorded worker pane when it still belongs to the stored tmux target, removes clean created worktrees, marks worker stopped, and marks phase complete. It preserves `.gjc/state/team/<team>` as evidence.
 
 ## Data Plane and Control Plane
@@ -206,8 +214,11 @@ Semantics:
 - `.gjc/state/team/<team>/phase.json`
 - `.gjc/state/team/<team>/events.jsonl`
 - `.gjc/state/team/<team>/telemetry.jsonl`
+- `.gjc/state/team/<team>/monitor-snapshot.json`
+- `.gjc/state/team/<team>/integration-report.md`
 - `.gjc/state/team/<team>/tasks/task-1.json`
 - `.gjc/state/team/<team>/mailbox/worker-1.json`
+- `.gjc/reports/team-commit-hygiene/<team>.ledger.json`
 
 ## Team Mutation Interop (CLI-first)
 
@@ -230,7 +241,8 @@ Worker protocol:
 
 - Claim pending work with `claim-task`.
 - Transition the task to `completed`, `failed`, or `blocked` with `transition-task-status`.
-- Record implementation/verification evidence in normal task output and state files; do not assume a separate leader confirmation mailbox or queue exists.
+- Commit or leave worktree changes in the worker worktree; the leader `status`/`resume` monitor path will auto-checkpoint dirty worktrees and integrate committed history where possible.
+- Record implementation/verification evidence in normal task output and state files; leader integration/conflict notifications are delivered through `.gjc/state/team/<team>/mailbox/leader-fixed.json`.
 
 ## Environment Knobs
 
@@ -256,6 +268,7 @@ Operator note (important for GJC panes):
 - **Split failure:** startup records a failed phase if state was already initialized, rolls back created worktrees, and never kills the leader tmux session.
 - **Worker API ENOENT:** team state is missing or `GJC_TEAM_STATE_ROOT` points somewhere else. Check `.gjc/state/team/<team>/` before assuming worker failure.
 - **Stale pane on shutdown:** shutdown only kills a recorded worker pane when it still belongs to the stored `tmux_target` and is not the leader pane. Stale panes outside that target require manual inspection.
+- **Integration conflict:** `gjc team status <team>` / `resume` aborts the failing merge, cherry-pick, or worker rebase; inspect `.gjc/state/team/<team>/integration-report.md`, `.gjc/state/team/<team>/events.jsonl`, `.gjc/state/team/<team>/mailbox/leader-fixed.json`, and `.gjc/reports/team-commit-hygiene/<team>.ledger.json`.
 
 ### Safe Manual Intervention (last resort)
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -88,6 +88,30 @@ export interface GjcTeamConfig {
 	updated_at: string;
 }
 
+export type GjcTeamIntegrationStatus =
+	| "idle"
+	| "integrated"
+	| "integration_failed"
+	| "merge_conflict"
+	| "cherry_pick_conflict"
+	| "rebase_conflict";
+
+export interface GjcTeamWorkerIntegrationState {
+	last_seen_head?: string;
+	last_integrated_head?: string;
+	last_leader_head?: string;
+	last_rebased_leader_head?: string;
+	status?: GjcTeamIntegrationStatus;
+	conflict_commit?: string;
+	conflict_files?: string[];
+	updated_at?: string;
+}
+
+export interface GjcTeamMonitorSnapshot {
+	integration_by_worker: Record<string, GjcTeamWorkerIntegrationState>;
+	updated_at: string;
+}
+
 export interface GjcTeamSnapshot {
 	team_name: string;
 	display_name: string;
@@ -99,6 +123,7 @@ export interface GjcTeamSnapshot {
 	task_total: number;
 	task_counts: Record<GjcTeamTaskStatus, number>;
 	workers: GjcTeamWorker[];
+	integration_by_worker?: Record<string, GjcTeamWorkerIntegrationState>;
 	updated_at: string;
 }
 
@@ -160,6 +185,26 @@ interface WorkerHeartbeatFile {
 	last_turn_at: string;
 	turn_count: number;
 	alive: boolean;
+}
+interface GitResult {
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+}
+interface GjcTeamCommitHygieneEntry {
+	recorded_at: string;
+	operation: "auto_checkpoint" | "integration_merge" | "integration_cherry_pick" | "cross_rebase";
+	worker_name: string;
+	task_id?: string;
+	status: "applied" | "skipped" | "conflict" | "failed";
+	operational_commit?: string | null;
+	source_commit?: string;
+	leader_head_before?: string;
+	leader_head_after?: string | null;
+	worker_head_before?: string | null;
+	worker_head_after?: string | null;
+	worktree_path?: string;
+	detail: string;
 }
 
 function isGjcTeamTaskStatus(value: string): value is GjcTeamTaskStatus {
@@ -376,14 +421,22 @@ function buildWorkers(count: number, agentType: string, stateRoot?: string): Gjc
 function sanitizePathToken(value: string): string {
 	return sanitizeName(value) || "default";
 }
-function runGit(cwd: string, args: string[]): string {
+function runGitResult(cwd: string, args: string[]): GitResult {
 	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-	if (result.exitCode === 0) return result.stdout.toString().trim();
-	throw new Error(result.stderr.toString().trim() || `git ${args.join(" ")} failed`);
+	return {
+		ok: result.exitCode === 0,
+		stdout: result.stdout.toString().trim(),
+		stderr: result.stderr.toString().trim(),
+	};
+}
+function runGit(cwd: string, args: string[]): string {
+	const result = runGitResult(cwd, args);
+	if (result.ok) return result.stdout;
+	throw new Error(result.stderr || `git ${args.join(" ")} failed`);
 }
 function tryRunGit(cwd: string, args: string[]): string | null {
-	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-	return result.exitCode === 0 ? result.stdout.toString().trim() : null;
+	const result = runGitResult(cwd, args);
+	return result.ok ? result.stdout : null;
 }
 function isGitRepository(cwd: string): boolean {
 	return tryRunGit(cwd, ["rev-parse", "--show-toplevel"]) != null;
@@ -665,6 +718,493 @@ async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<vo
 			});
 }
 
+function monitorSnapshotPath(dir: string): string {
+	return path.join(dir, "monitor-snapshot.json");
+}
+function integrationReportPath(dir: string): string {
+	return path.join(dir, "integration-report.md");
+}
+function commitHygieneLedgerPath(config: GjcTeamConfig): string {
+	return path.join(config.leader_cwd, ".gjc", "reports", "team-commit-hygiene", `${config.team_name}.ledger.json`);
+}
+function integrationNowState(
+	status: GjcTeamIntegrationStatus,
+): Pick<GjcTeamWorkerIntegrationState, "status" | "updated_at"> {
+	return { status, updated_at: now() };
+}
+async function appendIntegrationReport(
+	dir: string,
+	entry: { worker: string; operation: "merge" | "cherry-pick" | "rebase"; files: string[]; detail: string },
+): Promise<void> {
+	const line = `- [${now()}] ${entry.worker}: ${entry.operation}; files=${entry.files.join(",") || "unknown"}; ${entry.detail}\n`;
+	await fs.mkdir(path.dirname(integrationReportPath(dir)), { recursive: true });
+	if (await pathExists(integrationReportPath(dir))) await fs.appendFile(integrationReportPath(dir), line, "utf-8");
+	else await Bun.write(integrationReportPath(dir), `# Integration Report\n\n${line}`);
+}
+async function appendCommitHygieneEntries(config: GjcTeamConfig, entries: GjcTeamCommitHygieneEntry[]): Promise<void> {
+	if (entries.length === 0) return;
+	const ledgerPath = commitHygieneLedgerPath(config);
+	const existing = (await readJsonFile<{ version: number; entries: GjcTeamCommitHygieneEntry[] }>(ledgerPath)) ?? {
+		version: 1,
+		entries: [],
+	};
+	await writeJsonFile(ledgerPath, { version: 1, entries: [...existing.entries, ...entries] });
+}
+function resolveHead(cwd: string): string | null {
+	return tryRunGit(cwd, ["rev-parse", "HEAD"]);
+}
+function isAncestor(cwd: string, ancestor: string, descendant: string): boolean {
+	return runGitResult(cwd, ["merge-base", "--is-ancestor", ancestor, descendant]).ok;
+}
+function listCommitRange(cwd: string, baseRef: string, headRef: string): string[] {
+	const result = runGitResult(cwd, ["rev-list", "--reverse", `${baseRef}..${headRef}`]);
+	if (!result.ok || !result.stdout) return [];
+	return result.stdout
+		.split(/\r?\n/)
+		.map(line => line.trim())
+		.filter(Boolean);
+}
+function listConflictFiles(cwd: string): string[] {
+	const result = runGitResult(cwd, ["diff", "--name-only", "--diff-filter=U"]);
+	if (!result.ok || !result.stdout) return [];
+	return result.stdout
+		.split(/\r?\n/)
+		.map(line => line.trim())
+		.filter(Boolean);
+}
+async function appendIntegrationEvent(
+	dir: string,
+	type: string,
+	worker: GjcTeamWorker,
+	data: Record<string, unknown>,
+): Promise<void> {
+	await appendEvent(dir, {
+		type,
+		worker: worker.id,
+		task_id: worker.assigned_tasks[0],
+		message: typeof data.summary === "string" ? data.summary : type,
+		data,
+	});
+}
+async function notifyLeader(
+	config: GjcTeamConfig,
+	worker: GjcTeamWorker,
+	body: string,
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+): Promise<void> {
+	await sendGjcTeamMessage(config.team_name, worker.id, "leader-fixed", body, cwd, env).catch(() => undefined);
+}
+function autoCommitDirtyWorker(worker: GjcTeamWorker): { committed: boolean; commit: string | null } {
+	if (!worker.worktree_path) return { committed: false, commit: null };
+	const status = runGitResult(worker.worktree_path, ["status", "--porcelain"]);
+	if (!status.ok || !status.stdout.trim()) return { committed: false, commit: null };
+	if (!runGitResult(worker.worktree_path, ["add", "-A"]).ok) return { committed: false, commit: null };
+	const message = `gjc(team): auto-checkpoint ${worker.id} [${worker.assigned_tasks[0] ?? "unknown"}]`;
+	if (!runGitResult(worker.worktree_path, ["commit", "--no-verify", "-m", message]).ok)
+		return { committed: false, commit: null };
+	return { committed: true, commit: resolveHead(worker.worktree_path) };
+}
+function workerMergeRef(worker: GjcTeamWorker, workerHead: string): string {
+	if (!worker.worktree_path) return workerHead;
+	const branch = tryRunGit(worker.worktree_path, ["rev-parse", "--abbrev-ref", "HEAD"]);
+	return !branch || branch === "HEAD" ? workerHead : branch;
+}
+async function integrateGjcWorkerCommits(
+	config: GjcTeamConfig,
+	dir: string,
+	previous: GjcTeamMonitorSnapshot | null,
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+): Promise<Record<string, GjcTeamWorkerIntegrationState>> {
+	const integrationByWorker: Record<string, GjcTeamWorkerIntegrationState> = {
+		...(previous?.integration_by_worker ?? {}),
+	};
+	const hygieneEntries: GjcTeamCommitHygieneEntry[] = [];
+	const leaderCwd = config.leader_cwd || cwd;
+	const cycleLeaderHead = resolveHead(leaderCwd);
+	for (const worker of config.workers) {
+		if (!worker.worktree_path || !worker.worktree_repo_root || !(await pathExists(worker.worktree_path))) continue;
+		const { committed, commit } = autoCommitDirtyWorker(worker);
+		if (!committed) continue;
+		await appendIntegrationEvent(dir, "worker_auto_commit", worker, {
+			worker_name: worker.id,
+			commit_hash: commit,
+			worktree_path: worker.worktree_path,
+			summary: `auto-committed dirty worktree for ${worker.id}`,
+		});
+		hygieneEntries.push({
+			recorded_at: now(),
+			operation: "auto_checkpoint",
+			worker_name: worker.id,
+			task_id: worker.assigned_tasks[0],
+			status: "applied",
+			operational_commit: commit,
+			worktree_path: worker.worktree_path,
+			detail: "Dirty worker worktree checkpointed before integration.",
+		});
+	}
+
+	for (const worker of config.workers) {
+		if (!worker.worktree_path || !worker.worktree_repo_root || !(await pathExists(worker.worktree_path))) continue;
+		const leaderHead = resolveHead(leaderCwd);
+		const workerHead = resolveHead(worker.worktree_path);
+		const state: GjcTeamWorkerIntegrationState = {
+			...(integrationByWorker[worker.id] ?? {}),
+			last_leader_head: leaderHead ?? integrationByWorker[worker.id]?.last_leader_head,
+		};
+		if (!leaderHead || !workerHead) {
+			integrationByWorker[worker.id] = state;
+			continue;
+		}
+		state.last_seen_head = workerHead;
+		if (isAncestor(leaderCwd, workerHead, "HEAD")) {
+			integrationByWorker[worker.id] = {
+				...state,
+				last_integrated_head: workerHead,
+				...integrationNowState("idle"),
+			};
+			continue;
+		}
+		if (isAncestor(worker.worktree_path, leaderHead, workerHead)) {
+			const mergeRef = workerMergeRef(worker, workerHead);
+			const merge = runGitResult(leaderCwd, [
+				"merge",
+				"--no-ff",
+				"-X",
+				"theirs",
+				"-m",
+				`gjc(team): merge ${worker.id}`,
+				mergeRef,
+			]);
+			if (merge.ok) {
+				const newLeaderHead = resolveHead(leaderCwd);
+				if (newLeaderHead && newLeaderHead !== leaderHead && isAncestor(leaderCwd, workerHead, "HEAD")) {
+					integrationByWorker[worker.id] = {
+						...state,
+						last_integrated_head: workerHead,
+						last_leader_head: newLeaderHead,
+						conflict_commit: undefined,
+						conflict_files: undefined,
+						...integrationNowState("integrated"),
+					};
+					await appendIntegrationEvent(dir, "worker_merge_applied", worker, {
+						worker_name: worker.id,
+						worker_head: workerHead,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worker.worktree_path,
+						summary: `merged ${worker.id} into leader`,
+					});
+					await notifyLeader(
+						config,
+						worker,
+						`INTEGRATED: merged ${worker.id} ${workerHead.slice(0, 12)} into leader.`,
+						cwd,
+						env,
+					);
+					hygieneEntries.push({
+						recorded_at: now(),
+						operation: "integration_merge",
+						worker_name: worker.id,
+						task_id: worker.assigned_tasks[0],
+						status: "applied",
+						operational_commit: newLeaderHead,
+						source_commit: workerHead,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worker.worktree_path,
+						detail: "Leader created a runtime merge commit to integrate worker history.",
+					});
+				} else {
+					integrationByWorker[worker.id] = { ...state, ...integrationNowState("integration_failed") };
+					hygieneEntries.push({
+						recorded_at: now(),
+						operation: "integration_merge",
+						worker_name: worker.id,
+						task_id: worker.assigned_tasks[0],
+						status: "failed",
+						source_commit: workerHead,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worker.worktree_path,
+						detail: "Runtime merge succeeded but did not advance the leader head.",
+					});
+					await notifyLeader(
+						config,
+						worker,
+						`INTEGRATION FAILED: merge for ${worker.id} did not advance leader HEAD.`,
+						cwd,
+						env,
+					);
+				}
+			} else {
+				const conflictFiles = listConflictFiles(leaderCwd);
+				runGitResult(leaderCwd, ["merge", "--abort"]);
+				integrationByWorker[worker.id] = {
+					...state,
+					conflict_commit: workerHead,
+					conflict_files: conflictFiles,
+					...integrationNowState("merge_conflict"),
+				};
+				await appendIntegrationEvent(dir, "worker_merge_conflict", worker, {
+					worker_name: worker.id,
+					worker_head: workerHead,
+					conflict_files: conflictFiles,
+					stderr: merge.stderr || merge.stdout,
+					summary: `merge conflict for ${worker.id}`,
+				});
+				await appendIntegrationReport(dir, {
+					worker: worker.id,
+					operation: "merge",
+					files: conflictFiles,
+					detail: `merge --no-ff -X theirs failed and was aborted: ${(merge.stderr || merge.stdout).slice(0, 200)}`,
+				});
+				await notifyLeader(
+					config,
+					worker,
+					`CONFLICT: merge failed for ${worker.id}; files: ${conflictFiles.join(",") || "unknown"}.`,
+					cwd,
+					env,
+				);
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "integration_merge",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "conflict",
+					source_commit: workerHead,
+					leader_head_before: leaderHead,
+					leader_head_after: resolveHead(leaderCwd),
+					worktree_path: worker.worktree_path,
+					detail: `Runtime merge failed and was aborted: ${(merge.stderr || merge.stdout).slice(0, 200)}`,
+				});
+			}
+			continue;
+		}
+
+		const baseline =
+			state.last_integrated_head &&
+			tryRunGit(worker.worktree_path, ["rev-parse", "--verify", state.last_integrated_head])
+				? state.last_integrated_head
+				: leaderHead;
+		const commits = listCommitRange(worker.worktree_path, baseline, workerHead);
+		for (const commit of commits) {
+			const pick = runGitResult(leaderCwd, ["cherry-pick", "--allow-empty", "-X", "theirs", commit]);
+			if (!pick.ok) {
+				const conflictFiles = listConflictFiles(leaderCwd);
+				runGitResult(leaderCwd, ["cherry-pick", "--abort"]);
+				integrationByWorker[worker.id] = {
+					...state,
+					conflict_commit: commit,
+					conflict_files: conflictFiles,
+					...integrationNowState("cherry_pick_conflict"),
+				};
+				await appendIntegrationEvent(dir, "worker_cherry_pick_conflict", worker, {
+					worker_name: worker.id,
+					commit,
+					conflict_files: conflictFiles,
+					stderr: pick.stderr || pick.stdout,
+					summary: `cherry-pick conflict for ${worker.id}`,
+				});
+				await appendIntegrationReport(dir, {
+					worker: worker.id,
+					operation: "cherry-pick",
+					files: conflictFiles,
+					detail: `cherry-pick -X theirs failed and was aborted: ${(pick.stderr || pick.stdout).slice(0, 200)}`,
+				});
+				await notifyLeader(
+					config,
+					worker,
+					`CONFLICT: cherry-pick failed for ${worker.id}; files: ${conflictFiles.join(",") || "unknown"}.`,
+					cwd,
+					env,
+				);
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "integration_cherry_pick",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "conflict",
+					source_commit: commit,
+					leader_head_before: leaderHead,
+					leader_head_after: resolveHead(leaderCwd),
+					worktree_path: worker.worktree_path,
+					detail: `Runtime cherry-pick failed and was aborted: ${(pick.stderr || pick.stdout).slice(0, 200)}`,
+				});
+				break;
+			}
+			const newLeaderHead = resolveHead(leaderCwd);
+			if (!newLeaderHead || newLeaderHead === leaderHead) {
+				integrationByWorker[worker.id] = { ...state, ...integrationNowState("integration_failed") };
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "integration_cherry_pick",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "failed",
+					source_commit: commit,
+					leader_head_before: leaderHead,
+					leader_head_after: newLeaderHead,
+					worktree_path: worker.worktree_path,
+					detail: "Runtime cherry-pick did not advance the leader head.",
+				});
+				break;
+			}
+			integrationByWorker[worker.id] = {
+				...state,
+				last_integrated_head: commit,
+				last_leader_head: newLeaderHead,
+				conflict_commit: undefined,
+				conflict_files: undefined,
+				...integrationNowState("integrated"),
+			};
+			await appendIntegrationEvent(dir, "worker_cherry_pick_applied", worker, {
+				worker_name: worker.id,
+				commit,
+				leader_head_before: leaderHead,
+				leader_head_after: newLeaderHead,
+				worktree_path: worker.worktree_path,
+				summary: `cherry-picked ${commit.slice(0, 12)} from ${worker.id}`,
+			});
+			await notifyLeader(
+				config,
+				worker,
+				`INTEGRATED: cherry-picked ${commit.slice(0, 12)} from ${worker.id}.`,
+				cwd,
+				env,
+			);
+			hygieneEntries.push({
+				recorded_at: now(),
+				operation: "integration_cherry_pick",
+				worker_name: worker.id,
+				task_id: worker.assigned_tasks[0],
+				status: "applied",
+				operational_commit: newLeaderHead,
+				source_commit: commit,
+				leader_head_before: leaderHead,
+				leader_head_after: newLeaderHead,
+				worktree_path: worker.worktree_path,
+				detail: "Leader cherry-picked diverged worker history.",
+			});
+		}
+	}
+
+	const newLeaderHead = resolveHead(leaderCwd);
+	if (cycleLeaderHead && newLeaderHead && cycleLeaderHead !== newLeaderHead) {
+		for (const worker of config.workers) {
+			if (!worker.worktree_path || !(await pathExists(worker.worktree_path))) continue;
+			const status = await readGjcWorkerStatus(config.team_name, worker.id, cwd, env);
+			if (!["idle", "done", "failed"].includes(status.state)) {
+				await appendIntegrationEvent(dir, "worker_cross_rebase_skipped", worker, {
+					worker_name: worker.id,
+					worker_state: status.state,
+					leader_head: newLeaderHead,
+					summary: `skipped cross-rebase for ${worker.id}`,
+				});
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "cross_rebase",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "skipped",
+					leader_head_after: newLeaderHead,
+					worktree_path: worker.worktree_path,
+					detail: `Worker state ${status.state} is not eligible for automatic cross-rebase.`,
+				});
+				continue;
+			}
+			if (worktreeIsDirty(worker.worktree_path)) {
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "cross_rebase",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "skipped",
+					leader_head_after: newLeaderHead,
+					worktree_path: worker.worktree_path,
+					detail: "Worker worktree is dirty after integration; automatic cross-rebase skipped.",
+				});
+				continue;
+			}
+			const before = resolveHead(worker.worktree_path);
+			const rebase = runGitResult(worker.worktree_path, ["rebase", "-X", "ours", newLeaderHead]);
+			if (rebase.ok) {
+				const after = resolveHead(worker.worktree_path);
+				integrationByWorker[worker.id] = {
+					...(integrationByWorker[worker.id] ?? {}),
+					last_rebased_leader_head: newLeaderHead,
+					conflict_commit: undefined,
+					conflict_files: undefined,
+					...integrationNowState("idle"),
+				};
+				await appendIntegrationEvent(dir, "worker_cross_rebase_applied", worker, {
+					worker_name: worker.id,
+					leader_head: newLeaderHead,
+					worktree_path: worker.worktree_path,
+					summary: `cross-rebased ${worker.id}`,
+				});
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "cross_rebase",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "applied",
+					operational_commit: after,
+					leader_head_after: newLeaderHead,
+					worker_head_before: before,
+					worker_head_after: after,
+					worktree_path: worker.worktree_path,
+					detail: "Runtime rebase moved worker history onto updated leader head.",
+				});
+			} else {
+				const conflictFiles = listConflictFiles(worker.worktree_path);
+				runGitResult(worker.worktree_path, ["rebase", "--abort"]);
+				integrationByWorker[worker.id] = {
+					...(integrationByWorker[worker.id] ?? {}),
+					conflict_commit: before ?? newLeaderHead,
+					conflict_files: conflictFiles,
+					...integrationNowState("rebase_conflict"),
+				};
+				await appendIntegrationEvent(dir, "worker_cross_rebase_conflict", worker, {
+					worker_name: worker.id,
+					leader_head: newLeaderHead,
+					conflict_files: conflictFiles,
+					stderr: rebase.stderr || rebase.stdout,
+					summary: `cross-rebase conflict for ${worker.id}`,
+				});
+				await appendIntegrationReport(dir, {
+					worker: worker.id,
+					operation: "rebase",
+					files: conflictFiles,
+					detail: `rebase -X ours failed and was aborted: ${(rebase.stderr || rebase.stdout).slice(0, 200)}`,
+				});
+				await notifyLeader(
+					config,
+					worker,
+					`CONFLICT: cross-rebase failed for ${worker.id}; files: ${conflictFiles.join(",") || "unknown"}.`,
+					cwd,
+					env,
+				);
+				hygieneEntries.push({
+					recorded_at: now(),
+					operation: "cross_rebase",
+					worker_name: worker.id,
+					task_id: worker.assigned_tasks[0],
+					status: "conflict",
+					leader_head_after: newLeaderHead,
+					worker_head_before: before,
+					worker_head_after: resolveHead(worker.worktree_path),
+					worktree_path: worker.worktree_path,
+					detail: `Runtime cross-rebase failed and was aborted: ${(rebase.stderr || rebase.stdout).slice(0, 200)}`,
+				});
+			}
+		}
+	}
+	await appendCommitHygieneEntries(config, hygieneEntries);
+	return integrationByWorker;
+}
+
 async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promise<void> {
 	for (const folder of ["tasks", "claims", "mailbox", "dispatch", "approvals", "workers"])
 		await fs.mkdir(path.join(dir, folder), { recursive: true });
@@ -798,6 +1338,7 @@ export async function readGjcTeamSnapshot(
 		failed: 0,
 	};
 	for (const task of tasks) taskCounts[task.status] += 1;
+	const monitor = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
 	return {
 		team_name: config.team_name,
 		display_name: config.display_name,
@@ -809,8 +1350,21 @@ export async function readGjcTeamSnapshot(
 		task_total: tasks.length,
 		task_counts: taskCounts,
 		workers: config.workers,
+		integration_by_worker: monitor?.integration_by_worker,
 		updated_at: config.updated_at,
 	};
+}
+export async function monitorGjcTeam(
+	teamName: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcTeamSnapshot> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const config = await readConfig(dir);
+	const previous = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
+	const integrationByWorker = await integrateGjcWorkerCommits(config, dir, previous, cwd, env);
+	await writeJsonFile(monitorSnapshotPath(dir), { integration_by_worker: integrationByWorker, updated_at: now() });
+	return readGjcTeamSnapshot(teamName, cwd, env);
 }
 export async function listGjcTeams(
 	cwd = process.cwd(),
@@ -1215,7 +1769,7 @@ export async function writeGjcMonitorSnapshot(
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<unknown> {
-	await writeJsonFile(path.join(await findTeamDir(teamName, cwd, env), "monitor-snapshot.json"), snapshot);
+	await writeJsonFile(monitorSnapshotPath(await findTeamDir(teamName, cwd, env)), snapshot);
 	return snapshot;
 }
 export async function readGjcMonitorSnapshot(
@@ -1223,7 +1777,7 @@ export async function readGjcMonitorSnapshot(
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<unknown> {
-	return readJsonFile<unknown>(path.join(await findTeamDir(teamName, cwd, env), "monitor-snapshot.json"));
+	return readJsonFile<unknown>(monitorSnapshotPath(await findTeamDir(teamName, cwd, env)));
 }
 export async function writeGjcTaskApproval(
 	teamName: string,

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -5,7 +5,9 @@ import * as path from "node:path";
 import {
 	claimGjcTeamTask,
 	executeGjcTeamApiOperation,
+	type GjcTeamConfig,
 	listGjcTeams,
+	monitorGjcTeam,
 	parseTeamLaunchArgs,
 	readGjcTeamSnapshot,
 	resolveGjcWorkerCommand,
@@ -15,9 +17,10 @@ import {
 } from "../../src/gjc-runtime/team-runtime";
 
 let cleanupRoot: string | undefined;
-function runGit(cwd: string, args: string[]): void {
+function runGit(cwd: string, args: string[]): string {
 	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
 	if (result.exitCode !== 0) throw new Error(result.stderr.toString() || `git ${args.join(" ")} failed`);
+	return result.stdout.toString().trim();
 }
 
 async function createFakeTmuxBin(
@@ -82,6 +85,36 @@ async function createGitRepo(): Promise<string> {
 	runGit(repo, ["add", "README.md"]);
 	runGit(repo, ["commit", "-m", "initial"]);
 	return repo;
+}
+
+async function readTeamConfig(stateDir: string): Promise<GjcTeamConfig> {
+	return Bun.file(path.join(stateDir, "config.json")).json() as Promise<GjcTeamConfig>;
+}
+
+async function commitFile(cwd: string, relativePath: string, content: string, message: string): Promise<string> {
+	await Bun.write(path.join(cwd, relativePath), content);
+	runGit(cwd, ["add", relativePath]);
+	runGit(cwd, ["commit", "-m", message]);
+	return runGit(cwd, ["rev-parse", "HEAD"]);
+}
+
+async function writeWorkerStatus(
+	stateDir: string,
+	worker: string,
+	state: "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown",
+): Promise<void> {
+	await Bun.write(
+		path.join(stateDir, "workers", worker, "status.json"),
+		`${JSON.stringify({ state, updated_at: new Date().toISOString() }, null, 2)}\n`,
+	);
+}
+
+async function readEvents(stateDir: string): Promise<string> {
+	return Bun.file(path.join(stateDir, "events.jsonl")).text();
+}
+
+async function readMailbox(stateDir: string, worker: string): Promise<string> {
+	return Bun.file(path.join(stateDir, "mailbox", `${worker}.json`)).text();
 }
 
 afterEach(async () => {
@@ -628,5 +661,222 @@ describe("native gjc team runtime", () => {
 			cleanupRoot,
 			{ PATH: "" },
 		);
+	});
+
+	it("monitor integrates dirty detached worker worktrees and records GJC-scoped hygiene artifacts", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Integrate dirty worker",
+			teamName: "integrate-dirty-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const worker = config.workers[0];
+		if (!worker?.worktree_path) throw new Error("missing worker worktree");
+		await Bun.write(path.join(worker.worktree_path, "worker-output.txt"), "from worker\n");
+
+		const monitored = await monitorGjcTeam("integrate-dirty-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+
+		expect(await Bun.file(path.join(cleanupRoot, "worker-output.txt")).text()).toBe("from worker\n");
+		const workerState = monitored.integration_by_worker?.["worker-1"];
+		expect(workerState?.status).toBe("idle");
+		expect(workerState?.last_integrated_head).toBeTruthy();
+		const events = await readEvents(snapshot.state_dir);
+		expect(events).toContain("worker_auto_commit");
+		expect(events).toContain("worker_merge_applied");
+		const leaderMailbox = await readMailbox(snapshot.state_dir, "leader-fixed");
+		expect(leaderMailbox).toContain("INTEGRATED: merged worker-1");
+		const ledger = await Bun.file(
+			path.join(cleanupRoot, ".gjc", "reports", "team-commit-hygiene", "integrate-dirty-team.ledger.json"),
+		).json();
+		expect(JSON.stringify(ledger)).toContain("auto_checkpoint");
+		expect(JSON.stringify(ledger)).toContain("integration_merge");
+		expect(await Bun.file(path.join(cleanupRoot, ".omx", "reports", "team-commit-hygiene")).exists()).toBe(false);
+	});
+
+	it("monitor cherry-picks diverged worker commits and stays idempotent on repeated status checks", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Integrate diverged worker",
+			teamName: "diverged-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(cleanupRoot, "leader.txt", "leader\n", "leader advances");
+		const workerHead = await commitFile(workerPath, "worker.txt", "worker\n", "worker diverges");
+
+		const first = await monitorGjcTeam("diverged-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+		const leaderAfterFirst = runGit(cleanupRoot, ["rev-parse", "HEAD"]);
+		const second = await monitorGjcTeam("diverged-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+
+		expect(await Bun.file(path.join(cleanupRoot, "worker.txt")).text()).toBe("worker\n");
+		expect(first.integration_by_worker?.["worker-1"]?.last_integrated_head).toBe(workerHead);
+		expect(second.integration_by_worker?.["worker-1"]?.last_integrated_head).toBeTruthy();
+		expect(runGit(cleanupRoot, ["rev-parse", "HEAD"])).toBe(leaderAfterFirst);
+		const events = await readEvents(snapshot.state_dir);
+		expect(events).toContain("worker_cherry_pick_applied");
+		const ledger = await Bun.file(
+			path.join(cleanupRoot, ".gjc", "reports", "team-commit-hygiene", "diverged-team.ledger.json"),
+		).json();
+		expect(JSON.stringify(ledger)).toContain("integration_cherry_pick");
+	});
+
+	it("monitor reports merge conflicts without falsely advancing last integrated head", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Conflict worker",
+			teamName: "merge-conflict-team",
+			worktreeMode: { enabled: true, detached: false, name: "feature/conflict" },
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
+		await Bun.write(path.join(cleanupRoot, "README.md"), "# leader dirty\n");
+
+		const monitored = await monitorGjcTeam("merge-conflict-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+
+		const workerState = monitored.integration_by_worker?.["worker-1"];
+		expect(workerState?.status).toBe("merge_conflict");
+		expect(workerState?.last_integrated_head).toBeUndefined();
+		expect(runGit(cleanupRoot, ["status", "--porcelain", "--untracked-files=no"])).toBe("M README.md");
+		expect(await readEvents(snapshot.state_dir)).toContain("worker_merge_conflict");
+		expect(await Bun.file(path.join(snapshot.state_dir, "integration-report.md")).text()).toContain("merge");
+		expect(await readMailbox(snapshot.state_dir, "leader-fixed")).toContain("CONFLICT: merge failed");
+		const ledger = await Bun.file(
+			path.join(cleanupRoot, ".gjc", "reports", "team-commit-hygiene", "merge-conflict-team.ledger.json"),
+		).json();
+		expect(JSON.stringify(ledger)).toContain('"status":"conflict"');
+		expect(JSON.stringify(ledger)).toContain("integration_merge");
+	});
+
+	it("monitor reports cherry-pick conflicts and aborts cleanly", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Cherry pick conflict worker",
+			teamName: "pick-conflict-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
+		await fs.rm(path.join(cleanupRoot, "README.md"));
+		runGit(cleanupRoot, ["add", "README.md"]);
+		runGit(cleanupRoot, ["commit", "-m", "leader deletes readme"]);
+
+		const monitored = await monitorGjcTeam("pick-conflict-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+
+		const workerState = monitored.integration_by_worker?.["worker-1"];
+		expect(workerState?.status).toBe("cherry_pick_conflict");
+		expect(workerState?.last_integrated_head).toBeUndefined();
+		expect(runGit(cleanupRoot, ["status", "--porcelain", "--untracked-files=no"])).toBe("");
+		expect(await readEvents(snapshot.state_dir)).toContain("worker_cherry_pick_conflict");
+		expect(await Bun.file(path.join(snapshot.state_dir, "integration-report.md")).text()).toContain("cherry-pick");
+		expect(await readMailbox(snapshot.state_dir, "leader-fixed")).toContain("CONFLICT: cherry-pick failed");
+		const ledger = await Bun.file(
+			path.join(cleanupRoot, ".gjc", "reports", "team-commit-hygiene", "pick-conflict-team.ledger.json"),
+		).json();
+		expect(JSON.stringify(ledger)).toContain('"status":"conflict"');
+		expect(JSON.stringify(ledger)).toContain("integration_cherry_pick");
+	});
+
+	it("cross-rebases idle, done, and failed workers while skipping working workers", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 4,
+			agentType: "executor",
+			task: "Cross rebase workers",
+			teamName: "cross-rebase-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		await writeWorkerStatus(snapshot.state_dir, "worker-1", "idle");
+		await writeWorkerStatus(snapshot.state_dir, "worker-2", "done");
+		await writeWorkerStatus(snapshot.state_dir, "worker-3", "failed");
+		await writeWorkerStatus(snapshot.state_dir, "worker-4", "working");
+		await Bun.write(path.join(snapshot.workers[0]?.worktree_path ?? "", "worker-output.txt"), "integrate\n");
+
+		const monitored = await monitorGjcTeam("cross-rebase-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+		const leaderHead = runGit(cleanupRoot, ["rev-parse", "HEAD"]);
+
+		expect(monitored.integration_by_worker?.["worker-1"]?.last_rebased_leader_head).toBe(leaderHead);
+		expect(monitored.integration_by_worker?.["worker-2"]?.last_rebased_leader_head).toBe(leaderHead);
+		expect(monitored.integration_by_worker?.["worker-3"]?.last_rebased_leader_head).toBe(leaderHead);
+		expect(monitored.integration_by_worker?.["worker-4"]?.last_rebased_leader_head).toBeUndefined();
+		const events = await readEvents(snapshot.state_dir);
+		expect(events).toContain("worker_cross_rebase_applied");
+		expect(events).toContain("worker_cross_rebase_skipped");
+		const ledger = await Bun.file(
+			path.join(cleanupRoot, ".gjc", "reports", "team-commit-hygiene", "cross-rebase-team.ledger.json"),
+		).json();
+		expect(JSON.stringify(ledger)).toContain("cross_rebase");
+	});
+
+	it("pure team reads and list operations do not trigger integration, while command status and resume are wired to monitor", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Pure reads stay pure",
+			teamName: "pure-read-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await Bun.write(path.join(workerPath, "unintegrated.txt"), "pending\n");
+
+		const listed = await listGjcTeams(cleanupRoot, { PATH: process.env.PATH ?? "" });
+		const read = await readGjcTeamSnapshot("pure-read-team", cleanupRoot, { PATH: process.env.PATH ?? "" });
+
+		expect(listed).toHaveLength(1);
+		expect(read.integration_by_worker).toBeUndefined();
+		expect(await Bun.file(path.join(cleanupRoot, "unintegrated.txt")).exists()).toBe(false);
+		expect(await Bun.file(path.join(snapshot.state_dir, "monitor-snapshot.json")).exists()).toBe(false);
+		const commandSource = await Bun.file(path.join(import.meta.dir, "../../src/commands/team.ts")).text();
+		expect(commandSource).toContain('action === "status" || action === "resume"');
+		expect(commandSource).toContain("monitorGjcTeam(teamName)");
+		expect(commandSource).toContain("listGjcTeams()");
 	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -207,6 +207,7 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 		add(tasks, "install-methods", "Install method smoke tests", ["bun", "run", "ci:test:install-methods"]);
 	}
 	if (paths.some(isCodingAgentRuntimePath) || fullWorkspace) {
+		add(tasks, "native-build", "Build native addon for CLI smoke test", ["bun", "run", "build:native"]);
 		add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {


### PR DESCRIPTION
## Summary

- Ported GJC team worker-worktree integration parity into the native runtime monitor path.
- Made `gjc team status` / `resume` auto-checkpoint dirty workers, merge clean-ahead worker history, cherry-pick diverged worker commits, cross-rebase idle/done/failed workers, and skip working workers.
- Added GJC-scoped integration evidence (`monitor-snapshot.json`, `integration-report.md`, leader mailbox messages, `.gjc/reports/team-commit-hygiene/*.ledger.json`) and docs/changelog updates.
- Kept pure list/snapshot reads non-mutating; also fixed latest-dev validation issues by preserving required README red-claw wording without public legacy leakage and building natives before affected-path CLI smoke.

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` — 20 pass / 146 expects
- `bun --cwd=packages/coding-agent run check`
- `bun run check:ts`
- `CI_DEV_CHANGED_PATHS=packages/coding-agent/src/gjc-runtime/team-runtime.ts bun scripts/ci-dev-affected.ts --dry-run`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts` — 7 pass / 65 expects
- `git diff --check`

## Review

- Local final review: APPROVE; no blocking correctness/security/namespace issues found after verification.
- Architecture audit: CLEAR; mutating monitor boundary is isolated to status/resume, pure list/read remain non-mutating, and conflict paths abort/report without false `last_integrated_head` advancement.
- Note: native subagent code-review lanes could not run due external auth refresh errors; the evidence above is from local deterministic tests/gates plus manual final review.
