### PR TITLE
Enforce Ultragoal architect review gate

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -65,9 +65,9 @@ Loop until `gjc ultragoal status` reports all goals complete:
 4. If no active GJC goal exists, call `create_goal({"objective":"<printed payload objective>"})` with the printed payload. In aggregate mode, if the same aggregate objective is already active, continue the current GJC story without creating a new GJC goal.
 5. Complete the current GJC story only.
 6. Run a completion audit against the story objective and real artifacts/tests.
-7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal({})` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({"status":"complete"})` only after that gate is clean, then call `get_goal({})` again for a fresh `complete` snapshot.
-8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--gjc-goal-json`; final clean checkpoints also require `--quality-gate-json`:
-   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
+7. Before any `--status complete` checkpoint, run the mandatory final cleanup/review gate below. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal({})` snapshot whose aggregate objective is still `active`. On the final story only, call `update_goal({"status":"complete"})` after the gate is clean, then call `get_goal({})` again for a fresh `complete` snapshot.
+8. Checkpoint the durable ledger with that snapshot. Complete checkpoints require `--quality-gate-json`; the runtime hook rejects closure without a clean architect review:
+   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get_goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>`
 9. If blocked or failed, checkpoint failure:
    `gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
 10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
@@ -130,9 +130,9 @@ gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evid
 
 Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden goal mutation.
 
-## Mandatory final cleanup and review gate
+## Mandatory completion cleanup and review gate
 
-The final ultragoal story is not complete until the active agent has run the final quality gate:
+An ultragoal story cannot be checkpointed `complete` until the active agent has run the quality gate:
 
 1. Run targeted verification for the story.
 2. Run a cleanup/refactor review pass on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -303,6 +303,26 @@ async function readStructuredValue(cwd: string, value: string): Promise<unknown>
 		throw error;
 	}
 }
+function qualityGateObject(value: unknown): JsonObject | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as JsonObject) : null;
+}
+
+async function readRequiredCompletionQualityGate(cwd: string, value: string | undefined): Promise<unknown> {
+	if (!value?.trim()) {
+		throw new Error(
+			"checkpoint --status complete requires --quality-gate-json with codeReview.recommendation APPROVE and codeReview.architectStatus CLEAR",
+		);
+	}
+	const gate = await readStructuredValue(cwd, value);
+	const gateObject = qualityGateObject(gate);
+	const codeReview = qualityGateObject(gateObject?.codeReview);
+	if (codeReview?.recommendation !== "APPROVE" || codeReview.architectStatus !== "CLEAR") {
+		throw new Error(
+			"checkpoint --status complete requires architect review approval: codeReview.recommendation must be APPROVE and codeReview.architectStatus must be CLEAR",
+		);
+	}
+	return gate;
+}
 
 export async function checkpointUltragoalGoal(input: {
 	cwd: string;
@@ -318,6 +338,12 @@ export async function checkpointUltragoalGoal(input: {
 	if (!goal) throw new Error(`No ultragoal goal found for ${input.goalId}.`);
 	const evidence = input.evidence.trim();
 	if (!evidence) throw new Error("checkpoint evidence is required");
+	const qualityGateJson =
+		input.status === "complete"
+			? await readRequiredCompletionQualityGate(input.cwd, input.qualityGateJson)
+			: input.qualityGateJson
+				? await readStructuredValue(input.cwd, input.qualityGateJson)
+				: undefined;
 	const now = new Date().toISOString();
 	goal.status = input.status;
 	goal.evidence = evidence;
@@ -331,7 +357,7 @@ export async function checkpointUltragoalGoal(input: {
 		status: input.status,
 		evidence,
 		gjcGoalJson: input.gjcGoalJson ? await readStructuredValue(input.cwd, input.gjcGoalJson) : undefined,
-		qualityGateJson: input.qualityGateJson ? await readStructuredValue(input.cwd, input.qualityGateJson) : undefined,
+		qualityGateJson,
 	});
 	return plan;
 }

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -62,13 +62,74 @@ describe("native GJC ultragoal runtime", () => {
 			status: "complete",
 			evidence: "tests passed",
 			gjcGoalJson: JSON.stringify({ goal: { status: "complete" } }),
-			qualityGateJson: JSON.stringify({ verification: { status: "passed" } }),
+			qualityGateJson: JSON.stringify({
+				verification: { status: "passed" },
+				codeReview: { recommendation: "APPROVE", architectStatus: "CLEAR" },
+			}),
 		});
 		const status = await getUltragoalStatus(root);
 
 		expect(plan.goals[0]?.status).toBe("complete");
 		expect(status.status).toBe("complete");
 		expect(status.counts.complete).toBe(1);
+	});
+	it("blocks complete checkpoints without a clean architect review gate", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "tests passed",
+				gjcGoalJson: JSON.stringify({ goal: { status: "complete" } }),
+			}),
+		).rejects.toThrow("requires --quality-gate-json");
+
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "tests passed",
+				gjcGoalJson: JSON.stringify({ goal: { status: "complete" } }),
+				qualityGateJson: JSON.stringify({
+					verification: { status: "passed" },
+					codeReview: { recommendation: "APPROVE", architectStatus: "WATCH" },
+				}),
+			}),
+		).rejects.toThrow("requires architect review approval");
+
+		const status = await getUltragoalStatus(root);
+		expect(status.goals[0]?.status).toBe("active");
+	});
+
+	it("blocks complete checkpoint commands without a clean architect review gate", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--gjc-goal-json",
+				JSON.stringify({ goal: { status: "complete" } }),
+			],
+			root,
+		);
+		const status = await getUltragoalStatus(root);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("requires --quality-gate-json");
+		expect(status.goals[0]?.status).toBe("active");
 	});
 
 	it("rejects mistyped checkpoint statuses instead of silently changing state", async () => {


### PR DESCRIPTION
## Summary
- Require `gjc ultragoal checkpoint --status complete` to include `--quality-gate-json` with `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`.
- Fail complete checkpoints before mutating the Ultragoal plan when the architect review gate is missing or non-clean.
- Update Ultragoal skill guidance and regression tests for the runtime hook.

## Validation
- `bun --cwd=packages/coding-agent test test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun --cwd=packages/coding-agent run check`