### PR TITLE
Publish GJC npm install surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ I created an earlier OpenAI code harness and `an earlier Anthropic-code harness`
 
 ## Usage
 
-Gajae-Code is published through the normal npm registry. Install it with Bun for the recommended runtime workflow:
+Gajae-Code is published through the normal npm registry. Install the one-line npm wrapper with Bun for the recommended runtime workflow:
 
 ```sh
-bun install -g @gajae-code/coding-agent
+bun install -g gajae-code
 ```
 
-For repository development, use the source checkout commands in [Development](#development).
+The scoped package is also available as `@gajae-code/coding-agent`. For repository development, use the source checkout commands in [Development](#development).
 
 Start the recommended tmux-backed experience:
 

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,16 @@
         "@types/bun": "catalog:",
       },
     },
+    "packages/gajae-code": {
+      "name": "gajae-code",
+      "version": "0.1.0",
+      "bin": {
+        "gjc": "bin/gjc.js",
+      },
+      "dependencies": {
+        "@gajae-code/coding-agent": "catalog:",
+      },
+    },
     "packages/natives": {
       "name": "@gajae-code/natives",
       "version": "0.1.0",
@@ -922,6 +932,8 @@
     "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gajae-code": ["gajae-code@workspace:packages/gajae-code"],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 

--- a/packages/gajae-code/CHANGELOG.md
+++ b/packages/gajae-code/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+
+- Added the unscoped `gajae-code` npm wrapper for one-line `gjc` installs.

--- a/packages/gajae-code/README.md
+++ b/packages/gajae-code/README.md
@@ -1,0 +1,9 @@
+# gajae-code
+
+One-line npm package for the Gajae-Code `gjc` CLI.
+
+```sh
+bun install -g gajae-code
+```
+
+This package is a thin public wrapper around `@gajae-code/coding-agent` so users can install the CLI without typing the npm organization scope.

--- a/packages/gajae-code/bin/gjc.js
+++ b/packages/gajae-code/bin/gjc.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import "@gajae-code/coding-agent/cli";

--- a/packages/gajae-code/package.json
+++ b/packages/gajae-code/package.json
@@ -1,0 +1,43 @@
+{
+	"type": "module",
+	"name": "gajae-code",
+	"version": "0.1.0",
+	"description": "One-line npm install wrapper for the Gajae-Code gjc CLI",
+	"homepage": "https://gajae-code.dev",
+	"author": "Can Boluk",
+	"contributors": [
+		"Mario Zechner"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"directory": "packages/gajae-code"
+	},
+	"bugs": {
+		"url": "https://github.com/gajae-ai/gajae-code/issues"
+	},
+	"keywords": [
+		"coding-agent",
+		"ai",
+		"llm",
+		"cli",
+		"tui",
+		"agent",
+		"gjc"
+	],
+	"bin": {
+		"gjc": "bin/gjc.js"
+	},
+	"dependencies": {
+		"@gajae-code/coding-agent": "catalog:"
+	},
+	"engines": {
+		"bun": ">=1.3.14"
+	},
+	"files": [
+		"bin",
+		"README.md",
+		"CHANGELOG.md"
+	]
+}

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -175,7 +175,15 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 	const webChanged = paths.some(changedPath => changedPath.startsWith("python/robogjc/web/"));
 	const rustChanged = paths.some(isRustPath);
 	const installChanged = paths.some(isInstallPath);
+	const publishChanged = paths.some(isReleasePublishPath);
+	const wrapperChanged = paths.some(isUnscopedWrapperPath);
+	const toolingScriptChanged = paths.some(isToolingScriptPath);
+	const needsNativeRuntime = paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace;
 	const ciOnly = paths.length > 0 && paths.every(changedPath => changedPath.startsWith(".github/"));
+
+	if (needsNativeRuntime) {
+		add(tasks, "native-build", "Build native addon for CLI/test smoke", ["bun", "run", "build:native"]);
+	}
 
 	if (fullWorkspace) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
@@ -189,6 +197,16 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 				add(tasks, `test:${workspacePackage.name}`, `Test ${workspacePackage.name}`, ["bun", "--cwd", workspacePackage.dir, "run", "test"]);
 			}
 		}
+	}
+
+	if (toolingScriptChanged && !fullWorkspace && !ciOnly) {
+		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
+	}
+	if (wrapperChanged) {
+		add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", ["bun", "packages/gajae-code/bin/gjc.js", "--version"]);
+	}
+	if (publishChanged) {
+		add(tasks, "release-publish-dry-run", "Release publish dry-run", ["bun", "scripts/ci-release-publish.ts", "--dry-run"]);
 	}
 
 	if (pythonChanged) {
@@ -206,8 +224,7 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 	if (installChanged) {
 		add(tasks, "install-methods", "Install method smoke tests", ["bun", "run", "ci:test:install-methods"]);
 	}
-	if (paths.some(isCodingAgentRuntimePath) || fullWorkspace) {
-		add(tasks, "native-build", "Build native addon for CLI smoke test", ["bun", "run", "build:native"]);
+	if (needsNativeRuntime) {
 		add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {
@@ -260,7 +277,6 @@ function dependsOnWorkspace(manifest: PackageManifest, dependencyName: string, w
 function isFullWorkspacePath(changedPath: string): boolean {
 	return [
 		"package.json",
-		"bun.lock",
 		"bunfig.toml",
 		"biome.json",
 		"tsconfig.json",
@@ -292,6 +308,18 @@ function isCodingAgentRuntimePath(changedPath: string): boolean {
 
 function isWorkflowOrScriptPath(changedPath: string): boolean {
 	return changedPath.startsWith(".github/workflows/") || changedPath === "scripts/ci-dev-affected.ts";
+}
+
+function isToolingScriptPath(changedPath: string): boolean {
+	return changedPath.startsWith("scripts/") || changedPath === "bun.lock";
+}
+
+function isReleasePublishPath(changedPath: string): boolean {
+	return changedPath === "scripts/ci-release-publish.ts" || changedPath.startsWith("packages/gajae-code/");
+}
+
+function isUnscopedWrapperPath(changedPath: string): boolean {
+	return changedPath.startsWith("packages/gajae-code/");
 }
 
 function isString(value: unknown): value is string {

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -21,7 +21,7 @@ import { $ } from "bun";
 
 interface PublishPackage {
 	dir: string;
-	kind: "typescript" | "native";
+	kind: "typescript" | "native" | "manifest";
 	/** Extra build steps before manifest rewrite (e.g. esbuild bundles). */
 	preBuild?: readonly (readonly string[])[];
 	/** Extra entries to splice into `files`. */
@@ -56,6 +56,7 @@ const packages: PublishPackage[] = [
 	},
 	{ dir: "packages/agent", kind: "typescript" },
 	{ dir: "packages/coding-agent", kind: "typescript" },
+	{ dir: "packages/gajae-code", kind: "manifest" },
 ];
 const dependencyFieldNames = [
 	"dependencies",
@@ -190,7 +191,7 @@ async function rewriteNativeManifest(pkgDir: string): Promise<PackageManifest> {
 
 async function preparePackage(pkg: PublishPackage): Promise<PackageManifest> {
 	const pkgDir = path.join(repoRoot, pkg.dir);
-	if (pkg.kind === "native") {
+	if (pkg.kind === "native" || pkg.kind === "manifest") {
 		return rewriteNativeManifest(pkgDir);
 	}
 	for (const argv of pkg.preBuild ?? []) {

--- a/scripts/rebrand-inventory.ts
+++ b/scripts/rebrand-inventory.ts
@@ -34,6 +34,7 @@ const expectedBundledRoleAgents = ["architect", "critic", "executor", "planner"]
 const expectedPackageScope = "@gajae-code/";
 const expectedCliBins = ["gjc", "gjc-stats", "gjc-swarm"] as const;
 const expectedRootPackageName = "gajae-code";
+const allowedUnscopedPackageNames = new Set([expectedRootPackageName]);
 const rootPublicMetadataFields = ["name", "description", "homepage", "repository", "bugs"] as const;
 const rootLegacyScriptKeys = new Set(["test:py"]);
 
@@ -239,7 +240,7 @@ const unexpectedBundledWorkflowSkills = bundledWorkflowSkills.filter(def => !exp
 const unexpectedBundledRoleAgents = bundledRoleAgents.filter(def => !expectedBundledRoleAgents.includes(def.name as (typeof expectedBundledRoleAgents)[number]));
 const missingBundledWorkflowSkills = expectedBundledWorkflowSkills.filter(name => !bundledWorkflowSkills.some(def => def.name === name));
 const missingBundledRoleAgents = expectedBundledRoleAgents.filter(name => !bundledRoleAgents.some(def => def.name === name));
-const nonGajaePackages = packages.filter(pkg => pkg.name && !pkg.name.startsWith(expectedPackageScope));
+const nonGajaePackages = packages.filter(pkg => pkg.name && !pkg.name.startsWith(expectedPackageScope) && !allowedUnscopedPackageNames.has(pkg.name));
 const observedBins = [...new Set(packages.flatMap(pkg => pkg.bins))].sort();
 const missingBins = expectedCliBins.filter(bin => !observedBins.includes(bin));
 const unexpectedLegacyHits = legacyHits.filter(hit => !hit.allowlist);

--- a/scripts/verify-g002-gates.ts
+++ b/scripts/verify-g002-gates.ts
@@ -16,9 +16,11 @@ const EXPECTED_DEFINITIONS = ["deep-interview", "ralplan", "team", "ultragoal"] 
 const EXPECTED_ROLE_AGENTS = ["architect", "critic", "executor", "planner"] as const;
 const EXPECTED_PUBLIC_PACKAGE_VERSION = "0.1.0";
 const ALLOWED_PRIVATE_PACKAGE_VERSIONS = new Map<string, string>([["@gajae-code/typescript-edit-benchmark", "0.0.1"]]);
+const ALLOWED_UNSCOPED_PACKAGE_NAMES = new Set<string>(["gajae-code"]);
 const ALLOWED_PACKAGE_BINARIES = new Map<string, readonly string[]>([
 	["@gajae-code/ai", ["pi-ai"]],
 	["@gajae-code/coding-agent", ["gjc"]],
+	["gajae-code", ["gjc"]],
 	["@gajae-code/stats", ["gjc-stats"]],
 	["@gajae-code/swarm-extension", ["gjc-swarm"]],
 	["@gajae-code/typescript-edit-benchmark", ["typescript-edit-benchmark"]],
@@ -208,7 +210,7 @@ async function verifyPackageVersionAndBinaryAllowlist(): Promise<GateResult> {
 			continue;
 		}
 
-		if (!packageName.startsWith("@gajae-code/")) {
+		if (!packageName.startsWith("@gajae-code/") && !ALLOWED_UNSCOPED_PACKAGE_NAMES.has(packageName)) {
 			nameFindings.push(`${relativePath}: package name ${packageName} is outside @gajae-code scope`);
 		}
 


### PR DESCRIPTION
## Summary\n- add unscoped `gajae-code` wrapper package for one-line Bun/npm global installs\n- include wrapper in CI release publish queue after `@gajae-code/coding-agent`\n- keep release publish rewriting catalog/workspace dependencies before npm publish\n- document `bun install -g gajae-code` while retaining scoped package availability\n\n## Verification\n- `bun scripts/check-visible-definitions.ts`\n- `bun scripts/verify-g002-gates.ts`\n- `bun scripts/rebrand-inventory.ts --strict`\n- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`\n- `bun packages/gajae-code/bin/gjc.js --version`\n- `bun packages/gajae-code/bin/gjc.js --smoke-test`\n- `bun run check:ts`\n- temp-copy `bun scripts/ci-release-publish.ts --dry-run`\n\n## Release note\n- GitHub secret `NPM_TOKEN` is configured from the local `GAJAE_CODE_NPM_TOKEN` shell value.\n