### PR TITLE
Preserve base prompts while honoring SYSTEM.md customization (#57)

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -480,21 +480,6 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 	}
 }
 
-/** Discover SYSTEM.md file if no CLI system prompt was provided */
-function discoverSystemPromptFile(): string | undefined {
-	// Check project-local first (.gjc/SYSTEM.md, .pi/SYSTEM.md legacy)
-	const projectPath = findConfigFile("SYSTEM.md", { user: false });
-	if (projectPath) {
-		return projectPath;
-	}
-	// If not found, check SYSTEM.md file in the global directory.
-	const globalPath = findConfigFile("SYSTEM.md", { user: true });
-	if (globalPath) {
-		return globalPath;
-	}
-	return undefined;
-}
-
 /** Discover APPEND_SYSTEM.md file if no CLI append system prompt was provided */
 function discoverAppendSystemPromptFile(): string | undefined {
 	const projectPath = findConfigFile("APPEND_SYSTEM.md", { user: false });
@@ -519,8 +504,7 @@ async function buildSessionOptions(
 		cwd: parsed.cwd ?? getProjectDir(),
 	};
 
-	// Auto-discover SYSTEM.md if no CLI system prompt provided
-	const systemPromptSource = parsed.systemPrompt ?? discoverSystemPromptFile();
+	const systemPromptSource = parsed.systemPrompt;
 	const resolvedSystemPrompt = await resolvePromptInput(systemPromptSource, "system prompt");
 	const appendPromptSource = parsed.appendSystemPrompt ?? discoverAppendSystemPromptFile();
 	const resolvedAppendPrompt = await resolvePromptInput(appendPromptSource, "append system prompt");

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -249,11 +249,10 @@ describe("system Handlebars prompt templates", () => {
 			expect(systemPrompt[1].indexOf("</workspace-tree>")).toBeLessThan(systemPrompt[1].indexOf("Today is "));
 		});
 	});
-	test("buildSystemPrompt includes SYSTEM.md customization without replacing default soul", async () => {
+	test("buildSystemPrompt wires SYSTEM.md customization without replacing the base prompt", async () => {
 		await withTempDir(async dir => {
-			const configDir = path.join(dir, ".agent");
-			await fs.mkdir(configDir, { recursive: true });
-			await fs.writeFile(path.join(configDir, "SYSTEM.md"), "Local system customization");
+			await fs.mkdir(path.join(dir, ".gjc"), { recursive: true });
+			await fs.writeFile(path.join(dir, ".gjc", "SYSTEM.md"), "Project system sentinel.");
 
 			const { systemPrompt } = await buildSystemPrompt({
 				cwd: dir,
@@ -275,9 +274,10 @@ describe("system Handlebars prompt templates", () => {
 			expect(systemPrompt[0]).toContain("<soul>");
 			expect(systemPrompt[0]).toContain("The Boss’s Orders = Absolute Obedience");
 			expect(systemPrompt[0]).toContain("<system-prompt-customization>");
-			expect(systemPrompt[0]).toContain("Local system customization");
+			expect(systemPrompt[0]).toContain("Project system sentinel.");
 		});
 	});
+
 	test("buildSystemPrompt renders workspace tree after directory context in project prompt", async () => {
 		await withTempDir(async dir => {
 			const { systemPrompt } = await buildSystemPrompt({


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Why

<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

<!-- How was this tested? -->

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)