### PR TITLE
Align model assignments with GJC role agents

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -80,6 +80,47 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 
 export const MODEL_ROLE_IDS: ModelRole[] = ["default", "smol", "slow", "vision", "plan", "designer", "commit", "task"];
 
+export type GjcModelAssignmentTargetId = "default" | "executor" | "architect" | "planner" | "critic";
+
+export interface GjcModelAssignmentTargetInfo extends ModelRoleInfo {
+	id: GjcModelAssignmentTargetId;
+	settingsPath: "modelRoles" | "task.agentModelOverrides";
+}
+
+export const GJC_MODEL_ASSIGNMENT_TARGET_IDS: GjcModelAssignmentTargetId[] = [
+	"default",
+	"executor",
+	"architect",
+	"planner",
+	"critic",
+];
+
+export const GJC_MODEL_ASSIGNMENT_TARGETS: Record<GjcModelAssignmentTargetId, GjcModelAssignmentTargetInfo> = {
+	default: { id: "default", tag: "DEFAULT", name: "Default", color: "success", settingsPath: "modelRoles" },
+	executor: {
+		id: "executor",
+		tag: "EXECUTOR",
+		name: "Executor",
+		color: "accent",
+		settingsPath: "task.agentModelOverrides",
+	},
+	architect: {
+		id: "architect",
+		tag: "ARCHITECT",
+		name: "Architect",
+		color: "muted",
+		settingsPath: "task.agentModelOverrides",
+	},
+	planner: {
+		id: "planner",
+		tag: "PLANNER",
+		name: "Planner",
+		color: "warning",
+		settingsPath: "task.agentModelOverrides",
+	},
+	critic: { id: "critic", tag: "CRITIC", name: "Critic", color: "error", settingsPath: "task.agentModelOverrides" },
+};
+
 /** Alias for ModelRoleInfo - used for both built-in and custom roles */
 export type RoleInfo = ModelRoleInfo;
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -12,9 +12,9 @@ import {
 	Text,
 	type TUI,
 } from "@gajae-code/tui";
-import type { ModelRegistry } from "../../config/model-registry";
-import { getRoleInfo } from "../../config/model-registry";
-import { resolveModelRoleValue } from "../../config/model-resolver";
+import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
+import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
+import { formatModelSelectorValue, resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
@@ -78,7 +78,7 @@ interface RoleAssignment {
 
 type RoleSelectCallback = (
 	model: Model,
-	role: "default" | null,
+	role: GjcModelAssignmentTargetId | null,
 	thinkingLevel?: ThinkingLevel,
 	selector?: string,
 ) => void;
@@ -108,7 +108,7 @@ function createProviderTab(providerId: string): ProviderTabState {
  * Component that renders a canonical model selector with provider tabs.
  * - Tab/Arrow Left/Right: Switch between provider tabs
  * - Arrow Up/Down: Navigate model list
- * - Enter: Select the highlighted model as the canonical/default model
+ * - Enter: Open assignment actions for default plus GJC role-agent models
  * - Escape: Close selector
  */
 export class ModelSelectorComponent extends Container {
@@ -130,6 +130,8 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
+	#pendingActionItem?: ModelItem | CanonicalModelItem;
+	#selectedActionIndex: number = 0;
 
 	// Tab state
 	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
@@ -141,7 +143,12 @@ export class ModelSelectorComponent extends Container {
 		settings: Settings,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (model: Model, role: "default" | null, thinkingLevel?: ThinkingLevel, selector?: string) => void,
+		onSelect: (
+			model: Model,
+			role: GjcModelAssignmentTargetId | null,
+			thinkingLevel?: ThinkingLevel,
+			selector?: string,
+		) => void,
 		onCancel: () => void,
 		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
 	) {
@@ -183,7 +190,7 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
+				this.#beginActionMenuOrSelect(selectedItem);
 			}
 		};
 		this.addChild(this.#searchInput);
@@ -219,8 +226,11 @@ export class ModelSelectorComponent extends Container {
 	#loadRoleModels(): void {
 		const allModels = this.#modelRegistry.getAll();
 		const matchPreferences = { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() };
-		for (const role of ["default"]) {
-			const roleValue = this.#settings.getModelRole(role);
+		const agentModelOverrides = this.#settings.get("task.agentModelOverrides");
+		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const roleValue =
+				target.settingsPath === "modelRoles" ? this.#settings.getModelRole(role) : agentModelOverrides[role];
 			if (!roleValue) continue;
 
 			const resolved = resolveModelRoleValue(roleValue, allModels, {
@@ -627,12 +637,14 @@ export class ModelSelectorComponent extends Container {
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
-			const defaultRoleInfo = getRoleInfo("default", this.#settings);
-			const defaultAssigned = this.#roles.default;
-			if (defaultRoleInfo.tag && defaultAssigned && modelsAreEqual(defaultAssigned.model, item.model)) {
-				const badge = makeInvertedBadge(defaultRoleInfo.tag, defaultRoleInfo.color ?? "success");
-				const thinkingLabel = getThinkingLevelMetadata(defaultAssigned.thinkingLevel).label;
-				roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+				const assigned = this.#roles[role];
+				if (roleInfo.tag && assigned && modelsAreEqual(assigned.model, item.model)) {
+					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
+					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
+					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+				}
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 
@@ -699,8 +711,26 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(
 				new Text(theme.fg("muted", `  Model Name: ${selected.model.name}${suffix}`), 0, 0),
 			);
+			if (this.#pendingActionItem) {
+				this.#renderActionMenu(this.#pendingActionItem);
+			}
 		}
 	}
+	#renderActionMenu(item: ModelItem | CanonicalModelItem): void {
+		this.#listContainer.addChild(new Spacer(1));
+		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for: ${item.model.id}`), 0, 0));
+		this.#listContainer.addChild(new Spacer(1));
+		for (let i = 0; i < GJC_MODEL_ASSIGNMENT_TARGET_IDS.length; i++) {
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const label = `Set as ${target.tag ?? role.toUpperCase()} (${target.name})`;
+			this.#listContainer.addChild(
+				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
+			);
+		}
+	}
+
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
@@ -712,6 +742,11 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#pendingActionItem) {
+			this.#handleActionMenuInput(keyData);
+			return;
+		}
+
 		// Tab bar navigation
 		if (this.#tabBar?.handleInput(keyData)) {
 			return;
@@ -735,12 +770,12 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 
-		// Enter - select highlighted model directly. Canonical setup exposes one default model,
-		// while temporary-only mode keeps the existing non-persistent quick-switch behavior.
+		// Enter opens the persistent assignment menu. Temporary-only mode keeps the
+		// existing non-persistent quick-switch behavior.
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
+				this.#beginActionMenuOrSelect(selectedItem);
 			}
 			return;
 		}
@@ -755,7 +790,49 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());
 	}
-	#handleSelect(item: ModelItem | CanonicalModelItem, role: "default" | null, thinkingLevel?: ThinkingLevel): void {
+	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
+		if (this.#temporaryOnly) {
+			this.#handleSelect(item, null);
+			return;
+		}
+		this.#pendingActionItem = item;
+		this.#selectedActionIndex = 0;
+		this.#updateList();
+	}
+
+	#handleActionMenuInput(keyData: string): void {
+		if (matchesKey(keyData, "up")) {
+			this.#selectedActionIndex =
+				this.#selectedActionIndex === 0
+					? GJC_MODEL_ASSIGNMENT_TARGET_IDS.length - 1
+					: this.#selectedActionIndex - 1;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#selectedActionIndex = (this.#selectedActionIndex + 1) % GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const item = this.#pendingActionItem;
+			if (!item) return;
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
+			this.#pendingActionItem = undefined;
+			this.#handleSelect(item, role);
+			return;
+		}
+		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+			this.#pendingActionItem = undefined;
+			this.#updateList();
+		}
+	}
+
+	#handleSelect(
+		item: ModelItem | CanonicalModelItem,
+		role: GjcModelAssignmentTargetId | null,
+		thinkingLevel?: ThinkingLevel,
+	): void {
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
 			this.#onSelectCallback(item.model, null, undefined, item.selector);
@@ -763,12 +840,14 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		const selectedThinkingLevel = thinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
+		const selectorValue =
+			role === "default" ? item.selector : formatModelSelectorValue(item.selector, selectedThinkingLevel);
 
 		// Update local state for UI
 		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel };
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback(item.model, role, selectedThinkingLevel, item.selector);
+		this.#onSelectCallback(item.model, role, selectedThinkingLevel, selectorValue);
 
 		// Update list to show new badges
 		this.#updateList();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -441,8 +441,8 @@ export class SelectorController {
 							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
-						} else {
-							// Default: update agent state and persist
+						} else if (role === "default") {
+							// Default: update agent state and persist as the active default model.
 							await this.ctx.session.setModel(model, role, {
 								selector,
 								thinkingLevel,
@@ -453,6 +453,19 @@ export class SelectorController {
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
+							done();
+							this.ctx.ui.requestRender();
+						} else {
+							// Role-agent assignments configure Task dispatch and must not switch the active chat model.
+							const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
+							if (!apiKey) {
+								throw new Error(`No API key for ${model.provider}/${model.id}`);
+							}
+							const overrides = this.ctx.settings.get("task.agentModelOverrides");
+							const value = selector ?? `${model.provider}/${model.id}`;
+							this.ctx.settings.set("task.agentModelOverrides", { ...overrides, [role]: value });
+							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+							this.ctx.showStatus(`${role} agent model: ${value}`);
 							done();
 							this.ctx.ui.requestRender();
 						}

--- a/packages/coding-agent/src/setup/model-onboarding-guidance.ts
+++ b/packages/coding-agent/src/setup/model-onboarding-guidance.ts
@@ -7,14 +7,16 @@ export const MODEL_ONBOARDING_OAUTH_COMMAND = "/provider login [provider-id] or 
 export function formatModelOnboardingGuidance(): string {
 	return [
 		"Model selection only shows configured providers.",
+		"Assignment targets are DEFAULT plus the GJC role agents: EXECUTOR, ARCHITECT, PLANNER, and CRITIC.",
+		"Legacy model-role aliases are compatibility-only and are not shown as assignment targets.",
 		`API-compatible providers: ${MODEL_ONBOARDING_API_PROVIDER_COMMAND} (or ${MODEL_ONBOARDING_SETUP_COMMAND}).`,
 		`OAuth/subscription providers: ${MODEL_ONBOARDING_OAUTH_COMMAND}.`,
-		"Then run /model to select a configured model.",
+		"Then run /model to select a configured model or assign it to a target.",
 	].join("\n");
 }
 
 export function formatModelOnboardingInlineHint(): string {
-	return `Add API-compatible providers with ${MODEL_ONBOARDING_API_PROVIDER_COMMAND} (or ${MODEL_ONBOARDING_SETUP_COMMAND}); OAuth/subscription with ${MODEL_ONBOARDING_OAUTH_COMMAND}; then run /model.`;
+	return `Add API-compatible providers with ${MODEL_ONBOARDING_API_PROVIDER_COMMAND} (or ${MODEL_ONBOARDING_SETUP_COMMAND}); OAuth/subscription with ${MODEL_ONBOARDING_OAUTH_COMMAND}; then run /model for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC.`;
 }
 
 export function formatNoModelOnboardingError(): string {
@@ -27,7 +29,7 @@ export function formatNoCredentialOnboardingError(providerId: string): string {
 		"",
 		`For API-compatible providers, configure credentials with ${MODEL_ONBOARDING_API_PROVIDER_COMMAND} (or ${MODEL_ONBOARDING_SETUP_COMMAND}).`,
 		`For OAuth/subscription providers, use ${MODEL_ONBOARDING_OAUTH_COMMAND}.`,
-		"Then run /model to select a configured model.",
+		"Then run /model to select a configured model or assign it to DEFAULT, EXECUTOR, ARCHITECT, PLANNER, or CRITIC.",
 	].join("\n");
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -247,6 +247,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 							selector: `${match.provider}/${match.id}`,
 							thinkingLevel: parsedModelSelector?.thinkingLevel,
 						});
+						if (parsedModelSelector?.thinkingLevel) {
+							runtime.session.setThinkingLevel(parsedModelSelector.thinkingLevel);
+						}
 						await runtime.output(`Default model set to ${persistedSelector}.`);
 						await runtime.notifyTitleChanged?.();
 					} else {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { Model } from "@gajae-code/ai";
+import type { ThinkingLevel } from "@gajae-code/agent-core";
+import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { setProjectDir } from "@gajae-code/utils";
 import {
@@ -8,7 +9,7 @@ import {
 	GJC_MODEL_ASSIGNMENT_TARGETS,
 	type GjcModelAssignmentTargetId,
 } from "../config/model-registry";
-import { formatModelSelectorValue, parseModelString } from "../config/model-resolver";
+import { extractExplicitThinkingSelector, formatModelSelectorValue, parseModelPattern } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
 import type { InteractiveModeContext } from "../modes/types";
@@ -18,6 +19,7 @@ import {
 	formatProviderSetupResult,
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
+import { parseThinkingLevel } from "../thinking";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
@@ -129,16 +131,43 @@ function parseModelCommandArgs(args: string): { targetId: GjcModelAssignmentTarg
 	return { targetId: "default", selector: args.trim() };
 }
 
-function findAvailableModel(availableModels: Model[], selector: string): Model | undefined {
-	const parsed = parseModelString(selector);
-	if (parsed) {
-		return availableModels.find(
-			model =>
-				(model.provider === parsed.provider && model.id === parsed.id) ||
-				`${model.provider}/${model.id}` === `${parsed.provider}/${parsed.id}`,
-		);
+function splitExplicitThinkingSelector(selector: string): { baseSelector: string; thinkingLevel?: ThinkingLevel } {
+	const trimmed = selector.trim();
+	const colonIndex = trimmed.lastIndexOf(":");
+	if (colonIndex === -1) {
+		return { baseSelector: trimmed };
 	}
-	return availableModels.find(model => model.id === selector || `${model.provider}/${model.id}` === selector);
+	const thinkingLevel = parseThinkingLevel(trimmed.slice(colonIndex + 1));
+	return thinkingLevel ? { baseSelector: trimmed.slice(0, colonIndex), thinkingLevel } : { baseSelector: trimmed };
+}
+
+function resolveModelCommandSelection(
+	runtime: SlashCommandRuntime,
+	selector: string,
+): { model: Model; selector: string; thinkingLevel?: ThinkingLevel } | undefined {
+	const availableModels = runtime.session.getAvailableModels?.() ?? [];
+	const matchPreferences = { usageOrder: runtime.settings.getStorage()?.getModelUsageOrder() };
+	const resolved = parseModelPattern(selector, availableModels, matchPreferences, {
+		modelRegistry: runtime.session.modelRegistry,
+	});
+	if (!resolved.model) {
+		return undefined;
+	}
+
+	const splitSelector = splitExplicitThinkingSelector(selector);
+	const canonicalModel = runtime.session.modelRegistry.resolveCanonicalModel?.(splitSelector.baseSelector, {
+		availableOnly: false,
+		candidates: availableModels,
+	});
+	const persistedSelector =
+		canonicalModel && modelsAreEqual(canonicalModel, resolved.model)
+			? splitSelector.baseSelector
+			: `${resolved.model.provider}/${resolved.model.id}`;
+	return {
+		model: resolved.model,
+		selector: persistedSelector,
+		thinkingLevel: resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined,
+	};
 }
 
 function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
@@ -225,9 +254,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime,
 					);
 				}
-				const availableModels = runtime.session.getAvailableModels?.() ?? [];
-				const match = findAvailableModel(availableModels, modelId);
-				if (!match) {
+				const selection = resolveModelCommandSelection(runtime, modelId);
+				if (!selection) {
 					return usage(
 						modelSelectionUsage(
 							runtime,
@@ -237,33 +265,36 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					);
 				}
 				try {
-					const parsedModelSelector = parseModelString(modelId);
-					const persistedSelector = formatModelSelectorValue(
-						`${match.provider}/${match.id}`,
-						parsedModelSelector?.thinkingLevel,
-					);
+					const persistedSelector = formatModelSelectorValue(selection.selector, selection.thinkingLevel);
 					if (parsedArgs.targetId === "default") {
-						await runtime.session.setModel(match, "default", {
-							selector: `${match.provider}/${match.id}`,
-							thinkingLevel: parsedModelSelector?.thinkingLevel,
+						await runtime.session.setModel(selection.model, "default", {
+							selector: selection.selector,
+							thinkingLevel: selection.thinkingLevel,
 						});
-						if (parsedModelSelector?.thinkingLevel) {
-							runtime.session.setThinkingLevel(parsedModelSelector.thinkingLevel);
+						if (selection.thinkingLevel) {
+							runtime.session.setThinkingLevel(selection.thinkingLevel);
 						}
 						await runtime.output(`Default model set to ${persistedSelector}.`);
 						await runtime.notifyTitleChanged?.();
 					} else {
-						const apiKey = await runtime.session.modelRegistry.getApiKey(match, runtime.session.sessionId);
+						const apiKey = await runtime.session.modelRegistry.getApiKey(
+							selection.model,
+							runtime.session.sessionId,
+						);
 						if (!apiKey) {
-							throw new Error(`No API key for ${match.provider}/${match.id}`);
+							throw new Error(`No API key for ${selection.model.provider}/${selection.model.id}`);
 						}
 						const overrides = runtime.settings.get("task.agentModelOverrides");
+						const thinkingLevel =
+							selection.thinkingLevel ??
+							extractExplicitThinkingSelector(overrides[parsedArgs.targetId], runtime.settings);
+						const roleSelector = formatModelSelectorValue(selection.selector, thinkingLevel);
 						runtime.settings.set("task.agentModelOverrides", {
 							...overrides,
-							[parsedArgs.targetId]: persistedSelector,
+							[parsedArgs.targetId]: roleSelector,
 						});
-						runtime.settings.getStorage()?.recordModelUsage(`${match.provider}/${match.id}`);
-						await runtime.output(`${parsedArgs.targetId} agent model set to ${persistedSelector}.`);
+						runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
+						await runtime.output(`${parsedArgs.targetId} agent model set to ${roleSelector}.`);
 					}
 					await runtime.notifyConfigChanged?.();
 					return commandConsumed();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,7 +1,14 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { Model } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { setProjectDir } from "@gajae-code/utils";
+import {
+	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
+	GJC_MODEL_ASSIGNMENT_TARGETS,
+	type GjcModelAssignmentTargetId,
+} from "../config/model-registry";
+import { formatModelSelectorValue, parseModelString } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
 import type { InteractiveModeContext } from "../modes/types";
@@ -92,8 +99,55 @@ function providerSetupUsage(): string {
 	].join("\n");
 }
 
-function modelSelectionUsage(currentModelLine?: string): string {
-	return [currentModelLine, formatModelOnboardingGuidance()]
+function formatModelAssignmentSummary(runtime: SlashCommandRuntime): string {
+	const agentModelOverrides = runtime.settings.get("task.agentModelOverrides");
+	const lines = ["Model assignments:"];
+	for (const targetId of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
+		const modelSelector =
+			target.settingsPath === "modelRoles" ? runtime.settings.getModelRole(targetId) : agentModelOverrides[targetId];
+		lines.push(`  ${target.tag ?? target.id.toUpperCase()} (${target.name}): ${modelSelector ?? "(unset)"}`);
+	}
+	return lines.join("\n");
+}
+
+function parseModelCommandArgs(args: string): { targetId: GjcModelAssignmentTargetId; selector: string } {
+	const tokens = args.trim().split(/\s+/).filter(Boolean);
+	const first = tokens[0]?.toLowerCase();
+	const explicitTarget = GJC_MODEL_ASSIGNMENT_TARGET_IDS.includes(first as GjcModelAssignmentTargetId)
+		? (first as GjcModelAssignmentTargetId)
+		: undefined;
+	if (explicitTarget) {
+		return { targetId: explicitTarget, selector: tokens.slice(1).join(" ") };
+	}
+	if (first === "set") {
+		const second = tokens[1]?.toLowerCase();
+		if (GJC_MODEL_ASSIGNMENT_TARGET_IDS.includes(second as GjcModelAssignmentTargetId)) {
+			return { targetId: second as GjcModelAssignmentTargetId, selector: tokens.slice(2).join(" ") };
+		}
+	}
+	return { targetId: "default", selector: args.trim() };
+}
+
+function findAvailableModel(availableModels: Model[], selector: string): Model | undefined {
+	const parsed = parseModelString(selector);
+	if (parsed) {
+		return availableModels.find(
+			model =>
+				(model.provider === parsed.provider && model.id === parsed.id) ||
+				`${model.provider}/${model.id}` === `${parsed.provider}/${parsed.id}`,
+		);
+	}
+	return availableModels.find(model => model.id === selector || `${model.provider}/${model.id}` === selector);
+}
+
+function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
+	return [
+		currentModelLine,
+		formatModelAssignmentSummary(runtime),
+		"ACP/text mode: use /model <model> for DEFAULT, or /model <target> <model> for EXECUTOR, ARCHITECT, PLANNER, or CRITIC.",
+		formatModelOnboardingGuidance(),
+	]
 		.filter((line): line is string => Boolean(line))
 		.join("\n\n");
 }
@@ -159,25 +213,55 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		aliases: ["models"],
 		description: "Select model (opens selector UI)",
 		acpDescription: "Show current model selection",
+		inlineHint: "[target] <model>",
+		acpInputHint: "[target] <model>",
 		handle: async (command, runtime) => {
 			if (command.args) {
-				const modelId = command.args.trim();
+				const parsedArgs = parseModelCommandArgs(command.args);
+				const modelId = parsedArgs.selector;
+				if (!modelId) {
+					return usage(
+						modelSelectionUsage(runtime, `Missing model for ${parsedArgs.targetId.toUpperCase()}.`),
+						runtime,
+					);
+				}
 				const availableModels = runtime.session.getAvailableModels?.() ?? [];
-				const match = availableModels.find(
-					model => model.id === modelId || `${model.provider}/${model.id}` === modelId,
-				);
+				const match = findAvailableModel(availableModels, modelId);
 				if (!match) {
 					return usage(
 						modelSelectionUsage(
+							runtime,
 							`Unknown model: ${modelId}. Configure or login to a provider first, then list/select models with /model.`,
 						),
 						runtime,
 					);
 				}
 				try {
-					await runtime.session.setModel(match);
-					await runtime.output(`Model set to ${match.provider}/${match.id}.`);
-					await runtime.notifyTitleChanged?.();
+					const parsedModelSelector = parseModelString(modelId);
+					const persistedSelector = formatModelSelectorValue(
+						`${match.provider}/${match.id}`,
+						parsedModelSelector?.thinkingLevel,
+					);
+					if (parsedArgs.targetId === "default") {
+						await runtime.session.setModel(match, "default", {
+							selector: `${match.provider}/${match.id}`,
+							thinkingLevel: parsedModelSelector?.thinkingLevel,
+						});
+						await runtime.output(`Default model set to ${persistedSelector}.`);
+						await runtime.notifyTitleChanged?.();
+					} else {
+						const apiKey = await runtime.session.modelRegistry.getApiKey(match, runtime.session.sessionId);
+						if (!apiKey) {
+							throw new Error(`No API key for ${match.provider}/${match.id}`);
+						}
+						const overrides = runtime.settings.get("task.agentModelOverrides");
+						runtime.settings.set("task.agentModelOverrides", {
+							...overrides,
+							[parsedArgs.targetId]: persistedSelector,
+						});
+						runtime.settings.getStorage()?.recordModelUsage(`${match.provider}/${match.id}`);
+						await runtime.output(`${parsedArgs.targetId} agent model set to ${persistedSelector}.`);
+					}
 					await runtime.notifyConfigChanged?.();
 					return commandConsumed();
 				} catch (err) {
@@ -188,6 +272,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			const model = runtime.session.model;
 			await runtime.output(
 				modelSelectionUsage(
+					runtime,
 					model ? `Current model: ${model.provider}/${model.id}` : "No model is currently selected.",
 				),
 			);

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -39,6 +39,7 @@ interface FakeAcpBuiltinSession {
 	getContextUsage(): { tokens?: number; contextWindow: number } | undefined;
 	getAvailableModels(): Array<{ provider: string; id: string; contextWindow?: number }>;
 	setModel(model: unknown): Promise<void>;
+	setThinkingLevel(thinkingLevel: unknown): void;
 }
 
 function createRuntime() {
@@ -98,6 +99,7 @@ function createRuntime() {
 		getContextUsage: () => undefined,
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
 		async setModel(_model: unknown) {},
+		setThinkingLevel(_thinkingLevel: unknown) {},
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
 	};
 	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
@@ -336,6 +338,23 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet");
 		expect(titleNotified).toBe(1);
 		expect(configNotified).toBe(1);
+	});
+
+	it("model: applies explicit thinking level to the live default session", async () => {
+		const { runtime, session } = createRuntime();
+		const available = [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		session.getAvailableModels = () => available;
+		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
+		const setThinkingLevelSpy = spyOn(session, "setThinkingLevel");
+
+		const result = await executeAcpBuiltinSlashCommand("/model anthropic/claude-3-5-sonnet:low", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
+			selector: "anthropic/claude-3-5-sonnet",
+			thinkingLevel: "low",
+		});
+		expect(setThinkingLevelSpy).toHaveBeenCalledWith("low");
 	});
 
 	it("model: assigns a known model to a GJC role-agent target without switching active model", async () => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -24,6 +24,10 @@ interface FakeAcpBuiltinSession {
 	messages: unknown[];
 	modelRegistry: {
 		getApiKey(model: { provider: string; id: string }, sessionId?: string): Promise<string | undefined>;
+		resolveCanonicalModel?: (
+			canonicalId: string,
+			options?: { candidates?: Array<{ provider: string; id: string; contextWindow?: number }> },
+		) => { provider: string; id: string; contextWindow?: number } | undefined;
 	};
 	model: { provider: string; id: string } | undefined;
 	newSession(opts?: { drop?: boolean; parentSession?: string }): Promise<boolean>;
@@ -357,6 +361,24 @@ describe("ACP builtin slash commands", () => {
 		expect(setThinkingLevelSpy).toHaveBeenCalledWith("low");
 	});
 
+	it("model: applies explicit thinking level from a bare model id", async () => {
+		const { output, runtime, session } = createRuntime();
+		const available = [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		session.getAvailableModels = () => available;
+		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
+		const setThinkingLevelSpy = spyOn(session, "setThinkingLevel");
+
+		const result = await executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
+			selector: "anthropic/claude-3-5-sonnet",
+			thinkingLevel: "low",
+		});
+		expect(setThinkingLevelSpy).toHaveBeenCalledWith("low");
+		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet:low");
+	});
+
 	it("model: assigns a known model to a GJC role-agent target without switching active model", async () => {
 		const { output, runtime, session } = createRuntime();
 		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
@@ -380,6 +402,53 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).toContain("executor agent model set to anthropic/claude-3-5-sonnet:low");
 		expect(titleNotified).toBe(0);
 		expect(configNotified).toBe(1);
+	});
+
+	it("model: preserves existing role-agent thinking when text assignment omits one", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		runtime.settings.set("task.agentModelOverrides", {
+			executor: "anthropic/old-model:high",
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/model executor claude-3-5-sonnet", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(output[0]).toContain("executor agent model set to anthropic/claude-3-5-sonnet:high");
+	});
+
+	it("model: lets explicit role-agent thinking override preserved thinking", async () => {
+		const { runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		runtime.settings.set("task.agentModelOverrides", {
+			executor: "anthropic/old-model:high",
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/model executor claude-3-5-sonnet:low", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+		});
+	});
+
+	it("model: preserves canonical selectors for text role-agent assignments", async () => {
+		const { output, runtime, session } = createRuntime();
+		const available = [{ provider: "anthropic", id: "claude-sonnet-4-5", contextWindow: 200_000 }];
+		session.getAvailableModels = () => available;
+		session.modelRegistry.resolveCanonicalModel = (canonicalId, options) =>
+			canonicalId === "claude-sonnet" ? options?.candidates?.[0] : undefined;
+
+		const result = await executeAcpBuiltinSlashCommand("/model executor claude-sonnet:low", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "claude-sonnet:low",
+		});
+		expect(output[0]).toContain("executor agent model set to claude-sonnet:low");
 	});
 
 	it("model: does not emit config change when id is unknown", async () => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -22,6 +22,9 @@ interface FakeAcpBuiltinSession {
 	formatSessionAsText: () => string;
 	getLastAssistantText: () => string | undefined;
 	messages: unknown[];
+	modelRegistry: {
+		getApiKey(model: { provider: string; id: string }, sessionId?: string): Promise<string | undefined>;
+	};
 	model: { provider: string; id: string } | undefined;
 	newSession(opts?: { drop?: boolean; parentSession?: string }): Promise<boolean>;
 	fork(): Promise<boolean>;
@@ -84,6 +87,11 @@ function createRuntime() {
 		formatSessionAsText: () => "",
 		getLastAssistantText: () => undefined,
 		messages: [],
+		modelRegistry: {
+			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string) {
+				return "test-api-key";
+			},
+		},
 		model: undefined,
 		getToolByName: (_name: string) => undefined,
 		async compact(_args?: string) {},
@@ -263,6 +271,38 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).toContain("No model");
 	});
 
+	it("model: reports only default plus GJC role-agent assignment targets", async () => {
+		const { output, runtime } = createRuntime();
+		runtime.settings = Settings.isolated({
+			cycleOrder: ["smol", "task", "default"],
+			modelRoles: {
+				default: "anthropic/default-model:medium",
+				smol: "anthropic/legacy-smol",
+				task: "anthropic/legacy-task",
+			},
+			"task.agentModelOverrides": {
+				executor: "anthropic/executor-model:low",
+			},
+			modelTags: {
+				smol: { name: "Quick", color: "error" },
+			},
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/model", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("DEFAULT (Default): anthropic/default-model:medium");
+		expect(output[0]).toContain("EXECUTOR (Executor): anthropic/executor-model:low");
+		expect(output[0]).toContain("ARCHITECT (Architect): (unset)");
+		expect(output[0]).toContain("PLANNER (Planner): (unset)");
+		expect(output[0]).toContain("CRITIC (Critic): (unset)");
+		expect(output[0]).not.toContain("SMOL");
+		expect(output[0]).not.toContain("TASK");
+		expect(output[0]).not.toContain("anthropic/legacy-smol");
+		expect(output[0]).not.toContain("anthropic/legacy-task");
+		expect(output[0]).not.toContain("Quick");
+	});
+
 	it("model: returns ACP usage message when args provided", async () => {
 		const { output, runtime } = createRuntime();
 
@@ -289,9 +329,37 @@ describe("ACP builtin slash commands", () => {
 		const result = await executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(setModelSpy).toHaveBeenCalledWith(available[0]);
-		expect(output[0]).toContain("Model set to anthropic/claude-3-5-sonnet");
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
+			selector: "anthropic/claude-3-5-sonnet",
+			thinkingLevel: undefined,
+		});
+		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet");
 		expect(titleNotified).toBe(1);
+		expect(configNotified).toBe(1);
+	});
+
+	it("model: assigns a known model to a GJC role-agent target without switching active model", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
+		let titleNotified = 0;
+		let configNotified = 0;
+		runtime.notifyTitleChanged = () => {
+			titleNotified++;
+		};
+		runtime.notifyConfigChanged = () => {
+			configNotified++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/model executor anthropic/claude-3-5-sonnet:low", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(setModelSpy).not.toHaveBeenCalled();
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+		});
+		expect(output[0]).toContain("executor agent model set to anthropic/claude-3-5-sonnet:low");
+		expect(titleNotified).toBe(0);
 		expect(configNotified).toBe(1);
 	});
 
@@ -585,7 +653,7 @@ describe("wave 5 — adapters and polish", () => {
 		};
 		const result = await executeAcpBuiltinSlashCommand("/model claude-sonnet-test", runtime);
 		expect(result).toEqual({ consumed: true });
-		expect(output[0]).toContain("Model set to anthropic/claude-sonnet-test.");
+		expect(output[0]).toContain("Default model set to anthropic/claude-sonnet-test.");
 		expect(titleChanged).toBe(true);
 	});
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -3,6 +3,10 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
+	GJC_MODEL_ASSIGNMENT_TARGETS,
+} from "@gajae-code/coding-agent/config/model-registry";
+import {
 	DEFAULT_GJC_DEFINITION_NAMES,
 	getDefaultGjcDefinitions,
 	installDefaultGjcDefinitions,
@@ -69,6 +73,17 @@ describe("default GJC definitions", () => {
 			expect(bundledRoleAgents).toEqual([...roleAgentNames].sort());
 			expect(agents.projectAgentsDir).toBeNull();
 		});
+	});
+
+	it("exposes only default plus four GJC role agents as model assignment targets", () => {
+		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS).toEqual(["default", "executor", "architect", "planner", "critic"]);
+		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => GJC_MODEL_ASSIGNMENT_TARGETS[id].tag)).toEqual([
+			"DEFAULT",
+			"EXECUTOR",
+			"ARCHITECT",
+			"PLANNER",
+			"CRITIC",
+		]);
 	});
 
 	it("enforces role-agent tool boundaries through parsed frontmatter", () => {

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -19,7 +19,7 @@ function normalizeRenderedText(text: string): string {
 
 interface SelectionCapture {
 	model: Model;
-	role: "default" | null;
+	role: string | null;
 	thinkingLevel: unknown;
 	selector: string | undefined;
 }
@@ -29,7 +29,7 @@ function createSelector(
 	settings: Settings,
 	onSelect: (
 		model: Model,
-		role: "default" | null,
+		role: string | null,
 		thinkingLevel: unknown,
 		selector: string | undefined,
 	) => void = () => {},
@@ -86,7 +86,7 @@ describe("ModelSelector canonical model selection", () => {
 		}
 	});
 
-	test("uses canonical default-only model assignment even when legacy roles are configured", async () => {
+	test("uses canonical GJC assignment actions while hiding legacy roles", async () => {
 		installTestTheme();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
@@ -97,6 +97,9 @@ describe("ModelSelector canonical model selection", () => {
 				default: `${model.provider}/${model.id}:low`,
 				"custom-fast": `${model.provider}/${model.id}:high`,
 				smol: `${model.provider}/${model.id}`,
+			},
+			"task.agentModelOverrides": {
+				executor: `${model.provider}/${model.id}:high`,
 			},
 			modelTags: {
 				smol: { name: "Quick", color: "error" },
@@ -112,8 +115,22 @@ describe("ModelSelector canonical model selection", () => {
 
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).toContain("EXECUTOR (high)");
 		expect(rendered).not.toContain("custom-fast");
 		expect(rendered).not.toContain("SMOL");
+
+		selector.handleInput("\n");
+		installTestTheme();
+		const actionRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(actionRendered).toContain("Action for:");
+		expect(actionRendered).toContain("Set as DEFAULT (Default)");
+		expect(actionRendered).toContain("Set as EXECUTOR (Executor)");
+		expect(actionRendered).toContain("Set as ARCHITECT (Architect)");
+		expect(actionRendered).toContain("Set as PLANNER (Planner)");
+		expect(actionRendered).toContain("Set as CRITIC (Critic)");
+		expect(actionRendered).not.toContain("Set as custom-fast");
+		expect(actionRendered).not.toContain("Set as SMOL");
+		expect(actionRendered).not.toContain("Set as TASK");
 
 		selector.handleInput("\n");
 		installTestTheme();
@@ -122,12 +139,34 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.model).toBe(model);
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
 
-		const afterEnterRendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(afterEnterRendered).not.toContain("Action for:");
-		expect(afterEnterRendered).not.toContain("Set as DEFAULT");
-		expect(afterEnterRendered).not.toContain("Set as custom-fast");
-		expect(afterEnterRendered).not.toContain("Set as SMOL");
+	test("selects role-agent assignment without using stale task role", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:medium`,
+			},
+		});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, settings, (selectedModel, role, thinkingLevel, selectorValue) => {
+			selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected role-agent selection");
+		expect(selectedAfterEnter.role).toBe("executor");
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
 	});
 
 	test("refreshes Ollama Cloud using provider id instead of tab label", async () => {


### PR DESCRIPTION
## Summary
- Limit model assignment targets to DEFAULT plus the four bundled GJC role agents: EXECUTOR, ARCHITECT, PLANNER, CRITIC.
- Wire role-agent selections through task.agentModelOverrides without switching the active chat/default model.
- Update /model text usage and onboarding copy so stale SMOL/SLOW/TASK-style roles are compatibility-only, not visible assignment targets.

## Verification
- bun test packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts
- bun check
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts

## Notes
- Not manually tested in an interactive TUI session against a live provider account.