### PR TITLE
Preserve slash command candidates during skill matches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash-command autocomplete so skill command matches no longer hide built-in fuzzy candidates like `/model` while typing `/mode`.
+
 ## [0.1.1] - 2026-05-28
 
 ### Changed

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -84,6 +84,34 @@ function isSkillCommandAutocompleteItem(item: AutocompleteItem): item is SkillCo
 	return "normalizedSkillCommand" in item && item.normalizedSkillCommand === true;
 }
 
+function mergeAutocompleteSuggestions(
+	primary: { items: AutocompleteItem[]; prefix: string } | null,
+	secondary: { items: AutocompleteItem[]; prefix: string } | null,
+): { items: AutocompleteItem[]; prefix: string } | null {
+	if (!primary) return secondary;
+	if (!secondary) return primary;
+	if (primary.prefix !== secondary.prefix) return primary;
+
+	const seen = new Set<string>();
+	const items: AutocompleteItem[] = [];
+	for (const item of [...primary.items, ...secondary.items]) {
+		const key = `${item.value}\0${item.label}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		items.push(item);
+	}
+
+	return { items, prefix: primary.prefix };
+}
+
+function withoutSkillCommandSuggestions(
+	suggestions: { items: AutocompleteItem[]; prefix: string } | null,
+): { items: AutocompleteItem[]; prefix: string } | null {
+	if (!suggestions) return null;
+	const items = suggestions.items.filter(item => !item.value.startsWith("skill:"));
+	return items.length > 0 ? { ...suggestions, items } : null;
+}
+
 function getPromptActionPrefix(textBeforeCursor: string): string | null {
 	const hashIndex = textBeforeCursor.lastIndexOf("#");
 	if (hashIndex === -1) return null;
@@ -148,8 +176,14 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			}
 		}
 
-		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
-		if (skillCommandSuggestions) return skillCommandSuggestions;
+		const slashPrefix = getSlashTokenPrefix(textBeforeCursor);
+		if (slashPrefix) {
+			const baseSuggestions = withoutSkillCommandSuggestions(
+				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
+			);
+			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
+			return mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions);
+		}
 
 		if (!isSettingsInitialized() || settings.get("emojiAutocomplete")) {
 			const emojiSuggestions = getEmojiSuggestions(textBeforeCursor);
@@ -215,9 +249,11 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		return this.#baseProvider.getInlineHint?.(lines, cursorLine, cursorCol) ?? null;
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		const baseSuggestions = withoutSkillCommandSuggestions(
+			this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null,
+		);
 		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
-		if (skillCommandSuggestions) return skillCommandSuggestions;
-		return this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null;
+		return mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions);
 	}
 	trySyncInlineReplace(textBeforeCursor: string): { replaceLen: number; insert: string } | null {
 		if (isSettingsInitialized() && !settings.get("emojiAutocomplete")) return null;
@@ -233,17 +269,6 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		const exactNonSkillCommand = this.#commands.some(
 			command => command.name === query && !command.name.startsWith("skill:"),
 		);
-		if (exactNonSkillCommand) {
-			const command = this.#commands.find(
-				candidate => candidate.name === query && !candidate.name.startsWith("skill:"),
-			);
-			if (command) {
-				return {
-					items: [{ value: command.name, label: command.name, description: command.description }],
-					prefix,
-				};
-			}
-		}
 		const items = this.#commands
 			.filter(command => command.name.startsWith("skill:"))
 			.map(command => {

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -6,8 +6,10 @@ function createProvider() {
 	return createPromptActionAutocompleteProvider({
 		commands: [
 			{ name: "fast", description: "Built-in fast mode" },
+			{ name: "model", description: "Select model" },
 			{ name: "skill:deep-interview", description: "Deep interview" },
 			{ name: "skill:fast", description: "Colliding skill" },
+			{ name: "skill:mode", description: "Mode skill" },
 		],
 		basePath: "/tmp",
 		keybindings: { getKeys: () => [] } as unknown as KeybindingsManager,
@@ -44,6 +46,15 @@ describe("prompt action skill autocomplete", () => {
 	it("does not let direct-name normalization shadow an exact non-skill command", async () => {
 		const provider = createProvider();
 		const suggestions = await provider.getSuggestions(["/fast"], 0, 5);
+		expect(suggestions?.items.some(item => item.value === "fast")).toBe(true);
 		expect(suggestions?.items.some(item => item.value === "skill:fast")).toBe(false);
+	});
+
+	it("keeps fuzzy builtin slash candidates when a skill command also matches", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.getSuggestions(["/mode"], 0, 5);
+		expect(suggestions?.prefix).toBe("/mode");
+		expect(suggestions?.items.some(item => item.value === "model")).toBe(true);
+		expect(suggestions?.items.some(item => item.value === "skill:mode")).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

- Merge built-in slash-command autocomplete results with skill-name normalization results instead of letting skill matches replace the candidate list.
- Keep raw `skill:*` entries out of the base slash provider path so exact built-in command collisions still behave as before.
- Add regression coverage for `/mode` preserving `/model` as a candidate when a matching skill command also exists.
- Add an Unreleased changelog entry for the user-facing autocomplete fix.

## Why

Typing `/mode` could match a skill command first, causing `PromptActionAutocompleteProvider` to return only skill suggestions and hide regular fuzzy slash candidates such as `/model`. Users should still see built-in command candidates while skill alias normalization remains available.

## Testing

- `bun test packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
