### PR TITLE
Preserve selected reasoning for model role assignment

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -53,6 +53,7 @@ interface ModelItem {
 	id: string;
 	model: Model;
 	selector: string;
+	thinkingLevel?: ThinkingLevel;
 }
 
 interface CanonicalModelItem {
@@ -64,11 +65,12 @@ interface CanonicalModelItem {
 	searchText: string;
 	normalizedSearchText: string;
 	compactSearchText: string;
+	thinkingLevel?: ThinkingLevel;
 }
 
 interface ScopedModelItem {
 	model: Model;
-	thinkingLevel?: string;
+	thinkingLevel?: ThinkingLevel;
 }
 
 interface RoleAssignment {
@@ -346,6 +348,7 @@ export class ModelSelectorComponent extends Container {
 				id: scoped.model.id,
 				model: scoped.model,
 				selector: `${scoped.model.provider}/${scoped.model.id}`,
+				thinkingLevel: scoped.thinkingLevel,
 			}));
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
@@ -379,17 +382,20 @@ export class ModelSelectorComponent extends Container {
 			}
 		}
 
+		const candidateModels = models.map(item => item.model);
 		const canonicalRecords = this.#modelRegistry.getCanonicalModels({
 			availableOnly: this.#scopedModels.length === 0,
-			candidates: models.map(item => item.model),
+			candidates: candidateModels,
 		});
+		const scopedThinkingBySelector = new Map(models.map(item => [item.selector, item.thinkingLevel]));
 		const canonicalModels = canonicalRecords
-			.map(record => {
+			.map((record): CanonicalModelItem | undefined => {
 				const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
 					availableOnly: this.#scopedModels.length === 0,
-					candidates: models.map(item => item.model),
+					candidates: candidateModels,
 				});
 				if (!selectedModel) return undefined;
+				const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
 				const searchText = [
 					record.id,
 					record.name,
@@ -398,8 +404,8 @@ export class ModelSelectorComponent extends Container {
 					selectedModel.name,
 					...record.variants.flatMap(variant => [variant.selector, variant.model.name]),
 				].join(" ");
-				return {
-					kind: "canonical" as const,
+				const item: CanonicalModelItem = {
+					kind: "canonical",
 					id: record.id,
 					model: selectedModel,
 					selector: record.id,
@@ -408,6 +414,11 @@ export class ModelSelectorComponent extends Container {
 					normalizedSearchText: normalizeSearchText(searchText),
 					compactSearchText: compactSearchText(searchText),
 				};
+				const scopedThinkingLevel = scopedThinkingBySelector.get(selectedSelector);
+				if (scopedThinkingLevel !== undefined) {
+					item.thinkingLevel = scopedThinkingLevel;
+				}
+				return item;
 			})
 			.filter((item): item is CanonicalModelItem => item !== undefined);
 
@@ -833,13 +844,15 @@ export class ModelSelectorComponent extends Container {
 		role: GjcModelAssignmentTargetId | null,
 		thinkingLevel?: ThinkingLevel,
 	): void {
+		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
+
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback(item.model, null, undefined, item.selector);
+			this.#onSelectCallback(item.model, null, itemThinkingLevel, item.selector);
 			return;
 		}
 
-		const selectedThinkingLevel = thinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
+		const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
 		const selectorValue =
 			role === "default" ? item.selector : formatModelSelectorValue(item.selector, selectedThinkingLevel);
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -435,7 +435,7 @@ export class SelectorController {
 					try {
 						if (role === null) {
 							// Temporary: update agent state but don't persist to settings
-							await this.ctx.session.setModelTemporary(model);
+							await this.ctx.session.setModelTemporary(model, thinkingLevel);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getBundledModel, type Model } from "@gajae-code/ai";
-import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -19,9 +20,15 @@ function normalizeRenderedText(text: string): string {
 
 interface SelectionCapture {
 	model: Model;
-	role: string | null;
-	thinkingLevel: unknown;
+	role: GjcModelAssignmentTargetId | null;
+	thinkingLevel: ThinkingLevel | undefined;
 	selector: string | undefined;
+}
+
+interface CreateSelectorOptions {
+	modelRegistry?: ModelRegistry;
+	temporaryOnly?: boolean;
+	thinkingLevel?: ThinkingLevel;
 }
 
 function createSelector(
@@ -29,17 +36,20 @@ function createSelector(
 	settings: Settings,
 	onSelect: (
 		model: Model,
-		role: string | null,
-		thinkingLevel: unknown,
+		role: GjcModelAssignmentTargetId | null,
+		thinkingLevel: ThinkingLevel | undefined,
 		selector: string | undefined,
 	) => void = () => {},
+	options: CreateSelectorOptions = {},
 ): ModelSelectorComponent {
-	const modelRegistry = {
-		getAll: () => [model],
-		getDiscoverableProviders: () => [],
-		getCanonicalModels: () => [],
-		resolveCanonicalModel: () => undefined,
-	} as unknown as ModelRegistry;
+	const modelRegistry =
+		options.modelRegistry ??
+		({
+			getAll: () => [model],
+			getDiscoverableProviders: () => [],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+		} as unknown as ModelRegistry);
 	const ui = {
 		requestRender: vi.fn(),
 	} as unknown as TUI;
@@ -49,9 +59,10 @@ function createSelector(
 		model,
 		settings,
 		modelRegistry,
-		[{ model, thinkingLevel: "off" }],
+		[{ model, thinkingLevel: options.thinkingLevel ?? ThinkingLevel.Off }],
 		onSelect,
 		() => {},
+		{ temporaryOnly: options.temporaryOnly },
 	);
 }
 
@@ -138,6 +149,7 @@ describe("ModelSelector canonical model selection", () => {
 		if (!selectedAfterEnter) throw new Error("Expected Enter to select a model");
 		expect(selectedAfterEnter.model).toBe(model);
 		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
 	});
 
@@ -149,6 +161,9 @@ describe("ModelSelector canonical model selection", () => {
 		const settings = Settings.isolated({
 			modelRoles: {
 				default: `${model.provider}/${model.id}:medium`,
+			},
+			"task.agentModelOverrides": {
+				executor: `${model.provider}/${model.id}:high`,
 			},
 		});
 
@@ -166,7 +181,88 @@ describe("ModelSelector canonical model selection", () => {
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected role-agent selection");
 		expect(selectedAfterEnter.role).toBe("executor");
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
+	});
+
+	test("temporary scoped model selection carries selected reasoning", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:high`,
+			},
+		});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ temporaryOnly: true, thinkingLevel: ThinkingLevel.Low },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected temporary selection");
+		expect(selectedAfterEnter.role).toBeNull();
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("canonical scoped model assignment preserves selected reasoning", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:high`,
+			},
+		});
+		const selectorValue = `${model.provider}/${model.id}`;
+		const modelRegistry = {
+			getAll: () => [model],
+			getDiscoverableProviders: () => [],
+			getCanonicalModels: () => [
+				{
+					id: "claude-sonnet",
+					name: "Claude Sonnet",
+					variants: [{ canonicalId: "claude-sonnet", selector: selectorValue, model, source: "bundled" }],
+				},
+			],
+			resolveCanonicalModel: () => model,
+		} as unknown as ModelRegistry;
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectedSelector) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectedSelector };
+			},
+			{ modelRegistry, thinkingLevel: ThinkingLevel.Medium },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\t");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected canonical role-agent selection");
+		expect(selectedAfterEnter.role).toBe("executor");
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Medium);
+		expect(selectedAfterEnter.selector).toBe("claude-sonnet:medium");
 	});
 
 	test("refreshes Ollama Cloud using provider id instead of tab label", async () => {


### PR DESCRIPTION
## Summary
- preserve scoped /model reasoning on provider and canonical rows through DEFAULT and GJC role-agent action-menu assignments
- forward temporary /model selections to setModelTemporary(model, thinkingLevel)
- extend selector coverage for stale-role hiding, default, role-agent, temporary, and canonical scoped reasoning paths

## Verification
- bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
- bun test packages/coding-agent/test/agent-session-role-thinking.test.ts
- bun test packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts
- bun check

## Planning / review
- Ralplan architect: APPROVE
- Ralplan critic: OKAY after typecheck blocker fix
- Cleanup pass: behavior-preserving simplification, no-op on controller
