### PR TITLE
Enforce Ultragoal verification receipts

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -64,15 +64,16 @@ Loop until `gjc ultragoal status` reports all goals complete:
 3. Call `get_goal({})`.
 4. If no active GJC goal exists, call `create_goal({"objective":"<printed payload objective>"})` with the printed payload. In aggregate mode, if the same aggregate objective is already active, continue the current GJC story without creating a new GJC goal.
 5. Complete the current GJC story only.
-6. Run a completion audit against the story objective and real artifacts/tests.
-7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal({})` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({"status":"complete"})` only after that gate is clean, then call `get_goal({})` again for a fresh `complete` snapshot.
-8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--gjc-goal-json`; final clean checkpoints also require `--quality-gate-json`:
-   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
-9. If blocked or failed, checkpoint failure:
+6. Run the mandatory blocking verification loop for this story: architect review (architecture-side, product-side, and code-side), executor QA (e2e plus red-team suite build/run), and steering/iteration until every verifier is clean.
+7. Do **not** checkpoint `complete` from self-verification, summary confidence, or partial tests. If any verifier reports a finding, checkpoint `review_blocked` / record blocker work instead of completing the story.
+8. In aggregate mode, do **not** call `update_goal` for intermediate stories. Checkpoint each story with a fresh `get_goal({})` snapshot whose aggregate objective is still `active`. On the final story, run the strict complete checkpoint first; that accepted checkpoint creates a fresh final aggregate receipt. Only after that receipt exists may `update_goal({"status":"complete"})` reconcile the inline GJC goal.
+9. Checkpoint the durable ledger with that snapshot and a structured quality gate for every complete story:
+   `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>`
+10. If blocked or failed, checkpoint failure:
    `gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
-10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
+11. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
    `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy GJC goal blocks create_goal in this thread>" --gjc-goal-json <get_goal-json-or-path>`
-11. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
+12. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
 
 ## Dynamic steering
 
@@ -120,6 +121,8 @@ If an Ultragoal request has no approved plan or consensus artifact, run `ralplan
 
 The Ultragoal leader owns `.gjc/ultragoal/goals.json` and `.gjc/ultragoal/ledger.jsonl`. Role agents return implementation/review evidence; they do not checkpoint Ultragoal or mutate goal state.
 
+For large subgoals with independent slices, the Ultragoal leader must spawn parallel `executor` subagents instead of doing serial solo work. Split only cleanly separable files/surfaces, give each executor bounded targets and acceptance criteria, and keep checkpoint ownership in the leader. Use `architect` / `critic` review lanes after integration; do not let worker agents mutate `.gjc/ultragoal` or call goal tools.
+
 ## Use Ultragoal and Team together
 
 Use ultragoal and team together for a durable Ultragoal story that benefits from one visible tmux worker session. Ultragoal remains leader-owned: `.gjc/ultragoal/goals.json` stores the story plan and `.gjc/ultragoal/ledger.jsonl` stores checkpoints. Team is the single-worker tmux execution engine and returns task/evidence status to the leader.
@@ -132,37 +135,59 @@ gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evid
 
 Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden goal mutation.
 
-## Mandatory final cleanup and review gate
+## Mandatory blocking verification loop
 
-The final ultragoal story is not complete until the active agent has run the final quality gate:
+No ultragoal story is complete until the active agent has obtained independent verification and every verifier is clean:
 
-1. Run targeted verification for the story.
-2. Run a cleanup/refactor review pass on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
-3. Rerun verification after the cleaner pass.
-4. Run a final code review pass. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
-5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
-
+1. Run targeted implementation verification for the story.
+2. Delegate an `architect` review covering all three lanes:
+   - architecture-side: system boundaries, layering, data/control flow, operational risks.
+   - product-side: user-visible behavior, acceptance criteria, edge cases, regressions.
+   - code-side: maintainability, tests, integration points, and unsafe shortcuts.
+3. Delegate an `executor` QA/red-team lane to build and run the e2e/read-teaming QA suite appropriate for the story. This lane must try to break the change, not just confirm the happy path.
+4. If any lane finds an issue, do **not** checkpoint `complete` and do **not** call `update_goal`. Record durable blocker work instead:
    ```sh
-   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --gjc-goal-json <active-get-goal-json-or-path>
+   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve verification blockers" --objective "<blocker-resolution objective>" --evidence "<architect/executor findings>" --gjc-goal-json <active-get-goal-json-or-path>
    ```
+5. Complete or steer through the blocker story, then rerun the full blocking verification loop. Repeat until all verifier lanes are clean.
+6. Only after the loop is clean, checkpoint the story as complete with a structured quality gate. The checkpoint creates a receipt; `goals.json.status` alone is not proof. Aggregate direct completion requires a fresh final aggregate receipt covering the full required-goal set before `update_goal({"status":"complete"})` is allowed.
 
-   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the GJC goal active, and lets `gjc ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available GJC goal context because the old per-story GJC goal remains active/incomplete.
-
-6. If review is clean, call `update_goal({"status":"complete"})`, call `get_goal({})`, and checkpoint with a structured final gate:
-
-   ```sh
-   gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --gjc-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
-   ```
-
-`--quality-gate-json` must include:
+The native `checkpoint --status complete` command rejects missing or shallow gates. `--quality-gate-json` must include:
 
 ```json
 {
-  "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
-  "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
-  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+  "architectReview": {
+    "architectureStatus": "CLEAR",
+    "productStatus": "CLEAR",
+    "codeStatus": "CLEAR",
+    "recommendation": "APPROVE",
+    "evidence": "architect review synthesis with architecture/product/code coverage",
+    "commands": ["architect review command or agent evidence id"],
+    "blockers": []
+  },
+  "executorQa": {
+    "status": "passed",
+    "e2eStatus": "passed",
+    "redTeamStatus": "passed",
+    "evidence": "executor-built e2e and red-team QA commands/results",
+    "e2eCommands": ["bun test:e2e"],
+    "redTeamCommands": ["bun test:red-team"],
+    "blockers": []
+  },
+  "iteration": {
+    "status": "passed",
+    "evidence": "blockers were absent or resolved and the full verification loop was rerun cleanly",
+    "fullRerun": true,
+    "rerunCommands": ["bun test:e2e", "bun test:red-team"],
+    "blockers": []
+  }
 }
 ```
+
+Receipts are freshness-scoped:
+- Per-goal receipts remain fresh for their target goal unless that goal, its blocker metadata, or its supersession metadata changes.
+- Normal later `goal_started` or clean receipt-backed `goal_checkpointed` events for other goals do not stale older per-goal receipts.
+- Appending required goals or changing final required-goal state stales final aggregate receipts. Final aggregate completion requires a fresh final aggregate receipt proving no incomplete, blocked, or `review_blocked` required goals remain.
 
 ## Constraints
 
@@ -171,6 +196,6 @@ The final ultragoal story is not complete until the active agent has run the fin
 - After a completed aggregate ultragoal run, clear the goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
-- In aggregate mode, intermediate story checkpoints require a matching `active` GJC goal snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.
+- In aggregate mode, intermediate story checkpoints require a matching `active` GJC goal snapshot; final story checkpoint also uses the active snapshot and creates the final aggregate receipt. Only after that receipt exists may `update_goal({"status":"complete"})` reconcile the inline goal state.
 - Completion checkpoints require read-only goal snapshot reconciliation: pass fresh `get_goal` JSON/path with `--gjc-goal-json`; shell commands and hooks must not mutate goal state.
 - Treat `ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,0 +1,239 @@
+import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import {
+	computeUltragoalPlanGeneration,
+	hashStructuredValue,
+	readUltragoalLedger,
+	readUltragoalPlan,
+	type UltragoalCompletionVerification,
+	type UltragoalGoal,
+	type UltragoalLedgerEvent,
+	type UltragoalPlan,
+	type UltragoalReceiptKind,
+} from "./ultragoal-runtime";
+
+export type UltragoalGuardState =
+	| "inactive"
+	| "unrelated_goal"
+	| "active_verified_complete"
+	| "active_missing_receipt"
+	| "active_stale_receipt"
+	| "active_missing_final_receipt"
+	| "active_dirty_quality_gate"
+	| "active_review_blocked_unrecorded"
+	| "active_review_blocked_recorded"
+	| "unreadable_fail_closed";
+
+export interface UltragoalGuardDiagnostic {
+	state: UltragoalGuardState;
+	message: string;
+	goalId?: string;
+}
+
+export interface CurrentGoalLike {
+	objective: string;
+	status?: string;
+}
+
+function objectiveMatches(currentObjective: string, plan: UltragoalPlan): boolean {
+	const normalized = currentObjective.trim();
+	if (!normalized) return false;
+	if (normalized === plan.gjcObjective || normalized === DEFAULT_ULTRAGOAL_OBJECTIVE) return true;
+	if (plan.gjcObjectiveAliases?.some(alias => alias === normalized)) return true;
+	return plan.goals.some(goal => goal.objective === normalized);
+}
+
+function requiredGoals(plan: UltragoalPlan): UltragoalGoal[] {
+	return plan.goals.filter(goal => goal.status !== "superseded");
+}
+
+function findReceiptGoal(
+	plan: UltragoalPlan,
+	currentObjective: string,
+): { goal: UltragoalGoal; receiptKind: UltragoalReceiptKind } | null {
+	if (
+		currentObjective === plan.gjcObjective ||
+		currentObjective === DEFAULT_ULTRAGOAL_OBJECTIVE ||
+		plan.gjcObjectiveAliases?.some(alias => alias === currentObjective)
+	) {
+		const finalGoal = [...requiredGoals(plan)]
+			.reverse()
+			.find(goal => goal.completionVerification?.receiptKind === "final-aggregate");
+		return finalGoal ? { goal: finalGoal, receiptKind: "final-aggregate" } : null;
+	}
+	const storyGoal = plan.goals.find(goal => goal.objective === currentObjective);
+	return storyGoal ? { goal: storyGoal, receiptKind: "per-goal" } : null;
+}
+
+function findLedgerReceiptEvent(
+	ledger: readonly UltragoalLedgerEvent[],
+	receipt: UltragoalCompletionVerification,
+): UltragoalLedgerEvent | null {
+	return (
+		ledger.find(event => {
+			if (event.eventId !== receipt.checkpointLedgerEventId) return false;
+			if (event.event !== "goal_checkpointed") return false;
+			if (event.goalId !== receipt.goalId) return false;
+			const eventReceipt = event.completionVerification as UltragoalCompletionVerification | undefined;
+			return (
+				event.status === "complete" &&
+				eventReceipt?.receiptId === receipt.receiptId &&
+				eventReceipt.receiptKind === receipt.receiptKind &&
+				eventReceipt.planGeneration === receipt.planGeneration
+			);
+		}) ?? null
+	);
+}
+
+export function validateCompletionReceipt(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receiptKind: UltragoalReceiptKind;
+}): UltragoalGuardDiagnostic {
+	const receipt = input.goal.completionVerification;
+	if (!receipt) {
+		return {
+			state: input.receiptKind === "final-aggregate" ? "active_missing_final_receipt" : "active_missing_receipt",
+			message: `Ultragoal ${input.goal.id} has no ${input.receiptKind} completion verification receipt.`,
+			goalId: input.goal.id,
+		};
+	}
+	if (
+		receipt.schemaVersion !== 1 ||
+		receipt.goalId !== input.goal.id ||
+		receipt.receiptKind !== input.receiptKind ||
+		!receipt.planGeneration ||
+		!receipt.checkpointLedgerEventId
+	) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt is malformed or stale.`,
+			goalId: input.goal.id,
+		};
+	}
+	const event = findLedgerReceiptEvent(input.ledger, receipt);
+	if (!event) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt ledger event is missing.`,
+			goalId: input.goal.id,
+		};
+	}
+	const generation = computeUltragoalPlanGeneration({
+		plan: input.plan,
+		ledger: input.ledger,
+		goal: input.goal,
+		receiptKind: input.receiptKind,
+		beforeStatus: receipt.goalStatusBeforeCheckpoint,
+		excludeEventId: receipt.checkpointLedgerEventId,
+	});
+	if (generation.planGeneration !== receipt.planGeneration) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt generation is stale.`,
+			goalId: input.goal.id,
+		};
+	}
+	if (hashStructuredValue(event.qualityGateJson) !== receipt.qualityGateHash) {
+		return {
+			state: "active_dirty_quality_gate",
+			message: `Ultragoal ${input.goal.id} receipt quality-gate hash does not match ledger.`,
+			goalId: input.goal.id,
+		};
+	}
+	if (input.goal.updatedAt !== receipt.verifiedAt) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt target changed after verification.`,
+			goalId: input.goal.id,
+		};
+	}
+	if (input.receiptKind === "final-aggregate") {
+		const incomplete = requiredGoals(input.plan).filter(goal => goal.status !== "complete");
+		if (incomplete.length > 0) {
+			return {
+				state: "active_missing_final_receipt",
+				message: `Ultragoal final receipt is not valid while required goals remain incomplete: ${incomplete.map(goal => goal.id).join(", ")}.`,
+				goalId: input.goal.id,
+			};
+		}
+		const missingReceipts = requiredGoals(input.plan).filter(
+			goal => goal.id !== input.goal.id && !goal.completionVerification,
+		);
+		if (missingReceipts.length > 0) {
+			return {
+				state: "active_missing_receipt",
+				message: `Ultragoal final receipt is missing per-goal evidence for: ${missingReceipts.map(goal => goal.id).join(", ")}.`,
+				goalId: input.goal.id,
+			};
+		}
+	}
+	return {
+		state: "active_verified_complete",
+		message: `Ultragoal ${input.goal.id} has a fresh ${input.receiptKind} receipt.`,
+		goalId: input.goal.id,
+	};
+}
+
+export async function readUltragoalVerificationState(input: {
+	cwd: string;
+	currentGoal?: CurrentGoalLike | null;
+}): Promise<UltragoalGuardDiagnostic> {
+	const currentObjective = input.currentGoal?.objective?.trim() ?? "";
+	if (!currentObjective) return { state: "inactive", message: "No current goal objective is active." };
+	let plan: UltragoalPlan | null;
+	let ledger: UltragoalLedgerEvent[];
+	try {
+		plan = await readUltragoalPlan(input.cwd);
+		ledger = await readUltragoalLedger(input.cwd);
+	} catch (error) {
+		if (currentObjective === DEFAULT_ULTRAGOAL_OBJECTIVE) {
+			return {
+				state: "unreadable_fail_closed",
+				message: `Unable to read Ultragoal verification state: ${error instanceof Error ? error.message : String(error)}`,
+			};
+		}
+		return { state: "unrelated_goal", message: "Current goal is not an active Ultragoal objective." };
+	}
+	if (!plan) return { state: "inactive", message: "No Ultragoal plan exists." };
+	if (!objectiveMatches(currentObjective, plan))
+		return { state: "unrelated_goal", message: "Current goal is not an active Ultragoal objective." };
+	if (plan.goals.some(goal => goal.status === "review_blocked")) {
+		return {
+			state: "active_review_blocked_recorded",
+			message: "Ultragoal has recorded review blockers; complete blocker work and rerun verification.",
+		};
+	}
+	if (plan.goals.some(goal => goal.status === "blocked" || goal.status === "failed")) {
+		return {
+			state: "active_dirty_quality_gate",
+			message: "Ultragoal has blocked or failed goals; record blockers or rerun verification.",
+		};
+	}
+	const receiptTarget = findReceiptGoal(plan, currentObjective);
+	if (!receiptTarget) {
+		return {
+			state: "active_missing_final_receipt",
+			message: "Ultragoal aggregate completion requires a fresh final aggregate receipt.",
+		};
+	}
+	return validateCompletionReceipt({ plan, ledger, goal: receiptTarget.goal, receiptKind: receiptTarget.receiptKind });
+}
+
+export async function assertCanCompleteCurrentGoal(input: {
+	cwd: string;
+	currentGoal?: CurrentGoalLike | null;
+}): Promise<void> {
+	if (!input.cwd) return;
+	const diagnostic = await readUltragoalVerificationState(input);
+	if (["inactive", "unrelated_goal", "active_verified_complete"].includes(diagnostic.state)) return;
+	throw new Error(
+		`${diagnostic.message} Run strict \`gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>\` first, or record review blockers and rerun verification.`,
+	);
+}
+
+export function isUltragoalBypassPrompt(prompt: string): boolean {
+	return /update_goal\s*\(|goal\s+complete|checkpoint[^\n]+--status\s+complete|skip\s+verification|weaken\s+verification|mark\s+.*complete/i.test(
+		prompt,
+	);
+}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
@@ -23,6 +24,7 @@ export interface UltragoalGoal {
 	completedAt?: string;
 	evidence?: string;
 	steering?: Record<string, unknown>;
+	completionVerification?: UltragoalCompletionVerification;
 }
 
 export interface UltragoalPlan {
@@ -34,6 +36,36 @@ export interface UltragoalPlan {
 	goals: UltragoalGoal[];
 	createdAt: string;
 	updatedAt: string;
+}
+
+export type UltragoalReceiptKind = "per-goal" | "final-aggregate";
+
+export interface UltragoalCompletionVerification {
+	schemaVersion: 1;
+	receiptId: string;
+	verifiedAt: string;
+	goalId: string;
+	receiptKind: UltragoalReceiptKind;
+	goalStatusBeforeCheckpoint: UltragoalGoalStatus;
+	gjcGoalMode: UltragoalGjcGoalMode;
+	gjcObjective: string;
+	qualityGateHash: string;
+	planGeneration: string;
+	basis: {
+		planHashBeforeCheckpoint: string;
+		latestRelevantLedgerEventIdBeforeCheckpoint: string | null;
+		goalUpdatedAtBeforeCheckpoint: string;
+		relevantGoalIdsBeforeCheckpoint: string[];
+		requiredGoalSetHashBeforeCheckpoint: string;
+	};
+	checkpointLedgerEventId: string;
+}
+
+export interface UltragoalLedgerEvent extends JsonObject {
+	eventId?: string;
+	event?: string;
+	goalId?: string;
+	timestamp?: string;
 }
 
 export interface UltragoalPaths {
@@ -65,6 +97,10 @@ interface JsonObject {
 }
 
 const TERMINAL_OR_SKIPPED_STATUSES = new Set<UltragoalGoalStatus>(["complete", "superseded"]);
+const CLEAN_ARCHITECT_STATUS = "CLEAR";
+const APPROVE_RECOMMENDATION = "APPROVE";
+const PASSED_STATUS = "passed";
+
 const SCHEDULABLE_STATUSES = new Set<UltragoalGoalStatus>(["pending", "active", "failed"]);
 
 export function getUltragoalPaths(cwd: string): UltragoalPaths {
@@ -87,11 +123,30 @@ async function ensureUltragoalDir(paths: UltragoalPaths): Promise<void> {
 	await fs.mkdir(paths.dir, { recursive: true });
 }
 
-async function appendLedger(cwd: string, event: JsonObject): Promise<void> {
+async function appendLedger(cwd: string, event: JsonObject): Promise<UltragoalLedgerEvent> {
 	const paths = getUltragoalPaths(cwd);
 	await ensureUltragoalDir(paths);
-	const entry = { ...event, timestamp: new Date().toISOString() };
+	const entry: UltragoalLedgerEvent = {
+		eventId: typeof event.eventId === "string" ? event.eventId : crypto.randomUUID(),
+		...event,
+		timestamp: new Date().toISOString(),
+	};
 	await fs.appendFile(paths.ledgerPath, `${JSON.stringify(entry)}\n`);
+	return entry;
+}
+
+export async function readUltragoalLedger(cwd: string): Promise<UltragoalLedgerEvent[]> {
+	try {
+		const raw = await Bun.file(getUltragoalPaths(cwd).ledgerPath).text();
+		return raw
+			.split(/\r?\n/)
+			.map(line => line.trim())
+			.filter(line => line.length > 0)
+			.map(line => JSON.parse(line) as UltragoalLedgerEvent);
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw error;
+	}
 }
 
 async function writePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
@@ -158,6 +213,10 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 			steering:
 				typeof goalRecord.steering === "object" && goalRecord.steering !== null
 					? (goalRecord.steering as Record<string, unknown>)
+					: undefined,
+			completionVerification:
+				typeof goalRecord.completionVerification === "object" && goalRecord.completionVerification !== null
+					? (goalRecord.completionVerification as UltragoalCompletionVerification)
 					: undefined,
 		};
 	});
@@ -304,6 +363,335 @@ async function readStructuredValue(cwd: string, value: string): Promise<unknown>
 	}
 }
 
+function recordValue(record: JsonObject, key: string): JsonObject | null {
+	const value = record[key];
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as JsonObject) : null;
+}
+
+function stringValue(record: JsonObject, key: string): string {
+	const value = record[key];
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function assertStringValue(record: JsonObject, key: string, expected: string, pathName: string): void {
+	const actual = stringValue(record, key);
+	if (actual !== expected) throw new Error(`${pathName}.${key} must be ${expected}`);
+}
+
+function assertNonEmptyString(record: JsonObject, key: string, pathName: string): void {
+	if (!stringValue(record, key)) throw new Error(`${pathName}.${key} is required`);
+}
+
+function assertStringArray(record: JsonObject, key: string, pathName: string): string[] {
+	const value = record[key];
+	if (!Array.isArray(value)) throw new Error(`${pathName}.${key} must be a non-empty string[]`);
+	const items = value.map(item => (typeof item === "string" ? item.trim() : ""));
+	if (items.length === 0 || items.some(item => item.length === 0)) {
+		throw new Error(`${pathName}.${key} must be a non-empty string[]`);
+	}
+	return items;
+}
+
+function assertEmptyArray(record: JsonObject, key: string, pathName: string): void {
+	const value = record[key];
+	if (!Array.isArray(value)) throw new Error(`${pathName}.${key} must be []`);
+	if (value.length !== 0) throw new Error(`${pathName}.${key} must be empty`);
+}
+
+function assertBooleanValue(record: JsonObject, key: string, expected: boolean, pathName: string): void {
+	if (record[key] !== expected) throw new Error(`${pathName}.${key} must be ${String(expected)}`);
+}
+
+function assertExactKeys(record: JsonObject, pathName: string, expectedKeys: readonly string[]): void {
+	const expected = new Set(expectedKeys);
+	const extra = Object.keys(record).filter(key => !expected.has(key));
+	if (extra.length > 0) throw new Error(`${pathName} contains unsupported keys: ${extra.join(", ")}`);
+}
+
+async function readQualityGate(cwd: string, qualityGateJson: string | undefined): Promise<unknown> {
+	if (qualityGateJson === undefined) {
+		throw new Error(
+			"complete checkpoints require --quality-gate-json with strict architectReview, executorQa, and iteration passes",
+		);
+	}
+	return await readStructuredValue(cwd, qualityGateJson);
+}
+
+export function stableJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(item => stableJson(item)).join(",")}]`;
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		return `{${Object.keys(record)
+			.sort()
+			.map(key => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+export function hashStructuredValue(value: unknown): string {
+	return crypto.createHash("sha256").update(stableJson(value)).digest("hex");
+}
+
+export function validateCompleteQualityGate(value: unknown): JsonObject {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("quality gate must be a JSON object");
+	}
+	const gate = value as JsonObject;
+	assertExactKeys(gate, "qualityGate", ["architectReview", "executorQa", "iteration"]);
+	const architectReview = recordValue(gate, "architectReview");
+	if (!architectReview) throw new Error("quality gate requires architectReview");
+	assertExactKeys(architectReview, "architectReview", [
+		"architectureStatus",
+		"productStatus",
+		"codeStatus",
+		"recommendation",
+		"evidence",
+		"commands",
+		"blockers",
+	]);
+	assertStringValue(architectReview, "architectureStatus", CLEAN_ARCHITECT_STATUS, "architectReview");
+	assertStringValue(architectReview, "productStatus", CLEAN_ARCHITECT_STATUS, "architectReview");
+	assertStringValue(architectReview, "codeStatus", CLEAN_ARCHITECT_STATUS, "architectReview");
+	assertStringValue(architectReview, "recommendation", APPROVE_RECOMMENDATION, "architectReview");
+	assertNonEmptyString(architectReview, "evidence", "architectReview");
+	assertStringArray(architectReview, "commands", "architectReview");
+	assertEmptyArray(architectReview, "blockers", "architectReview");
+
+	const executorQa = recordValue(gate, "executorQa");
+	if (!executorQa) throw new Error("quality gate requires executorQa");
+	assertExactKeys(executorQa, "executorQa", [
+		"status",
+		"e2eStatus",
+		"redTeamStatus",
+		"evidence",
+		"e2eCommands",
+		"redTeamCommands",
+		"blockers",
+	]);
+	assertStringValue(executorQa, "status", PASSED_STATUS, "executorQa");
+	assertStringValue(executorQa, "e2eStatus", PASSED_STATUS, "executorQa");
+	assertStringValue(executorQa, "redTeamStatus", PASSED_STATUS, "executorQa");
+	assertNonEmptyString(executorQa, "evidence", "executorQa");
+	assertStringArray(executorQa, "e2eCommands", "executorQa");
+	assertStringArray(executorQa, "redTeamCommands", "executorQa");
+	assertEmptyArray(executorQa, "blockers", "executorQa");
+
+	const iteration = recordValue(gate, "iteration");
+	if (!iteration) throw new Error("quality gate requires iteration");
+	assertExactKeys(iteration, "iteration", ["status", "evidence", "fullRerun", "rerunCommands", "blockers"]);
+	assertStringValue(iteration, "status", PASSED_STATUS, "iteration");
+	assertNonEmptyString(iteration, "evidence", "iteration");
+	assertBooleanValue(iteration, "fullRerun", true, "iteration");
+	assertStringArray(iteration, "rerunCommands", "iteration");
+	assertEmptyArray(iteration, "blockers", "iteration");
+
+	return gate;
+}
+
+function requiredGoals(plan: UltragoalPlan): UltragoalGoal[] {
+	return plan.goals.filter(goal => goal.status !== "superseded");
+}
+
+function receiptRelevantGoals(
+	plan: UltragoalPlan,
+	goal: UltragoalGoal,
+	receiptKind: UltragoalReceiptKind,
+): UltragoalGoal[] {
+	if (receiptKind === "final-aggregate") return requiredGoals(plan);
+	const relatedIds = new Set([goal.id]);
+	const blockedGoalId =
+		typeof goal.steering?.kind === "string" && goal.steering.kind === "review_blocker"
+			? nonEmptyString(goal.steering.blockedGoalId)
+			: null;
+	if (blockedGoalId) relatedIds.add(blockedGoalId);
+	for (const item of plan.goals) {
+		const linkedBlockedGoalId =
+			typeof item.steering?.kind === "string" && item.steering.kind === "review_blocker"
+				? nonEmptyString(item.steering.blockedGoalId)
+				: null;
+		if (linkedBlockedGoalId === goal.id) relatedIds.add(item.id);
+	}
+	return plan.goals.filter(item => relatedIds.has(item.id));
+}
+
+function normalizedGoalForGeneration(
+	goal: UltragoalGoal,
+	targetGoalId: string,
+	beforeStatus: UltragoalGoalStatus,
+): JsonObject {
+	return {
+		id: goal.id,
+		title: goal.title,
+		objective: goal.objective,
+		status: goal.id === targetGoalId ? beforeStatus : goal.status,
+		evidence: goal.id === targetGoalId ? undefined : goal.evidence,
+		steering: goal.steering ?? null,
+	};
+}
+
+function latestRelevantLedgerEventId(
+	ledger: readonly UltragoalLedgerEvent[],
+	goalIds: readonly string[],
+	receiptKind: UltragoalReceiptKind,
+	excludeEventId?: string,
+): string | null {
+	const goalIdSet = new Set(goalIds);
+	for (let index = ledger.length - 1; index >= 0; index -= 1) {
+		const event = ledger[index];
+		if (!event || event.eventId === excludeEventId) continue;
+		const eventName = typeof event.event === "string" ? event.event : "";
+		const eventGoalId = typeof event.goalId === "string" ? event.goalId : "";
+		if (receiptKind === "final-aggregate") {
+			if (
+				[
+					"plan_created",
+					"goal_started",
+					"goal_checkpointed",
+					"steering_accepted",
+					"review_blockers_recorded",
+				].includes(eventName)
+			) {
+				return event.eventId ?? null;
+			}
+			continue;
+		}
+		const blockerGoalId = typeof event.blockerGoalId === "string" ? event.blockerGoalId : "";
+		if (goalIdSet.has(eventGoalId) || goalIdSet.has(blockerGoalId)) return event.eventId ?? null;
+	}
+	return null;
+}
+
+export function computeUltragoalPlanGeneration(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receiptKind: UltragoalReceiptKind;
+	beforeStatus: UltragoalGoalStatus;
+	excludeEventId?: string;
+}): {
+	planGeneration: string;
+	planHash: string;
+	latestRelevantLedgerEventId: string | null;
+	relevantGoalIds: string[];
+	requiredGoalSetHash: string;
+} {
+	const relevantGoals = receiptRelevantGoals(input.plan, input.goal, input.receiptKind);
+	const relevantGoalIds = relevantGoals.map(goal => goal.id).sort();
+	const requiredGoalIds = requiredGoals(input.plan)
+		.map(goal => goal.id)
+		.sort();
+	const latestEventId = latestRelevantLedgerEventId(
+		input.ledger,
+		relevantGoalIds,
+		input.receiptKind,
+		input.excludeEventId,
+	);
+	const snapshot = {
+		gjcGoalMode: input.plan.gjcGoalMode,
+		gjcObjective: input.plan.gjcObjective,
+		gjcObjectiveAliases: input.plan.gjcObjectiveAliases ?? [],
+		receiptKind: input.receiptKind,
+		goals: relevantGoals.map(goal => normalizedGoalForGeneration(goal, input.goal.id, input.beforeStatus)),
+		requiredGoalIds: input.receiptKind === "final-aggregate" ? requiredGoalIds : [],
+		latestRelevantLedgerEventId: latestEventId,
+	};
+	const planHash = hashStructuredValue(snapshot);
+	return {
+		planGeneration: planHash,
+		planHash,
+		latestRelevantLedgerEventId: latestEventId,
+		relevantGoalIds,
+		requiredGoalSetHash: hashStructuredValue(requiredGoalIds),
+	};
+}
+
+function chooseReceiptKind(
+	plan: UltragoalPlan,
+	goal: UltragoalGoal,
+	status: UltragoalGoalStatus,
+): UltragoalReceiptKind {
+	if (plan.gjcGoalMode === "per-story") return "per-goal";
+	const incomplete = requiredGoals(plan).filter(
+		item => item.id !== goal.id && !TERMINAL_OR_SKIPPED_STATUSES.has(item.status),
+	);
+	return status === "complete" && incomplete.length === 0 ? "final-aggregate" : "per-goal";
+}
+
+function buildCompletionReceipt(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receiptKind: UltragoalReceiptKind;
+	beforeStatus: UltragoalGoalStatus;
+	qualityGateJson: JsonObject;
+	now: string;
+	checkpointLedgerEventId: string;
+}): UltragoalCompletionVerification {
+	const generation = computeUltragoalPlanGeneration({
+		plan: input.plan,
+		ledger: input.ledger,
+		goal: input.goal,
+		receiptKind: input.receiptKind,
+		beforeStatus: input.beforeStatus,
+	});
+	return {
+		schemaVersion: 1,
+		receiptId: crypto.randomUUID(),
+		verifiedAt: input.now,
+		goalId: input.goal.id,
+		receiptKind: input.receiptKind,
+		goalStatusBeforeCheckpoint: input.beforeStatus,
+		gjcGoalMode: input.plan.gjcGoalMode,
+		gjcObjective: input.plan.gjcObjective,
+		qualityGateHash: hashStructuredValue(input.qualityGateJson),
+		planGeneration: generation.planGeneration,
+		basis: {
+			planHashBeforeCheckpoint: generation.planHash,
+			latestRelevantLedgerEventIdBeforeCheckpoint: generation.latestRelevantLedgerEventId,
+			goalUpdatedAtBeforeCheckpoint: input.goal.updatedAt,
+			relevantGoalIdsBeforeCheckpoint: generation.relevantGoalIds,
+			requiredGoalSetHashBeforeCheckpoint: generation.requiredGoalSetHash,
+		},
+		checkpointLedgerEventId: input.checkpointLedgerEventId,
+	};
+}
+
+function findGoalSnapshot(value: unknown): { objective?: unknown; status?: unknown } | null {
+	if (typeof value !== "object" || value === null) return null;
+	const record = value as JsonObject;
+	const directGoal = record.goal;
+	if (typeof directGoal === "object" && directGoal !== null)
+		return directGoal as { objective?: unknown; status?: unknown };
+	const details = record.details;
+	if (typeof details === "object" && details !== null) {
+		const detailsGoal = (details as JsonObject).goal;
+		if (typeof detailsGoal === "object" && detailsGoal !== null)
+			return detailsGoal as { objective?: unknown; status?: unknown };
+	}
+	if ("objective" in record || "status" in record) return record as { objective?: unknown; status?: unknown };
+	return null;
+}
+
+function validateGjcGoalSnapshot(input: { value: unknown; plan: UltragoalPlan; goal: UltragoalGoal }): void {
+	const snapshot = findGoalSnapshot(input.value);
+	if (!snapshot) throw new Error("complete checkpoints require --gjc-goal-json with a get_goal snapshot");
+	const objective = typeof snapshot.objective === "string" ? snapshot.objective.trim() : "";
+	const status = typeof snapshot.status === "string" ? snapshot.status.trim() : "";
+	const allowedObjectives = new Set([
+		input.plan.gjcObjective,
+		DEFAULT_ULTRAGOAL_OBJECTIVE,
+		input.goal.objective,
+		...(input.plan.gjcObjectiveAliases ?? []),
+	]);
+	if (!allowedObjectives.has(objective)) {
+		throw new Error("complete checkpoint --gjc-goal-json objective does not match the active Ultragoal objective");
+	}
+	if (status !== "active" && status !== "paused") {
+		throw new Error("complete checkpoint --gjc-goal-json status must be active before receipt-backed reconciliation");
+	}
+}
+
 export async function checkpointUltragoalGoal(input: {
 	cwd: string;
 	goalId: string;
@@ -318,7 +706,47 @@ export async function checkpointUltragoalGoal(input: {
 	if (!goal) throw new Error(`No ultragoal goal found for ${input.goalId}.`);
 	const evidence = input.evidence.trim();
 	if (!evidence) throw new Error("checkpoint evidence is required");
+	const gjcGoalJson = input.gjcGoalJson ? await readStructuredValue(input.cwd, input.gjcGoalJson) : undefined;
+	const qualityGateJson =
+		input.status === "complete"
+			? validateCompleteQualityGate(await readQualityGate(input.cwd, input.qualityGateJson))
+			: input.qualityGateJson
+				? await readStructuredValue(input.cwd, input.qualityGateJson)
+				: undefined;
+	if (input.status === "complete") {
+		if (gjcGoalJson === undefined)
+			throw new Error("complete checkpoints require --gjc-goal-json with a fresh get_goal snapshot");
+		validateGjcGoalSnapshot({ value: gjcGoalJson, plan, goal });
+	}
 	const now = new Date().toISOString();
+	const ledgerBefore = await readUltragoalLedger(input.cwd);
+	const beforeStatus = goal.status;
+	if (input.status === "complete") {
+		const blockedGoalId =
+			typeof goal.steering?.kind === "string" && goal.steering.kind === "review_blocker"
+				? nonEmptyString(goal.steering.blockedGoalId)
+				: null;
+		const blockedGoal = blockedGoalId ? plan.goals.find(item => item.id === blockedGoalId) : undefined;
+		if (blockedGoal?.status === "review_blocked") {
+			blockedGoal.status = "superseded";
+			blockedGoal.evidence = `Resolved by verification blocker story ${goal.id}: ${evidence}`;
+			blockedGoal.updatedAt = now;
+		}
+	}
+	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, goal, input.status) : null;
+	const pendingCheckpointEventId = crypto.randomUUID();
+	if (input.status === "complete" && receiptKind && qualityGateJson && !Array.isArray(qualityGateJson)) {
+		goal.completionVerification = buildCompletionReceipt({
+			plan,
+			ledger: ledgerBefore,
+			goal,
+			receiptKind,
+			beforeStatus,
+			qualityGateJson: qualityGateJson as JsonObject,
+			now,
+			checkpointLedgerEventId: pendingCheckpointEventId,
+		});
+	}
 	goal.status = input.status;
 	goal.evidence = evidence;
 	goal.updatedAt = now;
@@ -326,12 +754,14 @@ export async function checkpointUltragoalGoal(input: {
 	plan.updatedAt = now;
 	await writePlan(input.cwd, plan);
 	await appendLedger(input.cwd, {
+		eventId: pendingCheckpointEventId,
 		event: "goal_checkpointed",
 		goalId: goal.id,
 		status: input.status,
 		evidence,
-		gjcGoalJson: input.gjcGoalJson ? await readStructuredValue(input.cwd, input.gjcGoalJson) : undefined,
-		qualityGateJson: input.qualityGateJson ? await readStructuredValue(input.cwd, input.qualityGateJson) : undefined,
+		gjcGoalJson,
+		qualityGateJson,
+		completionVerification: input.status === "complete" ? goal.completionVerification : undefined,
 	});
 	return plan;
 }
@@ -480,7 +910,8 @@ function renderCompleteHandoff(
 		`Ultragoal handoff: ${result.goal.id} — ${result.goal.title}`,
 		`Objective: ${result.goal.objective}`,
 		`GJC objective: ${result.plan.gjcObjective}`,
-		"Call get_goal({}); create_goal only if no active GJC goal exists, then complete this GJC story and checkpoint it.",
+		"Call get_goal({}); create_goal only if no active GJC goal exists, then complete this GJC story.",
+		"Before checkpointing complete, obtain a passing architectReview (architecture/product/code CLEAR + APPROVE) and executorQa (e2e/red-team passed); record blockers instead of completing on any finding.",
 		"",
 	].join("\n");
 }

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -4,6 +4,7 @@ import { Text } from "@gajae-code/tui";
 import { formatNumber, prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
+import { assertCanCompleteCurrentGoal } from "../../gjc-runtime/ultragoal-guard";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
 import createGoalDescription from "../../prompts/tools/create-goal.md" with { type: "text" };
 import getGoalDescription from "../../prompts/tools/get-goal.md" with { type: "text" };
@@ -127,6 +128,11 @@ async function executeGoalOperation(session: ToolSession, params: GoalToolInput)
 	if (params.op === "drop") {
 		const dropped = await runtime.dropGoal();
 		return buildGoalToolResponse(dropped ?? null);
+	}
+	try {
+		await assertCanCompleteCurrentGoal({ cwd: session.cwd, currentGoal: session.getGoalModeState?.()?.goal ?? null });
+	} catch (error) {
+		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}
 	const completed = await runtime.completeGoalFromTool();
 	return buildGoalToolResponse(completed, { includeCompletionReport: true });

--- a/packages/coding-agent/src/hooks/native-skill-hook.ts
+++ b/packages/coding-agent/src/hooks/native-skill-hook.ts
@@ -152,6 +152,16 @@ function readTurnId(payload: HookPayload): string | undefined {
 	return safeString(payload.turn_id ?? payload.turnId).trim() || undefined;
 }
 
+function readSessionFile(payload: HookPayload): string | undefined {
+	return (
+		safeString(
+			payload.session_file ?? payload.sessionFile ?? payload.transcript_path ?? payload.transcriptPath,
+		).trim() ||
+		process.env.GJC_SESSION_FILE?.trim() ||
+		undefined
+	);
+}
+
 export async function dispatchGjcNativeSkillHook(
 	payload: HookPayload,
 	options: GjcNativeHookDispatchOptions = {},
@@ -180,7 +190,22 @@ export async function dispatchGjcNativeSkillHook(
 					sessionId: readSessionId(payload),
 					threadId: readThreadId(payload),
 					stateDir: options.stateDir,
+					prompt,
+					sessionFile: readSessionFile(payload),
 				});
+		if (activeUltragoalContext?.startsWith("BLOCK_ULTRAGOAL_COMPLETION:")) {
+			return {
+				hookEventName,
+				outputJson: {
+					decision: "block",
+					reason: activeUltragoalContext,
+					hookSpecificOutput: {
+						hookEventName,
+						additionalContext: activeUltragoalContext,
+					},
+				},
+			};
+		}
 		return {
 			hookEventName,
 			outputJson:
@@ -205,6 +230,7 @@ export async function dispatchGjcNativeSkillHook(
 				sessionId: readSessionId(payload),
 				threadId: readThreadId(payload),
 				stateDir: options.stateDir,
+				sessionFile: readSessionFile(payload),
 			}),
 		};
 	}

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
+import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
+import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
 import {
 	compareSkillKeywordMatches,
 	GJC_SKILL_KEYWORD_DEFINITIONS,
@@ -124,6 +126,7 @@ export interface StopHookInput {
 	sessionId?: string;
 	threadId?: string;
 	stateDir?: string;
+	sessionFile?: string;
 }
 
 export interface UserPromptSubmitStateInput {
@@ -131,6 +134,8 @@ export interface UserPromptSubmitStateInput {
 	sessionId?: string;
 	threadId?: string;
 	stateDir?: string;
+	prompt?: string;
+	sessionFile?: string;
 }
 
 function escapeRegex(value: string): string {
@@ -361,6 +366,19 @@ function stateMatchesContext(state: ModeState, sessionId?: string, threadId?: st
 	return true;
 }
 
+async function readCurrentGoalObjectiveFromSessionFile(sessionFile: string | undefined): Promise<string | null> {
+	const trimmed = sessionFile?.trim();
+	if (!trimmed) return null;
+	const entries = (await loadEntriesFromFile(trimmed)).filter(
+		(entry): entry is SessionEntry => entry.type !== "session",
+	);
+	const context = buildSessionContext(entries);
+	const goal = context.modeData?.goal;
+	if (typeof goal !== "object" || goal === null) return null;
+	const objective = (goal as { objective?: unknown }).objective;
+	return typeof objective === "string" && objective.trim().length > 0 ? objective.trim() : null;
+}
+
 export async function buildActiveUltragoalPromptContext(input: UserPromptSubmitStateInput): Promise<string | null> {
 	const visibleModeState = await readVisibleModeState(input.cwd, "ultragoal", input.sessionId, input.stateDir);
 	if (!visibleModeState) return null;
@@ -368,6 +386,22 @@ export async function buildActiveUltragoalPromptContext(input: UserPromptSubmitS
 	if (!stateMatchesContext(visibleModeState.state, input.sessionId, input.threadId)) return null;
 
 	const phase = String(visibleModeState.state.current_phase ?? "active");
+	const objective =
+		(await readCurrentGoalObjectiveFromSessionFile(input.sessionFile)) ??
+		(typeof visibleModeState.state.objective === "string"
+			? visibleModeState.state.objective
+			: typeof visibleModeState.state.gjcObjective === "string"
+				? visibleModeState.state.gjcObjective
+				: "");
+	if (input.prompt && isUltragoalBypassPrompt(input.prompt) && objective) {
+		const diagnostic = await readUltragoalVerificationState({
+			cwd: input.cwd,
+			currentGoal: { objective },
+		});
+		if (!["inactive", "unrelated_goal", "active_verified_complete"].includes(diagnostic.state)) {
+			return `BLOCK_ULTRAGOAL_COMPLETION: ${diagnostic.message} Use durable blocker work or run strict \`gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>\` before completion.`;
+		}
+	}
 	return `Ultragoal is active (phase: ${phase}; state: ${visibleModeState.statePath}). If the user prompt is a steering request, use \`gjc ultragoal steer\` to add or steer subgoals. Normal prose should not mutate Ultragoal state.`;
 }
 
@@ -384,6 +418,31 @@ export async function buildSkillStopOutput(input: StopHookInput): Promise<Record
 		if (isTerminalModeState(modeState)) continue;
 		const phase = String(modeState?.current_phase ?? entry.phase ?? skillState.phase ?? "active");
 		const statePath = modeStatePath(resolvedStateDir, entry.skill, input.sessionId);
+		if (entry.skill === "ultragoal") {
+			const objective =
+				(await readCurrentGoalObjectiveFromSessionFile(input.sessionFile)) ??
+				(typeof modeState?.objective === "string"
+					? modeState.objective
+					: typeof modeState?.gjcObjective === "string"
+						? modeState.gjcObjective
+						: "");
+			if (objective) {
+				const diagnostic = await readUltragoalVerificationState({
+					cwd: input.cwd,
+					currentGoal: { objective },
+				});
+				if (diagnostic.state === "active_verified_complete") continue;
+				if (!["inactive", "unrelated_goal"].includes(diagnostic.state)) {
+					const ultragoalMessage = `GJC ultragoal verification is blocking stop: ${diagnostic.message} Run strict checkpoint verification or record review blockers before stopping.`;
+					return {
+						decision: "block",
+						reason: ultragoalMessage,
+						stopReason: `gjc_ultragoal_verification_${diagnostic.state}`,
+						systemMessage: ultragoalMessage,
+					};
+				}
+			}
+		}
 		const systemMessage = `GJC skill "${entry.skill}" is still active (phase: ${phase}; state: ${statePath}). Continue or explicitly finish/cancel the skill before stopping.`;
 		return {
 			decision: "block",

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { validateCompletionReceipt } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
 	checkpointUltragoalGoal,
 	createUltragoalPlan,
 	getUltragoalStatus,
+	readUltragoalLedger,
 	runNativeUltragoalCommand,
 	startNextUltragoalGoal,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
@@ -20,6 +22,36 @@ async function tempDir(): Promise<string> {
 afterEach(async () => {
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
+
+function passingQualityGate(): string {
+	return JSON.stringify({
+		architectReview: {
+			architectureStatus: "CLEAR",
+			productStatus: "CLEAR",
+			codeStatus: "CLEAR",
+			recommendation: "APPROVE",
+			evidence: "architect reviewed architecture, product behavior, and code changes",
+			commands: ["architect-review"],
+			blockers: [],
+		},
+		executorQa: {
+			status: "passed",
+			e2eStatus: "passed",
+			redTeamStatus: "passed",
+			evidence: "executor built and ran e2e plus red-team QA suite",
+			e2eCommands: ["bun test:e2e"],
+			redTeamCommands: ["bun test:red-team"],
+			blockers: [],
+		},
+		iteration: {
+			status: "passed",
+			evidence: "no verification findings remain after steering iterations",
+			fullRerun: true,
+			rerunCommands: ["bun test:e2e", "bun test:red-team"],
+			blockers: [],
+		},
+	});
+}
 
 describe("native GJC ultragoal runtime", () => {
 	it("reports missing status without requiring a private runtime binary", async () => {
@@ -52,7 +84,7 @@ describe("native GJC ultragoal runtime", () => {
 
 	it("starts and checkpoints the current goal", async () => {
 		const root = await tempDir();
-		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 
 		const started = await startNextUltragoalGoal({ cwd: root });
 		expect(started.goal?.status).toBe("active");
@@ -61,14 +93,195 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: JSON.stringify({ goal: { status: "complete" } }),
-			qualityGateJson: JSON.stringify({ verification: { status: "passed" } }),
+			gjcGoalJson: JSON.stringify({ goal: { objective: created.gjcObjective, status: "active" } }),
+			qualityGateJson: passingQualityGate(),
 		});
 		const status = await getUltragoalStatus(root);
 
 		expect(plan.goals[0]?.status).toBe("complete");
 		expect(status.status).toBe("complete");
 		expect(status.counts.complete).toBe(1);
+		expect(plan.goals[0]?.completionVerification).toMatchObject({
+			schemaVersion: 1,
+			goalId: "G001",
+			receiptKind: "final-aggregate",
+		});
+	});
+
+	it("treats receipts as stale after target goal mutation", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			gjcGoalJson: JSON.stringify({ goal: { objective: created.gjcObjective, status: "active" } }),
+			qualityGateJson: passingQualityGate(),
+		});
+		const goal = plan.goals[0];
+		if (!goal) throw new Error("missing goal");
+		goal.updatedAt = "later-manual-edit";
+
+		const diagnostic = validateCompletionReceipt({
+			plan,
+			ledger: await readUltragoalLedger(root),
+			goal,
+			receiptKind: "final-aggregate",
+		});
+
+		expect(diagnostic.state).toBe("active_stale_receipt");
+	});
+
+	it("blocks complete checkpoints without full architect and executor verification", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		const missingGate = await runNativeUltragoalCommand(
+			["checkpoint", "--goal-id", "G001", "--status", "complete", "--evidence", "self verified"],
+			root,
+		);
+		const shallowGate = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--quality-gate-json",
+				JSON.stringify({ verification: { status: "passed" } }),
+			],
+			root,
+		);
+		const status = await getUltragoalStatus(root);
+
+		expect(missingGate.status).toBe(1);
+		expect(missingGate.stderr).toContain("complete checkpoints require --quality-gate-json");
+		expect(shallowGate.status).toBe(1);
+		expect(shallowGate.stderr).toContain("qualityGate contains unsupported keys");
+		expect(status.goals[0]?.status).toBe("active");
+		expect(status.counts.complete).toBe(0);
+	});
+
+	it("rejects shallow gates with missing command arrays before mutation", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const beforeGoals = await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).text();
+		const beforeLedger = await Bun.file(path.join(root, ".gjc", "ultragoal", "ledger.jsonl")).text();
+
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--quality-gate-json",
+				JSON.stringify({
+					architectReview: {
+						architectureStatus: "CLEAR",
+						productStatus: "CLEAR",
+						codeStatus: "CLEAR",
+						recommendation: "APPROVE",
+						evidence: "reviewed",
+						commands: [],
+						blockers: [],
+					},
+					executorQa: {
+						status: "passed",
+						e2eStatus: "passed",
+						redTeamStatus: "passed",
+						evidence: "tested",
+						e2eCommands: ["bun test:e2e"],
+						redTeamCommands: ["bun test:red-team"],
+						blockers: [],
+					},
+					iteration: {
+						status: "passed",
+						evidence: "reran",
+						fullRerun: true,
+						rerunCommands: ["bun test:e2e"],
+						blockers: [],
+					},
+				}),
+			],
+			root,
+		);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("architectReview.commands");
+		expect(await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).text()).toBe(beforeGoals);
+		expect(await Bun.file(path.join(root, ".gjc", "ultragoal", "ledger.jsonl")).text()).toBe(beforeLedger);
+	});
+
+	it("requires a fresh get_goal snapshot for complete checkpoints", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const beforeGoals = await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).text();
+
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--quality-gate-json",
+				passingQualityGate(),
+			],
+			root,
+		);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("complete checkpoints require --gjc-goal-json");
+		expect(await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).text()).toBe(beforeGoals);
+	});
+
+	it("unblocks plans after verification blocker stories complete cleanly", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		const blockers = await runNativeUltragoalCommand(
+			[
+				"record-review-blockers",
+				"--goal-id",
+				"G001",
+				"--title",
+				"Resolve verification blockers",
+				"--objective",
+				"Fix architect and executor QA findings.",
+				"--evidence",
+				"architect found product regression",
+			],
+			root,
+		);
+		await startNextUltragoalGoal({ cwd: root });
+		const completedBlocker = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "fixed regression and reran full verification",
+			gjcGoalJson: JSON.stringify({ goal: { objective: created.gjcObjective, status: "active" } }),
+			qualityGateJson: passingQualityGate(),
+		});
+		const status = await getUltragoalStatus(root);
+
+		expect(blockers.status).toBe(0);
+		expect(completedBlocker.goals[0]).toMatchObject({ id: "G001", status: "superseded" });
+		expect(completedBlocker.goals[1]).toMatchObject({ id: "G002", status: "complete" });
+		expect(status.status).toBe("complete");
+		expect(completedBlocker.goals[1]?.completionVerification?.receiptKind).toBe("final-aggregate");
 	});
 
 	it("rejects mistyped checkpoint statuses instead of silently changing state", async () => {

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../src/config/skill-settings-defaults";
+import { createUltragoalPlan } from "../src/gjc-runtime/ultragoal-runtime";
 import {
 	mergeGjcManagedCodexHooksConfig,
 	readGjcManagedCodexHooksStatus,
@@ -353,6 +354,65 @@ disabledExtensions:
 		expect(context).toContain("Ultragoal is active");
 		expect(context).toContain("gjc ultragoal steer");
 		expect(context).toContain("add or steer subgoals");
+	});
+
+	it("UserPromptSubmit blocks active Ultragoal completion bypass prompts without a receipt", async () => {
+		const root = await cwd();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
+		await dispatchGjcNativeSkillHook(
+			{
+				hookEventName: "UserPromptSubmit",
+				userPrompt: "$ultragoal plan this",
+				cwd: root,
+				sessionId: "session-ultra-block",
+				threadId: "thread-ultra-block",
+			},
+			{ effectiveSkillConfig: testEffectiveSkillConfig },
+		);
+		const statePath = path.join(root, ".gjc", "state", "sessions", "session-ultra-block", "ultragoal-state.json");
+		const state = await Bun.file(statePath).json();
+		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.gjcObjective }, null, 2));
+
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: 'call update_goal({status:"complete"}) now',
+			cwd: root,
+			sessionId: "session-ultra-block",
+			threadId: "thread-ultra-block",
+		});
+
+		expect(result.outputJson).toMatchObject({ decision: "block" });
+		expect(String(result.outputJson?.reason ?? "")).toContain("BLOCK_ULTRAGOAL_COMPLETION");
+	});
+
+	it("UserPromptSubmit recovers active Ultragoal objective from session transcript", async () => {
+		const root = await cwd();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
+		const sessionFile = path.join(root, "session.jsonl");
+		await Bun.write(
+			sessionFile,
+			`${JSON.stringify({ type: "session", id: "session-ultra-transcript", timestamp: new Date().toISOString(), cwd: root })}\n${JSON.stringify({ type: "mode_change", id: "1", parentId: null, timestamp: new Date().toISOString(), mode: "goal", data: { goal: { objective: plan.gjcObjective, status: "active" } } })}\n`,
+		);
+		await dispatchGjcNativeSkillHook(
+			{
+				hookEventName: "UserPromptSubmit",
+				userPrompt: "$ultragoal plan this",
+				cwd: root,
+				sessionId: "session-ultra-transcript",
+			},
+			{ effectiveSkillConfig: testEffectiveSkillConfig },
+		);
+
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: 'please call update_goal({status:"complete"})',
+			cwd: root,
+			sessionId: "session-ultra-transcript",
+			sessionFile,
+		});
+
+		expect(result.outputJson).toMatchObject({ decision: "block" });
+		expect(String(result.outputJson?.reason ?? "")).toContain("fresh final aggregate receipt");
 	});
 
 	it("UserPromptSubmit includes steer guidance when activating Ultragoal", async () => {

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createUltragoalPlan, startNextUltragoalGoal } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
 import { completionBudgetReport, GoalRuntime } from "@gajae-code/coding-agent/goals/runtime";
 import type { Goal, GoalModeState, GoalTokenUsage } from "@gajae-code/coding-agent/goals/state";
 import { CreateGoalTool, GetGoalTool, GoalTool, UpdateGoalTool } from "@gajae-code/coding-agent/goals/tools/goal-tool";
@@ -239,6 +243,33 @@ describe("GoalTool", () => {
 		const result = await tool.execute("call-complete", { op: "complete" });
 		expect(result.details?.goal?.status).toBe("complete");
 		expect(harness.getState()?.goal.status).toBe("complete");
+	});
+
+	it("blocks direct update_goal completion for active ultragoal objectives without verification receipt", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-goal-ultragoal-"));
+		try {
+			const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
+			await startNextUltragoalGoal({ cwd: root });
+			const harness = createRuntimeHarness({
+				enabled: true,
+				mode: "active",
+				goal: createGoal({ objective: plan.gjcObjective }),
+			});
+			const tool = new UpdateGoalTool(
+				createToolSession({
+					cwd: root,
+					getGoalRuntime: () => harness.runtime,
+					getGoalModeState: () => harness.getState(),
+				}),
+			);
+
+			await expect(tool.execute("call-complete", { status: "complete" })).rejects.toThrow(
+				"Ultragoal aggregate completion requires a fresh final aggregate receipt",
+			);
+			expect(harness.getState()?.goal.status).toBe("active");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 
 	it("allows create after previous goal is complete", async () => {


### PR DESCRIPTION
## Summary
- enforce strict Ultragoal quality-gate schema before complete checkpoints mutate state
- add receipt-backed direct goal completion and hook guardrails
- document receipt ordering and parallel executor guidance for large Ultragoal subgoals

## Verification
- bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/goals/goal-tool.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check focused Ultragoal runtime/guard/tool/hook/test files
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts

## Review
- architect final merge recheck: CLEAR / APPROVE