### PR TITLE
Enforce deep-interview mutation boundaries

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -60,11 +60,11 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 ## Native Plugin Invocation Guard (Issue #3030)
 
-If this raw bundled skill is loaded by GJC's native skill loader through `/gajae-code:deep-interview` or `Skill("gajae-code:deep-interview")`, do not treat that path as permission to skip rendered GJC setup. The user-facing invocation is `/skill:deep-interview`; do not recommend or advertise `/deep-interview` or `/gajae-code:deep-interview` as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
+If this raw bundled skill is loaded by GJC's native skill loader through `/skill:deep-interview` or `gjc deep-interview`, do not treat that path as permission to skip rendered GJC setup. The user-facing invocation is `/skill:deep-interview`; do not recommend or advertise deprecated aliases as the deep-interview entrypoint. Regardless of invocation path, Phase 0 below remains blocking and must resolve `gjc.deepInterview.ambiguityThreshold` from settings before any announcement, state write, question, or ambiguity score.
 
 ## Phase 0: Resolve Ambiguity Threshold (blocking prerequisite)
 
-Complete this phase before Phase 1, before brownfield exploration, before `state_write`, before Round 0, and before any ambiguity scoring. Do not continue if the resolved threshold and source are unknown.
+Complete this phase before Phase 1, before brownfield exploration, before GJC state persistence, before Round 0, and before any ambiguity scoring. Do not continue if the resolved threshold and source are unknown.
 
 1. **Read threshold settings in precedence order**:
    - User settings: `[$GJC_CONFIG_DIR|~/.gjc]/settings.json`
@@ -81,7 +81,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
 
 4. **Carry threshold source forward mechanically**:
    - Substitute `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` throughout the remaining instructions before continuing.
-   - Include `threshold_source` in the first `state_write(mode="deep-interview")` state payload and preserve it on later state updates.
+   - Include `threshold_source` in the first `gjc state write` payload (or `.gjc/state/` state file) and preserve it on later state updates.
    - Include both threshold and source in the final spec metadata.
 
 ## Phase 1: Initialize
@@ -106,9 +106,9 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
    - Wait until the summary exists before ambiguity scoring, weakest-dimension selection, brownfield exploration prompts, or any bridge to `ralplan`, `execution`, `execution`, or `team`.
 3.7. **Artifact path discipline**:
    - Final specs MUST be written to `.gjc/specs/deep-interview-{slug}.md` exactly.
-   - Ephemeral interview artifacts (scoring scratchpads, prompt-safe summaries, transient queues, resume metadata) belong in `.gjc/state/` or in `state_write` state, never in the repo root or arbitrary working files.
+   - Ephemeral interview artifacts (scoring scratchpads, prompt-safe summaries, transient queues, resume metadata) belong in `.gjc/state/` or via `gjc state write` when available, never in the repo root or arbitrary working files.
 
-4. **Initialize state** via `state_write(mode="deep-interview")`:
+4. **Initialize state** via `gjc state write` when available, otherwise by writing the deep-interview state under `.gjc/state/`:
 
 ```json
 {
@@ -226,7 +226,7 @@ Build the question generation prompt with:
 - Brownfield codebase context (if applicable), summarized to cited paths/symbols/patterns instead of raw dumps
 - Locked topology from Round 0, including active components, deferred components, prior per-component scores, and `last_targeted_component_id`
 
-If any prompt input is too large, summarize it first and then continue from the summary. Do not ask the next `AskUserQuestion`, score ambiguity, or hand off to execution from an over-budget raw transcript.
+If any prompt input is too large, summarize it first and then continue from the summary. Do not ask the next the `ask` tool, score ambiguity, or hand off to execution from an over-budget raw transcript.
 
 **Question targeting strategy:**
 - Identify the active component + dimension pair with the LOWEST clarity score across the locked topology
@@ -247,7 +247,7 @@ If any prompt input is too large, summarize it first and then continue from the 
 
 ### Step 2b: Ask the Question
 
-Use `AskUserQuestion` with the generated question. Present it clearly with the current ambiguity context:
+Use the `ask` tool with the generated question. Present it clearly with the current ambiguity context:
 
 ```
 Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_rationale} | Ambiguity: {score}%
@@ -354,7 +354,7 @@ Round {n} complete.
 
 ### Step 2e: Update State
 
-Update interview state with the new round, global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, ontology snapshot, and `topology.last_targeted_component_id` via `state_write`.
+Update interview state with the new round, global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, ontology snapshot, and `topology.last_targeted_component_id` via `gjc state write`.
 
 ### Step 2f: Check Soft Limits
 
@@ -388,7 +388,7 @@ When ambiguity ≤ threshold (or hard cap / early exit):
 1. **Generate the specification** using opus model with the prompt-safe transcript. If the full interview transcript or initial context is too large, include the summary plus all concrete decisions, acceptance criteria, unresolved gaps, and ontology snapshots; never overflow the prompt with raw oversized context.
 2. **Write to file**: `.gjc/specs/deep-interview-{slug}.md`
    - Always use this exact final spec path. Do not write temporary working files to the repo root or other ad hoc paths; repos may allowlist `.gjc/` for planning artifacts while protecting product branches.
-   - For ephemeral artifacts during interview rounds (for example scoring intermediate results, prompt-safe summaries, question queues, or resume metadata), use `.gjc/state/` or in-memory state via `state_write`.
+   - For ephemeral artifacts during interview rounds (for example scoring intermediate results, prompt-safe summaries, question queues, or resume metadata), use `.gjc/state/` or in-memory state via `gjc state write`.
    - Persist the final `spec_path` in state when available so downstream skills and resumed sessions can pass the artifact path explicitly.
 
 Spec structure:
@@ -483,9 +483,9 @@ Spec structure:
 
 ## Phase 5: Execution Bridge
 
-**Research workflow override:** if `--research-setup` is active, skip the standard execution options below. The only valid bridge is the `Skill("gajae-code:research workflow")` handoff described above. The `gjc research workflow` CLI is a hard-deprecated shim and must not be used for execution.
+**Research workflow override:** if `--research-setup` is active, skip the standard execution options below and write a pending-approval spec that names research setup as an unresolved follow-up. Do not invoke deprecated research workflow shims.
 
-After the spec is written, mark it `pending approval` and present execution options via `AskUserQuestion`. Until the user selects an execution option, the deep-interview module MUST NOT run mutation-oriented shell commands, edit source files, commit, push, open PRs, invoke execution skills, or delegate implementation tasks:
+After the spec is written, mark it `pending approval` and present execution options via the `ask` tool. Until the user selects an execution option, the deep-interview module MUST NOT run mutation-oriented shell commands, edit source files, commit, push, open PRs, invoke execution skills, or delegate implementation tasks:
 
 **Question:** "Your spec is ready (ambiguity: {score}%). How would you like to proceed?"
 
@@ -493,26 +493,26 @@ After the spec is written, mark it `pending approval` and present execution opti
 
 1. **Refine with ralplan consensus (Recommended)**
    - Description: "Consensus-refine this spec with Planner/Architect/Critic, then stop for explicit execution approval. Maximum quality."
-   - Action: Only after the user selects this option, invoke `Skill("gajae-code:plan")` with `--consensus --direct` flags and the spec file path as context. The `--direct` flag skips the ralplan skill's interview phase (the deep interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.gjc/plans/`, stop with that plan marked `pending approval`; do not automatically invoke execution or any other execution skill.
+   - Action: Only after the user selects this option, invoke `/skill:ralplan` or `gjc ralplan --consensus --direct` with the spec file path as context. The `--direct` flag skips the ralplan skill's interview phase (the deep interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.gjc/plans/`, stop with that plan marked `pending approval`; do not automatically invoke execution or any other execution skill.
    - Pipeline: `deep-interview spec → explicit approval to refine → ralplan --consensus --direct → pending approval → separate execution approval`
 
 2. **Execute with team**
    - Description: "Full autonomous pipeline — planning, parallel implementation, QA, validation. Faster but without consensus refinement."
-   - Action: Invoke `Skill("gajae-code:execution")` with the spec file path as context only after the user explicitly selects this execution option. The spec replaces execution's Phase 0 — execution starts at Phase 1 (Planning).
+   - Action: Invoke `/skill:team` or `gjc team` with the spec file path as context only after the user explicitly selects this execution option. The spec replaces team planning input.
 
 3. **Execute with team**
    - Description: "Persistence loop with architect verification — keeps working until all acceptance criteria pass"
-   - Action: Invoke `Skill("gajae-code:execution")` with the spec file path as the task definition.
+   - Action: Invoke `/skill:team` or `gjc team` with the spec file path as the task definition.
 
 4. **Execute with team**
    - Description: "N coordinated parallel agents — fastest execution for large specs"
-   - Action: Invoke `Skill("gajae-code:team")` with the spec file path as the shared plan.
+   - Action: Invoke `/skill:team` or `gjc team` with the spec file path as the shared plan.
 
 5. **Refine further**
    - Description: "Continue interviewing to improve clarity (current: {score}%)"
    - Action: Return to Phase 2 interview loop.
 
-**IMPORTANT:** On explicit execution selection, **MUST** invoke the chosen skill via `Skill()`. Do NOT implement directly. The deep-interview agent is a requirements agent, not an execution agent. If oversized initial context was summarized, pass the spec and prompt-safe summary forward, not the raw oversized source material. Without explicit execution selection, stop with the spec marked `pending approval`.
+**IMPORTANT:** On explicit execution selection, **MUST** use the chosen public GJC workflow entrypoint (`/skill:ralplan`, `/skill:team`, `gjc ralplan`, or `gjc team`). Do NOT implement directly. The deep-interview agent is a requirements agent, not an execution agent. If oversized initial context was summarized, pass the spec and prompt-safe summary forward, not the raw oversized source material. Without explicit execution selection, stop with the spec marked `pending approval`.
 
 ### Approval-Gated Refinement Path (Recommended)
 
@@ -541,14 +541,14 @@ Skipping any stage is possible but reduces quality assurance:
 </Steps>
 
 <Tool_Usage>
-- Use `AskUserQuestion` for each interview question — provides clickable UI with contextual options
-- Preserve the AskUserQuestion path for GJC-native interaction; do not introduce GJC-only structured-question transport into this skill
-- Use `Task(subagent_type="gajae-code:explore", model="haiku")` for brownfield codebase exploration (run BEFORE asking user about codebase)
+- Use the `ask` tool for each interview question — provides clickable UI with contextual options
+- Preserve the GJC `ask` tool path for native interaction; do not introduce parallel structured-question transport into this skill
+- Use `read/search/find exploration or a bounded read-only planner/architect subagent` for brownfield codebase exploration (run BEFORE asking user about codebase)
 - Use opus model (temperature 0.1) for ambiguity scoring — consistency is critical
 - Round 0 topology confirmation happens before ambiguity scoring; Phase 2 scoring must honor locked topology and rotate targeting across active components when more than one is present
-- Use `state_write` / `state_read` for interview state persistence; the initial and subsequent deep-interview state payloads must include `threshold_source` alongside `threshold`
-- Use `Write` tool to save the final spec to `.gjc/specs/deep-interview-{slug}.md` exactly; use `.gjc/state/` or `state_write` for ephemeral artifacts
-- Use `Skill()` to bridge to execution modes only after explicit execution approval — never implement directly
+- Use `gjc state write` / `gjc state read` for interview state persistence; the initial and subsequent deep-interview state payloads must include `threshold_source` alongside `threshold`
+- Use the `write` tool to save the final spec to `.gjc/specs/deep-interview-{slug}.md` exactly; use `.gjc/state/` or `gjc state write` for ephemeral artifacts
+- Use public GJC workflow entrypoints to bridge to ralplan/team only after explicit execution approval — never implement directly
 - Challenge agent modes are prompt injections, not separate agent spawns
 </Tool_Usage>
 
@@ -671,12 +671,12 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 - [ ] Ambiguity score displayed after every round
 - [ ] Every round explicitly names the weakest dimension and why it is the next target
 - [ ] Challenge agents activated at correct thresholds (round 4, 6, 8)
-- [ ] Spec file written to `.gjc/specs/deep-interview-{slug}.md` exactly; ephemeral artifacts stayed under `.gjc/state/` or `state_write`
+- [ ] Spec file written to `.gjc/specs/deep-interview-{slug}.md` exactly; ephemeral artifacts stayed under `.gjc/state/` or `gjc state write`
 - [ ] Spec includes: topology, goal, constraints, acceptance criteria, clarity breakdown, transcript
-- [ ] Execution bridge presented via AskUserQuestion
-- [ ] Selected execution mode invoked via Skill() only after explicit execution approval (never direct implementation)
+- [ ] Execution bridge presented via the `ask` tool
+- [ ] Selected execution mode invoked via public GJC workflow entrypoint only after explicit execution approval (never direct implementation)
 - [ ] If 3-stage pipeline selected: ralplan --consensus --direct invoked, then stopped with the consensus plan marked `pending approval` until the user explicitly approves execution
-- [ ] State cleaned up after execution handoff
+- [ ] State cleaned up after approved workflow handoff
 - [ ] Brownfield confirmation questions cite repo evidence (file/path/pattern) before asking the user to decide
 - [ ] Scope-fuzzy tasks can trigger ontology-style questioning to stabilize the core entity before feature elaboration
 - [ ] Round 0 topology gate completed before ambiguity scoring and persisted `topology.confirmed_at`
@@ -712,17 +712,17 @@ Optional settings in `.gjc/settings.json`:
 
 If interrupted, run `/skill:deep-interview` again. The skill reads state from `.gjc/state/deep-interview-state.json` and resumes from the last completed round.
 
-## Integration with Staged execution
+## Integration with staged team routing
 
 When team receives a vague input (no file paths, function names, or concrete anchors), it can redirect to deep-interview:
 
 ```
 User: "team build me a thing"
-Staged execution: "Your request is quite open-ended. Would you like to run a deep interview first to clarify requirements?"
+Team routing: "Your request is quite open-ended. Would you like to run a deep interview first to clarify requirements?"
   [Yes, interview first] [No, expand directly]
 ```
 
-If the user chooses interview, execution invokes `/skill:deep-interview`. When the interview completes and the user selects "Execute with team", the spec becomes Phase 0 output and execution continues from Phase 1 (Planning).
+If the user chooses interview, team routing invokes `/skill:deep-interview`. When the interview completes and the user selects "Execute with team", the spec becomes Phase 0 output and team proceeds from the approved spec.
 
 ## Approval-Gated Pipeline: deep-interview → ralplan → pending approval
 
@@ -753,7 +753,7 @@ The recommended refinement path chains clarity and feasibility gates, then stops
 
 ## Integration with Ralplan Gate
 
-The ralplan pre-execution gate already redirects vague prompts to planning. Deep interview can serve as an alternative redirect target for prompts that are too vague even for ralplan:
+The ralplan pre-approval gate already redirects vague prompts to planning. Deep interview can serve as an alternative redirect target for prompts that are too vague even for ralplan:
 
 ```
 Vague prompt → ralplan gate → deep-interview (if extremely vague) → ralplan (with clear spec) → pending approval → explicitly approved execution

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -167,6 +167,7 @@ import {
 import { deobfuscateSessionContext, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatNoCredentialOnboardingError, formatNoModelOnboardingError } from "../setup/model-onboarding-guidance";
 import { isCanonicalGjcWorkflowSkill, syncSkillActiveState } from "../skill-state/active-state";
+import { assertDeepInterviewMutationAllowed } from "../skill-state/deep-interview-mutation-guard";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import { resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
 import {
@@ -3273,6 +3274,35 @@ export class AgentSession {
 		}) as T;
 	}
 
+	/**
+	 * Wrap a tool with the deep-interview mutation guard. This guard is intentionally
+	 * outermost so active interviews reject product-code mutation before ACP permission
+	 * prompts or tool execution can run.
+	 */
+	#wrapToolForDeepInterviewMutationGuard<T extends AgentTool>(tool: T): T {
+		if (!["edit", "write", "ast_edit"].includes(tool.name)) return tool;
+		return new Proxy(tool, {
+			get: (target, prop) => {
+				if (prop !== "execute") return Reflect.get(target, prop, target);
+				return async (
+					toolCallId: string,
+					args: unknown,
+					signal: AbortSignal | undefined,
+					onUpdate: never,
+					ctx: never,
+				) => {
+					await assertDeepInterviewMutationAllowed({
+						cwd: this.sessionManager.getCwd(),
+						sessionId: this.sessionManager.getSessionId(),
+						tool: target,
+						args,
+					});
+					return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
+				};
+			},
+		}) as T;
+	}
+
 	async #applyActiveToolsByName(
 		toolNames: string[],
 		options?: { persistMCPSelection?: boolean; previousSelectedMCPToolNames?: string[] },
@@ -3284,7 +3314,7 @@ export class AgentSession {
 		for (const name of toolNames) {
 			const tool = this.#toolRegistry.get(name);
 			if (tool) {
-				tools.push(this.#wrapToolForAcpPermission(tool));
+				tools.push(this.#wrapToolForDeepInterviewMutationGuard(this.#wrapToolForAcpPermission(tool)));
 				validToolNames.push(name);
 			}
 		}

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -1,0 +1,303 @@
+import * as path from "node:path";
+import type { AgentTool } from "@gajae-code/agent-core";
+import { expandApplyPatchToEntries } from "../edit/modes/apply-patch";
+import { LocalProtocolHandler, resolveLocalUrlToPath } from "../internal-urls/local-protocol";
+import { resolveToCwd } from "../tools/path-utils";
+import { ToolError } from "../tools/tool-errors";
+import { listActiveSkills, readVisibleSkillActiveState, type SkillActiveEntry } from "./active-state";
+
+export const DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE =
+	"Deep-interview is active; either continue interviewing with `ask`, or write/finalize the pending spec under `.gjc/specs/` / update state under `.gjc/state/`. Do not edit product code until explicit execution approval.";
+
+const BLOCKED_TOOL_NAMES = new Set(["edit", "write", "ast_edit"]);
+const ARCHIVE_OR_SQLITE_BASE_RE = /^(.+?\.(?:tar\.gz|sqlite3|sqlite|db3|zip|tgz|tar|db))(?:$|:)/i;
+const INTERNAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const GLOB_META_RE = /[*?[\]{}]/;
+const VIM_FILE_SWITCH_RE = /^\s*:(?:e|e!|edit|edit!)(?:\s+([^<\r\n]+))?(?:<CR>|\r|\n|$)/i;
+
+type ToolWithEditMode = AgentTool & {
+	mode?: unknown;
+	customWireName?: unknown;
+};
+
+export interface DeepInterviewMutationGuardInput {
+	cwd: string;
+	sessionId?: string;
+	threadId?: string;
+	tool: ToolWithEditMode;
+	args: unknown;
+}
+
+interface ExtractedTargets {
+	paths: string[];
+	unknown: boolean;
+}
+
+export interface DeepInterviewMutationDecision {
+	blocked: boolean;
+	message?: string;
+	targets: string[];
+	reason?: string;
+}
+
+interface ModeState {
+	active?: boolean;
+	current_phase?: string;
+	session_id?: string;
+	thread_id?: string;
+	[key: string]: unknown;
+}
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
+function modeStatePath(cwd: string, skill: string, sessionId?: string): string {
+	const stateDir = path.join(cwd, ".gjc", "state");
+	const fileName = `${skill}-state.json`;
+	if (sessionId) return path.join(stateDir, "sessions", encodePathSegment(sessionId), fileName);
+	return path.join(stateDir, fileName);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+	try {
+		return JSON.parse(await Bun.file(filePath).text()) as T;
+	} catch {
+		return null;
+	}
+}
+async function readVisibleModeState(cwd: string, skill: string, sessionId?: string): Promise<ModeState | null> {
+	if (sessionId) {
+		const sessionState = await readJsonFile<ModeState>(modeStatePath(cwd, skill, sessionId));
+		if (sessionState) return sessionState;
+	}
+	return await readJsonFile<ModeState>(modeStatePath(cwd, skill));
+}
+
+function isTerminalModeState(state: ModeState | null): boolean {
+	if (!state || state.active !== true) return true;
+	const phase = String(state.current_phase ?? "")
+		.trim()
+		.toLowerCase();
+	return ["complete", "completed", "failed", "cancelled", "canceled", "inactive"].includes(phase);
+}
+
+function entryMatchesContext(entry: SkillActiveEntry, sessionId?: string, threadId?: string): boolean {
+	if (sessionId && entry.session_id && entry.session_id !== sessionId) return false;
+	if (threadId && entry.thread_id && entry.thread_id !== threadId) return false;
+	return true;
+}
+
+function modeStateMatchesContext(state: ModeState, sessionId?: string, threadId?: string): boolean {
+	if (sessionId && state.session_id && state.session_id !== sessionId) return false;
+	if (threadId && state.thread_id && state.thread_id !== threadId) return false;
+	return true;
+}
+
+async function isActiveDeepInterview(cwd: string, sessionId?: string, threadId?: string): Promise<boolean> {
+	const skillState = await readVisibleSkillActiveState(cwd, sessionId);
+	const activeDeepInterview = listActiveSkills(skillState).find(
+		entry => entry.skill === "deep-interview" && entryMatchesContext(entry, sessionId, threadId),
+	);
+	if (!activeDeepInterview) return false;
+
+	const modeState = await readVisibleModeState(cwd, "deep-interview", sessionId);
+	if (isTerminalModeState(modeState)) return false;
+	if (modeState && !modeStateMatchesContext(modeState, sessionId, threadId)) return false;
+	return true;
+}
+
+function normalizePosix(value: string): string {
+	return value.replace(/\\/g, "/");
+}
+
+function addPath(targets: ExtractedTargets, value: unknown): void {
+	if (typeof value === "string" && value.trim().length > 0) {
+		targets.paths.push(value.trim());
+	}
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function extractWriteTargets(args: unknown): ExtractedTargets {
+	const record = getRecord(args);
+	const targets: ExtractedTargets = { paths: [], unknown: false };
+	addPath(targets, record?.path);
+	if (targets.paths.length === 0) targets.unknown = true;
+	return targets;
+}
+
+function extractAstEditTargets(args: unknown): ExtractedTargets {
+	const record = getRecord(args);
+	const targets: ExtractedTargets = { paths: [], unknown: false };
+	const paths = record?.paths;
+	if (Array.isArray(paths)) {
+		for (const entry of paths) addPath(targets, entry);
+	}
+	if (targets.paths.length === 0) targets.unknown = true;
+	return targets;
+}
+
+function extractVimSwitchTargets(steps: unknown, targets: ExtractedTargets): void {
+	if (!Array.isArray(steps)) return;
+	for (const step of steps) {
+		const record = getRecord(step);
+		const keys = record?.kbd;
+		if (!Array.isArray(keys)) continue;
+		for (const key of keys) {
+			if (typeof key !== "string") continue;
+			const match = key.match(VIM_FILE_SWITCH_RE);
+			if (!match) continue;
+			const targetPath = match[1]?.trim();
+			if (!targetPath) {
+				targets.unknown = true;
+				continue;
+			}
+			targets.paths.push(targetPath);
+		}
+	}
+}
+
+function extractApplyPatchTargets(args: unknown, targets: ExtractedTargets): boolean {
+	const record = getRecord(args);
+	const input = record?.input;
+	if (typeof input !== "string") return false;
+	try {
+		for (const entry of expandApplyPatchToEntries({ input })) {
+			addPath(targets, entry.path);
+			addPath(targets, entry.rename);
+		}
+	} catch {
+		targets.unknown = true;
+	}
+	return true;
+}
+
+function extractEditTargets(args: unknown, tool: ToolWithEditMode): ExtractedTargets {
+	const record = getRecord(args);
+	const targets: ExtractedTargets = { paths: [], unknown: false };
+	const customWireName = safeString(tool.customWireName);
+	const mode = safeString(tool.mode);
+
+	const isApplyPatchMode = customWireName === "apply_patch" || mode === "apply_patch";
+	const hasApplyPatchInput = typeof record?.input === "string";
+	if (isApplyPatchMode || hasApplyPatchInput) {
+		extractApplyPatchTargets(args, targets);
+		if (targets.paths.length === 0) targets.unknown = true;
+		return targets;
+	}
+
+	addPath(targets, record?.path);
+	addPath(targets, record?.file);
+	const edits = record?.edits;
+	if (Array.isArray(edits)) {
+		for (const edit of edits) {
+			const editRecord = getRecord(edit);
+			addPath(targets, editRecord?.rename);
+			addPath(targets, editRecord?.path);
+		}
+	}
+	if (record?.file !== undefined || mode === "vim") {
+		extractVimSwitchTargets(record?.steps, targets);
+	}
+	if (targets.paths.length === 0) targets.unknown = true;
+	return targets;
+}
+
+function extractTargets(tool: ToolWithEditMode, args: unknown): ExtractedTargets {
+	if (tool.name === "write") return extractWriteTargets(args);
+	if (tool.name === "ast_edit") return extractAstEditTargets(args);
+	if (tool.name === "edit") return extractEditTargets(args, tool);
+	return { paths: [], unknown: true };
+}
+
+function stripSelectorBase(rawPath: string): string {
+	const archiveOrSqlite = rawPath.match(ARCHIVE_OR_SQLITE_BASE_RE);
+	if (archiveOrSqlite?.[1]) return archiveOrSqlite[1];
+	return rawPath;
+}
+
+function resolveRawPath(cwd: string, rawPath: string): { absolutePath?: string; unknown: boolean } {
+	const normalized = rawPath.trim();
+	if (!normalized) return { unknown: true };
+	if (normalized === ".") return { absolutePath: path.resolve(cwd), unknown: false };
+	if (normalized.startsWith("local://") || normalized.startsWith("local:/")) {
+		const options = LocalProtocolHandler.resolveOptions();
+		if (!options) return { unknown: true };
+		try {
+			return { absolutePath: resolveLocalUrlToPath(normalized, options), unknown: false };
+		} catch {
+			return { unknown: true };
+		}
+	}
+	if (INTERNAL_SCHEME_RE.test(normalized)) return { unknown: true };
+
+	const basePath = stripSelectorBase(normalized);
+	try {
+		return { absolutePath: resolveToCwd(basePath, cwd), unknown: false };
+	} catch {
+		return { unknown: true };
+	}
+}
+
+function isAllowlistedPath(cwd: string, rawPath: string): boolean {
+	const { absolutePath, unknown } = resolveRawPath(cwd, rawPath);
+	if (unknown || !absolutePath) return false;
+	const relative = path.relative(path.resolve(cwd), path.resolve(absolutePath));
+	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return false;
+	const segments = normalizePosix(relative).split("/").filter(Boolean);
+	return segments[0] === ".gjc" && (segments[1] === "specs" || segments[1] === "state");
+}
+
+function allTargetsAllowlisted(cwd: string, targets: ExtractedTargets): boolean {
+	if (targets.unknown || targets.paths.length === 0) return false;
+	return targets.paths.every(rawPath => {
+		if (GLOB_META_RE.test(rawPath)) {
+			return isAllowlistedPath(cwd, rawPath);
+		}
+		return isAllowlistedPath(cwd, rawPath);
+	});
+}
+
+export async function assertDeepInterviewMutationRawPathsAllowed(input: {
+	cwd: string;
+	sessionId?: string;
+	threadId?: string;
+	rawPaths: string[];
+}): Promise<void> {
+	if (!(await isActiveDeepInterview(input.cwd, input.sessionId, input.threadId))) return;
+	const targets: ExtractedTargets = { paths: input.rawPaths, unknown: input.rawPaths.length === 0 };
+	if (!allTargetsAllowlisted(input.cwd, targets)) {
+		throw new ToolError(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+	}
+}
+
+export async function getDeepInterviewMutationDecision(
+	input: DeepInterviewMutationGuardInput,
+): Promise<DeepInterviewMutationDecision> {
+	if (!BLOCKED_TOOL_NAMES.has(input.tool.name)) return { blocked: false, targets: [] };
+	if (!(await isActiveDeepInterview(input.cwd, input.sessionId, input.threadId))) {
+		return { blocked: false, targets: [] };
+	}
+	const targets = extractTargets(input.tool, input.args);
+	if (allTargetsAllowlisted(input.cwd, targets)) {
+		return { blocked: false, targets: targets.paths };
+	}
+	return {
+		blocked: true,
+		message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
+		targets: targets.paths,
+		reason: targets.unknown ? "unknown-target" : "product-target",
+	};
+}
+
+export async function assertDeepInterviewMutationAllowed(input: DeepInterviewMutationGuardInput): Promise<void> {
+	const decision = await getDeepInterviewMutationDecision(input);
+	if (decision.blocked) throw new ToolError(decision.message ?? DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -16,7 +16,16 @@
  */
 
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
-import { type Component, Container, Markdown, renderInlineMarkdown, TERMINAL, Text } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	Markdown,
+	renderInlineMarkdown,
+	TERMINAL,
+	Text,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@gajae-code/tui";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
@@ -598,6 +607,31 @@ function renderCustomInput(
 	return text;
 }
 
+interface RenderOptionListEntry {
+	prefix: string;
+	label: string;
+}
+
+class AskOptionList implements Component {
+	constructor(private readonly entries: RenderOptionListEntry[]) {}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+		for (const entry of this.entries) {
+			const prefixWidth = visibleWidth(entry.prefix);
+			const availableWidth = Math.max(1, width - prefixWidth);
+			const wrapped = wrapTextWithAnsi(entry.label, availableWidth);
+			const continuation = " ".repeat(prefixWidth);
+			for (let i = 0; i < wrapped.length; i++) {
+				lines.push(`${i === 0 ? entry.prefix : continuation}${wrapped[i]}`);
+			}
+		}
+		return lines;
+	}
+
+	invalidate(): void {}
+}
+
 export const askToolRenderer = {
 	renderCall(args: AskRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const label = formatTitle("Ask", uiTheme);
@@ -625,16 +659,18 @@ export const askToolRenderer = {
 				);
 				container.addChild(new Markdown(q.question, 3, 0, mdTheme, accentStyle));
 
-				if (q.options?.length) {
-					let optText = "";
-					for (let j = 0; j < q.options.length; j++) {
-						const opt = q.options[j];
-						const isLastOpt = j === q.options.length - 1;
+				const qOptions = q.options;
+				if (qOptions?.length) {
+					const entries = qOptions.map((opt, j) => {
+						const isLastOpt = j === qOptions.length - 1;
 						const optBranch = isLastOpt ? uiTheme.tree.last : uiTheme.tree.branch;
 						const optLabel = renderInlineMarkdown(opt.label, mdTheme, t => uiTheme.fg("muted", t));
-						optText += `\n ${uiTheme.fg("dim", continuation)}   ${uiTheme.fg("dim", optBranch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} ${optLabel}`;
-					}
-					container.addChild(new Text(optText, 0, 0));
+						return {
+							prefix: ` ${uiTheme.fg("dim", continuation)}   ${uiTheme.fg("dim", optBranch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} `,
+							label: optLabel,
+						};
+					});
+					container.addChild(new AskOptionList(entries));
 				}
 			}
 			return container;
@@ -652,16 +688,18 @@ export const askToolRenderer = {
 		container.addChild(new Text(`${label}${formatMeta(meta, uiTheme)}`, 0, 0));
 		container.addChild(new Markdown(args.question, 1, 0, mdTheme, accentStyle));
 
-		if (args.options?.length) {
-			let optText = "";
-			for (let i = 0; i < args.options.length; i++) {
-				const opt = args.options[i];
-				const isLast = i === args.options.length - 1;
+		const options = args.options;
+		if (options?.length) {
+			const entries = options.map((opt, i) => {
+				const isLast = i === options.length - 1;
 				const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
 				const optLabel = renderInlineMarkdown(opt.label, mdTheme, t => uiTheme.fg("muted", t));
-				optText += `\n ${uiTheme.fg("dim", branch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} ${optLabel}`;
-			}
-			container.addChild(new Text(optText, 0, 0));
+				return {
+					prefix: ` ${uiTheme.fg("dim", branch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} `,
+					label: optLabel,
+				};
+			});
+			container.addChild(new AskOptionList(entries));
 		}
 
 		return container;

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -9,6 +9,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { computeLineHash, HL_BODY_SEP } from "../hashline/hash";
 import type { Theme } from "../modes/theme/theme";
 import astEditDescription from "../prompts/tools/ast-edit.md" with { type: "text" };
+import { assertDeepInterviewMutationRawPathsAllowed } from "../skill-state/deep-interview-mutation-guard";
 import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
@@ -322,10 +323,16 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 			if (!result.applied && result.totalReplacements > 0) {
 				const previewReplacementPlural = result.totalReplacements !== 1 ? "s" : "";
 				const previewFilePlural = result.filesTouched !== 1 ? "s" : "";
+				const previewedFiles = fileList;
 				queueResolveHandler(this.session, {
 					label: `AST Edit: ${result.totalReplacements} replacement${previewReplacementPlural} in ${result.filesTouched} file${previewFilePlural}`,
 					sourceToolName: this.name,
 					apply: async (_reason: string) => {
+						await assertDeepInterviewMutationRawPathsAllowed({
+							cwd: this.session.cwd,
+							sessionId: this.session.getSessionId?.() ?? undefined,
+							rawPaths: previewedFiles,
+						});
 						const applyResult = await runAstEditOnce(multiTargets, resolvedSearchPath, globFilter, {
 							rewrites: normalizedRewrites,
 							dryRun: false,

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentTool } from "@gajae-code/agent-core";
+import {
+	assertDeepInterviewMutationRawPathsAllowed,
+	DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
+	getDeepInterviewMutationDecision,
+} from "@gajae-code/coding-agent/skill-state/deep-interview-mutation-guard";
+import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
+
+const tempRoots: string[] = [];
+
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
+async function makeTempRoot(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-deep-interview-guard-"));
+	tempRoots.push(root);
+	return root;
+}
+
+async function writeActiveDeepInterview(cwd: string, sessionId = "session-a", phase = "interviewing"): Promise<void> {
+	const now = new Date().toISOString();
+	const sessionDir = path.join(cwd, ".gjc", "state", "sessions", encodePathSegment(sessionId));
+	await fs.mkdir(sessionDir, { recursive: true });
+	const activeState = {
+		version: 1,
+		active: true,
+		skill: "deep-interview",
+		phase,
+		updated_at: now,
+		active_skills: [
+			{
+				skill: "deep-interview",
+				phase,
+				active: true,
+				updated_at: now,
+				session_id: sessionId,
+			},
+		],
+	};
+	await Bun.write(path.join(sessionDir, "skill-active-state.json"), `${JSON.stringify(activeState, null, 2)}\n`);
+	await Bun.write(
+		path.join(sessionDir, "deep-interview-state.json"),
+		`${JSON.stringify({ active: true, current_phase: phase, session_id: sessionId }, null, 2)}\n`,
+	);
+}
+
+function tool(name: string, extra: Record<string, unknown> = {}): AgentTool {
+	return {
+		name,
+		label: name,
+		description: name,
+		parameters: {} as never,
+		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		...extra,
+	} as AgentTool;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("deep-interview mutation guard", () => {
+	it("blocks product write/edit/ast_edit targets while deep-interview is active", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const [name, args] of [
+			["write", { path: "packages/coding-agent/src/foo.ts", content: "x" }],
+			["edit", { path: "src/foo.ts", edits: [{ old_text: "a", new_text: "b" }] }],
+			["ast_edit", { paths: ["packages/**"], ops: [{ pat: "foo", out: "bar" }] }],
+		] as const) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool(name),
+				args,
+			});
+			expect(decision.blocked).toBe(true);
+			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+		}
+	});
+
+	it("allows .gjc/specs and .gjc/state targets while deep-interview is active", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		const allowedCases: Array<[string, AgentTool, unknown]> = [
+			["write spec", tool("write"), { path: ".gjc/specs/deep-interview-x.md", content: "x" }],
+			["write state", tool("write"), { path: ".gjc/state/deep-interview-x.json", content: "{}" }],
+			[
+				"edit spec",
+				tool("edit"),
+				{ path: ".gjc/specs/deep-interview-x.md", edits: [{ old_text: "a", new_text: "b" }] },
+			],
+			[
+				"apply_patch spec",
+				tool("edit", { mode: "apply_patch", customWireName: "apply_patch" }),
+				{
+					input: "*** Begin Patch\n*** Update File: .gjc/specs/deep-interview-x.md\n@@\n-a\n+b\n*** End Patch\n",
+				},
+			],
+			[
+				"vim spec",
+				tool("edit", { mode: "vim" }),
+				{ file: ".gjc/specs/deep-interview-x.md", steps: [{ kbd: [":edit .gjc/state/note.md<CR>"] }] },
+			],
+			["ast_edit state", tool("ast_edit"), { paths: [".gjc/state/**/*.md"], ops: [{ pat: "foo", out: "bar" }] }],
+		];
+
+		for (const [, targetTool, args] of allowedCases) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: targetTool,
+				args,
+			});
+			expect(decision.blocked).toBe(false);
+		}
+	});
+
+	it("rejects path containment bypasses and mixed target sets", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const rawPath of [
+			".gjc/specs-evil/plan.md",
+			".gjc/stateful/data.json",
+			"../outside.md",
+			path.join(os.tmpdir(), "outside-gjc-plan.md"),
+			"agent://123",
+			"product/archive.zip:product.ts",
+			"data.sqlite:rows:1",
+		]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("write"),
+				args: { path: rawPath, content: "x" },
+			});
+			expect(decision.blocked).toBe(true);
+		}
+
+		const mixed = await getDeepInterviewMutationDecision({
+			cwd,
+			sessionId: "session-a",
+			tool: tool("ast_edit"),
+			args: { paths: [".gjc/specs/**/*.md", "packages/**"], ops: [{ pat: "foo", out: "bar" }] },
+		});
+		expect(mixed.blocked).toBe(true);
+	});
+
+	it("blocks vim file-switch bypasses", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		const decision = await getDeepInterviewMutationDecision({
+			cwd,
+			sessionId: "session-a",
+			tool: tool("edit", { mode: "vim" }),
+			args: {
+				file: ".gjc/specs/deep-interview-x.md",
+				steps: [{ kbd: [":edit packages/coding-agent/src/product.ts<CR>", "iunsafe"] }],
+			},
+		});
+
+		expect(decision.blocked).toBe(true);
+		expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+	});
+
+	it("does not block after deep-interview reaches a terminal phase", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd, "session-a", "complete");
+
+		const decision = await getDeepInterviewMutationDecision({
+			cwd,
+			sessionId: "session-a",
+			tool: tool("write"),
+			args: { path: "src/product.ts", content: "x" },
+		});
+		expect(decision.blocked).toBe(false);
+	});
+
+	it("guards deferred ast_edit apply targets while deep-interview is active", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		await expect(
+			assertDeepInterviewMutationRawPathsAllowed({
+				cwd,
+				sessionId: "session-a",
+				rawPaths: ["packages/coding-agent/src/product.ts"],
+			}),
+		).rejects.toBeInstanceOf(ToolError);
+		await expect(
+			assertDeepInterviewMutationRawPathsAllowed({
+				cwd,
+				sessionId: "session-a",
+				rawPaths: [".gjc/specs/deep-interview-x.md"],
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -169,6 +169,30 @@ Project executor override body.
 		expect(ultragoal).toContain("become unrecoverably wrong");
 	});
 
+	it("keeps bundled deep-interview skill on GJC-native workflow vocabulary", () => {
+		const deepInterview = getDefaultGjcDefinitions().find(definition => definition.name === "deep-interview");
+		expect(deepInterview).toBeDefined();
+		const content = deepInterview?.content ?? "";
+
+		for (const required of ["ask", ".gjc/state", "pending approval"]) {
+			expect(content).toContain(required);
+		}
+		expect(content).toMatch(/\/skill:ralplan|gjc ralplan/);
+		expect(content).toMatch(/\/skill:team|gjc team/);
+
+		for (const forbidden of [
+			"AskUserQuestion",
+			"AskUserQuestionTool",
+			"state_write",
+			"state_read",
+			"Skill(",
+			"gajae-code:",
+			"/gajae-code",
+		]) {
+			expect(content).not.toContain(forbidden);
+		}
+	});
+
 	it("installs bundled workflow skill definitions without overwriting local edits unless forced", async () => {
 		const targetRoot = await makeTempRoot();
 		const initial = await installDefaultGjcDefinitions({ targetRoot });

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/hooks/codex-native-hooks-config";
 import { dispatchGjcNativeSkillHook } from "../src/hooks/native-skill-hook";
 import { detectSkillKeywords, readVisibleSkillActiveState } from "../src/hooks/skill-state";
+import { getDeepInterviewMutationDecision } from "../src/skill-state/deep-interview-mutation-guard";
 
 describe("GJC native skill-state hooks", () => {
 	let tempDir: string | undefined;
@@ -81,6 +82,40 @@ describe("GJC native skill-state hooks", () => {
 		);
 		const modeState = await Bun.file(state?.initialized_state_path ?? "").json();
 		expect(modeState).toMatchObject({ active: true, current_phase: "interviewing", session_id: "session-1" });
+	});
+
+	it("rich deep-interview prompt activation blocks guarded product mutation and allows spec artifacts", async () => {
+		const root = await cwd();
+		await dispatchGjcNativeSkillHook(
+			{
+				hookEventName: "UserPromptSubmit",
+				userPrompt:
+					"$deep-interview implement this detailed feature with runtime guards, tests, renderer changes, and visible-definition gates",
+				cwd: root,
+				sessionId: "session-rich",
+				threadId: "thread-rich",
+			},
+			{ effectiveSkillConfig: testEffectiveSkillConfig },
+		);
+
+		const state = await readVisibleSkillActiveState(root, "session-rich");
+		expect(state).toMatchObject({ active: true, skill: "deep-interview" });
+
+		const blocked = await getDeepInterviewMutationDecision({
+			cwd: root,
+			sessionId: "session-rich",
+			tool: { name: "write" } as never,
+			args: { path: "packages/coding-agent/src/product.ts", content: "unsafe" },
+		});
+		expect(blocked.blocked).toBe(true);
+
+		const allowed = await getDeepInterviewMutationDecision({
+			cwd: root,
+			sessionId: "session-rich",
+			tool: { name: "write" } as never,
+			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
+		});
+		expect(allowed.blocked).toBe(false);
 	});
 
 	it("encodes hook session ids before writing skill and mode state paths", async () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -643,6 +643,57 @@ describe("AskTool custom input", () => {
 	});
 });
 
+describe("AskTool option rendering", () => {
+	it("wraps long single-question option labels without ellipsis", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		const longLabel =
+			"Wrap this long option label across multiple indented lines so the entire choice remains visible to the user";
+		const rendered = askToolRenderer.renderCall(
+			{
+				question: "Choose one",
+				options: [{ label: longLabel }, { label: "short" }],
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+		);
+		const lines = stripAnsi(rendered.render(44).join("\n")).split("\n");
+		const renderedText = lines.join("\n");
+
+		expect(renderedText).toContain("Wrap this long option label across");
+		expect(renderedText).toContain("choice remains visible");
+		expect(renderedText).not.toContain("...");
+		expect(lines.some(line => /^\s{5,}multiple indented lines/.test(line))).toBe(true);
+	});
+
+	it("wraps long multi-question option labels under their option prefix", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		const longLabel =
+			"Keep every multi question option fully readable by wrapping continuation text under the checkbox prefix";
+		const rendered = askToolRenderer.renderCall(
+			{
+				questions: [
+					{
+						id: "render",
+						question: "Choose one",
+						options: [{ label: longLabel }, { label: "short" }],
+					},
+				],
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+		);
+		const lines = stripAnsi(rendered.render(48).join("\n")).split("\n");
+		const renderedText = lines.join("\n");
+
+		expect(renderedText).toContain("Keep every multi question option fully");
+		expect(renderedText).toContain("under the checkbox prefix");
+		expect(renderedText).not.toContain("...");
+		expect(lines.some(line => /^\s{8,}.*readable by wrapping/.test(line))).toBe(true);
+	});
+});
+
 describe("AskTool multiline custom input rendering", () => {
 	it("renders multiline custom answer as one block, not multiple checked items", async () => {
 		const tool = new AskTool(createSession());


### PR DESCRIPTION
## Summary
- Add runtime guard that blocks product edit/write/ast_edit while deep-interview is active, with .gjc/specs and .gjc/state allowlist
- Guard deferred ast_edit apply and vim file-switch paths
- Update deep-interview bundled skill wording to GJC-native ask/state/skill vocabulary
- Wrap long ask option labels instead of truncating with ellipsis

## Verification
- bun test packages/coding-agent/test/deep-interview-mutation-guard.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts
- bun run check:ts
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict

## Ultragoal
- G001 checkpointed complete in .gjc/ultragoal/ledger.jsonl
