### PR TITLE
Make composer look like an input box

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -121,9 +121,14 @@ const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 };
 
 function configureDefaultComposerChrome(editor: CustomEditor): void {
-	editor.setBorderVisible(false);
-	editor.setPromptGutter(`${theme.fg("accent", "›")} `);
+	editor.setBorderVisible(true);
+	editor.setBorderStyle("sharp");
+	editor.setClosedBorderBox(true);
+	editor.setPromptGutter(undefined);
+	editor.setInputPrefix(`${theme.fg("accent", ">")} `);
+	editor.setPlaceholder("Type your message...");
 	editor.setPaddingX(1);
+	editor.setTopBorder(undefined);
 }
 
 interface WorkingMessageAccent {
@@ -376,7 +381,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#syncEditorMaxHeight();
 		this.#resizeHandler = () => {
 			this.#syncEditorMaxHeight();
-			this.updateEditorTopBorder();
+			this.updateEditorChrome();
 		};
 		process.stdout.on("resize", this.#resizeHandler);
 		try {
@@ -500,7 +505,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.statusContainer);
 		this.ui.addChild(this.todoContainer);
 		this.ui.addChild(this.btwContainer);
-		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer stays borderless.
+		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer chrome is rendered by the editor.
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);
@@ -526,7 +531,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.start();
 		pushTerminalTitle();
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
-		this.updateEditorBorderColor();
+		this.updateEditorChrome();
 		this.#syncEditorMaxHeight();
 		this.isInitialized = true;
 		this.ui.requestRender(true);
@@ -544,7 +549,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			const draft = await this.sessionManager.consumeDraft();
 			if (draft && !this.editor.getText()) {
 				this.editor.setText(draft);
-				this.updateEditorBorderColor();
+				this.updateEditorChrome();
 				this.ui.requestRender();
 			}
 		} catch (err) {
@@ -564,7 +569,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			clearRenderCache();
 			configureDefaultComposerChrome(this.editor);
 			this.ui.invalidate();
-			this.updateEditorBorderColor();
+			this.updateEditorChrome();
 			this.ui.requestRender();
 		});
 
@@ -577,12 +582,12 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Set up git branch watcher
 		this.statusLine.watchBranch(() => {
-			this.updateEditorTopBorder();
+			this.updateEditorChrome();
 			this.ui.requestRender();
 		});
 
 		// Initial top border update
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 	}
 
 	/** Reload slash commands and autocomplete for the provided working directory. */
@@ -749,7 +754,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopLimit = undefined;
 		this.#cancelLoopAutoSubmit();
 		this.statusLine.setLoopModeStatus(undefined);
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 		if (wasEnabled) {
 			this.showStatus(message);
@@ -780,7 +785,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopPrompt = undefined;
 		this.loopLimit = createLoopLimitRuntime(parsedLimit);
 		this.statusLine.setLoopModeStatus({ enabled: true });
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 		const limitSuffix = parsedLimit ? ` Limited to ${describeLoopLimit(parsedLimit)}.` : "";
 		const remainingSuffix = this.loopLimit ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
@@ -874,7 +879,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.rebuildChatFromMessages();
 			this.editor.setText(submission.text);
 		}
-		this.updateEditorBorderColor();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 		return true;
 	}
@@ -921,7 +926,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setMaxHeight(this.#computeEditorMaxHeight());
 	}
 
-	updateEditorBorderColor(): void {
+	updateEditorChrome(): void {
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
@@ -938,13 +943,21 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.editor.borderColor = theme.getThinkingBorderColor(level);
 			}
 		}
-		this.updateEditorTopBorder();
+		this.#setComposerTopBorder();
 		this.ui.requestRender();
 	}
 
+	updateEditorBorderColor(): void {
+		this.updateEditorChrome();
+	}
+
 	updateEditorTopBorder(): void {
-		// The opencode-style composer is intentionally borderless. Keep status-line
-		// rendering out of the input area so the prompt remains a simple gutter + body.
+		this.#setComposerTopBorder();
+	}
+
+	#setComposerTopBorder(): void {
+		// Keep the composer as a plain closed input rectangle; status-line
+		// rendering stays outside the input area.
 		this.editor.setTopBorder(undefined);
 	}
 
@@ -1048,7 +1061,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					}
 				: undefined;
 		this.statusLine.setPlanModeStatus(status);
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 	}
 
@@ -1058,7 +1071,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				? { enabled: this.goalModeEnabled, paused: this.goalModePaused }
 				: undefined;
 		this.statusLine.setGoalModeStatus(status);
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 	}
 
@@ -1650,7 +1663,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			const applied = await this.sessionManager.setSessionName(seededName, "auto");
 			if (applied) {
 				setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
-				this.updateEditorBorderColor();
+				this.updateEditorChrome();
 			}
 		}
 
@@ -2121,8 +2134,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			logger.warn("Failed to refresh slash command state for custom editor", { error: String(error) });
 		});
 
-		this.updateEditorBorderColor();
-		this.updateEditorTopBorder();
+		this.updateEditorChrome();
 		this.ui.requestRender();
 	}
 
@@ -2417,7 +2429,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				} else {
 					this.#cleanupMicAnimation();
 				}
-				this.updateEditorTopBorder();
+				this.updateEditorChrome();
 				this.ui.requestRender();
 			},
 		});

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -57,6 +58,36 @@ describe("InteractiveMode.setEditorComponent", () => {
 		authStorage?.close();
 		tempDir?.removeSync();
 		resetSettingsForTest();
+	});
+
+	it("renders the default composer as a closed square input box", () => {
+		const lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+
+		expect(lines[0]).toStartWith("┌");
+		expect(lines[0]).toEndWith("┐");
+		expect(lines.at(-1)).toStartWith("└");
+		expect(lines.at(-1)).toEndWith("┘");
+		expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.endsWith("│"))).toBe(true);
+		expect(lines.join("\n")).toContain("Type your message...");
+		expect(lines.join("\n")).not.toContain("›");
+	});
+
+	it("keeps closed square composer chrome for one-line, multiline, and narrow prompts", () => {
+		for (const [width, text] of [
+			[48, "Ask gjc to improve the composer"],
+			[48, "first line\nsecond line"],
+			[28, "narrow terminal composer"],
+		] as const) {
+			mode.editor.setText(text);
+			const lines = mode.editor.render(width).map(line => stripVTControlCharacters(line));
+
+			expect(lines[0]).toStartWith("┌");
+			expect(lines[0]).toEndWith("┐");
+			expect(lines.at(-1)).toStartWith("└");
+			expect(lines.at(-1)).toEndWith("┘");
+			expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.endsWith("│"))).toBe(true);
+			expect(lines.join("\n")).not.toContain("Type your message...");
+		}
 	});
 
 	it("replaces the editor and rebinds interactive handlers", () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -772,7 +772,7 @@ export class Editor implements Component, Focusable {
 			let displayWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
 			const absoluteVisibleIndex = this.#scrollOffset + visibleIndex;
-			const showPromptGutter = promptGutter !== undefined && absoluteVisibleIndex === 0;
+			const showPromptGutter = promptGutter !== undefined && visibleIndex === 0;
 			const gutterText =
 				promptGutter === undefined ? "" : showPromptGutter ? promptGutter.firstLine : promptGutter.continuation;
 			const inputPrefix = absoluteVisibleIndex === 0 ? (this.#inputPrefix ?? "") : padding(inputPrefixWidth);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -309,6 +309,8 @@ export interface EditorTopBorder {
 	width: number;
 }
 
+export type EditorBorderStyle = "round" | "sharp";
+
 interface HistoryEntry {
 	prompt: string;
 }
@@ -338,6 +340,9 @@ export class Editor implements Component, Focusable {
 	/** Display width of the cursorOverride glyph (needed because override may contain ANSI escapes). */
 	cursorOverrideWidth: number | undefined;
 	#promptGutter: string | undefined;
+	#inputPrefix: string | undefined;
+	#inputPrefixWidth = 0;
+	#placeholder: string | undefined;
 
 	// Store last layout width for cursor navigation
 	#lastLayoutWidth: number = 80;
@@ -395,6 +400,8 @@ export class Editor implements Component, Focusable {
 	// Custom top border (for status line integration)
 	#topBorderContent?: EditorTopBorder;
 	#borderVisible = true;
+	#borderStyle: EditorBorderStyle = "round";
+	#closedBorderBox = false;
 
 	constructor(theme: EditorTheme) {
 		this.#theme = theme;
@@ -420,8 +427,26 @@ export class Editor implements Component, Focusable {
 		this.#borderVisible = borderVisible;
 	}
 
+	setBorderStyle(borderStyle: EditorBorderStyle): void {
+		this.#borderStyle = borderStyle;
+	}
+
+	setClosedBorderBox(closedBorderBox: boolean): void {
+		this.#closedBorderBox = closedBorderBox;
+	}
+
 	setPromptGutter(promptGutter: string | undefined): void {
 		this.#promptGutter = promptGutter;
+	}
+
+	setInputPrefix(inputPrefix: string | undefined): void {
+		this.#inputPrefix = inputPrefix;
+		this.#inputPrefixWidth = inputPrefix ? visibleWidth(inputPrefix) : 0;
+	}
+
+	setPlaceholder(placeholder: string | undefined): void {
+		const trimmed = placeholder?.trim();
+		this.#placeholder = trimmed ? trimmed : undefined;
 	}
 
 	/**
@@ -690,11 +715,12 @@ export class Editor implements Component, Focusable {
 		const borderVisible = this.#borderVisible;
 		const promptGutter = this.#getPromptGutter(width, paddingX);
 		const contentAreaWidth = this.#getContentWidth(width, paddingX);
-		const layoutWidth = this.#getLayoutWidth(width, paddingX);
+		const inputPrefixWidth = this.#inputPrefixWidth;
+		const layoutWidth = Math.max(1, this.#getLayoutWidth(width, paddingX) - inputPrefixWidth);
 		this.#lastLayoutWidth = layoutWidth;
 
-		// Box-drawing characters for rounded corners
-		const box = this.#theme.symbols.boxRound;
+		// Box-drawing characters for the configured input box shape.
+		const box = this.#borderStyle === "sharp" ? this.#theme.symbols.boxSharp : this.#theme.symbols.boxRound;
 		const borderWidth = this.#getHorizontalChromeWidth(paddingX);
 		const topLeft = this.borderColor(`${box.topLeft}${box.horizontal.repeat(paddingX)}`);
 		const topRight = this.borderColor(`${box.horizontal.repeat(paddingX)}${box.topRight}`);
@@ -733,24 +759,34 @@ export class Editor implements Component, Focusable {
 		// Render each layout line
 		// Emit hardware cursor marker only when focused and not showing autocomplete
 		const emitCursorMarker = this.focused && !this.#autocompleteState;
-		const lineContentWidth = contentAreaWidth;
+		const lineContentWidth = Math.max(0, contentAreaWidth - inputPrefixWidth);
 
 		// Compute inline hint text (dim ghost text after cursor)
 		const inlineHint = this.#getInlineHint();
 		const hintStyle = this.#theme.hintStyle ?? ((t: string) => `\x1b[2m${t}\x1b[0m`);
+		const showPlaceholder = this.#isEditorEmpty() && !inlineHint && !!this.#placeholder;
 
 		for (let visibleIndex = 0; visibleIndex < visibleLayoutLines.length; visibleIndex++) {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
 			let displayText = layoutLine.text;
 			let displayWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
-			const showPromptGutter = promptGutter !== undefined && visibleIndex === 0;
+			const absoluteVisibleIndex = this.#scrollOffset + visibleIndex;
+			const showPromptGutter = promptGutter !== undefined && absoluteVisibleIndex === 0;
 			const gutterText =
 				promptGutter === undefined ? "" : showPromptGutter ? promptGutter.firstLine : promptGutter.continuation;
+			const inputPrefix = absoluteVisibleIndex === 0 ? (this.#inputPrefix ?? "") : padding(inputPrefixWidth);
 
 			// Add cursor if this line has it
-			const hasCursor = layoutLine.hasCursor && layoutLine.cursorPos !== undefined;
+			let hasCursor = layoutLine.hasCursor && layoutLine.cursorPos !== undefined;
 			const marker = emitCursorMarker ? CURSOR_MARKER : "";
+
+			if (showPlaceholder) {
+				const hintText = hintStyle(truncateToWidth(this.#placeholder ?? "", lineContentWidth));
+				displayText = hintText;
+				displayWidth = Math.min(visibleWidth(this.#placeholder ?? ""), lineContentWidth);
+				hasCursor = false;
+			}
 
 			if (!borderVisible && displayWidth > lineContentWidth) {
 				displayText = sliceByColumn(displayText, 0, lineContentWidth, true);
@@ -800,10 +836,11 @@ export class Editor implements Component, Focusable {
 				if (marker) {
 					const before = displayText.slice(0, layoutLine.cursorPos);
 					const after = displayText.slice(layoutLine.cursorPos);
-					if (after.length === 0 && inlineHint) {
-						const hintText = hintStyle(truncateToWidth(inlineHint, Math.max(0, lineContentWidth - displayWidth)));
+					const ghostText = showPlaceholder ? this.#placeholder : inlineHint;
+					if (after.length === 0 && ghostText) {
+						const hintText = hintStyle(truncateToWidth(ghostText, Math.max(0, lineContentWidth - displayWidth)));
 						displayText = before + marker + hintText;
-						displayWidth += visibleWidth(inlineHint);
+						displayWidth += Math.min(visibleWidth(ghostText), Math.max(0, lineContentWidth - displayWidth));
 					} else if (after.length === 0 && !borderVisible && displayWidth >= lineContentWidth) {
 						displayText = this.#renderTerminalCursorMarker(before, marker, lineContentWidth);
 					} else {
@@ -826,6 +863,7 @@ export class Editor implements Component, Focusable {
 				} else if (this.cursorOverride) {
 					// Cursor override replaces the normal end-of-text cursor glyph
 					const overrideWidth = this.cursorOverrideWidth ?? 1;
+					const ghostText = showPlaceholder ? this.#placeholder : inlineHint;
 					if (!borderVisible && displayWidth + overrideWidth > lineContentWidth) {
 						// Borderless editors have no spare padding cell for an end-of-line cursor glyph.
 						// Preserve cursorOverride by replacing the tail of the line with it.
@@ -835,11 +873,11 @@ export class Editor implements Component, Focusable {
 						});
 						displayText = widthLimitedCursor.text;
 						displayWidth = widthLimitedCursor.width;
-					} else if (inlineHint) {
+					} else if (ghostText) {
 						const availWidth = Math.max(0, lineContentWidth - displayWidth - overrideWidth);
-						const hintText = hintStyle(truncateToWidth(inlineHint, availWidth));
+						const hintText = hintStyle(truncateToWidth(ghostText, availWidth));
 						displayText = before + marker + this.cursorOverride + hintText;
-						displayWidth += overrideWidth + Math.min(visibleWidth(inlineHint), availWidth);
+						displayWidth += overrideWidth + Math.min(visibleWidth(ghostText), availWidth);
 					} else {
 						displayText = before + marker + this.cursorOverride;
 						displayWidth += overrideWidth;
@@ -847,17 +885,18 @@ export class Editor implements Component, Focusable {
 				} else {
 					// Cursor is at the end - add thin cursor glyph
 					const { text: cursor, width: cursorWidth } = this.#getStyledInputCursor();
+					const ghostText = showPlaceholder ? this.#placeholder : inlineHint;
 					if (!borderVisible && displayWidth + cursorWidth > lineContentWidth) {
 						// Borderless editors have no spare padding cell for an end-of-line cursor glyph.
 						// Highlight the last grapheme so the cursor stays visible without consuming width.
 						const widthLimitedCursor = this.#renderEndOfLineCursorAtWidthLimit(before, marker, lineContentWidth);
 						displayText = widthLimitedCursor.text;
 						displayWidth = widthLimitedCursor.width;
-					} else if (inlineHint) {
+					} else if (ghostText) {
 						const availWidth = Math.max(0, lineContentWidth - displayWidth - cursorWidth);
-						const hintText = hintStyle(truncateToWidth(inlineHint, availWidth));
+						const hintText = hintStyle(truncateToWidth(ghostText, availWidth));
 						displayText = before + marker + cursor + hintText;
-						displayWidth += cursorWidth + Math.min(visibleWidth(inlineHint), availWidth);
+						displayWidth += cursorWidth + Math.min(visibleWidth(ghostText), availWidth);
 					} else {
 						displayText = before + marker + cursor;
 						displayWidth += cursorWidth;
@@ -868,27 +907,39 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
+			const displayWithPrefix = inputPrefix + displayText;
 			const linePad = padding(Math.max(0, lineContentWidth - displayWidth));
 
 			if (!borderVisible) {
-				result.push(gutterText + displayText + linePad);
+				result.push(gutterText + displayWithPrefix + linePad);
 				continue;
 			}
 
-			// All lines have consistent borders based on padding
+			// All lines have consistent borders based on padding.
 			const isLastLine = visibleIndex === visibleLayoutLines.length - 1;
 			const rightPaddingWidth = Math.max(0, paddingX - (cursorInPadding ? 1 : 0));
-			if (isLastLine) {
+			if (this.#closedBorderBox) {
+				const leftBorder = this.borderColor(`${box.vertical}${padding(paddingX)}`);
+				const rightBorder = this.borderColor(`${padding(rightPaddingWidth)}${box.vertical}`);
+				result.push(leftBorder + displayWithPrefix + linePad + rightBorder);
+			} else if (isLastLine) {
 				const bottomRightPadding = Math.max(0, paddingX - 1 - (cursorInPadding ? 1 : 0));
 				const bottomRightAdjusted = this.borderColor(
 					`${padding(bottomRightPadding)}${box.horizontal}${box.bottomRight}`,
 				);
-				result.push(`${bottomLeft}${displayText}${linePad}${bottomRightAdjusted}`);
+				result.push(`${bottomLeft}${displayWithPrefix}${linePad}${bottomRightAdjusted}`);
 			} else {
 				const leftBorder = this.borderColor(`${box.vertical}${padding(paddingX)}`);
 				const rightBorder = this.borderColor(`${padding(rightPaddingWidth)}${box.vertical}`);
-				result.push(leftBorder + displayText + linePad + rightBorder);
+				result.push(leftBorder + displayWithPrefix + linePad + rightBorder);
 			}
+		}
+
+		if (borderVisible && this.#closedBorderBox) {
+			const bottomFillWidth = Math.max(0, width - borderWidth * 2);
+			const bottomLeftClosed = this.borderColor(`${box.bottomLeft}${box.horizontal.repeat(paddingX)}`);
+			const bottomRightClosed = this.borderColor(`${box.horizontal.repeat(paddingX)}${box.bottomRight}`);
+			result.push(bottomLeftClosed + horizontal.repeat(bottomFillWidth) + bottomRightClosed);
 		}
 
 		// Add autocomplete list if active


### PR DESCRIPTION
## Summary
- render the default composer as a closed square input box
- add a clear `>` input prefix and placeholder copy
- keep status-line chrome outside the editor while preserving existing editor replacement behavior

## Tests
- `bunx biome check packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts packages/tui/src/components/editor.ts`
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts`