### PR TITLE
Expose setup paths in the model catalog

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -13,9 +13,9 @@ import {
 	Text,
 	type TUI,
 } from "@gajae-code/tui";
-import type { ModelRegistry } from "../../config/model-registry";
-import { getRoleInfo } from "../../config/model-registry";
-import { resolveModelRoleValue } from "../../config/model-resolver";
+import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
+import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
+import { formatModelSelectorValue, resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { getThinkingLevelMetadata } from "../../thinking";
@@ -71,6 +71,7 @@ interface ModelItem {
 	id: string;
 	model: Model;
 	selector: string;
+	thinkingLevel?: ThinkingLevel;
 	availability: ModelAvailability;
 }
 
@@ -83,12 +84,13 @@ interface CanonicalModelItem {
 	searchText: string;
 	normalizedSearchText: string;
 	compactSearchText: string;
+	thinkingLevel?: ThinkingLevel;
 	availability: ModelAvailability;
 }
 
 interface ScopedModelItem {
 	model: Model;
-	thinkingLevel?: string;
+	thinkingLevel?: ThinkingLevel;
 }
 
 interface RoleAssignment {
@@ -98,7 +100,7 @@ interface RoleAssignment {
 
 type RoleSelectCallback = (
 	model: Model,
-	role: "default" | null,
+	role: GjcModelAssignmentTargetId | null,
 	thinkingLevel?: ThinkingLevel,
 	selector?: string,
 ) => void;
@@ -124,7 +126,7 @@ function createProviderTab(providerId: string): ProviderTabState {
  * Component that renders a canonical model selector with provider tabs.
  * - Tab/Arrow Left/Right: Switch between provider tabs
  * - Arrow Up/Down: Navigate model list
- * - Enter: Select the highlighted model as the canonical/default model
+ * - Enter: Open assignment actions for default plus GJC role-agent models
  * - Escape: Close selector
  */
 export class ModelSelectorComponent extends Container {
@@ -146,6 +148,8 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
+	#pendingActionItem?: ModelItem | CanonicalModelItem;
+	#selectedActionIndex: number = 0;
 	#onLoginProviderCallback?: (providerId: string) => Promise<boolean>;
 
 	// Tab state
@@ -158,7 +162,12 @@ export class ModelSelectorComponent extends Container {
 		settings: Settings,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (model: Model, role: "default" | null, thinkingLevel?: ThinkingLevel, selector?: string) => void,
+		onSelect: (
+			model: Model,
+			role: GjcModelAssignmentTargetId | null,
+			thinkingLevel?: ThinkingLevel,
+			selector?: string,
+		) => void,
 		onCancel: () => void,
 		options?: {
 			temporaryOnly?: boolean;
@@ -207,7 +216,7 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
+				this.#beginActionMenuOrSelect(selectedItem);
 			}
 		};
 		this.addChild(this.#searchInput);
@@ -243,8 +252,11 @@ export class ModelSelectorComponent extends Container {
 	#loadRoleModels(): void {
 		const allModels = this.#modelRegistry.getAll();
 		const matchPreferences = { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() };
-		for (const role of ["default"]) {
-			const roleValue = this.#settings.getModelRole(role);
+		const agentModelOverrides = this.#settings.get("task.agentModelOverrides") ?? {};
+		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const roleValue =
+				target.settingsPath === "modelRoles" ? this.#settings.getModelRole(role) : agentModelOverrides[role];
 			if (!roleValue) continue;
 
 			const resolved = resolveModelRoleValue(roleValue, allModels, {
@@ -438,6 +450,7 @@ export class ModelSelectorComponent extends Container {
 				id: scoped.model.id,
 				model: scoped.model,
 				selector: `${scoped.model.provider}/${scoped.model.id}`,
+				thinkingLevel: scoped.thinkingLevel,
 				availability: { status: "ready" },
 			}));
 		} else {
@@ -483,13 +496,15 @@ export class ModelSelectorComponent extends Container {
 			availableOnly: false,
 			candidates: candidateModels,
 		});
+		const scopedThinkingBySelector = new Map(models.map(item => [item.selector, item.thinkingLevel]));
 		const canonicalModels = canonicalRecords
-			.map(record => {
+			.map((record): CanonicalModelItem | undefined => {
 				const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
 					availableOnly: false,
 					candidates: candidateModels,
 				});
 				if (!selectedModel) return undefined;
+				const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
 				const searchText = [
 					record.id,
 					record.name,
@@ -498,8 +513,8 @@ export class ModelSelectorComponent extends Container {
 					selectedModel.name,
 					...record.variants.flatMap(variant => [variant.selector, variant.model.name]),
 				].join(" ");
-				return {
-					kind: "canonical" as const,
+				const item: CanonicalModelItem = {
+					kind: "canonical",
 					id: record.id,
 					model: selectedModel,
 					selector: record.id,
@@ -507,10 +522,13 @@ export class ModelSelectorComponent extends Container {
 					searchText,
 					normalizedSearchText: normalizeSearchText(searchText),
 					compactSearchText: compactSearchText(searchText),
-					availability: modelsBySelector.get(`${selectedModel.provider}/${selectedModel.id}`)?.availability ?? {
-						status: "ready",
-					},
+					availability: modelsBySelector.get(selectedSelector)?.availability ?? { status: "ready" },
 				};
+				const scopedThinkingLevel = scopedThinkingBySelector.get(selectedSelector);
+				if (scopedThinkingLevel !== undefined) {
+					item.thinkingLevel = scopedThinkingLevel;
+				}
+				return item;
 			})
 			.filter((item): item is CanonicalModelItem => item !== undefined);
 
@@ -531,8 +549,7 @@ export class ModelSelectorComponent extends Container {
 			providerSet.add(item.provider);
 		}
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
-			const discoveryState = this.#modelRegistry.getProviderDiscoveryState(provider);
-			if ((discoveryState?.models.length ?? 0) > 0) providerSet.add(provider);
+			providerSet.add(provider);
 		}
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>
 			formatProviderTabLabel(left).localeCompare(formatProviderTabLabel(right)),
@@ -562,7 +579,12 @@ export class ModelSelectorComponent extends Container {
 		const tabs: Tab[] = this.#providers.map(provider => ({ id: provider.id, label: provider.label }));
 		const tabBar = new TabBar("Models", tabs, getTabBarTheme(), this.#activeTabIndex);
 		tabBar.onTabChange = (_tab, index) => {
-			this.#activeTabIndex = index;
+			if (this.#scopedModels.length > 0 && this.#canonicalModels.length > 0) {
+				this.#activeTabIndex = this.#providers.findIndex(tab => tab.id === CANONICAL_TAB);
+				this.#tabBar?.setActiveIndex(this.#activeTabIndex);
+			} else {
+				this.#activeTabIndex = index;
+			}
 			this.#selectedIndex = 0;
 			this.#applyTabFilter();
 			void this.#refreshSelectedProvider().catch(error => {
@@ -638,7 +660,9 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		const visibleCount =
-			hasQuery || !this.#isCanonicalTab() ? this.#filteredModels.length : this.#filteredCanonicalModels.length;
+			hasQuery || !this.#isCanonicalTab() || this.#filteredCanonicalModels.length === 0
+				? this.#filteredModels.length
+				: this.#filteredCanonicalModels.length;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, visibleCount - 1));
 		this.#updateList();
 	}
@@ -676,8 +700,17 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#getProviderEmptyStateMessage(): string | undefined {
-		const activeProviderId = this.#getActiveProviderId();
-		if (!activeProviderId || this.#searchInput.getValue().trim()) {
+		let activeProviderId = this.#getActiveProviderId();
+		if (this.#searchInput.getValue().trim()) {
+			return undefined;
+		}
+		if (!activeProviderId && this.#isCanonicalTab() && this.#filteredCanonicalModels.length === 0) {
+			const discoverableProviders = this.#modelRegistry.getDiscoverableProviders();
+			if (discoverableProviders.length === 1) {
+				activeProviderId = discoverableProviders[0];
+			}
+		}
+		if (!activeProviderId) {
 			return undefined;
 		}
 		const state = this.#modelRegistry.getProviderDiscoveryState(activeProviderId);
@@ -709,8 +742,9 @@ export class ModelSelectorComponent extends Container {
 	#updateList(): void {
 		this.#listContainer.clear();
 		const isGlobalSearch = this.#isGlobalSearchActive();
-		const isCanonicalTab = this.#isCanonicalTab() && !isGlobalSearch;
-		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
+		const showCanonicalList = this.#isCanonicalTab() && !isGlobalSearch && this.#filteredCanonicalModels.length > 0;
+		const isCanonicalTab = showCanonicalList;
+		const visibleItems = showCanonicalList ? this.#filteredCanonicalModels : this.#filteredModels;
 
 		const maxVisible = 10;
 		const startIndex = Math.max(
@@ -732,12 +766,14 @@ export class ModelSelectorComponent extends Container {
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
-			const defaultRoleInfo = getRoleInfo("default", this.#settings);
-			const defaultAssigned = this.#roles.default;
-			if (defaultRoleInfo.tag && defaultAssigned && modelsAreEqual(defaultAssigned.model, item.model)) {
-				const badge = makeInvertedBadge(defaultRoleInfo.tag, defaultRoleInfo.color ?? "success");
-				const thinkingLabel = getThinkingLevelMetadata(defaultAssigned.thinkingLevel).label;
-				roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+				const assigned = this.#roles[role];
+				if (roleInfo.tag && assigned && modelsAreEqual(assigned.model, item.model)) {
+					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
+					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
+					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+				}
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 			const availabilityText =
@@ -810,19 +846,42 @@ export class ModelSelectorComponent extends Container {
 			if (selected.availability.status !== "ready" && selected.availability.action) {
 				this.#listContainer.addChild(new Text(theme.fg("warning", `  ${selected.availability.action}`), 0, 0));
 			}
+			if (this.#pendingActionItem) {
+				this.#renderActionMenu(this.#pendingActionItem);
+			}
 		}
 	}
+	#renderActionMenu(item: ModelItem | CanonicalModelItem): void {
+		this.#listContainer.addChild(new Spacer(1));
+		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for: ${item.model.id}`), 0, 0));
+		this.#listContainer.addChild(new Spacer(1));
+		for (let i = 0; i < GJC_MODEL_ASSIGNMENT_TARGET_IDS.length; i++) {
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const label = `Set as ${target.tag ?? role.toUpperCase()} (${target.name})`;
+			this.#listContainer.addChild(
+				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
+			);
+		}
+	}
+
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
 
 	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
-		return this.#isCanonicalTab() && !this.#isGlobalSearchActive()
+		return this.#isCanonicalTab() && !this.#isGlobalSearchActive() && this.#filteredCanonicalModels.length > 0
 			? this.#filteredCanonicalModels[this.#selectedIndex]
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#pendingActionItem) {
+			this.#handleActionMenuInput(keyData);
+			return;
+		}
+
 		// Tab bar navigation
 		if (this.#tabBar?.handleInput(keyData)) {
 			return;
@@ -831,7 +890,7 @@ export class ModelSelectorComponent extends Container {
 		// Up arrow - navigate list (wrap to bottom when at top)
 		if (matchesKey(keyData, "up")) {
 			const itemCount =
-				this.#isCanonicalTab() && !this.#isGlobalSearchActive()
+				this.#isCanonicalTab() && !this.#isGlobalSearchActive() && this.#filteredCanonicalModels.length > 0
 					? this.#filteredCanonicalModels.length
 					: this.#filteredModels.length;
 			if (itemCount === 0) return;
@@ -843,7 +902,7 @@ export class ModelSelectorComponent extends Container {
 		// Down arrow - navigate list (wrap to top when at bottom)
 		if (matchesKey(keyData, "down")) {
 			const itemCount =
-				this.#isCanonicalTab() && !this.#isGlobalSearchActive()
+				this.#isCanonicalTab() && !this.#isGlobalSearchActive() && this.#filteredCanonicalModels.length > 0
 					? this.#filteredCanonicalModels.length
 					: this.#filteredModels.length;
 			if (itemCount === 0) return;
@@ -852,12 +911,12 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 
-		// Enter - select highlighted model directly. Canonical setup exposes one default model,
-		// while temporary-only mode keeps the existing non-persistent quick-switch behavior.
+		// Enter opens the persistent assignment menu. Temporary-only mode keeps the
+		// existing non-persistent quick-switch behavior.
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
+				this.#beginActionMenuOrSelect(selectedItem);
 			}
 			return;
 		}
@@ -872,7 +931,7 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());
 	}
-	#handleSelect(item: ModelItem | CanonicalModelItem, role: "default" | null, thinkingLevel?: ThinkingLevel): void {
+	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
 		if (item.availability.status !== "ready") {
 			if (item.availability.setup?.kind === "oauth_login" && this.#onLoginProviderCallback) {
 				void this.#onLoginProviderCallback(item.availability.setup.provider).then(success => {
@@ -892,19 +951,65 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 
+		if (this.#temporaryOnly) {
+			this.#handleSelect(item, null);
+			return;
+		}
+		this.#pendingActionItem = item;
+		this.#selectedActionIndex = 0;
+		this.#updateList();
+	}
+
+	#handleActionMenuInput(keyData: string): void {
+		if (matchesKey(keyData, "up")) {
+			this.#selectedActionIndex =
+				this.#selectedActionIndex === 0
+					? GJC_MODEL_ASSIGNMENT_TARGET_IDS.length - 1
+					: this.#selectedActionIndex - 1;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#selectedActionIndex = (this.#selectedActionIndex + 1) % GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const item = this.#pendingActionItem;
+			if (!item) return;
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
+			this.#pendingActionItem = undefined;
+			this.#handleSelect(item, role);
+			return;
+		}
+		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+			this.#pendingActionItem = undefined;
+			this.#updateList();
+		}
+	}
+
+	#handleSelect(
+		item: ModelItem | CanonicalModelItem,
+		role: GjcModelAssignmentTargetId | null,
+		thinkingLevel?: ThinkingLevel,
+	): void {
+		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
+
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback(item.model, null, undefined, item.selector);
+			this.#onSelectCallback(item.model, null, itemThinkingLevel, item.selector);
 			return;
 		}
 
-		const selectedThinkingLevel = thinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
+		const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
+		const selectorValue =
+			role === "default" ? item.selector : formatModelSelectorValue(item.selector, selectedThinkingLevel);
 
 		// Update local state for UI
 		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel };
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback(item.model, role, selectedThinkingLevel, item.selector);
+		this.#onSelectCallback(item.model, role, selectedThinkingLevel, selectorValue);
 
 		// Update list to show new badges
 		this.#updateList();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,6 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import {
 	Container,
 	fuzzyFilter,
@@ -12,12 +13,11 @@ import {
 	Text,
 	type TUI,
 } from "@gajae-code/tui";
-import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
-import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
-import { formatModelSelectorValue, resolveModelRoleValue } from "../../config/model-resolver";
+import type { ModelRegistry } from "../../config/model-registry";
+import { getRoleInfo } from "../../config/model-registry";
+import { resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
-import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
 import { getThinkingLevelMetadata } from "../../thinking";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
@@ -39,13 +39,31 @@ function compactSearchText(value: string): string {
 	return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
-function getAlphaSearchTokens(query: string): string[] {
-	return [...normalizeSearchText(query).matchAll(/[a-z]+/g)].map(match => match[0]).filter(token => token.length > 0);
-}
-
 function computeModelRank(model: Model, roles: Record<string, RoleAssignment | undefined>): number {
 	return roles.default && modelsAreEqual(roles.default.model, model) ? 0 : 1;
 }
+
+function computeAvailabilityRank(availability: ModelAvailability): number {
+	return availability.status === "ready" ? 0 : 1;
+}
+
+function getModelSearchText(item: ModelItem): string {
+	return `${item.provider}/${item.id} ${item.provider} ${item.id} ${item.model.name}`;
+}
+
+function requiresAdvancedProviderSetup(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	return /[<{]/.test(baseUrl) || /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i.test(baseUrl);
+}
+
+type ModelAvailability =
+	| { status: "ready" }
+	| { status: "unavailable"; reason: string; action?: string; setup?: ModelSetupAction };
+
+type ModelSetupAction =
+	| { kind: "api_key_prompt"; provider: string }
+	| { kind: "oauth_login"; provider: string }
+	| { kind: "manual"; message: string };
 
 interface ModelItem {
 	kind: "provider";
@@ -53,7 +71,7 @@ interface ModelItem {
 	id: string;
 	model: Model;
 	selector: string;
-	thinkingLevel?: ThinkingLevel;
+	availability: ModelAvailability;
 }
 
 interface CanonicalModelItem {
@@ -65,12 +83,12 @@ interface CanonicalModelItem {
 	searchText: string;
 	normalizedSearchText: string;
 	compactSearchText: string;
-	thinkingLevel?: ThinkingLevel;
+	availability: ModelAvailability;
 }
 
 interface ScopedModelItem {
 	model: Model;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: string;
 }
 
 interface RoleAssignment {
@@ -80,7 +98,7 @@ interface RoleAssignment {
 
 type RoleSelectCallback = (
 	model: Model,
-	role: GjcModelAssignmentTargetId | null,
+	role: "default" | null,
 	thinkingLevel?: ThinkingLevel,
 	selector?: string,
 ) => void;
@@ -91,13 +109,9 @@ interface ProviderTabState {
 	label: string;
 	providerId?: string;
 }
-const ALL_TAB = "ALL";
 const CANONICAL_TAB = "CANONICAL";
 
-const STATIC_PROVIDER_TABS: ProviderTabState[] = [
-	{ id: ALL_TAB, label: ALL_TAB },
-	{ id: CANONICAL_TAB, label: CANONICAL_TAB },
-];
+const STATIC_PROVIDER_TABS: ProviderTabState[] = [{ id: CANONICAL_TAB, label: CANONICAL_TAB }];
 
 function formatProviderTabLabel(providerId: string): string {
 	return providerId.replace(/[-_]+/g, " ").toUpperCase();
@@ -110,7 +124,7 @@ function createProviderTab(providerId: string): ProviderTabState {
  * Component that renders a canonical model selector with provider tabs.
  * - Tab/Arrow Left/Right: Switch between provider tabs
  * - Arrow Up/Down: Navigate model list
- * - Enter: Open assignment actions for default plus GJC role-agent models
+ * - Enter: Select the highlighted model as the canonical/default model
  * - Escape: Close selector
  */
 export class ModelSelectorComponent extends Container {
@@ -132,8 +146,7 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
-	#pendingActionItem?: ModelItem | CanonicalModelItem;
-	#selectedActionIndex: number = 0;
+	#onLoginProviderCallback?: (providerId: string) => Promise<boolean>;
 
 	// Tab state
 	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
@@ -145,14 +158,13 @@ export class ModelSelectorComponent extends Container {
 		settings: Settings,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (
-			model: Model,
-			role: GjcModelAssignmentTargetId | null,
-			thinkingLevel?: ThinkingLevel,
-			selector?: string,
-		) => void,
+		onSelect: (model: Model, role: "default" | null, thinkingLevel?: ThinkingLevel, selector?: string) => void,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
+		options?: {
+			temporaryOnly?: boolean;
+			initialSearchInput?: string;
+			onLoginProvider?: (providerId: string) => Promise<boolean>;
+		},
 	) {
 		super();
 
@@ -163,6 +175,7 @@ export class ModelSelectorComponent extends Container {
 		this.#onSelectCallback = onSelect;
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
+		this.#onLoginProviderCallback = options?.onLoginProvider;
 		const initialSearchInput = options?.initialSearchInput;
 
 		// Load current role assignments from settings
@@ -174,7 +187,9 @@ export class ModelSelectorComponent extends Container {
 
 		// Add hint about model filtering
 		const hintText =
-			scopedModels.length > 0 ? "Showing models from --models scope" : formatModelOnboardingInlineHint();
+			scopedModels.length > 0
+				? "Showing models from --models scope"
+				: "Type to search all models. Enter selects or opens setup. Tab switches providers.";
 		this.addChild(new Text(theme.fg("warning", hintText), 0, 0));
 		this.addChild(new Spacer(1));
 
@@ -192,7 +207,7 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#beginActionMenuOrSelect(selectedItem);
+				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
 			}
 		};
 		this.addChild(this.#searchInput);
@@ -228,11 +243,8 @@ export class ModelSelectorComponent extends Container {
 	#loadRoleModels(): void {
 		const allModels = this.#modelRegistry.getAll();
 		const matchPreferences = { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() };
-		const agentModelOverrides = this.#settings.get("task.agentModelOverrides");
-		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
-			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-			const roleValue =
-				target.settingsPath === "modelRoles" ? this.#settings.getModelRole(role) : agentModelOverrides[role];
+		for (const role of ["default"]) {
+			const roleValue = this.#settings.getModelRole(role);
 			if (!roleValue) continue;
 
 			const resolved = resolveModelRoleValue(roleValue, allModels, {
@@ -337,6 +349,84 @@ export class ModelSelectorComponent extends Container {
 		});
 	}
 
+	#sortSearchModels(models: ModelItem[], query: string): void {
+		const normalizedQuery = normalizeSearchText(query);
+		const compactQuery = compactSearchText(query);
+		const rank = (item: ModelItem): number => {
+			const selector = item.selector.toLowerCase();
+			const id = item.id.toLowerCase();
+			const provider = item.provider.toLowerCase();
+			const name = item.model.name.toLowerCase();
+			const normalized = normalizeSearchText(getModelSearchText(item));
+			const compact = compactSearchText(getModelSearchText(item));
+			if (selector === normalizedQuery || id === normalizedQuery) return 0;
+			if (provider === normalizedQuery) return 1;
+			if (provider.startsWith(normalizedQuery)) return 2;
+			if (id.startsWith(normalizedQuery) || selector.startsWith(normalizedQuery)) return 3;
+			if (provider.includes(normalizedQuery)) return 4;
+			if (id.includes(normalizedQuery) || selector.includes(normalizedQuery)) return 5;
+			if (name.includes(normalizedQuery)) return 6;
+			if (compactQuery && compact.includes(compactQuery)) return 7;
+			if (normalized.includes(normalizedQuery)) return 8;
+			return 9;
+		};
+		models.sort((a, b) => {
+			const aRank = rank(a);
+			const bRank = rank(b);
+			if (aRank !== bRank) return aRank - bRank;
+			const aAvailability = computeAvailabilityRank(a.availability);
+			const bAvailability = computeAvailabilityRank(b.availability);
+			if (aAvailability !== bAvailability) return aAvailability - bAvailability;
+			const providerCmp = a.provider.localeCompare(b.provider);
+			if (providerCmp !== 0) return providerCmp;
+			return a.id.localeCompare(b.id);
+		});
+	}
+
+	#resolveModelAvailability(model: Model, availableSelectors: Set<string>): ModelAvailability {
+		const selector = `${model.provider}/${model.id}`;
+		if (availableSelectors.has(selector)) return { status: "ready" };
+
+		const disabledProviders = new Set(this.#settings.get("disabledProviders") ?? []);
+		if (disabledProviders.has(model.provider)) {
+			return {
+				status: "unavailable",
+				reason: "Disabled in settings",
+				action: "Remove it from disabledProviders to use this model",
+			};
+		}
+
+		const oauthProvider = getOAuthProviders().find(provider => provider.id === model.provider);
+		if (oauthProvider) {
+			return {
+				status: "unavailable",
+				reason: "Login required",
+				action: "Press Enter to login or re-login",
+				setup: { kind: "oauth_login", provider: model.provider },
+			};
+		}
+
+		if (!this.#modelRegistry.hasConfiguredAuth(model)) {
+			const baseUrl = model.baseUrl ?? this.#modelRegistry.getProviderBaseUrl(model.provider);
+			if (requiresAdvancedProviderSetup(baseUrl)) {
+				return {
+					status: "unavailable",
+					reason: "Provider setup required",
+					action: "Use /provider add to configure endpoint and credentials",
+					setup: { kind: "manual", message: "Use /provider add to configure endpoint and credentials" },
+				};
+			}
+			return {
+				status: "unavailable",
+				reason: "API key or provider config required",
+				action: "Use /provider add or set an API key for this provider",
+				setup: { kind: "api_key_prompt", provider: model.provider },
+			};
+		}
+
+		return { status: "unavailable", reason: "Unavailable", action: "Check provider settings and credentials" };
+	}
+
 	async #loadModels(): Promise<void> {
 		let models: ModelItem[];
 
@@ -348,7 +438,7 @@ export class ModelSelectorComponent extends Container {
 				id: scoped.model.id,
 				model: scoped.model,
 				selector: `${scoped.model.provider}/${scoped.model.id}`,
-				thinkingLevel: scoped.thinkingLevel,
+				availability: { status: "ready" },
 			}));
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
@@ -362,15 +452,18 @@ export class ModelSelectorComponent extends Container {
 				this.#errorMessage = undefined;
 			}
 
-			// Load available models (built-in models still work even if models.json failed)
+			// Show the whole bundled/configured catalog, not only authenticated models.
 			try {
-				const availableModels = this.#modelRegistry.getAvailable();
-				models = availableModels.map((model: Model) => ({
+				const availableSelectors = new Set(
+					this.#modelRegistry.getAvailable().map(model => `${model.provider}/${model.id}`),
+				);
+				models = this.#modelRegistry.getAll().map((model: Model) => ({
 					kind: "provider",
 					provider: model.provider,
 					id: model.id,
 					model,
 					selector: `${model.provider}/${model.id}`,
+					availability: this.#resolveModelAvailability(model, availableSelectors),
 				}));
 			} catch (error) {
 				this.#allModels = [];
@@ -382,20 +475,21 @@ export class ModelSelectorComponent extends Container {
 			}
 		}
 
-		const candidateModels = models.map(item => item.model);
+		const modelsBySelector = new Map(models.map(item => [item.selector, item]));
+		const canonicalCandidateItems =
+			this.#scopedModels.length > 0 ? models : models.filter(item => item.availability.status === "ready");
+		const candidateModels = canonicalCandidateItems.map(item => item.model);
 		const canonicalRecords = this.#modelRegistry.getCanonicalModels({
-			availableOnly: this.#scopedModels.length === 0,
+			availableOnly: false,
 			candidates: candidateModels,
 		});
-		const scopedThinkingBySelector = new Map(models.map(item => [item.selector, item.thinkingLevel]));
 		const canonicalModels = canonicalRecords
-			.map((record): CanonicalModelItem | undefined => {
+			.map(record => {
 				const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
-					availableOnly: this.#scopedModels.length === 0,
+					availableOnly: false,
 					candidates: candidateModels,
 				});
 				if (!selectedModel) return undefined;
-				const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
 				const searchText = [
 					record.id,
 					record.name,
@@ -404,8 +498,8 @@ export class ModelSelectorComponent extends Container {
 					selectedModel.name,
 					...record.variants.flatMap(variant => [variant.selector, variant.model.name]),
 				].join(" ");
-				const item: CanonicalModelItem = {
-					kind: "canonical",
+				return {
+					kind: "canonical" as const,
 					id: record.id,
 					model: selectedModel,
 					selector: record.id,
@@ -413,12 +507,10 @@ export class ModelSelectorComponent extends Container {
 					searchText,
 					normalizedSearchText: normalizeSearchText(searchText),
 					compactSearchText: compactSearchText(searchText),
+					availability: modelsBySelector.get(`${selectedModel.provider}/${selectedModel.id}`)?.availability ?? {
+						status: "ready",
+					},
 				};
-				const scopedThinkingLevel = scopedThinkingBySelector.get(selectedSelector);
-				if (scopedThinkingLevel !== undefined) {
-					item.thinkingLevel = scopedThinkingLevel;
-				}
-				return item;
 			})
 			.filter((item): item is CanonicalModelItem => item !== undefined);
 
@@ -439,7 +531,8 @@ export class ModelSelectorComponent extends Container {
 			providerSet.add(item.provider);
 		}
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
-			providerSet.add(provider);
+			const discoveryState = this.#modelRegistry.getProviderDiscoveryState(provider);
+			if ((discoveryState?.models.length ?? 0) > 0) providerSet.add(provider);
 		}
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>
 			formatProviderTabLabel(left).localeCompare(formatProviderTabLabel(right)),
@@ -498,64 +591,54 @@ export class ModelSelectorComponent extends Container {
 		return this.#getActiveTabId() === CANONICAL_TAB;
 	}
 
-	#filterModels(query: string): void {
-		const activeTabId = this.#getActiveTabId();
-		const activeProviderId = this.#getActiveProviderId();
-		const isCanonicalTab = activeTabId === CANONICAL_TAB;
+	#isGlobalSearchActive(): boolean {
+		return this.#searchInput.getValue().trim().length > 0;
+	}
 
-		// Start with all models or filter by provider/canonical view
-		let baseModels = this.#allModels;
-		const baseCanonicalModels = this.#canonicalModels;
-		if (activeProviderId) {
+	#filterModels(query: string): void {
+		const activeProviderId = this.#getActiveProviderId();
+		const trimmedQuery = query.trim();
+		const hasQuery = trimmedQuery.length > 0;
+		const includeSetupCatalog = activeProviderId !== undefined || trimmedQuery.length >= 2;
+
+		let baseModels = includeSetupCatalog
+			? this.#allModels
+			: this.#allModels.filter(m => m.availability.status === "ready");
+		const baseCanonicalModels =
+			this.#isCanonicalTab() && !hasQuery
+				? this.#canonicalModels.filter(m => m.availability.status === "ready")
+				: this.#canonicalModels;
+
+		if (activeProviderId && !hasQuery) {
 			baseModels = this.#allModels.filter(m => m.provider === activeProviderId);
 		}
 
-		// Apply fuzzy filter if query is present
-		if (query.trim()) {
-			// If user is searching from a provider tab, auto-switch to ALL to show global provider results.
-			if (activeProviderId && !isCanonicalTab) {
-				this.#activeTabIndex = 0;
-				if (this.#tabBar && this.#tabBar.getActiveIndex() !== 0) {
-					this.#tabBar.setActiveIndex(0);
-					return;
-				}
-				this.#updateTabBar();
-				baseModels = this.#allModels;
-			}
-
-			if (isCanonicalTab) {
-				const alphaTokens = getAlphaSearchTokens(query);
-				const alphaFiltered =
-					alphaTokens.length === 0
-						? baseCanonicalModels
-						: baseCanonicalModels.filter(item =>
-								alphaTokens.every(token => item.normalizedSearchText.includes(token)),
-							);
-				const compactQuery = compactSearchText(query);
-				const substringFiltered =
-					compactQuery.length === 0
-						? alphaFiltered
-						: alphaFiltered.filter(item => item.compactSearchText.includes(compactQuery));
-				const fuzzySource =
-					substringFiltered.length > 0
-						? substringFiltered
-						: alphaFiltered.length > 0
-							? alphaFiltered
-							: baseCanonicalModels;
-				const fuzzyMatches = fuzzyFilter(fuzzySource, query, ({ searchText }) => searchText);
-				this.#sortCanonicalModels(fuzzyMatches);
-				this.#filteredCanonicalModels = fuzzyMatches;
-			} else {
-				const fuzzyMatches = fuzzyFilter(baseModels, query, ({ id, provider }) => `${id} ${provider}`);
-				this.#sortModels(fuzzyMatches);
-				this.#filteredModels = fuzzyMatches;
-			}
+		if (hasQuery) {
+			const normalizedQuery = normalizeSearchText(query);
+			const compactQuery = compactSearchText(query);
+			const queryTokens = normalizedQuery.split(/\s+/).filter(token => token.length > 0);
+			const substringMatches = baseModels.filter(item => {
+				const searchText = getModelSearchText(item);
+				const normalized = normalizeSearchText(searchText);
+				const compact = compactSearchText(searchText);
+				return (
+					(queryTokens.length === 0 || queryTokens.every(token => normalized.includes(token))) &&
+					(compactQuery.length === 0 || compact.includes(compactQuery))
+				);
+			});
+			const matches =
+				substringMatches.length > 0
+					? substringMatches
+					: fuzzyFilter(baseModels, query, item => getModelSearchText(item));
+			this.#sortSearchModels(matches, query);
+			this.#filteredModels = matches;
 		} else {
 			this.#filteredModels = baseModels;
 			this.#filteredCanonicalModels = baseCanonicalModels;
 		}
 
-		const visibleCount = isCanonicalTab ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+		const visibleCount =
+			hasQuery || !this.#isCanonicalTab() ? this.#filteredModels.length : this.#filteredCanonicalModels.length;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, visibleCount - 1));
 		this.#updateList();
 	}
@@ -625,7 +708,8 @@ export class ModelSelectorComponent extends Container {
 
 	#updateList(): void {
 		this.#listContainer.clear();
-		const isCanonicalTab = this.#isCanonicalTab();
+		const isGlobalSearch = this.#isGlobalSearchActive();
+		const isCanonicalTab = this.#isCanonicalTab() && !isGlobalSearch;
 		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
 
 		const maxVisible = 10;
@@ -635,7 +719,7 @@ export class ModelSelectorComponent extends Container {
 		);
 		const endIndex = Math.min(startIndex + maxVisible, visibleItems.length);
 
-		const showProvider = this.#getActiveTabId() === ALL_TAB;
+		const showProvider = isGlobalSearch || this.#getActiveProviderId() !== undefined;
 
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
@@ -648,16 +732,17 @@ export class ModelSelectorComponent extends Container {
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
-			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
-				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-				const assigned = this.#roles[role];
-				if (roleInfo.tag && assigned && modelsAreEqual(assigned.model, item.model)) {
-					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
-					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
-					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
-				}
+			const defaultRoleInfo = getRoleInfo("default", this.#settings);
+			const defaultAssigned = this.#roles.default;
+			if (defaultRoleInfo.tag && defaultAssigned && modelsAreEqual(defaultAssigned.model, item.model)) {
+				const badge = makeInvertedBadge(defaultRoleInfo.tag, defaultRoleInfo.color ?? "success");
+				const thinkingLabel = getThinkingLevelMetadata(defaultAssigned.thinkingLevel).label;
+				roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
+			const availabilityText =
+				item.availability.status === "ready" ? "" : theme.fg("warning", `  · ${item.availability.reason}`);
+			const itemSuffix = `${badgeText}${availabilityText}`;
 
 			let line = "";
 			if (isSelected) {
@@ -665,24 +750,24 @@ export class ModelSelectorComponent extends Container {
 				if (isCanonicalTab) {
 					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
 					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${theme.fg("accent", item.id)}${variants}${backing}${badgeText}`;
+					line = `${prefix}${theme.fg("accent", item.id)}${variants}${backing}${itemSuffix}`;
 				} else if (showProvider) {
 					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${theme.fg("accent", providerItem?.id ?? item.id)}${badgeText}`;
+					line = `${prefix}${providerPrefix}${theme.fg("accent", providerItem?.id ?? item.id)}${itemSuffix}`;
 				} else {
-					line = `${prefix}${theme.fg("accent", item.id)}${badgeText}`;
+					line = `${prefix}${theme.fg("accent", item.id)}${itemSuffix}`;
 				}
 			} else {
 				const prefix = "  ";
 				if (isCanonicalTab) {
 					const variants = theme.fg("dim", ` [${canonicalItem?.variantCount ?? 0}]`);
 					const backing = theme.fg("dim", ` -> ${item.model.provider}/${item.model.id}`);
-					line = `${prefix}${item.id}${variants}${backing}${badgeText}`;
+					line = `${prefix}${item.id}${variants}${backing}${itemSuffix}`;
 				} else if (showProvider) {
 					const providerPrefix = theme.fg("dim", `${providerItem?.provider ?? ""}/`);
-					line = `${prefix}${providerPrefix}${providerItem?.id ?? item.id}${badgeText}`;
+					line = `${prefix}${providerPrefix}${providerItem?.id ?? item.id}${itemSuffix}`;
 				} else {
-					line = `${prefix}${item.id}${badgeText}`;
+					line = `${prefix}${item.id}${itemSuffix}`;
 				}
 			}
 
@@ -705,7 +790,7 @@ export class ModelSelectorComponent extends Container {
 			const statusMessage = this.#getProviderEmptyStateMessage();
 			this.#listContainer.addChild(
 				new Text(
-					theme.fg("muted", statusMessage ?? `  No matching models. ${formatModelOnboardingInlineHint()}`),
+					theme.fg("muted", statusMessage ?? "  No matching models. Try another search or provider tab."),
 					0,
 					0,
 				),
@@ -722,42 +807,22 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(
 				new Text(theme.fg("muted", `  Model Name: ${selected.model.name}${suffix}`), 0, 0),
 			);
-			if (this.#pendingActionItem) {
-				this.#renderActionMenu(this.#pendingActionItem);
+			if (selected.availability.status !== "ready" && selected.availability.action) {
+				this.#listContainer.addChild(new Text(theme.fg("warning", `  ${selected.availability.action}`), 0, 0));
 			}
 		}
 	}
-	#renderActionMenu(item: ModelItem | CanonicalModelItem): void {
-		this.#listContainer.addChild(new Spacer(1));
-		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for: ${item.model.id}`), 0, 0));
-		this.#listContainer.addChild(new Spacer(1));
-		for (let i = 0; i < GJC_MODEL_ASSIGNMENT_TARGET_IDS.length; i++) {
-			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
-			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-			const label = `Set as ${target.tag ?? role.toUpperCase()} (${target.name})`;
-			this.#listContainer.addChild(
-				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
-			);
-		}
-	}
-
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
 
 	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
-		return this.#isCanonicalTab()
+		return this.#isCanonicalTab() && !this.#isGlobalSearchActive()
 			? this.#filteredCanonicalModels[this.#selectedIndex]
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
 	handleInput(keyData: string): void {
-		if (this.#pendingActionItem) {
-			this.#handleActionMenuInput(keyData);
-			return;
-		}
-
 		// Tab bar navigation
 		if (this.#tabBar?.handleInput(keyData)) {
 			return;
@@ -765,7 +830,10 @@ export class ModelSelectorComponent extends Container {
 
 		// Up arrow - navigate list (wrap to bottom when at top)
 		if (matchesKey(keyData, "up")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount =
+				this.#isCanonicalTab() && !this.#isGlobalSearchActive()
+					? this.#filteredCanonicalModels.length
+					: this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === 0 ? itemCount - 1 : this.#selectedIndex - 1;
 			this.#updateList();
@@ -774,19 +842,22 @@ export class ModelSelectorComponent extends Container {
 
 		// Down arrow - navigate list (wrap to top when at bottom)
 		if (matchesKey(keyData, "down")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount =
+				this.#isCanonicalTab() && !this.#isGlobalSearchActive()
+					? this.#filteredCanonicalModels.length
+					: this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === itemCount - 1 ? 0 : this.#selectedIndex + 1;
 			this.#updateList();
 			return;
 		}
 
-		// Enter opens the persistent assignment menu. Temporary-only mode keeps the
-		// existing non-persistent quick-switch behavior.
+		// Enter - select highlighted model directly. Canonical setup exposes one default model,
+		// while temporary-only mode keeps the existing non-persistent quick-switch behavior.
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#beginActionMenuOrSelect(selectedItem);
+				this.#handleSelect(selectedItem, this.#temporaryOnly ? null : "default");
 			}
 			return;
 		}
@@ -801,66 +872,39 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());
 	}
-	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
-		if (this.#temporaryOnly) {
-			this.#handleSelect(item, null);
-			return;
-		}
-		this.#pendingActionItem = item;
-		this.#selectedActionIndex = 0;
-		this.#updateList();
-	}
-
-	#handleActionMenuInput(keyData: string): void {
-		if (matchesKey(keyData, "up")) {
-			this.#selectedActionIndex =
-				this.#selectedActionIndex === 0
-					? GJC_MODEL_ASSIGNMENT_TARGET_IDS.length - 1
-					: this.#selectedActionIndex - 1;
+	#handleSelect(item: ModelItem | CanonicalModelItem, role: "default" | null, thinkingLevel?: ThinkingLevel): void {
+		if (item.availability.status !== "ready") {
+			if (item.availability.setup?.kind === "oauth_login" && this.#onLoginProviderCallback) {
+				void this.#onLoginProviderCallback(item.availability.setup.provider).then(success => {
+					if (success)
+						void this.#loadModels().then(() => {
+							this.#buildProviderTabs();
+							this.#updateTabBar();
+							this.#applyTabFilter();
+							this.#tui.requestRender();
+						});
+				});
+				return;
+			}
+			this.#errorMessage = item.availability.action ?? item.availability.reason;
 			this.#updateList();
+			this.#tui.requestRender();
 			return;
 		}
-		if (matchesKey(keyData, "down")) {
-			this.#selectedActionIndex = (this.#selectedActionIndex + 1) % GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
-			this.#updateList();
-			return;
-		}
-		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const item = this.#pendingActionItem;
-			if (!item) return;
-			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
-			this.#pendingActionItem = undefined;
-			this.#handleSelect(item, role);
-			return;
-		}
-		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
-			this.#pendingActionItem = undefined;
-			this.#updateList();
-		}
-	}
-
-	#handleSelect(
-		item: ModelItem | CanonicalModelItem,
-		role: GjcModelAssignmentTargetId | null,
-		thinkingLevel?: ThinkingLevel,
-	): void {
-		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback(item.model, null, itemThinkingLevel, item.selector);
+			this.#onSelectCallback(item.model, null, undefined, item.selector);
 			return;
 		}
 
-		const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
-		const selectorValue =
-			role === "default" ? item.selector : formatModelSelectorValue(item.selector, selectedThinkingLevel);
+		const selectedThinkingLevel = thinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
 
 		// Update local state for UI
 		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel };
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback(item.model, role, selectedThinkingLevel, selectorValue);
+		this.#onSelectCallback(item.model, role, selectedThinkingLevel, item.selector);
 
 		// Update list to show new badges
 		this.#updateList();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -2,16 +2,19 @@ import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import {
+	type Component,
 	Container,
 	fuzzyFilter,
 	getKeybindings,
 	Input,
 	matchesKey,
+	padding,
 	Spacer,
 	type Tab,
 	TabBar,
 	Text,
 	type TUI,
+	visibleWidth,
 } from "@gajae-code/tui";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
 import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
@@ -86,6 +89,29 @@ interface CanonicalModelItem {
 	compactSearchText: string;
 	thinkingLevel?: ThinkingLevel;
 	availability: ModelAvailability;
+}
+
+class SearchInputBox implements Component {
+	constructor(private readonly input: Input) {}
+
+	invalidate(): void {
+		this.input.invalidate();
+	}
+
+	render(width: number): string[] {
+		const frameWidth = Math.max(8, width - 4);
+		const inputLine = this.input.render(frameWidth)[0] ?? "";
+		const inputLineWidth = visibleWidth(inputLine);
+		const paddedInputLine = `${inputLine}${padding(Math.max(0, frameWidth - inputLineWidth))}`;
+		const border = "─".repeat(frameWidth);
+
+		return [
+			theme.fg("muted", "  🔎 Search models"),
+			theme.fg("borderMuted", `  ┌${border}┐`),
+			`${theme.fg("borderMuted", "  │")}${paddedInputLine}${theme.fg("borderMuted", "│")}`,
+			theme.fg("borderMuted", `  └${border}┘`),
+		];
+	}
 }
 
 interface ScopedModelItem {
@@ -219,7 +245,7 @@ export class ModelSelectorComponent extends Container {
 				this.#beginActionMenuOrSelect(selectedItem);
 			}
 		};
-		this.addChild(this.#searchInput);
+		this.addChild(new SearchInputBox(this.#searchInput));
 
 		this.addChild(new Spacer(1));
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2,7 +2,7 @@ import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
-import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
+import { Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
@@ -37,6 +37,7 @@ import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
 import { HistorySearchComponent } from "../components/history-search";
+import { LoginDialogComponent } from "../components/login-dialog";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
@@ -51,16 +52,6 @@ import { ToolExecutionComponent } from "../components/tool-execution";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
-
-const CALLBACK_SERVER_PROVIDERS = new Set<OAuthProvider>([
-	"anthropic",
-	"openai-codex",
-	"gitlab-duo",
-	"google-gemini-cli",
-	"google-antigravity",
-]);
-
-const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";
 
 function formatProviderOnboardingCommandGuide(): string {
 	return [
@@ -435,14 +426,14 @@ export class SelectorController {
 					try {
 						if (role === null) {
 							// Temporary: update agent state but don't persist to settings
-							await this.ctx.session.setModelTemporary(model, thinkingLevel);
+							await this.ctx.session.setModelTemporary(model);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
-						} else if (role === "default") {
-							// Default: update agent state and persist as the active default model.
+						} else {
+							// Default: update agent state and persist
 							await this.ctx.session.setModel(model, role, {
 								selector,
 								thinkingLevel,
@@ -455,19 +446,6 @@ export class SelectorController {
 							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
-						} else {
-							// Role-agent assignments configure Task dispatch and must not switch the active chat model.
-							const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
-							if (!apiKey) {
-								throw new Error(`No API key for ${model.provider}/${model.id}`);
-							}
-							const overrides = this.ctx.settings.get("task.agentModelOverrides");
-							const value = selector ?? `${model.provider}/${model.id}`;
-							this.ctx.settings.set("task.agentModelOverrides", { ...overrides, [role]: value });
-							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
-							this.ctx.showStatus(`${role} agent model: ${value}`);
-							done();
-							this.ctx.ui.requestRender();
 						}
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
@@ -477,7 +455,10 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				options,
+				{
+					...options,
+					onLoginProvider: providerId => this.#handleOAuthLogin(providerId),
+				},
 			);
 			return { component: selector, focus: selector };
 		});
@@ -869,69 +850,51 @@ export class SelectorController {
 		await this.showSessionSelector();
 	}
 
-	async #handleOAuthLogin(providerId: string): Promise<void> {
+	async #handleOAuthLogin(providerId: string): Promise<boolean> {
 		this.ctx.showStatus(`Logging in to ${providerId}…`);
-		const manualInput = this.ctx.oauthManualInput;
-		const useManualInput = CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider);
+		let overlayHandle: OverlayHandle | undefined;
+		const loginDialog = new LoginDialogComponent(this.ctx.ui, providerId, () => {
+			overlayHandle?.hide();
+			this.ctx.ui.requestRender();
+		});
+		overlayHandle = this.ctx.ui.showOverlay(loginDialog, {
+			anchor: "center",
+			width: "80%",
+			maxHeight: "70%",
+			margin: 1,
+		});
+		this.ctx.ui.setFocus(loginDialog);
+		this.ctx.ui.requestRender();
+
 		try {
 			await this.ctx.session.modelRegistry.authStorage.login(providerId as OAuthProvider, {
+				signal: loginDialog.signal,
 				onAuth: (info: { url: string; instructions?: string }) => {
-					this.ctx.chatContainer.addChild(new Spacer(1));
-					this.ctx.chatContainer.addChild(new Text(theme.fg("dim", info.url), 1, 0));
-					const hyperlink = `\x1b]8;;${info.url}\x07Click here to login\x1b]8;;\x07`;
-					this.ctx.chatContainer.addChild(new Text(theme.fg("accent", hyperlink), 1, 0));
-					if (info.instructions) {
-						this.ctx.chatContainer.addChild(new Spacer(1));
-						this.ctx.chatContainer.addChild(new Text(theme.fg("warning", info.instructions), 1, 0));
-					}
-					if (useManualInput) {
-						this.ctx.chatContainer.addChild(new Spacer(1));
-						this.ctx.chatContainer.addChild(new Text(theme.fg("dim", MANUAL_LOGIN_TIP), 1, 0));
-					}
-					this.ctx.ui.requestRender();
-					this.ctx.openInBrowser(info.url);
+					loginDialog.showAuth(info.url, info.instructions);
 				},
-				onPrompt: async (prompt: { message: string; placeholder?: string }) => {
-					this.ctx.chatContainer.addChild(new Spacer(1));
-					this.ctx.chatContainer.addChild(new Text(theme.fg("warning", prompt.message), 1, 0));
-					if (prompt.placeholder) {
-						this.ctx.chatContainer.addChild(new Text(theme.fg("dim", prompt.placeholder), 1, 0));
-					}
-					this.ctx.ui.requestRender();
-					const { promise, resolve } = Promise.withResolvers<string>();
-					const codeInput = new Input();
-					codeInput.onSubmit = () => {
-						const code = codeInput.getValue();
-						this.ctx.editorContainer.clear();
-						this.ctx.editorContainer.addChild(this.ctx.editor);
-						this.ctx.ui.setFocus(this.ctx.editor);
-						resolve(code);
-					};
-					this.ctx.editorContainer.clear();
-					this.ctx.editorContainer.addChild(codeInput);
-					this.ctx.ui.setFocus(codeInput);
-					this.ctx.ui.requestRender();
-					return promise;
-				},
+				onPrompt: (prompt: { message: string; placeholder?: string }) =>
+					loginDialog.showPrompt(prompt.message, prompt.placeholder),
 				onProgress: (message: string) => {
-					this.ctx.chatContainer.addChild(new Text(theme.fg("dim", message), 1, 0));
-					this.ctx.ui.requestRender();
+					loginDialog.showProgress(message);
 				},
-				onManualCodeInput: useManualInput ? () => manualInput.waitForInput(providerId) : undefined,
+				onManualCodeInput: () => loginDialog.showManualInput("Paste the authorization code or final redirect URL:"),
 			});
 			await this.ctx.session.modelRegistry.refresh();
-			this.ctx.chatContainer.addChild(new Spacer(1));
-			this.ctx.chatContainer.addChild(
-				new Text(theme.fg("success", `${theme.status.success} Successfully logged in to ${providerId}`), 1, 0),
-			);
-			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`), 1, 0));
+			overlayHandle?.hide();
+			this.ctx.ui.setFocus(this.ctx.editor);
+			this.ctx.showStatus(`Logged in to ${providerId}`);
 			this.ctx.ui.requestRender();
+			return true;
 		} catch (error: unknown) {
-			this.ctx.showError(`Login failed: ${error instanceof Error ? error.message : String(error)}`);
-		} finally {
-			if (useManualInput) {
-				manualInput.clear(`Manual OAuth input cleared for ${providerId}`);
+			overlayHandle?.hide();
+			this.ctx.ui.setFocus(this.ctx.editor);
+			if (loginDialog.signal.aborted) {
+				this.ctx.showStatus("Login cancelled");
+				this.ctx.ui.requestRender();
+				return false;
 			}
+			this.ctx.showError(`Login failed: ${error instanceof Error ? error.message : String(error)}`);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- keep Canonical as the ready/selectable default view
- search the full catalog when the user types, including unconfigured provider models
- show setup state inline for login/API-key/manual provider setup paths
- route OAuth setup from the model picker into the login popup flow

## Tests
- `bunx biome check packages/coding-agent/src/modes/components/model-selector.ts packages/coding-agent/src/modes/controllers/selector-controller.ts`
- `bun /tmp/test-model-catalog-visible.mjs`
- targeted `tsgo` check for model-selector/controller/login-dialog emitted no errors