### PR TITLE
Replace PR #13 with GJC-only team worker CLI guard

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -155,6 +155,7 @@ Important:
 
 - Leader remains in the existing left pane.
 - Worker panes are independent full GJC worker CLI sessions on the right side of a leader-left/worker-right split.
+- Worker CLI selection is teammate-only: `GJC_TEAM_WORKER_CLI` and `GJC_TEAM_WORKER_CLI_MAP` accept only `auto` or `gjc`; legacy/provider values such as `codex`, `claude`, or `gemini` are rejected before launch.
 - The worker may run in a dedicated git worktree (`gjc team --worktree[=<name>]`) while sharing the team state root.
 - `shutdown` kills only the recorded worker pane after confirming it still belongs to the stored tmux target and is not the leader pane. It never kills the tmux session.
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -8,6 +8,11 @@ export type GjcWorkerStatusState = "idle" | "working" | "blocked" | "done" | "fa
 
 export const GJC_TEAM_DEFAULT_WORKERS = 3;
 export const GJC_TEAM_MAX_WORKERS = 20;
+const GJC_TEAM_WORKER_CLI_ENV = "GJC_TEAM_WORKER_CLI";
+const GJC_TEAM_WORKER_CLI_MAP_ENV = "GJC_TEAM_WORKER_CLI_MAP";
+
+export type GjcTeamWorkerCli = "gjc";
+type GjcTeamWorkerCliMode = "auto" | GjcTeamWorkerCli;
 
 export interface GjcTeamLeader {
 	session_id: string;
@@ -75,6 +80,7 @@ export interface GjcTeamConfig {
 	max_workers: number;
 	state_root: string;
 	worker_command: string;
+	worker_cli_plan: GjcTeamWorkerCli[];
 	tmux_command: string;
 	tmux_session: string;
 	tmux_session_name: string;
@@ -159,6 +165,70 @@ export interface GjcTeamMailboxMessage {
 interface FsError {
 	code?: string;
 }
+
+function normalizeGjcTeamWorkerCliMode(
+	raw: string | undefined,
+	sourceEnv = GJC_TEAM_WORKER_CLI_ENV,
+): GjcTeamWorkerCliMode {
+	const normalized = String(raw ?? "auto")
+		.trim()
+		.toLowerCase();
+	if (normalized === "" || normalized === "auto") return "auto";
+	if (normalized === "gjc") return "gjc";
+	if (normalized === "codex" || normalized === "claude" || normalized === "gemini") {
+		throw new Error(`Unsupported ${sourceEnv} value "${raw}". GJC team launches GJC teammate sessions only.`);
+	}
+	throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto or gjc`);
+}
+
+export function resolveGjcTeamWorkerCli(env: NodeJS.ProcessEnv = process.env): GjcTeamWorkerCli {
+	const mode = normalizeGjcTeamWorkerCliMode(env[GJC_TEAM_WORKER_CLI_ENV]);
+	return mode === "auto" ? "gjc" : mode;
+}
+
+export function resolveGjcTeamWorkerCliPlan(
+	workerCount: number,
+	env: NodeJS.ProcessEnv = process.env,
+): GjcTeamWorkerCli[] {
+	if (!Number.isInteger(workerCount) || workerCount < 1) {
+		throw new Error(`workerCount must be >= 1 (got ${workerCount})`);
+	}
+	normalizeGjcTeamWorkerCliMode(env[GJC_TEAM_WORKER_CLI_ENV]);
+	const rawMap = String(env[GJC_TEAM_WORKER_CLI_MAP_ENV] ?? "").trim();
+	if (rawMap === "") {
+		const cli = resolveGjcTeamWorkerCli(env);
+		return Array.from({ length: workerCount }, () => cli);
+	}
+	const entries = rawMap.split(",").map(entry => entry.trim());
+	if (entries.length === 0 || entries.every(entry => entry.length === 0)) {
+		throw new Error(
+			`Invalid ${GJC_TEAM_WORKER_CLI_MAP_ENV} value "${env[GJC_TEAM_WORKER_CLI_MAP_ENV]}". Expected: auto or gjc`,
+		);
+	}
+	if (entries.some(entry => entry.length === 0)) {
+		throw new Error(
+			`Invalid ${GJC_TEAM_WORKER_CLI_MAP_ENV} value "${env[GJC_TEAM_WORKER_CLI_MAP_ENV]}". Empty entries are not allowed.`,
+		);
+	}
+	if (entries.length !== 1 && entries.length !== workerCount) {
+		throw new Error(
+			`Invalid ${GJC_TEAM_WORKER_CLI_MAP_ENV} length ${entries.length}; expected 1 or ${workerCount} comma-separated values.`,
+		);
+	}
+	const expanded = entries.length === 1 ? Array.from({ length: workerCount }, () => entries[0] ?? "") : entries;
+	return expanded.map(entry => {
+		const mode = normalizeGjcTeamWorkerCliMode(entry, GJC_TEAM_WORKER_CLI_MAP_ENV);
+		return mode === "auto" ? "gjc" : mode;
+	});
+}
+
+export function translateGjcWorkerLaunchArgsForCli(workerCli: GjcTeamWorkerCli, args: string[]): string[] {
+	if (workerCli !== "gjc") {
+		throw new Error(`Unsupported team worker CLI "${workerCli}". GJC team launches GJC teammate sessions only.`);
+	}
+	return [...args];
+}
+
 interface GjcTmuxLeaderContext {
 	sessionName: string;
 	windowIndex: string;
@@ -341,6 +411,7 @@ async function readConfig(dir: string): Promise<GjcTeamConfig> {
 		tmux_target: config.tmux_target ?? config.tmux_session ?? tmuxSessionName,
 		leader_cwd: config.leader_cwd ?? config.leader.cwd,
 		team_state_root: config.team_state_root ?? config.state_root,
+		worker_cli_plan: config.worker_cli_plan ?? Array.from({ length: config.worker_count }, () => "gjc"),
 	};
 }
 async function readPhase(dir: string): Promise<GjcTeamPhase> {
@@ -1227,6 +1298,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const env = options.env ?? process.env;
 	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > GJC_TEAM_MAX_WORKERS)
 		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
+	const workerCliPlan = resolveGjcTeamWorkerCliPlan(options.workerCount, env);
 	const stateRoot = resolveGjcTeamStateRoot(cwd, env);
 	const teamName = sanitizeName(options.teamName ?? makeTeamName(options.task, env));
 	const displayName = sanitizeName(options.teamName ?? options.task).slice(0, 30) || teamName;
@@ -1256,6 +1328,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		max_workers: GJC_TEAM_MAX_WORKERS,
 		state_root: stateRoot,
 		worker_command: resolveGjcWorkerCommand(cwd, env),
+		worker_cli_plan: workerCliPlan,
 		tmux_command: tmuxCommand,
 		tmux_session: tmuxContext.sessionName,
 		tmux_session_name: tmuxContext.sessionName,
@@ -1279,6 +1352,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		tmux_session_name: config.tmux_session_name,
 		tmux_target: config.tmux_target,
 		worker_command: config.worker_command,
+		worker_cli_plan: config.worker_cli_plan,
 		tmux_command: config.tmux_command,
 		leader: config.leader,
 		workers: config.workers,
@@ -1296,7 +1370,12 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	await appendTelemetry(dir, {
 		type: "team_runtime",
 		message: "Native gjc team runtime initialized",
-		data: { state_root: stateRoot, worker_command: config.worker_command, workspace_mode: config.workspace_mode },
+		data: {
+			state_root: stateRoot,
+			worker_command: config.worker_command,
+			worker_cli_plan: workerCliPlan,
+			workspace_mode: config.workspace_mode,
+		},
 	});
 	let tmuxWorkers: GjcTeamWorker[];
 	try {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -10,10 +10,13 @@ import {
 	monitorGjcTeam,
 	parseTeamLaunchArgs,
 	readGjcTeamSnapshot,
+	resolveGjcTeamWorkerCli,
+	resolveGjcTeamWorkerCliPlan,
 	resolveGjcWorkerCommand,
 	shutdownGjcTeam,
 	startGjcTeam,
 	transitionGjcTeamTask,
+	translateGjcWorkerLaunchArgsForCli,
 } from "../../src/gjc-runtime/team-runtime";
 
 let cleanupRoot: string | undefined;
@@ -179,6 +182,55 @@ describe("native gjc team runtime", () => {
 		expect(manifest.worker_command).toBe("bun ./packages/coding-agent/src/cli.ts");
 		expect(telemetry).toContain("bun ./packages/coding-agent/src/cli.ts");
 		expect(resolveGjcWorkerCommand(cleanupRoot, { GJC_TEAM_WORKER_COMMAND: "gjc-dev" })).toBe("gjc-dev");
+	});
+
+	it("keeps worker CLI selection limited to GJC teammate sessions", async () => {
+		expect(resolveGjcTeamWorkerCli({})).toBe("gjc");
+		expect(resolveGjcTeamWorkerCli({ GJC_TEAM_WORKER_CLI: "auto" })).toBe("gjc");
+		expect(resolveGjcTeamWorkerCli({ GJC_TEAM_WORKER_CLI: "gjc" })).toBe("gjc");
+		expect(resolveGjcTeamWorkerCliPlan(3, { GJC_TEAM_WORKER_CLI_MAP: "auto" })).toEqual(["gjc", "gjc", "gjc"]);
+		expect(resolveGjcTeamWorkerCliPlan(2, { GJC_TEAM_WORKER_CLI_MAP: "gjc,auto" })).toEqual(["gjc", "gjc"]);
+		expect(translateGjcWorkerLaunchArgsForCli("gjc", ["--model", "frontier"])).toEqual(["--model", "frontier"]);
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		const snapshot = await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Launch GJC teammate sessions",
+			teamName: "gjc-worker-cli-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "", GJC_TEAM_WORKER_CLI_MAP: "gjc,auto" },
+		});
+		const config = await Bun.file(path.join(snapshot.state_dir, "config.json")).json();
+		const manifest = await Bun.file(path.join(snapshot.state_dir, "manifest.v2.json")).json();
+		const telemetry = await Bun.file(path.join(snapshot.state_dir, "telemetry.jsonl")).text();
+		expect(config.worker_cli_plan).toEqual(["gjc", "gjc"]);
+		expect(manifest.worker_cli_plan).toEqual(["gjc", "gjc"]);
+		expect(telemetry).toContain('"worker_cli_plan":["gjc","gjc"]');
+
+		for (const provider of ["codex", "claude", "gemini"]) {
+			expect(() => resolveGjcTeamWorkerCli({ GJC_TEAM_WORKER_CLI: provider })).toThrow(
+				/GJC team launches GJC teammate sessions only/,
+			);
+			expect(() => resolveGjcTeamWorkerCliPlan(1, { GJC_TEAM_WORKER_CLI_MAP: provider })).toThrow(
+				/GJC team launches GJC teammate sessions only/,
+			);
+			expect(() =>
+				resolveGjcTeamWorkerCliPlan(1, { GJC_TEAM_WORKER_CLI: provider, GJC_TEAM_WORKER_CLI_MAP: "gjc" }),
+			).toThrow(/GJC team launches GJC teammate sessions only/);
+			if (!cleanupRoot) cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+			await expect(
+				startGjcTeam({
+					workerCount: 1,
+					agentType: "executor",
+					task: "Do not launch external teammate providers",
+					teamName: `unsupported-${provider}`,
+					cwd: cleanupRoot,
+					dryRun: true,
+					env: { PATH: "", GJC_TEAM_WORKER_CLI: provider },
+				}),
+			).rejects.toThrow(/GJC team launches GJC teammate sessions only/);
+		}
 	});
 
 	it("parses team starts with automatic detached worktrees and legacy --worktree stripping", () => {


### PR DESCRIPTION
## Summary

Replaces closed PR #13 with a smaller clean port onto current `dev`.

This keeps the useful GJC Team runtime behavior that matters for the current surface: Team workers are GJC teammate sessions only. `GJC_TEAM_WORKER_CLI` and `GJC_TEAM_WORKER_CLI_MAP` now accept only `auto`/`gjc`; legacy/provider values (`codex`, `claude`, `gemini`) are rejected before launch. The resolved worker CLI plan is persisted to config/manifest/telemetry for audit, with legacy config backfill to `gjc`.

## Why smaller than closed #13

Closed #13 was dirty against current `dev` and carried repo-contract regressions. This replacement avoids a blind merge and does not revive the broad multi-provider/team runtime surface.

## Repo-contract guardrails

- No `ReturnType<>` in the changed scope
- No dynamic imports in the changed scope
- No direct `console.log` / `console.warn` / `console.error` in `packages/coding-agent` source changes
- No committed repo-visible `.gjc` default definitions

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `git diff --check`
- Independent code review after fix: code-reviewer `APPROVE`, architect `CLEAR`

## Limitations / deferred

- Does not port the broad closed-PR #13 Team/Ultragoal runtime expansion.
- Live tmux worker-pane launch was not exercised beyond existing dry-run/fake-tmux tests.
