### PR TITLE
fix(cli): register update command

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -34,6 +34,7 @@ const commands: CommandEntry[] = [
 	{ name: "question", load: () => import("./commands/question").then(m => m.default) },
 	{ name: "state", load: () => import("./commands/state").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
+	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },


### PR DESCRIPTION
## What

Register the existing root `gjc update` command in the CLI command table and update the public command-surface regression test.

## Why

`commands/update.ts` and `cli/update-cli.ts` already implement the advertised self-update path, but the root command registry omitted `update`, so `gjc update` fell through to interactive launch prompt handling instead of running the updater.

## Testing

- `bun test packages/coding-agent/test/cli-command-surface.test.ts`
- `bun packages/coding-agent/src/cli.ts update --help`
- `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
