### PR TITLE
Require explicit OpenAI reasoning choices

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,5 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { type Model, modelsAreEqual } from "@gajae-code/ai";
+import { getSupportedEfforts, type Model, modelsAreEqual } from "@gajae-code/ai";
 import {
 	Container,
 	fuzzyFilter,
@@ -18,7 +18,7 @@ import { formatModelSelectorValue, resolveModelRoleValue } from "../../config/mo
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
-import { getThinkingLevelMetadata } from "../../thinking";
+import { getThinkingLevelMetadata, parseThinkingLevel } from "../../thinking";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -78,6 +78,12 @@ interface RoleAssignment {
 	thinkingLevel: ThinkingLevel;
 }
 
+interface PendingThinkingChoice {
+	item: ModelItem | CanonicalModelItem;
+	role: GjcModelAssignmentTargetId | null;
+	levels: ThinkingLevel[];
+}
+
 type RoleSelectCallback = (
 	model: Model,
 	role: GjcModelAssignmentTargetId | null,
@@ -134,6 +140,8 @@ export class ModelSelectorComponent extends Container {
 	#temporaryOnly: boolean;
 	#pendingActionItem?: ModelItem | CanonicalModelItem;
 	#selectedActionIndex: number = 0;
+	#pendingThinkingChoice?: PendingThinkingChoice;
+	#selectedThinkingIndex: number = 0;
 
 	// Tab state
 	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
@@ -722,11 +730,14 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(
 				new Text(theme.fg("muted", `  Model Name: ${selected.model.name}${suffix}`), 0, 0),
 			);
-			if (this.#pendingActionItem) {
+			if (this.#pendingThinkingChoice) {
+				this.#renderThinkingMenu(this.#pendingThinkingChoice);
+			} else if (this.#pendingActionItem) {
 				this.#renderActionMenu(this.#pendingActionItem);
 			}
 		}
 	}
+
 	#renderActionMenu(item: ModelItem | CanonicalModelItem): void {
 		this.#listContainer.addChild(new Spacer(1));
 		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for: ${item.model.id}`), 0, 0));
@@ -742,6 +753,24 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	#renderThinkingMenu(choice: PendingThinkingChoice): void {
+		const targetLabel = choice.role === null ? "temporary model" : GJC_MODEL_ASSIGNMENT_TARGETS[choice.role].name;
+		this.#listContainer.addChild(new Spacer(1));
+		this.#listContainer.addChild(
+			new Text(theme.fg("muted", `  Reasoning for ${targetLabel}: ${choice.item.model.id}`), 0, 0),
+		);
+		this.#listContainer.addChild(new Spacer(1));
+		for (let i = 0; i < choice.levels.length; i++) {
+			const level = choice.levels[i];
+			const metadata = getThinkingLevelMetadata(level);
+			const prefix = i === this.#selectedThinkingIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const label = `${metadata.label} — ${metadata.description}`;
+			this.#listContainer.addChild(
+				new Text(`${prefix}${i === this.#selectedThinkingIndex ? theme.fg("accent", label) : label}`, 0, 0),
+			);
+		}
+	}
+
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
@@ -753,6 +782,10 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#pendingThinkingChoice) {
+			this.#handleThinkingMenuInput(keyData);
+			return;
+		}
 		if (this.#pendingActionItem) {
 			this.#handleActionMenuInput(keyData);
 			return;
@@ -839,12 +872,49 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	#handleThinkingMenuInput(keyData: string): void {
+		const choice = this.#pendingThinkingChoice;
+		if (!choice) return;
+		if (matchesKey(keyData, "up")) {
+			this.#selectedThinkingIndex =
+				this.#selectedThinkingIndex === 0 ? choice.levels.length - 1 : this.#selectedThinkingIndex - 1;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#selectedThinkingIndex = (this.#selectedThinkingIndex + 1) % choice.levels.length;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const level = choice.levels[this.#selectedThinkingIndex];
+			if (!level) return;
+			this.#pendingThinkingChoice = undefined;
+			this.#handleSelect(choice.item, choice.role, level);
+			return;
+		}
+		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+			this.#pendingThinkingChoice = undefined;
+			if (choice.role !== null) {
+				this.#pendingActionItem = choice.item;
+				this.#selectedActionIndex = Math.max(0, GJC_MODEL_ASSIGNMENT_TARGET_IDS.indexOf(choice.role));
+			}
+			this.#updateList();
+		}
+	}
+
 	#handleSelect(
 		item: ModelItem | CanonicalModelItem,
 		role: GjcModelAssignmentTargetId | null,
 		thinkingLevel?: ThinkingLevel,
 	): void {
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
+		if (itemThinkingLevel === undefined && requiresExplicitThinkingChoice(item.model)) {
+			this.#pendingThinkingChoice = { item, role, levels: getSelectableThinkingLevels(item.model) };
+			this.#selectedThinkingIndex = 0;
+			this.#updateList();
+			return;
+		}
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
@@ -869,6 +939,33 @@ export class ModelSelectorComponent extends Container {
 	getSearchInput(): Input {
 		return this.#searchInput;
 	}
+}
+
+function requiresExplicitThinkingChoice(model: Model): boolean {
+	return model.reasoning === true && (model.provider === "openai" || model.provider === "openai-codex");
+}
+
+function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {
+	const levels: ThinkingLevel[] = [ThinkingLevel.Off];
+	try {
+		for (const effort of getSupportedEfforts(model)) {
+			const level = parseThinkingLevel(effort);
+			if (level && !levels.includes(level)) {
+				levels.push(level);
+			}
+		}
+	} catch {
+		for (const level of [
+			ThinkingLevel.Minimal,
+			ThinkingLevel.Low,
+			ThinkingLevel.Medium,
+			ThinkingLevel.High,
+			ThinkingLevel.XHigh,
+		]) {
+			levels.push(level);
+		}
+	}
+	return levels;
 }
 
 /** Extract the first version number from a model ID (e.g. "gemini-2.5-pro" → 2.5, "Anthropic model-sonnet-4-6" → 4.6). */

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -121,6 +121,16 @@ describe("ModelRegistry", () => {
 		};
 	}
 
+	function unsetEnvForTest(key: string): () => void {
+		const previous = Bun.env[key];
+		delete Bun.env[key];
+		return () => {
+			if (previous !== undefined) {
+				Bun.env[key] = previous;
+			}
+		};
+	}
+
 	function mockOpenAiCompatibleModels(url: string, modelIds: string[]) {
 		return hookFetch(input => {
 			const requestUrl = String(input);
@@ -163,6 +173,20 @@ describe("ModelRegistry", () => {
 				expect(openaiModels.length).toBeGreaterThan(0);
 				expect(openaiModels.every(model => model.baseUrl === "https://openai-proxy.example.com/v1")).toBe(true);
 				expect(registry.getProviderBaseUrl("openai")).toBe("https://openai-proxy.example.com/v1");
+			} finally {
+				restore();
+			}
+		});
+
+		test("does not apply OPENAI_BASE_URL to OpenAI Codex models", () => {
+			const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const codexModels = getModelsForProvider(registry, "openai-codex");
+
+				expect(codexModels.length).toBeGreaterThan(0);
+				expect(codexModels.every(model => model.baseUrl !== "https://openai-proxy.example.com/v1")).toBe(true);
+				expect(registry.getProviderBaseUrl("openai-codex")).not.toBe("https://openai-proxy.example.com/v1");
 			} finally {
 				restore();
 			}
@@ -581,6 +605,27 @@ describe("ModelRegistry", () => {
 				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
 			}
 		});
+
+		test("OPENAI_API_KEY supplies env auth for bundled OpenAI models only", async () => {
+			const restoreOpenAiKey = setEnvForTest("OPENAI_API_KEY", "env-openai-key");
+			const restoreCodexToken = unsetEnvForTest("OPENAI_CODEX_OAUTH_TOKEN");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const openaiModels = getModelsForProvider(registry, "openai");
+				const codexModels = getModelsForProvider(registry, "openai-codex");
+
+				expect(openaiModels.length).toBeGreaterThan(0);
+				expect(codexModels.length).toBeGreaterThan(0);
+				expect(registry.getAvailable().some(model => model.provider === "openai")).toBe(true);
+				expect(registry.getAvailable().some(model => model.provider === "openai-codex")).toBe(false);
+				await expect(registry.getApiKey(openaiModels[0])).resolves.toBe("env-openai-key");
+				await expect(registry.getApiKey(codexModels[0])).resolves.toBeUndefined();
+			} finally {
+				restoreCodexToken();
+				restoreOpenAiKey();
+			}
+		});
+
 		test("baseUrl-only override does not affect other providers", () => {
 			writeRawModelsJson({
 				anthropic: overrideConfig("https://my-proxy.example.com/v1"),

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { getBundledModel, type Model } from "@gajae-code/ai";
+import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
@@ -28,7 +28,7 @@ interface SelectionCapture {
 interface CreateSelectorOptions {
 	modelRegistry?: ModelRegistry;
 	temporaryOnly?: boolean;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ThinkingLevel | null;
 }
 
 function createSelector(
@@ -53,17 +53,35 @@ function createSelector(
 	const ui = {
 		requestRender: vi.fn(),
 	} as unknown as TUI;
+	const scopedModel =
+		options.thinkingLevel === null ? { model } : { model, thinkingLevel: options.thinkingLevel ?? ThinkingLevel.Off };
 
-	return new ModelSelectorComponent(
-		ui,
-		model,
-		settings,
-		modelRegistry,
-		[{ model, thinkingLevel: options.thinkingLevel ?? ThinkingLevel.Off }],
-		onSelect,
-		() => {},
-		{ temporaryOnly: options.temporaryOnly },
-	);
+	return new ModelSelectorComponent(ui, model, settings, modelRegistry, [scopedModel], onSelect, () => {}, {
+		temporaryOnly: options.temporaryOnly,
+	});
+}
+
+function createOpenAIModel(provider: "openai" | "openai-codex", id: string, reasoning = true): Model {
+	return {
+		id,
+		name: id,
+		api: provider === "openai-codex" ? "openai-codex-responses" : "openai-responses",
+		provider,
+		baseUrl: provider === "openai-codex" ? "https://chatgpt.com/backend-api" : "https://api.openai.com/v1",
+		reasoning,
+		thinking: reasoning
+			? {
+					minLevel: Effort.Low,
+					maxLevel: Effort.High,
+					defaultLevel: Effort.Medium,
+					mode: "effort",
+				}
+			: undefined,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 8192,
+	};
 }
 
 function createOllamaCloudModel(id: string): Model {
@@ -320,5 +338,136 @@ describe("ModelSelector canonical model selection", () => {
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("deepseek-v4-pro");
 		expect(rendered).not.toContain("Provider has not been refreshed yet");
+	});
+
+	test("prompts for reasoning before assigning OpenAI reasoning default models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-reasoning-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Default");
+		expect(thinkingRendered).toContain("off");
+		expect(thinkingRendered).toContain("high");
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after reasoning choice");
+		expect(selectedAfterThinking.model).toBe(model);
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("can explicitly choose off for OpenAI reasoning default models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-reasoning-off-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after off choice");
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("prompts for reasoning before assigning OpenAI Codex role-agent models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai-codex", "gpt-codex-reasoning-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Executor");
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI Codex selection after reasoning choice");
+		expect(selectedAfterThinking.role).toBe("executor");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}:high`);
+	});
+
+	test("does not prompt for non-reasoning OpenAI models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-non-reasoning-test", false);
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected direct non-reasoning selection");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Inherit);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
 	});
 });


### PR DESCRIPTION
## Summary
- Prompt for an explicit reasoning choice when selecting reasoning-capable OpenAI or OpenAI Codex models in `/model`.
- Keep default role selectors bare while passing the selected `thinkingLevel`; role-agent assignments continue storing suffixed selectors.
- Add focused regression coverage for OpenAI env behavior and OpenAI Codex non-interference.

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/model-resolver.test.ts`

## Notes
- No new config surface.
- No OpenAI Codex auth/base URL semantic changes.
