### PR TITLE
Fix scoped OpenAI reasoning prompt bypass

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -23,9 +23,13 @@ import type { Settings } from "./settings";
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = DEFAULT_MODEL_PER_PROVIDER;
 
-export interface ScopedModel {
+export interface ScopedModelSelection {
 	model: Model<Api>;
 	thinkingLevel?: ThinkingLevel;
+	explicitThinkingLevel?: boolean;
+}
+
+export interface ScopedModel extends ScopedModelSelection {
 	explicitThinkingLevel: boolean;
 }
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -601,6 +601,7 @@ async function buildSessionOptions(
 			thinkingLevel: scopedModel.explicitThinkingLevel
 				? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
 				: defaultThinkingLevel,
+			explicitThinkingLevel: scopedModel.explicitThinkingLevel,
 		}));
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -14,7 +14,11 @@ import {
 } from "@gajae-code/tui";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
 import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
-import { formatModelSelectorValue, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	formatModelSelectorValue,
+	resolveModelRoleValue,
+	type ScopedModelSelection,
+} from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
@@ -54,6 +58,7 @@ interface ModelItem {
 	model: Model;
 	selector: string;
 	thinkingLevel?: ThinkingLevel;
+	explicitThinkingLevel?: boolean;
 }
 
 interface CanonicalModelItem {
@@ -66,12 +71,10 @@ interface CanonicalModelItem {
 	normalizedSearchText: string;
 	compactSearchText: string;
 	thinkingLevel?: ThinkingLevel;
+	explicitThinkingLevel?: boolean;
 }
 
-interface ScopedModelItem {
-	model: Model;
-	thinkingLevel?: ThinkingLevel;
-}
+type ScopedModelItem = ScopedModelSelection;
 
 interface RoleAssignment {
 	model: Model;
@@ -357,6 +360,7 @@ export class ModelSelectorComponent extends Container {
 				model: scoped.model,
 				selector: `${scoped.model.provider}/${scoped.model.id}`,
 				thinkingLevel: scoped.thinkingLevel,
+				explicitThinkingLevel: scoped.explicitThinkingLevel,
 			}));
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
@@ -425,6 +429,10 @@ export class ModelSelectorComponent extends Container {
 				const scopedThinkingLevel = scopedThinkingBySelector.get(selectedSelector);
 				if (scopedThinkingLevel !== undefined) {
 					item.thinkingLevel = scopedThinkingLevel;
+				}
+				const scopedModel = models.find(model => `${model.model.provider}/${model.model.id}` === selectedSelector);
+				if (scopedModel?.explicitThinkingLevel !== undefined) {
+					item.explicitThinkingLevel = scopedModel.explicitThinkingLevel;
 				}
 				return item;
 			})
@@ -909,7 +917,8 @@ export class ModelSelectorComponent extends Container {
 		thinkingLevel?: ThinkingLevel,
 	): void {
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
-		if (itemThinkingLevel === undefined && requiresExplicitThinkingChoice(item.model)) {
+		const hasExplicitThinkingChoice = thinkingLevel !== undefined || item.explicitThinkingLevel === true;
+		if (!hasExplicitThinkingChoice && requiresExplicitThinkingChoice(item.model)) {
 			this.#pendingThinkingChoice = { item, role, levels: getSelectableThinkingLevels(item.model) };
 			this.#selectedThinkingIndex = 0;
 			this.#updateList();
@@ -947,21 +956,15 @@ function requiresExplicitThinkingChoice(model: Model): boolean {
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {
 	const levels: ThinkingLevel[] = [ThinkingLevel.Off];
+	let efforts: readonly string[];
 	try {
-		for (const effort of getSupportedEfforts(model)) {
-			const level = parseThinkingLevel(effort);
-			if (level && !levels.includes(level)) {
-				levels.push(level);
-			}
-		}
+		efforts = getSupportedEfforts(model);
 	} catch {
-		for (const level of [
-			ThinkingLevel.Minimal,
-			ThinkingLevel.Low,
-			ThinkingLevel.Medium,
-			ThinkingLevel.High,
-			ThinkingLevel.XHigh,
-		]) {
+		return levels;
+	}
+	for (const effort of efforts) {
+		const level = parseThinkingLevel(effort);
+		if (level && !levels.includes(level)) {
 			levels.push(level);
 		}
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -40,6 +40,7 @@ import {
 	parseModelString,
 	resolveAllowedModels,
 	resolveModelRoleValue,
+	type ScopedModelSelection,
 } from "./config/model-resolver";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { Settings, type SkillsSettings } from "./config/settings";
@@ -230,7 +231,7 @@ export interface CreateAgentSessionOptions {
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
-	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	scopedModels?: ScopedModelSelection[];
 
 	/** System prompt blocks. Array replaces default, function receives default blocks and returns final blocks. */
 	systemPrompt?: string[] | ((defaultPrompt: string[]) => string[]);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -95,6 +95,7 @@ import {
 	parseModelString,
 	type ResolvedModelRoleValue,
 	resolveModelRoleValue,
+	type ScopedModelSelection,
 } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -258,7 +259,7 @@ export interface AgentSessionConfig {
 	sessionManager: SessionManager;
 	settings: Settings;
 	/** Models to cycle through with Ctrl+P (from --models flag) */
-	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	scopedModels?: ScopedModelSelection[];
 	/** Initial session thinking selector. */
 	thinkingLevel?: ThinkingLevel;
 	/** Prompt templates for expansion */
@@ -748,7 +749,7 @@ export class AgentSession {
 
 	readonly configWarnings: string[] = [];
 
-	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
@@ -3749,7 +3750,7 @@ export class AgentSession {
 	}
 
 	/** Scoped models for cycling (from --models flag) */
-	get scopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> {
+	get scopedModels(): ReadonlyArray<ScopedModelSelection> {
 		return this.#scopedModels;
 	}
 

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -29,6 +29,7 @@ interface CreateSelectorOptions {
 	modelRegistry?: ModelRegistry;
 	temporaryOnly?: boolean;
 	thinkingLevel?: ThinkingLevel | null;
+	explicitThinkingLevel?: boolean;
 }
 
 function createSelector(
@@ -54,7 +55,13 @@ function createSelector(
 		requestRender: vi.fn(),
 	} as unknown as TUI;
 	const scopedModel =
-		options.thinkingLevel === null ? { model } : { model, thinkingLevel: options.thinkingLevel ?? ThinkingLevel.Off };
+		options.thinkingLevel === null
+			? { model, explicitThinkingLevel: options.explicitThinkingLevel }
+			: {
+					model,
+					thinkingLevel: options.thinkingLevel ?? ThinkingLevel.Off,
+					explicitThinkingLevel: options.explicitThinkingLevel,
+				};
 
 	return new ModelSelectorComponent(ui, model, settings, modelRegistry, [scopedModel], onSelect, () => {}, {
 		temporaryOnly: options.temporaryOnly,
@@ -442,6 +449,86 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterThinking.role).toBe("executor");
 		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.High);
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}:high`);
+	});
+
+	test("prompts for reasoning when scoped OpenAI thinking came from defaults", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-defaulted-scope-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: ThinkingLevel.High, explicitThinkingLevel: false },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Default");
+
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after explicit off choice");
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("does not prompt when scoped OpenAI thinking was explicit", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-explicit-scope-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ thinkingLevel: ThinkingLevel.High, explicitThinkingLevel: true },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected direct explicit scoped selection");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("limits missing OpenAI thinking metadata to off choice", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-missing-thinking-metadata");
+		model.thinking = undefined;
+		const settings = Settings.isolated({});
+
+		const selector = createSelector(model, settings, () => {}, { thinkingLevel: null });
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Default");
+		expect(thinkingRendered).toContain("off");
+		expect(thinkingRendered).not.toContain("high");
+		expect(thinkingRendered).not.toContain("xhigh");
 	});
 
 	test("does not prompt for non-reasoning OpenAI models", async () => {

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -40,6 +40,63 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	return result;
 }
 
+function stripInlineShellComment(value: string): string {
+	let quote: '"' | "'" | undefined;
+	for (let i = 0; i < value.length; i++) {
+		const char = value[i];
+		if (char === "\\") {
+			i++;
+			continue;
+		}
+		if ((char === '"' || char === "'") && (!quote || quote === char)) {
+			quote = quote ? undefined : char;
+			continue;
+		}
+		if (char === "#" && !quote && (i === 0 || /\s/.test(value[i - 1] ?? ""))) {
+			return value.slice(0, i).trimEnd();
+		}
+	}
+	return value.trimEnd();
+}
+
+/**
+ * Parses simple POSIX shell environment assignments from files such as
+ * ~/.zshrc without executing user shell code. Supports `export KEY=value` and
+ * `KEY=value`, including single/double quoted literal values. Dynamic shell
+ * expressions are intentionally ignored because evaluating startup files would
+ * run arbitrary code during CLI startup.
+ */
+export function parseShellEnvFile(filePath: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		for (const line of content.split("\n")) {
+			const trimmed = line.trim();
+			if (!trimmed || trimmed.startsWith("#")) continue;
+
+			const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+			if (!match) continue;
+
+			const key = match[1];
+			if (!isValidEnvName(key)) continue;
+
+			let value = stripInlineShellComment(match[2] ?? "").trim();
+			if (value.endsWith(";")) value = value.slice(0, -1).trimEnd();
+			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+				value = value.slice(1, -1);
+			}
+			if (!isSafeEnvValue(value)) continue;
+			if (/[$`]/.test(value)) continue;
+
+			result[key] = value;
+		}
+	} catch {
+		// File doesn't exist or can't be read - return empty result
+	}
+
+	return result;
+}
+
 /**
  * Parses a .env file synchronously and extracts key-value string pairs.
  * Ignores lines that are empty or start with '#'. Trims whitespace.
@@ -79,6 +136,13 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 }
 
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
+const homeShellEnv = {
+	...parseShellEnvFile(path.join(os.homedir(), ".zshenv")),
+	...parseShellEnvFile(path.join(os.homedir(), ".zprofile")),
+	...parseShellEnvFile(path.join(os.homedir(), ".zshrc")),
+	...parseShellEnvFile(path.join(os.homedir(), ".bash_profile")),
+	...parseShellEnvFile(path.join(os.homedir(), ".bashrc")),
+};
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
@@ -91,7 +155,7 @@ for (const key of Object.keys(Bun.env)) {
 	}
 }
 
-for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
+for (const file of [projectEnv, agentEnv, piEnv, homeEnv, homeShellEnv]) {
 	for (const key in file) {
 		if (!Bun.env[key]) {
 			Bun.env[key] = file[key];

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { filterProcessEnv, parseEnvFile } from "../src/env";
+import { filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 
@@ -12,10 +12,10 @@ afterEach(() => {
 	}
 });
 
-function writeTempEnv(content: string): string {
+function writeTempEnv(content: string, fileName = ".env"): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-"));
 	tempDirs.push(dir);
-	const filePath = path.join(dir, ".env");
+	const filePath = path.join(dir, fileName);
 	fs.writeFileSync(filePath, content);
 	return filePath;
 }
@@ -46,6 +46,26 @@ describe("parseEnvFile", () => {
 
 		expect(parseEnvFile(filePath)).toEqual({
 			GJC_FEATURE: "enabled",
+		});
+	});
+});
+
+describe("parseShellEnvFile", () => {
+	it("loads simple exported zshrc-style OpenAI env values without executing shell code", () => {
+		const filePath = writeTempEnv(
+			[
+				"export OPENAI_BASE_URL=https://openai-proxy.example.com/v1",
+				"OPENAI_API_KEY='shell-key' # local comment",
+				"DYNAMIC_VALUE=$(secret-tool lookup service openai)",
+				"BACKTICK_VALUE=`secret-tool lookup service openai`",
+				"BAD_VALUE=before\0after",
+			].join("\n"),
+			".zshrc",
+		);
+
+		expect(parseShellEnvFile(filePath)).toEqual({
+			OPENAI_BASE_URL: "https://openai-proxy.example.com/v1",
+			OPENAI_API_KEY: "shell-key",
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Carry scoped-model `explicitThinkingLevel` into sessions and the `/model` selector so defaulted scoped thinking does not bypass the required OpenAI/OpenAI Codex reasoning prompt.
- Preserve direct assignment when scoped thinking was explicit, such as `--models openai/model:high`.
- Stop offering unsupported reasoning levels when a reasoning model lacks thinking metadata; only `off` remains selectable.
- Load simple literal env assignments from shell startup files (`~/.zshrc`, `~/.zprofile`, etc.) when process env/.env do not already provide them, so `OPENAI_BASE_URL` / `OPENAI_API_KEY` defined in `~/.zshrc` are visible without a separate `.env` file.

## Verification
- `bun --cwd=packages/utils run check`
- `bun test packages/utils/test/env.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/model-resolver.test.ts`

## Follow-up context
- Resolves post-merge review blockers from PR #70 and the remaining `~/.zshrc` OpenAI env issue.
