### PR TITLE
Respect OpenAI base URL env overrides

### DIFF
--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -26,7 +26,9 @@ import {
 	getOpenAIResponsesHistoryPayload,
 	normalizeResponsesToolCallId,
 } from "@gajae-code/ai/utils";
-import { logger } from "@gajae-code/utils";
+import { $env, logger } from "@gajae-code/utils";
+
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
 // ============================================================================
 // Public types
@@ -77,8 +79,12 @@ function resolveOpenAiCompactEndpoint(model: Model): string {
 		return resolveOpenAiCodexCompactEndpoint(model.baseUrl);
 	}
 
-	const defaultBase = "https://api.openai.com/v1";
-	const rawBase = model.baseUrl && model.baseUrl.length > 0 ? model.baseUrl : defaultBase;
+	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const configuredBaseUrl = model.baseUrl?.trim();
+	const rawBase =
+		envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))
+			? envBaseUrl
+			: configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
 	const normalizedBase = rawBase.endsWith("/") ? rawBase.slice(0, -1) : rawBase;
 	if (normalizedBase.endsWith("/v1")) return `${normalizedBase}/responses/compact`;
 	return `${normalizedBase}/v1/responses/compact`;

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -3,6 +3,18 @@ import { buildOpenAiNativeHistory, requestOpenAiRemoteCompaction } from "@gajae-
 import type { AssistantMessage, Model, ToolResultMessage } from "@gajae-code/ai/types";
 import { hookFetch } from "@gajae-code/utils";
 
+function setEnvForTest(key: string, value: string): () => void {
+	const previous = Bun.env[key];
+	Bun.env[key] = value;
+	return () => {
+		if (previous === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = previous;
+		}
+	};
+}
+
 function makeOpenAiModel(overrides: Partial<Model<"openai-responses">> = {}): Model<"openai-responses"> {
 	return {
 		id: "gpt-5",
@@ -128,6 +140,32 @@ describe("remote compaction input trimming", () => {
 
 		expect(requestInput?.some(item => item.type === "custom_tool_call")).toBe(false);
 		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(false);
+	});
+});
+
+describe("remote compaction endpoint", () => {
+	test("uses OPENAI_BASE_URL for OpenAI compaction when bundled metadata has the default OpenAI URL", async () => {
+		const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+		let requestUrl: string | undefined;
+		try {
+			using _hook = hookFetch(async input => {
+				requestUrl = String(input instanceof Request ? input.url : input);
+				return Response.json({
+					output: [{ type: "compaction_summary", summary: "compact" }],
+				});
+			});
+
+			await requestOpenAiRemoteCompaction(
+				makeOpenAiModel({ baseUrl: "https://api.openai.com/v1" }),
+				"test-key",
+				[{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+				"compact",
+			);
+
+			expect(requestUrl).toBe("https://openai-proxy.example.com/v1/responses/compact");
+		} finally {
+			restore();
+		}
 	});
 });
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -356,7 +356,7 @@ async function generateModels() {
 	for (const models of Object.values(prevModelsJson as Record<string, Record<string, Model>>)) {
 		for (const model of Object.values(models)) {
 			if (!fetchedKeys.has(`${model.provider}/${model.id}`) && !discoveryOnlyProviders.has(model.provider)) {
-				allModels.push(model);
+				allModels.push(model.provider === "openai" ? { ...model, baseUrl: "" } : model);
 			}
 		}
 	}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -8452,7 +8452,7 @@
 			"cost": {
 				"input": 1,
 				"output": 3,
-				"cacheRead": 0,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -8471,7 +8471,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -8495,7 +8495,7 @@
 			"cost": {
 				"input": 0.075,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.0375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -12860,6 +12860,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"moonshotai/kimi-k2.6:free": {
+			"id": "moonshotai/kimi-k2.6:free",
+			"name": "MoonshotAI: Kimi K2.6 (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"morph-warp-grep-v2": {
 			"id": "morph-warp-grep-v2",
@@ -51146,7 +51165,7 @@
 			"name": "OpenAI code Mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -51170,7 +51189,7 @@
 			"name": "GPT-4",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text"
@@ -51189,7 +51208,7 @@
 			"name": "GPT-4 Turbo",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51209,7 +51228,7 @@
 			"name": "GPT-4.1",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51229,7 +51248,7 @@
 			"name": "GPT-4.1 mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51249,7 +51268,7 @@
 			"name": "GPT-4.1 nano",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51269,7 +51288,7 @@
 			"name": "GPT-4o",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51289,7 +51308,7 @@
 			"name": "GPT-4o (2024-05-13)",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51309,7 +51328,7 @@
 			"name": "GPT-4o (2024-08-06)",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51329,7 +51348,7 @@
 			"name": "GPT-4o (2024-11-20)",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51349,7 +51368,7 @@
 			"name": "GPT-4o mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51369,7 +51388,7 @@
 			"name": "GPT-5",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51394,7 +51413,7 @@
 			"id": "gpt-5-chat-latest",
 			"name": "GPT-5 Chat Latest",
 			"api": "openai-responses",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"provider": "openai",
 			"reasoning": false,
 			"input": [
@@ -51416,7 +51435,7 @@
 			"name": "GPT-5-OpenAI code",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51442,7 +51461,7 @@
 			"name": "GPT-5 Mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51468,7 +51487,7 @@
 			"name": "GPT-5 Nano",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51494,7 +51513,7 @@
 			"name": "GPT-5 Pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51520,7 +51539,7 @@
 			"name": "GPT-5.1",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51546,7 +51565,7 @@
 			"name": "GPT-5.1 Chat",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51572,7 +51591,7 @@
 			"name": "GPT-5.1 OpenAI code",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51598,7 +51617,7 @@
 			"name": "GPT-5.1 OpenAI code Max",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51624,7 +51643,7 @@
 			"name": "GPT-5.1 OpenAI code mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51650,7 +51669,7 @@
 			"name": "GPT-5.2",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51676,7 +51695,7 @@
 			"name": "GPT-5.2 Chat",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51702,7 +51721,7 @@
 			"name": "GPT-5.2 OpenAI code",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51728,7 +51747,7 @@
 			"name": "GPT-5.2 Pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51754,7 +51773,7 @@
 			"name": "GPT-5.3 Chat (latest)",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": false,
 			"input": [
 				"text",
@@ -51775,7 +51794,7 @@
 			"name": "GPT-5.3 OpenAI code",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51801,7 +51820,7 @@
 			"name": "GPT-5.3 OpenAI code Spark",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51828,7 +51847,7 @@
 			"name": "GPT-5.4",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51854,7 +51873,7 @@
 			"name": "GPT-5.4 mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51880,7 +51899,7 @@
 			"name": "GPT-5.4 nano",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51906,7 +51925,7 @@
 			"name": "GPT-5.4 Pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51932,7 +51951,7 @@
 			"name": "GPT-5.5",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51959,7 +51978,7 @@
 			"name": "GPT-5.5 Pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -51986,7 +52005,7 @@
 			"name": "o1",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52011,7 +52030,7 @@
 			"name": "o1-pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52036,7 +52055,7 @@
 			"name": "o3",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52061,7 +52080,7 @@
 			"name": "o3-deep-research",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52086,7 +52105,7 @@
 			"name": "o3-mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -52110,7 +52129,7 @@
 			"name": "o3-pro",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52135,7 +52154,7 @@
 			"name": "o4-mini",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52160,7 +52179,7 @@
 			"name": "o4-mini-deep-research",
 			"api": "openai-responses",
 			"provider": "openai",
-			"baseUrl": "https://api.openai.com/v1",
+			"baseUrl": "",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -52973,9 +52992,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.08,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -52997,9 +53016,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.2,
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0.0145,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -54261,6 +54280,31 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2.5-free": {
+			"id": "mimo-v2.5-free",
+			"name": "MiMo V2.5 Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -57044,7 +57088,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 262144,
 			"maxTokens": 8192,
 			"compat": {
 				"supportsToolChoice": false
@@ -57720,6 +57764,31 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262142,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"moonshotai/kimi-k2.6:free": {
+			"id": "moonshotai/kimi-k2.6:free",
+			"name": "MoonshotAI: Kimi K2.6 (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -58616,11 +58685,11 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 32000
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -58636,7 +58705,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -58686,11 +58755,11 @@
 			"cost": {
 				"input": 0.25,
 				"output": 2,
-				"cacheRead": 0.03,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 128000,
+			"maxTokens": 100000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "medium",
@@ -58740,7 +58809,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 32000
+			"maxTokens": 16384
 		},
 		"openai/gpt-5.2-codex": {
 			"id": "openai/gpt-5.2-codex",
@@ -61027,13 +61096,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06599999999999999,
-				"output": 0.26,
-				"cacheRead": 0.029,
+				"input": 0.063,
+				"output": 0.21,
+				"cacheRead": 0.020999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1,3 +1,4 @@
+import { $env } from "@gajae-code/utils";
 import type { ModelManagerOptions } from "../model-manager";
 import { Effort } from "../model-thinking";
 import { getBundledModels } from "../models";
@@ -14,6 +15,7 @@ import { createBundledReferenceMap, createReferenceResolver } from "./bundled-re
 
 const MODELS_DEV_URL = "https://models.dev/api.json";
 const ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 const ANTHROPIC_OAUTH_BETA =
 	"claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05";
 
@@ -494,7 +496,7 @@ export interface OpenAIModelManagerConfig {
 
 export function openaiModelManagerOptions(config?: OpenAIModelManagerConfig): ModelManagerOptions<"openai-responses"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl ?? "https://api.openai.com/v1";
+	const baseUrl = config?.baseUrl?.trim() || $env.OPENAI_BASE_URL?.trim() || OPENAI_DEFAULT_BASE_URL;
 	const references = createBundledReferenceMap<"openai-responses">("openai");
 	return {
 		providerId: "openai",
@@ -2105,7 +2107,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 		"https://generativelanguage.googleapis.com/v1beta",
 	),
 	// --- OpenAI ---
-	simpleModelsDevDescriptor("openai", "openai", "openai-responses", "https://api.openai.com/v1"),
+	simpleModelsDevDescriptor("openai", "openai", "openai-responses", ""),
 	// --- Groq ---
 	openAiCompletionsDescriptor("groq", "groq", "https://api.groq.com/openai/v1"),
 	// --- Cerebras ---

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -70,6 +70,17 @@ import { createInitialResponsesAssistantMessage } from "./openai-responses-share
 import { transformMessages } from "./transform-messages";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+function resolveOpenAIProviderBaseUrl(baseUrl: string | undefined): string {
+	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const configuredBaseUrl = baseUrl?.trim();
+	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
+		return envBaseUrl;
+	}
+	return configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
+}
+
 /**
  * Normalize tool call ID for Mistral.
  * Mistral requires tool IDs to be exactly 9 alphanumeric characters (a-z, A-Z, 0-9).
@@ -931,7 +942,7 @@ async function createClient(
 	}
 	let copilotPremiumRequests: number | undefined;
 
-	let baseUrl = model.baseUrl;
+	let baseUrl = model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl) : model.baseUrl;
 	if (model.provider === "github-copilot") {
 		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
 		const hasImages = hasCopilotVisionInput(context.messages);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -102,6 +102,16 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 const OPENAI_RESPONSES_PROVIDER_SESSION_STATE_PREFIX = "openai-responses:";
 const OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI responses stream timed out while waiting for the first event";
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+function resolveOpenAIProviderBaseUrl(baseUrl: string | undefined): string {
+	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const configuredBaseUrl = baseUrl?.trim();
+	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
+		return envBaseUrl;
+	}
+	return configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
+}
 
 const OPENAI_RESPONSES_PROGRESS_EVENT_TYPES = new Set([
 	"response.created",
@@ -224,7 +234,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				api: output.api,
 				model: model.id,
 				method: "POST",
-				url: `${baseUrl ?? "https://api.openai.com/v1"}/responses`,
+				url: `${baseUrl}/responses`,
 				body: params,
 			};
 			const openaiStream = await callWithCopilotModelRetry(
@@ -331,7 +341,7 @@ function createClient(
 	const headers = { ...(model.headers ?? {}), ...(extraHeaders ?? {}) };
 	let copilotPremiumRequests: number | undefined;
 
-	let baseUrl = model.baseUrl;
+	let baseUrl = model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl) : model.baseUrl;
 	if (model.provider === "github-copilot") {
 		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
 		const hasImages = hasCopilotVisionInput(context.messages);

--- a/packages/ai/test/provider-fetch-override.test.ts
+++ b/packages/ai/test/provider-fetch-override.test.ts
@@ -10,6 +10,18 @@ afterEach(() => {
 	global.fetch = originalFetch;
 });
 
+function setEnvForTest(key: string, value: string): () => void {
+	const previous = Bun.env[key];
+	Bun.env[key] = value;
+	return () => {
+		if (previous === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = previous;
+		}
+	};
+}
+
 const openAIResponsesModel = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
 const openAICompletionsModel = {
 	...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
@@ -122,5 +134,67 @@ describe("StreamOptions.fetch override", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(calls.length).toBeGreaterThanOrEqual(1);
 		expect(calls[0]?.url).toContain("/responses");
+	});
+
+	it("uses OPENAI_BASE_URL for openai-responses even when bundled metadata has the default OpenAI URL", async () => {
+		const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+		const calls: Array<{ url: string }> = [];
+		try {
+			const customFetch = async (input: string | URL | Request, _init?: RequestInit) => {
+				calls.push({ url: String(input instanceof Request ? input.url : input) });
+				return createSseResponse([
+					{ type: "response.created", response: { id: "resp_test" } },
+					{
+						type: "response.completed",
+						response: {
+							id: "resp_test",
+							status: "completed",
+							usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+						},
+					},
+				]);
+			};
+
+			const staleBundledDefault = { ...openAIResponsesModel, baseUrl: "https://api.openai.com/v1" };
+			await streamOpenAIResponses(staleBundledDefault, baseContext(), {
+				apiKey: "test-key",
+				fetch: customFetch,
+			}).result();
+
+			expect(calls[0]?.url).toBe("https://openai-proxy.example.com/v1/responses");
+		} finally {
+			restore();
+		}
+	});
+
+	it("uses OPENAI_BASE_URL for openai-completions even when bundled metadata has the default OpenAI URL", async () => {
+		const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+		const calls: Array<{ url: string }> = [];
+		try {
+			const customFetch = async (input: string | URL | Request, _init?: RequestInit) => {
+				calls.push({ url: String(input instanceof Request ? input.url : input) });
+				return createSseResponse([
+					{
+						id: "chatcmpl-test",
+						object: "chat.completion.chunk",
+						created: 0,
+						model: openAICompletionsModel.id,
+						choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+						usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+					},
+					"[DONE]",
+				]);
+			};
+
+			const staleBundledDefault = { ...openAICompletionsModel, baseUrl: "https://api.openai.com/v1" };
+			await streamOpenAICompletions(staleBundledDefault, baseContext(), {
+				apiKey: "test-key",
+				fetch: customFetch,
+			}).result();
+
+			expect(calls[0]?.url).toBe("https://openai-proxy.example.com/v1/chat/completions");
+		} finally {
+			restore();
+		}
 	});
 });

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -701,11 +701,15 @@ function getOpenAIResponseErrorMessage(rawText: string): string {
 }
 
 function getOpenAIBaseUrl(model: Model): string {
-	const fallback =
-		model.api === "openai-codex-responses" || model.provider === "openai-codex"
-			? CODEX_BASE_URL
-			: DEFAULT_OPENAI_BASE_URL;
-	return (model.baseUrl || fallback).replace(/\/+$/, "");
+	if (model.api === "openai-codex-responses" || model.provider === "openai-codex") {
+		return (model.baseUrl || CODEX_BASE_URL).replace(/\/+$/, "");
+	}
+	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const configuredBaseUrl = model.baseUrl?.trim();
+	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
+		return envBaseUrl.replace(/\/+$/, "");
+	}
+	return (configuredBaseUrl || envBaseUrl || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }
 
 function getOpenAIResponsesUrl(model: Model): string {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -164,6 +164,19 @@ describe("ModelRegistry", () => {
 	}
 
 	describe("provider base URL environment variables", () => {
+		test("does not bake the public OpenAI API URL into bundled OpenAI models", () => {
+			const restore = unsetEnvForTest("OPENAI_BASE_URL");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const openaiModels = getModelsForProvider(registry, "openai");
+
+				expect(openaiModels.length).toBeGreaterThan(0);
+				expect(openaiModels.some(model => model.baseUrl.includes("api.openai.com"))).toBe(false);
+			} finally {
+				restore();
+			}
+		});
+
 		test("uses OPENAI_BASE_URL for bundled OpenAI models when models config has no baseUrl override", () => {
 			const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
 			try {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -8,6 +8,7 @@ import { imageGenTool, setPreferredImageProvider } from "@gajae-code/coding-agen
 
 const originalFetch = global.fetch;
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
+const originalOpenAIBaseUrl = Bun.env.OPENAI_BASE_URL;
 const generatedImagePaths: string[] = [];
 
 afterEach(async () => {
@@ -18,11 +19,17 @@ afterEach(async () => {
 	} else {
 		Bun.env.OPENROUTER_API_KEY = originalOpenRouterKey;
 	}
+	if (originalOpenAIBaseUrl === undefined) {
+		delete Bun.env.OPENAI_BASE_URL;
+	} else {
+		Bun.env.OPENAI_BASE_URL = originalOpenAIBaseUrl;
+	}
 	setPreferredImageProvider("auto");
 });
 
 describe("imageGenTool", () => {
 	it("e2e writes OpenAI Responses image_generation WebP output to a temp file", async () => {
+		delete Bun.env.OPENAI_BASE_URL;
 		let requestUrl: string | undefined;
 		let requestBody: unknown;
 
@@ -88,5 +95,55 @@ describe("imageGenTool", () => {
 		if (!savedPath) throw new Error("Expected generated image path");
 		expect(savedPath.endsWith(".webp")).toBe(true);
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-webp"));
+	});
+
+	it("uses OPENAI_BASE_URL for OpenAI image generation when active model still has the default OpenAI URL", async () => {
+		Bun.env.OPENAI_BASE_URL = "https://openai-proxy.example.com/v1";
+		let requestUrl: string | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			requestUrl = input.toString();
+			return new Response(
+				JSON.stringify({
+					output: [
+						{
+							type: "image_generation_call",
+							result: Buffer.from("fake-webp").toString("base64"),
+							status: "completed",
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "https://api.openai.com/v1",
+		} as Model;
+		const ctx: CustomToolContext = {
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "test-openai-key",
+				getApiKeyForProvider: async () => undefined,
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://openai-proxy.example.com/v1/responses");
 	});
 });


### PR DESCRIPTION
## Summary
- stop baking the public OpenAI API URL into generated OpenAI model metadata
- make OpenAI responses/completions, remote compaction, image generation, and discovery prefer OPENAI_BASE_URL over stale api.openai.com metadata
- keep OpenAI Codex base URL/auth behavior isolated from OPENAI_BASE_URL

## Tests
- bun test packages/ai/test/provider-fetch-override.test.ts packages/agent/test/remote-compaction.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/tools/image-gen.test.ts
- bun --cwd=packages/ai run check
- bun --cwd=packages/agent run check
- bun --cwd=packages/coding-agent run check