### PR TITLE
Pin OpenAI OAuth requests to default API base URL

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -671,6 +671,8 @@ async function streamAssistantResponse(
 
 	// Re-resolve metadata after credential selection so the per-request value
 	// reflects the credential actually used, not the snapshot from AgentLoopConfig construction.
+	const authCredentialType = config.getAuthCredentialType?.(config.model.provider);
+
 	const resolvedMetadata = config.metadataResolver ? config.metadataResolver(config.model.provider) : config.metadata;
 
 	const dynamicToolChoice = config.getToolChoice?.();
@@ -731,6 +733,7 @@ async function streamAssistantResponse(
 			const response = await streamFunction(config.model, llmContext, {
 				...config,
 				apiKey: resolvedApiKey,
+				authCredentialType,
 				metadata: resolvedMetadata,
 				toolChoice: effectiveToolChoice,
 				reasoning: effectiveReasoning,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -128,6 +128,7 @@ export interface AgentOptions {
 	 * Useful for expiring tokens (e.g., GitHub Copilot OAuth).
 	 */
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	getAuthCredentialType?: (provider: string) => "api_key" | "oauth" | undefined;
 
 	/**
 	 * Inspect or replace provider payloads before they are sent.
@@ -307,6 +308,7 @@ export class Agent {
 
 	streamFn: StreamFn;
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	getAuthCredentialType?: (provider: string) => "api_key" | "oauth" | undefined;
 	/**
 	 * Hook invoked after tool arguments are validated and before execution.
 	 * Reassign at any time to swap the implementation (e.g. on extension reload).
@@ -339,6 +341,7 @@ export class Agent {
 		this.#hideThinkingSummary = opts.hideThinkingSummary;
 		this.#maxRetryDelayMs = opts.maxRetryDelayMs;
 		this.getApiKey = opts.getApiKey;
+		this.getAuthCredentialType = opts.getAuthCredentialType;
 		this.#onPayload = opts.onPayload;
 		this.#onResponse = opts.onResponse;
 		this.#onSseEvent = opts.onSseEvent;
@@ -1081,6 +1084,7 @@ export class Agent {
 			onSseEvent: this.#onSseEvent,
 			signal: abortController.signal,
 			getApiKey: this.getApiKey,
+			getAuthCredentialType: this.getAuthCredentialType,
 			getToolContext: this.#getToolContext,
 			syncContextBeforeModelCall: async context => {
 				if (this.#listeners.size > 0) {

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -521,6 +521,7 @@ export interface SummaryOptions {
 	 * or `compaction_turn_prefix`). `undefined` keeps the call paths zero-cost.
 	 */
 	telemetry?: AgentTelemetry;
+	authCredentialType?: "api_key" | "oauth";
 }
 
 export async function generateSummary(
@@ -621,6 +622,7 @@ export interface HandoffOptions {
 	 * wrapped in an OTEL chat span tagged with `pi.gen_ai.oneshot.kind = "handoff"`.
 	 */
 	telemetry?: AgentTelemetry;
+	authCredentialType?: "api_key" | "oauth";
 }
 
 export function renderHandoffPrompt(customInstructions?: string): string {
@@ -928,6 +930,7 @@ export async function compact(
 					remoteHistory,
 					summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
 					signal,
+					{ authCredentialType: options?.authCredentialType },
 				);
 				preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, remote);
 			} catch (err) {

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -74,7 +74,7 @@ export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
 	return model.provider === "openai" || model.provider === "openai-codex";
 }
 
-function resolveOpenAiCompactEndpoint(model: Model): string {
+function resolveOpenAiCompactEndpoint(model: Model, authCredentialType?: "api_key" | "oauth"): string {
 	if (model.provider === "openai-codex") {
 		return resolveOpenAiCodexCompactEndpoint(model.baseUrl);
 	}
@@ -82,9 +82,11 @@ function resolveOpenAiCompactEndpoint(model: Model): string {
 	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = model.baseUrl?.trim();
 	const rawBase =
-		envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))
-			? envBaseUrl
-			: configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
+		authCredentialType === "oauth"
+			? OPENAI_DEFAULT_BASE_URL
+			: envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))
+				? envBaseUrl
+				: configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
 	const normalizedBase = rawBase.endsWith("/") ? rawBase.slice(0, -1) : rawBase;
 	if (normalizedBase.endsWith("/v1")) return `${normalizedBase}/responses/compact`;
 	return `${normalizedBase}/v1/responses/compact`;
@@ -457,8 +459,9 @@ export async function requestOpenAiRemoteCompaction(
 	compactInput: Array<Record<string, unknown>>,
 	instructions: string,
 	signal?: AbortSignal,
+	options?: { authCredentialType?: "api_key" | "oauth" },
 ): Promise<OpenAiRemoteCompactionResponse> {
-	const endpoint = resolveOpenAiCompactEndpoint(model);
+	const endpoint = resolveOpenAiCompactEndpoint(model, options?.authCredentialType);
 	const request: OpenAiRemoteCompactionRequest = {
 		model: model.id,
 		input: trimOpenAiCompactInput(compactInput, model.contextWindow, instructions),

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -106,6 +106,9 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 */
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 
+	/** Returns the credential type selected by the most recent getApiKey call for this session/provider. */
+	getAuthCredentialType?: (provider: string) => "api_key" | "oauth" | undefined;
+
 	/**
 	 * Returns steering messages to inject into the conversation mid-run.
 	 *

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -167,6 +167,32 @@ describe("remote compaction endpoint", () => {
 			restore();
 		}
 	});
+
+	test("keeps OAuth OpenAI compaction on the default API base URL when OPENAI_BASE_URL is set", async () => {
+		const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+		let requestUrl: string | undefined;
+		try {
+			using _hook = hookFetch(async input => {
+				requestUrl = String(input instanceof Request ? input.url : input);
+				return Response.json({
+					output: [{ type: "compaction_summary", summary: "compact" }],
+				});
+			});
+
+			await requestOpenAiRemoteCompaction(
+				makeOpenAiModel({ baseUrl: "" }),
+				"oauth-token",
+				[{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+				"compact",
+				undefined,
+				{ authCredentialType: "oauth" },
+			);
+
+			expect(requestUrl).toBe("https://api.openai.com/v1/responses/compact");
+		} finally {
+			restore();
+		}
+	});
 });
 
 describe("requestOpenAiRemoteCompaction abort", () => {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1046,6 +1046,11 @@ export class AuthStorage {
 		return this.#sessionLastCredential.get(provider)?.get(sessionId);
 	}
 
+	/** Returns the credential type selected for a provider/session, if one has been recorded. */
+	getSessionCredentialType(provider: string, sessionId?: string): AuthCredential["type"] | undefined {
+		return this.#getSessionCredential(provider, sessionId)?.type;
+	}
+
 	/** Clears the last credential used by a session for a provider. */
 	#clearSessionCredential(provider: string, sessionId: string | undefined): void {
 		if (!sessionId) return;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -72,7 +72,11 @@ import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER } from "./vi
 
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
-function resolveOpenAIProviderBaseUrl(baseUrl: string | undefined): string {
+function resolveOpenAIProviderBaseUrl(
+	baseUrl: string | undefined,
+	authCredentialType: "api_key" | "oauth" | undefined,
+): string {
+	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
 	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
 	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
@@ -424,6 +428,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				options?.onSseEvent,
 				options?.fetch,
 				options?.streamFirstEventTimeoutMs,
+				options?.authCredentialType,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			getCapturedErrorResponse = captureErrorResponse;
@@ -899,6 +904,7 @@ async function createClient(
 	onSseEvent?: OpenAICompletionsOptions["onSseEvent"],
 	fetchOverride?: FetchImpl,
 	streamFirstEventTimeoutOverride?: number,
+	authCredentialType?: OpenAICompletionsOptions["authCredentialType"],
 ): Promise<{
 	client: OpenAI;
 	copilotPremiumRequests: number | undefined;
@@ -942,7 +948,8 @@ async function createClient(
 	}
 	let copilotPremiumRequests: number | undefined;
 
-	let baseUrl = model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl) : model.baseUrl;
+	let baseUrl =
+		model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl, authCredentialType) : model.baseUrl;
 	if (model.provider === "github-copilot") {
 		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
 		const hasImages = hasCopilotVisionInput(context.messages);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -104,7 +104,11 @@ const OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI responses stream timed out while waiting for the first event";
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
-function resolveOpenAIProviderBaseUrl(baseUrl: string | undefined): string {
+function resolveOpenAIProviderBaseUrl(
+	baseUrl: string | undefined,
+	authCredentialType: "api_key" | "oauth" | undefined,
+): string {
+	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
 	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
 	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
@@ -223,6 +227,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				cacheSessionId,
 				options?.onSseEvent,
 				options?.fetch,
+				options?.authCredentialType,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
@@ -323,6 +328,7 @@ function createClient(
 	sessionId?: string,
 	onSseEvent?: OpenAIResponsesOptions["onSseEvent"],
 	fetchOverride?: FetchImpl,
+	authCredentialType?: OpenAIResponsesOptions["authCredentialType"],
 ): {
 	client: OpenAI;
 	copilotPremiumRequests: number | undefined;
@@ -341,7 +347,8 @@ function createClient(
 	const headers = { ...(model.headers ?? {}), ...(extraHeaders ?? {}) };
 	let copilotPremiumRequests: number | undefined;
 
-	let baseUrl = model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl) : model.baseUrl;
+	let baseUrl =
+		model.provider === "openai" ? resolveOpenAIProviderBaseUrl(model.baseUrl, authCredentialType) : model.baseUrl;
 	if (model.provider === "github-copilot") {
 		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
 		const hasImages = hasCopilotVisionInput(context.messages);

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -364,6 +364,11 @@ export interface StreamOptions {
 	 * channel) silently ignore the override.
 	 */
 	fetch?: FetchImpl;
+	/**
+	 * Authentication credential type selected for this request.
+	 * Providers use this only when endpoint routing differs between API-key and OAuth credentials.
+	 */
+	authCredentialType?: "api_key" | "oauth";
 	/** Cursor exec/MCP tool handlers (cursor-agent only). */
 	execHandlers?: CursorExecHandlers;
 }

--- a/packages/ai/test/provider-fetch-override.test.ts
+++ b/packages/ai/test/provider-fetch-override.test.ts
@@ -197,4 +197,35 @@ describe("StreamOptions.fetch override", () => {
 			restore();
 		}
 	});
+
+	it("keeps OAuth OpenAI requests on the default API base URL even when OPENAI_BASE_URL is set", async () => {
+		const restore = setEnvForTest("OPENAI_BASE_URL", "https://openai-proxy.example.com/v1");
+		const calls: Array<{ url: string }> = [];
+		try {
+			const customFetch = async (input: string | URL | Request, _init?: RequestInit) => {
+				calls.push({ url: String(input instanceof Request ? input.url : input) });
+				return createSseResponse([
+					{ type: "response.created", response: { id: "resp_test" } },
+					{
+						type: "response.completed",
+						response: {
+							id: "resp_test",
+							status: "completed",
+							usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+						},
+					},
+				]);
+			};
+
+			await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+				apiKey: "oauth-token",
+				authCredentialType: "oauth",
+				fetch: customFetch,
+			}).result();
+
+			expect(calls[0]?.url).toBe("https://api.openai.com/v1/responses");
+		} finally {
+			restore();
+		}
+	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2170,6 +2170,10 @@ export class ModelRegistry {
 		return this.authStorage.hasOAuth(model.provider);
 	}
 
+	getSessionCredentialType(provider: string, sessionId?: string): "api_key" | "oauth" | undefined {
+		return this.authStorage.getSessionCredentialType(provider, sessionId);
+	}
+
 	#clearRuntimeProviderState(providerName: string): void {
 		this.#runtimeProviderApiKeys.delete(providerName);
 		this.#runtimeProviderOverrides.delete(providerName);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1761,6 +1761,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 				return key;
 			},
+			getAuthCredentialType: provider => modelRegistry.getSessionCredentialType(provider, agent.sessionId),
 			streamFn: (streamModel, context, streamOptions) =>
 				streamSimple(streamModel, context, {
 					...streamOptions,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6446,6 +6446,7 @@ export class AgentSession {
 					metadata: this.agent.metadataForProvider(candidate.provider),
 					convertToLlm,
 					telemetry,
+					authCredentialType: this.#modelRegistry.getSessionCredentialType(candidate.provider, this.sessionId),
 				});
 			} catch (error) {
 				if (!this.#isCompactionAuthFailure(error)) {
@@ -6701,6 +6702,10 @@ export class AgentSession {
 								initiatorOverride: "agent",
 								convertToLlm,
 								telemetry,
+								authCredentialType: this.#modelRegistry.getSessionCredentialType(
+									candidate.provider,
+									this.sessionId,
+								),
 							});
 							break;
 						} catch (error) {

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -44,6 +44,7 @@ interface ImageApiKey {
 	apiKey: string;
 	projectId?: string;
 	model?: Model;
+	authCredentialType?: "api_key" | "oauth";
 }
 
 const responseModalitySchema = z.enum(["IMAGE", "TEXT"] as const);
@@ -441,6 +442,7 @@ async function findOpenAIHostedImageCredentials(
 		provider: getOpenAIHostedImageProvider(activeModel),
 		apiKey,
 		model: activeModel,
+		authCredentialType: modelRegistry.getSessionCredentialType?.(activeModel.provider, sessionId),
 	};
 }
 
@@ -700,10 +702,11 @@ function getOpenAIResponseErrorMessage(rawText: string): string {
 	}
 }
 
-function getOpenAIBaseUrl(model: Model): string {
+function getOpenAIBaseUrl(model: Model, authCredentialType?: "api_key" | "oauth"): string {
 	if (model.api === "openai-codex-responses" || model.provider === "openai-codex") {
 		return (model.baseUrl || CODEX_BASE_URL).replace(/\/+$/, "");
 	}
+	if (authCredentialType === "oauth") return DEFAULT_OPENAI_BASE_URL;
 	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = model.baseUrl?.trim();
 	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
@@ -712,8 +715,8 @@ function getOpenAIBaseUrl(model: Model): string {
 	return (configuredBaseUrl || envBaseUrl || DEFAULT_OPENAI_BASE_URL).replace(/\/+$/, "");
 }
 
-function getOpenAIResponsesUrl(model: Model): string {
-	const baseUrl = getOpenAIBaseUrl(model);
+function getOpenAIResponsesUrl(model: Model, authCredentialType?: "api_key" | "oauth"): string {
+	const baseUrl = getOpenAIBaseUrl(model, authCredentialType);
 	if (model.api !== "openai-codex-responses" && model.provider !== "openai-codex") {
 		return `${baseUrl}/responses`;
 	}
@@ -786,11 +789,12 @@ async function generateOpenAIHostedImage(
 	inputImages: InlineImageData[],
 	signal: AbortSignal | undefined,
 	sessionId: string | undefined,
+	options?: { authCredentialType?: "api_key" | "oauth" },
 ): Promise<OpenAIHostedImageResult> {
 	const promptText = assemblePrompt(params);
 	const stream = model.api === "openai-codex-responses" || model.provider === "openai-codex";
 	const requestBody = buildOpenAIHostedImageRequest(model, promptText, params, inputImages, stream);
-	const response = await fetch(getOpenAIResponsesUrl(model), {
+	const response = await fetch(getOpenAIResponsesUrl(model, options?.authCredentialType), {
 		method: "POST",
 		headers: buildOpenAIImageHeaders(model, apiKey, sessionId),
 		body: JSON.stringify(requestBody),
@@ -950,6 +954,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					resolvedImages,
 					requestSignal,
 					sessionId,
+					{ authCredentialType: apiKey.authCredentialType },
 				);
 
 				if (parsed.images.length === 0) {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -146,4 +146,49 @@ describe("imageGenTool", () => {
 
 		expect(requestUrl).toBe("https://openai-proxy.example.com/v1/responses");
 	});
+
+	it("keeps OAuth OpenAI image generation on the default API base URL when OPENAI_BASE_URL is set", async () => {
+		Bun.env.OPENAI_BASE_URL = "https://openai-proxy.example.com/v1";
+		let requestUrl: string | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			requestUrl = input.toString();
+			return new Response(
+				JSON.stringify({
+					output: [{ type: "image_generation_call", result: Buffer.from("fake-webp").toString("base64") }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "",
+		} as Model;
+		const ctx: CustomToolContext = {
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "oauth-token",
+				getApiKeyForProvider: async () => undefined,
+				getSessionCredentialType: () => "oauth",
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://api.openai.com/v1/responses");
+	});
 });


### PR DESCRIPTION
## Summary
- carry selected credential type from auth storage into provider request options
- keep API-key OpenAI honoring OPENAI_BASE_URL and default to https://api.openai.com/v1 when unset
- pin OAuth-authenticated OpenAI responses/completions, image generation, and remote compaction to https://api.openai.com/v1

## Tests
- bun test packages/ai/test/provider-fetch-override.test.ts packages/agent/test/remote-compaction.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/tools/image-gen.test.ts
- bun --cwd=packages/ai run check
- bun --cwd=packages/agent run check
- bun --cwd=packages/coding-agent run check