### PR TITLE
Fix OpenAI proxy URL feature gates

### DIFF
--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1,4 +1,4 @@
-import { $env } from "@gajae-code/utils";
+import { $env, $inheritedEnv } from "@gajae-code/utils";
 import type { ModelManagerOptions } from "../model-manager";
 import { Effort } from "../model-thinking";
 import { getBundledModels } from "../models";
@@ -496,7 +496,11 @@ export interface OpenAIModelManagerConfig {
 
 export function openaiModelManagerOptions(config?: OpenAIModelManagerConfig): ModelManagerOptions<"openai-responses"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl?.trim() || $env.OPENAI_BASE_URL?.trim() || OPENAI_DEFAULT_BASE_URL;
+	const baseUrl =
+		config?.baseUrl?.trim() ||
+		$inheritedEnv("OPENAI_BASE_URL") ||
+		$env.OPENAI_BASE_URL?.trim() ||
+		OPENAI_DEFAULT_BASE_URL;
 	const references = createBundledReferenceMap<"openai-responses">("openai");
 	return {
 		providerId: "openai",

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,4 +1,4 @@
-import { $env, extractHttpStatusFromError } from "@gajae-code/utils";
+import { $env, $inheritedEnv, extractHttpStatusFromError } from "@gajae-code/utils";
 import OpenAI from "openai";
 import type {
 	ChatCompletionAssistantMessageParam,
@@ -77,7 +77,7 @@ function resolveOpenAIProviderBaseUrl(
 	authCredentialType: "api_key" | "oauth" | undefined,
 ): string {
 	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
-	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const envBaseUrl = $inheritedEnv("OPENAI_BASE_URL") ?? $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
 	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
 		return envBaseUrl;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -71,6 +71,17 @@ import { transformMessages } from "./transform-messages";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+const OPENAI_DEFAULT_BASE_URL_HOST = "api.openai.com";
+
+function isDefaultOpenAIBaseUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return url.hostname === OPENAI_DEFAULT_BASE_URL_HOST && (url.pathname === "" || url.pathname === "/v1");
+	} catch {
+		return baseUrl === OPENAI_DEFAULT_BASE_URL;
+	}
+}
+
 
 function resolveOpenAIProviderBaseUrl(
 	baseUrl: string | undefined,
@@ -79,7 +90,7 @@ function resolveOpenAIProviderBaseUrl(
 	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
 	const envBaseUrl = $inheritedEnv("OPENAI_BASE_URL") ?? $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
-	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
+	if (envBaseUrl && (!configuredBaseUrl || isDefaultOpenAIBaseUrl(configuredBaseUrl))) {
 		return envBaseUrl;
 	}
 	return configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -69,11 +69,11 @@ import { transformMessages } from "./transform-messages";
  * Get prompt cache retention based on cacheRetention and base URL.
  * Only applies to direct OpenAI API calls (api.openai.com).
  */
-function getPromptCacheRetention(baseUrl: string, cacheRetention: CacheRetention): "24h" | undefined {
+function getPromptCacheRetention(baseUrl: string | undefined, cacheRetention: CacheRetention): "24h" | undefined {
 	if (cacheRetention !== "long") {
 		return undefined;
 	}
-	if (baseUrl.includes("api.openai.com")) {
+	if (baseUrl && isDefaultOpenAIBaseUrl(baseUrl)) {
 		return "24h";
 	}
 	return undefined;
@@ -103,6 +103,17 @@ const OPENAI_RESPONSES_PROVIDER_SESSION_STATE_PREFIX = "openai-responses:";
 const OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI responses stream timed out while waiting for the first event";
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+const OPENAI_DEFAULT_BASE_URL_HOST = "api.openai.com";
+
+function isDefaultOpenAIBaseUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return url.hostname === OPENAI_DEFAULT_BASE_URL_HOST && (url.pathname === "" || url.pathname === "/v1");
+	} catch {
+		return baseUrl === OPENAI_DEFAULT_BASE_URL;
+	}
+}
+
 
 function resolveOpenAIProviderBaseUrl(
 	baseUrl: string | undefined,
@@ -111,7 +122,7 @@ function resolveOpenAIProviderBaseUrl(
 	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
 	const envBaseUrl = $inheritedEnv("OPENAI_BASE_URL") ?? $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
-	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
+	if (envBaseUrl && (!configuredBaseUrl || isDefaultOpenAIBaseUrl(configuredBaseUrl))) {
 		return envBaseUrl;
 	}
 	return configuredBaseUrl || envBaseUrl || OPENAI_DEFAULT_BASE_URL;
@@ -363,7 +374,7 @@ function createClient(
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}
-	if (sessionId && model.provider === "openai" && (baseUrl ?? "").toLowerCase().includes("api.openai.com")) {
+	if (sessionId && model.provider === "openai" && baseUrl && isDefaultOpenAIBaseUrl(baseUrl)) {
 		headers.session_id ??= sessionId;
 		headers["x-client-request-id"] ??= sessionId;
 	}
@@ -434,7 +445,7 @@ function buildParams(
 		instructions: systemInstructions,
 		stream: true,
 		prompt_cache_key: promptCacheKey,
-		prompt_cache_retention: promptCacheKey ? getPromptCacheRetention(model.baseUrl, cacheRetention) : undefined,
+		prompt_cache_retention: promptCacheKey ? getPromptCacheRetention(resolvedBaseUrl ?? model.baseUrl, cacheRetention) : undefined,
 		store: false,
 		stream_options: model.provider === "openai" ? { include_obfuscation: false } : undefined,
 	};
@@ -482,24 +493,25 @@ function isAzureOpenAIBaseUrl(baseUrl: string): boolean {
 function supportsStrictMode(model: Model<"openai-responses">): boolean {
 	if (model.provider === "openai" || model.provider === "azure" || model.provider === "github-copilot") return true;
 
-	const baseUrl = model.baseUrl.toLowerCase();
+	const baseUrl = model.baseUrl;
+	const lowerBaseUrl = baseUrl.toLowerCase();
 	return (
-		baseUrl.includes("api.openai.com") ||
-		baseUrl.includes(".openai.azure.com") ||
-		baseUrl.includes("models.inference.ai.azure.com")
+		isDefaultOpenAIBaseUrl(baseUrl) ||
+		lowerBaseUrl.includes(".openai.azure.com") ||
+		lowerBaseUrl.includes("models.inference.ai.azure.com")
 	);
 }
 
 export function supportsDeveloperRole(modelOrBaseUrl: Pick<Model, "provider" | "baseUrl"> | string): boolean {
-	const baseUrl =
-		typeof modelOrBaseUrl === "string" ? modelOrBaseUrl.toLowerCase() : (modelOrBaseUrl.baseUrl ?? "").toLowerCase();
+	const baseUrl = typeof modelOrBaseUrl === "string" ? modelOrBaseUrl : (modelOrBaseUrl.baseUrl ?? "");
+	const lowerBaseUrl = baseUrl.toLowerCase();
 	return (
-		baseUrl.includes("api.openai.com") ||
-		baseUrl.includes(".openai.azure.com") ||
-		baseUrl.includes("azure.com/openai") ||
-		baseUrl.includes("models.inference.ai.azure.com") ||
-		baseUrl.includes("githubcopilot.com") ||
-		baseUrl.includes("copilot-api.")
+		isDefaultOpenAIBaseUrl(baseUrl) ||
+		lowerBaseUrl.includes(".openai.azure.com") ||
+		lowerBaseUrl.includes("azure.com/openai") ||
+		lowerBaseUrl.includes("models.inference.ai.azure.com") ||
+		lowerBaseUrl.includes("githubcopilot.com") ||
+		lowerBaseUrl.includes("copilot-api.")
 	);
 }
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1,4 +1,4 @@
-import { $env, extractHttpStatusFromError, structuredCloneJSON } from "@gajae-code/utils";
+import { $env, $inheritedEnv, extractHttpStatusFromError, structuredCloneJSON } from "@gajae-code/utils";
 import OpenAI from "openai";
 import type {
 	Tool as OpenAITool,
@@ -109,7 +109,7 @@ function resolveOpenAIProviderBaseUrl(
 	authCredentialType: "api_key" | "oauth" | undefined,
 ): string {
 	if (authCredentialType === "oauth") return OPENAI_DEFAULT_BASE_URL;
-	const envBaseUrl = $env.OPENAI_BASE_URL?.trim();
+	const envBaseUrl = $inheritedEnv("OPENAI_BASE_URL") ?? $env.OPENAI_BASE_URL?.trim();
 	const configuredBaseUrl = baseUrl?.trim();
 	if (envBaseUrl && (!configuredBaseUrl || configuredBaseUrl.toLowerCase().includes("api.openai.com"))) {
 		return envBaseUrl;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $env, $pickenv, extractHttpStatusFromError } from "@gajae-code/utils";
+import { $env, $inheritedEnv, $pickenv, extractHttpStatusFromError } from "@gajae-code/utils";
 import { getCustomApi } from "./api-registry";
 import type { Effort } from "./model-thinking";
 import {
@@ -77,7 +77,7 @@ type KeyResolver = string | (() => string | undefined);
 
 const serviceProviderMap: Record<string, KeyResolver> = {
 	"alibaba-coding-plan": "ALIBABA_CODING_PLAN_API_KEY",
-	openai: "OPENAI_API_KEY",
+	openai: () => $inheritedEnv("OPENAI_API_KEY") ?? $env.OPENAI_API_KEY,
 	google: "GEMINI_API_KEY",
 	groq: "GROQ_API_KEY",
 	cerebras: "CEREBRAS_API_KEY",

--- a/packages/ai/test/openai-model-discovery-env.test.ts
+++ b/packages/ai/test/openai-model-discovery-env.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+function runDiscoveryIsolationScript(script: string, env: Record<string, string>, dotenv: string): void {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-ai-openai-model-env-"));
+	tempDirs.push(dir);
+	fs.writeFileSync(path.join(dir, ".env"), dotenv);
+	const scriptPath = path.join(dir, "openai-model-discovery-env.test.ts");
+	fs.writeFileSync(scriptPath, script);
+
+	const result = Bun.spawnSync({
+		cmd: [process.execPath, scriptPath],
+		cwd: dir,
+		env: {
+			HOME: os.homedir(),
+			PATH: Bun.env.PATH ?? "",
+			...env,
+		},
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	if (result.exitCode !== 0) {
+		const output = [new TextDecoder().decode(result.stdout), new TextDecoder().decode(result.stderr)]
+			.filter(Boolean)
+			.join("\n");
+		throw new Error(output || `model discovery isolation script exited with ${result.exitCode}`);
+	}
+}
+
+describe("OpenAI model discovery environment precedence", () => {
+	it("uses inherited shell OPENAI_BASE_URL before fallback $env.OPENAI_BASE_URL", () => {
+		const providerModelsUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/provider-models/openai-compat.ts")).href;
+		runDiscoveryIsolationScript(
+			`
+import { openaiModelManagerOptions } from ${JSON.stringify(providerModelsUrl)};
+
+function assertEqual(actual: string | undefined, expected: string, label: string): void {
+	if (actual !== expected) {
+		throw new Error(\`\${label}: expected \${expected}, got \${actual}\`);
+	}
+}
+
+Bun.env.OPENAI_BASE_URL = "https://fallback-openai.example.com/v1";
+const requests: Array<{ url: string; authorization: string | null }> = [];
+globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+	requests.push({
+		url: String(input instanceof Request ? input.url : input),
+		authorization: new Headers(init?.headers).get("authorization"),
+	});
+	return new Response(JSON.stringify({ data: [{ id: "gpt-4o", name: "GPT 4o" }] }), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}) as typeof fetch;
+
+const options = openaiModelManagerOptions({ apiKey: "test-key" });
+const models = await options.fetchDynamicModels?.();
+if (!models?.some(model => model.id === "gpt-4o")) {
+	throw new Error("expected discovered gpt-4o model");
+}
+assertEqual(requests[0]?.url, "https://inherited-openai.example.com/v1/models", "discovery URL");
+assertEqual(requests[0]?.authorization, "Bearer test-key", "discovery authorization");
+`,
+			{ OPENAI_BASE_URL: "https://inherited-openai.example.com/v1" },
+			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
+		);
+	});
+});

--- a/packages/ai/test/provider-fetch-override.test.ts
+++ b/packages/ai/test/provider-fetch-override.test.ts
@@ -403,6 +403,80 @@ assertEqual(calls[0]?.url, "https://runtime-gateway.example.com/v1/responses", "
 			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
 		);
 	});
+	it("does not apply direct OpenAI Responses session or prompt-cache fields to proxy-shaped configured base URLs", () => {
+		runProviderIsolationScript(
+			`${openAIProviderIsolationPrelude()}
+Bun.env.OPENAI_BASE_URL = "https://fallback-openai.example.com/v1";
+
+const calls: Array<{
+	url: string;
+	sessionId: string | null;
+	clientRequestId: string | null;
+	promptCacheKey?: unknown;
+	promptCacheRetention?: unknown;
+}> = [];
+const customFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+	const body = JSON.parse(String(init?.body ?? "{}")) as {
+		prompt_cache_key?: unknown;
+		prompt_cache_retention?: unknown;
+	};
+	const headers = new Headers(init?.headers);
+	calls.push({
+		url: String(input instanceof Request ? input.url : input),
+		sessionId: headers.get("session_id"),
+		clientRequestId: headers.get("x-client-request-id"),
+		promptCacheKey: body.prompt_cache_key,
+		promptCacheRetention: body.prompt_cache_retention,
+	});
+	return sse([
+		{ type: "response.created", response: { id: "resp_test" } },
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_test",
+				status: "completed",
+				usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+			},
+		},
+	]);
+};
+
+await streamOpenAIResponses(
+	{ ...responsesModel, baseUrl: "https://api.openai.com.proxy.example.com/v1" },
+	baseContext(),
+	{
+		apiKey: "test-key",
+		cacheRetention: "long",
+		fetch: customFetch,
+		sessionId: "proxy-session",
+	},
+).result();
+await streamOpenAIResponses(
+	{ ...responsesModel, baseUrl: "https://proxy.example.com/api.openai.com/v1" },
+	baseContext(),
+	{
+		apiKey: "test-key",
+		cacheRetention: "long",
+		fetch: customFetch,
+		sessionId: "path-session",
+	},
+).result();
+
+assertEqual(calls[0]?.url, "https://api.openai.com.proxy.example.com/v1/responses", "host proxy URL");
+assertEqual(calls[0]?.sessionId, null, "host proxy session header");
+assertEqual(calls[0]?.clientRequestId, null, "host proxy request id header");
+assertEqual(String(calls[0]?.promptCacheKey), "proxy-session", "host proxy prompt cache key");
+assertEqual(calls[0]?.promptCacheRetention as string | undefined, undefined, "host proxy prompt cache retention");
+assertEqual(calls[1]?.url, "https://proxy.example.com/api.openai.com/v1/responses", "path proxy URL");
+assertEqual(calls[1]?.sessionId, null, "path proxy session header");
+assertEqual(calls[1]?.clientRequestId, null, "path proxy request id header");
+assertEqual(String(calls[1]?.promptCacheKey), "path-session", "path proxy prompt cache key");
+assertEqual(calls[1]?.promptCacheRetention as string | undefined, undefined, "path proxy prompt cache retention");
+`,
+			{ OPENAI_BASE_URL: "https://inherited-openai.example.com/v1" },
+			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
+		);
+	});
 
 	it("keeps OAuth OpenAI Responses on the default API base URL ahead of inherited and fallback OPENAI_BASE_URL", () => {
 		runProviderIsolationScript(

--- a/packages/ai/test/provider-fetch-override.test.ts
+++ b/packages/ai/test/provider-fetch-override.test.ts
@@ -1,16 +1,30 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { $inheritedEnv } from "@gajae-code/utils";
 import { getBundledModel } from "../src/models";
 import { streamOpenAICompletions } from "../src/providers/openai-completions";
 import { streamOpenAIResponses } from "../src/providers/openai-responses";
 import type { Context, Model } from "../src/types";
 
 const originalFetch = global.fetch;
+const tempDirs: string[] = [];
+
 
 afterEach(() => {
 	global.fetch = originalFetch;
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { force: true, recursive: true });
+	}
 });
 
 function setEnvForTest(key: string, value: string): () => void {
+	const inherited = $inheritedEnv(key);
+	if (inherited !== undefined) {
+		return () => {};
+	}
 	const previous = Bun.env[key];
 	Bun.env[key] = value;
 	return () => {
@@ -20,6 +34,83 @@ function setEnvForTest(key: string, value: string): () => void {
 			Bun.env[key] = previous;
 		}
 	};
+}
+
+function runProviderIsolationScript(script: string, env: Record<string, string>, dotenv: string): void {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-ai-openai-env-"));
+	tempDirs.push(dir);
+	fs.writeFileSync(path.join(dir, ".env"), dotenv);
+	const scriptPath = path.join(dir, "provider-env-isolation.test.ts");
+	fs.writeFileSync(scriptPath, script);
+
+	const result = Bun.spawnSync({
+		cmd: [process.execPath, scriptPath],
+		cwd: dir,
+		env: {
+			HOME: os.homedir(),
+			PATH: Bun.env.PATH ?? "",
+			...env,
+		},
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	if (result.exitCode !== 0) {
+		const output = [new TextDecoder().decode(result.stdout), new TextDecoder().decode(result.stderr)]
+			.filter(Boolean)
+			.join("\n");
+		throw new Error(output || `provider isolation script exited with ${result.exitCode}`);
+	}
+}
+
+function providerImportUrls(): {
+	models: string;
+	openAICompletions: string;
+	openAIResponses: string;
+	types: string;
+} {
+	return {
+		models: pathToFileURL(path.resolve(import.meta.dir, "../src/models.ts")).href,
+		openAICompletions: pathToFileURL(path.resolve(import.meta.dir, "../src/providers/openai-completions.ts")).href,
+		openAIResponses: pathToFileURL(path.resolve(import.meta.dir, "../src/providers/openai-responses.ts")).href,
+		types: pathToFileURL(path.resolve(import.meta.dir, "../src/types.ts")).href,
+	};
+}
+
+function openAIProviderIsolationPrelude(): string {
+	const urls = providerImportUrls();
+	return `
+import { getBundledModel } from ${JSON.stringify(urls.models)};
+import { streamOpenAICompletions } from ${JSON.stringify(urls.openAICompletions)};
+import { streamOpenAIResponses } from ${JSON.stringify(urls.openAIResponses)};
+import type { Context, Model } from ${JSON.stringify(urls.types)};
+
+const responsesModel = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+const completionsModel = {
+	...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
+	api: "openai-completions",
+} satisfies Model<"openai-completions">;
+
+function assertEqual(actual: string | undefined | null, expected: string | undefined | null, label: string): void {
+	if (actual !== expected) {
+		throw new Error(\`\${label}: expected \${expected}, got \${actual}\`);
+	}
+}
+
+function baseContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+	};
+}
+
+function sse(events: unknown[]): Response {
+	const payload = \`\${events.map(event => \`data: \${typeof event === "string" ? event : JSON.stringify(event)}\`).join("\\n\\n")}\\n\\n\`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+`;
 }
 
 const openAIResponsesModel = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
@@ -161,7 +252,7 @@ describe("StreamOptions.fetch override", () => {
 				fetch: customFetch,
 			}).result();
 
-			expect(calls[0]?.url).toBe("https://openai-proxy.example.com/v1/responses");
+			expect(calls[0]?.url).toBe(`${$inheritedEnv("OPENAI_BASE_URL") ?? "https://openai-proxy.example.com/v1"}/responses`);
 		} finally {
 			restore();
 		}
@@ -192,7 +283,7 @@ describe("StreamOptions.fetch override", () => {
 				fetch: customFetch,
 			}).result();
 
-			expect(calls[0]?.url).toBe("https://openai-proxy.example.com/v1/chat/completions");
+			expect(calls[0]?.url).toBe(`${$inheritedEnv("OPENAI_BASE_URL") ?? "https://openai-proxy.example.com/v1"}/chat/completions`);
 		} finally {
 			restore();
 		}
@@ -227,5 +318,174 @@ describe("StreamOptions.fetch override", () => {
 		} finally {
 			restore();
 		}
+	});
+
+	it("uses inherited shell OPENAI_BASE_URL ahead of fallback $env for default OpenAI Responses and Completions", () => {
+		runProviderIsolationScript(
+			`${openAIProviderIsolationPrelude()}
+Bun.env.OPENAI_BASE_URL = "https://fallback-openai.example.com/v1";
+
+const calls: Array<{ url: string }> = [];
+const customFetch = async (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+	calls.push({ url: String(input instanceof Request ? input.url : input) });
+	if (calls.length === 1) {
+		return sse([
+			{ type: "response.created", response: { id: "resp_test" } },
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_test",
+					status: "completed",
+					usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+				},
+			},
+		]);
+	}
+	return sse([
+		{
+			id: "chatcmpl-test",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: completionsModel.id,
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+		},
+		"[DONE]",
+	]);
+};
+
+await streamOpenAIResponses({ ...responsesModel, baseUrl: "https://api.openai.com/v1" }, baseContext(), {
+	apiKey: "test-key",
+	fetch: customFetch,
+}).result();
+await streamOpenAICompletions({ ...completionsModel, baseUrl: "https://api.openai.com/v1" }, baseContext(), {
+	apiKey: "test-key",
+	fetch: customFetch,
+}).result();
+
+assertEqual(calls[0]?.url, "https://inherited-openai.example.com/v1/responses", "responses inherited base URL");
+assertEqual(calls[1]?.url, "https://inherited-openai.example.com/v1/chat/completions", "completions inherited base URL");
+`,
+			{ OPENAI_BASE_URL: "https://inherited-openai.example.com/v1" },
+			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
+		);
+	});
+
+	it("keeps deliberate non-default OpenAI model base URLs ahead of inherited OPENAI_BASE_URL", () => {
+		runProviderIsolationScript(
+			`${openAIProviderIsolationPrelude()}
+Bun.env.OPENAI_BASE_URL = "https://fallback-openai.example.com/v1";
+
+const calls: Array<{ url: string }> = [];
+const customFetch = async (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+	calls.push({ url: String(input instanceof Request ? input.url : input) });
+	return sse([
+		{ type: "response.created", response: { id: "resp_test" } },
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_test",
+				status: "completed",
+				usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+			},
+		},
+	]);
+};
+
+await streamOpenAIResponses({ ...responsesModel, baseUrl: "https://runtime-gateway.example.com/v1" }, baseContext(), {
+	apiKey: "test-key",
+	fetch: customFetch,
+}).result();
+
+assertEqual(calls[0]?.url, "https://runtime-gateway.example.com/v1/responses", "runtime model base URL");
+`,
+			{ OPENAI_BASE_URL: "https://inherited-openai.example.com/v1" },
+			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
+		);
+	});
+
+	it("keeps OAuth OpenAI Responses on the default API base URL ahead of inherited and fallback OPENAI_BASE_URL", () => {
+		runProviderIsolationScript(
+			`${openAIProviderIsolationPrelude()}
+Bun.env.OPENAI_BASE_URL = "https://fallback-openai.example.com/v1";
+
+const calls: Array<{ url: string }> = [];
+const customFetch = async (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+	calls.push({ url: String(input instanceof Request ? input.url : input) });
+	return sse([
+		{ type: "response.created", response: { id: "resp_test" } },
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_test",
+				status: "completed",
+				usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+			},
+		},
+	]);
+};
+
+await streamOpenAIResponses(responsesModel, baseContext(), {
+	apiKey: "oauth-token",
+	authCredentialType: "oauth",
+	fetch: customFetch,
+}).result();
+
+assertEqual(calls[0]?.url, "https://api.openai.com/v1/responses", "oauth base URL");
+`,
+			{ OPENAI_BASE_URL: "https://inherited-openai.example.com/v1" },
+			"OPENAI_BASE_URL=https://dotenv-openai.example.com/v1\n",
+		);
+	});
+
+	it("uses inherited shell OPENAI_API_KEY for Authorization and lets explicit apiKey win", () => {
+		runProviderIsolationScript(
+			`${openAIProviderIsolationPrelude()}
+Bun.env.OPENAI_API_KEY = "fallback-key";
+
+const authorizations: Array<string | null> = [];
+const customFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+	const url = String(input instanceof Request ? input.url : input);
+	authorizations.push(new Headers(init?.headers).get("authorization"));
+	if (url.endsWith("/chat/completions")) {
+		return sse([
+			{
+				id: "chatcmpl-test",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: completionsModel.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+			},
+			"[DONE]",
+		]);
+	}
+	return sse([
+		{ type: "response.created", response: { id: "resp_test" } },
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_test",
+				status: "completed",
+				usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+			},
+		},
+	]);
+};
+
+await streamOpenAIResponses(responsesModel, baseContext(), { fetch: customFetch }).result();
+await streamOpenAICompletions(completionsModel, baseContext(), { fetch: customFetch }).result();
+await streamOpenAIResponses(responsesModel, baseContext(), {
+	apiKey: "explicit-key",
+	fetch: customFetch,
+}).result();
+
+assertEqual(authorizations[0], "Bearer inherited-key", "responses inherited authorization");
+assertEqual(authorizations[1], "Bearer inherited-key", "completions inherited authorization");
+assertEqual(authorizations[2], "Bearer explicit-key", "explicit authorization");
+`,
+			{ OPENAI_API_KEY: "inherited-key" },
+			"OPENAI_API_KEY=dotenv-key\n",
+		);
 	});
 });

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -135,6 +135,16 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 	return result;
 }
 
+const inheritedEnv = filterProcessEnv(Bun.env);
+
+export function $inheritedEnv(name: string): string | undefined {
+	if (!isSafeEnvName(name)) return undefined;
+	const value = inheritedEnv[name];
+	if (value === undefined || !isSafeEnvValue(value)) return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
 const homeShellEnv = {
 	...parseShellEnvFile(path.join(os.homedir(), ".zshenv")),

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
@@ -18,6 +19,30 @@ function writeTempEnv(content: string, fileName = ".env"): string {
 	const filePath = path.join(dir, fileName);
 	fs.writeFileSync(filePath, content);
 	return filePath;
+}
+
+function runEnvIsolationScript(script: string, env: Record<string, string>, cwd: string): void {
+	const scriptPath = path.join(cwd, "env-isolation.test.ts");
+	fs.writeFileSync(scriptPath, script);
+
+	const result = Bun.spawnSync({
+		cmd: [process.execPath, scriptPath],
+		cwd,
+		env: {
+			HOME: os.homedir(),
+			PATH: Bun.env.PATH ?? "",
+			...env,
+		},
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	if (result.exitCode !== 0) {
+		const output = [new TextDecoder().decode(result.stdout), new TextDecoder().decode(result.stderr)]
+			.filter(Boolean)
+			.join("\n");
+		throw new Error(output || `env isolation script exited with ${result.exitCode}`);
+	}
 }
 
 describe("parseEnvFile", () => {
@@ -67,6 +92,38 @@ describe("parseShellEnvFile", () => {
 			OPENAI_BASE_URL: "https://openai-proxy.example.com/v1",
 			OPENAI_API_KEY: "shell-key",
 		});
+	});
+});
+
+describe("$inheritedEnv", () => {
+	it("keeps the inherited shell snapshot stable while $env reflects later fallback overlay mutation", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-inherited-"));
+		tempDirs.push(dir);
+		fs.writeFileSync(path.join(dir, ".env"), "GJC_ENV_TEST_UNUSED=unused\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $env, $inheritedEnv } from ${JSON.stringify(envSourceUrl)};
+
+function assertEqual(actual: string | undefined, expected: string | undefined, label: string): void {
+	if (actual !== expected) {
+		throw new Error(\`\${label}: expected \${expected}, got \${actual}\`);
+	}
+}
+
+assertEqual($inheritedEnv("GJC_ENV_TEST_INHERITED_ONLY"), "shell-from-parent", "inherited shell value");
+assertEqual($env.GJC_ENV_TEST_INHERITED_ONLY, "shell-from-parent", "initial merged env value");
+Bun.env.GJC_ENV_TEST_INHERITED_ONLY = "overlay-after-import";
+assertEqual($inheritedEnv("GJC_ENV_TEST_INHERITED_ONLY"), "shell-from-parent", "stable inherited shell snapshot");
+assertEqual($env.GJC_ENV_TEST_INHERITED_ONLY, "overlay-after-import", "live $env overlay value");
+Bun.env.GJC_ENV_TEST_FALLBACK_ONLY = "fallback-after-import";
+assertEqual($inheritedEnv("GJC_ENV_TEST_FALLBACK_ONLY"), undefined, "absent inherited value");
+assertEqual($env.GJC_ENV_TEST_FALLBACK_ONLY, "fallback-after-import", "fallback remains available through $env");
+`,
+			{ GJC_ENV_TEST_INHERITED_ONLY: "shell-from-parent" },
+			dir,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
- tighten OpenAI default base URL detection to exact api.openai.com host/path checks
- use resolved Responses base URL for direct-OpenAI session and prompt-cache gates
- add regression coverage for proxy-shaped configured base URLs containing api.openai.com

## Verification
- bun test packages/ai/test/provider-fetch-override.test.ts
- bun --cwd=packages/ai run check:types