### PR TITLE
Implement workflow skill HUD summaries

### DIFF
--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -1,5 +1,6 @@
 import { Command } from "@gajae-code/utils/cli";
-import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
+import { syncSkillActiveState } from "../skill-state/active-state";
+import { runGjcRuntimeBridgeWithHudSidecar } from "./gjc-runtime-bridge";
 
 export default class DeepInterview extends Command {
 	static description = "Run private GJC deep-interview workflow commands";
@@ -7,6 +8,24 @@ export default class DeepInterview extends Command {
 	static examples = ["$ gjc deep-interview --help"];
 
 	async run(): Promise<void> {
-		await runBridgedRuntimeEndpoint("deep-interview", this.argv);
+		const cwd = process.cwd();
+		const result = await runGjcRuntimeBridgeWithHudSidecar("deep-interview", this.argv, {
+			cwd,
+			sidecarSkill: "deep-interview",
+			onHudPayload: payload =>
+				syncSkillActiveState({
+					cwd,
+					skill: "deep-interview",
+					active: payload.active ?? true,
+					phase: payload.phase,
+					sessionId: payload.session_id,
+					threadId: payload.thread_id,
+					turnId: payload.turn_id,
+					hud: payload.hud,
+					source: "gjc-runtime-bridge",
+				}),
+		});
+		if (result.error) process.stderr.write(`${result.error}\n`);
+		process.exitCode = result.status;
 	}
 }

--- a/packages/coding-agent/src/commands/gjc-runtime-bridge.ts
+++ b/packages/coding-agent/src/commands/gjc-runtime-bridge.ts
@@ -1,9 +1,15 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { normalizeWorkflowHudSummary, type WorkflowHudSummary } from "../skill-state/active-state";
 
 const BRIDGE_ENV = "GJC_RUNTIME_BINARY";
 const LEGACY_BRIDGE_ENV = "GJC_LEGACY_RUNTIME_BINARY";
 const GUARD_ENV = "GJC_RUNTIME_BRIDGE_ACTIVE";
+export const WORKFLOW_HUD_PROTOCOL = "workflow-hud-summary-v1";
 
 export interface GjcRuntimeBridgeResult {
 	status: number;
@@ -11,6 +17,29 @@ export interface GjcRuntimeBridgeResult {
 }
 
 const SKILL_ENTRYPOINT_ENDPOINTS = new Set(["deep-interview", "ralplan"]);
+
+export interface WorkflowHudBridgePayload {
+	version: 1;
+	skill: string;
+	phase?: string;
+	active?: boolean;
+	session_id?: string;
+	thread_id?: string;
+	turn_id?: string;
+	hud: WorkflowHudSummary;
+}
+
+export interface GjcRuntimeHudBridgeResult extends GjcRuntimeBridgeResult {
+	hudPayload?: WorkflowHudBridgePayload;
+}
+
+export interface GjcRuntimeHudBridgeOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	sidecarSkill: string;
+	onHudPayload?: (payload: WorkflowHudBridgePayload) => Promise<void> | void;
+	pollIntervalMs?: number;
+}
 
 function candidateBinaries(env: NodeJS.ProcessEnv): string[] {
 	return [env[BRIDGE_ENV], env[LEGACY_BRIDGE_ENV]].filter(
@@ -24,6 +53,61 @@ function isPathLike(command: string): boolean {
 
 function canAttempt(command: string): boolean {
 	return !isPathLike(command) || existsSync(command);
+}
+
+function unavailableBridgeResult(
+	endpoint: string,
+	env: NodeJS.ProcessEnv,
+	attempted: string[],
+): GjcRuntimeBridgeResult {
+	const configured = [env[BRIDGE_ENV], env[LEGACY_BRIDGE_ENV]].filter(Boolean).join(", ");
+	const guidance = SKILL_ENTRYPOINT_ENDPOINTS.has(endpoint)
+		? `Inside a GJC agent session, invoke /skill:${endpoint} instead so the bundled skill is loaded directly.`
+		: `Configure ${BRIDGE_ENV} with a GJC-compatible private runtime binary for the ${endpoint} endpoint.`;
+	return {
+		status: 1,
+		error: [
+			`gjc ${endpoint} is a private runtime bridge command.`,
+			guidance,
+			`Only private runtime deployments should call this bridge command; configure them with ${BRIDGE_ENV}.`,
+			configured
+				? `Configured runtime candidates failed: ${configured}.`
+				: "No private GJC runtime binary was configured.",
+			attempted.length > 0 ? `Attempted: ${attempted.join(", ")}.` : undefined,
+		]
+			.filter(Boolean)
+			.join("\n"),
+	};
+}
+
+export function normalizeWorkflowHudBridgePayload(
+	raw: unknown,
+	expectedSkill: string,
+): WorkflowHudBridgePayload | null {
+	if (!raw || typeof raw !== "object") return null;
+	const record = raw as Record<string, unknown>;
+	if (record.version !== 1 || record.skill !== expectedSkill) return null;
+	const hud = normalizeWorkflowHudSummary(record.hud);
+	if (!hud) return null;
+	return {
+		version: 1,
+		skill: expectedSkill,
+		phase: typeof record.phase === "string" && record.phase.trim() ? record.phase.trim() : undefined,
+		active: typeof record.active === "boolean" ? record.active : undefined,
+		session_id:
+			typeof record.session_id === "string" && record.session_id.trim() ? record.session_id.trim() : undefined,
+		thread_id: typeof record.thread_id === "string" && record.thread_id.trim() ? record.thread_id.trim() : undefined,
+		turn_id: typeof record.turn_id === "string" && record.turn_id.trim() ? record.turn_id.trim() : undefined,
+		hud,
+	};
+}
+
+async function readHudPayload(sidecarPath: string, expectedSkill: string): Promise<WorkflowHudBridgePayload | null> {
+	try {
+		return normalizeWorkflowHudBridgePayload(JSON.parse(await Bun.file(sidecarPath).text()), expectedSkill);
+	} catch {
+		return null;
+	}
 }
 
 export function runGjcRuntimeBridge(
@@ -60,24 +144,80 @@ export function runGjcRuntimeBridge(
 		return { status: child.status ?? (child.signal ? 1 : 0) };
 	}
 
-	const configured = [env[BRIDGE_ENV], env[LEGACY_BRIDGE_ENV]].filter(Boolean).join(", ");
-	const guidance = SKILL_ENTRYPOINT_ENDPOINTS.has(endpoint)
-		? `Inside a GJC agent session, invoke /skill:${endpoint} instead so the bundled skill is loaded directly.`
-		: `Configure ${BRIDGE_ENV} with a GJC-compatible private runtime binary for the ${endpoint} endpoint.`;
-	return {
-		status: 1,
-		error: [
-			`gjc ${endpoint} is a private runtime bridge command.`,
-			guidance,
-			`Only private runtime deployments should call this bridge command; configure them with ${BRIDGE_ENV}.`,
-			configured
-				? `Configured runtime candidates failed: ${configured}.`
-				: "No private GJC runtime binary was configured.",
-			attempted.length > 0 ? `Attempted: ${attempted.join(", ")}.` : undefined,
-		]
-			.filter(Boolean)
-			.join("\n"),
-	};
+	return unavailableBridgeResult(endpoint, env, attempted);
+}
+
+export async function runGjcRuntimeBridgeWithHudSidecar(
+	endpoint: string,
+	args: string[],
+	options: GjcRuntimeHudBridgeOptions,
+): Promise<GjcRuntimeHudBridgeResult> {
+	const env = options.env ?? process.env;
+	if (env[GUARD_ENV] === "1") return { status: 1, error: `Refusing recursive gjc runtime bridge for ${endpoint}.` };
+
+	const attempted: string[] = [];
+	for (const binary of candidateBinaries(env)) {
+		const command = binary.trim();
+		if (!canAttempt(command)) continue;
+		attempted.push(command);
+		const sidecarDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-workflow-hud-"));
+		const sidecarPath = path.join(sidecarDir, `${options.sidecarSkill}-${randomUUID()}.json`);
+		let latestPayload: WorkflowHudBridgePayload | undefined;
+		let lastRaw = "";
+		const publishPayload = async (): Promise<void> => {
+			let raw = "";
+			try {
+				raw = await Bun.file(sidecarPath).text();
+			} catch {
+				return;
+			}
+			if (!raw || raw === lastRaw) return;
+			lastRaw = raw;
+			const payload = await readHudPayload(sidecarPath, options.sidecarSkill);
+			if (!payload) return;
+			latestPayload = payload;
+			try {
+				await options.onHudPayload?.(payload);
+			} catch {
+				// HUD sidecar sync is best-effort and must not change child command semantics.
+			}
+		};
+		try {
+			const child = spawn(command, [endpoint, ...args], {
+				cwd: options.cwd,
+				stdio: "inherit",
+				env: {
+					...env,
+					[GUARD_ENV]: "1",
+					GJC_WORKFLOW_HUD_PROTOCOL: WORKFLOW_HUD_PROTOCOL,
+					GJC_WORKFLOW_HUD_SIDECAR: sidecarPath,
+					GJC_WORKFLOW_HUD_SKILL: options.sidecarSkill,
+				},
+			});
+			const interval = setInterval(() => {
+				void publishPayload();
+			}, options.pollIntervalMs ?? 100);
+			const exit = Promise.withResolvers<{ status: number; error?: string; code?: string }>();
+			child.on("error", error => {
+				const fsError = error as NodeJS.ErrnoException;
+				exit.resolve({ status: 1, error: error.message, code: fsError.code });
+			});
+			child.on("exit", (code, signal) => exit.resolve({ status: code ?? (signal ? 1 : 0) }));
+			const result = await exit.promise;
+			clearInterval(interval);
+			await publishPayload();
+			if (result.code === "ENOENT") continue;
+			return {
+				status: result.status,
+				...(result.error ? { error: result.error } : {}),
+				...(latestPayload ? { hudPayload: latestPayload } : {}),
+			};
+		} finally {
+			await fs.rm(sidecarDir, { recursive: true, force: true });
+		}
+	}
+
+	return unavailableBridgeResult(endpoint, env, attempted);
 }
 
 export async function runBridgedRuntimeEndpoint(endpoint: string, args: string[]): Promise<void> {

--- a/packages/coding-agent/src/commands/ralplan.ts
+++ b/packages/coding-agent/src/commands/ralplan.ts
@@ -1,5 +1,6 @@
 import { Command } from "@gajae-code/utils/cli";
-import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
+import { syncSkillActiveState } from "../skill-state/active-state";
+import { runGjcRuntimeBridgeWithHudSidecar } from "./gjc-runtime-bridge";
 
 export default class Ralplan extends Command {
 	static description = "Run private GJC RALPLAN workflow commands";
@@ -7,6 +8,24 @@ export default class Ralplan extends Command {
 	static examples = ["$ gjc ralplan --help"];
 
 	async run(): Promise<void> {
-		await runBridgedRuntimeEndpoint("ralplan", this.argv);
+		const cwd = process.cwd();
+		const result = await runGjcRuntimeBridgeWithHudSidecar("ralplan", this.argv, {
+			cwd,
+			sidecarSkill: "ralplan",
+			onHudPayload: payload =>
+				syncSkillActiveState({
+					cwd,
+					skill: "ralplan",
+					active: payload.active ?? true,
+					phase: payload.phase,
+					sessionId: payload.session_id,
+					threadId: payload.thread_id,
+					turnId: payload.turn_id,
+					hud: payload.hud,
+					source: "gjc-runtime-bridge",
+				}),
+		});
+		if (result.error) process.stderr.write(`${result.error}\n`);
+		process.exitCode = result.status;
 	}
 }

--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -1,12 +1,17 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import {
+	buildTeamHudSummary,
 	executeGjcTeamApiOperation,
+	type GjcTeamSnapshot,
 	listGjcTeams,
 	monitorGjcTeam,
 	parseTeamLaunchArgs,
+	readGjcTeamEvents,
+	readGjcTeamSnapshot,
 	shutdownGjcTeam,
 	startGjcTeam,
 } from "../gjc-runtime/team-runtime";
+import { syncSkillActiveState } from "../skill-state/active-state";
 
 function writeJson(value: unknown): void {
 	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -14,6 +19,21 @@ function writeJson(value: unknown): void {
 
 function writeText(lines: string[]): void {
 	process.stdout.write(`${lines.join("\n")}\n`);
+}
+async function syncTeamHud(snapshot: GjcTeamSnapshot): Promise<void> {
+	try {
+		const events = await readGjcTeamEvents(snapshot.team_name);
+		await syncSkillActiveState({
+			cwd: process.cwd(),
+			skill: "team",
+			active: snapshot.phase !== "complete" && snapshot.phase !== "cancelled",
+			phase: snapshot.phase,
+			hud: await buildTeamHudSummary(snapshot, events.at(-1)),
+			source: "gjc-team",
+		});
+	} catch {
+		// HUD sync is best-effort and must not change command semantics.
+	}
 }
 
 function formatTaskCounts(counts: Record<string, number>): string {
@@ -86,6 +106,7 @@ export default class Team extends Command {
 			const teamName = rest.find(arg => !arg.startsWith("--"));
 			if (!teamName) throw new Error("missing_team_name");
 			const snapshot = await monitorGjcTeam(teamName);
+			await syncTeamHud(snapshot);
 			if (json) {
 				writeJson(snapshot);
 				return;
@@ -106,6 +127,7 @@ export default class Team extends Command {
 			const teamName = rest.find(arg => !arg.startsWith("--"));
 			if (!teamName) throw new Error("missing_team_name");
 			const snapshot = await shutdownGjcTeam(teamName);
+			await syncTeamHud(snapshot);
 			if (json) {
 				writeJson(snapshot);
 				return;
@@ -127,13 +149,23 @@ export default class Team extends Command {
 				return;
 			}
 			const input = parseInputFlag(rest);
-			writeJson(await executeGjcTeamApiOperation(operation, input));
+			const result = await executeGjcTeamApiOperation(operation, input);
+			const teamName = String(input.team_name ?? input.teamName ?? "").trim();
+			if (teamName) {
+				try {
+					await syncTeamHud(await readGjcTeamSnapshot(teamName));
+				} catch {
+					// API operations without a resolvable snapshot leave HUD state unchanged.
+				}
+			}
+			writeJson(result);
 			return;
 		}
 
 		const startArgs = action === "start" ? rest : this.argv;
 		const options = parseTeamLaunchArgs(startArgs);
 		const snapshot = await startGjcTeam({ ...options, dryRun });
+		await syncTeamHud(snapshot);
 		if (json) {
 			writeJson(snapshot);
 			return;

--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -6,7 +6,13 @@ import {
 	writeCurrentSessionGoalModeState,
 	writePendingGoalModeRequest,
 } from "../gjc-runtime/goal-mode-request";
-import { runNativeUltragoalCommand } from "../gjc-runtime/ultragoal-runtime";
+import {
+	buildUltragoalHudSummary,
+	getUltragoalStatus,
+	readUltragoalLedger,
+	runNativeUltragoalCommand,
+} from "../gjc-runtime/ultragoal-runtime";
+import { syncSkillActiveState } from "../skill-state/active-state";
 
 export default class Ultragoal extends Command {
 	static description = "Run native GJC Ultragoal workflow commands";
@@ -19,6 +25,20 @@ export default class Ultragoal extends Command {
 		if (result.stdout) process.stdout.write(result.stdout);
 		if (result.stderr) process.stderr.write(result.stderr);
 		process.exitCode = result.status;
+		try {
+			const summary = await getUltragoalStatus(process.cwd());
+			const ledger = await readUltragoalLedger(process.cwd());
+			await syncSkillActiveState({
+				cwd: process.cwd(),
+				skill: "ultragoal",
+				active: summary.exists && summary.status !== "complete",
+				phase: summary.status,
+				hud: buildUltragoalHudSummary(summary, ledger.at(-1)),
+				source: "gjc-ultragoal",
+			});
+		} catch {
+			// HUD sync is best-effort and must not change command semantics.
+		}
 		if (result.status !== 0 || !shouldActivateGoalMode) return;
 
 		const cwd = process.cwd();

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { WorkflowHudSummary } from "../skill-state/active-state";
+import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { applyGjcTmuxProfile } from "./launch-tmux";
 
 export type GjcTeamPhase = "starting" | "running" | "complete" | "failed" | "cancelled";
@@ -236,7 +238,7 @@ interface GjcTmuxLeaderContext {
 	leaderPaneId: string;
 	target: string;
 }
-interface GjcTeamEvent {
+export interface GjcTeamEvent {
 	event_id: string;
 	ts: string;
 	type: string;
@@ -1647,6 +1649,22 @@ export async function requestGjcWorkerIntegrationAttempt(
 		head,
 		status: classification.kind,
 	};
+}
+
+export async function buildTeamHudSummary(
+	snapshot: GjcTeamSnapshot,
+	latestEvent?: GjcTeamEvent,
+	latestMessage?: GjcTeamMailboxMessage,
+): Promise<WorkflowHudSummary> {
+	return buildWorkflowTeamHudSummary({
+		phase: snapshot.phase,
+		task_total: snapshot.task_total,
+		task_counts: snapshot.task_counts,
+		workers: snapshot.workers,
+		updated_at: snapshot.updated_at,
+		latestEvent,
+		latestMessage,
+	});
 }
 
 export async function monitorGjcTeam(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1,6 +1,8 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { WorkflowHudSummary } from "../skill-state/active-state";
+import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 
 export type UltragoalGjcGoalMode = "aggregate" | "per-story";
@@ -447,6 +449,19 @@ export async function getUltragoalStatus(cwd: string): Promise<UltragoalStatusSu
 		counts,
 		goals: plan.goals,
 	};
+}
+export function buildUltragoalHudSummary(
+	summary: UltragoalStatusSummary,
+	latestLedger?: UltragoalLedgerEvent,
+): WorkflowHudSummary {
+	return buildWorkflowUltragoalHudSummary({
+		status: summary.status,
+		currentGoal: summary.currentGoal,
+		counts: summary.counts,
+		goals: summary.goals,
+		latestLedgerEvent: latestLedger,
+		updatedAt: new Date().toISOString(),
+	});
 }
 
 function titleFromBrief(brief: string): string {

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
 import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
+import type { SkillActiveEntry as CanonicalSkillActiveEntry, WorkflowHudSummary } from "../skill-state/active-state";
 import {
 	compareSkillKeywordMatches,
 	GJC_SKILL_KEYWORD_DEFINITIONS,
@@ -72,7 +73,7 @@ export interface SkillKeywordMatch {
 	priority: number;
 }
 
-export interface SkillActiveEntry {
+export interface SkillActiveEntry extends Omit<CanonicalSkillActiveEntry, "skill"> {
 	skill: GjcWorkflowSkill;
 	phase?: string;
 	active?: boolean;
@@ -81,6 +82,8 @@ export interface SkillActiveEntry {
 	session_id?: string;
 	thread_id?: string;
 	turn_id?: string;
+	hud?: WorkflowHudSummary;
+	stale?: boolean;
 }
 
 export interface SkillActiveState {

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -1,4 +1,4 @@
-import type { SkillActiveEntry } from "../../../skill-state/active-state";
+import type { SkillActiveEntry, WorkflowHudChip } from "../../../skill-state/active-state";
 
 const ANSI_RESET_FG = "\x1b[39m";
 const ANSI_RESET_BOLD = "\x1b[22m";
@@ -31,16 +31,43 @@ function compareEntries(a: SkillActiveEntry, b: SkillActiveEntry): number {
 	return a.skill.localeCompare(b.skill) || (a.phase ?? "").localeCompare(b.phase ?? "");
 }
 
+function compareChips(a: WorkflowHudChip, b: WorkflowHudChip): number {
+	return (a.priority ?? 50) - (b.priority ?? 50) || a.label.localeCompare(b.label);
+}
+
+function chipPrefix(chip: WorkflowHudChip): string {
+	if (chip.severity === "error") return "!";
+	if (chip.severity === "blocked") return "block";
+	if (chip.severity === "warning") return "warn";
+	return "";
+}
+
+function formatChip(chip: WorkflowHudChip): string | null {
+	const label = sanitizeHudPart(chip.label);
+	const value = sanitizeHudPart(chip.value);
+	if (!label) return null;
+	const body = value ? `${label}=${value}` : label;
+	const prefix = chipPrefix(chip);
+	return prefix ? `${prefix}:${body}` : body;
+}
+
+function formatEntry(entry: SkillActiveEntry): string {
+	const skill = sanitizeHudPart(entry.skill);
+	const phase = sanitizeHudPart(entry.phase);
+	const base = phase ? `${skill}:${phase}` : skill;
+	const chips = [...(entry.hud?.chips ?? [])]
+		.sort(compareChips)
+		.map(formatChip)
+		.filter((chip): chip is string => Boolean(chip));
+	if (entry.stale === true) chips.unshift("warn:stale");
+	const summary = sanitizeHudPart(entry.hud?.summary);
+	return [base, summary, ...chips].filter(Boolean).join(" ");
+}
+
 export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
 	const active = entries.filter(entry => entry.active !== false && sanitizeHudPart(entry.skill)).sort(compareEntries);
 	if (active.length === 0 || width <= 0) return null;
-	const body = active
-		.map(entry => {
-			const skill = sanitizeHudPart(entry.skill);
-			const phase = sanitizeHudPart(entry.phase);
-			return phase ? `${skill}:${phase}` : skill;
-		})
-		.join(" + ");
+	const body = active.map(formatEntry).join(" + ");
 	const prefix = `${ANSI_BORDER}◆${ANSI_RESET_FG} ${ANSI_BOLD}${ANSI_ACCENT}hud${ANSI_RESET_FG}${ANSI_RESET_BOLD} `;
 	const budget = Math.max(1, width - visibleWidth(prefix));
 	return truncateToWidth(`${prefix}${ANSI_DIM}${truncateToWidth(body, budget)}${ANSI_RESET_BOLD}`, width);

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -7,6 +7,23 @@ export const SKILL_ACTIVE_STALE_MS = 24 * 60 * 60 * 1000;
 export const CANONICAL_GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
 
 export type CanonicalGjcWorkflowSkill = (typeof CANONICAL_GJC_WORKFLOW_SKILLS)[number];
+export type WorkflowHudSeverity = "info" | "warning" | "blocked" | "error" | "success";
+
+export interface WorkflowHudChip {
+	label: string;
+	value?: string;
+	priority?: number;
+	severity?: WorkflowHudSeverity;
+}
+
+export interface WorkflowHudSummary {
+	version: 1;
+	summary?: string;
+	chips?: WorkflowHudChip[];
+	details?: WorkflowHudChip[];
+	severity?: WorkflowHudSeverity;
+	updated_at?: string;
+}
 
 export interface SkillActiveEntry {
 	skill: string;
@@ -17,6 +34,8 @@ export interface SkillActiveEntry {
 	session_id?: string;
 	thread_id?: string;
 	turn_id?: string;
+	hud?: WorkflowHudSummary;
+	stale?: boolean;
 }
 
 export interface SkillActiveState {
@@ -50,10 +69,77 @@ export interface SyncSkillActiveStateOptions {
 	turnId?: string;
 	nowIso?: string;
 	source?: string;
+	hud?: WorkflowHudSummary;
 }
+
+const HUD_TEXT_LIMIT = 80;
+const HUD_CHIP_LIMIT = 6;
+const HUD_DETAIL_LIMIT = 12;
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const HUD_SEVERITIES = new Set<WorkflowHudSeverity>(["info", "warning", "blocked", "error", "success"]);
 
 function safeString(value: unknown): string {
 	return typeof value === "string" ? value : "";
+}
+
+function sanitizeHudString(value: unknown, limit = HUD_TEXT_LIMIT): string | undefined {
+	const normalized = safeString(value)
+		.replace(ANSI_PATTERN, "")
+		.replace(/[\r\n\t]+/g, " ")
+		.trim();
+	if (!normalized) return undefined;
+	return normalized.length > limit ? normalized.slice(0, limit) : normalized;
+}
+
+function normalizeSeverity(value: unknown): WorkflowHudSeverity | undefined {
+	return typeof value === "string" && HUD_SEVERITIES.has(value as WorkflowHudSeverity)
+		? (value as WorkflowHudSeverity)
+		: undefined;
+}
+
+function normalizeHudChip(raw: unknown): WorkflowHudChip | null {
+	if (!raw || typeof raw !== "object") return null;
+	const record = raw as Record<string, unknown>;
+	const label = sanitizeHudString(record.label, 32);
+	if (!label) return null;
+	const value = sanitizeHudString(record.value, HUD_TEXT_LIMIT);
+	const priority =
+		typeof record.priority === "number" && Number.isFinite(record.priority) ? record.priority : undefined;
+	const severity = normalizeSeverity(record.severity);
+	return {
+		label,
+		...(value ? { value } : {}),
+		...(priority !== undefined ? { priority } : {}),
+		...(severity ? { severity } : {}),
+	};
+}
+
+function normalizeHudChips(raw: unknown, limit: number): WorkflowHudChip[] | undefined {
+	if (!Array.isArray(raw)) return undefined;
+	const chips = raw
+		.map(normalizeHudChip)
+		.filter((chip): chip is WorkflowHudChip => chip !== null)
+		.slice(0, limit);
+	return chips.length > 0 ? chips : undefined;
+}
+
+export function normalizeWorkflowHudSummary(raw: unknown): WorkflowHudSummary | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const record = raw as Record<string, unknown>;
+	if (record.version !== 1) return undefined;
+	const summary = sanitizeHudString(record.summary);
+	const chips = normalizeHudChips(record.chips, HUD_CHIP_LIMIT);
+	const details = normalizeHudChips(record.details, HUD_DETAIL_LIMIT);
+	const severity = normalizeSeverity(record.severity);
+	const updatedAt = sanitizeHudString(record.updated_at, 40);
+	return {
+		version: 1,
+		...(summary ? { summary } : {}),
+		...(chips ? { chips } : {}),
+		...(details ? { details } : {}),
+		...(severity ? { severity } : {}),
+		...(updatedAt ? { updated_at: updatedAt } : {}),
+	};
 }
 
 function encodePathSegment(value: string): string {
@@ -70,9 +156,17 @@ function timestampMs(value: string | undefined): number | null {
 	return Number.isFinite(ms) ? ms : null;
 }
 
+function entryTimestampMs(entry: SkillActiveEntry): number | null {
+	return timestampMs(entry.hud?.updated_at) ?? timestampMs(entry.updated_at) ?? timestampMs(entry.activated_at);
+}
+
 function isFreshEntry(entry: SkillActiveEntry, nowMs = Date.now()): boolean {
-	const ms = timestampMs(entry.updated_at) ?? timestampMs(entry.activated_at);
+	const ms = entryTimestampMs(entry);
 	return ms === null || nowMs - ms <= SKILL_ACTIVE_STALE_MS;
+}
+
+function withDerivedStale(entry: SkillActiveEntry, nowMs = Date.now()): SkillActiveEntry {
+	return { ...entry, stale: !isFreshEntry(entry, nowMs) };
 }
 
 function normalizeEntry(raw: unknown): SkillActiveEntry | null {
@@ -80,6 +174,7 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 	const record = raw as Record<string, unknown>;
 	const skill = safeString(record.skill).trim();
 	if (!skill) return null;
+	const hud = normalizeWorkflowHudSummary(record.hud);
 	return {
 		...record,
 		skill,
@@ -90,6 +185,8 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 		session_id: safeString(record.session_id).trim() || undefined,
 		thread_id: safeString(record.thread_id).trim() || undefined,
 		turn_id: safeString(record.turn_id).trim() || undefined,
+		...(hud ? { hud } : {}),
+		stale: undefined,
 	};
 }
 
@@ -185,11 +282,12 @@ function mergeVisibleEntries(
 	rootState: SkillActiveState | null,
 	sessionId?: string,
 ): SkillActiveEntry[] {
-	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId).filter(entry =>
-		isFreshEntry(entry),
+	const nowMs = Date.now();
+	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId).map(entry =>
+		withDerivedStale(entry, nowMs),
 	);
 	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of listActiveSkills(sessionState).filter(entry => isFreshEntry(entry))) {
+	for (const entry of listActiveSkills(sessionState).map(candidate => withDerivedStale(candidate, nowMs))) {
 		merged.set(entryKey(entry), entry);
 	}
 	return [...merged.values()];
@@ -229,6 +327,7 @@ function upsertEntry(entries: SkillActiveEntry[], entry: SkillActiveEntry, activ
 
 export async function syncSkillActiveState(options: SyncSkillActiveStateOptions): Promise<void> {
 	const nowIso = options.nowIso ?? new Date().toISOString();
+	const hud = normalizeWorkflowHudSummary(options.hud);
 	const entry: SkillActiveEntry = {
 		skill: options.skill,
 		phase: options.phase,
@@ -238,6 +337,7 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 		session_id: options.sessionId,
 		thread_id: options.threadId,
 		turn_id: options.turnId,
+		...(hud ? { hud } : {}),
 	};
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, options.sessionId);
 	const rootState = (await readStateFile(rootPath)) ?? { version: 1, active_skills: [] };

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -1,0 +1,160 @@
+import type { WorkflowHudChip, WorkflowHudSummary } from "./active-state";
+
+interface DeepInterviewHudState {
+	phase?: string;
+	ambiguity?: number;
+	threshold?: number;
+	roundCount?: number;
+	targetComponent?: string;
+	weakestDimension?: string;
+	specStatus?: string;
+	updatedAt?: string;
+}
+
+interface RalplanHudState {
+	stage?: string;
+	waiting?: string;
+	iteration?: number;
+	verdict?: string;
+	latestSummary?: string;
+	pendingApproval?: boolean;
+	updatedAt?: string;
+}
+
+interface UltragoalLikeGoal {
+	id: string;
+	title: string;
+	status: string;
+}
+
+interface UltragoalHudState {
+	status: string;
+	currentGoal?: UltragoalLikeGoal;
+	counts: Record<string, number>;
+	goals: UltragoalLikeGoal[];
+	latestLedgerEvent?: { event?: string; goalId?: string; timestamp?: string };
+	updatedAt?: string;
+}
+
+interface TeamHudWorker {
+	id: string;
+	status?: string;
+}
+
+interface TeamHudState {
+	phase: string;
+	task_total: number;
+	task_counts: Record<string, number>;
+	workers: TeamHudWorker[];
+	updated_at?: string;
+	latestEvent?: { type?: string; worker?: string; message?: string };
+	latestMessage?: { from_worker?: string; body?: string };
+}
+
+function percent(value: number | undefined): string | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+	return `${Math.round(value * 100)}%`;
+}
+
+function chip(
+	label: string,
+	value: string | undefined,
+	priority: number,
+	severity?: WorkflowHudChip["severity"],
+): WorkflowHudChip | null {
+	if (!value) return null;
+	return { label, value, priority, ...(severity ? { severity } : {}) };
+}
+
+function compactChips(chips: Array<WorkflowHudChip | null>): WorkflowHudChip[] {
+	return chips.filter((item): item is WorkflowHudChip => item !== null);
+}
+
+export function buildDeepInterviewHudSummary(state: DeepInterviewHudState): WorkflowHudSummary {
+	return {
+		version: 1,
+		chips: compactChips([
+			chip("phase", state.phase, 10),
+			chip("ambiguity", [percent(state.ambiguity), percent(state.threshold)].filter(Boolean).join("/"), 20),
+			chip("round", state.roundCount === undefined ? undefined : String(state.roundCount), 30),
+			chip("target", state.targetComponent, 40),
+			chip("weakest", state.weakestDimension, 50),
+			chip("spec", state.specStatus, 60),
+		]),
+		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
+	};
+}
+
+export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSummary {
+	const verdict = state.verdict?.toUpperCase();
+	const verdictSeverity =
+		verdict === "BLOCK"
+			? "blocked"
+			: verdict === "ITERATE" || verdict === "WATCH"
+				? "warning"
+				: verdict === "APPROVE" || verdict === "CLEAR"
+					? "success"
+					: undefined;
+	return {
+		version: 1,
+		summary: state.latestSummary,
+		chips: compactChips([
+			state.pendingApproval ? { label: "pending", value: "approval", priority: 5, severity: "warning" } : null,
+			chip("stage", state.stage, 10),
+			chip("waiting", state.waiting, 20),
+			chip("iter", state.iteration === undefined ? undefined : String(state.iteration), 30),
+			chip("verdict", verdict, 40, verdictSeverity),
+		]),
+		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
+	};
+}
+
+export function buildUltragoalHudSummary(state: UltragoalHudState): WorkflowHudSummary {
+	const total = state.goals.length;
+	const complete = state.counts.complete ?? 0;
+	const blockers = (state.counts.blocked ?? 0) + (state.counts.review_blocked ?? 0) + (state.counts.failed ?? 0);
+	return {
+		version: 1,
+		chips: compactChips([
+			blockers > 0 ? { label: "blocked", value: String(blockers), priority: 5, severity: "blocked" } : null,
+			chip("goals", `${complete}/${total}`, 10),
+			chip("current", state.currentGoal ? `${state.currentGoal.id}:${state.currentGoal.title}` : state.status, 20),
+			chip("status", state.status, 30, state.status === "complete" ? "success" : undefined),
+		]),
+		details: state.latestLedgerEvent
+			? compactChips([
+					chip(
+						"ledger",
+						[state.latestLedgerEvent.event, state.latestLedgerEvent.goalId].filter(Boolean).join(":"),
+						100,
+					),
+				])
+			: undefined,
+		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
+	};
+}
+
+export function buildTeamHudSummary(state: TeamHudState): WorkflowHudSummary {
+	const failedWorkers = state.workers.filter(
+		worker => worker.status === "failed" || worker.status === "blocked",
+	).length;
+	const stoppedWorkers = state.workers.filter(worker => worker.status === "stopped").length;
+	const completed = state.task_counts.completed ?? 0;
+	const failedTasks = (state.task_counts.failed ?? 0) + (state.task_counts.blocked ?? 0);
+	const latest = state.latestEvent?.message ?? state.latestEvent?.type ?? state.latestMessage?.body;
+	return {
+		version: 1,
+		chips: compactChips([
+			failedWorkers > 0 || failedTasks > 0
+				? { label: "blocked", value: String(failedWorkers + failedTasks), priority: 5, severity: "blocked" }
+				: stoppedWorkers > 0
+					? { label: "stopped", value: String(stoppedWorkers), priority: 5, severity: "warning" }
+					: null,
+			chip("phase", state.phase, 10),
+			chip("workers", `${state.workers.length - failedWorkers}/${state.workers.length}`, 20),
+			chip("tasks", `${completed}/${state.task_total}`, 30),
+			chip("latest", latest, 50),
+		]),
+		...(state.updated_at ? { updated_at: state.updated_at } : {}),
+	};
+}

--- a/packages/coding-agent/test/gjc-runtime-bridge.test.ts
+++ b/packages/coding-agent/test/gjc-runtime-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runGjcRuntimeBridge } from "../src/commands/gjc-runtime-bridge";
+import { runGjcRuntimeBridge, runGjcRuntimeBridgeWithHudSidecar } from "../src/commands/gjc-runtime-bridge";
 
 let cleanupRoot: string | undefined;
 
@@ -49,5 +49,107 @@ describe("gjc runtime bridge", () => {
 		expect(result.error).toContain("gjc state is a private runtime bridge command");
 		expect(result.error).toContain("Configure GJC_RUNTIME_BINARY with a GJC-compatible private runtime binary");
 		expect(result.error).not.toContain("/skill:state");
+	});
+
+	it("streams workflow HUD sidecar payloads without changing child status", async () => {
+		cleanupRoot = await mkdtemp(join(tmpdir(), "gjc-runtime-bridge-"));
+		const runtimePath = join(cleanupRoot, "gjc-runtime.sh");
+		await writeFile(
+			runtimePath,
+			`#!/bin/sh
+printf '{"version":1,"skill":"ralplan","phase":"planner","hud":{"version":1,"chips":[{"label":"stage","value":"planner"}]}}' > "$GJC_WORKFLOW_HUD_SIDECAR"
+/bin/sleep 0.2
+printf '{"version":1,"skill":"ralplan","phase":"critic","hud":{"version":1,"chips":[{"label":"stage","value":"critic"}]}}' > "$GJC_WORKFLOW_HUD_SIDECAR"
+`,
+			{ mode: 0o755 },
+		);
+		const payloads: string[] = [];
+
+		const result = await runGjcRuntimeBridgeWithHudSidecar("ralplan", ["--direct"], {
+			env: { GJC_RUNTIME_BINARY: runtimePath, PATH: "" },
+			sidecarSkill: "ralplan",
+			pollIntervalMs: 25,
+			onHudPayload: payload => {
+				payloads.push(payload.phase ?? "");
+			},
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.hudPayload?.phase).toBe("critic");
+		expect(payloads).toContain("planner");
+		expect(payloads).toContain("critic");
+	});
+
+	it("keeps HUD callback failures non-fatal", async () => {
+		cleanupRoot = await mkdtemp(join(tmpdir(), "gjc-runtime-bridge-"));
+		const runtimePath = join(cleanupRoot, "gjc-runtime.sh");
+		await writeFile(
+			runtimePath,
+			`#!/bin/sh
+printf '{"version":1,"skill":"ralplan","hud":{"version":1,"chips":[{"label":"stage","value":"critic"}]}}' > "$GJC_WORKFLOW_HUD_SIDECAR"
+`,
+			{ mode: 0o755 },
+		);
+
+		const result = await runGjcRuntimeBridgeWithHudSidecar("ralplan", [], {
+			env: { GJC_RUNTIME_BINARY: runtimePath, PATH: "" },
+			sidecarSkill: "ralplan",
+			onHudPayload: () => {
+				throw new Error("hud-write-failed");
+			},
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.error).toBeUndefined();
+		expect(result.hudPayload?.hud.chips?.[0]?.value).toBe("critic");
+	});
+
+	it("tries the legacy runtime candidate when the HUD bridge primary candidate is missing", async () => {
+		cleanupRoot = await mkdtemp(join(tmpdir(), "gjc-runtime-bridge-"));
+		const logPath = join(cleanupRoot, "argv.log");
+		const runtimePath = join(cleanupRoot, "gjc-runtime.sh");
+		await writeFile(
+			runtimePath,
+			`#!/bin/sh
+printf '%s\n' "$1|$2" > ${JSON.stringify(logPath)}
+printf '{"version":1,"skill":"ralplan","hud":{"version":1,"chips":[{"label":"stage","value":"legacy"}]}}' > "$GJC_WORKFLOW_HUD_SIDECAR"
+`,
+			{ mode: 0o755 },
+		);
+
+		const result = await runGjcRuntimeBridgeWithHudSidecar("ralplan", ["--direct"], {
+			env: {
+				GJC_RUNTIME_BINARY: join(cleanupRoot, "missing-runtime"),
+				GJC_LEGACY_RUNTIME_BINARY: runtimePath,
+				PATH: "",
+			},
+			sidecarSkill: "ralplan",
+		});
+
+		expect(result.status).toBe(0);
+		expect(await readFile(logPath, "utf-8")).toBe("ralplan|--direct\n");
+		expect(result.hudPayload?.hud.chips?.[0]?.value).toBe("legacy");
+	});
+
+	it("keeps child failure authoritative even with a valid sidecar", async () => {
+		cleanupRoot = await mkdtemp(join(tmpdir(), "gjc-runtime-bridge-"));
+		const runtimePath = join(cleanupRoot, "gjc-runtime.sh");
+		await writeFile(
+			runtimePath,
+			`#!/bin/sh
+printf '{"version":1,"skill":"ralplan","hud":{"version":1,"chips":[{"label":"stage","value":"critic"}]}}' > "$GJC_WORKFLOW_HUD_SIDECAR"
+exit 7
+`,
+			{ mode: 0o755 },
+		);
+
+		const result = await runGjcRuntimeBridgeWithHudSidecar("ralplan", [], {
+			env: { GJC_RUNTIME_BINARY: runtimePath, PATH: "" },
+			sidecarSkill: "ralplan",
+			pollIntervalMs: 25,
+		});
+
+		expect(result.status).toBe(7);
+		expect(result.hudPayload?.hud.chips?.[0]?.value).toBe("critic");
 	});
 });

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -100,7 +100,7 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
-	it("suppresses stale visible entries left by crashed sessions", async () => {
+	it("keeps stale active entries visible with derived stale metadata", async () => {
 		await withTempCwd(async cwd => {
 			await syncSkillActiveState({
 				cwd,
@@ -110,7 +110,38 @@ describe("GJC skill-active state", () => {
 				nowIso: "2000-01-01T00:00:00.000Z",
 			});
 
-			expect(await readVisibleSkillActiveState(cwd, "sess-old")).toBeNull();
+			const visible = await readVisibleSkillActiveState(cwd, "sess-old");
+			expect(visible?.active_skills?.[0]).toEqual(expect.objectContaining({ skill: "team", stale: true }));
+		});
+	});
+
+	it("normalizes and preserves HUD summaries during root/session merge", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({
+				cwd,
+				skill: "deep-interview",
+				active: true,
+				phase: "interviewing",
+				sessionId: "sess-hud",
+				nowIso: new Date().toISOString(),
+				hud: {
+					version: 1,
+					summary: "round\tone",
+					chips: [{ label: "ambiguity\n", value: "15%", priority: 10, severity: "success" }],
+					details: Array.from({ length: 20 }, (_, index) => ({ label: `d${index}`, value: "x" })),
+				},
+			});
+
+			const visible = await readVisibleSkillActiveState(cwd, "sess-hud");
+			const entry = visible?.active_skills?.[0];
+			expect(entry?.hud?.summary).toBe("round one");
+			expect(entry?.hud?.chips?.[0]).toEqual({
+				label: "ambiguity",
+				value: "15%",
+				priority: 10,
+				severity: "success",
+			});
+			expect(entry?.hud?.details?.length).toBe(12);
 		});
 	});
 

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -37,4 +37,48 @@ describe("skill HUD bar renderer", () => {
 	it("omits inactive entries so statusLine.showSkillHud can gate the rail", () => {
 		expect(renderSkillHudBar([{ skill: "team", phase: "running", active: false }], 100)).toBeNull();
 	});
+	it("renders normalized HUD chips in priority order with stale warning", () => {
+		const rendered = Bun.stripANSI(
+			renderSkillHudBar(
+				[
+					{
+						skill: "ralplan",
+						phase: "planning",
+						stale: true,
+						hud: {
+							version: 1,
+							summary: "consensus",
+							chips: [
+								{ label: "verdict", value: "ITERATE", priority: 40, severity: "warning" },
+								{ label: "stage", value: "critic", priority: 10 },
+							],
+						},
+					},
+				],
+				120,
+			) ?? "",
+		);
+		expect(rendered).toContain("ralplan:planning consensus warn:stale stage=critic warn:verdict=ITERATE");
+	});
+
+	it("sanitizes HUD chips and keeps constrained rendering within width", () => {
+		const rendered = renderSkillHudBar(
+			[
+				{
+					skill: "team",
+					phase: "running",
+					hud: {
+						version: 1,
+						summary: "workers\nok",
+						chips: [{ label: "latest\t", value: "a-very-long-message-with-\u001b[31mansi" }],
+					},
+				},
+			],
+			35,
+		);
+		expect(rendered).not.toBeNull();
+		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\n");
+		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\t");
+		expect(visibleWidth(rendered ?? "")).toBeLessThanOrEqual(35);
+	});
 });

--- a/packages/coding-agent/test/workflow-hud-summary.test.ts
+++ b/packages/coding-agent/test/workflow-hud-summary.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildDeepInterviewHudSummary,
+	buildRalplanHudSummary,
+	buildTeamHudSummary,
+	buildUltragoalHudSummary,
+} from "../src/skill-state/workflow-hud";
+
+describe("workflow HUD summary builders", () => {
+	it("builds deep-interview progress chips", () => {
+		const hud = buildDeepInterviewHudSummary({
+			phase: "interviewing",
+			ambiguity: 0.15,
+			threshold: 0.2,
+			roundCount: 7,
+			targetComponent: "Team HUD",
+			weakestDimension: "criteria",
+		});
+		expect(hud.chips?.map(chip => `${chip.label}:${chip.value}`)).toEqual([
+			"phase:interviewing",
+			"ambiguity:15%/20%",
+			"round:7",
+			"target:Team HUD",
+			"weakest:criteria",
+		]);
+	});
+
+	it("builds ralplan stage and verdict chips", () => {
+		const hud = buildRalplanHudSummary({
+			stage: "critic",
+			waiting: "critic",
+			iteration: 2,
+			verdict: "ITERATE",
+			latestSummary: "needs revision",
+			pendingApproval: true,
+		});
+		expect(hud.summary).toBe("needs revision");
+		expect(hud.chips?.find(chip => chip.label === "verdict")?.severity).toBe("warning");
+		expect(hud.chips?.[0]).toEqual({ label: "pending", value: "approval", priority: 5, severity: "warning" });
+	});
+
+	it("keeps ultragoal latest ledger event in details only", () => {
+		const hud = buildUltragoalHudSummary({
+			status: "blocked",
+			currentGoal: { id: "G001", title: "Build HUD", status: "blocked" },
+			counts: { complete: 1, blocked: 1, review_blocked: 0, failed: 0 },
+			goals: [
+				{ id: "G001", title: "Build HUD", status: "blocked" },
+				{ id: "G002", title: "Verify", status: "complete" },
+			],
+			latestLedgerEvent: { event: "goal_checkpointed", goalId: "G001" },
+		});
+		expect(hud.chips?.some(chip => chip.label === "ledger")).toBe(false);
+		expect(hud.details?.[0]?.label).toBe("ledger");
+		expect(hud.chips?.[0]?.severity).toBe("blocked");
+	});
+
+	it("prioritizes team blockers before progress and latest activity", () => {
+		const hud = buildTeamHudSummary({
+			phase: "running",
+			task_total: 3,
+			task_counts: { completed: 1, failed: 1, blocked: 0 },
+			workers: [
+				{ id: "worker-1", status: "busy" },
+				{ id: "worker-2", status: "failed" },
+			],
+			latestEvent: { type: "message", message: "working" },
+		});
+		expect(hud.chips?.[0]).toEqual({ label: "blocked", value: "2", priority: 5, severity: "blocked" });
+		expect(hud.chips?.map(chip => chip.label)).toEqual(["blocked", "phase", "workers", "tasks", "latest"]);
+	});
+});


### PR DESCRIPTION
## Summary
- add normalized workflow HUD summaries to active skill state with stale-active warnings
- render HUD chips while preserving generic skill:phase fallback and read-only rendering
- wire bridged deep-interview/ralplan sidecar HUD updates plus ultragoal/team summary producers
- add focused tests for HUD rendering, active-state HUD/stale semantics, bridge sidecars, and workflow summary builders

## Verification
- bun test packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/skill-active-state.test.ts packages/coding-agent/test/gjc-runtime-bridge.test.ts packages/coding-agent/test/workflow-hud-summary.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/deep-interview-mutation-guard.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
- bun run check:ts