### PR TITLE
Fix Windows first-run provider add bootstrap

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed first-run API provider onboarding so `models.yml` parent directories are created before writing, and malformed `/provicer` startup invocations now report the intended `/provider add` spelling instead of falling through to model bootstrap.
+
 ## [0.2.0] - 2026-05-28
 
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -55,6 +55,15 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 }
 
+function isStartupSlashCommandArg(arg: string | undefined): boolean {
+	return (
+		arg === "/provider" ||
+		arg?.startsWith("/provider:") === true ||
+		arg === "/provicer" ||
+		arg?.startsWith("/provicer:") === true
+	);
+}
+
 export function parseArgs(args: string[]): Args {
 	const result: Args = {
 		messages: [],
@@ -64,6 +73,11 @@ export function parseArgs(args: string[]): Args {
 
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
+
+		if (isStartupSlashCommandArg(arg)) {
+			result.messages.push(args.slice(i).join(" "));
+			break;
+		}
 
 		// Support --flag=value syntax (e.g. --tools=ask,read)
 		if (arg.startsWith("--") && arg.includes("=")) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -46,6 +46,7 @@ import type { AgentSession } from "./session/agent-session";
 import type { AuthStorage } from "./session/auth-storage";
 import { resolveResumableSession, type SessionInfo, SessionManager } from "./session/session-manager";
 import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance";
+import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
 import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
@@ -295,7 +296,14 @@ async function runInteractiveMode(
 
 	for (const message of initialMessages) {
 		try {
-			await session.prompt(message);
+			let text = message;
+			const slashResult = await executeBuiltinSlashCommand(text, {
+				ctx: mode,
+				handleBackgroundCommand: () => mode.handleBackgroundCommand(),
+			});
+			if (slashResult === true) continue;
+			if (typeof slashResult === "string") text = slashResult;
+			await session.prompt(text);
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
@@ -131,6 +132,7 @@ async function writeModelsConfig(modelsPath: string, config: ModelsConfig): Prom
 		const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
 		throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
 	}
+	await fs.mkdir(path.dirname(modelsPath), { recursive: true });
 	await Bun.write(modelsPath, YAML.stringify(checked.data, null, 2));
 }
 

--- a/packages/coding-agent/src/slash-commands/acp-builtins.ts
+++ b/packages/coding-agent/src/slash-commands/acp-builtins.ts
@@ -1,5 +1,9 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
-import { BUILTIN_SLASH_COMMANDS_INTERNAL, lookupBuiltinSlashCommand } from "./builtin-registry";
+import {
+	BUILTIN_SLASH_COMMANDS_INTERNAL,
+	formatUnknownBuiltinSlashCommandDiagnostic,
+	lookupBuiltinSlashCommand,
+} from "./builtin-registry";
 import { parseSlashCommand } from "./helpers/parse";
 import type { AcpBuiltinCommandRuntime, AcpBuiltinSlashCommandResult } from "./types";
 
@@ -39,7 +43,12 @@ export async function executeAcpBuiltinSlashCommand(
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return false;
 	const command = lookupBuiltinSlashCommand(parsed.name);
-	if (!command?.handle) return false;
+	if (!command?.handle) {
+		const diagnostic = formatUnknownBuiltinSlashCommandDiagnostic(parsed.name);
+		if (!diagnostic) return false;
+		await runtime.output(diagnostic);
+		return { consumed: true };
+	}
 	const result = await command.handle(parsed, runtime);
 	if (result === undefined) return { consumed: true };
 	return result;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -993,6 +993,15 @@ for (const command of ACTIVE_BUILTIN_SLASH_COMMAND_REGISTRY) {
 	}
 }
 
+export function formatUnknownBuiltinSlashCommandDiagnostic(commandName: string): string | undefined {
+	if (commandName !== "provicer") return undefined;
+	return [
+		"Unknown slash command: /provicer.",
+		"Did you mean /provider?",
+		"Run: /provider add --compat <openai|anthropic> --provider <id> --base-url <url> --api-key-env <ENV> --model <model>",
+	].join("\n");
+}
+
 /** Builtin command metadata used for slash-command autocomplete and help text. */
 export const BUILTIN_SLASH_COMMAND_DEFS: ReadonlyArray<BuiltinSlashCommand> = ACTIVE_BUILTIN_SLASH_COMMAND_REGISTRY.map(
 	command => ({
@@ -1025,7 +1034,13 @@ export async function executeBuiltinSlashCommand(
 	if (!parsed) return false;
 
 	const command = BUILTIN_SLASH_COMMAND_LOOKUP.get(parsed.name);
-	if (!command) return false;
+	if (!command) {
+		const diagnostic = formatUnknownBuiltinSlashCommandDiagnostic(parsed.name);
+		if (!diagnostic) return false;
+		runtime.ctx.showError(diagnostic);
+		runtime.ctx.editor.setText("");
+		return true;
+	}
 	if (parsed.args.length > 0 && !command.allowArgs) {
 		return false;
 	}

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { parseArgs } from "../src/cli/args";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -25,6 +26,59 @@ describe("GJC public CLI command surface", () => {
 			"ralplan",
 			"deep-interview",
 			"launch",
+		]);
+	});
+
+	it("does not capture absolute-path prompts as startup slash commands", () => {
+		const parsed = parseArgs(["/tmp/request.md", "--model", "opus", "summarize"]);
+
+		expect(parsed.model).toBe("opus");
+		expect(parsed.messages).toEqual(["/tmp/request.md", "summarize"]);
+	});
+
+	it("keeps startup slash payload intact after normal CLI flags", () => {
+		const parsed = parseArgs([
+			"--no-lsp",
+			"/provider",
+			"add",
+			"--compat",
+			"anthropic",
+			"--provider",
+			"minimax",
+			"--base-url",
+			"https://api.minimax.io/anthropic",
+			"--api-key-env",
+			"MINIMAX_APIKEY",
+			"--model",
+			"MiniMax-M2.7-highspeed",
+		]);
+
+		expect(parsed.noLsp).toBe(true);
+		expect(parsed.provider).toBeUndefined();
+		expect(parsed.model).toBeUndefined();
+		expect(parsed.messages).toEqual([
+			"/provider add --compat anthropic --provider minimax --base-url https://api.minimax.io/anthropic --api-key-env MINIMAX_APIKEY --model MiniMax-M2.7-highspeed",
+		]);
+	});
+
+	it("keeps CLI slash-command invocations as one initial message", () => {
+		const parsed = parseArgs([
+			"/provider",
+			"add",
+			"--compat",
+			"anthropic",
+			"--provider",
+			"minimax",
+			"--base-url",
+			"https://api.minimax.io/anthropic",
+			"--api-key-env",
+			"MINIMAX_APIKEY",
+			"--model",
+			"MiniMax-M2.7-highspeed",
+		]);
+
+		expect(parsed.messages).toEqual([
+			"/provider add --compat anthropic --provider minimax --base-url https://api.minimax.io/anthropic --api-key-env MINIMAX_APIKEY --model MiniMax-M2.7-highspeed",
 		]);
 	});
 

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -53,6 +53,28 @@ describe("provider onboarding setup core", () => {
 		expect(parsed.providers["my-oai"]?.models.map(model => model.id)).toEqual(["gpt-example", "gpt-second"]);
 	});
 
+	it("creates the models.yml parent directory on first provider add", async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-onboarding-"));
+		const modelsPath = path.join(tempRoot, "Users", "example", ".gjc", "agent", "models.yml");
+
+		await addApiCompatibleProvider({
+			compatibility: "anthropic",
+			providerId: "minimax",
+			baseUrl: "https://api.minimax.io/anthropic",
+			apiKeyEnv: "MINIMAX_APIKEY",
+			models: ["MiniMax-M2.7-highspeed"],
+			modelsPath,
+		});
+
+		expect(await Bun.file(modelsPath).exists()).toBe(true);
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
+			providers: Record<string, { api: string; apiKeyEnv?: string; models: Array<{ id: string }> }>;
+		};
+		expect(parsed.providers.minimax?.api).toBe("anthropic-messages");
+		expect(parsed.providers.minimax?.apiKeyEnv).toBe("MINIMAX_APIKEY");
+		expect(parsed.providers.minimax?.models.map(model => model.id)).toEqual(["MiniMax-M2.7-highspeed"]);
+	});
+
 	it("adds an Anthropic-compatible provider without deleting unrelated providers", async () => {
 		const modelsPath = await tempModelsPath();
 		await Bun.write(

--- a/packages/coding-agent/test/provider-slash-command.test.ts
+++ b/packages/coding-agent/test/provider-slash-command.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
-import { BUILTIN_SLASH_COMMANDS_INTERNAL } from "../src/slash-commands/builtin-registry";
+import { BUILTIN_SLASH_COMMANDS_INTERNAL, executeBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
 import type { SlashCommandRuntime } from "../src/slash-commands/types";
 
 let tempAgentDir: string | undefined;
@@ -24,6 +24,21 @@ describe("provider slash command", () => {
 		const command = BUILTIN_SLASH_COMMANDS_INTERNAL.find(entry => entry.name === "provider");
 		expect(command?.description).toContain("providers");
 		expect(command?.allowArgs).toBe(true);
+	});
+
+	it("reports the /provicer typo without falling through to model bootstrap", async () => {
+		const errors: string[] = [];
+		const result = await executeBuiltinSlashCommand("/provicer add --compat anthropic", {
+			ctx: {
+				showError: (text: string) => errors.push(text),
+				editor: { setText: () => undefined },
+			},
+			handleBackgroundCommand: () => undefined,
+		} as unknown as Parameters<typeof executeBuiltinSlashCommand>[1]);
+
+		expect(result).toBe(true);
+		expect(errors.join("\n")).toContain("Unknown slash command: /provicer");
+		expect(errors.join("\n")).toContain("Did you mean /provider?");
 	});
 
 	it("adds API-compatible providers through the shared onboarding core", async () => {


### PR DESCRIPTION
## Summary

Fixes #83.

- create the `models.yml` parent directory before first provider-add writes config
- preserve startup `/provider add ...` and `/provicer ...` payloads as one slash command message, including when normal CLI flags precede it
- route startup slash commands through builtin slash dispatch and emit a clear `/provicer` → `/provider` diagnostic
- keep scope limited to provider-add bootstrap/diagnostics; broader custom provider UX remains #82

## Verification

- `bun test packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/provider-onboarding.test.ts packages/coding-agent/test/provider-slash-command.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`
- first-run nested path smoke with `gjc setup provider --json --compat anthropic --provider minimax ...`
- `bun packages/coding-agent/src/cli.ts --version`
- `bun packages/coding-agent/src/cli.ts --help`
- `bun packages/coding-agent/src/cli.ts --smoke-test`

Not tested on native Windows 11 PowerShell; covered deterministically with nested first-run path and argv parsing regressions.
