### PR TITLE
Fix model catalog setup selector flow

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -57,6 +57,8 @@ interface ModelItem {
 	id: string;
 	model: Model;
 	selector: string;
+	available?: boolean;
+	setupHint?: string;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel?: boolean;
 }
@@ -70,6 +72,8 @@ interface CanonicalModelItem {
 	searchText: string;
 	normalizedSearchText: string;
 	compactSearchText: string;
+	available: boolean;
+	setupHint?: string;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel?: boolean;
 }
@@ -94,6 +98,7 @@ type RoleSelectCallback = (
 	selector?: string,
 ) => void;
 type CancelCallback = () => void;
+type LoginProviderCallback = (providerId: string) => void | Promise<void>;
 
 interface ProviderTabState {
 	id: string;
@@ -137,6 +142,7 @@ export class ModelSelectorComponent extends Container {
 	#modelRegistry = null as unknown as ModelRegistry;
 	#onSelectCallback = (() => {}) as RoleSelectCallback;
 	#onCancelCallback = (() => {}) as CancelCallback;
+	#onLoginProviderCallback?: LoginProviderCallback;
 	#errorMessage?: unknown;
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
@@ -163,7 +169,7 @@ export class ModelSelectorComponent extends Container {
 			selector?: string,
 		) => void,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
+		options?: { temporaryOnly?: boolean; initialSearchInput?: string; onLoginProvider?: LoginProviderCallback },
 	) {
 		super();
 
@@ -173,6 +179,7 @@ export class ModelSelectorComponent extends Container {
 		this.#scopedModels = scopedModels;
 		this.#onSelectCallback = onSelect;
 		this.#onCancelCallback = onCancel;
+		this.#onLoginProviderCallback = options?.onLoginProvider;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		const initialSearchInput = options?.initialSearchInput;
 
@@ -350,6 +357,7 @@ export class ModelSelectorComponent extends Container {
 
 	async #loadModels(): Promise<void> {
 		let models: ModelItem[];
+		let catalogModels: ModelItem[] | undefined;
 
 		// Use scoped models if provided via --models flag
 		if (this.#scopedModels.length > 0) {
@@ -377,13 +385,8 @@ export class ModelSelectorComponent extends Container {
 			// Load available models (built-in models still work even if models.json failed)
 			try {
 				const availableModels = this.#modelRegistry.getAvailable();
-				models = availableModels.map((model: Model) => ({
-					kind: "provider",
-					provider: model.provider,
-					id: model.id,
-					model,
-					selector: `${model.provider}/${model.id}`,
-				}));
+				models = this.#modelsToItems(availableModels);
+				catalogModels = this.#modelsToItems(this.#modelRegistry.getAll());
 			} catch (error) {
 				this.#allModels = [];
 				this.#filteredModels = [];
@@ -394,20 +397,22 @@ export class ModelSelectorComponent extends Container {
 			}
 		}
 
-		const candidateModels = models.map(item => item.model);
-		const canonicalRecords = this.#modelRegistry.getCanonicalModels({
-			availableOnly: this.#scopedModels.length === 0,
-			candidates: candidateModels,
+		const catalogCandidateModels = (catalogModels ?? models).map(item => item.model);
+		const availableSelectors = new Set(models.map(item => item.selector));
+		const catalogCanonicalRecords = this.#modelRegistry.getCanonicalModels({
+			availableOnly: false,
+			candidates: catalogCandidateModels,
 		});
 		const scopedThinkingBySelector = new Map(models.map(item => [item.selector, item.thinkingLevel]));
-		const canonicalModels = canonicalRecords
+		const canonicalModels = catalogCanonicalRecords
 			.map((record): CanonicalModelItem | undefined => {
 				const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
-					availableOnly: this.#scopedModels.length === 0,
-					candidates: candidateModels,
+					availableOnly: false,
+					candidates: catalogCandidateModels,
 				});
 				if (!selectedModel) return undefined;
 				const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
+				const available = availableSelectors.has(selectedSelector);
 				const searchText = [
 					record.id,
 					record.name,
@@ -425,6 +430,8 @@ export class ModelSelectorComponent extends Container {
 					searchText,
 					normalizedSearchText: normalizeSearchText(searchText),
 					compactSearchText: compactSearchText(searchText),
+					available,
+					setupHint: available ? undefined : this.#getProviderSetupHint(selectedModel.provider),
 				};
 				const scopedThinkingLevel = scopedThinkingBySelector.get(selectedSelector);
 				if (scopedThinkingLevel !== undefined) {
@@ -443,15 +450,57 @@ export class ModelSelectorComponent extends Container {
 
 		this.#allModels = models;
 		this.#filteredModels = models;
-		this.#canonicalModels = canonicalModels;
-		this.#filteredCanonicalModels = canonicalModels;
+		this.#canonicalModels = canonicalModels.filter(item => item.available);
+		this.#filteredCanonicalModels = this.#canonicalModels;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, models.length - 1));
+	}
+
+	#modelsToItems(models: readonly Model[], availableSelectors?: ReadonlySet<string>): ModelItem[] {
+		return models.map((model: Model) => {
+			const selector = `${model.provider}/${model.id}`;
+			const available = availableSelectors?.has(selector);
+			return {
+				kind: "provider",
+				provider: model.provider,
+				id: model.id,
+				model,
+				selector,
+				available,
+				setupHint: available === false ? this.#getProviderSetupHint(model.provider) : undefined,
+			};
+		});
+	}
+
+	#getProviderSetupHint(providerId: string): string | undefined {
+		const providerModel = this.#modelRegistry.getAll().find(model => model.provider === providerId);
+		if (providerModel && !this.#modelRegistry.hasConfiguredAuth(providerModel)) {
+			return `Configure ${providerId} credentials to use this model.`;
+		}
+		const state = this.#modelRegistry.getProviderDiscoveryState(providerId);
+		if (state?.status === "unauthenticated") {
+			return `Authenticate ${providerId} to discover and use models.`;
+		}
+		return undefined;
+	}
+
+	#getProviderCatalogItems(providerId: string): ModelItem[] {
+		if (this.#scopedModels.length > 0) {
+			return this.#allModels.filter(item => item.provider === providerId);
+		}
+		const availableSelectors = new Set(this.#allModels.map(item => item.selector));
+		return this.#modelsToItems(
+			this.#modelRegistry.getAll().filter(model => model.provider === providerId),
+			availableSelectors,
+		);
 	}
 
 	#buildProviderTabs(): void {
 		const activeTabId = this.#getActiveTab().id;
 		const providerSet = new Set<string>();
 		for (const item of this.#allModels) {
+			providerSet.add(item.provider);
+		}
+		for (const item of this.#modelRegistry.getAll()) {
 			providerSet.add(item.provider);
 		}
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
@@ -514,32 +563,60 @@ export class ModelSelectorComponent extends Container {
 		return this.#getActiveTabId() === CANONICAL_TAB;
 	}
 
+	#isShowingCanonicalList(): boolean {
+		return this.#isCanonicalTab() && this.#filteredCanonicalModels.length > 0;
+	}
+
 	#filterModels(query: string): void {
-		const activeTabId = this.#getActiveTabId();
 		const activeProviderId = this.#getActiveProviderId();
-		const isCanonicalTab = activeTabId === CANONICAL_TAB;
+		const hasQuery = query.trim().length > 0;
 
 		// Start with all models or filter by provider/canonical view
 		let baseModels = this.#allModels;
-		const baseCanonicalModels = this.#canonicalModels;
+		let baseCanonicalModels = this.#canonicalModels;
 		if (activeProviderId) {
-			baseModels = this.#allModels.filter(m => m.provider === activeProviderId);
+			baseModels = this.#getProviderCatalogItems(activeProviderId);
+		}
+		if (hasQuery && this.#scopedModels.length === 0) {
+			const searchAvailableSelectors = new Set(this.#allModels.map(item => item.selector));
+			baseModels = this.#modelsToItems(this.#modelRegistry.getAll(), searchAvailableSelectors);
+			baseCanonicalModels = this.#modelRegistry
+				.getCanonicalModels({ availableOnly: false, candidates: baseModels.map(item => item.model) })
+				.map((record): CanonicalModelItem | undefined => {
+					const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
+						availableOnly: false,
+						candidates: baseModels.map(item => item.model),
+					});
+					if (!selectedModel) return undefined;
+					const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
+					const available = this.#allModels.some(item => item.selector === selectedSelector);
+					const searchText = [
+						record.id,
+						record.name,
+						selectedModel.provider,
+						selectedModel.id,
+						selectedModel.name,
+						...record.variants.flatMap(variant => [variant.selector, variant.model.name]),
+					].join(" ");
+					return {
+						kind: "canonical",
+						id: record.id,
+						model: selectedModel,
+						selector: record.id,
+						variantCount: record.variants.length,
+						searchText,
+						normalizedSearchText: normalizeSearchText(searchText),
+						compactSearchText: compactSearchText(searchText),
+						available,
+						setupHint: available ? undefined : this.#getProviderSetupHint(selectedModel.provider),
+					};
+				})
+				.filter((item): item is CanonicalModelItem => item !== undefined);
 		}
 
 		// Apply fuzzy filter if query is present
-		if (query.trim()) {
-			// If user is searching from a provider tab, auto-switch to ALL to show global provider results.
-			if (activeProviderId && !isCanonicalTab) {
-				this.#activeTabIndex = 0;
-				if (this.#tabBar && this.#tabBar.getActiveIndex() !== 0) {
-					this.#tabBar.setActiveIndex(0);
-					return;
-				}
-				this.#updateTabBar();
-				baseModels = this.#allModels;
-			}
-
-			if (isCanonicalTab) {
+		if (hasQuery) {
+			if (this.#isCanonicalTab()) {
 				const alphaTokens = getAlphaSearchTokens(query);
 				const alphaFiltered =
 					alphaTokens.length === 0
@@ -571,7 +648,9 @@ export class ModelSelectorComponent extends Container {
 			this.#filteredCanonicalModels = baseCanonicalModels;
 		}
 
-		const visibleCount = isCanonicalTab ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+		const visibleCount = this.#isShowingCanonicalList()
+			? this.#filteredCanonicalModels.length
+			: this.#filteredModels.length;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, visibleCount - 1));
 		this.#updateList();
 	}
@@ -617,6 +696,10 @@ export class ModelSelectorComponent extends Container {
 		if (!state) {
 			return undefined;
 		}
+		const providerModel = this.#modelRegistry.getAll().find(model => model.provider === activeProviderId);
+		if (providerModel && !this.#modelRegistry.hasConfiguredAuth(providerModel)) {
+			return `  ${activeProviderId} requires credentials. Press Enter on a setup item or use /provider login ${activeProviderId}.`;
+		}
 		const age = this.#formatDiscoveryAge(state.fetchedAt);
 		switch (state.status) {
 			case "cached":
@@ -641,7 +724,7 @@ export class ModelSelectorComponent extends Container {
 
 	#updateList(): void {
 		this.#listContainer.clear();
-		const isCanonicalTab = this.#isCanonicalTab();
+		const isCanonicalTab = this.#isShowingCanonicalList();
 		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
 
 		const maxVisible = 10;
@@ -738,6 +821,10 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(
 				new Text(theme.fg("muted", `  Model Name: ${selected.model.name}${suffix}`), 0, 0),
 			);
+			const setupHint = "setupHint" in selected ? selected.setupHint : undefined;
+			if (setupHint) {
+				this.#listContainer.addChild(new Text(theme.fg("warning", `  ${setupHint}`), 0, 0));
+			}
 			if (this.#pendingThinkingChoice) {
 				this.#renderThinkingMenu(this.#pendingThinkingChoice);
 			} else if (this.#pendingActionItem) {
@@ -784,7 +871,7 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
-		return this.#isCanonicalTab()
+		return this.#isShowingCanonicalList()
 			? this.#filteredCanonicalModels[this.#selectedIndex]
 			: this.#filteredModels[this.#selectedIndex];
 	}
@@ -806,7 +893,9 @@ export class ModelSelectorComponent extends Container {
 
 		// Up arrow - navigate list (wrap to bottom when at top)
 		if (matchesKey(keyData, "up")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount = this.#isShowingCanonicalList()
+				? this.#filteredCanonicalModels.length
+				: this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === 0 ? itemCount - 1 : this.#selectedIndex - 1;
 			this.#updateList();
@@ -815,7 +904,9 @@ export class ModelSelectorComponent extends Container {
 
 		// Down arrow - navigate list (wrap to top when at bottom)
 		if (matchesKey(keyData, "down")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount = this.#isShowingCanonicalList()
+				? this.#filteredCanonicalModels.length
+				: this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === itemCount - 1 ? 0 : this.#selectedIndex + 1;
 			this.#updateList();
@@ -916,6 +1007,13 @@ export class ModelSelectorComponent extends Container {
 		role: GjcModelAssignmentTargetId | null,
 		thinkingLevel?: ThinkingLevel,
 	): void {
+		if (item.available === false) {
+			if (this.#onLoginProviderCallback) {
+				void this.#onLoginProviderCallback(item.model.provider);
+			}
+			return;
+		}
+
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
 		const hasExplicitThinkingChoice = thinkingLevel !== undefined || item.explicitThinkingLevel === true;
 		if (!hasExplicitThinkingChoice && requiresExplicitThinkingChoice(item.model)) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -477,7 +477,10 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				options,
+				{
+					...options,
+					onLoginProvider: providerId => this.#handleOAuthLogin(providerId),
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -557,4 +557,140 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Inherit);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
 	});
+
+	test("falls back to scoped provider models when canonical tab has no records", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({});
+		const modelRegistry = {
+			getAll: () => [model],
+			getDiscoverableProviders: () => [],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+		} as unknown as ModelRegistry;
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			{ modelRegistry, temporaryOnly: true, thinkingLevel: ThinkingLevel.Low },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\t");
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(model.id);
+		expect(rendered).not.toContain("No matching models");
+
+		selector.handleInput("\n");
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected scoped fallback model selection");
+		expect(selectedAfterEnter.role).toBeNull();
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("shows unavailable provider catalog setup items and starts provider login", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const model = createOpenAIModel("openai", "gpt-needs-setup", false);
+		const loginProvider = vi.fn();
+		const modelRegistry = {
+			getAll: () => [model],
+			getAvailable: () => [],
+			refresh: vi.fn(async () => {}),
+			getError: () => undefined,
+			getDiscoverableProviders: () => ["openai"],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+			hasConfiguredAuth: () => false,
+			getProviderDiscoveryState: () => ({
+				provider: "openai",
+				status: "unauthenticated",
+				optional: false,
+				stale: false,
+				models: [],
+			}),
+		} as unknown as ModelRegistry;
+		const ui = {
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+
+		let selected: SelectionCapture | undefined;
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			settings,
+			modelRegistry,
+			[],
+			(selectedModel, role, thinkingLevel, selectorValue) => {
+				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			},
+			() => {},
+			{ temporaryOnly: true, onLoginProvider: loginProvider },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\t");
+		selector.handleInput("\t");
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("OPENAI");
+		expect(rendered).toContain(model.id);
+		expect(rendered).toContain("Configure openai credentials");
+
+		selector.handleInput("\n");
+		expect(selected).toBeUndefined();
+		expect(loginProvider).toHaveBeenCalledWith("openai");
+	});
+
+	test("keeps discoverable provider error tabs visible without catalog models", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const modelRegistry = {
+			getAll: () => [],
+			getAvailable: () => [],
+			refresh: vi.fn(async () => {}),
+			getError: () => undefined,
+			getDiscoverableProviders: () => ["custom-provider"],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+			getProviderDiscoveryState: () => ({
+				provider: "custom-provider",
+				status: "unavailable",
+				optional: false,
+				stale: true,
+				error: "HTTP 404 from https://example.invalid/models",
+				models: [],
+			}),
+		} as unknown as ModelRegistry;
+		const ui = {
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			settings,
+			modelRegistry,
+			[],
+			() => {},
+			() => {},
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\t");
+		selector.handleInput("\t");
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("CUSTOM PROVIDER");
+		expect(rendered).toContain("Discovery endpoint https://example.invalid/models returned 404");
+		expect(rendered).not.toContain("No matching models");
+	});
 });


### PR DESCRIPTION
## Summary
- Reopens the model catalog setup selector fix as a replacement PR after the direct dev commit was reverted.
- Keeps provider tabs visible for catalog/discoverable providers even when no models are currently available.
- Falls back from an empty canonical tab to scoped/provider model rows, while preserving role assignment and temporary reasoning selections.
- Shows setup hints for unavailable provider catalog entries and routes Enter to provider login instead of selecting unusable models.

## Verification
- bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
- cd packages/coding-agent && bun run check

Ticket: T-20260528-033
Supersedes closed PR #86.