### PR TITLE
Expose embedded skills for installed binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Added a `gjc skills` inspection command so installed binaries can list and read embedded workflow skills from any project without relying on source-tree `.gjc` files.
 - Fixed first-run API provider onboarding so `models.yml` parent directories are created before writing, and malformed `/provicer` startup invocations now report the intended `/provider add` spelling instead of falling through to model bootstrap.
 
 ## [0.2.0] - 2026-05-28

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -34,6 +34,7 @@ const commands: CommandEntry[] = [
 	{ name: "question", load: () => import("./commands/question").then(m => m.default) },
 	{ name: "state", load: () => import("./commands/state").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
+	{ name: "skills", load: () => import("./commands/skills").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },

--- a/packages/coding-agent/src/cli/skills-cli.ts
+++ b/packages/coding-agent/src/cli/skills-cli.ts
@@ -1,0 +1,84 @@
+/**
+ * Handles `gjc skills` for inspecting bundled workflow skill definitions.
+ */
+import { DEFAULT_GJC_DEFINITION_NAMES, getEmbeddedDefaultGjcSkills } from "../defaults/gjc-defaults";
+
+export type SkillsAction = "list" | "read";
+
+export interface SkillsCommandArgs {
+	action: SkillsAction;
+	name?: string;
+	flags?: {
+		json?: boolean;
+	};
+}
+
+interface SkillsListEntry {
+	name: string;
+	description: string;
+	path: string;
+	source: string;
+}
+
+interface SkillsReadEntry extends SkillsListEntry {
+	content: string;
+}
+
+function getEmbeddedSkill(name: string): ReturnType<typeof getEmbeddedDefaultGjcSkills>[number] | undefined {
+	return getEmbeddedDefaultGjcSkills().find(skill => skill.name === name);
+}
+
+function listEmbeddedSkills(): SkillsListEntry[] {
+	return getEmbeddedDefaultGjcSkills().map(skill => ({
+		name: skill.name,
+		description: skill.description,
+		path: skill.filePath,
+		source: skill.source,
+	}));
+}
+
+function writeJson(value: unknown): void {
+	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function runSkillsCommand(cmd: SkillsCommandArgs): Promise<void> {
+	if (cmd.action === "list") {
+		const skills = listEmbeddedSkills();
+		if (cmd.flags?.json) {
+			writeJson({ skills });
+			return;
+		}
+		for (const skill of skills) {
+			process.stdout.write(`${skill.name}\t${skill.description}\t${skill.path}\n`);
+		}
+		return;
+	}
+
+	const name = cmd.name?.trim();
+	if (!name) {
+		process.stderr.write(`error: skill name is required for read (${DEFAULT_GJC_DEFINITION_NAMES.join(", ")})\n`);
+		process.exitCode = 1;
+		return;
+	}
+
+	const skill = getEmbeddedSkill(name);
+	if (!skill) {
+		process.stderr.write(`error: unknown embedded skill "${name}" (${DEFAULT_GJC_DEFINITION_NAMES.join(", ")})\n`);
+		process.exitCode = 1;
+		return;
+	}
+
+	const entry: SkillsReadEntry = {
+		name: skill.name,
+		description: skill.description,
+		path: skill.filePath,
+		source: skill.source,
+		content: skill.content,
+	};
+	if (cmd.flags?.json) {
+		writeJson(entry);
+		return;
+	}
+	process.stdout.write(skill.content);
+	if (!skill.content.endsWith("\n")) process.stdout.write("\n");
+}

--- a/packages/coding-agent/src/cli/skills-cli.ts
+++ b/packages/coding-agent/src/cli/skills-cli.ts
@@ -1,7 +1,11 @@
 /**
  * Handles `gjc skills` for inspecting bundled workflow skill definitions.
  */
-import { DEFAULT_GJC_DEFINITION_NAMES, getEmbeddedDefaultGjcSkills } from "../defaults/gjc-defaults";
+import {
+	DEFAULT_GJC_DEFINITION_NAMES,
+	type EmbeddedDefaultGjcSkill,
+	getEmbeddedDefaultGjcSkills,
+} from "../defaults/gjc-defaults";
 
 export type SkillsAction = "list" | "read";
 
@@ -24,7 +28,7 @@ interface SkillsReadEntry extends SkillsListEntry {
 	content: string;
 }
 
-function getEmbeddedSkill(name: string): ReturnType<typeof getEmbeddedDefaultGjcSkills>[number] | undefined {
+function getEmbeddedSkill(name: string): EmbeddedDefaultGjcSkill | undefined {
 	return getEmbeddedDefaultGjcSkills().find(skill => skill.name === name);
 }
 

--- a/packages/coding-agent/src/commands/skills.ts
+++ b/packages/coding-agent/src/commands/skills.ts
@@ -1,0 +1,48 @@
+/**
+ * Inspect bundled workflow skills.
+ */
+import { Args, Command, Flags, renderCommandHelp } from "@gajae-code/utils/cli";
+import { runSkillsCommand, type SkillsAction, type SkillsCommandArgs } from "../cli/skills-cli";
+
+const ACTIONS: SkillsAction[] = ["list", "read"];
+
+export default class Skills extends Command {
+	static description = "Inspect bundled GJC workflow skills";
+
+	static args = {
+		action: Args.string({
+			description: "Skills action",
+			required: false,
+			options: ACTIONS,
+		}),
+		name: Args.string({
+			description: "Bundled skill name to read",
+			required: false,
+		}),
+	};
+
+	static flags = {
+		json: Flags.boolean({ description: "Output JSON" }),
+	};
+
+	static examples = [
+		"# List bundled workflow skills\n  gjc skills list",
+		"# Read an embedded workflow skill without requiring .gjc files\n  gjc skills read ultragoal",
+		"# Machine-readable embedded skill content\n  gjc skills read ralplan --json",
+	];
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Skills);
+		if (!args.action) {
+			renderCommandHelp("gjc", "skills", Skills);
+			return;
+		}
+
+		const cmd: SkillsCommandArgs = {
+			action: args.action as SkillsAction,
+			name: args.name,
+			flags: { json: flags.json },
+		};
+		await runSkillsCommand(cmd);
+	}
+}

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -251,3 +251,74 @@ Project executor override body.
 		expect(await Bun.file(deepInterviewSkillPath).text()).toBe(installedDeepInterview);
 	});
 });
+
+describe("bundled skills CLI", () => {
+	it("reads embedded workflow skills from outside the repository without .gjc files", async () => {
+		const externalRoot = await makeTempRoot();
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
+				"skills",
+				"read",
+				"ultragoal",
+				"--json",
+			],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: await makeTempRoot(),
+					PI_NO_TITLE: "1",
+					NO_COLOR: "1",
+				},
+			},
+		);
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		const exitCode = await proc.exited;
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		const parsed = JSON.parse(stdout) as { name: string; path: string; source: string; content: string };
+		expect(parsed.name).toBe("ultragoal");
+		expect(parsed.path).toBe("embedded:gjc/skills/ultragoal/SKILL.md");
+		expect(parsed.source).toBe("bundled:default");
+		expect(parsed.content).toContain("# Ultragoal");
+	});
+
+	it("lists exactly the embedded default workflow skills", async () => {
+		const externalRoot = await makeTempRoot();
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
+				"skills",
+				"list",
+				"--json",
+			],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: await makeTempRoot(),
+					PI_NO_TITLE: "1",
+					NO_COLOR: "1",
+				},
+			},
+		);
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		const exitCode = await proc.exited;
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		const parsed = JSON.parse(stdout) as { skills: Array<{ name: string; path: string }> };
+		expect(parsed.skills.map(skill => skill.name).sort()).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
+		expect(parsed.skills.every(skill => skill.path.startsWith("embedded:gjc/skills/"))).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds a gjc skills CLI surface to list/read bundled embedded workflow skills from any cwd, with regression coverage for external projects without .gjc files.\n\nVerification:\n- bun --cwd=packages/coding-agent run check\n- bun scripts/check-visible-definitions.ts\n- bun scripts/verify-g002-gates.ts\n- bun scripts/rebrand-inventory.ts --strict\n- bun test packages/coding-agent/test/default-gjc-definitions.test.ts\n- gjc skills list/read smoke from repo and temp cwd