### PR TITLE
Add OpenAI Codex role preset

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,5 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { getSupportedEfforts, type Model, modelsAreEqual } from "@gajae-code/ai";
+import { clampThinkingLevelForModel, getSupportedEfforts, type Model, modelsAreEqual } from "@gajae-code/ai";
 import {
 	Container,
 	fuzzyFilter,
@@ -81,18 +81,36 @@ interface RoleAssignment {
 	thinkingLevel: ThinkingLevel;
 }
 
+export interface ModelAssignmentPreset {
+	id: "openai-codex";
+	label: string;
+	description: string;
+	assignments: Partial<Record<GjcModelAssignmentTargetId, ThinkingLevel>>;
+}
+
+export type ModelSelectorSelection =
+	| {
+			kind: "assignment";
+			model: Model;
+			role: GjcModelAssignmentTargetId | null;
+			thinkingLevel?: ThinkingLevel;
+			selector?: string;
+	  }
+	| {
+			kind: "preset";
+			model: Model;
+			selector: string;
+			preset: ModelAssignmentPreset;
+			assignments: Record<GjcModelAssignmentTargetId, ThinkingLevel>;
+	  };
+
 interface PendingThinkingChoice {
 	item: ModelItem | CanonicalModelItem;
 	role: GjcModelAssignmentTargetId | null;
 	levels: ThinkingLevel[];
 }
 
-type RoleSelectCallback = (
-	model: Model,
-	role: GjcModelAssignmentTargetId | null,
-	thinkingLevel?: ThinkingLevel,
-	selector?: string,
-) => void;
+type RoleSelectCallback = (selection: ModelSelectorSelection) => void;
 type CancelCallback = () => void;
 
 interface ProviderTabState {
@@ -107,6 +125,18 @@ const STATIC_PROVIDER_TABS: ProviderTabState[] = [
 	{ id: ALL_TAB, label: ALL_TAB },
 	{ id: CANONICAL_TAB, label: CANONICAL_TAB },
 ];
+const OPENAI_CODE_PROFILE_PRESET: ModelAssignmentPreset = {
+	id: "openai-codex",
+	label: "Apply OpenAI Codex role preset",
+	description: "Default medium, Executor low, Architect xhigh, Planner medium, Critic high",
+	assignments: {
+		default: ThinkingLevel.Medium,
+		executor: ThinkingLevel.Low,
+		architect: ThinkingLevel.XHigh,
+		planner: ThinkingLevel.Medium,
+		critic: ThinkingLevel.High,
+	},
+};
 
 function formatProviderTabLabel(providerId: string): string {
 	return providerId.replace(/[-_]+/g, " ").toUpperCase();
@@ -156,12 +186,7 @@ export class ModelSelectorComponent extends Container {
 		settings: Settings,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (
-			model: Model,
-			role: GjcModelAssignmentTargetId | null,
-			thinkingLevel?: ThinkingLevel,
-			selector?: string,
-		) => void,
+		onSelect: RoleSelectCallback,
 		onCancel: () => void,
 		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
 	) {
@@ -750,11 +775,13 @@ export class ModelSelectorComponent extends Container {
 		this.#listContainer.addChild(new Spacer(1));
 		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for: ${item.model.id}`), 0, 0));
 		this.#listContainer.addChild(new Spacer(1));
-		for (let i = 0; i < GJC_MODEL_ASSIGNMENT_TARGET_IDS.length; i++) {
-			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
-			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+		const actionCount = this.#getActionCount(item.model);
+		for (let i = 0; i < actionCount; i++) {
 			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-			const label = `Set as ${target.tag ?? role.toUpperCase()} (${target.name})`;
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
+			const label = role
+				? `Set as ${GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()} (${GJC_MODEL_ASSIGNMENT_TARGETS[role].name})`
+				: `${OPENAI_CODE_PROFILE_PRESET.label} (${OPENAI_CODE_PROFILE_PRESET.description})`;
 			this.#listContainer.addChild(
 				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
 			);
@@ -781,6 +808,9 @@ export class ModelSelectorComponent extends Container {
 
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
+	}
+	#getActionCount(model: Model): number {
+		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length + (supportsOpenAICodexPreset(model) ? 1 : 0);
 	}
 
 	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
@@ -853,25 +883,27 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#handleActionMenuInput(keyData: string): void {
+		const item = this.#pendingActionItem;
+		if (!item) return;
+		const actionCount = this.#getActionCount(item.model);
 		if (matchesKey(keyData, "up")) {
-			this.#selectedActionIndex =
-				this.#selectedActionIndex === 0
-					? GJC_MODEL_ASSIGNMENT_TARGET_IDS.length - 1
-					: this.#selectedActionIndex - 1;
+			this.#selectedActionIndex = this.#selectedActionIndex === 0 ? actionCount - 1 : this.#selectedActionIndex - 1;
 			this.#updateList();
 			return;
 		}
 		if (matchesKey(keyData, "down")) {
-			this.#selectedActionIndex = (this.#selectedActionIndex + 1) % GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
+			this.#selectedActionIndex = (this.#selectedActionIndex + 1) % actionCount;
 			this.#updateList();
 			return;
 		}
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const item = this.#pendingActionItem;
-			if (!item) return;
-			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
 			this.#pendingActionItem = undefined;
-			this.#handleSelect(item, role);
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
+			if (role) {
+				this.#handleSelect(item, role);
+			} else {
+				this.#handlePresetSelect(item, OPENAI_CODE_PROFILE_PRESET);
+			}
 			return;
 		}
 		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
@@ -910,6 +942,18 @@ export class ModelSelectorComponent extends Container {
 			this.#updateList();
 		}
 	}
+	#handlePresetSelect(item: ModelItem | CanonicalModelItem, preset: ModelAssignmentPreset): void {
+		const selectorValue = item.selector;
+		const assignments = resolvePresetAssignments(item.model, preset);
+		for (const [role, thinkingLevel] of Object.entries(assignments) as [
+			GjcModelAssignmentTargetId,
+			ThinkingLevel,
+		][]) {
+			this.#roles[role] = { model: item.model, thinkingLevel };
+		}
+		this.#onSelectCallback({ kind: "preset", model: item.model, selector: selectorValue, preset, assignments });
+		this.#updateList();
+	}
 
 	#handleSelect(
 		item: ModelItem | CanonicalModelItem,
@@ -927,7 +971,13 @@ export class ModelSelectorComponent extends Container {
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback(item.model, null, itemThinkingLevel, item.selector);
+			this.#onSelectCallback({
+				kind: "assignment",
+				model: item.model,
+				role: null,
+				thinkingLevel: itemThinkingLevel,
+				selector: item.selector,
+			});
 			return;
 		}
 
@@ -939,7 +989,13 @@ export class ModelSelectorComponent extends Container {
 		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel };
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback(item.model, role, selectedThinkingLevel, selectorValue);
+		this.#onSelectCallback({
+			kind: "assignment",
+			model: item.model,
+			role,
+			thinkingLevel: selectedThinkingLevel,
+			selector: selectorValue,
+		});
 
 		// Update list to show new badges
 		this.#updateList();
@@ -952,6 +1008,31 @@ export class ModelSelectorComponent extends Container {
 
 function requiresExplicitThinkingChoice(model: Model): boolean {
 	return model.reasoning === true && (model.provider === "openai" || model.provider === "openai-codex");
+}
+
+function supportsOpenAICodexPreset(model: Model): boolean {
+	return model.provider === "openai-codex" && model.reasoning === true;
+}
+
+function resolvePresetAssignments(
+	model: Model,
+	preset: ModelAssignmentPreset,
+): Record<GjcModelAssignmentTargetId, ThinkingLevel> {
+	const resolved = {} as Record<GjcModelAssignmentTargetId, ThinkingLevel>;
+	for (const [role, requestedLevel] of Object.entries(preset.assignments) as [
+		GjcModelAssignmentTargetId,
+		ThinkingLevel,
+	][]) {
+		const clampedLevel =
+			requestedLevel === ThinkingLevel.Off || requestedLevel === ThinkingLevel.Inherit
+				? requestedLevel
+				: clampThinkingLevelForModel(model, requestedLevel);
+		if (!clampedLevel) {
+			throw new Error(`Model ${model.provider}/${model.id} does not support ${requestedLevel} reasoning`);
+		}
+		resolved[role] = clampedLevel;
+	}
+	return resolved;
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -37,7 +37,7 @@ import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
 import { HistorySearchComponent } from "../components/history-search";
-import { ModelSelectorComponent } from "../components/model-selector";
+import { ModelSelectorComponent, type ModelSelectorSelection } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
 import {
@@ -431,8 +431,15 @@ export class SelectorController {
 				this.ctx.settings,
 				this.ctx.session.modelRegistry,
 				this.ctx.session.scopedModels,
-				async (model, role, thinkingLevel, selector) => {
+				async selection => {
 					try {
+						if (selection.kind === "preset") {
+							await this.#applyModelAssignmentPreset(selection);
+							done();
+							this.ctx.ui.requestRender();
+							return;
+						}
+						const { model, role, thinkingLevel, selector } = selection;
 						if (role === null) {
 							// Temporary: update agent state but don't persist to settings
 							await this.ctx.session.setModelTemporary(model, thinkingLevel);
@@ -481,6 +488,39 @@ export class SelectorController {
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	async #applyModelAssignmentPreset(selection: Extract<ModelSelectorSelection, { kind: "preset" }>): Promise<void> {
+		const { assignments, model, preset, selector } = selection;
+		const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
+		if (!apiKey) {
+			throw new Error(`No API key for ${model.provider}/${model.id}`);
+		}
+
+		const defaultThinkingLevel = assignments.default;
+		await this.ctx.session.setModel(model, "default", {
+			selector,
+			thinkingLevel: defaultThinkingLevel,
+		});
+		if (defaultThinkingLevel && defaultThinkingLevel !== ThinkingLevel.Inherit) {
+			this.ctx.session.setThinkingLevel(defaultThinkingLevel);
+		}
+
+		const overrides = this.ctx.settings.get("task.agentModelOverrides");
+		const nextOverrides = { ...overrides };
+		for (const [targetRole, presetThinkingLevel] of Object.entries(assignments) as [
+			keyof Extract<ModelSelectorSelection, { kind: "preset" }>["assignments"],
+			ThinkingLevel,
+		][]) {
+			if (!targetRole || targetRole === "default") continue;
+			nextOverrides[targetRole] =
+				presetThinkingLevel === ThinkingLevel.Inherit ? selector : `${selector}:${presetThinkingLevel}`;
+		}
+		this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
+		this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+		this.ctx.statusLine.invalidate();
+		this.ctx.updateEditorBorderColor();
+		this.ctx.showStatus(`${preset.label}: ${selector}`);
 	}
 
 	async showPluginSelector(mode: "install" | "uninstall" = "install"): Promise<void> {

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -21,9 +21,26 @@ function normalizeRenderedText(text: string): string {
 interface SelectionCapture {
 	model: Model;
 	role: GjcModelAssignmentTargetId | null;
-	thinkingLevel: ThinkingLevel | undefined;
-	selector: string | undefined;
+	thinkingLevel?: ThinkingLevel;
+	selector?: string;
 }
+
+interface PresetCapture {
+	kind: "preset";
+	model: Model;
+	selector: string;
+	assignments: Record<GjcModelAssignmentTargetId, ThinkingLevel>;
+}
+
+type TestModelSelectorSelection =
+	| {
+			kind: "assignment";
+			model: Model;
+			role: GjcModelAssignmentTargetId | null;
+			thinkingLevel?: ThinkingLevel;
+			selector?: string;
+	  }
+	| PresetCapture;
 
 interface CreateSelectorOptions {
 	modelRegistry?: ModelRegistry;
@@ -35,12 +52,7 @@ interface CreateSelectorOptions {
 function createSelector(
 	model: Model,
 	settings: Settings,
-	onSelect: (
-		model: Model,
-		role: GjcModelAssignmentTargetId | null,
-		thinkingLevel: ThinkingLevel | undefined,
-		selector: string | undefined,
-	) => void = () => {},
+	onSelect: (selection: TestModelSelectorSelection) => void = () => {},
 	options: CreateSelectorOptions = {},
 ): ModelSelectorComponent {
 	const modelRegistry =
@@ -63,9 +75,18 @@ function createSelector(
 					explicitThinkingLevel: options.explicitThinkingLevel,
 				};
 
-	return new ModelSelectorComponent(ui, model, settings, modelRegistry, [scopedModel], onSelect, () => {}, {
-		temporaryOnly: options.temporaryOnly,
-	});
+	return new ModelSelectorComponent(
+		ui,
+		model,
+		settings,
+		modelRegistry,
+		[scopedModel],
+		selection => onSelect(selection as TestModelSelectorSelection),
+		() => {},
+		{
+			temporaryOnly: options.temporaryOnly,
+		},
+	);
 }
 
 function createOpenAIModel(provider: "openai" | "openai-codex", id: string, reasoning = true): Model {
@@ -143,8 +164,8 @@ describe("ModelSelector canonical model selection", () => {
 		});
 
 		let selected: SelectionCapture | undefined;
-		const selector = createSelector(model, settings, (selectedModel, role, thinkingLevel, selectorValue) => {
-			selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment") selected = selection;
 		});
 		await Bun.sleep(0);
 		installTestTheme();
@@ -193,8 +214,8 @@ describe("ModelSelector canonical model selection", () => {
 		});
 
 		let selected: SelectionCapture | undefined;
-		const selector = createSelector(model, settings, (selectedModel, role, thinkingLevel, selectorValue) => {
-			selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment") selected = selection;
 		});
 		await Bun.sleep(0);
 		installTestTheme();
@@ -225,8 +246,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ temporaryOnly: true, thinkingLevel: ThinkingLevel.Low },
 		);
@@ -270,8 +291,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectedSelector) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectedSelector };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ modelRegistry, thinkingLevel: ThinkingLevel.Medium },
 		);
@@ -356,8 +377,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: null },
 		);
@@ -395,8 +416,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: null },
 		);
@@ -423,8 +444,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: null },
 		);
@@ -451,6 +472,88 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}:high`);
 	});
 
+	test("shows OpenAI Codex role preset action with requested reasoning map", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai-codex", "gpt-codex-preset-test");
+		model.thinking = {
+			minLevel: Effort.Low,
+			maxLevel: Effort.XHigh,
+			defaultLevel: Effort.Medium,
+			mode: "effort",
+		};
+		const settings = Settings.isolated({});
+
+		let selected: PresetCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "preset") selected = selection;
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		const actionRendered = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(actionRendered).toContain("Apply OpenAI Codex role preset");
+		expect(actionRendered).toContain("Default medium, Executor low, Architect xhigh, Planner medium, Critic high");
+
+		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterPreset = selected;
+		if (!selectedAfterPreset) throw new Error("Expected OpenAI Codex preset selection");
+		expect(selectedAfterPreset.kind).toBe("preset");
+		expect(selectedAfterPreset.selector).toBe(`${model.provider}/${model.id}`);
+		expect(selectedAfterPreset.assignments).toEqual({
+			default: ThinkingLevel.Medium,
+			executor: ThinkingLevel.Low,
+			architect: ThinkingLevel.XHigh,
+			planner: ThinkingLevel.Medium,
+			critic: ThinkingLevel.High,
+		});
+	});
+
+	test("clamps OpenAI Codex role preset to selected model supported reasoning", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai-codex", "gpt-codex-clamped-preset-test");
+		model.thinking = {
+			minLevel: Effort.Medium,
+			maxLevel: Effort.High,
+			defaultLevel: Effort.Medium,
+			mode: "effort",
+		};
+		const settings = Settings.isolated({});
+
+		let selected: PresetCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "preset") selected = selection;
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterPreset = selected;
+		if (!selectedAfterPreset) throw new Error("Expected OpenAI Codex preset selection");
+		expect(selectedAfterPreset.assignments).toEqual({
+			default: ThinkingLevel.Medium,
+			executor: ThinkingLevel.Medium,
+			architect: ThinkingLevel.High,
+			planner: ThinkingLevel.Medium,
+			critic: ThinkingLevel.High,
+		});
+	});
+
 	test("prompts for reasoning when scoped OpenAI thinking came from defaults", async () => {
 		installTestTheme();
 		const model = createOpenAIModel("openai", "gpt-defaulted-scope-test");
@@ -460,8 +563,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: ThinkingLevel.High, explicitThinkingLevel: false },
 		);
@@ -493,8 +596,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: ThinkingLevel.High, explicitThinkingLevel: true },
 		);
@@ -540,8 +643,8 @@ describe("ModelSelector canonical model selection", () => {
 		const selector = createSelector(
 			model,
 			settings,
-			(selectedModel, role, thinkingLevel, selectorValue) => {
-				selected = { model: selectedModel, role, thinkingLevel, selector: selectorValue };
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
 			},
 			{ thinkingLevel: null },
 		);


### PR DESCRIPTION
## Summary
- add an OpenAI Codex model selector preset for default/executor/architect/planner/critic reasoning levels
- emit a typed selector event for preset application and clamp preset reasoning to selected model support
- persist default through session model assignment and role agents through task.agentModelOverrides

## Verification
- bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
- bun run check:ts

Ralplan consensus: .gjc/plans/openai-codex-model-preset-ralplan.md