### PR TITLE
Handle vanished PTY writes in TUI rendering

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppressed uncaught TUI render writes after stdout/PTY write failures such as `EIO`, marking the terminal unavailable and skipping follow-up render/cleanup writes when the PTY has disappeared.
+
 ## [0.2.0] - 2026-05-28
 
 ### Changed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -50,6 +50,9 @@ export function emergencyTerminalRestore(): void {
 /** Terminal-reported appearance (dark/light mode). */
 export type TerminalAppearance = "dark" | "light";
 export interface Terminal {
+	// Whether terminal writes have failed and future rendering should be skipped
+	readonly isDead?: boolean;
+
 	// Start the terminal with input and resize handlers
 	start(onInput: (data: string) => void, onResize: () => void): void;
 
@@ -132,6 +135,11 @@ export class ProcessTerminal implements Terminal {
 	#osc11PollTimer?: Timer;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: ReturnType<typeof setInterval>;
+	#stdoutErrorHandler?: (error: Error) => void;
+
+	get isDead(): boolean {
+		return this.#dead;
+	}
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;
@@ -152,6 +160,8 @@ export class ProcessTerminal implements Terminal {
 		// Register for emergency cleanup
 		activeTerminal = this;
 		terminalEverStarted = true;
+		this.#dead = false;
+		this.#installStdoutErrorHandler();
 
 		// Save previous state and enable raw mode
 		this.#wasRaw = process.stdin.isRaw || false;
@@ -621,6 +631,8 @@ export class ProcessTerminal implements Terminal {
 		if (process.stdin.setRawMode) {
 			process.stdin.setRawMode(this.#wasRaw);
 		}
+
+		this.#removeStdoutErrorHandler();
 	}
 
 	write(data: string): void {
@@ -639,13 +651,48 @@ export class ProcessTerminal implements Terminal {
 		// Skip control sequences when stdout isn't a TTY (piped output, tests, log
 		// files). They serve no purpose there and would surface as visible noise.
 		if (!process.stdout.isTTY) return;
-		try {
-			process.stdout.write(data);
-		} catch (err) {
-			// Any write failure means terminal is dead - no recovery possible
-			this.#dead = true;
-			logger.warn("terminal is dead - no recovery possible", { error: err, data });
+		if (this.#isStdoutClosed()) {
+			this.#markDead(new Error("stdout is closed"));
+			return;
 		}
+		try {
+			process.stdout.write(data, err => {
+				if (err) this.#markDead(err, data);
+			});
+		} catch (err) {
+			this.#markDead(err, data);
+		}
+	}
+
+	#installStdoutErrorHandler(): void {
+		this.#removeStdoutErrorHandler();
+		this.#stdoutErrorHandler = error => {
+			this.#markDead(error);
+		};
+		process.stdout.on("error", this.#stdoutErrorHandler);
+	}
+
+	#removeStdoutErrorHandler(): void {
+		if (!this.#stdoutErrorHandler) return;
+		process.stdout.removeListener("error", this.#stdoutErrorHandler);
+		this.#stdoutErrorHandler = undefined;
+	}
+
+	#isStdoutClosed(): boolean {
+		const stream = process.stdout as NodeJS.WriteStream & { writableEnded?: boolean; writableDestroyed?: boolean };
+		return stream.destroyed || stream.writableEnded === true || stream.writableDestroyed === true;
+	}
+
+	#markDead(error: unknown, data?: string): void {
+		if (this.#dead) return;
+		this.#dead = true;
+		this.#stopOsc11Poll();
+		this.#clearProgressTimer();
+		if (this.#mode2031DebounceTimer) {
+			clearTimeout(this.#mode2031DebounceTimer);
+			this.#mode2031DebounceTimer = undefined;
+		}
+		logger.warn("terminal output is unavailable; suppressing further TUI writes", { error, data });
 	}
 
 	get columns(): number {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -574,7 +574,7 @@ export class TUI extends Container {
 			this.#renderTimer = undefined;
 		}
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
-		if (this.#previousLines.length > 0) {
+		if (this.terminal.isDead !== true && this.#previousLines.length > 0) {
 			const targetRow = this.#previousLines.length; // Line after the last content
 			const lineDiff = targetRow - this.#hardwareCursorRow;
 			if (lineDiff > 0) {
@@ -585,7 +585,7 @@ export class TUI extends Container {
 			this.terminal.write("\r\n");
 		}
 
-		this.terminal.showCursor();
+		if (this.terminal.isDead !== true) this.terminal.showCursor();
 		this.terminal.stop();
 	}
 
@@ -1040,7 +1040,7 @@ export class TUI extends Container {
 	}
 
 	#doRender(): void {
-		if (this.#stopped) return;
+		if (this.#stopped || this.terminal.isDead === true) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
 		let viewportTop = Math.max(0, this.#maxLinesRendered - height);

--- a/packages/tui/test/terminal-write-failure.test.ts
+++ b/packages/tui/test/terminal-write-failure.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, ProcessTerminal, type Terminal, type TerminalAppearance, TUI } from "@gajae-code/tui";
+
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+type StdoutWrite = typeof process.stdout.write;
+
+class StaticComponent implements Component {
+	#renderCount = 0;
+
+	get renderCount(): number {
+		return this.#renderCount;
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		this.#renderCount++;
+		return ["content"];
+	}
+}
+
+class DeadTerminal implements Terminal {
+	get isDead(): boolean {
+		return true;
+	}
+
+	get columns(): number {
+		return 80;
+	}
+
+	get rows(): number {
+		return 24;
+	}
+
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+
+	get appearance(): TerminalAppearance | undefined {
+		return undefined;
+	}
+
+	start(): void {}
+
+	stop(): void {}
+
+	async drainInput(): Promise<void> {}
+
+	write(): void {
+		throw new Error("dead terminal write should be skipped");
+	}
+
+	moveBy(): void {
+		throw new Error("dead terminal move should be skipped");
+	}
+
+	hideCursor(): void {
+		throw new Error("dead terminal hide should be skipped");
+	}
+
+	showCursor(): void {
+		throw new Error("dead terminal show should be skipped");
+	}
+
+	clearLine(): void {
+		throw new Error("dead terminal clear should be skipped");
+	}
+
+	clearFromCursor(): void {
+		throw new Error("dead terminal clear should be skipped");
+	}
+
+	clearScreen(): void {
+		throw new Error("dead terminal clear should be skipped");
+	}
+
+	setTitle(): void {}
+
+	setProgress(): void {}
+
+	onAppearanceChange(): void {}
+}
+
+function restoreStdoutIsTty(): void {
+	if (stdoutIsTtyDescriptor) {
+		Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		return;
+	}
+	delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+}
+
+describe("terminal write failure handling", () => {
+	beforeEach(() => {
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		restoreStdoutIsTty();
+	});
+
+	it("marks ProcessTerminal dead after synchronous stdout write failure", () => {
+		const terminal = new ProcessTerminal();
+		const eio = Object.assign(new Error("EIO: i/o error, write"), { code: "EIO" });
+		const write = vi.spyOn(process.stdout, "write").mockImplementation(() => {
+			throw eio;
+		}) as unknown as { mock: { calls: unknown[] } };
+
+		expect(() => terminal.write("first")).not.toThrow();
+		expect(terminal.isDead).toBe(true);
+
+		expect(() => terminal.write("second")).not.toThrow();
+		expect(write.mock.calls).toHaveLength(1);
+	});
+
+	it("marks ProcessTerminal dead after asynchronous stdout write callback failure", () => {
+		const terminal = new ProcessTerminal();
+		const eio = Object.assign(new Error("EIO: i/o error, write"), { code: "EIO" });
+		vi.spyOn(process.stdout, "write").mockImplementation(((
+			_chunk: string | Uint8Array,
+			callback?: (err?: Error | null) => void,
+		) => {
+			callback?.(eio);
+			return false;
+		}) as StdoutWrite);
+
+		expect(() => terminal.write("frame")).not.toThrow();
+		expect(terminal.isDead).toBe(true);
+	});
+
+	it("skips render and stop cleanup writes when the terminal is already dead", async () => {
+		const terminal = new DeadTerminal();
+		const tui = new TUI(terminal);
+		const component = new StaticComponent();
+		tui.addChild(component);
+
+		tui.requestRender(true);
+		await new Promise<void>(resolve => process.nextTick(resolve));
+
+		expect(component.renderCount).toBe(0);
+		expect(() => tui.stop()).not.toThrow();
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -15,6 +15,7 @@ export class VirtualTerminal implements Terminal {
 	#writeLog: string[] = [];
 	private _columns: number;
 	private _rows: number;
+	#dead = false;
 
 	constructor(columns = 80, rows = 24) {
 		this._columns = columns;
@@ -28,6 +29,10 @@ export class VirtualTerminal implements Terminal {
 			disableStdin: true,
 			allowProposedApi: true,
 		});
+	}
+
+	get isDead(): boolean {
+		return this.#dead;
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {


### PR DESCRIPTION
## Summary
- Mark `ProcessTerminal` output dead after stdout write failures, including synchronous throws, async write callback errors, stream `error` events, and closed stdout state.
- Skip TUI render/exit cleanup writes once the terminal reports unavailable output, preventing follow-up uncaught writes after a PTY disappears.
- Add focused regression coverage for EIO-style write failures and dead-terminal render skipping.

## Tests
- `bun test packages/tui/test/terminal-write-failure.test.ts`
- `bun --cwd=packages/tui run test`
- `bun --cwd=packages/tui run check`

## Notes
- Treats EIO as downstream of a vanished/closed PTY; this does not attempt to work around Terminal.app internal buffer crashes or reproduce private crash logs.

Fixes #98