### PR TITLE
Fix team status while integration is pending

### DIFF
--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -42,6 +42,13 @@ function formatTaskCounts(counts: Record<string, number>): string {
 		.join(" ");
 }
 
+function formatAwaitingIntegrationNextStep(snapshot: GjcTeamSnapshot): string[] {
+	if (snapshot.phase !== "awaiting_integration") return [];
+	return [
+		"next: worker tasks are completed, but integration still needs leader attention before the team is complete",
+	];
+}
+
 function formatIntegrationSummary(snapshot: {
 	integration_by_worker?: Record<string, { status?: string; conflict_files?: string[] }>;
 }): string[] {
@@ -118,6 +125,7 @@ export default class Team extends Command {
 				`state: ${snapshot.state_dir}`,
 				`tasks: ${snapshot.task_total} (${formatTaskCounts(snapshot.task_counts)})`,
 				`workers: ${snapshot.workers.map(worker => `${worker.id}:${worker.status}`).join(" ")}`,
+				...formatAwaitingIntegrationNextStep(snapshot),
 				...formatIntegrationSummary(snapshot),
 			]);
 			return;

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -5,7 +5,7 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { applyGjcTmuxProfile } from "./launch-tmux";
 
-export type GjcTeamPhase = "starting" | "running" | "complete" | "failed" | "cancelled";
+export type GjcTeamPhase = "starting" | "running" | "awaiting_integration" | "complete" | "failed" | "cancelled";
 export type GjcTeamTaskStatus = "pending" | "blocked" | "in_progress" | "completed" | "failed";
 export type GjcWorkerStatusState = "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown";
 
@@ -462,6 +462,51 @@ function normalizeTask(raw: GjcTeamTask): GjcTeamTask {
 		version: raw.version ?? 1,
 	};
 }
+
+const GJC_TEAM_INTEGRATION_ATTENTION_STATUSES = new Set<GjcTeamIntegrationStatus>([
+	"integration_failed",
+	"merge_conflict",
+	"cherry_pick_conflict",
+	"rebase_conflict",
+]);
+const GJC_TEAM_INTEGRATION_SETTLED_STATUSES = new Set<GjcTeamIntegrationStatus>(["idle", "integrated"]);
+
+async function hasPendingGjcTeamIntegration(
+	dir: string,
+	config: GjcTeamConfig,
+	monitor: GjcTeamMonitorSnapshot | null,
+): Promise<boolean> {
+	for (const worker of config.workers) {
+		const integration = monitor?.integration_by_worker?.[worker.id];
+		if (integration?.status && GJC_TEAM_INTEGRATION_ATTENTION_STATUSES.has(integration.status)) return true;
+
+		const request = await readJsonFile<GjcWorkerIntegrationDedupeState>(workerIntegrationDedupePath(dir, worker.id));
+		if (!request?.last_requested_at) continue;
+		if (!integration?.status || !integration.updated_at) return true;
+		if (GJC_TEAM_INTEGRATION_ATTENTION_STATUSES.has(integration.status)) return true;
+		if (
+			GJC_TEAM_INTEGRATION_SETTLED_STATUSES.has(integration.status) &&
+			integration.updated_at >= request.last_requested_at
+		) {
+			continue;
+		}
+		return true;
+	}
+	return false;
+}
+
+async function resolveGjcTeamSnapshotPhase(
+	dir: string,
+	config: GjcTeamConfig,
+	storedPhase: GjcTeamPhase,
+	tasks: GjcTeamTask[],
+	monitor: GjcTeamMonitorSnapshot | null,
+): Promise<GjcTeamPhase> {
+	if (storedPhase !== "running") return storedPhase;
+	if (tasks.length === 0 || !tasks.every(task => task.status === "completed")) return storedPhase;
+	return (await hasPendingGjcTeamIntegration(dir, config, monitor)) ? "awaiting_integration" : storedPhase;
+}
+
 async function readTasks(dir: string): Promise<GjcTeamTask[]> {
 	try {
 		const entries = await fs.readdir(path.join(dir, "tasks"), { withFileTypes: true });
@@ -1539,7 +1584,7 @@ export async function readGjcTeamSnapshot(
 ): Promise<GjcTeamSnapshot> {
 	const dir = await findTeamDir(teamName, cwd, env);
 	const config = await readConfig(dir);
-	const phase = await readPhase(dir);
+	const storedPhase = await readPhase(dir);
 	const tasks = await readTasks(dir);
 	const taskCounts: Record<GjcTeamTaskStatus, number> = {
 		pending: 0,
@@ -1550,6 +1595,7 @@ export async function readGjcTeamSnapshot(
 	};
 	for (const task of tasks) taskCounts[task.status] += 1;
 	const monitor = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
+	const phase = await resolveGjcTeamSnapshotPhase(dir, config, storedPhase, tasks, monitor);
 	return {
 		team_name: config.team_name,
 		display_name: config.display_name,

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -833,6 +833,51 @@ describe("native gjc team runtime", () => {
 		expect(JSON.stringify(ledger)).toContain("leader_integration_attempt");
 	});
 
+	it("reports awaiting integration when all worker tasks completed after an integration request", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Complete then integrate",
+			teamName: "awaiting-request-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const worker = config.workers[0];
+		if (!worker?.worktree_path) throw new Error("missing worker worktree");
+		await Bun.write(path.join(worker.worktree_path, "requested-output.txt"), "pending integration\n");
+		const requestEnv = {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_NAME: "awaiting-request-team",
+			GJC_TEAM_WORKER_ID: "worker-1",
+			GJC_TEAM_STATE_ROOT: config.state_root,
+			GJC_TEAM_WORKTREE_PATH: worker.worktree_path,
+		};
+		const requested = await requestGjcWorkerIntegrationAttempt(worker.worktree_path, requestEnv);
+		expect(requested.requested).toBe(true);
+
+		const claim = await claimGjcTeamTask("awaiting-request-team", "worker-1", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+		});
+		await transitionGjcTeamTask(
+			"awaiting-request-team",
+			"task-1",
+			"completed",
+			cleanupRoot,
+			{
+				PATH: process.env.PATH ?? "",
+			},
+			claim.claim_token,
+		);
+
+		const status = await readGjcTeamSnapshot("awaiting-request-team", cleanupRoot, { PATH: process.env.PATH ?? "" });
+		expect(status.task_counts.completed).toBe(1);
+		expect(status.phase).toBe("awaiting_integration");
+		expect(status.phase).not.toBe("running");
+	});
+
 	it("monitor cherry-picks diverged worker commits and stays idempotent on repeated status checks", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
@@ -908,6 +953,48 @@ describe("native gjc team runtime", () => {
 		).json();
 		expect(JSON.stringify(ledger)).toContain('"status":"conflict"');
 		expect(JSON.stringify(ledger)).toContain("integration_merge");
+	});
+
+	it("keeps completed conflicting teams in awaiting integration instead of plain running", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Conflict after completion",
+			teamName: "awaiting-conflict-team",
+			worktreeMode: { enabled: true, detached: false, name: "feature/awaiting-conflict" },
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+		const config = await readTeamConfig(snapshot.state_dir);
+		const workerPath = config.workers[0]?.worktree_path;
+		if (!workerPath) throw new Error("missing worker worktree");
+		await commitFile(workerPath, "README.md", "# worker\n", "worker readme");
+		await Bun.write(path.join(cleanupRoot, "README.md"), "# leader dirty\n");
+		const claim = await claimGjcTeamTask("awaiting-conflict-team", "worker-1", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+		});
+		await transitionGjcTeamTask(
+			"awaiting-conflict-team",
+			"task-1",
+			"completed",
+			cleanupRoot,
+			{
+				PATH: process.env.PATH ?? "",
+			},
+			claim.claim_token,
+		);
+
+		const monitored = await monitorGjcTeam("awaiting-conflict-team", cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+			GJC_TEAM_TMUX_COMMAND: fakeTmux,
+		});
+
+		expect(monitored.task_counts.completed).toBe(1);
+		expect(monitored.integration_by_worker?.["worker-1"]?.status).toBe("merge_conflict");
+		expect(monitored.phase).toBe("awaiting_integration");
+		expect(monitored.phase).not.toBe("running");
 	});
 
 	it("monitor reports cherry-pick conflicts and aborts cleanly", async () => {


### PR DESCRIPTION
## Summary
- add a derived `awaiting_integration` team phase when all tasks are complete but integration still needs leader attention
- surface an explicit next-step line in `gjc team status` for completed-but-not-integrated teams
- cover requested-integration and conflict regressions in the team runtime test suite

Fixes #108

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`
- `bun run check:ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## Review
- code-reviewer: APPROVE
- architect: CLEAR
