### PR TITLE
Fix Anthropic thinking replay recovery

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -857,37 +857,35 @@ async function streamAssistantResponse(
 }
 
 function emitAbortedAssistantMessage(
-	partialMessage: AssistantMessage | null,
+	_partialMessage: AssistantMessage | null,
 	addedPartial: boolean,
 	context: AgentContext,
 	config: AgentLoopConfig,
 	stream: EventStream<AgentEvent, AgentMessage[]>,
 ): AssistantMessage {
 	const errorMessage = "Request was aborted";
-	const abortedMessage: AssistantMessage = partialMessage
-		? { ...partialMessage, stopReason: "aborted", errorMessage }
-		: {
-				role: "assistant",
-				content: [],
-				api: config.model.api,
-				provider: config.model.provider,
-				model: config.model.id,
-				usage: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				},
-				stopReason: "aborted",
-				errorMessage,
-				timestamp: Date.now(),
-			};
+	const now = Date.now();
+	const abortedMessage: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: config.model.api,
+		provider: config.model.provider,
+		model: config.model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "aborted",
+		errorMessage,
+		timestamp: now,
+	};
 	if (addedPartial) {
-		context.messages[context.messages.length - 1] = abortedMessage;
+		context.messages.pop();
 	} else {
-		context.messages.push(abortedMessage);
 		stream.push({ type: "message_start", message: { ...abortedMessage } });
 	}
 	stream.push({ type: "message_end", message: abortedMessage });

--- a/packages/agent/test/agent-force-abort.test.ts
+++ b/packages/agent/test/agent-force-abort.test.ts
@@ -195,4 +195,49 @@ describe("Agent.forceAbort", () => {
 		});
 		await expect(secondPrompt).resolves.toBeUndefined();
 	});
+
+	it("drops partial thinking and tool-use from replay history when a streamed turn is aborted", async () => {
+		const model = createMockModel({ responses: [{ content: ["after abort"] }] });
+		const firstStream = new AssistantMessageEventStream();
+		let callCount = 0;
+		const streamFn: StreamFn = (selectedModel, context, options) => {
+			callCount += 1;
+			if (callCount === 1) return firstStream;
+			return model.stream(selectedModel, context, options);
+		};
+		const agent = new Agent({
+			initialState: { model: model.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn,
+		});
+
+		const firstPrompt = agent.prompt("start risky turn");
+		await waitForStreaming(agent);
+		const partial = createAssistantMessage(
+			[
+				{ type: "thinking", thinking: "partial private reasoning", thinkingSignature: "partial_sig" },
+				{ type: "toolCall", id: "toolu_partial", name: "read", arguments: { path: "README.md" } },
+			],
+			"toolUse",
+		);
+		firstStream.push({ type: "start", partial });
+		firstStream.push({ type: "thinking_start", contentIndex: 0, partial });
+		firstStream.push({
+			type: "toolcall_end",
+			contentIndex: 1,
+			toolCall: { type: "toolCall", id: "toolu_partial", name: "read", arguments: { path: "README.md" } },
+			partial,
+		});
+
+		expect(agent.forceAbort("test timeout")).toBe(true);
+		await expect(firstPrompt).resolves.toBeUndefined();
+
+		await expect(agent.prompt("after abort")).resolves.toBeUndefined();
+
+		const assistantMessages = agent.state.messages.filter(message => message.role === "assistant");
+		expect(assistantMessages).toHaveLength(1);
+		expect(assistantMessages[0]?.content).toEqual([{ type: "text", text: "after abort" }]);
+		expect(model.calls[0]?.context.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "after abort" }], timestamp: expect.any(Number) },
+		]);
+	});
 });

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic extended-thinking replay after aborted turns by dropping partial `thinking`/`redacted_thinking` blocks before the next request, preserving/synthesizing matching tool results, and retrying once with repaired latest-assistant thinking when Anthropic rejects a replay with the immutable-thinking HTTP 400 ([#107](https://github.com/Yeachan-Heo/gajae-code/issues/107)).
+
 ## [0.2.1] - 2026-05-30
 
 ### Changed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -304,6 +304,17 @@ export function isAnthropicFastModeUnsupportedError(error: unknown): boolean {
 	return false;
 }
 
+export function isAnthropicThinkingBlockMutationError(error: unknown): boolean {
+	if (extractHttpStatusFromError(error) !== 400) return false;
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		/invalid_request_error/i.test(message) &&
+		/thinking|redacted_thinking/i.test(message) &&
+		/latest assistant message/i.test(message) &&
+		/cannot be modified/i.test(message)
+	);
+}
+
 function hasStrictAnthropicTools(params: MessageCreateParamsStreaming): boolean {
 	const tools = params.tools as Array<{ strict?: unknown }> | undefined;
 	return tools?.some(tool => tool.strict === true) ?? false;
@@ -1058,8 +1069,18 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				(providerSessionState?.strictToolsDisabled ?? false) || (model.compat?.disableStrictTools ?? false);
 			let strictFallbackErrorMessage: string | undefined;
 			let dropFastMode = providerSessionState?.fastModeDisabled ?? false;
-			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
-				let nextParams = buildParams(model, baseUrl, context, isOAuthToken, options, disableStrictTools);
+			const prepareParams = async (paramsOptions?: {
+				repairLatestAssistantThinking?: boolean;
+			}): Promise<MessageCreateParamsStreaming> => {
+				let nextParams = buildParams(
+					model,
+					baseUrl,
+					context,
+					isOAuthToken,
+					options,
+					disableStrictTools,
+					paramsOptions?.repairLatestAssistantThinking === true,
+				);
 				if (disableStrictTools) {
 					dropAnthropicStrictTools(nextParams);
 				}
@@ -1096,6 +1117,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			// Provider-level transport/rate-limit failures: only before any streamed content starts.
 			// Malformed envelopes/JSON: only before replay-unsafe text/tool events are visible on this stream.
 			let providerRetryAttempt = 0;
+			let thinkingRepairAttempted = false;
 			while (true) {
 				activeAbortTracker = createAbortSourceTracker(options?.signal);
 				const firstEventTimeoutAbortError = new Error(
@@ -1363,6 +1385,26 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						}
 						disableStrictTools = true;
 						params = await prepareParams();
+						providerRetryAttempt = 0;
+						output.content.length = 0;
+						output.responseId = undefined;
+						output.providerPayload = undefined;
+						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
+						output.stopReason = "stop";
+						firstTokenTime = undefined;
+						continue;
+					}
+					if (
+						!thinkingRepairAttempted &&
+						firstTokenTime === undefined &&
+						isAnthropicThinkingBlockMutationError(streamFailure)
+					) {
+						logger.debug("anthropic: repairing latest assistant thinking replay after provider rejection", {
+							model: model.id,
+							error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
+						});
+						thinkingRepairAttempted = true;
+						params = await prepareParams({ repairLatestAssistantThinking: true });
 						providerRetryAttempt = 0;
 						output.content.length = 0;
 						output.responseId = undefined;
@@ -1887,11 +1929,12 @@ function buildParams(
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
 	disableStrictTools = false,
+	repairLatestAssistantThinking = false,
 ): MessageCreateParamsStreaming {
 	const { cacheControl } = getCacheControl(model, baseUrl, options?.cacheRetention);
 	const params: AnthropicSamplingParams = {
 		model: model.id,
-		messages: convertAnthropicMessages(context.messages, model, isOAuthToken),
+		messages: convertAnthropicMessages(context.messages, model, isOAuthToken, { repairLatestAssistantThinking }),
 		max_tokens: options?.maxTokens || (model.maxTokens / 3) | 0,
 		stream: true,
 	};
@@ -2074,10 +2117,11 @@ export function convertAnthropicMessages(
 	messages: Message[],
 	model: Model<"anthropic-messages">,
 	isOAuthToken: boolean,
+	options?: { repairLatestAssistantThinking?: boolean },
 ): MessageParam[] {
 	const params: MessageParam[] = [];
 
-	const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
+	const transformedMessages = transformMessages(messages, model, normalizeToolCallId, options);
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -31,6 +31,7 @@ export function transformMessages<TApi extends Api>(
 	messages: Message[],
 	model: Model<TApi>,
 	normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
+	options?: { repairLatestAssistantThinking?: boolean },
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
@@ -64,16 +65,24 @@ export function transformMessages<TApi extends Api>(
 				index === latestAssistantIndex &&
 				model.api === "anthropic-messages" &&
 				assistantMsg.api === "anthropic-messages";
-			// Aborted/errored messages may have partially-streamed thinking signatures.
-			// A partial signature is invalid and will be rejected by the API, so we must
-			// strip signatures from thinking blocks in these messages.
-			const hasInvalidSignatures = assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error";
+			// Aborted/errored messages may contain partially-streamed thinking blocks.
+			// Anthropic requires thinking/redacted_thinking bytes in replayed assistant
+			// messages to match the original response exactly; stripping a signature,
+			// well-forming text, or keeping a partial redacted block would emit a
+			// modified thinking sequence. Drop those private blocks instead. Tool calls
+			// are kept so the second pass can either preserve real results or synthesize
+			// an explicit aborted result without leaving dangling tool_use blocks.
+			const hasPartialThinking = assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error";
+			const dropLatestAssistantThinking =
+				options?.repairLatestAssistantThinking === true &&
+				index === latestAssistantIndex &&
+				model.api === "anthropic-messages" &&
+				assistantMsg.api === "anthropic-messages";
 
 			const transformedContent = assistantMsg.content.flatMap(block => {
 				if (block.type === "thinking") {
-					// Strip signature from aborted/errored messages — it's likely incomplete
-					const sanitized =
-						hasInvalidSignatures && block.thinkingSignature ? { ...block, thinkingSignature: undefined } : block;
+					if (hasPartialThinking || dropLatestAssistantThinking) return [];
+					const sanitized = block;
 					if (mustPreserveLatestAnthropicThinking) return sanitized;
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)
@@ -88,6 +97,7 @@ export function transformMessages<TApi extends Api>(
 				}
 
 				if (block.type === "redactedThinking") {
+					if (hasPartialThinking || dropLatestAssistantThinking) return [];
 					if (mustPreserveLatestAnthropicThinking) return block;
 					if (isSameModel) return block;
 					return [];

--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -102,7 +102,43 @@ function sanitizeDump(dump: RawHttpRequestDump): RawHttpRequestDump {
 	return {
 		...dump,
 		headers: redactHeaders(dump.headers),
+		body: sanitizeDumpBody(dump.body),
 	};
+}
+
+function sanitizeDumpBody(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(item => sanitizeDumpBody(item));
+	}
+	if (!isObject(value)) {
+		return value;
+	}
+
+	const type = typeof value.type === "string" ? value.type : undefined;
+	const redactedKeys = getRedactedBodyKeys(type);
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, property] of Object.entries(value)) {
+		if (redactedKeys.has(key)) {
+			sanitized[key] = "[redacted]";
+			continue;
+		}
+		sanitized[key] = sanitizeDumpBody(property);
+	}
+	return sanitized;
+}
+
+function getRedactedBodyKeys(type: string | undefined): Set<string> {
+	const keys = new Set<string>();
+	if (type === "thinking") {
+		keys.add("thinking");
+		keys.add("signature");
+		keys.add("thinkingSignature");
+		keys.add("thoughtSignature");
+	}
+	if (type === "redacted_thinking" || type === "redactedThinking") {
+		keys.add("data");
+	}
+	return keys;
 }
 
 function redactHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {

--- a/packages/ai/test/anthropic-prefill.test.ts
+++ b/packages/ai/test/anthropic-prefill.test.ts
@@ -178,7 +178,7 @@ it("preserves latest Anthropic thinking blocks even when model id changes", () =
 	expect(transformedAssistant?.content[1]).toEqual(assistant.content[1]);
 });
 
-it("strips invalid thinking signatures from aborted Anthropic replay messages", () => {
+it("drops invalid thinking blocks from aborted Anthropic replay messages", () => {
 	const model: Model<"anthropic-messages"> = {
 		api: "anthropic-messages",
 		provider: "anthropic",
@@ -219,9 +219,5 @@ it("strips invalid thinking signatures from aborted Anthropic replay messages", 
 	const transformedAssistant = transformed.find(m => m.role === "assistant") as AssistantMessage | undefined;
 
 	expect(transformedAssistant).toBeDefined();
-	const thinkingBlock = transformedAssistant?.content[0];
-	expect(thinkingBlock).toMatchObject({ type: "thinking", thinking: "partial reasoning" });
-	expect(
-		thinkingBlock && "thinkingSignature" in thinkingBlock ? thinkingBlock.thinkingSignature : undefined,
-	).toBeUndefined();
+	expect(transformedAssistant?.content).toEqual([{ type: "text", text: "partial answer" }]);
 });

--- a/packages/ai/test/anthropic-thinking-immutability.test.ts
+++ b/packages/ai/test/anthropic-thinking-immutability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { convertAnthropicMessages } from "@gajae-code/ai/providers/anthropic";
-import type { AssistantMessage, Model, UserMessage } from "@gajae-code/ai/types";
+import type { AssistantMessage, Model, ToolResultMessage, UserMessage } from "@gajae-code/ai/types";
 
 const model: Model<"anthropic-messages"> = {
 	api: "anthropic-messages",
@@ -58,6 +58,172 @@ describe("Anthropic thinking replay immutability", () => {
 			{ type: "thinking", thinking: `analysis ${malformed}`, signature: "sig_thinking" },
 			{ type: "text", text: `text ${malformed.toWellFormed()}` },
 			{ type: "tool_use", id: "toolu_123", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
+	it("drops aborted assistant thinking while preserving a resolved tool-use turn", () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "use a tool",
+			timestamp: Date.now(),
+		};
+		const abortedAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "partial synthetic thinking", thinkingSignature: "partial_test_sig" },
+				{ type: "redactedThinking", data: "synthetic-redacted-block" },
+				{
+					type: "toolCall",
+					id: "toolu_abort",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			errorMessage: "Request was aborted",
+			timestamp: Date.now(),
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "toolu_abort",
+			toolName: "read",
+			content: [{ type: "text", text: "synthetic result" }],
+			isError: true,
+			timestamp: Date.now(),
+		};
+
+		const params = convertAnthropicMessages([user, abortedAssistant, toolResult], model, false);
+
+		expect(params).toEqual([
+			{ role: "user", content: "use a tool" },
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_abort", name: "read", input: { path: "README.md" } }],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_abort",
+						content: "synthetic result",
+						is_error: true,
+					},
+				],
+			},
+			{
+				role: "user",
+				content: expect.stringContaining("<turn-aborted>"),
+			},
+		]);
+	});
+
+	it("synthesizes an aborted tool result after dropping aborted thinking-only private blocks", () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "use a tool",
+			timestamp: Date.now(),
+		};
+		const abortedAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "partial synthetic thinking", thinkingSignature: "partial_test_sig" },
+				{
+					type: "toolCall",
+					id: "toolu_no_result",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			errorMessage: "Request was aborted",
+			timestamp: Date.now(),
+		};
+
+		const params = convertAnthropicMessages([user, abortedAssistant], model, false);
+
+		expect(params).toEqual([
+			{ role: "user", content: "use a tool" },
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_no_result", name: "read", input: { path: "README.md" } }],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_no_result",
+						content: "aborted",
+						is_error: true,
+					},
+				],
+			},
+			{
+				role: "user",
+				content: expect.stringContaining("<turn-aborted>"),
+			},
+		]);
+	});
+
+	it("drops latest assistant thinking for one-shot Anthropic replay repair", () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "continue",
+			timestamp: Date.now(),
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "synthetic thinking", thinkingSignature: "synthetic_sig" },
+				{ type: "redactedThinking", data: "synthetic-redacted-block" },
+				{ type: "text", text: "visible answer" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const params = convertAnthropicMessages([user, assistant], model, false, {
+			repairLatestAssistantThinking: true,
+		});
+
+		expect(params).toEqual([
+			{ role: "user", content: "continue" },
+			{ role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+			{ role: "user", content: "Continue." },
 		]);
 	});
 });

--- a/packages/ai/test/anthropic-thinking-repair-retry.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-retry.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import { streamAnthropic } from "@gajae-code/ai/providers/anthropic";
+import type { AssistantMessage, Context, Model, UserMessage } from "@gajae-code/ai/types";
+
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+type MockAnthropicStream = AsyncIterable<MockAnthropicEvent>;
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: MockAnthropicStream;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+function createSuccessfulRequest(): MockAnthropicRequest {
+	const response = new Response(null, {
+		status: 200,
+		headers: { "request-id": "req_repair" },
+	});
+	const events: MockAnthropicEvent[] = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_repair_success",
+				usage: {
+					input_tokens: 1,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "recovered" } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		},
+		{ type: "message_stop" },
+	];
+
+	return {
+		async withResponse() {
+			return {
+				data: {
+					async *[Symbol.asyncIterator]() {
+						for (const event of events) yield event;
+					},
+				},
+				response,
+				request_id: response.headers.get("request-id"),
+			};
+		},
+	};
+}
+
+function createAnthropicThinking400(): MockAnthropicRequest {
+	return {
+		async withResponse() {
+			const error = new Error(
+				"400 invalid_request_error: thinking blocks in the latest assistant message cannot be modified",
+			);
+			(error as { status?: number }).status = 400;
+			throw error;
+		},
+	};
+}
+
+describe("Anthropic thinking replay repair retry", () => {
+	it("retries once without latest assistant thinking blocks after the Anthropic 400 invariant error", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "continue",
+			timestamp: Date.now(),
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "synthetic thinking", thinkingSignature: "synthetic_sig" },
+				{ type: "redactedThinking", data: "synthetic-redacted-block" },
+				{ type: "text", text: "visible answer" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [user, assistant, { ...user, content: "next prompt", timestamp: Date.now() + 1 }],
+		};
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			return (attempt === 1 ? createAnthropicThinking400() : createSuccessfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+		expect(requestBodies).toHaveLength(2);
+		expect(JSON.stringify(requestBodies[0])).toContain("synthetic_sig");
+		expect(JSON.stringify(requestBodies[1])).not.toContain("synthetic_sig");
+		expect(JSON.stringify(requestBodies[1])).not.toContain("redacted_thinking");
+		expect(JSON.stringify(requestBodies[1])).toContain("visible answer");
+	});
+
+	it("does not retry or scrub history for non-matching Anthropic 400 errors", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "continue",
+			timestamp: Date.now(),
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "synthetic thinking", thinkingSignature: "synthetic_sig" },
+				{ type: "text", text: "visible answer" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [user, assistant, { ...user, content: "next prompt", timestamp: Date.now() + 1 }],
+		};
+		const requestBodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			const error = new Error("400 invalid_request_error: max_tokens is too low");
+			(error as { status?: number }).status = 400;
+			throw error;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(400);
+		expect(result.errorMessage).toContain("max_tokens is too low");
+		expect(requestBodies).toHaveLength(1);
+		expect(JSON.stringify(requestBodies[0])).toContain("synthetic_sig");
+	});
+});

--- a/packages/ai/test/http-inspector.test.ts
+++ b/packages/ai/test/http-inspector.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
+import { finalizeErrorMessage, type RawHttpRequestDump } from "../src/utils/http-inspector";
+
+let previousAgentDir: string | undefined;
+let previousPiConfigDir: string | undefined;
+let previousGjcConfigDir: string | undefined;
+let tempAgentDir: string | undefined;
+let tempConfigRoot: string | undefined;
+
+async function useTempAgentDir(): Promise<string> {
+	previousAgentDir = getConfigRootDir();
+	previousPiConfigDir = process.env.PI_CONFIG_DIR;
+	previousGjcConfigDir = process.env.GJC_CONFIG_DIR;
+	tempConfigRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-http-inspector-"));
+	process.env.PI_CONFIG_DIR = path.relative(os.homedir(), tempConfigRoot);
+	delete process.env.GJC_CONFIG_DIR;
+	tempAgentDir = path.join(tempConfigRoot, "agent");
+	setAgentDir(tempAgentDir);
+	return tempAgentDir;
+}
+
+afterEach(async () => {
+	if (previousPiConfigDir === undefined) {
+		delete process.env.PI_CONFIG_DIR;
+	} else {
+		process.env.PI_CONFIG_DIR = previousPiConfigDir;
+	}
+	previousPiConfigDir = undefined;
+	if (previousGjcConfigDir === undefined) {
+		delete process.env.GJC_CONFIG_DIR;
+	} else {
+		process.env.GJC_CONFIG_DIR = previousGjcConfigDir;
+	}
+	previousGjcConfigDir = undefined;
+	if (previousAgentDir) {
+		setAgentDir(previousAgentDir);
+		previousAgentDir = undefined;
+	}
+	if (tempConfigRoot) {
+		await fs.rm(tempConfigRoot, { recursive: true, force: true });
+		tempAgentDir = undefined;
+		tempConfigRoot = undefined;
+	}
+});
+
+describe("HTTP 400 request dump sanitization", () => {
+	it("redacts Anthropic thinking and redacted-thinking payloads in saved request dumps", async () => {
+		await useTempAgentDir();
+		const syntheticThinking = "synthetic-private-thinking";
+		const syntheticSignature = "synthetic-private-signature";
+		const syntheticRedacted = "synthetic-redacted-payload";
+		const dump: RawHttpRequestDump = {
+			provider: "anthropic",
+			api: "anthropic-messages",
+			model: "claude-sonnet-4-6",
+			method: "POST",
+			url: "https://api.anthropic.com/v1/messages",
+			headers: {
+				"X-Api-Key": "synthetic-key",
+			},
+			body: {
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "thinking",
+								thinking: syntheticThinking,
+								signature: syntheticSignature,
+							},
+							{
+								type: "redacted_thinking",
+								data: syntheticRedacted,
+							},
+							{
+								type: "text",
+								text: "visible text",
+							},
+						],
+					},
+				],
+			},
+		};
+		const error = new Error("400 invalid_request_error: synthetic bad request");
+		(error as { status?: number }).status = 400;
+
+		const message = await finalizeErrorMessage(error, dump);
+		const match = /raw-http-request=(.+)$/m.exec(message);
+		expect(match?.[1]).toBeDefined();
+		const saved = await fs.readFile(match?.[1] ?? "", "utf-8");
+
+		expect(saved).not.toContain(syntheticThinking);
+		expect(saved).not.toContain(syntheticSignature);
+		expect(saved).not.toContain(syntheticRedacted);
+		expect(saved).not.toContain("synthetic-key");
+		expect(saved).toContain("visible text");
+		expect(saved).toContain("[redacted]");
+	});
+});


### PR DESCRIPTION
Fixes #107.

## Summary
- drop partial assistant stream content from replay history on abort so thinking/tool-use fragments are not persisted as replayable turns
- strip private thinking/redacted-thinking blocks from aborted/error Anthropic assistant replay while preserving tool-use pairing and scrubbed abort guidance
- retry once for Anthropic latest-assistant thinking mutation 400s by rebuilding the request without latest assistant thinking blocks
- redact thinking signatures and redacted-thinking payloads from saved HTTP 400 request dumps

## Verification
- bun test packages/agent/test/agent-force-abort.test.ts packages/ai/test/anthropic-thinking-repair-retry.test.ts packages/ai/test/anthropic-thinking-immutability.test.ts packages/ai/test/anthropic-prefill.test.ts packages/ai/test/anthropic-stream-envelope.test.ts
- (packages/ai) bun run check
- (packages/agent) bun run check

## Scope delta
- Live issue comments only noted an existing OMX fix session/worktree and one unrelated praise comment; no scope change.