### PR TITLE
fix: lower deep-interview ambiguity threshold

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -71,7 +71,7 @@ Complete this phase before Phase 1, before brownfield exploration, before GJC st
    - Project settings: `./.gjc/settings.json` (overrides user settings)
 2. **Resolve threshold and source**:
    - Read `gjc.deepInterview.ambiguityThreshold` from both files when present.
-   - Use the project value when valid; otherwise use the user value when valid; otherwise use the default `0.2`.
+   - Use the project value when valid; otherwise use the user value when valid; otherwise use the default `0.05`.
    - Set these run variables exactly: `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` (for example `./.gjc/settings.json`, `[$GJC_CONFIG_DIR|~/.gjc]/settings.json`, or `default`).
 3. **Emit the required first line to the user before any other interview announcement**:
 

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -21,6 +21,7 @@ export interface EffectiveSkillConfigInput {
 }
 
 const SANITIZED_CONFIG_VALUE_LIMIT = 80;
+const DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD = 0.05;
 
 function sanitizeConfigValue(value: string): string {
 	const compact = value.replace(/[\r\n\t]+/g, " ").trim();
@@ -329,6 +330,10 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 		...(input.threadId ? { thread_id: input.threadId } : {}),
 		...(input.turnId ? { turn_id: input.turnId } : {}),
 	};
+	if (match.skill === "deep-interview") {
+		modeState.threshold = DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;
+		modeState.threshold_source = "default";
+	}
 
 	await writeJsonFile(initializedStatePath, modeState);
 	await writeJsonFile(skillStatePath(resolvedStateDir, input.sessionId), state);

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -214,6 +214,9 @@ Project executor override body.
 		expect(content).toContain("private runtime bridge");
 		expect(content).toContain("Direct `.gjc/` file edits are forbidden");
 		expect(content).toContain("do not edit `.gjc/state` directly without force override");
+		expect(content).toContain("default `0.05`");
+		expect(content).not.toContain("default `0.2`");
+		expect(content).not.toContain("20%");
 
 		for (const forbidden of [
 			"AskUserQuestion",

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -82,7 +82,13 @@ describe("GJC native skill-state hooks", () => {
 			path.join(root, ".gjc", "state", "sessions", "session-1", "deep-interview-state.json"),
 		);
 		const modeState = await Bun.file(state?.initialized_state_path ?? "").json();
-		expect(modeState).toMatchObject({ active: true, current_phase: "interviewing", session_id: "session-1" });
+		expect(modeState).toMatchObject({
+			active: true,
+			current_phase: "interviewing",
+			session_id: "session-1",
+			threshold: 0.05,
+			threshold_source: "default",
+		});
 	});
 
 	it("rich deep-interview prompt activation allows product mutation and blocks direct spec artifacts", async () => {


### PR DESCRIPTION
Closes #91

## Summary
- lower bundled deep-interview default ambiguity threshold from 0.2 to 0.05
- initialize deep-interview hook state with default threshold metadata
- assert bundled default text no longer claims 0.2/20% and hook state persists 5%

## Verification
- bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/deep-interview-mutation-guard.test.ts
- bun scripts/check-visible-definitions.ts
- bun scripts/verify-g002-gates.ts
- bun scripts/rebrand-inventory.ts --strict

Note: an initial `bun run test ...` invocation used the root package script incorrectly, triggering broad test runners and failing on unrelated environment/tooling issues (`cargo nextest` missing and unrelated package tests). Targeted `bun test ...` passed after installing worktree dependencies and building local natives.