### PR TITLE
fix: prevent duplicate PR creation

### DIFF
--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -425,6 +425,7 @@ interface PrCreateDuplicateCheck {
 	base: string;
 	head: string;
 	issue?: GhIssueViewData;
+	linkedPr?: GhPrListData;
 	pr?: GhPrListData;
 }
 
@@ -682,6 +683,7 @@ function resolveSearchLimit(value: number | undefined): number {
 async function resolvePrCreateBase(
 	cwd: string,
 	explicitBase: string | undefined,
+	repo: string | undefined,
 	signal?: AbortSignal,
 ): Promise<string | undefined> {
 	if (explicitBase) return explicitBase;
@@ -695,10 +697,10 @@ async function resolvePrCreateBase(
 		// local git metadata is unavailable.
 	}
 	try {
-		const repo = await resolveDefaultRepoMemoized(cwd, signal);
+		const resolvedRepo = repo ?? (await resolveDefaultRepoMemoized(cwd, signal));
 		const repoView = await git.github.json<GhRepoViewData>(
 			cwd,
-			["repo", "view", repo, "--json", "defaultBranchRef"],
+			["repo", "view", resolvedRepo, "--json", "defaultBranchRef"],
 			signal,
 			{ repoProvided: true },
 		);
@@ -716,18 +718,33 @@ function normalizePrHead(value: string): string {
 	return separator >= 0 ? value.slice(separator + 1) : value;
 }
 
-function extractClosingIssueReference(body: string | undefined, repo: string | undefined): number | undefined {
-	if (!body) return undefined;
+function extractClosingIssueReferences(body: string | undefined, repo: string | undefined): number[] {
+	if (!body) return [];
+	const issueNumbers: number[] = [];
 	ISSUE_CLOSING_REFERENCE_PATTERN.lastIndex = 0;
 	let match = ISSUE_CLOSING_REFERENCE_PATTERN.exec(body);
 	while (match !== null) {
 		const issueRepo = normalizeOptionalString(match[1]);
-		if (issueRepo && repo && issueRepo.toLowerCase() !== repo.toLowerCase()) continue;
-		const issueNumber = Number(match[2]);
-		if (Number.isInteger(issueNumber) && issueNumber > 0) return issueNumber;
+		if (!issueRepo || !repo || issueRepo.toLowerCase() === repo.toLowerCase()) {
+			const issueNumber = Number(match[2]);
+			if (Number.isInteger(issueNumber) && issueNumber > 0) issueNumbers.push(issueNumber);
+		}
 		match = ISSUE_CLOSING_REFERENCE_PATTERN.exec(body);
 	}
-	return undefined;
+	return issueNumbers;
+}
+
+async function resolvePrCreateHead(
+	cwd: string,
+	explicitHead: string | undefined,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	if (explicitHead) return explicitHead;
+	try {
+		return (await git.branch.current(cwd, signal)) ?? undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 async function fetchPrCreateDuplicateCheck(
@@ -761,10 +778,11 @@ async function fetchPrCreateDuplicateCheck(
 		{ repoProvided: true },
 	);
 	const existingPr = prs.find(pr => pr.headRefName === normalizedHead && pr.baseRefName === base) ?? prs[0];
-	const issueNumber = existingPr ? undefined : extractClosingIssueReference(body, resolvedRepo);
+	const issueNumbers = existingPr ? [] : extractClosingIssueReferences(body, resolvedRepo);
 	let issue: GhIssueViewData | undefined;
-	if (issueNumber !== undefined) {
-		issue = await git.github.json<GhIssueViewData>(
+	let linkedPr: GhPrListData | undefined;
+	for (const issueNumber of issueNumbers) {
+		const candidateIssue = await git.github.json<GhIssueViewData>(
 			cwd,
 			[
 				"issue",
@@ -778,8 +796,29 @@ async function fetchPrCreateDuplicateCheck(
 			signal,
 			{ repoProvided: true },
 		);
+		issue = candidateIssue;
+		if (candidateIssue.state && candidateIssue.state.toUpperCase() !== "OPEN") break;
+		const linkedPrs = await git.github.json<GhPrListData[]>(
+			cwd,
+			[
+				"pr",
+				"list",
+				"--repo",
+				resolvedRepo,
+				"--search",
+				`${issueNumber} linked:issue`,
+				"--state",
+				"open",
+				"--json",
+				"number,title,state,url,baseRefName,headRefName,isDraft",
+			],
+			signal,
+			{ repoProvided: true },
+		);
+		linkedPr = linkedPrs.find(pr => pr.headRefName !== normalizedHead) ?? linkedPrs[0];
+		if (linkedPr) break;
 	}
-	return { base, head: normalizedHead, issue, pr: existingPr };
+	return { base, head: normalizedHead, issue, linkedPr, pr: existingPr };
 }
 
 function formatPrCreateExistingResult(check: PrCreateDuplicateCheck): string | undefined {
@@ -793,6 +832,18 @@ function formatPrCreateExistingResult(check: PrCreateDuplicateCheck): string | u
 		if (check.pr) pushLine(lines, "Existing PR", check.pr.url);
 		pushLine(lines, "Base", check.base);
 		pushLine(lines, "Head", check.head);
+		return lines.join("\n").trim();
+	}
+	if (check.linkedPr) {
+		const number = check.linkedPr.number !== undefined ? ` #${check.linkedPr.number}` : "";
+		const title = check.linkedPr.title ? `: ${check.linkedPr.title}` : "";
+		const lines = [`# Pull Request Already Linked${number}${title}`, ""];
+		pushLine(lines, "URL", check.linkedPr.url);
+		pushLine(lines, "Issue", check.issue?.url);
+		pushLine(lines, "State", check.linkedPr.state);
+		pushLine(lines, "Draft", check.linkedPr.isDraft);
+		pushLine(lines, "Base", check.linkedPr.baseRefName ?? check.base);
+		pushLine(lines, "Head", check.linkedPr.headRefName ?? check.head);
 		return lines.join("\n").trim();
 	}
 	if (check.pr) {
@@ -3267,7 +3318,7 @@ async function executePrCreate(
 	const title = normalizeOptionalString(params.title);
 	const body = params.body;
 	const requestedBase = normalizeOptionalString(params.base);
-	const head = normalizeOptionalString(params.head);
+	const requestedHead = normalizeOptionalString(params.head);
 	const draft = params.draft ?? false;
 	const fill = params.fill ?? false;
 	const reviewers = normalizePrIdentifierList(params.reviewer);
@@ -3280,11 +3331,15 @@ async function executePrCreate(
 	if (fill && (title || body !== undefined)) {
 		throw new ToolError("fill is mutually exclusive with title and body");
 	}
-	const base = await resolvePrCreateBase(session.cwd, requestedBase, signal);
+	const base = await resolvePrCreateBase(session.cwd, requestedBase, repo, signal);
+	const head = await resolvePrCreateHead(session.cwd, requestedHead, signal);
 	const duplicateCheck = await fetchPrCreateDuplicateCheck(session.cwd, repo, base, head, body, signal);
 	const existingText = duplicateCheck ? formatPrCreateExistingResult(duplicateCheck) : undefined;
 	if (existingText) {
-		return buildTextResult(existingText, duplicateCheck?.pr?.url ?? duplicateCheck?.issue?.url);
+		return buildTextResult(
+			existingText,
+			duplicateCheck?.pr?.url ?? duplicateCheck?.linkedPr?.url ?? duplicateCheck?.issue?.url,
+		);
 	}
 
 	const args = ["pr", "create"];

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -225,6 +225,10 @@ const RUN_SUCCESS_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
 const RUN_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure"]);
 const JOB_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
 
+const PR_CREATE_BASE_CONFIG_KEYS = ["github.prBase", "gh.prBase", "gjc.github.prBase"] as const;
+const ISSUE_CLOSING_REFERENCE_PATTERN =
+	/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:https:\/\/github\.com\/([^\s/]+\/[^\s/]+)\/issues\/)?#(\d+)\b/gi;
+
 const githubSchema = z
 	.object({
 		op: z
@@ -406,6 +410,22 @@ interface GhIssueViewData {
 	title?: string;
 	updatedAt?: string;
 	url?: string;
+}
+interface GhPrListData {
+	baseRefName?: string;
+	headRefName?: string;
+	isDraft?: boolean;
+	number?: number;
+	state?: string;
+	title?: string;
+	url?: string;
+}
+
+interface PrCreateDuplicateCheck {
+	base: string;
+	head: string;
+	issue?: GhIssueViewData;
+	pr?: GhPrListData;
 }
 
 interface GhPrFile {
@@ -658,6 +678,135 @@ function resolveSearchLimit(value: number | undefined): number {
 	}
 
 	return Math.min(Math.floor(value), SEARCH_LIMIT_MAX);
+}
+async function resolvePrCreateBase(
+	cwd: string,
+	explicitBase: string | undefined,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	if (explicitBase) return explicitBase;
+	try {
+		for (const key of PR_CREATE_BASE_CONFIG_KEYS) {
+			const configured = normalizeOptionalString(await git.config.get(cwd, key, signal));
+			if (configured) return configured;
+		}
+	} catch {
+		// Repository config is optional for pr_create; prefer GitHub metadata when
+		// local git metadata is unavailable.
+	}
+	try {
+		const repo = await resolveDefaultRepoMemoized(cwd, signal);
+		const repoView = await git.github.json<GhRepoViewData>(
+			cwd,
+			["repo", "view", repo, "--json", "defaultBranchRef"],
+			signal,
+			{ repoProvided: true },
+		);
+		const defaultBranch = normalizeOptionalString(repoView.defaultBranchRef?.name);
+		if (defaultBranch) return defaultBranch;
+	} catch {
+		// Fall back to local git metadata below so pr_create can still work when gh
+		// cannot resolve repository metadata in otherwise-valid checkouts.
+	}
+	return (await git.branch.default(cwd, signal)) ?? undefined;
+}
+
+function normalizePrHead(value: string): string {
+	const separator = value.lastIndexOf(":");
+	return separator >= 0 ? value.slice(separator + 1) : value;
+}
+
+function extractClosingIssueReference(body: string | undefined, repo: string | undefined): number | undefined {
+	if (!body) return undefined;
+	ISSUE_CLOSING_REFERENCE_PATTERN.lastIndex = 0;
+	let match = ISSUE_CLOSING_REFERENCE_PATTERN.exec(body);
+	while (match !== null) {
+		const issueRepo = normalizeOptionalString(match[1]);
+		if (issueRepo && repo && issueRepo.toLowerCase() !== repo.toLowerCase()) continue;
+		const issueNumber = Number(match[2]);
+		if (Number.isInteger(issueNumber) && issueNumber > 0) return issueNumber;
+		match = ISSUE_CLOSING_REFERENCE_PATTERN.exec(body);
+	}
+	return undefined;
+}
+
+async function fetchPrCreateDuplicateCheck(
+	cwd: string,
+	repo: string | undefined,
+	base: string | undefined,
+	head: string | undefined,
+	body: string | undefined,
+	signal: AbortSignal | undefined,
+): Promise<PrCreateDuplicateCheck | undefined> {
+	if (!base || !head) return undefined;
+	const resolvedRepo = repo ?? (await resolveDefaultRepoMemoized(cwd, signal));
+	const normalizedHead = normalizePrHead(head);
+	const prs = await git.github.json<GhPrListData[]>(
+		cwd,
+		[
+			"pr",
+			"list",
+			"--repo",
+			resolvedRepo,
+			"--head",
+			normalizedHead,
+			"--base",
+			base,
+			"--state",
+			"all",
+			"--json",
+			"number,title,state,url,baseRefName,headRefName,isDraft",
+		],
+		signal,
+		{ repoProvided: true },
+	);
+	const existingPr = prs.find(pr => pr.headRefName === normalizedHead && pr.baseRefName === base) ?? prs[0];
+	const issueNumber = existingPr ? undefined : extractClosingIssueReference(body, resolvedRepo);
+	let issue: GhIssueViewData | undefined;
+	if (issueNumber !== undefined) {
+		issue = await git.github.json<GhIssueViewData>(
+			cwd,
+			[
+				"issue",
+				"view",
+				String(issueNumber),
+				"--repo",
+				resolvedRepo,
+				"--json",
+				GH_ISSUE_FIELDS_NO_COMMENTS.join(","),
+			],
+			signal,
+			{ repoProvided: true },
+		);
+	}
+	return { base, head: normalizedHead, issue, pr: existingPr };
+}
+
+function formatPrCreateExistingResult(check: PrCreateDuplicateCheck): string | undefined {
+	if (check.issue?.state && check.issue.state.toUpperCase() !== "OPEN") {
+		const lines = [
+			"# Pull Request Not Created",
+			"",
+			`Issue #${check.issue.number ?? ""} is ${check.issue.state.toLowerCase()}.`,
+		];
+		pushLine(lines, "Issue", check.issue.url);
+		if (check.pr) pushLine(lines, "Existing PR", check.pr.url);
+		pushLine(lines, "Base", check.base);
+		pushLine(lines, "Head", check.head);
+		return lines.join("\n").trim();
+	}
+	if (check.pr) {
+		const number = check.pr.number !== undefined ? ` #${check.pr.number}` : "";
+		const title = check.pr.title ? `: ${check.pr.title}` : "";
+		const lines = [`# Pull Request Already Exists${number}${title}`, ""];
+		pushLine(lines, "URL", check.pr.url);
+		pushLine(lines, "State", check.pr.state);
+		pushLine(lines, "Draft", check.pr.isDraft);
+		pushLine(lines, "Base", check.pr.baseRefName ?? check.base);
+		pushLine(lines, "Head", check.pr.headRefName ?? check.head);
+		return lines.join("\n").trim();
+	}
+	return undefined;
 }
 
 function resolveTailLimit(value: number | undefined): number {
@@ -3117,7 +3266,7 @@ async function executePrCreate(
 	const repo = normalizeOptionalString(params.repo);
 	const title = normalizeOptionalString(params.title);
 	const body = params.body;
-	const base = normalizeOptionalString(params.base);
+	const requestedBase = normalizeOptionalString(params.base);
 	const head = normalizeOptionalString(params.head);
 	const draft = params.draft ?? false;
 	const fill = params.fill ?? false;
@@ -3130,6 +3279,12 @@ async function executePrCreate(
 	}
 	if (fill && (title || body !== undefined)) {
 		throw new ToolError("fill is mutually exclusive with title and body");
+	}
+	const base = await resolvePrCreateBase(session.cwd, requestedBase, signal);
+	const duplicateCheck = await fetchPrCreateDuplicateCheck(session.cwd, repo, base, head, body, signal);
+	const existingText = duplicateCheck ? formatPrCreateExistingResult(duplicateCheck) : undefined;
+	if (existingText) {
+		return buildTextResult(existingText, duplicateCheck?.pr?.url ?? duplicateCheck?.issue?.url);
 	}
 
 	const args = ["pr", "create"];

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -250,23 +250,25 @@ describe("github tool", () => {
 			return "https://github.com/owner/repo/pull/77\n";
 		});
 		const jsonCalls: string[][] = [];
-		const jsonSpy = vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
-			if (args[0] === "pr" && args[1] === "list") return [];
-			jsonCalls.push([...args]);
-			return {
-				number: 77,
-				title: "Add gizmo",
-				state: "OPEN",
-				isDraft: true,
-				baseRefName: "main",
-				headRefName: "feature/gizmo",
-				author: { login: "octocat" },
-				createdAt: "2026-05-01T09:00:00Z",
-				labels: [{ name: "enhancement" }],
-				body: "Adds a gizmo.",
-				url: "https://github.com/owner/repo/pull/77",
-			} as never;
-		});
+		const jsonSpy = vi
+			.spyOn(git.github, "json")
+			.mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+				if (args[0] === "pr" && args[1] === "list") return [] as T;
+				jsonCalls.push([...args]);
+				return {
+					number: 77,
+					title: "Add gizmo",
+					state: "OPEN",
+					isDraft: true,
+					baseRefName: "main",
+					headRefName: "feature/gizmo",
+					author: { login: "octocat" },
+					createdAt: "2026-05-01T09:00:00Z",
+					labels: [{ name: "enhancement" }],
+					body: "Adds a gizmo.",
+					url: "https://github.com/owner/repo/pull/77",
+				} as T;
+			});
 
 		const tool = new GithubTool(createSession());
 		const result = await tool.execute("pr-create", {
@@ -319,7 +321,7 @@ describe("github tool", () => {
 
 	it("returns an existing same head/base pull request instead of creating a duplicate", async () => {
 		const textSpy = vi.spyOn(git.github, "text");
-		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
 			if (args[0] === "pr" && args[1] === "list") {
 				return [
 					{
@@ -331,7 +333,7 @@ describe("github tool", () => {
 						headRefName: "fix/issue-102",
 						url: "https://github.com/owner/repo/pull/101",
 					},
-				];
+				] as T;
 			}
 			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
 		});
@@ -356,8 +358,8 @@ describe("github tool", () => {
 
 	it("does not create a pull request when the closing issue is already closed", async () => {
 		const textSpy = vi.spyOn(git.github, "text");
-		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
-			if (args[0] === "pr" && args[1] === "list") return [];
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
 			if (args[0] === "issue" && args[1] === "view") {
 				return {
 					number: 98,
@@ -365,7 +367,7 @@ describe("github tool", () => {
 					state: "CLOSED",
 					stateReason: "COMPLETED",
 					url: "https://github.com/owner/repo/issues/98",
-				};
+				} as T;
 			}
 			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
 		});
@@ -393,8 +395,8 @@ describe("github tool", () => {
 			textCalls.push([...args]);
 			return "https://github.com/owner/repo/pull/88\n";
 		});
-		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
-			if (args[0] === "pr" && args[1] === "list") return [];
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
 			if (args[0] === "pr" && args[1] === "view") {
 				return {
 					number: 88,
@@ -422,6 +424,193 @@ describe("github tool", () => {
 		expect(createArgs).toEqual(expect.arrayContaining(["--base", "release"]));
 	});
 
+	it("uses explicit repo metadata when pr_create base is omitted", async () => {
+		const textCalls: string[][] = [];
+		const jsonCalls: string[][] = [];
+		vi.spyOn(git.github, "text").mockImplementation(async (_cwd, args) => {
+			textCalls.push([...args]);
+			return "https://github.com/other/repo/pull/90\n";
+		});
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			jsonCalls.push([...args]);
+			if (args[0] === "repo" && args[1] === "view") return { defaultBranchRef: { name: "trunk" } } as T;
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
+			if (args[0] === "pr" && args[1] === "view")
+				return { number: 90, url: "https://github.com/other/repo/pull/90" } as T;
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "other/repo",
+			title: "Explicit repo default",
+			head: "feature/default-base",
+		});
+
+		expect(jsonCalls[0]).toEqual(["repo", "view", "other/repo", "--json", "defaultBranchRef"]);
+		expect(jsonCalls.find(args => args[0] === "pr" && args[1] === "list")).toEqual(
+			expect.arrayContaining(["--repo", "other/repo", "--base", "trunk"]),
+		);
+		expect(textCalls[0]).toEqual(expect.arrayContaining(["--repo", "other/repo", "--base", "trunk"]));
+	});
+
+	it("uses current branch for omitted pr_create head duplicate preflight", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		vi.spyOn(git.branch, "current").mockResolvedValue("feature/current");
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") {
+				expect(args).toEqual(expect.arrayContaining(["--head", "feature/current"]));
+				return [
+					{
+						number: 91,
+						title: "Existing current branch",
+						state: "OPEN",
+						baseRefName: "dev",
+						headRefName: "feature/current",
+						url: "https://github.com/owner/repo/pull/91",
+					},
+				] as T;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Existing current branch",
+			base: "dev",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(text).toContain("# Pull Request Already Exists #91: Existing current branch");
+	});
+
+	it("uses current branch for omitted pr_create head closed issue preflight", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		vi.spyOn(git.branch, "current").mockResolvedValue("feature/closed-issue");
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
+			if (args[0] === "issue" && args[1] === "view")
+				return { number: 92, state: "CLOSED", url: "https://github.com/owner/repo/issues/92" } as T;
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Closed issue",
+			body: "Fixes #92",
+			base: "dev",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(text).toContain("Issue #92 is closed.");
+	});
+
+	it("skips cross-repo closing refs and checks later same-repo refs", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		const issueNumbers: string[] = [];
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
+			if (args[0] === "issue" && args[1] === "view") {
+				issueNumbers.push(args[2] ?? "");
+				return {
+					number: Number(args[2]),
+					state: "CLOSED",
+					url: `https://github.com/owner/repo/issues/${args[2]}`,
+				} as T;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Later same repo",
+			body: "Fixes https://github.com/other/repo/issues/#1 and closes #93",
+			base: "dev",
+			head: "feature/later-ref",
+		});
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(issueNumbers).toEqual(["93"]);
+	});
+
+	it("checks multiple same-repo closing refs until one blocks creation", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		const issueNumbers: string[] = [];
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
+			if (args[0] === "issue" && args[1] === "view") {
+				issueNumbers.push(args[2] ?? "");
+				return (
+					args[2] === "95"
+						? { number: 95, state: "CLOSED", url: "https://github.com/owner/repo/issues/95" }
+						: { number: 94, state: "OPEN", url: "https://github.com/owner/repo/issues/94" }
+				) as T;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Multiple refs",
+			body: "Fixes #94 and resolves #95",
+			base: "dev",
+			head: "feature/multiple-refs",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(issueNumbers).toEqual(["94", "95"]);
+		expect(text).toContain("Issue #95 is closed.");
+	});
+
+	it("returns an existing linked pull request for an open closing issue", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "pr" && args[1] === "list" && args.includes("--head")) return [] as T;
+			if (args[0] === "issue" && args[1] === "view")
+				return { number: 96, state: "OPEN", url: "https://github.com/owner/repo/issues/96" } as T;
+			if (args[0] === "pr" && args[1] === "list" && args.includes("--search")) {
+				return [
+					{
+						number: 97,
+						title: "Linked issue work",
+						state: "OPEN",
+						baseRefName: "dev",
+						headRefName: "feature/other-branch",
+						url: "https://github.com/owner/repo/pull/97",
+					},
+				] as T;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Linked issue duplicate",
+			body: "Closes #96",
+			base: "dev",
+			head: "feature/new-branch",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(text).toContain("# Pull Request Already Linked #97: Linked issue work");
+		expect(text).toContain("URL: https://github.com/owner/repo/pull/97");
+	});
+
 	it("defaults pr_create base from repository metadata instead of hard-coding main", async () => {
 		const textCalls: string[][] = [];
 		vi.spyOn(git.github, "text").mockImplementation(async (_cwd, args) => {
@@ -429,9 +618,9 @@ describe("github tool", () => {
 			if (args[0] === "repo" && args[1] === "view") return "owner/repo";
 			return "https://github.com/owner/repo/pull/89\n";
 		});
-		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
-			if (args[0] === "repo" && args[1] === "view") return { defaultBranchRef: { name: "dev" } };
-			if (args[0] === "pr" && args[1] === "list") return [];
+		vi.spyOn(git.github, "json").mockImplementation(async <T>(_cwd: string, args: string[]): Promise<T> => {
+			if (args[0] === "repo" && args[1] === "view") return { defaultBranchRef: { name: "dev" } } as T;
+			if (args[0] === "pr" && args[1] === "list") return [] as T;
 			if (args[0] === "pr" && args[1] === "view") {
 				return {
 					number: 89,

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -251,6 +251,7 @@ describe("github tool", () => {
 		});
 		const jsonCalls: string[][] = [];
 		const jsonSpy = vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args[0] === "pr" && args[1] === "list") return [];
 			jsonCalls.push([...args]);
 			return {
 				number: 77,
@@ -301,7 +302,7 @@ describe("github tool", () => {
 		expect(createArgs).not.toContain("--body");
 
 		// Follow-up summary fetch must target the parsed PR number/repo.
-		expect(jsonSpy).toHaveBeenCalledTimes(1);
+		expect(jsonSpy).toHaveBeenCalledTimes(2);
 		const viewArgs = jsonCalls[0];
 		expect(viewArgs.slice(0, 3)).toEqual(["pr", "view", "77"]);
 		expect(viewArgs).toEqual(expect.arrayContaining(["--repo", "owner/repo"]));
@@ -314,6 +315,145 @@ describe("github tool", () => {
 		expect(text).toContain("Head: feature/gizmo");
 		expect(text).toContain("Labels: enhancement");
 		expect(text).toContain("Adds a gizmo.");
+	});
+
+	it("returns an existing same head/base pull request instead of creating a duplicate", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args[0] === "pr" && args[1] === "list") {
+				return [
+					{
+						number: 101,
+						title: "Existing fix",
+						state: "OPEN",
+						isDraft: false,
+						baseRefName: "dev",
+						headRefName: "fix/issue-102",
+						url: "https://github.com/owner/repo/pull/101",
+					},
+				];
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Existing fix",
+			body: "Fixes #102",
+			base: "dev",
+			head: "fix/issue-102",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(text).toContain("# Pull Request Already Exists #101: Existing fix");
+		expect(text).toContain("URL: https://github.com/owner/repo/pull/101");
+		expect(text).toContain("Base: dev");
+		expect(text).toContain("Head: fix/issue-102");
+	});
+
+	it("does not create a pull request when the closing issue is already closed", async () => {
+		const textSpy = vi.spyOn(git.github, "text");
+		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args[0] === "pr" && args[1] === "list") return [];
+			if (args[0] === "issue" && args[1] === "view") {
+				return {
+					number: 98,
+					title: "Already done",
+					state: "CLOSED",
+					stateReason: "COMPLETED",
+					url: "https://github.com/owner/repo/issues/98",
+				};
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Duplicate issue work",
+			body: "Closes #98",
+			base: "dev",
+			head: "duplicate/issue-98",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		expect(text).toContain("# Pull Request Not Created");
+		expect(text).toContain("Issue #98 is closed.");
+		expect(text).toContain("Issue: https://github.com/owner/repo/issues/98");
+	});
+
+	it("keeps an explicit pr_create base and checks duplicates against it", async () => {
+		const textCalls: string[][] = [];
+		vi.spyOn(git.github, "text").mockImplementation(async (_cwd, args) => {
+			textCalls.push([...args]);
+			return "https://github.com/owner/repo/pull/88\n";
+		});
+		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args[0] === "pr" && args[1] === "list") return [];
+			if (args[0] === "pr" && args[1] === "view") {
+				return {
+					number: 88,
+					title: "Explicit base",
+					state: "OPEN",
+					baseRefName: "release",
+					headRefName: "feature/explicit-base",
+					url: "https://github.com/owner/repo/pull/88",
+				} as never;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		await tool.execute("pr-create", {
+			op: "pr_create",
+			repo: "owner/repo",
+			title: "Explicit base",
+			base: "release",
+			head: "feature/explicit-base",
+		});
+
+		const createArgs = textCalls[0];
+		expect(textCalls).toHaveLength(1);
+		expect(createArgs).toEqual(expect.arrayContaining(["--base", "release"]));
+	});
+
+	it("defaults pr_create base from repository metadata instead of hard-coding main", async () => {
+		const textCalls: string[][] = [];
+		vi.spyOn(git.github, "text").mockImplementation(async (_cwd, args) => {
+			textCalls.push([...args]);
+			if (args[0] === "repo" && args[1] === "view") return "owner/repo";
+			return "https://github.com/owner/repo/pull/89\n";
+		});
+		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args[0] === "repo" && args[1] === "view") return { defaultBranchRef: { name: "dev" } };
+			if (args[0] === "pr" && args[1] === "list") return [];
+			if (args[0] === "pr" && args[1] === "view") {
+				return {
+					number: 89,
+					title: "Default base",
+					state: "OPEN",
+					baseRefName: "dev",
+					headRefName: "feature/default-base",
+					url: "https://github.com/owner/repo/pull/89",
+				} as never;
+			}
+			throw new Error(`unexpected gh json args: ${args.join(" ")}`);
+		});
+
+		const tool = new GithubTool(createSession());
+		await tool.execute("pr-create", {
+			op: "pr_create",
+			title: "Default base",
+			head: "feature/default-base",
+		});
+
+		const createArgs = textCalls.find(args => args[0] === "pr" && args[1] === "create");
+		expect(createArgs).toEqual(expect.arrayContaining(["--base", "dev"]));
 	});
 
 	it("rejects pr_create when neither title nor fill is supplied", async () => {


### PR DESCRIPTION
Fixes #102

## Summary
- resolve pr_create base from explicit base, repo config, repository default branch, then local git default
- check existing same head/base PRs before gh pr create and return the existing PR instead
- block PR creation when the body closes an already-closed issue

## Verification
- bun test packages/coding-agent/test/tools/gh.test.ts
- bun run check:tools packages/coding-agent/src/tools/gh.ts packages/coding-agent/test/tools/gh.test.ts