### PR TITLE
feat: route workflow state through receipts

### DIFF
--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -1,13 +1,18 @@
-import { Command } from "@gajae-code/utils/cli";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { syncSkillActiveState, type WorkflowHudSummary } from "../skill-state/active-state";
+import { Command } from "@gajae-code/utils/cli";
+import {
+	listActiveSkills,
+	readVisibleSkillActiveState,
+	syncSkillActiveState,
+	type WorkflowHudSummary,
+} from "../skill-state/active-state";
 import {
 	buildWorkflowStateReceipt,
 	canonicalWorkflowSkill,
 	describeWorkflowStateContract,
-	workflowStateStoragePath,
 	type WorkflowStateReceipt,
+	workflowStateStoragePath,
 } from "../skill-state/workflow-state-contract";
 import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
 
@@ -23,7 +28,9 @@ interface ParsedStateArgs {
 
 interface WorkflowStatePayload {
 	active?: boolean;
+	skill?: string;
 	phase?: string;
+	current_phase?: string;
 	hud?: WorkflowHudSummary;
 	state?: Record<string, unknown>;
 }
@@ -59,8 +66,15 @@ function parseStateArgs(argv: string[]): ParsedStateArgs {
 		}
 		positional.push(arg);
 	}
-	parsed.skill = positional[0];
-	parsed.action = positional[1];
+	if (
+		(positional[0] === "read" || positional[0] === "write" || positional[0] === "contract") &&
+		positional[1] === undefined
+	) {
+		parsed.action = positional[0];
+	} else {
+		parsed.skill = positional[0];
+		parsed.action = positional[1];
+	}
 	return parsed;
 }
 
@@ -74,7 +88,9 @@ function readInputPayload(input: string | undefined): WorkflowStatePayload {
 async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
 	try {
 		const parsed = JSON.parse(await Bun.file(filePath).text()) as unknown;
-		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: null;
 	} catch {
 		return null;
 	}
@@ -85,6 +101,16 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
 	await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function payloadSkill(payload: WorkflowStatePayload): string | undefined {
+	if (typeof payload.skill === "string") return payload.skill;
+	if (payload.state && typeof payload.state.skill === "string") return payload.state.skill;
+	return undefined;
+}
+
+function payloadPhase(payload: WorkflowStatePayload): unknown {
+	return payload.phase ?? payload.current_phase ?? payload.state?.current_phase;
+}
+
 function writeOutput(value: unknown, json: boolean): void {
 	if (json) {
 		process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -92,13 +118,15 @@ function writeOutput(value: unknown, json: boolean): void {
 	}
 	if (value && typeof value === "object" && "receipt" in value) {
 		const receipt = (value as { receipt: WorkflowStateReceipt }).receipt;
-		process.stdout.write([
-			`Updated ${receipt.skill} workflow state`,
-			`state: ${receipt.state_path}`,
-			`storage: ${receipt.storage_path}`,
-			`receipt: ${receipt.status} until ${receipt.fresh_until}`,
-			`command: ${receipt.command}`,
-		].join("\n") + "\n");
+		process.stdout.write(
+			`${[
+				`Updated ${receipt.skill} workflow state`,
+				`state: ${receipt.state_path}`,
+				`storage: ${receipt.storage_path}`,
+				`receipt: ${receipt.status} until ${receipt.fresh_until}`,
+				`command: ${receipt.command}`,
+			].join("\n")}\n`,
+		);
 		return;
 	}
 	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -106,10 +134,15 @@ function writeOutput(value: unknown, json: boolean): void {
 
 async function runNativeWorkflowStateCommand(argv: string[]): Promise<boolean> {
 	const args = parseStateArgs(argv);
-	const skill = args.skill ? canonicalWorkflowSkill(args.skill) : null;
-	if (!skill) return false;
 	const action = args.action ?? "read";
+	const payload = action === "write" ? readInputPayload(args.input) : {};
 	const cwd = process.cwd();
+	let skill = canonicalWorkflowSkill(args.skill ?? payloadSkill(payload) ?? "");
+	if (!skill && action === "read") {
+		const activeState = await readVisibleSkillActiveState(cwd, args.sessionId);
+		skill = canonicalWorkflowSkill(String(listActiveSkills(activeState)[0]?.skill ?? activeState?.skill ?? ""));
+	}
+	if (!skill) return false;
 	const storagePath = workflowStateStoragePath(cwd, skill, args.sessionId);
 	if (action === "contract") {
 		writeOutput({ skill, contract: describeWorkflowStateContract(skill) }, args.json);
@@ -120,7 +153,6 @@ async function runNativeWorkflowStateCommand(argv: string[]): Promise<boolean> {
 		return true;
 	}
 	if (action !== "write") return false;
-	const payload = readInputPayload(args.input);
 	const nowIso = new Date().toISOString();
 	const receipt = buildWorkflowStateReceipt({
 		cwd,
@@ -131,13 +163,18 @@ async function runNativeWorkflowStateCommand(argv: string[]): Promise<boolean> {
 		nowIso,
 	});
 	const existing = (await readJsonFile(storagePath)) ?? {};
+	const incomingPhase = payloadPhase(payload);
+	const currentPhase =
+		typeof incomingPhase === "string" && incomingPhase.trim()
+			? incomingPhase.trim()
+			: String(existing.current_phase ?? "active");
 	const nextState = {
 		...existing,
 		...(payload.state ?? {}),
 		version: typeof existing.version === "number" ? existing.version : 1,
 		skill,
 		active: payload.active ?? existing.active ?? true,
-		current_phase: payload.phase ?? existing.current_phase ?? payload.state?.current_phase ?? "active",
+		current_phase: currentPhase,
 		updated_at: nowIso,
 		receipt,
 	};
@@ -146,7 +183,7 @@ async function runNativeWorkflowStateCommand(argv: string[]): Promise<boolean> {
 		cwd,
 		skill,
 		active: Boolean(nextState.active),
-		phase: String(nextState.current_phase),
+		phase: currentPhase,
 		sessionId: args.sessionId,
 		threadId: args.threadId,
 		turnId: args.turnId,

--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -1,14 +1,182 @@
 import { Command } from "@gajae-code/utils/cli";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { syncSkillActiveState, type WorkflowHudSummary } from "../skill-state/active-state";
+import {
+	buildWorkflowStateReceipt,
+	canonicalWorkflowSkill,
+	describeWorkflowStateContract,
+	workflowStateStoragePath,
+	type WorkflowStateReceipt,
+} from "../skill-state/workflow-state-contract";
 import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
+
+interface ParsedStateArgs {
+	skill?: string;
+	action?: string;
+	input?: string;
+	json: boolean;
+	sessionId?: string;
+	threadId?: string;
+	turnId?: string;
+}
+
+interface WorkflowStatePayload {
+	active?: boolean;
+	phase?: string;
+	hud?: WorkflowHudSummary;
+	state?: Record<string, unknown>;
+}
+
+function parseStateArgs(argv: string[]): ParsedStateArgs {
+	const parsed: ParsedStateArgs = { json: false };
+	const positional: string[] = [];
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--json") {
+			parsed.json = true;
+			continue;
+		}
+		if (arg === "--input") {
+			parsed.input = argv[index + 1];
+			index += 1;
+			continue;
+		}
+		if (arg === "--session-id") {
+			parsed.sessionId = argv[index + 1];
+			index += 1;
+			continue;
+		}
+		if (arg === "--thread-id") {
+			parsed.threadId = argv[index + 1];
+			index += 1;
+			continue;
+		}
+		if (arg === "--turn-id") {
+			parsed.turnId = argv[index + 1];
+			index += 1;
+			continue;
+		}
+		positional.push(arg);
+	}
+	parsed.skill = positional[0];
+	parsed.action = positional[1];
+	return parsed;
+}
+
+function readInputPayload(input: string | undefined): WorkflowStatePayload {
+	if (!input) return {};
+	const parsed = JSON.parse(input) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+	return parsed as WorkflowStatePayload;
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
+	try {
+		const parsed = JSON.parse(await Bun.file(filePath).text()) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+	} catch {
+		return null;
+	}
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeOutput(value: unknown, json: boolean): void {
+	if (json) {
+		process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+		return;
+	}
+	if (value && typeof value === "object" && "receipt" in value) {
+		const receipt = (value as { receipt: WorkflowStateReceipt }).receipt;
+		process.stdout.write([
+			`Updated ${receipt.skill} workflow state`,
+			`state: ${receipt.state_path}`,
+			`storage: ${receipt.storage_path}`,
+			`receipt: ${receipt.status} until ${receipt.fresh_until}`,
+			`command: ${receipt.command}`,
+		].join("\n") + "\n");
+		return;
+	}
+	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function runNativeWorkflowStateCommand(argv: string[]): Promise<boolean> {
+	const args = parseStateArgs(argv);
+	const skill = args.skill ? canonicalWorkflowSkill(args.skill) : null;
+	if (!skill) return false;
+	const action = args.action ?? "read";
+	const cwd = process.cwd();
+	const storagePath = workflowStateStoragePath(cwd, skill, args.sessionId);
+	if (action === "contract") {
+		writeOutput({ skill, contract: describeWorkflowStateContract(skill) }, args.json);
+		return true;
+	}
+	if (action === "read") {
+		writeOutput({ skill, state: await readJsonFile(storagePath), storage_path: storagePath }, args.json);
+		return true;
+	}
+	if (action !== "write") return false;
+	const payload = readInputPayload(args.input);
+	const nowIso = new Date().toISOString();
+	const receipt = buildWorkflowStateReceipt({
+		cwd,
+		skill,
+		owner: "gjc-state-cli",
+		command: `gjc state ${skill} write`,
+		sessionId: args.sessionId,
+		nowIso,
+	});
+	const existing = (await readJsonFile(storagePath)) ?? {};
+	const nextState = {
+		...existing,
+		...(payload.state ?? {}),
+		version: typeof existing.version === "number" ? existing.version : 1,
+		skill,
+		active: payload.active ?? existing.active ?? true,
+		current_phase: payload.phase ?? existing.current_phase ?? payload.state?.current_phase ?? "active",
+		updated_at: nowIso,
+		receipt,
+	};
+	await writeJsonFile(storagePath, nextState);
+	await syncSkillActiveState({
+		cwd,
+		skill,
+		active: Boolean(nextState.active),
+		phase: String(nextState.current_phase),
+		sessionId: args.sessionId,
+		threadId: args.threadId,
+		turnId: args.turnId,
+		nowIso,
+		source: "gjc-state-cli",
+		hud: payload.hud,
+		receipt,
+	});
+	writeOutput({ skill, state: nextState, receipt }, args.json);
+	return true;
+}
 
 export default class State extends Command {
 	static description = "Read or update private GJC workflow state through the bridge (requires GJC_RUNTIME_BINARY)";
 	static strict = false;
 	static examples = [
 		'$ GJC_RUNTIME_BINARY=/path/to/private-runtime gjc state read --input \'{"mode":"team"}\' --json',
+		"$ gjc state deep-interview read --json",
+		'$ gjc state ralplan write --input \'{"phase":"approval","active":true}\' --json',
+		"$ gjc state team contract",
 	];
 
 	async run(): Promise<void> {
+		try {
+			if (await runNativeWorkflowStateCommand(this.argv)) return;
+		} catch (error) {
+			process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+			process.exitCode = 1;
+			return;
+		}
 		await runBridgedRuntimeEndpoint("state", this.argv);
 	}
 }

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -3,7 +3,12 @@ import * as path from "node:path";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
 import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
-import type { SkillActiveEntry as CanonicalSkillActiveEntry, WorkflowHudSummary } from "../skill-state/active-state";
+import {
+	type SkillActiveEntry as CanonicalSkillActiveEntry,
+	syncSkillActiveState,
+	type WorkflowHudSummary,
+} from "../skill-state/active-state";
+import { buildWorkflowStateReceipt, type WorkflowStateReceipt } from "../skill-state/workflow-state-contract";
 import {
 	compareSkillKeywordMatches,
 	GJC_SKILL_KEYWORD_DEFINITIONS,
@@ -99,6 +104,7 @@ export interface SkillActiveState {
 	session_id?: string;
 	thread_id?: string;
 	turn_id?: string;
+	receipt?: WorkflowStateReceipt;
 	initialized_mode?: GjcWorkflowSkill;
 	initialized_state_path?: string;
 	active_skills: SkillActiveEntry[];
@@ -112,6 +118,7 @@ export interface ModeState {
 	thread_id?: string;
 	cwd?: string;
 	updated_at?: string;
+	receipt?: WorkflowStateReceipt;
 	[key: string]: unknown;
 }
 
@@ -294,6 +301,14 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 	const nowIso = input.nowIso ?? new Date().toISOString();
 	const phase = initialPhaseForSkill(match.skill);
 	const initializedStatePath = modeStatePath(resolvedStateDir, match.skill, input.sessionId);
+	const receipt = buildWorkflowStateReceipt({
+		cwd: input.cwd,
+		skill: match.skill,
+		owner: "gjc-hook",
+		command: `gjc state ${match.skill} write`,
+		sessionId: input.sessionId,
+		nowIso,
+	});
 	const entry: SkillActiveEntry = {
 		skill: match.skill,
 		phase,
@@ -303,6 +318,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 		...(input.sessionId ? { session_id: input.sessionId } : {}),
 		...(input.threadId ? { thread_id: input.threadId } : {}),
 		...(input.turnId ? { turn_id: input.turnId } : {}),
+		receipt,
 	};
 	const state: SkillActiveState = {
 		version: 1,
@@ -316,6 +332,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 		...(input.sessionId ? { session_id: input.sessionId } : {}),
 		...(input.threadId ? { thread_id: input.threadId } : {}),
 		...(input.turnId ? { turn_id: input.turnId } : {}),
+		receipt,
 		initialized_mode: match.skill,
 		initialized_state_path: initializedStatePath,
 		active_skills: [entry],
@@ -329,6 +346,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 		...(input.sessionId ? { session_id: input.sessionId } : {}),
 		...(input.threadId ? { thread_id: input.threadId } : {}),
 		...(input.turnId ? { turn_id: input.turnId } : {}),
+		receipt,
 	};
 	if (match.skill === "deep-interview") {
 		modeState.threshold = DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;
@@ -336,6 +354,18 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 	}
 
 	await writeJsonFile(initializedStatePath, modeState);
+	await syncSkillActiveState({
+		cwd: input.cwd,
+		skill: match.skill,
+		active: true,
+		phase,
+		sessionId: input.sessionId,
+		threadId: input.threadId,
+		turnId: input.turnId,
+		nowIso,
+		source: "gjc-skill-state-hook",
+		receipt,
+	});
 	await writeJsonFile(skillStatePath(resolvedStateDir, input.sessionId), state);
 	if (!input.sessionId) return state;
 	await writeJsonFile(skillStatePath(resolvedStateDir), state);
@@ -484,7 +514,7 @@ export function buildSkillActivationAdditionalContext(
 	return [
 		`GJC native UserPromptSubmit detected workflow keyword "${state.keyword}" -> ${state.skill}.`,
 		state.initialized_mode && state.initialized_state_path
-			? `skill: ${state.initialized_mode} activated and initial state initialized at ${state.initialized_state_path}; use \`gjc state write/read/clear --input '<json>' --json\` for runtime state updates when the private GJC runtime endpoint is available.`
+			? `skill: ${state.initialized_mode} activated and initial state initialized at ${state.initialized_state_path}; use \`gjc state write/read --input '<json>' --json\` for runtime state updates when the private GJC runtime endpoint is available.`
 			: null,
 		state.skill === "ultragoal"
 			? "Ultragoal is active. If the user prompt is a steering request, use `gjc ultragoal steer` to add or steer subgoals."

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -1,4 +1,5 @@
 import type { SkillActiveEntry, WorkflowHudChip } from "../../../skill-state/active-state";
+import { workflowReceiptStatus } from "../../../skill-state/workflow-state-contract";
 
 const ANSI_RESET_FG = "\x1b[39m";
 const ANSI_RESET_BOLD = "\x1b[22m";
@@ -60,6 +61,9 @@ function formatEntry(entry: SkillActiveEntry): string {
 		.map(formatChip)
 		.filter((chip): chip is string => Boolean(chip));
 	if (entry.stale === true) chips.unshift("warn:stale");
+	const receiptStatus = workflowReceiptStatus(entry.receipt);
+	if (receiptStatus === "stale") chips.unshift("warn:receipt=stale");
+	if (receiptStatus === "fresh") chips.push("receipt=fresh");
 	const summary = sanitizeHudPart(entry.hud?.summary);
 	return [base, summary, ...chips].filter(Boolean).join(" ");
 }

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { WorkflowStateReceipt } from "./workflow-state-contract";
 
 export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
 export const SKILL_ACTIVE_STALE_MS = 24 * 60 * 60 * 1000;
@@ -25,6 +26,8 @@ export interface WorkflowHudSummary {
 	updated_at?: string;
 }
 
+export type { WorkflowStateReceipt } from "./workflow-state-contract";
+
 export interface SkillActiveEntry {
 	skill: string;
 	phase?: string;
@@ -36,6 +39,7 @@ export interface SkillActiveEntry {
 	turn_id?: string;
 	hud?: WorkflowHudSummary;
 	stale?: boolean;
+	receipt?: WorkflowStateReceipt;
 }
 
 export interface SkillActiveState {
@@ -70,6 +74,7 @@ export interface SyncSkillActiveStateOptions {
 	nowIso?: string;
 	source?: string;
 	hud?: WorkflowHudSummary;
+	receipt?: WorkflowStateReceipt;
 }
 
 const HUD_TEXT_LIMIT = 80;
@@ -142,6 +147,36 @@ export function normalizeWorkflowHudSummary(raw: unknown): WorkflowHudSummary | 
 	};
 }
 
+function normalizeWorkflowStateReceipt(raw: unknown): WorkflowStateReceipt | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const record = raw as Record<string, unknown>;
+	if (record.version !== 1) return undefined;
+	const skill = safeString(record.skill).trim();
+	if (!isCanonicalGjcWorkflowSkill(skill)) return undefined;
+	const owner = safeString(record.owner).trim();
+	if (owner !== "gjc-state-cli" && owner !== "gjc-runtime" && owner !== "gjc-hook") return undefined;
+	const command = sanitizeHudString(record.command, 120);
+	const statePath = sanitizeHudString(record.state_path, 240);
+	const storagePath = sanitizeHudString(record.storage_path, 240);
+	const mutatedAt = sanitizeHudString(record.mutated_at, 40);
+	const freshUntil = sanitizeHudString(record.fresh_until, 40);
+	const status = safeString(record.status).trim();
+	const mutationId = sanitizeHudString(record.mutation_id, 120);
+	if (!command || !statePath || !storagePath || !mutatedAt || !freshUntil || !mutationId) return undefined;
+	return {
+		version: 1,
+		skill,
+		owner,
+		command,
+		state_path: statePath,
+		storage_path: storagePath,
+		mutated_at: mutatedAt,
+		fresh_until: freshUntil,
+		status: status === "stale" ? "stale" : "fresh",
+		mutation_id: mutationId,
+	};
+}
+
 function encodePathSegment(value: string): string {
 	return encodeURIComponent(value).replaceAll(".", "%2E");
 }
@@ -175,6 +210,7 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 	const skill = safeString(record.skill).trim();
 	if (!skill) return null;
 	const hud = normalizeWorkflowHudSummary(record.hud);
+	const receipt = normalizeWorkflowStateReceipt(record.receipt);
 	return {
 		...record,
 		skill,
@@ -186,6 +222,7 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 		thread_id: safeString(record.thread_id).trim() || undefined,
 		turn_id: safeString(record.turn_id).trim() || undefined,
 		...(hud ? { hud } : {}),
+		...(receipt ? { receipt } : {}),
 		stale: undefined,
 	};
 }
@@ -338,6 +375,7 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 		thread_id: options.threadId,
 		turn_id: options.turnId,
 		...(hud ? { hud } : {}),
+		...(options.receipt ? { receipt: options.receipt } : {}),
 	};
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, options.sessionId);
 	const rootState = (await readStateFile(rootPath)) ?? { version: 1, active_skills: [] };

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -5,9 +5,16 @@ import { LocalProtocolHandler, resolveLocalUrlToPath } from "../internal-urls/lo
 import { resolveToCwd } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 import { listActiveSkills, readVisibleSkillActiveState, type SkillActiveEntry } from "./active-state";
+import {
+	sanctionedWorkflowStateCommand,
+	workflowModeStateFileName,
+	type CanonicalGjcWorkflowSkill,
+} from "./workflow-state-contract";
 
 export const DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE =
 	"Deep-interview is active; continue interviewing with `ask`, write/finalize pending specs through the required GJC workflow CLI, or use an explicit force override. Direct `.gjc/` and product-code edits are blocked until explicit execution approval.";
+export const WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE =
+	"Workflow state JSON is runtime-owned. Use `gjc state <skill> read|write --input '<json>'` for deep-interview, ralplan, ultragoal, and team. Planning artifacts under `.gjc/specs/` and `.gjc/plans/` remain allowed.";
 
 const BLOCKED_TOOL_NAMES = new Set(["edit", "write", "ast_edit"]);
 const ARCHIVE_OR_SQLITE_BASE_RE = /^(.+?\.(?:tar\.gz|sqlite3|sqlite|db3|zip|tgz|tar|db))(?:$|:)/i;
@@ -26,6 +33,7 @@ export interface DeepInterviewMutationGuardInput {
 	tool: ToolWithEditMode;
 	args: unknown;
 	forceOverride?: boolean;
+	enforceWorkflowState?: boolean;
 }
 
 interface ExtractedTargets {
@@ -38,6 +46,7 @@ export interface DeepInterviewMutationDecision {
 	message?: string;
 	targets: string[];
 	reason?: string;
+	command?: string;
 }
 
 interface ModeState {
@@ -246,13 +255,45 @@ function resolveRawPath(cwd: string, rawPath: string): { absolutePath?: string; 
 	}
 }
 
-function isGjcManagedPath(cwd: string, rawPath: string): boolean {
+function relativeGjcSegments(cwd: string, rawPath: string): string[] | null {
 	const { absolutePath, unknown } = resolveRawPath(cwd, rawPath);
-	if (unknown || !absolutePath) return false;
+	if (unknown || !absolutePath) return null;
 	const relative = path.relative(path.resolve(cwd), path.resolve(absolutePath));
-	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return false;
-	const segments = normalizePosix(relative).split("/").filter(Boolean);
-	return segments[0] === ".gjc";
+	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+	return normalizePosix(relative).split("/").filter(Boolean);
+}
+
+function blockedWorkflowStateSkill(cwd: string, rawPath: string): CanonicalGjcWorkflowSkill | null {
+	const segments = relativeGjcSegments(cwd, rawPath);
+	if (!segments || segments[0] !== ".gjc") return null;
+	if (segments[1] === "specs" || segments[1] === "plans") return null;
+	if (segments[1] !== "state") return null;
+	const fileName = segments.at(-1) ?? "";
+	for (const skillName of ["deep-interview", "ralplan", "ultragoal", "team"] as const) {
+		if (fileName === workflowModeStateFileName(skillName)) return skillName;
+	}
+	if (fileName === "skill-active-state.json") return "deep-interview";
+	return null;
+}
+
+function firstBlockedWorkflowStateSkill(cwd: string, targets: ExtractedTargets): CanonicalGjcWorkflowSkill | null {
+	for (const rawPath of targets.paths) {
+		const skill = blockedWorkflowStateSkill(cwd, rawPath);
+		if (skill) return skill;
+	}
+	return null;
+}
+
+function isGjcManagedPath(cwd: string, rawPath: string): boolean {
+	const segments = relativeGjcSegments(cwd, rawPath);
+	return segments?.[0] === ".gjc";
+}
+
+function isAllowlistedPath(cwd: string, rawPath: string): boolean {
+	const segments = relativeGjcSegments(cwd, rawPath);
+	if (!segments || segments[0] !== ".gjc") return false;
+	if (segments[1] === "specs" || segments[1] === "plans") return true;
+	return segments[1] === "state" && blockedWorkflowStateSkill(cwd, rawPath) === null;
 }
 
 function hasGjcManagedTarget(cwd: string, targets: ExtractedTargets): boolean {
@@ -260,6 +301,9 @@ function hasGjcManagedTarget(cwd: string, targets: ExtractedTargets): boolean {
 	return targets.paths.some(rawPath => isGjcManagedPath(cwd, rawPath));
 }
 
+function allTargetsAllowlisted(cwd: string, targets: ExtractedTargets): boolean {
+	return !targets.unknown && targets.paths.length > 0 && targets.paths.every(rawPath => isAllowlistedPath(cwd, rawPath));
+}
 export async function assertDeepInterviewMutationRawPathsAllowed(input: {
 	cwd: string;
 	sessionId?: string;
@@ -279,12 +323,25 @@ export async function getDeepInterviewMutationDecision(
 	input: DeepInterviewMutationGuardInput,
 ): Promise<DeepInterviewMutationDecision> {
 	if (!BLOCKED_TOOL_NAMES.has(input.tool.name)) return { blocked: false, targets: [] };
+	const targets = extractTargets(input.tool, input.args);
+	if (input.enforceWorkflowState !== false) {
+		const stateSkill = firstBlockedWorkflowStateSkill(input.cwd, targets);
+		if (stateSkill) {
+			const command = sanctionedWorkflowStateCommand(stateSkill);
+			return {
+				blocked: true,
+				message: `${WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE}\nUse: ${command}`,
+				targets: targets.paths,
+				reason: "workflow-state-target",
+				command,
+			};
+		}
+	}
 	if (!(await isActiveDeepInterview(input.cwd, input.sessionId, input.threadId))) {
 		return { blocked: false, targets: [] };
 	}
 	if (input.forceOverride) return { blocked: false, targets: [] };
-	const targets = extractTargets(input.tool, input.args);
-	if (!hasGjcManagedTarget(input.cwd, targets)) {
+	if (allTargetsAllowlisted(input.cwd, targets)) {
 		return { blocked: false, targets: targets.paths };
 	}
 	return {

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -6,9 +6,9 @@ import { resolveToCwd } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 import { listActiveSkills, readVisibleSkillActiveState, type SkillActiveEntry } from "./active-state";
 import {
+	type CanonicalGjcWorkflowSkill,
 	sanctionedWorkflowStateCommand,
 	workflowModeStateFileName,
-	type CanonicalGjcWorkflowSkill,
 } from "./workflow-state-contract";
 
 export const DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE =
@@ -292,8 +292,7 @@ function isGjcManagedPath(cwd: string, rawPath: string): boolean {
 function isAllowlistedPath(cwd: string, rawPath: string): boolean {
 	const segments = relativeGjcSegments(cwd, rawPath);
 	if (!segments || segments[0] !== ".gjc") return false;
-	if (segments[1] === "specs" || segments[1] === "plans") return true;
-	return segments[1] === "state" && blockedWorkflowStateSkill(cwd, rawPath) === null;
+	return segments[1] === "specs" || segments[1] === "plans";
 }
 
 function hasGjcManagedTarget(cwd: string, targets: ExtractedTargets): boolean {
@@ -302,7 +301,9 @@ function hasGjcManagedTarget(cwd: string, targets: ExtractedTargets): boolean {
 }
 
 function allTargetsAllowlisted(cwd: string, targets: ExtractedTargets): boolean {
-	return !targets.unknown && targets.paths.length > 0 && targets.paths.every(rawPath => isAllowlistedPath(cwd, rawPath));
+	return (
+		!targets.unknown && targets.paths.length > 0 && targets.paths.every(rawPath => isAllowlistedPath(cwd, rawPath))
+	);
 }
 export async function assertDeepInterviewMutationRawPathsAllowed(input: {
 	cwd: string;
@@ -341,15 +342,23 @@ export async function getDeepInterviewMutationDecision(
 		return { blocked: false, targets: [] };
 	}
 	if (input.forceOverride) return { blocked: false, targets: [] };
-	if (allTargetsAllowlisted(input.cwd, targets)) {
-		return { blocked: false, targets: targets.paths };
+	if (targets.unknown) {
+		return {
+			blocked: true,
+			message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
+			targets: targets.paths,
+			reason: "unknown-target",
+		};
 	}
-	return {
-		blocked: true,
-		message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
-		targets: targets.paths,
-		reason: targets.unknown ? "unknown-target" : "gjc-managed-target",
-	};
+	if (hasGjcManagedTarget(input.cwd, targets) && !allTargetsAllowlisted(input.cwd, targets)) {
+		return {
+			blocked: true,
+			message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
+			targets: targets.paths,
+			reason: "gjc-managed-target",
+		};
+	}
+	return { blocked: false, targets: targets.paths };
 }
 
 export async function assertDeepInterviewMutationAllowed(input: DeepInterviewMutationGuardInput): Promise<void> {

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -1,6 +1,12 @@
 import type { WorkflowHudChip, WorkflowHudSummary } from "./active-state";
 
-interface DeepInterviewHudState {
+interface WorkflowGateHudState {
+	approvalStatus?: string;
+	blockedReason?: string;
+	nextAction?: string;
+}
+
+interface DeepInterviewHudState extends WorkflowGateHudState {
 	phase?: string;
 	ambiguity?: number;
 	threshold?: number;
@@ -11,7 +17,7 @@ interface DeepInterviewHudState {
 	updatedAt?: string;
 }
 
-interface RalplanHudState {
+interface RalplanHudState extends WorkflowGateHudState {
 	stage?: string;
 	waiting?: string;
 	iteration?: number;
@@ -27,7 +33,7 @@ interface UltragoalLikeGoal {
 	status: string;
 }
 
-interface UltragoalHudState {
+interface UltragoalHudState extends WorkflowGateHudState {
 	status: string;
 	currentGoal?: UltragoalLikeGoal;
 	counts: Record<string, number>;
@@ -41,7 +47,7 @@ interface TeamHudWorker {
 	status?: string;
 }
 
-interface TeamHudState {
+interface TeamHudState extends WorkflowGateHudState {
 	phase: string;
 	task_total: number;
 	task_counts: Record<string, number>;
@@ -66,6 +72,14 @@ function chip(
 	return { label, value, priority, ...(severity ? { severity } : {}) };
 }
 
+function gateChips(state: WorkflowGateHudState, gatePriority: number): Array<WorkflowHudChip | null> {
+	return [
+		chip("gate", state.approvalStatus, gatePriority, state.approvalStatus === "approved" ? "success" : "warning"),
+		chip("blocked", state.blockedReason, gatePriority + 10, "blocked"),
+		chip("next", state.nextAction, gatePriority + 20),
+	];
+}
+
 function compactChips(chips: Array<WorkflowHudChip | null>): WorkflowHudChip[] {
 	return chips.filter((item): item is WorkflowHudChip => item !== null);
 }
@@ -74,6 +88,7 @@ export function buildDeepInterviewHudSummary(state: DeepInterviewHudState): Work
 	return {
 		version: 1,
 		chips: compactChips([
+			...gateChips(state, 5),
 			chip("phase", state.phase, 10),
 			chip("ambiguity", [percent(state.ambiguity), percent(state.threshold)].filter(Boolean).join("/"), 20),
 			chip("round", state.roundCount === undefined ? undefined : String(state.roundCount), 30),
@@ -100,6 +115,7 @@ export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSumma
 		summary: state.latestSummary,
 		chips: compactChips([
 			state.pendingApproval ? { label: "pending", value: "approval", priority: 5, severity: "warning" } : null,
+			...gateChips(state, 6),
 			chip("stage", state.stage, 10),
 			chip("waiting", state.waiting, 20),
 			chip("iter", state.iteration === undefined ? undefined : String(state.iteration), 30),
@@ -120,6 +136,7 @@ export function buildUltragoalHudSummary(state: UltragoalHudState): WorkflowHudS
 			chip("goals", `${complete}/${total}`, 10),
 			chip("current", state.currentGoal ? `${state.currentGoal.id}:${state.currentGoal.title}` : state.status, 20),
 			chip("status", state.status, 30, state.status === "complete" ? "success" : undefined),
+			...gateChips(state, 40),
 		]),
 		details: state.latestLedgerEvent
 			? compactChips([
@@ -153,7 +170,8 @@ export function buildTeamHudSummary(state: TeamHudState): WorkflowHudSummary {
 			chip("phase", state.phase, 10),
 			chip("workers", `${state.workers.length - failedWorkers}/${state.workers.length}`, 20),
 			chip("tasks", `${completed}/${state.task_total}`, 30),
-			chip("latest", latest, 50),
+			...gateChips(state, 40),
+			chip("latest", latest, 70),
 		]),
 		...(state.updated_at ? { updated_at: state.updated_at } : {}),
 	};

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,0 +1,107 @@
+import * as path from "node:path";
+import {
+	CANONICAL_GJC_WORKFLOW_SKILLS,
+	SKILL_ACTIVE_STATE_FILE,
+	type CanonicalGjcWorkflowSkill,
+} from "./active-state";
+export type { CanonicalGjcWorkflowSkill };
+
+export const WORKFLOW_STATE_RECEIPT_VERSION = 1;
+export const WORKFLOW_STATE_RECEIPT_FRESH_MS = 30 * 60 * 1000;
+
+export type WorkflowStateMutationOwner = "gjc-state-cli" | "gjc-runtime" | "gjc-hook";
+export type WorkflowStateReceiptStatus = "fresh" | "stale";
+
+export interface WorkflowStateReceipt {
+	version: 1;
+	skill: CanonicalGjcWorkflowSkill;
+	owner: WorkflowStateMutationOwner;
+	command: string;
+	state_path: string;
+	storage_path: string;
+	mutated_at: string;
+	fresh_until: string;
+	status: WorkflowStateReceiptStatus;
+	mutation_id: string;
+}
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
+export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): string {
+	return `${skill}-state.json`;
+}
+
+export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflowSkill, sessionId?: string): string {
+	const normalizedSessionId = safeString(sessionId).trim();
+	if (normalizedSessionId) {
+		return path.join(cwd, ".gjc", "state", "sessions", encodePathSegment(normalizedSessionId), workflowModeStateFileName(skill));
+	}
+	return path.join(cwd, ".gjc", "state", workflowModeStateFileName(skill));
+}
+
+export function workflowActiveStatePath(cwd: string, sessionId?: string): string {
+	const normalizedSessionId = safeString(sessionId).trim();
+	if (normalizedSessionId) {
+		return path.join(cwd, ".gjc", "state", "sessions", encodePathSegment(normalizedSessionId), SKILL_ACTIVE_STATE_FILE);
+	}
+	return path.join(cwd, ".gjc", "state", SKILL_ACTIVE_STATE_FILE);
+}
+
+export function buildWorkflowStateReceipt(input: {
+	cwd: string;
+	skill: CanonicalGjcWorkflowSkill;
+	owner: WorkflowStateMutationOwner;
+	command: string;
+	sessionId?: string;
+	nowIso?: string;
+	mutationId?: string;
+}): WorkflowStateReceipt {
+	const mutatedAt = input.nowIso ?? new Date().toISOString();
+	const freshUntil = new Date(Date.parse(mutatedAt) + WORKFLOW_STATE_RECEIPT_FRESH_MS).toISOString();
+	return {
+		version: WORKFLOW_STATE_RECEIPT_VERSION,
+		skill: input.skill,
+		owner: input.owner,
+		command: input.command,
+		state_path: workflowActiveStatePath(input.cwd, input.sessionId),
+		storage_path: workflowStateStoragePath(input.cwd, input.skill, input.sessionId),
+		mutated_at: mutatedAt,
+		fresh_until: freshUntil,
+		status: "fresh",
+		mutation_id: input.mutationId ?? `${input.skill}:${mutatedAt}`,
+	};
+}
+
+export function workflowReceiptStatus(receipt: WorkflowStateReceipt | undefined, nowMs = Date.now()): WorkflowStateReceiptStatus | undefined {
+	if (!receipt) return undefined;
+	const freshUntilMs = Date.parse(receipt.fresh_until);
+	if (!Number.isFinite(freshUntilMs)) return "stale";
+	return nowMs <= freshUntilMs ? "fresh" : "stale";
+}
+
+export function canonicalWorkflowSkill(value: string): CanonicalGjcWorkflowSkill | null {
+	return (CANONICAL_GJC_WORKFLOW_SKILLS as readonly string[]).includes(value)
+		? (value as CanonicalGjcWorkflowSkill)
+		: null;
+}
+
+export function sanctionedWorkflowStateCommand(skill: CanonicalGjcWorkflowSkill): string {
+	return `gjc state ${skill} write --input '<json>'`;
+}
+
+export function describeWorkflowStateContract(skill: CanonicalGjcWorkflowSkill): string[] {
+	return [
+		`Sanctioned mutation path: gjc state ${skill} read|write --input '<json>'`,
+		`Canonical active HUD state: .gjc/state/${SKILL_ACTIVE_STATE_FILE} and .gjc/state/sessions/<session>/${SKILL_ACTIVE_STATE_FILE}`,
+		`Skill mode state: .gjc/state/${workflowModeStateFileName(skill)} or .gjc/state/sessions/<session>/${workflowModeStateFileName(skill)}`,
+		"Receipts include version, skill, owner, command, state_path, storage_path, mutated_at, fresh_until, status, and mutation_id.",
+		"Receipts are fresh for 30 minutes; older receipts are stale and render as HUD warnings.",
+		"Planning artifacts under .gjc/specs/** and .gjc/plans/** remain writable outside the state command.",
+	];
+}

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -1,9 +1,6 @@
 import * as path from "node:path";
-import {
-	CANONICAL_GJC_WORKFLOW_SKILLS,
-	SKILL_ACTIVE_STATE_FILE,
-	type CanonicalGjcWorkflowSkill,
-} from "./active-state";
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill, SKILL_ACTIVE_STATE_FILE } from "./active-state";
+
 export type { CanonicalGjcWorkflowSkill };
 
 export const WORKFLOW_STATE_RECEIPT_VERSION = 1;
@@ -40,7 +37,14 @@ export function workflowModeStateFileName(skill: CanonicalGjcWorkflowSkill): str
 export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflowSkill, sessionId?: string): string {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (normalizedSessionId) {
-		return path.join(cwd, ".gjc", "state", "sessions", encodePathSegment(normalizedSessionId), workflowModeStateFileName(skill));
+		return path.join(
+			cwd,
+			".gjc",
+			"state",
+			"sessions",
+			encodePathSegment(normalizedSessionId),
+			workflowModeStateFileName(skill),
+		);
 	}
 	return path.join(cwd, ".gjc", "state", workflowModeStateFileName(skill));
 }
@@ -48,7 +52,14 @@ export function workflowStateStoragePath(cwd: string, skill: CanonicalGjcWorkflo
 export function workflowActiveStatePath(cwd: string, sessionId?: string): string {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (normalizedSessionId) {
-		return path.join(cwd, ".gjc", "state", "sessions", encodePathSegment(normalizedSessionId), SKILL_ACTIVE_STATE_FILE);
+		return path.join(
+			cwd,
+			".gjc",
+			"state",
+			"sessions",
+			encodePathSegment(normalizedSessionId),
+			SKILL_ACTIVE_STATE_FILE,
+		);
 	}
 	return path.join(cwd, ".gjc", "state", SKILL_ACTIVE_STATE_FILE);
 }
@@ -78,7 +89,10 @@ export function buildWorkflowStateReceipt(input: {
 	};
 }
 
-export function workflowReceiptStatus(receipt: WorkflowStateReceipt | undefined, nowMs = Date.now()): WorkflowStateReceiptStatus | undefined {
+export function workflowReceiptStatus(
+	receipt: WorkflowStateReceipt | undefined,
+	nowMs = Date.now(),
+): WorkflowStateReceiptStatus | undefined {
 	if (!receipt) return undefined;
 	const freshUntilMs = Date.parse(receipt.fresh_until);
 	if (!Number.isFinite(freshUntilMs)) return "stale";

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -84,31 +84,52 @@ describe("deep-interview mutation guard", () => {
 		}
 	});
 
-	it("blocks direct .gjc targets while deep-interview is active", async () => {
+	it("allows planning artifacts and blocks canonical workflow state targets", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 
+		for (const rawPath of [".gjc/specs/deep-interview-x.md", ".gjc/plans/plan.md"]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("write"),
+				args: { path: rawPath, content: "x" },
+			});
+			expect(decision.blocked).toBe(false);
+		}
+
 		const blockedCases: Array<[string, AgentTool, unknown]> = [
-			["write spec", tool("write"), { path: ".gjc/specs/deep-interview-x.md", content: "x" }],
-			["write state", tool("write"), { path: ".gjc/state/deep-interview-x.json", content: "{}" }],
+			["write active", tool("write"), { path: ".gjc/state/skill-active-state.json", content: "{}" }],
 			[
-				"edit spec",
-				tool("edit"),
-				{ path: ".gjc/specs/deep-interview-x.md", edits: [{ old_text: "a", new_text: "b" }] },
+				"write session active",
+				tool("write"),
+				{ path: ".gjc/state/sessions/session-a/skill-active-state.json", content: "{}" },
 			],
+			...(["deep-interview", "ralplan", "ultragoal", "team"] as const).map(
+				skill =>
+					[
+						`write ${skill}`,
+						tool("write"),
+						{ path: `.gjc/state/sessions/session-a/${skill}-state.json`, content: "{}" },
+					] as [string, AgentTool, unknown],
+			),
 			[
-				"apply_patch spec",
+				"apply_patch state",
 				tool("edit", { mode: "apply_patch", customWireName: "apply_patch" }),
 				{
-					input: "*** Begin Patch\n*** Update File: .gjc/specs/deep-interview-x.md\n@@\n-a\n+b\n*** End Patch\n",
+					input: "*** Begin Patch\n*** Update File: .gjc/state/team-state.json\n@@\n-a\n+b\n*** End Patch\n",
 				},
 			],
 			[
-				"vim spec",
+				"vim state",
 				tool("edit", { mode: "vim" }),
-				{ file: ".gjc/specs/deep-interview-x.md", steps: [{ kbd: [":edit .gjc/state/note.md<CR>"] }] },
+				{ file: "src/foo.ts", steps: [{ kbd: [":edit .gjc/state/sessions/session-a/ralplan-state.json<CR>"] }] },
 			],
-			["ast_edit state", tool("ast_edit"), { paths: [".gjc/state/**/*.md"], ops: [{ pat: "foo", out: "bar" }] }],
+			[
+				"ast_edit state",
+				tool("ast_edit"),
+				{ paths: [".gjc/state/**/team-state.json"], ops: [{ pat: "foo", out: "bar" }] },
+			],
 		];
 
 		for (const [, targetTool, args] of blockedCases) {
@@ -119,7 +140,11 @@ describe("deep-interview mutation guard", () => {
 				args,
 			});
 			expect(decision.blocked).toBe(true);
-			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+			if (decision.reason === "workflow-state-target") {
+				expect(decision.message).toContain("Workflow state JSON is runtime-owned");
+			} else {
+				expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+			}
 		}
 	});
 
@@ -157,7 +182,7 @@ describe("deep-interview mutation guard", () => {
 			cwd,
 			sessionId: "session-a",
 			tool: tool("ast_edit"),
-			args: { paths: [".gjc/specs/**/*.md", "packages/**"], ops: [{ pat: "foo", out: "bar" }] },
+			args: { paths: [".gjc/state/deep-interview-state.json", "packages/**"], ops: [{ pat: "foo", out: "bar" }] },
 		});
 		expect(mixed.blocked).toBe(true);
 	});

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -125,6 +125,32 @@ describe("GJC native skill-state hooks", () => {
 		expect(blocked.blocked).toBe(true);
 	});
 
+	it("blocks direct workflow state JSON writes and points to gjc state", async () => {
+		const root = await cwd();
+		const blocked = await getDeepInterviewMutationDecision({
+			cwd: root,
+			tool: { name: "write" } as never,
+			args: { path: ".gjc/state/ralplan-state.json", content: "{}" },
+		});
+		expect(blocked.blocked).toBe(true);
+		expect(blocked.reason).toBe("workflow-state-target");
+		expect(blocked.message).toContain("gjc state ralplan");
+
+		const allowedSpec = await getDeepInterviewMutationDecision({
+			cwd: root,
+			tool: { name: "write" } as never,
+			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
+		});
+		expect(allowedSpec.blocked).toBe(false);
+
+		const allowedPlan = await getDeepInterviewMutationDecision({
+			cwd: root,
+			tool: { name: "write" } as never,
+			args: { path: ".gjc/plans/sample.md", content: "plan" },
+		});
+		expect(allowedPlan.blocked).toBe(false);
+	});
+
 	it("encodes hook session ids before writing skill and mode state paths", async () => {
 		const root = await cwd();
 		await dispatchGjcNativeSkillHook(

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -116,13 +116,22 @@ describe("GJC native skill-state hooks", () => {
 		});
 		expect(allowed.blocked).toBe(false);
 
-		const blocked = await getDeepInterviewMutationDecision({
+		const allowedSpec = await getDeepInterviewMutationDecision({
 			cwd: root,
 			sessionId: "session-rich",
 			tool: { name: "write" } as never,
 			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
 		});
+		expect(allowedSpec.blocked).toBe(false);
+
+		const blocked = await getDeepInterviewMutationDecision({
+			cwd: root,
+			sessionId: "session-rich",
+			tool: { name: "write" } as never,
+			args: { path: ".gjc/state/sessions/session-rich/deep-interview-state.json", content: "{}" },
+		});
 		expect(blocked.blocked).toBe(true);
+		expect(blocked.reason).toBe("workflow-state-target");
 	});
 
 	it("blocks direct workflow state JSON writes and points to gjc state", async () => {

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -81,4 +81,43 @@ describe("skill HUD bar renderer", () => {
 		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\t");
 		expect(visibleWidth(rendered ?? "")).toBeLessThanOrEqual(35);
 	});
+	it("renders gate and receipt status from canonical state entries", () => {
+		const rendered = Bun.stripANSI(
+			renderSkillHudBar(
+				[
+					{
+						skill: "deep-interview",
+						phase: "interviewing",
+						hud: {
+							version: 1,
+							chips: [
+								{ label: "gate", value: "approval-required", priority: 5, severity: "warning" },
+								{ label: "blocked", value: "execution approval missing", priority: 10, severity: "blocked" },
+								{ label: "next", value: "ask user for approval", priority: 20 },
+							],
+						},
+						receipt: {
+							version: 1,
+							skill: "deep-interview",
+							owner: "gjc-state-cli",
+							command: "gjc state deep-interview write",
+							state_path: ".gjc/state/skill-active-state.json",
+							storage_path: ".gjc/state/deep-interview-state.json",
+							mutated_at: new Date().toISOString(),
+							fresh_until: new Date(Date.now() + 60_000).toISOString(),
+							status: "fresh",
+							mutation_id: "test",
+						},
+					},
+				],
+				160,
+			) ?? "",
+		);
+		expect(rendered).toContain("deep-interview:interviewing");
+		expect(rendered).toContain("warn:gate=approval-required");
+		expect(rendered).toContain("block:blocked=execution approval missing");
+		expect(rendered).toContain("next=ask user for approval");
+		expect(rendered).toContain("receipt=fresh");
+	});
+
 });

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -119,5 +119,4 @@ describe("skill HUD bar renderer", () => {
 		expect(rendered).toContain("next=ask user for approval");
 		expect(rendered).toContain("receipt=fresh");
 	});
-
 });

--- a/packages/coding-agent/test/workflow-state-command.test.ts
+++ b/packages/coding-agent/test/workflow-state-command.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+describe("gjc state workflow command", () => {
+	it("writes readable canonical state and receipt for workflow skills", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-command-"));
+		try {
+			const result = Bun.spawnSync(
+				[
+					"bun",
+					cliEntry,
+					"state",
+					"deep-interview",
+					"write",
+					"--session-id",
+					"session-1",
+					"--input",
+					JSON.stringify({
+						phase: "interviewing",
+						active: true,
+						hud: {
+							version: 1,
+							chips: [{ label: "gate", value: "approval-required", priority: 5, severity: "warning" }],
+						},
+						state: { blocked_reason: "execution approval missing" },
+					}),
+					"--json",
+				],
+				{ cwd, stderr: "pipe", stdout: "pipe", env: { ...process.env, GJC_RUNTIME_BINARY: "" } },
+			);
+			expect(result.exitCode, result.stderr.toString()).toBe(0);
+			const stdout = result.stdout.toString();
+			expect(stdout).toContain("\n  \"receipt\": {");
+			const payload = JSON.parse(stdout) as { receipt: { skill: string; owner: string; status: string } };
+			expect(payload.receipt).toMatchObject({ skill: "deep-interview", owner: "gjc-state-cli", status: "fresh" });
+
+			const modeState = await Bun.file(
+				path.join(cwd, ".gjc", "state", "sessions", "session-1", "deep-interview-state.json"),
+			).json();
+			expect(modeState).toMatchObject({
+				skill: "deep-interview",
+				current_phase: "interviewing",
+				blocked_reason: "execution approval missing",
+			});
+			expect(modeState.receipt.command).toBe("gjc state deep-interview write");
+
+			const activeState = await Bun.file(
+				path.join(cwd, ".gjc", "state", "sessions", "session-1", "skill-active-state.json"),
+			).json();
+			expect(activeState.active_skills[0]).toMatchObject({
+				skill: "deep-interview",
+				phase: "interviewing",
+				receipt: { owner: "gjc-state-cli" },
+			});
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/workflow-state-command.test.ts
+++ b/packages/coding-agent/test/workflow-state-command.test.ts
@@ -5,23 +5,38 @@ import * as path from "node:path";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const workflowSkills = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
+
+async function withTempCwd<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-command-"));
+	try {
+		return await fn(cwd);
+	} finally {
+		await fs.rm(cwd, { recursive: true, force: true });
+	}
+}
+
+function runState(cwd: string, args: string[]) {
+	return Bun.spawnSync(["bun", cliEntry, "state", ...args], {
+		cwd,
+		stderr: "pipe",
+		stdout: "pipe",
+		env: { ...process.env, GJC_RUNTIME_BINARY: "" },
+	});
+}
 
 describe("gjc state workflow command", () => {
-	it("writes readable canonical state and receipt for workflow skills", async () => {
-		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-command-"));
-		try {
-			const result = Bun.spawnSync(
-				[
-					"bun",
-					cliEntry,
-					"state",
-					"deep-interview",
+	it("writes readable canonical state and receipt for workflow skills through documented invocation", async () => {
+		await withTempCwd(async cwd => {
+			for (const skill of workflowSkills) {
+				const result = runState(cwd, [
 					"write",
 					"--session-id",
-					"session-1",
+					`session-${skill}`,
 					"--input",
 					JSON.stringify({
-						phase: "interviewing",
+						skill,
+						current_phase: "initializing",
 						active: true,
 						hud: {
 							version: 1,
@@ -30,35 +45,76 @@ describe("gjc state workflow command", () => {
 						state: { blocked_reason: "execution approval missing" },
 					}),
 					"--json",
-				],
-				{ cwd, stderr: "pipe", stdout: "pipe", env: { ...process.env, GJC_RUNTIME_BINARY: "" } },
-			);
-			expect(result.exitCode, result.stderr.toString()).toBe(0);
-			const stdout = result.stdout.toString();
-			expect(stdout).toContain("\n  \"receipt\": {");
-			const payload = JSON.parse(stdout) as { receipt: { skill: string; owner: string; status: string } };
-			expect(payload.receipt).toMatchObject({ skill: "deep-interview", owner: "gjc-state-cli", status: "fresh" });
+				]);
+				expect(result.exitCode, result.stderr.toString()).toBe(0);
+				const payload = JSON.parse(result.stdout.toString()) as {
+					receipt: { skill: string; owner: string; status: string };
+				};
+				expect(payload.receipt).toMatchObject({ skill, owner: "gjc-state-cli", status: "fresh" });
+
+				const modeState = await Bun.file(
+					path.join(cwd, ".gjc", "state", "sessions", `session-${skill}`, `${skill}-state.json`),
+				).json();
+				expect(modeState).toMatchObject({
+					skill,
+					current_phase: "initializing",
+					blocked_reason: "execution approval missing",
+				});
+				expect(modeState.receipt.command).toBe(`gjc state ${skill} write`);
+
+				const activeState = await Bun.file(
+					path.join(cwd, ".gjc", "state", "sessions", `session-${skill}`, "skill-active-state.json"),
+				).json();
+				expect(activeState.active_skills[0]).toMatchObject({
+					skill,
+					phase: "initializing",
+					receipt: { owner: "gjc-state-cli" },
+				});
+			}
+		});
+	}, 30_000);
+
+	it("infers read skill from session context and prefers incoming phase transitions", async () => {
+		await withTempCwd(async cwd => {
+			const initial = runState(cwd, [
+				"write",
+				"--session-id",
+				"session-1",
+				"--input",
+				JSON.stringify({
+					skill: "deep-interview",
+					current_phase: "interviewing",
+					state: { current_phase: "ignored" },
+				}),
+				"--json",
+			]);
+			expect(initial.exitCode, initial.stderr.toString()).toBe(0);
+
+			const transition = runState(cwd, [
+				"write",
+				"--session-id",
+				"session-1",
+				"--input",
+				JSON.stringify({ skill: "deep-interview", phase: "approval", state: { current_phase: "stale" } }),
+				"--json",
+			]);
+			expect(transition.exitCode, transition.stderr.toString()).toBe(0);
 
 			const modeState = await Bun.file(
 				path.join(cwd, ".gjc", "state", "sessions", "session-1", "deep-interview-state.json"),
 			).json();
-			expect(modeState).toMatchObject({
-				skill: "deep-interview",
-				current_phase: "interviewing",
-				blocked_reason: "execution approval missing",
-			});
-			expect(modeState.receipt.command).toBe("gjc state deep-interview write");
+			expect(modeState.current_phase).toBe("approval");
 
 			const activeState = await Bun.file(
 				path.join(cwd, ".gjc", "state", "sessions", "session-1", "skill-active-state.json"),
 			).json();
-			expect(activeState.active_skills[0]).toMatchObject({
-				skill: "deep-interview",
-				phase: "interviewing",
-				receipt: { owner: "gjc-state-cli" },
-			});
-		} finally {
-			await fs.rm(cwd, { recursive: true, force: true });
-		}
-	}, 15_000);
+			expect(activeState.active_skills[0]).toMatchObject({ skill: "deep-interview", phase: "approval" });
+
+			const read = runState(cwd, ["read", "--session-id", "session-1", "--json"]);
+			expect(read.exitCode, read.stderr.toString()).toBe(0);
+			const readPayload = JSON.parse(read.stdout.toString()) as { skill: string; state: { current_phase: string } };
+			expect(readPayload.skill).toBe("deep-interview");
+			expect(readPayload.state.current_phase).toBe("approval");
+		});
+	}, 20_000);
 });


### PR DESCRIPTION
Closes #95.
Closes #92.

## Summary
- Adds a canonical workflow state receipt contract for deep-interview, ralplan, ultragoal, and team.
- Implements native `gjc state <skill> read|write|contract` behavior with readable JSON output and active HUD state sync.
- Blocks direct `.gjc/state/*-state.json` and `skill-active-state.json` workflow writes with guidance to `gjc state <skill> ...`, while preserving `.gjc/specs/**` and `.gjc/plans/**` artifact writes.
- Renders gate/blocker/next-action HUD chips plus receipt freshness from canonical active state.

## Verification
- `bun install` (to hydrate the isolated worktree dependencies)
- `bun --cwd=packages/natives run build` (required for local native-addon test loading in the isolated worktree)
- `bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/workflow-hud-summary.test.ts packages/coding-agent/test/workflow-state-command.test.ts`
- `bun run check:types` from `packages/coding-agent`

## Scope delta
- Live issue comments were empty for both #95 and #92; no requested scope changes beyond the issue bodies.
- Coupled #95/#92 because the CLI-only state mutation path and HUD receipt/gate visualization share the same canonical active-state contract.