### PR TITLE
Add first-class Azure OpenAI and Bedrock providers

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -59,6 +59,7 @@ These are consumed via `getEnvApiKey()` (`packages/ai/src/stream.ts`) unless not
 | `MISTRAL_API_KEY`               | Mistral auth                                     | Using Mistral models                                           |                                                                                                     |
 | `ZAI_API_KEY`                   | z.ai auth                                        | Using z.ai models                                              | Also used by z.ai web search provider                                                               |
 | `MINIMAX_API_KEY`               | MiniMax auth                                     | Using `minimax` provider                                       |                                                                                                     |
+| `AZURE_OPENAI_API_KEY`          | Azure OpenAI auth                               | Using `azure-openai` / `azure-openai-responses` models         | Pair with `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_RESOURCE_NAME`                                   |
 | `MINIMAX_CODE_API_KEY`          | MiniMax Code auth                                | Using `minimax-code` provider                                  |                                                                                                     |
 | `MINIMAX_CODE_CN_API_KEY`       | MiniMax Code CN auth                             | Using `minimax-code-cn` provider                               |                                                                                                     |
 | `OPENCODE_API_KEY`              | OpenCode auth                                    | Using `opencode-go` / `opencode-zen` models                    |                                                                                                     |
@@ -140,6 +141,8 @@ When `ANTHROPIC_MODEL_CODE_USE_FOUNDRY` is enabled, Anthropic requests switch to
 | `NO_PROXY`                                                                      | Excludes matching hosts from proxy routing when a proxy variable is configured                |
 
 Region fallback in provider code: `options.region` → `AWS_REGION` → `AWS_DEFAULT_REGION` → `us-east-1`.
+
+Credential fallback order is static env (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` plus optional `AWS_SESSION_TOKEN`), named profile / SSO / `credential_process`, then EC2 IMDSv2. `models.yml` Bedrock entries use `api: bedrock-converse-stream` and do not require `apiKey` or `apiKeyEnv` because the provider signs requests from this AWS chain.
 
 ### Azure OpenAI Responses
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -107,6 +107,7 @@ modelBindings:
 - `openai-responses`
 - `openai-codex-responses`
 - `azure-openai-responses`
+- `bedrock-converse-stream`
 - `anthropic-messages`
 - `bedrock-converse-stream`
 - `google-generative-ai`
@@ -115,6 +116,71 @@ modelBindings:
 - `ollama-chat`
 - `cursor-agent`
 
+
+### First-class Azure OpenAI and Amazon Bedrock examples
+
+Azure OpenAI uses canonical OpenAI model IDs in GJC and resolves those IDs to Azure deployment names at request time. Set `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` to avoid assuming model id equals deployment name:
+
+```yaml
+providers:
+  azure-openai:
+    baseUrl: https://my-resource.openai.azure.com/openai/v1
+    apiKeyEnv: AZURE_OPENAI_API_KEY
+    api: azure-openai-responses
+    models:
+      - id: gpt-4.1
+      - id: o3
+```
+
+```sh
+export AZURE_OPENAI_DEPLOYMENT_NAME_MAP='gpt-4.1=gpt-41-prod,o3=o3-reasoning-prod'
+```
+
+Amazon Bedrock uses the native `bedrock-converse-stream` transport and AWS credential chain auth. Do not put AWS access keys in `models.yml`; configure `AWS_REGION` / `AWS_PROFILE` or standard static AWS credential environment variables instead:
+
+```yaml
+providers:
+  amazon-bedrock:
+    baseUrl: https://bedrock-runtime.us-east-1.amazonaws.com
+    api: bedrock-converse-stream
+    models:
+      - id: us.anthropic.claude-opus-4-6-v1
+      - id: anthropic.claude-3-5-sonnet-20241022-v2:0
+```
+
+### MiniMax and GLM custom provider examples
+
+MiniMax's OpenAI-compatible endpoint rejects multiple system messages and emits thinking in `reasoning_content`, so pin the public-safe compatibility fields when hand-authoring a custom provider:
+
+```yaml
+providers:
+  minimax-custom:
+    baseUrl: https://api.minimax.io/v1
+    apiKeyEnv: MINIMAX_API_KEY
+    api: openai-completions
+    compat:
+      supportsStore: false
+      supportsDeveloperRole: false
+      supportsReasoningEffort: false
+      reasoningContentField: reasoning_content
+    models:
+      - id: MiniMax-M2.5
+```
+
+GLM via z.ai is available as the first-class `zai` provider. For a private GLM-compatible proxy, keep secrets in an env var and disable OpenAI-only request fields as needed:
+
+```yaml
+providers:
+  glm-proxy:
+    baseUrl: https://open.bigmodel.cn/api/paas/v4
+    apiKeyEnv: ZAI_API_KEY
+    api: openai-completions
+    compat:
+      supportsDeveloperRole: false
+      supportsReasoningEffort: false
+    models:
+      - id: glm-4.6
+```
 ### Allowed auth/discovery values
 
 - `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Anthropic extended-thinking replay after aborted turns by dropping partial `thinking`/`redacted_thinking` blocks before the next request, preserving/synthesizing matching tool results, and retrying once with repaired latest-assistant thinking when Anthropic rejects a replay with the immutable-thinking HTTP 400 ([#107](https://github.com/Yeachan-Heo/gajae-code/issues/107)).
+- Fixed first-class `azure-openai` catalog models so normal provider auth resolution reads `AZURE_OPENAI_API_KEY` when streaming `azure-openai/gpt-*` models.
 
 ## [0.2.1] - 2026-05-30
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -39,6 +39,29 @@ import { fetchAntigravityDiscoveryModels } from "../src/utils/discovery/antigrav
 import { fetchCodexModels } from "../src/utils/discovery/codex";
 import type { OAuthProvider } from "../src/utils/oauth/types";
 
+const AZURE_OPENAI_CATALOG_MODEL_IDS = ["gpt-4.1", "gpt-4o", "gpt-4o-mini", "o3", "o3-mini"] as const;
+
+function createAzureOpenAICatalogModels(): Model<"azure-openai-responses">[] {
+	return AZURE_OPENAI_CATALOG_MODEL_IDS.map(modelId => {
+		const reference = (prevModelsJson as Record<string, Record<string, Model>>).openai?.[modelId];
+		return {
+			...(reference ?? {
+				name: modelId,
+				reasoning: modelId.startsWith("o"),
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: UNK_CONTEXT_WINDOW,
+				maxTokens: UNK_MAX_TOKENS,
+			}),
+			id: modelId,
+			name: reference?.name ?? modelId,
+			api: "azure-openai-responses",
+			provider: "azure-openai",
+			baseUrl: "",
+		} as Model<"azure-openai-responses">;
+	});
+}
+
 const packageRoot = path.join(import.meta.dir, "..");
 
 async function resolveProviderApiKey(providerId: string, catalog: CatalogDiscoveryConfig): Promise<string | undefined> {
@@ -319,7 +342,7 @@ async function generateModels() {
 	const gitLabDuoModels = getGitLabDuoModels();
 	// Combine models (models.dev has priority)
 	let allModels = applyGlobalModelsDevFallback(
-		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels],
+		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels, ...createAzureOpenAICatalogModels()],
 		modelsDevModels,
 	);
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -458,6 +458,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic.claude-opus-4-8": {
+			"id": "anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Anthropic Haiku 4.5 (AU)",
@@ -497,6 +522,31 @@
 			"cost": {
 				"input": 16.5,
 				"output": 82.5,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"au.anthropic.claude-opus-4-8": {
+			"id": "au.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
@@ -958,6 +1008,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"eu.anthropic.claude-opus-4-8": {
+			"id": "eu.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"eu.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Anthropic Sonnet 4 (EU)",
@@ -1055,7 +1130,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Anthropic Haiku 4.5 (Global)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1153,6 +1228,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"global.anthropic.claude-opus-4-8": {
+			"id": "global.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Anthropic Sonnet 4 (Global)",
@@ -1180,7 +1280,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Anthropic Sonnet 4.5 (Global)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1205,7 +1305,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6",
+			"name": "Anthropic Sonnet 4.6 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1271,6 +1371,31 @@
 		"jp.anthropic.claude-opus-4-7": {
 			"id": "jp.anthropic.claude-opus-4-7",
 			"name": "Anthropic Opus 4.7 (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"jp.anthropic.claude-opus-4-8": {
+			"id": "jp.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (JP)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -2281,6 +2406,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"us.anthropic.claude-opus-4-8": {
+			"id": "us.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"us.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Anthropic Sonnet 4 (US)",
@@ -2949,6 +3099,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",
@@ -3070,6 +3245,117 @@
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
+	"azure-openai": {
+		"gpt-4.1": {
+			"id": "gpt-4.1",
+			"name": "GPT-4.1",
+			"api": "azure-openai-responses",
+			"provider": "azure-openai",
+			"baseUrl": "",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768
+		},
+		"gpt-4o": {
+			"id": "gpt-4o",
+			"name": "GPT-4o",
+			"api": "azure-openai-responses",
+			"provider": "azure-openai",
+			"baseUrl": "",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 10,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"gpt-4o-mini": {
+			"id": "gpt-4o-mini",
+			"name": "GPT-4o mini",
+			"api": "azure-openai-responses",
+			"provider": "azure-openai",
+			"baseUrl": "",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"o3": {
+			"id": "o3",
+			"name": "o3",
+			"api": "azure-openai-responses",
+			"provider": "azure-openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"o3-mini": {
+			"id": "o3-mini",
+			"name": "o3-mini",
+			"api": "azure-openai-responses",
+			"provider": "azure-openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.1,
+				"output": 4.4,
+				"cacheRead": 0.55,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
@@ -3445,6 +3731,31 @@
 		"anthropic/claude-opus-4-7": {
 			"id": "anthropic/claude-opus-4-7",
 			"name": "Anthropic Opus 4.7",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-opus-4-8": {
+			"id": "anthropic/claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
@@ -5344,8 +5655,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 144000,
-			"maxTokens": 32000,
+			"contextWindow": 200000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5373,7 +5684,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 160000,
+			"contextWindow": 200000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5430,7 +5741,35 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 144000,
+			"contextWindow": 200000,
+			"maxTokens": 32000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"claude-opus-4.8": {
+			"id": "claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5486,7 +5825,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 144000,
+			"contextWindow": 200000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5640,7 +5979,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5677,7 +6016,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -9506,6 +9845,44 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic: Anthropic Opus 4.8 (new)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"anthropic/claude-opus-4.8-fast": {
+			"id": "anthropic/claude-opus-4.8-fast",
+			"name": "Anthropic: Anthropic Opus 4.8 (Fast) ($$$$)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Anthropic Sonnet 4",
@@ -10394,6 +10771,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek/deepseek-v4-flash:discounted": {
+			"id": "deepseek/deepseek-v4-flash:discounted",
+			"name": "DeepSeek: DeepSeek V4 Flash (>40% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
 			"name": "DeepSeek: DeepSeek V4 Flash (free)",
@@ -10436,6 +10832,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"deepseek/deepseek-v4-pro:discounted": {
+			"id": "deepseek/deepseek-v4-pro:discounted",
+			"name": "DeepSeek: DeepSeek V4 Pro (>80% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"eleutherai/llemma_7b": {
 			"id": "eleutherai/llemma_7b",
@@ -10515,7 +10930,7 @@
 		},
 		"google/gemini-2.0-flash-001": {
 			"id": "google/gemini-2.0-flash-001",
-			"name": "Google: Gemini 2.0 Flash",
+			"name": "Google: Gemini 2.0 Flash (retires Jun 1)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10534,7 +10949,7 @@
 		},
 		"google/gemini-2.0-flash-lite-001": {
 			"id": "google/gemini-2.0-flash-lite-001",
-			"name": "Google: Gemini 2.0 Flash Lite",
+			"name": "Google: Gemini 2.0 Flash Lite (retires Jun 1)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -12996,7 +13411,7 @@
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
-			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B",
+			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13391,7 +13806,7 @@
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
-			"name": "OpenAI: GPT-4 Turbo (older v1106)",
+			"name": "OpenAI: GPT-4 Turbo (older v1106) ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13430,7 +13845,7 @@
 		},
 		"openai/gpt-4-turbo-preview": {
 			"id": "openai/gpt-4-turbo-preview",
-			"name": "OpenAI: GPT-4 Turbo Preview",
+			"name": "OpenAI: GPT-4 Turbo Preview ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13767,7 +14182,7 @@
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
-			"name": "OpenAI: GPT-5 Image",
+			"name": "OpenAI: GPT-5 Image ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13843,7 +14258,7 @@
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
-			"name": "OpenAI: GPT-5 Pro",
+			"name": "OpenAI: GPT-5 Pro ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14001,7 +14416,7 @@
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
-			"name": "OpenAI: GPT-5.2 Chat",
+			"name": "OpenAI: GPT-5.2 Chat (retires Aug 10)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14488,7 +14903,7 @@
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
-			"name": "OpenAI: o3 Deep Research",
+			"name": "OpenAI: o3 Deep Research ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15327,7 +15742,7 @@
 		},
 		"qwen/qwen3-30b-a3b": {
 			"id": "qwen/qwen3-30b-a3b",
-			"name": "Qwen: Qwen3 30B A3B",
+			"name": "Qwen: Qwen3 30B A3B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16214,7 +16629,7 @@
 		},
 		"sao10k/l3-euryale-70b": {
 			"id": "sao10k/l3-euryale-70b",
-			"name": "Sao10k: Llama 3 Euryale 70B v2.1",
+			"name": "Sao10k: Llama 3 Euryale 70B v2.1 (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16345,9 +16760,47 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"stealth/claude-opus-4.8": {
+			"id": "stealth/claude-opus-4.8",
+			"name": "Stealth: Anthropic Opus 4.8 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
 			"name": "Stealth: Anthropic Sonnet 4.6 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stealth/qwen3.6-plus": {
+			"id": "stealth/qwen3.6-plus",
+			"name": "Stealth: Qwen3.6 Plus (50% off)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16386,6 +16839,44 @@
 		"stepfun/step-3.5-flash:free": {
 			"id": "stepfun/step-3.5-flash:free",
 			"name": "StepFun: Step 3.5 Flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "StepFun: Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun/step-3.7-flash:free": {
+			"id": "stepfun/step-3.7-flash:free",
+			"name": "StepFun: Step 3.7 Flash (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -50967,6 +51458,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"stepfun-ai/step-3.7-flash": {
+			"id": "stepfun-ai/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
 			"name": "solar-10.7b-instruct",
@@ -53322,6 +53838,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
 			"name": "Anthropic Sonnet 4",
@@ -54687,13 +55228,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55224,6 +55765,56 @@
 				"output": 150,
 				"cacheRead": 3,
 				"cacheWrite": 37.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic: Anthropic Opus 4.8",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"anthropic/claude-opus-4.8-fast": {
+			"id": "anthropic/claude-opus-4.8-fast",
+			"name": "Anthropic: Anthropic Opus 4.8 (Fast)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -55923,13 +56514,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.02,
+				"input": 0.0983,
+				"output": 0.1966,
+				"cacheRead": 0.019700000000000002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -56020,7 +56611,7 @@
 				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0.08333333333333334
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1048576,
 			"maxTokens": 8192
 		},
 		"google/gemini-2.0-flash-lite-001": {
@@ -57110,13 +57701,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27899999999999997,
+				"input": 0.26,
 				"output": 1.2,
 				"cacheRead": 0.059,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"maxTokens": 131070,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -57757,13 +58348,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -59184,13 +59775,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
+				"input": 0.029,
 				"output": 0.14,
 				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -59945,13 +60536,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14950000000000002,
-				"output": 1.495,
-				"cacheRead": 0.055,
+				"input": 0.09999999999999999,
+				"output": 0.09999999999999999,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -60581,13 +61172,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13899999999999998,
+				"input": 0.14,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61072,6 +61663,34 @@
 				"input": 0,
 				"output": 0,
 				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"compat": {
+				"supportsToolChoice": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "StepFun: Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 1.15,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -61729,8 +62348,8 @@
 			],
 			"cost": {
 				"input": 0.125,
-				"output": 0.84,
-				"cacheRead": 0.024999999999999998,
+				"output": 0.85,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -62815,6 +63434,56 @@
 		"claude-opus-4-7-fast": {
 			"id": "claude-opus-4-7-fast",
 			"name": "anthropic-opus-4-7-fast",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"claude-opus-4-8-fast": {
+			"id": "claude-opus-4-8-fast",
+			"name": "anthropic-opus-4-8-fast",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -65001,7 +65670,7 @@
 		},
 		"alibaba/qwen-3-235b": {
 			"id": "alibaba/qwen-3-235b",
-			"name": "Qwen3 235B A22b Instruct 2507",
+			"name": "Qwen3 235B A22B",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -65010,13 +65679,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.2,
+				"input": 0.22,
+				"output": 0.88,
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 40000
+			"contextWindow": 262144,
+			"maxTokens": 16384
 		},
 		"alibaba/qwen-3-30b": {
 			"id": "alibaba/qwen-3-30b",
@@ -65642,6 +66311,31 @@
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
 			"name": "Anthropic Opus 4.7",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -68188,6 +68882,31 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 1.15,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -295,6 +295,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 export const DEFAULT_MODEL_PER_PROVIDER: Record<KnownProvider, string> = {
 	...Object.fromEntries(PROVIDER_DESCRIPTORS.map(d => [d.providerId, d.defaultModel])),
 	// Providers not in PROVIDER_DESCRIPTORS (special auth or no standard discovery)
+	"azure-openai": "gpt-4.1",
 	"alibaba-coding-plan": "qwen3.5-plus",
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
 	"google-antigravity": "gemini-3-pro-high",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -97,6 +97,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	cursor: "CURSOR_ACCESS_TOKEN",
 	deepseek: "DEEPSEEK_API_KEY",
 	"openai-codex": "OPENAI_CODEX_OAUTH_TOKEN",
+	"azure-openai": "AZURE_OPENAI_API_KEY",
 	"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 	exa: "EXA_API_KEY",
 	jina: "JINA_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -98,6 +98,7 @@ export interface ThinkingConfig {
 export type KnownProvider =
 	| "alibaba-coding-plan"
 	| "amazon-bedrock"
+	| "azure-openai"
 	| "anthropic"
 	| "google"
 	| "google-gemini-cli"

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { getEnvApiKey } from "../src/stream";
 import { type AzureOpenAIResponsesOptions, streamAzureOpenAIResponses } from "../src/providers/azure-openai-responses";
 import type { Context, Model, Tool } from "../src/types";
 
@@ -15,6 +16,13 @@ const azureModel: Model<"azure-openai-responses"> = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	contextWindow: 400000,
 	maxTokens: 128000,
+};
+
+const firstClassAzureModel: Model<"azure-openai-responses"> = {
+	...azureModel,
+	id: "gpt-4.1",
+	name: "GPT-4.1",
+	provider: "azure-openai",
 };
 
 function createAbortedSignal(): AbortSignal {
@@ -78,6 +86,37 @@ async function captureAzurePayload(
 afterEach(() => {
 	global.fetch = originalFetch;
 	vi.restoreAllMocks();
+});
+
+describe("azure openai first-class provider auth", () => {
+	it("resolves azure-openai provider ids from AZURE_OPENAI_API_KEY", () => {
+		const originalApiKey = Bun.env.AZURE_OPENAI_API_KEY;
+		try {
+			Bun.env.AZURE_OPENAI_API_KEY = "azure-test-key";
+			expect(getEnvApiKey("azure-openai")).toBe("azure-test-key");
+		} finally {
+			if (originalApiKey === undefined) delete Bun.env.AZURE_OPENAI_API_KEY;
+			else Bun.env.AZURE_OPENAI_API_KEY = originalApiKey;
+		}
+	});
+
+	it("uses AZURE_OPENAI_API_KEY for first-class azure-openai/gpt-* stream auth", async () => {
+		const originalApiKey = Bun.env.AZURE_OPENAI_API_KEY;
+		try {
+			Bun.env.AZURE_OPENAI_API_KEY = "azure-env-key";
+			const payload = await captureAzurePayload(
+				{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+				firstClassAzureModel,
+				{},
+			);
+
+			expect(payload.model).toBe("gpt-4.1");
+			expect(getEnvApiKey(firstClassAzureModel.provider)).toBe("azure-env-key");
+		} finally {
+			if (originalApiKey === undefined) delete Bun.env.AZURE_OPENAI_API_KEY;
+			else Bun.env.AZURE_OPENAI_API_KEY = originalApiKey;
+		}
+	});
 });
 
 describe("azure openai responses streaming", () => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -243,6 +243,10 @@ interface ProviderValidationConfig {
 	models: ProviderValidationModel[];
 }
 
+function usesAwsCredentialChain(api: Api | undefined): boolean {
+	return api === "bedrock-converse-stream";
+}
+
 function validateProviderConfiguration(
 	providerName: string,
 	config: ProviderValidationConfig,
@@ -274,10 +278,11 @@ function validateProviderConfiguration(
 		if (!config.baseUrl) {
 			throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
 		}
+		const usesProviderCredentialChain = usesAwsCredentialChain(config.api);
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && !config.apiKeyEnv && (config.auth ?? "apiKey") !== "none";
+				? !usesProviderCredentialChain && !config.apiKey && !config.oauthConfigured
+				: !usesProviderCredentialChain && !config.apiKey && !config.apiKeyEnv && (config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -4,8 +4,8 @@ import * as path from "node:path";
 import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@gajae-code/ai";
 import { $ } from "bun";
-import { shortenPath } from "../tools/render-utils";
 import { resolveGjcCommand } from "../task/gjc-command";
+import { shortenPath } from "../tools/render-utils";
 
 export const CONTRIBUTION_PREP_SCHEMA_VERSION = 1;
 
@@ -294,10 +294,25 @@ export async function prepareContributionPrep(
 		const spawn =
 			options.spawn ??
 			(async (args, cwd, shell) => {
-				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit", shell });
+				if (shell) {
+					Bun.spawn({
+						cmd: args,
+						cwd,
+						stdout: "inherit",
+						stderr: "inherit",
+						stdin: "inherit",
+						windowsVerbatimArguments: true,
+					});
+					return;
+				}
+				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
 			});
 		const command = resolveGjcCommand();
-		await spawn([command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`], context.cwd, command.shell);
+		await spawn(
+			[command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`],
+			context.cwd,
+			command.shell,
+		);
 		spawned = true;
 	}
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -126,6 +126,35 @@ describe("ModelRegistry runtime provider registration", () => {
 		}
 	});
 
+	test("loads Bedrock models without apiKey because AWS credential chain supplies auth", async () => {
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"amazon-bedrock": {
+						baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+						api: "bedrock-converse-stream",
+						models: [{ id: "us.anthropic.claude-opus-4-6-v1" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("amazon-bedrock", "us.anthropic.claude-opus-4-6-v1");
+
+		expect(registry.getError()).toBeUndefined();
+		expect(model?.api).toBe("bedrock-converse-stream");
+		expect(model?.baseUrl).toBe("https://bedrock-runtime.us-east-1.amazonaws.com");
+	});
+
+	test("exposes first-class Azure OpenAI catalog models", () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("azure-openai", "gpt-4.1");
+
+		expect(model?.api).toBe("azure-openai-responses");
+		expect(model?.provider).toBe("azure-openai");
+	});
 	test("validates provider config before mutating custom API state", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		const beforeAnthropicCount = registry.getAll().filter(model => model.provider === "anthropic").length;

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -75,6 +75,39 @@ describe("provider onboarding setup core", () => {
 		expect(parsed.providers.minimax?.models.map(model => model.id)).toEqual(["MiniMax-M2.7-highspeed"]);
 	});
 
+	it("accepts first-class Azure OpenAI and Bedrock provider config shapes", async () => {
+		const modelsPath = await tempModelsPath();
+		await Bun.write(
+			modelsPath,
+			YAML.stringify({
+				providers: {
+					"azure-openai": {
+						baseUrl: "https://example-resource.openai.azure.com/openai/v1",
+						apiKeyEnv: "AZURE_OPENAI_API_KEY",
+						api: "azure-openai-responses",
+						models: [{ id: "gpt-4.1" }],
+					},
+					"amazon-bedrock": {
+						baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+						api: "bedrock-converse-stream",
+						models: [{ id: "us.anthropic.claude-opus-4-6-v1" }],
+					},
+				},
+			}),
+		);
+
+		const result = await addApiCompatibleProvider({
+			compatibility: "openai",
+			providerId: "glm-proxy",
+			baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+			apiKeyEnv: "ZAI_API_KEY",
+			models: ["glm-4.6"],
+			modelsPath,
+		});
+
+		expect(result.providerId).toBe("glm-proxy");
+	});
+
 	it("adds an Anthropic-compatible provider without deleting unrelated providers", async () => {
 		const modelsPath = await tempModelsPath();
 		await Bun.write(


### PR DESCRIPTION
Closes #85. Advances #82.

## Summary
- adds first-class `azure-openai` catalog entries generated from OpenAI references
- allows `bedrock-converse-stream` in `models.yml` and treats it as AWS credential-chain auth instead of api-key auth
- documents Azure deployment mapping, Bedrock AWS credential-chain setup, and MiniMax/GLM custom-provider examples
- regenerates `packages/ai/src/models.json` via `bun --cwd=packages/ai run generate-models`

## Verification
- `bun --cwd=packages/ai run generate-models`
- `bun test packages/coding-agent/test/provider-onboarding.test.ts packages/coding-agent/test/model-registry-runtime-provider.test.ts packages/ai/test/aws-credentials.test.ts packages/ai/test/azure-openai-responses-stream.test.ts`
- `bun --cwd=packages/ai run check:types`
- `bun --cwd=packages/coding-agent run check:types`