### PR TITLE
Fix proxy config and team dry-run discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ I created an earlier OpenAI code harness and `an earlier Anthropic-code harness`
 
 ## Usage
 
-Gajae-Code is published through the normal npm registry. Install the one-line npm wrapper with Bun for the recommended runtime workflow:
+Gajae-Code is published through the normal npm registry as `gajae-code`; that package installs the `gjc` binary. Install the one-line npm wrapper with Bun for the recommended runtime workflow:
 
 ```sh
 bun install -g gajae-code

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -189,6 +189,50 @@ providers:
 
 For OpenRouter traffic, GJC explicitly sends `User-Agent: Gajae-Code/<package version>` plus OpenRouter attribution headers. For the built-in OpenAI Responses transport and generic OpenAI-compatible Chat Completions transport, GJC passes model/provider headers through the OpenAI JavaScript SDK and does not set a GJC user-agent unless the provider-specific code adds one.
 
+### OpenAI-compatible proxy provider config
+
+For OpenAI-compatible proxies that only implement Chat Completions, prefer a custom `models.yml` provider over `OPENAI_BASE_URL`:
+
+```yaml
+providers:
+  openai-compatible:
+    baseUrl: https://proxy.example.com/v1
+    apiKeyEnv: OPENAI_API_KEY
+    api: openai-completions
+    auth: apiKey
+    headers:
+      User-Agent: curl/8.7.1
+    models:
+      - id: gpt-4o
+        name: GPT-4o via proxy
+        reasoning: false
+        input: [text]
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+```
+
+`models.yml` is strict: unsupported provider/model keys fail validation before the provider request is dispatched.
+
+### GJC workflow bridge commands
+
+`gjc ralplan`, `gjc deep-interview`, and `gjc state` are private runtime bridge commands. They require `GJC_RUNTIME_BINARY` (or legacy `GJC_LEGACY_RUNTIME_BINARY`) to point at the private runtime executable; public bundled workflow use remains through `/skill:ralplan` and `/skill:deep-interview` inside a GJC session.
+
+| Variable | Behavior |
+| --- | --- |
+| `GJC_RUNTIME_BINARY` | Private runtime bridge binary for `gjc ralplan`, `gjc deep-interview`, and `gjc state` |
+| `GJC_LEGACY_RUNTIME_BINARY` | Legacy fallback bridge binary name |
+
+### Team dry-run and state paths
+
+`gjc team ... --dry-run --json` creates the same machine-readable state tree as a team launch without starting tmux panes. By default that state is written under `<cwd>/.gjc/state/team/<team>/`; treat it as ephemeral smoke-test/review state. Do not commit generated `.gjc/state/team` contents. Remove the generated team directory after a dry-run when the harness no longer needs it.
+
+| Variable | Behavior |
+| --- | --- |
+| `GJC_TEAM_STATE_ROOT` | Overrides the team state root (default `<cwd>/.gjc/state/team`) |
+| `GJC_TEAM_TMUX_COMMAND` | tmux binary/command override for team launch |
+| `GJC_TEAM_WORKER_COMMAND` | Worker GJC command override |
+| `GJC_TEAM_WORKER_CLI` | Team worker CLI selector; accepted values are `auto` or `gjc` |
+| `GJC_TEAM_WORKER_CLI_MAP` | Comma-separated worker CLI selector map; entries must be `auto` or `gjc` |
+
 ### Google Vertex AI
 
 | Variable                         | Required?                      | Notes                                                                                                                     |

--- a/docs/models.md
+++ b/docs/models.md
@@ -108,8 +108,12 @@ modelBindings:
 - `openai-codex-responses`
 - `azure-openai-responses`
 - `anthropic-messages`
+- `bedrock-converse-stream`
 - `google-generative-ai`
 - `google-vertex`
+- `google-gemini-cli`
+- `ollama-chat`
+- `cursor-agent`
 
 ### Allowed auth/discovery values
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -76,13 +76,6 @@ providers:
         maxTokens: 16384
         headers:
           X-Model: value
-        wireModelId: upstream-model-id
-        requestTransform:
-          profile: openai-proxy
-          setHeaders:
-            X-Proxy-Route: default
-          extraBody:
-            gateway: default
         thinking:
           minLevel: low
           maxLevel: xhigh
@@ -121,27 +114,24 @@ modelBindings:
 ### Allowed auth/discovery values
 
 - `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement
+- `models.yml` is strict: unknown provider/model keys fail validation before provider dispatch, so stale keys such as `requestTransform` or `wireModelId` only work where this document lists them.
 - `discovery.type`: `ollama`, `llama.cpp`, or `lm-studio`
 
-## OpenAI-compatible proxy request shaping
+## OpenAI-compatible proxy configuration
 
-OpenAI-compatible proxy providers can declare request shaping without hardcoding a provider name:
+OpenAI-compatible proxy providers should use schema-supported provider keys first:
 
 ```yaml
 providers:
   proxy-provider:
     baseUrl: https://api.proxy.example/v1
-    apiKey: PROXY_API_KEY
+    apiKeyEnv: PROXY_API_KEY
     api: openai-completions
-    requestTransform:
-      profile: openai-proxy
-      setHeaders:
-        X-Proxy-Route: default
-      extraBody:
-        gateway: default
+    auth: apiKey
+    headers:
+      User-Agent: curl/8.7.1
     models:
       - id: local-gpt
-        wireModelId: upstream/gpt-5.5
         name: Local GPT
         reasoning: true
         input: [text]
@@ -150,8 +140,13 @@ providers:
         maxTokens: 128000
 ```
 
-`requestTransform.profile: openai-proxy` strips OpenAI SDK/Stainless telemetry headers at final fetch time and sets a generic GJC user agent. Explicit config wins over the preset:
+Use provider-level `headers` for proxy-required headers. Keep the provider `api` set to `openai-completions` when the proxy exposes Chat Completions-compatible `/v1/chat/completions` semantics. `auth: apiKey` sends the resolved token as bearer auth; use `auth: none` only for trusted local/no-auth endpoints.
 
+`requestTransform` and `wireModelId` remain supported for request-body shaping, but they are not needed for ordinary OpenAI-compatible proxies whose local model id is already the upstream wire id. Unknown config keys fail validation before a provider request is sent.
+
+When request shaping is needed:
+
+- `requestTransform.profile: openai-proxy` strips OpenAI SDK/Stainless telemetry headers at final fetch time and sets a generic GJC user agent.
 - `stripHeaders` replaces the preset strip list when provided.
 - `setHeaders` is applied after stripping; use `null` to remove a header.
 - `extraBody` is shallow-merged into the JSON request body after provider compatibility fields; core transport keys such as `model`, `messages`/`input`, `stream`, `tools`, and `tool_choice` are protected and ignored.
@@ -164,13 +159,13 @@ providers:
 providers:
   layofflabs:
     baseUrl: https://api.layofflabs.com/v1
-    apiKeyEnv: LAYOFFLABS_API_KEY
+    apiKeyEnv: OPENAI_API_KEY
     api: openai-completions
-    requestTransform:
-      profile: openai-proxy
+    auth: apiKey
+    headers:
+      User-Agent: curl/8.7.1
     models:
       - id: gpt-5.5
-        wireModelId: gpt-5.5
         name: GPT 5.5 via Layofflabs
         reasoning: true
         thinking:
@@ -221,6 +216,7 @@ Must define at least one of:
 
 - `id` required
 - `contextWindow` and `maxTokens` must be positive if provided
+- unknown provider, model, override, and request-transform keys fail schema validation; remove stale keys instead of relying on them being ignored.
 
 ## Merge and override order
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `gjc session` for listing, inspecting, removing, and attaching GJC-managed tmux sessions.
+- Added stricter `models.yml` validation and docs for OpenAI-compatible proxy providers, bridge-command requirements, and team dry-run state behavior.
 
 ### Changed
 

--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -3,9 +3,9 @@ import { syncSkillActiveState } from "../skill-state/active-state";
 import { runGjcRuntimeBridgeWithHudSidecar } from "./gjc-runtime-bridge";
 
 export default class DeepInterview extends Command {
-	static description = "Run private GJC deep-interview workflow commands";
+	static description = "Run private GJC deep-interview bridge commands (requires GJC_RUNTIME_BINARY)";
 	static strict = false;
-	static examples = ["$ gjc deep-interview --help"];
+	static examples = ["$ GJC_RUNTIME_BINARY=/path/to/private-runtime gjc deep-interview --help"];
 
 	async run(): Promise<void> {
 		const cwd = process.cwd();

--- a/packages/coding-agent/src/commands/ralplan.ts
+++ b/packages/coding-agent/src/commands/ralplan.ts
@@ -3,9 +3,9 @@ import { syncSkillActiveState } from "../skill-state/active-state";
 import { runGjcRuntimeBridgeWithHudSidecar } from "./gjc-runtime-bridge";
 
 export default class Ralplan extends Command {
-	static description = "Run private GJC RALPLAN workflow commands";
+	static description = "Run private GJC RALPLAN bridge commands (requires GJC_RUNTIME_BINARY)";
 	static strict = false;
-	static examples = ["$ gjc ralplan --help"];
+	static examples = ["$ GJC_RUNTIME_BINARY=/path/to/private-runtime gjc ralplan --help"];
 
 	async run(): Promise<void> {
 		const cwd = process.cwd();

--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -2,9 +2,11 @@ import { Command } from "@gajae-code/utils/cli";
 import { runBridgedRuntimeEndpoint } from "./gjc-runtime-bridge";
 
 export default class State extends Command {
-	static description = "Read or update private GJC workflow state";
+	static description = "Read or update private GJC workflow state through the bridge (requires GJC_RUNTIME_BINARY)";
 	static strict = false;
-	static examples = ['$ gjc state read --input \'{"mode":"team"}\' --json'];
+	static examples = [
+		'$ GJC_RUNTIME_BINARY=/path/to/private-runtime gjc state read --input \'{"mode":"team"}\' --json',
+	];
 
 	async run(): Promise<void> {
 		await runBridgedRuntimeEndpoint("state", this.argv);

--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -71,7 +71,7 @@ function parseInputFlag(argv: string[]): Record<string, unknown> {
 }
 
 export default class Team extends Command {
-	static description = "Run native GJC tmux team orchestration commands";
+	static description = "Run native GJC tmux team orchestration; --dry-run writes ephemeral .gjc/state/team state only";
 	static strict = false;
 
 	static args = {
@@ -83,13 +83,18 @@ export default class Team extends Command {
 
 	static flags = {
 		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
-		"dry-run": Flags.boolean({ description: "Create team state without starting tmux panes", default: false }),
+		"dry-run": Flags.boolean({
+			description:
+				"Create ephemeral .gjc/state/team state without starting tmux panes; do not commit generated state",
+			default: false,
+		}),
 	};
 
 	static examples = [
 		'gjc team 3:executor "Implement the approved plan"',
 		"gjc team status <team-name> --json",
 		'gjc team api claim-task --input \'{"team_name":"demo","worker_id":"worker-1"}\' --json',
+		'gjc team 2:executor --dry-run --json "Preview state only"',
 		"gjc team shutdown <team-name>",
 	];
 
@@ -184,6 +189,7 @@ export default class Team extends Command {
 			`tmux: ${snapshot.tmux_session}`,
 			`state: ${snapshot.state_dir}`,
 			`workers: ${snapshot.workers.length}`,
+			...(dryRun ? ["dry-run: wrote ephemeral .gjc/state/team state only; do not commit generated .gjc state"] : []),
 		]);
 	}
 }

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -63,76 +63,86 @@ const ModelThinkingSchema = z.object({
 	levels: z.array(EffortSchema).optional(),
 });
 
-const RequestTransformSchema = z.object({
-	profile: z.enum(["openai-proxy"]).optional(),
-	stripHeaders: z.array(z.string().min(1)).optional(),
-	setHeaders: z.record(z.string(), z.string().nullable()).optional(),
-	extraBody: z.record(z.string(), z.unknown()).optional(),
-});
+const RequestTransformSchema = z
+	.object({
+		profile: z.enum(["openai-proxy"]).optional(),
+		stripHeaders: z.array(z.string().min(1)).optional(),
+		setHeaders: z.record(z.string(), z.string().nullable()).optional(),
+		extraBody: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
 
 const ModelBindingsSchema = z.object({
 	modelRoles: z.record(z.string(), z.string().min(1)).optional(),
 	agentModelOverrides: z.record(z.string(), z.string().min(1)).optional(),
 });
 
-const ModelDefinitionSchema = z.object({
-	id: z.string().min(1),
-	name: z.string().min(1).optional(),
-	api: z
-		.enum([
-			"openai-completions",
-			"openai-responses",
-			"openai-codex-responses",
-			"azure-openai-responses",
-			"anthropic-messages",
-			"google-generative-ai",
-			"google-vertex",
-		])
-		.optional(),
-	baseUrl: z.string().min(1).optional(),
-	reasoning: z.boolean().optional(),
-	thinking: ModelThinkingSchema.optional(),
-	input: z.array(z.enum(["text", "image"])).optional(),
-	cost: z
-		.object({
-			input: z.number(),
-			output: z.number(),
-			cacheRead: z.number(),
-			cacheWrite: z.number(),
-		})
-		.optional(),
-	premiumMultiplier: z.number().optional(),
-	contextWindow: z.number().optional(),
-	maxTokens: z.number().optional(),
-	headers: z.record(z.string(), z.string()).optional(),
-	compat: OpenAICompatSchema.optional(),
-	contextPromotionTarget: z.string().min(1).optional(),
-	wireModelId: z.string().min(1).optional(),
-	requestTransform: RequestTransformSchema.optional(),
-});
+const ModelDefinitionSchema = z
+	.object({
+		id: z.string().min(1),
+		name: z.string().min(1).optional(),
+		api: z
+			.enum([
+				"openai-completions",
+				"openai-responses",
+				"openai-codex-responses",
+				"azure-openai-responses",
+				"anthropic-messages",
+				"bedrock-converse-stream",
+				"google-generative-ai",
+				"google-vertex",
+				"google-gemini-cli",
+				"ollama-chat",
+				"cursor-agent",
+			])
+			.optional(),
+		baseUrl: z.string().min(1).optional(),
+		reasoning: z.boolean().optional(),
+		thinking: ModelThinkingSchema.optional(),
+		input: z.array(z.enum(["text", "image"])).optional(),
+		cost: z
+			.object({
+				input: z.number(),
+				output: z.number(),
+				cacheRead: z.number(),
+				cacheWrite: z.number(),
+			})
+			.optional(),
+		premiumMultiplier: z.number().optional(),
+		contextWindow: z.number().optional(),
+		maxTokens: z.number().optional(),
+		headers: z.record(z.string(), z.string()).optional(),
+		compat: OpenAICompatSchema.optional(),
+		contextPromotionTarget: z.string().min(1).optional(),
+		wireModelId: z.string().min(1).optional(),
+		requestTransform: RequestTransformSchema.optional(),
+	})
+	.strict();
 
-export const ModelOverrideSchema = z.object({
-	name: z.string().min(1).optional(),
-	reasoning: z.boolean().optional(),
-	thinking: ModelThinkingSchema.optional(),
-	input: z.array(z.enum(["text", "image"])).optional(),
-	cost: z
-		.object({
-			input: z.number().optional(),
-			output: z.number().optional(),
-			cacheRead: z.number().optional(),
-			cacheWrite: z.number().optional(),
-		})
-		.optional(),
-	premiumMultiplier: z.number().optional(),
-	contextWindow: z.number().optional(),
-	maxTokens: z.number().optional(),
-	headers: z.record(z.string(), z.string()).optional(),
-	compat: OpenAICompatSchema.optional(),
-	contextPromotionTarget: z.string().min(1).optional(),
-	wireModelId: z.string().min(1).optional(),
-	requestTransform: RequestTransformSchema.optional(),
-});
+export const ModelOverrideSchema = z
+	.object({
+		name: z.string().min(1).optional(),
+		reasoning: z.boolean().optional(),
+		thinking: ModelThinkingSchema.optional(),
+		input: z.array(z.enum(["text", "image"])).optional(),
+		cost: z
+			.object({
+				input: z.number().optional(),
+				output: z.number().optional(),
+				cacheRead: z.number().optional(),
+				cacheWrite: z.number().optional(),
+			})
+			.optional(),
+		premiumMultiplier: z.number().optional(),
+		contextWindow: z.number().optional(),
+		maxTokens: z.number().optional(),
+		headers: z.record(z.string(), z.string()).optional(),
+		compat: OpenAICompatSchema.optional(),
+		contextPromotionTarget: z.string().min(1).optional(),
+		wireModelId: z.string().min(1).optional(),
+		requestTransform: RequestTransformSchema.optional(),
+	})
+	.strict();
 
 export type ModelOverride = z.infer<typeof ModelOverrideSchema>;
 
@@ -145,49 +155,57 @@ export const ProviderAuthSchema = z.enum(["apiKey", "none", "oauth"]);
 export type ProviderAuthMode = z.infer<typeof ProviderAuthSchema>;
 export type ProviderDiscovery = z.infer<typeof ProviderDiscoverySchema>;
 
-const ProviderConfigSchema = z.object({
-	baseUrl: z.string().min(1).optional(),
-	apiKey: z.string().min(1).optional(),
-	apiKeyEnv: z.string().min(1).optional(),
-	api: z
-		.enum([
-			"openai-completions",
-			"openai-responses",
-			"openai-codex-responses",
-			"azure-openai-responses",
-			"anthropic-messages",
-			"google-generative-ai",
-			"google-vertex",
-		])
-		.optional(),
-	headers: z.record(z.string(), z.string()).optional(),
-	compat: OpenAICompatSchema.optional(),
-	authHeader: z.boolean().optional(),
-	auth: ProviderAuthSchema.optional(),
-	discovery: ProviderDiscoverySchema.optional(),
-	requestTransform: RequestTransformSchema.optional(),
-	models: z.array(ModelDefinitionSchema).optional(),
-	modelOverrides: z.record(z.string(), ModelOverrideSchema).optional(),
-	disableStrictTools: z.boolean().optional(),
-	/**
-	 * Streaming transport override. When set to `"pi-native"`, gjc dispatches
-	 * every model under this provider via the auth-gateway's
-	 * `POST /v1/pi/stream` endpoint instead of the per-provider SDK. The
-	 * provider's `baseUrl` must point at a compatible `gjc auth-gateway`
-	 * and `apiKey` must carry the gateway bearer.
-	 */
-	transport: z.literal("pi-native").optional(),
-});
+const ProviderConfigSchema = z
+	.object({
+		baseUrl: z.string().min(1).optional(),
+		apiKey: z.string().min(1).optional(),
+		apiKeyEnv: z.string().min(1).optional(),
+		api: z
+			.enum([
+				"openai-completions",
+				"openai-responses",
+				"openai-codex-responses",
+				"azure-openai-responses",
+				"anthropic-messages",
+				"bedrock-converse-stream",
+				"google-generative-ai",
+				"google-vertex",
+				"google-gemini-cli",
+				"ollama-chat",
+				"cursor-agent",
+			])
+			.optional(),
+		headers: z.record(z.string(), z.string()).optional(),
+		compat: OpenAICompatSchema.optional(),
+		authHeader: z.boolean().optional(),
+		auth: ProviderAuthSchema.optional(),
+		discovery: ProviderDiscoverySchema.optional(),
+		requestTransform: RequestTransformSchema.optional(),
+		models: z.array(ModelDefinitionSchema).optional(),
+		modelOverrides: z.record(z.string(), ModelOverrideSchema).optional(),
+		disableStrictTools: z.boolean().optional(),
+		/**
+		 * Streaming transport override. When set to `"pi-native"`, gjc dispatches
+		 * every model under this provider via the auth-gateway's
+		 * `POST /v1/pi/stream` endpoint instead of the per-provider SDK. The
+		 * provider's `baseUrl` must point at a compatible `gjc auth-gateway`
+		 * and `apiKey` must carry the gateway bearer.
+		 */
+		transport: z.literal("pi-native").optional(),
+	})
+	.strict();
 
 const EquivalenceConfigSchema = z.object({
 	overrides: z.record(z.string(), z.string().min(1)).optional(),
 	exclude: z.array(z.string().min(1)).optional(),
 });
 
-export const ModelsConfigSchema = z.object({
-	providers: z.record(z.string(), ProviderConfigSchema).optional(),
-	modelBindings: ModelBindingsSchema.optional(),
-	equivalence: EquivalenceConfigSchema.optional(),
-});
+export const ModelsConfigSchema = z
+	.object({
+		providers: z.record(z.string(), ProviderConfigSchema).optional(),
+		modelBindings: ModelBindingsSchema.optional(),
+		equivalence: EquivalenceConfigSchema.optional(),
+	})
+	.strict();
 
 export type ModelsConfig = z.infer<typeof ModelsConfigSchema>;

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -89,6 +89,7 @@ export interface GjcTeamConfig {
 	tmux_session_name: string;
 	tmux_target: string;
 	workspace_mode: "direct" | "worktree";
+	dry_run: boolean;
 	leader: GjcTeamLeader;
 	leader_cwd: string;
 	team_state_root: string;
@@ -437,6 +438,7 @@ async function readConfig(dir: string): Promise<GjcTeamConfig> {
 		tmux_session: tmuxSessionName,
 		tmux_session_name: tmuxSessionName,
 		tmux_target: config.tmux_target ?? config.tmux_session ?? tmuxSessionName,
+		dry_run: config.dry_run ?? config.tmux_session_name === "dry-run",
 		leader_cwd: config.leader_cwd ?? config.leader.cwd,
 		team_state_root: config.team_state_root ?? config.state_root,
 		worker_cli_plan: config.worker_cli_plan ?? Array.from({ length: config.worker_count }, () => "gjc"),
@@ -1511,6 +1513,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		tmux_session_name: tmuxContext.sessionName,
 		tmux_target: tmuxContext.target,
 		workspace_mode: worktreeMode.enabled ? "worktree" : "direct",
+		dry_run: options.dryRun ?? false,
 		leader: { session_id: env.GJC_SESSION_ID ?? env.CODEX_SESSION_ID ?? "", pane_id: tmuxContext.leaderPaneId, cwd },
 		leader_cwd: cwd,
 		team_state_root: stateRoot,
@@ -1534,6 +1537,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		leader: config.leader,
 		workers: config.workers,
 		workspace_mode: config.workspace_mode,
+		dry_run: config.dry_run,
 		created_at: createdAt,
 		updated_at: createdAt,
 	});
@@ -1541,17 +1545,25 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	for (const task of buildInitialTasks(options.task, config.workers)) await writeTask(dir, task);
 	await appendEvent(dir, {
 		type: "team_started",
-		message: "Started native gjc team runtime",
-		data: { worker_count: options.workerCount, agent_type: options.agentType, workspace_mode: config.workspace_mode },
+		message: options.dryRun
+			? "Created native gjc team dry-run state without starting tmux workers"
+			: "Started native gjc team runtime",
+		data: {
+			worker_count: options.workerCount,
+			agent_type: options.agentType,
+			workspace_mode: config.workspace_mode,
+			dry_run: config.dry_run,
+		},
 	});
 	await appendTelemetry(dir, {
 		type: "team_runtime",
-		message: "Native gjc team runtime initialized",
+		message: options.dryRun ? "Native gjc team dry-run state initialized" : "Native gjc team runtime initialized",
 		data: {
 			state_root: stateRoot,
 			worker_command: config.worker_command,
 			worker_cli_plan: workerCliPlan,
 			workspace_mode: config.workspace_mode,
+			dry_run: config.dry_run,
 		},
 	});
 	let tmuxWorkers: GjcTeamWorker[];

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -31,6 +31,34 @@ describe("GJC public CLI command surface", () => {
 		]);
 	});
 
+	it("documents private bridge runtime requirements in command help", async () => {
+		for (const command of ["ralplan", "deep-interview", "state"]) {
+			const result = Bun.spawnSync(["bun", cliEntry, command, "--help"], {
+				cwd: repoRoot,
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+
+			expect(result.exitCode, output).toBe(0);
+			expect(output).toContain("GJC_RUNTIME_BINARY");
+		}
+	});
+
+	it("documents team dry-run state behavior in command help", async () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "team", "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+
+		expect(result.exitCode, output).toBe(0);
+		expect(output).toContain("--dry-run");
+		expect(output).toContain(".gjc/state/team");
+		expect(output).toContain("do not commit");
+	});
+
 	it("does not capture absolute-path prompts as startup slash commands", () => {
 		const parsed = parseArgs(["/tmp/request.md", "--model", "opus", "summarize"]);
 

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -160,8 +160,14 @@ describe("native gjc team runtime", () => {
 		expect(snapshot.tmux_target).toBe("dry-run:0");
 		expect(snapshot.workers[0]?.pane_id).toBe("%dry-run-worker-1");
 
+		const config = await readTeamConfig(snapshot.state_dir);
+		const manifest = await Bun.file(path.join(snapshot.state_dir, "manifest.v2.json")).json();
+		expect(config.dry_run).toBe(true);
+		expect(manifest.dry_run).toBe(true);
+
 		const telemetry = await Bun.file(path.join(snapshot.state_dir, "telemetry.jsonl")).text();
-		expect(telemetry).toContain("Native gjc team runtime initialized");
+		expect(telemetry).toContain("Native gjc team dry-run state initialized");
+		expect(telemetry).toContain('"dry_run":true');
 	});
 
 	it("persists the active worker command so tmux workers use the same gjc entrypoint", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2693,6 +2693,41 @@ describe("ModelRegistry", () => {
 		);
 	});
 
+	test("rejects unknown provider and model config keys before provider dispatch", () => {
+		writeRawModelsConfig({
+			providers: {
+				layofflabs: {
+					baseUrl: "https://api.layofflabs.com/v1",
+					apiKeyEnv: "OPENAI_API_KEY",
+					api: "openai-completions",
+					auth: "apiKey",
+					requestTransform: { profile: "openai-proxy" },
+					models: [
+						{
+							id: "gpt-5.5",
+							name: "GPT 5.5 via Layofflabs",
+							reasoning: true,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 400000,
+							maxTokens: 128000,
+							unsupportedModelKey: true,
+						},
+					],
+					unsupportedProviderKey: true,
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const message = String(registry.getError()?.message);
+
+		expect(message).toContain("/providers/layofflabs");
+		expect(message).toContain("unsupportedProviderKey");
+		expect(message).toContain("/providers/layofflabs/models/0");
+		expect(message).toContain("unsupportedModelKey");
+	});
+
 	test("rejects model-level request shaping on non-OpenAI-compatible APIs", () => {
 		writeRawModelsConfig({
 			providers: {


### PR DESCRIPTION
Closes #96

## Summary
- document schema-supported OpenAI-compatible/LayoffLabs proxy config and package install discovery
- make models.yml strict for unknown provider/model/request-transform keys before provider dispatch
- surface GJC_RUNTIME_BINARY requirements in bridge command help and clarify team dry-run .gjc/state/team behavior
- persist dry_run in team state/manifest telemetry for dry-run harnesses

## Verification
- OPENAI_API_KEY=env-openai-key bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/model-registry.test.ts
- bun --cwd=packages/coding-agent run check

Note: attempted `bun run check:ts --filter @gajae-code/coding-agent`; root script fans out workspace checks and tsgo panics on the forwarded filter path (`vfs: path "gajae-code/coding-agent" is not absolute`). Package-local check above passes.

gajae.pr-review-verdict.v1 merge-blocked sha256:dbb538663068fcb287d4b68cf1de6d907d9a271301c0b2638b8496af67f9e0fa reviewer:human reviewer-id:probepark evidence:exact-head-aba35a63-proxy-docs-cross-provider-credential-leak
