### PR TITLE
feat: add detached contribution prep workflow

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -39,7 +39,7 @@ const commands: CommandEntry[] = [
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
-	{ name: "contribution-prep", load: () => import("./commands/contribution-prep").then(m => m.default) },
+	{ name: "contribute-pr", aliases: ["contribution-prep"], load: () => import("./commands/contribution-prep").then(m => m.default) },
 	{ name: "deep-interview", load: () => import("./commands/deep-interview").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
 ];

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -39,6 +39,7 @@ const commands: CommandEntry[] = [
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
+	{ name: "contribution-prep", load: () => import("./commands/contribution-prep").then(m => m.default) },
 	{ name: "deep-interview", load: () => import("./commands/deep-interview").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
 ];

--- a/packages/coding-agent/src/commands/contribution-prep.ts
+++ b/packages/coding-agent/src/commands/contribution-prep.ts
@@ -6,16 +6,16 @@ function writeText(lines: string[]): void {
 }
 
 export default class ContributionPrep extends Command {
-	static description = "Dump redacted context and prepare a fresh contribution-prep worker prompt";
+	static description = "Dump redacted context and prepare a fresh contribute-pr worker prompt";
 	static strict = false;
 
 	static flags = {
-		spawn: Flags.boolean({ description: "Spawn a fresh GJC worker after writing artifacts", default: false }),
+		"no-spawn": Flags.boolean({ description: "Only write artifacts; do not spawn a fresh GJC worker" }),
 		"source-session-id": Flags.string({ description: "Source session id to record in the manifest" }),
-		"artifact-root": Flags.string({ description: "Directory where contribution-prep artifacts are written" }),
+		"artifact-root": Flags.string({ description: "Directory where contribute-pr artifacts are written" }),
 	};
 
-	static examples = ["gjc contribution-prep", "gjc contribution-prep --spawn"];
+	static examples = ["gjc contribute-pr", "gjc contribute-pr --no-spawn"];
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(ContributionPrep);
@@ -27,7 +27,7 @@ export default class ContributionPrep extends Command {
 				messages: [],
 			},
 			{
-				spawnWorker: flags.spawn ?? false,
+				spawnWorker: !flags["no-spawn"],
 				artifactRoot: flags["artifact-root"],
 			},
 		);

--- a/packages/coding-agent/src/commands/contribution-prep.ts
+++ b/packages/coding-agent/src/commands/contribution-prep.ts
@@ -1,0 +1,41 @@
+import { Command, Flags } from "@gajae-code/utils/cli";
+import { prepareContributionPrep } from "../session/contribution-prep";
+
+function writeText(lines: string[]): void {
+	process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+export default class ContributionPrep extends Command {
+	static description = "Dump redacted context and prepare a fresh contribution-prep worker prompt";
+	static strict = false;
+
+	static flags = {
+		spawn: Flags.boolean({ description: "Spawn a fresh GJC worker after writing artifacts", default: false }),
+		"source-session-id": Flags.string({ description: "Source session id to record in the manifest" }),
+		"artifact-root": Flags.string({ description: "Directory where contribution-prep artifacts are written" }),
+	};
+
+	static examples = ["gjc contribution-prep", "gjc contribution-prep --spawn"];
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(ContributionPrep);
+		const cwd = process.cwd();
+		const result = await prepareContributionPrep(
+			{
+				sessionId: flags["source-session-id"] ?? "cli",
+				cwd,
+				messages: [],
+			},
+			{
+				spawnWorker: flags.spawn ?? false,
+				artifactRoot: flags["artifact-root"],
+			},
+		);
+		writeText([
+			"Contribution prep artifacts written.",
+			`Manifest: ${result.manifestPath}`,
+			`Worker prompt: ${result.workerPromptPath}`,
+			`Spawned worker: ${result.spawned ? "yes" : "no"}`,
+		]);
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1248,7 +1248,31 @@ export class CommandController {
 			this.ctx.statusContainer.clear();
 			this.ctx.editor.onEscape = originalOnEscape;
 		}
-		this.ctx.ui.requestRender();
+	}
+
+	async handleContributionPrepCommand(customInstructions?: string): Promise<void> {
+		this.ctx.editor.setText("");
+		try {
+			const result = await this.ctx.session.prepareContributionPrep({ customInstructions, spawnWorker: true });
+			this.ctx.showStatus(
+				[
+					"Contribution prep artifacts written.",
+					`Manifest: ${result.manifestPath}`,
+					`Worker prompt: ${result.workerPromptPath}`,
+				].join("\n"),
+			);
+			this.ctx.chatContainer.addChild(
+				new Text(
+					`${theme.fg("accent", `${theme.status.success} Contribution prep ready`)}\nManifest: ${result.manifestPath}`,
+					1,
+					1,
+				),
+			);
+			this.ctx.ui.requestRender();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.ctx.showError(`Contribution prep failed: ${message}`);
+		}
 	}
 }
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2439,6 +2439,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleHandoffCommand(customInstructions);
 	}
 
+	handleContributionPrepCommand(customInstructions?: string): Promise<void> {
+		return this.#commandController.handleContributionPrepCommand(customInstructions);
+	}
+
 	executeCompaction(
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto?: boolean,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -221,6 +221,7 @@ export interface InteractiveModeContext {
 	handleSSHCommand(text: string): Promise<void>;
 	handleCompactCommand(customInstructions?: string): Promise<CompactionOutcome>;
 	handleHandoffCommand(customInstructions?: string): Promise<void>;
+	handleContributionPrepCommand(customInstructions?: string): Promise<void>;
 	handleMoveCommand(targetPath: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -193,6 +193,11 @@ import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { AuthStorage } from "./auth-storage";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
 import {
+	type ContributionPrepOptions,
+	type ContributionPrepResult,
+	prepareContributionPrep,
+} from "./contribution-prep";
+import {
 	type BashExecutionMessage,
 	type CompactionSummaryMessage,
 	type CustomMessage,
@@ -5760,6 +5765,19 @@ export class AgentSession {
 			sourceSignal?.removeEventListener("abort", onSourceAbort);
 			this.#handoffAbortController = undefined;
 		}
+	}
+
+	async prepareContributionPrep(options: ContributionPrepOptions = {}): Promise<ContributionPrepResult> {
+		return prepareContributionPrep(
+			{
+				sessionId: this.sessionId,
+				cwd: this.sessionManager.getCwd(),
+				sessionFile: this.sessionFile,
+				messages: this.agent.state.messages,
+				customInstructions: options.customInstructions,
+			},
+			options,
+		);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -5,6 +5,7 @@ import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@gajae-code/ai";
 import { $ } from "bun";
 import { shortenPath } from "../tools/render-utils";
+import { resolveGjcCommand } from "../task/gjc-command";
 
 export const CONTRIBUTION_PREP_SCHEMA_VERSION = 1;
 
@@ -43,7 +44,7 @@ export interface ContributionPrepOptions {
 	spawnWorker?: boolean;
 	artifactRoot?: string;
 	now?: Date;
-	spawn?: (args: string[], cwd: string) => Promise<void>;
+	spawn?: (args: string[], cwd: string, shell: boolean) => Promise<void>;
 }
 
 export interface ContributionPrepContext {
@@ -79,7 +80,14 @@ export function redactContributionPrepText(
 	let redacted = text;
 	redacted = replaceRegex(
 		redacted,
-		/\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])-[-_A-Za-z0-9]{12,}\b/g,
+		/\b(?:sk|pk|rk|xox[baprs])-[-_A-Za-z0-9]{12,}\b/g,
+		"[REDACTED_TOKEN]",
+		state,
+		"tokens",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/\b(?:ghp_[A-Za-z0-9_]{12,}|gho_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b/g,
 		"[REDACTED_TOKEN]",
 		state,
 		"tokens",
@@ -285,10 +293,11 @@ export async function prepareContributionPrep(
 	if (options.spawnWorker) {
 		const spawn =
 			options.spawn ??
-			(async (args, cwd) => {
-				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
+			(async (args, cwd, shell) => {
+				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit", shell });
 			});
-		await spawn([process.execPath, "--no-skills", "--", `@${workerPromptPath}`], context.cwd);
+		const command = resolveGjcCommand();
+		await spawn([command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`], context.cwd, command.shell);
 		spawned = true;
 	}
 

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -1,0 +1,296 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentMessage } from "@gajae-code/agent-core";
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "@gajae-code/ai";
+import { $ } from "bun";
+import { shortenPath } from "../tools/render-utils";
+
+export const CONTRIBUTION_PREP_SCHEMA_VERSION = 1;
+
+const MAX_TRANSCRIPT_MESSAGES = 20;
+const MAX_TEXT_CHARS = 12000;
+const MAX_GIT_OUTPUT_CHARS = 60000;
+
+export interface ContributionPrepArtifact {
+	path: string;
+	description: string;
+}
+
+export interface ContributionPrepManifest {
+	schema_version: number;
+	source_session_id: string;
+	created_at: string;
+	cwd: string;
+	git_head: string | null;
+	changed_files: string[];
+	artifacts: ContributionPrepArtifact[];
+	redactions: string[];
+	recommended_output: string[];
+	worker_prompt_path: string;
+}
+
+export interface ContributionPrepResult {
+	manifestPath: string;
+	workerPromptPath: string;
+	artifactDir: string;
+	changedFiles: string[];
+	spawned: boolean;
+}
+
+export interface ContributionPrepOptions {
+	customInstructions?: string;
+	spawnWorker?: boolean;
+	artifactRoot?: string;
+	now?: Date;
+	spawn?: (args: string[], cwd: string) => Promise<void>;
+}
+
+export interface ContributionPrepContext {
+	sessionId: string;
+	cwd: string;
+	sessionFile?: string;
+	messages: AgentMessage[];
+	customInstructions?: string;
+	now?: Date;
+}
+
+interface RedactionState {
+	labels: Set<string>;
+}
+
+function limitText(text: string, maxChars = MAX_TEXT_CHARS): string {
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}\n\n[truncated ${text.length - maxChars} chars]`;
+}
+
+function replaceRegex(text: string, regex: RegExp, replacement: string, state: RedactionState, label: string): string {
+	if (!regex.test(text)) return text;
+	state.labels.add(label);
+	regex.lastIndex = 0;
+	return text.replace(regex, replacement);
+}
+
+export function redactContributionPrepText(
+	text: string,
+	cwd: string,
+	state: RedactionState = { labels: new Set() },
+): string {
+	let redacted = text;
+	redacted = replaceRegex(
+		redacted,
+		/\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])-[-_A-Za-z0-9]{12,}\b/g,
+		"[REDACTED_TOKEN]",
+		state,
+		"tokens",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/\b((?:ANTHROPIC|OPENAI|GITHUB|GOOGLE|GEMINI|KAGI|TAVILY|EXA|PERPLEXITY|ZAI|KIMI|BRAVE|SEARXNG|AWS)_[A-Z0-9_]*(?:KEY|TOKEN|SECRET|COOKIE|PASSWORD))\s*=\s*[^\s\n]+/gi,
+		"$1=[REDACTED_SECRET]",
+		state,
+		"provider_keys",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/\b(Authorization|Proxy-Authorization)\s*:\s*(?:Bearer|Basic|Token)\s+[^\s\n]+/gi,
+		"$1: [REDACTED_AUTH_HEADER]",
+		state,
+		"auth_headers",
+	);
+	redacted = replaceRegex(redacted, /\b(Cookie|Set-Cookie)\s*:\s*[^\n]+/gi, "$1: [REDACTED_COOKIE]", state, "cookies");
+	redacted = replaceRegex(
+		redacted,
+		/https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})[^\s)>'"]*/gi,
+		"[REDACTED_PRIVATE_ENDPOINT]",
+		state,
+		"private_endpoints",
+	);
+	const home = os.homedir();
+	if (home && redacted.includes(home)) {
+		state.labels.add("home_paths");
+		redacted = redacted.split(home).join("~");
+	}
+	const normalizedCwd = path.resolve(cwd);
+	if (normalizedCwd && redacted.includes(normalizedCwd)) {
+		state.labels.add("cwd_paths");
+		redacted = redacted.split(normalizedCwd).join(shortenPath(normalizedCwd));
+	}
+	return redacted;
+}
+
+function contentText(content: UserMessage["content"] | AssistantMessage["content"]): string {
+	if (typeof content === "string") return content;
+	return content
+		.map(part => {
+			if (part.type === "text") return part.text;
+			if (part.type === "toolCall") return `[tool call: ${part.name}] ${JSON.stringify(part.arguments)}`;
+			if (part.type === "image") return "[image]";
+			return `[${part.type}]`;
+		})
+		.join("\n");
+}
+
+function formatMessage(message: AgentMessage): string {
+	if (message.role === "user" || message.role === "assistant") {
+		return `## ${message.role}\n\n${contentText(message.content)}\n`;
+	}
+	if (message.role === "toolResult") {
+		const tool = message as ToolResultMessage;
+		return `## toolResult: ${tool.toolName}\n\n${typeof tool.content === "string" ? tool.content : JSON.stringify(tool.content)}\n`;
+	}
+	return `## ${message.role}\n\n${JSON.stringify(message)}\n`;
+}
+
+async function gitOutput(cwd: string, args: string[], maxChars = MAX_GIT_OUTPUT_CHARS): Promise<string> {
+	try {
+		const output = await $`git ${args}`.cwd(cwd).quiet().text();
+		return limitText(output.trim(), maxChars);
+	} catch {
+		return "";
+	}
+}
+
+async function changedFiles(cwd: string): Promise<string[]> {
+	const output = await gitOutput(cwd, ["status", "--short"]);
+	return output
+		.split("\n")
+		.map(line => line.trim())
+		.filter(Boolean)
+		.map(line => line.replace(/^..\s+/, ""));
+}
+
+async function writeArtifact(
+	dir: string,
+	name: string,
+	description: string,
+	text: string,
+): Promise<ContributionPrepArtifact> {
+	const filePath = path.join(dir, name);
+	await Bun.write(filePath, `${text.trimEnd()}\n`);
+	return { path: filePath, description };
+}
+
+export function buildContributionPrepWorkerPrompt(manifestPath: string): string {
+	return [
+		"Prepare a maintainer-friendly contribution draft from the redacted context dump.",
+		"Read the manifest and referenced artifact file pointers. Do not assume transcript context was inlined here.",
+		`Manifest: ${manifestPath}`,
+		"Produce structured markdown with: title, problem summary, reproduction/context, proposed fix or implementation plan, affected files, tests to run, and uncertainty/remaining risks.",
+		"Do not create GitHub issues, open PRs, push branches, or perform remote writes unless the user explicitly confirms that action in this fresh session.",
+	].join("\n");
+}
+
+export async function prepareContributionPrep(
+	context: ContributionPrepContext,
+	options: ContributionPrepOptions = {},
+): Promise<ContributionPrepResult> {
+	const createdAt = (options.now ?? context.now ?? new Date()).toISOString();
+	const safeTimestamp = createdAt.replace(/[:.]/g, "-");
+	const artifactDir = path.join(
+		options.artifactRoot ?? path.join(context.cwd, ".gjc", "contribution-prep"),
+		safeTimestamp,
+	);
+	await fs.mkdir(artifactDir, { recursive: true });
+
+	const redactions: RedactionState = { labels: new Set() };
+	const recentMessages = context.messages.slice(-MAX_TRANSCRIPT_MESSAGES);
+	const artifacts: ContributionPrepArtifact[] = [];
+	const redact = (text: string) => redactContributionPrepText(text, context.cwd, redactions);
+
+	artifacts.push(
+		await writeArtifact(
+			artifactDir,
+			"transcript.md",
+			"Redacted recent transcript window",
+			redact(recentMessages.map(formatMessage).join("\n---\n")),
+		),
+	);
+	artifacts.push(
+		await writeArtifact(
+			artifactDir,
+			"summary.md",
+			"Current session summary and operator instructions",
+			redact(
+				[
+					`# Contribution prep context`,
+					`Source session: ${context.sessionId}`,
+					`Session file: ${context.sessionFile ?? "(none)"}`,
+					`Working directory: ${context.cwd}`,
+					options.customInstructions || context.customInstructions
+						? `Custom instructions: ${options.customInstructions ?? context.customInstructions}`
+						: "Custom instructions: (none)",
+				].join("\n"),
+			),
+		),
+	);
+
+	const gitHead = (await gitOutput(context.cwd, ["rev-parse", "HEAD"])) || null;
+	const files = await changedFiles(context.cwd);
+	artifacts.push(
+		await writeArtifact(artifactDir, "changed-files.txt", "Changed files from git status", redact(files.join("\n"))),
+	);
+	artifacts.push(
+		await writeArtifact(
+			artifactDir,
+			"git-diff.patch",
+			"Bounded redacted git diff",
+			redact(await gitOutput(context.cwd, ["diff", "--no-ext-diff"])),
+		),
+	);
+	artifacts.push(
+		await writeArtifact(
+			artifactDir,
+			"environment.md",
+			"Redacted environment and reproduction metadata",
+			redact(
+				[
+					`cwd: ${context.cwd}`,
+					`git_head: ${gitHead ?? "unknown"}`,
+					`platform: ${process.platform}`,
+					`arch: ${process.arch}`,
+					`bun: ${Bun.version}`,
+				].join("\n"),
+			),
+		),
+	);
+
+	const manifestPath = path.join(artifactDir, "manifest.json");
+	const workerPromptPath = path.join(artifactDir, "worker-prompt.md");
+	await Bun.write(workerPromptPath, `${buildContributionPrepWorkerPrompt(manifestPath)}\n`);
+
+	const manifest: ContributionPrepManifest = {
+		schema_version: CONTRIBUTION_PREP_SCHEMA_VERSION,
+		source_session_id: context.sessionId,
+		created_at: createdAt,
+		cwd: redact(context.cwd),
+		git_head: gitHead,
+		changed_files: files,
+		artifacts,
+		redactions: [...redactions.labels].sort(),
+		recommended_output: [
+			"title",
+			"problem summary",
+			"reproduction/context",
+			"proposed fix or implementation plan",
+			"affected files",
+			"tests to run",
+			"uncertainty / remaining risks",
+		],
+		worker_prompt_path: workerPromptPath,
+	};
+	await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+	let spawned = false;
+	if (options.spawnWorker) {
+		const spawn =
+			options.spawn ??
+			(async (args, cwd) => {
+				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
+			});
+		await spawn([process.execPath, "--no-skills", "--", `@${workerPromptPath}`], context.cwd);
+		spawned = true;
+	}
+
+	return { manifestPath, workerPromptPath, artifactDir, changedFiles: files, spawned };
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -793,8 +793,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
-		name: "contribution-prep",
-		description: "Dump redacted session context and spawn a fresh contribution-prep worker",
+		name: "contribute-pr",
+		aliases: ["contribution-prep"],
+		description: "Dump redacted session context and spawn a fresh contribute-pr worker",
 		inlineHint: "[focus instructions]",
 		allowArgs: true,
 		handle: async (command, runtime) => {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -793,6 +793,29 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "contribution-prep",
+		description: "Dump redacted session context and spawn a fresh contribution-prep worker",
+		inlineHint: "[focus instructions]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const result = await runtime.session.prepareContributionPrep({
+				customInstructions: command.args || undefined,
+				spawnWorker: true,
+			});
+			await runtime.output(
+				[
+					"Contribution prep artifacts written.",
+					`Manifest: ${result.manifestPath}`,
+					`Worker prompt: ${result.workerPromptPath}`,
+				].join("\n"),
+			);
+			return commandConsumed();
+		},
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.handleContributionPrepCommand(command.args || undefined);
+		},
+	},
+	{
 		name: "resume",
 		description: "Resume a different session",
 		handleTui: (_command, runtime) => {

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -92,6 +92,19 @@ describe("AgentSession handoff", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("prepares contribution artifacts without switching the active session", async () => {
+		const beforeSessionFile = session.sessionFile;
+		const beforeSessionId = session.sessionId;
+		const result = await session.prepareContributionPrep({ artifactRoot: path.join(tempDir.path(), "prep") });
+
+		expect(result.manifestPath).toEndWith("manifest.json");
+		expect(session.sessionFile).toBe(beforeSessionFile);
+		expect(session.sessionId).toBe(beforeSessionId);
+		expect(
+			sessionManager.getEntries().filter(entry => entry.type === "custom" && entry.customType === "handoff"),
+		).toHaveLength(0);
+	});
+
 	it("does not run auto-compaction after handoff turn completes", async () => {
 		const handoffText = "## Goal\nContinue from here";
 		const generateHandoffSpy = vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue(handoffText);

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -26,7 +26,7 @@ describe("GJC public CLI command surface", () => {
 			"team",
 			"ultragoal",
 			"ralplan",
-			"contribution-prep",
+			"contribute-pr",
 			"deep-interview",
 			"launch",
 		]);

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -26,6 +26,7 @@ describe("GJC public CLI command surface", () => {
 			"team",
 			"ultragoal",
 			"ralplan",
+			"contribution-prep",
 			"deep-interview",
 			"launch",
 		]);

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import type { AgentMessage } from "@gajae-code/agent-core";
+import { $ } from "bun";
 import { TempDir } from "@gajae-code/utils";
 import {
 	buildContributionPrepWorkerPrompt,
 	prepareContributionPrep,
 	redactContributionPrepText,
 } from "../src/session/contribution-prep";
+import { lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
 
 describe("contribution prep", () => {
 	it("redacts secrets, private endpoints, cookies, auth headers, and home paths", () => {
@@ -15,6 +17,9 @@ describe("contribution prep", () => {
 			"Cookie: sid=abc123; token=private",
 			"OPENAI_API_KEY=sk-providersecret123456789",
 			"callback http://127.0.0.1:8787/internal",
+			"classic ghp_abcdefghijklmnopqrstuvwxyz123456",
+			"oauth gho_abcdefghijklmnopqrstuvwxyz123456",
+			"fine github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890",
 			`${process.env.HOME ?? ""}/project/file.ts`,
 		].join("\n");
 
@@ -25,6 +30,9 @@ describe("contribution prep", () => {
 		expect(redacted).toContain("OPENAI_API_KEY=[REDACTED_SECRET]");
 		expect(redacted).toContain("[REDACTED_PRIVATE_ENDPOINT]");
 		expect(redacted).not.toContain("sk-testsecret123456789");
+		expect(redacted).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+		expect(redacted).not.toContain("gho_abcdefghijklmnopqrstuvwxyz123456");
+		expect(redacted).not.toContain("github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890");
 		expect(redacted).not.toContain(process.env.HOME ?? "__missing_home__");
 	});
 
@@ -32,6 +40,13 @@ describe("contribution prep", () => {
 		const tempDir = TempDir.createSync("@gjc-contribution-prep-");
 		try {
 			await Bun.write(path.join(tempDir.path(), "tracked.txt"), "changed");
+			await $`git init`.cwd(tempDir.path()).quiet();
+			await $`git add tracked.txt`.cwd(tempDir.path()).quiet();
+			await $`git -c user.email=test@example.com -c user.name=Test commit -m initial`.cwd(tempDir.path()).quiet();
+			await Bun.write(
+				path.join(tempDir.path(), "tracked.txt"),
+				"changed ghp_abcdefghijklmnopqrstuvwxyz123456 github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890\n",
+			);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "Failure uses Authorization: Bearer ghp_secretsecretsecret", timestamp: 1 },
 				{
@@ -82,6 +97,12 @@ describe("contribution prep", () => {
 			const transcript = await Bun.file(transcriptPath ?? "").text();
 			expect(transcript).toContain("[REDACTED_AUTH_HEADER]");
 			expect(transcript).toContain("[REDACTED_PRIVATE_ENDPOINT]");
+			const diffPath = manifest.artifacts.find(artifact => artifact.path.endsWith("git-diff.patch"))?.path;
+			expect(diffPath).toBeTruthy();
+			const gitDiff = await Bun.file(diffPath ?? "").text();
+			expect(gitDiff).toContain("[REDACTED_TOKEN]");
+			expect(gitDiff).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+			expect(gitDiff).not.toContain("github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890");
 		} finally {
 			tempDir.remove();
 		}
@@ -113,11 +134,57 @@ describe("contribution prep", () => {
 
 			expect(result.spawned).toBe(true);
 			expect(spawns).toHaveLength(1);
-			expect(spawns[0]?.args.some(arg => arg === `@${result.workerPromptPath}`)).toBe(true);
+			expect(spawns[0]?.args).toContain(`@${result.workerPromptPath}`);
+			expect(spawns[0]?.args).toContain("--no-skills");
+			expect(spawns[0]?.args[0]).toBeTruthy();
 			expect(spawns[0]?.cwd).toBe(tempDir.path());
 			expect(manifest.source_session_id).toBe("source-session");
 		} finally {
 			tempDir.remove();
 		}
+	});
+
+	it("resolves worker spawn argv through the GJC command and prompt file", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-real-spawn-");
+		try {
+			const child = Bun.spawn({
+				cmd: [process.execPath, "--version"],
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const exitCode = await child.exited;
+			expect(exitCode).toBe(0);
+
+			let observed: string[] = [];
+			await prepareContributionPrep(
+				{ sessionId: "source-session", cwd: tempDir.path(), messages: [] },
+				{
+					artifactRoot: path.join(tempDir.path(), "artifacts"),
+					spawnWorker: true,
+					spawn: async args => {
+						observed = args;
+						const probe = Bun.spawn({
+							cmd: [args[0] ?? process.execPath, "--version"],
+							stdout: "pipe",
+							stderr: "pipe",
+						});
+						expect(await probe.exited).toBe(0);
+					},
+				},
+			);
+
+			expect(observed).toContain("--no-skills");
+			expect(observed.some(arg => arg.startsWith("@") && arg.endsWith("worker-prompt.md"))).toBe(true);
+		} finally {
+			tempDir.remove();
+		}
+	});
+
+	it("advertises the issue-approved contribute-pr slash command with legacy alias", () => {
+		const command = lookupBuiltinSlashCommand("contribute-pr");
+		const legacy = lookupBuiltinSlashCommand("contribution-prep");
+
+		expect(command?.name).toBe("contribute-pr");
+		expect(legacy).toBe(command);
 	});
 });

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { AgentMessage } from "@gajae-code/agent-core";
+import { TempDir } from "@gajae-code/utils";
+import {
+	buildContributionPrepWorkerPrompt,
+	prepareContributionPrep,
+	redactContributionPrepText,
+} from "../src/session/contribution-prep";
+
+describe("contribution prep", () => {
+	it("redacts secrets, private endpoints, cookies, auth headers, and home paths", () => {
+		const text = [
+			"Authorization: Bearer sk-testsecret123456789",
+			"Cookie: sid=abc123; token=private",
+			"OPENAI_API_KEY=sk-providersecret123456789",
+			"callback http://127.0.0.1:8787/internal",
+			`${process.env.HOME ?? ""}/project/file.ts`,
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).toContain("Authorization: [REDACTED_AUTH_HEADER]");
+		expect(redacted).toContain("Cookie: [REDACTED_COOKIE]");
+		expect(redacted).toContain("OPENAI_API_KEY=[REDACTED_SECRET]");
+		expect(redacted).toContain("[REDACTED_PRIVATE_ENDPOINT]");
+		expect(redacted).not.toContain("sk-testsecret123456789");
+		expect(redacted).not.toContain(process.env.HOME ?? "__missing_home__");
+	});
+
+	it("writes a manifest with redacted file-pointer artifacts", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-");
+		try {
+			await Bun.write(path.join(tempDir.path(), "tracked.txt"), "changed");
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "Failure uses Authorization: Bearer ghp_secretsecretsecret", timestamp: 1 },
+				{
+					role: "assistant",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-test",
+					timestamp: 2,
+					content: [{ type: "text", text: "Check http://192.168.0.10:3000/private" }],
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+				},
+			];
+
+			const result = await prepareContributionPrep(
+				{
+					sessionId: "session-123",
+					cwd: tempDir.path(),
+					messages,
+					sessionFile: path.join(tempDir.path(), "session.jsonl"),
+				},
+				{ artifactRoot: path.join(tempDir.path(), "artifacts"), now: new Date("2026-05-31T00:00:00.000Z") },
+			);
+
+			const manifest = JSON.parse(await Bun.file(result.manifestPath).text()) as {
+				schema_version: number;
+				source_session_id: string;
+				artifacts: Array<{ path: string; description: string }>;
+				redactions: string[];
+				recommended_output: string[];
+				worker_prompt_path: string;
+			};
+			const transcriptPath = manifest.artifacts.find(artifact => artifact.path.endsWith("transcript.md"))?.path;
+			expect(manifest.schema_version).toBe(1);
+			expect(manifest.source_session_id).toBe("session-123");
+			expect(manifest.worker_prompt_path).toBe(result.workerPromptPath);
+			expect(manifest.recommended_output).toContain("uncertainty / remaining risks");
+			expect(manifest.redactions).toContain("auth_headers");
+			expect(manifest.redactions).toContain("private_endpoints");
+			expect(transcriptPath).toBeTruthy();
+			const transcript = await Bun.file(transcriptPath ?? "").text();
+			expect(transcript).toContain("[REDACTED_AUTH_HEADER]");
+			expect(transcript).toContain("[REDACTED_PRIVATE_ENDPOINT]");
+		} finally {
+			tempDir.remove();
+		}
+	});
+
+	it("worker prompt references the manifest instead of inlining transcript", () => {
+		const prompt = buildContributionPrepWorkerPrompt("/tmp/context/manifest.json");
+
+		expect(prompt).toContain("Manifest: /tmp/context/manifest.json");
+		expect(prompt).toContain("file pointers");
+		expect(prompt).toContain("Do not create GitHub issues");
+	});
+
+	it("can prepare a worker spawn without mutating source-session identity", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-spawn-");
+		try {
+			const spawns: Array<{ args: string[]; cwd: string }> = [];
+			const result = await prepareContributionPrep(
+				{ sessionId: "source-session", cwd: tempDir.path(), messages: [] },
+				{
+					artifactRoot: path.join(tempDir.path(), "artifacts"),
+					spawnWorker: true,
+					spawn: async (args, cwd) => {
+						spawns.push({ args, cwd });
+					},
+				},
+			);
+			const manifest = JSON.parse(await Bun.file(result.manifestPath).text()) as { source_session_id: string };
+
+			expect(result.spawned).toBe(true);
+			expect(spawns).toHaveLength(1);
+			expect(spawns[0]?.args.some(arg => arg === `@${result.workerPromptPath}`)).toBe(true);
+			expect(spawns[0]?.cwd).toBe(tempDir.path());
+			expect(manifest.source_session_id).toBe("source-session");
+		} finally {
+			tempDir.remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -76,4 +76,43 @@ describe("/handoff command", () => {
 		expect(ctx.editor.onEscape).toBe(originalOnEscape);
 		expect(ctx.session.handoff).toHaveBeenCalledWith("focus on tests");
 	});
+
+	it("runs contribution-prep without rebuilding or switching the active chat", async () => {
+		const statusContainer = createContainer();
+		const chatContainer = createContainer();
+		const requestRender = vi.fn();
+		const ctx = {
+			sessionManager: { getEntries: () => [{ type: "message" }, { type: "message" }] },
+			session: {
+				prepareContributionPrep: vi.fn(async () => ({
+					manifestPath: "/tmp/prep/manifest.json",
+					workerPromptPath: "/tmp/prep/worker-prompt.md",
+					artifactDir: "/tmp/prep",
+					changedFiles: [],
+					spawned: true,
+				})),
+			},
+			statusContainer,
+			chatContainer,
+			ui: { requestRender },
+			editor: { setText: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			statusLine: { invalidate: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		await controller.handleContributionPrepCommand("focus on repro");
+
+		expect(ctx.session.prepareContributionPrep).toHaveBeenCalledWith({
+			customInstructions: "focus on repro",
+			spawnWorker: true,
+		});
+		expect(ctx.rebuildChatFromMessages).not.toHaveBeenCalled();
+		expect(ctx.statusLine.invalidate).not.toHaveBeenCalled();
+		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("Manifest: /tmp/prep/manifest.json"));
+		expect(chatContainer.children).toHaveLength(1);
+		expect(requestRender).toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
- Adds /contribution-prep and gjc contribution-prep as command/session orchestration, not a workflow skill.
- Writes redacted context artifacts plus manifest.json with source session, git, changed-file, artifact, redaction, recommended output, and worker prompt metadata.
- Spawns/prepares a fresh worker from a file-pointer prompt and leaves the active session untouched.

Fixes #64

## Verification
- bun test packages/coding-agent/test/contribution-prep.test.ts packages/coding-agent/test/agent-session-handoff.test.ts packages/coding-agent/test/modes/controllers/handoff-command.test.ts packages/coding-agent/test/cli-command-surface.test.ts
- bun run check:ts