### PR TITLE
fix(team): address PR #112 review blockers (rebased from #120)

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -218,6 +218,7 @@ Semantics:
 - `.gjc/state/team/<team>/monitor-snapshot.json`
 - `.gjc/state/team/<team>/integration-report.md`
 - `.gjc/state/team/<team>/tasks/task-1.json`
+- `.gjc/state/team/<team>/evidence/tasks/task-1.json`
 - `.gjc/state/team/<team>/mailbox/worker-1/<message-id>.json`
 - `.gjc/state/team/<team>/mailbox/worker-1.json` (legacy compatibility view)
 - `.gjc/state/team/<team>/notifications/<notification-id>.json`
@@ -230,14 +231,16 @@ Semantics:
 Use `gjc team api` for machine-readable task lifecycle operations.
 
 ```bash
+gjc team api worker-startup-ack --input '{"team_name":"my-team","worker_id":"worker-1","protocol_version":"1"}' --json
 gjc team api claim-task --input '{"team_name":"my-team","worker_id":"worker-1"}' --json
-gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","claim_token":"<claim-token>"}' --json
+gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","worker_id":"worker-1","claim_token":"<claim-token>","evidence":"summary of completed work and validation"}' --json
 ```
 
 Canonical worker lifecycle operations:
 
+- `worker-startup-ack` before task work
 - `claim-task`
-- `transition-task-status`
+- `transition-task-status` with the claim token, worker id, and completion evidence
 - `release-task-claim`
 
 GJC-team interop operations are also available for mailbox, native notification, worker heartbeat/status, startup ACK, events, monitor snapshots, approvals, and shutdown request/ack flows; run `gjc team api --help` for the full operation list.

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -431,6 +431,9 @@ function safePathSegment(kind: string, value: string): string {
 function taskPath(dir: string, taskId: string): string {
 	return path.join(dir, "tasks", `${safePathSegment("task_id", taskId)}.json`);
 }
+function taskEvidencePath(dir: string, taskId: string): string {
+	return path.join(dir, "evidence", "tasks", `${safePathSegment("task_id", taskId)}.json`);
+}
 function mailboxPath(dir: string, worker: string): string {
 	return path.join(dir, "mailbox", `${safePathSegment("worker_id", worker)}.json`);
 }
@@ -615,16 +618,31 @@ async function resolveGjcTeamSnapshotPhase(
 	return (await hasPendingGjcTeamIntegration(dir, config, monitor)) ? "awaiting_integration" : storedPhase;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value != null;
+}
+function isGjcTeamTaskRecord(value: unknown): value is GjcTeamTask {
+	return (
+		isRecord(value) &&
+		typeof value.id === "string" &&
+		typeof value.status === "string" &&
+		(isGjcTeamTaskStatus(value.status) || value.status === "complete") &&
+		(typeof value.subject === "string" || typeof value.title === "string") &&
+		(typeof value.description === "string" || typeof value.objective === "string")
+	);
+}
+function isGjcTeamTaskFile(entry: { isFile(): boolean; name: string }): boolean {
+	return entry.isFile() && entry.name.endsWith(".json") && !entry.name.endsWith(".evidence.json");
+}
+
 async function readTasks(dir: string): Promise<GjcTeamTask[]> {
 	try {
 		const entries = await fs.readdir(path.join(dir, "tasks"), { withFileTypes: true });
 		const tasks = await Promise.all(
-			entries
-				.filter(entry => entry.isFile() && entry.name.endsWith(".json"))
-				.map(entry => readJsonFile<GjcTeamTask>(path.join(dir, "tasks", entry.name))),
+			entries.filter(isGjcTeamTaskFile).map(entry => readJsonFile<unknown>(path.join(dir, "tasks", entry.name))),
 		);
 		return tasks
-			.filter((task): task is GjcTeamTask => task != null)
+			.filter(isGjcTeamTaskRecord)
 			.map(normalizeTask)
 			.sort((a, b) => a.id.localeCompare(b.id));
 	} catch (error) {
@@ -831,6 +849,7 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 		`Team state root: ${config.state_root}.`,
 		workspace,
 		`Task: ${config.task}`,
+		`Before claiming work, send startup ACK: gjc team api worker-startup-ack --input '{"team_name":"${config.team_name}","worker_id":"${worker.id}","protocol_version":"1"}' --json.`,
 		`Use gjc team api claim-task/transition-task-status with this worker id, record evidence, and do not mutate leader-owned goal state.`,
 	].join("\n");
 	const env = [
@@ -2186,7 +2205,7 @@ export async function transitionGjcTeamTaskStatus(
 	};
 	await writeTask(dir, updated);
 	if (terminal && evidence)
-		await writeJsonFile(path.join(dir, "tasks", `${taskId}.evidence.json`), {
+		await writeJsonFile(taskEvidencePath(dir, taskId), {
 			task_id: taskId,
 			worker: workerId ?? task.claim.owner,
 			evidence,
@@ -2739,7 +2758,9 @@ export async function executeGjcTeamApiOperation(
 ): Promise<unknown> {
 	const teamName = String(input.team_name ?? input.teamName ?? "").trim();
 	if (!teamName) throw new Error("missing_team_name");
-	const worker = String(input.worker ?? input.worker_id ?? input.workerId ?? "worker-1");
+	const workerInput = input.worker ?? input.worker_id ?? input.workerId;
+	const worker = String(workerInput ?? "worker-1");
+	const explicitWorker = workerInput == null ? undefined : String(workerInput);
 	switch (operation) {
 		case "list-tasks":
 			return { tasks: await listGjcTeamTasks(teamName, cwd, env) };
@@ -2787,7 +2808,7 @@ export async function executeGjcTeamApiOperation(
 					cwd,
 					env,
 					typeof input.claim_token === "string" ? input.claim_token : undefined,
-					worker,
+					explicitWorker,
 					typeof input.evidence === "string"
 						? input.evidence
 						: typeof input.result === "string"

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -301,6 +301,9 @@ describe("native gjc team runtime", () => {
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
 		expect(tmuxLog).toContain("split-window -h -t %1 -d -P -F #{pane_id}");
+		expect(tmuxLog).toContain("worker-startup-ack");
+		expect(tmuxLog).toContain("protocol_version");
+		expect(tmuxLog).toContain("claim-task/transition-task-status");
 		expect(tmuxLog).toContain("select-layout -t test-session:0 main-vertical");
 		expect(tmuxLog).toContain("set-option -t test-session:0 mouse on");
 		expect(tmuxLog).toContain("set-option -t test-session:0 set-clipboard on");
@@ -541,6 +544,64 @@ describe("native gjc team runtime", () => {
 		const stopped = await shutdownGjcTeam("life-team", cleanupRoot, { PATH: "" });
 		expect(stopped.phase).toBe("complete");
 		expect(stopped.workers[0]?.status).toBe("stopped");
+	});
+
+	it("keeps terminal evidence out of task listings and honors claim tokens without implicit worker defaults", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Complete with evidence",
+			teamName: "evidence-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+		const stateDir = path.join(cleanupRoot, ".gjc", "state", "team", "evidence-team");
+
+		const workerTwoClaim = await claimGjcTeamTask("evidence-team", "worker-2", cleanupRoot, { PATH: "" }, "task-2");
+		expect(workerTwoClaim.ok).toBe(true);
+		await executeGjcTeamApiOperation(
+			"transition-task-status",
+			{
+				team_name: "evidence-team",
+				task_id: "task-2",
+				to: "completed",
+				claim_token: workerTwoClaim.claim_token,
+				evidence: "worker-2 completed the task",
+			},
+			cleanupRoot,
+			{ PATH: "" },
+		);
+
+		expect(await Bun.file(path.join(stateDir, "evidence", "tasks", "task-2.json")).exists()).toBe(true);
+		expect(await Bun.file(path.join(stateDir, "tasks", "task-2.evidence.json")).exists()).toBe(false);
+		await Bun.write(
+			path.join(stateDir, "tasks", "task-2.evidence.json"),
+			`${JSON.stringify({ task_id: "task-2", evidence: "legacy colocated evidence" }, null, 2)}\n`,
+		);
+		const listed = (await executeGjcTeamApiOperation("list-tasks", { team_name: "evidence-team" }, cleanupRoot, {
+			PATH: "",
+		})) as { tasks: Array<{ id: string; status: string }> };
+		expect(listed.tasks.map(task => task.id)).toEqual(["task-1", "task-2"]);
+		expect(listed.tasks.find(task => task.id === "task-2")?.status).toBe("completed");
+
+		const workerOneClaim = await claimGjcTeamTask("evidence-team", "worker-1", cleanupRoot, { PATH: "" }, "task-1");
+		expect(workerOneClaim.ok).toBe(true);
+		await expect(
+			executeGjcTeamApiOperation(
+				"transition-task-status",
+				{
+					team_name: "evidence-team",
+					task_id: "task-1",
+					to: "failed",
+					claim_token: workerOneClaim.claim_token,
+					worker_id: "worker-2",
+				},
+				cleanupRoot,
+				{ PATH: "" },
+			),
+		).rejects.toThrow("claim_owner_mismatch:task-1");
 	});
 
 	it("allows only one worker to claim a task under concurrent claim attempts", async () => {


### PR DESCRIPTION
Rebased version of #120 (by @PeterPonyu) onto current `dev` after #112 squash-merged.

The original PR was reopened and retargeted to `dev`, which surfaced a topology conflict from the squash. To avoid asking the external contributor to rebase manually, the head commit `f6f5502` was cherry-picked onto `dev` with authorship preserved (`PeterPonyu <fuzeyu99@126.com>`).

Diff is identical to #120 head: +94 / -9 across:
- `packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md`
- `packages/coding-agent/src/gjc-runtime/team-runtime.ts`
- `packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`

Verdict already issued on #120: APPROVE — clean fix for the validated P0 blockers from #112 review (`worker-startup-ack` nudge, evidence path moved to `evidence/tasks/`, no implicit `worker-1` default in `transition-task-status`).

Closes #120.
