### PR TITLE
ci: use gajae self-hosted linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
    # in that case, so the canary's retention window (see build-native action) is the
    # effective TTL of a cache hit before main rebuilds anyway.
    rust-hash:
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       outputs:
          hash: ${{ steps.compute.outputs.hash }}
          run-id: ${{ steps.find.outputs.run-id }}
@@ -76,7 +76,7 @@ jobs:
 
    # Fast lint + type check (no Rust, no native build needed)
    check:
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
          - uses: oven-sh/setup-bun@v2
@@ -96,7 +96,7 @@ jobs:
    native_linux:
       needs: [rust-hash]
       if: ${{ startsWith(github.ref, 'refs/tags/v') || needs.rust-hash.outputs.run-id == '' }}
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       strategy:
          fail-fast: false
          matrix:
@@ -139,7 +139,7 @@ jobs:
               save_cache: ${{ github.event_name == 'push' && ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') || startsWith(github.ref, 'refs/tags/v')) }}
 
    test:
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       needs: [native_linux, rust-hash]
       if: ${{ !cancelled() && !startsWith(github.ref, 'refs/tags/v') && needs.native_linux.result != 'failure' }}
       timeout-minutes: 30
@@ -190,7 +190,7 @@ jobs:
            run: bun run ci:test:smoke
 
    install_methods:
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
          - uses: oven-sh/setup-bun@v2
@@ -315,7 +315,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs.release_binary.result == 'success' }}
       needs: [release_binary]
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       permissions:
          contents: write
       steps:
@@ -358,7 +358,7 @@ jobs:
          needs.release_github_verify.result == 'success' &&
          !inputs.skip_npm }}
       needs: [release_binary, release_github_verify, rust-hash]
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
          - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
    # in that case, so the canary's retention window (see build-native action) is the
    # effective TTL of a cache hit before main rebuilds anyway.
    rust-hash:
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       outputs:
          hash: ${{ steps.compute.outputs.hash }}
@@ -76,6 +77,7 @@ jobs:
 
    # Fast lint + type check (no Rust, no native build needed)
    check:
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
@@ -95,7 +97,8 @@ jobs:
    # unless rust-hash found a cached run. Tags always rebuild for fresh artifacts.
    native_linux:
       needs: [rust-hash]
-      if: ${{ startsWith(github.ref, 'refs/tags/v') || needs.rust-hash.outputs.run-id == '' }}
+      if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+         (startsWith(github.ref, 'refs/tags/v') || needs.rust-hash.outputs.run-id == '') }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       strategy:
          fail-fast: false
@@ -141,7 +144,8 @@ jobs:
    test:
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       needs: [native_linux, rust-hash]
-      if: ${{ !cancelled() && !startsWith(github.ref, 'refs/tags/v') && needs.native_linux.result != 'failure' }}
+      if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+         !startsWith(github.ref, 'refs/tags/v') && needs.native_linux.result != 'failure' }}
       timeout-minutes: 30
       steps:
          - uses: actions/checkout@v4
@@ -190,6 +194,7 @@ jobs:
            run: bun run ci:test:smoke
 
    install_methods:
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
@@ -312,7 +317,9 @@ jobs:
               path: ${{ matrix.binary_path }}
 
    release-github:
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
+      if: ${{ (github.event_name != 'pull_request' ||
+         github.event.pull_request.head.repo.full_name == github.repository) &&
+         startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs.release_binary.result == 'success' }}
       needs: [release_binary]
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
@@ -353,7 +360,9 @@ jobs:
               HOME="$runtime_dir/home" XDG_DATA_HOME="$runtime_dir/xdg" ./gjc-darwin-arm64 --version
 
    release-npm:
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
+      if: ${{ (github.event_name != 'pull_request' ||
+         github.event.pull_request.head.repo.full_name == github.repository) &&
+         startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs.release_binary.result == 'success' &&
          needs.release_github_verify.result == 'success' &&
          !inputs.skip_npm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"
@@ -149,6 +152,9 @@ jobs:
       timeout-minutes: 30
       steps:
          - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"
@@ -198,6 +204,9 @@ jobs:
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"
@@ -275,6 +284,9 @@ jobs:
          contents: read
       steps:
          - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"
@@ -370,6 +382,9 @@ jobs:
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
            run: |
               sudo apt-get update
               sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
-              sudo ln -s $(which fdfind) /usr/local/bin/fd
+              sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile
          - name: Resolve native source run
@@ -220,7 +220,7 @@ jobs:
            run: |
               sudo apt-get update
               sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
-              sudo ln -s $(which fdfind) /usr/local/bin/fd
+              sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile
          - name: Install method smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
          - name: Install system deps
            run: |
               sudo apt-get update
-              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
+              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
               sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile
@@ -228,7 +228,7 @@ jobs:
          - name: Install system deps
            run: |
               sudo apt-get update
-              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
+              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
               sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
    affected:
       name: Affected path validation
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       timeout-minutes: 30
       env:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -47,7 +47,7 @@ jobs:
          - name: Install system deps
            run: |
               sudo apt-get update
-              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
+              sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
               sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -24,6 +24,9 @@ jobs:
          - uses: actions/checkout@v4
            with:
               fetch-depth: 0
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
          - uses: oven-sh/setup-bun@v2
            with:
               bun-version: "1.3"

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
    affected:
       name: Affected path validation
-      runs-on: ubuntu-22.04
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       timeout-minutes: 30
       env:
          GITHUB_EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -45,7 +45,7 @@ jobs:
            run: |
               sudo apt-get update
               sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
-              sudo ln -s $(which fdfind) /usr/local/bin/fd
+              sudo ln -sf $(which fdfind) /usr/local/bin/fd
               sudo ln -sf /usr/bin/convert /usr/local/bin/magick
          - run: bun install --frozen-lockfile
          - name: Run affected path checks and tests

--- a/scripts/check-workflow-yaml.ts
+++ b/scripts/check-workflow-yaml.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+import { $ } from "bun";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const workflowDir = path.join(repoRoot, ".github", "workflows");
+const entries = await fs.readdir(workflowDir, { withFileTypes: true });
+const workflowFiles = entries
+	.filter(entry => entry.isFile() && /\.ya?ml$/i.test(entry.name))
+	.map(entry => path.join(workflowDir, entry.name))
+	.sort();
+
+for (const workflowFile of workflowFiles) {
+	const relativePath = path.relative(repoRoot, workflowFile);
+	const result = await $`bunx --bun --package yaml@2 yaml valid < ${workflowFile}`.cwd(repoRoot).quiet().nothrow();
+	if (result.exitCode !== 0) {
+		console.error(`Failed to parse ${relativePath}:`);
+		console.error(result.stderr.toString().trim() || result.stdout.toString().trim());
+		process.exit(result.exitCode || 1);
+	}
+	console.log(`parsed ${relativePath}`);
+}

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -91,11 +91,16 @@ async function resolveBaseRef(): Promise<string> {
 	const baseSha = Bun.env.GITHUB_BASE_SHA?.trim();
 	const baseRef = Bun.env.GITHUB_BASE_REF?.trim();
 
+	if (eventName === "pull_request" && baseRef) {
+		const mergeBase = await $`git merge-base HEAD ${`origin/${baseRef}`}`.cwd(repoRoot).quiet().nothrow();
+		if (mergeBase.exitCode === 0) {
+			const value = mergeBase.stdout.toString().trim();
+			if (value !== "") return value;
+		}
+		return `origin/${baseRef}`;
+	}
 	if (baseSha && !ZERO_SHA.test(baseSha)) {
 		return baseSha;
-	}
-	if (eventName === "pull_request" && baseRef) {
-		return `origin/${baseRef}`;
 	}
 	if (before && !ZERO_SHA.test(before)) {
 		return `${before}..${Bun.env.GITHUB_SHA?.trim() || "HEAD"}`;

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -180,6 +180,7 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 	const wrapperChanged = paths.some(isUnscopedWrapperPath);
 	const toolingScriptChanged = paths.some(isToolingScriptPath);
 	const needsNativeRuntime = paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace;
+	const workflowHarnessOnly = paths.length > 0 && paths.every(isWorkflowHarnessPath);
 	const ciOnly = paths.length > 0 && paths.every(changedPath => changedPath.startsWith(".github/"));
 
 	if (needsNativeRuntime) {
@@ -190,7 +191,7 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
 		addNativeBuild(tasks);
 		add(tasks, "root-test", "Root workspace TypeScript tests", ["bun", "run", "test:ts"]);
-	} else if (!ciOnly) {
+	} else if (!ciOnly && !workflowHarnessOnly) {
 		const affectedPackages = expandWithDependents(touchedPackages, packages);
 		if (affectedPackages.some(workspacePackage => workspacePackage.manifest.scripts?.test)) {
 			addNativeBuild(tasks);
@@ -205,7 +206,7 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 		}
 	}
 
-	if (toolingScriptChanged && !fullWorkspace && !ciOnly) {
+	if (toolingScriptChanged && !fullWorkspace && !ciOnly && !workflowHarnessOnly) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
 	}
 	if (wrapperChanged) {
@@ -349,6 +350,10 @@ function isWorkflowOrScriptPath(changedPath: string): boolean {
 
 function isWorkflowPath(changedPath: string): boolean {
 	return changedPath.startsWith(".github/workflows/");
+}
+
+function isWorkflowHarnessPath(changedPath: string): boolean {
+	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/check-workflow-yaml.ts";
 }
 
 function isToolingScriptPath(changedPath: string): boolean {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -350,7 +350,7 @@ function isCodingAgentRuntimePath(changedPath: string): boolean {
 }
 
 function isWorkflowOrScriptPath(changedPath: string): boolean {
-	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts";
+	return isWorkflowHarnessPath(changedPath);
 }
 
 function isWorkflowPath(changedPath: string): boolean {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -236,6 +236,9 @@ function planTasks(paths: readonly string[], packages: readonly WorkspacePackage
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {
 		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
+		if (paths.some(isWorkflowPath)) {
+			add(tasks, "workflow-yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
+		}
 	}
 
 	return Array.from(tasks.values());
@@ -341,7 +344,11 @@ function isCodingAgentRuntimePath(changedPath: string): boolean {
 }
 
 function isWorkflowOrScriptPath(changedPath: string): boolean {
-	return changedPath.startsWith(".github/workflows/") || changedPath === "scripts/ci-dev-affected.ts";
+	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts";
+}
+
+function isWorkflowPath(changedPath: string): boolean {
+	return changedPath.startsWith(".github/workflows/");
 }
 
 function isToolingScriptPath(changedPath: string): boolean {


### PR DESCRIPTION
Switch Linux GitHub Actions jobs from GitHub-hosted Ubuntu runners to the trusted gajae self-hosted runner label. macOS/Windows jobs are left unchanged. External fork PRs are excluded at job level before using the self-hosted runner.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*