### PR TITLE
feat(coding-agent): add skill tool for agent-initiated skill chaining

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a built-in `skill` tool so the agent can chain into another loaded skill on its next turn. Mirrors `/skill:<name>` typing and subagent `autoloadSkills` by dispatching the chained skill's SKILL.md as a user-attribution custom message; controlled by the new `skill.enabled` setting (default true).
+
 ## [0.2.2] - 2026-05-31
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1940,6 +1940,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"skill.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			label: "Skill",
+			description: "Enable the skill tool so the agent can chain into another available skill on its next turn",
+		},
+	},
+
 	// Fetching and browser
 	"fetch.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -1,0 +1,27 @@
+Invoke another available skill as the next turn.
+
+<conditions>
+- A SKILL document instructs you to chain into another skill on completion (e.g. ralplan → ultragoal)
+- You finished one skill's workflow and the next step requires another skill's full prompt context
+</conditions>
+
+<instruction>
+- `name` is the skill name as it appears in `/skill:<name>` (e.g. `ralplan`, `ultragoal`, `team`, `deep-interview`)
+- `args` is the free-form argument string the skill would receive after `/skill:<name>` on the command line
+- The skill's SKILL.md is queued as a user-attribution message and activates on the **next** turn — current turn finishes first
+- Call once per chained skill. To chain `A → B → C`, A's skill calls `skill(B)`, then B's skill (running next turn) calls `skill(C)`
+</instruction>
+
+<critical>
+- Do NOT use this tool to "remind yourself" of a skill you're already running. The current SKILL.md is already in your context.
+- Do NOT chain into the same skill recursively. If a skill's flow needs another iteration, follow its in-document instructions.
+- The chained skill's planning/execution-boundary rules still apply. Chaining does not grant execution approval.
+</critical>
+
+<examples>
+# Hand off from ralplan to ultragoal after an approved plan
+{"name": "ultragoal", "args": "track execution of .gjc/plans/ralplan/<run-id>/pending-approval.md"}
+
+# Trigger deep-interview with no arguments
+{"name": "deep-interview"}
+</examples>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1195,6 +1195,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					attribution: "agent",
 					timestamp: Date.now(),
 				}),
+			sendCustomMessage: (msg, opts) => session.sendCustomMessage(msg, opts),
 			peekQueueInvoker: () => session.peekQueueInvoker(),
 			peekStandingResolveHandler: () => session.peekStandingResolveHandler(),
 			setStandingResolveHandler: handler => session.setStandingResolveHandler(handler),

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -47,6 +47,7 @@ import { ResolveTool } from "./resolve";
 import { reportFindingTool } from "./review";
 import { SearchTool } from "./search";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
+import { SkillTool } from "./skill";
 import { loadSshTool } from "./ssh";
 import { SubagentTool } from "./subagent";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
@@ -84,6 +85,7 @@ export * from "./resolve";
 export * from "./review";
 export * from "./search";
 export * from "./search-tool-bm25";
+export * from "./skill";
 export * from "./ssh";
 export * from "./subagent";
 export * from "./todo-write";
@@ -246,6 +248,12 @@ export interface ToolSession {
 
 	/** Queue a hidden message to be injected at the next agent turn. */
 	queueDeferredMessage?(message: CustomMessage): void;
+	/** Dispatch a custom message through the active session. Used by the `skill`
+	 *  tool to chain another skill prompt as a queued next-turn message. */
+	sendCustomMessage?(
+		message: Pick<CustomMessage, "customType" | "content" | "display" | "details" | "attribution">,
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	): Promise<void>;
 	/** Get the active OpenTelemetry config so subagent dispatch can forward
 	 *  the parent's tracer/hooks with the subagent's own identity stamped. */
 	getTelemetry?: () => AgentTelemetryConfig | undefined;
@@ -308,6 +316,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	retain: HindsightRetainTool.createIf,
 	recall: HindsightRecallTool.createIf,
 	reflect: HindsightReflectTool.createIf,
+	skill: SkillTool.createIf,
 	goal: s => new GoalTool(s),
 };
 
@@ -464,6 +473,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		// search_tool_bm25 is allowed when either legacy mcp.discoveryMode or new tools.discoveryMode is active.
 		if (name === "search_tool_bm25") return discoveryActive;
 		if (name === "calc") return session.settings.get("calc.enabled");
+		if (name === "skill") return session.settings.get("skill.enabled");
 		if (name === "browser") return session.settings.get("browser.enabled");
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
 		if (name === "irc") {

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -1,0 +1,111 @@
+/**
+ * Skill Tool — agent-initiated skill chaining.
+ *
+ * Lets a skill prompt the agent to hand off to another available skill once the
+ * current turn completes. The chained skill's SKILL.md is dispatched through
+ * the same custom-message path used by `/skill:<name>` typing and the
+ * subagent `autoloadSkills` mechanic — queued as a user-attribution message
+ * delivered with `deliverAs: "nextTurn"`, so the current skill finishes
+ * cleanly before the next one activates.
+ */
+
+import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
+import { prompt, untilAborted } from "@gajae-code/utils";
+import * as z from "zod/v4";
+import { buildSkillPromptMessage } from "../extensibility/skills";
+import skillDescription from "../prompts/tools/skill.md" with { type: "text" };
+import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
+import type { ToolSession } from ".";
+import { ToolError } from "./tool-errors";
+
+const skillSchema = z.object({
+	name: z.string().describe("skill name as it appears in /skill:<name>"),
+	args: z.string().describe("argument string passed to the skill").optional(),
+});
+
+type SkillToolInput = z.infer<typeof skillSchema>;
+
+export interface SkillToolDetails {
+	name: string;
+	path: string;
+	args?: string;
+	lineCount: number;
+}
+
+export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails> {
+	readonly name = "skill";
+	readonly label = "Skill";
+	readonly summary = "Chain into another available skill on the next turn";
+	readonly loadMode = "discoverable";
+	readonly description: string;
+	readonly parameters = skillSchema;
+	readonly strict = true;
+
+	readonly #session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+		this.description = prompt.render(skillDescription);
+	}
+
+	static createIf(session: ToolSession): SkillTool | null {
+		// The tool can only chain when the session can deliver the queued
+		// next-turn message. Without `sendCustomMessage` (e.g. minimal tool
+		// harnesses in tests) there is nothing useful to do.
+		if (!session.sendCustomMessage) return null;
+		const skills = session.skills ?? [];
+		if (skills.length === 0) return null;
+		return new SkillTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		input: SkillToolInput,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<SkillToolDetails>> {
+		return untilAborted(signal, async () => {
+			const sendCustomMessage = this.#session.sendCustomMessage;
+			if (!sendCustomMessage) {
+				throw new ToolError("skill tool: session has no custom-message bridge");
+			}
+			const skills = this.#session.skills ?? [];
+			const requestedName = input.name.trim();
+			if (!requestedName) {
+				throw new ToolError("skill tool: `name` is required");
+			}
+			const skill = skills.find(s => s.name === requestedName);
+			if (!skill) {
+				const available = skills.map(s => s.name).sort();
+				const hint = available.length > 0 ? ` Available: ${available.join(", ")}` : "";
+				throw new ToolError(`skill tool: unknown skill "${requestedName}".${hint}`);
+			}
+
+			const args = (input.args ?? "").trim();
+			const built = await buildSkillPromptMessage(skill, args);
+
+			await sendCustomMessage(
+				{
+					customType: SKILL_PROMPT_MESSAGE_TYPE,
+					content: built.message,
+					display: true,
+					details: built.details,
+					attribution: "user",
+				},
+				{ deliverAs: "nextTurn", triggerTurn: false },
+			);
+
+			const summary = args
+				? `Queued /skill:${skill.name} ${args} for the next turn.`
+				: `Queued /skill:${skill.name} for the next turn.`;
+			return {
+				content: [{ type: "text", text: summary }],
+				details: {
+					name: skill.name,
+					path: skill.filePath,
+					args: args || undefined,
+					lineCount: built.details.lineCount,
+				},
+			};
+		});
+	}
+}

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -72,6 +72,17 @@ const toolSession: ToolSession = {
 	activateDiscoveredTools: async names => names,
 	getGoalModeState: () => activeGoalState,
 	getGoalRuntime: () => goalRuntime,
+	skills: [
+		{
+			name: "stub-skill",
+			description: "stub skill for tool metadata coverage",
+			filePath: "/tmp/stub-skill/SKILL.md",
+			baseDir: "/tmp/stub-skill",
+			source: "test",
+			content: "stub",
+		},
+	],
+	sendCustomMessage: async () => {},
 };
 
 async function getToolMetadata(): Promise<Map<string, { loadMode?: string; summary?: string }>> {

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { Skill } from "@gajae-code/coding-agent/extensibility/skills";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@gajae-code/coding-agent/session/messages";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
+import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
+
+async function makeSkill(name: string, content: string): Promise<Skill> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), `skill-tool-${name}-`));
+	const filePath = path.join(dir, "SKILL.md");
+	await writeFile(filePath, content, "utf8");
+	return {
+		name,
+		description: `${name} test skill`,
+		filePath,
+		baseDir: dir,
+		source: "test",
+		content,
+	};
+}
+
+interface CapturedSend {
+	message: { customType: string; content: unknown; details?: unknown; attribution?: string };
+	options?: { deliverAs?: string; triggerTurn?: boolean };
+}
+
+function createSession(skills: Skill[], capture: CapturedSend[]): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		skills,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		sendCustomMessage: async (message, options) => {
+			capture.push({ message, options });
+		},
+	};
+}
+
+describe("SkillTool", () => {
+	it("createIf returns null when no skills are loaded", () => {
+		const session: ToolSession = {
+			cwd: "/tmp",
+			hasUI: false,
+			skills: [],
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+			sendCustomMessage: async () => {},
+		};
+		expect(SkillTool.createIf(session)).toBeNull();
+	});
+
+	it("createIf returns null when session lacks sendCustomMessage", async () => {
+		const ultragoal = await makeSkill("ultragoal", "# Ultragoal\nBody");
+		const session: ToolSession = {
+			cwd: "/tmp",
+			hasUI: false,
+			skills: [ultragoal],
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		expect(SkillTool.createIf(session)).toBeNull();
+	});
+
+	it("queues the chained skill as a next-turn user message", async () => {
+		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\n# Ultragoal\nTrack execution.");
+		const captured: CapturedSend[] = [];
+		const session = createSession([ultragoal], captured);
+		const tool = SkillTool.createIf(session);
+		expect(tool).not.toBeNull();
+
+		const result = await tool!.execute("call-1", { name: "ultragoal", args: "go" });
+		const firstBlock = result.content[0];
+		expect(firstBlock?.type).toBe("text");
+		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain("ultragoal");
+		expect(result.details?.name).toBe("ultragoal");
+		expect(result.details?.args).toBe("go");
+
+		expect(captured).toHaveLength(1);
+		const sent = captured[0]!;
+		expect(sent.message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(sent.message.attribution).toBe("user");
+		expect(sent.options).toEqual({ deliverAs: "nextTurn", triggerTurn: false });
+
+		const content = sent.message.content as string;
+		expect(content).toContain("# Ultragoal");
+		expect(content).toContain("Track execution.");
+		expect(content).toContain("User: go");
+	});
+
+	it("omits the User: line when args are absent or whitespace", async () => {
+		const di = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const captured: CapturedSend[] = [];
+		const session = createSession([di], captured);
+		const tool = SkillTool.createIf(session)!;
+		await tool.execute("call-1", { name: "deep-interview", args: "   " });
+		const content = captured[0]!.message.content as string;
+		expect(content).not.toContain("User:");
+	});
+
+	it("throws a ToolError naming the available skills when the name is unknown", async () => {
+		const a = await makeSkill("ralplan", "ralplan body");
+		const b = await makeSkill("team", "team body");
+		const captured: CapturedSend[] = [];
+		const session = createSession([a, b], captured);
+		const tool = SkillTool.createIf(session)!;
+		await expect(tool.execute("call-1", { name: "does-not-exist" })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-1", { name: "does-not-exist" })).rejects.toThrow(/Available: ralplan, team/);
+		expect(captured).toHaveLength(0);
+	});
+
+	it("rejects empty name", async () => {
+		const a = await makeSkill("ralplan", "body");
+		const captured: CapturedSend[] = [];
+		const session = createSession([a], captured);
+		const tool = SkillTool.createIf(session)!;
+		await expect(tool.execute("call-1", { name: "   " })).rejects.toBeInstanceOf(ToolError);
+		expect(captured).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Adds a new built-in `skill` tool so an active skill can hand off to another loaded skill on its next turn. Mirrors the user-typed `/skill:<name>` and subagent `autoloadSkills` mechanic: the chained skill's `SKILL.md` is dispatched through `session.sendCustomMessage` with `deliverAs: \"nextTurn\", triggerTurn: false`, attributed as a user message.

## Why

The four bundled workflow skills already document handoffs between each other (e.g. ralplan → ultragoal, deep-interview → ralplan), but until now the agent could not initiate those chains itself — only a user typing `/skill:<name>` or a subagent's `autoloadSkills` frontmatter could. This tool unlocks model-initiated chaining without changing the existing skill activation surface.

Usage example from inside the ralplan workflow:

```json
skill({"name": "ultragoal", "args": "track execution of .gjc/plans/ralplan/<run-id>/pending-approval.md"})
```

The current turn finishes cleanly; ultragoal's SKILL.md activates on the next turn.

## How it works

- `SkillTool` (`packages/coding-agent/src/tools/skill.ts`) resolves `input.name` against `session.skills`, builds the prompt via the existing `buildSkillPromptMessage` helper, and dispatches through `session.sendCustomMessage` with `customType: SKILL_PROMPT_MESSAGE_TYPE` and `attribution: \"user\"`.
- `ToolSession.sendCustomMessage` is a new optional bridge wired in `sdk.ts:1198`.
- Gated by `skill.enabled` setting (default `true`). `SkillTool.createIf` returns `null` when no skills are loaded or the bridge is absent, so non-skill-bearing sessions never see the tool.
- The HUD-state sync (`syncSkillPromptActiveStateSafely`) already runs on `sendCustomMessage`, so the workflow HUD reflects the chained skill correctly.

## Testing

- `packages/coding-agent/test/tools/skill.test.ts` — 6 unit tests:
  - `createIf` returns `null` when no skills loaded
  - `createIf` returns `null` when session lacks `sendCustomMessage`
  - queues chained skill as `nextTurn` user-attribution message with correct content
  - omits `User:` line when args absent or whitespace
  - throws `ToolError` naming available skills on unknown name
  - rejects empty/whitespace name
- `packages/coding-agent/test/tool-discovery/initial-tools.test.ts` — extended the shared test session with a stub skill + `sendCustomMessage` so the `BUILTIN_TOOLS` metadata coverage assertion includes the new tool.

Verification:
- `bun run check:ts` — clean
- `bun test packages/coding-agent/test/tools/skill.test.ts packages/coding-agent/test/tools/index.test.ts packages/coding-agent/test/tool-discovery/initial-tools.test.ts` — 36/36 pass
- Pre-existing failures in `agent-session-concurrent` (TTSR) and `model-registry` tests are present on this branch's base commit (60bab38) without my changes.

---

- [x] `bun check` passes (typecheck + biome + node20-baseline + UI redesign + rebrand inventory)
- [x] Tested locally (focused tests + tool-discovery coverage)
- [ ] CHANGELOG updated (if user-facing) — happy to add a `packages/coding-agent/CHANGELOG.md` entry if desired