### PR TITLE
fix(coding-agent): guard skill tool recursion

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1153,6 +1153,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			trackEvalExecution: (execution, abortController) =>
 				session ? session.trackEvalExecution(execution, abortController) : execution,
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
+			getActiveSkillState: () => session?.getActiveSkillState(),
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getAgentId: () => resolvedAgentId,
 			getToolByName: name => session?.getToolByName(name),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1196,6 +1196,15 @@ export class AgentSession {
 		return this.#toolChoiceQueue;
 	}
 
+	/** Current skill prompt executing in this session, if any. */
+	getActiveSkillState(): { skill: string; session_id?: string } | undefined {
+		if (!this.#activeSkillState) return undefined;
+		return {
+			skill: this.#activeSkillState.skill,
+			...(this.#activeSkillState.sessionId ? { session_id: this.#activeSkillState.sessionId } : {}),
+		};
+	}
+
 	/** Peek the in-flight directive's invocation handler for use by the resolve tool. */
 	peekQueueInvoker(): ((input: unknown) => Promise<unknown> | unknown) | undefined {
 		return this.#toolChoiceQueue.peekInFlightInvoker();
@@ -4092,18 +4101,21 @@ export class AgentSession {
 		const details = message.details;
 		if (!details || typeof details !== "object") return;
 		const name = (details as { name?: unknown }).name;
-		if (typeof name !== "string" || !isCanonicalGjcWorkflowSkill(name)) return;
-		const cwd = this.sessionManager.getCwd();
+		if (typeof name !== "string" || !name.trim()) return;
+		const skill = name.trim();
 		const sessionId = this.sessionManager.getSessionId();
-		await syncSkillActiveState({
-			cwd,
-			skill: name,
-			active,
-			phase: active ? "running" : "complete",
-			sessionId,
-			source: "skill-prompt",
-		});
-		this.#activeSkillState = active ? { skill: name, sessionId } : undefined;
+		if (isCanonicalGjcWorkflowSkill(skill)) {
+			const cwd = this.sessionManager.getCwd();
+			await syncSkillActiveState({
+				cwd,
+				skill,
+				active,
+				phase: active ? "running" : "complete",
+				sessionId,
+				source: "skill-prompt",
+			});
+		}
+		this.#activeSkillState = active ? { skill, sessionId } : undefined;
 	}
 
 	async #syncSkillPromptActiveStateSafely(

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -16,6 +16,7 @@ import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
+import type { SkillActiveEntry } from "../skill-state/active-state";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
 import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../tool-discovery/tool-index";
@@ -124,6 +125,8 @@ export interface ToolSession {
 	workspaceTree?: WorkspaceTree;
 	/** Pre-loaded skills */
 	skills?: Skill[];
+	/** Currently executing skill prompt, when this tool session is inside one. */
+	getActiveSkillState?: () => Pick<SkillActiveEntry, "skill" | "session_id"> | undefined;
 	/** Pre-loaded prompt templates */
 	promptTemplates?: PromptTemplate[];
 	/** Whether LSP integrations are enabled */

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -23,6 +23,10 @@ const skillSchema = z.object({
 	args: z.string().describe("argument string passed to the skill").optional(),
 });
 
+function normalizeSkillName(name: string | undefined): string {
+	return (name ?? "").trim();
+}
+
 type SkillToolInput = z.infer<typeof skillSchema>;
 
 export interface SkillToolDetails {
@@ -69,10 +73,17 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 				throw new ToolError("skill tool: session has no custom-message bridge");
 			}
 			const skills = this.#session.skills ?? [];
-			const requestedName = input.name.trim();
+			const requestedName = normalizeSkillName(input.name);
 			if (!requestedName) {
 				throw new ToolError("skill tool: `name` is required");
 			}
+			const activeSkill = normalizeSkillName(this.#session.getActiveSkillState?.()?.skill);
+			if (activeSkill && requestedName === activeSkill) {
+				throw new ToolError(
+					`skill tool: refusing to chain into currently active skill "${requestedName}". Follow the active skill instructions instead of invoking it recursively.`,
+				);
+			}
+
 			const skill = skills.find(s => s.name === requestedName);
 			if (!skill) {
 				const available = skills.map(s => s.name).sort();

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -106,6 +106,30 @@ describe("BUILTIN_TOOLS public factory map", () => {
 		expect(missing).toEqual([]);
 	});
 
+	it("exposes the skill tool by default when skills and custom-message bridge are available", async () => {
+		const tools = await createTools(
+			{
+				...toolSession,
+				settings: Settings.isolated(),
+			},
+			["skill"],
+		);
+
+		expect(tools.some(tool => tool.name === "skill")).toBe(true);
+	});
+
+	it("omits the skill tool when skill.enabled is false", async () => {
+		const tools = await createTools(
+			{
+				...toolSession,
+				settings: Settings.isolated({ "skill.enabled": false }),
+			},
+			["skill"],
+		);
+
+		expect(tools.some(tool => tool.name === "skill")).toBe(false);
+	});
+
 	it("exposes detached subagent controls and keeps generic job controls without async flags", async () => {
 		const session = {
 			...toolSession,

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -28,7 +28,7 @@ interface CapturedSend {
 	options?: { deliverAs?: string; triggerTurn?: boolean };
 }
 
-function createSession(skills: Skill[], capture: CapturedSend[]): ToolSession {
+function createSession(skills: Skill[], capture: CapturedSend[], overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
@@ -39,6 +39,7 @@ function createSession(skills: Skill[], capture: CapturedSend[]): ToolSession {
 		sendCustomMessage: async (message, options) => {
 			capture.push({ message, options });
 		},
+		...overrides,
 	};
 }
 
@@ -103,6 +104,37 @@ describe("SkillTool", () => {
 		await tool.execute("call-1", { name: "deep-interview", args: "   " });
 		const content = captured[0]!.message.content as string;
 		expect(content).not.toContain("User:");
+	});
+
+	it("rejects chaining into the currently active skill", async () => {
+		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nBody");
+		const captured: CapturedSend[] = [];
+		const session = createSession([deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "session-1" }),
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await expect(tool.execute("call-1", { name: " deep-interview " })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-1", { name: "deep-interview" })).rejects.toThrow(
+			/refusing to chain into currently active skill "deep-interview"/,
+		);
+		expect(captured).toHaveLength(0);
+	});
+
+	it("allows chaining into a different skill while a skill is active", async () => {
+		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+		const captured: CapturedSend[] = [];
+		const session = createSession([deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "session-1" }),
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		const result = await tool.execute("call-1", { name: "ralplan" });
+
+		expect(result.details?.name).toBe("ralplan");
+		expect(captured).toHaveLength(1);
 	});
 
 	it("throws a ToolError naming the available skills when the name is unknown", async () => {


### PR DESCRIPTION
## Summary
- add a typed active-skill bridge from AgentSession into ToolSession
- reject skill tool attempts to chain into the currently active skill
- cover same-skill rejection, different-skill handoff, skill.enabled=false discovery, default skill exposure, and schema validation

## Verification
- bun install
- bun --cwd=packages/natives run build
- bun test packages/coding-agent/test/tools/skill.test.ts packages/coding-agent/test/tool-discovery/initial-tools.test.ts packages/coding-agent/test/tools/schema-validation.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/src/tools/index.ts packages/coding-agent/src/tools/skill.ts packages/coding-agent/test/tool-discovery/initial-tools.test.ts packages/coding-agent/test/tools/skill.test.ts

Note: full repo bun check still reports unrelated pre-existing optional-chain lint warnings outside this change.