### PR TITLE
fix(coding-agent): embed CHANGELOG for deterministic display and register gjc update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added a built-in `skill` tool so the agent can chain into another loaded skill on its next turn. Mirrors `/skill:<name>` typing and subagent `autoloadSkills` by dispatching the chained skill's SKILL.md as a user-attribution custom message; controlled by the new `skill.enabled` setting (default true).
 
+### Fixed
+
+- Made startup CHANGELOG display deterministic by embedding `packages/coding-agent/CHANGELOG.md` into the binary so post-update launches show the shipped history regardless of cwd or `GJC_PACKAGE_DIR`/`PI_PACKAGE_DIR` overrides.
+- Registered `gjc update` as a public root subcommand so it invokes the bundled updater instead of routing into the interactive launcher.
+
 ## [0.2.2] - 2026-05-31
 
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -44,6 +44,7 @@ const commands: CommandEntry[] = [
 		load: () => import("./commands/contribution-prep").then(m => m.default),
 	},
 	{ name: "deep-interview", load: () => import("./commands/deep-interview").then(m => m.default) },
+	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
 ];
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -49,7 +49,7 @@ import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
 import type { LspStartupServerInfo } from "./tools";
-import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
+import { getDisplayChangelogEntries, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
@@ -341,8 +341,7 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 		return undefined;
 	}
 
-	const changelogPath = getChangelogPath();
-	const entries = await parseChangelog(changelogPath);
+	const entries = getDisplayChangelogEntries();
 
 	if (!lastVersion) {
 		if (entries.length > 0) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -42,7 +42,7 @@ import type { NewSessionOptions } from "../../session/session-manager";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs } from "../../tools/render-utils";
-import { getChangelogPath, parseChangelog } from "../../utils/changelog";
+import { getDisplayChangelogEntries } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
@@ -525,8 +525,7 @@ export class CommandController {
 	}
 
 	async handleChangelogCommand(showFull = false): Promise<void> {
-		const changelogPath = getChangelogPath();
-		const allEntries = await parseChangelog(changelogPath);
+		const allEntries = getDisplayChangelogEntries();
 		// Default to showing only the latest 3 versions unless --full is specified
 		// allEntries comes from parseChangelog with newest first, reverse to show oldest->newest
 		const entriesToShow = showFull ? allEntries : allEntries.slice(0, 3);

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,4 +1,5 @@
 import { isEnoent, logger } from "@gajae-code/utils";
+import CHANGELOG_TEXT from "../../CHANGELOG.md" with { type: "text" };
 
 export interface ChangelogEntry {
 	major: number;
@@ -8,58 +9,67 @@ export interface ChangelogEntry {
 }
 
 /**
- * Parse changelog entries from CHANGELOG.md
- * Scans for ## lines and collects content until next ## or EOF
+ * Parse changelog entries from a CHANGELOG.md text body.
+ * Scans for ## lines and collects content until next ## or EOF.
+ * Pure and synchronous so it can be reused by the embedded display path.
+ */
+export function parseChangelogContent(content: string): ChangelogEntry[] {
+	const lines = content.split("\n");
+	const entries: ChangelogEntry[] = [];
+
+	let currentLines: string[] = [];
+	let currentVersion: { major: number; minor: number; patch: number } | null = null;
+
+	for (const line of lines) {
+		// Check if this is a version header (## [x.y.z] ...)
+		if (line.startsWith("## ")) {
+			// Save previous entry if exists
+			if (currentVersion && currentLines.length > 0) {
+				entries.push({
+					...currentVersion,
+					content: currentLines.join("\n").trim(),
+				});
+			}
+
+			// Try to parse version from this line
+			const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
+			if (versionMatch) {
+				currentVersion = {
+					major: Number.parseInt(versionMatch[1], 10),
+					minor: Number.parseInt(versionMatch[2], 10),
+					patch: Number.parseInt(versionMatch[3], 10),
+				};
+				currentLines = [line];
+			} else {
+				// Reset if we can't parse version
+				currentVersion = null;
+				currentLines = [];
+			}
+		} else if (currentVersion) {
+			// Collect lines for current version
+			currentLines.push(line);
+		}
+	}
+
+	// Save last entry
+	if (currentVersion && currentLines.length > 0) {
+		entries.push({
+			...currentVersion,
+			content: currentLines.join("\n").trim(),
+		});
+	}
+
+	return entries;
+}
+
+/**
+ * Parse changelog entries from a CHANGELOG.md file on disk.
+ * Returns [] on ENOENT; logs and returns [] on other read/parse errors.
  */
 export async function parseChangelog(changelogPath: string): Promise<ChangelogEntry[]> {
 	try {
 		const content = await Bun.file(changelogPath).text();
-		const lines = content.split("\n");
-		const entries: ChangelogEntry[] = [];
-
-		let currentLines: string[] = [];
-		let currentVersion: { major: number; minor: number; patch: number } | null = null;
-
-		for (const line of lines) {
-			// Check if this is a version header (## [x.y.z] ...)
-			if (line.startsWith("## ")) {
-				// Save previous entry if exists
-				if (currentVersion && currentLines.length > 0) {
-					entries.push({
-						...currentVersion,
-						content: currentLines.join("\n").trim(),
-					});
-				}
-
-				// Try to parse version from this line
-				const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
-				if (versionMatch) {
-					currentVersion = {
-						major: Number.parseInt(versionMatch[1], 10),
-						minor: Number.parseInt(versionMatch[2], 10),
-						patch: Number.parseInt(versionMatch[3], 10),
-					};
-					currentLines = [line];
-				} else {
-					// Reset if we can't parse version
-					currentVersion = null;
-					currentLines = [];
-				}
-			} else if (currentVersion) {
-				// Collect lines for current version
-				currentLines.push(line);
-			}
-		}
-
-		// Save last entry
-		if (currentVersion && currentLines.length > 0) {
-			entries.push({
-				...currentVersion,
-				content: currentLines.join("\n").trim(),
-			});
-		}
-
-		return entries;
+		return parseChangelogContent(content);
 	} catch (error) {
 		if (isEnoent(error)) {
 			return [];
@@ -67,6 +77,19 @@ export async function parseChangelog(changelogPath: string): Promise<ChangelogEn
 		logger.error(`Warning: Could not parse changelog: ${error}`);
 		return [];
 	}
+}
+
+/**
+ * Return changelog entries from the CHANGELOG.md that shipped with this binary.
+ *
+ * The text is embedded at build time via `with { type: "text" }`, so the
+ * displayed changelog is deterministic across compiled binaries, source-tree
+ * dev runs, and `GJC_PACKAGE_DIR` / `PI_PACKAGE_DIR` overrides (which scope to
+ * optional package assets like docs/examples and do not influence the
+ * binary-identity changelog).
+ */
+export function getDisplayChangelogEntries(): ChangelogEntry[] {
+	return parseChangelogContent(CHANGELOG_TEXT);
 }
 
 /**

--- a/packages/coding-agent/test/changelog.test.ts
+++ b/packages/coding-agent/test/changelog.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { VERSION } from "@gajae-code/utils";
+import { getDisplayChangelogEntries, parseChangelogContent } from "../src/utils/changelog";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-changelog-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("parseChangelogContent", () => {
+	it("returns entries newest first and ignores [Unreleased]", () => {
+		const fixture = [
+			"# Changelog",
+			"",
+			"## [Unreleased]",
+			"",
+			"## [0.0.2] - 2024-01-02",
+			"",
+			"### Added",
+			"",
+			"- second entry",
+			"",
+			"## [0.0.1] - 2024-01-01",
+			"",
+			"### Added",
+			"",
+			"- first entry",
+			"",
+		].join("\n");
+
+		const entries = parseChangelogContent(fixture);
+
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toMatchObject({ major: 0, minor: 0, patch: 2 });
+		expect(entries[0].content).toContain("second entry");
+		expect(entries[1]).toMatchObject({ major: 0, minor: 0, patch: 1 });
+		expect(entries[1].content).toContain("first entry");
+	});
+
+	it("returns no entries when no semver heading is present", () => {
+		const fixture = ["# Changelog", "", "## [Unreleased]", "", "- pending", ""].join("\n");
+
+		expect(parseChangelogContent(fixture)).toEqual([]);
+	});
+});
+
+describe("getDisplayChangelogEntries", () => {
+	it("returns the embedded coding-agent changelog whose top entry matches VERSION", () => {
+		const entries = getDisplayChangelogEntries();
+
+		expect(entries.length).toBeGreaterThanOrEqual(1);
+		const top = entries[0];
+		expect(`${top.major}.${top.minor}.${top.patch}`).toBe(VERSION);
+	});
+
+	it("ignores cwd and GJC_PACKAGE_DIR / PI_PACKAGE_DIR overrides for the displayed changelog", async () => {
+		const tempDir = await makeTempDir();
+		const decoyContent = [
+			"# Changelog",
+			"",
+			"## [99.99.99] - 2099-01-01",
+			"",
+			"### Added",
+			"",
+			"- bogus stale entry from cwd",
+			"",
+		].join("\n");
+		await fs.writeFile(path.join(tempDir, "CHANGELOG.md"), decoyContent);
+
+		const originalCwd = process.cwd();
+		const originalGjcPackageDir = process.env.GJC_PACKAGE_DIR;
+		const originalPiPackageDir = process.env.PI_PACKAGE_DIR;
+
+		try {
+			process.chdir(tempDir);
+			process.env.GJC_PACKAGE_DIR = tempDir;
+			process.env.PI_PACKAGE_DIR = tempDir;
+
+			const entries = getDisplayChangelogEntries();
+
+			expect(entries.length).toBeGreaterThanOrEqual(1);
+			const top = entries[0];
+			expect(`${top.major}.${top.minor}.${top.patch}`).toBe(VERSION);
+			expect(top.major).not.toBe(99);
+			expect(top.content).not.toContain("bogus stale entry from cwd");
+		} finally {
+			process.chdir(originalCwd);
+			if (originalGjcPackageDir === undefined) delete process.env.GJC_PACKAGE_DIR;
+			else process.env.GJC_PACKAGE_DIR = originalGjcPackageDir;
+			if (originalPiPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
+			else process.env.PI_PACKAGE_DIR = originalPiPackageDir;
+		}
+	});
+});

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -27,8 +27,25 @@ describe("GJC public CLI command surface", () => {
 			"ralplan",
 			"contribute-pr",
 			"deep-interview",
+			"update",
 			"launch",
 		]);
+	});
+
+	it("exposes the update command help without launching the TUI", () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "update", "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const stdout = result.stdout.toString();
+		const stderr = result.stderr.toString();
+		const combined = `${stdout}\n${stderr}`;
+
+		expect(result.exitCode, combined).toBe(0);
+		expect(stdout).toContain("Check for and install updates");
+		expect(combined).not.toContain("What's New");
+		expect(combined).not.toContain("chatContainer");
 	});
 
 	it("documents the native CLI surface in command help", async () => {


### PR DESCRIPTION
## Summary

Two related bugs reported after fresh `gjc` installs:

1. **Stale CHANGELOG on startup.** `getChangelogPath()` → `getPackageDir()` walks up from `import.meta.dir` and falls back to the user's cwd in compiled binaries, so the startup display picked up whatever `CHANGELOG.md` happened to be next to the user's project rather than the one shipped with the binary.
2. **`gjc update` opened the TUI.** `update` was missing from the registered `commands` array in `packages/coding-agent/src/cli.ts`, so `isSubcommand("update")` returned `false`, `runCli()` rewrote argv to `["launch", "update", ...]`, and the user landed in the interactive launcher instead of the existing updater.

## Solution

Consensus-approved Option A from `.gjc/plans/ralplan/2026-06-01-0043-cc1c/stage-04-final.md`:

- **Embed `packages/coding-agent/CHANGELOG.md`** via `with { type: "text" }`. Split the parser into pure `parseChangelogContent(text)` and a thin `parseChangelog(path)` wrapper. Add a single display-oriented `getDisplayChangelogEntries()` helper in `packages/coding-agent/src/utils/changelog.ts`. Route startup (`packages/coding-agent/src/main.ts`) and the `/changelog` slash command (`packages/coding-agent/src/modes/controllers/command-controller.ts`) through it.
- **Register `update`** between `deep-interview` and `launch` in `packages/coding-agent/src/cli.ts` so `gjc update` reaches the existing handler (`packages/coding-agent/src/cli/update-cli.ts`).

`getPackageDir()` semantics are unchanged for other callers (docs/examples). The displayed changelog is now part of the binary's identity and is no longer overridable via `GJC_PACKAGE_DIR` / `PI_PACKAGE_DIR` (which still scope to optional package assets like docs/examples).

## Files

- `packages/coding-agent/src/utils/changelog.ts` — embed + split parser + `getDisplayChangelogEntries`
- `packages/coding-agent/src/main.ts` — route through embedded helper
- `packages/coding-agent/src/modes/controllers/command-controller.ts` — route `/changelog` through embedded helper
- `packages/coding-agent/src/cli.ts` — register `update`
- `packages/coding-agent/test/cli-command-surface.test.ts` — extended expected list + `update --help` smoke
- `packages/coding-agent/test/changelog.test.ts` — parser, embedded helper, stale-cwd discriminator
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased]` fixed entries

## Verification

- `cd packages/coding-agent && bun test test/changelog.test.ts test/cli-command-surface.test.ts test/update-cli.test.ts` → 17 pass / 0 fail / 50 assertions
- `bun packages/coding-agent/src/cli.ts update --help` → exit 0; stdout contains `Check for and install updates`; no TUI markers
- `bun packages/coding-agent/src/cli.ts update --check` → exit 0; stdout `Current version: 0.2.2` + `Already up to date`; no TUI markers
- `bunx biome check` on the 6 touched files → `OK`
- `bun --cwd=packages/coding-agent run check:types` → clean
- Stale-cwd red-team: in a temp dir with `## [99.99.99]` decoy + `cwd` + `GJC_PACKAGE_DIR` + `PI_PACKAGE_DIR` all poisoned, `getDisplayChangelogEntries()[0]` returns `0.2.2` (the embedded shipped entry), not `99.99.99`

## Quality gate

- Architect (3 lanes): architecture `CLEAR`, product `CLEAR`, code `CLEAR`, recommendation `APPROVE`
- Executor QA: e2e `passed`, red-team `passed`, iteration `passed` (full rerun clean)

## Notes

- The embedded `CHANGELOG.md` adds approximately +½ MB to the compiled binary, in line with the existing prompt/skill text embeds in `src/edit/index.ts` and `src/defaults/gjc-defaults.ts`.
- `/changelog` now reflects only the binary-bundled history; post-release on-disk amendments are intentionally not shown.
- Persistence flow at `packages/coding-agent/src/main.ts:347-358` (`settings.set("lastChangelogVersion", VERSION)` + `flushChangelogVersion()`) is structurally unchanged; only the entry source flips.

## Planning artifacts

Consensus loop: planner 1 → architect 1 (ITERATE) → critic 1 (ITERATE) → revision 2 → architect 2 (APPROVE) → critic 2 (ITERATE) → revision 3 → architect 3 (ITERATE) → critic 3 (ITERATE) → revision 4 → architect 4 (APPROVE) → critic 4 (APPROVE). Run id: `2026-06-01-0043-cc1c`.
