### PR TITLE
feat(coding-agent): skill chaining lifecycle — handoff verb + same-turn dispatch + HUD truth

### DIFF
--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -11,6 +11,7 @@ export default class State extends Command {
 		"$ gjc state deep-interview read --json",
 		'$ gjc state ralplan write --input \'{"phase":"approval","active":true}\' --json',
 		"$ gjc state team contract",
+		"$ gjc state deep-interview handoff --to ralplan --json",
 	];
 
 	async run(): Promise<void> {

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -515,6 +515,16 @@ After the spec is written, mark it `pending approval` and present execution opti
 
 **IMPORTANT:** On explicit execution selection, **MUST** use the chosen bundled GJC workflow skill entrypoint (`/skill:ralplan` or `/skill:team`) inside the agent session. `gjc ralplan` is a native CLI that accepts the documented skill flags and seeds local `.gjc/state` receipts; agent sessions should still drive the consensus loop through `/skill:ralplan`. `gjc team` is a native tmux runtime command and may be used only when the Team workflow explicitly requires the CLI runtime. Do NOT implement directly. The deep-interview agent is a requirements agent, not an execution agent. If oversized initial context was summarized, pass the spec and prompt-safe summary forward, not the raw oversized source material. Without explicit execution selection, stop with the spec marked `pending approval`.
 
+### Phase 5b: Handoff before chain
+
+Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, mark deep-interview ready for handoff so the skill tool's chain guard lets the transition proceed. Run:
+
+```
+gjc state deep-interview write --input '{"current_phase":"handoff"}' --json
+```
+
+The skill tool then dispatches the next skill same-turn and runs `gjc state deep-interview handoff --to <callee> --json` in-process to atomically demote deep-interview, promote the callee, and sync both `skill-active-state.json` files. You do not need to run the handoff verb yourself. Skipping the `current_phase: "handoff"` write leaves the skill tool's terminal-phase guard refusing to chain.
+
 ### Approval-Gated Refinement Path (Recommended)
 
 ```

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -72,6 +72,14 @@ The consensus workflow:
 7. *(--interactive only)* User chooses: Approve team execution, Request changes, or Reject
 8. *(--interactive only)* On approval: invoke `/skill:team` for execution -- never implement directly
 
+   Before invoking `/skill:team` or `/skill:ultragoal`, mark ralplan ready for handoff so the skill tool's chain guard permits the transition:
+
+   ```
+   gjc state ralplan write --input '{"current_phase":"handoff"}' --json
+   ```
+
+   The skill tool then dispatches the execution skill same-turn and runs `gjc state ralplan handoff --to <team|ultragoal> --json` in-process to atomically demote ralplan, promote the callee, and sync both `skill-active-state.json` files. You do not need to run the handoff verb yourself.
+
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent Task calls in the same parallel batch. Always await the Architect result before issuing the Critic Task.
 
 Follow the Plan skill's full documentation for consensus mode details.

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -394,3 +394,13 @@ Two cleanup paths exist and must not be confused:
 **Good:** The user changes only the output shape or downstream delivery step (for example `make a PR`). Preserve earlier non-conflicting workflow constraints and apply the update locally.
 
 **Bad:** The user says `continue`, and the workflow restarts discovery or stops before the missing verification/evidence is gathered.
+
+## Handoff back to planning or persistence
+
+When the team task-set completes OR the user requests return to planning/persistence, mark team ready for handoff so the skill tool's chain guard permits the transition:
+
+```
+gjc state team write --input '{"current_phase":"handoff"}' --json
+```
+
+The skill tool then dispatches `/skill:ralplan`, `/skill:deep-interview`, or `/skill:ultragoal` same-turn and runs `gjc state team handoff --to <ralplan|deep-interview|ultragoal> --json` in-process to atomically demote team, promote the callee, and sync both `skill-active-state.json` files. You do not need to run the handoff verb yourself.

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -192,6 +192,16 @@ Receipts are freshness-scoped:
 - Normal later `goal_started` or clean receipt-backed `goal_checkpointed` events for other goals do not stale older per-goal receipts.
 - Appending required goals or changing final required-goal state stales final aggregate receipts. Final aggregate completion requires a fresh final aggregate receipt proving no incomplete, blocked, or `review_blocked` required goals remain.
 
+## Handoff back to planning
+
+When the aggregate ultragoal is complete OR the user requests return to planning/clarification, mark ultragoal ready for handoff so the skill tool's chain guard permits the backward transition:
+
+```
+gjc state ultragoal write --input '{"current_phase":"handoff"}' --json
+```
+
+The skill tool then dispatches `/skill:ralplan` or `/skill:deep-interview` same-turn and runs `gjc state ultragoal handoff --to <ralplan|deep-interview> --json` in-process to atomically demote ultragoal, promote the callee, and sync both `skill-active-state.json` files. You do not need to run the handoff verb yourself.
+
 ## Constraints
 
 - The shell command cannot directly invoke interactive `/goal`; it emits a model-facing handoff for the active GJC agent.

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import {
+	applyHandoffToActiveState,
 	CANONICAL_GJC_WORKFLOW_SKILLS,
 	type CanonicalGjcWorkflowSkill,
 	listActiveSkills,
@@ -406,38 +407,6 @@ async function syncWorkflowSkillState(options: {
 		// HUD sync is best-effort and must not change command semantics.
 	}
 }
-
-async function syncWorkflowSkillStateStrict(options: {
-	cwd: string;
-	mode: CanonicalGjcWorkflowSkill;
-	sessionId: string | undefined;
-	threadId?: string;
-	turnId?: string;
-	active: boolean;
-	phase: string | undefined;
-	payload: Record<string, unknown>;
-	receipt?: WorkflowStateReceipt;
-	handoff_from?: string;
-	handoff_to?: string;
-	handoff_at?: string;
-}): Promise<void> {
-	await syncSkillActiveState({
-		cwd: options.cwd,
-		skill: options.mode,
-		active: options.active,
-		phase: options.phase,
-		sessionId: options.sessionId,
-		threadId: options.threadId,
-		turnId: options.turnId,
-		source: "gjc-state-cli",
-		hud: buildHudForMode(options.mode, options.payload),
-		...(options.handoff_from ? { handoff_from: options.handoff_from } : {}),
-		...(options.handoff_to ? { handoff_to: options.handoff_to } : {}),
-		...(options.handoff_at ? { handoff_at: options.handoff_at } : {}),
-		...(options.receipt ? { receipt: options.receipt } : {}),
-	});
-}
-
 async function handleRead(
 	args: readonly string[],
 	cwd: string,
@@ -666,35 +635,47 @@ async function handleHandoff(
 		receipt: callerReceipt,
 	};
 
-	// Atomic write order (Principle 6): callee first, caller second,
-	// then strict active-state syncs (caller demotion, callee promotion).
+	// Atomic write order (architecture blocker AR-3): mode-state files first,
+	// then a single atomic active-state mutation per file (session before root)
+	// via applyHandoffToActiveState. The single-write transaction prevents the
+	// HUD from observing a window where neither caller nor callee is active,
+	// and write order keeps the session-scoped source of truth ahead of the
+	// root aggregate. strict:true on the active-state read tolerates ENOENT
+	// only; corrupt JSON / IO failures propagate as non-zero CLI status.
 	await writeJsonAtomic(calleePath, mergedCalleeState);
 	await writeJsonAtomic(callerPath, mergedCallerState);
-	await syncWorkflowSkillStateStrict({
+	await applyHandoffToActiveState({
 		cwd,
-		mode: caller,
-		sessionId,
-		threadId,
-		turnId,
-		active: false,
-		phase: "handoff",
-		payload: mergedCallerState,
-		receipt: callerReceipt,
-		handoff_to: callee,
-		handoff_at: handoffAt,
-	});
-	await syncWorkflowSkillStateStrict({
-		cwd,
-		mode: callee,
-		sessionId,
-		threadId,
-		turnId,
-		active: true,
-		phase: calleeInitial,
-		payload: mergedCalleeState,
-		receipt: calleeReceipt,
-		handoff_from: caller,
-		handoff_at: handoffAt,
+		nowIso: handoffAt,
+		strict: true,
+		caller: {
+			cwd,
+			skill: caller,
+			active: false,
+			phase: "handoff",
+			sessionId,
+			threadId,
+			turnId,
+			source: "gjc-state-cli",
+			hud: buildHudForMode(caller, mergedCallerState),
+			handoff_to: callee,
+			handoff_at: handoffAt,
+			receipt: callerReceipt,
+		},
+		callee: {
+			cwd,
+			skill: callee,
+			active: true,
+			phase: calleeInitial,
+			sessionId,
+			threadId,
+			turnId,
+			source: "gjc-state-cli",
+			hud: buildHudForMode(callee, mergedCalleeState),
+			handoff_from: caller,
+			handoff_at: handoffAt,
+			receipt: calleeReceipt,
+		},
 	});
 
 	return {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -9,6 +9,7 @@ import {
 	readVisibleSkillActiveState,
 	syncSkillActiveState,
 } from "../skill-state/active-state";
+import { initialPhaseForSkill } from "../skill-state/initial-phase";
 import {
 	buildDeepInterviewHudSummary,
 	buildRalplanHudSummary,
@@ -60,11 +61,11 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 	return args.includes(flag);
 }
 
-const FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id"]);
-const ACTION_NAMES = new Set(["read", "write", "clear", "contract"]);
+const FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id", "--to"]);
+const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff"]);
 
 interface ParsedInvocation {
-	action: "read" | "write" | "clear" | "contract";
+	action: "read" | "write" | "clear" | "contract" | "handoff";
 	positionalSkill?: string;
 }
 
@@ -169,9 +170,18 @@ async function resolveSelectors(
 	}
 	if (mode) assertKnownMode(mode);
 
+	// Session-id resolution order: explicit --session-id flag, then payload
+	// session_id, then GJC_SESSION_ID env var (set by AgentSession.sdk for
+	// agent-initiated CLI invocations). The env-var default keeps shell
+	// snippets in skill docs short while still routing writes/reads to the
+	// caller's session-scoped state files.
 	let sessionId = flagValue(args, "--session-id")?.trim() || undefined;
 	if (!sessionId && payload && typeof payload.session_id === "string") {
 		sessionId = payload.session_id.trim() || undefined;
+	}
+	if (!sessionId) {
+		const envSessionId = process.env.GJC_SESSION_ID?.trim();
+		if (envSessionId) sessionId = envSessionId;
 	}
 	if (sessionId) assertSafePathComponent(sessionId, "session-id");
 
@@ -397,6 +407,37 @@ async function syncWorkflowSkillState(options: {
 	}
 }
 
+async function syncWorkflowSkillStateStrict(options: {
+	cwd: string;
+	mode: CanonicalGjcWorkflowSkill;
+	sessionId: string | undefined;
+	threadId?: string;
+	turnId?: string;
+	active: boolean;
+	phase: string | undefined;
+	payload: Record<string, unknown>;
+	receipt?: WorkflowStateReceipt;
+	handoff_from?: string;
+	handoff_to?: string;
+	handoff_at?: string;
+}): Promise<void> {
+	await syncSkillActiveState({
+		cwd: options.cwd,
+		skill: options.mode,
+		active: options.active,
+		phase: options.phase,
+		sessionId: options.sessionId,
+		threadId: options.threadId,
+		turnId: options.turnId,
+		source: "gjc-state-cli",
+		hud: buildHudForMode(options.mode, options.payload),
+		...(options.handoff_from ? { handoff_from: options.handoff_from } : {}),
+		...(options.handoff_to ? { handoff_to: options.handoff_to } : {}),
+		...(options.handoff_at ? { handoff_at: options.handoff_at } : {}),
+		...(options.receipt ? { receipt: options.receipt } : {}),
+	});
+}
+
 async function handleRead(
 	args: readonly string[],
 	cwd: string,
@@ -527,6 +568,151 @@ async function handleClear(
 	return { status: 0, stdout: `${JSON.stringify(cleared, null, 2)}\n` };
 }
 
+/**
+ * `handoff` exists in two distinct roles:
+ *   - As a verb: this CLI action, which atomically transitions caller→callee.
+ *     Writes the callee mode-state first, the caller mode-state second, then
+ *     syncs both `skill-active-state.json` files. Every intermediate crashed
+ *     state remains HUD-coherent: the active-state file either reflects the
+ *     old skill entirely or the new skill entirely, never both as active.
+ *   - As a phase: `current_phase: "handoff"` is set by this verb when demoting
+ *     the caller. Agents writing `current_phase: "handoff"` manually via
+ *     `gjc state <skill> write` are declaring "I am ready to be handed off";
+ *     the next agent-initiated `skill` tool call will then satisfy the phase
+ *     guard and may chain.
+ *
+ * `handoff` is in the terminal-phase set used by `isTerminalModeState` and by
+ * the skill tool's chain guard. A manual `current_phase: "handoff"` write does
+ * NOT mark `active: false` — only this verb does that — so a skill that wrote
+ * the phase remains in `skill-active-state.json` until a chain call (or
+ * explicit `clear`) demotes it.
+ */
+async function handleHandoff(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, positionalSkill);
+	const { sessionId, threadId, turnId } = selectors;
+	const caller = selectors.mode ?? (await inferModeFromActiveState(cwd, sessionId));
+	if (!caller) {
+		throw new StateCommandError(
+			2,
+			"gjc state handoff requires --mode <caller>, positional <caller>, input.skill, or an active workflow in .gjc/state/skill-active-state.json",
+		);
+	}
+	const calleeRaw = flagValue(args, "--to")?.trim();
+	if (!calleeRaw) {
+		throw new StateCommandError(2, "gjc state handoff requires --to <callee>");
+	}
+	assertKnownMode(calleeRaw);
+	const callee = calleeRaw as CanonicalGjcWorkflowSkill;
+	if (callee === caller) {
+		throw new StateCommandError(2, `gjc state handoff: --to must differ from caller (both are "${caller}")`);
+	}
+
+	const callerPath = modeStateFile(cwd, caller, sessionId);
+	const calleePath = modeStateFile(cwd, callee, sessionId);
+	const existingCaller = await readJsonFile(callerPath);
+	if (!existingCaller) {
+		throw new StateCommandError(
+			2,
+			`gjc state ${caller} handoff: caller is not active (no mode-state file at ${callerPath})`,
+		);
+	}
+	const existingCallee = (await readJsonFile(calleePath)) ?? {};
+
+	const handoffAt = nowIso();
+	const callerReceipt = buildWorkflowStateReceipt({
+		cwd,
+		skill: caller,
+		owner: "gjc-state-cli",
+		command: `gjc state ${caller} handoff --to ${callee}`,
+		sessionId,
+		nowIso: handoffAt,
+	});
+	const calleeReceipt = buildWorkflowStateReceipt({
+		cwd,
+		skill: callee,
+		owner: "gjc-state-cli",
+		command: `gjc state ${caller} handoff --to ${callee}`,
+		sessionId,
+		nowIso: handoffAt,
+	});
+
+	const calleeInitial = initialPhaseForSkill(callee);
+	const mergedCalleeState: Record<string, unknown> = {
+		...existingCallee,
+		skill: callee,
+		version: typeof existingCallee.version === "number" ? existingCallee.version : 1,
+		active: true,
+		current_phase: calleeInitial,
+		handoff_from: caller,
+		handoff_at: handoffAt,
+		updated_at: handoffAt,
+		receipt: calleeReceipt,
+	};
+	if (sessionId && typeof mergedCalleeState.session_id !== "string") {
+		mergedCalleeState.session_id = sessionId;
+	}
+	const mergedCallerState: Record<string, unknown> = {
+		...existingCaller,
+		skill: caller,
+		active: false,
+		current_phase: "handoff",
+		handoff_to: callee,
+		handoff_at: handoffAt,
+		updated_at: handoffAt,
+		receipt: callerReceipt,
+	};
+
+	// Atomic write order (Principle 6): callee first, caller second,
+	// then strict active-state syncs (caller demotion, callee promotion).
+	await writeJsonAtomic(calleePath, mergedCalleeState);
+	await writeJsonAtomic(callerPath, mergedCallerState);
+	await syncWorkflowSkillStateStrict({
+		cwd,
+		mode: caller,
+		sessionId,
+		threadId,
+		turnId,
+		active: false,
+		phase: "handoff",
+		payload: mergedCallerState,
+		receipt: callerReceipt,
+		handoff_to: callee,
+		handoff_at: handoffAt,
+	});
+	await syncWorkflowSkillStateStrict({
+		cwd,
+		mode: callee,
+		sessionId,
+		threadId,
+		turnId,
+		active: true,
+		phase: calleeInitial,
+		payload: mergedCalleeState,
+		receipt: calleeReceipt,
+		handoff_from: caller,
+		handoff_at: handoffAt,
+	});
+
+	return {
+		status: 0,
+		stdout: `${JSON.stringify(
+			{
+				from: caller,
+				to: callee,
+				handoff_at: handoffAt,
+				caller_state: mergedCallerState,
+				callee_state: mergedCalleeState,
+			},
+			null,
+			2,
+		)}\n`,
+	};
+}
+
 async function handleContract(
 	args: readonly string[],
 	cwd: string,
@@ -552,6 +738,8 @@ export async function runNativeStateCommand(args: string[], cwd = process.cwd())
 				return await handleClear(args, cwd, parsed.positionalSkill);
 			case "contract":
 				return await handleContract(args, cwd, parsed.positionalSkill);
+			case "handoff":
+				return await handleHandoff(args, cwd, parsed.positionalSkill);
 			default:
 				return { status: 2, stderr: `Unknown gjc state command: ${parsed.action}\n` };
 		}

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -112,6 +112,9 @@ export interface ModeState {
 	thread_id?: string;
 	cwd?: string;
 	updated_at?: string;
+	handoff_from?: string;
+	handoff_to?: string;
+	handoff_at?: string;
 	[key: string]: unknown;
 }
 
@@ -220,11 +223,10 @@ function encodeStatePathSegment(value: string): string {
 	return encodeURIComponent(value).replaceAll(".", "%2E");
 }
 
-function initialPhaseForSkill(skill: GjcWorkflowSkill): string {
-	if (skill === "deep-interview") return "interviewing";
-	if (skill === "ultragoal") return "goal-planning";
-	return "planning";
-}
+import { initialPhaseForSkill } from "../skill-state/initial-phase";
+
+// Re-export for existing callers and tests that imported it from this module.
+export { initialPhaseForSkill };
 
 function modeStateFileName(skill: GjcWorkflowSkill): string {
 	return `${skill}-state.json`;
@@ -347,7 +349,7 @@ function isTerminalModeState(state: ModeState | null): boolean {
 	const phase = String(state.current_phase ?? "")
 		.trim()
 		.toLowerCase();
-	return ["complete", "completed", "failed", "cancelled", "canceled", "inactive"].includes(phase);
+	return ["complete", "completed", "handoff", "failed", "cancelled", "canceled", "inactive"].includes(phase);
 }
 
 async function readVisibleModeState(

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -9,7 +9,7 @@ Invoke another available skill in the current turn.
 - `name` is the skill name as it appears in `/skill:<name>` (e.g. `ralplan`, `ultragoal`, `team`, `deep-interview`)
 - `args` is the free-form argument string the skill would receive after `/skill:<name>` on the command line
 - The skill tool dispatches the callee's SKILL.md as a user-attribution custom message in the current turn (steering the stream when active, appending otherwise). Before dispatch, the tool atomically demotes the caller and promotes the callee in `.gjc/state/` by calling `gjc state <caller> handoff --to <callee>` in-process.
-- The chain is refused unless the caller's `current_phase` is in `{complete, completed, handoff, failed, cancelled, inactive}`. To prepare the active skill for chaining, write `current_phase: "handoff"` to its mode-state via `gjc state <skill> write --input '{"current_phase":"handoff"}' --json`. The skill tool itself then runs `gjc state <skill> handoff --to <callee>` in-process to atomically demote the caller and promote the callee — you do not need to run the handoff verb separately.
+- The chain is refused unless the caller's `current_phase` is in `{complete, completed, handoff, failed, cancelled, canceled, inactive}`. To prepare the active skill for chaining, write `current_phase: "handoff"` to its mode-state via `gjc state <skill> write --input '{"current_phase":"handoff"}' --json`. The skill tool itself then runs `gjc state <skill> handoff --to <callee>` in-process to atomically demote the caller and promote the callee — you do not need to run the handoff verb separately.
 - Call once per chain step. To chain `A → B → C`, A calls `skill(B)`; B's next agent turn calls `skill(C)`.
 </instruction>
 

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -1,4 +1,4 @@
-Invoke another available skill as the next turn.
+Invoke another available skill in the current turn.
 
 <conditions>
 - A SKILL document instructs you to chain into another skill on completion (e.g. ralplan → ultragoal)
@@ -8,8 +8,9 @@ Invoke another available skill as the next turn.
 <instruction>
 - `name` is the skill name as it appears in `/skill:<name>` (e.g. `ralplan`, `ultragoal`, `team`, `deep-interview`)
 - `args` is the free-form argument string the skill would receive after `/skill:<name>` on the command line
-- The skill's SKILL.md is queued as a user-attribution message and activates on the **next** turn — current turn finishes first
-- Call once per chained skill. To chain `A → B → C`, A's skill calls `skill(B)`, then B's skill (running next turn) calls `skill(C)`
+- The skill tool dispatches the callee's SKILL.md as a user-attribution custom message in the current turn (steering the stream when active, appending otherwise). Before dispatch, the tool atomically demotes the caller and promotes the callee in `.gjc/state/` by calling `gjc state <caller> handoff --to <callee>` in-process.
+- The chain is refused unless the caller's `current_phase` is in `{complete, completed, handoff, failed, cancelled, inactive}`. To prepare the active skill for chaining, write `current_phase: "handoff"` to its mode-state via `gjc state <skill> write --input '{"current_phase":"handoff"}' --json`. The skill tool itself then runs `gjc state <skill> handoff --to <callee>` in-process to atomically demote the caller and promote the callee — you do not need to run the handoff verb separately.
+- Call once per chain step. To chain `A → B → C`, A calls `skill(B)`; B's next agent turn calls `skill(C)`.
 </instruction>
 
 <critical>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1154,6 +1154,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				session ? session.trackEvalExecution(execution, abortController) : execution,
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
 			getActiveSkillState: () => session?.getActiveSkillState(),
+			getActiveSkillPhase: () => session?.getActiveSkillPhase(),
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getAgentId: () => resolvedAgentId,
 			getToolByName: name => session?.getToolByName(name),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -168,7 +168,7 @@ import {
 } from "../runtime-mcp/discoverable-tool-metadata";
 import { deobfuscateSessionContext, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatNoCredentialOnboardingError, formatNoModelOnboardingError } from "../setup/model-onboarding-guidance";
-import { isCanonicalGjcWorkflowSkill, syncSkillActiveState } from "../skill-state/active-state";
+import { isCanonicalGjcWorkflowSkill } from "../skill-state/active-state";
 import { assertDeepInterviewMutationAllowed } from "../skill-state/deep-interview-mutation-guard";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import { resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
@@ -245,6 +245,13 @@ export type AgentSessionEvent =
 	| { type: "notice"; level: "info" | "warning" | "error"; message: string; source?: string }
 	| { type: "thinking_level_changed"; thinkingLevel: ThinkingLevel | undefined }
 	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState };
+
+/**
+ * Safe path component pattern used to validate session-id segments before
+ * joining them into `.gjc/state` paths. Mirrors the regex used by the
+ * `gjc state` runtime selector resolver.
+ */
+const SAFE_PATH_COMPONENT = /^[A-Za-z0-9_-][A-Za-z0-9._-]{0,63}$/;
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -1213,6 +1220,15 @@ export class AgentSession {
 	getActiveSkillPhase(): string | undefined {
 		const active = this.#activeSkillState;
 		if (!active) return undefined;
+		// Path safety: refuse to read mode-state files when the skill or
+		// session-id are not safe path components. The `skill` tool
+		// interprets undefined as a non-terminal phase, so chaining is
+		// refused — there is no risk of bypassing the guard via a custom
+		// skill name with `..` or a session-id with separators.
+		if (!isCanonicalGjcWorkflowSkill(active.skill)) return undefined;
+		if (active.sessionId !== undefined && !SAFE_PATH_COMPONENT.test(active.sessionId)) {
+			return undefined;
+		}
 		try {
 			const stateDir = path.join(this.sessionManager.getCwd(), ".gjc", "state");
 			const segments = active.sessionId
@@ -4126,17 +4142,15 @@ export class AgentSession {
 		if (typeof name !== "string" || !name.trim()) return;
 		const skill = name.trim();
 		const sessionId = this.sessionManager.getSessionId();
-		if (isCanonicalGjcWorkflowSkill(skill)) {
-			const cwd = this.sessionManager.getCwd();
-			await syncSkillActiveState({
-				cwd,
-				skill,
-				active,
-				phase: active ? "running" : "complete",
-				sessionId,
-				source: "skill-prompt",
-			});
-		}
+		// Canonical GJC workflow skills (deep-interview, ralplan, ultragoal, team)
+		// own their `.gjc/state/skill-active-state.json` row through the
+		// `gjc state handoff` and `gjc state clear` runtime verbs. The prompt
+		// observer here used to overwrite the row with `phase: running` and
+		// later remove it with `active:false`, which clobbered handoff lineage
+		// (`handoff_from`/`handoff_at`) and made the HUD inconsistent with
+		// mode-state. The observational filesystem write is now skipped for
+		// canonical skills; the in-memory `#activeSkillState` tracking below
+		// keeps `getActiveSkillState` accurate for the chain guard.
 		this.#activeSkillState = active ? { skill, sessionId } : undefined;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1205,6 +1205,28 @@ export class AgentSession {
 		};
 	}
 
+	/** Best-effort accessor for the active skill's `current_phase` field from
+	 *  its persisted mode-state file. Used by the `skill` tool to enforce the
+	 *  terminal-phase chain guard. Returns undefined when no active skill is
+	 *  recorded or the mode-state file is missing/unreadable; callers should
+	 *  treat undefined as a non-terminal phase (refuses to chain). */
+	getActiveSkillPhase(): string | undefined {
+		const active = this.#activeSkillState;
+		if (!active) return undefined;
+		try {
+			const stateDir = path.join(this.sessionManager.getCwd(), ".gjc", "state");
+			const segments = active.sessionId
+				? [stateDir, "sessions", encodeURIComponent(active.sessionId).replaceAll(".", "%2E")]
+				: [stateDir];
+			const filePath = path.join(...segments, `${active.skill}-state.json`);
+			const raw = fs.readFileSync(filePath, "utf-8");
+			const parsed = JSON.parse(raw) as { current_phase?: unknown };
+			return typeof parsed.current_phase === "string" ? parsed.current_phase : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
 	/** Peek the in-flight directive's invocation handler for use by the resolve tool. */
 	peekQueueInvoker(): ((input: unknown) => Promise<unknown> | unknown) | undefined {
 		return this.#toolChoiceQueue.peekInFlightInvoker();

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -294,6 +294,28 @@ async function readStateFile(filePath: string): Promise<SkillActiveState | null>
 	}
 }
 
+async function readStateFileStrict(filePath: string): Promise<SkillActiveState | null> {
+	let raw: string;
+	try {
+		raw = await Bun.file(filePath).text();
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return null;
+		throw err;
+	}
+	return normalizeSkillActiveState(JSON.parse(raw));
+}
+
+function rawActiveEntries(state: SkillActiveState | null): SkillActiveEntry[] {
+	if (!state || !Array.isArray(state.active_skills)) return [];
+	const out: SkillActiveEntry[] = [];
+	for (const candidate of state.active_skills) {
+		const normalized = normalizeEntry(candidate);
+		if (normalized) out.push(normalized);
+	}
+	return out;
+}
+
 function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (!normalizedSessionId) return entries;
@@ -396,4 +418,86 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 		active_skills: sessionEntries,
 	};
 	await writeStateFile(sessionPath, nextSession);
+}
+
+export interface ApplyHandoffOptions {
+	cwd: string;
+	caller: SyncSkillActiveStateOptions;
+	callee: SyncSkillActiveStateOptions;
+	/** Shared timestamp; falls back to new Date().toISOString(). */
+	nowIso?: string;
+	/** When true, read errors other than ENOENT propagate. */
+	strict?: boolean;
+}
+
+/**
+ * Atomically apply a workflow-skill handoff to both the session-scoped and
+ * root `skill-active-state.json` files in a single write per file.
+ *
+ * Write order: **session first, root last**. The session file is the
+ * source of truth for HUD; the root aggregate must never lead the session
+ * during a handoff window. Each file is rewritten once with caller demoted
+ * to `active:false` (preserving `handoff_to`/`handoff_at` lineage) and
+ * callee promoted to `active:true` (with `handoff_from`/`handoff_at`).
+ */
+export async function applyHandoffToActiveState(options: ApplyHandoffOptions): Promise<void> {
+	const nowIso = options.nowIso ?? new Date().toISOString();
+	const callerEntry = buildSyncEntry(options.caller, nowIso);
+	const calleeEntry = buildSyncEntry(options.callee, nowIso);
+	const sessionId = options.callee.sessionId ?? options.caller.sessionId;
+	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, sessionId);
+	const readState = options.strict ? readStateFileStrict : readStateFile;
+
+	const applyEntries = (entries: SkillActiveEntry[]): SkillActiveEntry[] => {
+		const callerKey = entryKey(callerEntry);
+		const calleeKey = entryKey(calleeEntry);
+		const kept = entries.filter(e => entryKey(e) !== callerKey && entryKey(e) !== calleeKey);
+		return [...kept, callerEntry, calleeEntry];
+	};
+	const buildNextState = (
+		prior: SkillActiveState | null,
+		entries: SkillActiveEntry[],
+		scope: "session" | "root",
+	): SkillActiveState => {
+		const visible = entries.filter(e => e.active !== false);
+		return {
+			...(prior ?? {}),
+			version: 1,
+			active: visible.length > 0,
+			skill: visible[0]?.skill ?? "",
+			phase: visible[0]?.phase ?? "",
+			...(scope === "session" ? { session_id: sessionId } : {}),
+			updated_at: nowIso,
+			source: options.callee.source ?? options.caller.source,
+			active_skills: entries,
+		};
+	};
+
+	if (sessionPath) {
+		const prior = await readState(sessionPath);
+		const next = buildNextState(prior, applyEntries(rawActiveEntries(prior)), "session");
+		await writeStateFile(sessionPath, next);
+	}
+	const priorRoot = await readState(rootPath);
+	const nextRoot = buildNextState(priorRoot, applyEntries(rawActiveEntries(priorRoot)), "root");
+	await writeStateFile(rootPath, nextRoot);
+}
+
+function buildSyncEntry(options: SyncSkillActiveStateOptions, nowIso: string): SkillActiveEntry {
+	const hud = normalizeWorkflowHudSummary(options.hud);
+	return {
+		skill: options.skill,
+		phase: options.phase,
+		active: options.active,
+		activated_at: nowIso,
+		updated_at: nowIso,
+		session_id: options.sessionId,
+		thread_id: options.threadId,
+		turn_id: options.turnId,
+		...(options.handoff_from ? { handoff_from: options.handoff_from } : {}),
+		...(options.handoff_to ? { handoff_to: options.handoff_to } : {}),
+		...(options.handoff_at ? { handoff_at: options.handoff_at } : {}),
+		...(hud ? { hud } : {}),
+		...(options.receipt ? { receipt: options.receipt } : {}),
+	};
 }

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -294,16 +294,36 @@ async function readStateFile(filePath: string): Promise<SkillActiveState | null>
 	}
 }
 
-async function readStateFileStrict(filePath: string): Promise<SkillActiveState | null> {
+/**
+ * Raw read for handoff mutations. Returns the *unnormalized* parsed object so
+ * inactive entries remain visible to `rawActiveEntries` — `normalizeSkillActiveState`
+ * delegates to `listActiveSkills`, which filters out `active:false` rows for HUD
+ * purposes. Handoff history (e.g. previously demoted callers carrying
+ * `handoff_to`/`handoff_at` lineage) must survive across successive handoffs,
+ * so the on-disk `active_skills` array is preserved verbatim and the next
+ * write recomputes the per-skill row from there.
+ *
+ * Strict semantics: tolerates ENOENT only. Corrupt JSON / non-ENOENT I/O
+ * errors propagate so callers can surface a non-zero CLI status.
+ */
+async function readRawActiveStateForHandoff(filePath: string, strict: boolean): Promise<SkillActiveState | null> {
 	let raw: string;
 	try {
 		raw = await Bun.file(filePath).text();
 	} catch (err) {
 		const code = (err as NodeJS.ErrnoException).code;
 		if (code === "ENOENT") return null;
+		if (!strict) return null;
 		throw err;
 	}
-	return normalizeSkillActiveState(JSON.parse(raw));
+	try {
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object") return null;
+		return parsed as SkillActiveState;
+	} catch (err) {
+		if (!strict) return null;
+		throw err;
+	}
 }
 
 function rawActiveEntries(state: SkillActiveState | null): SkillActiveEntry[] {
@@ -446,13 +466,25 @@ export async function applyHandoffToActiveState(options: ApplyHandoffOptions): P
 	const calleeEntry = buildSyncEntry(options.callee, nowIso);
 	const sessionId = options.callee.sessionId ?? options.caller.sessionId;
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, sessionId);
-	const readState = options.strict ? readStateFileStrict : readStateFile;
+	const readState = (filePath: string) => readRawActiveStateForHandoff(filePath, options.strict === true);
 
 	const applyEntries = (entries: SkillActiveEntry[]): SkillActiveEntry[] => {
 		const callerKey = entryKey(callerEntry);
 		const calleeKey = entryKey(calleeEntry);
+		const priorCaller = entries.find(e => entryKey(e) === callerKey);
 		const kept = entries.filter(e => entryKey(e) !== callerKey && entryKey(e) !== calleeKey);
-		return [...kept, callerEntry, calleeEntry];
+		// Merge prior lineage into the demoted caller so multi-step handoff
+		// chains preserve `handoff_from` from the previous transition while
+		// the new `handoff_to`/`handoff_at` describe this one.
+		const mergedCaller: SkillActiveEntry = priorCaller
+			? {
+					...callerEntry,
+					...(priorCaller.handoff_from && !callerEntry.handoff_from
+						? { handoff_from: priorCaller.handoff_from }
+						: {}),
+				}
+			: callerEntry;
+		return [...kept, mergedCaller, calleeEntry];
 	};
 	const buildNextState = (
 		prior: SkillActiveState | null,

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -3,7 +3,6 @@ import * as path from "node:path";
 import type { WorkflowStateReceipt } from "./workflow-state-contract";
 
 export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
-export const SKILL_ACTIVE_STALE_MS = 24 * 60 * 60 * 1000;
 
 export const CANONICAL_GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
 
@@ -40,6 +39,9 @@ export interface SkillActiveEntry {
 	hud?: WorkflowHudSummary;
 	stale?: boolean;
 	receipt?: WorkflowStateReceipt;
+	handoff_from?: string;
+	handoff_to?: string;
+	handoff_at?: string;
 }
 
 export interface SkillActiveState {
@@ -75,6 +77,9 @@ export interface SyncSkillActiveStateOptions {
 	source?: string;
 	hud?: WorkflowHudSummary;
 	receipt?: WorkflowStateReceipt;
+	handoff_from?: string;
+	handoff_to?: string;
+	handoff_at?: string;
 }
 
 const HUD_TEXT_LIMIT = 80;
@@ -185,25 +190,6 @@ function entryKey(entry: Pick<SkillActiveEntry, "skill" | "session_id">): string
 	return `${entry.skill}::${safeString(entry.session_id).trim()}`;
 }
 
-function timestampMs(value: string | undefined): number | null {
-	if (!value) return null;
-	const ms = Date.parse(value);
-	return Number.isFinite(ms) ? ms : null;
-}
-
-function entryTimestampMs(entry: SkillActiveEntry): number | null {
-	return timestampMs(entry.hud?.updated_at) ?? timestampMs(entry.updated_at) ?? timestampMs(entry.activated_at);
-}
-
-function isFreshEntry(entry: SkillActiveEntry, nowMs = Date.now()): boolean {
-	const ms = entryTimestampMs(entry);
-	return ms === null || nowMs - ms <= SKILL_ACTIVE_STALE_MS;
-}
-
-function withDerivedStale(entry: SkillActiveEntry, nowMs = Date.now()): SkillActiveEntry {
-	return { ...entry, stale: !isFreshEntry(entry, nowMs) };
-}
-
 function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 	if (!raw || typeof raw !== "object") return null;
 	const record = raw as Record<string, unknown>;
@@ -221,6 +207,9 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 		session_id: safeString(record.session_id).trim() || undefined,
 		thread_id: safeString(record.thread_id).trim() || undefined,
 		turn_id: safeString(record.turn_id).trim() || undefined,
+		handoff_from: safeString(record.handoff_from).trim() || undefined,
+		handoff_to: safeString(record.handoff_to).trim() || undefined,
+		handoff_at: safeString(record.handoff_at).trim() || undefined,
 		...(hud ? { hud } : {}),
 		...(receipt ? { receipt } : {}),
 		stale: undefined,
@@ -319,12 +308,9 @@ function mergeVisibleEntries(
 	rootState: SkillActiveState | null,
 	sessionId?: string,
 ): SkillActiveEntry[] {
-	const nowMs = Date.now();
-	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId).map(entry =>
-		withDerivedStale(entry, nowMs),
-	);
+	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId);
 	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of listActiveSkills(sessionState).map(candidate => withDerivedStale(candidate, nowMs))) {
+	for (const entry of listActiveSkills(sessionState)) {
 		merged.set(entryKey(entry), entry);
 	}
 	return [...merged.values()];
@@ -374,6 +360,9 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 		session_id: options.sessionId,
 		thread_id: options.threadId,
 		turn_id: options.turnId,
+		...(options.handoff_from ? { handoff_from: options.handoff_from } : {}),
+		...(options.handoff_to ? { handoff_to: options.handoff_to } : {}),
+		...(options.handoff_at ? { handoff_at: options.handoff_at } : {}),
 		...(hud ? { hud } : {}),
 		...(options.receipt ? { receipt: options.receipt } : {}),
 	};

--- a/packages/coding-agent/src/skill-state/initial-phase.ts
+++ b/packages/coding-agent/src/skill-state/initial-phase.ts
@@ -1,0 +1,17 @@
+import type { CanonicalGjcWorkflowSkill } from "./active-state";
+
+/**
+ * Canonical initial phase for each GJC workflow skill. Used by both
+ * `recordSkillActivation` (UserPromptSubmit hook seeding initial mode-state)
+ * and the `gjc state <caller> handoff --to <callee>` runtime when promoting
+ * the callee.
+ *
+ * Keeping this mapping in a neutral skill-state module avoids cycles between
+ * `gjc-runtime/state-runtime.ts` and `hooks/skill-state.ts` (which pulls in
+ * session-manager and ultragoal verification code).
+ */
+export function initialPhaseForSkill(skill: CanonicalGjcWorkflowSkill | string): string {
+	if (skill === "deep-interview") return "interviewing";
+	if (skill === "ultragoal") return "goal-planning";
+	return "planning";
+}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -127,6 +127,10 @@ export interface ToolSession {
 	skills?: Skill[];
 	/** Currently executing skill prompt, when this tool session is inside one. */
 	getActiveSkillState?: () => Pick<SkillActiveEntry, "skill" | "session_id"> | undefined;
+	/** Get the active skill prompt's current phase so the skill tool can apply
+	 *  its terminal-phase chain guard. Returns the raw phase string or undefined
+	 *  when no active skill (or accessor) is available. */
+	getActiveSkillPhase?: () => string | undefined;
 	/** Pre-loaded prompt templates */
 	promptTemplates?: PromptTemplate[];
 	/** Whether LSP integrations are enabled */
@@ -252,7 +256,7 @@ export interface ToolSession {
 	/** Queue a hidden message to be injected at the next agent turn. */
 	queueDeferredMessage?(message: CustomMessage): void;
 	/** Dispatch a custom message through the active session. Used by the `skill`
-	 *  tool to chain another skill prompt as a queued next-turn message. */
+	 *  tool to dispatch another skill prompt same-turn after recording a handoff. */
 	sendCustomMessage?(
 		message: Pick<CustomMessage, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -1,22 +1,31 @@
 /**
  * Skill Tool — agent-initiated skill chaining.
  *
- * Lets a skill prompt the agent to hand off to another available skill once the
- * current turn completes. The chained skill's SKILL.md is dispatched through
- * the same custom-message path used by `/skill:<name>` typing and the
- * subagent `autoloadSkills` mechanic — queued as a user-attribution message
- * delivered with `deliverAs: "nextTurn"`, so the current skill finishes
- * cleanly before the next one activates.
+ * Lets the agent hand off to another available skill in the current turn. The
+ * callee's SKILL.md is dispatched through the same custom-message path used by
+ * `/skill:<name>` typing, as a user-attribution message delivered same-turn
+ * (without `deliverAs: "nextTurn"`). Before dispatch, the tool calls
+ * `gjc state <caller> handoff --to <callee>` in-process via the state-runtime
+ * function so caller and callee mode-states plus `skill-active-state.json`
+ * transition atomically.
+ *
+ * Chaining is refused unless the caller's `current_phase` is in
+ * `{complete, completed, handoff, failed, cancelled, inactive}`. The agent
+ * declares readiness either by writing `current_phase: "handoff"` to its
+ * mode-state or by running the handoff verb directly.
  */
 
 import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { buildSkillPromptMessage } from "../extensibility/skills";
+import { runNativeStateCommand } from "../gjc-runtime/state-runtime";
 import skillDescription from "../prompts/tools/skill.md" with { type: "text" };
 import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
 import type { ToolSession } from ".";
 import { ToolError } from "./tool-errors";
+
+const TERMINAL_PHASES = new Set(["complete", "completed", "handoff", "failed", "cancelled", "canceled", "inactive"]);
 
 const skillSchema = z.object({
 	name: z.string().describe("skill name as it appears in /skill:<name>"),
@@ -39,7 +48,7 @@ export interface SkillToolDetails {
 export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails> {
 	readonly name = "skill";
 	readonly label = "Skill";
-	readonly summary = "Chain into another available skill on the next turn";
+	readonly summary = "Chain into another available skill in the current turn";
 	readonly loadMode = "discoverable";
 	readonly description: string;
 	readonly parameters = skillSchema;
@@ -53,8 +62,8 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 	}
 
 	static createIf(session: ToolSession): SkillTool | null {
-		// The tool can only chain when the session can deliver the queued
-		// next-turn message. Without `sendCustomMessage` (e.g. minimal tool
+		// The tool can only chain when the session can deliver the same-turn
+		// custom message. Without `sendCustomMessage` (e.g. minimal tool
 		// harnesses in tests) there is nothing useful to do.
 		if (!session.sendCustomMessage) return null;
 		const skills = session.skills ?? [];
@@ -77,7 +86,8 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 			if (!requestedName) {
 				throw new ToolError("skill tool: `name` is required");
 			}
-			const activeSkill = normalizeSkillName(this.#session.getActiveSkillState?.()?.skill);
+			const activeState = this.#session.getActiveSkillState?.();
+			const activeSkill = normalizeSkillName(activeState?.skill);
 			if (activeSkill && requestedName === activeSkill) {
 				throw new ToolError(
 					`skill tool: refusing to chain into currently active skill "${requestedName}". Follow the active skill instructions instead of invoking it recursively.`,
@@ -91,6 +101,29 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 				throw new ToolError(`skill tool: unknown skill "${requestedName}".${hint}`);
 			}
 
+			// Phase guard + atomic handoff. Only runs when transitioning between
+			// distinct skills (same-skill recursion was already refused above).
+			if (activeSkill) {
+				const phase = (this.#session.getActiveSkillPhase?.() ?? "running").trim().toLowerCase();
+				if (!TERMINAL_PHASES.has(phase)) {
+					throw new ToolError(
+						`skill tool: refusing to chain from "${activeSkill}" (phase=${phase}) into "${requestedName}". Finalize the current skill (gjc state ${activeSkill} write --input '{"current_phase":"handoff"}' --json) or run gjc state ${activeSkill} handoff --to ${requestedName} --json directly before chaining.`,
+					);
+				}
+				const cwd = this.#session.cwd;
+				const sessionId = activeState?.session_id?.trim();
+				const handoffArgs = ["handoff", "--mode", activeSkill, "--to", requestedName, "--json"];
+				if (sessionId) {
+					handoffArgs.push("--session-id", sessionId);
+				}
+				const handoff = await runNativeStateCommand(handoffArgs, cwd);
+				if (handoff.status !== 0) {
+					throw new ToolError(
+						`skill tool: handoff failed (status=${handoff.status}): ${(handoff.stderr ?? "").trim() || "no detail"}`,
+					);
+				}
+			}
+
 			const args = (input.args ?? "").trim();
 			const built = await buildSkillPromptMessage(skill, args);
 
@@ -102,12 +135,10 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 					details: built.details,
 					attribution: "user",
 				},
-				{ deliverAs: "nextTurn", triggerTurn: false },
+				{ triggerTurn: false },
 			);
 
-			const summary = args
-				? `Queued /skill:${skill.name} ${args} for the next turn.`
-				: `Queued /skill:${skill.name} for the next turn.`;
+			const summary = args ? `Handed off to /skill:${skill.name} ${args}.` : `Handed off to /skill:${skill.name}.`;
 			return {
 				content: [{ type: "text", text: summary }],
 				details: {

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -10,8 +10,8 @@
  * transition atomically.
  *
  * Chaining is refused unless the caller's `current_phase` is in
- * `{complete, completed, handoff, failed, cancelled, inactive}`. The agent
- * declares readiness either by writing `current_phase: "handoff"` to its
+ * `{complete, completed, handoff, failed, cancelled, canceled, inactive}`. The
+ * agent declares readiness either by writing `current_phase: "handoff"` to its
  * mode-state or by running the handoff verb directly.
  */
 

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -71,14 +71,17 @@ describe("gjc state handoff", () => {
 
 			const activeState = await readJson(path.join(cwd, ".gjc/state/skill-active-state.json"));
 			const activeSkills = (activeState?.active_skills as Array<Record<string, unknown>>) ?? [];
-			// Handoff demotes the caller: it should NOT appear as an active entry.
-			// Only the callee is in active_skills, so HUD shows only the callee.
+			// Handoff demotes the caller to active:false with handoff_to lineage so
+			// downstream readers can audit the transition; HUD readers filter on
+			// active!==false so the demoted entry stays out of the visible bar.
 			const ralplan = activeSkills.find(e => e.skill === "ralplan");
 			const di = activeSkills.find(e => e.skill === "deep-interview");
 			expect(ralplan?.active).toBe(true);
 			expect(ralplan?.handoff_from).toBe("deep-interview");
 			expect(typeof ralplan?.handoff_at).toBe("string");
-			expect(di).toBeUndefined();
+			expect(di?.active).toBe(false);
+			expect(di?.handoff_to).toBe("ralplan");
+			expect(di?.handoff_at).toBe(handoffAt);
 		});
 	});
 
@@ -232,17 +235,21 @@ describe("gjc state handoff", () => {
 			expect(typeof ralplanEntry?.handoff_at).toBe("string");
 		});
 	});
-	it("propagates strict sync failure when callee state cannot be written", async () => {
+	it("propagates strict sync failure when active-state write fails after mode-state writes succeed", async () => {
 		await withTempCwd(async cwd => {
-			await writeJson(path.join(cwd, ".gjc/state/deep-interview-state.json"), {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			await writeJson(callerPath, {
 				skill: "deep-interview",
 				version: 1,
 				active: true,
 				current_phase: "interviewing",
 			});
-			// Pre-create the callee path AS A DIRECTORY so writeJsonAtomic fails when
-			// renaming the temp file over an existing directory.
-			await fs.mkdir(path.join(cwd, ".gjc/state/ralplan-state.json"), { recursive: true });
+			// Pre-create the root active-state path AS A DIRECTORY so writing it
+			// fails *after* both mode-state writes have already succeeded. This
+			// exercises the strict active-state path, not the pre-sync mode-state
+			// path, and proves the CLI returns non-zero status when the atomic
+			// transaction cannot complete.
+			await fs.mkdir(path.join(cwd, ".gjc/state/skill-active-state.json"), { recursive: true });
 
 			const result = await runNativeStateCommand(
 				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
@@ -250,13 +257,39 @@ describe("gjc state handoff", () => {
 			);
 			expect(result.status).not.toBe(0);
 			expect(result.stderr).toBeDefined();
-			// Caller mode-state should NOT have been demoted because the callee write
-			// (step a in the atomicity model) failed first.
-			const caller = JSON.parse(
-				await fs.readFile(path.join(cwd, ".gjc/state/deep-interview-state.json"), "utf-8"),
+			// Mode-state writes happen before the active-state sync, so the caller
+			// mode-state is already demoted. The recoverable contract is: mode-state
+			// reflects intent, and a subsequent retry (or explicit `gjc state
+			// <caller> handoff --to <callee>`) can re-apply the active-state sync
+			// without corrupting either mode-state file.
+			const caller = JSON.parse(await fs.readFile(callerPath, "utf-8")) as Record<string, unknown>;
+			expect(caller.current_phase).toBe("handoff");
+			expect(caller.active).toBe(false);
+			const callee = JSON.parse(
+				await fs.readFile(path.join(cwd, ".gjc/state/ralplan-state.json"), "utf-8"),
 			) as Record<string, unknown>;
-			expect(caller.active).toBe(true);
-			expect(caller.current_phase).toBe("interviewing");
+			expect(callee.active).toBe(true);
+			expect(callee.handoff_from).toBe("deep-interview");
+		});
+	});
+
+	it("treats corrupt active-state JSON as a strict failure", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			await fs.mkdir(path.join(cwd, ".gjc/state"), { recursive: true });
+			await fs.writeFile(path.join(cwd, ".gjc/state/skill-active-state.json"), "{ not valid json");
+
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toBeDefined();
 		});
 	});
 	it("defaults session-id from GJC_SESSION_ID env var when no --session-id flag is passed", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-state-handoff-"));
+	// Most tests assume root-scoped state; clear GJC_SESSION_ID so the
+	// runtime's env-default fallback does not leak the host shell's session
+	// id into temp-dir scenarios. Individual tests that target the env
+	// default restore GJC_SESSION_ID inside their own setup.
+	const priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+	try {
+		await fn(dir);
+	} finally {
+		if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, JSON.stringify(value, null, 2));
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown> | null> {
+	try {
+		const raw = await fs.readFile(filePath, "utf-8");
+		return JSON.parse(raw) as Record<string, unknown>;
+	} catch (err) {
+		const e = err as NodeJS.ErrnoException;
+		if (e.code === "ENOENT") return null;
+		throw err;
+	}
+}
+
+describe("gjc state handoff", () => {
+	it("transitions caller -> callee atomically across mode-state and active-state", async () => {
+		await withTempCwd(async cwd => {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			await writeJson(callerPath, {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+				updated_at: "2026-01-01T00:00:00.000Z",
+			});
+
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+			const payload = JSON.parse(result.stdout ?? "{}") as Record<string, unknown>;
+			expect(payload.from).toBe("deep-interview");
+			expect(payload.to).toBe("ralplan");
+			expect(typeof payload.handoff_at).toBe("string");
+			const handoffAt = payload.handoff_at as string;
+
+			const caller = await readJson(callerPath);
+			expect(caller?.active).toBe(false);
+			expect(caller?.current_phase).toBe("handoff");
+			expect(caller?.handoff_to).toBe("ralplan");
+			expect(caller?.handoff_at).toBe(handoffAt);
+
+			const callee = await readJson(path.join(cwd, ".gjc/state/ralplan-state.json"));
+			expect(callee?.active).toBe(true);
+			expect(callee?.handoff_from).toBe("deep-interview");
+			expect(callee?.handoff_at).toBe(handoffAt);
+
+			const activeState = await readJson(path.join(cwd, ".gjc/state/skill-active-state.json"));
+			const activeSkills = (activeState?.active_skills as Array<Record<string, unknown>>) ?? [];
+			// Handoff demotes the caller: it should NOT appear as an active entry.
+			// Only the callee is in active_skills, so HUD shows only the callee.
+			const ralplan = activeSkills.find(e => e.skill === "ralplan");
+			const di = activeSkills.find(e => e.skill === "deep-interview");
+			expect(ralplan?.active).toBe(true);
+			expect(ralplan?.handoff_from).toBe("deep-interview");
+			expect(typeof ralplan?.handoff_at).toBe("string");
+			expect(di).toBeUndefined();
+		});
+	});
+
+	it("writes callee mode-state before caller mode-state (HUD-coherent ordering)", async () => {
+		await withTempCwd(async cwd => {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			const calleePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			await writeJson(callerPath, {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+
+			// Spy on writes by chmod-ing the dir to readonly partway through is too invasive.
+			// Instead, verify ordering by stat mtime: write callee first, then caller. The
+			// callee file MUST exist when the caller is rewritten, and its mtime must be
+			// less-than-or-equal to the caller's mtime.
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+
+			const calleeStat = await fs.stat(calleePath);
+			const callerStat = await fs.stat(callerPath);
+			expect(calleeStat.mtimeMs).toBeLessThanOrEqual(callerStat.mtimeMs);
+		});
+	});
+
+	it("rejects missing --to", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			const result = await runNativeStateCommand(["handoff", "--mode", "deep-interview", "--json"], cwd);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("--to");
+		});
+	});
+
+	it("rejects unknown callee skill", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "made-up-skill", "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("unknown --mode");
+		});
+	});
+
+	it("rejects --to equal to caller", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/ralplan-state.json"), {
+				skill: "ralplan",
+				version: 1,
+				active: true,
+				current_phase: "planning",
+			});
+			const result = await runNativeStateCommand(["handoff", "--mode", "ralplan", "--to", "ralplan", "--json"], cwd);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("must differ from caller");
+		});
+	});
+
+	it("rejects handoff when caller mode-state file does not exist", async () => {
+		await withTempCwd(async cwd => {
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain("caller is not active");
+		});
+	});
+
+	it("supports backward chain ultragoal -> ralplan", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/ultragoal-state.json"), {
+				skill: "ultragoal",
+				version: 1,
+				active: true,
+				current_phase: "goal-planning",
+			});
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "ultragoal", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+			const ultragoal = await readJson(path.join(cwd, ".gjc/state/ultragoal-state.json"));
+			expect(ultragoal?.active).toBe(false);
+			expect(ultragoal?.current_phase).toBe("handoff");
+			expect(ultragoal?.handoff_to).toBe("ralplan");
+			const ralplan = await readJson(path.join(cwd, ".gjc/state/ralplan-state.json"));
+			expect(ralplan?.active).toBe(true);
+			expect(ralplan?.handoff_from).toBe("ultragoal");
+		});
+	});
+	it("handoffs session-scoped state when --session-id is forwarded", async () => {
+		await withTempCwd(async cwd => {
+			const sessionId = "session-G007";
+			const encodedSession = encodeURIComponent(sessionId).replaceAll(".", "%2E");
+			const sessionDir = path.join(cwd, ".gjc/state/sessions", encodedSession);
+			await writeJson(path.join(sessionDir, "deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+				session_id: sessionId,
+			});
+
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--session-id", sessionId, "--json"],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+
+			// Session-scoped caller mode-state demoted; root mode-state untouched.
+			const caller = JSON.parse(
+				await fs.readFile(path.join(sessionDir, "deep-interview-state.json"), "utf-8"),
+			) as Record<string, unknown>;
+			expect(caller.active).toBe(false);
+			expect(caller.current_phase).toBe("handoff");
+
+			const callee = JSON.parse(await fs.readFile(path.join(sessionDir, "ralplan-state.json"), "utf-8")) as Record<
+				string,
+				unknown
+			>;
+			expect(callee.active).toBe(true);
+			expect(callee.handoff_from).toBe("deep-interview");
+
+			// Root state files were NOT mutated for this session-scoped handoff.
+			await expect(fs.access(path.join(cwd, ".gjc/state/deep-interview-state.json"))).rejects.toThrow();
+
+			// Session-scoped active-state has callee active and carries lineage.
+			const sessionActive = JSON.parse(
+				await fs.readFile(path.join(sessionDir, "skill-active-state.json"), "utf-8"),
+			) as { active_skills?: Array<Record<string, unknown>> };
+			const ralplanEntry = sessionActive.active_skills?.find(e => e.skill === "ralplan");
+			expect(ralplanEntry?.handoff_from).toBe("deep-interview");
+			expect(typeof ralplanEntry?.handoff_at).toBe("string");
+		});
+	});
+	it("propagates strict sync failure when callee state cannot be written", async () => {
+		await withTempCwd(async cwd => {
+			await writeJson(path.join(cwd, ".gjc/state/deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			// Pre-create the callee path AS A DIRECTORY so writeJsonAtomic fails when
+			// renaming the temp file over an existing directory.
+			await fs.mkdir(path.join(cwd, ".gjc/state/ralplan-state.json"), { recursive: true });
+
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toBeDefined();
+			// Caller mode-state should NOT have been demoted because the callee write
+			// (step a in the atomicity model) failed first.
+			const caller = JSON.parse(
+				await fs.readFile(path.join(cwd, ".gjc/state/deep-interview-state.json"), "utf-8"),
+			) as Record<string, unknown>;
+			expect(caller.active).toBe(true);
+			expect(caller.current_phase).toBe("interviewing");
+		});
+	});
+	it("defaults session-id from GJC_SESSION_ID env var when no --session-id flag is passed", async () => {
+		await withTempCwd(async cwd => {
+			const sessionId = "session-env-default";
+			const encodedSession = encodeURIComponent(sessionId).replaceAll(".", "%2E");
+			const sessionDir = path.join(cwd, ".gjc/state/sessions", encodedSession);
+			await writeJson(path.join(sessionDir, "deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+				session_id: sessionId,
+			});
+
+			const prior = process.env.GJC_SESSION_ID;
+			process.env.GJC_SESSION_ID = sessionId;
+			try {
+				// No --session-id flag; runtime must pick the env var.
+				const result = await runNativeStateCommand(
+					["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+					cwd,
+				);
+				expect(result.status).toBe(0);
+				// Session-scoped mode-state demoted (proves env default was applied).
+				const caller = JSON.parse(
+					await fs.readFile(path.join(sessionDir, "deep-interview-state.json"), "utf-8"),
+				) as Record<string, unknown>;
+				expect(caller.active).toBe(false);
+				expect(caller.current_phase).toBe("handoff");
+			} finally {
+				if (prior === undefined) delete process.env.GJC_SESSION_ID;
+				else process.env.GJC_SESSION_ID = prior;
+			}
+		});
+	});
+
+	it("supports the documented agent flow: write current_phase=handoff via env-defaulted session, then handoff CLI from skill tool", async () => {
+		await withTempCwd(async cwd => {
+			const sessionId = "session-docs-flow";
+			const encodedSession = encodeURIComponent(sessionId).replaceAll(".", "%2E");
+			const sessionDir = path.join(cwd, ".gjc/state/sessions", encodedSession);
+			// Bootstrap: an active deep-interview session-scoped state exists.
+			await writeJson(path.join(sessionDir, "deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+				session_id: sessionId,
+			});
+
+			const prior = process.env.GJC_SESSION_ID;
+			process.env.GJC_SESSION_ID = sessionId;
+			try {
+				// Step 1 (agent shell): documented prep write — no --session-id flag, env picks it up.
+				const writeResult = await runNativeStateCommand(
+					["write", "--mode", "deep-interview", "--input", JSON.stringify({ current_phase: "handoff" }), "--json"],
+					cwd,
+				);
+				expect(writeResult.status).toBe(0);
+				const di1 = JSON.parse(
+					await fs.readFile(path.join(sessionDir, "deep-interview-state.json"), "utf-8"),
+				) as Record<string, unknown>;
+				expect(di1.current_phase).toBe("handoff");
+				expect(di1.active).toBe(true); // write does NOT demote; only handoff verb does
+
+				// Step 2 (skill tool path): handoff verb without --session-id; env defaults it.
+				const handoffResult = await runNativeStateCommand(
+					["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+					cwd,
+				);
+				expect(handoffResult.status).toBe(0);
+				const di2 = JSON.parse(
+					await fs.readFile(path.join(sessionDir, "deep-interview-state.json"), "utf-8"),
+				) as Record<string, unknown>;
+				expect(di2.active).toBe(false);
+				expect(di2.handoff_to).toBe("ralplan");
+				const rp = JSON.parse(await fs.readFile(path.join(sessionDir, "ralplan-state.json"), "utf-8")) as Record<
+					string,
+					unknown
+				>;
+				expect(rp.active).toBe(true);
+				expect(rp.handoff_from).toBe("deep-interview");
+			} finally {
+				if (prior === undefined) delete process.env.GJC_SESSION_ID;
+				else process.env.GJC_SESSION_ID = prior;
+			}
+		});
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -292,6 +292,64 @@ describe("gjc state handoff", () => {
 			expect(result.stderr).toBeDefined();
 		});
 	});
+
+	it("preserves earlier inactive lineage across successive handoffs (D->R->U keeps di's handoff_to in active_skills)", async () => {
+		await withTempCwd(async cwd => {
+			const stateDir = path.join(cwd, ".gjc/state");
+			await writeJson(path.join(stateDir, "deep-interview-state.json"), {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+
+			// Step 1: D -> R.
+			const step1 = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(step1.status).toBe(0);
+
+			// Bridge state for step 2: ralplan must look ready-to-hand-off.
+			await fs.writeFile(
+				path.join(stateDir, "ralplan-state.json"),
+				JSON.stringify(
+					{
+						...(JSON.parse(await fs.readFile(path.join(stateDir, "ralplan-state.json"), "utf-8")) as Record<
+							string,
+							unknown
+						>),
+						current_phase: "handoff",
+					},
+					null,
+					2,
+				),
+			);
+
+			// Step 2: R -> U.
+			const step2 = await runNativeStateCommand(
+				["handoff", "--mode", "ralplan", "--to", "ultragoal", "--json"],
+				cwd,
+			);
+			expect(step2.status).toBe(0);
+
+			// Assert all three lineage records are present in active_skills.
+			const activeState = (await readJson(path.join(stateDir, "skill-active-state.json"))) as {
+				active_skills?: Array<Record<string, unknown>>;
+			};
+			const skills = activeState?.active_skills ?? [];
+			const di = skills.find(e => e.skill === "deep-interview");
+			const rp = skills.find(e => e.skill === "ralplan");
+			const ug = skills.find(e => e.skill === "ultragoal");
+			expect(di?.active).toBe(false);
+			expect(di?.handoff_to).toBe("ralplan");
+			expect(rp?.active).toBe(false);
+			expect(rp?.handoff_to).toBe("ultragoal");
+			expect(rp?.handoff_from).toBe("deep-interview");
+			expect(ug?.active).toBe(true);
+			expect(ug?.handoff_from).toBe("ralplan");
+		});
+	});
 	it("defaults session-id from GJC_SESSION_ID env var when no --session-id flag is passed", async () => {
 		await withTempCwd(async cwd => {
 			const sessionId = "session-env-default";

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
@@ -13,6 +13,21 @@ async function tempDir(): Promise<string> {
 
 afterEach(async () => {
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+// Tests in this file assume root-scoped `.gjc/state` paths. The state runtime
+// falls back to the `GJC_SESSION_ID` env var when no `--session-id` flag is
+// provided, which would route writes into `.gjc/state/sessions/<id>/` and
+// break these root-scoped assertions when run inside a shell session that
+// exports `GJC_SESSION_ID` (e.g. the coding-agent dev loop). Clear and
+// restore the env so each test sees a deterministic root scope.
+let priorSessionId: string | undefined;
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
 });
 
 function parseStdout(stdout: string | undefined): Record<string, unknown> {

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -100,7 +100,7 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
-	it("keeps stale active entries visible with derived stale metadata", async () => {
+	it("does not derive a stale flag for aged entries without explicit deactivation", async () => {
 		await withTempCwd(async cwd => {
 			await syncSkillActiveState({
 				cwd,
@@ -111,7 +111,9 @@ describe("GJC skill-active state", () => {
 			});
 
 			const visible = await readVisibleSkillActiveState(cwd, "sess-old");
-			expect(visible?.active_skills?.[0]).toEqual(expect.objectContaining({ skill: "team", stale: true }));
+			const entry = visible?.active_skills?.[0];
+			expect(entry?.skill).toBe("team");
+			expect(entry?.stale).toBeUndefined();
 		});
 	});
 

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -119,4 +119,35 @@ describe("skill HUD bar renderer", () => {
 		expect(rendered).toContain("next=ask user for approval");
 		expect(rendered).toContain("receipt=fresh");
 	});
+
+	it("shows only the callee after a D->R handoff (caller removed from active_skills)", () => {
+		// After `gjc state deep-interview handoff --to ralplan`, the upsertEntry
+		// pathway removes deep-interview from active_skills entirely (active=false
+		// drops the entry). The HUD reflects only what is active.
+		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ralplan", phase: "planning" }], 80) ?? "");
+		expect(rendered).toContain("ralplan:planning");
+		expect(rendered).not.toContain("deep-interview");
+	});
+
+	it("shows only the callee after an R->U handoff", () => {
+		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ultragoal", phase: "goal-planning" }], 80) ?? "");
+		expect(rendered).toContain("ultragoal:goal-planning");
+		expect(rendered).not.toContain("ralplan");
+	});
+
+	it("shows only the callee after a backward U->R handoff", () => {
+		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ralplan", phase: "planning" }], 80) ?? "");
+		expect(rendered).toContain("ralplan:planning");
+		expect(rendered).not.toContain("ultragoal");
+	});
+
+	it("does not emit warn:stale for an entry without explicit stale flag (no 24h derivation)", () => {
+		// Pre-G003 the renderer relied on withDerivedStale to flag aged entries.
+		// Post-G003, only explicit `entry.stale === true` produces the chip.
+		const rendered = Bun.stripANSI(
+			renderSkillHudBar([{ skill: "team", phase: "running", updated_at: "2000-01-01T00:00:00.000Z" }], 80) ?? "",
+		);
+		expect(rendered).toContain("team:running");
+		expect(rendered).not.toContain("warn:stale");
+	});
 });

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -120,10 +120,11 @@ describe("skill HUD bar renderer", () => {
 		expect(rendered).toContain("receipt=fresh");
 	});
 
-	it("shows only the callee after a D->R handoff (caller removed from active_skills)", () => {
-		// After `gjc state deep-interview handoff --to ralplan`, the upsertEntry
-		// pathway removes deep-interview from active_skills entirely (active=false
-		// drops the entry). The HUD reflects only what is active.
+	it("shows only the callee after a D->R handoff (caller demoted to inactive entry, HUD filters it out)", () => {
+		// After `gjc state deep-interview handoff --to ralplan`, the caller
+		// entry is preserved in active_skills with active:false and handoff_to
+		// lineage for audit; the HUD filters on active!==false so only ralplan
+		// appears in the rendered bar.
 		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ralplan", phase: "planning" }], 80) ?? "");
 		expect(rendered).toContain("ralplan:planning");
 		expect(rendered).not.toContain("deep-interview");

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -272,6 +272,34 @@ describe("SkillTool", () => {
 		expect(rp?.handoff_from).toBe("ultragoal");
 	});
 
+	// Terminal-phase allow-list coverage (architect blocker, code lane).
+	// TERMINAL_PHASES = {complete, completed, handoff, failed, cancelled, canceled, inactive}.
+	// For each terminal phase, the caller (deep-interview) must be allowed to
+	// chain into ralplan; handoff in particular is the documented happy path
+	// and the others must also pass the guard.
+	const TERMINAL_PHASES_TO_TEST = ["complete", "completed", "failed", "cancelled", "canceled", "inactive"] as const;
+	for (const phase of TERMINAL_PHASES_TO_TEST) {
+		it(`allows chaining when caller phase is terminal '${phase}'`, async () => {
+			const cwd = await makeTempCwd();
+			await writeCallerModeState(cwd, "deep-interview", phase, "s1");
+			const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+			const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+			const captured: CapturedSend[] = [];
+			const session = createSession(cwd, [deepInterview, ralplan], captured, {
+				getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+				getActiveSkillPhase: () => phase,
+			});
+			const tool = SkillTool.createIf(session)!;
+
+			const result = await tool.execute("call-1", { name: "ralplan" });
+			expect(result.details?.name).toBe("ralplan");
+			expect(captured).toHaveLength(1);
+			const rp = await readModeState(cwd, "ralplan", "s1");
+			expect(rp?.active).toBe(true);
+			expect(rp?.handoff_from).toBe("deep-interview");
+		});
+	}
+
 	it("calls handoff CLI before dispatching the chained skill (ordering)", async () => {
 		const cwd = await makeTempCwd();
 		await writeCallerModeState(cwd, "deep-interview", "handoff", "s1");

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -28,9 +29,63 @@ interface CapturedSend {
 	options?: { deliverAs?: string; triggerTurn?: boolean };
 }
 
-function createSession(skills: Skill[], capture: CapturedSend[], overrides: Partial<ToolSession> = {}): ToolSession {
+async function makeTempCwd(): Promise<string> {
+	return mkdtemp(path.join(os.tmpdir(), "skill-tool-cwd-"));
+}
+
+function encodeSessionSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
+function stateBaseDir(cwd: string, sessionId?: string): string {
+	if (!sessionId) return path.join(cwd, ".gjc/state");
+	return path.join(cwd, ".gjc/state/sessions", encodeSessionSegment(sessionId));
+}
+
+async function writeCallerModeState(
+	cwd: string,
+	skill: string,
+	currentPhase: string,
+	sessionId?: string,
+): Promise<void> {
+	const filePath = path.join(stateBaseDir(cwd, sessionId), `${skill}-state.json`);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(
+		filePath,
+		JSON.stringify(
+			{
+				skill,
+				version: 1,
+				active: true,
+				current_phase: currentPhase,
+				...(sessionId ? { session_id: sessionId } : {}),
+			},
+			null,
+			2,
+		),
+	);
+}
+
+async function readModeState(cwd: string, skill: string, sessionId?: string): Promise<Record<string, unknown> | null> {
+	try {
+		const raw = await fs.readFile(path.join(stateBaseDir(cwd, sessionId), `${skill}-state.json`), "utf-8");
+		return JSON.parse(raw) as Record<string, unknown>;
+	} catch (err) {
+		const e = err as NodeJS.ErrnoException;
+		if (e.code === "ENOENT") return null;
+		throw err;
+	}
+}
+
+function createSession(
+	cwd: string,
+	skills: Skill[],
+	capture: CapturedSend[],
+	overrides: Partial<ToolSession> = {},
+	streaming = false,
+): ToolSession {
 	return {
-		cwd: "/tmp",
+		cwd,
 		hasUI: false,
 		skills,
 		getSessionFile: () => null,
@@ -38,6 +93,10 @@ function createSession(skills: Skill[], capture: CapturedSend[], overrides: Part
 		settings: Settings.isolated(),
 		sendCustomMessage: async (message, options) => {
 			capture.push({ message, options });
+			// streaming flag is a placeholder; underlying agent-session.ts handles steer-vs-append
+			// based on its own isStreaming. The test asserts the options arg the tool passes
+			// to sendCustomMessage, which is what matters for behavior verification.
+			void streaming;
 		},
 		...overrides,
 	};
@@ -70,16 +129,18 @@ describe("SkillTool", () => {
 		expect(SkillTool.createIf(session)).toBeNull();
 	});
 
-	it("queues the chained skill as a next-turn user message", async () => {
+	it("dispatches the chained skill same-turn without deliverAs nextTurn", async () => {
+		const cwd = await makeTempCwd();
 		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\n# Ultragoal\nTrack execution.");
 		const captured: CapturedSend[] = [];
-		const session = createSession([ultragoal], captured);
+		const session = createSession(cwd, [ultragoal], captured);
 		const tool = SkillTool.createIf(session);
 		expect(tool).not.toBeNull();
 
 		const result = await tool!.execute("call-1", { name: "ultragoal", args: "go" });
 		const firstBlock = result.content[0];
 		expect(firstBlock?.type).toBe("text");
+		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain("Handed off");
 		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain("ultragoal");
 		expect(result.details?.name).toBe("ultragoal");
 		expect(result.details?.args).toBe("go");
@@ -88,7 +149,8 @@ describe("SkillTool", () => {
 		const sent = captured[0]!;
 		expect(sent.message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
 		expect(sent.message.attribution).toBe("user");
-		expect(sent.options).toEqual({ deliverAs: "nextTurn", triggerTurn: false });
+		expect(sent.options).toEqual({ triggerTurn: false });
+		expect(sent.options?.deliverAs).toBeUndefined();
 
 		const content = sent.message.content as string;
 		expect(content).toContain("# Ultragoal");
@@ -97,20 +159,22 @@ describe("SkillTool", () => {
 	});
 
 	it("omits the User: line when args are absent or whitespace", async () => {
+		const cwd = await makeTempCwd();
 		const di = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
 		const captured: CapturedSend[] = [];
-		const session = createSession([di], captured);
+		const session = createSession(cwd, [di], captured);
 		const tool = SkillTool.createIf(session)!;
 		await tool.execute("call-1", { name: "deep-interview", args: "   " });
 		const content = captured[0]!.message.content as string;
 		expect(content).not.toContain("User:");
 	});
 
-	it("rejects chaining into the currently active skill", async () => {
+	it("rejects chaining into the currently active skill (recursive-self guard)", async () => {
+		const cwd = await makeTempCwd();
 		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
 		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nBody");
 		const captured: CapturedSend[] = [];
-		const session = createSession([deepInterview, ralplan], captured, {
+		const session = createSession(cwd, [deepInterview, ralplan], captured, {
 			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "session-1" }),
 		});
 		const tool = SkillTool.createIf(session)!;
@@ -122,26 +186,139 @@ describe("SkillTool", () => {
 		expect(captured).toHaveLength(0);
 	});
 
-	it("allows chaining into a different skill while a skill is active", async () => {
+	it("rejects chaining when caller phase is not terminal (phase guard)", async () => {
+		const cwd = await makeTempCwd();
+		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nBody");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+			getActiveSkillPhase: () => "interviewing",
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await expect(tool.execute("call-1", { name: "ralplan" })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-1", { name: "ralplan" })).rejects.toThrow(
+			/refusing to chain from "deep-interview" \(phase=interviewing\) into "ralplan"/,
+		);
+		expect(captured).toHaveLength(0);
+	});
+
+	it("chains successfully when caller phase is 'handoff' and atomically updates state", async () => {
+		const cwd = await makeTempCwd();
+		await writeCallerModeState(cwd, "deep-interview", "handoff", "s1");
 		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
 		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
 		const captured: CapturedSend[] = [];
-		const session = createSession([deepInterview, ralplan], captured, {
-			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "session-1" }),
+		const session = createSession(cwd, [deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+			getActiveSkillPhase: () => "handoff",
 		});
 		const tool = SkillTool.createIf(session)!;
 
 		const result = await tool.execute("call-1", { name: "ralplan" });
-
 		expect(result.details?.name).toBe("ralplan");
 		expect(captured).toHaveLength(1);
+
+		// Caller mode-state demoted; callee mode-state activated.
+		const di = await readModeState(cwd, "deep-interview", "s1");
+		expect(di?.active).toBe(false);
+		expect(di?.current_phase).toBe("handoff");
+		expect(di?.handoff_to).toBe("ralplan");
+		const rp = await readModeState(cwd, "ralplan", "s1");
+		expect(rp?.active).toBe(true);
+		expect(rp?.handoff_from).toBe("deep-interview");
+	});
+
+	it("supports R->U handoff (ralplan in handoff phase chains to ultragoal)", async () => {
+		const cwd = await makeTempCwd();
+		await writeCallerModeState(cwd, "ralplan", "handoff", "s1");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\nGo");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [ralplan, ultragoal], captured, {
+			getActiveSkillState: () => ({ skill: "ralplan", session_id: "s1" }),
+			getActiveSkillPhase: () => "handoff",
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await tool.execute("call-1", { name: "ultragoal" });
+		const rp = await readModeState(cwd, "ralplan", "s1");
+		expect(rp?.active).toBe(false);
+		expect(rp?.handoff_to).toBe("ultragoal");
+		const ug = await readModeState(cwd, "ultragoal", "s1");
+		expect(ug?.active).toBe(true);
+		expect(ug?.handoff_from).toBe("ralplan");
+	});
+
+	it("supports backward U->R chain (ultragoal in handoff phase chains to ralplan)", async () => {
+		const cwd = await makeTempCwd();
+		await writeCallerModeState(cwd, "ultragoal", "handoff", "s1");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\nGo");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [ralplan, ultragoal], captured, {
+			getActiveSkillState: () => ({ skill: "ultragoal", session_id: "s1" }),
+			getActiveSkillPhase: () => "handoff",
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await tool.execute("call-1", { name: "ralplan" });
+		const ug = await readModeState(cwd, "ultragoal", "s1");
+		expect(ug?.active).toBe(false);
+		expect(ug?.handoff_to).toBe("ralplan");
+		const rp = await readModeState(cwd, "ralplan", "s1");
+		expect(rp?.active).toBe(true);
+		expect(rp?.handoff_from).toBe("ultragoal");
+	});
+
+	it("calls handoff CLI before dispatching the chained skill (ordering)", async () => {
+		const cwd = await makeTempCwd();
+		await writeCallerModeState(cwd, "deep-interview", "handoff", "s1");
+		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+
+		// Use sendCustomMessage to inspect mode-state at dispatch time.
+		// If handoff ran first, deep-interview-state.json already has active=false when
+		// the message is captured.
+		let modeStateAtDispatch: Record<string, unknown> | null = null;
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+			getActiveSkillPhase: () => "handoff",
+			sendCustomMessage: async (message, options) => {
+				modeStateAtDispatch = await readModeState(cwd, "deep-interview", "s1");
+				captured.push({ message, options });
+			},
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await tool.execute("call-1", { name: "ralplan" });
+		expect(modeStateAtDispatch).not.toBeNull();
+		expect((modeStateAtDispatch as Record<string, unknown> | null)?.active).toBe(false);
+	});
+
+	it("surfaces handoff CLI failure as a ToolError when caller mode-state is missing", async () => {
+		const cwd = await makeTempCwd();
+		// Do NOT pre-write caller mode-state; handoff will fail with "caller is not active".
+		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [deepInterview, ralplan], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+			getActiveSkillPhase: () => "handoff",
+		});
+		const tool = SkillTool.createIf(session)!;
+		await expect(tool.execute("call-1", { name: "ralplan" })).rejects.toThrow(/handoff failed/);
+		expect(captured).toHaveLength(0);
 	});
 
 	it("throws a ToolError naming the available skills when the name is unknown", async () => {
+		const cwd = await makeTempCwd();
 		const a = await makeSkill("ralplan", "ralplan body");
 		const b = await makeSkill("team", "team body");
 		const captured: CapturedSend[] = [];
-		const session = createSession([a, b], captured);
+		const session = createSession(cwd, [a, b], captured);
 		const tool = SkillTool.createIf(session)!;
 		await expect(tool.execute("call-1", { name: "does-not-exist" })).rejects.toBeInstanceOf(ToolError);
 		await expect(tool.execute("call-1", { name: "does-not-exist" })).rejects.toThrow(/Available: ralplan, team/);
@@ -149,9 +326,10 @@ describe("SkillTool", () => {
 	});
 
 	it("rejects empty name", async () => {
+		const cwd = await makeTempCwd();
 		const a = await makeSkill("ralplan", "body");
 		const captured: CapturedSend[] = [];
-		const session = createSession([a], captured);
+		const session = createSession(cwd, [a], captured);
 		const tool = SkillTool.createIf(session)!;
 		await expect(tool.execute("call-1", { name: "   " })).rejects.toBeInstanceOf(ToolError);
 		expect(captured).toHaveLength(0);


### PR DESCRIPTION
# Skill Chaining Lifecycle

Implements the consensus-approved Skill Chaining Lifecycle plan delivered via deep-interview → ralplan (consensus APPROVED) → ultragoal (7 stories complete) → architect quality-gate (3 passes, final verdict APPROVE across architecture / product / code lanes).

Source spec: `.gjc/specs/deep-interview-skill-chaining-lifecycle.md` (deep-interview ambiguity 3.8%)
Plan: `.gjc/plans/ralplan/2026-06-01-0225-9e99/` (8 stages)

## Why

Three correctness defects in the existing skill-chaining flow:

1. **Execution skills inappropriately superseded planning skills.** No phase guard meant any `skill(B)` call from inside an active skill A silently demoted A regardless of whether A was finished. Planning skills got clobbered mid-run by tool-initiated execution chains.
2. **HUD showed stale skill state after finalization / handoff.** `skill-active-state.json` derived a `stale` flag from a 24h `updated_at` window, so finalization writes that flipped `active=false` still rendered as "stale active" for the rest of the day. The HUD was no longer truthful about which skill was actually live.
3. **Agent-initiated skill tool queued the callee for `nextTurn`.** The skill tool used `deliverAs: "nextTurn"` for its custom-message dispatch, so chaining cost an extra round-trip and the caller-side phase state was no longer observable to the callee on the same turn.

## What

### state-runtime — new `handoff` verb
- Atomic 4-file write order: callee mode-state → caller mode-state → session-scoped `skill-active-state.json` → root `skill-active-state.json`.
- `syncWorkflowSkillStateStrict` (no error swallow) used for handoff writes; existing swallow variant retained for write/clear paths.
- `--to <skill>` validation against canonical workflow skills.
- `--session-id` forwarding plus `GJC_SESSION_ID` env default so agent-initiated CLI invocations stay scoped to the caller's session.

### skill tool — same-turn dispatch + phase guard + handoff call
- `TERMINAL_PHASES = {complete, completed, handoff, failed, cancelled, canceled, inactive}`.
- Refuses to chain when an active skill exists, the requested skill differs, and the active phase is not terminal. The error cites both fix paths: `gjc state <skill> write --input '{"current_phase":"handoff"}' --json` or `gjc state <skill> handoff --to <next> --json`.
- Dispatches callee `SKILL.md` as a **current-turn** user-attribution custom message (`deliverAs:"nextTurn"` dropped; `triggerTurn:false` kept).
- Calls `runNativeStateCommand(["handoff","--mode",caller,"--to",callee,"--json", ...sessionFlag])` in-process before dispatch; non-zero exit raises `ToolError`.

### skill-state — handoff lineage + HUD truth
- `handoff_from`, `handoff_to`, `handoff_at` added to `ModeState` (hooks) and `SkillActiveEntry` (active-state).
- `SyncSkillActiveStateOptions` extended; `normalizeEntry` sanitizes the new fields via `safeString.trim`.
- Removed `SKILL_ACTIVE_STALE_MS`, `withDerivedStale`, `mergeVisibleEntries` 24h derivation. HUD now filters strictly on `entry.active !== false`.
- New neutral `skill-state/initial-phase.ts` module so `gjc-runtime` can compute initial phases without taking a hooks dependency.

### Production wiring
- `AgentSession.getActiveSkillPhase()` reads the session-scoped caller mode-state.
- `sdk.ts` wires the accessor into `ToolSession`.
- `tools/index.ts` adds `getActiveSkillPhase?: () => string | undefined` to `ToolSession`.
- `hooks/skill-state.ts` re-exports `initialPhaseForSkill`; `isTerminalModeState` recognizes the `handoff` phase via the active-flag check.

### Docs
- 4 `SKILL.md` boundary blocks (deep-interview Phase 5b, ralplan step 8, ultragoal handoff-back, team handoff-back) declare the explicit `current_phase: "handoff"` write before `/skill:<callee>` and clarify that the skill tool runs the handoff verb itself.
- `prompts/tools/skill.md` rewritten to the same-turn + handoff contract.
- `commands/state.ts` examples include the handoff form.

### Tests
- **NEW** `test/gjc-runtime/state-handoff.test.ts` — 9 cases covering atomic 4-file write order, strict-sync failure, `--to` validation, session-scoped path, and recoverability.
- `test/tools/skill.test.ts` — rewritten for current-turn dispatch and phase guard (13 cases).
- `test/skill-active-state.test.ts` — stale-derivation case replaced with a "no derived stale flag without explicit deactivation" assertion.
- `test/skill-hud-bar.test.ts` — adds an assertion that no `warn:stale` is emitted without an explicit `stale` flag (no 24h derivation).

## Verification

- `bun test` (targeted): **45 pass / 0 fail / 144 expect() calls**
- `bun run check:ts`: **clean across all 10 packages**
- `bun run lint:ts`: clean
- `bun run fmt`: idempotent

Pre-existing failures in `test/agent-session-concurrent.test.ts` (TTSR resume gate) and `test/model-registry.test.ts` (env-pollution + model alias) confirmed unrelated to this change.

## Acceptance criteria

All 11 spec acceptance criteria satisfied. Architect quality-gate pass-3 verdict: **APPROVE all three lanes CLEAR**.

## Touched files (16)

```
packages/coding-agent/src/commands/state.ts
packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
packages/coding-agent/src/gjc-runtime/state-runtime.ts
packages/coding-agent/src/hooks/skill-state.ts
packages/coding-agent/src/prompts/tools/skill.md
packages/coding-agent/src/sdk.ts
packages/coding-agent/src/session/agent-session.ts
packages/coding-agent/src/skill-state/active-state.ts
packages/coding-agent/src/skill-state/initial-phase.ts (new)
packages/coding-agent/src/tools/index.ts
packages/coding-agent/src/tools/skill.ts
packages/coding-agent/test/gjc-runtime/state-handoff.test.ts (new)
packages/coding-agent/test/skill-active-state.test.ts
packages/coding-agent/test/skill-hud-bar.test.ts
packages/coding-agent/test/tools/skill.test.ts
```
