### PR TITLE
Implement deep-interview spec persistence handoff

### DIFF
--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -1,10 +1,33 @@
-import { Command } from "@gajae-code/utils/cli";
+import { Command, Flags } from "@gajae-code/utils/cli";
 import { runNativeDeepInterviewCommand } from "../gjc-runtime/deep-interview-runtime";
 
 export default class DeepInterview extends Command {
 	static description = "Run native GJC deep-interview workflow";
 	static strict = false;
-	static examples = ['$ gjc deep-interview --standard "<idea>"'];
+	static flags = {
+		quick: Flags.boolean({ description: "Seed a quick deep-interview run" }),
+		standard: Flags.boolean({ description: "Seed a standard deep-interview run" }),
+		deep: Flags.boolean({ description: "Seed a deep deep-interview run" }),
+		threshold: Flags.string({ description: "Override ambiguity threshold for kickoff" }),
+		"threshold-source": Flags.string({ description: "Describe the threshold override source" }),
+		"session-id": Flags.string({
+			description: "Route state/spec handoff through a session-scoped .gjc state directory",
+		}),
+		write: Flags.boolean({ description: "Persist a final deep-interview spec through the sanctioned GJC CLI/API" }),
+		stage: Flags.string({ description: 'Spec stage for --write (currently "final")' }),
+		slug: Flags.string({ description: "Safe slug for .gjc/specs/deep-interview-<slug>.md" }),
+		spec: Flags.string({ description: "Final spec markdown or a path to the final spec markdown" }),
+		handoff: Flags.string({ description: 'After --write, hand off to a workflow target (currently "ralplan")' }),
+		deliberate: Flags.boolean({
+			description: "Shortcut for --write handoff to ralplan in deliberate consensus mode",
+		}),
+		json: Flags.boolean({ description: "Output JSON" }),
+	};
+	static examples = [
+		'$ gjc deep-interview --standard "<idea>"',
+		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md",
+		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md --deliberate",
+	];
 
 	async run(): Promise<void> {
 		const result = await runNativeDeepInterviewCommand(this.argv, process.cwd());

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -389,8 +389,9 @@ When ambiguity ≤ threshold (or hard cap / early exit):
 1. **Generate the specification** using opus model with the prompt-safe transcript. If the full interview transcript or initial context is too large, include the summary plus all concrete decisions, acceptance criteria, unresolved gaps, and ontology snapshots; never overflow the prompt with raw oversized context.
 2. **Write the final spec through the workflow CLI**: persist the artifact at `.gjc/specs/deep-interview-{slug}.md`
    - Always use this exact final spec path. Do not write temporary working files to the repo root or other ad hoc paths; repos may allowlist `.gjc/` for planning artifacts while protecting product branches.
-   - Use the GJC workflow/state CLI for artifact and state persistence; direct `.gjc/` file edits are forbidden unless an explicit force override is active.
+   - Use the native deep-interview write command with `--write --stage final --slug {slug} --spec <markdown-or-path> [--json]` for artifact and state persistence; direct `.gjc/` file edits are forbidden unless an explicit force override is active.
    - Persist the final `spec_path` in state when available so downstream skills and resumed sessions can pass the artifact path explicitly.
+   - If the user preselected the deliberate ralplan path, use the native deep-interview write command with `--write --stage final --slug {slug} --spec <markdown-or-path> --deliberate [--json]` so the final spec is persisted before deep-interview hands off to ralplan.
 
 Spec structure:
 
@@ -517,13 +518,20 @@ After the spec is written, mark it `pending approval` and present execution opti
 
 ### Phase 5b: Handoff before chain
 
-Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, mark deep-interview ready for handoff so the skill tool's chain guard lets the transition proceed. Run:
+Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, the final spec must already be persisted through the native deep-interview write command. For ordinary user-selected handoff, mark deep-interview ready for the skill tool's chain guard:
 
 ```
 gjc state deep-interview write --input '{"current_phase":"handoff"}' --json
 ```
 
-The skill tool then dispatches the next skill same-turn and runs `gjc state deep-interview handoff --to <callee> --json` in-process to atomically demote deep-interview, promote the callee, and sync both `skill-active-state.json` files. You do not need to run the handoff verb yourself. Skipping the `current_phase: "handoff"` write leaves the skill tool's terminal-phase guard refusing to chain.
+For a preselected deliberate ralplan path, prefer the single sanctioned bridge command instead:
+
+```
+gjc \
+deep-interview --write --stage final --slug {slug} --spec <markdown-or-path> --deliberate --json
+```
+
+That command persists `.gjc/specs/deep-interview-{slug}.md`, seeds ralplan in deliberate mode, and performs the safe deep-interview → ralplan state handoff. Skipping spec persistence leaves the Phase 5 chain blocked by design.
 
 ### Approval-Gated Refinement Path (Recommended)
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -1,8 +1,11 @@
+import { createHash, randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildDeepInterviewHudSummary } from "../skill-state/workflow-hud";
+import { runNativeRalplanCommand } from "./ralplan-runtime";
+import { runNativeStateCommand } from "./state-runtime";
 
 /**
  * Native implementation of `gjc deep-interview`.
@@ -42,7 +45,15 @@ class DeepInterviewCommandError extends Error {
 	}
 }
 
-const VALUE_FLAGS = new Set(["--session-id", "--threshold", "--threshold-source"]);
+const VALUE_FLAGS = new Set([
+	"--session-id",
+	"--threshold",
+	"--threshold-source",
+	"--stage",
+	"--slug",
+	"--spec",
+	"--handoff",
+]);
 
 function flagValue(args: readonly string[], flag: string): string | undefined {
 	const index = args.indexOf(flag);
@@ -64,6 +75,56 @@ function encodeSessionSegment(value: string): string {
 	return encodeURIComponent(value).replaceAll(".", "%2E");
 }
 
+function defaultSpecSlug(now: Date = new Date()): string {
+	const yyyy = now.getUTCFullYear().toString().padStart(4, "0");
+	const mm = (now.getUTCMonth() + 1).toString().padStart(2, "0");
+	const dd = now.getUTCDate().toString().padStart(2, "0");
+	const hh = now.getUTCHours().toString().padStart(2, "0");
+	const min = now.getUTCMinutes().toString().padStart(2, "0");
+	return `${yyyy}-${mm}-${dd}-${hh}${min}-${randomBytes(2).toString("hex")}`;
+}
+
+function stateDirFor(cwd: string, sessionId: string | undefined): string {
+	return sessionId
+		? path.join(cwd, ".gjc", "state", "sessions", encodeSessionSegment(sessionId))
+		: path.join(cwd, ".gjc", "state");
+}
+
+function deepInterviewStatePath(cwd: string, sessionId: string | undefined): string {
+	return path.join(stateDirFor(cwd, sessionId), "deep-interview-state.json");
+}
+
+async function readJsonObject(filePath: string): Promise<Record<string, unknown>> {
+	try {
+		const parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+	} catch {
+		// Missing/corrupt state should not prevent the sanctioned persistence CLI from writing a receipt.
+	}
+	return {};
+}
+
+async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	const tmp = `${filePath}.tmp-${randomBytes(6).toString("hex")}`;
+	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`);
+	await fs.rename(tmp, filePath);
+}
+
+async function resolveSpecContent(rawSpec: string, cwd: string): Promise<string> {
+	const candidate = path.isAbsolute(rawSpec) ? rawSpec : path.resolve(cwd, rawSpec);
+	try {
+		const stat = await fs.stat(candidate);
+		if (stat.isFile()) return await fs.readFile(candidate, "utf-8");
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code !== "ENOENT" && err.code !== "ENOTDIR") {
+			throw new DeepInterviewCommandError(2, `failed to read --spec ${candidate}: ${err.message}`);
+		}
+	}
+	return rawSpec;
+}
+
 interface ResolvedDeepInterviewArgs {
 	resolution: DeepInterviewResolution;
 	threshold: number;
@@ -71,6 +132,41 @@ interface ResolvedDeepInterviewArgs {
 	sessionId?: string;
 	idea: string;
 	json: boolean;
+}
+
+export interface ResolvedDeepInterviewSpecWriteArgs {
+	stage: "final";
+	slug: string;
+	spec: string;
+	sessionId?: string;
+	json: boolean;
+	deliberate: boolean;
+	handoff?: "ralplan";
+}
+
+export interface PersistedDeepInterviewSpec {
+	slug: string;
+	path: string;
+	stage: "final";
+	sha256: string;
+	createdAt: string;
+	statePath: string;
+}
+
+interface DeepInterviewSpecWriteSummary {
+	skill: "deep-interview";
+	stage: "final";
+	slug: string;
+	path: string;
+	sha256: string;
+	created_at: string;
+	state_path: string;
+	handoff?: {
+		to: "ralplan";
+		mode: "deliberate";
+		state_path?: string;
+		run_id?: string;
+	};
 }
 
 async function readSettingsAmbiguityThreshold(
@@ -107,6 +203,68 @@ async function resolveConfiguredAmbiguityThreshold(
 	const configDir = process.env.GJC_CONFIG_DIR?.trim() || path.join(os.homedir(), ".gjc");
 	const userSettings = path.join(configDir, "settings.json");
 	return await readSettingsAmbiguityThreshold(userSettings);
+}
+
+function isDeepInterviewSpecWriteInvocation(args: readonly string[]): boolean {
+	return hasFlag(args, "--write");
+}
+
+async function resolveSpecWriteArgs(args: readonly string[], cwd: string): Promise<ResolvedDeepInterviewSpecWriteArgs> {
+	const stage = flagValue(args, "--stage")?.trim() || "final";
+	if (stage !== "final") {
+		throw new DeepInterviewCommandError(2, 'unknown --stage for deep-interview --write: expected "final"');
+	}
+
+	const slug = flagValue(args, "--slug")?.trim() || defaultSpecSlug();
+	assertSafePathComponent(slug, "slug");
+
+	const rawSpec = flagValue(args, "--spec");
+	if (rawSpec === undefined || rawSpec === "") {
+		throw new DeepInterviewCommandError(2, "--spec is required for deep-interview --write");
+	}
+
+	const sessionId = flagValue(args, "--session-id")?.trim() || undefined;
+	if (sessionId) assertSafePathComponent(sessionId, "session-id");
+
+	const rawHandoff = flagValue(args, "--handoff")?.trim() || undefined;
+	if (rawHandoff && rawHandoff !== "ralplan") {
+		throw new DeepInterviewCommandError(2, 'unknown --handoff target: expected "ralplan"');
+	}
+
+	const allowedFlags = new Set([
+		"--write",
+		"--stage",
+		"--slug",
+		"--spec",
+		"--session-id",
+		"--handoff",
+		"--deliberate",
+		"--json",
+	]);
+	let skipNext = false;
+	for (const arg of args) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (["--stage", "--slug", "--spec", "--session-id", "--handoff"].includes(arg)) {
+			skipNext = true;
+			continue;
+		}
+		if (arg.startsWith("-") && !allowedFlags.has(arg)) {
+			throw new DeepInterviewCommandError(2, `unknown flag for gjc deep-interview --write: ${arg}`);
+		}
+	}
+
+	return {
+		stage: "final",
+		slug,
+		spec: await resolveSpecContent(rawSpec, cwd),
+		sessionId,
+		json: hasFlag(args, "--json"),
+		deliberate: hasFlag(args, "--deliberate"),
+		handoff: rawHandoff as "ralplan" | undefined,
+	};
 }
 
 async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): Promise<ResolvedDeepInterviewArgs> {
@@ -173,6 +331,57 @@ async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): P
 	};
 }
 
+export async function persistDeepInterviewSpec(
+	cwd: string,
+	resolved: ResolvedDeepInterviewSpecWriteArgs,
+): Promise<PersistedDeepInterviewSpec> {
+	const specsDir = path.join(cwd, ".gjc", "specs");
+	await fs.mkdir(specsDir, { recursive: true });
+	const specPath = path.join(specsDir, `deep-interview-${resolved.slug}.md`);
+	const content = resolved.spec.endsWith("\n") ? resolved.spec : `${resolved.spec}\n`;
+	await fs.writeFile(specPath, content);
+
+	const sha256 = createHash("sha256").update(content).digest("hex");
+	const createdAt = new Date().toISOString();
+	await fs.appendFile(
+		path.join(specsDir, "deep-interview-index.jsonl"),
+		`${JSON.stringify({ slug: resolved.slug, stage: resolved.stage, path: specPath, created_at: createdAt, sha256 })}\n`,
+	);
+
+	const statePath = deepInterviewStatePath(cwd, resolved.sessionId);
+	const existing = await readJsonObject(statePath);
+	const payload: Record<string, unknown> = {
+		...existing,
+		active: true,
+		current_phase: "handoff",
+		skill: "deep-interview",
+		version: typeof existing.version === "number" ? existing.version : 1,
+		spec_slug: resolved.slug,
+		spec_path: specPath,
+		spec_sha256: sha256,
+		spec_stage: resolved.stage,
+		spec_persisted_at: createdAt,
+		updated_at: createdAt,
+	};
+	if (resolved.sessionId) payload.session_id = resolved.sessionId;
+	await writeJsonAtomic(statePath, payload);
+	await syncDeepInterviewHud({
+		cwd,
+		sessionId: resolved.sessionId,
+		phase: "handoff",
+		specStatus: "persisted",
+	});
+
+	return {
+		slug: resolved.slug,
+		path: specPath,
+		stage: resolved.stage,
+		sha256,
+		createdAt,
+		statePath,
+	};
+}
+
 async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepInterviewArgs): Promise<string> {
 	const stateDir = resolved.sessionId
 		? path.join(cwd, ".gjc", "state", "sessions", encodeSessionSegment(resolved.sessionId))
@@ -232,11 +441,69 @@ async function syncDeepInterviewHud(options: {
 	}
 }
 
+async function handleSpecWrite(args: readonly string[], cwd: string): Promise<DeepInterviewCommandResult> {
+	const resolved = await resolveSpecWriteArgs(args, cwd);
+	const persisted = await persistDeepInterviewSpec(cwd, resolved);
+	const shouldHandoff = resolved.deliberate || resolved.handoff === "ralplan";
+	const summary: DeepInterviewSpecWriteSummary = {
+		skill: "deep-interview",
+		stage: persisted.stage,
+		slug: persisted.slug,
+		path: persisted.path,
+		sha256: persisted.sha256,
+		created_at: persisted.createdAt,
+		state_path: persisted.statePath,
+	};
+
+	if (shouldHandoff) {
+		const ralplanArgs = ["--deliberate", "--json"];
+		if (resolved.sessionId) ralplanArgs.push("--session-id", resolved.sessionId);
+		ralplanArgs.push(persisted.path);
+		const ralplanResult = await runNativeRalplanCommand(ralplanArgs, cwd);
+		if (ralplanResult.status !== 0) {
+			throw new DeepInterviewCommandError(
+				ralplanResult.status,
+				ralplanResult.stderr?.trim() || "failed to seed ralplan",
+			);
+		}
+
+		const handoffArgs = ["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"];
+		if (resolved.sessionId) handoffArgs.push("--session-id", resolved.sessionId);
+		const handoffResult = await runNativeStateCommand(handoffArgs, cwd);
+		if (handoffResult.status !== 0) {
+			throw new DeepInterviewCommandError(
+				handoffResult.status,
+				handoffResult.stderr?.trim() || "failed to hand off deep-interview to ralplan",
+			);
+		}
+
+		const ralplanPayload = ralplanResult.stdout ? (JSON.parse(ralplanResult.stdout) as Record<string, unknown>) : {};
+		summary.handoff = {
+			to: "ralplan",
+			mode: "deliberate",
+			state_path: typeof ralplanPayload.state_path === "string" ? ralplanPayload.state_path : undefined,
+			run_id: typeof ralplanPayload.run_id === "string" ? ralplanPayload.run_id : undefined,
+		};
+	}
+
+	const stdout = resolved.json
+		? `${JSON.stringify(summary, null, 2)}\n`
+		: [
+				`Persisted deep-interview ${persisted.stage} spec at ${persisted.path}.`,
+				shouldHandoff ? "Handed off deep-interview to ralplan (deliberate)." : undefined,
+				"",
+			]
+				.filter((line): line is string => Boolean(line))
+				.join("\n");
+	return { status: 0, stdout };
+}
+
 export async function runNativeDeepInterviewCommand(
 	args: string[],
 	cwd = process.cwd(),
 ): Promise<DeepInterviewCommandResult> {
 	try {
+		if (isDeepInterviewSpecWriteInvocation(args)) return await handleSpecWrite(args, cwd);
 		const resolved = await resolveDeepInterviewArgs(args, cwd);
 		if (!resolved.idea) {
 			throw new DeepInterviewCommandError(

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 
 const tempRoots: string[] = [];
 
@@ -16,6 +17,105 @@ afterEach(async () => {
 });
 
 describe("native gjc deep-interview runtime", () => {
+	it("advertises the deep-interview spec persistence and handoff surface in command help", async () => {
+		const source = await fs.readFile(
+			path.join(process.cwd(), "packages/coding-agent/src/commands/deep-interview.ts"),
+			"utf-8",
+		);
+		// The lightweight CLI help renderer advertises exactly the static flags/examples declared by the command.
+		expect(source).toContain("write: Flags.boolean");
+		expect(source).toContain("stage: Flags.string");
+		expect(source).toContain("slug: Flags.string");
+		expect(source).toContain("spec: Flags.string");
+		expect(source).toContain("deliberate: Flags.boolean");
+		expect(source).toContain("handoff: Flags.string");
+	});
+
+	it("persists a final spec under .gjc/specs through the native CLI/API", async () => {
+		const root = await tempDir();
+		const specPath = path.join(root, "final-spec.md");
+		await fs.writeFile(specPath, "# Final Spec\n\nAcceptance: persist me.\n");
+
+		const result = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "persist-me", "--spec", specPath, "--json"],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.path).toBe(path.join(root, ".gjc", "specs", "deep-interview-persist-me.md"));
+		expect(await fs.readFile(payload.path, "utf-8")).toBe("# Final Spec\n\nAcceptance: persist me.\n");
+
+		const state = JSON.parse(
+			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
+		);
+		expect(state.current_phase).toBe("handoff");
+		expect(state.active).toBe(true);
+		expect(state.spec_path).toBe(payload.path);
+		expect(state.spec_slug).toBe("persist-me");
+		await expect(fs.access(path.join(root, ".gjc", "plans"))).rejects.toThrow();
+	});
+
+	it("uses --deliberate to persist the final spec and hand off to ralplan", async () => {
+		const root = await tempDir();
+		const result = await runNativeDeepInterviewCommand(
+			[
+				"--write",
+				"--stage",
+				"final",
+				"--slug",
+				"deliberate-spec",
+				"--spec",
+				"# Final Spec\n\nUse ralplan deliberately.",
+				"--deliberate",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.handoff).toMatchObject({ to: "ralplan", mode: "deliberate" });
+
+		const specPath = path.join(root, ".gjc", "specs", "deep-interview-deliberate-spec.md");
+		expect(await fs.readFile(specPath, "utf-8")).toContain("Use ralplan deliberately.");
+
+		const deepInterviewState = JSON.parse(
+			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
+		);
+		expect(deepInterviewState.active).toBe(false);
+		expect(deepInterviewState.current_phase).toBe("handoff");
+		expect(deepInterviewState.handoff_to).toBe("ralplan");
+		expect(deepInterviewState.spec_path).toBe(specPath);
+
+		const ralplanState = JSON.parse(
+			await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8"),
+		);
+		expect(ralplanState.active).toBe(true);
+		expect(ralplanState.current_phase).toBe("planning");
+		expect(ralplanState.mode).toBe("deliberate");
+		expect(ralplanState.task).toBe(specPath);
+		expect(ralplanState.handoff_from).toBe("deep-interview");
+	});
+
+	it("keeps deep-interview spec persistence distinct from ralplan plan writes", async () => {
+		const root = await tempDir();
+		const deepResult = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "separate", "--spec", "# Requirements", "--json"],
+			root,
+		);
+		expect(deepResult.status).toBe(0);
+		const deepPayload = JSON.parse(deepResult.stdout ?? "{}");
+		expect(deepPayload.path).toContain(path.join(".gjc", "specs", "deep-interview-separate.md"));
+
+		const ralplanResult = await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "separate", "--json"],
+			root,
+		);
+		expect(ralplanResult.status).toBe(0);
+		const ralplanPayload = JSON.parse(ralplanResult.stdout ?? "{}");
+		expect(ralplanPayload.path).toContain(path.join(".gjc", "plans", "ralplan", "separate", "stage-01-final.md"));
+		expect(await fs.readFile(deepPayload.path, "utf-8")).toBe("# Requirements\n");
+		expect(await fs.readFile(ralplanPayload.path, "utf-8")).toBe("# Plan\n");
+	});
 	it("defaults to the SKILL.md default threshold (0.05) when no resolution flag or settings exist", async () => {
 		const root = await tempDir();
 		const result = await runNativeDeepInterviewCommand(["my vague idea"], root);

--- a/scripts/verify-g002-gates.ts
+++ b/scripts/verify-g002-gates.ts
@@ -14,7 +14,7 @@ import * as path from "node:path";
 const repoRoot = path.join(import.meta.dir, "..");
 const EXPECTED_DEFINITIONS = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
 const EXPECTED_ROLE_AGENTS = ["architect", "critic", "executor", "planner"] as const;
-const EXPECTED_PUBLIC_PACKAGE_VERSION = "0.2.1";
+const EXPECTED_PUBLIC_PACKAGE_VERSION = "0.2.2";
 const ALLOWED_PUBLIC_PACKAGE_VERSIONS = new Map<string, string>();
 const ALLOWED_PRIVATE_PACKAGE_VERSIONS = new Map<string, string>([["@gajae-code/typescript-edit-benchmark", "0.0.1"]]);
 const ALLOWED_UNSCOPED_PACKAGE_NAMES = new Set<string>(["gajae-code"]);


### PR DESCRIPTION
## Summary
- Add a native `gjc deep-interview --write --stage final` surface that persists final specs under `.gjc/specs/deep-interview-<slug>.md`.
- Add `--deliberate` / `--handoff ralplan` bridging that seeds ralplan deliberate mode and performs the safe deep-interview → ralplan state handoff.
- Update bundled deep-interview Phase 4/5 guidance and regression coverage; keep ralplan plan writes distinct.

Fixes #133

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- Manual: `bun --cwd=packages/coding-agent src/cli.ts deep-interview --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*