### PR TITLE
Fix local memory backend persistence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Made startup CHANGELOG display deterministic by embedding `packages/coding-agent/CHANGELOG.md` into the binary so post-update launches show the shipped history regardless of cwd or `GJC_PACKAGE_DIR`/`PI_PACKAGE_DIR` overrides.
 - Registered `gjc update` as a public root subcommand so it invokes the bundled updater instead of routing into the interactive launcher.
+- Fixed local memory backend persistence so manual enqueue/rebuild starts maintenance immediately and prompt injection reads the active session's memory root.
 
 ## [0.2.2] - 2026-05-31
 

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -15,11 +15,12 @@ const MEMORY_NAMESPACE = "root";
  * may see different roots.
  */
 export function memoryRootsFromRegistry(): string[] {
-	const agentDir = getAgentDir();
 	const roots: string[] = [];
 	for (const ref of AgentRegistry.global().list()) {
-		const sm = ref.session?.sessionManager;
+		const session = ref.session;
+		const sm = session?.sessionManager;
 		if (!sm) continue;
+		const agentDir = session.settings?.getAgentDir() ?? getAgentDir();
 		const root = getMemoryRoot(agentDir, sm.getCwd());
 		if (root && !roots.includes(root)) roots.push(root);
 	}

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -149,10 +149,11 @@ export function startMemoryStartupTask(options: {
 export async function buildMemoryToolDeveloperInstructions(
 	agentDir: string,
 	settings: Settings,
+	session?: AgentSession,
 ): Promise<string | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+	const memoryRoot = getMemoryRoot(agentDir, session?.sessionManager.getCwd() ?? settings.getCwd());
 	const summaryPath = path.join(memoryRoot, "memory_summary.md");
 
 	let text: string;

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -9,22 +9,30 @@ import type { MemoryBackend } from "./types";
 /**
  * Wraps the existing `memories/` module as a `MemoryBackend`.
  *
- * No behavioural change — every call delegates to the legacy entry points so
- * the local memory pipeline (rollout summarisation → SQLite → memory_summary.md)
- * keeps working exactly as before.
+ * The local pipeline owns rollout summarisation, SQLite retention, and
+ * `memory_summary.md`. Prompt reads use the live session cwd when available so
+ * manual enqueue/rebuild and startup hydration address the same memory root.
  */
 export const localBackend: MemoryBackend = {
 	id: "local",
 	start(options) {
 		startMemoryStartupTask(options);
 	},
-	async buildDeveloperInstructions(agentDir, settings) {
-		return buildMemoryToolDeveloperInstructions(agentDir, settings);
+	async buildDeveloperInstructions(agentDir, settings, session) {
+		return buildMemoryToolDeveloperInstructions(agentDir, settings, session);
 	},
 	async clear(agentDir, cwd) {
 		await clearMemoryData(agentDir, cwd);
 	},
-	async enqueue(agentDir, cwd) {
+	async enqueue(agentDir, cwd, session) {
 		enqueueMemoryConsolidation(agentDir, cwd);
+		if (!session) return;
+		startMemoryStartupTask({
+			session,
+			settings: session.settings,
+			modelRegistry: session.modelRegistry,
+			agentDir,
+			taskDepth: session.taskDepth,
+		});
 	},
 };

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1872,6 +1872,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skillWarnings,
 			skillsSettings: settings.getGroup("skills"),
 			modelRegistry,
+			taskDepth,
 			toolRegistry,
 			transformContext,
 			onPayload,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -319,6 +319,8 @@ export interface AgentSessionConfig {
 	skillsSettings?: SkillsSettings;
 	/** Model registry for API key resolution and model discovery */
 	modelRegistry: ModelRegistry;
+	/** Task recursion depth for nested sessions. Top-level sessions use 0. */
+	taskDepth?: number;
 	/** Tool registry for LSP and settings */
 	toolRegistry?: Map<string, AgentTool>;
 	/** Current session pre-LLM message transform pipeline */
@@ -791,6 +793,7 @@ export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
 	readonly settings: Settings;
+	readonly taskDepth: number;
 	readonly yieldQueue: YieldQueue;
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
@@ -1050,6 +1053,7 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
+		this.taskDepth = config.taskDepth ?? 0;
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
@@ -6321,7 +6325,7 @@ export class AgentSession {
 
 	#closeCodexProviderSessionsForHistoryRewrite(): void {
 		const currentModel = this.model;
-		if (!currentModel || currentModel.api !== "openai-codex-responses") return;
+		if (currentModel?.api !== "openai-codex-responses") return;
 		this.#closeProviderSessionsForModelSwitch(currentModel, currentModel);
 	}
 
@@ -8402,7 +8406,7 @@ export class AgentSession {
 		const previousSessionFile = this.sessionFile;
 		const selectedEntry = this.sessionManager.getEntry(entryId);
 
-		if (!selectedEntry || selectedEntry.type !== "message" || selectedEntry.message.role !== "user") {
+		if (selectedEntry?.type !== "message" || selectedEntry.message.role !== "user") {
 			throw new Error("Invalid entry ID for branching");
 		}
 

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -31,6 +31,9 @@ async function withMemoryFixture(fn: (fixture: MemoryFixture) => Promise<void>):
 			displayName: "test",
 			kind: "main",
 			session: {
+				settings: {
+					getAgentDir: () => agentDir,
+				},
 				sessionManager: {
 					getCwd: () => cwd,
 					getArtifactsDir: () => null,
@@ -67,6 +70,52 @@ describe("MemoryProtocolHandler", () => {
 			expect(resource.content).toBe("summary");
 			expect(resource.contentType).toBe("text/markdown");
 		});
+	});
+
+	it("uses the registered session agent dir instead of the process-global agent dir", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-custom-agent-"));
+		const previousAgentDir = getAgentDir();
+		try {
+			const globalAgentDir = path.join(cleanupRoot, "global-agent");
+			const sessionAgentDir = path.join(cleanupRoot, "session-agent");
+			const cwd = path.join(cleanupRoot, "project");
+			await fs.mkdir(globalAgentDir, { recursive: true });
+			await fs.mkdir(sessionAgentDir, { recursive: true });
+			await fs.mkdir(cwd, { recursive: true });
+			setAgentDir(globalAgentDir);
+
+			const sessionMemoryRoot = getMemoryRoot(sessionAgentDir, cwd);
+			await fs.mkdir(sessionMemoryRoot, { recursive: true });
+			await Bun.write(path.join(sessionMemoryRoot, "memory_summary.md"), "session-agent summary");
+
+			AgentRegistry.global().register({
+				id: "test-main",
+				displayName: "test",
+				kind: "main",
+				session: {
+					settings: {
+						getAgentDir: () => sessionAgentDir,
+					},
+					sessionManager: {
+						getCwd: () => cwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "test",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root");
+
+			expect(resource.content).toBe("session-agent summary");
+			const sourcePath = resource.sourcePath;
+			if (sourcePath === undefined) throw new Error("Expected memory resource source path");
+			expect(sourcePath.startsWith(sessionMemoryRoot)).toBe(true);
+		} finally {
+			setAgentDir(previousAgentDir);
+			await fs.rm(cleanupRoot, { recursive: true, force: true });
+		}
 	});
 
 	it("resolves memory://root/<path> within memory root", async () => {

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -11,7 +11,9 @@ import {
 	startMemoryStartupTask,
 } from "@gajae-code/coding-agent/memories";
 import * as memoryStorage from "@gajae-code/coding-agent/memories/storage";
+import { localBackend } from "@gajae-code/coding-agent/memory-backend";
 import { getAgentDbPath, Snowflake } from "@gajae-code/utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 interface SessionFixture {
 	agentDir: string;
@@ -75,6 +77,7 @@ async function createFixture(overrides?: Partial<Record<string, unknown>>): Prom
 			getCwd: () => agentDir,
 		},
 		settings,
+		taskDepth: 0,
 		model,
 		modelRegistry,
 		refreshBaseSystemPrompt,
@@ -174,33 +177,24 @@ describe("memories runtime", () => {
 		await fs.writeFile(rolloutPath, `${rolloutRows.map(row => JSON.stringify(row)).join("\n")}\n`);
 
 		vi.spyOn(ai, "completeSimple")
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
-					{
-						type: "text",
-						text: JSON.stringify({
-							rollout_summary: "Rollout summary A",
-							rollout_slug: "thread-a-rollout",
-							raw_memory: "Raw memory A",
-						}),
-					},
-				],
-				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 },
-			} as any)
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
-					{
-						type: "text",
-						text: JSON.stringify({
-							memory_md: "# Memory\n\nConsolidated body",
-							memory_summary: "Consolidated summary",
-							skills: [{ name: "deploy-playbook", content: "# Deploy\nUse blue/green." }],
-						}),
-					},
-				],
-			} as any);
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					JSON.stringify({
+						rollout_summary: "Rollout summary A",
+						rollout_slug: "thread-a-rollout",
+						raw_memory: "Raw memory A",
+					}),
+				),
+			)
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					JSON.stringify({
+						memory_md: "# Memory\n\nConsolidated body",
+						memory_summary: "Consolidated summary",
+						skills: [{ name: "deploy-playbook", content: "# Deploy\nUse blue/green." }],
+					}),
+				),
+			);
 
 		startMemoryStartupTask({
 			session: fx.session,
@@ -223,26 +217,85 @@ describe("memories runtime", () => {
 			).toBe("# Deploy\nUse blue/green.");
 		});
 
-		expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+		await waitFor(() => {
+			expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+		});
 		expect(ai.completeSimple).toHaveBeenCalled();
 		expect(ai.completeSimple).toHaveBeenCalledTimes(2);
 	});
 
+	test("local backend enqueue starts maintenance immediately for the explicit local selector", async () => {
+		const fx = await createFixture({ "memory.backend": "local", "memories.enabled": false });
+		const rolloutPath = path.join(fx.sessionDir, "thread-local.jsonl");
+		const rolloutRows = [
+			{ type: "session", id: "thread-local", cwd: fx.agentDir },
+			{ type: "message", message: { role: "user", content: "persist this local memory" } },
+		];
+		await fs.writeFile(rolloutPath, `${rolloutRows.map(row => JSON.stringify(row)).join("\n")}\n`);
+
+		vi.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					JSON.stringify({
+						rollout_summary: "Local backend rollout summary",
+						rollout_slug: "local-memory",
+						raw_memory: "Local backend raw memory",
+					}),
+				),
+			)
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					JSON.stringify({
+						memory_md: "# Memory\n\nLocal backend persisted body",
+						memory_summary: "Local backend persisted summary",
+						skills: [],
+					}),
+				),
+			);
+
+		await localBackend.enqueue(fx.agentDir, fx.session.sessionManager.getCwd(), fx.session);
+
+		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
+		expect(fx.settings.getCwd()).not.toBe(fx.session.sessionManager.getCwd());
+		await waitFor(async () => {
+			expect((await fs.readFile(path.join(memoryRoot, "memory_summary.md"), "utf8")).trim()).toBe(
+				"Local backend persisted summary",
+			);
+			const payload = await localBackend.buildDeveloperInstructions(fx.agentDir, fx.settings, fx.session);
+			expect(payload).toContain("Local backend persisted summary");
+			expect(payload).toContain("memory://root/memory_summary.md");
+			expect(payload).not.toContain(memoryRoot);
+		});
+
+		expect(ai.completeSimple).toHaveBeenCalledTimes(2);
+		await waitFor(() => {
+			expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	test("local backend enqueue keeps subagent sessions from starting local maintenance", async () => {
+		const fx = await createFixture({ "memory.backend": "local" });
+		fx.session.taskDepth = 1;
+		const completeSimpleSpy = vi.spyOn(ai, "completeSimple");
+
+		await localBackend.enqueue(fx.agentDir, fx.session.sessionManager.getCwd(), fx.session);
+		await Bun.sleep(50);
+
+		expect(completeSimpleSpy).not.toHaveBeenCalled();
+		expect(fx.session.refreshBaseSystemPrompt).not.toHaveBeenCalled();
+	});
+
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {
 		const fx = await createFixture();
-		vi.spyOn(ai, "completeSimple").mockResolvedValue({
-			stopReason: "end_turn",
-			content: [
-				{
-					type: "text",
-					text: JSON.stringify({
-						memory_md: "# Memory\n\nMerged",
-						memory_summary: "Merged summary",
-						skills: [{ name: "ops", content: "# Ops\nRunbook" }],
-					}),
-				},
-			],
-		} as any);
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			createAssistantMessage(
+				JSON.stringify({
+					memory_md: "# Memory\n\nMerged",
+					memory_summary: "Merged summary",
+					skills: [{ name: "ops", content: "# Ops\nRunbook" }],
+				}),
+			),
+		);
 
 		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
 		memoryStorage.upsertThreads(db, [


### PR DESCRIPTION
## Summary

Closes #136.

- Align local memory prompt hydration with the live session cwd so saved summaries are read from the same root that maintenance writes.
- Make local `/memory enqueue` / rebuild start local maintenance immediately in the current process while preserving subagent `taskDepth` gating.
- Resolve `memory://root` from the registered session agent dir so custom SDK agent dirs do not fall back to a different process-global memory root.
- Add regressions for local backend enqueue persistence, subagent skip behavior, sanitized prompt payloads, and custom-agent-dir memory URL resolution.

## Verification

- `bunx biome check packages/coding-agent/src/memories/index.ts packages/coding-agent/src/memory-backend/local-backend.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/src/sdk.ts packages/coding-agent/src/internal-urls/memory-protocol.ts packages/coding-agent/test/memories-runtime.test.ts packages/coding-agent/test/internal-urls/memory-protocol.test.ts packages/coding-agent/CHANGELOG.md`
- `bun test packages/coding-agent/test/memories-runtime.test.ts packages/coding-agent/test/memory-backend-resolve.test.ts packages/coding-agent/test/internal-urls/memory-protocol.test.ts packages/coding-agent/test/acp-builtins.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run build`
- `bun run check:ts`
- `git diff --check`
- OMX code-review gate: code-reviewer APPROVE; architect CLEAR

## Notes

- No private memory, user paths, credentials, or hidden prompts are included; tests use temp fixtures and assert model-facing memory payloads use `memory://root/...` rather than absolute memory roots.
- Not manually tested in an interactive TUI against a real user memory store.
