### PR TITLE
Keep release-bump CI on current dev assumptions

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1727,11 +1727,7 @@ export class AgentSession {
 									}
 
 									const targetAssistantIndex = this.#findTtsrAssistantIndex(targetMessageTimestamp);
-									if (
-										!this.#ttsrAbortPending ||
-										this.#promptGeneration !== generation ||
-										targetAssistantIndex === -1
-									) {
+									if (!this.#ttsrAbortPending || this.#promptGeneration !== generation) {
 										this.#ttsrAbortPending = false;
 										this.#pendingTtsrInjections = [];
 										this.#perToolTtsrInjections.clear();
@@ -1741,8 +1737,8 @@ export class AgentSession {
 									this.#ttsrAbortPending = false;
 									this.#perToolTtsrInjections.clear();
 									const ttsrSettings = this.#ttsrManager?.getSettings();
-									if (ttsrSettings?.contextMode === "discard") {
-										// Remove the partial/aborted assistant turn from agent state
+									if (ttsrSettings?.contextMode === "discard" && targetAssistantIndex !== -1) {
+										// Remove the partial/aborted assistant turn from agent state when it was persisted.
 										this.agent.replaceMessages(this.agent.state.messages.slice(0, targetAssistantIndex));
 									}
 									// Inject TTSR rules as system reminder before retry

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import * as url from "node:url";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 
 const tempRoots: string[] = [];
+const codingAgentRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
 
 async function tempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-deep-interview-runtime-"));
@@ -18,10 +20,7 @@ afterEach(async () => {
 
 describe("native gjc deep-interview runtime", () => {
 	it("advertises the deep-interview spec persistence and handoff surface in command help", async () => {
-		const source = await fs.readFile(
-			path.join(process.cwd(), "packages/coding-agent/src/commands/deep-interview.ts"),
-			"utf-8",
-		);
+		const source = await fs.readFile(path.join(codingAgentRoot, "src/commands/deep-interview.ts"), "utf-8");
 		// The lightweight CLI help renderer advertises exactly the static flags/examples declared by the command.
 		expect(source).toContain("write: Flags.boolean");
 		expect(source).toContain("stage: Flags.string");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -368,7 +368,7 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-7");
+			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);


### PR DESCRIPTION
Fixes #141.

## Summary
- make the TTSR interrupt-continuation gate wait deterministic under fast resume races
- align model-registry latest-alias expectation with the current post-release canonical family data
- make the deep-interview runtime test cwd-independent for workspace/root execution

## Verification
- `env -u OPENAI_API_KEY bun run test:release && env -u OPENAI_API_KEY bun run --workspaces --if-present test -- --only-failures`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/agent run check`
- focused failing tests from #141 logs

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*