### PR TITLE
Enforce deep-interview phase boundary before edits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Enforced the deep-interview phase boundary so active interviews block mutation tools until a handoff/spec is produced.
 - Made settings theme browsing confirm-only so arrowing through themes no longer changes the rendered theme before the displayed/persisted theme name changes.
 - Made startup CHANGELOG display deterministic by embedding `packages/coding-agent/CHANGELOG.md` into the binary so post-update launches show the shipped history regardless of cwd or `GJC_PACKAGE_DIR`/`PI_PACKAGE_DIR` overrides.
 - Registered `gjc update` as a public root subcommand so it invokes the bundled updater instead of routing into the interactive launcher.

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -12,7 +12,7 @@ import {
 } from "./workflow-state-contract";
 
 export const DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE =
-	"Deep-interview is active; continue interviewing with `ask`, write/finalize pending specs through the required GJC workflow CLI, or use an explicit force override. Direct `.gjc/` and product-code edits are blocked until explicit execution approval.";
+	"Deep-interview phase boundary: continue gathering context/questions/risks and emit a handoff/spec before code edits. Mutation tools and patch execution are blocked while deep-interview is active; finalize specs through `gjc deep-interview --write --stage final` or hand off to an execution phase.";
 export const WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE =
 	"Workflow state JSON is runtime-owned. Use `gjc state <skill> read|write --input '<json>'` for deep-interview, ralplan, ultragoal, and team. Planning artifacts under `.gjc/specs/` and `.gjc/plans/` remain allowed.";
 
@@ -88,7 +88,7 @@ async function readVisibleModeState(cwd: string, skill: string, sessionId?: stri
 }
 
 function isTerminalModeState(state: ModeState | null): boolean {
-	if (!state || state.active !== true) return true;
+	if (state?.active !== true) return true;
 	const phase = String(state.current_phase ?? "")
 		.trim()
 		.toLowerCase();
@@ -265,7 +265,7 @@ function relativeGjcSegments(cwd: string, rawPath: string): string[] | null {
 
 function blockedWorkflowStateSkill(cwd: string, rawPath: string): CanonicalGjcWorkflowSkill | null {
 	const segments = relativeGjcSegments(cwd, rawPath);
-	if (!segments || segments[0] !== ".gjc") return null;
+	if (segments?.[0] !== ".gjc") return null;
 	if (segments[1] === "specs" || segments[1] === "plans") return null;
 	if (segments[1] !== "state") return null;
 	const fileName = segments.at(-1) ?? "";
@@ -284,20 +284,10 @@ function firstBlockedWorkflowStateSkill(cwd: string, targets: ExtractedTargets):
 	return null;
 }
 
-function isGjcManagedPath(cwd: string, rawPath: string): boolean {
-	const segments = relativeGjcSegments(cwd, rawPath);
-	return segments?.[0] === ".gjc";
-}
-
 function isAllowlistedPath(cwd: string, rawPath: string): boolean {
 	const segments = relativeGjcSegments(cwd, rawPath);
-	if (!segments || segments[0] !== ".gjc") return false;
+	if (segments?.[0] !== ".gjc") return false;
 	return segments[1] === "specs" || segments[1] === "plans";
-}
-
-function hasGjcManagedTarget(cwd: string, targets: ExtractedTargets): boolean {
-	if (targets.unknown || targets.paths.length === 0) return false;
-	return targets.paths.some(rawPath => isGjcManagedPath(cwd, rawPath));
 }
 
 function allTargetsAllowlisted(cwd: string, targets: ExtractedTargets): boolean {
@@ -315,7 +305,7 @@ export async function assertDeepInterviewMutationRawPathsAllowed(input: {
 	if (input.forceOverride) return;
 	if (!(await isActiveDeepInterview(input.cwd, input.sessionId, input.threadId))) return;
 	const targets: ExtractedTargets = { paths: input.rawPaths, unknown: input.rawPaths.length === 0 };
-	if (hasGjcManagedTarget(input.cwd, targets)) {
+	if (targets.unknown || targets.paths.length > 0) {
 		throw new ToolError(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
 	}
 }
@@ -350,15 +340,12 @@ export async function getDeepInterviewMutationDecision(
 			reason: "unknown-target",
 		};
 	}
-	if (hasGjcManagedTarget(input.cwd, targets) && !allTargetsAllowlisted(input.cwd, targets)) {
-		return {
-			blocked: true,
-			message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
-			targets: targets.paths,
-			reason: "gjc-managed-target",
-		};
-	}
-	return { blocked: false, targets: targets.paths };
+	return {
+		blocked: true,
+		message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
+		targets: targets.paths,
+		reason: allTargetsAllowlisted(input.cwd, targets) ? "handoff-artifact-tool-target" : "phase-boundary",
+	};
 }
 
 export async function assertDeepInterviewMutationAllowed(input: DeepInterviewMutationGuardInput): Promise<void> {

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -65,26 +65,34 @@ afterEach(async () => {
 });
 
 describe("deep-interview mutation guard", () => {
-	it("allows product write/edit/ast_edit targets while deep-interview is active", async () => {
+	it("blocks product write/edit/ast_edit targets while deep-interview is active", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 
-		for (const [name, args] of [
+		for (const [name, args, extra = {}] of [
 			["write", { path: "packages/coding-agent/src/foo.ts", content: "x" }],
 			["edit", { path: "src/foo.ts", edits: [{ old_text: "a", new_text: "b" }] }],
+			[
+				"edit",
+				{ input: "*** Begin Patch\n*** Update File: src/foo.ts\n@@\n-a\n+b\n*** End Patch\n" },
+				{ mode: "apply_patch", customWireName: "apply_patch" },
+			],
 			["ast_edit", { paths: ["packages/**"], ops: [{ pat: "foo", out: "bar" }] }],
 		] as const) {
 			const decision = await getDeepInterviewMutationDecision({
 				cwd,
 				sessionId: "session-a",
-				tool: tool(name),
+				tool: tool(name, extra),
 				args,
 			});
-			expect(decision.blocked).toBe(false);
+			expect(decision.blocked).toBe(true);
+			expect(decision.reason).toBe("phase-boundary");
+			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+			expect(decision.message).toContain("handoff/spec before code edits");
 		}
 	});
 
-	it("allows planning artifacts and blocks canonical workflow state targets", async () => {
+	it("blocks direct planning artifact tools and canonical workflow state targets", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 
@@ -95,7 +103,9 @@ describe("deep-interview mutation guard", () => {
 				tool: tool("write"),
 				args: { path: rawPath, content: "x" },
 			});
-			expect(decision.blocked).toBe(false);
+			expect(decision.blocked).toBe(true);
+			expect(decision.reason).toBe("handoff-artifact-tool-target");
+			expect(decision.message).toContain("gjc deep-interview --write --stage final");
 		}
 
 		const blockedCases: Array<[string, AgentTool, unknown]> = [
@@ -148,7 +158,7 @@ describe("deep-interview mutation guard", () => {
 		}
 	});
 
-	it("allows non-.gjc paths and blocks .gjc-prefixed target sets", async () => {
+	it("blocks all write targets during active deep-interview, including non-.gjc paths", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 
@@ -165,7 +175,8 @@ describe("deep-interview mutation guard", () => {
 				tool: tool("write"),
 				args: { path: rawPath, content: "x" },
 			});
-			expect(decision.blocked).toBe(false);
+			expect(decision.blocked).toBe(true);
+			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
 		}
 
 		for (const rawPath of [".gjc/specs-evil/plan.md", ".gjc/stateful/data.json"]) {
@@ -176,6 +187,7 @@ describe("deep-interview mutation guard", () => {
 				args: { path: rawPath, content: "x" },
 			});
 			expect(decision.blocked).toBe(true);
+			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
 		}
 
 		const mixed = await getDeepInterviewMutationDecision({
@@ -218,22 +230,24 @@ describe("deep-interview mutation guard", () => {
 		expect(decision.blocked).toBe(false);
 	});
 
-	it("guards deferred ast_edit apply .gjc targets unless force override is explicit", async () => {
+	it("guards deferred ast_edit apply targets unless force override is explicit", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 
+		for (const rawPaths of [["src/product.ts"], [".gjc/specs/deep-interview-x.md"], []]) {
+			await expect(
+				assertDeepInterviewMutationRawPathsAllowed({
+					cwd,
+					sessionId: "session-a",
+					rawPaths,
+				}),
+			).rejects.toBeInstanceOf(ToolError);
+		}
 		await expect(
 			assertDeepInterviewMutationRawPathsAllowed({
 				cwd,
 				sessionId: "session-a",
-				rawPaths: [".gjc/specs/deep-interview-x.md"],
-			}),
-		).rejects.toBeInstanceOf(ToolError);
-		await expect(
-			assertDeepInterviewMutationRawPathsAllowed({
-				cwd,
-				sessionId: "session-a",
-				rawPaths: [".gjc/specs/deep-interview-x.md"],
+				rawPaths: ["src/product.ts"],
 				forceOverride: true,
 			}),
 		).resolves.toBeUndefined();

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -91,7 +91,7 @@ describe("GJC native skill-state hooks", () => {
 		});
 	});
 
-	it("rich deep-interview prompt activation allows product mutation and blocks direct spec artifacts", async () => {
+	it("rich deep-interview prompt activation blocks product mutation and direct spec artifacts", async () => {
 		const root = await cwd();
 		await dispatchGjcNativeSkillHook(
 			{
@@ -108,21 +108,25 @@ describe("GJC native skill-state hooks", () => {
 		const state = await readVisibleSkillActiveState(root, "session-rich");
 		expect(state).toMatchObject({ active: true, skill: "deep-interview" });
 
-		const allowed = await getDeepInterviewMutationDecision({
+		const blockedProduct = await getDeepInterviewMutationDecision({
 			cwd: root,
 			sessionId: "session-rich",
 			tool: { name: "write" } as never,
 			args: { path: "packages/coding-agent/src/product.ts", content: "unsafe" },
 		});
-		expect(allowed.blocked).toBe(false);
+		expect(blockedProduct.blocked).toBe(true);
+		expect(blockedProduct.reason).toBe("phase-boundary");
+		expect(blockedProduct.message).toContain("handoff/spec before code edits");
 
-		const allowedSpec = await getDeepInterviewMutationDecision({
+		const blockedSpec = await getDeepInterviewMutationDecision({
 			cwd: root,
 			sessionId: "session-rich",
 			tool: { name: "write" } as never,
 			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
 		});
-		expect(allowedSpec.blocked).toBe(false);
+		expect(blockedSpec.blocked).toBe(true);
+		expect(blockedSpec.reason).toBe("handoff-artifact-tool-target");
+		expect(blockedSpec.message).toContain("gjc deep-interview --write --stage final");
 
 		const blocked = await getDeepInterviewMutationDecision({
 			cwd: root,


### PR DESCRIPTION
## Summary
- Blocks write/edit/apply_patch/ast_edit mutation targets while deep-interview is active.
- Keeps final spec persistence on the sanctioned `gjc deep-interview --write --stage final` path.
- Updates regression coverage for active interview mutation denial and hook activation behavior.

Closes #139.

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/deep-interview-mutation-guard.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts packages/coding-agent/test/deep-interview-mutation-guard.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check` (exits 0; reports unrelated optional-chain warnings outside this change)
