### PR TITLE
feat(ask): multi-line render for focused option label

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -110,6 +110,12 @@ export interface ExtensionUIDialogOptions {
 	onExternalEditor?: () => void;
 	/** Optional footer hint text rendered by interactive selector */
 	helpText?: string;
+	/**
+	 * For interactive TUI select dialogs, render the focused option across
+	 * multiple rows instead of truncating it. This is a select-only rendering
+	 * hint; non-TUI bridges (RPC, ACP) drop it and do not serialize it.
+	 */
+	wrapFocused?: boolean;
 }
 
 /** Raw terminal input listener for extensions. */

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -14,6 +14,7 @@ import {
 	type TUI,
 	truncateToWidth,
 	visibleWidth,
+	wrapTextWithAnsi,
 } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { matchesAppExternalEditor, matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
@@ -31,6 +32,13 @@ export interface HookSelectorOptions {
 	onRight?: () => void;
 	onExternalEditor?: () => void;
 	helpText?: string;
+	/**
+	 * When true, the focused option's label wraps across multiple rows so the
+	 * full text is visible. Non-focused options remain single-row with the
+	 * existing `…` truncation hint. When unset/false, rendering is
+	 * byte-identical to the previous implementation for all consumers.
+	 */
+	wrapFocused?: boolean;
 }
 
 class OutlinedList extends Container {
@@ -55,12 +63,140 @@ class OutlinedList extends Container {
 	}
 }
 
+/**
+ * Width-aware list child that owns wrapped focused-option layout.
+ *
+ * Single layout owner for the `wrapFocused` branch: row budgeting, sibling
+ * selection, marker placement, and finalized row construction all happen
+ * inside `render(width)` using the actual incoming width. The outer host
+ * (`HookSelectorComponent`) feeds it `options`, `selectedIndex`, and
+ * `maxVisibleRows`; everything that depends on terminal width is recomputed
+ * on each render so resize Just Works.
+ *
+ * `maxVisibleRows` is a sibling budget before it is a hard cap: surrounding
+ * options shrink first so the focused option is never clipped. The single
+ * allowed overflow exception is when the focused option's wrapped block
+ * alone exceeds the budget — in that case the focused option is rendered
+ * fully with zero siblings.
+ */
+class FocusAwareList extends Container {
+	#options: string[] = [];
+	#selectedIndex = 0;
+	#maxVisibleRows = 0;
+	#outline: boolean;
+
+	constructor(outline: boolean) {
+		super();
+		this.#outline = outline;
+	}
+
+	setState(options: string[], selectedIndex: number, maxVisibleRows: number): void {
+		this.#options = options;
+		this.#selectedIndex = Math.max(0, Math.min(selectedIndex, options.length - 1));
+		this.#maxVisibleRows = Math.max(1, maxVisibleRows);
+		this.invalidate();
+	}
+
+	render(width: number): string[] {
+		if (this.#options.length === 0) return this.#outline ? this.#wrapOutline([], width) : [];
+
+		const mdTheme = getMarkdownTheme();
+		const innerWidth = this.#outline ? Math.max(1, width - 2) : Math.max(1, width);
+
+		// Selected/non-selected prefixes mirror the legacy `#updateList` shape.
+		const styledSelectedPrefix = theme.fg("accent", `${theme.nav.cursor} `);
+		const nonSelectedPrefix = "  ";
+		const prefixWidth = visibleWidth(styledSelectedPrefix);
+		const continuationPrefix = " ".repeat(prefixWidth);
+		const availableLabelWidth = Math.max(1, innerWidth - prefixWidth);
+
+		// Render the focused label up front so we can measure how many rows it
+		// will consume at the current width and budget siblings accordingly.
+		const focusedLabel = renderInlineMarkdown(this.#options[this.#selectedIndex] ?? "", mdTheme, t =>
+			theme.fg("accent", t),
+		);
+		const focusedWrappedSegments = wrapTextWithAnsi(focusedLabel, availableLabelWidth);
+		const focusedRows = Math.max(1, focusedWrappedSegments.length);
+
+		// Decide whether the position marker is going to be shown. We make a
+		// pessimistic first pass assuming the marker is needed; if the window
+		// ends up covering every option we drop it.
+		const totalOptions = this.#options.length;
+		const willHaveSiblings = totalOptions > 1;
+		const wouldNeedMarker = willHaveSiblings; // tentative; refined below
+		const markerSlot = wouldNeedMarker ? 1 : 0;
+
+		// Sibling budget. If the focused block alone is over budget, render it
+		// fully with zero siblings (only allowed overflow exception).
+		const siblingBudget = Math.max(0, this.#maxVisibleRows - focusedRows - markerSlot);
+
+		// Distribute sibling slots around focus, preferring closest options.
+		const availableAbove = this.#selectedIndex;
+		const availableBelow = totalOptions - this.#selectedIndex - 1;
+		let above = Math.min(availableAbove, Math.floor(siblingBudget / 2));
+		let below = Math.min(availableBelow, siblingBudget - above);
+		// Transfer unused quota across the focus when one side has fewer
+		// options than its share.
+		const unusedBelow = siblingBudget - above - below;
+		if (unusedBelow > 0) above = Math.min(availableAbove, above + unusedBelow);
+		const unusedAbove = siblingBudget - above - below;
+		if (unusedAbove > 0) below = Math.min(availableBelow, below + unusedAbove);
+
+		const startIndex = this.#selectedIndex - above;
+		const endIndex = this.#selectedIndex + below + 1;
+		const showMarker = startIndex > 0 || endIndex < totalOptions;
+
+		const rows: string[] = [];
+		for (let i = startIndex; i < endIndex; i++) {
+			if (i === this.#selectedIndex) {
+				// Emit focused wrapped rows. Cursor only on row 0; continuation
+				// rows are whitespace-aligned under the label start.
+				for (let r = 0; r < focusedWrappedSegments.length; r++) {
+					const segment = focusedWrappedSegments[r] ?? "";
+					rows.push(r === 0 ? styledSelectedPrefix + segment : continuationPrefix + segment);
+				}
+			} else {
+				const label = renderInlineMarkdown(this.#options[i] ?? "", mdTheme, t => theme.fg("text", t));
+				// Non-focused rows stay single-line. Truncate here so the
+				// outline (post-padded by `#wrapOutline`) and non-outline
+				// paths render the same `…` hint for over-wide labels.
+				const fittedLabel = truncateToWidth(label, availableLabelWidth);
+				rows.push(nonSelectedPrefix + fittedLabel);
+			}
+		}
+
+		if (showMarker) {
+			rows.push(theme.fg("dim", `  (${this.#selectedIndex + 1}/${totalOptions})`));
+		}
+
+		return this.#outline ? this.#wrapOutline(rows, width) : rows;
+	}
+
+	#wrapOutline(rows: string[], width: number): string[] {
+		// Mirror the outline border drawn by `OutlinedList.render(width)`. The
+		// rows passed in are already constrained to `innerWidth` by
+		// `wrapTextWithAnsi`, so we only normalize tabs and pad — no further
+		// truncation, which would clip wrapped focused labels.
+		const borderColor = (text: string) => theme.fg("border", text);
+		const horizontal = borderColor(theme.boxSharp.horizontal.repeat(Math.max(1, width)));
+		const innerWidth = Math.max(1, width - 2);
+		const content = rows.map(line => {
+			const normalized = replaceTabs(line);
+			const fitted = truncateToWidth(normalized, innerWidth);
+			const pad = Math.max(0, innerWidth - visibleWidth(fitted));
+			return `${borderColor(theme.boxSharp.vertical)}${fitted}${padding(pad)}${borderColor(theme.boxSharp.vertical)}`;
+		});
+		return [horizontal, ...content, horizontal];
+	}
+}
+
 export class HookSelectorComponent extends Container {
 	#options: string[];
 	#selectedIndex: number;
 	#maxVisible: number;
 	#listContainer: Container | undefined;
 	#outlinedList: OutlinedList | undefined;
+	#focusAwareList: FocusAwareList | undefined;
 	#onSelectCallback: (option: string) => void;
 	#onCancelCallback: () => void;
 	#titleComponent: Markdown;
@@ -69,6 +205,8 @@ export class HookSelectorComponent extends Container {
 	#onLeftCallback: (() => void) | undefined;
 	#onRightCallback: (() => void) | undefined;
 	#onExternalEditorCallback: (() => void) | undefined;
+	#wrapFocused: boolean;
+	#outline: boolean;
 	constructor(
 		title: string,
 		options: string[],
@@ -87,6 +225,8 @@ export class HookSelectorComponent extends Container {
 		this.#onLeftCallback = opts?.onLeft;
 		this.#onRightCallback = opts?.onRight;
 		this.#onExternalEditorCallback = opts?.onExternalEditor;
+		this.#wrapFocused = opts?.wrapFocused === true;
+		this.#outline = opts?.outline === true;
 
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
@@ -113,7 +253,13 @@ export class HookSelectorComponent extends Container {
 			);
 		}
 
-		if (opts?.outline) {
+		if (this.#wrapFocused) {
+			// Width-aware child owns wrapped layout. It handles both outline
+			// and non-outline rendering paths internally so the cursor signal
+			// + continuation indent are identical across branches.
+			this.#focusAwareList = new FocusAwareList(this.#outline);
+			this.addChild(this.#focusAwareList);
+		} else if (this.#outline) {
 			this.#outlinedList = new OutlinedList();
 			this.addChild(this.#outlinedList);
 		} else {
@@ -130,6 +276,15 @@ export class HookSelectorComponent extends Container {
 	}
 
 	#updateList(): void {
+		if (this.#wrapFocused && this.#focusAwareList) {
+			this.#focusAwareList.setState(this.#options, this.#selectedIndex, this.#maxVisible);
+			return;
+		}
+
+		// Legacy branch — byte-identical to the previous implementation. Any
+		// change here is a regression against
+		// `BASELINE_OUTLINED_RENDER_80_STRIPPED` in
+		// `packages/coding-agent/test/hook-selector-overflow.test.ts`.
 		const lines: string[] = [];
 		const startIndex = Math.max(
 			0,

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -623,6 +623,7 @@ export class ExtensionUiController {
 				onTimeout: dialogOptions?.onTimeout,
 				tui: this.ctx.ui,
 				outline: dialogOptions?.outline,
+				wrapFocused: dialogOptions?.wrapFocused,
 				maxVisible,
 			},
 		);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -149,6 +149,7 @@ interface UIContext {
 			timeout?: number;
 			signal?: AbortSignal;
 			outline?: boolean;
+			wrapFocused?: boolean;
 			onTimeout?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
@@ -194,6 +195,7 @@ async function askSingleQuestion(
 			timeout,
 			signal,
 			outline: true,
+			wrapFocused: true,
 			onTimeout,
 			helpText,
 			onLeft: navigation?.allowBack

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -1,20 +1,68 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components/hook-selector";
-import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { visibleWidth } from "@gajae-code/tui";
 
 beforeAll(async () => {
-	const theme = await getThemeByName("dark");
-	if (!theme) {
+	const themeInstance = await getThemeByName("dark");
+	if (!themeInstance) {
 		throw new Error("Failed to load dark theme for tests");
 	}
-	setThemeInstance(theme);
+	setThemeInstance(themeInstance);
 });
+
+// =============================================================================
+// Required Test 3 — True baseline legacy regression
+//
+// Captured from pre-implementation `HookSelectorComponent.render(80)` BEFORE
+// any `wrapFocused` behavior was added. Both omitted and `wrapFocused:false`
+// must exactly equal this fixture; any drift means today's bytes regressed
+// for shared selector consumers (plan-mode, session-delete, MCP wizard,
+// registry-search, restart picker, branch-summary).
+// =============================================================================
+
+const BASELINE_LONG_FOCUSED =
+	"Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango";
+const BASELINE_LONG_NON_FOCUSED =
+	"Zulu yankee xray whiskey victor uniform tango sierra romeo quebec papa oscar november mike lima kilo juliet india hotel golf";
+const BASELINE_SHORT = "short option";
+
+const BASELINE_OUTLINED_RENDER_80_STRIPPED = [
+	"────────────────────────────────────────────────────────────────────────────────",
+	"",
+	" Choose an option                                                               ",
+	"",
+	"────────────────────────────────────────────────────────────────────────────────",
+	"│❯ Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mi…│",
+	"│  Zulu yankee xray whiskey victor uniform tango sierra romeo quebec papa osca…│",
+	"│  short option                                                                │",
+	"────────────────────────────────────────────────────────────────────────────────",
+	"",
+	" up/down navigate  enter select  esc cancel                                     ",
+	"",
+	"────────────────────────────────────────────────────────────────────────────────",
+].join("\n");
+
+function renderStripped(
+	width: number,
+	opts: { outline?: boolean; wrapFocused?: boolean; initialIndex?: number; maxVisible?: number },
+	options: string[] = [BASELINE_LONG_FOCUSED, BASELINE_LONG_NON_FOCUSED, BASELINE_SHORT],
+): string {
+	const component = new HookSelectorComponent(
+		"Choose an option",
+		options,
+		() => {},
+		() => {},
+		opts,
+	);
+	return Bun.stripANSI(component.render(width).join("\n"));
+}
+
 describe("HookSelectorComponent", () => {
 	it("keeps outlined options within render width", () => {
 		const options = [
-			"aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;b",
-			"bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;a",
+			"aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;b",
+			"bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;aaa;bbb;a",
 			"a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b;a;b",
 		];
 		const component = new HookSelectorComponent(
@@ -30,5 +78,15 @@ describe("HookSelectorComponent", () => {
 		for (const line of lines) {
 			expect(visibleWidth(Bun.stripANSI(line))).toBeLessThanOrEqual(width);
 		}
+	});
+
+	it("legacy outlined render at width 80 is byte-identical to captured baseline (wrapFocused unset)", () => {
+		const rendered = renderStripped(80, { outline: true, initialIndex: 0, maxVisible: 5 });
+		expect(rendered).toBe(BASELINE_OUTLINED_RENDER_80_STRIPPED);
+	});
+
+	it("legacy outlined render at width 80 is byte-identical to captured baseline (wrapFocused:false)", () => {
+		const rendered = renderStripped(80, { outline: true, initialIndex: 0, maxVisible: 5, wrapFocused: false });
+		expect(rendered).toBe(BASELINE_OUTLINED_RENDER_80_STRIPPED);
 	});
 });

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -3,6 +3,28 @@ import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components
 import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { visibleWidth } from "@gajae-code/tui";
 
+// =============================================================================
+// Helpers shared across required tests.
+// =============================================================================
+
+/**
+ * For outlined render, strip the leading box border glyph from each row so
+ * downstream column-aware assertions can inspect the option-content cell
+ * directly. Rows that don't start with the border are returned untouched.
+ */
+function stripBorder(line: string, glyph: string): string {
+	return line.startsWith(glyph) ? line.slice(glyph.length) : line;
+}
+
+/**
+ * Bare (ANSI-stripped) selected-prefix the focused option uses on its first
+ * wrapped row. Mirrors `theme.fg("accent", `${theme.nav.cursor} `)` used in
+ * `FocusAwareList.render` so tests don't depend on the styled (ANSI) form.
+ */
+function bareSelectedPrefix(): string {
+	return Bun.stripANSI(theme.fg("accent", `${theme.nav.cursor} `));
+}
+
 beforeAll(async () => {
 	const themeInstance = await getThemeByName("dark");
 	if (!themeInstance) {
@@ -88,5 +110,173 @@ describe("HookSelectorComponent", () => {
 	it("legacy outlined render at width 80 is byte-identical to captured baseline (wrapFocused:false)", () => {
 		const rendered = renderStripped(80, { outline: true, initialIndex: 0, maxVisible: 5, wrapFocused: false });
 		expect(rendered).toBe(BASELINE_OUTLINED_RENDER_80_STRIPPED);
+	});
+
+	it("Required Test 1 — focused long option wraps fully without ellipsis", () => {
+		const longLabel =
+			"Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango";
+		const rendered = renderStripped(32, { outline: true, initialIndex: 0, maxVisible: 5, wrapFocused: true }, [
+			longLabel,
+			"short",
+		]);
+		const lines = rendered.split("\n");
+
+		// Identify the lines that hold rendered focused-label segments. We
+		// strip the outline border glyph so we can match on the inner cell.
+		const innerLines = lines.map(line => stripBorder(line, "│"));
+		const focusedFragments = innerLines.filter(
+			line => line.includes("Alpha") || line.includes("kilo") || line.includes("juliet"),
+		);
+		expect(focusedFragments.length).toBeGreaterThan(1);
+
+		// Full label text must appear across the wrapped rows.
+		expect(rendered).toContain("Alpha bravo");
+		expect(rendered).toContain("sierra tango");
+
+		// No truncation glyph inside the focused block.
+		const focusedBlock = focusedFragments.join("\n");
+		expect(focusedBlock).not.toContain("…");
+		expect(focusedBlock).not.toContain("...");
+	});
+
+	it("Required Test 2 — non-focused long option remains single-row with ellipsis", () => {
+		const longNonFocused =
+			"Zulu yankee xray whiskey victor uniform tango sierra romeo quebec papa oscar november mike lima kilo juliet india hotel golf";
+		const rendered = renderStripped(34, { outline: true, initialIndex: 0, maxVisible: 5, wrapFocused: true }, [
+			"selected short",
+			longNonFocused,
+		]);
+
+		const innerLines = rendered.split("\n").map(line => stripBorder(line, "│"));
+		const nonFocusedLines = innerLines.filter(line => line.includes("Zulu yankee"));
+		expect(nonFocusedLines).toHaveLength(1);
+		expect(nonFocusedLines[0]).toContain("…");
+		// The truncated row must not contain text from the far end of the
+		// label — it is still one-line behavior.
+		expect(nonFocusedLines[0]).not.toContain("hotel golf");
+	});
+
+	it("Required Test 4 — cursor prefix-column assertion (single cursor row, aligned continuations)", () => {
+		const longLabel =
+			"Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango";
+		const rendered = renderStripped(32, { outline: true, initialIndex: 0, maxVisible: 5, wrapFocused: true }, [
+			longLabel,
+			"short",
+		]);
+		const lines = rendered.split("\n");
+
+		const cursorPrefix = bareSelectedPrefix();
+		const continuationPrefix = " ".repeat(visibleWidth(cursorPrefix));
+
+		// Walk the rows inside the outline border. Only one row is allowed to
+		// start with the bare cursor prefix at the option-content column.
+		const innerLines = lines.map(line => stripBorder(line, "│"));
+
+		// Rows that belong to the focused wrapped block contain pieces of
+		// `longLabel`. We collect them and verify cursor + continuation
+		// columns.
+		const focusedRows = innerLines.filter(line =>
+			["Alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "kilo", "lima", "juliet", "sierra", "tango"].some(
+				token => line.includes(token),
+			),
+		);
+		expect(focusedRows.length).toBeGreaterThan(1);
+
+		const cursorRows = focusedRows.filter(line => line.startsWith(cursorPrefix));
+		expect(cursorRows).toHaveLength(1);
+
+		const continuationRows = focusedRows.filter(line => !line.startsWith(cursorPrefix));
+		expect(continuationRows.length).toBeGreaterThan(0);
+		for (const row of continuationRows) {
+			expect(row.startsWith(continuationPrefix)).toBe(true);
+			// Continuation rows must contain wrapped focused-label text, not
+			// the cursor glyph itself.
+			expect(row.slice(continuationPrefix.length).trim().length).toBeGreaterThan(0);
+		}
+	});
+
+	it("Required Test 5 — mandatory row-budget keeps focused block intact and shrinks siblings", () => {
+		const longLabel =
+			"Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango";
+		const options = ["above-1", "above-2", longLabel, "below-1", "below-2", "below-3"];
+		const rendered = renderStripped(
+			32,
+			{ outline: true, initialIndex: 2, maxVisible: 4, wrapFocused: true },
+			options,
+		);
+
+		// Focused block stays intact: first and last segments are both present.
+		expect(rendered).toContain("Alpha bravo");
+		expect(rendered).toContain("sierra tango");
+
+		// Siblings must shrink — fewer than the full 5 non-focused options can
+		// appear in the window.
+		const visibleSiblings = ["above-1", "above-2", "below-1", "below-2", "below-3"].filter(label =>
+			rendered.includes(label),
+		);
+		expect(visibleSiblings.length).toBeLessThan(5);
+
+		// Marker is present because the window omits at least one option.
+		expect(rendered).toContain("(3/6)");
+	});
+
+	it("Required Test 6 — non-outline parity (wrapFocused:true, outline:false)", () => {
+		const longLabel =
+			"Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango";
+		const rendered = renderStripped(32, { outline: false, initialIndex: 0, maxVisible: 8, wrapFocused: true }, [
+			longLabel,
+			"short non-focused",
+		]);
+		const lines = rendered.split("\n");
+
+		const cursorPrefix = bareSelectedPrefix();
+		const continuationPrefix = " ".repeat(visibleWidth(cursorPrefix));
+
+		// Focused option spans multiple rows.
+		const focusedRows = lines.filter(line =>
+			["Alpha", "bravo", "kilo", "juliet", "sierra"].some(token => line.includes(token)),
+		);
+		expect(focusedRows.length).toBeGreaterThan(1);
+
+		// Exactly one row carries the cursor prefix at the option-content column.
+		const cursorRows = focusedRows.filter(line => line.startsWith(cursorPrefix));
+		expect(cursorRows).toHaveLength(1);
+
+		// Continuation rows start with whitespace aligned under the label.
+		const continuationRows = focusedRows.filter(line => !line.startsWith(cursorPrefix));
+		expect(continuationRows.length).toBeGreaterThan(0);
+		for (const row of continuationRows) {
+			expect(row.startsWith(continuationPrefix)).toBe(true);
+		}
+
+		// Non-focused short label appears exactly once.
+		const shortLines = lines.filter(line => line.includes("short non-focused"));
+		expect(shortLines).toHaveLength(1);
+
+		// No truncation glyph in the focused block.
+		const focusedBlock = focusedRows.join("\n");
+		expect(focusedBlock).not.toContain("…");
+		expect(focusedBlock).not.toContain("...");
+	});
+
+	it("Required Test 6b — non-outline path truncates long non-focused siblings with ellipsis", () => {
+		// Architect blocker fix: the non-outline path also has to render
+		// long non-focused options as one row with `…`, mirroring outline
+		// behavior. Without per-row truncation in `FocusAwareList.render`,
+		// non-focused labels would overflow uncontrolled in non-outline mode.
+		const focused = "selected short";
+		const longNonFocused =
+			"Zulu yankee xray whiskey victor uniform tango sierra romeo quebec papa oscar november mike lima kilo juliet india hotel golf";
+		const rendered = renderStripped(34, { outline: false, initialIndex: 0, maxVisible: 6, wrapFocused: true }, [
+			focused,
+			longNonFocused,
+		]);
+
+		const nonFocusedLines = rendered.split("\n").filter(line => line.includes("Zulu yankee"));
+		expect(nonFocusedLines).toHaveLength(1);
+		expect(nonFocusedLines[0]).toContain("…");
+		// The truncated row must not contain text from the far end of the
+		// label — it is still one-line behavior.
+		expect(nonFocusedLines[0]).not.toContain("hotel golf");
 	});
 });


### PR DESCRIPTION
## Summary

Make the `ask` tool's interactive picker render the **highlighted option's full label across multiple rows** instead of clipping it with `…`. Non-focused options keep today's single-row `…` truncation hint. Shared dialogs (plan-mode, session-delete, MCP wizard, registry-search, restart picker, branch-summary) are opt-out: their rendering is **byte-identical** when `wrapFocused` is unset/false, guarded by a captured-pre-implementation fixture.

Pipeline: `/skill:deep-interview` → `/skill:ralplan --consensus --direct` → `/skill:ultragoal`.

Ralplan run id: `2026-06-01-0740-c488`. Architect (3 lanes) + Critic both APPROVED at iteration 2.

## ADR

**Decision.** Add a per-call `wrapFocused?: boolean` to `ExtensionUIDialogOptions` and thread it through `HookSelectorOptions` into `HookSelectorComponent`. When the flag is `true`, a private file-local `FocusAwareList` owns wrapped layout: it renders the focused option's label across multiple rows via `wrapTextWithAnsi`, keeps non-focused options single-row with `…`, and budgets visible siblings around the focused row count. `OutlinedList` stays a `string[]`-only renderer (no discriminated-union refactor). The ask tool opts in (`wrapFocused: true` in `selectOption.dialogOptions`). RPC and ACP bridges silently drop the flag — it is an interactive-TUI rendering hint only.

**Decision drivers.**
1. **User-visible information loss** — today's `truncateToWidth` in `OutlinedList.render` clips long focused labels with `…`, hiding critical text.
2. **Blast radius across shared consumers** — `HookSelectorComponent` is reused by ≥5 other dialogs; default rendering must remain byte-identical.
3. **Test verifiability** — must be unit-testable through `HookSelectorComponent.render(width)` with `bun:test`.

**Alternatives considered.**
- **Option B — dedicated ask-only selector** (rejected). Duplicates timeout/nav/help/cancel/border code; contradicts the ralplan opt-in plumbing.
- **Option C — generic `renderEntry?(label, isSelected, innerWidth)` callback** (rejected). Over-generalizes; leaks layout details to call sites.

**Why chosen.** Option A has the smallest durable API surface, keeps the new entry type private, and lets a single width-aware owner handle scroll math.

**Consequences.**
- One optional select-only field on `ExtensionUIDialogOptions`.
- One private class added in `hook-selector.ts`. `OutlinedList` unchanged.
- Six required `bun:test` cases added in `hook-selector-overflow.test.ts`, including a literal `BASELINE_OUTLINED_RENDER_80_STRIPPED` fixture captured from pre-implementation output (Step 0 commit).
- No RPC/ACP schema or wire-protocol change.

## Acceptance criteria

- [x] `ExtensionUIDialogOptions.wrapFocused?: boolean` with select-only TSDoc that explicitly drops the flag on RPC and ACP.
- [x] `HookSelectorOptions.wrapFocused?: boolean` plumbed; `extension-ui-controller.ts` `showHookSelector` forwards it.
- [x] Ask tool's local `UIContext.select` options include `wrapFocused?: boolean`.
- [x] `ask.ts` `selectOption` sets `wrapFocused: true` next to `outline: true`.
- [x] Private `FocusAwareList` is the single owner of wrapped layout; `OutlinedList` stays `string[]`-only.
- [x] Legacy `#updateList()` branch (`!wrapFocused`) is byte-identical to today for both outline and non-outline paths.
- [x] All 6 required tests pass (plus Test 6b for long non-focused siblings in non-outline mode).
- [x] `BASELINE_OUTLINED_RENDER_80_STRIPPED` captured BEFORE behavior change (commit `423472b`).
- [x] Existing `packages/coding-agent/test/tools/ask.test.ts` continues to pass without modification.
- [x] `bun test packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/tools/ask.test.ts` → 34/34 pass.
- [x] `bun run check:ts` clean across all 10 workspaces.
- [x] `bun run lint:ts` clean across all 10 workspaces.

## Implementation invariants

1. **One width-aware owner.** `FocusAwareList.render(width)` computes `focusedRows`, sibling budget, finalized rows. `OutlinedList` only wraps the box border.
2. **Cursor signal exactly once.** `theme.fg("accent", `${theme.nav.cursor} `)` only on focused row 0; continuation rows use `" ".repeat(visibleWidth(prefix))`.
3. **Height-budget precedence.** Siblings shrink first; if the focused block alone exceeds `maxVisibleRows`, render focused fully with zero siblings (only allowed overflow exception).
4. **Width clamp.** `availableLabelWidth = Math.max(1, innerWidth - visibleWidth(prefix))` mirrors `AskOptionList`'s clamp.
5. **Both branches honor the flag.** Outline + non-outline produce the same focused-wrap + cursor + continuation + non-focused-truncated shape.

## Verification

```sh
bun test packages/coding-agent/test/hook-selector-overflow.test.ts \
         packages/coding-agent/test/tools/ask.test.ts
# 34 pass, 0 fail, 156 expect() calls

bun run check:ts  # all 10 workspaces clean
bun run lint:ts   # all 10 workspaces clean
```

## Quality gates

- **Deep-interview**: ambiguity 8% at user-approved early exit; topology confirmed (1 active component, AskOptionsRendering).
- **Ralplan consensus (run `2026-06-01-0740-c488`)**: Architect APPROVE + Critic APPROVE at iteration 2; final plan persisted with ADR.
- **Architect three-lane review**: Architecture CLEAR, Product CLEAR, Code CLEAR, recommendation APPROVE.
- **Executor QA + 8-case red-team**: `e2eStatus: passed`, `redTeamStatus: passed`, 0 blockers.

## Commits

- `423472b test(coding-agent): capture pre-implementation baseline for HookSelectorComponent` (Step 0 baseline)
- `c9f78e3 feat(ask): multi-line render for focused option label` (implementation + tests)
