### PR TITLE
Add context usage breakdown

### DIFF
--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@gajae-code/agent-core";
 import type { CompactionSettings } from "@gajae-code/agent-core/compaction";
 import { effectiveReserveTokens, estimateTokens, resolveThresholdTokens } from "@gajae-code/agent-core/compaction";
 import type { Model } from "@gajae-code/ai";
@@ -18,7 +19,7 @@ const CELL_FILLED_MESSAGES = "⛃";
 const CELL_FREE = "⛶";
 const CELL_BUFFER = "⛝";
 
-type CategoryId = "systemPrompt" | "systemContext" | "systemTools" | "skills" | "messages";
+type CategoryId = "systemPrompt" | "systemContext" | "rules" | "tools" | "skills" | "messages" | "lastUserTurn";
 
 interface CategoryInfo {
 	id: CategoryId;
@@ -32,6 +33,7 @@ export interface ContextBreakdown {
 	model: Model | undefined;
 	contextWindow: number;
 	categories: CategoryInfo[];
+	lastUserTurnTokens: number;
 	usedTokens: number;
 	autoCompactBufferTokens: number;
 	freeTokens: number;
@@ -76,7 +78,9 @@ export function estimateToolSchemaTokens(
  */
 export function computeNonMessageTokens(session: AgentSession): number {
 	const parts = computeNonMessageBreakdown(session);
-	return parts.systemPromptTokens + parts.systemContextTokens + parts.toolsTokens + parts.skillsTokens;
+	return (
+		parts.systemPromptTokens + parts.systemContextTokens + parts.rulesTokens + parts.toolsTokens + parts.skillsTokens
+	);
 }
 
 /**
@@ -86,6 +90,7 @@ export function computeNonMessageTokens(session: AgentSession): number {
  * the two surfaces — they MUST report the same numbers.
  */
 function computeNonMessageBreakdown(session: AgentSession): {
+	rulesTokens: number;
 	skillsTokens: number;
 	toolsTokens: number;
 	systemContextTokens: number;
@@ -94,26 +99,60 @@ function computeNonMessageBreakdown(session: AgentSession): {
 	const skillsTokens = estimateSkillsTokens(session.skills ?? []);
 	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? []);
 	const systemPromptParts = session.systemPrompt ?? [];
+	const rulesTokens = estimateRulesTokens(systemPromptParts);
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));
-	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens);
-	return { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
+	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens - rulesTokens);
+	return { rulesTokens, skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
+}
+
+function estimateRulesTokens(systemPromptParts: readonly string[]): number {
+	const fragments: string[] = [];
+	for (const part of systemPromptParts) {
+		for (const match of part.matchAll(/<rules>[\s\S]*?<\/rules>/g)) {
+			fragments.push(match[0]);
+		}
+	}
+	return fragments.length === 0 ? 0 : countTokens(fragments);
+}
+
+function splitLastUserTurn(messages: readonly AgentMessage[]): {
+	regularMessagesTokens: number;
+	lastUserTurnTokens: number;
+} {
+	let lastUserIndex = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i]?.role === "user") {
+			lastUserIndex = i;
+			break;
+		}
+	}
+
+	let regularMessagesTokens = 0;
+	let lastUserTurnTokens = 0;
+	for (let i = 0; i < messages.length; i++) {
+		const tokens = estimateTokens(messages[i]);
+		if (i === lastUserIndex) {
+			lastUserTurnTokens = tokens;
+		} else {
+			regularMessagesTokens += tokens;
+		}
+	}
+	return { regularMessagesTokens, lastUserTurnTokens };
 }
 
 /**
  * Compute a breakdown of estimated context usage by category for the active
  * session and model.
  */
-export function computeContextBreakdown(session: AgentSession): ContextBreakdown {
+export function computeContextBreakdown(
+	session: AgentSession,
+	options: { messages?: readonly AgentMessage[] } = {},
+): ContextBreakdown {
 	const model = session.model;
 	const contextWindow = model?.contextWindow ?? 0;
 
-	let messagesTokens = 0;
-	const convo = session.messages;
-	if (convo) {
-		for (const message of convo) {
-			messagesTokens += estimateTokens(message);
-		}
-	}
+	const convo = options.messages ?? session.messages ?? [];
+	const { regularMessagesTokens, lastUserTurnTokens } = splitLastUserTurn(convo);
 
 	// The rendered system prompt already contains the skill descriptions and the
 	// markdown tool descriptions. To present a non-overlapping breakdown:
@@ -121,14 +160,16 @@ export function computeContextBreakdown(session: AgentSession): ContextBreakdown
 	//   Tools         = JSON tool schema sent separately on the wire
 	//   Skills        = the skill list embedded in the system prompt
 	//   Messages      = conversation messages
-	const { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens } = computeNonMessageBreakdown(session);
+	const { rulesTokens, skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens } =
+		computeNonMessageBreakdown(session);
 
 	const categories: CategoryInfo[] = [
-		{ id: "systemPrompt", label: "System prompt", tokens: systemPromptTokens, color: "accent", glyph: CELL_FILLED },
-		{ id: "systemTools", label: "System tools", tokens: toolsTokens, color: "warning", glyph: CELL_FILLED },
+		{ id: "systemPrompt", label: "System", tokens: systemPromptTokens, color: "accent", glyph: CELL_FILLED },
+		{ id: "rules", label: "Rules", tokens: rulesTokens, color: "warning", glyph: CELL_FILLED },
+		{ id: "tools", label: "Tools", tokens: toolsTokens, color: "warning", glyph: CELL_FILLED },
 		{
 			id: "systemContext",
-			label: "System context",
+			label: "Context files",
 			tokens: systemContextTokens,
 			color: "customMessageLabel",
 			glyph: CELL_FILLED,
@@ -137,7 +178,14 @@ export function computeContextBreakdown(session: AgentSession): ContextBreakdown
 		{
 			id: "messages",
 			label: "Messages",
-			tokens: messagesTokens,
+			tokens: regularMessagesTokens,
+			color: "userMessageText",
+			glyph: CELL_FILLED_MESSAGES,
+		},
+		{
+			id: "lastUserTurn",
+			label: "Last user turn",
+			tokens: lastUserTurnTokens,
 			color: "userMessageText",
 			glyph: CELL_FILLED_MESSAGES,
 		},
@@ -167,6 +215,7 @@ export function computeContextBreakdown(session: AgentSession): ContextBreakdown
 		model,
 		contextWindow,
 		categories,
+		lastUserTurnTokens,
 		usedTokens,
 		autoCompactBufferTokens,
 		freeTokens,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -21,6 +21,7 @@ import {
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
+import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
@@ -513,6 +514,19 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (_command, runtime) => {
 			await runtime.ctx.handleJobsCommand();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "context",
+		description: "Show active context token usage breakdown",
+		acpDescription: "Show active context token usage breakdown",
+		handle: async (_command, runtime) => {
+			await runtime.output(buildContextReportText(runtime));
+			return commandConsumed();
+		},
+		handleTui: (_command, runtime) => {
+			runtime.ctx.handleContextCommand();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/helpers/context-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/context-report.ts
@@ -1,6 +1,87 @@
+import type { AgentMessage } from "@gajae-code/agent-core";
+import { type CompactionSettings, calculatePromptTokens } from "@gajae-code/agent-core/compaction";
+import type { AssistantMessage, Usage } from "@gajae-code/ai";
 import { computeContextBreakdown } from "../../modes/utils/context-usage";
+import type { CompactionEntry, SessionEntry } from "../../session/session-manager";
 import type { SlashCommandRuntime } from "../types";
 import { renderAsciiBar } from "./format";
+
+interface ActiveHistorySummary {
+	activeMessages: readonly AgentMessage[];
+	rawBranchMessages: number;
+	rawBranchEntries: number;
+	compaction: CompactionEntry | undefined;
+	compactedRawMessages: number | undefined;
+}
+
+function isMessageEntry(entry: SessionEntry): boolean {
+	return entry.type === "message" || entry.type === "custom_message" || entry.type === "branch_summary";
+}
+
+function summarizeActiveHistory(runtime: SlashCommandRuntime): ActiveHistorySummary {
+	const activeContext = runtime.sessionManager.buildSessionContext();
+	const branch = runtime.sessionManager.getBranch();
+	let compaction: CompactionEntry | undefined;
+	let compactionIndex = -1;
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry.type === "compaction") {
+			compaction = entry;
+			compactionIndex = i;
+			break;
+		}
+	}
+
+	const rawBranchMessages = branch.filter(isMessageEntry).length;
+	let compactedRawMessages: number | undefined;
+	if (compaction) {
+		const firstKeptIndex = branch.findIndex(entry => entry.id === compaction?.firstKeptEntryId);
+		if (firstKeptIndex >= 0 && compactionIndex >= 0) {
+			compactedRawMessages = branch.slice(0, firstKeptIndex).filter(isMessageEntry).length;
+		}
+	}
+
+	return {
+		activeMessages: activeContext.messages,
+		rawBranchMessages,
+		rawBranchEntries: branch.length,
+		compaction,
+		compactedRawMessages,
+	};
+}
+
+function findLastAssistantUsage(messages: readonly AgentMessage[]):
+	| {
+			message: AssistantMessage;
+			usage: Usage;
+	  }
+	| undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role === "assistant") {
+			const assistant = message as AssistantMessage;
+			return { message: assistant, usage: assistant.usage };
+		}
+	}
+	return undefined;
+}
+
+function formatUnknownNumber(value: number | undefined): string {
+	return value === undefined ? "unknown" : value.toLocaleString();
+}
+
+function formatTokenLine(label: string, tokens: number, contextWindow: number): string {
+	const fraction = contextWindow > 0 ? tokens / contextWindow : 0;
+	return `  ${label.padEnd(16)} ${renderAsciiBar(fraction)}  ${tokens.toLocaleString()} tokens`;
+}
+
+function formatReserveText(runtime: SlashCommandRuntime, contextWindow: number, reserveTokens: number): string {
+	if (contextWindow <= 0) return "unknown";
+	if (reserveTokens > 0) return `${reserveTokens.toLocaleString()} tokens`;
+	const compaction = runtime.settings.getGroup("compaction") as CompactionSettings;
+	if (!compaction.enabled || compaction.strategy === "off") return "none configured";
+	return "unknown";
+}
 
 /**
  * Build the `/context` ACP-mode text. Tries the rich breakdown first
@@ -9,31 +90,60 @@ import { renderAsciiBar } from "./format";
  */
 export function buildContextReportText(runtime: SlashCommandRuntime): string {
 	try {
-		const breakdown = computeContextBreakdown(runtime.session);
+		const history = summarizeActiveHistory(runtime);
+		const breakdown = computeContextBreakdown(runtime.session, { messages: history.activeMessages });
 		if (breakdown.contextWindow <= 0) {
 			return "Context usage is unavailable: no model is selected for this session.";
 		}
-		const usedPct = Math.round((breakdown.usedTokens / breakdown.contextWindow) * 100);
-		const lines = [`Context window: ${breakdown.contextWindow} tokens (${usedPct}% used)`];
+		const promptUsage = findLastAssistantUsage(history.activeMessages);
+		const usedPct = (breakdown.usedTokens / breakdown.contextWindow) * 100;
+		const lines = [
+			"Context usage",
+			`Model: ${breakdown.model?.provider ?? "unknown"}/${breakdown.model?.id ?? "unknown"}`,
+			`Active context: ${breakdown.usedTokens.toLocaleString()} / ${breakdown.contextWindow.toLocaleString()} tokens (${usedPct.toFixed(1)}% used)`,
+			`Reserve: ${formatReserveText(runtime, breakdown.contextWindow, breakdown.autoCompactBufferTokens)}`,
+			"",
+			"Active context breakdown (estimated)",
+		];
 		for (const category of breakdown.categories) {
-			if (category.tokens === 0) continue;
-			const fraction = category.tokens / breakdown.contextWindow;
-			lines.push(`  ${category.label.padEnd(16)} ${renderAsciiBar(fraction)}  ${category.tokens} tokens`);
+			lines.push(formatTokenLine(category.label, category.tokens, breakdown.contextWindow));
 		}
 		if (breakdown.autoCompactBufferTokens > 0) {
-			const fraction = breakdown.autoCompactBufferTokens / breakdown.contextWindow;
-			lines.push(
-				`  ${"Auto-compact buf".padEnd(16)} ${renderAsciiBar(fraction)}  ${breakdown.autoCompactBufferTokens} tokens`,
-			);
+			lines.push(formatTokenLine("Reserve", breakdown.autoCompactBufferTokens, breakdown.contextWindow));
 		}
-		if (breakdown.freeTokens > 0) {
-			const fraction = breakdown.freeTokens / breakdown.contextWindow;
-			lines.push(`  ${"Free".padEnd(16)} ${renderAsciiBar(fraction)}  ${breakdown.freeTokens} tokens`);
+		lines.push(formatTokenLine("Free", breakdown.freeTokens, breakdown.contextWindow));
+		lines.push(
+			"",
+			"History",
+			`Active messages sent next turn: ${history.activeMessages.length.toLocaleString()}`,
+			`Raw branch history: ${history.rawBranchMessages.toLocaleString()} message entries / ${history.rawBranchEntries.toLocaleString()} total entries`,
+			history.compaction
+				? `Compacted history: summary active; compacted raw messages: ${formatUnknownNumber(history.compactedRawMessages)}; tokens before compaction: ${history.compaction.tokensBefore.toLocaleString()}`
+				: "Compacted history: none on active branch",
+			"",
+			"Last recorded provider turn",
+		);
+		if (promptUsage) {
+			lines.push(
+				`Model: ${promptUsage.message.provider}/${promptUsage.message.model}`,
+				`Prompt tokens: ${calculatePromptTokens(promptUsage.usage).toLocaleString()}`,
+				`Input/output/cache: ${promptUsage.usage.input.toLocaleString()} / ${promptUsage.usage.output.toLocaleString()} / ${(
+					promptUsage.usage.cacheRead + promptUsage.usage.cacheWrite
+				).toLocaleString()}`,
+				`Cost: $${promptUsage.usage.cost.total.toFixed(6)}`,
+			);
+		} else {
+			lines.push("Usage/cost: unknown (no assistant response with recorded provider usage yet)");
 		}
 		return lines.join("\n");
 	} catch {
 		const fallback = runtime.session.getContextUsage();
 		if (!fallback) return "Context usage is unavailable.";
-		return ["Context", `Window: ${fallback.contextWindow}`, `Used: ${fallback.tokens ?? 0}`].join("\n");
+		return [
+			"Context usage",
+			`Active context: ${fallback.tokens === null || fallback.tokens === undefined ? "unknown" : fallback.tokens.toLocaleString()}`,
+			`Context window: ${fallback.contextWindow.toLocaleString()}`,
+			"Breakdown: unknown",
+		].join("\n");
 	}
 }

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
+import type { AgentMessage } from "@gajae-code/agent-core";
 import { Settings } from "../src/config/settings";
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
@@ -29,7 +30,15 @@ interface FakeAcpBuiltinSession {
 			options?: { candidates?: Array<{ provider: string; id: string; contextWindow?: number }> },
 		) => { provider: string; id: string; contextWindow?: number } | undefined;
 	};
-	model: { provider: string; id: string } | undefined;
+	model: { provider: string; id: string; contextWindow?: number } | undefined;
+	agent: {
+		state: {
+			tools: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+		};
+	};
+	settings: Settings;
+	systemPrompt: string[];
+	skills: Array<{ name: string; description: string }>;
 	newSession(opts?: { drop?: boolean; parentSession?: string }): Promise<boolean>;
 	fork(): Promise<boolean>;
 	handoff(instr?: string): Promise<{ document: string; savedPath?: string } | undefined>;
@@ -48,6 +57,7 @@ interface FakeAcpBuiltinSession {
 
 function createRuntime() {
 	const output: string[] = [];
+	const settings = Settings.isolated();
 	const session: FakeAcpBuiltinSession = {
 		fastMode: false,
 		forcedToolChoice: undefined as string | undefined,
@@ -98,6 +108,10 @@ function createRuntime() {
 			},
 		},
 		model: undefined,
+		agent: { state: { tools: [] } },
+		settings,
+		systemPrompt: [],
+		skills: [],
 		getToolByName: (_name: string) => undefined,
 		async compact(_args?: string) {},
 		getContextUsage: () => undefined,
@@ -141,6 +155,20 @@ function createRuntime() {
 		getCwd(): string {
 			return this._cwd;
 		},
+		buildSessionContext() {
+			return {
+				messages: [] as AgentMessage[],
+				thinkingLevel: "off",
+				models: {},
+				injectedTtsrRules: [],
+				selectedMCPToolNames: [],
+				hasPersistedMCPToolSelection: false,
+				mode: "none",
+			};
+		},
+		getUsageStatistics() {
+			return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 };
+		},
 		async setSessionName(name: string, _source: string): Promise<boolean> {
 			this._sessionName = name;
 			return true;
@@ -153,7 +181,7 @@ function createRuntime() {
 		runtime: {
 			session: typedSession,
 			sessionManager: fakeSessionManager as unknown as SessionManager,
-			settings: Settings.isolated(),
+			settings,
 			cwd: "/tmp/project",
 			output: (text: string) => {
 				output.push(text);
@@ -473,7 +501,6 @@ describe("ACP builtin slash commands", () => {
 			"/branch",
 			"/browser",
 			"/changelog",
-			"/context",
 			"/plan",
 			"/share",
 			"/hotkeys",
@@ -769,6 +796,73 @@ describe("wave 5 — adapters and polish", () => {
 	});
 
 	// /context breakdown
+	it("/context: renders active context, history, and last provider usage", async () => {
+		const { output, runtime, session, fakeSessionManager } = createRuntime();
+		session.model = { provider: "openai", id: "gpt-test", contextWindow: 100_000 };
+		session.systemPrompt = [
+			[
+				"<system>base instructions</system>",
+				'<skills><skill name="sample">Skill description</skill></skills>',
+				'<rules><rule name="repo">Repo rule</rule></rules>',
+			].join("\n"),
+			"<project>project context</project>",
+		];
+		session.skills = [{ name: "sample", description: "Skill description" }];
+		session.agent.state.tools = [{ name: "read", description: "Read files", parameters: { type: "object" } }];
+		const messages: AgentMessage[] = [
+			{ role: "user", content: "older prompt", timestamp: 1 },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "older answer" }],
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-test",
+				usage: {
+					input: 1000,
+					output: 200,
+					cacheRead: 300,
+					cacheWrite: 0,
+					totalTokens: 1500,
+					cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0, total: 0.0031 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			},
+			{ role: "user", content: "what is the current context?", timestamp: 3 },
+		];
+		fakeSessionManager.buildSessionContext = () => ({
+			messages,
+			thinkingLevel: "off",
+			models: {},
+			injectedTtsrRules: [],
+			selectedMCPToolNames: [],
+			hasPersistedMCPToolSelection: false,
+			mode: "none",
+		});
+		fakeSessionManager.getBranch = () => [
+			{ type: "message", id: "1", parentId: null, timestamp: "t", message: messages[0] },
+			{
+				type: "compaction",
+				id: "2",
+				parentId: "1",
+				timestamp: "t",
+				summary: "summary",
+				firstKeptEntryId: "1",
+				tokensBefore: 42_000,
+			},
+			{ type: "message", id: "3", parentId: "2", timestamp: "t", message: messages[1] },
+			{ type: "message", id: "4", parentId: "3", timestamp: "t", message: messages[2] },
+		];
+
+		const result = await executeAcpBuiltinSlashCommand("/context", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Context usage");
+		expect(output[0]).toContain("Active context breakdown");
+		expect(output[0]).toContain("Last user turn");
+		expect(output[0]).toContain("Compacted history: summary active");
+		expect(output[0]).toContain("Cost: $0.003100");
+	});
 
 	// /jobs empty state
 	it("/jobs: empty-state output mentions background jobs definition", async () => {


### PR DESCRIPTION
Closes #149.

## Summary
- Adds `/context` as a built-in slash command for ACP/text sessions and keeps TUI `/context` on the existing context command path.
- Reuses `SessionManager.buildSessionContext()` plus existing context-usage helpers to report active context, model window/reserve, category estimates, active vs raw/compacted history, and last recorded provider usage/cost.
- Extends the shared context breakdown to split system/rules/tools/context files/skills/messages/last user turn without creating a second prompt assembly path.

## Tests
- `bun test packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/slash-command-format.test.ts packages/coding-agent/test/status-line-context-cache.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run check`
