### PR TITLE
Add internal Deep Interview auto-mode fragments

### DIFF
--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -1,5 +1,9 @@
 import * as path from "node:path";
 import { getAgentDir, isEnoent, parseFrontmatter } from "@gajae-code/utils";
+import autoAnswerUncertainFragment from "./gjc/skills/deep-interview/auto-answer-uncertain.md" with { type: "text" };
+import autoResearchGreenfieldFragment from "./gjc/skills/deep-interview/auto-research-greenfield.md" with {
+	type: "text",
+};
 import deepInterviewSkill from "./gjc/skills/deep-interview/SKILL.md" with { type: "text" };
 import ralplanSkill from "./gjc/skills/ralplan/SKILL.md" with { type: "text" };
 import teamSkill from "./gjc/skills/team/SKILL.md" with { type: "text" };
@@ -7,7 +11,7 @@ import ultragoalSkill from "./gjc/skills/ultragoal/SKILL.md" with { type: "text"
 
 export const DEFAULT_GJC_DEFINITION_NAMES = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
 export type DefaultGjcDefinitionName = (typeof DEFAULT_GJC_DEFINITION_NAMES)[number];
-export type DefaultGjcDefinitionKind = "skill";
+export type DefaultGjcDefinitionKind = "skill" | "skill-fragment";
 export type EmbeddedDefaultGjcSkill = {
 	name: DefaultGjcDefinitionName;
 	description: string;
@@ -19,12 +23,21 @@ export type EmbeddedDefaultGjcSkill = {
 };
 export type DefaultGjcInstallStatus = "different" | "matching" | "missing" | "skipped" | "written";
 
-export interface DefaultGjcDefinition {
-	kind: DefaultGjcDefinitionKind;
+export interface DefaultGjcSkillDefinition {
+	kind: "skill";
 	name: DefaultGjcDefinitionName;
 	relativePath: string;
 	content: string;
 }
+
+export interface DefaultGjcSkillFragmentDefinition {
+	kind: "skill-fragment";
+	parentSkillName: DefaultGjcDefinitionName;
+	relativePath: string;
+	content: string;
+}
+
+export type DefaultGjcDefinition = DefaultGjcSkillDefinition | DefaultGjcSkillFragmentDefinition;
 
 export interface InstallDefaultGjcDefinitionsOptions {
 	check?: boolean;
@@ -32,12 +45,19 @@ export interface InstallDefaultGjcDefinitionsOptions {
 	targetRoot?: string;
 }
 
-export interface DefaultGjcDefinitionInstallFile {
-	kind: DefaultGjcDefinitionKind;
-	name: DefaultGjcDefinitionName;
-	path: string;
-	status: DefaultGjcInstallStatus;
-}
+export type DefaultGjcDefinitionInstallFile =
+	| {
+			kind: "skill";
+			name: DefaultGjcDefinitionName;
+			path: string;
+			status: DefaultGjcInstallStatus;
+	  }
+	| {
+			kind: "skill-fragment";
+			parentSkillName: DefaultGjcDefinitionName;
+			path: string;
+			status: DefaultGjcInstallStatus;
+	  };
 
 export interface DefaultGjcDefinitionInstallResult {
 	targetRoot: string;
@@ -60,6 +80,18 @@ const DEFAULT_GJC_DEFINITIONS: readonly DefaultGjcDefinition[] = [
 	{ kind: "skill", name: "ralplan", relativePath: "skills/ralplan/SKILL.md", content: ralplanSkill },
 	{ kind: "skill", name: "team", relativePath: "skills/team/SKILL.md", content: teamSkill },
 	{ kind: "skill", name: "ultragoal", relativePath: "skills/ultragoal/SKILL.md", content: ultragoalSkill },
+	{
+		kind: "skill-fragment",
+		parentSkillName: "deep-interview",
+		relativePath: "skill-fragments/deep-interview/auto-research-greenfield.md",
+		content: autoResearchGreenfieldFragment,
+	},
+	{
+		kind: "skill-fragment",
+		parentSkillName: "deep-interview",
+		relativePath: "skill-fragments/deep-interview/auto-answer-uncertain.md",
+		content: autoAnswerUncertainFragment,
+	},
 ];
 
 export function getDefaultGjcDefinitions(): readonly DefaultGjcDefinition[] {
@@ -70,8 +102,19 @@ export function getDefaultGjcAgentDefinitions(): readonly DefaultGjcDefinition[]
 	return [];
 }
 
+export function getEmbeddedDefaultGjcSkillFragments(
+	parentSkillName: DefaultGjcDefinitionName,
+): DefaultGjcSkillFragmentDefinition[] {
+	return DEFAULT_GJC_DEFINITIONS.filter(
+		(definition): definition is DefaultGjcSkillFragmentDefinition =>
+			definition.kind === "skill-fragment" && definition.parentSkillName === parentSkillName,
+	);
+}
+
 export function getEmbeddedDefaultGjcSkills(): EmbeddedDefaultGjcSkill[] {
-	return DEFAULT_GJC_DEFINITIONS.filter(definition => definition.kind === "skill").map(definition => {
+	return DEFAULT_GJC_DEFINITIONS.filter(
+		(definition): definition is DefaultGjcSkillDefinition => definition.kind === "skill",
+	).map(definition => {
 		const { frontmatter } = parseFrontmatter(definition.content, {
 			source: `embedded:gjc/${definition.relativePath}`,
 			level: "warn",
@@ -110,12 +153,21 @@ export async function installDefaultGjcDefinitions(
 			status = "written";
 		}
 
-		files.push({
-			kind: definition.kind,
-			name: definition.name,
-			path: destination,
-			status,
-		});
+		if (definition.kind === "skill") {
+			files.push({
+				kind: definition.kind,
+				name: definition.name,
+				path: destination,
+				status,
+			});
+		} else {
+			files.push({
+				kind: definition.kind,
+				parentSkillName: definition.parentSkillName,
+				path: destination,
+				status,
+			});
+		}
 	}
 
 	return summarizeInstallResult(targetRoot, files);

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -54,6 +54,15 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 - Challenge agents activate at specific round thresholds to shift perspective
 </Execution_Policy>
 
+<Internal_Auto_Mode_Protocol>
+- `auto-research-greenfield.md` and `auto-answer-uncertain.md` are internal prompt fragments loaded on demand with bundle metadata `kind: "skill-fragment"`; they are not public skills, are never slash-command/discoverable, and must not be registered through any `skill://` route.
+- Load fragments only for the specific hook that needs them, with forked inherited context kept read-only and prompt-budgeted; summarize active interview context before spawning the architect if the payload is large.
+- Auto-mode architects are read-only: no code edits, no `.gjc/` mutation, no workflow chaining, no formatters, and no execution delegation.
+- Validate every fragment response before using it: required sections must be present, candidates/answer must match the requested shape, rationale must cite available context, confidence must be explicit, and insufficient-context fallbacks must be honored.
+- If architect spawn, fragment loading, or response validation fails, continue the normal manual interview path silently and record an internal audit note in state by incrementing `architect_failures`; do not expose tool noise to the user unless it changes the next user-facing question.
+- Track `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures` in state and final spec metadata.
+</Internal_Auto_Mode_Protocol>
+
 
 
 <Steps>
@@ -133,7 +142,10 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
       "last_targeted_component_id": null
     },
     "challenge_modes_used": [],
-    "ontology_snapshots": []
+    "ontology_snapshots": [],
+    "auto_researched_rounds": [],
+    "auto_answered_rounds": [],
+    "architect_failures": 0
   }
 }
 ```
@@ -246,6 +258,12 @@ If any prompt input is too large, summarize it first and then continue from the 
 | Context Clarity (brownfield) | "How does this fit?" | "I found JWT auth middleware in `src/auth/` (pattern: passport + JWT). Should this feature extend that path or intentionally diverge from it?" |
 | Scope-fuzzy / ontology stress | "What IS the core thing here?" | "You have named Tasks, Projects, and Workspaces across the last rounds. Which one is the core entity, and which are supporting views or containers?" |
 
+### Step 2a′: Auto-Research Greenfield Questions
+
+When the next question is for a greenfield interview and is tagged `research: true`, load `auto-research-greenfield.md` as an internal `kind: "skill-fragment"` prompt for a fork-context architect before Step 2b. Pass only the tagged question, locked topology summary, prompt-safe initial idea, trimmed prior decisions/gaps, and relevant constraints. The architect must return 2-3 ranked candidates with rationale, confidence, and fallback notes. Validate the shape before use; if valid, incorporate the candidates as concise answer options or context for the single user-facing question and append the round number to `auto_researched_rounds`. If invalid or unavailable, fall back silently to the normal generated question and increment `architect_failures`.
+
+Auto-research must never add a public skill entrypoint, never be slash-command/discoverable, never register a `skill://` handler, and never alter the one-question-per-round rule.
+
 ### Step 2b: Ask the Question
 
 Use the `ask` tool with the generated question. Present it clearly with the current ambiguity context:
@@ -258,9 +276,17 @@ Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} 
 
 Options should include contextually relevant choices plus free-text.
 
+### Step 2b′: Auto-Answer Opted-Out Questions
+
+After the `ask` tool resolves and before ambiguity scoring, if the user opts out of answering the current question or explicitly asks the agent to decide, load `auto-answer-uncertain.md` as an internal `kind: "skill-fragment"` prompt for a fork-context architect. Pass the opted-out question, prompt-safe transcript summary, locked topology, current scores/gaps, and any auto-research candidates used for the round. The architect must return exactly one decisive answer with rationale, confidence, and explicit uncertainty. Validate the response shape before using it; if valid, record it as the tentative answer for scoring, append the round number to `auto_answered_rounds`, and mark the transcript answer as architect-assisted.
+
+Auto-answer has a clarity cap: unless the architect confidence is `high` and uncertainty is negligible, no dimension score improved solely by the auto-answer may exceed `0.85`. If the auto-answer would make ambiguity cross the resolved threshold, ask the user for threshold-crossing confirmation before Phase 4: present the tentative assumption and require explicit confirmation, revision, or continued questioning. On architect failure or invalid response, continue with the user's opt-out as an unresolved gap, increment `architect_failures`, and do not block the interview.
+
 ### Step 2c: Score Ambiguity
 
 After receiving the user's answer, score clarity across all dimensions.
+
+If the round used an auto-answer, include the architect answer, rationale, confidence, and uncertainty in the scoring prompt. Apply the Step 2b′ clarity cap mechanically before calculating ambiguity, and treat any low-confidence or insufficient-context auto-answer as an unresolved gap rather than user-confirmed truth.
 
 **Scoring prompt** (use opus model, temperature 0.1 for consistency):
 
@@ -355,7 +381,7 @@ Round {n} complete.
 
 ### Step 2e: Update State
 
-Update interview state with the new round, global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, ontology snapshot, and `topology.last_targeted_component_id` via `gjc state write`; never patch `.gjc/state` directly unless an explicit force override is active.
+Update interview state with the new round, global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures` via `gjc state write`; never patch `.gjc/state` directly unless an explicit force override is active.
 
 ### Step 2f: Check Soft Limits
 
@@ -408,6 +434,9 @@ Spec structure:
 - Threshold Source: <resolvedThresholdSource>
 - Initial Context Summarized: {yes|no}
 - Status: {PASSED | BELOW_THRESHOLD_EARLY_EXIT}
+- Auto-Researched Rounds: {auto_researched_rounds}
+- Auto-Answered Rounds: {auto_answered_rounds}
+- Architect Failures: {architect_failures}
 
 ## Clarity Breakdown
 | Dimension | Score | Weight | Weighted |
@@ -569,6 +598,8 @@ Skipping any stage is possible but reduces quality assurance:
 - Use the GJC workflow CLI to save the final spec at `.gjc/specs/deep-interview-{slug}.md` exactly; do not use `write`, `edit`, or `ast_edit` directly on `.gjc/` paths without force override.
 - Use public GJC workflow entrypoints to bridge to ralplan/team only after explicit execution approval — never implement directly
 - Challenge agent modes are prompt injections, not separate agent spawns
+- Use internal fragment auto-modes only at their documented hooks: `auto-research-greenfield.md` between Step 2a and 2b for greenfield `research: true` questions, and `auto-answer-uncertain.md` as Step 2b′ after `ask` resolves and before scoring.
+- Fragment auto-modes are loaded on demand as `kind: "skill-fragment"`; they are not public workflow skills, not slash-command/discoverable, and not `skill://` registrations.
 </Tool_Usage>
 
 <Examples>
@@ -703,6 +734,8 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 - [ ] Multi-component interviews rotate targeting across active components when N > 1
 - [ ] Spec includes Topology section with confirmed active components and user-confirmed deferrals
 - [ ] Spec includes Ontology (Key Entities) table and Ontology Convergence section
+- [ ] Internal auto-mode fragments, when used, were loaded only on demand as non-public `kind: "skill-fragment"` prompts; responses were validated, failures incremented `architect_failures`, and final metadata includes `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`
+- [ ] Auto-answer threshold crossing, if any, received explicit user confirmation before spec crystallization
 </Final_Checklist>
 
 <Advanced>

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/auto-answer-uncertain.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/auto-answer-uncertain.md
@@ -1,0 +1,37 @@
+# Deep Interview Auto Answer: Uncertain User Opt-Out
+
+You are a read-only architect helping the deep-interview workflow resolve one question after the user opted out, answered with uncertainty, or explicitly asked the agent to decide.
+
+Inherited context is read-only background. Do not edit code, write files, mutate `.gjc/` state, run formatters, invoke workflow handoffs, or implement anything. Use only inherited context, the opted-out question, prior interview decisions, topology/ontology notes, confirmed constraints, and read-only repo/context inspection if available.
+
+Keep the response compact enough to fit into ambiguity scoring.
+
+## Task
+
+Provide one decisive answer the parent workflow can tentatively carry forward. Choose the most conservative answer that preserves user intent, avoids irreversible assumptions, and keeps the interview moving.
+
+## Response Shape
+
+Respond with only this JSON object:
+
+```json
+{
+  "status": "answered",
+  "answer": "One concise decisive answer phrased as the assumption Deep Interview should carry.",
+  "rationale": [
+    "Context or repo fact supporting the answer."
+  ],
+  "confidence": "high|medium|low",
+  "uncertainty": "Explicit remaining uncertainty, or null if negligible."
+}
+```
+
+Rules:
+- `answer` must be non-empty and must not contradict confirmed user constraints.
+- `rationale` must contain 2-4 bullets citing inherited context, confirmed constraints, or repo facts available in the prompt.
+- `confidence` must be `high`, `medium`, or `low`.
+- Use `uncertainty` whenever context is thin, ambiguous, or depends on a product choice the transcript has not settled.
+
+## Fallback
+
+If inherited context is insufficient for a defensible decisive answer, do not guess. Return the safest reversible default if one exists, mark confidence `low`, set `uncertainty` to `Insufficient context for a reliable answer: <missing decision or evidence>`, and clearly identify what the user must confirm before execution approval.

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/auto-research-greenfield.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/auto-research-greenfield.md
@@ -1,0 +1,42 @@
+# Deep Interview Auto Research: Greenfield
+
+You are a read-only architect helping the deep-interview workflow evaluate one greenfield question tagged `research: true`.
+
+Inherited context is read-only background. Do not edit code, write files, mutate `.gjc/` state, run formatters, invoke workflow handoffs, or implement anything. Use only inherited context, the tagged question, prior interview decisions, topology/ontology notes, confirmed constraints, and read-only repo/context inspection if available.
+
+Keep the response compact enough to fit back into the parent interview prompt.
+
+## Task
+
+Return 2-3 ranked candidate answers for the tagged greenfield question. Candidates must be concrete, mutually distinct, consistent with confirmed constraints, and useful as answer options or context for the next single Socratic question.
+
+## Response Shape
+
+Respond with only this JSON object:
+
+```json
+{
+  "status": "answered",
+  "candidates": [
+    {
+      "rank": 1,
+      "answer": "Concise candidate answer.",
+      "rationale": "Why this candidate fits the inherited context and confirmed constraints.",
+      "risks_or_tradeoffs": "Main risk, tradeoff, or caveat for this candidate.",
+      "confidence": "high|medium|low"
+    }
+  ],
+  "recommendation": "One sentence naming the strongest candidate and why it should be offered first.",
+  "follow_up_gap": "One sentence naming the remaining uncertainty the user should still confirm."
+}
+```
+
+Rules:
+- `candidates` must contain 2 or 3 entries when context supports that many.
+- `rank` starts at 1 and increases by 1.
+- `confidence` must be `high`, `medium`, or `low`.
+- Every rationale must cite inherited context, confirmed constraints, or repo facts available in the prompt.
+
+## Fallback
+
+If inherited context is insufficient to produce at least two meaningful candidates, say so explicitly in `follow_up_gap`, return the best single defensible candidate only if one exists, mark confidence `low`, and name the missing context. Do not fabricate certainty.

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -469,6 +469,7 @@ async function handleSpecWrite(args: readonly string[], cwd: string): Promise<De
 
 		const handoffArgs = ["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"];
 		if (resolved.sessionId) handoffArgs.push("--session-id", resolved.sessionId);
+		else handoffArgs.push("--session-id", "");
 		const handoffResult = await runNativeStateCommand(handoffArgs, cwd);
 		if (handoffResult.status !== 0) {
 			throw new DeepInterviewCommandError(

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -171,16 +171,17 @@ async function resolveSelectors(
 	}
 	if (mode) assertKnownMode(mode);
 
+	const explicitSessionId = flagValue(args, "--session-id");
 	// Session-id resolution order: explicit --session-id flag, then payload
 	// session_id, then GJC_SESSION_ID env var (set by AgentSession.sdk for
 	// agent-initiated CLI invocations). The env-var default keeps shell
 	// snippets in skill docs short while still routing writes/reads to the
 	// caller's session-scoped state files.
-	let sessionId = flagValue(args, "--session-id")?.trim() || undefined;
+	let sessionId = explicitSessionId !== undefined ? explicitSessionId.trim() || undefined : undefined;
 	if (!sessionId && payload && typeof payload.session_id === "string") {
 		sessionId = payload.session_id.trim() || undefined;
 	}
-	if (!sessionId) {
+	if (!sessionId && explicitSessionId === undefined) {
 		const envSessionId = process.env.GJC_SESSION_ID?.trim();
 		if (envSessionId) sessionId = envSessionId;
 	}

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -144,7 +144,7 @@ describe("GJC public CLI command surface", () => {
 
 			expect(result.exitCode, stderr).toBe(0);
 			const payload = JSON.parse(stdout) as { written?: number; targetRoot?: string };
-			expect(payload.written).toBe(4);
+			expect(payload.written).toBe(6);
 			expect(payload.targetRoot).toContain(path.join(home, ".gjc", "agent"));
 		} finally {
 			await fs.rm(home, { recursive: true, force: true });

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -9,9 +9,13 @@ import {
 import {
 	DEFAULT_GJC_DEFINITION_NAMES,
 	getDefaultGjcDefinitions,
+	getEmbeddedDefaultGjcSkillFragments,
+	getEmbeddedDefaultGjcSkills,
 	installDefaultGjcDefinitions,
 } from "@gajae-code/coding-agent/defaults/gjc-defaults";
-import { loadSkills } from "@gajae-code/coding-agent/extensibility/skills";
+import { loadSkills, resetActiveSkillsForTests, setActiveSkills } from "@gajae-code/coding-agent/extensibility/skills";
+import { parseInternalUrl } from "@gajae-code/coding-agent/internal-urls/parse";
+import { SkillProtocolHandler } from "@gajae-code/coding-agent/internal-urls/skill-protocol";
 import { getBundledAgent } from "@gajae-code/coding-agent/task/agents";
 import { discoverAgents } from "@gajae-code/coding-agent/task/discovery";
 
@@ -42,20 +46,49 @@ async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
 }
 
 afterEach(async () => {
+	resetActiveSkillsForTests();
 	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
 });
 
 describe("default GJC definitions", () => {
-	it("bundles exactly the four default workflow skills as installable source assets", () => {
+	it("bundles exactly the four default workflow skills plus deep-interview fragments as installable assets", () => {
 		const definitions = getDefaultGjcDefinitions();
-		const skills = definitions.map(definition => definition.name).sort();
+		const workflowDefinitions = definitions.filter(definition => definition.kind === "skill");
+		const fragmentDefinitions = definitions.filter(definition => definition.kind === "skill-fragment");
+		const skills = workflowDefinitions.map(definition => definition.name).sort();
 		const expected = [...DEFAULT_GJC_DEFINITION_NAMES].sort();
 
-		expect(definitions.every(definition => definition.kind === "skill")).toBe(true);
 		expect(skills).toEqual(expected);
-		expect(definitions).toHaveLength(4);
-		expect(definitions.every(definition => definition.relativePath.startsWith("skills/"))).toBe(true);
-		expect(definitions.every(definition => definition.content.includes(definition.name))).toBe(true);
+		expect(workflowDefinitions).toHaveLength(4);
+		expect(definitions).toHaveLength(6);
+		expect(workflowDefinitions.every(definition => definition.relativePath.startsWith("skills/"))).toBe(true);
+		expect(workflowDefinitions.every(definition => definition.content.includes(definition.name))).toBe(true);
+		expect(fragmentDefinitions).toHaveLength(2);
+		expect(fragmentDefinitions.map(definition => definition.parentSkillName)).toEqual([
+			"deep-interview",
+			"deep-interview",
+		]);
+		expect(fragmentDefinitions.map(definition => definition.relativePath).sort()).toEqual([
+			"skill-fragments/deep-interview/auto-answer-uncertain.md",
+			"skill-fragments/deep-interview/auto-research-greenfield.md",
+		]);
+	});
+
+	it("exposes deep-interview fragments only through the parent-scoped fragment accessor", () => {
+		const fragments = getEmbeddedDefaultGjcSkillFragments("deep-interview");
+
+		expect(
+			getEmbeddedDefaultGjcSkills()
+				.map(skill => skill.name)
+				.sort(),
+		).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
+		expect(fragments).toHaveLength(2);
+		expect(fragments.map(fragment => fragment.kind)).toEqual(["skill-fragment", "skill-fragment"]);
+		expect(fragments.map(fragment => fragment.relativePath).sort()).toEqual([
+			"skill-fragments/deep-interview/auto-answer-uncertain.md",
+			"skill-fragments/deep-interview/auto-research-greenfield.md",
+		]);
+		expect(fragments.every(fragment => fragment.content.includes("read-only architect"))).toBe(true);
 	});
 
 	it("keeps the four role agents bundled when project .gjc is absent", async () => {
@@ -127,6 +160,8 @@ describe("default GJC definitions", () => {
 			const expected = [...DEFAULT_GJC_DEFINITION_NAMES].sort();
 
 			expect(skills.skills.map(skill => skill.name).sort()).toEqual(expected);
+			expect(skills.skills.some(skill => skill.name === "auto-research-greenfield")).toBe(false);
+			expect(skills.skills.some(skill => skill.name === "auto-answer-uncertain")).toBe(false);
 			expect(
 				agents.agents
 					.filter(agent => agent.source === "project")
@@ -202,7 +237,9 @@ Project executor override body.
 	});
 
 	it("keeps bundled deep-interview skill on GJC-native workflow vocabulary", () => {
-		const deepInterview = getDefaultGjcDefinitions().find(definition => definition.name === "deep-interview");
+		const deepInterview = getDefaultGjcDefinitions().find(
+			definition => definition.kind === "skill" && definition.name === "deep-interview",
+		);
 		expect(deepInterview).toBeDefined();
 		const content = deepInterview?.content ?? "";
 
@@ -233,7 +270,9 @@ Project executor override body.
 	});
 
 	it("keeps bundled ralplan stage artifacts on CLI write path", () => {
-		const ralplan = getDefaultGjcDefinitions().find(definition => definition.name === "ralplan");
+		const ralplan = getDefaultGjcDefinitions().find(
+			definition => definition.kind === "skill" && definition.name === "ralplan",
+		);
 		expect(ralplan).toBeDefined();
 		const content = ralplan?.content ?? "";
 
@@ -253,22 +292,54 @@ Project executor override body.
 		const deepInterviewSkillPath = path.join(targetRoot, "skills", "deep-interview", "SKILL.md");
 		const installedDeepInterview = await Bun.file(deepInterviewSkillPath).text();
 
-		expect(initial.written).toBe(4);
+		expect(initial.written).toBe(6);
+		expect(initial.total).toBe(6);
 		expect(initial.skipped).toBe(0);
+		expect(initial.files.filter(file => file.kind === "skill-fragment")).toHaveLength(2);
 
+		const installedResearchFragment = await Bun.file(
+			path.join(targetRoot, "skill-fragments", "deep-interview", "auto-research-greenfield.md"),
+		).text();
+		expect(installedResearchFragment).toContain("ranked candidate answers");
 		await Bun.write(deepInterviewSkillPath, "local edit");
 		const skipped = await installDefaultGjcDefinitions({ targetRoot });
 		expect(skipped.written).toBe(0);
-		expect(skipped.skipped).toBe(4);
+		expect(skipped.skipped).toBe(6);
 		expect(await Bun.file(deepInterviewSkillPath).text()).toBe("local edit");
 
 		const check = await installDefaultGjcDefinitions({ targetRoot, check: true });
 		expect(check.different).toBe(1);
-		expect(check.matching).toBe(3);
+		expect(check.matching).toBe(5);
 
 		const forced = await installDefaultGjcDefinitions({ targetRoot, force: true });
-		expect(forced.written).toBe(4);
+		expect(forced.written).toBe(6);
 		expect(await Bun.file(deepInterviewSkillPath).text()).toBe(installedDeepInterview);
+		expect(
+			forced.files.some(file => file.kind === "skill-fragment" && file.parentSkillName === "deep-interview"),
+		).toBe(true);
+	});
+
+	it("does not make installed fragments reachable as skill-relative internal URL assets", async () => {
+		await withTempHome(async () => {
+			const repoRoot = await makeTempRoot();
+			await installDefaultGjcDefinitions({ targetRoot: path.join(repoRoot, ".gjc") });
+
+			const skills = await loadSkills({
+				cwd: repoRoot,
+				enabled: true,
+				enablePiProject: true,
+				enablePiUser: false,
+			});
+			const deepInterview = skills.skills.find(
+				skill => skill.name === "deep-interview" && skill.source === "native:project",
+			);
+			if (!deepInterview) throw new Error("missing installed deep-interview skill");
+
+			setActiveSkills([deepInterview]);
+			await expect(
+				new SkillProtocolHandler().resolve(parseInternalUrl("skill://deep-interview/auto-research-greenfield.md")),
+			).rejects.toThrow("File not found");
+		});
 	});
 });
 
@@ -340,5 +411,39 @@ describe("bundled skills CLI", () => {
 		const parsed = JSON.parse(stdout) as { skills: Array<{ name: string; path: string }> };
 		expect(parsed.skills.map(skill => skill.name).sort()).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
 		expect(parsed.skills.every(skill => skill.path.startsWith("embedded:gjc/skills/"))).toBe(true);
+		expect(parsed.skills.some(skill => skill.name === "auto-research-greenfield")).toBe(false);
+		expect(parsed.skills.some(skill => skill.name === "auto-answer-uncertain")).toBe(false);
+	});
+
+	it("does not expose embedded fragments through skills read", async () => {
+		const externalRoot = await makeTempRoot();
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
+				"skills",
+				"read",
+				"auto-research-greenfield",
+				"--json",
+			],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: await makeTempRoot(),
+					PI_NO_TITLE: "1",
+					NO_COLOR: "1",
+				},
+			},
+		);
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		const exitCode = await proc.exited;
+
+		expect(exitCode).not.toBe(0);
+		expect(stdout).toBe("");
+		expect(stderr).toContain("unknown embedded skill");
 	});
 });


### PR DESCRIPTION
## Summary
- add bundled `skill-fragment` defaults for Deep Interview auto-research and auto-answer prompts
- keep public workflow skill surfaces limited to `deep-interview`, `ralplan`, `team`, and `ultragoal`
- install fragments under `.gjc/skill-fragments/deep-interview/` so they are not skill-relative `'/Users/bellman/Documents/Workspace/gajae-code.gajae-code-worktrees/feat-deep-interview-auto-modes-dcf8b80a/embedded:gjc/skills/deep-interview/*'` assets
- document Deep Interview hook, validation, fallback, scoring, threshold confirmation, and metadata rules
- fix explicit blank `--session-id ""` state handoff behavior for sessionless runtime calls

## Verification
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts packages/coding-agent/test/utility-extensibility-quarantine.test.ts`
- `bun test packages/coding-agent/test/cli-command-surface.test.ts -t "routes bare setup"`
- `bun --cwd=packages/coding-agent run check:types`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`

## Review gates
- Architect review: CLEAR/CLEAR/CLEAR, APPROVE
- Executor QA/red-team: PASS/PASS/PASS

## Notes
- Full `bun --cwd=packages/coding-agent test` was attempted. With sanitized env it exposed unrelated HOME/path-sensitive failures; without HOME override it still fails the existing `memory-protocol.test.ts` realpath-vs-symlink sourcePath assertion. Focused story tests and required default-surface gates are green.
