### PR TITLE
Fix dev CI tooling format check

### DIFF
--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -16,9 +16,11 @@ import { validateGoalObjective } from "../runtime";
 import type { Goal, GoalStatus, GoalToolDetails } from "../state";
 
 const goalSchema = z.object({
-	op: z.enum(["create", "get", "complete", "resume", "drop"]).describe(
-		"op: get | create | complete | drop | resume — drop clears the active goal without exiting goal mode (tool stays callable for the next create)",
-	),
+	op: z
+		.enum(["create", "get", "complete", "resume", "drop"])
+		.describe(
+			"op: get | create | complete | drop | resume — drop clears the active goal without exiting goal mode (tool stays callable for the next create)",
+		),
 	objective: z.string().describe("goal objective").optional(),
 });
 


### PR DESCRIPTION
## Summary
- Format `packages/coding-agent/src/goals/tools/goal-tool.ts` to satisfy the Biome formatter error blocking Dev CI.
- Leave existing optional-chain warnings untouched because they were warnings, not the hard CI blocker.

## Validation
- `bun run check:tools` — passed with existing warnings only
- `bun run check:ts` — passed with existing warnings only
- `bun scripts/ci-dev-affected.ts --dry-run` — passed; no local changed paths in the default diff context

## Notes
- No package test suites were rerun for this formatter-only hotfix.
- Do not merge until the required review/CI verdict is available.