### PR TITLE
Fix gjc update binary fallback release repo

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `gjc update` binary fallback downloads to use the current owner release repository and report actionable manual update commands for unsupported fallback targets.
+
 ### Added
 
 - Added `retry.requestMaxRetries` and `retry.streamMaxRetries` settings plus docs for codex-cli-style provider retry budgets.

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -12,7 +12,7 @@ import { $ } from "bun";
 import chalk from "chalk";
 import { theme } from "../modes/theme/theme";
 
-const REPO = "can1357/gajae-code";
+const RELEASE_REPO = "Yeachan-Heo/gajae-code";
 const PACKAGE = "@gajae-code/coding-agent";
 
 interface ReleaseInfo {
@@ -122,7 +122,7 @@ async function resolveUpdateTarget(): Promise<UpdateTarget> {
 
 	if (bunBinDir) return { method: "bun" };
 
-	throw new Error(`Could not resolve ${APP_NAME} binary path in PATH`);
+	throw new Error(formatUnsupportedTargetMessage(`Could not resolve ${APP_NAME} binary path in PATH`));
 }
 
 /**
@@ -166,10 +166,7 @@ function compareVersions(a: string, b: string): number {
 /**
  * Get the appropriate binary name for this platform.
  */
-function getBinaryName(): string {
-	const platform = process.platform;
-	const arch = process.arch;
-
+function getBinaryName(platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
 	let os: string;
 	switch (platform) {
 		case "linux":
@@ -182,7 +179,7 @@ function getBinaryName(): string {
 			os = "windows";
 			break;
 		default:
-			throw new Error(`Unsupported platform: ${platform}`);
+			throw new Error(formatUnsupportedTargetMessage(`Unsupported platform: ${platform}`));
 	}
 
 	let archName: string;
@@ -194,7 +191,7 @@ function getBinaryName(): string {
 			archName = "arm64";
 			break;
 		default:
-			throw new Error(`Unsupported architecture: ${arch}`);
+			throw new Error(formatUnsupportedTargetMessage(`Unsupported architecture: ${arch}`));
 	}
 
 	if (os === "windows") {
@@ -233,6 +230,65 @@ function printVerifiedVersion(expectedVersion: string): void {
 	console.log(chalk.green(`\n${theme.status.success} Updated to ${expectedVersion}`));
 }
 
+function formatBinaryInstallInstruction(platform: NodeJS.Platform = process.platform): string {
+	if (platform === "win32") {
+		return `For a supported binary install, reinstall with PowerShell: irm https://raw.githubusercontent.com/${RELEASE_REPO}/main/scripts/install.ps1 | iex`;
+	}
+	return `For a supported binary install, reinstall with: curl -fsSL https://raw.githubusercontent.com/${RELEASE_REPO}/main/scripts/install.sh | sh -s -- --binary`;
+}
+
+function formatManualUpdateInstructions(platform: NodeJS.Platform = process.platform): string {
+	return [
+		`If ${APP_NAME} was installed with Bun, run: bun install -g ${PACKAGE}@latest`,
+		`If ${APP_NAME} was installed with npm, pnpm, or another package manager, update it with that same manager.`,
+		formatBinaryInstallInstruction(platform),
+	].join("\n");
+}
+
+function formatUnsupportedTargetMessage(reason: string, platform: NodeJS.Platform = process.platform): string {
+	return `${reason}.\n${formatManualUpdateInstructions(platform)}`;
+}
+
+function buildReleaseBinaryUrl(
+	version: string,
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch,
+): string {
+	const binaryName = getBinaryName(platform, arch);
+	const tag = `v${version}`;
+	return `https://github.com/${RELEASE_REPO}/releases/download/${tag}/${binaryName}`;
+}
+
+function formatBinaryDownloadFailureMessage(
+	binaryName: string,
+	url: string,
+	status: string | number,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	return `Download failed for ${binaryName} from ${url}: ${status}.\n${formatManualUpdateInstructions(platform)}`;
+}
+
+export function formatBinaryDownloadFailureMessageForTest(
+	binaryName: string,
+	url: string,
+	status: string | number,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	return formatBinaryDownloadFailureMessage(binaryName, url, status, platform);
+}
+
+export function buildReleaseBinaryUrlForTest(
+	version: string,
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch,
+): string {
+	return buildReleaseBinaryUrl(version, platform, arch);
+}
+
+export function formatManualUpdateInstructionsForTest(platform: NodeJS.Platform = process.platform): string {
+	return formatManualUpdateInstructions(platform);
+}
+
 function formatVerificationFailure(result: InstalledVersionVerification, expectedVersion: string): string {
 	if (result.actual) {
 		return `${APP_NAME} at ${result.path} still reports ${result.actual} (expected ${expectedVersion})`;
@@ -250,11 +306,7 @@ async function printVerification(expectedVersion: string): Promise<void> {
 		return;
 	}
 	console.log(chalk.yellow(`\nWarning: ${formatVerificationFailure(result, expectedVersion)}`));
-	console.log(
-		chalk.yellow(
-			`You may need to reinstall: curl -fsSL https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.sh | sh`,
-		),
-	);
+	console.log(chalk.yellow(formatManualUpdateInstructions()));
 }
 
 async function unlinkIfExists(filePath: string): Promise<void> {
@@ -314,8 +366,7 @@ async function updateViaBun(expectedVersion: string): Promise<void> {
  */
 async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
 	const binaryName = getBinaryName();
-	const tag = `v${expectedVersion}`;
-	const url = `https://github.com/${REPO}/releases/download/${tag}/${binaryName}`;
+	const url = buildReleaseBinaryUrl(expectedVersion);
 
 	const tempPath = `${targetPath}.new`;
 	const backupPath = `${targetPath}.bak`;
@@ -323,7 +374,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 
 	const response = await fetch(url, { redirect: "follow" });
 	if (!response.ok || !response.body) {
-		throw new Error(`Download failed: ${response.statusText}`);
+		throw new Error(formatBinaryDownloadFailureMessage(binaryName, url, response.statusText || response.status));
 	}
 	const fileStream = fs.createWriteStream(tempPath, { mode: 0o755 });
 	await pipeline(response.body, fileStream);

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -2,9 +2,16 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { replaceBinaryForUpdate, resolveUpdateMethodForTest } from "../src/cli/update-cli";
+import {
+	buildReleaseBinaryUrlForTest,
+	formatBinaryDownloadFailureMessageForTest,
+	formatManualUpdateInstructionsForTest,
+	replaceBinaryForUpdate,
+	resolveUpdateMethodForTest,
+} from "../src/cli/update-cli";
 
 const tempDirs: string[] = [];
+const repoRoot = path.resolve(import.meta.dir, "../../..");
 
 async function makeTempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-update-test-"));
@@ -32,6 +39,72 @@ describe("update-cli install target detection", () => {
 		const method = resolveUpdateMethodForTest("/Users/test/.local/bin/gjc", undefined);
 
 		expect(method).toBe("binary");
+	});
+});
+
+describe("update-cli binary release assets", () => {
+	it("downloads fallback binaries from the current owner release repository", () => {
+		expect(buildReleaseBinaryUrlForTest("0.2.3", "linux", "x64")).toBe(
+			"https://github.com/Yeachan-Heo/gajae-code/releases/download/v0.2.3/gjc-linux-x64",
+		);
+	});
+
+	it("uses the existing Windows .exe release asset name", () => {
+		expect(buildReleaseBinaryUrlForTest("0.2.3", "win32", "x64")).toBe(
+			"https://github.com/Yeachan-Heo/gajae-code/releases/download/v0.2.3/gjc-windows-x64.exe",
+		);
+	});
+
+	it("reports actionable Unix manual update commands for unsupported fallback paths", () => {
+		const instructions = formatManualUpdateInstructionsForTest("linux");
+
+		expect(instructions).toContain("bun install -g @gajae-code/coding-agent@latest");
+		expect(instructions).toContain("npm, pnpm, or another package manager");
+		expect(instructions).toContain(
+			"curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh -s -- --binary",
+		);
+	});
+
+	it("reports actionable Windows manual update commands for unsupported fallback paths", () => {
+		const instructions = formatManualUpdateInstructionsForTest("win32");
+
+		expect(instructions).toContain("bun install -g @gajae-code/coding-agent@latest");
+		expect(instructions).toContain("npm, pnpm, or another package manager");
+		expect(instructions).toContain(
+			"irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1 | iex",
+		);
+	});
+
+	it("keeps manual reinstall guidance aligned with bundled installer repositories", async () => {
+		const instructions = formatManualUpdateInstructionsForTest("linux");
+		const shellInstaller = await Bun.file(path.join(repoRoot, "scripts/install.sh")).text();
+		const windowsInstaller = await Bun.file(path.join(repoRoot, "scripts/install.ps1")).text();
+
+		expect(instructions).toContain("raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh");
+		expect(shellInstaller).toContain('REPO="Yeachan-Heo/gajae-code"');
+		expect(windowsInstaller).toContain('$Repo = "Yeachan-Heo/gajae-code"');
+		expect(formatManualUpdateInstructionsForTest("win32")).toContain(
+			"raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1",
+		);
+	});
+
+	it("includes actionable guidance when a release asset download fails", () => {
+		const message = formatBinaryDownloadFailureMessageForTest(
+			"gjc-linux-x64",
+			"https://github.com/Yeachan-Heo/gajae-code/releases/download/v0.2.3/gjc-linux-x64",
+			"Not Found",
+			"linux",
+		);
+
+		expect(message).toContain("Download failed for gjc-linux-x64");
+		expect(message).toContain("Yeachan-Heo/gajae-code/releases/download/v0.2.3/gjc-linux-x64");
+		expect(message).toContain("bun install -g @gajae-code/coding-agent@latest");
+	});
+
+	it("includes actionable guidance when the platform has no release asset", () => {
+		expect(() => buildReleaseBinaryUrlForTest("0.2.3", "freebsd", "x64")).toThrow(
+			"bun install -g @gajae-code/coding-agent@latest",
+		);
 	});
 });
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,12 +1,12 @@
 # GJC Coding Agent Installer for Windows
-# Usage: irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1 | iex
+# Usage: irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1 | iex
 #
 # Or with options:
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1))) -Source
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1))) -Binary
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1))) -Source -Ref v3.20.1
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1))) -Source -Ref main
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.ps1))) -Binary -Ref v3.20.1
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1))) -Source
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1))) -Binary
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1))) -Source -Ref v3.20.1
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1))) -Source -Ref main
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.ps1))) -Binary -Ref v3.20.1
 
 param(
     [switch]$Source,
@@ -16,7 +16,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "can1357/gajae-code"
+$Repo = "Yeachan-Heo/gajae-code"
 $Package = "@gajae-code/coding-agent"
 $InstallDir = if ($env:GJC_INSTALL_DIR) { $env:GJC_INSTALL_DIR } else { "$env:LOCALAPPDATA\gjc" }
 $BinaryName = "gjc-windows-x64.exe"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # GJC Coding Agent Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/can1357/gajae-code/main/scripts/install.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh
 #
 # Options:
 #   --source       Install via bun (installs bun if needed)
@@ -10,7 +10,7 @@ set -e
 #   --ref <ref>    Install specific tag/commit/branch
 #   -r <ref>       Shorthand for --ref
 
-REPO="can1357/gajae-code"
+REPO="Yeachan-Heo/gajae-code"
 PACKAGE="@gajae-code/coding-agent"
 INSTALL_DIR="${GJC_INSTALL_DIR:-$HOME/.local/bin}"
 MIN_BUN_VERSION="1.3.14"


### PR DESCRIPTION
## Summary

- point `gjc update` binary fallback downloads at the current `Yeachan-Heo/gajae-code` release assets
- add platform-specific actionable recovery guidance for unsupported/download/verification fallback failures
- align shell and PowerShell installer repo constants with the updater and cover the contract with regression tests

Fixes #160.

## Validation

- `bun test packages/coding-agent/test/update-cli.test.ts`
- `bun --cwd=packages/coding-agent test test/update-cli.test.ts`
- `bunx biome check packages/coding-agent/src/cli/update-cli.ts packages/coding-agent/test/update-cli.test.ts scripts/install.sh scripts/install.ps1 packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `sh -n scripts/install.sh`

## Review

- Independent code-reviewer: APPROVE
- Independent architect: CLEAR
