### PR TITLE
Prevent false local-memory success claims

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- Added local-memory empty-payload guidance so the agent does not claim facts were saved or remembered when local memory has no confirmed payload/readback.
 - Enforced the deep-interview phase boundary so active interviews block mutation tools until a handoff/spec is produced.
 - Made settings theme browsing confirm-only so arrowing through themes no longer changes the rendered theme before the displayed/persisted theme name changes.
 - Made startup CHANGELOG display deterministic by embedding `packages/coding-agent/CHANGELOG.md` into the binary so post-update launches show the shipped history regardless of cwd or `GJC_PACKAGE_DIR`/`PI_PACKAGE_DIR` overrides.

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -12,6 +12,7 @@ import consolidationTemplate from "../prompts/memories/consolidation.md" with { 
 import readPathTemplate from "../prompts/memories/read-path.md" with { type: "text" };
 import stageOneInputTemplate from "../prompts/memories/stage_one_input.md" with { type: "text" };
 import stageOneSystemTemplate from "../prompts/memories/stage_one_system.md" with { type: "text" };
+import unavailableTemplate from "../prompts/memories/unavailable.md" with { type: "text" };
 import type { AgentSession } from "../session/agent-session";
 import {
 	claimStage1Jobs,
@@ -153,20 +154,20 @@ export async function buildMemoryToolDeveloperInstructions(
 ): Promise<string | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, session?.sessionManager.getCwd() ?? settings.getCwd());
+	const memoryRoot = getMemoryRoot(agentDir, session?.sessionManager?.getCwd() ?? settings.getCwd());
 	const summaryPath = path.join(memoryRoot, "memory_summary.md");
 
 	let text: string;
 	try {
 		text = await Bun.file(summaryPath).text();
 	} catch {
-		return undefined;
+		return unavailableTemplate;
 	}
 
 	const summary = text.trim();
-	if (!summary) return undefined;
+	if (!summary) return unavailableTemplate;
 	const truncated = truncateByApproxTokens(summary, cfg.summaryInjectionTokenLimit);
-	if (!truncated.trim()) return undefined;
+	if (!truncated.trim()) return unavailableTemplate;
 
 	return prompt.render(readPathTemplate, {
 		memory_summary: truncated,

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -585,7 +585,7 @@ export class CommandController {
 		if (action === "view") {
 			const payload = await backend.buildDeveloperInstructions(agentDir, this.ctx.settings, this.ctx.session);
 			if (!payload) {
-				this.ctx.showWarning("Memory payload is empty (memory backend off, disabled, or no memory available).");
+				this.ctx.showWarning("Memory payload is empty; durable memory is unavailable or unconfirmed.");
 				return;
 			}
 			this.ctx.chatContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/prompts/memories/unavailable.md
+++ b/packages/coding-agent/src/prompts/memories/unavailable.md
@@ -1,0 +1,9 @@
+# Memory Guidance
+Memory root: memory://root
+Status: local memory is enabled, but no confirmed memory payload is available for this project yet.
+
+Operational rules:
+1) Do not claim that a user preference, fact, or instruction has been saved, remembered, or persisted unless a backend operation or a non-empty memory payload confirms it.
+2) If the user asks you to save or remember something now, explain that durable memory is not confirmed because local memory has no available payload/readback yet. You may use the instruction for the current session only.
+3) If reading `memory://root` or `memory://root/memory_summary.md` fails, treat that as no confirmed memory, not as successful persistence.
+4) The local backend consolidates prior session rollouts asynchronously; an empty payload is a degraded/unconfirmed state, not a successful save.

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -931,7 +931,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime.settings,
 						runtime.session,
 					);
-					await runtime.output(payload || "Memory payload is empty.");
+					await runtime.output(
+						payload || "Memory payload is empty; durable memory is unavailable or unconfirmed.",
+					);
 					return commandConsumed();
 				}
 				case "clear":

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -646,6 +646,19 @@ describe("wave 3 commands", () => {
 		expect(output.length).toBeGreaterThan(0);
 	});
 
+	it("/memory view: local empty payload is explicit and not success-coded", async () => {
+		const { output, runtime } = createRuntime();
+		runtime.settings.set("memory.backend", "local");
+
+		const result = await executeAcpBuiltinSlashCommand("/memory view", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("no confirmed memory payload");
+		expect(output[0]).toContain("Do not claim");
+		expect(output[0]).toContain("unless a backend operation or a non-empty memory payload confirms it");
+		expect(output[0]).toContain("not confirmed");
+	});
+
 	it("/memory (no args): defaults to view", async () => {
 		const { output, runtime } = createRuntime();
 		const result = await executeAcpBuiltinSlashCommand("/memory", runtime);

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -400,16 +400,31 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 		createdDirs.clear();
 	});
 
-	test("returns undefined for missing or empty summaries", async () => {
+	test("returns undefined when local memory is disabled", async () => {
+		const agentDir = await makeTempDir("memories-runtime-instructions");
+		const settings = Settings.isolated({ "memory.backend": "off" });
+
+		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings)).toBeUndefined();
+	});
+
+	test("renders unconfirmed guidance for missing or empty local summaries", async () => {
 		const agentDir = await makeTempDir("memories-runtime-instructions");
 		const settings = Settings.isolated({ "memory.backend": "local" });
 
-		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings)).toBeUndefined();
+		const missingPayload = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+		expect(missingPayload).toBeDefined();
+		expect(missingPayload).toContain("no confirmed memory payload");
+		expect(missingPayload).toContain("Do not claim");
+		expect(missingPayload).toContain("memory://root");
+		expect(missingPayload).not.toContain(agentDir);
 
 		const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
 		await fs.mkdir(memoryRoot, { recursive: true });
 		await fs.writeFile(path.join(memoryRoot, "memory_summary.md"), "   \n\t\n");
-		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings)).toBeUndefined();
+		const emptyPayload = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+		expect(emptyPayload).toBeDefined();
+		expect(emptyPayload).toContain("durable memory is not confirmed");
+		expect(emptyPayload).not.toContain(memoryRoot);
 	});
 
 	test("renders payload with truncation for non-empty summary", async () => {


### PR DESCRIPTION
## Summary
- Add explicit local-memory unavailable guidance when `memory.backend = local` has no confirmed non-empty payload/readback.
- Keep positive memory-summary injection unchanged when `memory_summary.md` exists and is non-empty.
- Update `/memory view` empty-state wording so empty/unavailable memory is degraded/unconfirmed, not success-coded.

Fixes #163.

## Tests
- `bun test packages/coding-agent/test/memories-runtime.test.ts`
- `bun test packages/coding-agent/test/internal-urls/memory-protocol.test.ts`
- `bun test packages/coding-agent/test/acp-builtins.test.ts`
- `bun test packages/coding-agent/test/memories-runtime.test.ts packages/coding-agent/test/internal-urls/memory-protocol.test.ts packages/coding-agent/test/acp-builtins.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes; reports pre-existing optional-chain Biome warnings only)

## Review
- Independent code-review subagent: APPROVE
- Independent architect subagent: CLEAR
