### PR TITLE
Restore independent Settings theme preview

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -21,7 +21,7 @@ import type {
 	StatusLineSeparatorStyle,
 } from "../../config/settings-schema";
 import { SETTING_TABS, TAB_METADATA } from "../../config/settings-schema";
-import { getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
+import { getCurrentThemeName, getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
@@ -200,6 +200,10 @@ export interface StatusLinePreviewSettings {
 export interface SettingsCallbacks {
 	/** Called when any setting value changes */
 	onChange: (path: SettingPath, newValue: unknown) => void;
+	/** Called for theme preview while browsing theme settings */
+	onThemePreview?: (theme: string) => void | Promise<void>;
+	/** Called to restore the rendered theme when theme settings preview is cancelled */
+	onThemePreviewCancel?: (theme: string) => void | Promise<void>;
 	/** Called for status line preview while configuring */
 	onStatusLinePreview?: (settings: StatusLinePreviewSettings) => void;
 	/** Get current rendered status line for inline preview */
@@ -217,7 +221,6 @@ export interface SettingsCallbacks {
 export class SettingsSelectorComponent extends Container {
 	#tabBar: TabBar;
 	#currentList: SettingsList | null = null;
-	#currentSubmenu: Container | null = null;
 	#pluginComponent: PluginSettingsComponent | null = null;
 	#statusPreviewContainer: Container | null = null;
 	#statusPreviewText: Text | null = null;
@@ -374,10 +377,15 @@ export class SettingsSelectorComponent extends Container {
 		let onPreview: ((value: string) => void | Promise<void>) | undefined;
 		let onPreviewCancel: (() => void) | undefined;
 
-		// Theme selection is confirm-only: moving through the list must not mutate
-		// the rendered theme while the displayed/persisted setting still names
-		// the previous value. Confirmation persists through Settings hooks.
-		if (def.path === "statusLine.preset") {
+		if (def.path === "theme.dark" || def.path === "theme.light") {
+			const activeThemeBeforePreview = getCurrentThemeName() ?? currentValue;
+			onPreview = value => {
+				return this.callbacks.onThemePreview?.(value);
+			};
+			onPreviewCancel = () => {
+				return this.callbacks.onThemePreviewCancel?.(activeThemeBeforePreview);
+			};
+		} else if (def.path === "statusLine.preset") {
 			onPreview = value => {
 				const presetDef = getPreset(
 					value as "default" | "minimal" | "compact" | "full" | "nerd" | "ascii" | "custom",
@@ -612,17 +620,20 @@ export class SettingsSelectorComponent extends Container {
 			return;
 		}
 
-		// Escape at top level cancels
-		if (matchesAppInterrupt(data) && !this.#currentSubmenu) {
-			this.callbacks.onCancel();
+		// Pass to current content. SettingsList owns Escape routing so open
+		// submenus can run their cancel/restore callbacks before closing.
+		if (this.#currentList) {
+			this.#currentList.handleInput(data);
+			return;
+		}
+		if (this.#pluginComponent) {
+			this.#pluginComponent.handleInput(data);
 			return;
 		}
 
-		// Pass to current content
-		if (this.#currentList) {
-			this.#currentList.handleInput(data);
-		} else if (this.#pluginComponent) {
-			this.#pluginComponent.handleInput(data);
+		// Fallback for future top-level content that does not own cancellation.
+		if (matchesAppInterrupt(data)) {
+			this.callbacks.onCancel();
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -67,6 +67,10 @@ const CALLBACK_SERVER_PROVIDERS = new Set<OAuthProvider>([
 
 const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";
 
+function isThemePreviewSuperseded(result: { success: boolean; error?: string }): boolean {
+	return !result.success && result.error?.includes("superseded by a newer request") === true;
+}
+
 function formatProviderOnboardingCommandGuide(): string {
 	return [
 		"Provider preset setup:",
@@ -139,6 +143,22 @@ export class SelectorController {
 					},
 					{
 						onChange: (id, value) => this.handleSettingChange(id, value),
+						onThemePreview: themeName => {
+							return previewTheme(themeName).then(result => {
+								if (!result.success && result.error && !isThemePreviewSuperseded(result)) {
+									this.ctx.showError(`Failed to preview theme: ${result.error}`);
+								}
+								this.#refreshThemeUi();
+							});
+						},
+						onThemePreviewCancel: themeName => {
+							return restoreThemePreview(themeName).then(result => {
+								if (!result.success && result.error && !isThemePreviewSuperseded(result)) {
+									this.ctx.showError(`Failed to restore theme preview: ${result.error}`);
+								}
+								this.#refreshThemeUi();
+							});
+						},
 						onStatusLinePreview: previewSettings => {
 							// Update status line with preview settings
 							this.ctx.statusLine.updateSettings({

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2091,10 +2091,12 @@ async function startThemeWatcher(): Promise<void> {
 function reevaluateAutoTheme(debugLabel: string): void {
 	if (!autoDetectedTheme) return;
 	const resolved = getDefaultTheme();
+	const requestId = ++themeLoadRequestId;
 	if (resolved === currentThemeName && !previewThemeActive) return;
 	currentThemeName = resolved;
 	loadTheme(resolved, getCurrentThemeOptions())
 		.then(loadedTheme => {
+			if (requestId !== themeLoadRequestId) return;
 			theme = loadedTheme;
 			previewThemeActive = false;
 			if (onThemeChangeCallback) {
@@ -2102,6 +2104,7 @@ function reevaluateAutoTheme(debugLabel: string): void {
 			}
 		})
 		.catch(err => {
+			if (requestId !== themeLoadRequestId) return;
 			logger.debug(`Theme switch on ${debugLabel} failed`, { error: String(err) });
 		});
 }

--- a/packages/coding-agent/test/modes/components/settings-selector-theme-confirm.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-theme-confirm.test.ts
@@ -1,9 +1,22 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { SettingPath } from "@gajae-code/coding-agent/config/settings";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 
 const THEMES = ["red-claw", "anthracite", "light"];
+
+type ChangedSetting = {
+	path: SettingPath;
+	value: unknown;
+};
+
+type SelectorHarness = {
+	component: SettingsSelectorComponent;
+	previewedThemes: string[];
+	restoredThemes: string[];
+	changedSettings: ChangedSetting[];
+};
 
 beforeAll(async () => {
 	await initTheme(false, undefined, undefined, "red-claw", "light");
@@ -18,10 +31,14 @@ beforeEach(async () => {
 
 afterEach(() => {
 	resetSettingsForTest();
+	vi.restoreAllMocks();
 });
 
-function createSelector(): SettingsSelectorComponent {
-	return new SettingsSelectorComponent(
+function createSelector(): SelectorHarness {
+	const previewedThemes: string[] = [];
+	const restoredThemes: string[] = [];
+	const changedSettings: ChangedSetting[] = [];
+	const component = new SettingsSelectorComponent(
 		{
 			availableThinkingLevels: [],
 			thinkingLevel: undefined,
@@ -29,55 +46,85 @@ function createSelector(): SettingsSelectorComponent {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: () => {},
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+			},
+			onThemePreview: themeName => {
+				previewedThemes.push(themeName);
+			},
+			onThemePreviewCancel: themeName => {
+				restoredThemes.push(themeName);
+			},
 			onCancel: () => {},
 			getStatusLinePreview: () => "status-preview",
 		},
 	);
+	return { component, previewedThemes, restoredThemes, changedSettings };
 }
 
 describe("SettingsSelectorComponent theme selection", () => {
-	it("does not preview or persist a dark theme while browsing, and cancel leaves the displayed value unchanged", () => {
-		const comp = createSelector();
+	it("previews a dark theme while browsing without persisting it", () => {
+		const { component, previewedThemes, restoredThemes, changedSettings } = createSelector();
 
-		comp.handleInput("\n"); // Open Dark Theme submenu; red-claw is preselected.
-		comp.handleInput("\x1b[B"); // Browse to anthracite.
+		component.handleInput("\n"); // Open Dark Theme submenu; red-claw is preselected.
+		component.handleInput("\x1b[B"); // Browse to anthracite.
 
+		expect(previewedThemes).toEqual(["anthracite"]);
+		expect(restoredThemes).toEqual([]);
+		expect(changedSettings).toEqual([]);
 		expect(settings.get("theme.dark")).toBe("red-claw");
+	});
 
-		comp.handleInput("\x1b"); // Cancel submenu.
+	it("restores the pre-preview rendered theme on cancel and leaves dark settings unchanged", () => {
+		const { component, previewedThemes, restoredThemes, changedSettings } = createSelector();
 
+		component.handleInput("\n"); // Open Dark Theme submenu; red-claw is preselected.
+		component.handleInput("\x1b[B"); // Browse to anthracite.
+		component.handleInput("\x1b"); // Cancel submenu.
+
+		expect(previewedThemes).toEqual(["anthracite"]);
+		expect(restoredThemes).toEqual(["red-claw"]);
+		expect(changedSettings).toEqual([]);
 		expect(settings.get("theme.dark")).toBe("red-claw");
-		expect(comp.render(120).join("\n")).toContain("red-claw");
+		expect(component.render(120).join("\n")).toContain("red-claw");
 	});
 
 	it("persists and displays the selected dark theme only after confirmation", () => {
-		const comp = createSelector();
+		const { component, previewedThemes, restoredThemes, changedSettings } = createSelector();
 
-		comp.handleInput("\n"); // Open Dark Theme submenu.
-		comp.handleInput("\x1b[B"); // Browse to anthracite.
-		comp.handleInput("\n"); // Confirm.
+		component.handleInput("\n"); // Open Dark Theme submenu.
+		component.handleInput("\x1b[B"); // Browse to anthracite.
+		component.handleInput("\n"); // Confirm.
 
+		expect(previewedThemes).toEqual(["anthracite"]);
+		expect(restoredThemes).toEqual([]);
+		expect(changedSettings).toEqual([{ path: "theme.dark", value: "anthracite" }]);
 		expect(settings.get("theme.dark")).toBe("anthracite");
-		const rendered = comp.render(120).join("\n");
+		const rendered = component.render(120).join("\n");
 		expect(rendered).toContain("Dark Theme");
 		expect(rendered).toContain("anthracite");
 	});
 
-	it("keeps light theme browsing confirm-only as well", () => {
-		const comp = createSelector();
+	it("keeps light theme preview independent from persisted light settings", () => {
+		const { component, previewedThemes, restoredThemes, changedSettings } = createSelector();
 
-		comp.handleInput("\x1b[B"); // Move from Dark Theme to Light Theme.
-		comp.handleInput("\n"); // Open Light Theme submenu; light is preselected.
-		comp.handleInput("\x1b[B"); // Wrap to red-claw.
-		comp.handleInput("\x1b"); // Cancel.
+		component.handleInput("\x1b[B"); // Move from Dark Theme to Light Theme.
+		component.handleInput("\n"); // Open Light Theme submenu; light is preselected.
+		component.handleInput("\x1b[B"); // Wrap to red-claw.
+		component.handleInput("\x1b"); // Cancel.
 
+		expect(previewedThemes).toEqual(["red-claw"]);
+		expect(restoredThemes).toEqual(["red-claw"]);
+		expect(changedSettings).toEqual([]);
 		expect(settings.get("theme.light")).toBe("light");
 
-		comp.handleInput("\n"); // Reopen Light Theme submenu.
-		comp.handleInput("\x1b[B"); // Wrap to red-claw.
-		comp.handleInput("\n"); // Confirm.
+		component.handleInput("\n"); // Reopen Light Theme submenu.
+		component.handleInput("\x1b[B"); // Wrap to red-claw.
+		component.handleInput("\n"); // Confirm.
 
+		expect(previewedThemes).toEqual(["red-claw", "red-claw"]);
+		expect(restoredThemes).toEqual(["red-claw"]);
+		expect(changedSettings).toEqual([{ path: "theme.light", value: "red-claw" }]);
 		expect(settings.get("theme.light")).toBe("red-claw");
 	});
 });

--- a/packages/coding-agent/test/theme-auto-detection.test.ts
+++ b/packages/coding-agent/test/theme-auto-detection.test.ts
@@ -165,6 +165,20 @@ describe("theme auto-detection", () => {
 		expect(themeModule.theme.getFgAnsi("accent")).toBe(darkAccent);
 	});
 
+	it("auto theme remapping supersedes an in-flight preview", async () => {
+		using _globals = withThemeTestGlobals({ colorfgbg: "15;0" });
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+		const darkAccent = themeModule.theme.getFgAnsi("accent");
+
+		const preview = themeModule.previewTheme("light");
+		themeModule.setAutoThemeMapping("dark", "dark");
+		await preview;
+		await Bun.sleep(0);
+
+		expect(themeModule.getCurrentThemeName()).toBe("dark");
+		expect(themeModule.theme.getFgAnsi("accent")).toBe(darkAccent);
+	});
+
 	it("Zellij fallback stays macOS-only (Linux + Zellij = honor terminal)", async () => {
 		using _globals = withThemeTestGlobals({ platform: "linux", zellij: "1" });
 		const detectSpy = vi.spyOn(nativesModule, "detectMacOSAppearance").mockReturnValue(MacOSAppearance.Light);


### PR DESCRIPTION
## Summary
- restore Settings theme browsing preview without mutating `theme.dark` / `theme.light`
- route Settings submenu Escape through the active submenu so preview cancel restores the prior rendered theme
- make auto-theme reevaluation supersede stale preview loads and suppress expected superseded-preview noise

Closes #162.

## Verification
- `bun test packages/coding-agent/test/modes/components/settings-selector-theme-confirm.test.ts`
- `bun test packages/coding-agent/test/theme-auto-detection.test.ts`
- `bunx biome check packages/coding-agent/src/modes/components/settings-selector.ts packages/coding-agent/src/modes/controllers/selector-controller.ts packages/coding-agent/src/modes/theme/theme.ts packages/coding-agent/test/modes/components/settings-selector-theme-confirm.test.ts packages/coding-agent/test/theme-auto-detection.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run build`
- `git diff --check`
- ai-slop-cleaner scoped no-op pass
- independent code-reviewer: APPROVE
- independent architect: CLEAR
