### PR TITLE
Preserve deep-interview session language

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -39,6 +39,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
+- Preserve the user/session language for every user-facing announcement, topology confirmation, option label, and interview question when state includes `language.instruction`; for example Korean initial ideas must receive Korean deep-interview questions unless the user explicitly requests another language
 - Target the WEAKEST clarity dimension with each question
 - Before Round 1 ambiguity scoring, run a one-time Round 0 topology enumeration gate that confirms the top-level component list and locks it into state
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
@@ -92,6 +93,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
    - Substitute `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` throughout the remaining instructions before continuing.
    - Include `threshold_source` in the first `gjc state write` payload and preserve it on later state updates; do not edit `.gjc/state` files directly unless an explicit force override is active.
    - Include both threshold and source in the final spec metadata.
+- Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, infer the user/session language from `{{ARGUMENTS}}` only when it is obvious. Do not surprise a Korean session with English questions.
 
 ## Phase 1: Initialize
 
@@ -182,7 +184,7 @@ I'm reading this as {N} top-level component(s):
 Is that topology right? Should any component be added, removed, merged, split, or explicitly deferred?
 ```
 
-Options should include contextually relevant choices such as **Looks right**, **Add/remove/merge components**, **Defer one or more components**, plus free-text. This is the only pre-scoring question and preserves the one-question-per-round rule.
+Options should include contextually relevant choices such as **Looks right**, **Add/remove/merge components**, **Defer one or more components**, plus free-text, translated/localized according to `language.instruction` when present. This is the only pre-scoring question and preserves the one-question-per-round rule.
 
 3. **Lock topology into state** after the answer. Store a normalized component list and confirmation timestamp:
 
@@ -266,7 +268,7 @@ Auto-research must never add a public skill entrypoint, never be slash-command/d
 
 ### Step 2b: Ask the Question
 
-Use the `ask` tool with the generated question. Present it clearly with the current ambiguity context:
+Use the `ask` tool with the generated question. Before rendering the prompt/options, apply `language.instruction` from state when present so the entire user-facing question remains in the preserved session language. Present it clearly with the current ambiguity context:
 
 ```
 Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_rationale} | Ambiguity: {score}%

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -131,7 +131,15 @@ interface ResolvedDeepInterviewArgs {
 	thresholdSource: string;
 	sessionId?: string;
 	idea: string;
+	language?: DeepInterviewLanguagePreference;
 	json: boolean;
+}
+
+interface DeepInterviewLanguagePreference {
+	code: "en" | "ko";
+	label: "English" | "Korean";
+	source: "explicit-user-request" | "initial-idea";
+	instruction: string;
 }
 
 export interface ResolvedDeepInterviewSpecWriteArgs {
@@ -203,6 +211,35 @@ async function resolveConfiguredAmbiguityThreshold(
 	const configDir = process.env.GJC_CONFIG_DIR?.trim() || path.join(os.homedir(), ".gjc");
 	const userSettings = path.join(configDir, "settings.json");
 	return await readSettingsAmbiguityThreshold(userSettings);
+}
+
+function englishLanguagePreference(): DeepInterviewLanguagePreference {
+	return {
+		code: "en",
+		label: "English",
+		source: "explicit-user-request",
+		instruction:
+			"Ask every user-facing deep-interview question in English because the user explicitly requested English.",
+	};
+}
+
+function resolveDeepInterviewLanguagePreference(idea: string): DeepInterviewLanguagePreference | undefined {
+	if (/\b(?:answer|ask|respond|reply|write|use|speak)\s+(?:only\s+)?in\s+English\b/i.test(idea)) {
+		return englishLanguagePreference();
+	}
+	if (/(?:영어로|영문으로|영어\s*(?:질문|답변|응답)|English\s+only)/i.test(idea)) {
+		return englishLanguagePreference();
+	}
+	if (/\p{Script=Hangul}/u.test(idea)) {
+		return {
+			code: "ko",
+			label: "Korean",
+			source: "initial-idea",
+			instruction:
+				"Ask every user-facing deep-interview question in Korean unless the user explicitly requests another language.",
+		};
+	}
+	return undefined;
 }
 
 function isDeepInterviewSpecWriteInvocation(args: readonly string[]): boolean {
@@ -327,6 +364,7 @@ async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): P
 		thresholdSource,
 		sessionId,
 		idea,
+		language: resolveDeepInterviewLanguagePreference(idea),
 		json: hasFlag(args, "--json"),
 	};
 }
@@ -405,6 +443,10 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		},
 		updated_at: now,
 	};
+	if (resolved.language) {
+		payload.language = resolved.language;
+		(payload.state as Record<string, unknown>).language = resolved.language;
+	}
 	if (resolved.sessionId) payload.session_id = resolved.sessionId;
 	await fs.writeFile(statePath, `${JSON.stringify(payload, null, 2)}\n`);
 	return statePath;
@@ -528,6 +570,7 @@ export async function runNativeDeepInterviewCommand(
 			threshold: resolved.threshold,
 			threshold_source: resolved.thresholdSource,
 			idea: resolved.idea,
+			language: resolved.language,
 			state_path: statePath,
 			handoff: "Run `/skill:deep-interview` inside the GJC agent to drive the Socratic interview loop.",
 		};

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -252,6 +252,8 @@ Project executor override body.
 		expect(content).toContain("Direct `.gjc/` file edits are forbidden");
 		expect(content).toContain("do not edit `.gjc/state` directly without force override");
 		expect(content).toContain("default `0.05`");
+		expect(content).toContain("language.instruction");
+		expect(content).toContain("Do not surprise a Korean session with English questions");
 		expect(content).not.toContain("default `0.2`");
 		expect(content).not.toContain("20%");
 

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -115,6 +115,38 @@ describe("native gjc deep-interview runtime", () => {
 		expect(await fs.readFile(deepPayload.path, "utf-8")).toBe("# Requirements\n");
 		expect(await fs.readFile(ralplanPayload.path, "utf-8")).toBe("# Plan\n");
 	});
+	it("persists Korean as the deep-interview question language when the initial idea is Korean", async () => {
+		const root = await tempDir();
+		const result = await runNativeDeepInterviewCommand(["--json", "한국어 세션에서 구현 방향을 명확히 해줘"], root);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.language).toMatchObject({
+			code: "ko",
+			label: "Korean",
+			source: "initial-idea",
+		});
+		expect(payload.language.instruction).toContain("Korean");
+
+		const state = JSON.parse(
+			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
+		);
+		expect(state.language).toEqual(payload.language);
+		expect(state.state.language).toEqual(payload.language);
+	});
+
+	it("lets explicit English requests override Korean deep-interview language detection", async () => {
+		const root = await tempDir();
+		const result = await runNativeDeepInterviewCommand(["--json", "한국어 배경이지만 질문은 영어로 해줘"], root);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.language).toMatchObject({
+			code: "en",
+			label: "English",
+			source: "explicit-user-request",
+		});
+		expect(payload.language.instruction).toContain("explicitly requested English");
+	});
+
 	it("defaults to the SKILL.md default threshold (0.05) when no resolution flag or settings exist", async () => {
 		const root = await tempDir();
 		const result = await runNativeDeepInterviewCommand(["my vague idea"], root);


### PR DESCRIPTION
## Summary
- detect explicit English requests and Korean initial ideas when seeding native `gjc deep-interview` state
- persist a `language` instruction into both the command summary and active interview state so the bundled skill can keep user-facing questions in the session language
- teach the bundled deep-interview skill to apply `language.instruction` to announcements, topology confirmation, options, and interview questions

Closes #167.

## Verification
- `bun --cwd=packages/natives run build` (required in this fresh worktree so native tests could load local addon)
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bunx biome check packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

## Notes
- Initial test attempts in the fresh worktree failed before code execution because workspace dependencies/native addon were missing; after `bun install --frozen-lockfile` and `bun --cwd=packages/natives run build`, the focused suite passed.
- No scope from #160/#162/#163 was included.
