### PR TITLE
Preserve interaction language across GJC workflows

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -48,6 +48,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 - Score ambiguity after every answer -- display the score transparently
 - When the locked topology has multiple active components, score and target each component explicitly so depth-first clarity on one component cannot hide ambiguity in siblings
 - Keep prompt payloads budgeted: summarize or trim oversized initial context/history before composing question, scoring, spec, or handoff prompts
+- Preserve the session `interaction_language` for all user-facing interview text.
 - If the user's initial context is oversized, create a concise prompt-safe summary first and wait for that summary before ambiguity scoring, question generation, or downstream execution handoff
 - Do not proceed to execution until ambiguity ≤ the resolved threshold for this run and the user explicitly approves a scoped execution path
 - Allow early exit with a clear warning if ambiguity is still high
@@ -93,11 +94,16 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
    - Substitute `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` throughout the remaining instructions before continuing.
    - Include `threshold_source` in the first `gjc state write` payload and preserve it on later state updates; do not edit `.gjc/state` files directly unless an explicit force override is active.
    - Include both threshold and source in the final spec metadata.
-- Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, infer the user/session language from `{{ARGUMENTS}}` only when it is obvious. Do not surprise a Korean session with English questions.
+
 
 ## Phase 1: Initialize
 
 1. **Parse the user's idea** from `{{ARGUMENTS}}`
+1.5. **Carry interaction language**:
+   - Use the GJC session interaction language inferred from recent user-authored messages.
+   - Store it as `interaction_language` in state before the first interview question.
+   - Render natural-language announcements, questions, option labels, ambiguity explanations, and spec prose in `interaction_language`; keep code identifiers, file paths, commands, JSON/settings keys, and quoted source text unchanged.
+   - Treat English examples in this skill as semantic templates, not required wording.
 2. **Detect brownfield vs greenfield**:
    - Run `explore` agent (haiku): check if cwd has existing source code, package files, or git history
    - If source files exist AND the user's idea references modifying/extending something: **brownfield**
@@ -135,6 +141,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
     "current_ambiguity": 1.0,
     "threshold": <resolvedThreshold>,
     "threshold_source": "<resolvedThresholdSource>",
+    "interaction_language": "<interaction_language>",
     "codebase_context": null,
     "topology": {
       "status": "pending|confirmed|legacy_missing",
@@ -241,6 +248,7 @@ Build the question generation prompt with:
 - Brownfield codebase context (if applicable), summarized to cited paths/symbols/patterns instead of raw dumps
 - Locked topology from Round 0, including active components, deferred components, prior per-component scores, and `last_targeted_component_id`
 
+- Resolved `interaction_language`; render the question frame and options in this language while preserving code/path/setting tokens verbatim
 If any prompt input is too large, summarize it first and then continue from the summary. Do not ask the next the `ask` tool, score ambiguity, or hand off to execution from an over-budget raw transcript.
 
 **Question targeting strategy:**
@@ -268,7 +276,7 @@ Auto-research must never add a public skill entrypoint, never be slash-command/d
 
 ### Step 2b: Ask the Question
 
-Use the `ask` tool with the generated question. Before rendering the prompt/options, apply `language.instruction` from state when present so the entire user-facing question remains in the preserved session language. Present it clearly with the current ambiguity context:
+Use the `ask` tool with the generated question. Present it clearly with the current ambiguity context in `interaction_language`:
 
 ```
 Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_rationale} | Ambiguity: {score}%
@@ -276,7 +284,7 @@ Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} 
 {question}
 ```
 
-Options should include contextually relevant choices plus free-text.
+Options should include contextually relevant choices plus free-text in `interaction_language`.
 
 ### Step 2b′: Auto-Answer Opted-Out Questions
 
@@ -718,6 +726,7 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 <Final_Checklist>
 - [ ] Phase 0 completed before Phase 1: settings files were read, threshold was resolved, and the first user-visible line was `Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`
 - [ ] State includes both `threshold` and `threshold_source`, and the final spec metadata records both values
+- [ ] GJC session `interaction_language` was persisted in deep-interview state and preserved in follow-up questions
 - [ ] Interview completed (ambiguity ≤ threshold OR user chose early exit)
 - [ ] Oversized initial context/history was summarized before scoring, question generation, spec generation, or execution handoff
 - [ ] Ambiguity score displayed after every round

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -82,6 +82,7 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 - Do not narrate progress, ceremony, timing, scope inflation, or session limits.
 - If the user's intent is clear, act without asking. Ask only when the next step is destructive or requires a missing choice that materially changes the outcome.
 - When the user proposes something wrong, say what breaks and what to do instead once; then defer to their call.
+- Preserve the user's/session's interaction language for natural-language responses. Infer it from recent user-authored messages, ignore assistant/tool/code excerpts, and continue in that language unless the user explicitly switches; workflows that persist state should carry it as `interaction_language`.
 </communication>
 
 <completion-contract>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -210,6 +210,9 @@ Project executor override body.
 		}
 		expect(systemPrompt).toContain("delegate bounded slices to `executor`");
 		expect(systemPrompt).toContain("committed repo-visible `.gjc` defaults are not the source of truth");
+		expect(systemPrompt).toContain("Preserve the user's/session's interaction language");
+		expect(systemPrompt).toContain("recent user-authored messages");
+		expect(systemPrompt).toContain("interaction_language");
 		expect(ultragoal).toContain("run `ralplan` first");
 		expect(ultragoal).toContain("Role agents return implementation/review evidence");
 		expect(ultragoal).toContain("await timeout only limits the leader's wait");
@@ -252,8 +255,8 @@ Project executor override body.
 		expect(content).toContain("Direct `.gjc/` file edits are forbidden");
 		expect(content).toContain("do not edit `.gjc/state` directly without force override");
 		expect(content).toContain("default `0.05`");
-		expect(content).toContain("language.instruction");
-		expect(content).toContain("Do not surprise a Korean session with English questions");
+		expect(content).toContain("Preserve the session `interaction_language`");
+		expect(content).toContain("Store it as `interaction_language` in state");
 		expect(content).not.toContain("default `0.2`");
 		expect(content).not.toContain("20%");
 


### PR DESCRIPTION
## Summary
- Add a GJC-level interaction-language policy for natural-language responses
- Carry the session interaction_language through deep-interview state and user-facing interview prompts
- Add bundled-definition regression assertions for the system prompt and deep-interview skill

## Verification
- bun test packages/coding-agent/test/default-gjc-definitions.test.ts
- bunx biome check packages/coding-agent/src/prompts/system/system-prompt.md packages/coding-agent/test/default-gjc-definitions.test.ts
- Prompt assertion eval for interaction-language strings
