### PR TITLE
Fix OAuth callback listener binding in CI

### DIFF
--- a/packages/ai/src/utils/oauth/callback-server.ts
+++ b/packages/ai/src/utils/oauth/callback-server.ts
@@ -23,6 +23,8 @@ export interface OAuthCallbackFlowOptions {
 	preferredPort: number;
 	callbackPath?: string;
 	callbackHostname?: string;
+	/** Local listener hostname; defaults to callbackHostname when omitted. */
+	callbackBindHostname?: string;
 	/** Exact redirect URI advertised to the provider; disables port fallback. */
 	redirectUri?: string;
 }
@@ -35,6 +37,7 @@ export abstract class OAuthCallbackFlow {
 	preferredPort: number;
 	callbackPath: string;
 	callbackHostname: string;
+	callbackBindHostname: string;
 	redirectUri?: string;
 	#callbackResolve?: (result: CallbackResult) => void;
 	#callbackReject?: (error: string) => void;
@@ -49,12 +52,14 @@ export abstract class OAuthCallbackFlow {
 			this.preferredPort = preferredPortOrOptions;
 			this.callbackPath = callbackPath;
 			this.callbackHostname = DEFAULT_HOSTNAME;
+			this.callbackBindHostname = DEFAULT_HOSTNAME;
 			return;
 		}
 
 		this.preferredPort = preferredPortOrOptions.preferredPort;
 		this.callbackPath = preferredPortOrOptions.callbackPath ?? CALLBACK_PATH;
 		this.callbackHostname = preferredPortOrOptions.callbackHostname ?? DEFAULT_HOSTNAME;
+		this.callbackBindHostname = preferredPortOrOptions.callbackBindHostname ?? this.callbackHostname;
 		this.redirectUri = preferredPortOrOptions.redirectUri;
 	}
 
@@ -144,7 +149,7 @@ export abstract class OAuthCallbackFlow {
 	 */
 	#createServer(port: number, expectedState: string): Bun.Server<unknown> {
 		return Bun.serve({
-			hostname: this.callbackHostname,
+			hostname: this.callbackBindHostname,
 			port,
 			reusePort: false,
 			fetch: req => this.#handleCallback(req, expectedState),

--- a/packages/coding-agent/src/runtime-mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/runtime-mcp/oauth-flow.ts
@@ -11,6 +11,7 @@ import type { OAuthController, OAuthCredentials } from "@gajae-code/ai/utils/oau
 
 const DEFAULT_PORT = 3000;
 const CALLBACK_PATH = "/callback";
+const CALLBACK_BIND_HOSTNAME = "127.0.0.1";
 
 function isLoopbackHostname(hostname: string): boolean {
 	return hostname === "localhost" || hostname === "127.0.0.1";
@@ -42,7 +43,7 @@ function getUriPort(uri: URL): number {
 
 function validateRedirectConfig(config: MCPOAuthConfig, redirectUri: string | undefined): void {
 	const parsed = parseRedirectUri(redirectUri);
-	if (!parsed || parsed.protocol !== "https:" || !isLoopbackHostname(parsed.hostname)) {
+	if (parsed?.protocol !== "https:" || !isLoopbackHostname(parsed.hostname)) {
 		return;
 	}
 
@@ -63,7 +64,7 @@ function resolveCallbackPort(callbackPort: number | undefined, redirectUri: stri
 	if (callbackPort !== undefined) return callbackPort;
 
 	const parsed = parseRedirectUri(redirectUri);
-	if (!parsed || parsed.protocol !== "http:" || !isLoopbackHostname(parsed.hostname)) {
+	if (parsed?.protocol !== "http:" || !isLoopbackHostname(parsed.hostname)) {
 		return DEFAULT_PORT;
 	}
 
@@ -93,6 +94,7 @@ function resolveCallbackOptions(config: MCPOAuthConfig): OAuthCallbackFlowOption
 		preferredPort: resolveCallbackPort(config.callbackPort, redirectUri),
 		callbackPath: resolveCallbackPath(config.callbackPath, redirectUri),
 		callbackHostname: resolveCallbackHostname(redirectUri),
+		callbackBindHostname: CALLBACK_BIND_HOSTNAME,
 		redirectUri,
 	};
 }

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -271,6 +271,7 @@ describe("mcp oauth flow", () => {
 
 	it("listens on the implied port for exact HTTP loopback redirectUri values", async () => {
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
+			expect(options.hostname).toBe("127.0.0.1");
 			expect(options.port).toBe(80);
 			throw new Error("EADDRINUSE");
 		});
@@ -292,6 +293,7 @@ describe("mcp oauth flow", () => {
 
 	it("listens on the explicit port for exact HTTP loopback redirectUri values", async () => {
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
+			expect(options.hostname).toBe("127.0.0.1");
 			expect(options.port).toBe(3000);
 			throw new Error("EADDRINUSE");
 		});
@@ -312,7 +314,8 @@ describe("mcp oauth flow", () => {
 	});
 
 	it("fails instead of falling back to a random port when redirectUri is exact", async () => {
-		vi.spyOn(Bun, "serve").mockImplementation(() => {
+		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
+			expect(options.hostname).toBe("127.0.0.1");
 			throw new Error("EADDRINUSE");
 		});
 
@@ -328,6 +331,7 @@ describe("mcp oauth flow", () => {
 		);
 
 		await expect(flow.login()).rejects.toThrow("cannot fall back to a random port when oauth.redirectUri is set");
+		expect(serveSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("exposes the dynamically registered client_id and client_secret after generateAuthUrl", async () => {


### PR DESCRIPTION
## Summary\n- separate provider-facing OAuth callback hostname from the local listener bind hostname\n- bind the GJC MCP OAuth callback listener to 127.0.0.1 while preserving exact redirectUri/callbackHostname semantics\n- cover exact loopback redirect URI listener behavior in OAuth flow tests\n\n## Verification\n- bun test packages/coding-agent/test/oauth-flow.test.ts\n- bun --cwd=packages/ai run check\n- bun --cwd=packages/coding-agent run check\n- git diff --check\n\nNote: package checks passed with existing Biome optional-chain warnings outside this patch.