### PR TITLE
Improve shell mode composer cues

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -28,6 +28,9 @@ function isExpandable(obj: unknown): obj is Expandable {
 }
 
 export class InputController {
+	#normalizingShellPrefix = false;
+	#bashExcludeFromContext = false;
+
 	constructor(private ctx: InteractiveModeContext) {}
 
 	#abortInteractive(): Promise<void> {
@@ -64,6 +67,8 @@ export class InputController {
 			} else if (this.ctx.isBashMode) {
 				this.ctx.editor.setText("");
 				this.ctx.isBashMode = false;
+				this.ctx.isBashNoContext = false;
+				this.#bashExcludeFromContext = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isEvalRunning) {
 				this.ctx.session.abortEval();
@@ -171,15 +176,57 @@ export class InputController {
 		}
 
 		this.ctx.editor.onChange = (text: string) => {
+			if (this.#normalizingShellPrefix) return;
+
 			const wasBashMode = this.ctx.isBashMode;
+			const wasBashNoContext = this.ctx.isBashNoContext;
 			const wasPythonMode = this.ctx.isPythonMode;
+			const shellNormalized = this.#normalizeShellModeInput(text);
+			if (shellNormalized !== undefined) {
+				this.#normalizingShellPrefix = true;
+				this.ctx.editor.setText(shellNormalized);
+				this.#normalizingShellPrefix = false;
+				this.ctx.updateEditorBorderColor();
+				return;
+			}
+
+			if (this.ctx.isBashMode) {
+				this.ctx.isPythonMode = false;
+				return;
+			}
+
 			const trimmed = text.trimStart();
-			this.ctx.isBashMode = text.trimStart().startsWith("!");
+			this.ctx.isBashMode = false;
+			this.ctx.isBashNoContext = false;
+			this.#bashExcludeFromContext = false;
 			this.ctx.isPythonMode = trimmed.startsWith("$") && !trimmed.startsWith("${");
-			if (wasBashMode !== this.ctx.isBashMode || wasPythonMode !== this.ctx.isPythonMode) {
+			if (
+				wasBashMode !== this.ctx.isBashMode ||
+				wasBashNoContext !== this.ctx.isBashNoContext ||
+				wasPythonMode !== this.ctx.isPythonMode
+			) {
 				this.ctx.updateEditorBorderColor();
 			}
 		};
+	}
+
+	#normalizeShellModeInput(text: string): string | undefined {
+		const trimmed = text.trimStart();
+		if (!this.ctx.isBashMode) {
+			if (!trimmed.startsWith("!")) return undefined;
+			this.ctx.isBashMode = true;
+			this.ctx.isPythonMode = false;
+			this.#bashExcludeFromContext = trimmed.startsWith("!!");
+			this.ctx.isBashNoContext = this.#bashExcludeFromContext;
+			return trimmed.slice(this.#bashExcludeFromContext ? 2 : 1).trimStart();
+		}
+
+		if (trimmed.startsWith("!")) {
+			this.#bashExcludeFromContext = true;
+			this.ctx.isBashNoContext = true;
+			return trimmed.slice(1).trimStart();
+		}
+		return undefined;
 	}
 
 	setupEditorSubmitHandler(): void {
@@ -225,6 +272,24 @@ export class InputController {
 			}
 
 			if (!text) return;
+
+			if (this.ctx.isBashMode) {
+				const command = text.trim();
+				if (!command) return;
+				if (this.ctx.session.isBashRunning) {
+					this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
+					this.ctx.editor.setText(command);
+					return;
+				}
+				this.ctx.editor.addToHistory(`${this.#bashExcludeFromContext ? "!!" : "!"}${command}`);
+				this.ctx.isBashNoContext = this.#bashExcludeFromContext;
+				await this.ctx.handleBashCommand(command, this.#bashExcludeFromContext);
+				this.ctx.isBashMode = false;
+				this.ctx.isBashNoContext = false;
+				this.#bashExcludeFromContext = false;
+				this.ctx.updateEditorBorderColor();
+				return;
+			}
 
 			// Handle built-in slash commands
 			const slashResult = await executeBuiltinSlashCommand(text, {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -236,6 +236,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	isInitialized = false;
 	isBackgrounded = false;
 	isBashMode = false;
+	isBashNoContext = false;
 	toolOutputExpanded = false;
 	todoExpanded = false;
 	planModeEnabled = false;
@@ -809,9 +810,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	updateEditorChrome(): void {
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
+			const prefix = this.isBashNoContext
+				? `${theme.fg("warning", theme.bold("!"))}${theme.fg("bashMode", theme.bold("$ "))}`
+				: theme.fg("bashMode", theme.bold("$ "));
+			this.editor.setInputPrefix(prefix);
 		} else if (this.isPythonMode) {
 			this.editor.borderColor = theme.getPythonModeBorderColor();
+			this.editor.setInputPrefix(undefined);
 		} else {
+			this.editor.setInputPrefix(undefined);
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;
 			const hex = sessionName ? getSessionAccentHex(sessionName) : undefined;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -86,6 +86,7 @@ export interface InteractiveModeContext {
 	isInitialized: boolean;
 	isBackgrounded: boolean;
 	isBashMode: boolean;
+	isBashNoContext: boolean;
 	toolOutputExpanded: boolean;
 	todoExpanded: boolean;
 	planModeEnabled: boolean;

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -22,6 +22,7 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onChange?: (text: string) => void;
+	onSubmit?: (text: string) => void;
 	setText(text: string): void;
 	getText(): string;
 	addToHistory(text: string): void;
@@ -40,6 +41,7 @@ async function createContext() {
 	const showModelSelector = vi.fn();
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
+	const handleBashCommand = vi.fn(async () => {});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -68,6 +70,7 @@ async function createContext() {
 			isEvalRunning: false,
 			extensionRunner: undefined,
 			prompt,
+			abortBash: vi.fn(),
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -104,6 +107,7 @@ async function createContext() {
 		},
 		updatePendingMessagesDisplay,
 		isBashMode: false,
+		isBashNoContext: false,
 		isPythonMode: false,
 		handleHotkeysCommand: vi.fn(),
 		handlePlanModeCommand: vi.fn(),
@@ -117,6 +121,8 @@ async function createContext() {
 		toggleThinkingBlockVisibility: vi.fn(),
 		showModelSelector,
 		updateEditorBorderColor: vi.fn(),
+		handleBashCommand,
+		showWarning: vi.fn(),
 		hasActiveBtw: vi.fn(() => false),
 	} as unknown as InteractiveModeContext;
 
@@ -129,6 +135,7 @@ async function createContext() {
 			showModelSelector,
 			prompt,
 			updatePendingMessagesDisplay,
+			handleBashCommand,
 		},
 	};
 }
@@ -211,5 +218,50 @@ describe("InputController keybinding setup", () => {
 		await expect(controller.handleFollowUp()).rejects.toThrow("queue full");
 
 		expect(ctx.locallySubmittedUserSignatures.has("queued during stream\u00000")).toBe(false);
+	});
+	it("enters modal shell mode by stripping the leading bang", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onChange?.("!pwd");
+
+		expect(ctx.isBashMode).toBe(true);
+		expect(ctx.isBashNoContext).toBe(false);
+		expect(ctx.isPythonMode).toBe(false);
+		expect(editor.getText()).toBe("pwd");
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
+	});
+
+	it("submits modal shell input without requiring the bang to remain visible", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		editor.onChange?.("!pwd");
+		await editor.onSubmit?.(editor.getText());
+
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", false);
+		expect(editor.addToHistory).toHaveBeenCalledWith("!pwd");
+		expect(ctx.isBashMode).toBe(false);
+	});
+
+	it("lets a second bang switch modal shell input to no-context execution", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		editor.onChange?.("!");
+		editor.onChange?.("!pwd");
+
+		expect(ctx.isBashNoContext).toBe(true);
+
+		await editor.onSubmit?.(editor.getText());
+
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", true);
+		expect(ctx.isBashNoContext).toBe(false);
+		expect(editor.addToHistory).toHaveBeenCalledWith("!!pwd");
 	});
 });


### PR DESCRIPTION
## Summary
- normalize `!` / `!!` shell entry so the bang is consumed as a mode switch instead of lingering in the editor buffer
- show bash-mode composer chrome with a `$ ` prefix, and show a distinct `!$ ` prefix for no-context shell mode
- add controller regression coverage for normal shell mode, no-context shell mode, and command submission/history behavior

## Verification
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts`
- `bunx biome check packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/test/input-controller-keybindings.test.ts`
- LSP diagnostics: `packages/coding-agent/src/modes/controllers/input-controller.ts`, `packages/coding-agent/src/modes/interactive-mode.ts`
