### PR TITLE
Harden OAuth listener bind regression test

### DIFF
--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -270,10 +270,10 @@ describe("mcp oauth flow", () => {
 	});
 
 	it("listens on the implied port for exact HTTP loopback redirectUri values", async () => {
+		let servedOptions: { hostname?: string; port?: number | string } | undefined;
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
-			expect(options.hostname).toBe("127.0.0.1");
-			expect(options.port).toBe(80);
-			throw new Error("EADDRINUSE");
+			servedOptions = { hostname: options.hostname, port: options.port };
+			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
 		});
 
 		const flow = new MCPOAuthFlow(
@@ -289,13 +289,14 @@ describe("mcp oauth flow", () => {
 			"OAuth callback port 80 unavailable; cannot fall back to a random port when oauth.redirectUri is set",
 		);
 		expect(serveSpy).toHaveBeenCalledTimes(1);
+		expect(servedOptions).toMatchObject({ hostname: "127.0.0.1", port: 80 });
 	});
 
 	it("listens on the explicit port for exact HTTP loopback redirectUri values", async () => {
+		let servedOptions: { hostname?: string; port?: number | string } | undefined;
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
-			expect(options.hostname).toBe("127.0.0.1");
-			expect(options.port).toBe(3000);
-			throw new Error("EADDRINUSE");
+			servedOptions = { hostname: options.hostname, port: options.port };
+			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
 		});
 
 		const flow = new MCPOAuthFlow(
@@ -311,12 +312,14 @@ describe("mcp oauth flow", () => {
 			"OAuth callback port 3000 unavailable; cannot fall back to a random port when oauth.redirectUri is set",
 		);
 		expect(serveSpy).toHaveBeenCalledTimes(1);
+		expect(servedOptions).toMatchObject({ hostname: "127.0.0.1", port: 3000 });
 	});
 
 	it("fails instead of falling back to a random port when redirectUri is exact", async () => {
+		let servedOptions: { hostname?: string; port?: number | string } | undefined;
 		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(options => {
-			expect(options.hostname).toBe("127.0.0.1");
-			throw new Error("EADDRINUSE");
+			servedOptions = { hostname: options.hostname, port: options.port };
+			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
 		});
 
 		const flow = new MCPOAuthFlow(
@@ -332,6 +335,7 @@ describe("mcp oauth flow", () => {
 
 		await expect(flow.login()).rejects.toThrow("cannot fall back to a random port when oauth.redirectUri is set");
 		expect(serveSpy).toHaveBeenCalledTimes(1);
+		expect(servedOptions).toMatchObject({ hostname: "127.0.0.1", port: 14569 });
 	});
 
 	it("exposes the dynamically registered client_id and client_secret after generateAuthUrl", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to merged #173, which merged before the mandatory review blocker fix was included.
- Hardens the OAuth listener bind regression test so mock assertions for bind host/port survive server-error wrapping instead of being swallowed inside the mocked `Bun.serve` failure path.

## Verification
- Confirmed PR diff is limited to `packages/coding-agent/test/oauth-flow.test.ts`.
- `bun test packages/coding-agent/test/oauth-flow.test.ts`

No merge performed.
