### PR TITLE
fix(skill-hud): show only currently-active workflow after handoff

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed the skill HUD rail showing already-handed-off `deep-interview`/`ralplan` workflows: handoffs now supersede every same-session-scope row of the caller and callee skills (not just the exact `skill::session_id` key), and the visible-state read collapses to the most-recent row per skill before filtering inactive entries, so the HUD renders only the currently-active workflow and self-heals stale on-disk state.
+- Fixed the skill HUD rail showing already-handed-off planning workflows so it renders only the currently-active stage. Handoffs now supersede every same-session-scope row of the caller and callee skills (not just the exact `skill::session_id` key), and the visible-state read collapses the `deep-interview → ralplan → ultragoal` pipeline to its most-recent stage. Activating a later stage (e.g. `gjc ultragoal` after ralplan) now supersedes the earlier one even when the activation path does not run the `handoff` verb, while `team` still coexists with ultragoal. Existing stale on-disk state self-heals on read.
 
 ## [0.2.4] - 2026-06-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Pruned bundled built-in themes to `red-claw` and `blue-crab`, with `blue-crab` now the default light-appearance theme.
 
+### Fixed
+
+- Fixed the skill HUD rail showing already-handed-off `deep-interview`/`ralplan` workflows: handoffs now supersede every same-session-scope row of the caller and callee skills (not just the exact `skill::session_id` key), and the visible-state read collapses to the most-recent row per skill before filtering inactive entries, so the HUD renders only the currently-active workflow and self-heals stale on-disk state.
+
 ## [0.2.4] - 2026-06-02
 
 ### Added

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -373,6 +373,30 @@ function dedupeVisibleBySkill(entries: SkillActiveEntry[]): SkillActiveEntry[] {
 	return [...winners.values()];
 }
 
+/**
+ * The planning pipeline advances one stage at a time: `deep-interview →
+ * ralplan → ultragoal`. Each stage is activated through its own command path
+ * (`gjc deep-interview`, `gjc ralplan`, `gjc ultragoal`), and those activations
+ * do not demote the previous stage's row — only the explicit `handoff` verb
+ * does. Without this collapse, activating ultragoal while ralplan is still
+ * `active:true` would render both stages and keep showing a workflow that has
+ * already handed control forward. Keep only the most recently updated pipeline
+ * stage so the HUD reflects the single current workflow. `team` is intentionally
+ * excluded — it runs alongside ultragoal — and every non-pipeline skill is left
+ * untouched.
+ */
+const PLANNING_PIPELINE_SKILLS = new Set<string>(["deep-interview", "ralplan", "ultragoal"]);
+
+function collapsePlanningPipeline(entries: SkillActiveEntry[]): SkillActiveEntry[] {
+	const pipeline = entries.filter(entry => PLANNING_PIPELINE_SKILLS.has(entry.skill));
+	if (pipeline.length <= 1) return entries;
+	let current = pipeline[0];
+	for (const entry of pipeline) {
+		if (entryRecency(entry) >= entryRecency(current)) current = entry;
+	}
+	return entries.filter(entry => !PLANNING_PIPELINE_SKILLS.has(entry.skill) || entry === current);
+}
+
 function mergeVisibleEntries(
 	sessionState: SkillActiveState | null,
 	rootState: SkillActiveState | null,
@@ -385,7 +409,8 @@ function mergeVisibleEntries(
 	for (const entry of rawActiveEntries(sessionState)) {
 		merged.set(entryKey(entry), entry);
 	}
-	return dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
+	const active = dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
+	return collapsePlanningPipeline(active);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -345,24 +345,54 @@ function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: st
 	});
 }
 
+function entryRecency(entry: SkillActiveEntry): number {
+	const stamp = entry.handoff_at || entry.updated_at || entry.activated_at;
+	const ms = stamp ? Date.parse(stamp) : Number.NaN;
+	return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Collapse the merged, session-scoped entries down to a single row per skill.
+ * A handed-off skill can leave more than one row visible to a session — e.g. a
+ * row seeded without a session id (rendered globally by
+ * `filterRootEntriesForSession`) plus a later, session-scoped handoff demotion
+ * of the same skill. Without this collapse the HUD renders the same workflow
+ * twice and keeps showing a skill that has already handed control to its
+ * successor. The most recently updated row wins, so a handoff demotion
+ * (`active:false`, newest timestamp) supersedes an older stale `active:true`
+ * row of the same skill and is then dropped by the active filter below.
+ */
+function dedupeVisibleBySkill(entries: SkillActiveEntry[]): SkillActiveEntry[] {
+	const winners = new Map<string, SkillActiveEntry>();
+	for (const entry of entries) {
+		const current = winners.get(entry.skill);
+		if (!current || entryRecency(entry) >= entryRecency(current)) {
+			winners.set(entry.skill, entry);
+		}
+	}
+	return [...winners.values()];
+}
+
 function mergeVisibleEntries(
 	sessionState: SkillActiveState | null,
 	rootState: SkillActiveState | null,
 	sessionId?: string,
 ): SkillActiveEntry[] {
-	const rootEntries = filterRootEntriesForSession(listActiveSkills(rootState), sessionId);
+	// Use the raw (active + inactive) rows so a handoff demotion stays visible
+	// long enough to supersede a stale same-skill row before the active filter.
+	const rootEntries = filterRootEntriesForSession(rawActiveEntries(rootState), sessionId);
 	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of listActiveSkills(sessionState)) {
+	for (const entry of rawActiveEntries(sessionState)) {
 		merged.set(entryKey(entry), entry);
 	}
-	return [...merged.values()];
+	return dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
 	const [rootState, sessionState] = await Promise.all([
-		readStateFile(rootPath),
-		sessionPath ? readStateFile(sessionPath) : Promise.resolve(null),
+		readRawActiveStateForHandoff(rootPath, false),
+		sessionPath ? readRawActiveStateForHandoff(sessionPath, false) : Promise.resolve(null),
 	]);
 	const activeSkills = mergeVisibleEntries(sessionState, rootState, sessionId);
 	if (activeSkills.length === 0) return null;
@@ -468,11 +498,25 @@ export async function applyHandoffToActiveState(options: ApplyHandoffOptions): P
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, sessionId);
 	const readState = (filePath: string) => readRawActiveStateForHandoff(filePath, options.strict === true);
 
+	// A skill can hold more than one visible row in this session's scope — e.g.
+	// it was seeded without a session id (rendered globally) and is now handed
+	// off under a concrete session id. Supersede every same-session-scope row of
+	// the caller and callee skills, not just the exact `skill::session_id` key,
+	// so a stale `active:true` row cannot survive the demotion and keep showing
+	// in the HUD. Rows owned by other sessions are left untouched.
+	const handoffSession = safeString(sessionId).trim();
+	const reassignedSkills = new Set([callerEntry.skill, calleeEntry.skill]);
+	const supersedesVisible = (entry: SkillActiveEntry): boolean => {
+		if (!reassignedSkills.has(entry.skill)) return false;
+		const entrySession = safeString(entry.session_id).trim();
+		return entrySession.length === 0 || entrySession === handoffSession;
+	};
 	const applyEntries = (entries: SkillActiveEntry[]): SkillActiveEntry[] => {
 		const callerKey = entryKey(callerEntry);
-		const calleeKey = entryKey(calleeEntry);
-		const priorCaller = entries.find(e => entryKey(e) === callerKey);
-		const kept = entries.filter(e => entryKey(e) !== callerKey && entryKey(e) !== calleeKey);
+		const priorCaller =
+			entries.find(e => entryKey(e) === callerKey) ??
+			entries.find(e => e.skill === callerEntry.skill && supersedesVisible(e) && Boolean(e.handoff_from));
+		const kept = entries.filter(e => !supersedesVisible(e));
 		// Merge prior lineage into the demoted caller so multi-step handoff
 		// chains preserve `handoff_from` from the previous transition while
 		// the new `handoff_to`/`handoff_at` describe this one.

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -268,6 +268,56 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
+	it("supersedes an upstream pipeline skill when a later stage is activated without a handoff verb", async () => {
+		await withTempCwd(async cwd => {
+			// `gjc ralplan` then `gjc ultragoal` each activate their own row; the
+			// ultragoal activation does not demote ralplan, so without the pipeline
+			// collapse the HUD would render ralplan + ultragoal. Only the current
+			// (most-recently-activated) stage should remain.
+			await syncSkillActiveState({
+				cwd,
+				skill: "ralplan",
+				phase: "final",
+				active: true,
+				source: "gjc-ralplan-native",
+				nowIso: "2026-01-01T00:00:00.000Z",
+			});
+			await syncSkillActiveState({
+				cwd,
+				skill: "ultragoal",
+				phase: "executing",
+				active: true,
+				source: "gjc-ultragoal",
+				nowIso: "2026-01-01T00:05:00.000Z",
+			});
+
+			const visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ultragoal"]);
+		});
+	});
+
+	it("keeps team alongside ultragoal since team is not part of the planning pipeline", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({
+				cwd,
+				skill: "ultragoal",
+				phase: "executing",
+				active: true,
+				nowIso: "2026-01-01T00:00:00.000Z",
+			});
+			await syncSkillActiveState({
+				cwd,
+				skill: "team",
+				phase: "running",
+				active: true,
+				nowIso: "2026-01-01T00:05:00.000Z",
+			});
+
+			const visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.active_skills?.map(entry => entry.skill).sort()).toEqual(["team", "ultragoal"]);
+		});
+	});
+
 	it("keeps the canonical GJC workflow skill set intentionally small", () => {
 		expect(CANONICAL_GJC_WORKFLOW_SKILLS).toEqual(["deep-interview", "ralplan", "ultragoal", "team"]);
 	});

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	applyHandoffToActiveState,
 	CANONICAL_GJC_WORKFLOW_SKILLS,
 	getSkillActiveStatePaths,
 	listActiveSkills,
@@ -144,6 +145,126 @@ describe("GJC skill-active state", () => {
 				severity: "success",
 			});
 			expect(entry?.hud?.details?.length).toBe(12);
+		});
+	});
+
+	it("shows only the callee when a skill is seeded session-less then handed off under a session", async () => {
+		await withTempCwd(async cwd => {
+			// `gjc deep-interview` run without --session-id seeds a global row, then
+			// the in-TUI skill chain hands off under a concrete session id. The
+			// demotion must supersede the global row so the HUD stops showing the
+			// already-handed-off skill.
+			await syncSkillActiveState({ cwd, skill: "deep-interview", phase: "interviewing", active: true });
+			await applyHandoffToActiveState({
+				cwd,
+				strict: true,
+				caller: {
+					cwd,
+					skill: "deep-interview",
+					active: false,
+					phase: "handoff",
+					sessionId: "sess1",
+					handoff_to: "ralplan",
+				},
+				callee: {
+					cwd,
+					skill: "ralplan",
+					active: true,
+					phase: "planner",
+					sessionId: "sess1",
+					handoff_from: "deep-interview",
+				},
+			});
+
+			const visible = await readVisibleSkillActiveState(cwd, "sess1");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ralplan"]);
+		});
+	});
+
+	it("does not demote a same-skill row owned by a different session during handoff", async () => {
+		await withTempCwd(async cwd => {
+			await syncSkillActiveState({ cwd, skill: "ralplan", phase: "planner", active: true, sessionId: "sessB" });
+			await syncSkillActiveState({
+				cwd,
+				skill: "deep-interview",
+				phase: "interviewing",
+				active: true,
+				sessionId: "sessA",
+			});
+			await applyHandoffToActiveState({
+				cwd,
+				strict: true,
+				caller: {
+					cwd,
+					skill: "deep-interview",
+					active: false,
+					phase: "handoff",
+					sessionId: "sessA",
+					handoff_to: "ralplan",
+				},
+				callee: {
+					cwd,
+					skill: "ralplan",
+					active: true,
+					phase: "planner",
+					sessionId: "sessA",
+					handoff_from: "deep-interview",
+				},
+			});
+
+			const sessionA = await readVisibleSkillActiveState(cwd, "sessA");
+			const sessionB = await readVisibleSkillActiveState(cwd, "sessB");
+			expect(sessionA?.active_skills?.map(entry => entry.skill)).toEqual(["ralplan"]);
+			expect(sessionB?.active_skills?.map(entry => entry.skill)).toEqual(["ralplan"]);
+		});
+	});
+
+	it("self-heals a stale active row left in an on-disk state file", async () => {
+		await withTempCwd(async cwd => {
+			const { rootPath } = getSkillActiveStatePaths(cwd, "sess1");
+			await fs.mkdir(path.dirname(rootPath), { recursive: true });
+			await fs.writeFile(
+				rootPath,
+				JSON.stringify({
+					version: 1,
+					active: true,
+					skill: "deep-interview",
+					active_skills: [
+						{
+							skill: "deep-interview",
+							phase: "interviewing",
+							active: true,
+							updated_at: "2026-01-01T00:00:00.000Z",
+						},
+						{
+							skill: "deep-interview",
+							phase: "handoff",
+							active: false,
+							session_id: "sess1",
+							updated_at: "2026-01-01T00:01:00.000Z",
+							handoff_to: "ralplan",
+						},
+						{
+							skill: "ralplan",
+							phase: "handoff",
+							active: false,
+							session_id: "sess1",
+							updated_at: "2026-01-01T00:02:00.000Z",
+							handoff_to: "ultragoal",
+						},
+						{
+							skill: "ultragoal",
+							phase: "executing",
+							active: true,
+							session_id: "sess1",
+							updated_at: "2026-01-01T00:03:00.000Z",
+						},
+					],
+				}),
+			);
+
+			const visible = await readVisibleSkillActiveState(cwd, "sess1");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ultragoal"]);
 		});
 	});
 


### PR DESCRIPTION
## Problem

Already-handed-off planning workflows kept showing in the in-TUI skill HUD rail. Concretely: **when ralplan hands off and ultragoal becomes active, ralplan should be superseded** — but the HUD rendered `ralplan + ultragoal` (and likewise `deep-interview + ralplan`). The HUD must show only the currently-active workflow stage.

## Root causes

Two distinct gaps:

1. **Handoff verb keyed too narrowly.** Handoff demotion and HUD visibility both key on `skill::session_id`. When a skill was seeded under one `session_id` (e.g. empty, from `gjc deep-interview`/`gjc ralplan` without `--session-id`) and later handed off under a different one, the `handoff` verb demoted only the exact key. The original `active:true` row for the same skill survived, and empty-`session_id` rows render globally, so the handed-off skill stayed in the bar.

2. **Forward activation never demotes the previous stage.** Each pipeline stage activates through its own command path (`gjc deep-interview`, `gjc ralplan`, `gjc ultragoal`), which calls `syncSkillActiveState` for *its own* skill only — it does not run the `handoff` verb and does not demote the previous stage. So `gjc ultragoal` adds an active `ultragoal` row while ralplan's row stays `active:true`, and the HUD shows both.

## Fix (`packages/coding-agent/src/skill-state/active-state.ts`)

- `applyHandoffToActiveState` now supersedes **every same-session-scope row** of the caller and callee skills (same `session_id` or empty), not just the exact `skill::session_id` key — rows owned by other sessions are untouched.
- `readVisibleSkillActiveState` reads the raw (active + inactive) rows, then:
  - collapses to the **most-recent row per skill** before filtering inactive (so a handoff demotion suppresses an older stale active row of the same skill), and
  - collapses the **`deep-interview → ralplan → ultragoal` pipeline to its most-recently-activated stage**, so activating a later stage supersedes the earlier ones even when the activation path didn't run the `handoff` verb. `team` is excluded — it coexists with ultragoal.

Result: the HUD shows only the current workflow stage, and pre-existing corrupted on-disk state **self-heals on read**. The backward `ultragoal → ralplan` handoff still works (the verb demotes ultragoal; ralplan, most-recent, wins).

## Tests (`skill-active-state.test.ts`)

- session-less seed → handoff under a session shows only the callee
- a same-skill row owned by a different session is not demoted by an unrelated session's handoff
- a stale active row in an on-disk state file self-heals on read
- **activating a later pipeline stage (`gjc ralplan` → `gjc ultragoal`) supersedes the earlier one without a handoff verb**
- **team coexists with ultragoal**

All affected suites pass (`skill-active-state`, `skill-hud-bar`, `state-handoff`, `skill`, `deep-interview-runtime`), typecheck clean, biome clean.