### PR TITLE
Allow restricted workflow CLI for review agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ GJC intentionally exposes exactly four default workflow skills. Do not add, docu
 Rules:
 - Bundled default workflow skills load from `packages/coding-agent/src/defaults/gjc/skills`.
 - Bundled role agents load from `packages/coding-agent/src/prompts/agents`.
+- `architect`, `planner`, and `critic` remain read-only for product files, but may use their restricted `bash` tool only for sanctioned workflow CLI persistence (`gjc ralplan --write ...`) and GJC workflow state read/write/contract commands (`gjc state ...`); the bash tool blocks env overrides, direct handoffs, state clears, artifact file-path ingestion, and all other command shapes for those role agents.
 - Do not commit repo-visible `.gjc` default definitions; runtime user/project `.gjc` discovery remains supported for local overrides and installed configs.
 - Runtime state, plans, specs, and workflow ledgers belong under `.gjc/`.
 - Preserve upstream attribution in source comments/docs where appropriate, but public commands, paths, and examples must use `gjc` and `.gjc`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Fixed
 
 - Enforced the deep-interview phase boundary so active interviews block mutation tools until a handoff/spec is produced.
+- Allowed read-only `architect`, `planner`, and `critic` role agents to persist ralplan/state workflow receipts through a restricted `bash` allowlist while blocking general shell and product-file mutations.
 - Made settings theme browsing confirm-only so arrowing through themes no longer changes the rendered theme before the displayed/persisted theme name changes.
 - Made startup CHANGELOG display deterministic by embedding `packages/coding-agent/CHANGELOG.md` into the binary so post-update launches show the shipped history regardless of cwd or `GJC_PACKAGE_DIR`/`PI_PACKAGE_DIR` overrides.
 - Registered `gjc update` as a public root subcommand so it invokes the bundled updater instead of routing into the interactive launcher.

--- a/packages/coding-agent/src/cli/agents-cli.ts
+++ b/packages/coding-agent/src/cli/agents-cli.ts
@@ -64,6 +64,9 @@ function toFrontmatter(agent: AgentDefinition): Record<string, unknown> {
 	if (agent.thinkingLevel) frontmatter.thinkingLevel = agent.thinkingLevel;
 	if (agent.output !== undefined) frontmatter.output = agent.output;
 	if (agent.blocking) frontmatter.blocking = true;
+	if (agent.bashAllowedPrefixes && agent.bashAllowedPrefixes.length > 0) {
+		frontmatter.bashAllowedPrefixes = agent.bashAllowedPrefixes;
+	}
 
 	return frontmatter;
 }

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -45,6 +45,8 @@ gjc ralplan --write --stage <type> --stage_n <N> --artifact "markdown file path 
 
 Use stage values that match the producer or artifact kind, such as `planner`, `architect`, `critic`, `revision`, `adr`, or `final`. Increment `--stage_n` for each consensus-loop pass. The `--artifact` value may be either a markdown file path prepared outside `.gjc/` for ingestion or the markdown content string itself. The native `--write` handler persists markdown under `.gjc/plans/ralplan/<run-id>/stage-<NN>-<stage>.md`, maintains an `index.jsonl` audit log, and for `final` stages additionally writes a `pending-approval.md` copy. Direct `write`, `edit`, or `ast_edit` calls against `.gjc/specs`, `.gjc/plans`, `.gjc/state`, or any other `.gjc/` path are forbidden unless an explicit force override is active.
 
+Restricted read-only role agents (`planner`, `architect`, and `critic`) must pass markdown content directly in `--artifact`; their restricted bash environment intentionally disables artifact file-path ingestion so a verdict command cannot persist arbitrary file contents.
+
 This skill runs GJC planning in consensus mode for the provided arguments.
 
 The consensus workflow:

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -217,6 +217,7 @@ export interface ParsedAgentFields {
 	blocking?: boolean;
 	hide?: boolean;
 	forkContext?: ForkContextPolicy;
+	bashAllowedPrefixes?: string[];
 }
 
 /**
@@ -274,6 +275,9 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	const autoloadSkills = parseArrayOrCSV(frontmatter.autoloadSkills)
 		?.map(s => s.trim())
 		.filter(Boolean);
+	const bashAllowedPrefixes = parseArrayOrCSV(frontmatter.bashAllowedPrefixes)
+		?.map(prefix => prefix.trim())
+		.filter(Boolean);
 	return {
 		name,
 		description,
@@ -286,6 +290,7 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 		autoloadSkills,
 		hide,
 		forkContext,
+		bashAllowedPrefixes,
 	};
 }
 

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildRalplanHudSummary } from "../skill-state/workflow-hud";
+import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 
 /**
  * Native implementation of `gjc ralplan`.
@@ -110,6 +111,7 @@ function defaultRunId(now: Date = new Date()): string {
 }
 
 async function resolveArtifactContent(rawArtifact: string, cwd: string): Promise<string> {
+	if (isRestrictedRoleAgentBash()) return rawArtifact;
 	const candidate = path.isAbsolute(rawArtifact) ? rawArtifact : path.resolve(cwd, rawArtifact);
 	try {
 		const stat = await fs.stat(candidate);

--- a/packages/coding-agent/src/gjc-runtime/restricted-role-agent-bash.ts
+++ b/packages/coding-agent/src/gjc-runtime/restricted-role-agent-bash.ts
@@ -1,0 +1,5 @@
+export const GJC_RESTRICTED_ROLE_AGENT_BASH_ENV = "GJC_RESTRICTED_ROLE_AGENT_BASH";
+
+export function isRestrictedRoleAgentBash(): boolean {
+	return process.env[GJC_RESTRICTED_ROLE_AGENT_BASH_ENV] === "1";
+}

--- a/packages/coding-agent/src/prompts/agents/architect.md
+++ b/packages/coding-agent/src/prompts/agents/architect.md
@@ -1,10 +1,13 @@
 ---
 name: architect
 description: Read-only architecture and code-review agent with severity-rated findings and status verdicts
-tools: read, search, find, lsp, ast_grep, web_search, report_finding
+tools: read, search, find, lsp, ast_grep, web_search, bash, report_finding
 thinking-level: high
 blocking: true
 forkContext: allowed
+bashAllowedPrefixes:
+  - gjc ralplan --write
+  - gjc state
 ---
 <identity>
 You are Architect. You combine system architecture review with code-review discipline. Diagnose, analyze, and recommend with file-backed evidence. You are read-only.
@@ -22,6 +25,7 @@ You may receive a forked parent-conversation snapshot as background. Your read-o
 
 <constraints>
 - Read-only: never write, edit, format, commit, push, or mutate files.
+- Exception: you may use the restricted `bash` tool only for sanctioned GJC workflow CLI persistence (`gjc ralplan --write ...`) and GJC workflow state read/write/contract commands (`gjc state ...`). For `gjc ralplan --write`, pass the verdict markdown inline in `--artifact`, not as a file path. Do not use bash for product-source writes, direct handoffs, state clears, or general shell work.
 - Never approve code or plans you have not grounded in inspected files.
 - Never give generic advice detached from this codebase.
 - Never approve CRITICAL or HIGH severity issues.

--- a/packages/coding-agent/src/prompts/agents/critic.md
+++ b/packages/coding-agent/src/prompts/agents/critic.md
@@ -1,8 +1,11 @@
 ---
 name: critic
 description: Read-only plan critic that approves only actionable, verifiable execution plans
-tools: read, search, find, lsp, ast_grep, web_search
+tools: read, search, find, lsp, ast_grep, web_search, bash
 thinking-level: high
+bashAllowedPrefixes:
+  - gjc ralplan --write
+  - gjc state
 ---
 <identity>
 You are Critic. Decide whether a work plan is actionable before execution begins.
@@ -14,6 +17,7 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 
 <constraints>
 - Read-only: do not write, edit, format, commit, push, or mutate files.
+- Exception: you may use the restricted `bash` tool only for sanctioned GJC workflow CLI persistence (`gjc ralplan --write ...`) and GJC workflow state read/write/contract commands (`gjc state ...`). For `gjc ralplan --write`, pass the evaluation markdown inline in `--artifact`, not as a file path. Do not use bash for product-source writes, direct handoffs, state clears, or general shell work.
 - A lone file path is valid input; read and evaluate it.
 - Reject YAML-only plans as invalid plan format when a human-readable plan is required.
 - Do not invent problems; report no issues found when the plan passes.

--- a/packages/coding-agent/src/prompts/agents/frontmatter.md
+++ b/packages/coding-agent/src/prompts/agents/frontmatter.md
@@ -9,5 +9,6 @@ description: {{jsonStringify description}}
 {{/if}}{{#if hide}}hide: true
 {{/if}}{{#if autoloadSkills}}autoloadSkills: {{jsonStringify autoloadSkills}}
 {{/if}}{{#if forkContext}}forkContext: {{jsonStringify forkContext}}
+{{/if}}{{#if bashAllowedPrefixes}}bashAllowedPrefixes: {{jsonStringify bashAllowedPrefixes}}
 {{/if}}---
 {{body}}

--- a/packages/coding-agent/src/prompts/agents/planner.md
+++ b/packages/coding-agent/src/prompts/agents/planner.md
@@ -1,8 +1,11 @@
 ---
 name: planner
 description: Read-only planning agent for sequencing, acceptance criteria, risks, and handoff shape
-tools: read, search, find, lsp, ast_grep, web_search
+tools: read, search, find, lsp, ast_grep, web_search, bash
 thinking-level: medium
+bashAllowedPrefixes:
+  - gjc ralplan --write
+  - gjc state
 ---
 <identity>
 You are Planner. Turn requests into actionable work plans. You plan; you do not implement.
@@ -14,6 +17,7 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 
 <constraints>
 - Read-only: never write, edit, format, commit, push, or mutate files.
+- Exception: you may use the restricted `bash` tool only for sanctioned GJC workflow CLI persistence (`gjc ralplan --write ...`) and GJC workflow state read/write/contract commands (`gjc state ...`). For `gjc ralplan --write`, pass the plan markdown inline in `--artifact`, not as a file path. Do not use bash for product-source writes, direct handoffs, state clears, or general shell work.
 - Inspect the repository before asking about code facts.
 - Ask only about priorities, tradeoffs, scope decisions, timelines, or preferences that repository inspection cannot resolve.
 - Right-size the step count to the task; do not default to a fixed number of steps.

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -11,6 +11,15 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 - Use `async: true` for long-running commands when you don't need immediate output; the call returns a background job ID and the result is delivered automatically as a follow-up.
 {{/if}}
 </instruction>
+{{#if restrictedAllowedPrefixes}}
+<restricted-role-agent-mode>
+This session's bash tool is restricted. It only accepts commands beginning with:
+{{#each restrictedAllowedPrefixes}}
+- `{{this}}`
+{{/each}}
+Use it only for sanctioned GJC workflow CLI persistence or state read/write/contract operations; per-command env overrides and all other shell command shapes are blocked before execution.
+</restricted-role-agent-mode>
+{{/if}}
 
 <critical>
 - NEVER use Linux coreutils (`cat`, `head`, `tail`, `less`, `more`, `ls`, `grep`, `rg`, `awk`, `sed`, `find`, `fd`, etc.) when a dedicated tool suffices — ALWAYS prefer `read`, `search`, `find`, `edit`, `write`.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -294,6 +294,8 @@ export interface CreateAgentSessionOptions {
 	agentId?: string;
 	/** Display name for the agent in IRC. Default: "main" or "sub". */
 	agentDisplayName?: string;
+	/** Optional restricted bash command prefixes for read-only role agents. */
+	bashAllowedPrefixes?: string[];
 	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
 	agentRegistry?: AgentRegistry;
 	/** Parent task ID prefix for nested artifact naming (e.g., "6-Extensions") */
@@ -1166,6 +1168,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				return agent?.state.model ?? model;
 			},
 			getAgentId: () => resolvedAgentId,
+			bashAllowedPrefixes: options.bashAllowedPrefixes,
 			getToolByName: name => session?.getToolByName(name),
 			agentRegistry,
 			getSessionSpawns: () => options.spawns ?? "*",

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -30,6 +30,7 @@ interface AgentFrontmatter {
 	blocking?: boolean;
 	hide?: boolean;
 	forkContext?: "forbidden" | "allowed";
+	bashAllowedPrefixes?: string[];
 }
 
 interface EmbeddedAgentDef {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1186,6 +1186,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					parentTaskPrefix: id,
 					agentId: id,
 					agentDisplayName: agent.name,
+					bashAllowedPrefixes: agent.bashAllowedPrefixes,
 					enableLsp: lspEnabled,
 					skipPythonPreflight,
 					enableMCP,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -181,6 +181,7 @@ export interface AgentDefinition {
 	autoloadSkills?: string[];
 	hide?: boolean;
 	forkContext?: ForkContextPolicy;
+	bashAllowedPrefixes?: string[];
 	source: AgentSource;
 	filePath?: string;
 }

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -1,0 +1,169 @@
+export interface BashAllowedPrefixesCheck {
+	allowed: boolean;
+	reason?: string;
+}
+
+const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
+const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
+const STATE_FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id", "--to"]);
+const STATE_ACTIONS = new Set(["read", "write", "clear", "contract", "handoff"]);
+const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
+
+function parseShellWords(command: string): { words: string[]; reason?: string } {
+	const words: string[] = [];
+	let current = "";
+	let quote: "single" | "double" | null = null;
+
+	for (let index = 0; index < command.length; index += 1) {
+		const char = command[index]!;
+		const next = command[index + 1];
+
+		if (quote === "single") {
+			if (char === "'") {
+				quote = null;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+
+		if (quote === "double") {
+			if (char === '"') {
+				quote = null;
+				continue;
+			}
+			if (char === "`" || (char === "$" && next === "(")) {
+				return { words, reason: "command substitution is not allowed in restricted bash commands" };
+			}
+			if (char === "$") {
+				return { words, reason: "shell expansion character '$' is not allowed in restricted bash commands" };
+			}
+			if (char === "\\") {
+				return { words, reason: "backslash escapes are not allowed in restricted bash commands" };
+			}
+			current += char;
+			continue;
+		}
+
+		if (char === "'") {
+			quote = "single";
+			continue;
+		}
+		if (char === '"') {
+			quote = "double";
+			continue;
+		}
+		if (char === "`" || (char === "$" && next === "(")) {
+			return { words, reason: "command substitution is not allowed in restricted bash commands" };
+		}
+		if (char === "\n" || char === "\r") {
+			return { words, reason: "multiple shell commands are not allowed in restricted bash mode" };
+		}
+		if (SHELL_CONTROL_CHARS.has(char)) {
+			return { words, reason: `shell control operator '${char}' is not allowed in restricted bash commands` };
+		}
+		if (UNSAFE_UNQUOTED_EXPANSION_CHARS.has(char)) {
+			return { words, reason: `shell expansion character '${char}' is not allowed in restricted bash commands` };
+		}
+		if (/\s/u.test(char)) {
+			if (current.length > 0) {
+				words.push(current);
+				current = "";
+			}
+			continue;
+		}
+		if (char === "\\") {
+			return { words, reason: "backslash escapes are not allowed in restricted bash commands" };
+		}
+		current += char;
+	}
+
+	if (quote !== null) {
+		return { words, reason: "unterminated quote in restricted bash command" };
+	}
+	if (current.length > 0) words.push(current);
+	return { words };
+}
+
+function prefixWords(prefix: string): string[] {
+	return prefix.trim().split(/\s+/u).filter(Boolean);
+}
+
+function wordsStartWith(words: readonly string[], prefix: readonly string[]): boolean {
+	if (prefix.length === 0 || words.length < prefix.length) return false;
+	return prefix.every((word, index) => words[index] === word);
+}
+
+function parseStateAction(words: readonly string[]): string | undefined {
+	const args = words.slice(2);
+	const positional: string[] = [];
+	let skipNext = false;
+	for (const arg of args) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (STATE_FLAGS_WITH_VALUES.has(arg)) {
+			skipNext = true;
+			continue;
+		}
+		if (!arg.startsWith("-")) positional.push(arg);
+	}
+
+	const [first, second, third] = positional;
+	if (!first) return "read";
+	if (STATE_ACTIONS.has(first)) return second ? undefined : first;
+	if (!second) return "read";
+	if (!STATE_ACTIONS.has(second)) return undefined;
+	return third ? undefined : second;
+}
+
+function validateMatchedGjcCommand(words: readonly string[]): BashAllowedPrefixesCheck {
+	if (words[0] !== "gjc") return { allowed: true };
+
+	if (words[1] === "ralplan") {
+		if (!words.includes("--write")) {
+			return { allowed: false, reason: "restricted role-agent bash only allows `gjc ralplan --write ...`" };
+		}
+		return { allowed: true };
+	}
+
+	if (words[1] === "state") {
+		const action = parseStateAction(words);
+		if (!action) {
+			return {
+				allowed: false,
+				reason: "restricted role-agent bash only allows documented `gjc state` action shapes",
+			};
+		}
+		if (!ALLOWED_STATE_ACTIONS.has(action)) {
+			return { allowed: false, reason: `restricted role-agent bash does not allow \`gjc state ${action}\`` };
+		}
+		return { allowed: true };
+	}
+
+	return { allowed: true };
+}
+
+export function checkBashAllowedPrefixes(
+	command: string,
+	allowedPrefixes: readonly string[] | undefined,
+): BashAllowedPrefixesCheck {
+	const normalizedPrefixes = allowedPrefixes?.map(prefix => prefix.trim()).filter(Boolean) ?? [];
+	if (normalizedPrefixes.length === 0) return { allowed: true };
+
+	const parsed = parseShellWords(command.trim());
+	if (parsed.reason) return { allowed: false, reason: parsed.reason };
+	if (parsed.words.length === 0)
+		return { allowed: false, reason: "empty command is not allowed in restricted bash mode" };
+
+	const matched = normalizedPrefixes.some(prefix => wordsStartWith(parsed.words, prefixWords(prefix)));
+	if (!matched) {
+		return {
+			allowed: false,
+			reason: `restricted role-agent bash only allows commands starting with: ${normalizedPrefixes.join(", ")}`,
+		};
+	}
+
+	return validateMatchedGjcCommand(parsed.words);
+}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -8,6 +8,7 @@ import { AsyncJobManager } from "../async";
 import { type BashResult, executeBash } from "../exec/bash-executor";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { buildGjcRuntimeSessionEnv } from "../gjc-runtime/goal-mode-request";
+import { GJC_RESTRICTED_ROLE_AGENT_BASH_ENV } from "../gjc-runtime/restricted-role-agent-bash";
 import { InternalUrlRouter } from "../internal-urls";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { highlightCode, type Theme } from "../modes/theme/theme";
@@ -18,6 +19,7 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { getSixelLineMask } from "../utils/sixel";
 import type { ToolSession } from ".";
+import { checkBashAllowedPrefixes } from "./bash-allowed-prefixes";
 import { applyBashFixups } from "./bash-command-fixup";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
@@ -253,6 +255,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			hasAstEdit: this.session.settings.get("astEdit.enabled"),
 			hasSearch: this.session.settings.get("search.enabled"),
 			hasFind: this.session.settings.get("find.enabled"),
+			restrictedAllowedPrefixes: this.session.bashAllowedPrefixes,
 		});
 	}
 
@@ -496,6 +499,20 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			throw new ToolError("Async bash execution is disabled. Enable async.enabled to use async mode.");
 		}
 
+		const allowedPrefixes = this.session.bashAllowedPrefixes;
+		if (allowedPrefixes && allowedPrefixes.length > 0) {
+			if (env && Object.keys(env).length > 0) {
+				throw new ToolError("Restricted role-agent bash does not allow per-command env overrides.");
+			}
+			const commandsToCheck = rawCommand === command ? [command] : [rawCommand, command];
+			for (const commandToCheck of commandsToCheck) {
+				const allowlist = checkBashAllowedPrefixes(commandToCheck, allowedPrefixes);
+				if (!allowlist.allowed) {
+					throw new ToolError(allowlist.reason ?? "Command blocked by restricted role-agent bash allowlist.");
+				}
+			}
+		}
+
 		// Check both the original command and the cwd-normalized command so
 		// leading `cd ... &&` wrappers do not hide either shell-navigation rules
 		// or the dedicated-tool command that follows the directory change.
@@ -541,6 +558,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				cwd: this.session.cwd,
 			}),
 			...expandedEnv,
+			...(allowedPrefixes && allowedPrefixes.length > 0 ? { [GJC_RESTRICTED_ROLE_AGENT_BASH_ENV]: "1" } : {}),
 		};
 
 		// Resolve protocol URLs (agent://, artifact://, etc.) in extracted cwd.

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -164,6 +164,8 @@ export interface ToolSession {
 	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Agent registry for IRC routing across live sessions. */
 	agentRegistry?: AgentRegistry;
+	/** Optional restricted bash command prefixes for read-only role agents. */
+	bashAllowedPrefixes?: string[];
 	/** Get artifacts directory for artifact:// URLs */
 	getArtifactsDir?: () => string | null;
 	/** Get the ArtifactManager backing this session (shared across parent + subagents). */

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -129,9 +129,10 @@ describe("default GJC definitions", () => {
 		for (const agent of [architect, planner, critic]) {
 			expect(agent?.tools).toBeDefined();
 			expect(agent?.tools).toContain("yield");
+			expect(agent?.tools).toContain("bash");
 			expect(agent?.tools).not.toContain("edit");
 			expect(agent?.tools).not.toContain("write");
-			expect(agent?.tools).not.toContain("bash");
+			expect(agent?.bashAllowedPrefixes).toEqual(["gjc ralplan --write", "gjc state"]);
 		}
 		for (const agent of [executor, architect, planner, critic]) {
 			expect(agent?.model).toBeUndefined();

--- a/packages/coding-agent/test/discovery/agent-fields.test.ts
+++ b/packages/coding-agent/test/discovery/agent-fields.test.ts
@@ -109,4 +109,14 @@ describe("parseAgentFields", () => {
 		expect(fields).toBeDefined();
 		expect(fields?.autoloadSkills).toBeUndefined();
 	});
+	test("parses bashAllowedPrefixes from array frontmatter", () => {
+		const fields = parseAgentFields({
+			name: "reviewer",
+			description: "desc",
+			bashAllowedPrefixes: ["gjc ralplan --write", " gjc state "],
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.bashAllowedPrefixes).toEqual(["gjc ralplan --write", "gjc state"]);
+	});
 });

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
+import { GJC_RESTRICTED_ROLE_AGENT_BASH_ENV } from "@gajae-code/coding-agent/gjc-runtime/restricted-role-agent-bash";
 
 const tempRoots: string[] = [];
 
@@ -128,6 +129,42 @@ describe("native gjc ralplan runtime — --write artifact path", () => {
 			"utf-8",
 		);
 		expect(content).toBe("# Draft\nbody\n");
+	});
+
+	it("restricted role-agent bash treats --artifact paths as inline text", async () => {
+		const root = await tempDir();
+		const artifactPath = path.join(root, "secret.md");
+		await fs.writeFile(artifactPath, "# Secret\nshould-not-be-read\n");
+		const previous = process.env[GJC_RESTRICTED_ROLE_AGENT_BASH_ENV];
+		process.env[GJC_RESTRICTED_ROLE_AGENT_BASH_ENV] = "1";
+		try {
+			const result = await runNativeRalplanCommand(
+				[
+					"--write",
+					"--stage",
+					"architect",
+					"--stage_n",
+					"2",
+					"--artifact",
+					artifactPath,
+					"--run-id",
+					"restricted-file-run",
+				],
+				root,
+			);
+			expect(result.status).toBe(0);
+			const content = await fs.readFile(
+				path.join(root, ".gjc", "plans", "ralplan", "restricted-file-run", "stage-02-architect.md"),
+				"utf-8",
+			);
+			expect(content).toBe(`${artifactPath}\n`);
+		} finally {
+			if (previous === undefined) {
+				delete process.env[GJC_RESTRICTED_ROLE_AGENT_BASH_ENV];
+			} else {
+				process.env[GJC_RESTRICTED_ROLE_AGENT_BASH_ENV] = previous;
+			}
+		}
 	});
 
 	it("final stage emits pending-approval.md alongside the stage artifact", async () => {

--- a/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
+++ b/packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { checkBashAllowedPrefixes } from "../../src/tools/bash-allowed-prefixes";
+
+const ROLE_AGENT_PREFIXES = ["gjc ralplan --write", "gjc state"] as const;
+
+describe("checkBashAllowedPrefixes", () => {
+	it("allows ralplan artifact writes for role agents", () => {
+		expect(
+			checkBashAllowedPrefixes(
+				"gjc ralplan --write --stage architect --stage_n 1 --artifact 'Architect verdict'",
+				ROLE_AGENT_PREFIXES,
+			),
+		).toEqual({ allowed: true });
+	});
+
+	it("blocks non-write ralplan commands", () => {
+		const result = checkBashAllowedPrefixes("gjc ralplan --consensus 'task'", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("gjc ralplan --write");
+	});
+
+	it("allows GJC state writes through the sanctioned workflow CLI", () => {
+		expect(
+			checkBashAllowedPrefixes(
+				'gjc state ralplan write --input \'{"current_phase":"handoff"}\' --json',
+				ROLE_AGENT_PREFIXES,
+			),
+		).toEqual({ allowed: true });
+	});
+
+	it("blocks destructive state clears", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan clear --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("gjc state clear");
+	});
+
+	it("blocks direct GJC state handoffs", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan handoff --to team --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("gjc state handoff");
+	});
+
+	it("blocks shell expansion that could synthesize a state action", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan $ACTION --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("shell expansion character");
+	});
+
+	it("blocks double-quoted shell expansion that could synthesize a state action", () => {
+		const dollar = "$";
+		const result = checkBashAllowedPrefixes(
+			`gjc state "${dollar}{X:-handoff}" --mode ralplan --to team`,
+			ROLE_AGENT_PREFIXES,
+		);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("shell expansion character");
+	});
+
+	it("blocks backslash escape smuggling", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan\\ clear --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("backslash escapes");
+	});
+
+	it("blocks malformed or unknown state action shapes", () => {
+		const result = checkBashAllowedPrefixes("gjc state ralplan nope --json", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("documented `gjc state` action shapes");
+	});
+
+	it("blocks shell chaining that could smuggle destructive commands", () => {
+		const result = checkBashAllowedPrefixes(
+			"gjc ralplan --write --stage critic --artifact ok; rm -rf .gjc",
+			ROLE_AGENT_PREFIXES,
+		);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("shell control operator");
+	});
+
+	it("blocks ordinary shell commands for restricted role agents", () => {
+		const result = checkBashAllowedPrefixes("echo verdict", ROLE_AGENT_PREFIXES);
+
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain("restricted role-agent bash only allows commands starting with");
+	});
+});

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { AgentToolContext } from "@gajae-code/agent-core";
 import { validateToolArguments } from "@gajae-code/ai/utils/validation";
 import type { BashInterceptorRule } from "../../src/config/settings-schema";
@@ -117,5 +119,92 @@ describe("BashTool head/tail stripping", () => {
 		const text = result.content.find(b => b.type === "text")?.text ?? "";
 		expect(text).toContain("1\n2\n3");
 		expect(text).not.toContain("100");
+	});
+});
+
+describe("BashTool restricted role-agent allowlist", () => {
+	function createRestrictedBashTool(
+		cwd = process.cwd(),
+		bashAllowedPrefixes = ["gjc ralplan --write", "gjc state"],
+	): BashTool {
+		const session = {
+			cwd,
+			getSessionFile: () => null,
+			getSessionId: () => undefined,
+			bashAllowedPrefixes,
+			settings: {
+				get(key: string) {
+					if (key === "bashInterceptor.enabled") return false;
+					if (key === "async.enabled") return false;
+					if (key === "bash.autoBackground.enabled") return false;
+					if (key === "bash.autoBackground.thresholdMs") return 60_000;
+					if (key === "bash.stripTrailingHeadTail") return false;
+					return undefined;
+				},
+				getBashInterceptorRules() {
+					return [];
+				},
+			},
+		} as unknown as ToolSession;
+		return new BashTool(session);
+	}
+
+	it("surfaces restricted prefixes in the tool description", () => {
+		const tool = createRestrictedBashTool();
+
+		expect(tool.description).toContain("This session's bash tool is restricted");
+		expect(tool.description).toContain("gjc ralplan --write");
+		expect(tool.description).toContain("gjc state");
+	});
+
+	it("blocks non-allowlisted commands before execution", async () => {
+		const tool = createRestrictedBashTool();
+
+		await expect(tool.execute("tool-call", { command: "echo should-not-run" })).rejects.toThrow(
+			"restricted role-agent bash only allows commands starting with",
+		);
+	});
+
+	it("blocks ralplan invocations that are not artifact writes", async () => {
+		const tool = createRestrictedBashTool();
+
+		await expect(tool.execute("tool-call", { command: "gjc ralplan --consensus 'task'" })).rejects.toThrow(
+			"gjc ralplan --write",
+		);
+	});
+
+	it("blocks per-command env overrides in restricted mode", async () => {
+		const tool = createRestrictedBashTool();
+
+		await expect(
+			tool.execute("tool-call", {
+				command: "gjc ralplan --write --stage architect --stage_n 1 --artifact ok",
+				env: { PATH: "/tmp/fake" },
+			}),
+		).rejects.toThrow("does not allow per-command env overrides");
+	});
+
+	it("marks restricted CLI subprocesses so ralplan does not ingest artifact file paths", async () => {
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-bash-"));
+		try {
+			const artifactPath = path.join(root, "secret.md");
+			await fs.writeFile(artifactPath, "# Secret\nshould-not-be-read\n");
+			const cliPath = path.resolve(process.cwd(), "packages/coding-agent/src/cli.ts");
+			const bunPath = process.execPath;
+			const tool = createRestrictedBashTool(root, [`${bunPath} ${cliPath} ralplan --write`]);
+			const result = await tool.execute("tool-call", {
+				command: `${bunPath} ${cliPath} ralplan --write --stage architect --stage_n 1 --artifact ${artifactPath} --run-id bash-marker`,
+				timeout: 30,
+			});
+
+			expect(result.content.find(part => part.type === "text")?.text).toContain("stage-01-architect.md");
+			const persisted = await fs.readFile(
+				path.join(root, ".gjc", "plans", "ralplan", "bash-marker", "stage-01-architect.md"),
+				"utf-8",
+			);
+			expect(persisted).toBe(`${artifactPath}\n`);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/scripts/verify-g002-gates.ts
+++ b/scripts/verify-g002-gates.ts
@@ -14,7 +14,7 @@ import * as path from "node:path";
 const repoRoot = path.join(import.meta.dir, "..");
 const EXPECTED_DEFINITIONS = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
 const EXPECTED_ROLE_AGENTS = ["architect", "critic", "executor", "planner"] as const;
-const EXPECTED_PUBLIC_PACKAGE_VERSION = "0.2.2";
+const EXPECTED_PUBLIC_PACKAGE_VERSION = "0.2.3";
 const ALLOWED_PUBLIC_PACKAGE_VERSIONS = new Map<string, string>();
 const ALLOWED_PRIVATE_PACKAGE_VERSIONS = new Map<string, string>([["@gajae-code/typescript-edit-benchmark", "0.0.1"]]);
 const ALLOWED_UNSCOPED_PACKAGE_NAMES = new Set<string>(["gajae-code"]);


### PR DESCRIPTION
## Summary
- Allow architect/planner/critic to use restricted bash for `gjc ralplan --write` and GJC state read/write/contract commands.
- Enforce conservative restricted shell parsing, block env overrides, disallow state clear/handoff, and prevent restricted ralplan artifact path ingestion.
- Update role-agent/ralplan guidance and regression coverage.

## Review
- Final architect review: Architectural Status `CLEAR`, Code Review Recommendation `APPROVE`.

## Verification
- `bun test packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts packages/coding-agent/test/tools/bash-interceptor.test.ts packages/coding-agent/test/discovery/agent-fields.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts`
- `bunx biome check scripts/verify-g002-gates.ts AGENTS.md packages/coding-agent/CHANGELOG.md packages/coding-agent/src/cli/agents-cli.ts packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md packages/coding-agent/src/discovery/helpers.ts packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts packages/coding-agent/src/gjc-runtime/restricted-role-agent-bash.ts packages/coding-agent/src/prompts/agents/frontmatter.md packages/coding-agent/src/prompts/agents/architect.md packages/coding-agent/src/prompts/agents/critic.md packages/coding-agent/src/prompts/agents/planner.md packages/coding-agent/src/prompts/tools/bash.md packages/coding-agent/src/sdk.ts packages/coding-agent/src/task/agents.ts packages/coding-agent/src/task/executor.ts packages/coding-agent/src/task/types.ts packages/coding-agent/src/tools/bash.ts packages/coding-agent/src/tools/index.ts packages/coding-agent/src/tools/bash-allowed-prefixes.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/discovery/agent-fields.test.ts packages/coding-agent/test/tools/bash-interceptor.test.ts packages/coding-agent/test/tools/bash-allowed-prefixes.test.ts packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun scripts/check-visible-definitions.ts && bun scripts/verify-g002-gates.ts && bun scripts/rebrand-inventory.ts --strict`
- `git diff --check`
- `bun --cwd=packages/coding-agent run check` completed with existing optional-chain warnings only.
