### PR TITLE
Improve shell mode composer cues

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -64,6 +64,7 @@ export class InputController {
 			} else if (this.ctx.isBashMode) {
 				this.ctx.editor.setText("");
 				this.ctx.isBashMode = false;
+				this.ctx.isBashNoContext = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isEvalRunning) {
 				this.ctx.session.abortEval();
@@ -172,11 +173,17 @@ export class InputController {
 
 		this.ctx.editor.onChange = (text: string) => {
 			const wasBashMode = this.ctx.isBashMode;
+			const wasBashNoContext = this.ctx.isBashNoContext;
 			const wasPythonMode = this.ctx.isPythonMode;
 			const trimmed = text.trimStart();
-			this.ctx.isBashMode = text.trimStart().startsWith("!");
+			this.ctx.isBashMode = trimmed.startsWith("!");
+			this.ctx.isBashNoContext = trimmed.startsWith("!!");
 			this.ctx.isPythonMode = trimmed.startsWith("$") && !trimmed.startsWith("${");
-			if (wasBashMode !== this.ctx.isBashMode || wasPythonMode !== this.ctx.isPythonMode) {
+			if (
+				wasBashMode !== this.ctx.isBashMode ||
+				wasBashNoContext !== this.ctx.isBashNoContext ||
+				wasPythonMode !== this.ctx.isPythonMode
+			) {
 				this.ctx.updateEditorBorderColor();
 			}
 		};
@@ -260,6 +267,7 @@ export class InputController {
 					this.ctx.editor.addToHistory(text);
 					await this.ctx.handleBashCommand(command, isExcluded);
 					this.ctx.isBashMode = false;
+					this.ctx.isBashNoContext = false;
 					this.ctx.updateEditorBorderColor();
 					return;
 				}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,12 +112,23 @@ const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	high: "borderAccent",
 };
 
+function getDefaultInputPrefix(): string {
+	return `${theme.fg("accent", ">")} `;
+}
+
+function getShellInputPrefix(isNoContext: boolean): string {
+	const shellLabel = isNoContext
+		? theme.fg("warning", theme.bold("shell no-context"))
+		: theme.fg("bashMode", theme.bold("shell"));
+	return `${shellLabel} ${getDefaultInputPrefix()}`;
+}
+
 function configureDefaultComposerChrome(editor: CustomEditor): void {
 	editor.setBorderVisible(true);
 	editor.setBorderStyle("sharp");
 	editor.setClosedBorderBox(true);
 	editor.setPromptGutter(undefined);
-	editor.setInputPrefix(`${theme.fg("accent", ">")} `);
+	editor.setInputPrefix(getDefaultInputPrefix());
 	editor.setPlaceholder("Type your message...");
 	editor.setPaddingX(1);
 	editor.setTopBorder(undefined);
@@ -236,6 +247,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	isInitialized = false;
 	isBackgrounded = false;
 	isBashMode = false;
+	isBashNoContext = false;
 	toolOutputExpanded = false;
 	todoExpanded = false;
 	planModeEnabled = false;
@@ -808,7 +820,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	updateEditorChrome(): void {
 		if (this.isBashMode) {
-			this.editor.borderColor = theme.getBashModeBorderColor();
+			this.editor.borderColor = this.isBashNoContext
+				? (str: string) => theme.fg("warning", str)
+				: theme.getBashModeBorderColor();
+			this.editor.setInputPrefix(getShellInputPrefix(this.isBashNoContext));
 		} else if (this.isPythonMode) {
 			this.editor.borderColor = theme.getPythonModeBorderColor();
 		} else {
@@ -822,6 +837,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				const level = this.session.thinkingLevel ?? ThinkingLevel.Off;
 				this.editor.borderColor = theme.getThinkingBorderColor(level);
 			}
+		}
+		if (!this.isBashMode) {
+			this.editor.setInputPrefix(getDefaultInputPrefix());
 		}
 		this.#setComposerTopBorder();
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -86,6 +86,7 @@ export interface InteractiveModeContext {
 	isInitialized: boolean;
 	isBackgrounded: boolean;
 	isBashMode: boolean;
+	isBashNoContext: boolean;
 	toolOutputExpanded: boolean;
 	todoExpanded: boolean;
 	planModeEnabled: boolean;

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -22,6 +22,7 @@ type FakeEditor = {
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onChange?: (text: string) => void;
+	onSubmit?: (text: string) => void | Promise<void>;
 	setText(text: string): void;
 	getText(): string;
 	addToHistory(text: string): void;
@@ -40,6 +41,7 @@ async function createContext() {
 	const showModelSelector = vi.fn();
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
+	const handleBashCommand = vi.fn(async () => {});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -66,6 +68,7 @@ async function createContext() {
 			isGeneratingHandoff: false,
 			isBashRunning: false,
 			isEvalRunning: false,
+			abortBash: vi.fn(),
 			extensionRunner: undefined,
 			prompt,
 		} as unknown as InteractiveModeContext["session"],
@@ -104,6 +107,7 @@ async function createContext() {
 		},
 		updatePendingMessagesDisplay,
 		isBashMode: false,
+		isBashNoContext: false,
 		isPythonMode: false,
 		handleHotkeysCommand: vi.fn(),
 		handlePlanModeCommand: vi.fn(),
@@ -117,6 +121,8 @@ async function createContext() {
 		toggleThinkingBlockVisibility: vi.fn(),
 		showModelSelector,
 		updateEditorBorderColor: vi.fn(),
+		handleBashCommand,
+		showWarning: vi.fn(),
 		hasActiveBtw: vi.fn(() => false),
 	} as unknown as InteractiveModeContext;
 
@@ -129,6 +135,7 @@ async function createContext() {
 			showModelSelector,
 			prompt,
 			updatePendingMessagesDisplay,
+			handleBashCommand,
 		},
 	};
 }
@@ -211,5 +218,49 @@ describe("InputController keybinding setup", () => {
 		await expect(controller.handleFollowUp()).rejects.toThrow("queue full");
 
 		expect(ctx.locallySubmittedUserSignatures.has("queued during stream\u00000")).toBe(false);
+	});
+});
+
+describe("InputController shell mode cues", () => {
+	it("marks leading bang input as shell mode without rewriting editor text", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("!pwd");
+		editor.onChange?.("!pwd");
+
+		expect(ctx.isBashMode).toBe(true);
+		expect(ctx.isBashNoContext).toBe(false);
+		expect(ctx.isPythonMode).toBe(false);
+		expect(editor.getText()).toBe("!pwd");
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
+	});
+
+	it("marks double bang input as no-context shell mode", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("!!pwd");
+		editor.onChange?.("!!pwd");
+
+		expect(ctx.isBashMode).toBe(true);
+		expect(ctx.isBashNoContext).toBe(true);
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
+	});
+
+	it("keeps existing shell submit and history semantics", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("!!pwd");
+
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", true);
+		expect(editor.addToHistory).toHaveBeenCalledWith("!!pwd");
+		expect(ctx.isBashMode).toBe(false);
+		expect(ctx.isBashNoContext).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
-import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -88,6 +88,40 @@ describe("InteractiveMode.setEditorComponent", () => {
 			expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.endsWith("│"))).toBe(true);
 			expect(lines.join("\n")).not.toContain("Type your message...");
 		}
+	});
+
+	it("keeps the default prompt prefix while reflecting shell modes in border color", () => {
+		mode.editor.setText("!!pwd");
+		mode.isBashMode = true;
+		mode.isBashNoContext = true;
+
+		mode.updateEditorChrome();
+
+		expect(mode.editor.borderColor("x")).toBe(theme.fg("warning", "x"));
+		let lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		expect(
+			lines.some(
+				line =>
+					line.startsWith("│") &&
+					line.includes("shell no-context") &&
+					line.includes(">") &&
+					line.includes("!!pwd"),
+			),
+		).toBe(true);
+
+		mode.isBashNoContext = false;
+		mode.updateEditorChrome();
+
+		expect(mode.editor.borderColor("x")).toBe(theme.getBashModeBorderColor()("x"));
+		lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		expect(lines.some(line => line.startsWith("│") && line.includes("shell") && line.includes("!!pwd"))).toBe(true);
+
+		mode.isBashMode = false;
+		mode.updateEditorChrome();
+
+		lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.includes("!!pwd"))).toBe(true);
+		expect(lines.join("\n")).not.toContain("shell");
 	});
 
 	it("replaces the editor and rebinds interactive handlers", () => {


### PR DESCRIPTION
## Summary
- Add an explicit composer prefix for shell input: `shell >` for `!` commands and `shell no-context >` for `!!` commands.
- Preserve the existing command text, submit parsing, and history behavior instead of rewriting the editor buffer.
- Keep the default `>` composer prefix restored outside shell mode and cover the chrome behavior with focused tests.

## Validation
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts`
- PTY E2E: launched `bun --cwd=packages/coding-agent src/cli.ts`, typed `!pwd` and `!!pwd`, and verified rendered composer output showed `shell > !pwd` and `shell no-context > !!pwd`.
- `bunx biome check packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts`
- LSP diagnostics OK for edited source/test files.