### PR TITLE
fix(skill-hud): scope pipeline collapse to renderer; session-aware visible read

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed the skill HUD rail showing already-handed-off planning workflows so it renders only the currently-active stage. Handoffs now supersede every same-session-scope row of the caller and callee skills (not just the exact `skill::session_id` key), and the visible-state read collapses the `deep-interview → ralplan → ultragoal` pipeline to its most-recent stage. Activating a later stage (e.g. `gjc ultragoal` after ralplan) now supersedes the earlier one even when the activation path does not run the `handoff` verb, while `team` still coexists with ultragoal. Existing stale on-disk state self-heals on read.
+- Fixed the skill HUD rail showing already-handed-off planning workflows so it renders only the currently-active stage. Handoffs now supersede every same-session-scope row of the caller and callee skills (not just the exact `skill::session_id` key), the visible-state read collapses duplicate same-skill rows to the most-recent one (so a handoff demotion drops a stale `active:true` row and on-disk state self-heals), and the HUD renderer collapses the `deep-interview → ralplan → ultragoal` pipeline to its most-recent stage. Activating a later stage (e.g. `gjc ultragoal` after ralplan) now supersedes the earlier one even when the activation path does not run the `handoff` verb, while `team` still coexists with ultragoal.
 
 ## [0.2.4] - 2026-06-02
 

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -1,4 +1,8 @@
-import type { SkillActiveEntry, WorkflowHudChip } from "../../../skill-state/active-state";
+import {
+	collapsePlanningPipeline,
+	type SkillActiveEntry,
+	type WorkflowHudChip,
+} from "../../../skill-state/active-state";
 import { workflowReceiptStatus } from "../../../skill-state/workflow-state-contract";
 
 const ANSI_RESET_FG = "\x1b[39m";
@@ -69,7 +73,8 @@ function formatEntry(entry: SkillActiveEntry): string {
 }
 
 export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
-	const active = entries.filter(entry => entry.active !== false && sanitizeHudPart(entry.skill)).sort(compareEntries);
+	const visible = collapsePlanningPipeline(entries.filter(entry => entry.active !== false));
+	const active = visible.filter(entry => sanitizeHudPart(entry.skill)).sort(compareEntries);
 	if (active.length === 0 || width <= 0) return null;
 	const body = active.map(formatEntry).join(" + ");
 	const prefix = `${ANSI_BORDER}◆${ANSI_RESET_FG} ${ANSI_BOLD}${ANSI_ACCENT}hud${ANSI_RESET_FG}${ANSI_RESET_BOLD} `;

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -327,11 +327,33 @@ async function readRawActiveStateForHandoff(filePath: string, strict: boolean): 
 }
 
 function rawActiveEntries(state: SkillActiveState | null): SkillActiveEntry[] {
-	if (!state || !Array.isArray(state.active_skills)) return [];
+	if (!state) return [];
 	const out: SkillActiveEntry[] = [];
-	for (const candidate of state.active_skills) {
-		const normalized = normalizeEntry(candidate);
-		if (normalized) out.push(normalized);
+	if (Array.isArray(state.active_skills)) {
+		for (const candidate of state.active_skills) {
+			const normalized = normalizeEntry(candidate);
+			if (normalized) out.push(normalized);
+		}
+	}
+	// Legacy top-level fallback: pre-`active_skills` state files persisted a single
+	// active workflow as top-level `{ active: true, skill, phase, … }` with no
+	// `active_skills` array. `normalizeSkillActiveState` still synthesizes that row,
+	// so the raw read used by the HUD, mutation guard, and caller inference must do
+	// the same or it would treat a legacy active workflow as absent.
+	if (out.length === 0 && state.active === true) {
+		const skill = safeString(state.skill).trim();
+		if (skill) {
+			out.push({
+				skill,
+				phase: safeString(state.phase).trim() || undefined,
+				active: true,
+				activated_at: safeString(state.activated_at).trim() || undefined,
+				updated_at: safeString(state.updated_at).trim() || undefined,
+				session_id: safeString(state.session_id).trim() || undefined,
+				thread_id: safeString(state.thread_id).trim() || undefined,
+				turn_id: safeString(state.turn_id).trim() || undefined,
+			});
+		}
 	}
 	return out;
 }
@@ -348,7 +370,55 @@ function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: st
 function entryRecency(entry: SkillActiveEntry): number {
 	const stamp = entry.handoff_at || entry.updated_at || entry.activated_at;
 	const ms = stamp ? Date.parse(stamp) : Number.NaN;
-	return Number.isFinite(ms) ? ms : 0;
+	// NaN signals "no trustworthy timestamp" so comparisons can refuse to let an
+	// unknown-recency row win a tie; callers must treat NaN explicitly.
+	return ms;
+}
+
+/**
+ * Session ownership rank for a row visible to a `sessionId` read. When a concrete
+ * session is in scope, a row owned by that exact session outranks a session-less
+ * fallback row, which outranks a foreign-session row. Session-less rows are global
+ * fallbacks and must never override a session's own state. With no scope session,
+ * every row ranks equally.
+ */
+function sessionScopeRank(entry: SkillActiveEntry, sessionId?: string): number {
+	const scope = safeString(sessionId).trim();
+	if (!scope) return 0;
+	const entrySession = safeString(entry.session_id).trim();
+	if (entrySession === scope) return 2;
+	if (entrySession.length === 0) return 1;
+	return 0;
+}
+
+/**
+ * Pick the surviving row for a single skill within a session-scoped visible set.
+ * Precedence, highest first:
+ *   1. exact-session ownership over a session-less fallback row,
+ *   2. a strictly-newer valid timestamp,
+ *   3. a valid timestamp over a missing/unparseable one,
+ *   4. active over inactive — so an untrustworthy inactive row can never hide an
+ *      active row — then merge order for a total tie.
+ * A genuine handoff demotion still supersedes a stale active row of the same skill
+ * because, within one session scope, it carries the newest valid timestamp.
+ */
+function moreVisibleEntry(
+	incumbent: SkillActiveEntry,
+	challenger: SkillActiveEntry,
+	sessionId?: string,
+): SkillActiveEntry {
+	const scopeDelta = sessionScopeRank(incumbent, sessionId) - sessionScopeRank(challenger, sessionId);
+	if (scopeDelta !== 0) return scopeDelta > 0 ? incumbent : challenger;
+	const ri = entryRecency(incumbent);
+	const rc = entryRecency(challenger);
+	const vi = Number.isFinite(ri);
+	const vc = Number.isFinite(rc);
+	if (vi && vc && ri !== rc) return ri > rc ? incumbent : challenger;
+	if (vi !== vc) return vi ? incumbent : challenger;
+	const incumbentActive = incumbent.active !== false;
+	const challengerActive = challenger.active !== false;
+	if (incumbentActive !== challengerActive) return incumbentActive ? incumbent : challenger;
+	return incumbent;
 }
 
 /**
@@ -358,17 +428,16 @@ function entryRecency(entry: SkillActiveEntry): number {
  * `filterRootEntriesForSession`) plus a later, session-scoped handoff demotion
  * of the same skill. Without this collapse the HUD renders the same workflow
  * twice and keeps showing a skill that has already handed control to its
- * successor. The most recently updated row wins, so a handoff demotion
- * (`active:false`, newest timestamp) supersedes an older stale `active:true`
- * row of the same skill and is then dropped by the active filter below.
+ * successor. `moreVisibleEntry` picks the winner so a handoff demotion supersedes
+ * an older stale `active:true` row (and is then dropped by the active filter
+ * below) while a session's own active row is never hidden by a session-less or
+ * untrustworthy-timestamp row.
  */
-function dedupeVisibleBySkill(entries: SkillActiveEntry[]): SkillActiveEntry[] {
+function dedupeVisibleBySkill(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
 	const winners = new Map<string, SkillActiveEntry>();
 	for (const entry of entries) {
 		const current = winners.get(entry.skill);
-		if (!current || entryRecency(entry) >= entryRecency(current)) {
-			winners.set(entry.skill, entry);
-		}
+		winners.set(entry.skill, current ? moreVisibleEntry(current, entry, sessionId) : entry);
 	}
 	return [...winners.values()];
 }
@@ -396,8 +465,17 @@ export function collapsePlanningPipeline(entries: readonly SkillActiveEntry[]): 
 	const pipeline = entries.filter(entry => PLANNING_PIPELINE_SKILLS.has(entry.skill));
 	if (pipeline.length <= 1) return [...entries];
 	let current = pipeline[0];
+	let currentRecency = entryRecency(current);
 	for (const entry of pipeline) {
-		if (entryRecency(entry) >= entryRecency(current)) current = entry;
+		const recency = entryRecency(entry);
+		// Prefer a strictly-newer valid timestamp; a valid timestamp also beats a
+		// missing/unparseable one. Ties (or all-invalid) keep the first stage
+		// deterministically rather than letting an unknown-recency row win.
+		const better = Number.isFinite(recency) && (!Number.isFinite(currentRecency) || recency > currentRecency);
+		if (better) {
+			current = entry;
+			currentRecency = recency;
+		}
 	}
 	return entries.filter(entry => !PLANNING_PIPELINE_SKILLS.has(entry.skill) || entry === current);
 }
@@ -414,7 +492,7 @@ function mergeVisibleEntries(
 	for (const entry of rawActiveEntries(sessionState)) {
 		merged.set(entryKey(entry), entry);
 	}
-	return dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
+	return dedupeVisibleBySkill([...merged.values()], sessionId).filter(entry => entry.active !== false);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -384,12 +384,17 @@ function dedupeVisibleBySkill(entries: SkillActiveEntry[]): SkillActiveEntry[] {
  * stage so the HUD reflects the single current workflow. `team` is intentionally
  * excluded — it runs alongside ultragoal — and every non-pipeline skill is left
  * untouched.
+ *
+ * This is a HUD-display policy only. It is applied by the skill HUD renderer and
+ * deliberately NOT folded into `readVisibleSkillActiveState`, whose callers (the
+ * deep-interview mutation guard and handoff caller inference) must keep seeing
+ * every genuinely-active skill rather than the single most-recent pipeline stage.
  */
 const PLANNING_PIPELINE_SKILLS = new Set<string>(["deep-interview", "ralplan", "ultragoal"]);
 
-function collapsePlanningPipeline(entries: SkillActiveEntry[]): SkillActiveEntry[] {
+export function collapsePlanningPipeline(entries: readonly SkillActiveEntry[]): SkillActiveEntry[] {
 	const pipeline = entries.filter(entry => PLANNING_PIPELINE_SKILLS.has(entry.skill));
-	if (pipeline.length <= 1) return entries;
+	if (pipeline.length <= 1) return [...entries];
 	let current = pipeline[0];
 	for (const entry of pipeline) {
 		if (entryRecency(entry) >= entryRecency(current)) current = entry;
@@ -409,8 +414,7 @@ function mergeVisibleEntries(
 	for (const entry of rawActiveEntries(sessionState)) {
 		merged.set(entryKey(entry), entry);
 	}
-	const active = dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
-	return collapsePlanningPipeline(active);
+	return dedupeVisibleBySkill([...merged.values()]).filter(entry => entry.active !== false);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -297,6 +297,87 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
+	it("keeps an active session-scoped row visible despite a newer session-less inactive same-skill row", async () => {
+		await withTempCwd(async cwd => {
+			// A session-less (global) deep-interview row was handed off (inactive,
+			// newest), but the current session still has its own active interview.
+			// Session ownership must win so the mutation guard still sees it.
+			const { rootPath } = getSkillActiveStatePaths(cwd, "sess1");
+			await fs.mkdir(path.dirname(rootPath), { recursive: true });
+			await fs.writeFile(
+				rootPath,
+				JSON.stringify({
+					version: 1,
+					active: true,
+					skill: "deep-interview",
+					active_skills: [
+						{
+							skill: "deep-interview",
+							phase: "interviewing",
+							active: true,
+							session_id: "sess1",
+							updated_at: "2026-01-01T00:00:00.000Z",
+						},
+						{
+							skill: "deep-interview",
+							phase: "handoff",
+							active: false,
+							updated_at: "2026-01-01T00:09:00.000Z",
+							handoff_to: "ralplan",
+						},
+					],
+				}),
+			);
+
+			const visible = await readVisibleSkillActiveState(cwd, "sess1");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["deep-interview"]);
+		});
+	});
+
+	it("does not let an inactive same-skill row without a valid timestamp hide an active row", async () => {
+		await withTempCwd(async cwd => {
+			// Root read (no session scope) with two same-skill rows that carry no
+			// trustworthy timestamp. The active row must win the tie instead of an
+			// inactive row suppressing it by merge order.
+			const { rootPath } = getSkillActiveStatePaths(cwd);
+			await fs.mkdir(path.dirname(rootPath), { recursive: true });
+			await fs.writeFile(
+				rootPath,
+				JSON.stringify({
+					version: 1,
+					active: true,
+					skill: "deep-interview",
+					active_skills: [
+						{ skill: "deep-interview", phase: "interviewing", active: true, session_id: "a" },
+						{ skill: "deep-interview", phase: "handoff", active: false, session_id: "b" },
+					],
+				}),
+			);
+
+			const visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["deep-interview"]);
+			expect(visible?.active_skills?.[0]?.phase).toBe("interviewing");
+		});
+	});
+
+	it("surfaces legacy top-level active state through the visible read", async () => {
+		await withTempCwd(async cwd => {
+			// Pre-`active_skills` state files stored a single workflow at the top
+			// level with no `active_skills` array. The raw visible read must still
+			// surface it for the HUD, mutation guard, and caller inference.
+			const { rootPath } = getSkillActiveStatePaths(cwd);
+			await fs.mkdir(path.dirname(rootPath), { recursive: true });
+			await fs.writeFile(
+				rootPath,
+				JSON.stringify({ version: 1, active: true, skill: "deep-interview", phase: "intent-first" }),
+			);
+
+			const visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["deep-interview"]);
+			expect(visible?.active_skills?.[0]?.phase).toBe("intent-first");
+		});
+	});
+
 	it("keeps the canonical GJC workflow skill set intentionally small", () => {
 		expect(CANONICAL_GJC_WORKFLOW_SKILLS).toEqual(["deep-interview", "ralplan", "ultragoal", "team"]);
 	});

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -268,12 +268,13 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
-	it("supersedes an upstream pipeline skill when a later stage is activated without a handoff verb", async () => {
+	it("keeps every active pipeline skill at the read layer (HUD pipeline collapse is render-only)", async () => {
 		await withTempCwd(async cwd => {
-			// `gjc ralplan` then `gjc ultragoal` each activate their own row; the
-			// ultragoal activation does not demote ralplan, so without the pipeline
-			// collapse the HUD would render ralplan + ultragoal. Only the current
-			// (most-recently-activated) stage should remain.
+			// `gjc ralplan` then `gjc ultragoal` each activate their own row without
+			// demoting the other. The shared read keeps both so blocking consumers
+			// (deep-interview mutation guard, handoff caller inference) still see the
+			// true active set; collapsing to the current stage is the HUD renderer's
+			// job, covered in skill-hud-bar.test.ts.
 			await syncSkillActiveState({
 				cwd,
 				skill: "ralplan",
@@ -292,29 +293,7 @@ describe("GJC skill-active state", () => {
 			});
 
 			const visible = await readVisibleSkillActiveState(cwd);
-			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ultragoal"]);
-		});
-	});
-
-	it("keeps team alongside ultragoal since team is not part of the planning pipeline", async () => {
-		await withTempCwd(async cwd => {
-			await syncSkillActiveState({
-				cwd,
-				skill: "ultragoal",
-				phase: "executing",
-				active: true,
-				nowIso: "2026-01-01T00:00:00.000Z",
-			});
-			await syncSkillActiveState({
-				cwd,
-				skill: "team",
-				phase: "running",
-				active: true,
-				nowIso: "2026-01-01T00:05:00.000Z",
-			});
-
-			const visible = await readVisibleSkillActiveState(cwd);
-			expect(visible?.active_skills?.map(entry => entry.skill).sort()).toEqual(["team", "ultragoal"]);
+			expect(visible?.active_skills?.map(entry => entry.skill).sort()).toEqual(["ralplan", "ultragoal"]);
 		});
 	});
 

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -142,6 +142,37 @@ describe("skill HUD bar renderer", () => {
 		expect(rendered).not.toContain("ultragoal");
 	});
 
+	it("collapses the planning pipeline to the most-recently-activated stage", () => {
+		// `gjc ralplan` then `gjc ultragoal` activate their own rows without
+		// running the handoff verb, so both arrive at the HUD active. Only the
+		// current (newest) stage should render.
+		const rendered = Bun.stripANSI(
+			renderSkillHudBar(
+				[
+					{ skill: "ralplan", phase: "final", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
+					{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
+				],
+				80,
+			) ?? "",
+		);
+		expect(rendered).toContain("ultragoal:executing");
+		expect(rendered).not.toContain("ralplan");
+	});
+
+	it("keeps team alongside ultragoal since team is not part of the planning pipeline", () => {
+		const rendered = Bun.stripANSI(
+			renderSkillHudBar(
+				[
+					{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
+					{ skill: "team", phase: "running", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
+				],
+				80,
+			) ?? "",
+		);
+		expect(rendered).toContain("ultragoal:executing");
+		expect(rendered).toContain("team:running");
+	});
+
 	it("does not emit warn:stale for an entry without explicit stale flag (no 24h derivation)", () => {
 		// Pre-G003 the renderer relied on withDerivedStale to flag aged entries.
 		// Post-G003, only explicit `entry.stale === true` produces the chip.


### PR DESCRIPTION
Follow-up to #176 (which merged the initial HUD handoff fix). This hardens the skill-HUD visible-state logic per an architect review.

## Background

#176 made the HUD show only the currently-active planning stage. The merged version folded the `deep-interview → ralplan → ultragoal` pipeline collapse into the **shared** `readVisibleSkillActiveState`. That shared read is also consumed by the **deep-interview mutation guard** (`isActiveDeepInterview`) and **handoff caller inference** (`inferModeFromActiveState`), which must keep seeing every genuinely-active skill — so a display-only collapse there could weaken the mutation boundary in edge cases.

## Changes

- **Scope the pipeline collapse to the renderer.** `collapsePlanningPipeline` is now exported and applied only in `renderSkillHudBar`; the shared read no longer collapses cross-skill. Guard/inference keep the true active set; the HUD still shows one stage. `team` stays alongside `ultragoal`.
- **Session-aware same-skill dedup.** `moreVisibleEntry`/`sessionScopeRank`: an exact-session row outranks a session-less fallback row, so a session's own active workflow can't be hidden by a newer session-less inactive same-skill row (no fail-open for the mutation guard).
- **Recency must be a strictly-newer VALID timestamp.** `entryRecency` returns `NaN` for missing/unparseable stamps; the comparator prefers `active` on ties, so an untrustworthy inactive row can't suppress an active one. `collapsePlanningPipeline` is NaN-safe and order-independent.
- **Legacy top-level state preserved.** `rawActiveEntries` synthesizes the single top-level entry when `active_skills` is absent and `active:true && skill`, so legacy `{active:true, skill}` files remain visible to the HUD/guard/inference.

A genuine same-scope handoff demotion (newest valid timestamp) still supersedes a stale active same-skill row, so on-disk state self-heals.

## Tests

New/updated in `skill-active-state.test.ts` and `skill-hud-bar.test.ts`:
- exact-session active row survives a newer session-less inactive same-skill row
- no-timestamp tie prefers the active row
- legacy top-level active state surfaces through `readVisibleSkillActiveState`
- shared read keeps every active pipeline skill (collapse is render-only)
- renderer collapses the pipeline to the most-recent stage; team coexists with ultragoal
- self-heal of stale on-disk rows preserved

126 affected tests pass; `tsc` clean for changed files (the pre-existing `runtime-mcp/oauth-flow.ts` error is unrelated and already on `dev`); biome clean.