### PR TITLE
Make web_search permissionless by default

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -13,6 +13,7 @@
   - `packages/coding-agent/src/web/search/providers/utils.ts` — credential lookup; source normalization.
   - `packages/coding-agent/src/web/search/providers/anthropic.ts` — Anthropic model web-search provider.
   - `packages/coding-agent/src/web/search/providers/brave.ts` — Brave Search API adapter.
+  - `packages/coding-agent/src/web/search/providers/duckduckgo.ts` — keyless DuckDuckGo html/lite scrape adapter (permissionless default/fallback).
   - `packages/coding-agent/src/web/search/providers/openai-code.ts` — OpenAI code provider SSE adapter.
   - `packages/coding-agent/src/web/search/providers/exa.ts` — Exa API adapter.
   - `packages/coding-agent/src/web/search/providers/gemini.ts` — Gemini grounding SSE adapter.
@@ -69,11 +70,12 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 
 ## Flow
 1. `WebSearchTool.execute()` in `packages/coding-agent/src/web/search/index.ts` delegates directly to `executeSearch()`.
-2. `executeSearch()` chooses a provider list:
-   - if `params.provider` is set and not `"auto"`, it loads that provider with `getSearchProvider()`; if `isAvailable()` returns true, the list is `[that provider]`, otherwise it falls back to `resolveProviderChain("auto")`.
-   - otherwise it calls `resolveProviderChain()` with the module-global preferred provider from `packages/coding-agent/src/web/search/provider.ts`.
-3. `resolveProviderChain()` lazily loads each provider module on demand, checks `isAvailable()`, and returns only available providers. If a preferred provider is set, it is tried first, then the static `SEARCH_PROVIDER_ORDER` excluding that provider.
-4. If no providers are available, `executeSearch()` returns `Error: No web search provider configured.` with `details.response.provider = "none"`.
+2. `executeSearch()` resolves the provider list via a single `resolveProviderChain(authStorage, params.provider ?? "auto", activeModelProvider)` call. The active model's provider is threaded in from `WebSearchTool` (`this.#session.model?.provider`, falling back to parsing `getActiveModelString()`) and from the CustomTool path (`ctx.model?.provider`).
+3. `resolveProviderChain()` is active-model-gated, not credential-scanning:
+   - an explicitly preferred/selected provider that is `isAvailable()` becomes the primary;
+   - otherwise the active model's own native search (`MODEL_PROVIDER_TO_SEARCH`) becomes the primary, but only when that provider's own credentials exist (`isAvailable()`);
+   - keyed standalone providers are never auto-selected — explicit selection only.
+4. DuckDuckGo (keyless, `isAvailable()` always true) is always appended as the terminal fallback, so a missing primary — or a primary runtime failure — still returns results with zero configuration. There is no longer a "No web search provider configured" path.
 5. For each provider in order, `executeSearch()` calls `provider.search()` with:
    - `query` after year-rewrite,
    - `limit`, `recency`, `temperature`, `maxOutputTokens`, `numSearchResults`,
@@ -88,9 +90,9 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 
 ## Modes / Variants
 - **Provider selection**
-  - **Forced provider**: internal callers may pass `provider`; unavailable forced providers fall back to the auto chain instead of hard-failing (`packages/coding-agent/src/web/search/index.ts`). This field is not in the model-facing schema.
-  - **Preferred provider**: `setPreferredSearchProvider()` sets a module-global default used by `resolveProviderChain()`. `packages/coding-agent/src/sdk.ts` and `packages/coding-agent/src/modes/controllers/selector-controller.ts` wire this from settings.
-  - **Auto chain order**: `tavily`, `perplexity`, `brave`, `jina`, `kimi`, `anthropic`, `gemini`, `openai-code`, `zai`, `exa`, `parallel`, `kagi`, `synthetic`, `searxng` (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/provider.ts`).
+  - **Forced provider**: internal callers may pass `provider`; an unavailable forced provider falls back to the chain (which always ends in DuckDuckGo) instead of hard-failing (`packages/coding-agent/src/web/search/index.ts`). This field is not in the model-facing schema.
+  - **Preferred provider**: `setPreferredSearchProvider()` sets a module-global default consumed by `resolveProviderChain()`. `packages/coding-agent/src/sdk.ts` and `packages/coding-agent/src/modes/controllers/selector-controller.ts` wire this from settings.
+  - **Active-model-gated auto**: in `auto` mode, resolution maps the active model's provider to its own native search via `MODEL_PROVIDER_TO_SEARCH` (`openai|openai-codex→codex`, `anthropic→anthropic`, `google|google-gemini-cli|google-antigravity|gemini→gemini`, `moonshot|kimi-code|kimi→kimi`, `zai`, `perplexity`, `synthetic`), used only if that provider's creds exist; everything else falls to DuckDuckGo. `SEARCH_PROVIDER_ORDER` no longer drives auto credential scanning — it is retained for explicit selection, labels, and CLI option lists.
 - **Provider adapters**
   - **Tavily** — `packages/coding-agent/src/web/search/providers/tavily.ts`
     - Availability: API key from env or `agent.db` via `findCredential()`.
@@ -188,7 +190,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
   - Many provider adapters accept `AbortSignal`, but `WebSearchTool.execute()` does not pass its `_signal` into `executeSearch()`. Internal callers can still use cancellation by calling `runSearchQuery()` / `executeSearch()` with `signal` embedded in params.
 
 ## Limits & Caps
-- Provider auto-order length: 14 providers (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/provider.ts`).
+- Provider registry size: 15 providers (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/provider.ts`), including the keyless `duckduckgo` default/fallback. `SEARCH_PROVIDER_ORDER` no longer drives auto selection — see "Active-model-gated auto" above.
 - `formatForLLM()` truncates source snippets and citation text to 240 chars (`packages/coding-agent/src/web/search/index.ts`).
 - `formatForLLM()` emits at most 3 search queries, each truncated to 120 chars (`packages/coding-agent/src/web/search/index.ts`).
 - Brave result count: default `10`, max `20` (`DEFAULT_NUM_RESULTS`, `MAX_NUM_RESULTS` in `packages/coding-agent/src/web/search/providers/brave.ts`).
@@ -202,7 +204,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 - Gemini retries: up to `3` retries per endpoint, base delay `1000` ms, rate-limit delay budget `5 * 60 * 1000` ms (`packages/coding-agent/src/web/search/providers/gemini.ts`).
 
 ## Errors
-- Tool-level no-provider case returns a normal tool result with `Error: No web search provider configured.`; it does not throw.
+- There is no "no provider configured" case: DuckDuckGo (keyless) is always appended as the terminal fallback, so the chain is never empty.
 - Tool-level all-failed case also returns a normal tool result with `Error: ...`; failures are summarized from the last attempted provider.
 - Provider adapters usually throw `SearchProviderError(provider, message, status)` for HTTP or protocol failures.
 - Availability probes intentionally swallow lookup errors and report `false` in many providers via `isApiKeyAvailable()`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Pruned bundled built-in themes to `red-claw` and `blue-crab`, with `blue-crab` now the default light-appearance theme.
 - Clarified ralplan role-agent handoff guidance so Planner/Architect/Critic return compact artifact receipts after `gjc ralplan --write --json` instead of duplicating full persisted verdict markdown into the parent context.
+- Made `web_search` permissionless by default with a keyless DuckDuckGo fallback, active-model-gated native provider selection, and explicit-only legacy provider selection so custom providers no longer auto-hit stray OpenAI/Codex OAuth credentials.
 
 ### Fixed
 

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -1044,18 +1044,18 @@ This tool is intentionally distinct from `fetch`: it executes page interactions 
 
 ### Search abstraction and fallback (`web/search/index.ts`, `provider.ts`)
 
-Provider registry (`SEARCH_PROVIDERS`) and fallback order (`SEARCH_PROVIDER_ORDER`) are defined in `provider.ts`:
+Provider registry (`PROVIDER_META`) and the explicit-selection/label/CLI order (`SEARCH_PROVIDER_ORDER`) are defined in `provider.ts`.
 
-`perplexity → brave → jina → kimi → anthropic → gemini → openai-code → zai → exa → tavily → kagi → synthetic`
+`resolveProviderChain(authStorage, preferredProvider, activeModelProvider?)` is active-model-gated, not credential-scanning:
 
-`resolveProviderChain(preferredProvider)` behavior:
-
-- If preferred is explicit (not `auto`) and `isAvailable()` is true, it is added first.
-- Remaining available providers are appended in fixed order, skipping duplicates.
+- If `preferredProvider` is explicit (not `auto`) and `isAvailable()` is true, it becomes the primary.
+- Otherwise the active model's own native search (`MODEL_PROVIDER_TO_SEARCH`: `openai|openai-codex→codex`, `anthropic`, `google|google-gemini-cli|google-antigravity|gemini→gemini`, `moonshot|kimi-code|kimi→kimi`, `zai`, `perplexity`, `synthetic`) becomes the primary, but only when that provider's own creds exist (`isAvailable()`).
+- Keyed standalone providers (brave/tavily/exa/kagi/jina/parallel/searxng) are never auto-selected — explicit selection only.
+- `duckduckgo` (keyless, always available) is appended as the terminal fallback, so a missing primary or a primary runtime failure still returns results with zero configuration.
 
 `executeSearch(...)` in `index.ts` then tries providers sequentially until one succeeds; it returns formatted text (`formatForLLM`) on first success. If all fail, it returns a synthesized error including provider list and last error.
 
-Explicit no-fallback path exists: if `params.provider !== "auto"` and `params.no_fallback` is true, only that provider is attempted (or none if unavailable).
+Explicit provider selection is not fail-closed: an explicitly selected provider that is unavailable or fails at runtime still falls back to the keyless `duckduckgo` terminal provider, which `resolveProviderChain` appends unconditionally.
 
 ### Auth/availability signals represented in code
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2530,6 +2530,7 @@ export const SETTINGS_SCHEMA = {
 		type: "enum",
 		values: [
 			"auto",
+			"duckduckgo",
 			"exa",
 			"brave",
 			"jina",
@@ -2554,7 +2555,12 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "auto",
 					label: "Auto",
-					description: "Preferred web-search provider",
+					description: "Active model's native search if its creds exist, else keyless DuckDuckGo",
+				},
+				{
+					value: "duckduckgo",
+					label: "DuckDuckGo",
+					description: "Keyless default — no API key or OAuth required",
 				},
 				{ value: "exa", label: "Exa", description: "Uses Exa API when EXA_API_KEY is set" },
 				{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -8,6 +8,7 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import type { AuthStorage } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { parseModelString } from "../../config/model-resolver";
 import type { CustomTool, CustomToolContext, RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme } from "../../modes/theme/theme";
 import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { type: "text" };
@@ -16,7 +17,7 @@ import { discoverAuthStorage } from "../../sdk";
 import type { ToolSession } from "../../tools";
 import { formatAge } from "../../tools/render-utils";
 import { throwIfAborted } from "../../tools/tool-errors";
-import { getSearchProvider, getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
+import { getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
 import type { SearchProviderId, SearchResponse } from "./types";
 import { SearchProviderError } from "./types";
@@ -115,10 +116,21 @@ function formatForLLM(response: SearchResponse): string {
 	return parts.join("\n");
 }
 
+/** Best-effort active model provider: prefer the resolved Model, fall back to parsing the model string. */
+function resolveActiveModelProvider(
+	modelProvider: string | undefined,
+	modelString: string | undefined,
+): string | undefined {
+	if (modelProvider) return modelProvider;
+	if (modelString) return parseModelString(modelString)?.provider;
+	return undefined;
+}
+
 interface ExecuteSearchOptions {
 	authStorage: AuthStorage;
 	sessionId?: string;
 	signal?: AbortSignal;
+	activeModelProvider?: string;
 }
 
 /** Execute web search */
@@ -127,20 +139,11 @@ async function executeSearch(
 	params: SearchQueryParams,
 	options: ExecuteSearchOptions,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const { authStorage, sessionId, signal } = options;
-	const providers =
-		params.provider && params.provider !== "auto"
-			? await getSearchProvider(params.provider).then(async provider =>
-					(await provider.isAvailable(authStorage)) ? [provider] : resolveProviderChain(authStorage, "auto"),
-				)
-			: await resolveProviderChain(authStorage);
-	if (providers.length === 0) {
-		const message = "No web search provider configured.";
-		return {
-			content: [{ type: "text" as const, text: `Error: ${message}` }],
-			details: { response: { provider: "none", sources: [] }, error: message },
-		};
-	}
+	const { authStorage, sessionId, signal, activeModelProvider } = options;
+	// Pass `params.provider` straight through: when omitted (the normal model-facing
+	// path) it is `undefined`, so `resolveProviderChain` applies the settings-configured
+	// preferred provider. Coalescing to "auto" here would silently bypass that preference.
+	const providers = await resolveProviderChain(authStorage, params.provider, activeModelProvider);
 
 	const failures: Array<{ provider: SearchProvider; error: unknown }> = [];
 	let lastProvider = providers[0];
@@ -207,13 +210,14 @@ async function executeSearch(
  */
 export async function runSearchQuery(
 	params: SearchQueryParams,
-	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal } = {},
+	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal; activeModelProvider?: string } = {},
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
 	const authStorage = options.authStorage ?? (await discoverAuthStorage());
 	return executeSearch("cli-web-search", params, {
 		authStorage,
 		sessionId: options.sessionId,
 		signal: options.signal,
+		activeModelProvider: options.activeModelProvider,
 	});
 }
 
@@ -247,7 +251,11 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 	): Promise<AgentToolResult<SearchRenderDetails>> {
 		const authStorage = this.#session.authStorage ?? (await discoverAuthStorage());
 		const sessionId = this.#session.getSessionId?.() ?? undefined;
-		return executeSearch(_toolCallId, params, { authStorage, sessionId, signal });
+		const activeModelProvider = resolveActiveModelProvider(
+			this.#session.model?.provider,
+			this.#session.getActiveModelString?.(),
+		);
+		return executeSearch(_toolCallId, params, { authStorage, sessionId, signal, activeModelProvider });
 	}
 }
 
@@ -267,7 +275,12 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	) {
 		const authStorage = ctx.modelRegistry?.authStorage ?? (await discoverAuthStorage());
 		const sessionId = ctx.sessionManager.getSessionId();
-		return executeSearch(toolCallId, params, { authStorage, sessionId, signal });
+		return executeSearch(toolCallId, params, {
+			authStorage,
+			sessionId,
+			signal,
+			activeModelProvider: ctx.model?.provider,
+		});
 	},
 
 	renderCall(args: SearchToolParams, options: RenderResultOptions, theme: Theme) {

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -93,6 +93,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: "SearXNG",
 		load: async () => new (await import("./providers/searxng")).SearXNGProvider(),
 	},
+	duckduckgo: {
+		id: "duckduckgo",
+		label: "DuckDuckGo",
+		load: async () => new (await import("./providers/duckduckgo")).DuckDuckGoProvider(),
+	},
 };
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();
@@ -119,6 +124,7 @@ export async function getSearchProvider(id: SearchProviderId): Promise<SearchPro
 }
 
 export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
+	"duckduckgo",
 	"tavily",
 	"perplexity",
 	"brave",
@@ -135,6 +141,30 @@ export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
 	"searxng",
 ];
 
+/**
+ * Map an active model's provider string to its own native web-search provider.
+ * Keys are real model provider ids (see packages/ai/src/types.ts KnownProvider);
+ * a few aliases (gemini/kimi) and API strings (openai-responses) are tolerated
+ * defensively. Providers absent from this map (custom/unknown) fall through to
+ * DuckDuckGo.
+ */
+const MODEL_PROVIDER_TO_SEARCH: Record<string, SearchProviderId> = {
+	openai: "codex",
+	"openai-codex": "codex",
+	"openai-responses": "codex",
+	anthropic: "anthropic",
+	google: "gemini",
+	"google-gemini-cli": "gemini",
+	"google-antigravity": "gemini",
+	gemini: "gemini",
+	moonshot: "kimi",
+	"kimi-code": "kimi",
+	kimi: "kimi",
+	zai: "zai",
+	perplexity: "perplexity",
+	synthetic: "synthetic",
+};
+
 /** Preferred provider set via settings (default: auto) */
 let preferredProvId: SearchProviderId | "auto" = "auto";
 
@@ -144,30 +174,45 @@ export function setPreferredSearchProvider(provider: SearchProviderId | "auto"):
 }
 
 /**
- * Determine which providers are configured and currently available.
- * Each candidate is loaded (and its `isAvailable()` called) only as the chain
- * is walked, so unconfigured providers never pay the load cost.
+ * Resolve the ordered provider chain for a search request.
+ *
+ * Resolution is active-model-gated, never credential-scanning:
+ *   1. An explicitly preferred provider (settings) that is available is primary.
+ *   2. Otherwise the active model's own native search is primary, but only when
+ *      that provider's own credentials are present (its `isAvailable()`).
+ *   3. DuckDuckGo (keyless) is always appended as the terminal fallback, so a
+ *      missing primary — or a primary runtime failure — still returns results
+ *      with zero configuration. Keyed standalone providers are never
+ *      auto-selected; they are reachable only via explicit selection (step 1).
  */
 export async function resolveProviderChain(
 	authStorage: AuthStorage,
 	preferredProvider: SearchProviderId | "auto" = preferredProvId,
+	activeModelProvider?: string,
 ): Promise<SearchProvider[]> {
-	const providers: SearchProvider[] = [];
+	const chain: SearchProviderId[] = [];
 
 	if (preferredProvider !== "auto") {
 		const provider = await getSearchProvider(preferredProvider);
 		if (await provider.isAvailable(authStorage)) {
-			providers.push(provider);
+			chain.push(preferredProvider);
+		}
+	} else if (activeModelProvider) {
+		const nativeId = MODEL_PROVIDER_TO_SEARCH[activeModelProvider.toLowerCase()];
+		if (nativeId) {
+			const provider = await getSearchProvider(nativeId);
+			if (await provider.isAvailable(authStorage)) {
+				chain.push(nativeId);
+			}
 		}
 	}
 
-	for (const id of SEARCH_PROVIDER_ORDER) {
-		if (id === preferredProvider) continue;
-		const provider = await getSearchProvider(id);
-		if (await provider.isAvailable(authStorage)) {
-			providers.push(provider);
-		}
-	}
+	// DuckDuckGo is the permissionless terminal fallback (deduped).
+	if (!chain.includes("duckduckgo")) chain.push("duckduckgo");
 
+	const providers: SearchProvider[] = [];
+	for (const id of chain) {
+		providers.push(await getSearchProvider(id));
+	}
 	return providers;
 }

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -1,0 +1,279 @@
+/**
+ * DuckDuckGo Web Search Provider
+ *
+ * Keyless, permissionless web search. Scrapes DuckDuckGo's no-JavaScript HTML
+ * endpoints and maps anchors/snippets into the unified SearchResponse shape
+ * (sources only — DuckDuckGo does not synthesize an answer).
+ *
+ * This is the zero-config default/fallback backend: it requires no API key and
+ * no OAuth, so `isAvailable()` is always true. Because DuckDuckGo applies
+ * anti-bot rate limiting (HTTP 202 / 403 / empty responses) from datacenter and
+ * VPN IPs, the provider is best-effort: it retries with backoff, rotates the
+ * user-agent, and alternates between the `html` and `lite` endpoints. When every
+ * attempt fails it throws a {@link SearchProviderError} rather than returning an
+ * empty success — it never falls through to keyed providers.
+ *
+ * Endpoints:
+ *   https://html.duckduckgo.com/html/  (primary)
+ *   https://lite.duckduckgo.com/lite/  (fallback markup)
+ *
+ * The HTML markup is liable to drift; the parser is deliberately small and is
+ * pinned by fixture-driven tests (see test/tools/web-search-duckduckgo.test.ts).
+ */
+
+import type { AuthStorage } from "@gajae-code/ai";
+
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const HTML_ENDPOINT = "https://html.duckduckgo.com/html/";
+const LITE_ENDPOINT = "https://lite.duckduckgo.com/lite/";
+
+const DEFAULT_NUM_RESULTS = 10;
+const MAX_NUM_RESULTS = 20;
+
+/** Endpoint order across retry attempts; rotates markup and user-agent. */
+const ATTEMPTS: Array<"html" | "lite"> = ["html", "lite", "html"];
+
+/** Backoff (ms) applied between attempts. Index 0 is unused (first attempt). */
+const BACKOFF_MS = [0, 400, 800];
+
+/** Realistic desktop user-agents rotated per attempt to dodge naive blocks. */
+const USER_AGENTS = [
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0",
+];
+
+/** Map our recency filter to DuckDuckGo's `df` time parameter. */
+const RECENCY_MAP: Record<"day" | "week" | "month" | "year", string> = {
+	day: "d",
+	week: "w",
+	month: "m",
+	year: "y",
+};
+
+interface ParsedResult {
+	title: string;
+	url: string;
+	snippet?: string;
+}
+
+/** Decode a small set of HTML entities without pulling in a DOM library. */
+function decodeEntities(input: string): string {
+	return input
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#0*39;|&#x0*27;|&apos;/gi, "'")
+		.replace(/&#x0*2f;/gi, "/")
+		.replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(Number(dec)))
+		.replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+		.replace(/&nbsp;/g, " ");
+}
+
+/** Strip tags, decode entities, and collapse whitespace from an HTML fragment. */
+function cleanText(fragment: string): string {
+	return decodeEntities(fragment.replace(/<[^>]+>/g, ""))
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Resolve a DuckDuckGo result href to the real destination URL. DuckDuckGo wraps
+ * external links in a `/l/?uddg=<encoded>` redirect; `lite` sometimes links
+ * directly. Returns null for unusable or internal links (so ads/redirect shells
+ * are dropped).
+ */
+export function decodeResultUrl(href: string): string | null {
+	let h = decodeEntities(href.trim());
+	if (!h || h.startsWith("#")) return null;
+	if (h.startsWith("//")) h = `https:${h}`;
+	let parsed: URL;
+	try {
+		parsed = new URL(h, "https://duckduckgo.com");
+	} catch {
+		return null;
+	}
+	const uddg = parsed.searchParams.get("uddg");
+	if (uddg) {
+		try {
+			const target = new URL(uddg);
+			if (target.protocol !== "http:" && target.protocol !== "https:") return null;
+			if (target.hostname.endsWith("duckduckgo.com")) return null;
+			return target.toString();
+		} catch {
+			return null;
+		}
+	}
+	// No redirect wrapper: accept only real external http(s) links.
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+	if (parsed.hostname.endsWith("duckduckgo.com")) return null;
+	return parsed.toString();
+}
+
+/** Parse results from the `html.duckduckgo.com/html/` markup. */
+export function parseHtmlResults(html: string): ParsedResult[] {
+	const titleRe = /<a\b[^>]*class="[^"]*\bresult__a\b[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+	const snippetRe = /<a\b[^>]*class="[^"]*\bresult__snippet\b[^"]*"[^>]*>([\s\S]*?)<\/a>/gi;
+	const snippets: string[] = [];
+	for (const m of html.matchAll(snippetRe)) snippets.push(cleanText(m[1]));
+
+	const results: ParsedResult[] = [];
+	let idx = 0;
+	for (const m of html.matchAll(titleRe)) {
+		const url = decodeResultUrl(m[1]);
+		const title = cleanText(m[2]);
+		const snippet = snippets[idx];
+		idx++;
+		if (!url || !title) continue;
+		results.push({ title, url, snippet: snippet || undefined });
+	}
+	return results;
+}
+
+/** Parse results from the `lite.duckduckgo.com/lite/` markup. */
+export function parseLiteResults(html: string): ParsedResult[] {
+	const linkRe = /<a\b[^>]*class="[^"]*\bresult-link\b[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+	const snippetRe = /<td\b[^>]*class="[^"]*\bresult-snippet\b[^"]*"[^>]*>([\s\S]*?)<\/td>/gi;
+	const snippets: string[] = [];
+	for (const m of html.matchAll(snippetRe)) snippets.push(cleanText(m[1]));
+
+	const results: ParsedResult[] = [];
+	let idx = 0;
+	for (const m of html.matchAll(linkRe)) {
+		const url = decodeResultUrl(m[1]);
+		const title = cleanText(m[2]);
+		const snippet = snippets[idx];
+		idx++;
+		if (!url || !title) continue;
+		results.push({ title, url, snippet: snippet || undefined });
+	}
+	return results;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("Aborted", "AbortError"));
+			return;
+		}
+		const timer = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				reject(new DOMException("Aborted", "AbortError"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+/** Fetch one endpoint and parse it. Throws on HTTP error, rate-limit, or empty parse. */
+async function fetchAndParse(
+	endpoint: "html" | "lite",
+	query: string,
+	df: string | undefined,
+	userAgent: string,
+	signal: AbortSignal | undefined,
+): Promise<ParsedResult[]> {
+	const url = endpoint === "html" ? HTML_ENDPOINT : LITE_ENDPOINT;
+	const body = new URLSearchParams({ q: query });
+	if (df) body.set("df", df);
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"User-Agent": userAgent,
+			Accept: "text/html,application/xhtml+xml",
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept-Language": "en-US,en;q=0.9",
+		},
+		body,
+		signal: withHardTimeout(signal),
+	});
+
+	// DuckDuckGo signals soft blocks with 202 (which is still response.ok).
+	if (response.status === 202) {
+		throw new SearchProviderError("duckduckgo", "duckduckgo: rate-limited (202)", 202);
+	}
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("duckduckgo", response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError("duckduckgo", `DuckDuckGo error (${response.status})`, response.status);
+	}
+
+	const text = await response.text();
+	const parsed = endpoint === "html" ? parseHtmlResults(text) : parseLiteResults(text);
+	if (parsed.length === 0) {
+		throw new SearchProviderError("duckduckgo", "duckduckgo: no parseable results (possible block)");
+	}
+	return parsed;
+}
+
+/** Execute a keyless DuckDuckGo web search with light resilience. */
+export async function searchDuckDuckGo(params: {
+	query: string;
+	num_results?: number;
+	recency?: "day" | "week" | "month" | "year";
+	signal?: AbortSignal;
+}): Promise<SearchResponse> {
+	const numResults = clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	const df = params.recency ? RECENCY_MAP[params.recency] : undefined;
+
+	let lastError: unknown;
+	for (let attempt = 0; attempt < ATTEMPTS.length; attempt++) {
+		if (params.signal?.aborted) throw new DOMException("Aborted", "AbortError");
+		if (BACKOFF_MS[attempt] > 0) await delay(BACKOFF_MS[attempt], params.signal);
+
+		const endpoint = ATTEMPTS[attempt];
+		const userAgent = USER_AGENTS[attempt % USER_AGENTS.length];
+		try {
+			const parsed = await fetchAndParse(endpoint, params.query, df, userAgent, params.signal);
+			const sources: SearchSource[] = parsed.slice(0, numResults).map(result => ({
+				title: result.title,
+				url: result.url,
+				snippet: result.snippet,
+			}));
+			return { provider: "duckduckgo", sources };
+		} catch (error) {
+			// A caller cancellation must abort immediately, never silently retry.
+			if (params.signal?.aborted) throw error;
+			lastError = error;
+		}
+	}
+
+	if (lastError instanceof SearchProviderError) throw lastError;
+	throw new SearchProviderError(
+		"duckduckgo",
+		`DuckDuckGo search failed after ${ATTEMPTS.length} attempts${
+			lastError instanceof Error ? `: ${lastError.message}` : ""
+		}`,
+	);
+}
+
+/** Keyless, permissionless web search provider backed by DuckDuckGo. */
+export class DuckDuckGoProvider extends SearchProvider {
+	readonly id = "duckduckgo";
+	readonly label = "DuckDuckGo";
+
+	isAvailable(_authStorage: AuthStorage): boolean {
+		return true;
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchDuckDuckGo({
+			query: params.query,
+			num_results: params.numSearchResults ?? params.limit,
+			recency: params.recency,
+			signal: params.signal,
+		});
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -6,6 +6,7 @@
 
 /** Supported web search providers */
 export type SearchProviderId =
+	| "duckduckgo"
 	| "exa"
 	| "brave"
 	| "jina"
@@ -23,6 +24,7 @@ export type SearchProviderId =
 
 export function isSearchProviderId(value: string): value is SearchProviderId {
 	return [
+		"duckduckgo",
 		"exa",
 		"brave",
 		"jina",

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import type { AuthStorage } from "../../src/session/auth-storage";
+import { runSearchQuery } from "../../src/web/search/index";
+import { resolveProviderChain, setPreferredSearchProvider } from "../../src/web/search/provider";
+import {
+	DuckDuckGoProvider,
+	decodeResultUrl,
+	parseHtmlResults,
+	parseLiteResults,
+	searchDuckDuckGo,
+} from "../../src/web/search/providers/duckduckgo";
+
+const HTML_FIXTURE = `<html><body>
+<div class="result results_links results_links_deep web-result">
+  <h2 class="result__title">
+    <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Falpha%3Fx%3D1&amp;rut=deadbeef">Alpha <b>Title</b></a>
+  </h2>
+  <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Falpha">Alpha <b>snippet</b> body.</a>
+</div>
+<div class="result result--ad">
+  <a class="result__a" href="//duckduckgo.com/y.js?ad_provider=foo">Sponsored</a>
+  <a class="result__snippet">Ad snippet</a>
+</div>
+<div class="result results_links">
+  <h2 class="result__title">
+    <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.org%2Fbeta">Beta Title</a>
+  </h2>
+  <a class="result__snippet">Beta snippet text.</a>
+</div>
+</body></html>`;
+
+const LITE_FIXTURE = `<html><body><table>
+<tr>
+  <td><a class="result-link" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Flite.example.com%2Fgamma">Gamma Title</a></td>
+</tr>
+<tr><td class="result-snippet">Gamma snippet text.</td></tr>
+<tr>
+  <td><a class="result-link" href="https://direct.example.net/delta">Delta Title</a></td>
+</tr>
+<tr><td class="result-snippet">Delta snippet.</td></tr>
+</table></body></html>`;
+
+/** Minimal AuthStorage stub exposing only the credential probes providers consult. */
+function fakeAuth(opts: { oauth?: string[]; auth?: string[] } = {}): AuthStorage {
+	const oauth = new Set(opts.oauth ?? []);
+	const auth = new Set([...(opts.auth ?? []), ...(opts.oauth ?? [])]);
+	return {
+		hasOAuth: (provider: string) => oauth.has(provider),
+		hasAuth: (provider: string) => auth.has(provider),
+	} as unknown as AuthStorage;
+}
+
+async function chainIds(...args: Parameters<typeof resolveProviderChain>): Promise<string[]> {
+	const providers = await resolveProviderChain(...args);
+	return providers.map(p => p.id);
+}
+
+// Web-search availability is env-sensitive; isolate it so resolution is deterministic.
+const SEARCH_ENV_KEYS = [
+	"ANTHROPIC_SEARCH_API_KEY",
+	"BRAVE_API_KEY",
+	"EXA_API_KEY",
+	"JINA_API_KEY",
+	"MOONSHOT_SEARCH_API_KEY",
+	"KIMI_SEARCH_API_KEY",
+	"PERPLEXITY_COOKIES",
+	"PERPLEXITY_API_KEY",
+	"TAVILY_API_KEY",
+	"KAGI_API_KEY",
+	"PARALLEL_API_KEY",
+	"SEARXNG_ENDPOINT",
+	"ZAI_API_KEY",
+	"SYNTHETIC_API_KEY",
+];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+	for (const key of SEARCH_ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const key of SEARCH_ENV_KEYS) {
+		if (savedEnv[key] === undefined) delete process.env[key];
+		else process.env[key] = savedEnv[key];
+	}
+});
+
+describe("DuckDuckGo URL decoding", () => {
+	it("decodes the uddg redirect to the real destination", () => {
+		expect(decodeResultUrl("//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa%3Fx%3D1&rut=z")).toBe(
+			"https://example.com/a?x=1",
+		);
+	});
+
+	it("accepts direct external links", () => {
+		expect(decodeResultUrl("https://direct.example.net/x")).toBe("https://direct.example.net/x");
+	});
+
+	it("drops internal/ad links and anchors", () => {
+		expect(decodeResultUrl("//duckduckgo.com/y.js?ad_provider=foo")).toBeNull();
+		expect(decodeResultUrl("#")).toBeNull();
+		// uddg shell that points back at duckduckgo is an ad redirect.
+		expect(decodeResultUrl("//duckduckgo.com/l/?uddg=https%3A%2F%2Fduckduckgo.com%2Fy.js")).toBeNull();
+	});
+});
+
+describe("DuckDuckGo HTML parsing (fixture-pinned)", () => {
+	it("parses the html endpoint markup, pairing snippets and skipping ads", () => {
+		expect(parseHtmlResults(HTML_FIXTURE)).toEqual([
+			{ title: "Alpha Title", url: "https://example.com/alpha?x=1", snippet: "Alpha snippet body." },
+			{ title: "Beta Title", url: "https://example.org/beta", snippet: "Beta snippet text." },
+		]);
+	});
+
+	it("parses the lite endpoint markup", () => {
+		expect(parseLiteResults(LITE_FIXTURE)).toEqual([
+			{ title: "Gamma Title", url: "https://lite.example.com/gamma", snippet: "Gamma snippet text." },
+			{ title: "Delta Title", url: "https://direct.example.net/delta", snippet: "Delta snippet." },
+		]);
+	});
+});
+
+describe("DuckDuckGo provider search", () => {
+	it("is always available (keyless)", () => {
+		const provider = new DuckDuckGoProvider();
+		expect(provider.id).toBe("duckduckgo");
+		expect(provider.isAvailable({} as AuthStorage)).toBe(true);
+	});
+
+	it("returns sources parsed from the html endpoint", async () => {
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://html.duckduckgo.com")) return new Response(HTML_FIXTURE, { status: 200 });
+			return new Response("", { status: 500 });
+		});
+		const response = await searchDuckDuckGo({ query: "alpha" });
+		expect(response.provider).toBe("duckduckgo");
+		expect(response.sources.map(s => s.url)).toEqual(["https://example.com/alpha?x=1", "https://example.org/beta"]);
+	});
+
+	it("falls back from html (202 block) to the lite endpoint", async () => {
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://html.duckduckgo.com")) return new Response("", { status: 202 });
+			if (url.startsWith("https://lite.duckduckgo.com")) return new Response(LITE_FIXTURE, { status: 200 });
+			return new Response("", { status: 500 });
+		});
+		const response = await searchDuckDuckGo({ query: "gamma" });
+		expect(response.sources[0]?.url).toBe("https://lite.example.com/gamma");
+	});
+
+	it("rotates the user-agent across attempts and throws after all fail", async () => {
+		const userAgents: string[] = [];
+		using _hook = hookFetch((_input, init) => {
+			userAgents.push(new Headers(init?.headers).get("user-agent") ?? "");
+			return new Response("", { status: 202 });
+		});
+		await expect(searchDuckDuckGo({ query: "blocked" })).rejects.toThrow(/rate-limited|failed/i);
+		expect(userAgents.length).toBe(3);
+		expect(new Set(userAgents).size).toBeGreaterThan(1);
+	});
+
+	it("aborts immediately on an already-aborted signal without fetching", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let fetched = false;
+		using _hook = hookFetch(() => {
+			fetched = true;
+			return new Response(HTML_FIXTURE, { status: 200 });
+		});
+		await expect(searchDuckDuckGo({ query: "x", signal: controller.signal })).rejects.toThrow();
+		expect(fetched).toBe(false);
+	});
+});
+
+describe("resolveProviderChain — active-model-gated resolution", () => {
+	it("uses an explicitly selected available provider, with DuckDuckGo appended", async () => {
+		expect(await chainIds(fakeAuth({ auth: ["anthropic"] }), "anthropic")).toEqual(["anthropic", "duckduckgo"]);
+	});
+
+	it("dedupes when DuckDuckGo is explicitly selected", async () => {
+		expect(await chainIds(fakeAuth(), "duckduckgo")).toEqual(["duckduckgo"]);
+	});
+
+	it("falls back to DuckDuckGo when the explicitly selected provider is unavailable", async () => {
+		expect(await chainIds(fakeAuth(), "anthropic")).toEqual(["duckduckgo"]);
+	});
+
+	it("uses the active model's native search when its own creds exist", async () => {
+		expect(await chainIds(fakeAuth({ auth: ["anthropic"] }), "auto", "anthropic")).toEqual([
+			"anthropic",
+			"duckduckgo",
+		]);
+	});
+
+	it("falls back to DuckDuckGo when the active model's native search lacks creds", async () => {
+		expect(await chainIds(fakeAuth(), "auto", "anthropic")).toEqual(["duckduckgo"]);
+	});
+
+	it("falls back to DuckDuckGo for custom/unknown model providers", async () => {
+		expect(await chainIds(fakeAuth(), "auto", "my-custom-llm")).toEqual(["duckduckgo"]);
+	});
+
+	it("falls back to DuckDuckGo when no active model is known", async () => {
+		expect(await chainIds(fakeAuth(), "auto")).toEqual(["duckduckgo"]);
+	});
+
+	it("maps real registry provider strings to their native search", async () => {
+		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai")).toEqual(["codex", "duckduckgo"]);
+		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai-codex")).toEqual([
+			"codex",
+			"duckduckgo",
+		]);
+		expect(await chainIds(fakeAuth({ oauth: ["google-gemini-cli"] }), "auto", "google-gemini-cli")).toEqual([
+			"gemini",
+			"duckduckgo",
+		]);
+		expect(await chainIds(fakeAuth({ oauth: ["google-antigravity"] }), "auto", "google-antigravity")).toEqual([
+			"gemini",
+			"duckduckgo",
+		]);
+		expect(await chainIds(fakeAuth({ auth: ["kimi-code"] }), "auto", "kimi-code")).toEqual(["kimi", "duckduckgo"]);
+	});
+
+	it("never auto-selects keyed standalone providers even when their key is present", async () => {
+		process.env.BRAVE_API_KEY = "present";
+		expect(await chainIds(fakeAuth(), "auto", "my-custom-llm")).toEqual(["duckduckgo"]);
+	});
+
+	it("REGRESSION: a stray openai-codex OAuth on a non-OpenAI model resolves to DuckDuckGo, not codex", async () => {
+		// This is the reported bug: auto mode used to 401 on a custom model because a
+		// stray OpenAI OAuth credential was selected. It must now resolve to DuckDuckGo.
+		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "my-custom-llm")).toEqual(["duckduckgo"]);
+	});
+});
+
+describe("executeSearch fallback", () => {
+	it("falls back to DuckDuckGo when an explicitly selected provider fails at runtime", async () => {
+		process.env.BRAVE_API_KEY = "test-key";
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://api.search.brave.com")) return new Response("upstream error", { status: 500 });
+			if (url.startsWith("https://html.duckduckgo.com")) return new Response(HTML_FIXTURE, { status: 200 });
+			return new Response("", { status: 404 });
+		});
+		const result = await runSearchQuery({ query: "alpha", provider: "brave" }, { authStorage: fakeAuth() });
+		expect(result.details.response.provider).toBe("duckduckgo");
+		expect(result.content[0]?.text).toContain("example.com/alpha");
+	});
+});
+
+describe("executeSearch honors the configured preferred provider", () => {
+	afterEach(() => setPreferredSearchProvider("auto"));
+
+	it("uses the settings-configured preferred provider when params.provider is omitted", async () => {
+		// Regression: the model-facing schema has no `provider` field, so executeSearch must
+		// NOT coalesce the omitted value to "auto" — that would bypass providers.webSearch.
+		process.env.BRAVE_API_KEY = "test-key";
+		setPreferredSearchProvider("brave");
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://api.search.brave.com")) {
+				return new Response(
+					JSON.stringify({
+						web: { results: [{ title: "Brave", url: "https://brave.example/x", description: "d" }] },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url.startsWith("https://html.duckduckgo.com")) return new Response(HTML_FIXTURE, { status: 200 });
+			return new Response("", { status: 500 });
+		});
+
+		const result = await runSearchQuery({ query: "preference wins" }, { authStorage: fakeAuth() });
+		expect(result.details.response.provider).toBe("brave");
+	});
+});
+
+const RUN_LIVE_DDG_E2E = process.env.GJC_LIVE_DUCKDUCKGO_E2E === "1";
+
+describe.skipIf(!RUN_LIVE_DDG_E2E)("DuckDuckGo live e2e", () => {
+	it("returns real web results without credentials", async () => {
+		const response = await searchDuckDuckGo({ query: "anthropic claude", num_results: 5 });
+		expect(response.provider).toBe("duckduckgo");
+		expect(response.sources.length).toBeGreaterThan(0);
+		expect(response.sources[0]?.title.length).toBeGreaterThan(0);
+		expect(response.sources[0]?.url).toMatch(/^https?:\/\//);
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-exa.test.ts
+++ b/packages/coding-agent/test/tools/web-search-exa.test.ts
@@ -360,15 +360,22 @@ describe("searchExa", () => {
 		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
-	it.skip("runSearchQuery with provider=exa fails closed without EXA_API_KEY", async () => {
+	it("runSearchQuery with provider=exa falls back to DuckDuckGo without EXA_API_KEY", async () => {
 		delete process.env.EXA_API_KEY;
-		const fetchSpy = vi.fn(async () => new Response(JSON.stringify(makeMockExaResponse()), { status: 200 }));
-		using _hook = hookFetch(fetchSpy);
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://html.duckduckgo.com")) {
+				return new Response(
+					'<a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fx">X</a>',
+					{ status: 200 },
+				);
+			}
+			return new Response("", { status: 500 });
+		});
 
 		const result = await runSearchQuery({ query: "provider exa", provider: "exa" });
-		expect(result.details.error).toBeDefined();
-		expect(String(result.details.error)).toContain("No web search provider configured");
-		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(result.details.response.provider).toBe("duckduckgo");
+		expect(result.details.error).toBeUndefined();
 	});
 
 	it("throws SearchProviderError on non-ok HTTP response", async () => {


### PR DESCRIPTION
## Summary

- Add a keyless DuckDuckGo (`duckduckgo`) web-search provider using DuckDuckGo HTML/lite endpoints, retry/backoff, user-agent rotation, `uddg` decoding, and sources-only `SearchResponse` output.
- Rework `web_search` provider resolution to honor explicit settings first, then the active model's own native search when its credentials exist, then DuckDuckGo as the terminal permissionless fallback.
- Keep legacy/keyed providers intact but explicit-only; custom/unknown providers no longer auto-hit stray OpenAI/Codex OAuth credentials.
- Update settings, docs, changelog, and tests, including the Exa no-key behavior under the new DuckDuckGo fallback contract.

## Verification

- `bun test test/tools/web-search-*.test.ts` → 90 pass, 1 skip, 0 fail
- `GJC_LIVE_DUCKDUCKGO_E2E=1 bun test test/tools/web-search-duckduckgo.test.ts` → 23 pass, 0 fail (real live DuckDuckGo e2e)
- Direct live search via `searchDuckDuckGo({ query: "anthropic claude", num_results: 5 })` → provider `duckduckgo`, 5 real sources returned
- `bun run check:types` → exit 0
- `bun run check` → exit 0 after reporting pre-existing Biome optional-chain warnings, then `tsgo` passed
- Architect quality gate: architecture/product/code all `CLEAR`, recommendation `APPROVE` (`agent://5-ArchitectConfirm`)
- Executor red-team QA: 9 adversarial live/mocked cases passed, 0 bugs found (`agent://3-RedTeamQa`)

## Notes

- Live DuckDuckGo e2e is gated behind `GJC_LIVE_DUCKDUCKGO_E2E=1` so CI does not depend on external network/rate-limit conditions by default.
- Existing untracked `node_modules/` in this worktree was left untouched.
