### PR TITLE
[TeamMode reliability 1/6] Require evidence before task completion

### DIFF
--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -166,6 +166,9 @@ export default class Team extends Command {
 					"create-task read-task list-tasks update-task claim-task transition-task-status release-task-claim",
 					"read-config read-manifest read-worker-status read-worker-heartbeat update-worker-heartbeat write-worker-inbox write-worker-identity",
 					"append-event read-events await-event write-shutdown-request read-shutdown-ack read-monitor-snapshot write-monitor-snapshot read-task-approval write-task-approval",
+					"Completion example:",
+					'transition-task-status --input \'{"team_name":"demo","task_id":"task-1","to":"completed","claim_token":"...","completion_evidence":{"summary":"done","items":[{"kind":"command","status":"passed","summary":"focused tests passed","command":"bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"}]}}\' --json',
+					'Review-only completion may use {"kind":"inspection","status":"verified","summary":"review passed","location":"agent://review"}.',
 				]);
 				return;
 			}

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -217,8 +217,7 @@ Semantics:
 - `.gjc/state/team/<team>/telemetry.jsonl`
 - `.gjc/state/team/<team>/monitor-snapshot.json`
 - `.gjc/state/team/<team>/integration-report.md`
-- `.gjc/state/team/<team>/tasks/task-1.json`
-- `.gjc/state/team/<team>/evidence/tasks/task-1.json`
+- `.gjc/state/team/<team>/tasks/task-1.json` (includes structured `completion_evidence` after completed transitions)
 - `.gjc/state/team/<team>/mailbox/worker-1/<message-id>.json`
 - `.gjc/state/team/<team>/mailbox/worker-1.json` (legacy compatibility view)
 - `.gjc/state/team/<team>/notifications/<notification-id>.json`
@@ -233,15 +232,17 @@ Use `gjc team api` for machine-readable task lifecycle operations.
 ```bash
 gjc team api worker-startup-ack --input '{"team_name":"my-team","worker_id":"worker-1","protocol_version":"1"}' --json
 gjc team api claim-task --input '{"team_name":"my-team","worker_id":"worker-1"}' --json
-gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","worker_id":"worker-1","claim_token":"<claim-token>","evidence":"summary of completed work and validation"}' --json
+gjc team api transition-task-status --input '{"team_name":"my-team","task_id":"task-1","to":"completed","worker_id":"worker-1","claim_token":"<claim-token>","completion_evidence":{"summary":"Completed requested work and verified it locally.","items":[{"kind":"command","status":"passed","summary":"Focused test passed","command":"bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"}],"files":["packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"],"notes":"Include at least one passed command or verified inspection/artifact item."}}' --json
 ```
 
 Canonical worker lifecycle operations:
 
 - `worker-startup-ack` before task work
 - `claim-task`
-- `transition-task-status` with the claim token, worker id, and completion evidence
+- `transition-task-status` with the claim token, worker id, and structured `completion_evidence` object
 - `release-task-claim`
+
+Completion evidence is stored inline on the task record as `completion_evidence`. It must include a non-empty `summary`, an `items` array, and at least one item with `status: "passed"` or `status: "verified"`. Valid item kinds are `command`, `inspection`, and `artifact`; command items require `command`. The camel-case alias `completionEvidence` is accepted by the API input, but legacy string `evidence` and separate evidence files are not part of the public completion contract.
 
 GJC-team interop operations are also available for mailbox, native notification, worker heartbeat/status, startup ACK, events, monitor snapshots, approvals, and shutdown request/ack flows; run `gjc team api --help` for the full operation list.
 

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -165,12 +165,13 @@ Follow this exact lifecycle when running `$team`:
 
 1. Start team and verify startup evidence (team line, tmux target, worker pane id, state dir).
 2. Monitor task progress with runtime/state tools first (`gjc team status <team>`, `gjc team resume <team>`, task files).
-3. Wait for terminal task state before shutdown:
+3. Wait for terminal task state and integration settlement before shutdown:
    - `pending=0`
    - `in_progress=0`
    - `failed=0` (or explicitly acknowledged failure path)
+   - no pending integration request/conflict (`status` / `resume` must not report `phase=awaiting_integration`)
 4. Only then run `gjc team shutdown <team>`.
-5. Verify shutdown evidence and preserved state (`phase=complete`, worker status `stopped`). If shutdown is forced before task completion, expect `phase=cancelled` or `phase=failed`, not `complete`.
+5. Verify shutdown evidence and preserved state (`phase=complete`, worker status `stopped`). If shutdown is forced before task completion, expect `phase=cancelled` or `phase=failed`; if tasks are complete but integration is still pending or conflicted, expect `phase=awaiting_integration`, not `complete`.
 
 Do not run `shutdown` while the worker is actively writing updates unless user explicitly requested abort/cancel. Do not treat ad-hoc pane typing as primary control flow when runtime/state evidence is available.
 
@@ -198,7 +199,7 @@ Semantics:
 - `resume`: mutating monitor path; performs the same integration-aware live snapshot for reconnect/inspection flows.
 - `list`: pure read path; lists known teams without integrating worker commits.
 - API/read-only snapshot operations are pure unless explicitly documented as a monitor/status path.
-- `shutdown`: kills the recorded worker pane when it still belongs to the stored tmux target, removes clean created worktrees, marks worker stopped, and sets phase from task state: `complete` only when all tasks completed, `failed` when tasks failed/blocked, and `cancelled` when work remains pending or in progress. It preserves `.gjc/state/team/<team>` as evidence.
+- `shutdown`: kills the recorded worker pane when it still belongs to the stored tmux target, removes clean created worktrees, marks worker stopped, and sets phase from task and integration state: `complete` only when all tasks have verified `completion_evidence` and no integration request/conflict is pending, `awaiting_integration` when tasks are complete but leader integration still requires action, `failed` when tasks failed/blocked or completed tasks lack valid evidence, and `cancelled` when work remains pending or in progress. It preserves `.gjc/state/team/<team>` as evidence.
 
 ## Data Plane and Control Plane
 
@@ -351,7 +352,7 @@ When operating this skill, provide concrete progress evidence:
 1. Team started line (`Team started: <name>`)
 2. tmux target and worker pane id
 3. task state from `gjc team status <team>` or `.gjc/state/team/<team>/tasks/task-1.json`
-4. shutdown outcome (`phase=complete`, worker status `stopped`) when the run is terminal; incomplete shutdowns must report `phase=cancelled`/`failed`
+4. shutdown outcome (`phase=complete`, worker status `stopped`) when the run is terminal; incomplete or integration-blocked shutdowns must report `phase=cancelled`/`failed`/`awaiting_integration`
 
 Do not claim success without file/pane evidence.
 Do not claim clean completion if shutdown occurred with `in_progress>0`.

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -57,6 +57,27 @@ export interface GjcTeamTaskClaim {
 	token: string;
 	leased_until: string;
 }
+export type GjcTeamTaskCompletionEvidenceKind = "command" | "inspection" | "artifact";
+export type GjcTeamTaskCompletionEvidenceStatus = "passed" | "failed" | "not_run" | "verified" | "rejected";
+
+export interface GjcTeamTaskCompletionEvidenceItem {
+	kind: GjcTeamTaskCompletionEvidenceKind;
+	status: GjcTeamTaskCompletionEvidenceStatus;
+	summary: string;
+	command?: string;
+	artifact?: string;
+	location?: string;
+	output?: string;
+}
+
+export interface GjcTeamTaskCompletionEvidence {
+	summary: string;
+	items: GjcTeamTaskCompletionEvidenceItem[];
+	files?: string[];
+	notes?: string;
+	recorded_by: string;
+	recorded_at: string;
+}
 
 export interface GjcTeamTask {
 	id: string;
@@ -68,6 +89,7 @@ export interface GjcTeamTask {
 	assignee?: string;
 	owner?: string;
 	result?: string;
+	completion_evidence?: GjcTeamTaskCompletionEvidence;
 	error?: string;
 	blocked_by?: string[];
 	depends_on?: string[];
@@ -447,9 +469,6 @@ function safePathSegment(kind: string, value: string): string {
 function taskPath(dir: string, taskId: string): string {
 	return path.join(dir, "tasks", `${safePathSegment("task_id", taskId)}.json`);
 }
-function taskEvidencePath(dir: string, taskId: string): string {
-	return path.join(dir, "evidence", "tasks", `${safePathSegment("task_id", taskId)}.json`);
-}
 function mailboxPath(dir: string, worker: string): string {
 	return path.join(dir, "mailbox", `${safePathSegment("worker_id", worker)}.json`);
 }
@@ -662,12 +681,152 @@ async function resolveGjcTeamSnapshotPhase(
 	monitor: GjcTeamMonitorSnapshot | null,
 ): Promise<GjcTeamPhase> {
 	if (storedPhase !== "running") return storedPhase;
-	if (tasks.length === 0 || !tasks.every(task => task.status === "completed")) return storedPhase;
+	if (tasks.length === 0 || !tasks.every(isGjcTeamTaskCompletionVerified)) return storedPhase;
 	return (await hasPendingGjcTeamIntegration(dir, config, monitor)) ? "awaiting_integration" : storedPhase;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value != null;
+}
+const GJC_TEAM_COMPLETION_EVIDENCE_SUMMARY_MAX = 4_000;
+const GJC_TEAM_COMPLETION_EVIDENCE_OUTPUT_MAX = 8_000;
+const GJC_TEAM_COMMAND_EVIDENCE_STATUSES = new Set<GjcTeamTaskCompletionEvidenceStatus>([
+	"passed",
+	"failed",
+	"not_run",
+]);
+const GJC_TEAM_VERIFICATION_EVIDENCE_STATUSES = new Set<GjcTeamTaskCompletionEvidenceStatus>(["verified", "rejected"]);
+
+function completionEvidenceError(taskId: string, field: string): Error {
+	return new Error(`invalid_completion_evidence:${taskId}:${field}`);
+}
+
+function trimRequiredCompletionEvidenceString(
+	taskId: string,
+	field: string,
+	value: unknown,
+	maxLength = GJC_TEAM_COMPLETION_EVIDENCE_SUMMARY_MAX,
+): string {
+	if (typeof value !== "string") throw completionEvidenceError(taskId, field);
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > maxLength) throw completionEvidenceError(taskId, field);
+	return trimmed;
+}
+
+function trimOptionalCompletionEvidenceString(
+	taskId: string,
+	field: string,
+	value: unknown,
+	maxLength = GJC_TEAM_COMPLETION_EVIDENCE_OUTPUT_MAX,
+): string | undefined {
+	if (value == null) return undefined;
+	if (typeof value !== "string") throw completionEvidenceError(taskId, field);
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	if (trimmed.length > maxLength) throw completionEvidenceError(taskId, field);
+	return trimmed;
+}
+
+function normalizeGjcTeamCompletionEvidenceStatus(
+	taskId: string,
+	kind: GjcTeamTaskCompletionEvidenceKind,
+	value: unknown,
+): GjcTeamTaskCompletionEvidenceStatus {
+	const status = trimRequiredCompletionEvidenceString(taskId, "items.status", value);
+	const allowed = kind === "command" ? GJC_TEAM_COMMAND_EVIDENCE_STATUSES : GJC_TEAM_VERIFICATION_EVIDENCE_STATUSES;
+	if (!allowed.has(status as GjcTeamTaskCompletionEvidenceStatus))
+		throw completionEvidenceError(taskId, "items.status");
+	return status as GjcTeamTaskCompletionEvidenceStatus;
+}
+
+function normalizeGjcTeamCompletionEvidenceItem(taskId: string, value: unknown): GjcTeamTaskCompletionEvidenceItem {
+	if (!isRecord(value) || Array.isArray(value)) throw completionEvidenceError(taskId, "items");
+	const kind = trimRequiredCompletionEvidenceString(taskId, "items.kind", value.kind);
+	if (kind !== "command" && kind !== "inspection" && kind !== "artifact")
+		throw completionEvidenceError(taskId, "items.kind");
+	const status = normalizeGjcTeamCompletionEvidenceStatus(taskId, kind, value.status);
+	const item: GjcTeamTaskCompletionEvidenceItem = {
+		kind,
+		status,
+		summary: trimRequiredCompletionEvidenceString(taskId, "items.summary", value.summary),
+	};
+	const command = trimOptionalCompletionEvidenceString(taskId, "items.command", value.command);
+	const artifact = trimOptionalCompletionEvidenceString(taskId, "items.artifact", value.artifact);
+	const location = trimOptionalCompletionEvidenceString(taskId, "items.location", value.location);
+	const output = trimOptionalCompletionEvidenceString(taskId, "items.output", value.output);
+	if (kind === "command" && !command) throw completionEvidenceError(taskId, "items.command");
+	if (command) item.command = command;
+	if (artifact) item.artifact = artifact;
+	if (location) item.location = location;
+	if (output) item.output = output;
+	return item;
+}
+
+function normalizeGjcTeamCompletionEvidenceFiles(taskId: string, value: unknown): string[] | undefined {
+	if (value == null) return undefined;
+	if (!Array.isArray(value)) throw completionEvidenceError(taskId, "files");
+	const files = new Set<string>();
+	for (const entry of value) {
+		if (typeof entry !== "string") throw completionEvidenceError(taskId, "files");
+		const filePath = entry.trim().replace(/\\/g, "/");
+		if (!filePath || filePath.includes("\0") || path.isAbsolute(filePath) || filePath.split("/").includes("..")) {
+			throw completionEvidenceError(taskId, "files");
+		}
+		files.add(filePath);
+	}
+	return files.size > 0 ? [...files].sort() : undefined;
+}
+
+function isGjcTeamCompletionEvidenceItemVerified(item: GjcTeamTaskCompletionEvidenceItem): boolean {
+	return (
+		(item.kind === "command" && item.status === "passed") ||
+		((item.kind === "inspection" || item.kind === "artifact") && item.status === "verified")
+	);
+}
+
+function normalizeGjcTeamTaskCompletionEvidence(
+	taskId: string,
+	owner: string,
+	input: unknown,
+	recordedAt = now(),
+): GjcTeamTaskCompletionEvidence {
+	if (!isRecord(input) || Array.isArray(input)) throw new Error(`completion_evidence_required:${taskId}`);
+	const itemsValue = input.items;
+	if (!Array.isArray(itemsValue) || itemsValue.length === 0) throw completionEvidenceError(taskId, "items");
+	const items = itemsValue.map(item => normalizeGjcTeamCompletionEvidenceItem(taskId, item));
+	if (!items.some(isGjcTeamCompletionEvidenceItemVerified))
+		throw new Error(`completion_evidence_no_verified_item:${taskId}`);
+	const evidence: GjcTeamTaskCompletionEvidence = {
+		summary: trimRequiredCompletionEvidenceString(taskId, "summary", input.summary),
+		items,
+		recorded_by: owner,
+		recorded_at: recordedAt,
+	};
+	const files = normalizeGjcTeamCompletionEvidenceFiles(taskId, input.files);
+	const notes = trimOptionalCompletionEvidenceString(taskId, "notes", input.notes);
+	if (files) evidence.files = files;
+	if (notes) evidence.notes = notes;
+	return evidence;
+}
+
+function getGjcTeamTaskCompletionEvidenceFailure(task: GjcTeamTask): string | null {
+	if (task.status !== "completed") return `task_not_completed:${task.id}`;
+	const evidence = task.completion_evidence;
+	if (!isRecord(evidence) || Array.isArray(evidence)) return `completion_evidence_required:${task.id}`;
+	if (typeof evidence.recorded_by !== "string" || evidence.recorded_by.trim().length === 0)
+		return `invalid_completion_evidence:${task.id}:recorded_by`;
+	if (typeof evidence.recorded_at !== "string" || evidence.recorded_at.trim().length === 0)
+		return `invalid_completion_evidence:${task.id}:recorded_at`;
+	try {
+		normalizeGjcTeamTaskCompletionEvidence(task.id, evidence.recorded_by.trim(), evidence, evidence.recorded_at);
+		return null;
+	} catch (error) {
+		return error instanceof Error ? error.message : `invalid_completion_evidence:${task.id}:unknown`;
+	}
+}
+
+function isGjcTeamTaskCompletionVerified(task: GjcTeamTask): boolean {
+	return getGjcTeamTaskCompletionEvidenceFailure(task) == null;
 }
 function isGjcTeamTaskRecord(value: unknown): value is GjcTeamTask {
 	return (
@@ -898,7 +1057,7 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 		workspace,
 		`Task: ${config.task}`,
 		`Before claiming work, send startup ACK: gjc team api worker-startup-ack --input '{"team_name":"${config.team_name}","worker_id":"${worker.id}","protocol_version":"1"}' --json.`,
-		`Use gjc team api claim-task/transition-task-status with this worker id, record evidence, and do not mutate leader-owned goal state.`,
+		`Use gjc team api claim-task/transition-task-status with this worker id, record completion_evidence (summary plus a passed command or verified inspection/artifact item) before completed, and do not mutate leader-owned goal state.`,
 	].join("\n");
 	const env = [
 		`GJC_TEAM_WORKER=${shellQuote(`${config.team_name}/${worker.id}`)}`,
@@ -2081,10 +2240,16 @@ export async function shutdownGjcTeam(
 	const dir = await findTeamDir(teamName, cwd, env);
 	const config = await readConfig(dir);
 	const tasks = await readTasks(dir);
+	const evidenceFailures = tasks
+		.map(task => {
+			const reason = task.status === "completed" ? getGjcTeamTaskCompletionEvidenceFailure(task) : null;
+			return reason ? { task_id: task.id, reason } : null;
+		})
+		.filter((failure): failure is { task_id: string; reason: string } => failure != null);
 	const shutdownPhase: GjcTeamPhase =
-		tasks.length === 0 || tasks.every(task => task.status === "completed")
+		tasks.length === 0 || tasks.every(isGjcTeamTaskCompletionVerified)
 			? "complete"
-			: tasks.some(task => task.status === "failed" || task.status === "blocked")
+			: evidenceFailures.length > 0 || tasks.some(task => task.status === "failed" || task.status === "blocked")
 				? "failed"
 				: "cancelled";
 	killWorkerPanes(config);
@@ -2096,13 +2261,15 @@ export async function shutdownGjcTeam(
 	};
 	await writeJsonFile(path.join(dir, "config.json"), stopped);
 	await writePhase(dir, shutdownPhase);
+	const shutdownData: Record<string, unknown> = { phase: shutdownPhase };
+	if (evidenceFailures.length > 0) shutdownData.evidence_failures = evidenceFailures;
 	await appendEvent(dir, {
 		type: "team_shutdown",
 		message:
 			shutdownPhase === "complete"
 				? "Shut down native gjc team runtime after completed tasks"
 				: "Shut down native gjc team runtime with incomplete tasks",
-		data: { phase: shutdownPhase },
+		data: shutdownData,
 	});
 	await appendTelemetry(dir, {
 		type: "team_shutdown",
@@ -2244,7 +2411,7 @@ export async function transitionGjcTeamTaskStatus(
 	env: NodeJS.ProcessEnv = process.env,
 	claimToken?: string,
 	workerId?: string,
-	evidence?: string,
+	completionEvidenceInput?: unknown,
 ): Promise<GjcTeamTask> {
 	const dir = await findTeamDir(teamName, cwd, env);
 	const config = await readConfig(dir);
@@ -2257,33 +2424,39 @@ export async function transitionGjcTeamTaskStatus(
 	if (task.claim.token !== claimToken) throw new Error(`claim_token_mismatch:${taskId}`);
 	if (workerId && task.claim.owner !== workerId) throw new Error(`claim_owner_mismatch:${taskId}`);
 	const terminal = status === "completed" || status === "failed";
-	if (status === "completed" && evidence !== undefined && evidence.trim().length === 0)
-		throw new Error(`task_evidence_required:${taskId}`);
+	const transitionedAt = now();
+	const completionEvidence =
+		status === "completed"
+			? normalizeGjcTeamTaskCompletionEvidence(taskId, task.claim.owner, completionEvidenceInput, transitionedAt)
+			: undefined;
 	const updated: GjcTeamTask = {
 		...task,
 		status,
 		claim: terminal ? undefined : task.claim,
 		version: task.version + 1,
-		updated_at: now(),
-		...(terminal ? { completed_at: now() } : {}),
+		updated_at: transitionedAt,
+		...(terminal ? { completed_at: transitionedAt } : {}),
+		...(completionEvidence ? { completion_evidence: completionEvidence } : {}),
 	};
 	await writeTask(dir, updated);
-	if (terminal && evidence)
-		await writeJsonFile(taskEvidencePath(dir, taskId), {
-			task_id: taskId,
-			worker: workerId ?? task.claim.owner,
-			evidence,
-			recorded_at: now(),
-		});
 	if (terminal) {
 		const claimPath = path.join(dir, "claims", `${taskId}.json`);
 		await removeFileAudited(claimPath, stateWriterOptions(claimPath, "prune", "terminal"));
+	}
+	const eventData: Record<string, unknown> = { status };
+	if (completionEvidence) {
+		eventData.completion_evidence = {
+			recorded_by: completionEvidence.recorded_by,
+			item_count: completionEvidence.items.length,
+			verified_item_count: completionEvidence.items.filter(isGjcTeamCompletionEvidenceItemVerified).length,
+			files_count: completionEvidence.files?.length ?? 0,
+		};
 	}
 	await appendEvent(dir, {
 		type: "task_transitioned",
 		task_id: taskId,
 		message: "Task status changed",
-		data: { status },
+		data: eventData,
 	});
 	return updated;
 }
@@ -2294,8 +2467,18 @@ export async function transitionGjcTeamTask(
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 	claimToken?: string,
+	completionEvidenceInput?: unknown,
 ): Promise<GjcTeamTask> {
-	return transitionGjcTeamTaskStatus(teamName, taskId, parseGjcTeamTaskStatus(status, true), cwd, env, claimToken);
+	return transitionGjcTeamTaskStatus(
+		teamName,
+		taskId,
+		parseGjcTeamTaskStatus(status, true),
+		cwd,
+		env,
+		claimToken,
+		undefined,
+		completionEvidenceInput,
+	);
 }
 export async function releaseGjcTeamTaskClaim(
 	teamName: string,
@@ -2880,11 +3063,7 @@ export async function executeGjcTeamApiOperation(
 					env,
 					typeof input.claim_token === "string" ? input.claim_token : undefined,
 					explicitWorker,
-					typeof input.evidence === "string"
-						? input.evidence
-						: typeof input.result === "string"
-							? input.result
-							: undefined,
+					input.completion_evidence ?? input.completionEvidence,
 				),
 			};
 		case "release-task-claim":

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -2246,12 +2246,16 @@ export async function shutdownGjcTeam(
 			return reason ? { task_id: task.id, reason } : null;
 		})
 		.filter((failure): failure is { task_id: string; reason: string } => failure != null);
-	const shutdownPhase: GjcTeamPhase =
-		tasks.length === 0 || tasks.every(isGjcTeamTaskCompletionVerified)
-			? "complete"
-			: evidenceFailures.length > 0 || tasks.some(task => task.status === "failed" || task.status === "blocked")
-				? "failed"
-				: "cancelled";
+	const monitor = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
+	const completionVerified = tasks.length === 0 || tasks.every(isGjcTeamTaskCompletionVerified);
+	const pendingIntegration = completionVerified ? await hasPendingGjcTeamIntegration(dir, config, monitor) : false;
+	const shutdownPhase: GjcTeamPhase = completionVerified
+		? pendingIntegration
+			? "awaiting_integration"
+			: "complete"
+		: evidenceFailures.length > 0 || tasks.some(task => task.status === "failed" || task.status === "blocked")
+			? "failed"
+			: "cancelled";
 	killWorkerPanes(config);
 	await removeCleanCreatedWorktrees(config.workers);
 	const stopped = {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -891,8 +891,15 @@
         "appliesToVerbs": [
           "api"
         ],
-        "name": "evidence",
-        "type": "string"
+        "name": "completion_evidence",
+        "type": "object"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "completionEvidence",
+        "type": "object"
       },
       {
         "name": "args",

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -29,7 +29,7 @@ export interface WorkflowVerb {
 
 export interface TypedArgSpec {
 	name: string;
-	type: "string" | "number" | "boolean" | "enum";
+	type: "string" | "number" | "boolean" | "enum" | "object";
 	enumValues?: string[];
 	required?: boolean;
 	appliesToVerbs?: string[];
@@ -354,7 +354,8 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 				enumValues: ["pending", "blocked", "in_progress", "completed", "failed"],
 				appliesToVerbs: ["api"],
 			},
-			{ name: "evidence", type: "string", appliesToVerbs: ["api"] },
+			{ name: "completion_evidence", type: "object", appliesToVerbs: ["api"] },
+			{ name: "completionEvidence", type: "object", appliesToVerbs: ["api"] },
 			{ name: "args", type: "string", planned: true },
 			{ name: "metadata-json", type: "string", planned: true },
 		],

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -11,6 +11,7 @@ import {
 	monitorGjcTeam,
 	parseTeamLaunchArgs,
 	readGjcTeamSnapshot,
+	readGjcTeamTask,
 	requestGjcWorkerIntegrationAttempt,
 	resolveGjcTeamWorkerCli,
 	resolveGjcTeamWorkerCliPlan,
@@ -120,6 +121,53 @@ async function readEvents(stateDir: string): Promise<string> {
 
 async function readMailbox(stateDir: string, worker: string): Promise<string> {
 	return Bun.file(path.join(stateDir, "mailbox", `${worker}.json`)).text();
+}
+
+function commandCompletionEvidence(summary = "Completed with focused verification") {
+	return {
+		summary,
+		items: [
+			{
+				kind: "command",
+				status: "passed",
+				summary: "Focused TeamMode runtime test passed",
+				command:
+					"bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern completion evidence",
+				output: "passed",
+			},
+		],
+		files: ["packages/coding-agent/src/gjc-runtime/team-runtime.ts"],
+		notes: "Focused completion evidence fixture",
+	};
+}
+
+function inspectionCompletionEvidence(summary = "Completed by inspection") {
+	return {
+		summary,
+		items: [
+			{
+				kind: "inspection",
+				status: "verified",
+				summary: "Leader-verifiable inspection evidence recorded",
+				location: "agent://team-evidence-inspection",
+			},
+		],
+		files: ["packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"],
+	};
+}
+
+function artifactCompletionEvidence(summary = "Completed by artifact review") {
+	return {
+		summary,
+		items: [
+			{
+				kind: "artifact",
+				status: "verified",
+				summary: "Artifact was reviewed",
+				artifact: ".gjc/state/team/demo/report.md",
+			},
+		],
+	};
 }
 
 afterEach(async () => {
@@ -517,8 +565,11 @@ describe("native gjc team runtime", () => {
 			cleanupRoot,
 			{ PATH: "" },
 			claim.claim_token,
+			commandCompletionEvidence(),
 		);
 		expect(task.status).toBe("completed");
+		expect(task.completion_evidence?.items[0]?.kind).toBe("command");
+		expect(task.completion_evidence?.recorded_by).toBe("worker-1");
 		expect(task.claim).toBeUndefined();
 		expect(
 			await Bun.file(path.join(cleanupRoot, ".gjc", "state", "team", "life-team", "claims", "task-1.json")).exists(),
@@ -552,7 +603,7 @@ describe("native gjc team runtime", () => {
 		expect(stopped.workers[0]?.status).toBe("stopped");
 	});
 
-	it("keeps terminal evidence out of task listings and honors claim tokens without implicit worker defaults", async () => {
+	it("stores structured completion evidence in task listings and honors claim tokens without implicit worker defaults", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
 		await startGjcTeam({
 			workerCount: 2,
@@ -574,13 +625,15 @@ describe("native gjc team runtime", () => {
 				task_id: "task-2",
 				to: "completed",
 				claim_token: workerTwoClaim.claim_token,
-				evidence: "worker-2 completed the task",
+				completion_evidence: inspectionCompletionEvidence("worker-2 completed by inspection"),
 			},
 			cleanupRoot,
 			{ PATH: "" },
 		);
 
-		expect(await Bun.file(path.join(stateDir, "evidence", "tasks", "task-2.json")).exists()).toBe(true);
+		const completedTask = await readGjcTeamTask("evidence-team", "task-2", cleanupRoot, { PATH: "" });
+		expect(completedTask.completion_evidence?.items[0]?.kind).toBe("inspection");
+		expect(await Bun.file(path.join(stateDir, "evidence", "tasks", "task-2.json")).exists()).toBe(false);
 		expect(await Bun.file(path.join(stateDir, "tasks", "task-2.evidence.json")).exists()).toBe(false);
 		await Bun.write(
 			path.join(stateDir, "tasks", "task-2.evidence.json"),
@@ -610,6 +663,156 @@ describe("native gjc team runtime", () => {
 		).rejects.toThrow("claim_owner_mismatch:task-1");
 	});
 
+	it("rejects completed transitions without valid evidence and leaves task state unchanged", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Reject invalid completion evidence",
+			teamName: "invalid-evidence-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+		const stateDir = path.join(cleanupRoot, ".gjc", "state", "team", "invalid-evidence-team");
+		const claim = await claimGjcTeamTask("invalid-evidence-team", "worker-1", cleanupRoot, { PATH: "" });
+		expect(claim.ok).toBe(true);
+		const taskBefore = await readGjcTeamTask("invalid-evidence-team", "task-1", cleanupRoot, { PATH: "" });
+		const eventsBefore = await readEvents(stateDir);
+		const claimPath = path.join(stateDir, "claims", "task-1.json");
+
+		await expect(
+			transitionGjcTeamTask(
+				"invalid-evidence-team",
+				"task-1",
+				"completed",
+				cleanupRoot,
+				{ PATH: "" },
+				claim.claim_token,
+			),
+		).rejects.toThrow("completion_evidence_required:task-1");
+
+		for (const invalid of [
+			{
+				evidence: { summary: "", items: [commandCompletionEvidence().items[0]] },
+				error: "invalid_completion_evidence:task-1:summary",
+			},
+			{
+				evidence: { summary: "No items", items: [] },
+				error: "invalid_completion_evidence:task-1:items",
+			},
+			{
+				evidence: { summary: "Bad kind", items: [{ kind: "note", status: "verified", summary: "bad" }] },
+				error: "invalid_completion_evidence:task-1:items.kind",
+			},
+			{
+				evidence: {
+					summary: "No verified item",
+					items: [{ kind: "command", status: "failed", summary: "failed check", command: "bun test" }],
+				},
+				error: "completion_evidence_no_verified_item:task-1",
+			},
+		]) {
+			await expect(
+				transitionGjcTeamTask(
+					"invalid-evidence-team",
+					"task-1",
+					"completed",
+					cleanupRoot,
+					{ PATH: "" },
+					claim.claim_token,
+					invalid.evidence,
+				),
+			).rejects.toThrow(invalid.error);
+		}
+
+		const taskAfter = await readGjcTeamTask("invalid-evidence-team", "task-1", cleanupRoot, { PATH: "" });
+		expect(taskAfter.status).toBe(taskBefore.status);
+		expect(taskAfter.version).toBe(taskBefore.version);
+		expect(taskAfter.completed_at).toBeUndefined();
+		expect(taskAfter.completion_evidence).toBeUndefined();
+		expect(await Bun.file(claimPath).exists()).toBe(true);
+		expect(await readEvents(stateDir)).toBe(eventsBefore);
+	});
+
+	it("allows non-command completion evidence and requires evidence-backed shutdown completion", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Complete with review evidence",
+			teamName: "review-evidence-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+
+		const firstClaim = await claimGjcTeamTask(
+			"review-evidence-team",
+			"worker-1",
+			cleanupRoot,
+			{ PATH: "" },
+			"task-1",
+		);
+		expect(firstClaim.ok).toBe(true);
+		const first = await transitionGjcTeamTask(
+			"review-evidence-team",
+			"task-1",
+			"completed",
+			cleanupRoot,
+			{ PATH: "" },
+			firstClaim.claim_token,
+			inspectionCompletionEvidence("inspection-only task completed"),
+		);
+		expect(first.completion_evidence?.items[0]?.kind).toBe("inspection");
+
+		const secondClaim = await claimGjcTeamTask(
+			"review-evidence-team",
+			"worker-2",
+			cleanupRoot,
+			{ PATH: "" },
+			"task-2",
+		);
+		expect(secondClaim.ok).toBe(true);
+		await executeGjcTeamApiOperation(
+			"transition-task-status",
+			{
+				team_name: "review-evidence-team",
+				task_id: "task-2",
+				to: "completed",
+				claim_token: secondClaim.claim_token,
+				completion_evidence: artifactCompletionEvidence("artifact-backed task completed"),
+			},
+			cleanupRoot,
+			{ PATH: "" },
+		);
+
+		const stopped = await shutdownGjcTeam("review-evidence-team", cleanupRoot, { PATH: "" });
+		expect(stopped.phase).toBe("complete");
+	});
+
+	it("treats legacy evidence-free completed tasks as failed on shutdown", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Legacy completed task",
+			teamName: "legacy-completed-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+		const stateDir = path.join(cleanupRoot, ".gjc", "state", "team", "legacy-completed-team");
+		const task = await readGjcTeamTask("legacy-completed-team", "task-1", cleanupRoot, { PATH: "" });
+		await Bun.write(
+			path.join(stateDir, "tasks", "task-1.json"),
+			`${JSON.stringify({ ...task, status: "completed", completed_at: new Date().toISOString() }, null, 2)}\n`,
+		);
+
+		const stopped = await shutdownGjcTeam("legacy-completed-team", cleanupRoot, { PATH: "" });
+		expect(stopped.phase).toBe("failed");
+		expect(await readEvents(stateDir)).toContain("completion_evidence_required:task-1");
+	});
 	it("allows only one worker to claim a task under concurrent claim attempts", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
 		await startGjcTeam({
@@ -685,7 +888,13 @@ describe("native gjc team runtime", () => {
 		)) as { claim_token: string };
 		await executeGjcTeamApiOperation(
 			"transition-task-status",
-			{ team_name: "api-team", task_id: created.task.id, to: "completed", claim_token: claimed.claim_token },
+			{
+				team_name: "api-team",
+				task_id: created.task.id,
+				to: "completed",
+				claim_token: claimed.claim_token,
+				completionEvidence: artifactCompletionEvidence("API parity task completed by artifact"),
+			},
 			cleanupRoot,
 			{ PATH: "" },
 		);
@@ -1079,6 +1288,7 @@ describe("native gjc team runtime", () => {
 				PATH: process.env.PATH ?? "",
 			},
 			claim.claim_token,
+			commandCompletionEvidence("integration request task completed"),
 		);
 
 		const status = await readGjcTeamSnapshot("awaiting-request-team", cleanupRoot, { PATH: process.env.PATH ?? "" });
@@ -1193,6 +1403,7 @@ describe("native gjc team runtime", () => {
 				PATH: process.env.PATH ?? "",
 			},
 			claim.claim_token,
+			commandCompletionEvidence("conflicting task completed before integration"),
 		);
 
 		const monitored = await monitorGjcTeam("awaiting-conflict-team", cleanupRoot, {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -1295,6 +1295,11 @@ describe("native gjc team runtime", () => {
 		expect(status.task_counts.completed).toBe(1);
 		expect(status.phase).toBe("awaiting_integration");
 		expect(status.phase).not.toBe("running");
+
+		const stopped = await shutdownGjcTeam("awaiting-request-team", cleanupRoot, { PATH: process.env.PATH ?? "" });
+		expect(stopped.task_counts.completed).toBe(1);
+		expect(stopped.phase).toBe("awaiting_integration");
+		expect(stopped.phase).not.toBe("complete");
 	});
 
 	it("monitor cherry-picks diverged worker commits and stays idempotent on repeated status checks", async () => {
@@ -1415,6 +1420,11 @@ describe("native gjc team runtime", () => {
 		expect(monitored.integration_by_worker?.["worker-1"]?.status).toBe("merge_conflict");
 		expect(monitored.phase).toBe("awaiting_integration");
 		expect(monitored.phase).not.toBe("running");
+
+		const stopped = await shutdownGjcTeam("awaiting-conflict-team", cleanupRoot, { PATH: process.env.PATH ?? "" });
+		expect(stopped.task_counts.completed).toBe(1);
+		expect(stopped.phase).toBe("awaiting_integration");
+		expect(stopped.phase).not.toBe("complete");
 	});
 
 	it("monitor reports cherry-pick conflicts and aborts cleanly", async () => {


### PR DESCRIPTION
## Draft status

This is draft PR **1/6** in the TeamMode reliability stack. Target base branch: **dev**.

**Merge order is mandatory:** merge this PR first, then merge PR 2, PR 3, PR 4, PR 5, and PR 6 in that order. Later PRs assume this PR has established the completion contract.

## Title

[TeamMode reliability 1/6] Require evidence before task completion

## Why this work exists

TeamMode is meant to be a glass-box runtime orchestration layer, not only a worker fanout mechanism. Today, a worker can mark a task `completed` once the claim token is valid, and team shutdown can mark the whole run `complete` when every task has terminal status. That treats `completed` as proof of completion.

For production use, that is unsafe. A completed task must include structured, leader-verifiable evidence: what was done, what was checked, which files or artifacts are relevant, and what review or inspection supports the terminal state.

## Current problem

The current runtime allows this path:

```text
claim token valid
→ transition task to completed
→ all tasks completed
→ team phase=complete
```

The missing invariant is:

```text
completed = claim token is valid
          + structured completion evidence exists
          + at least one evidence item is verified
```

Current implementation basis:

- `GjcTeamTask` has task status and optional `result`, but no structured completion evidence.
- `transitionGjcTeamTaskStatus()` verifies claim ownership, then writes terminal status and removes the claim.
- `executeGjcTeamApiOperation()` currently forwards transition status and claim token, but not completion evidence.
- `shutdownGjcTeam()` currently treats `tasks.every(task => task.status === "completed")` as enough for `phase=complete`.
- Existing lifecycle/API tests expect evidence-free completion to succeed and must be updated.

## Approved design

Use task-local structured evidence as the source of truth.

Add `completion_evidence` to `GjcTeamTask`. Keep the existing `result?: string` for read compatibility; do not synthesize evidence for legacy tasks.

Recommended shape:

```ts
export type GjcTeamTaskCompletionEvidenceKind = "command" | "inspection" | "artifact";

export type GjcTeamTaskCompletionEvidenceStatus =
  | "passed"
  | "failed"
  | "not_run"
  | "verified"
  | "rejected";

export interface GjcTeamTaskCompletionEvidenceItem {
  kind: GjcTeamTaskCompletionEvidenceKind;
  status: GjcTeamTaskCompletionEvidenceStatus;
  summary: string;
  command?: string;
  artifact?: string;
  location?: string;
  output?: string;
}

export interface GjcTeamTaskCompletionEvidence {
  summary: string;
  items: GjcTeamTaskCompletionEvidenceItem[];
  files?: string[];
  notes?: string;
  recorded_by: string;
  recorded_at: string;
}
```

Why the evidence item is not command-only:

- `command` evidence covers tests, builds, lint, smoke checks, and other executed commands.
- `inspection` evidence covers review/planning work where no command was run.
- `artifact` evidence covers generated reports, traces, documents, or other inspectable outputs.

This prevents workers from inventing fake command checks for tasks that are legitimately review-only or planning-only.

## Completion validation rules

For `status === "completed"`:

1. Claim validation still runs first.
   - Missing claim/token keeps existing `claim_token_required:<taskId>` behavior.
   - Mismatched token keeps existing `claim_token_mismatch:<taskId>` behavior.
2. Missing or non-object evidence fails with:
   - `completion_evidence_required:<taskId>`
3. Empty summary fails with:
   - `invalid_completion_evidence:<taskId>:summary`
4. Missing/empty/non-array `items` fails with:
   - `invalid_completion_evidence:<taskId>:items`
5. Invalid item kind fails with:
   - `invalid_completion_evidence:<taskId>:items.kind`
6. Invalid item summary fails with:
   - `invalid_completion_evidence:<taskId>:items.summary`
7. At least one verified item is required:
   - `command` item counts only when `status === "passed"`
   - `inspection` item counts only when `status === "verified"`
   - `artifact` item counts only when `status === "verified"`
   - otherwise fail with `completion_evidence_no_verified_item:<taskId>`
8. Runtime, not the caller, fills:
   - `recorded_by = task.claim.owner`
   - `recorded_at = now()`

For non-completed transitions, completion evidence is not required. Failed/blocked semantics should not be expanded in this PR.

## Atomicity requirement

Invalid evidence must not partially mutate state.

If evidence validation fails, these must remain unchanged:

- task status
- task version
- `completed_at`
- `completion_evidence`
- claim JSON file
- `task_transitioned` event log

Therefore evidence validation must happen after claim validation but before `writeTask`, claim-file removal, and event append.

## API contract

`transition-task` and `transition-task-status` should accept both snake_case and camelCase evidence input:

```json
{
  "team_name": "demo",
  "task_id": "task-1",
  "to": "completed",
  "claim_token": "...",
  "completion_evidence": {
    "summary": "Implemented the TeamMode completion evidence gate",
    "items": [
      {
        "kind": "command",
        "status": "passed",
        "summary": "Focused TeamMode runtime tests passed",
        "command": "bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern completion evidence"
      }
    ],
    "files": [
      "packages/coding-agent/src/gjc-runtime/team-runtime.ts",
      "packages/coding-agent/test/gjc-runtime/team-runtime.test.ts"
    ]
  }
}
```

Also accept:

```json
{
  "completionEvidence": {
    "summary": "Architect review completed",
    "items": [
      {
        "kind": "inspection",
        "status": "verified",
        "summary": "Reviewed the implementation plan and accepted the tradeoffs",
        "location": "agent://review-output"
      }
    ]
  }
}
```

The caller-facing contract must be exposed in this PR through `team api help`, the worker launch prompt, or both. Preferred: update both the API help example and the worker prompt one-liner.

## Shutdown semantics

Change team completion from status-only to evidence-backed completion.

Current logic:

```ts
tasks.every(task => task.status === "completed")
```

New logic:

```ts
tasks.every(isGjcTeamTaskCompletionVerified)
```

If every task is status `completed` but at least one task lacks valid `completion_evidence`, shutdown should not mark the team complete. Treat this as `phase=failed`, because it is a reliability invariant violation rather than a user cancellation.

Shutdown events/telemetry should include a compact evidence failure summary such as:

```json
{
  "phase": "failed",
  "evidence_failures": [
    { "task_id": "task-1", "reason": "completion_evidence_required:task-1" }
  ]
}
```

Do not duplicate large evidence output into event JSONL. Store full evidence on the task record only.

## Exact implementation touchpoints

### `packages/coding-agent/src/gjc-runtime/team-runtime.ts`

- Add exported completion evidence types.
- Add `completion_evidence?: GjcTeamTaskCompletionEvidence` to `GjcTeamTask`.
- Keep `normalizeTask()` from synthesizing legacy evidence.
- Add a single validation/helper path, for example:
  - `normalizeGjcTeamTaskCompletionEvidence(...)`
  - `getGjcTeamTaskCompletionEvidenceFailure(...)`
  - `isGjcTeamTaskCompletionVerified(...)`
- Extend `transitionGjcTeamTaskStatus(..., claimToken?, completionEvidenceInput?)` with an optional tail parameter.
- Extend `transitionGjcTeamTask(..., claimToken?, completionEvidenceInput?)` similarly.
- In completed transitions, validate evidence before task write, claim removal, or event append.
- In `executeGjcTeamApiOperation()`, pass `input.completion_evidence ?? input.completionEvidence` into the transition function.
- In `shutdownGjcTeam()`, use the evidence-backed completion helper for `phase=complete`.

### `packages/coding-agent/src/commands/team.ts`

- Update `team api help` to include a completed-transition evidence example.
- Prefer also updating the worker prompt one-liner so worker sessions know `completed` requires `completion_evidence`.

### `packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`

Update existing success-path tests to include valid evidence, then add focused regression coverage.

## Acceptance criteria

- Evidence-free `completed` transition fails with `completion_evidence_required:<taskId>`.
- Invalid evidence fails with stable `invalid_completion_evidence:<taskId>:<field>` errors.
- Evidence with no verified item fails with `completion_evidence_no_verified_item:<taskId>`.
- Missing/invalid evidence failure does not mutate task state, claim file, or event log.
- Valid command evidence allows `completed`.
- Valid inspection evidence allows `completed`.
- Valid artifact evidence allows `completed`.
- Runtime forces `recorded_by` and `recorded_at`; caller-provided values are ignored.
- `completion_evidence` and `completionEvidence` API inputs both work.
- Legacy evidence-free completed task files remain readable but cannot drive `phase=complete` at shutdown.
- Evidence-backed completed tasks still allow `phase=complete` at shutdown.
- Failed/blocked task transitions remain outside the completion-evidence requirement.

## Verification plan

Focused test command after implementation:

```bash
bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern "completion evidence|task claim|API parity|shutdown"
```

Additional package checks may be run after implementation if the TypeScript surface changes materially.

## Explicitly out of scope for this PR

- Managed worker bootstrap. That is PR 2.
- Worker liveness and stale claim recovery. That is PR 3.
- Structured execution traces. That is PR 4.
- Typed work lanes. That is PR 5.
- Read-only vs mutating status semantics. That is PR 6.

## Consensus review status

Planner, Architect, and Critic review agreed on the final shape after one iteration:

- Store evidence on the task record, not in approvals.
- Do not rely on `result: string`.
- Do not force command-only evidence.
- Enforce no-mutation on invalid evidence.
- Use the same helper for completed transition and shutdown complete.
- Expose the evidence contract to API callers/workers in this PR.
