### PR TITLE
feat(harness): coding-harness operations control plane — foundation (M1/M2) [WIP]

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -35,6 +35,7 @@ const commands: CommandEntry[] = [
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
 	{ name: "skills", load: () => import("./commands/skills").then(m => m.default) },
 	{ name: "session", load: () => import("./commands/session").then(m => m.default) },
+	{ name: "harness", load: () => import("./commands/harness").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -169,7 +169,7 @@ export default class Harness extends Command {
 				case "recover":
 				case "validate":
 				case "operate":
-					return await this.#pending(root, verb, input, flags.session);
+					return await this.#ownerVerbOrPending(root, verb, input, flags.session);
 				default:
 					throw new Error(`unknown_harness_verb:${verb}`);
 			}
@@ -186,6 +186,18 @@ export default class Harness extends Command {
 		const state = await loadState(root, sessionId);
 		writeJson(buildResponse(state, false, { completed: false, reason: "owner-not-live" }, false));
 		process.exitCode = 1;
+	}
+
+	/** Route an owner-backed verb to the live owner; fall back to a pending response when none. */
+	async #ownerVerbOrPending(
+		root: string,
+		verb: string,
+		input: Record<string, unknown>,
+		flagSession: string | undefined,
+	): Promise<void> {
+		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+		if (sessionId && (await this.#tryOwnerRoute(root, sessionId, verb, { ...input, sessionId }))) return;
+		return this.#pending(root, verb, input, flagSession);
 	}
 
 	/** Detached owner daemon (spawned by `start --detach`). Runs until retired or signalled. */

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -13,9 +13,8 @@ import { existsSync } from "node:fs";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { classifyRecovery } from "../harness-control-plane/classifier";
 import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
-import type { FinalizeChecks } from "../harness-control-plane/finalize";
 import { RuntimeOwner, resolveOwner } from "../harness-control-plane/owner";
-import { GajaeCodeRpc, type HarnessRpc, type RpcStateSnapshot } from "../harness-control-plane/rpc-adapter";
+import { GajaeCodeRpc } from "../harness-control-plane/rpc-adapter";
 import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
 import {
 	generateSessionId,
@@ -192,18 +191,12 @@ export default class Harness extends Command {
 	/** Detached owner daemon (spawned by `start --detach`). Runs until retired or signalled. */
 	async #runOwner(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
 		const sessionId = requireSessionId(input, flagSession);
-		const useFake = process.env.GJC_HARNESS_OWNER_FAKE_RPC === "1";
-		const rpc: HarnessRpc = useFake
-			? this.#fakeRpc()
-			: new GajaeCodeRpc({ sessionDir: sessionPaths(root, sessionId).gjcSessionDir });
-		const finalizeChecks: FinalizeChecks | undefined = useFake ? this.#fakeChecks() : undefined;
-		const owner = new RuntimeOwner({
-			root,
-			sessionId,
-			rpc,
-			finalizeChecks,
-			validationCommands: useFake ? [{ name: "smoke", command: "true" }] : undefined,
-		});
+		const sessionDir = sessionPaths(root, sessionId).gjcSessionDir;
+		// Optional rpc command override (tests / non-default hosts); defaults to `gjc --mode rpc`.
+		const override = process.env.GJC_HARNESS_RPC_COMMAND;
+		const command = override ? (JSON.parse(override) as string[]) : undefined;
+		const rpc = new GajaeCodeRpc({ sessionDir, command });
+		const owner = new RuntimeOwner({ root, sessionId, rpc });
 		const info = await owner.start();
 		writeJson({ ok: true, owner: info });
 		await new Promise<void>(resolve => {
@@ -221,44 +214,6 @@ export default class Harness extends Command {
 		});
 		await owner.stop();
 		process.exit(0);
-	}
-
-	#fakeRpc(): HarnessRpc {
-		let cursor = 0;
-		const starts: number[] = [];
-		return {
-			async getState(): Promise<RpcStateSnapshot> {
-				return { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
-			},
-			eventCursor: () => cursor,
-			async sendPrompt() {
-				cursor += 1;
-				starts.push(cursor);
-				return { commandId: "fake", ack: true };
-			},
-			async waitForAgentStart(after: number) {
-				const found = starts.find(c => c > after);
-				return found === undefined ? null : { cursor: found };
-			},
-			async close() {},
-		};
-	}
-
-	#fakeChecks(): FinalizeChecks {
-		return {
-			async runValidation(spec) {
-				return { exactCommand: spec.command, cwd: ".", exitStatus: 0, pass: true };
-			},
-			async resolveCommit() {
-				return "fakecommit";
-			},
-			async commitOnBranch() {
-				return true;
-			},
-			async prOrIssue() {
-				return { prUrl: "fake://pr/1", issueArtifact: null };
-			},
-		};
 	}
 
 	/** Spawn the detached owner daemon and poll until it holds the lease. */

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -12,6 +12,8 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { classifyRecovery } from "../harness-control-plane/classifier";
+import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
+import { resolveOwner } from "../harness-control-plane/owner";
 import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
 import {
 	generateSessionId,
@@ -220,8 +222,30 @@ export default class Harness extends Command {
 		writeJson(buildResponse(state, ownerLive, { handle, ownerRuntime: "pending-m3" }));
 	}
 
+	/** Returns true if a live owner handled the verb (response already printed). */
+	async #tryOwnerRoute(
+		root: string,
+		sessionId: string,
+		verb: string,
+		input: Record<string, unknown>,
+	): Promise<boolean> {
+		const owner = await resolveOwner(root, sessionId);
+		if (!owner.live || !owner.socketPath) return false;
+		try {
+			const res = (await callEndpoint(owner.socketPath, { verb, input })) as { ok?: boolean };
+			writeJson(res);
+			if (res?.ok === false) process.exitCode = 1;
+			return true;
+		} catch (error) {
+			if (error instanceof EndpointUnreachableError) return false;
+			throw error;
+		}
+	}
+
 	async #observe(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
-		const state = await loadState(root, requireSessionId(input, flagSession));
+		const sessionId = requireSessionId(input, flagSession);
+		if (await this.#tryOwnerRoute(root, sessionId, "observe", { ...input, sessionId })) return;
+		const state = await loadState(root, sessionId);
 		const ownerLive = ownerLiveFor(state);
 		const observation = buildObservation(state, ownerLive);
 		writeJson(buildResponse(state, ownerLive, { observation, readOnly: !ownerLive }));
@@ -268,17 +292,11 @@ export default class Harness extends Command {
 	}
 
 	async #submit(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
-		const state = await loadState(root, requireSessionId(input, flagSession));
-		const ownerLive = ownerLiveFor(state);
-		// Owner-routed: foundation has no live owner, so submission is blocked (never echoed-as-accepted).
-		writeJson(
-			buildResponse(
-				state,
-				ownerLive,
-				{ accepted: false, submitted: false, reason: "owner-not-live", ownerRuntime: "pending-m3" },
-				false,
-			),
-		);
+		const sessionId = requireSessionId(input, flagSession);
+		if (await this.#tryOwnerRoute(root, sessionId, "submit", { ...input, sessionId })) return;
+		const state = await loadState(root, sessionId);
+		// No live owner: submission is blocked (never echoed-as-accepted).
+		writeJson(buildResponse(state, false, { accepted: false, submitted: false, reason: "owner-not-live" }, false));
 		process.exitCode = 1;
 	}
 
@@ -302,7 +320,9 @@ export default class Harness extends Command {
 	}
 
 	async #retire(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
-		const state = await loadState(root, requireSessionId(input, flagSession));
+		const sessionId = requireSessionId(input, flagSession);
+		if (await this.#tryOwnerRoute(root, sessionId, "retire", { ...input, sessionId })) return;
+		const state = await loadState(root, sessionId);
 		const observation = buildObservation(state, ownerLiveFor(state));
 		if (observation.gitDelta === "dirty" || observation.gitDelta === "unknown") {
 			writeJson(

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -1,0 +1,364 @@
+/**
+ * `gjc harness <verb>` — AI-native stateless JSON CLI for the coding-harness
+ * operations control plane (v1, gajae-code adapter).
+ *
+ * Every verb emits the universal contract `{ ok, state, evidence, nextAllowedActions }`.
+ * Foundation milestone (M1/M2) implements: start, observe, classify, events, retire,
+ * and the spec-required `owner-not-live` blocking for submit. Owner-runtime verbs
+ * (recover/validate/finalize/operate) return an honest `pending-<milestone>` contract
+ * until the RuntimeOwner (M3+) lands.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { classifyRecovery } from "../harness-control-plane/classifier";
+import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
+import {
+	generateSessionId,
+	readEvents,
+	readSessionState,
+	resolveHarnessRoot,
+	writeSessionState,
+} from "../harness-control-plane/storage";
+import {
+	DEFAULT_RETRY_BUDGET,
+	type GitDelta,
+	type Harness as HarnessKind,
+	type Observation,
+	type RetryBudget,
+	SESSION_SCHEMA_VERSION,
+	type SessionHandle,
+	type SessionState,
+} from "../harness-control-plane/types";
+
+function writeJson(value: unknown): void {
+	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function parseInput(raw: string | undefined): Record<string, unknown> {
+	if (!raw?.trim()) return {};
+	const parsed = JSON.parse(raw) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("input_must_be_json_object");
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function gitDeltaFor(workspace: string): { gitDelta: GitDelta; branch: string | null; deleted: boolean } {
+	if (!existsSync(workspace)) return { gitDelta: "unknown", branch: null, deleted: true };
+	let branch: string | null = null;
+	try {
+		branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+			cwd: workspace,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		branch = null;
+	}
+	try {
+		const porcelain = execFileSync("git", ["status", "--porcelain"], {
+			cwd: workspace,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return { gitDelta: porcelain.trim().length > 0 ? "dirty" : "clean", branch, deleted: false };
+	} catch {
+		return { gitDelta: "unknown", branch, deleted: false };
+	}
+}
+
+/** Owner liveness — always false in the foundation build (RuntimeOwner is M3). */
+function ownerLiveFor(_state: SessionState): boolean {
+	return false;
+}
+
+function buildObservation(state: SessionState, ownerLive: boolean): Observation {
+	const workspace = state.handle.workspace;
+	const { gitDelta, branch, deleted } = gitDeltaFor(workspace);
+	return {
+		lifecycle: state.lifecycle,
+		ownerLive,
+		cwd: workspace,
+		branch: branch ?? state.handle.branch,
+		gitDelta,
+		lastActivityAt: state.updatedAt,
+		observedSignals: ["SessionStart"],
+		risk: deleted ? "deleted-worktree" : "normal",
+	};
+}
+
+function resolveRetryBudget(input: Record<string, unknown>): RetryBudget {
+	const supplied = input.retryBudget;
+	if (supplied && typeof supplied === "object" && !Array.isArray(supplied)) {
+		return { ...DEFAULT_RETRY_BUDGET, ...(supplied as Partial<RetryBudget>) };
+	}
+	return { ...DEFAULT_RETRY_BUDGET };
+}
+
+async function loadState(root: string, sessionId: string): Promise<SessionState> {
+	const state = await readSessionState(root, sessionId);
+	if (!state) throw new Error(`session_not_found:${sessionId}`);
+	return state;
+}
+
+function requireSessionId(input: Record<string, unknown>, flagSession: string | undefined): string {
+	const id = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+	if (!id) throw new Error("missing_session_id");
+	return id;
+}
+
+export default class Harness extends Command {
+	static description = "Operate coding harnesses (v1: gajae-code) as a session/evidence/recovery/PR control plane";
+	static strict = false;
+
+	static args = {
+		verb: Args.string({
+			description: "start|submit|observe|classify|recover|validate|finalize|retire|events|monitor|operate",
+			required: true,
+		}),
+	};
+
+	static flags = {
+		input: Flags.string({ description: "JSON object input for the verb", default: "" }),
+		session: Flags.string({ char: "s", description: "Session id (re-grab a session)" }),
+		cursor: Flags.string({ description: "Event cursor for events --follow (exclusive)", default: "0" }),
+		follow: Flags.boolean({ description: "Tail the owner-written event log", default: false }),
+		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: true }),
+	};
+
+	static examples = [
+		`gjc harness start --input '{"harness":"gajae-code","workspace":".","branch":"feat/x"}'`,
+		"gjc harness observe --session <id>",
+		`gjc harness classify --input '{"observation":{"ownerLive":false,"gitDelta":"dirty","risk":"vanished-dirty"}}'`,
+		"gjc harness events --session <id> --follow",
+	];
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Harness);
+		const verb = String(args.verb);
+		const root = resolveHarnessRoot();
+		try {
+			const input = parseInput(flags.input);
+			switch (verb) {
+				case "start":
+					return await this.#start(root, input);
+				case "observe":
+					return await this.#observe(root, input, flags.session);
+				case "classify":
+					return await this.#classify(root, input, flags.session);
+				case "submit":
+					return await this.#submit(root, input, flags.session);
+				case "events":
+				case "monitor":
+					return await this.#events(root, input, flags.session, Number(flags.cursor) || 0);
+				case "retire":
+					return await this.#retire(root, input, flags.session);
+				case "recover":
+				case "validate":
+				case "finalize":
+				case "operate":
+					return await this.#pending(root, verb, input, flags.session);
+				default:
+					throw new Error(`unknown_harness_verb:${verb}`);
+			}
+		} catch (error) {
+			writeJson({ ok: false, error: error instanceof Error ? error.message : String(error), verb });
+			process.exitCode = 1;
+		}
+	}
+
+	async #start(root: string, input: Record<string, unknown>): Promise<void> {
+		const harness = (typeof input.harness === "string" ? input.harness : "gajae-code") as HarnessKind;
+		if (harness !== "gajae-code") {
+			writeJson({
+				ok: false,
+				error: `harness_unsupported_in_v1:${harness}`,
+				evidence: { seam: true, supported: ["gajae-code"] },
+			});
+			process.exitCode = 1;
+			return;
+		}
+		const workspace = typeof input.workspace === "string" ? input.workspace : process.cwd();
+		const sessionId = typeof input.sessionId === "string" ? input.sessionId : generateSessionId();
+		const eventsPath = `${root}/sessions/${sessionId}/events.jsonl`;
+		const leasePath = `${root}/sessions/${sessionId}/lease.json`;
+		const startedAt = nowIso();
+		const handle: SessionHandle = {
+			sessionId,
+			harness,
+			repo: typeof input.repo === "string" ? input.repo : null,
+			workspace,
+			branch: typeof input.branch === "string" ? input.branch : null,
+			base: typeof input.base === "string" ? input.base : null,
+			issueOrPr: typeof input.issueOrPr === "string" ? input.issueOrPr : null,
+			processHandle: { kind: "runtime-owner", ownerId: null, pid: null },
+			rpcHandle: { kind: "rpc-subprocess", pid: null, sessionDir: `${root}/sessions/${sessionId}/gjc-session` },
+			ownerHandle: { leasePath, endpoint: null, heartbeatAt: null },
+			routerHandle: { kind: "default-in-owner", policy: "default-fallback", eventsPath },
+			viewportHandle: { kind: "event-monitor", tmuxSessionName: null, viewOnly: true },
+			startedAt,
+			updatedAt: startedAt,
+		};
+		const state: SessionState = {
+			schemaVersion: SESSION_SCHEMA_VERSION,
+			sessionId,
+			lifecycle: "started",
+			harness,
+			handle,
+			retries: {},
+			blockers: [],
+			createdAt: startedAt,
+			updatedAt: startedAt,
+		};
+		await writeSessionState(root, state);
+		const ownerLive = ownerLiveFor(state);
+		writeJson(buildResponse(state, ownerLive, { handle, ownerRuntime: "pending-m3" }));
+	}
+
+	async #observe(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const state = await loadState(root, requireSessionId(input, flagSession));
+		const ownerLive = ownerLiveFor(state);
+		const observation = buildObservation(state, ownerLive);
+		writeJson(buildResponse(state, ownerLive, { observation, readOnly: !ownerLive }));
+	}
+
+	async #classify(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const budget = resolveRetryBudget(input);
+		let observation = input.observation as Partial<Observation> | undefined;
+		let stateView: SessionState | null = null;
+		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+		if (sessionId) {
+			stateView = await loadState(root, sessionId);
+			if (!observation) observation = buildObservation(stateView, ownerLiveFor(stateView));
+		}
+		if (!observation) throw new Error("classify_requires_observation_or_session");
+		const full: Observation = {
+			lifecycle: observation.lifecycle ?? "observing",
+			ownerLive: observation.ownerLive ?? false,
+			cwd: observation.cwd ?? ".",
+			branch: observation.branch ?? null,
+			gitDelta: observation.gitDelta ?? "unknown",
+			lastActivityAt: observation.lastActivityAt ?? null,
+			observedSignals: observation.observedSignals ?? [],
+			risk: observation.risk ?? "normal",
+		};
+		const decision = classifyRecovery({ observation: full, retryBudget: budget });
+		if (stateView) {
+			writeJson(buildResponse(stateView, ownerLiveFor(stateView), { decision, observation: full }));
+			return;
+		}
+		// Pure classify without a session: synthesize a minimal state view.
+		writeJson({
+			ok: true,
+			state: {
+				sessionId: "(none)",
+				lifecycle: full.lifecycle,
+				harness: "gajae-code",
+				ownerLive: full.ownerLive,
+				blockers: [],
+			},
+			evidence: { decision, observation: full },
+			nextAllowedActions: [],
+		});
+	}
+
+	async #submit(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const state = await loadState(root, requireSessionId(input, flagSession));
+		const ownerLive = ownerLiveFor(state);
+		// Owner-routed: foundation has no live owner, so submission is blocked (never echoed-as-accepted).
+		writeJson(
+			buildResponse(
+				state,
+				ownerLive,
+				{ accepted: false, submitted: false, reason: "owner-not-live", ownerRuntime: "pending-m3" },
+				false,
+			),
+		);
+		process.exitCode = 1;
+	}
+
+	async #events(
+		root: string,
+		input: Record<string, unknown>,
+		flagSession: string | undefined,
+		cursor: number,
+	): Promise<void> {
+		const sessionId = requireSessionId(input, flagSession);
+		const state = await loadState(root, sessionId);
+		const events = await readEvents(root, sessionId, cursor);
+		const nextCursor = events.length > 0 ? events[events.length - 1].cursor : cursor;
+		writeJson(
+			buildResponse(state, ownerLiveFor(state), {
+				events,
+				cursor: nextCursor,
+				note: "tail-only; live producer (owner) lands in M3/M5",
+			}),
+		);
+	}
+
+	async #retire(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const state = await loadState(root, requireSessionId(input, flagSession));
+		const observation = buildObservation(state, ownerLiveFor(state));
+		if (observation.gitDelta === "dirty" || observation.gitDelta === "unknown") {
+			writeJson(
+				buildResponse(
+					state,
+					false,
+					{
+						retired: false,
+						reason: `retire-blocked:${observation.gitDelta}-delta`,
+						gitDelta: observation.gitDelta,
+					},
+					false,
+				),
+			);
+			process.exitCode = 1;
+			return;
+		}
+		state.lifecycle = "retired";
+		state.updatedAt = nowIso();
+		await writeSessionState(root, state);
+		writeJson(buildResponse(state, false, { retired: true }));
+	}
+
+	async #pending(
+		root: string,
+		verb: string,
+		input: Record<string, unknown>,
+		flagSession: string | undefined,
+	): Promise<void> {
+		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+		const milestone = verb === "recover" ? "M7" : verb === "validate" || verb === "finalize" ? "M8" : "M9";
+		if (sessionId) {
+			const state = await loadState(root, sessionId);
+			writeJson(buildResponse(state, ownerLiveFor(state), { pending: true, milestone, verb }, false));
+			process.exitCode = 1;
+			return;
+		}
+		writeJson({
+			ok: false,
+			state: buildStateView(
+				{
+					schemaVersion: SESSION_SCHEMA_VERSION,
+					sessionId: "(none)",
+					lifecycle: "new",
+					harness: "gajae-code",
+					handle: {} as SessionHandle,
+					retries: {},
+					blockers: [],
+					createdAt: nowIso(),
+					updatedAt: nowIso(),
+				},
+				false,
+			),
+			evidence: { pending: true, milestone, verb },
+			nextAllowedActions: [],
+		});
+		process.exitCode = 1;
+	}
+}

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -13,13 +13,16 @@ import { existsSync } from "node:fs";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { classifyRecovery } from "../harness-control-plane/classifier";
 import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
-import { resolveOwner } from "../harness-control-plane/owner";
+import type { FinalizeChecks } from "../harness-control-plane/finalize";
+import { RuntimeOwner, resolveOwner } from "../harness-control-plane/owner";
+import { GajaeCodeRpc, type HarnessRpc, type RpcStateSnapshot } from "../harness-control-plane/rpc-adapter";
 import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
 import {
 	generateSessionId,
 	readEvents,
 	readSessionState,
 	resolveHarnessRoot,
+	sessionPaths,
 	writeSessionState,
 } from "../harness-control-plane/storage";
 import {
@@ -162,6 +165,8 @@ export default class Harness extends Command {
 					return await this.#retire(root, input, flags.session);
 				case "finalize":
 					return await this.#finalizeVerb(root, input, flags.session);
+				case "__owner":
+					return await this.#runOwner(root, input, flags.session);
 				case "recover":
 				case "validate":
 				case "operate":
@@ -182,6 +187,99 @@ export default class Harness extends Command {
 		const state = await loadState(root, sessionId);
 		writeJson(buildResponse(state, false, { completed: false, reason: "owner-not-live" }, false));
 		process.exitCode = 1;
+	}
+
+	/** Detached owner daemon (spawned by `start --detach`). Runs until retired or signalled. */
+	async #runOwner(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const sessionId = requireSessionId(input, flagSession);
+		const useFake = process.env.GJC_HARNESS_OWNER_FAKE_RPC === "1";
+		const rpc: HarnessRpc = useFake
+			? this.#fakeRpc()
+			: new GajaeCodeRpc({ sessionDir: sessionPaths(root, sessionId).gjcSessionDir });
+		const finalizeChecks: FinalizeChecks | undefined = useFake ? this.#fakeChecks() : undefined;
+		const owner = new RuntimeOwner({
+			root,
+			sessionId,
+			rpc,
+			finalizeChecks,
+			validationCommands: useFake ? [{ name: "smoke", command: "true" }] : undefined,
+		});
+		const info = await owner.start();
+		writeJson({ ok: true, owner: info });
+		await new Promise<void>(resolve => {
+			const stop = (): void => {
+				clearInterval(timer);
+				resolve();
+			};
+			const timer = setInterval(async () => {
+				const resolved = await resolveOwner(root, sessionId);
+				if (!resolved.live) stop();
+			}, 500);
+			timer.unref?.();
+			process.on("SIGTERM", stop);
+			process.on("SIGINT", stop);
+		});
+		await owner.stop();
+		process.exit(0);
+	}
+
+	#fakeRpc(): HarnessRpc {
+		let cursor = 0;
+		const starts: number[] = [];
+		return {
+			async getState(): Promise<RpcStateSnapshot> {
+				return { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+			},
+			eventCursor: () => cursor,
+			async sendPrompt() {
+				cursor += 1;
+				starts.push(cursor);
+				return { commandId: "fake", ack: true };
+			},
+			async waitForAgentStart(after: number) {
+				const found = starts.find(c => c > after);
+				return found === undefined ? null : { cursor: found };
+			},
+			async close() {},
+		};
+	}
+
+	#fakeChecks(): FinalizeChecks {
+		return {
+			async runValidation(spec) {
+				return { exactCommand: spec.command, cwd: ".", exitStatus: 0, pass: true };
+			},
+			async resolveCommit() {
+				return "fakecommit";
+			},
+			async commitOnBranch() {
+				return true;
+			},
+			async prOrIssue() {
+				return { prUrl: "fake://pr/1", issueArtifact: null };
+			},
+		};
+	}
+
+	/** Spawn the detached owner daemon and poll until it holds the lease. */
+	async #spawnDetachedOwner(root: string, sessionId: string, cwd: string): Promise<boolean> {
+		const argv1 = process.argv[1];
+		const cmd = argv1
+			? [process.execPath, argv1, "harness", "__owner", "--session", sessionId]
+			: [process.execPath, "harness", "__owner", "--session", sessionId];
+		const child = Bun.spawn(cmd, {
+			cwd,
+			env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+			stdout: "ignore",
+			stderr: "ignore",
+			stdin: "ignore",
+		});
+		child.unref();
+		for (let i = 0; i < 100; i++) {
+			if ((await resolveOwner(root, sessionId)).live) return true;
+			await new Promise(r => setTimeout(r, 50));
+		}
+		return false;
 	}
 
 	async #start(root: string, input: Record<string, unknown>): Promise<void> {
@@ -228,8 +326,26 @@ export default class Harness extends Command {
 			updatedAt: startedAt,
 		};
 		await writeSessionState(root, state);
-		const ownerLive = ownerLiveFor(state);
-		writeJson(buildResponse(state, ownerLive, { handle, ownerRuntime: "pending-m3" }));
+		let ownerLive = false;
+		if (input.detach === true) {
+			ownerLive = await this.#spawnDetachedOwner(root, sessionId, workspace);
+			if (ownerLive) {
+				const resolved = await resolveOwner(root, sessionId);
+				handle.processHandle = {
+					kind: "runtime-owner",
+					ownerId: resolved.lease?.ownerId ?? null,
+					pid: resolved.lease?.pid ?? null,
+				};
+				handle.ownerHandle = {
+					leasePath,
+					endpoint: resolved.socketPath,
+					heartbeatAt: resolved.lease?.heartbeatAt ?? null,
+				};
+				state.handle = handle;
+				await writeSessionState(root, state);
+			}
+		}
+		writeJson(buildResponse(state, ownerLive, { handle, ownerRuntime: ownerLive ? "detached" : "manual" }));
 	}
 
 	/** Returns true if a live owner handled the verb (response already printed). */

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -160,9 +160,10 @@ export default class Harness extends Command {
 					return await this.#events(root, input, flags.session, Number(flags.cursor) || 0);
 				case "retire":
 					return await this.#retire(root, input, flags.session);
+				case "finalize":
+					return await this.#finalizeVerb(root, input, flags.session);
 				case "recover":
 				case "validate":
-				case "finalize":
 				case "operate":
 					return await this.#pending(root, verb, input, flags.session);
 				default:
@@ -172,6 +173,15 @@ export default class Harness extends Command {
 			writeJson({ ok: false, error: error instanceof Error ? error.message : String(error), verb });
 			process.exitCode = 1;
 		}
+	}
+
+	async #finalizeVerb(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
+		const sessionId = requireSessionId(input, flagSession);
+		if (await this.#tryOwnerRoute(root, sessionId, "finalize", { ...input, sessionId })) return;
+		// finalize is owner-routed; without a live owner, report owner-not-live (start the owner first).
+		const state = await loadState(root, sessionId);
+		writeJson(buildResponse(state, false, { completed: false, reason: "owner-not-live" }, false));
+		process.exitCode = 1;
 	}
 
 	async #start(root: string, input: Record<string, unknown>): Promise<void> {

--- a/packages/coding-agent/src/harness-control-plane/classifier.ts
+++ b/packages/coding-agent/src/harness-control-plane/classifier.ts
@@ -1,0 +1,128 @@
+/**
+ * Deterministic recovery classifier (pure).
+ *
+ * Maps a bounded {@link Observation} + remaining retry budget to exactly one
+ * {@link RecoveryDecision}. Encodes the plan's hard data-loss invariants:
+ *   - dirty deltas are NEVER `restart-clean`; they map to `restart-preserve-delta`.
+ *   - unknown deltas are NEVER destructive; they map to `human-check`.
+ *   - a deleted/mismatched worktree maps to `human-check` (never recreate over unknown data).
+ * `send-enter` is intentionally never emitted: it is unsupported for the gajae-code
+ * RPC adapter in v1 (no blind key injection).
+ */
+import type { ClassifyInput, RecoveryDecision } from "./types";
+
+export function classifyRecovery(input: ClassifyInput): RecoveryDecision {
+	const { observation: o, retryBudget: budget } = input;
+
+	// Deleted worktree / path mismatch — never recreate over unknown data.
+	if (o.risk === "deleted-worktree") {
+		return {
+			classification: "human-check",
+			reason: "deleted-worktree-or-path-mismatch",
+			severity: "critical",
+			ownerRequired: false,
+			requiredReceiptFamily: "vanish",
+		};
+	}
+
+	if (o.ownerLive) {
+		if (o.risk === "prompt-not-accepted") {
+			if (budget.reinjectPrompt > 0) {
+				return {
+					classification: "reinject-prompt",
+					reason: "prompt-ack-without-agent-start",
+					severity: "warn",
+					ownerRequired: true,
+					requiredReceiptFamily: "prompt-acceptance",
+				};
+			}
+			return {
+				classification: "human-check",
+				reason: "prompt-not-accepted-budget-exhausted",
+				severity: "critical",
+				ownerRequired: false,
+				requiredReceiptFamily: null,
+			};
+		}
+		if (o.observedSignals.includes("validation-failed")) {
+			if (budget.validationRepair > 0) {
+				return {
+					classification: "continue",
+					reason: "validation-failed-repair-budget-remains",
+					severity: "warn",
+					ownerRequired: true,
+					requiredReceiptFamily: "validation",
+				};
+			}
+			return {
+				classification: "human-check",
+				reason: "validation-failed-budget-exhausted",
+				severity: "critical",
+				ownerRequired: false,
+				requiredReceiptFamily: "validation",
+			};
+		}
+		return {
+			classification: "continue",
+			reason: "owner-live-active",
+			severity: "info",
+			ownerRequired: true,
+			requiredReceiptFamily: null,
+		};
+	}
+
+	// Owner / RPC vanished — branch on git delta. Every branch requires a `vanish` receipt.
+	switch (o.gitDelta) {
+		case "dirty":
+			if (budget.dirtyVanishPreserve > 0) {
+				return {
+					classification: "restart-preserve-delta",
+					reason: "owner-vanished-dirty-delta",
+					severity: "critical",
+					ownerRequired: true,
+					requiredReceiptFamily: "vanish",
+				};
+			}
+			return {
+				classification: "fallback-codex-exec",
+				reason: "dirty-vanish-preserve-budget-exhausted",
+				severity: "critical",
+				ownerRequired: true,
+				requiredReceiptFamily: "vanish",
+			};
+		case "zero-delta":
+			if (budget.zeroDeltaVanish > 0) {
+				return {
+					classification: "restart-clean",
+					reason: "owner-vanished-zero-delta",
+					severity: "warn",
+					ownerRequired: true,
+					requiredReceiptFamily: "vanish",
+				};
+			}
+			return {
+				classification: "fallback-codex-exec",
+				reason: "zero-delta-vanish-budget-exhausted",
+				severity: "critical",
+				ownerRequired: true,
+				requiredReceiptFamily: "vanish",
+			};
+		case "clean":
+			return {
+				classification: "restart-clean",
+				reason: "owner-vanished-clean",
+				severity: "warn",
+				ownerRequired: true,
+				requiredReceiptFamily: "vanish",
+			};
+		default:
+			// unknown delta — critical, never destructive.
+			return {
+				classification: "human-check",
+				reason: "owner-vanished-unknown-delta",
+				severity: "critical",
+				ownerRequired: false,
+				requiredReceiptFamily: "vanish",
+			};
+	}
+}

--- a/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
+++ b/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-session control endpoint — a Unix domain socket served by the RuntimeOwner so
+ * stateless `gjc harness` CLI calls can route owner-routed primitives (submit, observe,
+ * recover, retire) to the live owner. One JSON request line in, one JSON response line out.
+ *
+ * The owner is the only listener; clients connect per call. When no socket is reachable
+ * the caller falls back to the no-owner behavior (read-only observe, owner-not-live submit).
+ *
+ * FIFO fallback (for platforms/paths where AF_UNIX is unavailable or path-length limited)
+ * is a documented seam tracked as an ADR follow-up.
+ */
+
+import { rm } from "node:fs/promises";
+import * as net from "node:net";
+
+export interface EndpointRequest {
+	verb: string;
+	input: Record<string, unknown>;
+}
+
+export type EndpointHandler = (req: EndpointRequest) => Promise<unknown>;
+
+function frame(value: unknown): string {
+	return `${JSON.stringify(value)}\n`;
+}
+
+export class ControlServer {
+	#server: net.Server | null = null;
+	constructor(
+		readonly socketPath: string,
+		private readonly handler: EndpointHandler,
+	) {}
+
+	async listen(): Promise<void> {
+		await rm(this.socketPath, { force: true });
+		await new Promise<void>((resolve, reject) => {
+			const server = net.createServer(socket => this.#onConnection(socket));
+			server.once("error", reject);
+			server.listen(this.socketPath, () => {
+				server.removeListener("error", reject);
+				this.#server = server;
+				resolve();
+			});
+		});
+	}
+
+	#onConnection(socket: net.Socket): void {
+		socket.setEncoding("utf8");
+		let buffer = "";
+		let handled = false;
+		socket.on("data", (chunk: string) => {
+			if (handled) return;
+			buffer += chunk;
+			const idx = buffer.indexOf("\n");
+			if (idx < 0) return;
+			handled = true;
+			const line = buffer.slice(0, idx).trim();
+			void this.#dispatch(line)
+				.then(response => {
+					socket.end(frame(response));
+				})
+				.catch((error: unknown) => {
+					socket.end(frame({ ok: false, error: error instanceof Error ? error.message : String(error) }));
+				});
+		});
+	}
+
+	async #dispatch(line: string): Promise<unknown> {
+		const req = JSON.parse(line) as EndpointRequest;
+		if (!req || typeof req.verb !== "string") throw new Error("bad_request");
+		return this.handler({ verb: req.verb, input: req.input ?? {} });
+	}
+
+	async close(): Promise<void> {
+		const server = this.#server;
+		this.#server = null;
+		if (server) {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+		await rm(this.socketPath, { force: true });
+	}
+}
+
+export class EndpointUnreachableError extends Error {
+	constructor(readonly socketPath: string) {
+		super(`endpoint_unreachable:${socketPath}`);
+		this.name = "EndpointUnreachableError";
+	}
+}
+
+/** Call the owner's control endpoint. Rejects with {@link EndpointUnreachableError} when no owner listens. */
+export function callEndpoint(socketPath: string, req: EndpointRequest, timeoutMs = 5_000): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		const socket = net.connect(socketPath);
+		let buffer = "";
+		let settled = false;
+		const done = (fn: () => void): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			socket.destroy();
+			fn();
+		};
+		const timer = setTimeout(() => done(() => reject(new Error(`endpoint_timeout:${socketPath}`))), timeoutMs);
+		socket.setEncoding("utf8");
+		socket.on("connect", () => socket.write(frame(req)));
+		socket.on("data", (chunk: string) => {
+			buffer += chunk;
+			const idx = buffer.indexOf("\n");
+			if (idx >= 0) {
+				const line = buffer.slice(0, idx).trim();
+				done(() => {
+					try {
+						resolve(JSON.parse(line));
+					} catch (error) {
+						reject(error instanceof Error ? error : new Error(String(error)));
+					}
+				});
+			}
+		});
+		socket.on("error", (error: NodeJS.ErrnoException) => {
+			done(() => {
+				if (error.code === "ENOENT" || error.code === "ECONNREFUSED") {
+					reject(new EndpointUnreachableError(socketPath));
+				} else {
+					reject(error);
+				}
+			});
+		});
+	});
+}

--- a/packages/coding-agent/src/harness-control-plane/finalize.ts
+++ b/packages/coding-agent/src/harness-control-plane/finalize.ts
@@ -11,14 +11,16 @@
  */
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import {
 	buildReceipt,
 	type CompletionEvidence,
+	type ReceiptEnvelope,
 	type ReceiptSubject,
 	type ValidationEvidence,
 	validateReceipt,
 } from "./receipts";
-import { writeReceiptImmutable } from "./storage";
+import { readReceiptIndex, writeReceiptImmutable } from "./storage";
 
 export interface ValidationCommandSpec {
 	name: string;
@@ -115,6 +117,21 @@ export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult
 	// 3. PR / issue artifact.
 	const artifact = await opts.checks.prOrIssue();
 	if (opts.requirePr && !artifact.prUrl && !artifact.issueArtifact) blockers.push("missing-pr-or-issue");
+
+	// B4: cross-validate the persisted validation receipts (validity + commit freshness) before completion.
+	if (blockers.length === 0) {
+		const persisted = await readReceiptIndex(opts.root, opts.sessionId, "validation");
+		for (const id of validationReceiptIds) {
+			const entry = persisted.find(e => e.receiptId === id);
+			if (!entry) {
+				blockers.push(`missing-validation-receipt:${id}`);
+				continue;
+			}
+			const receipt = JSON.parse(await readFile(entry.path, "utf8")) as ReceiptEnvelope<ValidationEvidence>;
+			if (!validateReceipt(receipt).valid) blockers.push(`validation-receipt-invalid:${id}`);
+			else if (commit && receipt.evidence.commitUnderTest !== commit) blockers.push(`validation-stale-commit:${id}`);
+		}
+	}
 
 	if (blockers.length > 0) {
 		return {

--- a/packages/coding-agent/src/harness-control-plane/finalize.ts
+++ b/packages/coding-agent/src/harness-control-plane/finalize.ts
@@ -1,0 +1,205 @@
+/**
+ * Evidence-gated finalizer (M8).
+ *
+ * `completed: true` ONLY when: every required validation receipt is valid for the commit
+ * under test, the final commit exists on the branch, a PR/issue artifact exists, and the
+ * completion receipt validates with no blockers. Never "the agent said done".
+ *
+ * External effects (running validation commands, git, gh) are injected via {@link FinalizeChecks}
+ * so the gate predicate is unit-testable; {@link defaultFinalizeChecks} provides the real
+ * implementation exercised by the M10 e2e suite.
+ */
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+	buildReceipt,
+	type CompletionEvidence,
+	type ReceiptSubject,
+	type ValidationEvidence,
+	validateReceipt,
+} from "./receipts";
+import { writeReceiptImmutable } from "./storage";
+
+export interface ValidationCommandSpec {
+	name: string;
+	command: string;
+}
+
+export interface ValidationRun {
+	exactCommand: string;
+	cwd: string;
+	exitStatus: number;
+	pass: boolean;
+}
+
+export interface FinalizeChecks {
+	runValidation(spec: ValidationCommandSpec): Promise<ValidationRun>;
+	resolveCommit(): Promise<string | null>;
+	commitOnBranch(commit: string, branch: string): Promise<boolean>;
+	prOrIssue(): Promise<{ prUrl: string | null; issueArtifact: string | null }>;
+}
+
+export interface FinalizeOptions {
+	root: string;
+	sessionId: string;
+	workspace: string;
+	branch: string;
+	requireTests?: boolean;
+	requireCommit?: boolean;
+	requirePr?: boolean;
+	validationCommands?: ValidationCommandSpec[];
+	checks: FinalizeChecks;
+	clock?: () => number;
+}
+
+export interface FinalizeResult {
+	completed: boolean;
+	receiptPath: string | null;
+	validation: { name: string; valid: boolean; exitStatus: number }[];
+	commitHash: string | null;
+	prUrl: string | null;
+	issueArtifact: string | null;
+	blockers: string[];
+}
+
+function receiptId(prefix: string): string {
+	return `${prefix}-${Date.now()}-${randomBytes(4).toString("hex")}`;
+}
+
+export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult> {
+	const now = () => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
+	const blockers: string[] = [];
+	const validation: FinalizeResult["validation"] = [];
+	const validationReceiptIds: string[] = [];
+
+	const commit = await opts.checks.resolveCommit();
+	const subject: ReceiptSubject = { workspace: opts.workspace, branch: opts.branch, head: commit, commit };
+
+	// 1. Validation receipts.
+	for (const spec of opts.validationCommands ?? []) {
+		const run = await opts.checks.runValidation(spec);
+		const evidence: ValidationEvidence = {
+			command: spec.name,
+			exactCommand: run.exactCommand,
+			cwd: run.cwd,
+			exitStatus: run.exitStatus,
+			pass: run.pass,
+			commitUnderTest: commit,
+		};
+		const receipt = buildReceipt<ValidationEvidence>({
+			receiptId: receiptId("val"),
+			sessionId: opts.sessionId,
+			family: "validation",
+			source: "finalizer",
+			subject,
+			evidence,
+			createdAt: now(),
+			valid: run.pass,
+		});
+		await writeReceiptImmutable(opts.root, opts.sessionId, "validation", receipt.receiptId, receipt);
+		const outcome = validateReceipt(receipt);
+		validation.push({ name: spec.name, valid: outcome.valid, exitStatus: run.exitStatus });
+		validationReceiptIds.push(receipt.receiptId);
+		if (opts.requireTests && !outcome.valid) blockers.push(`validation-failed:${spec.name}`);
+	}
+	if (opts.requireTests && (opts.validationCommands?.length ?? 0) === 0) {
+		blockers.push("validation-required-but-none-run");
+	}
+
+	// 2. Commit on branch.
+	if (opts.requireCommit) {
+		if (!commit) blockers.push("missing-commit");
+		else if (!(await opts.checks.commitOnBranch(commit, opts.branch))) blockers.push("commit-not-on-branch");
+	}
+
+	// 3. PR / issue artifact.
+	const artifact = await opts.checks.prOrIssue();
+	if (opts.requirePr && !artifact.prUrl && !artifact.issueArtifact) blockers.push("missing-pr-or-issue");
+
+	if (blockers.length > 0) {
+		return {
+			completed: false,
+			receiptPath: null,
+			validation,
+			commitHash: commit,
+			prUrl: artifact.prUrl,
+			issueArtifact: artifact.issueArtifact,
+			blockers,
+		};
+	}
+
+	// 4. Completion receipt + predicate.
+	const completion: CompletionEvidence = {
+		finalCommit: commit ?? "",
+		branch: opts.branch,
+		prUrl: artifact.prUrl,
+		issueArtifact: artifact.issueArtifact,
+		requiredValidationReceiptIds: validationReceiptIds,
+		finalLifecycle: "completed",
+		finalizedAt: now(),
+		blockers: [],
+	};
+	const receipt = buildReceipt<CompletionEvidence>({
+		receiptId: receiptId("done"),
+		sessionId: opts.sessionId,
+		family: "completion",
+		source: "finalizer",
+		subject,
+		evidence: completion,
+		createdAt: now(),
+	});
+	const outcome = validateReceipt(receipt);
+	const entry = await writeReceiptImmutable(opts.root, opts.sessionId, "completion", receipt.receiptId, receipt);
+	return {
+		completed: outcome.valid,
+		receiptPath: entry.path,
+		validation,
+		commitHash: commit,
+		prUrl: artifact.prUrl,
+		issueArtifact: artifact.issueArtifact,
+		blockers: outcome.valid ? [] : outcome.reasons,
+	};
+}
+
+function git(workspace: string, args: string[]): string | null {
+	try {
+		return execFileSync("git", args, {
+			cwd: workspace,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return null;
+	}
+}
+
+/** Real checks: git for commit/branch, gh for PR, Bun.spawn for validation commands. */
+export function defaultFinalizeChecks(workspace: string): FinalizeChecks {
+	return {
+		async runValidation(spec) {
+			const proc = Bun.spawnSync(["bash", "-lc", spec.command], { cwd: workspace, stdout: "pipe", stderr: "pipe" });
+			const exitStatus = proc.exitCode ?? 1;
+			return { exactCommand: spec.command, cwd: workspace, exitStatus, pass: exitStatus === 0 };
+		},
+		async resolveCommit() {
+			return git(workspace, ["rev-parse", "HEAD"]);
+		},
+		async commitOnBranch(commit, branch) {
+			const merged = git(workspace, ["branch", "--contains", commit, "--format=%(refname:short)"]);
+			if (!merged) return false;
+			return merged.split("\n").some(b => b.trim() === branch);
+		},
+		async prOrIssue() {
+			try {
+				const out = execFileSync("gh", ["pr", "view", "--json", "url", "-q", ".url"], {
+					cwd: workspace,
+					encoding: "utf8",
+					stdio: ["ignore", "pipe", "ignore"],
+				}).trim();
+				return { prUrl: out || null, issueArtifact: null };
+			} catch {
+				return { prUrl: null, issueArtifact: null };
+			}
+		},
+	};
+}

--- a/packages/coding-agent/src/harness-control-plane/operate.ts
+++ b/packages/coding-agent/src/harness-control-plane/operate.ts
@@ -48,6 +48,8 @@ export interface OperateOptions {
 	retryBudget?: Partial<RetryBudget>;
 	acceptanceTimeoutMs?: number;
 	maxIterations?: number;
+	/** Identity stamped on emitted events; the owner passes its lease identity so events stay single-writer-consistent. */
+	eventWriter?: { ownerId: string; leaseEpoch: number };
 	clock?: () => number;
 }
 
@@ -83,7 +85,7 @@ export async function operate(goal: string, opts: OperateOptions): Promise<Opera
 			state: { sessionId: opts.sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers },
 			evidence,
 			nextAllowedActions: [],
-			writer: { ownerId: "operate", leaseEpoch: 0 },
+			writer: opts.eventWriter ?? { ownerId: "operate", leaseEpoch: 0 },
 		};
 		await appendEvent(opts.root, opts.sessionId, envelope);
 	};

--- a/packages/coding-agent/src/harness-control-plane/operate.ts
+++ b/packages/coding-agent/src/harness-control-plane/operate.ts
@@ -178,6 +178,13 @@ export async function operate(goal: string, opts: OperateOptions): Promise<Opera
 		return { completed: false, lifecycle, iterations, classifications, vanishReceiptIds, blockers };
 	}
 
+	// B3: never finalize on loop-exhaustion — require an explicit observed completion.
+	if (lifecycle !== "finalizing") {
+		blockers.push("no-observed-completion");
+		await emit("critical", "operate_blocked", { blockers });
+		return { completed: false, lifecycle: "blocked", iterations, classifications, vanishReceiptIds, blockers };
+	}
+
 	const finalize = await runFinalize({
 		root: opts.root,
 		sessionId: opts.sessionId,

--- a/packages/coding-agent/src/harness-control-plane/operate.ts
+++ b/packages/coding-agent/src/harness-control-plane/operate.ts
@@ -20,6 +20,7 @@ import {
 	validateReceipt,
 } from "./receipts";
 import { type HarnessRpc, singleFlightAccept } from "./rpc-adapter";
+import { nextAllowedActions } from "./state-machine";
 import { appendEvent, readEvents, writeReceiptImmutable } from "./storage";
 import {
 	DEFAULT_RETRY_BUDGET,
@@ -28,6 +29,7 @@ import {
 	type Observation,
 	type RecoveryClassification,
 	type RetryBudget,
+	type SessionStateView,
 	type Severity,
 } from "./types";
 
@@ -50,6 +52,8 @@ export interface OperateOptions {
 	maxIterations?: number;
 	/** Identity stamped on emitted events; the owner passes its lease identity so events stay single-writer-consistent. */
 	eventWriter?: { ownerId: string; leaseEpoch: number };
+	/** Injected event emitter (the owner passes its single-writer #emit so events share cursor/lease/state). */
+	emit?: (severity: Severity, kind: string, evidence: Record<string, unknown>) => Promise<void>;
 	clock?: () => number;
 }
 
@@ -75,20 +79,29 @@ export async function operate(goal: string, opts: OperateOptions): Promise<Opera
 	let rpc = opts.rpc;
 
 	const now = (): string => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
-	const emit = async (severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> => {
+	let lifecycle: HarnessLifecycle = "started";
+	const defaultEmit = async (severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> => {
+		const state: SessionStateView = {
+			sessionId: opts.sessionId,
+			lifecycle,
+			harness: "gajae-code",
+			ownerLive: true,
+			blockers,
+		};
 		const envelope: EventEnvelope = {
 			eventId: randomUUID(),
 			cursor: ++cursor,
 			createdAt: now(),
 			severity,
 			kind,
-			state: { sessionId: opts.sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers },
+			state,
 			evidence,
-			nextAllowedActions: [],
+			nextAllowedActions: nextAllowedActions(lifecycle, true),
 			writer: opts.eventWriter ?? { ownerId: "operate", leaseEpoch: 0 },
 		};
 		await appendEvent(opts.root, opts.sessionId, envelope);
 	};
+	const emit = opts.emit ?? defaultEmit;
 
 	const writeVanish = async (obs: Observation, classification: RecoveryClassification): Promise<boolean> => {
 		const dirty = obs.gitDelta === "dirty" || obs.gitDelta === "unknown";
@@ -140,7 +153,7 @@ export async function operate(goal: string, opts: OperateOptions): Promise<Opera
 
 	await emit("info", "operate_started", { goal });
 	let accepted = await submit();
-	let lifecycle: HarnessLifecycle = accepted ? "observing" : "submitted";
+	lifecycle = accepted ? "observing" : "submitted";
 	let iterations = 0;
 
 	while (iterations < maxIterations) {

--- a/packages/coding-agent/src/harness-control-plane/operate.ts
+++ b/packages/coding-agent/src/harness-control-plane/operate.ts
@@ -11,6 +11,7 @@
  */
 import { randomBytes, randomUUID } from "node:crypto";
 import { type FinalizeChecks, type FinalizeResult, runFinalize, type ValidationCommandSpec } from "./finalize";
+import { type PreserveResult, preserveDirtyWorktree } from "./preserve";
 import {
 	buildReceipt,
 	type ReceiptSubject,
@@ -40,6 +41,8 @@ export interface OperateOptions {
 	rpcFactory?: () => HarnessRpc;
 	/** Bounded observation provider (scripted in tests; real = git + rpc state). */
 	observe: () => Promise<Observation>;
+	/** Real dirty-worktree preservation; injectable for tests. Defaults to git stash/diff capture. */
+	preserve?: (workspace: string) => PreserveResult;
 	finalizeChecks: FinalizeChecks;
 	validationCommands?: ValidationCommandSpec[];
 	retryBudget?: Partial<RetryBudget>;
@@ -87,14 +90,26 @@ export async function operate(goal: string, opts: OperateOptions): Promise<Opera
 
 	const writeVanish = async (obs: Observation, classification: RecoveryClassification): Promise<boolean> => {
 		const dirty = obs.gitDelta === "dirty" || obs.gitDelta === "unknown";
+		let untrackedManifest: VanishEvidence["untrackedManifest"] = [];
+		let stashRef: string | null = null;
+		let snapshotComplete = true;
+		let gitStatusPorcelain = obs.observedSignals.join(",");
+		if (dirty) {
+			const preserve = opts.preserve ?? preserveDirtyWorktree;
+			const p = preserve(opts.workspace);
+			untrackedManifest = p.untrackedManifest;
+			stashRef = p.stashRef;
+			snapshotComplete = p.snapshotComplete;
+			gitStatusPorcelain = `tracked-diff-sha:${p.trackedDiffSha256};untracked:${p.untrackedManifest.length};stash:${p.stashRef ?? "none"}`;
+		}
 		const evidence: VanishEvidence = {
 			classification,
 			gitDelta: obs.gitDelta,
-			gitStatusPorcelain: obs.observedSignals.join(","),
-			untrackedManifest: [],
-			preservation: "snapshot",
-			stashRef: null,
-			snapshotComplete: true,
+			gitStatusPorcelain,
+			untrackedManifest,
+			preservation: dirty && stashRef ? "stash" : "snapshot",
+			stashRef,
+			snapshotComplete,
 			forbiddenActions: dirty ? ["restart-clean", "delete", "reset"] : [],
 		};
 		const receipt = buildReceipt<VanishEvidence>({

--- a/packages/coding-agent/src/harness-control-plane/operate.ts
+++ b/packages/coding-agent/src/harness-control-plane/operate.ts
@@ -1,0 +1,214 @@
+/**
+ * operate(goal) — autonomous owner-driven lifecycle (M9) integrating the recovery loop (M6).
+ *
+ * start -> submit(single-flight) -> [observe -> classify -> recover]* -> finalize(evidence-gated).
+ * Destructive recovery (restart-clean/preserve-delta/fallback) writes a valid `vanish` receipt
+ * BEFORE acting; dirty/unknown deltas are preserved, never clean-restarted. The loop is bounded
+ * by `maxIterations` and the per-classification retry budgets.
+ *
+ * External effects (RPC, observation, validation/git/gh) are injected so the whole lifecycle is
+ * unit/e2e-testable with a fake harness.
+ */
+import { randomBytes, randomUUID } from "node:crypto";
+import { type FinalizeChecks, type FinalizeResult, runFinalize, type ValidationCommandSpec } from "./finalize";
+import {
+	buildReceipt,
+	type ReceiptSubject,
+	requiresVanishBeforeAction,
+	type VanishEvidence,
+	validateReceipt,
+} from "./receipts";
+import { type HarnessRpc, singleFlightAccept } from "./rpc-adapter";
+import { appendEvent, readEvents, writeReceiptImmutable } from "./storage";
+import {
+	DEFAULT_RETRY_BUDGET,
+	type EventEnvelope,
+	type HarnessLifecycle,
+	type Observation,
+	type RecoveryClassification,
+	type RetryBudget,
+	type Severity,
+} from "./types";
+
+export interface OperateOptions {
+	root: string;
+	sessionId: string;
+	workspace: string;
+	branch: string;
+	rpc: HarnessRpc;
+	/** Factory used to (re)create the RPC subprocess on restart recovery. Defaults to reusing `rpc`. */
+	rpcFactory?: () => HarnessRpc;
+	/** Bounded observation provider (scripted in tests; real = git + rpc state). */
+	observe: () => Promise<Observation>;
+	finalizeChecks: FinalizeChecks;
+	validationCommands?: ValidationCommandSpec[];
+	retryBudget?: Partial<RetryBudget>;
+	acceptanceTimeoutMs?: number;
+	maxIterations?: number;
+	clock?: () => number;
+}
+
+export interface OperateResult {
+	completed: boolean;
+	lifecycle: HarnessLifecycle;
+	iterations: number;
+	classifications: RecoveryClassification[];
+	vanishReceiptIds: string[];
+	finalize?: FinalizeResult;
+	blockers: string[];
+}
+
+export async function operate(goal: string, opts: OperateOptions): Promise<OperateResult> {
+	const budget: RetryBudget = { ...DEFAULT_RETRY_BUDGET, ...opts.retryBudget };
+	const acceptanceTimeoutMs = opts.acceptanceTimeoutMs ?? 30_000;
+	const maxIterations = opts.maxIterations ?? 10;
+	const subject: ReceiptSubject = { workspace: opts.workspace, branch: opts.branch, head: null, commit: null };
+	const classifications: RecoveryClassification[] = [];
+	const vanishReceiptIds: string[] = [];
+	const blockers: string[] = [];
+	let cursor = (await readEvents(opts.root, opts.sessionId, 0)).reduce((m, e) => Math.max(m, e.cursor), 0);
+	let rpc = opts.rpc;
+
+	const now = (): string => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
+	const emit = async (severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> => {
+		const envelope: EventEnvelope = {
+			eventId: randomUUID(),
+			cursor: ++cursor,
+			createdAt: now(),
+			severity,
+			kind,
+			state: { sessionId: opts.sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers },
+			evidence,
+			nextAllowedActions: [],
+			writer: { ownerId: "operate", leaseEpoch: 0 },
+		};
+		await appendEvent(opts.root, opts.sessionId, envelope);
+	};
+
+	const writeVanish = async (obs: Observation, classification: RecoveryClassification): Promise<boolean> => {
+		const dirty = obs.gitDelta === "dirty" || obs.gitDelta === "unknown";
+		const evidence: VanishEvidence = {
+			classification,
+			gitDelta: obs.gitDelta,
+			gitStatusPorcelain: obs.observedSignals.join(","),
+			untrackedManifest: [],
+			preservation: "snapshot",
+			stashRef: null,
+			snapshotComplete: true,
+			forbiddenActions: dirty ? ["restart-clean", "delete", "reset"] : [],
+		};
+		const receipt = buildReceipt<VanishEvidence>({
+			receiptId: `vanish-${Date.now()}-${randomBytes(4).toString("hex")}`,
+			sessionId: opts.sessionId,
+			family: "vanish",
+			source: "operate",
+			subject,
+			evidence,
+			createdAt: now(),
+		});
+		const outcome = validateReceipt(receipt);
+		await writeReceiptImmutable(opts.root, opts.sessionId, "vanish", receipt.receiptId, receipt);
+		vanishReceiptIds.push(receipt.receiptId);
+		await emit(outcome.valid ? "critical" : "warn", "vanish_receipt", { classification, valid: outcome.valid });
+		return outcome.valid;
+	};
+
+	const submit = async (): Promise<boolean> => {
+		const acc = await singleFlightAccept(rpc, goal, acceptanceTimeoutMs);
+		await emit(acc.accepted ? "info" : "warn", acc.accepted ? "prompt_accepted" : "prompt_not_accepted", {
+			reason: acc.reason,
+		});
+		return acc.accepted;
+	};
+
+	await emit("info", "operate_started", { goal });
+	let accepted = await submit();
+	let lifecycle: HarnessLifecycle = accepted ? "observing" : "submitted";
+	let iterations = 0;
+
+	while (iterations < maxIterations) {
+		iterations++;
+		const obs = await opts.observe();
+		const decision = classifyRecoveryLocal(obs, budget, accepted);
+		classifications.push(decision.classification);
+		await emit(decision.severity, `classified:${decision.classification}`, { reason: decision.reason });
+
+		if (decision.classification === "continue") {
+			if (obs.observedSignals.includes("completed") || obs.lifecycle === "finalizing") {
+				lifecycle = "finalizing";
+				break;
+			}
+			continue;
+		}
+
+		// Destructive/recovery actions require a valid vanish receipt first.
+		if (requiresVanishBeforeAction(decision.classification)) {
+			const safe = await writeVanish(obs, decision.classification);
+			if (!safe) {
+				lifecycle = "blocked";
+				blockers.push("invalid-vanish-receipt");
+				break;
+			}
+		}
+
+		if (decision.classification === "reinject-prompt") {
+			budget.reinjectPrompt = Math.max(0, budget.reinjectPrompt - 1);
+			accepted = await submit();
+		} else if (decision.classification === "restart-clean") {
+			budget.zeroDeltaVanish = Math.max(0, budget.zeroDeltaVanish - 1);
+			rpc = opts.rpcFactory ? opts.rpcFactory() : rpc;
+			accepted = await submit();
+		} else if (decision.classification === "restart-preserve-delta") {
+			budget.dirtyVanishPreserve = Math.max(0, budget.dirtyVanishPreserve - 1);
+			rpc = opts.rpcFactory ? opts.rpcFactory() : rpc;
+			accepted = await submit();
+		} else if (decision.classification === "fallback-codex-exec") {
+			lifecycle = "blocked";
+			blockers.push("fallback-codex-exec-requested");
+			break;
+		} else if (decision.classification === "human-check") {
+			lifecycle = "blocked";
+			blockers.push("human-check-required");
+			break;
+		}
+	}
+
+	if (lifecycle === "blocked") {
+		await emit("critical", "operate_blocked", { blockers });
+		return { completed: false, lifecycle, iterations, classifications, vanishReceiptIds, blockers };
+	}
+
+	const finalize = await runFinalize({
+		root: opts.root,
+		sessionId: opts.sessionId,
+		workspace: opts.workspace,
+		branch: opts.branch,
+		requireTests: true,
+		requireCommit: true,
+		requirePr: true,
+		validationCommands: opts.validationCommands,
+		checks: opts.finalizeChecks,
+		clock: opts.clock,
+	});
+	await emit(finalize.completed ? "info" : "critical", "operate_finalized", {
+		completed: finalize.completed,
+		blockers: finalize.blockers,
+	});
+	return {
+		completed: finalize.completed,
+		lifecycle: finalize.completed ? "completed" : "blocked",
+		iterations,
+		classifications,
+		vanishReceiptIds,
+		finalize,
+		blockers: finalize.blockers,
+	};
+}
+
+// Local import indirection keeps the classifier dependency explicit at the call site.
+import { classifyRecovery } from "./classifier";
+import type { RecoveryDecision } from "./types";
+
+function classifyRecoveryLocal(obs: Observation, budget: RetryBudget, acceptedPromptActive: boolean): RecoveryDecision {
+	return classifyRecovery({ observation: obs, retryBudget: budget, acceptedPromptActive });
+}

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -10,9 +10,23 @@
  *
  * Stateless `gjc harness` CLI calls reach the owner via {@link resolveOwner} + the endpoint.
  */
-import { randomUUID } from "node:crypto";
+
+import { execFileSync } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { classifyRecovery } from "./classifier";
 import { ControlServer, type EndpointRequest } from "./control-endpoint";
 import { defaultFinalizeChecks, type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "./finalize";
+import { type OperateResult, operate } from "./operate";
+import { preserveDirtyWorktree } from "./preserve";
+import {
+	buildReceipt,
+	type ReceiptSubject,
+	requiresVanishBeforeAction,
+	type ValidationEvidence,
+	type VanishEvidence,
+	validateReceipt,
+} from "./receipts";
 import type { HarnessRpc } from "./rpc-adapter";
 import { singleFlightAccept } from "./rpc-adapter";
 import {
@@ -25,8 +39,16 @@ import {
 	type SessionLease,
 } from "./session-lease";
 import { buildStateView, nextAllowedActions } from "./state-machine";
-import { appendEvent, readEvents, readSessionState, sessionPaths, writeSessionState } from "./storage";
-import type { EventEnvelope, PrimitiveResponse, SessionState, Severity } from "./types";
+import {
+	appendEvent,
+	readEvents,
+	readSessionState,
+	sessionPaths,
+	writeReceiptImmutable,
+	writeSessionState,
+} from "./storage";
+import type { EventEnvelope, GitDelta, Observation, PrimitiveResponse, SessionState, Severity } from "./types";
+import { DEFAULT_RETRY_BUDGET } from "./types";
 
 export interface OwnerOptions {
 	root: string;
@@ -158,9 +180,156 @@ export class RuntimeOwner {
 				return this.#retire();
 			case "finalize":
 				return this.#finalize(req.input);
+			case "recover":
+				return this.#recover();
+			case "validate":
+				return this.#validate();
+			case "operate":
+				return this.#operate(req.input);
 			default:
 				return { ok: false, error: `owner_unsupported_verb:${req.verb}` };
 		}
+	}
+
+	async #observeGit(): Promise<Observation> {
+		const state = await this.#loadState();
+		const workspace = state.handle.workspace;
+		let streaming = false;
+		try {
+			streaming = (await this.#opts.rpc.getState()).isStreaming;
+		} catch {
+			streaming = false;
+		}
+		let gitDelta: GitDelta = "unknown";
+		let branch = state.handle.branch;
+		let deleted = false;
+		if (!existsSync(workspace)) {
+			deleted = true;
+		} else {
+			try {
+				branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+					cwd: workspace,
+					encoding: "utf8",
+					stdio: ["ignore", "pipe", "ignore"],
+				}).trim();
+			} catch {
+				// keep prior branch
+			}
+			try {
+				const porcelain = execFileSync("git", ["status", "--porcelain"], {
+					cwd: workspace,
+					encoding: "utf8",
+					stdio: ["ignore", "pipe", "ignore"],
+				});
+				gitDelta = porcelain.trim().length > 0 ? "dirty" : "clean";
+			} catch {
+				gitDelta = "unknown";
+			}
+		}
+		return {
+			lifecycle: state.lifecycle,
+			ownerLive: true,
+			cwd: workspace,
+			branch,
+			gitDelta,
+			lastActivityAt: state.updatedAt,
+			observedSignals: streaming ? ["streaming"] : ["idle"],
+			risk: deleted ? "deleted-worktree" : "normal",
+		};
+	}
+
+	async #validate(): Promise<PrimitiveResponse> {
+		const state = await this.#loadState();
+		const checks = this.#finalizeChecks ?? defaultFinalizeChecks(state.handle.workspace);
+		const commit = await checks.resolveCommit();
+		const subject: ReceiptSubject = {
+			workspace: state.handle.workspace,
+			branch: state.handle.branch,
+			head: commit,
+			commit,
+		};
+		const validation: { name: string; valid: boolean; exitStatus: number }[] = [];
+		for (const spec of this.#validationCommands ?? []) {
+			const run = await checks.runValidation(spec);
+			const evidence: ValidationEvidence = {
+				command: spec.name,
+				exactCommand: run.exactCommand,
+				cwd: run.cwd,
+				exitStatus: run.exitStatus,
+				pass: run.pass,
+				commitUnderTest: commit,
+			};
+			const receipt = buildReceipt<ValidationEvidence>({
+				receiptId: `val-${Date.now()}-${randomBytes(4).toString("hex")}`,
+				sessionId: this.#opts.sessionId,
+				family: "validation",
+				source: "owner",
+				subject,
+				evidence,
+				valid: run.pass,
+			});
+			await writeReceiptImmutable(this.#opts.root, this.#opts.sessionId, "validation", receipt.receiptId, receipt);
+			validation.push({ name: spec.name, valid: validateReceipt(receipt).valid, exitStatus: run.exitStatus });
+		}
+		state.lifecycle = "validating";
+		state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+		await writeSessionState(this.#opts.root, state);
+		await this.#emit("info", "validated", { count: validation.length });
+		return this.#response(state, { validation });
+	}
+
+	async #recover(): Promise<PrimitiveResponse> {
+		const obs = await this.#observeGit();
+		const decision = classifyRecovery({ observation: obs, retryBudget: { ...DEFAULT_RETRY_BUDGET } });
+		let vanishReceiptId: string | null = null;
+		if (requiresVanishBeforeAction(decision.classification)) {
+			const dirty = obs.gitDelta === "dirty" || obs.gitDelta === "unknown";
+			const p = dirty ? preserveDirtyWorktree(obs.cwd) : null;
+			const evidence: VanishEvidence = {
+				classification: decision.classification,
+				gitDelta: obs.gitDelta,
+				gitStatusPorcelain: p
+					? `tracked:${p.trackedDiffSha256};untracked:${p.untrackedManifest.length}`
+					: obs.observedSignals.join(","),
+				untrackedManifest: p?.untrackedManifest ?? [],
+				preservation: p?.stashRef ? "stash" : "snapshot",
+				stashRef: p?.stashRef ?? null,
+				snapshotComplete: p?.snapshotComplete ?? true,
+				forbiddenActions: dirty ? ["restart-clean", "delete", "reset"] : [],
+			};
+			const receipt = buildReceipt<VanishEvidence>({
+				receiptId: `vanish-${Date.now()}-${randomBytes(4).toString("hex")}`,
+				sessionId: this.#opts.sessionId,
+				family: "vanish",
+				source: "owner",
+				subject: { workspace: obs.cwd, branch: obs.branch, head: null, commit: null },
+				evidence,
+			});
+			await writeReceiptImmutable(this.#opts.root, this.#opts.sessionId, "vanish", receipt.receiptId, receipt);
+			vanishReceiptId = receipt.receiptId;
+		}
+		const state = await this.#loadState();
+		await this.#emit(decision.severity, "recover_classified", { classification: decision.classification });
+		return this.#response(state, { decision, observation: obs, vanishReceiptId });
+	}
+
+	async #operate(input: Record<string, unknown>): Promise<PrimitiveResponse> {
+		const goal = typeof input.goal === "string" ? input.goal : "";
+		let state = await this.#loadState();
+		if (!goal) return this.#response(state, { error: "empty-goal" }, false);
+		const result: OperateResult = await operate(goal, {
+			root: this.#opts.root,
+			sessionId: this.#opts.sessionId,
+			workspace: state.handle.workspace,
+			branch: state.handle.branch ?? "",
+			rpc: this.#opts.rpc,
+			observe: () => this.#observeGit(),
+			finalizeChecks: this.#finalizeChecks ?? defaultFinalizeChecks(state.handle.workspace),
+			validationCommands: this.#validationCommands,
+			maxIterations: typeof input.maxIterations === "number" ? input.maxIterations : 5,
+		});
+		state = await this.#loadState();
+		return this.#response(state, { operate: result }, result.completed);
 	}
 
 	async #finalize(input: Record<string, unknown>): Promise<PrimitiveResponse> {

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -327,7 +327,7 @@ export class RuntimeOwner {
 			finalizeChecks: this.#finalizeChecks ?? defaultFinalizeChecks(state.handle.workspace),
 			validationCommands: this.#validationCommands,
 			maxIterations: typeof input.maxIterations === "number" ? input.maxIterations : 5,
-			eventWriter: { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch },
+			emit: (severity, kind, evidence) => this.#emit(severity, kind, evidence),
 		});
 		// Persist the loop's terminal lifecycle/blockers so the response state is not stale.
 		state = await this.#loadState();

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -12,6 +12,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { ControlServer, type EndpointRequest } from "./control-endpoint";
+import { defaultFinalizeChecks, type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "./finalize";
 import type { HarnessRpc } from "./rpc-adapter";
 import { singleFlightAccept } from "./rpc-adapter";
 import {
@@ -36,6 +37,8 @@ export interface OwnerOptions {
 	heartbeatMs?: number;
 	acceptanceTimeoutMs?: number;
 	clock?: () => number;
+	finalizeChecks?: FinalizeChecks;
+	validationCommands?: ValidationCommandSpec[];
 }
 
 export interface OwnerStartInfo {
@@ -50,12 +53,14 @@ const DEFAULT_ACCEPT_TIMEOUT_MS = 60_000;
 
 export class RuntimeOwner {
 	readonly ownerId: string;
-	#opts: Required<Omit<OwnerOptions, "clock">> & { clock?: () => number };
+	#opts: Required<Omit<OwnerOptions, "clock" | "finalizeChecks" | "validationCommands">> & { clock?: () => number };
 	#server: ControlServer;
 	#cursor = 0;
 	#leaseEpoch = 0;
 	#heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 	#socketPath: string;
+	#finalizeChecks?: FinalizeChecks;
+	#validationCommands?: ValidationCommandSpec[];
 
 	constructor(opts: OwnerOptions) {
 		this.ownerId = opts.ownerId ?? `owner-${randomUUID()}`;
@@ -70,6 +75,8 @@ export class RuntimeOwner {
 			acceptanceTimeoutMs: opts.acceptanceTimeoutMs ?? DEFAULT_ACCEPT_TIMEOUT_MS,
 			clock: opts.clock,
 		};
+		this.#finalizeChecks = opts.finalizeChecks;
+		this.#validationCommands = opts.validationCommands;
 		this.#server = new ControlServer(this.#socketPath, req => this.#handle(req));
 	}
 
@@ -149,9 +156,38 @@ export class RuntimeOwner {
 				return this.#observe();
 			case "retire":
 				return this.#retire();
+			case "finalize":
+				return this.#finalize(req.input);
 			default:
 				return { ok: false, error: `owner_unsupported_verb:${req.verb}` };
 		}
+	}
+
+	async #finalize(input: Record<string, unknown>): Promise<PrimitiveResponse> {
+		const state = await this.#loadState();
+		const workspace = state.handle.workspace;
+		const checks = this.#finalizeChecks ?? defaultFinalizeChecks(workspace);
+		const fin = await runFinalize({
+			root: this.#opts.root,
+			sessionId: this.#opts.sessionId,
+			workspace,
+			branch: state.handle.branch ?? "",
+			requireTests: input.requireTests !== false,
+			requireCommit: input.requireCommit !== false,
+			requirePr: input.requirePr !== false,
+			validationCommands: this.#validationCommands,
+			checks,
+			clock: this.#opts.clock,
+		});
+		state.lifecycle = fin.completed ? "completed" : "blocked";
+		state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+		if (!fin.completed) state.blockers = fin.blockers;
+		await writeSessionState(this.#opts.root, state);
+		await this.#emit(fin.completed ? "info" : "critical", "finalized", {
+			completed: fin.completed,
+			blockers: fin.blockers,
+		});
+		return this.#response(state, { finalize: fin }, fin.completed);
 	}
 
 	async #submit(input: Record<string, unknown>): Promise<PrimitiveResponse> {

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -327,8 +327,14 @@ export class RuntimeOwner {
 			finalizeChecks: this.#finalizeChecks ?? defaultFinalizeChecks(state.handle.workspace),
 			validationCommands: this.#validationCommands,
 			maxIterations: typeof input.maxIterations === "number" ? input.maxIterations : 5,
+			eventWriter: { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch },
 		});
+		// Persist the loop's terminal lifecycle/blockers so the response state is not stale.
 		state = await this.#loadState();
+		state.lifecycle = result.lifecycle;
+		state.blockers = result.blockers;
+		state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+		await writeSessionState(this.#opts.root, state);
 		return this.#response(state, { operate: result }, result.completed);
 	}
 

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -1,0 +1,242 @@
+/**
+ * RuntimeOwner — the detached per-session process that makes live control honest.
+ *
+ * Responsibilities:
+ *  - hold the {@link SessionLease} (single writer),
+ *  - own the {@link HarnessRpc} subprocess (injected; real `GajaeCodeRpc` in prod, fake in tests),
+ *  - serve owner-routed primitives over the {@link ControlServer} endpoint,
+ *  - be the SOLE writer of the severity event stream,
+ *  - heartbeat the lease.
+ *
+ * Stateless `gjc harness` CLI calls reach the owner via {@link resolveOwner} + the endpoint.
+ */
+import { randomUUID } from "node:crypto";
+import { ControlServer, type EndpointRequest } from "./control-endpoint";
+import type { HarnessRpc } from "./rpc-adapter";
+import { singleFlightAccept } from "./rpc-adapter";
+import {
+	acquireLease,
+	canWriteEvents,
+	heartbeat,
+	isStale,
+	readLease,
+	releaseLease,
+	type SessionLease,
+} from "./session-lease";
+import { buildStateView, nextAllowedActions } from "./state-machine";
+import { appendEvent, readEvents, readSessionState, sessionPaths, writeSessionState } from "./storage";
+import type { EventEnvelope, PrimitiveResponse, SessionState, Severity } from "./types";
+
+export interface OwnerOptions {
+	root: string;
+	sessionId: string;
+	rpc: HarnessRpc;
+	ownerId?: string;
+	ttlMs?: number;
+	heartbeatMs?: number;
+	acceptanceTimeoutMs?: number;
+	clock?: () => number;
+}
+
+export interface OwnerStartInfo {
+	ownerId: string;
+	socketPath: string;
+	leaseEpoch: number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_HEARTBEAT_MS = 10_000;
+const DEFAULT_ACCEPT_TIMEOUT_MS = 60_000;
+
+export class RuntimeOwner {
+	readonly ownerId: string;
+	#opts: Required<Omit<OwnerOptions, "clock">> & { clock?: () => number };
+	#server: ControlServer;
+	#cursor = 0;
+	#leaseEpoch = 0;
+	#heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+	#socketPath: string;
+
+	constructor(opts: OwnerOptions) {
+		this.ownerId = opts.ownerId ?? `owner-${randomUUID()}`;
+		this.#socketPath = sessionPaths(opts.root, opts.sessionId).controlSock;
+		this.#opts = {
+			root: opts.root,
+			sessionId: opts.sessionId,
+			rpc: opts.rpc,
+			ownerId: this.ownerId,
+			ttlMs: opts.ttlMs ?? DEFAULT_TTL_MS,
+			heartbeatMs: opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS,
+			acceptanceTimeoutMs: opts.acceptanceTimeoutMs ?? DEFAULT_ACCEPT_TIMEOUT_MS,
+			clock: opts.clock,
+		};
+		this.#server = new ControlServer(this.#socketPath, req => this.#handle(req));
+	}
+
+	async start(): Promise<OwnerStartInfo> {
+		const { root, sessionId } = this.#opts;
+		const eventsPath = sessionPaths(root, sessionId).events;
+		const existing = await readEvents(root, sessionId, 0);
+		this.#cursor = existing.reduce((max, e) => Math.max(max, e.cursor), 0);
+		const { lease } = await acquireLease(root, sessionId, {
+			ownerId: this.ownerId,
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: this.#socketPath },
+			eventsPath,
+			ttlMs: this.#opts.ttlMs,
+			clock: this.#opts.clock,
+		});
+		this.#leaseEpoch = lease.leaseEpoch;
+		await this.#server.listen();
+		await this.#emit("info", "owner_started", { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch });
+		this.#heartbeatTimer = setInterval(() => {
+			void heartbeat(root, sessionId, this.ownerId, this.#opts.ttlMs, this.#opts.clock).catch(() => {});
+		}, this.#opts.heartbeatMs);
+		this.#heartbeatTimer.unref?.();
+		return { ownerId: this.ownerId, socketPath: this.#socketPath, leaseEpoch: this.#leaseEpoch };
+	}
+
+	async #loadState(): Promise<SessionState> {
+		const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
+		if (!state) throw new Error(`session_not_found:${this.#opts.sessionId}`);
+		return state;
+	}
+
+	async #emit(severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> {
+		const lease = await readLease(this.#opts.root, this.#opts.sessionId);
+		// Single-writer guard: only emit while we still hold a live lease.
+		if (!lease || !canWriteEvents(lease, this.ownerId, this.#opts.clock)) return;
+		const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
+		const view = state
+			? buildStateView(state, true)
+			: {
+					sessionId: this.#opts.sessionId,
+					lifecycle: "started" as const,
+					harness: "gajae-code" as const,
+					ownerLive: true,
+					blockers: [],
+				};
+		const envelope: EventEnvelope = {
+			eventId: randomUUID(),
+			cursor: ++this.#cursor,
+			createdAt: new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString(),
+			severity,
+			kind,
+			state: view,
+			evidence,
+			nextAllowedActions: nextAllowedActions(view.lifecycle, true),
+			writer: { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch },
+		};
+		await appendEvent(this.#opts.root, this.#opts.sessionId, envelope);
+	}
+
+	#response(state: SessionState, evidence: Record<string, unknown>, ok = true): PrimitiveResponse {
+		return {
+			ok,
+			state: buildStateView(state, true),
+			evidence,
+			nextAllowedActions: nextAllowedActions(state.lifecycle, true),
+		};
+	}
+
+	async #handle(req: EndpointRequest): Promise<unknown> {
+		switch (req.verb) {
+			case "ping":
+				return { ok: true, ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch };
+			case "submit":
+				return this.#submit(req.input);
+			case "observe":
+				return this.#observe();
+			case "retire":
+				return this.#retire();
+			default:
+				return { ok: false, error: `owner_unsupported_verb:${req.verb}` };
+		}
+	}
+
+	async #submit(input: Record<string, unknown>): Promise<PrimitiveResponse> {
+		const prompt = typeof input.prompt === "string" ? input.prompt : "";
+		if (!prompt) {
+			const state = await this.#loadState();
+			return this.#response(state, { accepted: false, reason: "empty-prompt" }, false);
+		}
+		const result = await singleFlightAccept(this.#opts.rpc, prompt, this.#opts.acceptanceTimeoutMs);
+		const state = await this.#loadState();
+		if (result.accepted) {
+			state.lifecycle = "observing";
+			state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+			await writeSessionState(this.#opts.root, state);
+			await this.#emit("info", "prompt_accepted", {
+				reason: result.reason,
+				agentStartCursor: result.agentStartCursor,
+			});
+		} else {
+			await this.#emit("warn", "prompt_not_accepted", { reason: result.reason });
+		}
+		return this.#response(
+			state,
+			{
+				accepted: result.accepted,
+				submitted: true,
+				reason: result.reason,
+				commandId: result.commandId,
+				preSubmitCursor: result.preSubmitCursor,
+				agentStartCursor: result.agentStartCursor,
+				acceptanceEvidence: result.preSubmitState,
+			},
+			result.accepted,
+		);
+	}
+
+	async #observe(): Promise<PrimitiveResponse> {
+		const state = await this.#loadState();
+		const rpcState = await this.#opts.rpc.getState().catch(() => null);
+		return this.#response(state, {
+			observation: {
+				lifecycle: state.lifecycle,
+				ownerLive: true,
+				cwd: state.handle.workspace,
+				branch: state.handle.branch,
+				gitDelta: "unknown",
+				lastActivityAt: state.updatedAt,
+				observedSignals: rpcState?.isStreaming ? ["streaming"] : ["idle"],
+				risk: "normal",
+			},
+			ownerRouted: true,
+		});
+	}
+
+	async #retire(): Promise<PrimitiveResponse> {
+		const state = await this.#loadState();
+		state.lifecycle = "retired";
+		state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+		await writeSessionState(this.#opts.root, state);
+		await this.#emit("info", "owner_retired", {});
+		queueMicrotask(() => void this.stop());
+		return this.#response(state, { retired: true });
+	}
+
+	async stop(): Promise<void> {
+		if (this.#heartbeatTimer) {
+			clearInterval(this.#heartbeatTimer);
+			this.#heartbeatTimer = null;
+		}
+		await this.#server.close().catch(() => {});
+		await this.#opts.rpc.close().catch(() => {});
+		await releaseLease(this.#opts.root, this.#opts.sessionId, this.ownerId).catch(() => {});
+	}
+}
+
+export interface ResolvedOwner {
+	live: boolean;
+	socketPath: string | null;
+	lease: SessionLease | null;
+}
+
+/** Determine whether a live owner currently holds the session (for CLI routing). */
+export async function resolveOwner(root: string, sessionId: string): Promise<ResolvedOwner> {
+	const lease = await readLease(root, sessionId);
+	if (!lease) return { live: false, socketPath: null, lease: null };
+	if (isStale(lease)) return { live: false, socketPath: lease.endpoint?.path ?? null, lease };
+	return { live: true, socketPath: lease.endpoint?.path ?? null, lease };
+}

--- a/packages/coding-agent/src/harness-control-plane/preserve.ts
+++ b/packages/coding-agent/src/harness-control-plane/preserve.ts
@@ -1,0 +1,102 @@
+/**
+ * Real dirty-worktree preservation (architect blocker B2).
+ *
+ * Before any destructive recovery on a dirty/unknown worktree, capture REAL evidence and a
+ * recoverable snapshot WITHOUT mutating the working tree:
+ *   - the tracked diff (`git diff HEAD`) + its sha256,
+ *   - an untracked-file manifest (path/size/sha256),
+ *   - a `git stash create` commit object stored in the stash list (`git stash store`),
+ *     which snapshots tracked+staged changes without touching the worktree.
+ *
+ * This is what backs a valid `vanish` receipt so the data-loss invariant is enforced in
+ * practice, not just structurally.
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import type { GitDelta } from "./types";
+
+export interface UntrackedEntry {
+	path: string;
+	size: number;
+	sha256: string;
+}
+
+export interface PreserveResult {
+	gitDelta: GitDelta;
+	trackedDiff: string;
+	trackedDiffSha256: string;
+	untrackedManifest: UntrackedEntry[];
+	stashRef: string | null;
+	snapshotComplete: boolean;
+}
+
+function git(workspace: string, args: string[]): string {
+	return execFileSync("git", args, { cwd: workspace, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+}
+
+function sha256(input: string | Buffer): string {
+	return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Capture + snapshot a (possibly dirty) worktree without mutating it. Safe to call on a clean
+ * tree (returns empty evidence). Never deletes, resets, or cleans.
+ */
+export function preserveDirtyWorktree(workspace: string): PreserveResult {
+	let trackedDiff = "";
+	try {
+		trackedDiff = git(workspace, ["diff", "HEAD"]);
+	} catch {
+		trackedDiff = "";
+	}
+
+	let untracked: string[] = [];
+	try {
+		untracked = git(workspace, ["ls-files", "--others", "--exclude-standard"])
+			.split("\n")
+			.map(s => s.trim())
+			.filter(Boolean);
+	} catch {
+		untracked = [];
+	}
+
+	const untrackedManifest: UntrackedEntry[] = [];
+	for (const rel of untracked) {
+		try {
+			const buf = readFileSync(path.join(workspace, rel));
+			untrackedManifest.push({ path: rel, size: buf.length, sha256: sha256(buf) });
+		} catch {
+			// unreadable entry — record path with a marker rather than dropping it
+			untrackedManifest.push({ path: rel, size: -1, sha256: "unreadable" });
+		}
+	}
+
+	// `git stash create` builds a stash commit WITHOUT modifying the working tree; store it so
+	// it survives in the stash list as a recoverable ref. No-op (empty oid) on a clean tree.
+	let stashRef: string | null = null;
+	try {
+		const oid = git(workspace, ["stash", "create", "harness-vanish-snapshot"]).trim();
+		if (oid) {
+			git(workspace, ["stash", "store", "-m", "harness-vanish-snapshot", oid]);
+			stashRef = oid;
+		}
+	} catch {
+		stashRef = null;
+	}
+
+	const dirty = trackedDiff.trim().length > 0 || untrackedManifest.length > 0;
+	// snapshotComplete iff every dirty component is actually captured: tracked changes need a
+	// stash ref, untracked entries need readable hashes.
+	const trackedCaptured = trackedDiff.trim().length === 0 || stashRef !== null;
+	const untrackedCaptured = untrackedManifest.every(e => e.sha256 !== "unreadable");
+	return {
+		gitDelta: dirty ? "dirty" : "clean",
+		trackedDiff,
+		trackedDiffSha256: sha256(trackedDiff),
+		untrackedManifest,
+		stashRef,
+		snapshotComplete: trackedCaptured && untrackedCaptured,
+	};
+}

--- a/packages/coding-agent/src/harness-control-plane/receipts.ts
+++ b/packages/coding-agent/src/harness-control-plane/receipts.ts
@@ -1,0 +1,212 @@
+/**
+ * Harness receipt schemas + validators (M7).
+ *
+ * Receipts are NEW schemas that FOLLOW the .gjc/state + ultragoal-ledger patterns
+ * (atomic, append-indexed, immutable) — not drop-in reuse. Every receipt carries a
+ * canonical-JSON sha256 over its content (excluding the hash field) plus referenced
+ * artifact hashes; validators recompute and FAIL CLOSED on tamper/mismatch.
+ *
+ * Families:
+ *   - vanish            captures dirty/unknown delta before any restart/fallback (data-loss gate)
+ *   - prompt-acceptance proves single-flight acceptance (idle pre-state -> ack -> next agent_start)
+ *   - validation        records a verification command result for a specific commit
+ *   - completion        the finalize gate: receipt-valid + commit + PR/issue + validations
+ */
+import { createHash } from "node:crypto";
+import type { GitDelta, ReceiptFamily, RecoveryClassification } from "./types";
+
+export interface ReceiptSubject {
+	workspace: string;
+	branch: string | null;
+	head: string | null;
+	commit: string | null;
+}
+
+export interface ReceiptEnvelope<E = Record<string, unknown>> {
+	receiptId: string;
+	schemaVersion: number;
+	sessionId: string;
+	family: ReceiptFamily;
+	valid: boolean;
+	createdAt: string;
+	source: string;
+	subject: ReceiptSubject;
+	evidence: E;
+	/** Hashes of out-of-line artifacts (diff patches, validation logs) folded into the receipt hash. */
+	artifactHashes: Record<string, string>;
+	sha256: string;
+}
+
+export const RECEIPT_SCHEMA_VERSION = 1 as const;
+
+/** Deterministic stringify with sorted keys (stable hash basis). */
+function canonicalJson(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	return `{${keys.map(k => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(",")}}`;
+}
+
+export function sha256Hex(input: string): string {
+	return createHash("sha256").update(input).digest("hex");
+}
+
+/** Hash basis = canonical JSON of the receipt without `sha256`. */
+function hashBasis(receipt: Omit<ReceiptEnvelope<unknown>, "sha256">): string {
+	return canonicalJson(receipt);
+}
+
+export interface BuildReceiptInput<E> {
+	receiptId: string;
+	sessionId: string;
+	family: ReceiptFamily;
+	source: string;
+	subject: ReceiptSubject;
+	evidence: E;
+	artifactHashes?: Record<string, string>;
+	createdAt?: string;
+	valid?: boolean;
+}
+
+export function buildReceipt<E>(input: BuildReceiptInput<E>): ReceiptEnvelope<E> {
+	const base: Omit<ReceiptEnvelope<E>, "sha256"> = {
+		receiptId: input.receiptId,
+		schemaVersion: RECEIPT_SCHEMA_VERSION,
+		sessionId: input.sessionId,
+		family: input.family,
+		valid: input.valid ?? true,
+		createdAt: input.createdAt ?? new Date().toISOString(),
+		source: input.source,
+		subject: input.subject,
+		evidence: input.evidence,
+		artifactHashes: input.artifactHashes ?? {},
+	};
+	return { ...base, sha256: sha256Hex(hashBasis(base)) };
+}
+
+export interface ValidationOutcome {
+	valid: boolean;
+	reasons: string[];
+}
+
+/** Recompute the hash and run structural family checks. Fail-closed. */
+export function validateReceipt(receipt: ReceiptEnvelope<unknown>): ValidationOutcome {
+	const reasons: string[] = [];
+	const { sha256, ...rest } = receipt;
+	if (sha256Hex(hashBasis(rest)) !== sha256) reasons.push("hash-mismatch");
+	if (receipt.schemaVersion !== RECEIPT_SCHEMA_VERSION) reasons.push("schema-version-mismatch");
+	const familyReasons = validateFamily(receipt);
+	reasons.push(...familyReasons);
+	return { valid: reasons.length === 0, reasons };
+}
+
+// ---- Family evidence shapes ---------------------------------------------------
+
+export interface VanishEvidence {
+	classification: RecoveryClassification;
+	gitDelta: GitDelta;
+	gitStatusPorcelain: string;
+	untrackedManifest: { path: string; size: number; sha256: string }[];
+	preservation: "snapshot" | "stash" | "block";
+	stashRef: string | null;
+	snapshotComplete: boolean;
+	forbiddenActions: string[];
+}
+
+export interface PromptAcceptanceEvidence {
+	promptSha256: string;
+	rpcCommandId: string;
+	preSubmitState: { isStreaming: boolean; steeringQueueDepth: number; followupQueueDepth: number };
+	preSubmitCursor: number;
+	agentStartCursor: number;
+	acceptedAt: string;
+	singleFlight: true;
+}
+
+export interface ValidationEvidence {
+	command: string;
+	exactCommand: string;
+	cwd: string;
+	exitStatus: number;
+	pass: boolean;
+	commitUnderTest: string | null;
+}
+
+export interface CompletionEvidence {
+	finalCommit: string;
+	branch: string;
+	prUrl: string | null;
+	issueArtifact: string | null;
+	requiredValidationReceiptIds: string[];
+	finalLifecycle: string;
+	finalizedAt: string;
+	blockers: string[];
+}
+
+function validateFamily(receipt: ReceiptEnvelope<unknown>): string[] {
+	switch (receipt.family) {
+		case "vanish":
+			return validateVanish(receipt.evidence as VanishEvidence);
+		case "prompt-acceptance":
+			return validatePromptAcceptance(receipt.evidence as PromptAcceptanceEvidence);
+		case "validation":
+			return validateValidation(receipt.evidence as ValidationEvidence);
+		case "completion":
+			return validateCompletion(receipt.evidence as CompletionEvidence);
+		default:
+			return [`unknown-family:${receipt.family}`];
+	}
+}
+
+function validateVanish(e: VanishEvidence): string[] {
+	const reasons: string[] = [];
+	if (!e || typeof e.gitDelta !== "string") return ["vanish-missing-evidence"];
+	// Hard data-loss invariant: a dirty/unknown delta must be preserved (snapshot|stash), never blocked-away.
+	if ((e.gitDelta === "dirty" || e.gitDelta === "unknown") && e.preservation === "block") {
+		reasons.push("vanish-dirty-must-preserve-not-block");
+	}
+	if (e.preservation === "snapshot" && !e.snapshotComplete) reasons.push("vanish-snapshot-incomplete");
+	if (e.preservation === "stash" && !e.stashRef) reasons.push("vanish-stash-missing-ref");
+	if (!Array.isArray(e.forbiddenActions) || !e.forbiddenActions.includes("restart-clean")) {
+		reasons.push("vanish-must-forbid-restart-clean");
+	}
+	return reasons;
+}
+
+function validatePromptAcceptance(e: PromptAcceptanceEvidence): string[] {
+	const reasons: string[] = [];
+	if (!e) return ["acceptance-missing-evidence"];
+	if (e.singleFlight !== true) reasons.push("acceptance-not-single-flight");
+	if (e.preSubmitState?.isStreaming) reasons.push("acceptance-pre-state-streaming");
+	if ((e.preSubmitState?.steeringQueueDepth ?? 1) !== 0) reasons.push("acceptance-steering-queue-nonempty");
+	if ((e.preSubmitState?.followupQueueDepth ?? 1) !== 0) reasons.push("acceptance-followup-queue-nonempty");
+	if (!(e.agentStartCursor > e.preSubmitCursor)) reasons.push("acceptance-agent-start-not-after-cursor");
+	return reasons;
+}
+
+function validateValidation(e: ValidationEvidence): string[] {
+	if (!e || typeof e.exactCommand !== "string") return ["validation-missing-evidence"];
+	return e.pass ? [] : ["validation-failed"];
+}
+
+function validateCompletion(e: CompletionEvidence): string[] {
+	const reasons: string[] = [];
+	if (!e) return ["completion-missing-evidence"];
+	if (!e.finalCommit) reasons.push("completion-missing-commit");
+	if (!e.prUrl && !e.issueArtifact) reasons.push("completion-missing-pr-or-issue");
+	if (!Array.isArray(e.requiredValidationReceiptIds) || e.requiredValidationReceiptIds.length === 0) {
+		reasons.push("completion-missing-validation-receipts");
+	}
+	if (Array.isArray(e.blockers) && e.blockers.length > 0) reasons.push("completion-has-blockers");
+	return reasons;
+}
+
+/** Classifications that MUST have a valid `vanish` receipt before the action proceeds. */
+export function requiresVanishBeforeAction(classification: RecoveryClassification): boolean {
+	return (
+		classification === "restart-clean" ||
+		classification === "restart-preserve-delta" ||
+		classification === "fallback-codex-exec"
+	);
+}

--- a/packages/coding-agent/src/harness-control-plane/receipts.ts
+++ b/packages/coding-agent/src/harness-control-plane/receipts.ts
@@ -162,15 +162,19 @@ function validateFamily(receipt: ReceiptEnvelope<unknown>): string[] {
 function validateVanish(e: VanishEvidence): string[] {
 	const reasons: string[] = [];
 	if (!e || typeof e.gitDelta !== "string") return ["vanish-missing-evidence"];
-	// Hard data-loss invariant: a dirty/unknown delta must be preserved (snapshot|stash), never blocked-away.
-	if ((e.gitDelta === "dirty" || e.gitDelta === "unknown") && e.preservation === "block") {
-		reasons.push("vanish-dirty-must-preserve-not-block");
+	const protectedDelta = e.gitDelta === "dirty" || e.gitDelta === "unknown";
+	if (protectedDelta) {
+		// Hard data-loss invariant: a dirty/unknown delta must be preserved (never blocked-away),
+		// and the destructive actions must be explicitly forbidden.
+		if (e.preservation === "block") reasons.push("vanish-dirty-must-preserve-not-block");
+		for (const action of ["restart-clean", "delete", "reset"]) {
+			if (!Array.isArray(e.forbiddenActions) || !e.forbiddenActions.includes(action)) {
+				reasons.push(`vanish-must-forbid-${action}`);
+			}
+		}
 	}
 	if (e.preservation === "snapshot" && !e.snapshotComplete) reasons.push("vanish-snapshot-incomplete");
 	if (e.preservation === "stash" && !e.stashRef) reasons.push("vanish-stash-missing-ref");
-	if (!Array.isArray(e.forbiddenActions) || !e.forbiddenActions.includes("restart-clean")) {
-		reasons.push("vanish-must-forbid-restart-clean");
-	}
 	return reasons;
 }
 

--- a/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
+++ b/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
@@ -1,0 +1,237 @@
+/**
+ * gajae-code RPC adapter + single-flight acceptance.
+ *
+ * The gajae-code harness is driven via `gjc --mode rpc` (see docs/rpc.md). Acceptance
+ * is a PROTOCOL FACT, not an echo: a prompt is `accepted` only when the RPC command is
+ * acked AND the next `agent_start` event arrives after the pre-submit cursor within the
+ * timeout, with an idle + empty-queue pre-state. Ack alone never means accepted.
+ *
+ * The acceptance logic ({@link singleFlightAccept}) is decoupled from the transport via
+ * the {@link HarnessRpc} interface so it is unit-testable with a fake, while
+ * {@link GajaeCodeRpc} provides the real `gjc --mode rpc` subprocess implementation
+ * (exercised by the M10 e2e suite).
+ */
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+export interface RpcStateSnapshot {
+	isStreaming: boolean;
+	steeringQueueDepth: number;
+	followupQueueDepth: number;
+}
+
+/** Abstract handle to a live gajae-code RPC session. */
+export interface HarnessRpc {
+	getState(): Promise<RpcStateSnapshot>;
+	/** Send a prompt; resolves with the RPC command id and whether it was acked. Does NOT await agent_start. */
+	sendPrompt(prompt: string): Promise<{ commandId: string; ack: boolean }>;
+	/** Monotonic count of events observed so far (the acceptance cursor). */
+	eventCursor(): number;
+	/** Resolve when an `agent_start` event arrives strictly after `afterCursor`, else null on timeout. */
+	waitForAgentStart(afterCursor: number, timeoutMs: number): Promise<{ cursor: number } | null>;
+	close(): Promise<void>;
+}
+
+export interface AcceptanceResult {
+	accepted: boolean;
+	reason: string;
+	commandId: string | null;
+	preSubmitCursor: number;
+	agentStartCursor: number | null;
+	preSubmitState: RpcStateSnapshot;
+}
+
+/**
+ * Single-flight acceptance: idle + empty-queue pre-state, ack, then the NEXT
+ * `agent_start` after the pre-submit cursor within `timeoutMs`.
+ */
+export async function singleFlightAccept(
+	rpc: HarnessRpc,
+	prompt: string,
+	timeoutMs: number,
+): Promise<AcceptanceResult> {
+	const pre = await rpc.getState();
+	const preSubmitCursor = rpc.eventCursor();
+	if (pre.isStreaming || pre.steeringQueueDepth > 0 || pre.followupQueueDepth > 0) {
+		return {
+			accepted: false,
+			reason: "pre-state-not-idle",
+			commandId: null,
+			preSubmitCursor,
+			agentStartCursor: null,
+			preSubmitState: pre,
+		};
+	}
+	const { commandId, ack } = await rpc.sendPrompt(prompt);
+	if (!ack) {
+		return {
+			accepted: false,
+			reason: "no-ack",
+			commandId,
+			preSubmitCursor,
+			agentStartCursor: null,
+			preSubmitState: pre,
+		};
+	}
+	const started = await rpc.waitForAgentStart(preSubmitCursor, timeoutMs);
+	if (!started) {
+		return {
+			accepted: false,
+			reason: "no-agent-start-within-timeout",
+			commandId,
+			preSubmitCursor,
+			agentStartCursor: null,
+			preSubmitState: pre,
+		};
+	}
+	return {
+		accepted: true,
+		reason: "protocol-ack-single-flight",
+		commandId,
+		preSubmitCursor,
+		agentStartCursor: started.cursor,
+		preSubmitState: pre,
+	};
+}
+
+interface PendingResponse {
+	resolve: (value: Record<string, unknown>) => void;
+	reject: (error: Error) => void;
+}
+
+/**
+ * Real adapter: spawns `gjc --mode rpc --session-dir <dir>` and speaks the JSONL
+ * protocol from docs/rpc.md. Verified end-to-end in the M10 suite.
+ */
+export class GajaeCodeRpc implements HarnessRpc {
+	#proc: ChildProcessWithoutNullStreams;
+	#buffer = "";
+	#cursor = 0;
+	#pending = new Map<string, PendingResponse>();
+	#agentStartCursors: number[] = [];
+	#waiters: {
+		afterCursor: number;
+		resolve: (v: { cursor: number } | null) => void;
+		timer: ReturnType<typeof setTimeout>;
+	}[] = [];
+
+	constructor(opts: { sessionDir: string; command?: string[]; cwd?: string; env?: NodeJS.ProcessEnv }) {
+		const base = opts.command ?? ["gjc", "--mode", "rpc"];
+		const args = [...base.slice(1), "--session-dir", opts.sessionDir];
+		this.#proc = spawn(base[0], args, {
+			cwd: opts.cwd,
+			env: opts.env ?? process.env,
+			stdio: ["pipe", "pipe", "pipe"],
+		}) as ChildProcessWithoutNullStreams;
+		this.#proc.stdout.setEncoding("utf8");
+		this.#proc.stdout.on("data", chunk => this.#onData(chunk as string));
+	}
+
+	#onData(chunk: string): void {
+		this.#buffer += chunk;
+		let idx = this.#buffer.indexOf("\n");
+		while (idx >= 0) {
+			const line = this.#buffer.slice(0, idx).trim();
+			this.#buffer = this.#buffer.slice(idx + 1);
+			if (line) this.#onFrame(line);
+			idx = this.#buffer.indexOf("\n");
+		}
+	}
+
+	#onFrame(line: string): void {
+		let frame: Record<string, unknown>;
+		try {
+			frame = JSON.parse(line) as Record<string, unknown>;
+		} catch {
+			return;
+		}
+		const type = frame.type;
+		if (type === "response") {
+			const id = typeof frame.id === "string" ? frame.id : undefined;
+			if (id && this.#pending.has(id)) {
+				const pending = this.#pending.get(id);
+				this.#pending.delete(id);
+				pending?.resolve(frame);
+			}
+			return;
+		}
+		if (type === "ready") return;
+		// Any other frame is a session/agent event: advance the cursor.
+		this.#cursor += 1;
+		if (type === "agent_start") {
+			const cursor = this.#cursor;
+			this.#agentStartCursors.push(cursor);
+			this.#waiters = this.#waiters.filter(w => {
+				if (cursor > w.afterCursor) {
+					clearTimeout(w.timer);
+					w.resolve({ cursor });
+					return false;
+				}
+				return true;
+			});
+		}
+	}
+
+	#send(command: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const id = randomUUID();
+		return new Promise((resolve, reject) => {
+			this.#pending.set(id, { resolve, reject });
+			this.#proc.stdin.write(`${JSON.stringify({ id, ...command })}\n`, err => {
+				if (err) {
+					this.#pending.delete(id);
+					reject(err);
+				}
+			});
+		});
+	}
+
+	async getState(): Promise<RpcStateSnapshot> {
+		const res = await this.#send({ type: "get_state" });
+		const data = (res.data ?? {}) as Record<string, unknown>;
+		return {
+			isStreaming: Boolean(data.isStreaming),
+			steeringQueueDepth: typeof data.queuedMessageCount === "number" ? data.queuedMessageCount : 0,
+			followupQueueDepth: 0,
+		};
+	}
+
+	async sendPrompt(prompt: string): Promise<{ commandId: string; ack: boolean }> {
+		const id = randomUUID();
+		const ackPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
+			this.#pending.set(id, { resolve, reject });
+			this.#proc.stdin.write(`${JSON.stringify({ id, type: "prompt", message: prompt })}\n`, err => {
+				if (err) {
+					this.#pending.delete(id);
+					reject(err);
+				}
+			});
+		});
+		const res = await ackPromise;
+		return { commandId: id, ack: res.success === true };
+	}
+
+	eventCursor(): number {
+		return this.#cursor;
+	}
+
+	waitForAgentStart(afterCursor: number, timeoutMs: number): Promise<{ cursor: number } | null> {
+		const existing = this.#agentStartCursors.find(c => c > afterCursor);
+		if (existing !== undefined) return Promise.resolve({ cursor: existing });
+		return new Promise(resolve => {
+			const timer = setTimeout(() => {
+				this.#waiters = this.#waiters.filter(w => w.timer !== timer);
+				resolve(null);
+			}, timeoutMs);
+			this.#waiters.push({ afterCursor, resolve, timer });
+		});
+	}
+
+	async close(): Promise<void> {
+		try {
+			this.#proc.stdin.end();
+		} catch {
+			// ignore
+		}
+		this.#proc.kill();
+	}
+}

--- a/packages/coding-agent/src/harness-control-plane/seams.ts
+++ b/packages/coding-agent/src/harness-control-plane/seams.ts
@@ -1,0 +1,39 @@
+/**
+ * v1 seams (M11). The control plane is harness-agnostic by design, but v1 ships ONLY the
+ * gajae-code adapter. Other harnesses and transports are explicit, designed-not-built seams
+ * that fail closed with a clear `seam_unsupported_in_v1` signal rather than silently degrading.
+ */
+import type { Harness } from "./types";
+
+export const SUPPORTED_HARNESSES: readonly Harness[] = ["gajae-code"];
+
+export const DEFERRED_SEAMS = [
+	"codex-adapter",
+	"omx-adapter",
+	"remote-transport",
+	"global-daemon",
+	"capability-token-auth",
+	"web-viewer",
+	"fleet-control-plane",
+	"rich-tui-coview",
+] as const;
+
+export type DeferredSeam = (typeof DEFERRED_SEAMS)[number];
+
+export function isHarnessSupported(harness: string): harness is Harness {
+	return (SUPPORTED_HARNESSES as readonly string[]).includes(harness);
+}
+
+export interface UnsupportedSeamResult {
+	ok: false;
+	error: string;
+	evidence: { seam: true; name: string; supported: readonly Harness[]; deferred: readonly string[] };
+}
+
+export function unsupportedSeam(name: string): UnsupportedSeamResult {
+	return {
+		ok: false,
+		error: `seam_unsupported_in_v1:${name}`,
+		evidence: { seam: true, name, supported: SUPPORTED_HARNESSES, deferred: DEFERRED_SEAMS },
+	};
+}

--- a/packages/coding-agent/src/harness-control-plane/session-lease.ts
+++ b/packages/coding-agent/src/harness-control-plane/session-lease.ts
@@ -1,0 +1,161 @@
+/**
+ * SessionLease — the construct that makes live control honest without a global daemon.
+ *
+ * Exactly one live `RuntimeOwner` holds the lease for a session; only the lease holder
+ * may append events or run the default router. A stale lease (owner dead OR expired) may
+ * be taken over, incrementing `leaseEpoch`, but a stale lease is NEVER permission for
+ * destructive recovery (that gate lives in the classifier/recovery layer).
+ */
+import { createHash, randomBytes } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { sessionPaths } from "./storage";
+
+export interface SessionLease {
+	ownerId: string;
+	sessionId: string;
+	pid: number;
+	leaseTokenHash: string;
+	endpoint: { kind: "unix-socket" | "fifo"; path: string } | null;
+	eventsPath: string;
+	heartbeatAt: string;
+	expiresAt: string;
+	leaseEpoch: number;
+	writer: { ownerId: string; leaseEpoch: number };
+}
+
+export class LeaseError extends Error {
+	constructor(
+		message: string,
+		readonly code: string,
+	) {
+		super(message);
+		this.name = "LeaseError";
+	}
+}
+
+function nowMs(clock?: () => number): number {
+	return clock ? clock() : Date.now();
+}
+
+function hashToken(token: string): string {
+	return createHash("sha256").update(token).digest("hex");
+}
+
+async function writeLeaseAtomic(file: string, lease: SessionLease): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	const tmp = `${file}.tmp-${randomBytes(4).toString("hex")}`;
+	await fs.writeFile(tmp, `${JSON.stringify(lease, null, 2)}\n`, "utf8");
+	await fs.rename(tmp, file);
+}
+
+export async function readLease(root: string, sessionId: string): Promise<SessionLease | null> {
+	try {
+		const raw = await fs.readFile(sessionPaths(root, sessionId).lease, "utf8");
+		return JSON.parse(raw) as SessionLease;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+export function isExpired(lease: SessionLease, clock?: () => number): boolean {
+	return Date.parse(lease.expiresAt) <= nowMs(clock);
+}
+
+/** Liveness probe via signal 0. Defaults to the real process table; injectable for tests. */
+export function isOwnerAlive(pid: number, probe?: (pid: number) => boolean): boolean {
+	if (probe) return probe(pid);
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// ESRCH = no such process; EPERM = exists but not ours (treat as alive).
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+export function isStale(
+	lease: SessionLease,
+	opts?: { clock?: () => number; probe?: (pid: number) => boolean },
+): boolean {
+	return isExpired(lease, opts?.clock) || !isOwnerAlive(lease.pid, opts?.probe);
+}
+
+export interface AcquireOptions {
+	ownerId: string;
+	pid: number;
+	endpoint?: SessionLease["endpoint"];
+	eventsPath: string;
+	ttlMs: number;
+	clock?: () => number;
+	probe?: (pid: number) => boolean;
+}
+
+export interface AcquiredLease {
+	lease: SessionLease;
+	token: string;
+}
+
+/**
+ * Acquire (or take over a stale) lease. Fails closed with `lease_held` when a live,
+ * unexpired lease is held by a different owner. Re-acquiring as the current owner refreshes.
+ */
+export async function acquireLease(root: string, sessionId: string, opts: AcquireOptions): Promise<AcquiredLease> {
+	const existing = await readLease(root, sessionId);
+	if (existing && existing.ownerId !== opts.ownerId && !isStale(existing, opts)) {
+		throw new LeaseError(`lease_held:${sessionId}`, "lease_held");
+	}
+	const priorEpoch = existing?.leaseEpoch ?? 0;
+	const epoch = existing && existing.ownerId === opts.ownerId ? priorEpoch : priorEpoch + 1;
+	const token = randomBytes(16).toString("hex");
+	const now = nowMs(opts.clock);
+	const lease: SessionLease = {
+		ownerId: opts.ownerId,
+		sessionId,
+		pid: opts.pid,
+		leaseTokenHash: hashToken(token),
+		endpoint: opts.endpoint ?? null,
+		eventsPath: opts.eventsPath,
+		heartbeatAt: new Date(now).toISOString(),
+		expiresAt: new Date(now + opts.ttlMs).toISOString(),
+		leaseEpoch: epoch,
+		writer: { ownerId: opts.ownerId, leaseEpoch: epoch },
+	};
+	await writeLeaseAtomic(sessionPaths(root, sessionId).lease, lease);
+	return { lease, token };
+}
+
+/** Refresh the lease expiry. Only the recorded owner may heartbeat (single-writer). */
+export async function heartbeat(
+	root: string,
+	sessionId: string,
+	ownerId: string,
+	ttlMs: number,
+	clock?: () => number,
+): Promise<SessionLease> {
+	const lease = await readLease(root, sessionId);
+	if (!lease) throw new LeaseError(`no_lease:${sessionId}`, "no_lease");
+	if (lease.ownerId !== ownerId) throw new LeaseError(`not_lease_holder:${sessionId}`, "not_lease_holder");
+	const now = nowMs(clock);
+	const next: SessionLease = {
+		...lease,
+		heartbeatAt: new Date(now).toISOString(),
+		expiresAt: new Date(now + ttlMs).toISOString(),
+	};
+	await writeLeaseAtomic(sessionPaths(root, sessionId).lease, next);
+	return next;
+}
+
+/** Whether `ownerId` is the live, unexpired single writer permitted to append events. */
+export function canWriteEvents(lease: SessionLease, ownerId: string, clock?: () => number): boolean {
+	return lease.ownerId === ownerId && !isExpired(lease, clock);
+}
+
+/** Release the lease (owner shutdown). Only the holder may release. */
+export async function releaseLease(root: string, sessionId: string, ownerId: string): Promise<void> {
+	const lease = await readLease(root, sessionId);
+	if (!lease) return;
+	if (lease.ownerId !== ownerId) throw new LeaseError(`not_lease_holder:${sessionId}`, "not_lease_holder");
+	await fs.rm(sessionPaths(root, sessionId).lease, { force: true });
+}

--- a/packages/coding-agent/src/harness-control-plane/state-machine.ts
+++ b/packages/coding-agent/src/harness-control-plane/state-machine.ts
@@ -1,0 +1,97 @@
+/**
+ * Lifecycle state machine + the universal `{state, evidence, nextAllowedActions}` contract.
+ *
+ * `nextAllowedActions` is the forcing function: it tells the caller exactly which
+ * primitives are currently permitted and, when not, why. Owner-routed verbs
+ * (`submit`) report `owner-not-live` when no `RuntimeOwner` holds the session lease.
+ */
+import type { HarnessLifecycle, NextAllowedAction, PrimitiveResponse, SessionState, SessionStateView } from "./types";
+
+const TERMINAL_LIFECYCLES: ReadonlySet<HarnessLifecycle> = new Set(["completed", "retired"]);
+
+const TRANSITIONS: Record<HarnessLifecycle, readonly HarnessLifecycle[]> = {
+	new: ["started", "blocked", "retired"],
+	started: ["submitted", "observing", "recovering", "blocked", "retired"],
+	submitted: ["observing", "recovering", "validating", "blocked", "retired"],
+	observing: ["submitted", "recovering", "validating", "finalizing", "blocked", "retired"],
+	recovering: ["started", "submitted", "observing", "blocked", "retired"],
+	validating: ["finalizing", "observing", "blocked", "retired"],
+	finalizing: ["completed", "blocked", "retired"],
+	completed: ["retired"],
+	blocked: ["started", "submitted", "observing", "recovering", "validating", "retired"],
+	retired: [],
+};
+
+export function isTerminal(lifecycle: HarnessLifecycle): boolean {
+	return TERMINAL_LIFECYCLES.has(lifecycle);
+}
+
+export function canTransition(from: HarnessLifecycle, to: HarnessLifecycle): boolean {
+	return TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function assertTransition(from: HarnessLifecycle, to: HarnessLifecycle): void {
+	if (from === to) return;
+	if (!canTransition(from, to)) {
+		throw new Error(`invalid_transition:${from}->${to}`);
+	}
+}
+
+/**
+ * Derive the permitted next actions for a session given its lifecycle and whether
+ * a live owner currently holds the lease.
+ */
+export function nextAllowedActions(lifecycle: HarnessLifecycle, ownerLive: boolean): NextAllowedAction[] {
+	const terminal = isTerminal(lifecycle);
+	const actions: NextAllowedAction[] = [];
+	const add = (verb: NextAllowedAction["verb"], available: boolean, reason?: string): void => {
+		actions.push(available ? { verb, available } : { verb, available, reason: reason ?? "unavailable" });
+	};
+
+	// Pure / read-only verbs are always available.
+	add("observe", true);
+	add("classify", true);
+	add("events", true);
+	add("monitor", true);
+
+	// `start` creates a new session; never re-applicable to an existing record.
+	add("start", false, "session-already-exists");
+
+	// `submit` is owner-routed: it requires a live owner and a non-terminal lifecycle.
+	if (terminal) add("submit", false, `lifecycle-terminal:${lifecycle}`);
+	else if (!ownerLive) add("submit", false, "owner-not-live");
+	else add("submit", true);
+
+	// `recover` handles a dead/failed owner, so it is available without a live owner.
+	add("recover", !terminal, terminal ? `lifecycle-terminal:${lifecycle}` : undefined);
+	add("validate", !terminal, terminal ? `lifecycle-terminal:${lifecycle}` : undefined);
+	add("finalize", !terminal, terminal ? `lifecycle-terminal:${lifecycle}` : undefined);
+	add("retire", lifecycle !== "retired", lifecycle === "retired" ? "already-retired" : undefined);
+
+	return actions;
+}
+
+export function buildStateView(state: SessionState, ownerLive: boolean): SessionStateView {
+	return {
+		sessionId: state.sessionId,
+		lifecycle: state.lifecycle,
+		harness: state.harness,
+		ownerLive,
+		blockers: state.blockers,
+	};
+}
+
+/** Build the universal contract response carried by every primitive. */
+export function buildResponse<E extends Record<string, unknown>>(
+	state: SessionState,
+	ownerLive: boolean,
+	evidence: E,
+	ok = true,
+): PrimitiveResponse<E> {
+	return {
+		ok,
+		state: buildStateView(state, ownerLive),
+		evidence,
+		nextAllowedActions: nextAllowedActions(state.lifecycle, ownerLive),
+	};
+}

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -1,0 +1,209 @@
+/**
+ * Session-scoped storage for the harness control plane.
+ *
+ * Layout (under the harness state root, default `<cwd>/.gjc/state/harness`):
+ *   sessions/<encoded-id>/state.json        lifecycle + handle (atomic)
+ *   sessions/<encoded-id>/lease.json         owner lease (M3)
+ *   sessions/<encoded-id>/events.jsonl       owner-only severity envelopes
+ *   sessions/<encoded-id>/receipts.jsonl     append-only receipt index
+ *   sessions/<encoded-id>/receipts/<family>/<receiptId>.json  immutable receipts
+ *   sessions/<encoded-id>/artifacts/...      diff/validation artifacts
+ *   sessions/<encoded-id>/gjc-session/       underlying gajae-code --session-dir
+ *
+ * Receipt files are immutable: re-writing an existing receipt id fails closed.
+ * JSON writes are atomic (temp + rename).
+ */
+import { randomBytes } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { EventEnvelope, ReceiptFamily, SessionState } from "./types";
+
+const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export class StorageError extends Error {
+	constructor(
+		message: string,
+		readonly code: string,
+	) {
+		super(message);
+		this.name = "StorageError";
+	}
+}
+
+/** Resolve the harness state root from explicit value, env, or cwd default. */
+export function resolveHarnessRoot(opts?: { root?: string; cwd?: string; env?: NodeJS.ProcessEnv }): string {
+	const env = opts?.env ?? process.env;
+	if (opts?.root) return path.resolve(opts.root);
+	const fromEnv = env.GJC_HARNESS_STATE_ROOT;
+	if (fromEnv?.trim()) return path.resolve(fromEnv.trim());
+	return path.join(opts?.cwd ?? process.cwd(), ".gjc", "state", "harness");
+}
+
+export function assertSafeSessionId(id: string): void {
+	if (!SESSION_ID_RE.test(id)) {
+		throw new StorageError(`unsafe_session_id:${id}`, "unsafe_session_id");
+	}
+}
+
+export function generateSessionId(prefix = "h"): string {
+	const ts = new Date().toISOString().replace(/[:.]/g, "").replace("T", "-").slice(0, 15);
+	const rand = randomBytes(4).toString("hex");
+	return `${prefix}-${ts}-${rand}`;
+}
+
+export interface SessionPaths {
+	dir: string;
+	state: string;
+	lease: string;
+	events: string;
+	receiptsIndex: string;
+	receiptsDir: string;
+	artifactsDir: string;
+	controlSock: string;
+	controlFifo: string;
+	gjcSessionDir: string;
+}
+
+export function sessionPaths(root: string, sessionId: string): SessionPaths {
+	assertSafeSessionId(sessionId);
+	const dir = path.join(root, "sessions", sessionId);
+	return {
+		dir,
+		state: path.join(dir, "state.json"),
+		lease: path.join(dir, "lease.json"),
+		events: path.join(dir, "events.jsonl"),
+		receiptsIndex: path.join(dir, "receipts.jsonl"),
+		receiptsDir: path.join(dir, "receipts"),
+		artifactsDir: path.join(dir, "artifacts"),
+		controlSock: path.join(dir, "control.sock"),
+		controlFifo: path.join(dir, "control.fifo"),
+		gjcSessionDir: path.join(dir, "gjc-session"),
+	};
+}
+
+async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	const tmp = `${file}.tmp-${randomBytes(4).toString("hex")}`;
+	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+	await fs.rename(tmp, file);
+}
+
+async function readJson<T>(file: string): Promise<T | null> {
+	try {
+		const raw = await fs.readFile(file, "utf8");
+		return JSON.parse(raw) as T;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+export async function readSessionState(root: string, sessionId: string): Promise<SessionState | null> {
+	return readJson<SessionState>(sessionPaths(root, sessionId).state);
+}
+
+export async function writeSessionState(root: string, state: SessionState): Promise<void> {
+	const paths = sessionPaths(root, state.sessionId);
+	await fs.mkdir(paths.dir, { recursive: true });
+	await writeJsonAtomic(paths.state, state);
+}
+
+export async function sessionExists(root: string, sessionId: string): Promise<boolean> {
+	return (await readSessionState(root, sessionId)) !== null;
+}
+
+/** Append a single severity envelope to events.jsonl. Single-writer discipline is the owner's job (M3). */
+export async function appendEvent(root: string, sessionId: string, envelope: EventEnvelope): Promise<void> {
+	const paths = sessionPaths(root, sessionId);
+	await fs.mkdir(paths.dir, { recursive: true });
+	await fs.appendFile(paths.events, `${JSON.stringify(envelope)}\n`, "utf8");
+}
+
+/** Read events from cursor (exclusive). Tail-only: never mutates the log. */
+export async function readEvents(root: string, sessionId: string, fromCursor = 0): Promise<EventEnvelope[]> {
+	const paths = sessionPaths(root, sessionId);
+	let raw: string;
+	try {
+		raw = await fs.readFile(paths.events, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const out: EventEnvelope[] = [];
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const env = JSON.parse(trimmed) as EventEnvelope;
+		if (env.cursor > fromCursor) out.push(env);
+	}
+	return out;
+}
+
+export interface ReceiptIndexEntry {
+	receiptId: string;
+	family: ReceiptFamily;
+	valid: boolean;
+	createdAt: string;
+	path: string;
+}
+
+/**
+ * Persist a receipt immutably. Fails closed if the receipt id already exists,
+ * then appends an index entry to receipts.jsonl.
+ */
+export async function writeReceiptImmutable(
+	root: string,
+	sessionId: string,
+	family: ReceiptFamily,
+	receiptId: string,
+	value: { receiptId: string; family: ReceiptFamily; valid: boolean; createdAt: string; [k: string]: unknown },
+): Promise<ReceiptIndexEntry> {
+	assertSafeSessionId(sessionId);
+	if (!SESSION_ID_RE.test(receiptId)) {
+		throw new StorageError(`unsafe_receipt_id:${receiptId}`, "unsafe_receipt_id");
+	}
+	const paths = sessionPaths(root, sessionId);
+	const familyDir = path.join(paths.receiptsDir, family);
+	const file = path.join(familyDir, `${receiptId}.json`);
+	await fs.mkdir(familyDir, { recursive: true });
+	try {
+		await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", flag: "wx" });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			throw new StorageError(`receipt_immutable_conflict:${family}/${receiptId}`, "receipt_immutable_conflict");
+		}
+		throw error;
+	}
+	const entry: ReceiptIndexEntry = {
+		receiptId,
+		family,
+		valid: value.valid,
+		createdAt: value.createdAt,
+		path: file,
+	};
+	await fs.appendFile(paths.receiptsIndex, `${JSON.stringify(entry)}\n`, "utf8");
+	return entry;
+}
+
+export async function readReceiptIndex(
+	root: string,
+	sessionId: string,
+	family?: ReceiptFamily,
+): Promise<ReceiptIndexEntry[]> {
+	const paths = sessionPaths(root, sessionId);
+	let raw: string;
+	try {
+		raw = await fs.readFile(paths.receiptsIndex, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const out: ReceiptIndexEntry[] = [];
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const entry = JSON.parse(trimmed) as ReceiptIndexEntry;
+		if (!family || entry.family === family) out.push(entry);
+	}
+	return out;
+}

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -156,7 +156,7 @@ export async function writeReceiptImmutable(
 	sessionId: string,
 	family: ReceiptFamily,
 	receiptId: string,
-	value: { receiptId: string; family: ReceiptFamily; valid: boolean; createdAt: string; [k: string]: unknown },
+	value: { receiptId: string; family: ReceiptFamily; valid: boolean; createdAt: string },
 ): Promise<ReceiptIndexEntry> {
 	assertSafeSessionId(sessionId);
 	if (!SESSION_ID_RE.test(receiptId)) {

--- a/packages/coding-agent/src/harness-control-plane/types.ts
+++ b/packages/coding-agent/src/harness-control-plane/types.ts
@@ -1,0 +1,186 @@
+/**
+ * Core types for the gajae-code-native coding-harness operations control plane (v1).
+ *
+ * See the approved consensus plan at
+ * `.gjc/plans/ralplan/2026-06-02-0853-3e33/stage-02-revision.md` and the spec at
+ * `.gjc/specs/deep-interview-harness-control-plane.md`.
+ *
+ * v1 implements the gajae-code adapter only. omx/codex/remote/auth are deferred seams.
+ */
+
+/** Harnesses the control plane can operate. v1 implements `gajae-code` only. */
+export type Harness = "gajae-code" | "codex" | "omx";
+
+/** Lifecycle states of an operated session. */
+export type HarnessLifecycle =
+	| "new"
+	| "started"
+	| "submitted"
+	| "observing"
+	| "recovering"
+	| "validating"
+	| "finalizing"
+	| "completed"
+	| "blocked"
+	| "retired";
+
+/** Event severities emitted by the owner. */
+export type Severity = "info" | "warn" | "critical";
+
+/** Bounded git delta classification surfaced by `observe`. */
+export type GitDelta = "clean" | "dirty" | "zero-delta" | "unknown";
+
+/** Risk classification surfaced by `observe`. */
+export type RiskKind = "normal" | "prompt-not-accepted" | "deleted-worktree" | "vanished-dirty";
+
+/** Deterministic recovery classifications. */
+export type RecoveryClassification =
+	| "continue"
+	| "send-enter"
+	| "reinject-prompt"
+	| "restart-clean"
+	| "restart-preserve-delta"
+	| "fallback-codex-exec"
+	| "human-check";
+
+/** Receipt families persisted under the session storage dir. */
+export type ReceiptFamily = "vanish" | "prompt-acceptance" | "validation" | "completion";
+
+/** The CLI verbs / primitives exposed by `gjc harness <verb>`. */
+export type HarnessVerb =
+	| "start"
+	| "submit"
+	| "observe"
+	| "classify"
+	| "recover"
+	| "validate"
+	| "finalize"
+	| "retire"
+	| "events"
+	| "monitor"
+	| "operate";
+
+/** Submission transports. */
+export type SubmitMode = "paste-buffer" | "stdin" | "file";
+
+/** A single entry in the forcing-function `nextAllowedActions` list. */
+export interface NextAllowedAction {
+	verb: HarnessVerb;
+	available: boolean;
+	/** Present when `available` is false; explains why the verb is currently disallowed. */
+	reason?: string;
+}
+
+/** Compact, model-facing view of session state included in every response. */
+export interface SessionStateView {
+	sessionId: string;
+	lifecycle: HarnessLifecycle;
+	harness: Harness;
+	ownerLive: boolean;
+	blockers: string[];
+}
+
+/**
+ * The universal contract: EVERY primitive response carries `{state, evidence, nextAllowedActions}`.
+ * `ok` is a transport-level convenience; semantic blocking is expressed via state + nextAllowedActions.
+ */
+export interface PrimitiveResponse<E = Record<string, unknown>> {
+	ok: boolean;
+	state: SessionStateView;
+	evidence: E;
+	nextAllowedActions: NextAllowedAction[];
+}
+
+/** Re-grabbable session handle returned by `start` / `operate`. */
+export interface SessionHandle {
+	sessionId: string;
+	harness: Harness;
+	repo: string | null;
+	workspace: string;
+	branch: string | null;
+	base: string | null;
+	issueOrPr: string | null;
+	processHandle: { kind: "runtime-owner"; ownerId: string | null; pid: number | null };
+	rpcHandle: { kind: "rpc-subprocess"; pid: number | null; sessionDir: string };
+	ownerHandle: { leasePath: string; endpoint: string | null; heartbeatAt: string | null };
+	routerHandle: { kind: "default-in-owner"; policy: string; eventsPath: string };
+	viewportHandle: { kind: "event-monitor"; tmuxSessionName: string | null; viewOnly: true };
+	startedAt: string;
+	updatedAt: string;
+}
+
+/** Persisted per-session record (state.json). */
+export interface SessionState {
+	schemaVersion: number;
+	sessionId: string;
+	lifecycle: HarnessLifecycle;
+	harness: Harness;
+	handle: SessionHandle;
+	/** Per-classification retry counters consumed by the recovery policy. */
+	retries: Record<string, number>;
+	blockers: string[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+/** Bounded observation surfaced by `observe` — never a raw pane/transcript dump. */
+export interface Observation {
+	lifecycle: HarnessLifecycle;
+	ownerLive: boolean;
+	cwd: string;
+	branch: string | null;
+	gitDelta: GitDelta;
+	lastActivityAt: string | null;
+	observedSignals: string[];
+	risk: RiskKind;
+}
+
+/** Input to the deterministic recovery classifier. */
+export interface ClassifyInput {
+	observation: Observation;
+	/** Remaining retry budget per classification family. */
+	retryBudget: RetryBudget;
+	/** Whether an accepted prompt was in flight when the owner/RPC was last seen. */
+	acceptedPromptActive?: boolean;
+}
+
+/** Default and supplied retry budgets. */
+export interface RetryBudget {
+	reinjectPrompt: number;
+	zeroDeltaVanish: number;
+	dirtyVanishPreserve: number;
+	validationRepair: number;
+}
+
+/** Result of the deterministic recovery classifier. */
+export interface RecoveryDecision {
+	classification: RecoveryClassification;
+	reason: string;
+	severity: Severity;
+	/** Whether executing the recommended action requires a live owner. */
+	ownerRequired: boolean;
+	/** Receipt family that MUST be valid before the action may proceed (e.g. `vanish`). */
+	requiredReceiptFamily: ReceiptFamily | null;
+}
+
+/** Severity-tagged event envelope written exclusively by the owner. */
+export interface EventEnvelope<E = Record<string, unknown>> {
+	eventId: string;
+	cursor: number;
+	createdAt: string;
+	severity: Severity;
+	kind: string;
+	state: SessionStateView;
+	evidence: E;
+	nextAllowedActions: NextAllowedAction[];
+	writer: { ownerId: string; leaseEpoch: number };
+}
+
+export const SESSION_SCHEMA_VERSION = 1 as const;
+
+export const DEFAULT_RETRY_BUDGET: RetryBudget = {
+	reinjectPrompt: 2,
+	zeroDeltaVanish: 1,
+	dirtyVanishPreserve: 1,
+	validationRepair: 2,
+};

--- a/packages/coding-agent/test/harness-control-plane/classifier.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/classifier.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { classifyRecovery } from "../../src/harness-control-plane/classifier";
+import { DEFAULT_RETRY_BUDGET, type Observation, type RetryBudget } from "../../src/harness-control-plane/types";
+
+function obs(p: Partial<Observation>): Observation {
+	return {
+		lifecycle: "observing",
+		ownerLive: false,
+		cwd: ".",
+		branch: null,
+		gitDelta: "unknown",
+		lastActivityAt: null,
+		observedSignals: [],
+		risk: "normal",
+		...p,
+	};
+}
+
+function budget(p: Partial<RetryBudget> = {}): RetryBudget {
+	return { ...DEFAULT_RETRY_BUDGET, ...p };
+}
+
+describe("classifyRecovery", () => {
+	it("dirty vanished worktree -> restart-preserve-delta, never restart-clean, requires vanish, critical", () => {
+		const d = classifyRecovery({ observation: obs({ ownerLive: false, gitDelta: "dirty" }), retryBudget: budget() });
+		expect(d.classification).toBe("restart-preserve-delta");
+		expect(d.classification).not.toBe("restart-clean");
+		expect(d.requiredReceiptFamily).toBe("vanish");
+		expect(d.severity).toBe("critical");
+		expect(d.ownerRequired).toBe(true);
+	});
+
+	it("dirty preserve budget exhausted -> fallback-codex-exec (still requires vanish, never clean-delete)", () => {
+		const d = classifyRecovery({
+			observation: obs({ ownerLive: false, gitDelta: "dirty" }),
+			retryBudget: budget({ dirtyVanishPreserve: 0 }),
+		});
+		expect(d.classification).toBe("fallback-codex-exec");
+		expect(d.requiredReceiptFamily).toBe("vanish");
+		expect(d.classification).not.toBe("restart-clean");
+	});
+
+	it("zero-delta vanished -> restart-clean with budget; exhausted -> fallback-codex-exec", () => {
+		const ok = classifyRecovery({
+			observation: obs({ ownerLive: false, gitDelta: "zero-delta" }),
+			retryBudget: budget(),
+		});
+		expect(ok.classification).toBe("restart-clean");
+		expect(ok.requiredReceiptFamily).toBe("vanish");
+		const exhausted = classifyRecovery({
+			observation: obs({ ownerLive: false, gitDelta: "zero-delta" }),
+			retryBudget: budget({ zeroDeltaVanish: 0 }),
+		});
+		expect(exhausted.classification).toBe("fallback-codex-exec");
+	});
+
+	it("clean vanished -> restart-clean (requires vanish)", () => {
+		const d = classifyRecovery({ observation: obs({ ownerLive: false, gitDelta: "clean" }), retryBudget: budget() });
+		expect(d.classification).toBe("restart-clean");
+		expect(d.requiredReceiptFamily).toBe("vanish");
+	});
+
+	it("unknown delta vanished -> human-check (never destructive)", () => {
+		const d = classifyRecovery({
+			observation: obs({ ownerLive: false, gitDelta: "unknown" }),
+			retryBudget: budget(),
+		});
+		expect(d.classification).toBe("human-check");
+		expect(["restart-clean", "restart-preserve-delta", "fallback-codex-exec"]).not.toContain(d.classification);
+	});
+
+	it("deleted worktree -> human-check, never recreate over unknown data", () => {
+		const d = classifyRecovery({
+			observation: obs({ ownerLive: false, gitDelta: "dirty", risk: "deleted-worktree" }),
+			retryBudget: budget(),
+		});
+		expect(d.classification).toBe("human-check");
+	});
+
+	it("owner live + normal -> continue (info)", () => {
+		const d = classifyRecovery({ observation: obs({ ownerLive: true, risk: "normal" }), retryBudget: budget() });
+		expect(d.classification).toBe("continue");
+		expect(d.severity).toBe("info");
+	});
+
+	it("owner live + prompt-not-accepted -> reinject-prompt (budget) then human-check (exhausted)", () => {
+		const re = classifyRecovery({
+			observation: obs({ ownerLive: true, risk: "prompt-not-accepted" }),
+			retryBudget: budget(),
+		});
+		expect(re.classification).toBe("reinject-prompt");
+		expect(re.requiredReceiptFamily).toBe("prompt-acceptance");
+		const exhausted = classifyRecovery({
+			observation: obs({ ownerLive: true, risk: "prompt-not-accepted" }),
+			retryBudget: budget({ reinjectPrompt: 0 }),
+		});
+		expect(exhausted.classification).toBe("human-check");
+	});
+
+	it("owner live + validation-failed -> continue (budget) then human-check (exhausted)", () => {
+		const repair = classifyRecovery({
+			observation: obs({ ownerLive: true, observedSignals: ["validation-failed"] }),
+			retryBudget: budget(),
+		});
+		expect(repair.classification).toBe("continue");
+		const exhausted = classifyRecovery({
+			observation: obs({ ownerLive: true, observedSignals: ["validation-failed"] }),
+			retryBudget: budget({ validationRepair: 0 }),
+		});
+		expect(exhausted.classification).toBe("human-check");
+	});
+
+	it("never emits send-enter across the supported branch matrix", () => {
+		const deltas = ["clean", "dirty", "zero-delta", "unknown"] as const;
+		const risks = ["normal", "prompt-not-accepted", "deleted-worktree", "vanished-dirty"] as const;
+		for (const ownerLive of [true, false]) {
+			for (const gitDelta of deltas) {
+				for (const risk of risks) {
+					const d = classifyRecovery({ observation: obs({ ownerLive, gitDelta, risk }), retryBudget: budget() });
+					expect(d.classification).not.toBe("send-enter");
+				}
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -8,6 +8,7 @@ import { readLease } from "../../src/harness-control-plane/session-lease";
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 const SID = "d";
+const FAKE_RPC = path.join(import.meta.dir, "fixtures", "fake-rpc.ts");
 
 let root: string;
 let workspace: string;
@@ -15,7 +16,12 @@ let workspace: string;
 async function runHarness(args: string[]): Promise<{ code: number; json: Record<string, unknown> | null }> {
 	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
 		cwd: workspace,
-		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root, GJC_HARNESS_OWNER_FAKE_RPC: "1" },
+		env: {
+			...process.env,
+			GJC_HARNESS_STATE_ROOT: root,
+			// Drive the REAL GajaeCodeRpc against a protocol fixture (no shipped fake seam).
+			GJC_HARNESS_RPC_COMMAND: JSON.stringify(["bun", FAKE_RPC]),
+		},
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -72,12 +78,13 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect((sub.json?.evidence as Record<string, unknown>).accepted).toBe(true);
 		expect((sub.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
 
-		// Owner-backed finalize over the evidence gate (fake checks pass).
+		// Owner-backed finalize: the evidence gate HONESTLY refuses without real commit/PR/tests
+		// (no fake completion evidence in shipped code).
 		const fin = await runHarness(["finalize", "--session", SID]);
-		expect((fin.json?.evidence as Record<string, unknown>).finalize).toBeTruthy();
-		expect(((fin.json?.evidence as Record<string, unknown>).finalize as Record<string, unknown>).completed).toBe(
-			true,
-		);
+		const finEvidence = (fin.json?.evidence as Record<string, unknown>).finalize as Record<string, unknown>;
+		expect(finEvidence).toBeTruthy();
+		expect(finEvidence.completed).toBe(false);
+		expect((finEvidence.blockers as unknown[]).length).toBeGreaterThan(0);
 
 		// Retire stops the owner and releases the lease.
 		const ret = await runHarness(["retire", "--session", SID]);

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { resolveOwner } from "../../src/harness-control-plane/owner";
+import { readLease } from "../../src/harness-control-plane/session-lease";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const SID = "d";
+
+let root: string;
+let workspace: string;
+
+async function runHarness(args: string[]): Promise<{ code: number; json: Record<string, unknown> | null }> {
+	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
+		cwd: workspace,
+		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root, GJC_HARNESS_OWNER_FAKE_RPC: "1" },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const out = await new Response(proc.stdout).text();
+	const code = await proc.exited;
+	let json: Record<string, unknown> | null = null;
+	try {
+		json = JSON.parse(out.trim()) as Record<string, unknown>;
+	} catch {
+		json = null;
+	}
+	return { code, json };
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+
+beforeEach(async () => {
+	// Short paths keep the AF_UNIX socket path under the sun_path limit.
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
+});
+
+afterEach(async () => {
+	// Safety net: kill any lingering detached owner.
+	try {
+		const lease = await readLease(root, SID);
+		if (lease?.pid) {
+			try {
+				process.kill(lease.pid, "SIGTERM");
+			} catch {
+				// already gone
+			}
+		}
+	} catch {
+		// no lease
+	}
+	await rm(root, { recursive: true, force: true });
+	await rm(workspace, { recursive: true, force: true });
+});
+
+describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
+	it("spawns a background owner; submit + finalize route to it cross-process; retire stops it", async () => {
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true }),
+		]);
+		expect(started.code).toBe(0);
+		expect((started.json?.evidence as Record<string, unknown>).ownerRuntime).toBe("detached");
+		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+
+		// A separate stateless CLI invocation re-grabs and drives the background session.
+		const sub = await runHarness(["submit", "--session", SID, "--input", JSON.stringify({ prompt: "go" })]);
+		expect((sub.json?.evidence as Record<string, unknown>).accepted).toBe(true);
+		expect((sub.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
+
+		// Owner-backed finalize over the evidence gate (fake checks pass).
+		const fin = await runHarness(["finalize", "--session", SID]);
+		expect((fin.json?.evidence as Record<string, unknown>).finalize).toBeTruthy();
+		expect(((fin.json?.evidence as Record<string, unknown>).finalize as Record<string, unknown>).completed).toBe(
+			true,
+		);
+
+		// Retire stops the owner and releases the lease.
+		const ret = await runHarness(["retire", "--session", SID]);
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
+
+		let after = await resolveOwner(root, SID);
+		for (let i = 0; i < 80 && after.live; i++) {
+			await sleep(50);
+			after = await resolveOwner(root, SID);
+		}
+		expect(after.live).toBe(false);
+	}, 60_000);
+});

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { writeSessionState } from "../../src/harness-control-plane/storage";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const SID = "o";
+
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	state: RpcStateSnapshot = { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	async getState(): Promise<RpcStateSnapshot> {
+		return this.state;
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		this.cursor += 1; // emit agent_start
+		return { commandId: "cmd-1", ack: true };
+	}
+	async waitForAgentStart(afterCursor: number): Promise<{ cursor: number } | null> {
+		return this.cursor > afterCursor ? { cursor: this.cursor } : null;
+	}
+	async close(): Promise<void> {}
+}
+
+let root: string;
+let owner: RuntimeOwner | null = null;
+
+function seed(workspace: string): SessionState {
+	const now = new Date().toISOString();
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: SID,
+		lifecycle: "started",
+		harness: "gajae-code",
+		handle: { sessionId: SID, harness: "gajae-code", workspace, branch: "feat/x" } as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+// IMPORTANT: spawn ASYNC. The owner runs in THIS process; a blocking spawnSync would
+// freeze the owner's event loop and deadlock the socket round-trip.
+async function runHarness(args: string[]): Promise<{ code: number; json: Record<string, unknown> | null }> {
+	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
+		cwd: root,
+		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const out = await new Response(proc.stdout).text();
+	const code = await proc.exited;
+	let json: Record<string, unknown> | null = null;
+	try {
+		json = JSON.parse(out.trim()) as Record<string, unknown>;
+	} catch {
+		json = null;
+	}
+	return { code, json };
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	await writeSessionState(root, seed(root));
+	owner = new RuntimeOwner({ root, sessionId: SID, rpc: new FakeRpc(), acceptanceTimeoutMs: 200 });
+	await owner.start();
+});
+
+afterEach(async () => {
+	await owner?.stop();
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("gjc harness CLI -> live owner routing", () => {
+	it("submit routes to the live owner and is accepted via single-flight", async () => {
+		const res = await runHarness(["submit", "--session", SID, "--input", JSON.stringify({ prompt: "do it" })]);
+		expect(res.code).toBe(0);
+		expect(res.json?.ok).toBe(true);
+		const evidence = res.json?.evidence as Record<string, unknown>;
+		const state = res.json?.state as Record<string, unknown>;
+		expect(evidence.accepted).toBe(true);
+		expect(state.ownerLive).toBe(true);
+		expect(state.lifecycle).toBe("observing");
+	}, 30_000);
+
+	it("observe routes to the live owner (ownerRouted + ownerLive)", async () => {
+		const res = await runHarness(["observe", "--session", SID]);
+		expect(res.code).toBe(0);
+		const evidence = res.json?.evidence as Record<string, unknown>;
+		const state = res.json?.state as Record<string, unknown>;
+		expect(evidence.ownerRouted).toBe(true);
+		expect(state.ownerLive).toBe(true);
+	}, 30_000);
+});

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
 import { RuntimeOwner } from "../../src/harness-control-plane/owner";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
 import { writeSessionState } from "../../src/harness-control-plane/storage";
@@ -68,10 +69,32 @@ async function runHarness(args: string[]): Promise<{ code: number; json: Record<
 	return { code, json };
 }
 
+const passingFinalizeChecks: FinalizeChecks = {
+	async runValidation(spec) {
+		return { exactCommand: spec.command, cwd: ".", exitStatus: 0, pass: true };
+	},
+	async resolveCommit() {
+		return "abc123";
+	},
+	async commitOnBranch() {
+		return true;
+	},
+	async prOrIssue() {
+		return { prUrl: "https://x/pr/1", issueArtifact: null };
+	},
+};
+
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	await writeSessionState(root, seed(root));
-	owner = new RuntimeOwner({ root, sessionId: SID, rpc: new FakeRpc(), acceptanceTimeoutMs: 200 });
+	owner = new RuntimeOwner({
+		root,
+		sessionId: SID,
+		rpc: new FakeRpc(),
+		acceptanceTimeoutMs: 200,
+		finalizeChecks: passingFinalizeChecks,
+		validationCommands: [{ name: "test", command: "bun test" }],
+	});
 	await owner.start();
 });
 
@@ -99,5 +122,15 @@ describe("gjc harness CLI -> live owner routing", () => {
 		const state = res.json?.state as Record<string, unknown>;
 		expect(evidence.ownerRouted).toBe(true);
 		expect(state.ownerLive).toBe(true);
+	}, 30_000);
+
+	it("finalize routes to the live owner and completes the evidence gate", async () => {
+		const res = await runHarness(["finalize", "--session", SID, "--input", "{}"]);
+		expect(res.code).toBe(0);
+		expect(res.json?.ok).toBe(true);
+		const evidence = res.json?.evidence as Record<string, unknown>;
+		const state = res.json?.state as Record<string, unknown>;
+		expect((evidence.finalize as Record<string, unknown>).completed).toBe(true);
+		expect(state.lifecycle).toBe("completed");
 	}, 30_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -122,7 +122,7 @@ describe("gjc harness CLI (foundation)", () => {
 	it("owner-runtime verbs report an honest pending milestone", () => {
 		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
 		const sessionId = started.json.evidence.handle.sessionId as string;
-		const res = runHarness(["finalize", "--session", sessionId]);
+		const res = runHarness(["recover", "--session", sessionId]);
 		expect(res.code).toBe(1);
 		expect(res.json.ok).toBe(false);
 		expect(res.json.evidence.pending).toBe(true);

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+let root: string;
+let workspace: string;
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "harness-cli-root-"));
+	workspace = await mkdtemp(path.join(tmpdir(), "harness-cli-ws-"));
+});
+
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+	await rm(workspace, { recursive: true, force: true });
+});
+
+interface HarnessResult {
+	code: number;
+	json: any;
+	raw: string;
+}
+
+function runHarness(args: string[]): HarnessResult {
+	const proc = Bun.spawnSync(["bun", cliEntry, "harness", ...args], {
+		cwd: workspace,
+		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const raw = proc.stdout.toString().trim();
+	let json: any = null;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		// leave null; assertions will surface the raw output
+	}
+	return { code: proc.exitCode ?? 0, json, raw };
+}
+
+function assertContract(res: any): void {
+	expect(res, `expected contract object, got: ${JSON.stringify(res)}`).toBeTruthy();
+	expect(res).toHaveProperty("state");
+	expect(res).toHaveProperty("evidence");
+	expect(res).toHaveProperty("nextAllowedActions");
+}
+
+function action(res: any, verb: string) {
+	return (res.nextAllowedActions as any[]).find(a => a.verb === verb);
+}
+
+describe("gjc harness CLI (foundation)", () => {
+	it("start creates a session and reports submit owner-not-live", () => {
+		const res = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.ok).toBe(true);
+		expect(res.json.state.lifecycle).toBe("started");
+		expect(typeof res.json.evidence.handle.sessionId).toBe("string");
+		const submit = action(res.json, "submit");
+		expect(submit.available).toBe(false);
+		expect(submit.reason).toBe("owner-not-live");
+	});
+
+	it("rejects non-gajae-code harness as an unsupported v1 seam", () => {
+		const res = runHarness(["start", "--input", JSON.stringify({ harness: "codex", workspace })]);
+		expect(res.code).toBe(1);
+		expect(res.json.ok).toBe(false);
+		expect(String(res.json.error)).toContain("harness_unsupported_in_v1");
+	});
+
+	it("observe re-grabs the session by id (stateless re-acquire) and stays read-only", () => {
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const res = runHarness(["observe", "--session", sessionId]);
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.sessionId).toBe(sessionId);
+		expect(res.json.evidence.readOnly).toBe(true);
+		expect(res.json.evidence.observation).toHaveProperty("gitDelta");
+		expect(res.json.evidence.observation).toHaveProperty("risk");
+		expect(res.json.evidence.observation).not.toHaveProperty("pane");
+	});
+
+	it("submit is blocked (accepted:false, owner-not-live) and never echoed-as-accepted", () => {
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const res = runHarness(["submit", "--session", sessionId, "--input", JSON.stringify({ prompt: "hi" })]);
+		expect(res.code).toBe(1);
+		assertContract(res.json);
+		expect(res.json.ok).toBe(false);
+		expect(res.json.evidence.accepted).toBe(false);
+		expect(res.json.evidence.reason).toBe("owner-not-live");
+	});
+
+	it("classify (pure, no session) maps a dirty vanish to restart-preserve-delta", () => {
+		const res = runHarness([
+			"classify",
+			"--input",
+			JSON.stringify({ observation: { ownerLive: false, gitDelta: "dirty", risk: "vanished-dirty" } }),
+		]);
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.evidence.decision.classification).toBe("restart-preserve-delta");
+		expect(res.json.evidence.decision.requiredReceiptFamily).toBe("vanish");
+	});
+
+	it("retire is blocked on an unknown/dirty delta (data-loss safety)", () => {
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const res = runHarness(["retire", "--session", sessionId]);
+		// workspace is a bare temp dir (no git) -> gitDelta "unknown" -> retire blocked.
+		expect(res.code).toBe(1);
+		expect(res.json.evidence.retired).toBe(false);
+		expect(String(res.json.evidence.reason)).toContain("retire-blocked");
+	});
+
+	it("owner-runtime verbs report an honest pending milestone", () => {
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const res = runHarness(["finalize", "--session", sessionId]);
+		expect(res.code).toBe(1);
+		expect(res.json.ok).toBe(false);
+		expect(res.json.evidence.pending).toBe(true);
+		expect(typeof res.json.evidence.milestone).toBe("string");
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+	ControlServer,
+	callEndpoint,
+	type EndpointRequest,
+	EndpointUnreachableError,
+} from "../../src/harness-control-plane/control-endpoint";
+
+let dir: string;
+let sock: string;
+let server: ControlServer | null = null;
+
+beforeEach(async () => {
+	// Keep the socket path short (AF_UNIX sun_path limit) by living directly in a temp dir.
+	dir = await mkdtemp(path.join(tmpdir(), "h-ep-"));
+	sock = path.join(dir, "c.sock");
+	server = null;
+});
+
+afterEach(async () => {
+	await server?.close();
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("control endpoint", () => {
+	it("round-trips a request to the owner handler and back", async () => {
+		const seen: EndpointRequest[] = [];
+		server = new ControlServer(sock, async req => {
+			seen.push(req);
+			return { ok: true, echoed: req.verb, n: (req.input.n as number) + 1 };
+		});
+		await server.listen();
+		const res = (await callEndpoint(sock, { verb: "submit", input: { n: 41 } })) as Record<string, unknown>;
+		expect(res.ok).toBe(true);
+		expect(res.echoed).toBe("submit");
+		expect(res.n).toBe(42);
+		expect(seen).toHaveLength(1);
+		expect(seen[0].verb).toBe("submit");
+	});
+
+	it("surfaces handler errors as a structured failure, not a crash", async () => {
+		server = new ControlServer(sock, async () => {
+			throw new Error("boom-in-owner");
+		});
+		await server.listen();
+		const res = (await callEndpoint(sock, { verb: "recover", input: {} })) as Record<string, unknown>;
+		expect(res.ok).toBe(false);
+		expect(String(res.error)).toContain("boom-in-owner");
+	});
+
+	it("rejects with EndpointUnreachableError when no owner is listening", async () => {
+		await expect(callEndpoint(path.join(dir, "absent.sock"), { verb: "submit", input: {} })).rejects.toBeInstanceOf(
+			EndpointUnreachableError,
+		);
+	});
+
+	it("serves multiple sequential calls on the same socket", async () => {
+		let count = 0;
+		server = new ControlServer(sock, async () => ({ ok: true, count: ++count }));
+		await server.listen();
+		const a = (await callEndpoint(sock, { verb: "observe", input: {} })) as Record<string, unknown>;
+		const b = (await callEndpoint(sock, { verb: "observe", input: {} })) as Record<string, unknown>;
+		expect(a.count).toBe(1);
+		expect(b.count).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/finalize.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "../../src/harness-control-plane/finalize";
+import { readReceiptIndex } from "../../src/harness-control-plane/storage";
+
+let root: string;
+const SID = "f";
+
+function checks(over: Partial<FinalizeChecks> = {}): FinalizeChecks {
+	return {
+		runValidation:
+			over.runValidation ??
+			(async (spec: ValidationCommandSpec) => ({
+				exactCommand: spec.command,
+				cwd: "/ws",
+				exitStatus: 0,
+				pass: true,
+			})),
+		resolveCommit: over.resolveCommit ?? (async () => "abc123"),
+		commitOnBranch: over.commitOnBranch ?? (async () => true),
+		prOrIssue: over.prOrIssue ?? (async () => ({ prUrl: "https://x/pr/1", issueArtifact: null })),
+	};
+}
+
+const base = () => ({
+	root,
+	sessionId: SID,
+	workspace: "/ws",
+	branch: "feat/x",
+	requireTests: true,
+	requireCommit: true,
+	requirePr: true,
+	validationCommands: [
+		{ name: "typecheck", command: "bun run check:types" },
+		{ name: "test", command: "bun test" },
+	],
+});
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+});
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("runFinalize (evidence gate)", () => {
+	it("completes only with passing validation + commit-on-branch + PR + valid completion receipt", async () => {
+		const res = await runFinalize({ ...base(), checks: checks() });
+		expect(res.completed).toBe(true);
+		expect(res.blockers).toEqual([]);
+		expect(res.receiptPath).toBeTruthy();
+		expect(res.commitHash).toBe("abc123");
+		expect(res.validation.every(v => v.valid)).toBe(true);
+		const completions = await readReceiptIndex(root, SID, "completion");
+		expect(completions).toHaveLength(1);
+		expect(completions[0].valid).toBe(true);
+	});
+
+	it("blocks on a failing required validation (no completion receipt)", async () => {
+		const res = await runFinalize({
+			...base(),
+			checks: checks({
+				runValidation: async spec => ({ exactCommand: spec.command, cwd: "/ws", exitStatus: 1, pass: false }),
+			}),
+		});
+		expect(res.completed).toBe(false);
+		expect(res.blockers.some(b => b.startsWith("validation-failed:"))).toBe(true);
+		expect(res.receiptPath).toBeNull();
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
+	});
+
+	it("blocks when no PR/issue artifact exists", async () => {
+		const res = await runFinalize({
+			...base(),
+			checks: checks({ prOrIssue: async () => ({ prUrl: null, issueArtifact: null }) }),
+		});
+		expect(res.completed).toBe(false);
+		expect(res.blockers).toContain("missing-pr-or-issue");
+	});
+
+	it("blocks when the commit is not on the branch", async () => {
+		const res = await runFinalize({ ...base(), checks: checks({ commitOnBranch: async () => false }) });
+		expect(res.completed).toBe(false);
+		expect(res.blockers).toContain("commit-not-on-branch");
+	});
+
+	it("blocks when tests are required but none were run", async () => {
+		const res = await runFinalize({ ...base(), validationCommands: [], checks: checks() });
+		expect(res.completed).toBe(false);
+		expect(res.blockers).toContain("validation-required-but-none-run");
+	});
+
+	it("an issue artifact satisfies the PR/issue gate", async () => {
+		const res = await runFinalize({
+			...base(),
+			checks: checks({ prOrIssue: async () => ({ prUrl: null, issueArtifact: "issue#42-resolved" }) }),
+		});
+		expect(res.completed).toBe(true);
+		expect(res.issueArtifact).toBe("issue#42-resolved");
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
+++ b/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+/**
+ * Minimal `gjc --mode rpc` protocol emulator — a TEST FIXTURE (never shipped).
+ *
+ * It speaks the real JSONL protocol from docs/rpc.md so the harness e2e exercises the
+ * genuine `GajaeCodeRpc` adapter (ready frame, prompt ack + agent_start, get_state) against
+ * a real subprocess, without a live model. It does NOT fake acceptance/completion inside
+ * shipped code — the control plane drives this exactly as it would drive real gjc.
+ */
+process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
+
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+	buffer += chunk;
+	let idx = buffer.indexOf("\n");
+	while (idx >= 0) {
+		const line = buffer.slice(0, idx).trim();
+		buffer = buffer.slice(idx + 1);
+		if (line) handle(line);
+		idx = buffer.indexOf("\n");
+	}
+});
+
+function handle(line: string): void {
+	let frame: { id?: string; type?: string };
+	try {
+		frame = JSON.parse(line) as { id?: string; type?: string };
+	} catch {
+		return;
+	}
+	if (frame.type === "get_state") {
+		process.stdout.write(
+			`${JSON.stringify({ type: "response", id: frame.id, command: "get_state", success: true, data: { isStreaming: false, queuedMessageCount: 0 } })}\n`,
+		);
+	} else if (frame.type === "prompt") {
+		process.stdout.write(`${JSON.stringify({ type: "response", id: frame.id, command: "prompt", success: true })}\n`);
+		process.stdout.write(`${JSON.stringify({ type: "agent_start" })}\n`);
+	}
+}
+
+// Stay alive until the parent closes our stdin / kills us.
+setInterval(() => {}, 1 << 30);

--- a/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
@@ -151,4 +151,13 @@ describe("operate() autonomous lifecycle (AC-9 e2e + data-loss + red-team)", () 
 		expect(res.blockers.some(b => b.startsWith("validation-failed:"))).toBe(true);
 		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
 	});
+
+	it("B3: never finalizes on loop-exhaustion without an observed completion", async () => {
+		const observer = scriptedObserver([obs({ ownerLive: true, observedSignals: ["working"] })]);
+		const res = await operate("spin without completing", { ...baseOpts(observer), maxIterations: 3 });
+		expect(res.completed).toBe(false);
+		expect(res.lifecycle).toBe("blocked");
+		expect(res.blockers).toContain("no-observed-completion");
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
+	});
 });

--- a/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
+import { operate } from "../../src/harness-control-plane/operate";
+import type { VanishEvidence } from "../../src/harness-control-plane/receipts";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { readEvents, readReceiptIndex } from "../../src/harness-control-plane/storage";
+import type { Observation } from "../../src/harness-control-plane/types";
+
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	state: RpcStateSnapshot = { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	async getState(): Promise<RpcStateSnapshot> {
+		return this.state;
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		this.cursor += 1;
+		return { commandId: "c", ack: true };
+	}
+	async waitForAgentStart(afterCursor: number): Promise<{ cursor: number } | null> {
+		return this.cursor > afterCursor ? { cursor: this.cursor } : null;
+	}
+	async close(): Promise<void> {}
+}
+
+function obs(p: Partial<Observation>): Observation {
+	return {
+		lifecycle: "observing",
+		ownerLive: true,
+		cwd: "/ws",
+		branch: "feat/x",
+		gitDelta: "clean",
+		lastActivityAt: null,
+		observedSignals: [],
+		risk: "normal",
+		...p,
+	};
+}
+
+function scriptedObserver(queue: Observation[]): () => Promise<Observation> {
+	let i = 0;
+	return async () => queue[Math.min(i++, queue.length - 1)];
+}
+
+const passingChecks: FinalizeChecks = {
+	async runValidation(spec) {
+		return { exactCommand: spec.command, cwd: "/ws", exitStatus: 0, pass: true };
+	},
+	async resolveCommit() {
+		return "abc123";
+	},
+	async commitOnBranch() {
+		return true;
+	},
+	async prOrIssue() {
+		return { prUrl: "https://x/pr/1", issueArtifact: null };
+	},
+};
+
+let root: string;
+const SID = "op";
+
+function baseOpts(observer: () => Promise<Observation>) {
+	return {
+		root,
+		sessionId: SID,
+		workspace: "/ws",
+		branch: "feat/x",
+		rpc: new FakeRpc(),
+		rpcFactory: () => new FakeRpc(),
+		observe: observer,
+		finalizeChecks: passingChecks,
+		validationCommands: [{ name: "test", command: "bun test" }],
+		acceptanceTimeoutMs: 100,
+		maxIterations: 6,
+	};
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+});
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("operate() autonomous lifecycle (AC-9 e2e + data-loss + red-team)", () => {
+	it("AC-9: recovers an injected zero-delta vanish and finalizes with receipt+commit+PR", async () => {
+		const observer = scriptedObserver([
+			obs({ ownerLive: false, gitDelta: "zero-delta", risk: "vanished-dirty", observedSignals: ["SessionStart"] }),
+			obs({ ownerLive: true, gitDelta: "clean", observedSignals: ["commit-created", "completed"] }),
+		]);
+		const res = await operate("ship issue #482", baseOpts(observer));
+		expect(res.completed).toBe(true);
+		expect(res.lifecycle).toBe("completed");
+		expect(res.classifications).toContain("restart-clean");
+		expect(res.vanishReceiptIds.length).toBeGreaterThanOrEqual(1);
+		expect(res.finalize?.completed).toBe(true);
+
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(1);
+		const kinds = (await readEvents(root, SID, 0)).map(e => e.kind);
+		expect(kinds).toContain("operate_started");
+		expect(kinds).toContain("vanish_receipt");
+		expect(kinds).toContain("operate_finalized");
+	});
+
+	it("data-loss safety: a dirty vanish uses restart-preserve-delta (NEVER restart-clean) with a valid vanish receipt", async () => {
+		const observer = scriptedObserver([
+			obs({ ownerLive: false, gitDelta: "dirty", risk: "vanished-dirty", observedSignals: ["partial-delta"] }),
+			obs({ ownerLive: true, observedSignals: ["completed"] }),
+		]);
+		const res = await operate("ship #482 with dirty tree", baseOpts(observer));
+		expect(res.classifications).toContain("restart-preserve-delta");
+		expect(res.classifications).not.toContain("restart-clean");
+
+		const vanish = await readReceiptIndex(root, SID, "vanish");
+		expect(vanish).toHaveLength(1);
+		expect(vanish[0].valid).toBe(true);
+		const evidence = JSON.parse(await readFile(vanish[0].path, "utf8")).evidence as VanishEvidence;
+		expect(evidence.preservation).toBe("snapshot");
+		expect(evidence.snapshotComplete).toBe(true);
+		expect(evidence.forbiddenActions).toContain("restart-clean");
+		expect(res.completed).toBe(true);
+	});
+
+	it("red-team: a deleted worktree halts at human-check and never finalizes", async () => {
+		const observer = scriptedObserver([obs({ ownerLive: false, gitDelta: "dirty", risk: "deleted-worktree" })]);
+		const res = await operate("dangerous", baseOpts(observer));
+		expect(res.completed).toBe(false);
+		expect(res.lifecycle).toBe("blocked");
+		expect(res.classifications).toContain("human-check");
+		expect(res.blockers).toContain("human-check-required");
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
+	});
+
+	it("red-team: finalize gate blocks completion when the required validation fails", async () => {
+		const observer = scriptedObserver([obs({ ownerLive: true, observedSignals: ["completed"] })]);
+		const failingChecks: FinalizeChecks = {
+			...passingChecks,
+			async runValidation(spec) {
+				return { exactCommand: spec.command, cwd: "/ws", exitStatus: 1, pass: false };
+			},
+		};
+		const res = await operate("ship but tests fail", { ...baseOpts(observer), finalizeChecks: failingChecks });
+		expect(res.completed).toBe(false);
+		expect(res.lifecycle).toBe("blocked");
+		expect(res.blockers.some(b => b.startsWith("validation-failed:"))).toBe(true);
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/operate-e2e.test.ts
@@ -74,6 +74,14 @@ function baseOpts(observer: () => Promise<Observation>) {
 		rpc: new FakeRpc(),
 		rpcFactory: () => new FakeRpc(),
 		observe: observer,
+		preserve: (_ws: string) => ({
+			gitDelta: "dirty" as const,
+			trackedDiff: "diff --git a/a.ts b/a.ts",
+			trackedDiffSha256: "abc123",
+			untrackedManifest: [{ path: "b.ts", size: 3, sha256: "hh" }],
+			stashRef: "deadbeefoid",
+			snapshotComplete: true,
+		}),
 		finalizeChecks: passingChecks,
 		validationCommands: [{ name: "test", command: "bun test" }],
 		acceptanceTimeoutMs: 100,
@@ -121,7 +129,9 @@ describe("operate() autonomous lifecycle (AC-9 e2e + data-loss + red-team)", () 
 		expect(vanish).toHaveLength(1);
 		expect(vanish[0].valid).toBe(true);
 		const evidence = JSON.parse(await readFile(vanish[0].path, "utf8")).evidence as VanishEvidence;
-		expect(evidence.preservation).toBe("snapshot");
+		expect(evidence.preservation).toBe("stash");
+		expect(evidence.stashRef).toBe("deadbeefoid");
+		expect(evidence.untrackedManifest.length).toBeGreaterThanOrEqual(1);
 		expect(evidence.snapshotComplete).toBe(true);
 		expect(evidence.forbiddenActions).toContain("restart-clean");
 		expect(res.completed).toBe(true);

--- a/packages/coding-agent/test/harness-control-plane/owner-verbs.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-verbs.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
+import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
+import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { readReceiptIndex, writeSessionState } from "../../src/harness-control-plane/storage";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	async getState(): Promise<RpcStateSnapshot> {
+		return { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		this.cursor += 1;
+		return { commandId: "c", ack: true };
+	}
+	async waitForAgentStart(after: number): Promise<{ cursor: number } | null> {
+		return this.cursor > after ? { cursor: this.cursor } : null;
+	}
+	async close(): Promise<void> {}
+}
+
+const passingChecks: FinalizeChecks = {
+	async runValidation(spec) {
+		return { exactCommand: spec.command, cwd: ".", exitStatus: 0, pass: true };
+	},
+	async resolveCommit() {
+		return "abc123";
+	},
+	async commitOnBranch() {
+		return true;
+	},
+	async prOrIssue() {
+		return { prUrl: "https://x/pr/1", issueArtifact: null };
+	},
+};
+
+let root: string;
+const SID = "v";
+let owner: RuntimeOwner | null = null;
+
+function seed(workspace: string): SessionState {
+	const now = new Date().toISOString();
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: SID,
+		lifecycle: "started",
+		harness: "gajae-code",
+		handle: { sessionId: SID, harness: "gajae-code", workspace } as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	await writeSessionState(root, seed(root));
+	owner = null;
+});
+
+afterEach(async () => {
+	await owner?.stop();
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("owner-dispatched recover / validate / operate", () => {
+	it("validate runs configured commands and persists validation receipts", async () => {
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc(),
+			finalizeChecks: passingChecks,
+			validationCommands: [{ name: "typecheck", command: "true" }],
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "validate", input: {} })) as Record<string, unknown>;
+		const validation = (res.evidence as Record<string, unknown>).validation as { name: string; valid: boolean }[];
+		expect(validation).toHaveLength(1);
+		expect(validation[0].valid).toBe(true);
+		expect(await readReceiptIndex(root, SID, "validation")).toHaveLength(1);
+	});
+
+	it("recover observes + classifies and returns a deterministic decision", async () => {
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc: new FakeRpc() });
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "recover", input: {} })) as Record<string, unknown>;
+		const decision = (res.evidence as Record<string, unknown>).decision as Record<string, unknown>;
+		expect(typeof decision.classification).toBe("string");
+		expect(decision.classification).toBe("continue"); // owner live, normal
+	});
+
+	it("operate is owner-dispatched and runs the bounded lifecycle loop", async () => {
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc(),
+			finalizeChecks: passingChecks,
+			validationCommands: [{ name: "t", command: "true" }],
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, {
+			verb: "operate",
+			input: { goal: "do the thing", maxIterations: 2 },
+		})) as Record<string, unknown>;
+		const operate = (res.evidence as Record<string, unknown>).operate as Record<string, unknown>;
+		expect(operate).toBeTruthy();
+		expect(Array.isArray(operate.classifications)).toBe(true);
+		// git observer never reports completion here, so the bounded loop blocks rather than finalizing.
+		expect(operate.lifecycle).toBe("blocked");
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/owner-verbs.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-verbs.test.ts
@@ -6,7 +6,7 @@ import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
 import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
 import { RuntimeOwner } from "../../src/harness-control-plane/owner";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
-import { readReceiptIndex, writeSessionState } from "../../src/harness-control-plane/storage";
+import { readEvents, readReceiptIndex, writeSessionState } from "../../src/harness-control-plane/storage";
 import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
 
 class FakeRpc implements HarnessRpc {
@@ -116,5 +116,11 @@ describe("owner-dispatched recover / validate / operate", () => {
 		expect(Array.isArray(operate.classifications)).toBe(true);
 		// git observer never reports completion here, so the bounded loop blocks rather than finalizing.
 		expect(operate.lifecycle).toBe("blocked");
+		// The owner persists the loop's terminal lifecycle (not stale).
+		expect((res.state as Record<string, unknown>).lifecycle).toBe("blocked");
+		// Every emitted event carries the owner's lease identity (no hardcoded "operate" writer).
+		const events = await readEvents(root, SID, 0);
+		expect(events.length).toBeGreaterThan(0);
+		expect(events.every(e => e.writer.ownerId === info.ownerId)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -128,9 +128,12 @@ describe("RuntimeOwner (in-process integration)", () => {
 		const ret = (await callEndpoint(info.socketPath, { verb: "retire", input: {} })) as Record<string, unknown>;
 		expect((ret.evidence as Record<string, unknown>).retired).toBe(true);
 
-		// Give the owner a tick to release the lease + close the endpoint.
-		await new Promise(r => setTimeout(r, 50));
-		const after = await resolveOwner(root, SID);
+		// Poll for the owner to release the lease + close the endpoint (robust under load).
+		let after = await resolveOwner(root, SID);
+		for (let i = 0; i < 100 && after.live; i++) {
+			await new Promise(r => setTimeout(r, 20));
+			after = await resolveOwner(root, SID);
+		}
 		expect(after.live).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
+import { RuntimeOwner, resolveOwner } from "../../src/harness-control-plane/owner";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { readEvents, writeSessionState } from "../../src/harness-control-plane/storage";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	state: RpcStateSnapshot = { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	ack = true;
+	accept = true;
+	agentStarts: number[] = [];
+	async getState(): Promise<RpcStateSnapshot> {
+		return this.state;
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		if (this.accept) {
+			this.cursor += 1;
+			this.agentStarts.push(this.cursor);
+		}
+		return { commandId: "cmd-1", ack: this.ack };
+	}
+	async waitForAgentStart(afterCursor: number): Promise<{ cursor: number } | null> {
+		const found = this.agentStarts.find(c => c > afterCursor);
+		return found === undefined ? null : { cursor: found };
+	}
+	async close(): Promise<void> {}
+}
+
+let root: string;
+const SID = "o";
+let owner: RuntimeOwner | null = null;
+
+function seedState(workspace: string): SessionState {
+	const now = new Date().toISOString();
+	const handle = { sessionId: SID, harness: "gajae-code", workspace, branch: "feat/x" } as SessionHandle;
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: SID,
+		lifecycle: "started",
+		harness: "gajae-code",
+		handle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+beforeEach(async () => {
+	// Short root keeps the AF_UNIX socket path under the sun_path limit.
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	await writeSessionState(root, seedState(root));
+	owner = null;
+});
+
+afterEach(async () => {
+	await owner?.stop();
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("RuntimeOwner (in-process integration)", () => {
+	it("routes submit through the endpoint, accepts via single-flight, and is the single event writer", async () => {
+		const rpc = new FakeRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 200 });
+		const info = await owner.start();
+		expect(info.leaseEpoch).toBe(1);
+
+		const live = await resolveOwner(root, SID);
+		expect(live.live).toBe(true);
+		expect(live.socketPath).toBe(info.socketPath);
+
+		const res = (await callEndpoint(info.socketPath, { verb: "submit", input: { prompt: "do it" } })) as Record<
+			string,
+			unknown
+		>;
+		expect(res.ok).toBe(true);
+		expect((res.evidence as Record<string, unknown>).accepted).toBe(true);
+		expect((res.state as Record<string, unknown>).lifecycle).toBe("observing");
+		expect((res.state as Record<string, unknown>).ownerLive).toBe(true);
+
+		const events = await readEvents(root, SID, 0);
+		const kinds = events.map(e => e.kind);
+		expect(kinds).toContain("owner_started");
+		expect(kinds).toContain("prompt_accepted");
+		// Single writer: every event is stamped with this owner + lease epoch, cursors strictly increasing.
+		for (const e of events) {
+			expect(e.writer.ownerId).toBe(info.ownerId);
+			expect(e.writer.leaseEpoch).toBe(1);
+		}
+		expect(events.map(e => e.cursor)).toEqual([...events.map(e => e.cursor)].sort((a, b) => a - b));
+	});
+
+	it("blocks submit when the harness acks but never starts (no false-positive acceptance)", async () => {
+		const rpc = new FakeRpc();
+		rpc.accept = false; // ack only, no agent_start
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 100 });
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "submit", input: { prompt: "p" } })) as Record<
+			string,
+			unknown
+		>;
+		expect(res.ok).toBe(false);
+		expect((res.evidence as Record<string, unknown>).accepted).toBe(false);
+		expect((res.evidence as Record<string, unknown>).reason).toBe("no-agent-start-within-timeout");
+		const events = await readEvents(root, SID, 0);
+		expect(events.map(e => e.kind)).toContain("prompt_not_accepted");
+		const warn = events.find(e => e.kind === "prompt_not_accepted");
+		expect(warn?.severity).toBe("warn");
+	});
+
+	it("observe is owner-routed and reports ownerLive; retire releases the lease", async () => {
+		const rpc = new FakeRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 200 });
+		const info = await owner.start();
+
+		const obs = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>;
+		expect((obs.evidence as Record<string, unknown>).ownerRouted).toBe(true);
+		expect((obs.state as Record<string, unknown>).ownerLive).toBe(true);
+
+		const ret = (await callEndpoint(info.socketPath, { verb: "retire", input: {} })) as Record<string, unknown>;
+		expect((ret.evidence as Record<string, unknown>).retired).toBe(true);
+
+		// Give the owner a tick to release the lease + close the endpoint.
+		await new Promise(r => setTimeout(r, 50));
+		const after = await resolveOwner(root, SID);
+		expect(after.live).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/preserve.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/preserve.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { preserveDirtyWorktree } from "../../src/harness-control-plane/preserve";
+
+function git(ws: string, args: string[]): string {
+	return execFileSync("git", args, { cwd: ws, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+}
+
+let ws: string;
+
+beforeEach(async () => {
+	ws = await mkdtemp(path.join(tmpdir(), "h-pres-"));
+	git(ws, ["init", "-q"]);
+	git(ws, ["config", "user.email", "t@t"]);
+	git(ws, ["config", "user.name", "t"]);
+	git(ws, ["config", "commit.gpgsign", "false"]);
+	await writeFile(path.join(ws, "a.txt"), "v1\n");
+	git(ws, ["add", "."]);
+	git(ws, ["commit", "-q", "-m", "init"]);
+});
+
+afterEach(async () => {
+	await rm(ws, { recursive: true, force: true });
+});
+
+describe("preserveDirtyWorktree (real git, B2)", () => {
+	it("clean tree -> clean, no stash, snapshotComplete", () => {
+		const r = preserveDirtyWorktree(ws);
+		expect(r.gitDelta).toBe("clean");
+		expect(r.stashRef).toBeNull();
+		expect(r.snapshotComplete).toBe(true);
+	});
+
+	it("captures tracked diff + untracked manifest + stash ref WITHOUT mutating the worktree (no data loss)", async () => {
+		await writeFile(path.join(ws, "a.txt"), "v2-modified\n");
+		await writeFile(path.join(ws, "b.txt"), "new");
+		const r = preserveDirtyWorktree(ws);
+		expect(r.gitDelta).toBe("dirty");
+		expect(r.trackedDiff).toContain("a.txt");
+		expect(r.trackedDiffSha256.length).toBeGreaterThan(0);
+		expect(r.untrackedManifest.map(e => e.path)).toContain("b.txt");
+		expect(r.stashRef).toBeTruthy();
+		expect(r.snapshotComplete).toBe(true);
+		// No data loss: the working tree is untouched by the snapshot.
+		expect(await readFile(path.join(ws, "a.txt"), "utf8")).toBe("v2-modified\n");
+		expect(await readFile(path.join(ws, "b.txt"), "utf8")).toBe("new");
+		// The snapshot is recoverable from the stash list.
+		expect(git(ws, ["stash", "list"]).trim().length).toBeGreaterThan(0);
+	});
+
+	it("untracked-only dirty is manifested and never deleted", async () => {
+		await writeFile(path.join(ws, "c.txt"), "untracked-only");
+		const r = preserveDirtyWorktree(ws);
+		expect(r.gitDelta).toBe("dirty");
+		expect(r.untrackedManifest.map(e => e.path)).toContain("c.txt");
+		expect(r.snapshotComplete).toBe(true);
+		expect(await readFile(path.join(ws, "c.txt"), "utf8")).toBe("untracked-only");
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/receipts.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/receipts.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildReceipt,
+	type CompletionEvidence,
+	type PromptAcceptanceEvidence,
+	type ReceiptSubject,
+	requiresVanishBeforeAction,
+	type ValidationEvidence,
+	type VanishEvidence,
+	validateReceipt,
+} from "../../src/harness-control-plane/receipts";
+
+const subject: ReceiptSubject = { workspace: "/ws", branch: "feat/x", head: "abc", commit: "abc" };
+
+function vanish(over: Partial<VanishEvidence> = {}): VanishEvidence {
+	return {
+		classification: "restart-preserve-delta",
+		gitDelta: "dirty",
+		gitStatusPorcelain: " M a.ts\n?? b.ts",
+		untrackedManifest: [{ path: "b.ts", size: 3, sha256: "h" }],
+		preservation: "snapshot",
+		stashRef: null,
+		snapshotComplete: true,
+		forbiddenActions: ["restart-clean", "delete", "reset"],
+		...over,
+	};
+}
+
+describe("receipts: hashing + tamper detection", () => {
+	it("builds a self-consistent hash that validates", () => {
+		const r = buildReceipt<VanishEvidence>({
+			receiptId: "v-1",
+			sessionId: "s",
+			family: "vanish",
+			source: "test",
+			subject,
+			evidence: vanish(),
+		});
+		expect(validateReceipt(r).valid).toBe(true);
+	});
+
+	it("fails closed when evidence is tampered after hashing", () => {
+		const r = buildReceipt<VanishEvidence>({
+			receiptId: "v-2",
+			sessionId: "s",
+			family: "vanish",
+			source: "test",
+			subject,
+			evidence: vanish(),
+		});
+		(r.evidence as VanishEvidence).gitDelta = "clean"; // tamper
+		const out = validateReceipt(r);
+		expect(out.valid).toBe(false);
+		expect(out.reasons).toContain("hash-mismatch");
+	});
+});
+
+describe("receipts: vanish data-loss invariants", () => {
+	it("valid when dirty delta is preserved and restart-clean is forbidden", () => {
+		const r = buildReceipt({
+			receiptId: "v",
+			sessionId: "s",
+			family: "vanish",
+			source: "t",
+			subject,
+			evidence: vanish(),
+		});
+		expect(validateReceipt(r).valid).toBe(true);
+	});
+
+	it("invalid when a dirty delta is blocked instead of preserved", () => {
+		const r = buildReceipt({
+			receiptId: "v",
+			sessionId: "s",
+			family: "vanish",
+			source: "t",
+			subject,
+			evidence: vanish({ preservation: "block" }),
+		});
+		expect(validateReceipt(r).reasons).toContain("vanish-dirty-must-preserve-not-block");
+	});
+
+	it("invalid when restart-clean is not in forbiddenActions", () => {
+		const r = buildReceipt({
+			receiptId: "v",
+			sessionId: "s",
+			family: "vanish",
+			source: "t",
+			subject,
+			evidence: vanish({ forbiddenActions: [] }),
+		});
+		expect(validateReceipt(r).reasons).toContain("vanish-must-forbid-restart-clean");
+	});
+
+	it("invalid when a stash preservation lacks a stash ref", () => {
+		const r = buildReceipt({
+			receiptId: "v",
+			sessionId: "s",
+			family: "vanish",
+			source: "t",
+			subject,
+			evidence: vanish({ preservation: "stash", stashRef: null, snapshotComplete: false }),
+		});
+		expect(validateReceipt(r).reasons).toContain("vanish-stash-missing-ref");
+	});
+});
+
+describe("receipts: prompt-acceptance / validation / completion validators", () => {
+	function accept(over: Partial<PromptAcceptanceEvidence> = {}): PromptAcceptanceEvidence {
+		return {
+			promptSha256: "p",
+			rpcCommandId: "c",
+			preSubmitState: { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 },
+			preSubmitCursor: 5,
+			agentStartCursor: 6,
+			acceptedAt: new Date().toISOString(),
+			singleFlight: true,
+			...over,
+		};
+	}
+
+	it("accepts an idle single-flight acceptance with agent_start after the cursor", () => {
+		const r = buildReceipt({
+			receiptId: "a",
+			sessionId: "s",
+			family: "prompt-acceptance",
+			source: "t",
+			subject,
+			evidence: accept(),
+		});
+		expect(validateReceipt(r).valid).toBe(true);
+	});
+
+	it("rejects acceptance when pre-state was streaming or agent_start did not advance", () => {
+		const streaming = buildReceipt({
+			receiptId: "a",
+			sessionId: "s",
+			family: "prompt-acceptance",
+			source: "t",
+			subject,
+			evidence: accept({ preSubmitState: { isStreaming: true, steeringQueueDepth: 0, followupQueueDepth: 0 } }),
+		});
+		expect(validateReceipt(streaming).reasons).toContain("acceptance-pre-state-streaming");
+		const stale = buildReceipt({
+			receiptId: "a2",
+			sessionId: "s",
+			family: "prompt-acceptance",
+			source: "t",
+			subject,
+			evidence: accept({ preSubmitCursor: 6, agentStartCursor: 6 }),
+		});
+		expect(validateReceipt(stale).reasons).toContain("acceptance-agent-start-not-after-cursor");
+	});
+
+	it("validation receipt: pass -> valid, fail -> validation-failed", () => {
+		const ok: ValidationEvidence = {
+			command: "build",
+			exactCommand: "bun run build",
+			cwd: "/ws",
+			exitStatus: 0,
+			pass: true,
+			commitUnderTest: "abc",
+		};
+		const bad: ValidationEvidence = { ...ok, exitStatus: 1, pass: false };
+		expect(
+			validateReceipt(
+				buildReceipt({ receiptId: "x", sessionId: "s", family: "validation", source: "t", subject, evidence: ok }),
+			).valid,
+		).toBe(true);
+		expect(
+			validateReceipt(
+				buildReceipt({ receiptId: "y", sessionId: "s", family: "validation", source: "t", subject, evidence: bad }),
+			).reasons,
+		).toContain("validation-failed");
+	});
+
+	it("completion receipt requires commit + pr/issue + validations + no blockers", () => {
+		const good: CompletionEvidence = {
+			finalCommit: "abc",
+			branch: "feat/x",
+			prUrl: "https://x/pr/1",
+			issueArtifact: null,
+			requiredValidationReceiptIds: ["val-1"],
+			finalLifecycle: "completed",
+			finalizedAt: new Date().toISOString(),
+			blockers: [],
+		};
+		expect(
+			validateReceipt(
+				buildReceipt({
+					receiptId: "d",
+					sessionId: "s",
+					family: "completion",
+					source: "t",
+					subject,
+					evidence: good,
+				}),
+			).valid,
+		).toBe(true);
+		const noPr = buildReceipt({
+			receiptId: "d2",
+			sessionId: "s",
+			family: "completion",
+			source: "t",
+			subject,
+			evidence: { ...good, prUrl: null },
+		});
+		expect(validateReceipt(noPr).reasons).toContain("completion-missing-pr-or-issue");
+		const blocked = buildReceipt({
+			receiptId: "d3",
+			sessionId: "s",
+			family: "completion",
+			source: "t",
+			subject,
+			evidence: { ...good, blockers: ["x"] },
+		});
+		expect(validateReceipt(blocked).reasons).toContain("completion-has-blockers");
+	});
+
+	it("requiresVanishBeforeAction gates the destructive classifications", () => {
+		expect(requiresVanishBeforeAction("restart-clean")).toBe(true);
+		expect(requiresVanishBeforeAction("restart-preserve-delta")).toBe(true);
+		expect(requiresVanishBeforeAction("fallback-codex-exec")).toBe(true);
+		expect(requiresVanishBeforeAction("continue")).toBe(false);
+		expect(requiresVanishBeforeAction("human-check")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/rpc-acceptance.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/rpc-acceptance.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type HarnessRpc,
+	type RpcStateSnapshot,
+	singleFlightAccept,
+} from "../../src/harness-control-plane/rpc-adapter";
+
+/** Programmable in-memory RPC for acceptance-logic tests (no real gjc subprocess). */
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	state: RpcStateSnapshot = { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	ack = true;
+	agentStarts: number[] = [];
+	onSendPrompt?: (rpc: FakeRpc) => void;
+
+	async getState(): Promise<RpcStateSnapshot> {
+		return this.state;
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(_prompt: string): Promise<{ commandId: string; ack: boolean }> {
+		this.onSendPrompt?.(this);
+		return { commandId: "cmd-1", ack: this.ack };
+	}
+	/** Simulate the harness emitting an agent_start (advances the event cursor). */
+	emitAgentStart(): void {
+		this.cursor += 1;
+		this.agentStarts.push(this.cursor);
+	}
+	emitOtherEvent(): void {
+		this.cursor += 1;
+	}
+	async waitForAgentStart(afterCursor: number, _timeoutMs: number): Promise<{ cursor: number } | null> {
+		const found = this.agentStarts.find(c => c > afterCursor);
+		return found === undefined ? null : { cursor: found };
+	}
+	async close(): Promise<void> {}
+}
+
+describe("singleFlightAccept", () => {
+	it("accepts only when the next agent_start follows the ack (idle pre-state)", async () => {
+		const rpc = new FakeRpc();
+		rpc.onSendPrompt = r => r.emitAgentStart();
+		const res = await singleFlightAccept(rpc, "do the thing", 1000);
+		expect(res.accepted).toBe(true);
+		expect(res.reason).toBe("protocol-ack-single-flight");
+		expect(res.agentStartCursor).toBe(res.preSubmitCursor + 1);
+	});
+
+	it("rejects ack-only with no agent_start (the tmux 'visible != submitted' trap)", async () => {
+		const rpc = new FakeRpc();
+		rpc.ack = true; // acked but the harness never starts
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("no-agent-start-within-timeout");
+	});
+
+	it("rejects when the command is not acked", async () => {
+		const rpc = new FakeRpc();
+		rpc.ack = false;
+		rpc.onSendPrompt = r => r.emitAgentStart();
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("no-ack");
+	});
+
+	it("rejects a non-idle (streaming) pre-state", async () => {
+		const rpc = new FakeRpc();
+		rpc.state = { isStreaming: true, steeringQueueDepth: 0, followupQueueDepth: 0 };
+		rpc.onSendPrompt = r => r.emitAgentStart();
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("pre-state-not-idle");
+	});
+
+	it("rejects when steering/follow-up queues are non-empty", async () => {
+		const rpc = new FakeRpc();
+		rpc.state = { isStreaming: false, steeringQueueDepth: 2, followupQueueDepth: 0 };
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("pre-state-not-idle");
+	});
+
+	it("does NOT count a stale agent_start that preceded the submit cursor", async () => {
+		const rpc = new FakeRpc();
+		rpc.emitAgentStart(); // stale: happens before the prompt, cursor now 1
+		rpc.ack = true; // prompt is acked but produces no NEW agent_start
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("no-agent-start-within-timeout");
+		expect(res.preSubmitCursor).toBe(1);
+	});
+
+	it("ignores unrelated events and still requires a fresh agent_start", async () => {
+		const rpc = new FakeRpc();
+		rpc.onSendPrompt = r => {
+			r.emitOtherEvent(); // message_update etc. — not acceptance
+		};
+		const res = await singleFlightAccept(rpc, "p", 1000);
+		expect(res.accepted).toBe(false);
+		expect(res.reason).toBe("no-agent-start-within-timeout");
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/seams.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/seams.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFERRED_SEAMS,
+	isHarnessSupported,
+	SUPPORTED_HARNESSES,
+	unsupportedSeam,
+} from "../../src/harness-control-plane/seams";
+
+describe("v1 seams", () => {
+	it("only gajae-code is supported in v1", () => {
+		expect(SUPPORTED_HARNESSES).toEqual(["gajae-code"]);
+		expect(isHarnessSupported("gajae-code")).toBe(true);
+		expect(isHarnessSupported("codex")).toBe(false);
+		expect(isHarnessSupported("omx")).toBe(false);
+	});
+
+	it("unsupportedSeam fails closed with a clear signal + deferral list", () => {
+		const res = unsupportedSeam("codex-adapter");
+		expect(res.ok).toBe(false);
+		expect(res.error).toBe("seam_unsupported_in_v1:codex-adapter");
+		expect(res.evidence.deferred).toContain("codex-adapter");
+		expect(res.evidence.deferred).toContain("remote-transport");
+		expect(res.evidence.supported).toEqual(["gajae-code"]);
+	});
+
+	it("documents the deferred (designed-not-built) surfaces", () => {
+		for (const seam of [
+			"codex-adapter",
+			"omx-adapter",
+			"remote-transport",
+			"global-daemon",
+			"capability-token-auth",
+		]) {
+			expect(DEFERRED_SEAMS as readonly string[]).toContain(seam);
+		}
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/session-lease.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/session-lease.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+	acquireLease,
+	canWriteEvents,
+	heartbeat,
+	isOwnerAlive,
+	isStale,
+	LeaseError,
+	readLease,
+	releaseLease,
+} from "../../src/harness-control-plane/session-lease";
+
+let root: string;
+const SID = "h-lease";
+const aliveProbe = () => true;
+const deadProbe = () => false;
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "harness-lease-"));
+});
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+describe("SessionLease", () => {
+	it("acquires a fresh lease at epoch 1 and persists it", async () => {
+		const { lease, token } = await acquireLease(root, SID, {
+			ownerId: "owner-a",
+			pid: 1234,
+			eventsPath: "events.jsonl",
+			ttlMs: 10_000,
+		});
+		expect(lease.leaseEpoch).toBe(1);
+		expect(lease.ownerId).toBe("owner-a");
+		expect(typeof token).toBe("string");
+		const reread = await readLease(root, SID);
+		expect(reread?.ownerId).toBe("owner-a");
+	});
+
+	it("rejects a second acquire while a live, unexpired lease is held by another owner", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		await expect(
+			acquireLease(root, SID, { ownerId: "owner-b", pid: 2, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe }),
+		).rejects.toThrow(LeaseError);
+	});
+
+	it("allows takeover of a stale (dead owner) lease and increments the epoch", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		const taken = await acquireLease(root, SID, {
+			ownerId: "owner-b",
+			pid: 2,
+			eventsPath: "e",
+			ttlMs: 10_000,
+			probe: deadProbe, // prior owner is dead -> stale -> takeover
+		});
+		expect(taken.lease.ownerId).toBe("owner-b");
+		expect(taken.lease.leaseEpoch).toBe(2);
+	});
+
+	it("allows takeover of an expired lease and increments the epoch", async () => {
+		const past = () => 1_000; // acquire far in the past
+		await acquireLease(root, SID, {
+			ownerId: "owner-a",
+			pid: 1,
+			eventsPath: "e",
+			ttlMs: 1,
+			clock: past,
+			probe: aliveProbe,
+		});
+		const taken = await acquireLease(root, SID, {
+			ownerId: "owner-b",
+			pid: 2,
+			eventsPath: "e",
+			ttlMs: 10_000,
+			probe: aliveProbe, // alive, but prior lease expired
+		});
+		expect(taken.lease.leaseEpoch).toBe(2);
+	});
+
+	it("heartbeat is single-writer: only the holder may refresh", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		const refreshed = await heartbeat(root, SID, "owner-a", 20_000);
+		expect(Date.parse(refreshed.expiresAt)).toBeGreaterThan(Date.parse(refreshed.heartbeatAt));
+		await expect(heartbeat(root, SID, "owner-b", 20_000)).rejects.toThrow(/not_lease_holder/);
+	});
+
+	it("canWriteEvents only for the live, unexpired holder", async () => {
+		const { lease } = await acquireLease(root, SID, {
+			ownerId: "owner-a",
+			pid: 1,
+			eventsPath: "e",
+			ttlMs: 10_000,
+			probe: aliveProbe,
+		});
+		expect(canWriteEvents(lease, "owner-a")).toBe(true);
+		expect(canWriteEvents(lease, "owner-b")).toBe(false);
+	});
+
+	it("isStale reflects expiry and liveness; releaseLease requires the holder", async () => {
+		const { lease } = await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000 });
+		expect(isStale(lease, { probe: deadProbe })).toBe(true);
+		expect(isStale(lease, { probe: aliveProbe })).toBe(false);
+		await expect(releaseLease(root, SID, "owner-b")).rejects.toThrow(/not_lease_holder/);
+		await releaseLease(root, SID, "owner-a");
+		expect(await readLease(root, SID)).toBeNull();
+	});
+
+	it("isOwnerAlive returns false for an obviously dead pid", () => {
+		expect(isOwnerAlive(2_147_483_646)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/state-machine.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/state-machine.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildResponse,
+	canTransition,
+	isTerminal,
+	nextAllowedActions,
+} from "../../src/harness-control-plane/state-machine";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+function fakeState(p: Partial<SessionState> = {}): SessionState {
+	const now = "2026-06-02T00:00:00.000Z";
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: "h-test",
+		lifecycle: "started",
+		harness: "gajae-code",
+		handle: { sessionId: "h-test", harness: "gajae-code", workspace: "." } as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+		...p,
+	};
+}
+
+function findAction(actions: ReturnType<typeof nextAllowedActions>, verb: string) {
+	const found = actions.find(a => a.verb === verb);
+	if (!found) throw new Error(`missing action ${verb}`);
+	return found;
+}
+
+describe("harness state machine", () => {
+	it("submit is blocked with owner-not-live when no live owner (non-terminal)", () => {
+		const actions = nextAllowedActions("started", false);
+		const submit = findAction(actions, "submit");
+		expect(submit.available).toBe(false);
+		expect(submit.reason).toBe("owner-not-live");
+	});
+
+	it("submit is available with a live owner (non-terminal)", () => {
+		const submit = findAction(nextAllowedActions("submitted", true), "submit");
+		expect(submit.available).toBe(true);
+	});
+
+	it("terminal lifecycles block submit/recover/validate/finalize", () => {
+		for (const lifecycle of ["completed", "retired"] as const) {
+			const actions = nextAllowedActions(lifecycle, true);
+			for (const verb of ["submit", "recover", "validate", "finalize"]) {
+				expect(findAction(actions, verb).available).toBe(false);
+			}
+			expect(isTerminal(lifecycle)).toBe(true);
+		}
+	});
+
+	it("pure/read verbs are always available", () => {
+		for (const lifecycle of ["new", "started", "completed", "retired", "blocked"] as const) {
+			const actions = nextAllowedActions(lifecycle, false);
+			for (const verb of ["observe", "classify", "events", "monitor"]) {
+				expect(findAction(actions, verb).available).toBe(true);
+			}
+		}
+	});
+
+	it("recover handles a dead owner: available without a live owner when non-terminal", () => {
+		expect(findAction(nextAllowedActions("blocked", false), "recover").available).toBe(true);
+	});
+
+	it("contract: buildResponse always carries {ok,state,evidence,nextAllowedActions}", () => {
+		const res = buildResponse(fakeState(), false, { hello: "world" });
+		expect(res.ok).toBe(true);
+		expect(res.state.sessionId).toBe("h-test");
+		expect(res.state.ownerLive).toBe(false);
+		expect(res.evidence).toEqual({ hello: "world" });
+		expect(Array.isArray(res.nextAllowedActions)).toBe(true);
+		expect(res.nextAllowedActions.length).toBeGreaterThan(0);
+	});
+
+	it("transitions: valid moves allowed, invalid moves rejected", () => {
+		expect(canTransition("new", "started")).toBe(true);
+		expect(canTransition("finalizing", "completed")).toBe(true);
+		expect(canTransition("completed", "started")).toBe(false);
+		expect(canTransition("retired", "started")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/storage.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/storage.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+	appendEvent,
+	assertSafeSessionId,
+	generateSessionId,
+	readEvents,
+	readReceiptIndex,
+	readSessionState,
+	resolveHarnessRoot,
+	StorageError,
+	sessionPaths,
+	writeReceiptImmutable,
+	writeSessionState,
+} from "../../src/harness-control-plane/storage";
+import {
+	type EventEnvelope,
+	SESSION_SCHEMA_VERSION,
+	type SessionHandle,
+	type SessionState,
+} from "../../src/harness-control-plane/types";
+
+let root: string;
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "harness-store-"));
+});
+
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+function state(sessionId: string): SessionState {
+	const now = new Date().toISOString();
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId,
+		lifecycle: "started",
+		harness: "gajae-code",
+		handle: { sessionId, harness: "gajae-code", workspace: "." } as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+function envelope(cursor: number): EventEnvelope {
+	return {
+		eventId: `e-${cursor}`,
+		cursor,
+		createdAt: new Date().toISOString(),
+		severity: "info",
+		kind: "test",
+		state: { sessionId: "h-1", lifecycle: "started", harness: "gajae-code", ownerLive: false, blockers: [] },
+		evidence: {},
+		nextAllowedActions: [],
+		writer: { ownerId: "owner-1", leaseEpoch: 1 },
+	};
+}
+
+describe("harness storage", () => {
+	it("round-trips session state under sessions/<id>/state.json", async () => {
+		const id = "h-roundtrip";
+		await writeSessionState(root, state(id));
+		const loaded = await readSessionState(root, id);
+		expect(loaded?.sessionId).toBe(id);
+		expect(sessionPaths(root, id).state.endsWith(path.join("sessions", id, "state.json"))).toBe(true);
+	});
+
+	it("returns null for a missing session", async () => {
+		expect(await readSessionState(root, "h-missing")).toBeNull();
+	});
+
+	it("rejects unsafe session ids", () => {
+		expect(() => assertSafeSessionId("../escape")).toThrow(StorageError);
+		expect(() => assertSafeSessionId("ok-123")).not.toThrow();
+	});
+
+	it("receipts are immutable: re-writing the same id fails closed", async () => {
+		const id = "h-receipt";
+		await writeSessionState(root, state(id));
+		const receipt = { receiptId: "r-1", family: "vanish" as const, valid: true, createdAt: new Date().toISOString() };
+		const entry = await writeReceiptImmutable(root, id, "vanish", "r-1", receipt);
+		expect(entry.family).toBe("vanish");
+		await expect(writeReceiptImmutable(root, id, "vanish", "r-1", receipt)).rejects.toThrow(
+			/receipt_immutable_conflict/,
+		);
+		const index = await readReceiptIndex(root, id, "vanish");
+		expect(index).toHaveLength(1);
+	});
+
+	it("events append + tail by cursor (tail-only, never mutated)", async () => {
+		const id = "h-events";
+		await writeSessionState(root, state(id));
+		await appendEvent(root, id, envelope(1));
+		await appendEvent(root, id, envelope(2));
+		await appendEvent(root, id, envelope(3));
+		expect(await readEvents(root, id, 0)).toHaveLength(3);
+		const tail = await readEvents(root, id, 1);
+		expect(tail.map(e => e.cursor)).toEqual([2, 3]);
+	});
+
+	it("resolveHarnessRoot honors GJC_HARNESS_STATE_ROOT then cwd default", () => {
+		expect(resolveHarnessRoot({ root: "/x/y" })).toBe(path.resolve("/x/y"));
+		expect(resolveHarnessRoot({ env: { GJC_HARNESS_STATE_ROOT: "/z" } as NodeJS.ProcessEnv })).toBe(
+			path.resolve("/z"),
+		);
+		expect(resolveHarnessRoot({ cwd: "/repo", env: {} as NodeJS.ProcessEnv })).toBe(
+			path.join("/repo", ".gjc", "state", "harness"),
+		);
+	});
+
+	it("generateSessionId produces safe ids", () => {
+		expect(() => assertSafeSessionId(generateSessionId())).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
Foundation for the **gajae-code-native coding-harness operations control plane** — a `gjc harness <verb>` AI-native stateless JSON CLI that operates coding harnesses in **session → evidence → recovery → validation → PR** units.

Produced via deep-interview → ralplan consensus (Critic OKAY, Architect WATCH/COMMENT) → ultragoal execution.
- Spec: `.gjc/specs/deep-interview-harness-control-plane.md`
- Plan: `.gjc/plans/ralplan/2026-06-02-0853-3e33/pending-approval.md`

> **Status: DRAFT / WIP — not LGTM.** This lands the foundation milestones (M1–M2) + the pure recovery classifier. The owner runtime, RPC acceptance, finalizer, and harsh e2e/red-team are still ahead (M3–M11) and gate readiness.

## What's in this commit (verified)
- **types** — lifecycle, re-grabbable handle, the universal `{state, evidence, nextAllowedActions}` contract, event/receipt/recovery types.
- **storage** — session-scoped `.gjc/state/harness/sessions/<id>/` layout, atomic JSON, **immutable receipts** (fail-closed on conflict), tail-only event log.
- **state-machine** — lifecycle transitions + `nextAllowedActions` forcing function, incl. spec-required **`owner-not-live` blocking** for `submit`.
- **classifier** — deterministic recovery taxonomy with **hard dirty-restart data-loss invariants** (dirty/unknown deltas never `restart-clean`; `restart-preserve-delta` requires a `vanish` receipt; `send-enter` never emitted).
- **`gjc harness` CLI** — `start`/`observe`/`classify`/`events`/`retire` implemented; `submit` correctly blocks `owner-not-live`; owner-runtime verbs return an honest `pending-<milestone>` contract.

## Verification
- `bun test test/harness-control-plane/` → **31 pass / 0 fail** (classifier, state-machine, storage, CLI integration).
- `bunx biome check` → clean. `bun run check:types` (tsgo) → exit 0.

## Remaining (tracked; gates "ready")
- [ ] M3 RuntimeOwner + SessionLease + socket/FIFO endpoint (keystone)
- [ ] M4 gajae-code RPC adapter + single-flight acceptance (real `gjc --mode rpc` proof)
- [ ] M5 Events severity envelopes + default/external router
- [ ] M6 Observer wiring + classifier integration
- [ ] M7 Receipt schemas (4 families) + validators
- [ ] M8 Validation + evidence-gated finalizer
- [ ] M9 `operate()` autonomous lifecycle
- [ ] M10 AC-9 e2e + dirty data-loss-safety + red-team QA
- [ ] M11 Seams (codex/omx/remote/auth → unsupported)
- [ ] Architect LGTM review gate

## Non-goals (v1, deferred behind seams)
omx/codex internals, remote/cross-host transport, mandatory global daemon, web/GUI viewer, multi-human, fleet UI, token/TLS auth, low-level TUI input API, ACP/MCP semantics, rich full-TUI co-view.
