### PR TITLE
Register builtin autoresearch slash command

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -32,6 +32,7 @@ import {
 	Snowflake,
 } from "@gajae-code/utils";
 import { type AsyncJob, AsyncJobManager, isBackgroundJobSupportEnabled } from "./async";
+import { createAutoresearchExtension } from "./autoresearch/index";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { ModelRegistry } from "./config/model-registry";
@@ -1277,7 +1278,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Custom tool and extension discovery is quarantined from the public GJC utility surface.
 		// Explicit SDK extension factories are still honored; callers use them to
 		// register in-process tools/providers without enabling filesystem discovery.
-		const inlineExtensions: ExtensionFactory[] = [...(options.extensions ?? [])];
+		const inlineExtensions: ExtensionFactory[] = [createAutoresearchExtension, ...(options.extensions ?? [])];
 		if (customTools.length > 0) {
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}

--- a/packages/coding-agent/test/autoresearch-discovery.test.ts
+++ b/packages/coding-agent/test/autoresearch-discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { createAutoresearchExtension } from "../src/autoresearch/index";
+import { KeybindingsManager } from "../src/config/keybindings";
+import type { ExtensionAPI, RegisteredCommand } from "../src/extensibility/extensions";
+import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
+
+const EXPERIMENT_TOOL_NAMES = ["init_experiment", "run_experiment", "log_experiment", "update_notes"];
+
+function registerAutoresearchForTest(): {
+	activeTools: string[];
+	commands: Map<string, RegisteredCommand>;
+	registeredToolNames: string[];
+	setActiveToolsCalls: number;
+} {
+	const activeTools: string[] = [];
+	const commands = new Map<string, RegisteredCommand>();
+	const registeredToolNames: string[] = [];
+	let setActiveToolsCalls = 0;
+
+	const api = {
+		appendEntry(): void {},
+		exec: async () => ({ code: 0, stderr: "", stdout: "" }),
+		getActiveTools(): string[] {
+			return [...activeTools];
+		},
+		on(): void {},
+		registerCommand(name: string, options: Omit<RegisteredCommand, "name">): void {
+			commands.set(name, { name, ...options });
+		},
+		registerShortcut(): void {},
+		registerTool(tool: Parameters<ExtensionAPI["registerTool"]>[0]): void {
+			registeredToolNames.push(tool.name);
+		},
+		sendMessage(): void {},
+		sendUserMessage(): void {},
+		setActiveTools: async (toolNames: string[]): Promise<void> => {
+			setActiveToolsCalls += 1;
+			activeTools.splice(0, activeTools.length, ...toolNames);
+		},
+	} as unknown as ExtensionAPI;
+
+	createAutoresearchExtension(api);
+
+	return { activeTools, commands, registeredToolNames, setActiveToolsCalls };
+}
+
+describe("autoresearch discovery", () => {
+	it("registers the built-in autoresearch slash command for TUI extension discovery", async () => {
+		const { activeTools, commands, registeredToolNames, setActiveToolsCalls } = registerAutoresearchForTest();
+
+		const command = commands.get("autoresearch");
+		expect(command?.name).toBe("autoresearch");
+		expect(command?.description).toContain("autoresearch mode");
+		expect(registeredToolNames.sort()).toEqual([...EXPERIMENT_TOOL_NAMES].sort());
+
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [...commands.values()].map(entry => ({
+				name: entry.name,
+				description: entry.description,
+				getArgumentCompletions: entry.getArgumentCompletions,
+			})),
+			basePath: "/tmp",
+			keybindings: KeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+		const suggestions = await provider.getSuggestions(["/auto"], 0, "/auto".length);
+		expect(suggestions?.prefix).toBe("/auto");
+		expect(suggestions?.items.map(item => item.value)).toContain("autoresearch");
+		expect(setActiveToolsCalls).toBe(0);
+		for (const toolName of EXPERIMENT_TOOL_NAMES) {
+			expect(activeTools).not.toContain(toolName);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Register the built-in autoresearch extension in the SDK inline extension list so the interactive TUI can discover `/autoresearch`.
- Keep root CLI commands unchanged; autoresearch remains a TUI slash-command surface.
- Add regression coverage for `/auto` autocomplete discovery and for keeping experiment tools inactive until the command runs.

## Verification
- `bun test packages/coding-agent/test/autoresearch-discovery.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/test/autoresearch-discovery.test.ts --no-errors-on-unmatched`

Fixes #195