### PR TITLE
Keep autoresearch internal-only

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -32,7 +32,6 @@ import {
 	Snowflake,
 } from "@gajae-code/utils";
 import { type AsyncJob, AsyncJobManager, isBackgroundJobSupportEnabled } from "./async";
-import { createAutoresearchExtension } from "./autoresearch/index";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { ModelRegistry } from "./config/model-registry";
@@ -1278,7 +1277,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Custom tool and extension discovery is quarantined from the public GJC utility surface.
 		// Explicit SDK extension factories are still honored; callers use them to
 		// register in-process tools/providers without enabling filesystem discovery.
-		const inlineExtensions: ExtensionFactory[] = [createAutoresearchExtension, ...(options.extensions ?? [])];
+		const inlineExtensions: ExtensionFactory[] = [...(options.extensions ?? [])];
 		if (customTools.length > 0) {
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}

--- a/packages/coding-agent/test/autoresearch-discovery.test.ts
+++ b/packages/coding-agent/test/autoresearch-discovery.test.ts
@@ -1,27 +1,28 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { createAutoresearchExtension } from "../src/autoresearch/index";
-import { KeybindingsManager } from "../src/config/keybindings";
+import { Settings } from "../src/config/settings";
 import type { ExtensionAPI, RegisteredCommand } from "../src/extensibility/extensions";
-import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
+import { SessionManager } from "../src/session/session-manager";
 
 const EXPERIMENT_TOOL_NAMES = ["init_experiment", "run_experiment", "log_experiment", "update_notes"];
 
 function registerAutoresearchForTest(): {
-	activeTools: string[];
 	commands: Map<string, RegisteredCommand>;
 	registeredToolNames: string[];
-	setActiveToolsCalls: number;
 } {
-	const activeTools: string[] = [];
 	const commands = new Map<string, RegisteredCommand>();
 	const registeredToolNames: string[] = [];
-	let setActiveToolsCalls = 0;
 
 	const api = {
 		appendEntry(): void {},
 		exec: async () => ({ code: 0, stderr: "", stdout: "" }),
 		getActiveTools(): string[] {
-			return [...activeTools];
+			return [];
 		},
 		on(): void {},
 		registerCommand(name: string, options: Omit<RegisteredCommand, "name">): void {
@@ -33,48 +34,58 @@ function registerAutoresearchForTest(): {
 		},
 		sendMessage(): void {},
 		sendUserMessage(): void {},
-		setActiveTools: async (toolNames: string[]): Promise<void> => {
-			setActiveToolsCalls += 1;
-			activeTools.splice(0, activeTools.length, ...toolNames);
-		},
+		setActiveTools: async (): Promise<void> => {},
 	} as unknown as ExtensionAPI;
 
 	createAutoresearchExtension(api);
 
-	return { activeTools, commands, registeredToolNames, setActiveToolsCalls };
+	return { commands, registeredToolNames };
 }
 
 describe("autoresearch discovery", () => {
-	it("registers the built-in autoresearch slash command for TUI extension discovery", async () => {
-		const { activeTools, commands, registeredToolNames, setActiveToolsCalls } = registerAutoresearchForTest();
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const tempDir of tempDirs.splice(0)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not register autoresearch as a built-in TUI slash command", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-autoresearch-discovery-"));
+		tempDirs.push(tempDir);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const registeredCommandNames =
+				session.extensionRunner?.getRegisteredCommands().map(command => command.name) ?? [];
+			expect(registeredCommandNames).not.toContain("autoresearch");
+			expect(session.getAllToolNames()).not.toEqual(expect.arrayContaining(EXPERIMENT_TOOL_NAMES));
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("keeps the internal autoresearch extension importable for explicit internal use", () => {
+		const { commands, registeredToolNames } = registerAutoresearchForTest();
 
 		const command = commands.get("autoresearch");
 		expect(command?.name).toBe("autoresearch");
 		expect(command?.description).toContain("autoresearch mode");
 		expect(registeredToolNames.sort()).toEqual([...EXPERIMENT_TOOL_NAMES].sort());
-
-		const provider = createPromptActionAutocompleteProvider({
-			commands: [...commands.values()].map(entry => ({
-				name: entry.name,
-				description: entry.description,
-				getArgumentCompletions: entry.getArgumentCompletions,
-			})),
-			basePath: "/tmp",
-			keybindings: KeybindingsManager.inMemory(),
-			copyCurrentLine: () => {},
-			copyPrompt: () => {},
-			undo: () => {},
-			moveCursorToMessageEnd: () => {},
-			moveCursorToMessageStart: () => {},
-			moveCursorToLineStart: () => {},
-			moveCursorToLineEnd: () => {},
-		});
-		const suggestions = await provider.getSuggestions(["/auto"], 0, "/auto".length);
-		expect(suggestions?.prefix).toBe("/auto");
-		expect(suggestions?.items.map(item => item.value)).toContain("autoresearch");
-		expect(setActiveToolsCalls).toBe(0);
-		for (const toolName of EXPERIMENT_TOOL_NAMES) {
-			expect(activeTools).not.toContain(toolName);
-		}
 	});
 });


### PR DESCRIPTION
## Summary
- Remove the PR #196 SDK inline registration that made builtin autoresearch discoverable as a TUI slash command.
- Replace the `/auto` discovery regression with coverage that default `createAgentSession()` does not register `autoresearch` or its experiment tools.
- Keep `createAutoresearchExtension` importable and explicitly registrable for internal/helper use instead of deleting useful internal code.

## Contract
- No root `gjc autoresearch` command is added.
- No default/top-level/TUI-discoverable `/autoresearch` command is registered.
- Deep-interview internal auto-research fragments remain internal-only.

Fixes #195

## Verification
- `bun install` (restored workspace symlinks)
- `bun --cwd=packages/natives run build` (built ignored local native addon required by tests)
- `bun test packages/coding-agent/test/autoresearch-discovery.test.ts`
- `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/test/autoresearch-discovery.test.ts --no-errors-on-unmatched`
- `bun test packages/coding-agent/test/autoresearch-discovery.test.ts packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun scripts/check-visible-definitions.ts && bun scripts/verify-g002-gates.ts && bun scripts/rebrand-inventory.ts --strict`

## Not tested
- Manual interactive TUI autocomplete smoke test.
