### PR TITLE
feat(gjc): CLI-mediated .gjc state, read-only ACL, manifest SSOT + state-machine viz

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -38,6 +38,7 @@ const commands: CommandEntry[] = [
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
+	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{
 		name: "contribute-pr",
 		aliases: ["contribution-prep"],

--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -12,12 +12,12 @@ import {
 	getEnumValues,
 	getType,
 	getUi,
+	SETTINGS_SCHEMA,
 	type SettingPath,
 	Settings,
 	type SettingValue,
 	settings,
 } from "../config/settings";
-import { SETTINGS_SCHEMA } from "../config/settings-schema";
 import { theme } from "../modes/theme/theme";
 import { initXdg } from "./commands/init-xdg";
 
@@ -183,10 +183,18 @@ function parseAndSetValue(path: SettingPath, rawValue: string): void {
 			else throw new Error(`Invalid boolean value: ${rawValue}. Use true/false, yes/no, on/off, or 1/0`);
 			break;
 		}
-		case "number":
+		case "number": {
 			parsedValue = Number(trimmed);
 			if (!Number.isFinite(parsedValue)) throw new Error(`Invalid number: ${rawValue}`);
+			const validate =
+				"validate" in SETTINGS_SCHEMA[path]
+					? (SETTINGS_SCHEMA[path].validate as ((value: number) => boolean) | undefined)
+					: undefined;
+			if (validate?.(parsedValue as number) === false) {
+				throw new Error(`Invalid number for ${path}: ${rawValue}`);
+			}
 			break;
+		}
 		case "enum": {
 			const valid = getEnumValues(path);
 			if (valid && !valid.includes(trimmed)) {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -147,6 +147,7 @@ interface StringDef {
 interface NumberDef {
 	type: "number";
 	default: number;
+	validate?: (value: number) => boolean;
 	ui?: UiNumber;
 }
 
@@ -318,6 +319,12 @@ export const SETTINGS_SCHEMA = {
 	modelProviderOrder: { type: "array", default: EMPTY_STRING_ARRAY },
 
 	cycleOrder: { type: "array", default: DEFAULT_CYCLE_ORDER },
+
+	"gjc.deepInterview.ambiguityThreshold": {
+		type: "number",
+		default: 0.05,
+		validate: (value: number) => Number.isFinite(value) && value > 0 && value <= 1,
+	},
 
 	// ────────────────────────────────────────────────────────────────────────
 	// Appearance

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -297,6 +297,11 @@ export class Settings {
 		return getDefault(path);
 	}
 
+	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
+	has(path: SettingPath): boolean {
+		return getByPath(this.#merged, path.split(".")) !== undefined;
+	}
+
 	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and queues a background save.

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -330,8 +330,8 @@ tmux list-panes -F '#{pane_id}	#{pane_current_command}	#{pane_start_command}'
 tmux kill-pane -t %450
 tmux kill-pane -t %451
 
-# 3) Remove stale team state only after preserving needed evidence (example)
-rm -rf .gjc/state/team/<team-name>
+# 3) Remove stale team state only after preserving needed evidence, using the state runtime
+# cleanup verb documented by the current manifest
 
 # 4) Retry
 gjc team executor "fresh retry"

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -2,10 +2,12 @@ import { createHash, randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "../config/settings";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildDeepInterviewHudSummary } from "../skill-state/workflow-hud";
 import { runNativeRalplanCommand } from "./ralplan-runtime";
 import { runNativeStateCommand } from "./state-runtime";
+import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
 
 /**
  * Native implementation of `gjc deep-interview`.
@@ -104,13 +106,6 @@ async function readJsonObject(filePath: string): Promise<Record<string, unknown>
 	return {};
 }
 
-async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	const tmp = `${filePath}.tmp-${randomBytes(6).toString("hex")}`;
-	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`);
-	await fs.rename(tmp, filePath);
-}
-
 async function resolveSpecContent(rawSpec: string, cwd: string): Promise<string> {
 	const candidate = path.isAbsolute(rawSpec) ? rawSpec : path.resolve(cwd, rawSpec);
 	try {
@@ -202,9 +197,29 @@ async function readSettingsAmbiguityThreshold(
 	return { threshold: candidate, source: settingsPath };
 }
 
+async function readModernSettingsAmbiguityThreshold(
+	cwd: string,
+): Promise<{ threshold: number; source: string } | undefined> {
+	const settings = await Settings.init({ cwd });
+	const modernConfigPath = path.join(settings.getAgentDir(), "config.yml");
+	let parsed: unknown;
+	try {
+		parsed = (await import("bun")).YAML.parse(await fs.readFile(modernConfigPath, "utf-8"));
+	} catch {
+		return undefined;
+	}
+	const candidate = (parsed as { gjc?: { deepInterview?: { ambiguityThreshold?: unknown } } })?.gjc?.deepInterview
+		?.ambiguityThreshold;
+	if (typeof candidate !== "number" || !Number.isFinite(candidate) || candidate <= 0 || candidate > 1)
+		return undefined;
+	return { threshold: candidate, source: modernConfigPath };
+}
+
 async function resolveConfiguredAmbiguityThreshold(
 	cwd: string,
 ): Promise<{ threshold: number; source: string } | undefined> {
+	const modernValue = await readModernSettingsAmbiguityThreshold(cwd);
+	if (modernValue) return modernValue;
 	const projectSettings = path.join(cwd, ".gjc", "settings.json");
 	const projectValue = await readSettingsAmbiguityThreshold(projectSettings);
 	if (projectValue) return projectValue;
@@ -373,17 +388,19 @@ export async function persistDeepInterviewSpec(
 	cwd: string,
 	resolved: ResolvedDeepInterviewSpecWriteArgs,
 ): Promise<PersistedDeepInterviewSpec> {
-	const specsDir = path.join(cwd, ".gjc", "specs");
-	await fs.mkdir(specsDir, { recursive: true });
-	const specPath = path.join(specsDir, `deep-interview-${resolved.slug}.md`);
+	const specPath = path.join(cwd, ".gjc", "specs", `deep-interview-${resolved.slug}.md`);
 	const content = resolved.spec.endsWith("\n") ? resolved.spec : `${resolved.spec}\n`;
-	await fs.writeFile(specPath, content);
+	await writeArtifact(specPath, content, {
+		cwd,
+		audit: { category: "artifact", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
+	});
 
 	const sha256 = createHash("sha256").update(content).digest("hex");
 	const createdAt = new Date().toISOString();
-	await fs.appendFile(
-		path.join(specsDir, "deep-interview-index.jsonl"),
-		`${JSON.stringify({ slug: resolved.slug, stage: resolved.stage, path: specPath, created_at: createdAt, sha256 })}\n`,
+	await appendJsonl(
+		path.join(cwd, ".gjc", "specs", "deep-interview-index.jsonl"),
+		{ slug: resolved.slug, stage: resolved.stage, path: specPath, created_at: createdAt, sha256 },
+		{ cwd, audit: { category: "ledger", verb: "append", owner: "gjc-runtime", skill: "deep-interview" } },
 	);
 
 	const statePath = deepInterviewStatePath(cwd, resolved.sessionId);
@@ -402,7 +419,10 @@ export async function persistDeepInterviewSpec(
 		updated_at: createdAt,
 	};
 	if (resolved.sessionId) payload.session_id = resolved.sessionId;
-	await writeJsonAtomic(statePath, payload);
+	await writeJsonAtomic(statePath, payload, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
+	});
 	await syncDeepInterviewHud({
 		cwd,
 		sessionId: resolved.sessionId,
@@ -421,11 +441,7 @@ export async function persistDeepInterviewSpec(
 }
 
 async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepInterviewArgs): Promise<string> {
-	const stateDir = resolved.sessionId
-		? path.join(cwd, ".gjc", "state", "sessions", encodeSessionSegment(resolved.sessionId))
-		: path.join(cwd, ".gjc", "state");
-	await fs.mkdir(stateDir, { recursive: true });
-	const statePath = path.join(stateDir, "deep-interview-state.json");
+	const statePath = deepInterviewStatePath(cwd, resolved.sessionId);
 	const now = new Date().toISOString();
 	const payload: Record<string, unknown> = {
 		active: true,
@@ -448,7 +464,10 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		(payload.state as Record<string, unknown>).language = resolved.language;
 	}
 	if (resolved.sessionId) payload.session_id = resolved.sessionId;
-	await fs.writeFile(statePath, `${JSON.stringify(payload, null, 2)}\n`);
+	await writeJsonAtomic(statePath, payload, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
+	});
 	return statePath;
 }
 

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -8,6 +8,7 @@ import {
 	type ModeChangeEntry,
 	type SessionEntry,
 } from "../session/session-manager";
+import { removeFileAudited, writeJsonAtomic } from "./state-writer";
 
 export const GJC_SESSION_FILE_ENV = "GJC_SESSION_FILE";
 export const GJC_SESSION_ID_ENV = "GJC_SESSION_ID";
@@ -88,8 +89,10 @@ export async function writePendingGoalModeRequest(input: {
 		goalsPath: input.goalsPath,
 	};
 	const filePath = requestPath(input.cwd);
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await Bun.write(filePath, `${JSON.stringify(request, null, 2)}\n`);
+	await writeJsonAtomic(filePath, request, {
+		cwd: input.cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime" },
+	});
 	return request;
 }
 
@@ -153,6 +156,8 @@ export async function writeCurrentSessionGoalModeState(input: {
 		mode: "goal",
 		data: { goal: state.goal },
 	};
+	// The session transcript file lives outside `.gjc/` (GJC_SESSION_FILE), so it is not a
+	// sanctioned-writer target; append directly.
 	await fs.appendFile(sessionFile, `${JSON.stringify(entry)}\n`);
 	return { status: "updated", goal: state.goal, sessionFile };
 }
@@ -176,7 +181,10 @@ export async function consumePendingGoalModeRequest(cwd: string): Promise<Pendin
 	) {
 		return null;
 	}
-	await fs.unlink(filePath).catch(error => {
+	await removeFileAudited(filePath, {
+		cwd,
+		audit: { category: "prune", verb: "remove", owner: "gjc-runtime" },
+	}).catch(error => {
 		if (!isEnoent(error)) throw error;
 	});
 	return { ...candidate, objective: candidate.objective.trim() } as PendingGoalModeRequest;

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildRalplanHudSummary } from "../skill-state/workflow-hud";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
+import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
 
 /**
  * Native implementation of `gjc ralplan`.
@@ -173,8 +174,10 @@ async function persistActiveRunId(cwd: string, sessionId: string | undefined, ru
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
 	if (typeof existing.active !== "boolean") existing.active = true;
 	existing.updated_at = new Date().toISOString();
-	await fs.mkdir(path.dirname(statePath), { recursive: true });
-	await fs.writeFile(statePath, `${JSON.stringify(existing, null, 2)}\n`);
+	await writeJsonAtomic(statePath, existing, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
+	});
 }
 
 async function resolveArtifactArgs(args: readonly string[], cwd: string): Promise<ResolvedArtifactArgs> {
@@ -220,27 +223,36 @@ interface PersistedArtifact {
 
 async function persistArtifact(resolved: ResolvedArtifactArgs, cwd: string): Promise<PersistedArtifact> {
 	const runDir = path.join(cwd, ".gjc", "plans", "ralplan", resolved.runId);
-	await fs.mkdir(runDir, { recursive: true });
+
 	const fileName = `stage-${pad2(resolved.stageN)}-${resolved.stage}.md`;
 	const filePath = path.join(runDir, fileName);
 	const content = resolved.artifact.endsWith("\n") ? resolved.artifact : `${resolved.artifact}\n`;
-	await fs.writeFile(filePath, content);
+	await writeArtifact(filePath, content, {
+		cwd,
+		audit: { category: "artifact", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
+	});
 
 	const sha256 = createHash("sha256").update(content).digest("hex");
 	const createdAt = new Date().toISOString();
-	const indexLine = `${JSON.stringify({
+	const indexEntry = {
 		stage: resolved.stage,
 		stage_n: resolved.stageN,
 		path: filePath,
 		created_at: createdAt,
 		sha256,
-	})}\n`;
-	await fs.appendFile(path.join(runDir, "index.jsonl"), indexLine);
+	};
+	await appendJsonl(path.join(runDir, "index.jsonl"), indexEntry, {
+		cwd,
+		audit: { category: "ledger", verb: "append", owner: "gjc-runtime", skill: "ralplan" },
+	});
 
 	let pendingApprovalPath: string | undefined;
 	if (resolved.stage === "final") {
 		pendingApprovalPath = path.join(runDir, "pending-approval.md");
-		await fs.writeFile(pendingApprovalPath, content);
+		await writeArtifact(pendingApprovalPath, content, {
+			cwd,
+			audit: { category: "artifact", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
+		});
 	}
 
 	return {
@@ -382,7 +394,7 @@ async function seedRalplanState(
 	const stateDir = resolved.sessionId
 		? path.join(cwd, ".gjc", "state", "sessions", encodeSessionSegment(resolved.sessionId))
 		: path.join(cwd, ".gjc", "state");
-	await fs.mkdir(stateDir, { recursive: true });
+
 	const statePath = path.join(stateDir, "ralplan-state.json");
 	// Reuse an existing run id when present so a re-invocation of `gjc ralplan "task"` doesn't
 	// orphan in-progress artifacts under a fresh run id.
@@ -403,7 +415,10 @@ async function seedRalplanState(
 	if (resolved.architectKind) payload.architect_kind = resolved.architectKind;
 	if (resolved.criticKind) payload.critic_kind = resolved.criticKind;
 	if (resolved.sessionId) payload.session_id = resolved.sessionId;
-	await fs.writeFile(statePath, `${JSON.stringify(payload, null, 2)}\n`);
+	await writeJsonAtomic(statePath, payload, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
+	});
 	return { statePath, runId };
 }
 

--- a/packages/coding-agent/src/gjc-runtime/state-graph.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-graph.ts
@@ -1,0 +1,86 @@
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/active-state";
+import { getSkillManifest } from "./workflow-manifest";
+
+export type StateGraphSkill = CanonicalGjcWorkflowSkill | "all";
+export type StateGraphFormat = "ascii" | "mermaid" | "dot";
+
+function assertGraphFormat(format: string): asserts format is StateGraphFormat {
+	if (format !== "ascii" && format !== "mermaid" && format !== "dot") {
+		throw new Error(`Invalid graph format: ${format}. Expected one of: ascii, mermaid, dot.`);
+	}
+}
+
+function skillsFor(skill: StateGraphSkill): CanonicalGjcWorkflowSkill[] {
+	return skill === "all" ? [...CANONICAL_GJC_WORKFLOW_SKILLS] : [skill];
+}
+
+function renderAscii(skill: StateGraphSkill): string {
+	const chunks = skillsFor(skill).map(item => {
+		const manifest = getSkillManifest(item);
+		const states = manifest.states
+			.map(state => {
+				const markers = [state.initial ? "initial" : undefined, state.terminal ? "terminal" : undefined]
+					.filter(Boolean)
+					.join(", ");
+				return `  - ${state.id}${markers ? ` (${markers})` : ""}`;
+			})
+			.join("\n");
+		const transitions = manifest.transitions
+			.map(transition => `  - ${transition.from} -> ${transition.to} [${transition.verb}]`)
+			.join("\n");
+		return `${manifest.skill} (${manifest.graphLabel})\nstates:\n${states}\ntransitions:\n${transitions}`;
+	});
+	return `${chunks.join("\n\n")}\n`;
+}
+
+function renderMermaid(skill: StateGraphSkill): string {
+	const lines = ["stateDiagram-v2"];
+	for (const item of skillsFor(skill)) {
+		const manifest = getSkillManifest(item);
+		lines.push(`  state "${manifest.graphLabel}" as ${item} {`);
+		lines.push(`    [*] --> ${manifest.initialState}`);
+		for (const transition of manifest.transitions) {
+			lines.push(`    ${transition.from} --> ${transition.to}: ${transition.verb}`);
+		}
+		for (const terminal of manifest.terminalStates) {
+			lines.push(`    ${terminal} --> [*]`);
+		}
+		lines.push("  }");
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function dotId(skill: CanonicalGjcWorkflowSkill, state: string): string {
+	return `"${skill}:${state}"`;
+}
+
+function renderDot(skill: StateGraphSkill): string {
+	const lines = ["digraph gjc_state {", "  rankdir=LR;"];
+	for (const item of skillsFor(skill)) {
+		const manifest = getSkillManifest(item);
+		lines.push(`  subgraph "cluster_${item}" {`);
+		lines.push(`    label="${manifest.graphLabel}";`);
+		for (const state of manifest.states) {
+			const shape = state.terminal ? "doublecircle" : "circle";
+			lines.push(`    ${dotId(item, state.id)} [label="${state.id}", shape=${shape}];`);
+		}
+		lines.push(`    "${item}:__start" [label="", shape=point];`);
+		lines.push(`    "${item}:__start" -> ${dotId(item, manifest.initialState)};`);
+		for (const transition of manifest.transitions) {
+			lines.push(
+				`    ${dotId(item, transition.from)} -> ${dotId(item, transition.to)} [label="${transition.verb}"];`,
+			);
+		}
+		lines.push("  }");
+	}
+	lines.push("}");
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderStateGraph(skill: StateGraphSkill, format: string = "ascii"): string {
+	assertGraphFormat(format);
+	if (format === "mermaid") return renderMermaid(skill);
+	if (format === "dot") return renderDot(skill);
+	return renderAscii(skill);
+}

--- a/packages/coding-agent/src/gjc-runtime/state-migrations.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-migrations.ts
@@ -1,0 +1,132 @@
+import * as fs from "node:fs/promises";
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import { initialPhaseForSkill } from "../skill-state/initial-phase";
+import { canonicalWorkflowSkill, WORKFLOW_STATE_RECEIPT_VERSION } from "../skill-state/workflow-state-contract";
+import { writeJsonAtomic } from "./state-writer";
+import { getSkillManifest } from "./workflow-manifest";
+
+export interface NormalizeLegacyStateResult {
+	state: Record<string, unknown>;
+	changed: boolean;
+}
+
+export interface MigrateAndPersistLegacyStateArgs {
+	cwd: string;
+	skill: string;
+	statePath: string;
+	sessionId?: string;
+}
+
+export interface MigrateAndPersistLegacyStateResult {
+	migrated: boolean;
+	path: string;
+}
+
+const RECEIPT_STRING_FIELDS = [
+	"command",
+	"state_path",
+	"storage_path",
+	"mutated_at",
+	"fresh_until",
+	"mutation_id",
+] as const;
+
+function cloneRecord(record: Record<string, unknown>): Record<string, unknown> {
+	return { ...record };
+}
+
+function canonicalSkillOrThrow(skill: string): CanonicalGjcWorkflowSkill {
+	const canonical = canonicalWorkflowSkill(skill);
+	if (!canonical) throw new Error(`Unsupported GJC workflow skill: ${skill}`);
+	return canonical;
+}
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function legacyPhaseForSkill(skill: CanonicalGjcWorkflowSkill, phase: string): string {
+	if (phase === "planning") return initialPhaseForSkill(skill);
+	return phase;
+}
+
+function normalizePhase(skill: CanonicalGjcWorkflowSkill, value: unknown): string {
+	const manifest = getSkillManifest(skill);
+	const manifestStates = new Set(manifest.states.map(state => state.id));
+	const phase = legacyPhaseForSkill(skill, safeString(value).trim());
+	return manifestStates.has(phase) ? phase : manifest.initialState;
+}
+
+function receiptWithRequiredFields(raw: unknown, skill: CanonicalGjcWorkflowSkill): Record<string, unknown> {
+	const receipt =
+		raw && typeof raw === "object" && !Array.isArray(raw) ? cloneRecord(raw as Record<string, unknown>) : {};
+	receipt.version = WORKFLOW_STATE_RECEIPT_VERSION;
+	receipt.skill = skill;
+	if (receipt.owner !== "gjc-state-cli" && receipt.owner !== "gjc-runtime" && receipt.owner !== "gjc-hook") {
+		receipt.owner = "gjc-state-cli";
+	}
+	if (receipt.status !== "fresh" && receipt.status !== "stale") receipt.status = "stale";
+	for (const field of RECEIPT_STRING_FIELDS) {
+		if (typeof receipt[field] !== "string") receipt[field] = "";
+	}
+	return receipt;
+}
+
+function recordsEqual(left: Record<string, unknown>, right: Record<string, unknown>): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Pure legacy state normalizer for background/internal readers.
+ *
+ * Readers that need compatibility with old on-disk workflow state shapes must call
+ * this in-memory helper and must never call `migrateAndPersistLegacyState`. The
+ * persist variant is reserved for explicit state migration commands because it is
+ * the only path allowed to write normalized upgrades back to `.gjc/state/**`.
+ */
+export function normalizeLegacyState(raw: Record<string, unknown>, skill: string): NormalizeLegacyStateResult {
+	const canonicalSkill = canonicalSkillOrThrow(skill);
+	const state = cloneRecord(raw);
+	state.skill = canonicalSkill;
+	if (typeof state.version !== "number") state.version = 1;
+	if (typeof state.active !== "boolean") state.active = true;
+
+	const sourcePhase = typeof state.current_phase === "string" ? state.current_phase : state.phase;
+	const normalizedPhase = normalizePhase(canonicalSkill, sourcePhase);
+	state.current_phase = normalizedPhase;
+	if ("phase" in state && typeof state.phase === "string") state.phase = normalizedPhase;
+	state.receipt = receiptWithRequiredFields(state.receipt, canonicalSkill);
+
+	return { state, changed: !recordsEqual(raw, state) };
+}
+
+export async function migrateAndPersistLegacyState(
+	args: MigrateAndPersistLegacyStateArgs,
+): Promise<MigrateAndPersistLegacyStateResult> {
+	const canonicalSkill = canonicalSkillOrThrow(args.skill);
+	const raw = JSON.parse(await fs.readFile(args.statePath, "utf-8")) as unknown;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		throw new Error(`Workflow state file must contain a JSON object: ${args.statePath}`);
+	}
+	const { state, changed } = normalizeLegacyState(raw as Record<string, unknown>, canonicalSkill);
+	if (!changed) return { migrated: false, path: args.statePath };
+
+	const persistedPath = await writeJsonAtomic(args.statePath, state, {
+		cwd: args.cwd,
+		receipt: {
+			cwd: args.cwd,
+			skill: canonicalSkill,
+			owner: "gjc-state-cli",
+			command: `gjc state ${canonicalSkill} migrate`,
+			sessionId: args.sessionId,
+		},
+		audit: {
+			cwd: args.cwd,
+			skill: canonicalSkill,
+			verb: "migrate",
+			owner: "gjc-state-cli",
+			category: "state",
+		},
+	});
+	return { migrated: true, path: persistedPath };
+}

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
@@ -23,6 +22,15 @@ import {
 	describeWorkflowStateContract,
 	type WorkflowStateReceipt,
 } from "../skill-state/workflow-state-contract";
+import { renderStateGraph, type StateGraphFormat } from "./state-graph";
+import { migrateAndPersistLegacyState } from "./state-migrations";
+import {
+	type GenericHardPruneTarget,
+	hardPrune,
+	type StateWriterAuditContext,
+	softDelete,
+	writeJsonAtomic as writeStateJsonAtomic,
+} from "./state-writer";
 
 /**
  * Native implementation of the `gjc state read|write|clear` command surface.
@@ -62,11 +70,23 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 	return args.includes(flag);
 }
 
-const FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id", "--to"]);
-const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff"]);
+const GRAPH_FORMATS = new Set(["ascii", "mermaid", "dot"]);
+const FLAGS_WITH_VALUES = new Set([
+	"--input",
+	"--mode",
+	"--session-id",
+	"--thread-id",
+	"--turn-id",
+	"--to",
+	"--skill",
+	"--format",
+	"--older-than",
+	"--status",
+]);
+const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate"]);
 
 interface ParsedInvocation {
-	action: "read" | "write" | "clear" | "contract" | "handoff";
+	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "migrate";
 	positionalSkill?: string;
 }
 
@@ -240,11 +260,16 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown> |
 	}
 }
 
-async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	const tmp = `${filePath}.tmp-${randomBytes(6).toString("hex")}`;
-	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`);
-	await fs.rename(tmp, filePath);
+async function writeJsonAtomic(
+	cwd: string,
+	filePath: string,
+	value: unknown,
+	verb: "write" | "clear" | "handoff" = "write",
+): Promise<void> {
+	await writeStateJsonAtomic(filePath, value, {
+		cwd,
+		audit: { category: "state", verb, owner: "gjc-state-cli" },
+	});
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -488,7 +513,7 @@ async function handleWrite(
 	merged.updated_at = nowIsoStr;
 	merged.receipt = receipt;
 	if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
-	await writeJsonAtomic(filePath, merged);
+	await writeJsonAtomic(cwd, filePath, merged, "write");
 
 	const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
 	const active = merged.active !== false;
@@ -522,7 +547,7 @@ async function handleClear(
 		current_phase: "complete",
 		updated_at: nowIso(),
 	};
-	await writeJsonAtomic(filePath, cleared);
+	await writeJsonAtomic(cwd, filePath, cleared, "clear");
 
 	await syncWorkflowSkillState({
 		cwd,
@@ -643,8 +668,8 @@ async function handleHandoff(
 	// and write order keeps the session-scoped source of truth ahead of the
 	// root aggregate. strict:true on the active-state read tolerates ENOENT
 	// only; corrupt JSON / IO failures propagate as non-zero CLI status.
-	await writeJsonAtomic(calleePath, mergedCalleeState);
-	await writeJsonAtomic(callerPath, mergedCallerState);
+	await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff");
+	await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff");
 	await applyHandoffToActiveState({
 		cwd,
 		nowIso: handoffAt,
@@ -708,11 +733,133 @@ async function handleContract(
 	return { status: 0, stdout: `${JSON.stringify(payload, null, 2)}\n` };
 }
 
+function parseNonNegativeIntegerFlag(args: readonly string[], flag: string): number | undefined {
+	const value = flagValue(args, flag);
+	if (value === undefined) return undefined;
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		throw new StateCommandError(2, `gjc state ${flag} requires a non-negative integer value`);
+	}
+	return parsed;
+}
+
+function statusFromFile(value: unknown): string | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	if (typeof record.status === "string") return record.status;
+	if (record.receipt && typeof record.receipt === "object" && !Array.isArray(record.receipt)) {
+		const receiptStatus = (record.receipt as Record<string, unknown>).status;
+		if (typeof receiptStatus === "string") return receiptStatus;
+	}
+	return undefined;
+}
+
+async function handleGraph(
+	args: readonly string[],
+	_cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const rawSkill = flagValue(args, "--skill")?.trim() || positionalSkill?.trim() || "all";
+	if (rawSkill !== "all") assertKnownMode(rawSkill);
+	const format = flagValue(args, "--format")?.trim() || "ascii";
+	if (!GRAPH_FORMATS.has(format)) {
+		throw new StateCommandError(2, `Invalid graph format: ${format}. Expected one of: ascii, mermaid, dot.`);
+	}
+	return {
+		status: 0,
+		stdout: renderStateGraph(rawSkill as CanonicalGjcWorkflowSkill | "all", format as StateGraphFormat),
+	};
+}
+
+async function handlePrune(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, positionalSkill);
+	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.sessionId));
+	if (!mode) {
+		throw new StateCommandError(
+			2,
+			"gjc state prune requires --mode <skill>, positional <skill>, input.skill, or an active workflow in .gjc/state/skill-active-state.json",
+		);
+	}
+	const filePath = modeStateFile(cwd, mode, selectors.sessionId);
+	const olderThanDays = parseNonNegativeIntegerFlag(args, "--older-than");
+	const status = flagValue(args, "--status")?.trim();
+	const targets: GenericHardPruneTarget[] = [{ path: filePath, category: "prune" }];
+	const audit: StateWriterAuditContext = {
+		cwd,
+		skill: mode,
+		category: "prune",
+		verb: hasFlag(args, "--hard") ? "hard-prune" : "soft-delete",
+		owner: "gjc-state-cli",
+	};
+	const olderThanMs = olderThanDays === undefined ? undefined : olderThanDays * 24 * 60 * 60 * 1000;
+	const matchesSelector = async (
+		stat: { mtimeMs: number | bigint },
+		readJson: () => Promise<unknown>,
+	): Promise<boolean> => {
+		const mtimeMs = typeof stat.mtimeMs === "bigint" ? Number(stat.mtimeMs) : stat.mtimeMs;
+		if (olderThanMs !== undefined && Date.now() - mtimeMs < olderThanMs) return false;
+		if (status) return statusFromFile(await readJson()) === status;
+		return true;
+	};
+	if (hasFlag(args, "--hard")) {
+		const pruned = await hardPrune(
+			targets,
+			context => (context.stat ? matchesSelector(context.stat, context.readJson) : false),
+			{ cwd, audit },
+		);
+		return { status: 0, stdout: `${JSON.stringify({ skill: mode, hard: true, pruned }, null, 2)}\n` };
+	}
+	let deleted: string[] = [];
+	try {
+		const stat = await fs.stat(filePath);
+		if (await matchesSelector(stat, async () => JSON.parse(await fs.readFile(filePath, "utf-8")))) {
+			const archivedPath = await softDelete(
+				filePath,
+				{ skill: mode, reason: "gjc state prune", status: status ?? null, older_than_days: olderThanDays ?? null },
+				{ cwd, audit },
+			);
+			deleted = [archivedPath];
+		}
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code !== "ENOENT") throw error;
+	}
+	return { status: 0, stdout: `${JSON.stringify({ skill: mode, hard: false, soft_deleted: deleted }, null, 2)}\n` };
+}
+
+async function handleMigrate(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, positionalSkill);
+	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.sessionId));
+	if (!mode) {
+		throw new StateCommandError(
+			2,
+			"gjc state migrate requires --mode <skill>, positional <skill>, input.skill, or an active workflow in .gjc/state/skill-active-state.json",
+		);
+	}
+	const filePath = modeStateFile(cwd, mode, selectors.sessionId);
+	const result = await migrateAndPersistLegacyState({
+		cwd,
+		skill: mode,
+		statePath: filePath,
+		sessionId: selectors.sessionId,
+	});
+	return { status: 0, stdout: `${JSON.stringify({ skill: mode, ...result }, null, 2)}\n` };
+}
+
 export async function runNativeStateCommand(args: string[], cwd = process.cwd()): Promise<StateCommandResult> {
 	try {
 		const parsed = parsePositionalArgs(args);
 		switch (parsed.action) {
 			case "read":
+				if (hasFlag(args, "--migrate")) return await handleMigrate(args, cwd, parsed.positionalSkill);
 				return await handleRead(args, cwd, parsed.positionalSkill);
 			case "write":
 				return await handleWrite(args, cwd, parsed.positionalSkill);
@@ -722,6 +869,12 @@ export async function runNativeStateCommand(args: string[], cwd = process.cwd())
 				return await handleContract(args, cwd, parsed.positionalSkill);
 			case "handoff":
 				return await handleHandoff(args, cwd, parsed.positionalSkill);
+			case "graph":
+				return await handleGraph(args, cwd, parsed.positionalSkill);
+			case "prune":
+				return await handlePrune(args, cwd, parsed.positionalSkill);
+			case "migrate":
+				return await handleMigrate(args, cwd, parsed.positionalSkill);
 			default:
 				return { status: 2, stderr: `Unknown gjc state command: ${parsed.action}\n` };
 		}

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -1,0 +1,557 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
+import {
+	type AuditEntry,
+	buildWorkflowStateReceipt,
+	type CanonicalGjcWorkflowSkill,
+	type WorkflowStateMutationOwner,
+	type WorkflowStateReceipt,
+} from "../skill-state/workflow-state-contract";
+
+/**
+ * Sole sanctioned project `.gjc/**` writer module (gate G1).
+ *
+ * All native `.gjc/**` filesystem mutations must route through these primitives.
+ * The primitives validate project `.gjc/**` ownership, create parent directories,
+ * and emit workflow receipts or audit entries where applicable by the caller's
+ * supplied mutation context. No lockfiles are used; isolation is by atomic rename,
+ * append, O_EXCL creates, conditional deletes, per-entry active-state files,
+ * and derived active-state snapshots.
+ */
+
+export type WriterCategory = "state" | "artifact" | "ledger" | "log" | "report" | "agents" | "prune" | "force";
+
+export interface StateWriterReceiptContext {
+	cwd?: string;
+	skill: CanonicalGjcWorkflowSkill;
+	owner: WorkflowStateMutationOwner;
+	command: string;
+	sessionId?: string;
+	mutationId?: string;
+	nowIso?: string;
+}
+
+export interface StateWriterAuditContext {
+	cwd?: string;
+	category: WriterCategory;
+	verb: string;
+	owner: WorkflowStateMutationOwner;
+	skill?: CanonicalGjcWorkflowSkill | string;
+	mutationId?: string;
+	fromPhase?: string;
+	toPhase?: string;
+	forced?: boolean;
+}
+
+export interface StateWriterOptions {
+	cwd?: string;
+	receipt?: StateWriterReceiptContext;
+	audit?: StateWriterAuditContext;
+}
+
+export interface DeleteIfOwnedOptions extends StateWriterOptions {
+	predicate?: (current: unknown) => boolean | Promise<boolean>;
+}
+
+export interface DeleteResult {
+	path: string;
+	deleted: boolean;
+}
+
+export interface ActiveSessionScope {
+	sessionId?: string;
+}
+
+export interface ActiveEntryWriteResult {
+	entryPath: string;
+	snapshotPath: string;
+}
+
+export interface HardPruneSelectorContext {
+	path: string;
+	value: unknown;
+}
+
+export interface GenericHardPruneTarget {
+	path: string;
+	category: WriterCategory | string;
+}
+
+export interface GenericHardPruneSelectorContext {
+	path: string;
+	category: WriterCategory | string;
+	stat: Awaited<ReturnType<typeof fs.stat>>;
+	readJson: () => Promise<unknown>;
+}
+
+export type GenericHardPruneSelector = (context: GenericHardPruneSelectorContext) => boolean | Promise<boolean>;
+
+export interface ForceOverwriteOptions extends StateWriterOptions {
+	raw?: boolean;
+}
+
+export type HardPruneSelector = (context: HardPruneSelectorContext) => boolean | Promise<boolean>;
+
+export class AlreadyExistsError extends Error {
+	constructor(public readonly path: string) {
+		super(`file already exists: ${path}`);
+		this.name = "AlreadyExistsError";
+	}
+}
+
+function isErrno(error: unknown, code: string): boolean {
+	return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code;
+}
+
+function cwdForOptions(options?: StateWriterOptions): string {
+	return path.resolve(options?.cwd ?? process.cwd());
+}
+
+function resolveGjcTarget(targetPath: string, cwd = process.cwd()): string {
+	if (!targetPath.trim()) throw new Error("targetPath is required");
+	const projectRoot = path.resolve(cwd);
+	const gjcRoot = path.join(projectRoot, ".gjc");
+	const resolved = path.resolve(projectRoot, targetPath);
+	const relative = path.relative(gjcRoot, resolved);
+	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new Error(`target path must be within project .gjc/**: ${targetPath}`);
+	}
+	return resolved;
+}
+
+function tempPathFor(filePath: string): string {
+	return `${filePath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
+}
+
+function jsonText(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value).replaceAll(".", "%2E");
+}
+
+function activeStateDir(cwd: string, sessionScope?: string | ActiveSessionScope): string {
+	const sessionId = typeof sessionScope === "string" ? sessionScope : sessionScope?.sessionId;
+	const normalizedSessionId = safeString(sessionId).trim();
+	const stateDir = path.join(cwd, ".gjc", "state");
+	return normalizedSessionId
+		? path.join(stateDir, "sessions", encodePathSegment(normalizedSessionId), "active")
+		: path.join(stateDir, "active");
+}
+
+function activeSnapshotPath(cwd: string, sessionScope?: string | ActiveSessionScope): string {
+	const sessionId = typeof sessionScope === "string" ? sessionScope : sessionScope?.sessionId;
+	const normalizedSessionId = safeString(sessionId).trim();
+	const stateDir = path.join(cwd, ".gjc", "state");
+	return normalizedSessionId
+		? path.join(stateDir, "sessions", encodePathSegment(normalizedSessionId), "skill-active-state.json")
+		: path.join(stateDir, "skill-active-state.json");
+}
+
+function activeEntryPath(cwd: string, sessionScope: string | ActiveSessionScope | undefined, skill: string): string {
+	const normalizedSkill = safeString(skill).trim();
+	if (!normalizedSkill) throw new Error("skill is required");
+	return path.join(activeStateDir(cwd, sessionScope), `${encodePathSegment(normalizedSkill)}.json`);
+}
+
+function buildActiveSnapshot(entries: SkillActiveEntry[]): SkillActiveState {
+	const visible = entries.filter(entry => entry.active !== false);
+	const primary = visible[0];
+	return {
+		version: 1,
+		active: visible.length > 0,
+		skill: primary?.skill ?? "",
+		phase: primary?.phase ?? "",
+		updated_at: primary?.updated_at ?? "",
+		session_id: primary?.session_id,
+		thread_id: primary?.thread_id,
+		turn_id: primary?.turn_id,
+		active_skills: entries,
+	};
+}
+
+async function atomicRemove(filePath: string): Promise<boolean> {
+	const tmpPath = tempPathFor(filePath);
+	try {
+		await fs.rename(filePath, tmpPath);
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return false;
+		throw error;
+	}
+	await fs.rm(tmpPath, { force: true });
+	return true;
+}
+
+async function readJsonIfPresent(filePath: string): Promise<unknown | undefined> {
+	try {
+		return JSON.parse(await fs.readFile(filePath, "utf-8"));
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return undefined;
+		throw error;
+	}
+}
+
+function withWorkflowReceipt(value: unknown, receipt: WorkflowStateReceipt | undefined): unknown {
+	if (!receipt || !value || typeof value !== "object" || Array.isArray(value)) return value;
+	return { ...(value as Record<string, unknown>), receipt };
+}
+
+function buildReceipt(options: StateWriterOptions | undefined): WorkflowStateReceipt | undefined {
+	if (!options?.receipt) return undefined;
+	return buildWorkflowStateReceipt({
+		cwd: path.resolve(options.receipt.cwd ?? options.cwd ?? process.cwd()),
+		skill: options.receipt.skill,
+		owner: options.receipt.owner,
+		command: options.receipt.command,
+		sessionId: options.receipt.sessionId,
+		nowIso: options.receipt.nowIso,
+		mutationId: options.receipt.mutationId,
+	});
+}
+
+async function maybeAudit(mutatedPath: string, options?: StateWriterOptions): Promise<void> {
+	if (!options?.audit) return;
+	const audit = options.audit;
+	const cwd = path.resolve(audit.cwd ?? options.cwd ?? process.cwd());
+	await appendAuditEntry(cwd, {
+		ts: new Date().toISOString(),
+		skill: audit.skill,
+		category: audit.category,
+		verb: audit.verb,
+		owner: audit.owner,
+		mutation_id: audit.mutationId ?? randomUUID(),
+		from_phase: audit.fromPhase,
+		to_phase: audit.toPhase,
+		forced: audit.forced ?? false,
+		paths: [mutatedPath],
+	});
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<string> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	const tmpPath = tempPathFor(filePath);
+	try {
+		await fs.writeFile(tmpPath, content, "utf-8");
+		await fs.rename(tmpPath, filePath);
+	} catch (error) {
+		await fs.rm(tmpPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
+	return filePath;
+}
+
+export async function writeJsonAtomic(
+	targetPath: string,
+	value: unknown,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function writeTextAtomic(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	await atomicWrite(filePath, text);
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function updateJsonAtomic<T = unknown>(
+	targetPath: string,
+	mutator: (current: T | undefined) => T | Promise<T>,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	const current = (await readJsonIfPresent(filePath)) as T | undefined;
+	const next = await mutator(current);
+	await atomicWrite(filePath, jsonText(withWorkflowReceipt(next, buildReceipt(options))));
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function appendJsonl(targetPath: string, entry: unknown, options?: StateWriterOptions): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function appendText(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.appendFile(filePath, text, "utf-8");
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function createJsonNoClobber(
+	targetPath: string,
+	value: unknown,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	let handle: fs.FileHandle | undefined;
+	try {
+		handle = await fs.open(filePath, "wx");
+		await handle.writeFile(jsonText(withWorkflowReceipt(value, buildReceipt(options))), "utf-8");
+	} catch (error) {
+		if (isErrno(error, "EEXIST")) throw new AlreadyExistsError(filePath);
+		throw error;
+	} finally {
+		await handle?.close();
+	}
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function deleteIfOwned(
+	targetPath: string,
+	predicateOrOptions?: ((current: unknown) => boolean | Promise<boolean>) | DeleteIfOwnedOptions,
+): Promise<DeleteResult> {
+	const options = typeof predicateOrOptions === "function" ? undefined : predicateOrOptions;
+	const predicate = typeof predicateOrOptions === "function" ? predicateOrOptions : predicateOrOptions?.predicate;
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	const current = await readJsonIfPresent(filePath);
+	if (current === undefined) return { path: filePath, deleted: false };
+	if (predicate && !(await predicate(current))) return { path: filePath, deleted: false };
+	const deleted = await atomicRemove(filePath);
+	if (deleted) await maybeAudit(filePath, options);
+	return { path: filePath, deleted };
+}
+
+export async function removeFileAudited(targetPath: string, options?: StateWriterOptions): Promise<DeleteResult> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	const deleted = await atomicRemove(filePath);
+	if (deleted) await maybeAudit(filePath, options);
+	return { path: filePath, deleted };
+}
+
+/**
+ * Active entry files under `.gjc/state/active/<skill>.json` and
+ * `.gjc/state/sessions/<id>/active/<skill>.json` are authoritative. The
+ * adjacent `skill-active-state.json` file is only a derived cache rebuilt from
+ * those entries, so concurrent snapshot rebuilds can race without losing any
+ * writer's per-skill state.
+ */
+export async function writeActiveEntry(
+	cwd: string,
+	sessionScope: string | ActiveSessionScope | undefined,
+	skill: string,
+	entry: SkillActiveEntry,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const filePath = activeEntryPath(path.resolve(cwd), sessionScope, skill);
+	await atomicWrite(filePath, jsonText({ ...entry, skill }));
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function removeActiveEntry(
+	cwd: string,
+	sessionScope: string | ActiveSessionScope | undefined,
+	skill: string,
+	options?: StateWriterOptions,
+): Promise<DeleteResult> {
+	const filePath = activeEntryPath(path.resolve(cwd), sessionScope, skill);
+	const deleted = await atomicRemove(filePath);
+	if (deleted) await maybeAudit(filePath, options);
+	return { path: filePath, deleted };
+}
+
+export async function readActiveEntries(
+	cwd: string,
+	sessionScope?: string | ActiveSessionScope,
+): Promise<SkillActiveEntry[]> {
+	const dir = activeStateDir(path.resolve(cwd), sessionScope);
+	let names: string[];
+	try {
+		names = await fs.readdir(dir);
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return [];
+		throw error;
+	}
+	const entries: SkillActiveEntry[] = [];
+	for (const name of names.sort()) {
+		if (!name.endsWith(".json")) continue;
+		const raw = await readJsonIfPresent(path.join(dir, name));
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+		const skill = safeString((raw as SkillActiveEntry).skill).trim();
+		if (!skill) continue;
+		entries.push(raw as SkillActiveEntry);
+	}
+	return entries;
+}
+
+export async function rebuildActiveSnapshot(
+	cwd: string,
+	sessionScope?: string | ActiveSessionScope,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const resolvedCwd = path.resolve(cwd);
+	const snapshotPath = activeSnapshotPath(resolvedCwd, sessionScope);
+	const entries = await readActiveEntries(resolvedCwd, sessionScope);
+	await atomicWrite(snapshotPath, jsonText(buildActiveSnapshot(entries)));
+	await maybeAudit(snapshotPath, options);
+	return snapshotPath;
+}
+
+export async function mergeActiveState(
+	cwd: string,
+	sessionScope: string | ActiveSessionScope | undefined,
+	skill: string,
+	entry: SkillActiveEntry,
+	options?: StateWriterOptions,
+): Promise<ActiveEntryWriteResult> {
+	const entryPath = await writeActiveEntry(cwd, sessionScope, skill, entry, options);
+	const snapshotPath = await rebuildActiveSnapshot(cwd, sessionScope, options);
+	return { entryPath, snapshotPath };
+}
+
+export async function writeArtifact(
+	targetPath: string,
+	content: string,
+	options?: StateWriterOptions,
+): Promise<string> {
+	return writeTextAtomic(targetPath, content, {
+		...options,
+		audit: options?.audit ?? { category: "artifact", verb: "write", owner: "gjc-runtime" },
+	});
+}
+
+export async function writeReport(targetPath: string, content: string, options?: StateWriterOptions): Promise<string> {
+	return writeTextAtomic(targetPath, content, {
+		...options,
+		audit: options?.audit ?? { category: "report", verb: "write", owner: "gjc-runtime" },
+	});
+}
+
+export async function writeLogJsonl(targetPath: string, entry: unknown, options?: StateWriterOptions): Promise<string> {
+	return appendJsonl(targetPath, entry, {
+		...options,
+		audit: options?.audit ?? { category: "log", verb: "append", owner: "gjc-runtime" },
+	});
+}
+
+export async function softDelete(
+	targetPath: string,
+	meta: Record<string, unknown>,
+	options?: StateWriterOptions,
+): Promise<string> {
+	return updateJsonAtomic<Record<string, unknown>>(
+		targetPath,
+		current => ({
+			...(current && typeof current === "object" && !Array.isArray(current) ? current : {}),
+			archived: true,
+			active: false,
+			tombstone: { ...meta, archived_at: new Date().toISOString() },
+		}),
+		{
+			...options,
+			audit: options?.audit ?? { category: "prune", verb: "soft-delete", owner: "gjc-runtime" },
+		},
+	);
+}
+
+export async function hardPruneJson(
+	targetPaths: readonly string[],
+	selector: HardPruneSelector,
+	options?: StateWriterOptions,
+): Promise<string[]> {
+	const targets: GenericHardPruneTarget[] = targetPaths.map(targetPath => ({ path: targetPath, category: "prune" }));
+	return hardPrune(
+		targets,
+		async context => {
+			const value = await context.readJson();
+			return selector({ path: context.path, value });
+		},
+		options,
+	);
+}
+
+export async function hardPrune(
+	targets: readonly GenericHardPruneTarget[],
+	selector: GenericHardPruneSelector,
+	options?: StateWriterOptions,
+): Promise<string[]> {
+	const cwd = cwdForOptions(options);
+	const removed: string[] = [];
+	for (const target of targets) {
+		const filePath = resolveGjcTarget(target.path, cwd);
+		let stat: Awaited<ReturnType<typeof fs.stat>>;
+		try {
+			stat = await fs.stat(filePath);
+		} catch (error) {
+			if (isErrno(error, "ENOENT")) continue;
+			throw error;
+		}
+		const shouldRemove = await selector({
+			path: filePath,
+			category: target.category,
+			stat,
+			readJson: async () => JSON.parse(await fs.readFile(filePath, "utf-8")),
+		});
+		if (!shouldRemove) continue;
+		const deleted = await atomicRemove(filePath);
+		if (deleted) removed.push(filePath);
+	}
+	if (options?.audit && removed.length > 0) {
+		const audit = options.audit;
+		await appendAuditEntry(path.resolve(audit.cwd ?? options.cwd ?? process.cwd()), {
+			ts: new Date().toISOString(),
+			skill: audit.skill,
+			category: audit.category,
+			verb: audit.verb,
+			owner: audit.owner,
+			mutation_id: audit.mutationId ?? randomUUID(),
+			from_phase: audit.fromPhase,
+			to_phase: audit.toPhase,
+			forced: audit.forced ?? false,
+			paths: removed,
+		});
+	}
+	return removed;
+}
+
+export async function forceOverwrite(
+	targetPath: string,
+	rawValue: unknown,
+	options?: ForceOverwriteOptions,
+): Promise<string> {
+	const auditOptions = {
+		...options,
+		audit: options?.audit ?? { category: "force", verb: "force-overwrite", owner: "gjc-state-cli", forced: true },
+	};
+	if (options?.raw === true) {
+		const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+		await atomicWrite(filePath, jsonText(rawValue));
+		await maybeAudit(filePath, auditOptions);
+		return filePath;
+	}
+	return writeJsonAtomic(
+		targetPath,
+		{
+			forced: true,
+			forced_at: new Date().toISOString(),
+			value: rawValue,
+		},
+		auditOptions,
+	);
+}
+
+export async function appendAuditEntry(cwd: string, entry: AuditEntry): Promise<string> {
+	const filePath = resolveGjcTarget(path.join(".gjc", "state", "audit.jsonl"), cwd);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+	return filePath;
+}

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -4,6 +4,16 @@ import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { applyGjcTmuxProfile } from "./launch-tmux";
+import {
+	AlreadyExistsError,
+	appendJsonl as appendJsonlAudited,
+	appendText,
+	createJsonNoClobber,
+	deleteIfOwned,
+	removeFileAudited,
+	writeJsonAtomic,
+	writeReport,
+} from "./state-writer";
 
 export type GjcTeamPhase = "starting" | "running" | "awaiting_integration" | "complete" | "failed" | "cancelled";
 export type GjcTeamTaskStatus = "pending" | "blocked" | "in_progress" | "completed" | "failed";
@@ -392,9 +402,14 @@ function now(): string {
 function isEnoent(error: unknown): error is FsError {
 	return typeof error === "object" && error !== null && "code" in error && (error as FsError).code === "ENOENT";
 }
-function isEexist(error: unknown): error is FsError {
-	return typeof error === "object" && error !== null && "code" in error && (error as FsError).code === "EEXIST";
+function stateWriterOptions(filePath: string, category: "state" | "ledger" | "report" | "prune", verb: string) {
+	const resolved = path.resolve(filePath);
+	const marker = `${path.sep}.gjc${path.sep}`;
+	const markerIndex = resolved.indexOf(marker);
+	const cwd = markerIndex >= 0 ? resolved.slice(0, markerIndex) : process.cwd();
+	return { cwd, audit: { category, verb, owner: "gjc-runtime" as const } };
 }
+
 function sanitizeName(value: string): string {
 	const sanitized = value
 		.toLowerCase()
@@ -503,29 +518,28 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 		throw error;
 	}
 }
+function stateCategoryForJsonPath(filePath: string): "state" | "ledger" {
+	return filePath.endsWith(".jsonl") || filePath.includes(`${path.sep}telemetry${path.sep}`) ? "ledger" : "state";
+}
+
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
-	await Bun.write(tmpPath, `${JSON.stringify(value, null, 2)}\n`);
-	await fs.rename(tmpPath, filePath);
+	await writeJsonAtomic(filePath, value, stateWriterOptions(filePath, stateCategoryForJsonPath(filePath), "write"));
 }
 async function writeJsonFileNoClobber(filePath: string, value: unknown): Promise<boolean> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	let handle: fs.FileHandle | undefined;
 	try {
-		handle = await fs.open(filePath, "wx");
-		await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf-8");
+		await createJsonNoClobber(
+			filePath,
+			value,
+			stateWriterOptions(filePath, stateCategoryForJsonPath(filePath), "create"),
+		);
 		return true;
 	} catch (error) {
-		if (isEexist(error)) return false;
+		if (error instanceof AlreadyExistsError) return false;
 		throw error;
-	} finally {
-		await handle?.close();
 	}
 }
 async function appendJsonl(filePath: string, value: unknown): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.appendFile(filePath, `${JSON.stringify(value)}\n`, "utf-8");
+	await appendJsonlAudited(filePath, value, stateWriterOptions(filePath, "ledger", "append"));
 }
 async function appendEvent(dir: string, event: Omit<GjcTeamEvent, "ts" | "event_id">): Promise<GjcTeamEvent> {
 	const full = { event_id: `evt-${Date.now()}-${Math.random().toString(16).slice(2)}`, ts: now(), ...event };
@@ -1032,9 +1046,18 @@ async function appendIntegrationReport(
 	entry: { worker: string; operation: "merge" | "cherry-pick" | "rebase"; files: string[]; detail: string },
 ): Promise<void> {
 	const line = `- [${now()}] ${entry.worker}: ${entry.operation}; files=${entry.files.join(",") || "unknown"}; ${entry.detail}\n`;
-	await fs.mkdir(path.dirname(integrationReportPath(dir)), { recursive: true });
-	if (await pathExists(integrationReportPath(dir))) await fs.appendFile(integrationReportPath(dir), line, "utf-8");
-	else await Bun.write(integrationReportPath(dir), `# Integration Report\n\n${line}`);
+	if (await pathExists(integrationReportPath(dir)))
+		await appendText(
+			integrationReportPath(dir),
+			line,
+			stateWriterOptions(integrationReportPath(dir), "report", "append"),
+		);
+	else
+		await writeReport(
+			integrationReportPath(dir),
+			`# Integration Report\n\n${line}`,
+			stateWriterOptions(integrationReportPath(dir), "report", "write"),
+		);
 }
 async function appendCommitHygieneEntries(config: GjcTeamConfig, entries: GjcTeamCommitHygieneEntry[]): Promise<void> {
 	if (entries.length === 0) return;
@@ -1583,10 +1606,9 @@ async function integrateGjcWorkerCommits(
 }
 
 async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promise<void> {
-	for (const folder of ["tasks", "claims", "mailbox", "notifications", "dispatch", "approvals", "workers"])
-		await fs.mkdir(path.join(dir, folder), { recursive: true });
+	// Empty mailbox directories are runtime state, so they must exist before messages arrive.
+	await fs.mkdir(path.join(dir, "mailbox"), { recursive: true });
 	for (const worker of workers) {
-		await fs.mkdir(workerDir(dir, worker.id), { recursive: true });
 		await fs.mkdir(mailboxDirPath(dir, worker.id), { recursive: true });
 		await writeJsonFile(mailboxPath(dir, worker.id), { messages: [] });
 		await writeJsonFile(path.join(workerDir(dir, worker.id), "status.json"), { state: "idle", updated_at: now() });
@@ -1597,6 +1619,7 @@ async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promi
 			alive: true,
 		});
 	}
+	// Empty leader mailbox directory is runtime state, so it must exist before messages arrive.
 	await fs.mkdir(mailboxDirPath(dir, "leader-fixed"), { recursive: true });
 	await writeJsonFile(mailboxPath(dir, "leader-fixed"), { messages: [] });
 }
@@ -2145,20 +2168,14 @@ export async function claimGjcTeamTask(
 		leased_until: new Date(Date.now() + 30 * 60_000).toISOString(),
 	};
 	const claimPath = path.join(dir, "claims", `${task.id}.json`);
-	await fs.mkdir(path.dirname(claimPath), { recursive: true });
-	let claimFile: fs.FileHandle | undefined;
-	try {
-		claimFile = await fs.open(claimPath, "wx");
-		await claimFile.writeFile(`${JSON.stringify(claim, null, 2)}\n`, "utf-8");
-	} catch (error) {
-		if (isEexist(error)) return { ok: false, reason: `task_already_claimed:${task.id}` };
-		throw error;
-	} finally {
-		await claimFile?.close();
-	}
+	const created = await writeJsonFileNoClobber(claimPath, claim);
+	if (!created) return { ok: false, reason: `task_already_claimed:${task.id}` };
 	const current = await readGjcTeamTask(teamName, task.id, cwd, env);
 	if (current.status !== "pending") {
-		await fs.rm(claimPath, { force: true });
+		await deleteIfOwned(claimPath, {
+			...stateWriterOptions(claimPath, "prune", "rollback"),
+			predicate: current => (current as GjcTeamTaskClaim).token === token,
+		});
 		return { ok: false, reason: `task_not_pending:${task.id}` };
 	}
 	const updated: GjcTeamTask = {
@@ -2173,7 +2190,10 @@ export async function claimGjcTeamTask(
 	try {
 		await writeTask(dir, updated);
 	} catch (error) {
-		await fs.rm(claimPath, { force: true });
+		await deleteIfOwned(claimPath, {
+			...stateWriterOptions(claimPath, "prune", "rollback"),
+			predicate: current => (current as GjcTeamTaskClaim).token === token,
+		});
 		throw error;
 	}
 	await appendEvent(dir, {
@@ -2223,7 +2243,10 @@ export async function transitionGjcTeamTaskStatus(
 			evidence,
 			recorded_at: now(),
 		});
-	if (terminal) await fs.rm(path.join(dir, "claims", `${taskId}.json`), { force: true });
+	if (terminal) {
+		const claimPath = path.join(dir, "claims", `${taskId}.json`);
+		await removeFileAudited(claimPath, stateWriterOptions(claimPath, "prune", "terminal"));
+	}
 	await appendEvent(dir, {
 		type: "task_transitioned",
 		task_id: taskId,
@@ -2263,7 +2286,11 @@ export async function releaseGjcTeamTaskClaim(
 		updated_at: now(),
 	};
 	await writeTask(dir, updated);
-	await fs.rm(path.join(dir, "claims", `${taskId}.json`), { force: true });
+	const claimPath = path.join(dir, "claims", `${taskId}.json`);
+	await deleteIfOwned(claimPath, {
+		...stateWriterOptions(claimPath, "prune", "release"),
+		predicate: current => (current as GjcTeamTaskClaim).token === claimToken,
+	});
 	await appendEvent(dir, {
 		type: "task_claim_released",
 		task_id: taskId,
@@ -2646,7 +2673,7 @@ export async function writeGjcWorkerInbox(
 	const config = await readConfig(dir);
 	assertKnownWorker(config, worker);
 	const filePath = path.join(workerDir(dir, worker), "inbox.md");
-	await Bun.write(filePath, content);
+	await writeReport(filePath, content, stateWriterOptions(filePath, "report", "write"));
 	return { path: filePath };
 }
 export async function writeGjcWorkerIdentity(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1,9 +1,9 @@
 import * as crypto from "node:crypto";
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
 
 export type UltragoalGjcGoalMode = "aggregate" | "per-story";
 export type UltragoalGoalStatus =
@@ -143,19 +143,17 @@ function isEnoent(error: unknown): boolean {
 	);
 }
 
-async function ensureUltragoalDir(paths: UltragoalPaths): Promise<void> {
-	await fs.mkdir(paths.dir, { recursive: true });
-}
-
 async function appendLedger(cwd: string, event: JsonObject): Promise<UltragoalLedgerEvent> {
 	const paths = getUltragoalPaths(cwd);
-	await ensureUltragoalDir(paths);
 	const entry: UltragoalLedgerEvent = {
 		eventId: typeof event.eventId === "string" ? event.eventId : crypto.randomUUID(),
 		...event,
 		timestamp: new Date().toISOString(),
 	};
-	await fs.appendFile(paths.ledgerPath, `${JSON.stringify(entry)}\n`);
+	await appendJsonl(paths.ledgerPath, entry, {
+		cwd,
+		audit: { category: "ledger", verb: "append", owner: "gjc-runtime" },
+	});
 	return entry;
 }
 
@@ -175,9 +173,14 @@ export async function readUltragoalLedger(cwd: string): Promise<UltragoalLedgerE
 
 async function writePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
 	const paths = getUltragoalPaths(cwd);
-	await ensureUltragoalDir(paths);
-	await Bun.write(paths.briefPath, `${plan.brief.trim()}\n`);
-	await Bun.write(paths.goalsPath, `${JSON.stringify(plan, null, 2)}\n`);
+	await writeArtifact(paths.briefPath, `${plan.brief.trim()}\n`, {
+		cwd,
+		audit: { category: "artifact", verb: "write", owner: "gjc-runtime" },
+	});
+	await writeJsonAtomic(paths.goalsPath, plan, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime" },
+	});
 }
 
 function requiredUltragoalGoals(plan: UltragoalPlan): UltragoalGoal[] {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -1,0 +1,1375 @@
+{
+  "deep-interview": {
+    "graphLabel": "Deep Interview",
+    "hudFields": [
+      "current_phase",
+      "ambiguity_score",
+      "threshold",
+      "spec_slug",
+      "spec_path",
+      "topology"
+    ],
+    "initialState": "interviewing",
+    "retention": [
+      {
+        "category": "state",
+        "keep": 1
+      },
+      {
+        "category": "artifact"
+      },
+      {
+        "category": "prune/delete",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "force",
+        "maxAgeDays": 90
+      }
+    ],
+    "skill": "deep-interview",
+    "states": [
+      {
+        "id": "interviewing",
+        "initial": true
+      },
+      {
+        "id": "handoff",
+        "terminal": true
+      },
+      {
+        "id": "complete",
+        "terminal": true
+      }
+    ],
+    "terminalStates": [
+      "handoff",
+      "complete"
+    ],
+    "transitions": [
+      {
+        "from": "interviewing",
+        "to": "handoff",
+        "verb": "write-spec"
+      },
+      {
+        "from": "handoff",
+        "to": "complete",
+        "verb": "clear"
+      },
+      {
+        "from": "interviewing",
+        "to": "complete",
+        "verb": "clear"
+      }
+    ],
+    "typedArgs": [
+      {
+        "appliesToVerbs": [
+          "write",
+          "api"
+        ],
+        "name": "input",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "mode",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff",
+          "kickoff",
+          "write-spec",
+          "write-artifact"
+        ],
+        "name": "session-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "thread-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "turn-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "to",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write"
+        ],
+        "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "quick",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "standard",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "deep",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "threshold",
+        "type": "number"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "threshold-source",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "enumValues": [
+          "final"
+        ],
+        "name": "stage",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "name": "slug",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "name": "spec",
+        "required": true,
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "enumValues": [
+          "ralplan"
+        ],
+        "name": "handoff",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "name": "deliberate",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "write-spec"
+        ],
+        "name": "json",
+        "type": "boolean"
+      },
+      {
+        "name": "args",
+        "planned": true,
+        "type": "string"
+      },
+      {
+        "name": "metadata-json",
+        "planned": true,
+        "type": "string"
+      }
+    ],
+    "verbs": [
+      {
+        "name": "read",
+        "surface": "state-action"
+      },
+      {
+        "name": "write",
+        "surface": "state-action"
+      },
+      {
+        "name": "clear",
+        "surface": "state-action"
+      },
+      {
+        "name": "contract",
+        "surface": "state-action"
+      },
+      {
+        "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "kickoff",
+        "surface": "command-flag"
+      },
+      {
+        "name": "write-spec",
+        "surface": "command-flag"
+      },
+      {
+        "name": "graph",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "prune",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "migrate",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "force-overwrite",
+        "planned": true,
+        "surface": "state-action"
+      }
+    ]
+  },
+  "ralplan": {
+    "graphLabel": "Ralplan",
+    "hudFields": [
+      "current_phase",
+      "mode",
+      "run_id",
+      "stage",
+      "stage_n",
+      "plan_path"
+    ],
+    "initialState": "planner",
+    "retention": [
+      {
+        "category": "state",
+        "keep": 1
+      },
+      {
+        "category": "artifact"
+      },
+      {
+        "category": "ledger"
+      },
+      {
+        "category": "prune/delete",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "force",
+        "maxAgeDays": 90
+      }
+    ],
+    "skill": "ralplan",
+    "states": [
+      {
+        "id": "planner",
+        "initial": true
+      },
+      {
+        "id": "architect"
+      },
+      {
+        "id": "critic"
+      },
+      {
+        "id": "revision"
+      },
+      {
+        "id": "adr"
+      },
+      {
+        "id": "final",
+        "terminal": true
+      }
+    ],
+    "terminalStates": [
+      "final"
+    ],
+    "transitions": [
+      {
+        "from": "planner",
+        "to": "architect",
+        "verb": "write-artifact"
+      },
+      {
+        "from": "architect",
+        "to": "critic",
+        "verb": "write-artifact"
+      },
+      {
+        "from": "critic",
+        "to": "revision",
+        "verb": "write-artifact"
+      },
+      {
+        "from": "revision",
+        "to": "adr",
+        "verb": "write-artifact"
+      },
+      {
+        "from": "adr",
+        "to": "final",
+        "verb": "write-artifact"
+      }
+    ],
+    "typedArgs": [
+      {
+        "appliesToVerbs": [
+          "write",
+          "api"
+        ],
+        "name": "input",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "mode",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff",
+          "kickoff",
+          "write-spec",
+          "write-artifact"
+        ],
+        "name": "session-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "thread-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "turn-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "to",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write"
+        ],
+        "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "interactive",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "deliberate",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "architect",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff"
+        ],
+        "name": "critic",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "kickoff",
+          "write-artifact"
+        ],
+        "name": "json",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "write-artifact"
+        ],
+        "enumValues": [
+          "planner",
+          "architect",
+          "critic",
+          "revision",
+          "adr",
+          "final"
+        ],
+        "name": "stage",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write-artifact"
+        ],
+        "name": "stage_n",
+        "type": "number"
+      },
+      {
+        "appliesToVerbs": [
+          "write-artifact"
+        ],
+        "name": "artifact",
+        "required": true,
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write-artifact"
+        ],
+        "name": "run-id",
+        "type": "string"
+      },
+      {
+        "name": "args",
+        "planned": true,
+        "type": "string"
+      },
+      {
+        "name": "metadata-json",
+        "planned": true,
+        "type": "string"
+      }
+    ],
+    "verbs": [
+      {
+        "name": "read",
+        "surface": "state-action"
+      },
+      {
+        "name": "write",
+        "surface": "state-action"
+      },
+      {
+        "name": "clear",
+        "surface": "state-action"
+      },
+      {
+        "name": "contract",
+        "surface": "state-action"
+      },
+      {
+        "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "kickoff",
+        "surface": "command-flag"
+      },
+      {
+        "name": "write-artifact",
+        "surface": "command-flag"
+      },
+      {
+        "name": "graph",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "prune",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "migrate",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "force-overwrite",
+        "planned": true,
+        "surface": "state-action"
+      }
+    ]
+  },
+  "team": {
+    "graphLabel": "Team",
+    "hudFields": [
+      "current_phase",
+      "team_name",
+      "workers",
+      "task_counts",
+      "phase",
+      "integration"
+    ],
+    "initialState": "starting",
+    "retention": [
+      {
+        "category": "state",
+        "keep": 1
+      },
+      {
+        "category": "artifact"
+      },
+      {
+        "category": "ledger"
+      },
+      {
+        "category": "log",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "report",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "agents"
+      },
+      {
+        "category": "prune/delete",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "force",
+        "maxAgeDays": 90
+      }
+    ],
+    "skill": "team",
+    "states": [
+      {
+        "id": "starting",
+        "initial": true
+      },
+      {
+        "id": "running"
+      },
+      {
+        "id": "awaiting_integration"
+      },
+      {
+        "id": "complete",
+        "terminal": true
+      },
+      {
+        "id": "failed",
+        "terminal": true
+      },
+      {
+        "id": "cancelled",
+        "terminal": true
+      }
+    ],
+    "terminalStates": [
+      "complete",
+      "failed",
+      "cancelled"
+    ],
+    "transitions": [
+      {
+        "from": "starting",
+        "to": "running",
+        "verb": "start"
+      },
+      {
+        "from": "starting",
+        "to": "failed",
+        "verb": "start"
+      },
+      {
+        "from": "running",
+        "to": "awaiting_integration",
+        "verb": "api"
+      },
+      {
+        "from": "running",
+        "to": "complete",
+        "verb": "shutdown"
+      },
+      {
+        "from": "running",
+        "to": "failed",
+        "verb": "shutdown"
+      },
+      {
+        "from": "running",
+        "to": "cancelled",
+        "verb": "shutdown"
+      },
+      {
+        "from": "awaiting_integration",
+        "to": "running",
+        "verb": "resume"
+      },
+      {
+        "from": "awaiting_integration",
+        "to": "complete",
+        "verb": "shutdown"
+      }
+    ],
+    "typedArgs": [
+      {
+        "appliesToVerbs": [
+          "write",
+          "api"
+        ],
+        "name": "input",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "mode",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff",
+          "kickoff",
+          "write-spec",
+          "write-artifact"
+        ],
+        "name": "session-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "thread-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "turn-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "to",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write"
+        ],
+        "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "start"
+        ],
+        "name": "dry-run",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "start"
+        ],
+        "name": "worktree",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "start"
+        ],
+        "name": "w",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "input",
+        "required": true,
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "enumValues": [
+          "send-message",
+          "broadcast",
+          "mailbox-list",
+          "mailbox-mark-delivered",
+          "mailbox-mark-notified",
+          "notification-list",
+          "notification-read",
+          "notification-replay",
+          "notification-mark-pane-attempt",
+          "worker-startup-ack",
+          "create-task",
+          "read-task",
+          "list-tasks",
+          "update-task",
+          "claim-task",
+          "transition-task-status",
+          "transition-task",
+          "release-task-claim",
+          "read-config",
+          "read-manifest",
+          "read-worker-status",
+          "read-worker-heartbeat",
+          "update-worker-heartbeat",
+          "write-worker-inbox",
+          "write-worker-identity",
+          "append-event",
+          "read-events",
+          "await-event",
+          "write-shutdown-request",
+          "read-shutdown-ack",
+          "read-monitor-snapshot",
+          "write-monitor-snapshot",
+          "read-task-approval",
+          "write-task-approval"
+        ],
+        "name": "operation",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "worker-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "task-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "claim-token",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "enumValues": [
+          "pending",
+          "blocked",
+          "in_progress",
+          "completed",
+          "failed"
+        ],
+        "name": "status",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "api"
+        ],
+        "name": "evidence",
+        "type": "string"
+      },
+      {
+        "name": "args",
+        "planned": true,
+        "type": "string"
+      },
+      {
+        "name": "metadata-json",
+        "planned": true,
+        "type": "string"
+      }
+    ],
+    "verbs": [
+      {
+        "name": "read",
+        "surface": "state-action"
+      },
+      {
+        "name": "write",
+        "surface": "state-action"
+      },
+      {
+        "name": "clear",
+        "surface": "state-action"
+      },
+      {
+        "name": "contract",
+        "surface": "state-action"
+      },
+      {
+        "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "start",
+        "surface": "command-positional"
+      },
+      {
+        "name": "list",
+        "surface": "command-positional"
+      },
+      {
+        "name": "status",
+        "surface": "command-positional"
+      },
+      {
+        "name": "resume",
+        "surface": "command-positional"
+      },
+      {
+        "name": "shutdown",
+        "surface": "command-positional"
+      },
+      {
+        "name": "api",
+        "surface": "command-positional"
+      },
+      {
+        "name": "graph",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "prune",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "migrate",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "force-overwrite",
+        "planned": true,
+        "surface": "state-action"
+      }
+    ]
+  },
+  "ultragoal": {
+    "graphLabel": "Ultragoal",
+    "hudFields": [
+      "current_phase",
+      "active_goal_id",
+      "status",
+      "counts",
+      "ledger_path",
+      "brief_path"
+    ],
+    "initialState": "goal-planning",
+    "retention": [
+      {
+        "category": "state",
+        "keep": 1
+      },
+      {
+        "category": "artifact"
+      },
+      {
+        "category": "ledger"
+      },
+      {
+        "category": "prune/delete",
+        "maxAgeDays": 30
+      },
+      {
+        "category": "force",
+        "maxAgeDays": 90
+      }
+    ],
+    "skill": "ultragoal",
+    "states": [
+      {
+        "id": "goal-planning",
+        "initial": true
+      },
+      {
+        "id": "pending"
+      },
+      {
+        "id": "active"
+      },
+      {
+        "id": "blocked"
+      },
+      {
+        "id": "failed",
+        "terminal": true
+      },
+      {
+        "id": "complete",
+        "terminal": true
+      }
+    ],
+    "terminalStates": [
+      "failed",
+      "complete"
+    ],
+    "transitions": [
+      {
+        "from": "goal-planning",
+        "to": "pending",
+        "verb": "create-goals"
+      },
+      {
+        "from": "pending",
+        "to": "active",
+        "verb": "complete-goals"
+      },
+      {
+        "from": "active",
+        "to": "blocked",
+        "verb": "checkpoint"
+      },
+      {
+        "from": "active",
+        "to": "failed",
+        "verb": "checkpoint"
+      },
+      {
+        "from": "active",
+        "to": "complete",
+        "verb": "checkpoint"
+      },
+      {
+        "from": "blocked",
+        "to": "active",
+        "verb": "checkpoint"
+      },
+      {
+        "from": "failed",
+        "to": "active",
+        "verb": "complete-goals"
+      }
+    ],
+    "typedArgs": [
+      {
+        "appliesToVerbs": [
+          "write",
+          "api"
+        ],
+        "name": "input",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "mode",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "read",
+          "write",
+          "clear",
+          "contract",
+          "handoff",
+          "kickoff",
+          "write-spec",
+          "write-artifact"
+        ],
+        "name": "session-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "thread-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "turn-id",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "handoff"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "to",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "write"
+        ],
+        "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "create-goals"
+        ],
+        "name": "brief",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "create-goals"
+        ],
+        "name": "brief-file",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "create-goals"
+        ],
+        "name": "from-stdin",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "create-goals"
+        ],
+        "enumValues": [
+          "aggregate",
+          "per-story"
+        ],
+        "name": "gjc-goal-mode",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "complete-goals"
+        ],
+        "name": "retry-failed",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "checkpoint",
+          "record-review-blockers"
+        ],
+        "name": "goal-id",
+        "required": true,
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "checkpoint"
+        ],
+        "enumValues": [
+          "pending",
+          "active",
+          "complete",
+          "failed",
+          "blocked",
+          "review_blocked",
+          "superseded"
+        ],
+        "name": "status",
+        "required": true,
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "checkpoint",
+          "record-review-blockers",
+          "steer"
+        ],
+        "name": "evidence",
+        "required": true,
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "checkpoint",
+          "record-review-blockers"
+        ],
+        "name": "gjc-goal-json",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "checkpoint"
+        ],
+        "name": "quality-gate-json",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "steer"
+        ],
+        "enumValues": [
+          "add_subgoal"
+        ],
+        "name": "kind",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "record-review-blockers",
+          "steer"
+        ],
+        "name": "title",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "record-review-blockers",
+          "steer"
+        ],
+        "name": "objective",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "steer"
+        ],
+        "name": "rationale",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "status",
+          "create-goals",
+          "complete-goals",
+          "checkpoint",
+          "record-review-blockers",
+          "steer"
+        ],
+        "name": "json",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "steer"
+        ],
+        "name": "directive-json",
+        "planned": true,
+        "type": "string"
+      },
+      {
+        "name": "args",
+        "planned": true,
+        "type": "string"
+      },
+      {
+        "name": "metadata-json",
+        "planned": true,
+        "type": "string"
+      }
+    ],
+    "verbs": [
+      {
+        "name": "read",
+        "surface": "state-action"
+      },
+      {
+        "name": "write",
+        "surface": "state-action"
+      },
+      {
+        "name": "clear",
+        "surface": "state-action"
+      },
+      {
+        "name": "contract",
+        "surface": "state-action"
+      },
+      {
+        "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "status",
+        "surface": "command-positional"
+      },
+      {
+        "name": "create",
+        "surface": "command-positional"
+      },
+      {
+        "name": "create-goals",
+        "surface": "command-positional"
+      },
+      {
+        "name": "complete-goals",
+        "surface": "command-positional"
+      },
+      {
+        "name": "checkpoint",
+        "surface": "command-positional"
+      },
+      {
+        "name": "record-review-blockers",
+        "surface": "command-positional"
+      },
+      {
+        "name": "steer",
+        "surface": "command-positional"
+      },
+      {
+        "name": "graph",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "prune",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "migrate",
+        "planned": true,
+        "surface": "state-action"
+      },
+      {
+        "name": "force-overwrite",
+        "planned": true,
+        "surface": "state-action"
+      }
+    ]
+  }
+}

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -1,0 +1,406 @@
+/**
+ * TypeScript is the authoritative source of truth for GJC workflow manifests.
+ * Any JSON manifest projection is derived from this module and must never be
+ * hand-edited.
+ */
+
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/active-state";
+import { initialPhaseForSkill } from "../skill-state/initial-phase";
+
+export interface WorkflowState {
+	id: string;
+	initial?: boolean;
+	terminal?: boolean;
+}
+
+export interface WorkflowTransition {
+	from: string;
+	to: string;
+	verb: string;
+}
+
+export interface WorkflowVerb {
+	name: string;
+	planned?: boolean;
+	/** Invocation surface that exposes this verb in the real CLI parser. */
+	surface?: "state-action" | "command-positional" | "command-flag";
+}
+
+export interface TypedArgSpec {
+	name: string;
+	type: "string" | "number" | "boolean" | "enum";
+	enumValues?: string[];
+	required?: boolean;
+	appliesToVerbs?: string[];
+	planned?: boolean;
+}
+
+export interface RetentionPolicy {
+	category: string;
+	keep?: number;
+	maxAgeDays?: number;
+}
+
+export interface SkillManifest {
+	skill: CanonicalGjcWorkflowSkill;
+	states: WorkflowState[];
+	initialState: string;
+	terminalStates: string[];
+	transitions: WorkflowTransition[];
+	verbs: WorkflowVerb[];
+	typedArgs: TypedArgSpec[];
+	retention: RetentionPolicy[];
+	hudFields: string[];
+	graphLabel: string;
+}
+
+const STATE_RETENTION: RetentionPolicy = { category: "state", keep: 1 };
+const ARTIFACT_RETENTION: RetentionPolicy = { category: "artifact" };
+const LEDGER_RETENTION: RetentionPolicy = { category: "ledger" };
+const LOG_RETENTION: RetentionPolicy = { category: "log", maxAgeDays: 30 };
+const REPORT_RETENTION: RetentionPolicy = { category: "report", maxAgeDays: 30 };
+const AGENTS_RETENTION: RetentionPolicy = { category: "agents" };
+const PRUNE_RETENTION: RetentionPolicy = { category: "prune/delete", maxAgeDays: 30 };
+const FORCE_RETENTION: RetentionPolicy = { category: "force", maxAgeDays: 90 };
+
+const STATE_VERBS = ["read", "write", "clear", "contract", "handoff"] as const;
+const PLANNED_ADMIN_VERBS = ["graph", "prune", "migrate", "force-overwrite"] as const;
+
+const COMMON_TYPED_ARGS: TypedArgSpec[] = [
+	{ name: "input", type: "string", appliesToVerbs: ["write", "api"] },
+	{ name: "mode", type: "enum", enumValues: [...CANONICAL_GJC_WORKFLOW_SKILLS], appliesToVerbs: [...STATE_VERBS] },
+	{ name: "session-id", type: "string", appliesToVerbs: [...STATE_VERBS, "kickoff", "write-spec", "write-artifact"] },
+	{ name: "thread-id", type: "string", appliesToVerbs: ["write", "clear", "handoff"] },
+	{ name: "turn-id", type: "string", appliesToVerbs: ["write", "clear", "handoff"] },
+	{
+		name: "to",
+		type: "enum",
+		enumValues: [...CANONICAL_GJC_WORKFLOW_SKILLS],
+		required: true,
+		appliesToVerbs: ["handoff"],
+	},
+	{ name: "replace", type: "boolean", appliesToVerbs: ["write"] },
+];
+
+function verb(name: string, surface: WorkflowVerb["surface"]): WorkflowVerb {
+	return { name, surface };
+}
+
+function stateVerbs(): WorkflowVerb[] {
+	return STATE_VERBS.map(name => verb(name, "state-action"));
+}
+
+function positionalVerbs(names: readonly string[]): WorkflowVerb[] {
+	return names.map(name => verb(name, "command-positional"));
+}
+
+function flagVerbs(names: readonly string[]): WorkflowVerb[] {
+	return names.map(name => verb(name, "command-flag"));
+}
+
+function plannedVerbs(names: readonly string[]): WorkflowVerb[] {
+	return names.map(name => ({ ...verb(name, "state-action"), planned: true }));
+}
+
+function state(id: string, initialState: string, terminalStates: readonly string[]): WorkflowState {
+	const entry: WorkflowState = { id };
+	if (id === initialState) entry.initial = true;
+	if (terminalStates.includes(id)) entry.terminal = true;
+	return entry;
+}
+
+function manifest(input: {
+	skill: CanonicalGjcWorkflowSkill;
+	states: string[];
+	terminalStates: string[];
+	transitions: WorkflowTransition[];
+	verbs: WorkflowVerb[];
+	typedArgs?: TypedArgSpec[];
+	retention: RetentionPolicy[];
+	hudFields: string[];
+	graphLabel: string;
+	initialState?: string;
+}): SkillManifest {
+	const staleInitialState = initialPhaseForSkill(input.skill);
+	const initialState = input.initialState ?? staleInitialState;
+	return {
+		skill: input.skill,
+		states: input.states.map(item => state(item, initialState, input.terminalStates)),
+		initialState,
+		terminalStates: input.terminalStates,
+		transitions: input.transitions,
+		verbs: input.verbs,
+		typedArgs: [...COMMON_TYPED_ARGS, ...(input.typedArgs ?? [])],
+		retention: input.retention,
+		hudFields: input.hudFields,
+		graphLabel: input.graphLabel,
+	};
+}
+
+export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest> = {
+	"deep-interview": manifest({
+		skill: "deep-interview",
+		states: ["interviewing", "handoff", "complete"],
+		terminalStates: ["handoff", "complete"],
+		transitions: [
+			{ from: "interviewing", to: "handoff", verb: "write-spec" },
+			{ from: "handoff", to: "complete", verb: "clear" },
+			{ from: "interviewing", to: "complete", verb: "clear" },
+		],
+		verbs: [...stateVerbs(), ...flagVerbs(["kickoff", "write-spec"]), ...plannedVerbs(PLANNED_ADMIN_VERBS)],
+		typedArgs: [
+			{ name: "quick", type: "boolean", appliesToVerbs: ["kickoff"] },
+			{ name: "standard", type: "boolean", appliesToVerbs: ["kickoff"] },
+			{ name: "deep", type: "boolean", appliesToVerbs: ["kickoff"] },
+			{ name: "threshold", type: "number", appliesToVerbs: ["kickoff"] },
+			{ name: "threshold-source", type: "string", appliesToVerbs: ["kickoff"] },
+			{ name: "stage", type: "enum", enumValues: ["final"], appliesToVerbs: ["write-spec"] },
+			{ name: "slug", type: "string", appliesToVerbs: ["write-spec"] },
+			{ name: "spec", type: "string", required: true, appliesToVerbs: ["write-spec"] },
+			{ name: "handoff", type: "enum", enumValues: ["ralplan"], appliesToVerbs: ["write-spec"] },
+			{ name: "deliberate", type: "boolean", appliesToVerbs: ["write-spec"] },
+			{ name: "json", type: "boolean", appliesToVerbs: ["write-spec"] },
+			{ name: "args", type: "string", planned: true },
+			{ name: "metadata-json", type: "string", planned: true },
+		],
+		retention: [STATE_RETENTION, ARTIFACT_RETENTION, PRUNE_RETENTION, FORCE_RETENTION],
+		hudFields: ["current_phase", "ambiguity_score", "threshold", "spec_slug", "spec_path", "topology"],
+		graphLabel: "Deep Interview",
+	}),
+	ralplan: manifest({
+		skill: "ralplan",
+		states: ["planner", "architect", "critic", "revision", "adr", "final"],
+		terminalStates: ["final"],
+		transitions: [
+			{ from: "planner", to: "architect", verb: "write-artifact" },
+			{ from: "architect", to: "critic", verb: "write-artifact" },
+			{ from: "critic", to: "revision", verb: "write-artifact" },
+			{ from: "revision", to: "adr", verb: "write-artifact" },
+			{ from: "adr", to: "final", verb: "write-artifact" },
+		],
+		verbs: [...stateVerbs(), ...flagVerbs(["kickoff", "write-artifact"]), ...plannedVerbs(PLANNED_ADMIN_VERBS)],
+		typedArgs: [
+			{ name: "interactive", type: "boolean", appliesToVerbs: ["kickoff"] },
+			{ name: "deliberate", type: "boolean", appliesToVerbs: ["kickoff"] },
+			{ name: "architect", type: "string", appliesToVerbs: ["kickoff"] },
+			{ name: "critic", type: "string", appliesToVerbs: ["kickoff"] },
+			{ name: "json", type: "boolean", appliesToVerbs: ["kickoff", "write-artifact"] },
+			{
+				name: "stage",
+				type: "enum",
+				enumValues: ["planner", "architect", "critic", "revision", "adr", "final"],
+				appliesToVerbs: ["write-artifact"],
+			},
+			{ name: "stage_n", type: "number", appliesToVerbs: ["write-artifact"] },
+			{ name: "artifact", type: "string", required: true, appliesToVerbs: ["write-artifact"] },
+			{ name: "run-id", type: "string", appliesToVerbs: ["write-artifact"] },
+			{ name: "args", type: "string", planned: true },
+			{ name: "metadata-json", type: "string", planned: true },
+		],
+		retention: [STATE_RETENTION, ARTIFACT_RETENTION, LEDGER_RETENTION, PRUNE_RETENTION, FORCE_RETENTION],
+		hudFields: ["current_phase", "mode", "run_id", "stage", "stage_n", "plan_path"],
+		graphLabel: "Ralplan",
+	}),
+	ultragoal: manifest({
+		skill: "ultragoal",
+		states: ["goal-planning", "pending", "active", "blocked", "failed", "complete"],
+		terminalStates: ["failed", "complete"],
+		transitions: [
+			{ from: "goal-planning", to: "pending", verb: "create-goals" },
+			{ from: "pending", to: "active", verb: "complete-goals" },
+			{ from: "active", to: "blocked", verb: "checkpoint" },
+			{ from: "active", to: "failed", verb: "checkpoint" },
+			{ from: "active", to: "complete", verb: "checkpoint" },
+			{ from: "blocked", to: "active", verb: "checkpoint" },
+			{ from: "failed", to: "active", verb: "complete-goals" },
+		],
+		verbs: [
+			...stateVerbs(),
+			...positionalVerbs([
+				"status",
+				"create",
+				"create-goals",
+				"complete-goals",
+				"checkpoint",
+				"record-review-blockers",
+				"steer",
+			]),
+			...plannedVerbs(PLANNED_ADMIN_VERBS),
+		],
+		typedArgs: [
+			{ name: "brief", type: "string", appliesToVerbs: ["create-goals"] },
+			{ name: "brief-file", type: "string", appliesToVerbs: ["create-goals"] },
+			{ name: "from-stdin", type: "boolean", appliesToVerbs: ["create-goals"] },
+			{
+				name: "gjc-goal-mode",
+				type: "enum",
+				enumValues: ["aggregate", "per-story"],
+				appliesToVerbs: ["create-goals"],
+			},
+			{ name: "retry-failed", type: "boolean", appliesToVerbs: ["complete-goals"] },
+			{ name: "goal-id", type: "string", required: true, appliesToVerbs: ["checkpoint", "record-review-blockers"] },
+			{
+				name: "status",
+				type: "enum",
+				enumValues: ["pending", "active", "complete", "failed", "blocked", "review_blocked", "superseded"],
+				required: true,
+				appliesToVerbs: ["checkpoint"],
+			},
+			{
+				name: "evidence",
+				type: "string",
+				required: true,
+				appliesToVerbs: ["checkpoint", "record-review-blockers", "steer"],
+			},
+			{ name: "gjc-goal-json", type: "string", appliesToVerbs: ["checkpoint", "record-review-blockers"] },
+			{ name: "quality-gate-json", type: "string", appliesToVerbs: ["checkpoint"] },
+			{ name: "kind", type: "enum", enumValues: ["add_subgoal"], appliesToVerbs: ["steer"] },
+			{ name: "title", type: "string", appliesToVerbs: ["record-review-blockers", "steer"] },
+			{ name: "objective", type: "string", appliesToVerbs: ["record-review-blockers", "steer"] },
+			{ name: "rationale", type: "string", appliesToVerbs: ["steer"] },
+			{
+				name: "json",
+				type: "boolean",
+				appliesToVerbs: [
+					"status",
+					"create-goals",
+					"complete-goals",
+					"checkpoint",
+					"record-review-blockers",
+					"steer",
+				],
+			},
+			{ name: "directive-json", type: "string", appliesToVerbs: ["steer"], planned: true },
+			{ name: "args", type: "string", planned: true },
+			{ name: "metadata-json", type: "string", planned: true },
+		],
+		retention: [STATE_RETENTION, ARTIFACT_RETENTION, LEDGER_RETENTION, PRUNE_RETENTION, FORCE_RETENTION],
+		hudFields: ["current_phase", "active_goal_id", "status", "counts", "ledger_path", "brief_path"],
+		graphLabel: "Ultragoal",
+	}),
+	team: manifest({
+		skill: "team",
+		states: ["starting", "running", "awaiting_integration", "complete", "failed", "cancelled"],
+		terminalStates: ["complete", "failed", "cancelled"],
+		transitions: [
+			{ from: "starting", to: "running", verb: "start" },
+			{ from: "starting", to: "failed", verb: "start" },
+			{ from: "running", to: "awaiting_integration", verb: "api" },
+			{ from: "running", to: "complete", verb: "shutdown" },
+			{ from: "running", to: "failed", verb: "shutdown" },
+			{ from: "running", to: "cancelled", verb: "shutdown" },
+			{ from: "awaiting_integration", to: "running", verb: "resume" },
+			{ from: "awaiting_integration", to: "complete", verb: "shutdown" },
+		],
+		verbs: [
+			...stateVerbs(),
+			...positionalVerbs(["start", "list", "status", "resume", "shutdown", "api"]),
+			...plannedVerbs(PLANNED_ADMIN_VERBS),
+		],
+		typedArgs: [
+			{ name: "dry-run", type: "boolean", appliesToVerbs: ["start"] },
+			{ name: "worktree", type: "string", appliesToVerbs: ["start"] },
+			{ name: "w", type: "string", appliesToVerbs: ["start"] },
+			{ name: "input", type: "string", required: true, appliesToVerbs: ["api"] },
+			{
+				name: "operation",
+				type: "enum",
+				enumValues: [
+					"send-message",
+					"broadcast",
+					"mailbox-list",
+					"mailbox-mark-delivered",
+					"mailbox-mark-notified",
+					"notification-list",
+					"notification-read",
+					"notification-replay",
+					"notification-mark-pane-attempt",
+					"worker-startup-ack",
+					"create-task",
+					"read-task",
+					"list-tasks",
+					"update-task",
+					"claim-task",
+					"transition-task-status",
+					"transition-task",
+					"release-task-claim",
+					"read-config",
+					"read-manifest",
+					"read-worker-status",
+					"read-worker-heartbeat",
+					"update-worker-heartbeat",
+					"write-worker-inbox",
+					"write-worker-identity",
+					"append-event",
+					"read-events",
+					"await-event",
+					"write-shutdown-request",
+					"read-shutdown-ack",
+					"read-monitor-snapshot",
+					"write-monitor-snapshot",
+					"read-task-approval",
+					"write-task-approval",
+				],
+				required: true,
+				appliesToVerbs: ["api"],
+			},
+			{ name: "worker-id", type: "string", appliesToVerbs: ["api"] },
+			{ name: "task-id", type: "string", appliesToVerbs: ["api"] },
+			{ name: "claim-token", type: "string", appliesToVerbs: ["api"] },
+			{
+				name: "status",
+				type: "enum",
+				enumValues: ["pending", "blocked", "in_progress", "completed", "failed"],
+				appliesToVerbs: ["api"],
+			},
+			{ name: "evidence", type: "string", appliesToVerbs: ["api"] },
+			{ name: "args", type: "string", planned: true },
+			{ name: "metadata-json", type: "string", planned: true },
+		],
+		retention: [
+			STATE_RETENTION,
+			ARTIFACT_RETENTION,
+			LEDGER_RETENTION,
+			LOG_RETENTION,
+			REPORT_RETENTION,
+			AGENTS_RETENTION,
+			PRUNE_RETENTION,
+			FORCE_RETENTION,
+		],
+		hudFields: ["current_phase", "team_name", "workers", "task_counts", "phase", "integration"],
+		graphLabel: "Team",
+	}),
+};
+
+export function getSkillManifest(skill: CanonicalGjcWorkflowSkill): SkillManifest {
+	return WORKFLOW_MANIFEST[skill];
+}
+
+export function isValidTransition(skill: CanonicalGjcWorkflowSkill, from: string, to: string): boolean {
+	return WORKFLOW_MANIFEST[skill].transitions.some(transition => transition.from === from && transition.to === to);
+}
+
+export function listVerbs(skill: CanonicalGjcWorkflowSkill): string[] {
+	return WORKFLOW_MANIFEST[skill].verbs.map(verb => verb.name);
+}
+
+export function typedArgsFor(skill: CanonicalGjcWorkflowSkill, verb: string): TypedArgSpec[] {
+	return WORKFLOW_MANIFEST[skill].typedArgs.filter(
+		arg => arg.appliesToVerbs === undefined || arg.appliesToVerbs.includes(verb),
+	);
+}
+
+function stableSort(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(item => stableSort(item));
+	if (value === null || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, item]) => [key, stableSort(item)]),
+	);
+}
+
+export function serializeManifestProjection(): string {
+	return `${JSON.stringify(stableSort(WORKFLOW_MANIFEST), null, 2)}\n`;
+}

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -1,6 +1,6 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
+import { writeJsonAtomic } from "../gjc-runtime/state-writer";
 import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
 import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
 import type { SkillActiveEntry as CanonicalSkillActiveEntry, WorkflowHudSummary } from "../skill-state/active-state";
@@ -252,9 +252,11 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 	}
 }
 
-async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
+async function writeJsonFile(filePath: string, value: unknown, cwd: string): Promise<void> {
+	await writeJsonAtomic(filePath, value, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-hook" },
+	});
 }
 
 function entryMatchesContext(
@@ -337,10 +339,10 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 		modeState.threshold_source = "default";
 	}
 
-	await writeJsonFile(initializedStatePath, modeState);
-	await writeJsonFile(skillStatePath(resolvedStateDir, input.sessionId), state);
+	await writeJsonFile(initializedStatePath, modeState, input.cwd);
+	await writeJsonFile(skillStatePath(resolvedStateDir, input.sessionId), state, input.cwd);
 	if (!input.sessionId) return state;
-	await writeJsonFile(skillStatePath(resolvedStateDir), state);
+	await writeJsonFile(skillStatePath(resolvedStateDir), state, input.cwd);
 	return state;
 }
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -167,6 +167,7 @@ import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
 import { buildGjcRuntimeSessionEnv, consumePendingGoalModeRequest } from "../gjc-runtime/goal-mode-request";
+import { writeArtifact } from "../gjc-runtime/state-writer";
 import { requestGjcWorkerIntegrationAttempt } from "../gjc-runtime/team-runtime";
 import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
@@ -281,6 +282,11 @@ export type AgentSessionEvent =
  * `gjc state` runtime selector resolver.
  */
 const SAFE_PATH_COMPONENT = /^[A-Za-z0-9_-][A-Za-z0-9._-]{0,63}$/;
+
+function isUnderProjectGjc(cwd: string, targetPath: string): boolean {
+	const relative = path.relative(path.join(path.resolve(cwd), ".gjc"), path.resolve(targetPath));
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -3474,7 +3480,7 @@ export class AgentSession {
 	 * prompts or tool execution can run.
 	 */
 	#wrapToolForDeepInterviewMutationGuard<T extends AgentTool>(tool: T): T {
-		if (!["edit", "write", "ast_edit"].includes(tool.name)) return tool;
+		if (!["edit", "write", "ast_edit", "bash"].includes(tool.name)) return tool;
 		return new Proxy(tool, {
 			get: (target, prop) => {
 				if (prop !== "execute") return Reflect.get(target, prop, target);
@@ -5920,7 +5926,14 @@ export class AgentSession {
 				if (artifactsDir) {
 					const handoffFilePath = path.join(artifactsDir, createHandoffFileName());
 					try {
-						await Bun.write(handoffFilePath, `${handoffText}\n`);
+						if (isUnderProjectGjc(this.sessionManager.getCwd(), handoffFilePath)) {
+							await writeArtifact(handoffFilePath, `${handoffText}\n`, {
+								cwd: this.sessionManager.getCwd(),
+								audit: { category: "artifact", verb: "write", owner: "gjc-runtime" },
+							});
+						} else {
+							await Bun.write(handoffFilePath, `${handoffText}\n`);
+						}
 						savedPath = handoffFilePath;
 					} catch (error) {
 						logger.warn("Failed to save handoff document to disk", {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -27,6 +27,7 @@ import {
 	Snowflake,
 	toError,
 } from "@gajae-code/utils";
+import { writeTextAtomic } from "../gjc-runtime/state-writer";
 import { ArtifactManager } from "./artifacts";
 import {
 	type BlobPutResult,
@@ -56,6 +57,10 @@ import type { SessionStorage, SessionStorageWriter } from "./session-storage";
 import { FileSessionStorage, MemorySessionStorage } from "./session-storage";
 
 export const CURRENT_SESSION_VERSION = 3;
+function isUnderProjectGjc(cwd: string, targetPath: string): boolean {
+	const relative = path.relative(path.join(path.resolve(cwd), ".gjc"), path.resolve(targetPath));
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
 
 export interface SessionHeader {
 	type: "session";
@@ -384,6 +389,7 @@ const migratedSessionRoots = new Set<string>();
  * Best effort: callers decide whether migration failures should surface.
  */
 function migrateSessionDirPath(oldPath: string, newPath: string): void {
+	// Session-dir lifecycle migration: moves/removes whole directories, not file content writes.
 	const existing = fs.statSync(newPath, { throwIfNoEntry: false });
 	if (existing?.isDirectory()) {
 		for (const file of fs.readdirSync(oldPath)) {
@@ -752,7 +758,13 @@ function writeTerminalBreadcrumb(cwd: string, sessionFile: string): void {
 	const breadcrumbFile = path.join(breadcrumbDir, terminalId);
 	const content = `${cwd}\n${sessionFile}\n`;
 	// Best-effort — don't break session creation if breadcrumb fails
-	Bun.write(breadcrumbFile, content).catch(() => {});
+	const write = isUnderProjectGjc(cwd, breadcrumbFile)
+		? writeTextAtomic(breadcrumbFile, content, {
+				cwd,
+				audit: { category: "artifact", verb: "write", owner: "gjc-runtime" },
+			})
+		: Bun.write(breadcrumbFile, content);
+	write.catch(() => {});
 }
 
 /**

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -1,5 +1,10 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import {
+	type ActiveSessionScope,
+	rebuildActiveSnapshot,
+	removeActiveEntry,
+	writeActiveEntry,
+} from "../gjc-runtime/state-writer";
 import type { WorkflowStateReceipt } from "./workflow-state-contract";
 
 export const SKILL_ACTIVE_STATE_FILE = "skill-active-state.json";
@@ -286,14 +291,6 @@ export function getSkillActiveStatePaths(cwd: string, sessionId?: string): Skill
 	};
 }
 
-async function readStateFile(filePath: string): Promise<SkillActiveState | null> {
-	try {
-		return normalizeSkillActiveState(JSON.parse(await Bun.file(filePath).text()));
-	} catch {
-		return null;
-	}
-}
-
 /**
  * Raw read for handoff mutations. Returns the *unnormalized* parsed object so
  * inactive entries remain visible to `rawActiveEntries` — `normalizeSkillActiveState`
@@ -516,15 +513,41 @@ export async function readVisibleSkillActiveState(cwd: string, sessionId?: strin
 	};
 }
 
-async function writeStateFile(filePath: string, state: SkillActiveState): Promise<void> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await Bun.write(filePath, `${JSON.stringify(state, null, 2)}\n`);
+function activeStateWriterAudit(verb: string) {
+	return { category: "state" as const, verb, owner: "gjc-runtime" as const };
 }
 
-function upsertEntry(entries: SkillActiveEntry[], entry: SkillActiveEntry, active: boolean): SkillActiveEntry[] {
-	const key = entryKey(entry);
-	const retained = entries.filter(candidate => entryKey(candidate) !== key);
-	return active ? [...retained, entry] : retained;
+async function persistActiveEntry(
+	cwd: string,
+	sessionScope: ActiveSessionScope | undefined,
+	entry: SkillActiveEntry,
+): Promise<void> {
+	if (entry.active === false) {
+		await removeActiveEntry(cwd, sessionScope, entry.skill, {
+			cwd,
+			audit: activeStateWriterAudit("remove-active-entry"),
+		});
+	} else {
+		await writeActiveEntry(cwd, sessionScope, entry.skill, entry, {
+			cwd,
+			audit: activeStateWriterAudit("write-active-entry"),
+		});
+	}
+}
+
+async function writeHandoffEntry(
+	cwd: string,
+	sessionScope: ActiveSessionScope | undefined,
+	entry: SkillActiveEntry,
+): Promise<void> {
+	await writeActiveEntry(cwd, sessionScope, entry.skill, entry, {
+		cwd,
+		audit: activeStateWriterAudit("write-active-entry"),
+	});
+}
+
+async function rebuildActiveState(cwd: string, sessionScope?: ActiveSessionScope): Promise<void> {
+	await rebuildActiveSnapshot(cwd, sessionScope, { cwd, audit: activeStateWriterAudit("rebuild-active-snapshot") });
 }
 
 export async function syncSkillActiveState(options: SyncSkillActiveStateOptions): Promise<void> {
@@ -545,36 +568,13 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 		...(hud ? { hud } : {}),
 		...(options.receipt ? { receipt: options.receipt } : {}),
 	};
-	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, options.sessionId);
-	const rootState = (await readStateFile(rootPath)) ?? { version: 1, active_skills: [] };
-	const rootEntries = upsertEntry(listActiveSkills(rootState), entry, options.active);
-	const nextRoot: SkillActiveState = {
-		...rootState,
-		version: 1,
-		active: rootEntries.length > 0,
-		skill: rootEntries[0]?.skill ?? "",
-		phase: rootEntries[0]?.phase ?? "",
-		updated_at: nowIso,
-		source: options.source,
-		active_skills: rootEntries,
-	};
-	await writeStateFile(rootPath, nextRoot);
+	await persistActiveEntry(options.cwd, undefined, entry);
+	await rebuildActiveState(options.cwd);
 
-	if (!sessionPath) return;
-	const sessionState = (await readStateFile(sessionPath)) ?? { version: 1, active_skills: [] };
-	const sessionEntries = upsertEntry(listActiveSkills(sessionState), entry, options.active);
-	const nextSession: SkillActiveState = {
-		...sessionState,
-		version: 1,
-		active: sessionEntries.length > 0,
-		skill: sessionEntries[0]?.skill ?? "",
-		phase: sessionEntries[0]?.phase ?? "",
-		session_id: options.sessionId,
-		updated_at: nowIso,
-		source: options.source,
-		active_skills: sessionEntries,
-	};
-	await writeStateFile(sessionPath, nextSession);
+	if (!options.sessionId) return;
+	const sessionScope = { sessionId: options.sessionId };
+	await persistActiveEntry(options.cwd, sessionScope, entry);
+	await rebuildActiveState(options.cwd, sessionScope);
 }
 
 export interface ApplyHandoffOptions {
@@ -604,6 +604,7 @@ export async function applyHandoffToActiveState(options: ApplyHandoffOptions): P
 	const sessionId = options.callee.sessionId ?? options.caller.sessionId;
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(options.cwd, sessionId);
 	const readState = (filePath: string) => readRawActiveStateForHandoff(filePath, options.strict === true);
+	await Promise.all([readState(rootPath), ...(sessionPath ? [readState(sessionPath)] : [])]);
 
 	// A skill can hold more than one visible row in this session's scope — e.g.
 	// it was seeded without a session id (rendered globally) and is now handed
@@ -637,33 +638,23 @@ export async function applyHandoffToActiveState(options: ApplyHandoffOptions): P
 			: callerEntry;
 		return [...kept, mergedCaller, calleeEntry];
 	};
-	const buildNextState = (
+	const writeEntries = async (
+		sessionScope: ActiveSessionScope | undefined,
 		prior: SkillActiveState | null,
-		entries: SkillActiveEntry[],
-		scope: "session" | "root",
-	): SkillActiveState => {
-		const visible = entries.filter(e => e.active !== false);
-		return {
-			...(prior ?? {}),
-			version: 1,
-			active: visible.length > 0,
-			skill: visible[0]?.skill ?? "",
-			phase: visible[0]?.phase ?? "",
-			...(scope === "session" ? { session_id: sessionId } : {}),
-			updated_at: nowIso,
-			source: options.callee.source ?? options.caller.source,
-			active_skills: entries,
-		};
+	): Promise<void> => {
+		const nextEntries = applyEntries(rawActiveEntries(prior));
+		for (const entry of nextEntries) {
+			await writeHandoffEntry(options.cwd, sessionScope, entry);
+		}
+		await rebuildActiveState(options.cwd, sessionScope);
 	};
 
 	if (sessionPath) {
 		const prior = await readState(sessionPath);
-		const next = buildNextState(prior, applyEntries(rawActiveEntries(prior)), "session");
-		await writeStateFile(sessionPath, next);
+		await writeEntries({ sessionId }, prior);
 	}
 	const priorRoot = await readState(rootPath);
-	const nextRoot = buildNextState(priorRoot, applyEntries(rawActiveEntries(priorRoot)), "root");
-	await writeStateFile(rootPath, nextRoot);
+	await writeEntries(undefined, priorRoot);
 }
 
 function buildSyncEntry(options: SyncSkillActiveStateOptions, nowIso: string): SkillActiveEntry {

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -415,6 +415,9 @@ export async function getDeepInterviewMutationDecision(
 			reason: "unknown-target",
 		};
 	}
+	if (input.tool.name === "bash") {
+		return { blocked: false, targets: targets.paths };
+	}
 	return {
 		blocked: true,
 		message: DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -14,12 +14,16 @@ import {
 export const DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE =
 	"Deep-interview phase boundary: continue gathering context/questions/risks and emit a handoff/spec before code edits. Mutation tools and patch execution are blocked while deep-interview is active; finalize specs through `gjc deep-interview --write --stage final` or hand off to an execution phase.";
 export const WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE =
-	"Workflow state JSON is runtime-owned. Use `gjc state <skill> read|write --input '<json>'` for deep-interview, ralplan, ultragoal, and team. Planning artifacts under `.gjc/specs/` and `.gjc/plans/` remain allowed.";
+	".gjc workflow state and artifacts are runtime-owned. Agent mutation tools cannot edit `.gjc/**`; use the sanctioned `gjc` CLI instead.";
 
-const BLOCKED_TOOL_NAMES = new Set(["edit", "write", "ast_edit"]);
+const BLOCKED_TOOL_NAMES = new Set(["edit", "write", "ast_edit", "bash"]);
 const ARCHIVE_OR_SQLITE_BASE_RE = /^(.+?\.(?:tar\.gz|sqlite3|sqlite|db3|zip|tgz|tar|db))(?:$|:)/i;
 const INTERNAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const VIM_FILE_SWITCH_RE = /^\s*:(?:e|e!|edit|edit!)(?:\s+([^<\r\n]+))?(?:<CR>|\r|\n|$)/i;
+const BASH_TOKEN_RE = /'[^']*'|"(?:\\.|[^"\\])*"|\S+/g;
+const BASH_REDIRECT_RE = /^(?:\d*)>>?$/;
+const BASH_HEREDOC_RE = /^(?:\d*)<<-?$/;
+const BASH_MUTATION_COMMANDS = new Set(["rm", "mv", "cp", "touch", "mkdir", "ln", "tee"]);
 
 type ToolWithEditMode = AgentTool & {
 	mode?: unknown;
@@ -219,10 +223,75 @@ function extractEditTargets(args: unknown, tool: ToolWithEditMode): ExtractedTar
 	return targets;
 }
 
+function extractBashTargets(args: unknown): ExtractedTargets {
+	const record = getRecord(args);
+	const command = safeString(record?.command).trim();
+	const targets: ExtractedTargets = { paths: [], unknown: false };
+	if (!command) {
+		targets.unknown = true;
+		return targets;
+	}
+	if (/^gjc(?:\s|$)/.test(command)) return targets;
+
+	const tokens = command.match(BASH_TOKEN_RE)?.map(unquoteBashToken) ?? [];
+	for (let index = 0; index < tokens.length; index++) {
+		const token = tokens[index] ?? "";
+		if (BASH_REDIRECT_RE.test(token)) {
+			addPath(targets, tokens[index + 1]);
+			index++;
+			continue;
+		}
+		const redirectMatch = token.match(/^(?:\d*)>>?(.+)$/);
+		if (redirectMatch?.[1]) {
+			addPath(targets, redirectMatch[1]);
+			continue;
+		}
+		if (BASH_HEREDOC_RE.test(token)) {
+			addPath(targets, tokens[index + 1]);
+			index++;
+			continue;
+		}
+		const heredocMatch = token.match(/^(?:\d*)<<-?(.+)$/);
+		if (heredocMatch?.[1]) {
+			addPath(targets, heredocMatch[1]);
+			continue;
+		}
+		if (isMutationBashCommand(tokens, index)) {
+			for (let targetIndex = index + 1; targetIndex < tokens.length; targetIndex++) {
+				const target = tokens[targetIndex] ?? "";
+				if (isBashCommandBoundary(target)) break;
+				if (target.startsWith("-")) continue;
+				addPath(targets, target);
+			}
+		}
+	}
+	return targets;
+}
+
+function unquoteBashToken(token: string): string {
+	if (token.length < 2) return token;
+	const quote = token[0];
+	if ((quote === "'" || quote === '"') && token.at(-1) === quote) return token.slice(1, -1);
+	return token;
+}
+
+function isBashCommandBoundary(token: string): boolean {
+	return [";", "&&", "||", "|"].includes(token);
+}
+
+function isMutationBashCommand(tokens: string[], index: number): boolean {
+	const token = path.basename(tokens[index] ?? "");
+	if (BASH_MUTATION_COMMANDS.has(token)) return true;
+	if (token !== "sed") return false;
+	const next = tokens[index + 1] ?? "";
+	return next === "-i" || next.startsWith("-i") || next.includes("i");
+}
+
 function extractTargets(tool: ToolWithEditMode, args: unknown): ExtractedTargets {
 	if (tool.name === "write") return extractWriteTargets(args);
 	if (tool.name === "ast_edit") return extractAstEditTargets(args);
 	if (tool.name === "edit") return extractEditTargets(args, tool);
+	if (tool.name === "bash") return extractBashTargets(args);
 	return { paths: [], unknown: true };
 }
 
@@ -289,6 +358,14 @@ function isAllowlistedPath(cwd: string, rawPath: string): boolean {
 	if (segments?.[0] !== ".gjc") return false;
 	return segments[1] === "specs" || segments[1] === "plans";
 }
+function isBlockedGjcPath(cwd: string, rawPath: string): boolean {
+	const segments = relativeGjcSegments(cwd, rawPath);
+	return segments?.[0] === ".gjc";
+}
+
+function hasBlockedGjcTarget(cwd: string, targets: ExtractedTargets): boolean {
+	return targets.paths.some(rawPath => isBlockedGjcPath(cwd, rawPath));
+}
 
 function allTargetsAllowlisted(cwd: string, targets: ExtractedTargets): boolean {
 	return (
@@ -315,18 +392,16 @@ export async function getDeepInterviewMutationDecision(
 ): Promise<DeepInterviewMutationDecision> {
 	if (!BLOCKED_TOOL_NAMES.has(input.tool.name)) return { blocked: false, targets: [] };
 	const targets = extractTargets(input.tool, input.args);
-	if (input.enforceWorkflowState !== false) {
+	if (input.enforceWorkflowState !== false && hasBlockedGjcTarget(input.cwd, targets)) {
 		const stateSkill = firstBlockedWorkflowStateSkill(input.cwd, targets);
-		if (stateSkill) {
-			const command = sanctionedWorkflowStateCommand(stateSkill);
-			return {
-				blocked: true,
-				message: `${WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE}\nUse: ${command}`,
-				targets: targets.paths,
-				reason: "workflow-state-target",
-				command,
-			};
-		}
+		const command = stateSkill ? sanctionedWorkflowStateCommand(stateSkill) : "gjc <workflow-command>";
+		return {
+			blocked: true,
+			message: `${WORKFLOW_STATE_MUTATION_BLOCK_MESSAGE}\nUse: ${command}`,
+			targets: targets.paths,
+			reason: stateSkill ? "workflow-state-target" : "gjc-target",
+			command,
+		};
 	}
 	if (!(await isActiveDeepInterview(input.cwd, input.sessionId, input.threadId))) {
 		return { blocked: false, targets: [] };

--- a/packages/coding-agent/src/skill-state/initial-phase.ts
+++ b/packages/coding-agent/src/skill-state/initial-phase.ts
@@ -13,5 +13,7 @@ import type { CanonicalGjcWorkflowSkill } from "./active-state";
 export function initialPhaseForSkill(skill: CanonicalGjcWorkflowSkill | string): string {
 	if (skill === "deep-interview") return "interviewing";
 	if (skill === "ultragoal") return "goal-planning";
+	if (skill === "ralplan") return "planner";
+	if (skill === "team") return "starting";
 	return "planning";
 }

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -20,6 +20,24 @@ export interface WorkflowStateReceipt {
 	fresh_until: string;
 	status: WorkflowStateReceiptStatus;
 	mutation_id: string;
+	verb?: string;
+	from_phase?: string;
+	to_phase?: string;
+	forced?: boolean;
+	paths?: string[];
+}
+
+export interface AuditEntry {
+	ts: string;
+	skill?: string;
+	category: string;
+	verb: string;
+	owner: WorkflowStateMutationOwner;
+	mutation_id: string;
+	from_phase?: string;
+	to_phase?: string;
+	forced: boolean;
+	paths: string[];
 }
 
 function safeString(value: unknown): string {

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -7,7 +7,7 @@ import { runConfigCommand } from "../src/cli/config-cli";
 import { resetSettingsForTest } from "../src/config/settings";
 
 let testAgentDir = "";
-const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalAgentDir = process.env.GJC_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 beforeEach(async () => {
@@ -23,7 +23,7 @@ afterEach(async () => {
 		setAgentDir(originalAgentDir);
 	} else {
 		setAgentDir(fallbackAgentDir);
-		delete process.env.PI_CODING_AGENT_DIR;
+		delete process.env.GJC_CODING_AGENT_DIR;
 	}
 	await fs.rm(testAgentDir, { recursive: true, force: true });
 });
@@ -74,6 +74,26 @@ describe("config CLI schema coverage", () => {
 		expect(parsed.key).toBe("enabledModels");
 		expect(parsed.type).toBe("array");
 		expect(parsed.value).toEqual(["claude-opus-4-6", "gpt-5.3-codex"]);
+	});
+
+	it("sets and gets deep-interview ambiguity threshold", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await runConfigCommand({
+			action: "set",
+			key: "gjc.deepInterview.ambiguityThreshold",
+			value: "0.2",
+			flags: { json: true },
+		});
+		await runConfigCommand({ action: "get", key: "gjc.deepInterview.ambiguityThreshold", flags: { json: true } });
+
+		const payload = logSpy.mock.calls.at(-1)?.[0];
+		expect(typeof payload).toBe("string");
+		expect(JSON.parse(String(payload))).toMatchObject({
+			key: "gjc.deepInterview.ambiguityThreshold",
+			type: "number",
+			value: 0.2,
+		});
 	});
 	it("sets numeric idle compaction settings from CLI values", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -104,8 +104,8 @@ describe("deep-interview mutation guard", () => {
 				args: { path: rawPath, content: "x" },
 			});
 			expect(decision.blocked).toBe(true);
-			expect(decision.reason).toBe("handoff-artifact-tool-target");
-			expect(decision.message).toContain("gjc deep-interview --write --stage final");
+			expect(decision.reason).toBe("gjc-target");
+			expect(decision.message).toContain("runtime-owned");
 		}
 
 		const blockedCases: Array<[string, AgentTool, unknown]> = [
@@ -150,8 +150,8 @@ describe("deep-interview mutation guard", () => {
 				args,
 			});
 			expect(decision.blocked).toBe(true);
-			if (decision.reason === "workflow-state-target") {
-				expect(decision.message).toContain("Workflow state JSON is runtime-owned");
+			if (decision.reason === "workflow-state-target" || decision.reason === "gjc-target") {
+				expect(decision.message).toContain("runtime-owned");
 			} else {
 				expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
 			}
@@ -187,7 +187,7 @@ describe("deep-interview mutation guard", () => {
 				args: { path: rawPath, content: "x" },
 			});
 			expect(decision.blocked).toBe(true);
-			expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+			expect(decision.message).toContain("runtime-owned");
 		}
 
 		const mixed = await getDeepInterviewMutationDecision({
@@ -214,7 +214,7 @@ describe("deep-interview mutation guard", () => {
 		});
 
 		expect(decision.blocked).toBe(true);
-		expect(decision.message).toBe(DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE);
+		expect(decision.message).toContain("runtime-owned");
 	});
 
 	it("does not block after deep-interview reaches a terminal phase", async () => {

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -199,6 +199,51 @@ describe("deep-interview mutation guard", () => {
 		expect(mixed.blocked).toBe(true);
 	});
 
+	it("allows read-only bash during active deep-interview when no mutation target is extracted", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			"git status --short",
+			"rg deep-interview packages/coding-agent/src",
+			"cat packages/coding-agent/package.json",
+			"sed -n '1,80p' packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts",
+			"bun test packages/coding-agent/test/deep-interview-mutation-guard.test.ts",
+		]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(false);
+			expect(decision.targets).toEqual([]);
+		}
+	});
+
+	it("blocks mutating bash that targets .gjc during active deep-interview", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			"rm .gjc/state/deep-interview-state.json",
+			"mkdir -p .gjc/specs",
+			"cp source.md .gjc/specs/deep-interview-x.md",
+			"sed -i 's/a/b/' .gjc/plans/plan.md",
+			"cat source.md > .gjc/specs/deep-interview-x.md",
+		]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+			expect(decision.message).toContain("runtime-owned");
+			expect(["gjc-target", "workflow-state-target"]).toContain(decision.reason ?? "");
+		}
+	});
+
 	it("blocks vim file-switches into .gjc", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -1,20 +1,37 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as url from "node:url";
 import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 
+import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
+import { resetSettingsForTest } from "../../src/config/settings";
+
 const tempRoots: string[] = [];
 const codingAgentRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
 
+const originalAgentDir = process.env.GJC_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 async function tempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-deep-interview-runtime-"));
 	tempRoots.push(dir);
 	return dir;
 }
 
+beforeEach(async () => {
+	resetSettingsForTest();
+	setAgentDir(await tempDir());
+});
+
 afterEach(async () => {
+	resetSettingsForTest();
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.GJC_CODING_AGENT_DIR;
+	}
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -89,7 +106,7 @@ describe("native gjc deep-interview runtime", () => {
 			await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8"),
 		);
 		expect(ralplanState.active).toBe(true);
-		expect(ralplanState.current_phase).toBe("planning");
+		expect(ralplanState.current_phase).toBe("planner");
 		expect(ralplanState.mode).toBe("deliberate");
 		expect(ralplanState.task).toBe(specPath);
 		expect(ralplanState.handoff_from).toBe("deep-interview");
@@ -172,6 +189,27 @@ describe("native gjc deep-interview runtime", () => {
 		const payload = JSON.parse(result.stdout ?? "{}");
 		expect(payload.threshold).toBeCloseTo(0.08);
 		expect(payload.threshold_source).toBe(path.join(root, ".gjc", "settings.json"));
+	});
+
+	it("prefers modern config.yml threshold over legacy project settings.json", async () => {
+		const root = await tempDir();
+		const agentDir = await tempDir();
+		setAgentDir(agentDir);
+		resetSettingsForTest();
+		await fs.writeFile(path.join(agentDir, "config.yml"), "gjc:\n  deepInterview:\n    ambiguityThreshold: 0.2\n");
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, ".gjc", "settings.json"),
+			JSON.stringify({ gjc: { deepInterview: { ambiguityThreshold: 0.08 } } }),
+		);
+
+		resetSettingsForTest();
+		const result = await runNativeDeepInterviewCommand(["--standard", "--json", "idea"], root);
+
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.threshold).toBeCloseTo(0.2);
+		expect(payload.threshold_source).toBe(path.join(agentDir, "config.yml"));
 	});
 
 	it("--threshold beats project settings.json", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-graph.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-graph.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { renderStateGraph } from "@gajae-code/coding-agent/gjc-runtime/state-graph";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+describe("GJC state graph rendering", () => {
+	it("renders one skill as ascii", () => {
+		const output = renderStateGraph("deep-interview", "ascii");
+
+		expect(output).toContain("deep-interview (Deep Interview)");
+		expect(output).toContain("states:");
+		expect(output).toContain("  - interviewing (initial)");
+		expect(output).toContain("transitions:");
+		expect(output).toContain("  - interviewing -> handoff [write-spec]");
+	});
+
+	it("renders one skill as mermaid", () => {
+		const output = renderStateGraph("deep-interview", "mermaid");
+
+		expect(output).toContain("stateDiagram-v2");
+		expect(output).toContain('state "Deep Interview" as deep-interview {');
+		expect(output).toContain("[*] --> interviewing");
+		expect(output).toContain("interviewing --> handoff: write-spec");
+	});
+
+	it("renders one skill as dot", () => {
+		const output = renderStateGraph("deep-interview", "dot");
+
+		expect(output).toContain("digraph gjc_state {");
+		expect(output).toContain('subgraph "cluster_deep-interview"');
+		expect(output).toContain('"deep-interview:interviewing" [label="interviewing", shape=circle];');
+		expect(output).toContain('"deep-interview:interviewing" -> "deep-interview:handoff" [label="write-spec"];');
+	});
+
+	it("returns exit 2 for invalid CLI graph format", async () => {
+		const result = await runNativeStateCommand(["graph", "--skill", "deep-interview", "--format", "svg"]);
+
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("Invalid graph format: svg");
+	});
+});

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -125,8 +125,8 @@ describe("GJC native skill-state hooks", () => {
 			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
 		});
 		expect(blockedSpec.blocked).toBe(true);
-		expect(blockedSpec.reason).toBe("handoff-artifact-tool-target");
-		expect(blockedSpec.message).toContain("gjc deep-interview --write --stage final");
+		expect(blockedSpec.reason).toBe("gjc-target");
+		expect(blockedSpec.message).toContain("runtime-owned");
 
 		const blocked = await getDeepInterviewMutationDecision({
 			cwd: root,
@@ -154,14 +154,14 @@ describe("GJC native skill-state hooks", () => {
 			tool: { name: "write" } as never,
 			args: { path: ".gjc/specs/deep-interview-sample.md", content: "spec" },
 		});
-		expect(allowedSpec.blocked).toBe(false);
+		expect(allowedSpec.blocked).toBe(true);
 
 		const allowedPlan = await getDeepInterviewMutationDecision({
 			cwd: root,
 			tool: { name: "write" } as never,
 			args: { path: ".gjc/plans/sample.md", content: "plan" },
 		});
-		expect(allowedPlan.blocked).toBe(false);
+		expect(allowedPlan.blocked).toBe(true);
 	});
 
 	it("encodes hook session ids before writing skill and mode state paths", async () => {
@@ -390,7 +390,7 @@ disabledExtensions:
 			sessionId: "session-2",
 			threadId: "thread-2",
 		});
-		expect(blocked.outputJson).toMatchObject({ decision: "block", stopReason: "gjc_skill_ralplan_planning" });
+		expect(blocked.outputJson).toMatchObject({ decision: "block", stopReason: "gjc_skill_ralplan_planner" });
 
 		await Bun.write(
 			path.join(root, ".gjc", "state", "sessions", "session-2", "ralplan-state.json"),

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -118,6 +118,14 @@ describe("GJC native skill-state hooks", () => {
 		expect(blockedProduct.reason).toBe("phase-boundary");
 		expect(blockedProduct.message).toContain("handoff/spec before code edits");
 
+		const allowedReadOnlyBash = await getDeepInterviewMutationDecision({
+			cwd: root,
+			sessionId: "session-rich",
+			tool: { name: "bash" } as never,
+			args: { command: "git status --short" },
+		});
+		expect(allowedReadOnlyBash.blocked).toBe(false);
+
 		const blockedSpec = await getDeepInterviewMutationDecision({
 			cwd: root,
 			sessionId: "session-rich",
@@ -127,6 +135,15 @@ describe("GJC native skill-state hooks", () => {
 		expect(blockedSpec.blocked).toBe(true);
 		expect(blockedSpec.reason).toBe("gjc-target");
 		expect(blockedSpec.message).toContain("runtime-owned");
+
+		const blockedGjcBash = await getDeepInterviewMutationDecision({
+			cwd: root,
+			sessionId: "session-rich",
+			tool: { name: "bash" } as never,
+			args: { command: "cat sample.md > .gjc/specs/deep-interview-sample.md" },
+		});
+		expect(blockedGjcBash.blocked).toBe(true);
+		expect(blockedGjcBash.reason).toBe("gjc-target");
 
 		const blocked = await getDeepInterviewMutationDecision({
 			cwd: root,

--- a/scripts/generate-gjc-workflow-manifest.ts
+++ b/scripts/generate-gjc-workflow-manifest.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { serializeManifestProjection } from "../packages/coding-agent/src/gjc-runtime/workflow-manifest";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const GENERATED_MANIFEST = path.join(
+	repoRoot,
+	"packages",
+	"coding-agent",
+	"src",
+	"gjc-runtime",
+	"workflow-manifest.generated.json",
+);
+
+function usage(): never {
+	console.error("Usage: bun scripts/generate-gjc-workflow-manifest.ts [--write|--check]");
+	process.exit(2);
+}
+
+function main(): void {
+	const args = process.argv.slice(2);
+	if (args.length > 1) usage();
+
+	const mode = args[0] ?? "--write";
+	if (mode !== "--write" && mode !== "--check") usage();
+
+	const generated = serializeManifestProjection();
+
+	if (mode === "--write") {
+		fs.writeFileSync(GENERATED_MANIFEST, generated, "utf8");
+		console.log(`G3 OK: wrote ${path.relative(repoRoot, GENERATED_MANIFEST)}.`);
+		return;
+	}
+
+	const committed = fs.readFileSync(GENERATED_MANIFEST, "utf8");
+	if (committed === generated) {
+		console.log(`G3 OK: ${path.relative(repoRoot, GENERATED_MANIFEST)} is up to date.`);
+		return;
+	}
+
+	console.error(
+		`G3 DRIFT: ${path.relative(repoRoot, GENERATED_MANIFEST)} does not match serializeManifestProjection(). Run bun scripts/generate-gjc-workflow-manifest.ts --write.`,
+	);
+	process.exit(1);
+}
+
+main();

--- a/scripts/verify-gjc-skill-docs.ts
+++ b/scripts/verify-gjc-skill-docs.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+
+/**
+ * G4 verifier for bundled GJC skill documentation.
+ *
+ *   --report  (default)  list command references and direct `.gjc` shell mutations, exit 0
+ *   --fail               exit non-zero on manifest drift or direct `.gjc` shell mutations
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { listVerbs } from "../packages/coding-agent/src/gjc-runtime/workflow-manifest";
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill } from "../packages/coding-agent/src/skill-state/active-state";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const skillsRoot = path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills");
+const skills = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
+
+interface CommandRef {
+	file: string;
+	line: number;
+	skill: CanonicalGjcWorkflowSkill;
+	verb: string;
+	command: string;
+	valid: boolean;
+}
+
+interface MutationRef {
+	file: string;
+	line: number;
+	text: string;
+}
+
+function isSkill(value: string): value is CanonicalGjcWorkflowSkill {
+	return skills.has(value);
+}
+
+function stripInlineCode(line: string): string {
+	return line.replace(/`[^`]*`/gu, "");
+}
+
+function isRoleSelectorVerb(line: string, commandEndIndex: number): boolean {
+	return line.slice(0, commandEndIndex).endsWith("gjc team executor") && /\bgjc\s+team\s+executor\s+["'`]/u.test(line);
+}
+
+
+function collectCommandRefs(file: string, content: string): CommandRef[] {
+	const refs: CommandRef[] = [];
+	const relative = path.relative(repoRoot, file);
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		const commandPattern = /\bgjc\s+(?:state\s+)?(deep-interview|ralplan|ultragoal|team)\s+([a-z][a-z0-9-]*)\b/gu;
+		for (const match of line.matchAll(commandPattern)) {
+			const skill = match[1];
+			if (!isSkill(skill)) continue;
+			const verb = match[2] ?? "";
+			const command = match[0];
+			if (isRoleSelectorVerb(line, (match.index ?? 0) + command.length)) continue;
+			const valid = listVerbs(skill).includes(verb);
+			refs.push({ file: relative, line: i + 1, skill, verb, command, valid });
+		}
+	}
+	return refs;
+}
+
+function collectDirectGjcMutations(file: string, content: string): MutationRef[] {
+	const refs: MutationRef[] = [];
+	const relative = path.relative(repoRoot, file);
+	const lines = content.split("\n");
+	const mutationPattern = /(?:^|[;&|]\s*)(?:rm\s+(?:-[A-Za-z]*\s+)*|rmdir\s+|mkdir\s+(?:-[A-Za-z]*\s+)*|touch\s+|mv\s+|cp\s+|install\s+|tee\s+(?:-[A-Za-z]*\s+)*|printf\b[^|;>]*>|echo\b[^|;>]*>|cat\b[^|;>]*>|>+\s*)\.?\.gjc(?:\b|\/)/u;
+	for (let i = 0; i < lines.length; i++) {
+		const line = stripInlineCode(lines[i] ?? "");
+		if (mutationPattern.test(line)) {
+			refs.push({ file: relative, line: i + 1, text: (lines[i] ?? "").trim().slice(0, 180) });
+		}
+	}
+	return refs;
+}
+
+function main(): void {
+	const argv = process.argv.slice(2);
+	const failMode = argv.includes("--fail");
+	const commandRefs: CommandRef[] = [];
+	const mutationRefs: MutationRef[] = [];
+
+	for (const skill of CANONICAL_GJC_WORKFLOW_SKILLS) {
+		const file = path.join(skillsRoot, skill, "SKILL.md");
+		const content = fs.readFileSync(file, "utf8");
+		commandRefs.push(...collectCommandRefs(file, content));
+		mutationRefs.push(...collectDirectGjcMutations(file, content));
+	}
+
+	const drift = commandRefs.filter(ref => !ref.valid);
+	console.log(`gjc skill docs verifier - scanned ${path.relative(repoRoot, skillsRoot)}/*/SKILL.md`);
+	console.log(`Found ${commandRefs.length} gjc command reference(s).`);
+	console.log(`Found ${mutationRefs.length} direct .gjc shell mutation example(s).\n`);
+
+	const byFile = new Map<string, CommandRef[]>();
+	for (const ref of commandRefs) {
+		const list = byFile.get(ref.file) ?? [];
+		list.push(ref);
+		byFile.set(ref.file, list);
+	}
+
+	for (const [file, refs] of [...byFile.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+		console.log(`[${refs.every(ref => ref.valid) ? "OK" : "DRIFT"}] ${file}  (${refs.length} command(s))`);
+		for (const ref of refs) {
+			console.log(`    ${ref.line}: ${ref.command}  ${ref.valid ? "OK" : `UNKNOWN VERB for ${ref.skill}`}`);
+		}
+	}
+
+	if (mutationRefs.length > 0) {
+		console.log("\n[DIRECT-.GJC-MUTATION]");
+		for (const ref of mutationRefs) {
+			console.log(`    ${ref.file}:${ref.line}: ${ref.text}`);
+		}
+	}
+
+	console.log(`\nSummary: ${drift.length} command drift issue(s), ${mutationRefs.length} direct .gjc shell mutation example(s).`);
+
+	if (failMode && (drift.length > 0 || mutationRefs.length > 0)) {
+		console.error(`\nG4 FAIL: skill docs must reference manifest verbs only and avoid direct .gjc shell mutation examples.`);
+		process.exit(1);
+	}
+}
+
+main();

--- a/scripts/verify-gjc-state-writers.ts
+++ b/scripts/verify-gjc-state-writers.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+
+/**
+ * Inventory / enforcement for the single-sanctioned-writer invariant (gate G1).
+ *
+ * The locked design requires that EVERY native write to `.gjc/**` flows through one sanctioned
+ * writer module. This verifier reports filesystem mutation call sites whose path argument is
+ * locally tied to a `.gjc` path literal or a known `.gjc` path helper.
+ *
+ *   --report  (default)  list every candidate `.gjc/**` write site, exit 0
+ *   --fail               exit non-zero unless all candidates are allowlisted
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const SCAN_ROOT = path.join(repoRoot, "packages", "coding-agent", "src");
+
+// The one module allowed to perform raw `.gjc/**` filesystem mutations once routing is complete.
+const ALLOWED_WRITER_RELATIVE = path.join("packages", "coding-agent", "src", "gjc-runtime", "state-writer.ts");
+
+// Remaining intentional non-writer direct operations: empty mailbox directory creation and legacy
+// session-directory lifecycle moves/removes. These do not write state file contents.
+const KNOWN_ALLOWED_SITES = new Set<string>([
+	"packages/coding-agent/src/gjc-runtime/team-runtime.ts:1610:fs.mkdir",
+	"packages/coding-agent/src/gjc-runtime/team-runtime.ts:1612:fs.mkdir",
+	"packages/coding-agent/src/gjc-runtime/team-runtime.ts:1623:fs.mkdir",
+	"packages/coding-agent/src/session/session-manager.ts:399:renameSync",
+	"packages/coding-agent/src/session/session-manager.ts:402:rmSync",
+	"packages/coding-agent/src/session/session-manager.ts:406:rmSync",
+	"packages/coding-agent/src/session/session-manager.ts:408:renameSync",
+]);
+
+// Filesystem-mutation APIs we treat as candidate writers.
+const MUTATION_API_PATTERNS: readonly RegExp[] = [
+	/\bfs(?:\/promises)?\.(?:writeFile|appendFile|mkdir|rm|rmdir|unlink|rename|cp|copyFile|open)\s*\(/u,
+	/\bfsp?\.(?:writeFile|appendFile|mkdir|rm|rmdir|unlink|rename|cp|copyFile|open)\s*\(/u,
+	/\bwriteFileSync\s*\(|\bappendFileSync\s*\(|\bmkdirSync\s*\(|\brmSync\s*\(|\bunlinkSync\s*\(|\brenameSync\s*\(/u,
+	/\bBun\.write\s*\(/u,
+	/\bcreateWriteStream\s*\(/u,
+];
+
+// `.gjc` is referenced directly, or via a known path-helper symbol that resolves under `.gjc`.
+const GJC_REFERENCE_PATTERNS: readonly RegExp[] = [
+	/["'`]\.gjc(?:[\\/]|["'`])/u,
+	/\bstateDirFor\b/u,
+	/\bmodeStateFile\b/u,
+	/\bworkflowStateStoragePath\b/u,
+	/\bresolveGjcTeamStateRoot\b/u,
+	/\bdeepInterviewStatePath\b/u,
+	/\bspecsDir\b/u,
+	/\brunDir\b/u,
+	/\bledgerPath\b/u,
+	/\bgoalsPath\b/u,
+	/\bbriefPath\b/u,
+	/\bintegrationReportPath\b/u,
+	/\bbreadcrumbFile\b/u,
+	/\bhandoffFilePath\b/u,
+	/\bgetUltragoalPaths\b/u,
+];
+
+interface Finding {
+	file: string;
+	line: number;
+	api: string;
+	text: string;
+	allowed: boolean;
+	knownAllowed: boolean;
+}
+
+function listTsFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules" || entry.name === "__snapshots__") continue;
+			out.push(...listTsFiles(full));
+		} else if (/\.ts$/u.test(entry.name) && !/\.test\.ts$/u.test(entry.name) && !/\.d\.ts$/u.test(entry.name)) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+function matchedApi(line: string): string | null {
+	for (const re of MUTATION_API_PATTERNS) {
+		const m = re.exec(line);
+		if (m) return m[0].replace(/\s*\($/u, "");
+	}
+	return null;
+}
+
+function locallyReferencesGjc(lines: readonly string[], index: number): boolean {
+	const start = Math.max(0, index - 3);
+	const end = Math.min(lines.length - 1, index + 3);
+	for (let i = start; i <= end; i++) {
+		const line = lines[i]?.trim() ?? "";
+		if (line.startsWith("//") || line.startsWith("*")) continue;
+		if (GJC_REFERENCE_PATTERNS.some(re => re.test(line))) return true;
+	}
+	return false;
+}
+
+function lineLooksLikeGeneratedStringLiteral(line: string): boolean {
+	return /^["'`][^"'`]+["'`]\s*:/u.test(line.trim());
+}
+
+function nearbyAssignmentTargetsThisLine(lines: readonly string[], index: number): boolean {
+	const line = lines[index]?.trim() ?? "";
+	const start = Math.max(0, index - 3);
+	for (let i = start; i < index; i++) {
+		const prior = lines[i]?.trim() ?? "";
+		if (!GJC_REFERENCE_PATTERNS.some(re => re.test(prior))) continue;
+		const assignment = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/u.exec(prior);
+		if (assignment && new RegExp(`\\b${assignment[1]}\\b`, "u").test(line)) return true;
+	}
+	return false;
+}
+
+function sameLineReferencesGjc(line: string): boolean {
+	return GJC_REFERENCE_PATTERNS.some(re => re.test(line));
+}
+
+
+function isGuardedOutsideProjectGjcFallback(lines: readonly string[], index: number): boolean {
+	const start = Math.max(0, index - 8);
+	const context = lines.slice(start, index + 1).join("\n");
+	return /isUnderProjectGjc\([\s\S]*?\}\s*else\s*\{[\s\S]*$/u.test(context);
+}
+
+function isGuardedOutsideProjectGjcTernaryFallback(lines: readonly string[], index: number): boolean {
+	const start = Math.max(0, index - 6);
+	const context = lines.slice(start, index + 1).join("\n");
+	return /isUnderProjectGjc\([\s\S]*?\?[\s\S]*?:\s*[^\n]*$/u.test(context);
+}
+
+
+function collectFindings(): Finding[] {
+	const findings: Finding[] = [];
+	for (const file of listTsFiles(SCAN_ROOT)) {
+		const content = fs.readFileSync(file, "utf8");
+		const relative = path.relative(repoRoot, file);
+		const lines = content.split("\n");
+		for (let i = 0; i < lines.length; i++) {
+			const raw = lines[i];
+			const line = raw.trim();
+			if (line.startsWith("//") || line.startsWith("*")) continue;
+			const api = matchedApi(line);
+			if (!api) continue;
+			const knownAllowed = KNOWN_ALLOWED_SITES.has(`${relative}:${i + 1}:${api}`);
+			const allowed = relative === ALLOWED_WRITER_RELATIVE || knownAllowed;
+			if (!allowed && !sameLineReferencesGjc(line) && !nearbyAssignmentTargetsThisLine(lines, i)) continue;
+			if (!allowed && (isGuardedOutsideProjectGjcFallback(lines, i) || isGuardedOutsideProjectGjcTernaryFallback(lines, i))) continue;
+			findings.push({ file: relative, line: i + 1, api, text: line.slice(0, 160), allowed, knownAllowed });
+		}
+	}
+	return findings;
+}
+
+function main(): void {
+	const argv = process.argv.slice(2);
+	const failMode = argv.includes("--fail");
+	const findings = collectFindings();
+
+	const byFile = new Map<string, Finding[]>();
+	for (const f of findings) {
+		const list = byFile.get(f.file) ?? [];
+		list.push(f);
+		byFile.set(f.file, list);
+	}
+
+	const offending = findings.filter(f => !f.allowed);
+
+	console.log(`gjc .gjc/** writer inventory - scanned ${path.relative(repoRoot, SCAN_ROOT)}`);
+	console.log(`Found ${findings.length} candidate write site(s) across ${byFile.size} file(s).`);
+	console.log(`Allowlisted sanctioned writer: ${ALLOWED_WRITER_RELATIVE}`);
+	console.log(`Known-allowed non-writer sites: ${KNOWN_ALLOWED_SITES.size}\n`);
+
+	for (const [file, list] of [...byFile.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+		const tag = list.every(f => f.file === ALLOWED_WRITER_RELATIVE)
+			? "OK"
+			: list.every(f => f.allowed)
+				? "KNOWN-ALLOWED"
+				: "ROUTE";
+		console.log(`[${tag}] ${file}  (${list.length} site(s))`);
+		for (const f of list) {
+			const suffix = f.knownAllowed ? "  KNOWN-ALLOWED" : "";
+			console.log(`    ${f.line}: ${f.api}  ${f.text}${suffix}`);
+		}
+	}
+
+	console.log(`\nSummary: ${offending.length} write site(s) outside the sanctioned writer / known allowlist.`);
+
+	if (failMode && offending.length > 0) {
+		console.error(`\nG1 FAIL: ${offending.length} direct .gjc/** write site(s) must route through ${ALLOWED_WRITER_RELATIVE}.`);
+		process.exit(1);
+	}
+}
+
+main();


### PR DESCRIPTION
## Summary
Makes the `gjc` CLI the **sole + complete** mutator of `.gjc/**`, with a **TS-authoritative workflow manifest** as the single source of truth across CLI / on-disk state / SKILL.md docs / HUD. Built via deep-interview spec → ralplan consensus (`.gjc/specs/deep-interview-gjc-cli-state-readonly-manifest.md`, `.gjc/plans/ralplan/2026-06-02-0730-18a1/`).

## What's in this PR (verified)
- **Sanctioned writer** (`state-writer.ts`): atomic temp+rename, O_EXCL `createJsonNoClobber`, conditional `deleteIfOwned`, per-entry + rebuilt active snapshot (no-lock, no-clobber), soft-delete / hard-prune, true-raw `forceOverwrite`, append-only `audit.jsonl`, receipts.
- **Manifest SSOT** (`workflow-manifest.ts`): statecharts for all 4 skills (accurate to real parsers; planned additions tagged) + deterministic JSON projection with **G3** drift check.
- **Routing**: all 8 native `.gjc` workflow writers go through the sanctioned writer; **team-runtime O_EXCL** claim/mailbox exclusivity + conditional rollback preserved.
- **Read-only ACL**: `write/edit/ast_edit` **and bash** blocked from mutating any `.gjc/**` (CLI-only), wired into `agent-session.ts` with a bash command parser.
- **Migrations**: pure `normalizeLegacyState` vs explicit `migrateAndPersistLegacyState` (background reads never persist).
- **Config**: `gjc config` registered, `gjc.deepInterview.ambiguityThreshold` schema key, `config.yml` preferred over legacy `.gjc/settings.json` (architect #3).
- **CLI**: additive `gjc state graph` (ascii/mermaid/dot), `prune` (soft/`--hard`), `migrate`.
- **Gates**: G1 writer-inventory verifier (`--fail` passes), G3 projection drift, **G4** SKILL.md doc-linter (removed `rm -rf .gjc` example, architect #6).

## Verification
- `tsc` clean; **193** gjc-runtime/guard/hook/config tests + **93** session/skill/handoff tests pass; **G1/G3/G4** gates pass.

## Deferred follow-ups (not in this PR)
- Markdown-default `gjc state read` (breaking; needs `readWorkflowStateJson` helper + caller migration) — graph/prune/migrate landed, markdown read still JSON-default.
- Team dual-model convergence (#4) and dedupe of duplicate hook active-state types (#5).
- Dedicated G2/G5/G6/G7/G8 CI test files (behaviors implemented + verified via existing/new tests; named gate files not all added). G8 typed-args reject-unknown not yet enforced.

🤖 Generated via deep-interview → ralplan consensus → ultragoal execution.
