### PR TITLE
feat(gjc): markdown state read, G8 enforcement, team convergence, dedupe + gate tests

### DIFF
--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -6,6 +6,7 @@ import {
 	listGjcTeams,
 	monitorGjcTeam,
 	parseTeamLaunchArgs,
+	persistGjcTeamModeStateSummary,
 	readGjcTeamEvents,
 	readGjcTeamSnapshot,
 	shutdownGjcTeam,
@@ -31,6 +32,7 @@ async function syncTeamHud(snapshot: GjcTeamSnapshot): Promise<void> {
 			hud: await buildTeamHudSummary(snapshot, events.at(-1)),
 			source: "gjc-team",
 		});
+		await persistGjcTeamModeStateSummary(snapshot, process.cwd());
 	} catch {
 		// HUD sync is best-effort and must not change command semantics.
 	}

--- a/packages/coding-agent/src/gjc-runtime/state-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-renderer.ts
@@ -1,0 +1,106 @@
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import type { SkillManifest } from "./workflow-manifest";
+
+function scalar(value: unknown): string | undefined {
+	if (typeof value === "string") return value.trim() || undefined;
+	if (typeof value === "number" || typeof value === "boolean") return String(value);
+	return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stateObject(stateJson: Record<string, unknown>): Record<string, unknown> {
+	const nested = stateJson.state;
+	return isRecord(nested) ? nested : stateJson;
+}
+
+function receiptObject(state: Record<string, unknown>): Record<string, unknown> | undefined {
+	return isRecord(state.receipt) ? state.receipt : undefined;
+}
+
+function artifactLinks(state: Record<string, unknown>): string[] {
+	const links = new Set<string>();
+	for (const key of [
+		"artifact",
+		"artifact_path",
+		"artifact_url",
+		"plan_path",
+		"spec_path",
+		"ledger_path",
+		"storage_path",
+		"state_path",
+	]) {
+		const value = scalar(state[key]);
+		if (value) links.add(value);
+	}
+	const artifacts = state.artifacts;
+	if (Array.isArray(artifacts)) {
+		for (const artifact of artifacts) {
+			const value = scalar(artifact);
+			if (value) links.add(value);
+			if (isRecord(artifact)) {
+				for (const key of ["path", "url", "href"]) {
+					const nested = scalar(artifact[key]);
+					if (nested) links.add(nested);
+				}
+			}
+		}
+	}
+	return [...links];
+}
+
+function keyStateFields(state: Record<string, unknown>, manifest: SkillManifest): Array<[string, string]> {
+	const keys = new Set<string>([
+		"active",
+		"current_phase",
+		"phase",
+		"status",
+		"updated_at",
+		"session_id",
+		...manifest.hudFields,
+	]);
+	const fields: Array<[string, string]> = [];
+	for (const key of keys) {
+		const value = scalar(state[key]);
+		if (value !== undefined) fields.push([key, value]);
+		if (fields.length >= 10) break;
+	}
+	return fields;
+}
+
+export function renderStateMarkdown(
+	skill: CanonicalGjcWorkflowSkill,
+	stateJson: Record<string, unknown>,
+	manifest: SkillManifest,
+): string {
+	const state = stateObject(stateJson);
+	const phase = scalar(state.current_phase) ?? scalar(state.phase) ?? manifest.initialState;
+	const next = manifest.transitions.filter(transition => transition.from === phase).map(transition => transition.to);
+	const receipt = receiptObject(state);
+	const receiptStatus = receipt ? (scalar(receipt.status) ?? "present") : "missing";
+	const artifacts = artifactLinks(state);
+	const fields = keyStateFields(state, manifest);
+
+	const lines = [`# ${skill} state`, "", `- Current phase: ${phase}`];
+	lines.push(`- Valid next transitions: ${next.length ? next.join(", ") : "none"}`);
+	if (fields.length) {
+		lines.push("- Key fields:");
+		for (const [key, value] of fields) lines.push(`  - ${key}: ${value}`);
+	} else {
+		lines.push("- Key fields: none");
+	}
+	lines.push(`- Receipt: ${receiptStatus}`);
+	if (receipt) {
+		const mutationId = scalar(receipt.mutation_id);
+		const freshUntil = scalar(receipt.fresh_until);
+		if (mutationId) lines.push(`  - mutation_id: ${mutationId}`);
+		if (freshUntil) lines.push(`  - fresh_until: ${freshUntil}`);
+	}
+	if (artifacts.length) {
+		lines.push("- Artifacts:");
+		for (const artifact of artifacts) lines.push(`  - ${artifact}`);
+	}
+	return `${lines.join("\n")}\n`;
+}

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -24,6 +24,7 @@ import {
 } from "../skill-state/workflow-state-contract";
 import { renderStateGraph, type StateGraphFormat } from "./state-graph";
 import { migrateAndPersistLegacyState } from "./state-migrations";
+import { renderStateMarkdown } from "./state-renderer";
 import {
 	type GenericHardPruneTarget,
 	hardPrune,
@@ -31,6 +32,7 @@ import {
 	softDelete,
 	writeJsonAtomic as writeStateJsonAtomic,
 } from "./state-writer";
+import { getSkillManifest, typedArgsFor } from "./workflow-manifest";
 
 /**
  * Native implementation of the `gjc state read|write|clear` command surface.
@@ -84,6 +86,43 @@ const FLAGS_WITH_VALUES = new Set([
 	"--status",
 ]);
 const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate"]);
+const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate"]);
+const VERB_SPECIFIC_FLAGS = new Set(["--skill", "--format", "--older-than", "--status"]);
+
+function flagName(arg: string): string | undefined {
+	if (!arg.startsWith("--")) return undefined;
+	const equalsIndex = arg.indexOf("=");
+	return equalsIndex >= 0 ? arg.slice(0, equalsIndex) : arg;
+}
+
+function manifestFlagNames(action: ParsedInvocation["action"], positionalSkill: string | undefined): Set<string> {
+	const names = new Set<string>();
+	const skills =
+		positionalSkill && KNOWN_MODES.includes(positionalSkill)
+			? [positionalSkill as CanonicalGjcWorkflowSkill]
+			: CANONICAL_GJC_WORKFLOW_SKILLS;
+	for (const skill of skills) {
+		for (const arg of typedArgsFor(skill, action)) names.add(`--${arg.name}`);
+	}
+	return names;
+}
+
+function assertKnownFlags(args: readonly string[], parsed: ParsedInvocation): void {
+	const manifestFlags = manifestFlagNames(parsed.action, parsed.positionalSkill);
+	for (const arg of args) {
+		const flag = flagName(arg);
+		if (!flag) continue;
+		if (
+			FLAGS_WITH_VALUES.has(flag) ||
+			BOOLEAN_FLAGS.has(flag) ||
+			VERB_SPECIFIC_FLAGS.has(flag) ||
+			manifestFlags.has(flag)
+		) {
+			continue;
+		}
+		throw new StateCommandError(2, `unknown gjc state flag: ${flag}`);
+	}
+}
 
 interface ParsedInvocation {
 	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "migrate";
@@ -433,6 +472,14 @@ async function syncWorkflowSkillState(options: {
 		// HUD sync is best-effort and must not change command semantics.
 	}
 }
+export async function readWorkflowStateJson(
+	cwd: string,
+	skill: CanonicalGjcWorkflowSkill,
+	sessionId?: string,
+): Promise<Record<string, unknown>> {
+	return (await readJsonFile(modeStateFile(cwd, skill, sessionId))) ?? {};
+}
+
 async function handleRead(
 	args: readonly string[],
 	cwd: string,
@@ -442,10 +489,13 @@ async function handleRead(
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.sessionId));
 	if (mode) {
 		const filePath = modeStateFile(cwd, mode, selectors.sessionId);
-		const existing = await readJsonFile(filePath);
+		const existing = await readWorkflowStateJson(cwd, mode, selectors.sessionId);
+		const envelope = { skill: mode, state: existing, storage_path: filePath };
 		return {
 			status: 0,
-			stdout: `${JSON.stringify({ skill: mode, state: existing, storage_path: filePath }, null, 2)}\n`,
+			stdout: hasFlag(args, "--json")
+				? `${JSON.stringify(envelope, null, 2)}\n`
+				: renderStateMarkdown(mode, envelope, getSkillManifest(mode)),
 		};
 	}
 	const filePath = activeStateFile(cwd, selectors.sessionId);
@@ -857,6 +907,7 @@ async function handleMigrate(
 export async function runNativeStateCommand(args: string[], cwd = process.cwd()): Promise<StateCommandResult> {
 	try {
 		const parsed = parsePositionalArgs(args);
+		assertKnownFlags(args, parsed);
 		switch (parsed.action) {
 			case "read":
 				if (hasFlag(args, "--migrate")) return await handleMigrate(args, cwd, parsed.positionalSkill);

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -577,6 +577,38 @@ async function writePhase(dir: string, phase: GjcTeamPhase): Promise<void> {
 	await writeJsonFile(path.join(dir, "phase.json"), { current_phase: phase, updated_at: now() });
 }
 
+function teamModeStatePath(): string {
+	return path.join(".gjc", "state", "team-state.json");
+}
+
+export async function persistGjcTeamModeStateSummary(snapshot: GjcTeamSnapshot, cwd = process.cwd()): Promise<void> {
+	const active = snapshot.phase !== "complete" && snapshot.phase !== "cancelled";
+	const updatedAt = now();
+	await writeJsonAtomic(
+		teamModeStatePath(),
+		{
+			skill: "team",
+			version: 1,
+			active,
+			current_phase: snapshot.phase,
+			team_name: snapshot.team_name,
+			task_counts: snapshot.task_counts,
+			updated_at: updatedAt,
+		},
+		{
+			cwd,
+			receipt: {
+				cwd,
+				skill: "team",
+				owner: "gjc-runtime",
+				command: "gjc team sync-team-summary",
+				nowIso: updatedAt,
+			},
+			audit: { category: "state", verb: "sync-team-summary", owner: "gjc-runtime", skill: "team" },
+		},
+	);
+}
+
 function normalizeTask(raw: GjcTeamTask): GjcTeamTask {
 	const status = raw.status === ("complete" as GjcTeamTaskStatus) ? "completed" : raw.status;
 	return {

--- a/packages/coding-agent/src/hooks/skill-keywords.ts
+++ b/packages/coding-agent/src/hooks/skill-keywords.ts
@@ -1,3 +1,5 @@
+import { CANONICAL_GJC_WORKFLOW_SKILLS, type CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+
 export interface SkillKeywordDefinition {
 	keyword: string;
 	skill: GjcWorkflowSkill;
@@ -5,9 +7,9 @@ export interface SkillKeywordDefinition {
 	guidance: string;
 }
 
-export const GJC_WORKFLOW_SKILLS = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
+export const GJC_WORKFLOW_SKILLS = CANONICAL_GJC_WORKFLOW_SKILLS;
 
-export type GjcWorkflowSkill = (typeof GJC_WORKFLOW_SKILLS)[number];
+export type GjcWorkflowSkill = CanonicalGjcWorkflowSkill;
 
 export const GJC_SKILL_KEYWORD_DEFINITIONS: readonly SkillKeywordDefinition[] = [
 	{

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -3,7 +3,11 @@ import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { writeJsonAtomic } from "../gjc-runtime/state-writer";
 import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
 import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
-import type { SkillActiveEntry as CanonicalSkillActiveEntry, WorkflowHudSummary } from "../skill-state/active-state";
+import {
+	readVisibleSkillActiveState as readCanonicalVisibleSkillActiveState,
+	type SkillActiveEntry,
+	type SkillActiveState,
+} from "../skill-state/active-state";
 import {
 	compareSkillKeywordMatches,
 	GJC_SKILL_KEYWORD_DEFINITIONS,
@@ -74,35 +78,7 @@ export interface SkillKeywordMatch {
 	priority: number;
 }
 
-export interface SkillActiveEntry extends Omit<CanonicalSkillActiveEntry, "skill"> {
-	skill: GjcWorkflowSkill;
-	phase?: string;
-	active?: boolean;
-	activated_at?: string;
-	updated_at?: string;
-	session_id?: string;
-	thread_id?: string;
-	turn_id?: string;
-	hud?: WorkflowHudSummary;
-	stale?: boolean;
-}
-
-export interface SkillActiveState {
-	version: number;
-	active: boolean;
-	skill: GjcWorkflowSkill;
-	keyword: string;
-	phase: string;
-	activated_at: string;
-	updated_at: string;
-	source: "gjc-skill-state-hook";
-	session_id?: string;
-	thread_id?: string;
-	turn_id?: string;
-	initialized_mode?: GjcWorkflowSkill;
-	initialized_state_path?: string;
-	active_skills: SkillActiveEntry[];
-}
+export type { SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
 
 export interface ModeState {
 	active?: boolean;
@@ -274,7 +250,11 @@ function entryMatchesContext(
 
 function listActiveSkills(state: SkillActiveState | null): SkillActiveEntry[] {
 	if (!state?.active) return [];
-	return state.active_skills.filter(entry => entry.active !== false);
+	return (state.active_skills ?? []).filter(entry => entry.active !== false);
+}
+
+function isWorkflowActiveEntry(entry: SkillActiveEntry): entry is SkillActiveEntry & { skill: GjcWorkflowSkill } {
+	return isGjcWorkflowSkill(entry.skill);
 }
 
 export async function readVisibleSkillActiveState(
@@ -282,6 +262,7 @@ export async function readVisibleSkillActiveState(
 	sessionId?: string,
 	stateDir?: string,
 ): Promise<SkillActiveState | null> {
+	if (!stateDir) return await readCanonicalVisibleSkillActiveState(cwd, sessionId);
 	const resolvedStateDir = resolveGjcStateDir(cwd, stateDir);
 	if (sessionId) {
 		const sessionState = await readJsonFile<SkillActiveState>(skillStatePath(resolvedStateDir, sessionId));
@@ -434,9 +415,9 @@ export async function buildActiveUltragoalPromptContext(input: UserPromptSubmitS
 export async function buildSkillStopOutput(input: StopHookInput): Promise<Record<string, unknown> | null> {
 	const resolvedStateDir = resolveGjcStateDir(input.cwd, input.stateDir);
 	const skillState = await readVisibleSkillActiveState(input.cwd, input.sessionId, input.stateDir);
-	const activeEntries = listActiveSkills(skillState).filter(entry =>
-		skillState ? entryMatchesContext(entry, skillState, input.sessionId, input.threadId) : false,
-	);
+	const activeEntries = listActiveSkills(skillState)
+		.filter(isWorkflowActiveEntry)
+		.filter(entry => (skillState ? entryMatchesContext(entry, skillState, input.sessionId, input.threadId) : false));
 	if (!skillState || activeEntries.length === 0) return null;
 
 	for (const entry of activeEntries) {

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -61,6 +61,8 @@ export interface SkillActiveState {
 	session_id?: string;
 	thread_id?: string;
 	turn_id?: string;
+	initialized_mode?: CanonicalGjcWorkflowSkill;
+	initialized_state_path?: string;
 	active_skills?: SkillActiveEntry[];
 	[key: string]: unknown;
 }

--- a/packages/coding-agent/test/gjc-runtime/gjc-acl-gate.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/gjc-acl-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentTool } from "@gajae-code/agent-core";
+import { getDeepInterviewMutationDecision } from "../../src/skill-state/deep-interview-mutation-guard";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-acl-gate-"));
+	const priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+	try {
+		await fn(dir);
+	} finally {
+		if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+function tool(name: string, extra: Record<string, unknown> = {}): AgentTool {
+	return {
+		name,
+		label: name,
+		description: name,
+		parameters: {} as never,
+		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		...extra,
+	} as AgentTool;
+}
+
+describe("G2 gjc ACL gate", () => {
+	it("blocks mutation tools targeting .gjc paths", async () => {
+		await withTempCwd(async cwd => {
+			const blockedCases: Array<[AgentTool, unknown]> = [
+				[tool("write"), { path: ".gjc/state/foo.json", content: "{}" }],
+				[tool("edit"), { path: ".gjc/specs/spec.md", edits: [{ old_text: "a", new_text: "b" }] }],
+				[tool("ast_edit"), { paths: [".gjc/state/foo.json"], ops: [{ pat: "foo", out: "bar" }] }],
+				[tool("bash"), { command: "echo x > .gjc/state/foo.json" }],
+				[tool("bash"), { command: "rm -rf .gjc/specs" }],
+			];
+
+			for (const [targetTool, args] of blockedCases) {
+				const decision = await getDeepInterviewMutationDecision({ cwd, tool: targetTool, args });
+				expect(decision.blocked).toBe(true);
+				expect(decision.message).toContain("runtime-owned");
+				if (decision.reason !== "unknown-target") {
+					expect(["gjc-target", "workflow-state-target"]).toContain(decision.reason as string);
+				}
+			}
+		});
+	});
+
+	it("allows sanctioned gjc bash commands and non-.gjc writes", async () => {
+		await withTempCwd(async cwd => {
+			const gjcCommand = await getDeepInterviewMutationDecision({
+				cwd,
+				tool: tool("bash"),
+				args: { command: "gjc state ralplan write --input '{}'" },
+			});
+			expect(gjcCommand.blocked).toBe(false);
+
+			const productWrite = await getDeepInterviewMutationDecision({
+				cwd,
+				tool: tool("write"),
+				args: { path: "src/product.ts", content: "x" },
+			});
+			expect(productWrite.blocked).toBe(false);
+		});
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-migration-gate.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-migration-gate.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { normalizeLegacyState } from "../../src/gjc-runtime/state-migrations";
+import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-migration-"));
+	const priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+	try {
+		await fn(dir);
+	} finally {
+		if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, JSON.stringify(value, null, 2));
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+}
+
+async function readAuditEntries(cwd: string): Promise<Array<Record<string, unknown>>> {
+	const raw = await fs.readFile(path.join(cwd, ".gjc/state/audit.jsonl"), "utf-8");
+	return raw
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("G7 gjc state migration gate", () => {
+	it("normalizes legacy state purely and persists migration only through the state command", async () => {
+		await withTempCwd(async cwd => {
+			const statePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			const legacy = {
+				current_phase: "planning",
+				extension_field: { nested: true },
+				custom_list: ["keep", "me"],
+			};
+			await writeJson(statePath, legacy);
+
+			const normalized = normalizeLegacyState(legacy, "ralplan");
+			expect(normalized.changed).toBe(true);
+			expect(normalized.state.current_phase).toBe("planner");
+			expect(normalized.state.extension_field).toEqual({ nested: true });
+			expect(normalized.state.custom_list).toEqual(["keep", "me"]);
+			expect(await readJson(statePath)).toEqual(legacy);
+
+			const result = await runNativeStateCommand(["ralplan", "migrate", "--json"], cwd);
+			expect(result.status).toBe(0);
+
+			const persisted = await readJson(statePath);
+			expect(persisted.current_phase).toBe("planner");
+			expect(persisted.extension_field).toEqual({ nested: true });
+			expect(persisted.custom_list).toEqual(["keep", "me"]);
+			expect(persisted.receipt).toMatchObject({
+				version: 1,
+				skill: "ralplan",
+				owner: "gjc-state-cli",
+				status: "fresh",
+			});
+
+			const auditEntry = (await readAuditEntries(cwd)).at(-1);
+			expect(auditEntry).toMatchObject({
+				skill: "ralplan",
+				category: "state",
+				verb: "migrate",
+				owner: "gjc-state-cli",
+			});
+		});
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-read-markdown.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-read-markdown.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { readWorkflowStateJson, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+let priorSessionId: string | undefined;
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-state-read-markdown-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+});
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("gjc state read markdown", () => {
+	it("defaults read output to markdown and keeps --json parseable", async () => {
+		const root = await tempDir();
+		await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"deep-interview",
+				"--input",
+				JSON.stringify({ active: true, current_phase: "interviewing", artifact_path: ".gjc/specs/draft.md" }),
+			],
+			root,
+		);
+
+		const markdown = await runNativeStateCommand(["read", "--mode", "deep-interview"], root);
+		expect(markdown.status).toBe(0);
+		expect(markdown.stdout).toStartWith("# deep-interview state\n");
+		expect(markdown.stdout).toContain("- Current phase: interviewing");
+		expect(markdown.stdout).toContain("- Valid next transitions:");
+		expect(markdown.stdout).toContain("- Receipt: fresh");
+		expect(markdown.stdout).toContain(".gjc/specs/draft.md");
+		expect(() => JSON.parse(markdown.stdout ?? "")).toThrow();
+
+		const json = await runNativeStateCommand(["read", "--mode", "deep-interview", "--json"], root);
+		expect(json.status).toBe(0);
+		const parsed = JSON.parse(json.stdout ?? "{}");
+		expect(parsed.skill).toBe("deep-interview");
+		expect(parsed.state.current_phase).toBe("interviewing");
+	});
+
+	it("exposes readWorkflowStateJson for programmatic callers", async () => {
+		const root = await tempDir();
+		await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ active: true, current_phase: "approval" })],
+			root,
+		);
+
+		const state = await readWorkflowStateJson(root, "ralplan");
+		expect(state.skill).toBe("ralplan");
+		expect(state.current_phase).toBe("approval");
+	});
+
+	it("rejects unknown gjc state flags", async () => {
+		const root = await tempDir();
+		const result = await runNativeStateCommand(["read", "--mode", "deep-interview", "--bogus"], root);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("unknown gjc state flag: --bogus");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-receipts.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-receipts.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-receipts-"));
+	const priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+	try {
+		await fn(dir);
+	} finally {
+		if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+}
+
+async function readAuditEntries(cwd: string): Promise<Array<Record<string, unknown>>> {
+	const raw = await fs.readFile(path.join(cwd, ".gjc/state/audit.jsonl"), "utf-8");
+	return raw
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+function expectValidReceipt(state: Record<string, unknown>, skill: string): void {
+	const receipt = state.receipt as Record<string, unknown> | undefined;
+	expect(receipt).toMatchObject({
+		version: 1,
+		skill,
+		status: "fresh",
+	});
+	expect(["gjc-state-cli", "gjc-runtime", "gjc-hook"]).toContain(receipt?.owner as string);
+	expect(typeof receipt?.mutated_at).toBe("string");
+	expect(Number.isNaN(Date.parse(receipt?.mutated_at as string))).toBe(false);
+}
+
+function expectAuditEntry(entry: Record<string, unknown> | undefined, verb: "write" | "clear" | "handoff"): void {
+	expect(entry).toMatchObject({
+		category: "state",
+		verb,
+		owner: "gjc-state-cli",
+	});
+	expect(typeof entry?.ts).toBe("string");
+	expect(Array.isArray(entry?.paths)).toBe(true);
+}
+
+function findAuditEntry(
+	entries: Array<Record<string, unknown>>,
+	verb: "write" | "clear" | "handoff",
+): Record<string, unknown> | undefined {
+	return entries.find(entry => entry.category === "state" && entry.verb === verb && entry.owner === "gjc-state-cli");
+}
+
+describe("G5 gjc state receipts", () => {
+	it("persists receipts and audit entries for write, clear, and handoff", async () => {
+		await withTempCwd(async cwd => {
+			const write = await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "planner" })],
+				cwd,
+			);
+			expect(write.status).toBe(0);
+			const statePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			expectValidReceipt(await readJson(statePath), "ralplan");
+			expectAuditEntry(findAuditEntry(await readAuditEntries(cwd), "write"), "write");
+
+			const clear = await runNativeStateCommand(["clear", "--mode", "ralplan"], cwd);
+			expect(clear.status).toBe(0);
+			expectValidReceipt(await readJson(statePath), "ralplan");
+			expectAuditEntry(findAuditEntry(await readAuditEntries(cwd), "clear"), "clear");
+
+			await runNativeStateCommand(
+				["write", "--mode", "deep-interview", "--input", JSON.stringify({ current_phase: "interviewing" })],
+				cwd,
+			);
+			const handoff = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(handoff.status).toBe(0);
+			expectValidReceipt(await readJson(path.join(cwd, ".gjc/state/deep-interview-state.json")), "deep-interview");
+			expectValidReceipt(await readJson(statePath), "ralplan");
+
+			const entries = await readAuditEntries(cwd);
+			const handoffEntries = entries.filter(
+				entry => entry.category === "state" && entry.verb === "handoff" && entry.owner === "gjc-state-cli",
+			);
+			expect(handoffEntries).toHaveLength(2);
+			for (const entry of handoffEntries) expectAuditEntry(entry, "handoff");
+		});
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -44,7 +44,7 @@ function envelopeState(stdout: string | undefined): Record<string, unknown> {
 describe("native gjc state runtime", () => {
 	it("reads an empty receipt as {}", async () => {
 		const root = await tempDir();
-		const result = await runNativeStateCommand(["read"], root);
+		const result = await runNativeStateCommand(["read", "--json"], root);
 		expect(result.status).toBe(0);
 		expect(envelopeState(result.stdout)).toEqual({});
 	});
@@ -75,7 +75,7 @@ describe("native gjc state runtime", () => {
 		await runNativeStateCommand(["write", "--input", JSON.stringify({ active: true }), "--mode", "ralplan"], root);
 
 		const result = await runNativeStateCommand(
-			["read", "--input", JSON.stringify({ mode: "deep-interview" }), "--mode", "ralplan"],
+			["read", "--input", JSON.stringify({ mode: "deep-interview" }), "--mode", "ralplan", "--json"],
 			root,
 		);
 

--- a/packages/coding-agent/test/gjc-runtime/team-convergence.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-convergence.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+import { monitorGjcTeam, persistGjcTeamModeStateSummary, startGjcTeam } from "../../src/gjc-runtime/team-runtime";
+
+let cleanupRoot: string | undefined;
+
+afterEach(async () => {
+	if (!cleanupRoot) return;
+	await fs.rm(cleanupRoot, { recursive: true, force: true });
+	cleanupRoot = undefined;
+});
+
+describe("native gjc team mode-state convergence", () => {
+	it("keeps gjc state team read aligned with dry-run team start and status snapshots", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-convergence-"));
+		const started = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Converge team state",
+			teamName: "converge-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+		await persistGjcTeamModeStateSummary(started, cleanupRoot);
+
+		const startRead = await runNativeStateCommand(
+			["read", "--mode", "team", "--session-id", "", "--json"],
+			cleanupRoot,
+		);
+		expect(startRead.status).toBe(0);
+		const startState = JSON.parse(startRead.stdout ?? "{}");
+		expect(startState.state.current_phase).toBe(started.phase);
+		expect(startState.state.team_name).toBe(started.team_name);
+		expect(startState.state.task_counts).toEqual(started.task_counts);
+
+		const status = await monitorGjcTeam(started.team_name, cleanupRoot, { PATH: "" });
+		await persistGjcTeamModeStateSummary(status, cleanupRoot);
+
+		const statusRead = await runNativeStateCommand(
+			["read", "--mode", "team", "--session-id", "", "--json"],
+			cleanupRoot,
+		);
+		expect(statusRead.status).toBe(0);
+		const statusState = JSON.parse(statusRead.stdout ?? "{}");
+		expect(statusState.state.current_phase).toBe(status.phase);
+		expect(statusState.state.team_name).toBe(status.team_name);
+		expect(statusState.state.task_counts).toEqual(status.task_counts);
+		expect(statusState.state.active).toBe(true);
+		expect(statusState.state.receipt.owner).toBe("gjc-runtime");
+	});
+});


### PR DESCRIPTION
## Summary
Follow-up to #198 (CLI-mediated `.gjc` state / manifest SSOT, already merged to `dev`). Closes the documented deferrals from that PR.

## Changes
- **Markdown-default `gjc state read`** (`state-renderer.ts`): token-efficient markdown by default; `--json` preserves the exact envelope; `readWorkflowStateJson()` for internal callers.
- **G8 typed-arg enforcement**: `gjc state` rejects unknown/non-manifest flags (exit 2).
- **Dedupe hook types (#5)**: `hooks/skill-state.ts` + `skill-keywords.ts` import canonical `SkillActiveState`/`SkillActiveEntry`/`CANONICAL_GJC_WORKFLOW_SKILLS`/`readVisibleSkillActiveState` from `skill-state/active-state` instead of redefining.
- **Team dual-model convergence (#4)**: `gjc team` start/status/resume/shutdown/api persist a thin derived summary into canonical `team-state.json` via the sanctioned writer, so `gjc state team read` + the receipt agree with the runtime snapshot (per-team files stay authoritative).
- **Dedicated gate tests**: G2 (.gjc/** ACL across write/edit/ast_edit/bash + allow `gjc ` bash), G5 (receipts + audit.jsonl on write/clear/handoff), G6 (markdown/graph renderers), G7 (pure normalize no-write + explicit migrate w/ audit + extension preservation).

## Verification
- `tsc` clean; **203 gjc tests pass**; **G1/G3/G4 gates pass** against current `dev`.
