### PR TITLE
fix(session): resolve auto-retry busy wedge causing AgentBusyError loop

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1893,6 +1893,15 @@ export class AgentSession {
 						attempt: this.#retryAttempt,
 					});
 					this.#retryAttempt = 0;
+					// Settle the retry gate here, colocated with the success event, rather
+					// than relying on the generic #resolveRetry() at the end of the
+					// agent_end branch. That tail resolver is bypassed by every early
+					// return in agent_end (successful `yield`, handoff-abort skip-maintenance,
+					// missing assistant message), so a retry that recovers on a yield turn
+					// would otherwise leave #retryPromise unresolved — wedging
+					// #waitForPostPromptRecovery and the session as permanently busy.
+					// #resolveRetry() is idempotent, so the later tail call is a no-op.
+					this.#resolveRetry();
 				}
 			}
 
@@ -7565,7 +7574,19 @@ export class AgentSession {
 		}
 
 		// Retry via continue() outside the agent_end event callback chain.
-		this.#scheduleAgentContinue({ delayMs: 1, generation });
+		// If the scheduled continue cannot run — it throws (e.g. AgentBusyError from a
+		// concurrent turn, or "Cannot continue ...") or is skipped because a newer
+		// generation took over — the agent_end that normally resolves #retryPromise
+		// never arrives. Finalize the retry in that case so #waitForPostPromptRecovery
+		// (and the in-flight prompt holding it open) cannot wedge the session as
+		// permanently busy, which would turn every later prompt() into a
+		// non-recoverable AgentBusyError loop.
+		this.#scheduleAgentContinue({
+			delayMs: 1,
+			generation,
+			onError: () => this.#failRetryRecovery("Retry continuation failed to start"),
+			onSkip: () => this.#failRetryRecovery("Retry continuation was superseded"),
+		});
 
 		return true;
 	}
@@ -7576,6 +7597,27 @@ export class AgentSession {
 	abortRetry(): void {
 		this.#retryAbortController?.abort();
 		// Note: _retryAttempt is reset in the catch block of _autoRetry
+		this.#resolveRetry();
+	}
+
+	/**
+	 * Finalize a pending auto-retry that can no longer reach a resolving agent_end
+	 * (the scheduled continue threw or was superseded). Without this, #retryPromise
+	 * stays unresolved, #waitForPostPromptRecovery never returns, the owning
+	 * prompt's in-flight count is never released, and the session reports
+	 * `isStreaming === true` forever — turning every later prompt() into a
+	 * non-recoverable AgentBusyError. No-op once the retry has already settled.
+	 */
+	#failRetryRecovery(reason: string): void {
+		if (!this.#retryPromise) return;
+		const attempt = this.#retryAttempt;
+		this.#retryAttempt = 0;
+		void this.#emitSessionEvent({
+			type: "auto_retry_end",
+			success: false,
+			attempt,
+			finalError: reason,
+		});
 		this.#resolveRetry();
 	}
 

--- a/packages/coding-agent/test/agent-session-retry-busy-recovery.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-busy-recovery.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
+import { Agent, AgentBusyError } from "@gajae-code/agent-core";
+import { type AssistantMessage, getBundledModel, type ToolCall } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+	// Uses a real timer (not the mocked scheduler.wait) so it survives the
+	// scheduler.wait spy that skips retry backoff.
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`TIMEOUT (session wedged busy): ${label}`)), ms);
+	});
+	return Promise.race([p, timeout]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
+/**
+ * Regression: a retryable provider error schedules an auto-retry `continue()`
+ * outside the agent_end callback chain. If that scheduled continue cannot start
+ * — it throws (e.g. AgentBusyError from a concurrent turn, or "Cannot continue
+ * ...") — the agent_end that normally resolves the internal retry promise never
+ * arrives. Before the fix, #waitForPostPromptRecovery awaited that promise
+ * forever, the owning prompt's in-flight counter was never released, and the
+ * session reported `isStreaming === true` permanently. Every subsequent
+ * `prompt()` then threw `AgentBusyError`, producing the reported infinite loop.
+ */
+describe("AgentSession auto-retry busy recovery", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-retry-busy-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	it("does not wedge the session busy when the scheduled retry continue throws", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 service unavailable: overloaded_error retry-after-ms=5" },
+				{ content: ["recovered on the next prompt"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		// Inject the failure: the first scheduled retry continue cannot start
+		// (mirrors the AgentBusyError race / "Cannot continue ..." edge cases).
+		const origContinue = agent.continue.bind(agent);
+		let continueFailed = false;
+		(agent as unknown as { continue: () => Promise<void> }).continue = async () => {
+			if (!continueFailed) {
+				continueFailed = true;
+				throw new AgentBusyError();
+			}
+			return origContinue();
+		};
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 5_000,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		// The owning prompt must settle instead of hanging on the dead retry promise.
+		await withTimeout(session.prompt("first message"), 5_000, "prompt(first)");
+		await withTimeout(session.waitForIdle(), 5_000, "waitForIdle");
+
+		expect(continueFailed).toBe(true);
+		expect(session.isStreaming).toBe(false);
+		expect(session.isRetrying).toBe(false);
+		// The aborted retry is reported as a failure so the UI can clean up.
+		expect(retryEndEvents.at(-1)).toMatchObject({ success: false });
+
+		// The actual user-visible symptom: subsequent prompts must work, not throw
+		// AgentBusyError forever.
+		await withTimeout(session.prompt("second message"), 5_000, "prompt(second)");
+		expect(session.isStreaming).toBe(false);
+	});
+
+	it("recovers a later retryable error normally after a prior retry was abandoned", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		// turn 1 (first prompt): retryable error -> scheduled retry continue throws -> abandoned.
+		// turn 2 (second prompt): retryable error -> scheduled retry continue runs -> recovers.
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 service unavailable: overloaded_error retry-after-ms=5" },
+				{ throw: "overloaded_error: provider returned error retry-after-ms=5" },
+				{ content: ["recovered via auto-retry on the second turn"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		// Only the FIRST scheduled continue fails; later auto-retry continues run normally.
+		const origContinue = agent.continue.bind(agent);
+		let failures = 0;
+		(agent as unknown as { continue: () => Promise<void> }).continue = async () => {
+			if (failures === 0) {
+				failures += 1;
+				throw new AgentBusyError();
+			}
+			return origContinue();
+		};
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 5_000,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await withTimeout(session.prompt("first message"), 5_000, "prompt(first)");
+		await withTimeout(session.waitForIdle(), 5_000, "waitForIdle(first)");
+		expect(session.isStreaming).toBe(false);
+		expect(session.isRetrying).toBe(false);
+
+		// A fresh prompt whose first turn errors retryably must auto-retry and recover,
+		// proving the abandoned retry did not poison the retry machinery.
+		await withTimeout(session.prompt("second message"), 5_000, "prompt(second)");
+		await withTimeout(session.waitForIdle(), 5_000, "waitForIdle(second)");
+		expect(session.isStreaming).toBe(false);
+		expect(session.isRetrying).toBe(false);
+		const last = session.agent.state.messages.at(-1) as AssistantMessage | undefined;
+		expect(last?.role).toBe("assistant");
+		expect(last?.stopReason).toBe("stop");
+	});
+
+	it("survives a consumer that re-prompts repeatedly after a failed retry continuation", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 service unavailable: overloaded_error retry-after-ms=5" },
+				{ content: ["ok-2"] },
+				{ content: ["ok-3"] },
+				{ content: ["ok-4"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+		const origContinue = agent.continue.bind(agent);
+		let continueFailed = false;
+		(agent as unknown as { continue: () => Promise<void> }).continue = async () => {
+			if (!continueFailed) {
+				continueFailed = true;
+				throw new AgentBusyError();
+			}
+			return origContinue();
+		};
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 5_000,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		const busyErrors: string[] = [];
+		const tryPrompt = async (text: string) => {
+			await withTimeout(session!.prompt(text), 5_000, `prompt(${text})`).catch((err: Error) => {
+				if (err instanceof AgentBusyError) busyErrors.push(err.message);
+			});
+			await withTimeout(session!.waitForIdle(), 5_000, `waitForIdle(${text})`);
+		};
+
+		await tryPrompt("first message");
+		// Simulate the reported looping consumer: fire several sequential prompts.
+		for (let i = 0; i < 3; i++) {
+			await tryPrompt(`follow-up ${i}`);
+		}
+
+		expect(continueFailed).toBe(true);
+		expect(busyErrors).toEqual([]);
+		expect(session.isStreaming).toBe(false);
+	});
+
+	it("does not wedge when an auto-retry recovers on a turn ending with a successful yield", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		// First turn errors retryably -> auto-retry schedules a continuation.
+		const mock = createMockModel({
+			responses: [{ throw: "503 service unavailable: overloaded_error retry-after-ms=5" }],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		// The scheduled retry continuation recovers on a turn that ends by calling the
+		// `yield` tool successfully. We drive that turn via emitExternalEvent (the same
+		// technique the handoff suite uses) because the agent loop has no real yield tool
+		// here. The agent_end handler early-returns at #assistantEndedWithSuccessfulYield,
+		// so the retry must be settled at message_end, not at the agent_end tail.
+		const yieldCall: ToolCall = { type: "toolCall", id: "call_yield_done", name: "yield", arguments: {} };
+		const yieldAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [yieldCall],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			stopReason: "toolUse",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		const origContinue = agent.continue.bind(agent);
+		let recovered = false;
+		(agent as unknown as { continue: () => Promise<void> }).continue = async () => {
+			if (!recovered) {
+				recovered = true;
+				agent.emitExternalEvent({ type: "message_end", message: yieldAssistant });
+				agent.emitExternalEvent({
+					type: "tool_execution_end",
+					toolCallId: yieldCall.id,
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { done: true } },
+					},
+					isError: false,
+				});
+				agent.emitExternalEvent({ type: "agent_end", messages: [yieldAssistant] });
+				return;
+			}
+			return origContinue();
+		};
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 5_000,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await withTimeout(session.prompt("first message"), 5_000, "prompt(first)");
+		await withTimeout(session.waitForIdle(), 5_000, "waitForIdle");
+
+		expect(recovered).toBe(true);
+		expect(session.isStreaming).toBe(false);
+		expect(session.isRetrying).toBe(false);
+		// Retry success is surfaced exactly once (resolved at message_end, idempotent at agent_end).
+		expect(retryEndEvents.filter(event => event.success === true)).toHaveLength(1);
+
+		await withTimeout(session.prompt("second message"), 5_000, "prompt(second)");
+		expect(session.isStreaming).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

A retryable provider error (e.g. `overloaded_error`, `503`, rate limits) could permanently wedge an `AgentSession` as busy, turning **every** subsequent `prompt()` into a non-recoverable loop of:

```
Error: Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion.
```

This is the reported infinite-loop-on-provider-error / edge-case bug.

## Root cause

`session.isStreaming` is `agent.state.isStreaming || #promptInFlightCount > 0`. The in-flight prompt's `#promptWithMessage` only releases `#promptInFlightCount` after `#waitForPostPromptRecovery()` returns, and that loop awaits the internal auto-retry promise `#retryPromise`. Two paths could leave `#retryPromise` unresolved forever:

1. **Scheduled retry continuation cannot start.** `#handleRetryableError` sets `#retryPromise` and schedules `agent.continue()` via `#scheduleAgentContinue`, which **swallows thrown errors**. If the continuation throws (`AgentBusyError` from a concurrent turn, or `"Cannot continue from message role: assistant"`) or is superseded, the `agent_end` that normally resolves `#retryPromise` never arrives.

2. **Retry recovers on a turn ending with a successful `yield`.** Retry success is emitted in the assistant `message_end` branch, but `#retryPromise` settlement relied on the generic `#resolveRetry()` at the **tail** of the `agent_end` branch — which is bypassed by every `agent_end` early return (successful `yield`, handoff-abort skip-maintenance, missing assistant).

Either way: `#waitForPostPromptRecovery()` hangs -> `#endInFlight()` never runs -> `#promptInFlightCount` stuck `> 0` -> `session.isStreaming` permanently `true` -> AgentBusyError loop.

## Fix (`packages/coding-agent/src/session/agent-session.ts`)

1. The retry's `#scheduleAgentContinue` now passes `onError`/`onSkip` finalizers calling a new `#failRetryRecovery()`, which settles the abandoned retry (resets attempt, emits `auto_retry_end{success:false}`, resolves the promise). This mirrors the existing TTSR-resume protection.
2. `#resolveRetry()` is now called in the assistant `message_end` retry-success branch, colocated with the `auto_retry_end{success:true}` emission, so success is finalized **before** any `agent_end` early return. `#resolveRetry()` is idempotent, so the tail call becomes a no-op.

The original provider error remains the last assistant message, so the turn surfaces as a recoverable failure instead of wedging the session.

## Edge-case sweep

Audited every `#waitForPostPromptRecovery` dependency:
- `#retryPromise` — **was unprotected; fixed (both paths above).**
- `#ttsrResumePromise` — already protected; the fix mirrors this pattern.
- `#postPromptTasksPromise` — self-resolving via `#trackPostPromptTask`'s `.finally()`.
- `agent.waitForIdle()` / agent-core recovery — verified robust against sync throw, error event, and rejected stream.

## Tests

New `packages/coding-agent/test/agent-session-retry-busy-recovery.test.ts` (4 cases): scheduled continuation throws; later retryable error recovers after an abandoned retry; looping consumer survives; successful-`yield` recovery. All four **hang/fail on the unfixed code** and pass with the fix.

## Verification

- New suite 4/4; adjacent suites (retry-cap, retry-fallback, manual-retry, concurrent, handoff, abort-timeout) 53/53; agent-core 186/186.
- `tsgo` typecheck clean; biome clean on changed files.
- Independent architect review (two rounds): architecture/product/code all **CLEAR**, **APPROVE** (a HIGH-severity sibling bug — the successful-`yield` path — was found in round 1 and fixed before approval).
