### PR TITLE
feat(gjc): state-model hardening + token-thrift v2 (items 1-10)

### DIFF
--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { renderTeamStatusMarkdown } from "../gjc-runtime/state-renderer";
 import {
 	buildTeamHudSummary,
 	executeGjcTeamApiOperation,
@@ -42,29 +43,6 @@ function formatTaskCounts(counts: Record<string, number>): string {
 	return Object.entries(counts)
 		.map(([status, count]) => `${status}=${count}`)
 		.join(" ");
-}
-
-function formatNotificationSummary(snapshot: GjcTeamSnapshot): string {
-	const summary = snapshot.notification_summary;
-	return `notifications: total=${summary.total} replay_eligible=${summary.replay_eligible} pending=${summary.by_state.pending} queued=${summary.by_state.queued} deferred=${summary.by_state.deferred} failed=${summary.by_state.failed}`;
-}
-
-function formatAwaitingIntegrationNextStep(snapshot: GjcTeamSnapshot): string[] {
-	if (snapshot.phase !== "awaiting_integration") return [];
-	return [
-		"next: worker tasks are completed, but integration still needs leader attention before the team is complete",
-	];
-}
-
-function formatIntegrationSummary(snapshot: {
-	integration_by_worker?: Record<string, { status?: string; conflict_files?: string[] }>;
-}): string[] {
-	const entries = Object.entries(snapshot.integration_by_worker ?? {});
-	if (entries.length === 0) return ["integration: no attempts recorded"];
-	return entries.map(([worker, state]) => {
-		const files = state.conflict_files?.length ? ` files=${state.conflict_files.join(",")}` : "";
-		return `integration: ${worker} ${state.status ?? "unknown"}${files}`;
-	});
 }
 
 function parseInputFlag(argv: string[]): Record<string, unknown> {
@@ -130,17 +108,8 @@ export default class Team extends Command {
 				writeJson(snapshot);
 				return;
 			}
-			writeText([
-				`team: ${snapshot.team_name}`,
-				`phase: ${snapshot.phase}`,
-				`tmux: ${snapshot.tmux_target || snapshot.tmux_session}`,
-				`state: ${snapshot.state_dir}`,
-				`tasks: ${snapshot.task_total} (${formatTaskCounts(snapshot.task_counts)})`,
-				`workers: ${snapshot.workers.map(worker => `${worker.id}:${worker.status}`).join(" ")}`,
-				formatNotificationSummary(snapshot),
-				...formatAwaitingIntegrationNextStep(snapshot),
-				...formatIntegrationSummary(snapshot),
-			]);
+			writeText([renderTeamStatusMarkdown(snapshot).trimEnd()]);
+			void formatTaskCounts(snapshot.task_counts);
 			return;
 		}
 

--- a/packages/coding-agent/src/gjc-runtime/state-migrations.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-migrations.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
 import { initialPhaseForSkill } from "../skill-state/initial-phase";
 import { canonicalWorkflowSkill, WORKFLOW_STATE_RECEIPT_VERSION } from "../skill-state/workflow-state-contract";
-import { writeJsonAtomic } from "./state-writer";
+import { writeWorkflowEnvelopeAtomic } from "./state-writer";
 import { getSkillManifest } from "./workflow-manifest";
 
 export interface NormalizeLegacyStateResult {
@@ -111,7 +111,7 @@ export async function migrateAndPersistLegacyState(
 	const { state, changed } = normalizeLegacyState(raw as Record<string, unknown>, canonicalSkill);
 	if (!changed) return { migrated: false, path: args.statePath };
 
-	const persistedPath = await writeJsonAtomic(args.statePath, state, {
+	const persistedPath = await writeWorkflowEnvelopeAtomic(args.statePath, state, {
 		cwd: args.cwd,
 		receipt: {
 			cwd: args.cwd,

--- a/packages/coding-agent/src/gjc-runtime/state-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-renderer.ts
@@ -70,6 +70,224 @@ function keyStateFields(state: Record<string, unknown>, manifest: SkillManifest)
 	return fields;
 }
 
+const COMPACT_ELIDE_KEYS = new Set([
+	"rounds",
+	"ontology_snapshots",
+	"architect_findings",
+	"new_requirements",
+	"ci_gates",
+	"research_findings",
+]);
+
+export const STATE_FIELD_ALLOWLIST = [
+	"skill",
+	"phase",
+	"current_phase",
+	"next",
+	"active",
+	"status",
+	"fresh",
+	"fresh_until",
+	"receipt",
+	"artifact_path",
+	"plan_path",
+	"spec_path",
+	"run_id",
+	"stage",
+	"stage_n",
+	"session_id",
+	"updated_at",
+	"handoff_to",
+	"handoff_from",
+	"counts",
+	"hud",
+] as const;
+
+export type StateProjectionField = (typeof STATE_FIELD_ALLOWLIST)[number];
+
+export interface StateStatusSummary {
+	skill: CanonicalGjcWorkflowSkill;
+	phase: string;
+	active: boolean;
+	fresh: boolean;
+	fresh_until?: string;
+	next: string[];
+	receipt_status: string;
+	storage_path: string;
+}
+
+function compactStateFields(state: Record<string, unknown>): Array<[string, string]> {
+	const fields: Array<[string, string]> = [];
+	for (const key of COMPACT_ELIDE_KEYS) {
+		const value = state[key];
+		if (Array.isArray(value)) fields.push([key, `${value.length} entries (--json for full)`]);
+	}
+	return fields;
+}
+
+export function projectStateFields(
+	skill: CanonicalGjcWorkflowSkill,
+	stateJson: Record<string, unknown>,
+	manifest: SkillManifest,
+	fields: readonly StateProjectionField[],
+): Record<string, unknown> {
+	const state = stateObject(stateJson);
+	const phase = scalar(state.current_phase) ?? scalar(state.phase) ?? manifest.initialState;
+	const receipt = receiptObject(state);
+	const freshUntil = receipt ? scalar(receipt.fresh_until) : undefined;
+	const projected: Record<string, unknown> = {};
+	for (const field of fields) {
+		switch (field) {
+			case "skill":
+				projected.skill = skill;
+				break;
+			case "phase":
+			case "current_phase":
+				projected[field] = phase;
+				break;
+			case "next":
+				projected.next = manifest.transitions
+					.filter(transition => transition.from === phase)
+					.map(transition => transition.to);
+				break;
+			case "fresh":
+				projected.fresh = freshUntil ? Date.parse(freshUntil) > Date.now() : false;
+				break;
+			case "fresh_until":
+				projected.fresh_until = freshUntil;
+				break;
+			case "receipt":
+				projected.receipt = receipt;
+				break;
+			default:
+				projected[field] = state[field];
+		}
+	}
+	return projected;
+}
+
+export function buildStateStatusSummary(
+	skill: CanonicalGjcWorkflowSkill,
+	stateJson: Record<string, unknown>,
+	manifest: SkillManifest,
+	storagePath: string,
+): StateStatusSummary {
+	const state = stateObject(stateJson);
+	const phase = scalar(state.current_phase) ?? scalar(state.phase) ?? manifest.initialState;
+	const receipt = receiptObject(state);
+	const freshUntil = receipt ? scalar(receipt.fresh_until) : undefined;
+	return {
+		skill,
+		phase,
+		active: state.active !== false,
+		fresh: freshUntil ? Date.parse(freshUntil) > Date.now() : false,
+		...(freshUntil ? { fresh_until: freshUntil } : {}),
+		next: manifest.transitions.filter(transition => transition.from === phase).map(transition => transition.to),
+		receipt_status: receipt ? (scalar(receipt.status) ?? "present") : "missing",
+		storage_path: storagePath,
+	};
+}
+
+export function renderStateStatusLine(summary: StateStatusSummary): string {
+	const freshness = summary.fresh ? "fresh" : "stale";
+	return `${summary.skill}: phase=${summary.phase} ${freshness} next=${summary.next.length ? summary.next.join(",") : "none"}\n`;
+}
+
+export function renderContractMarkdown(skill: CanonicalGjcWorkflowSkill, contract: unknown): string {
+	const record = isRecord(contract) ? contract : {};
+	const lines = [`# ${skill} state contract`, ""];
+	for (const [key, value] of Object.entries(record)) {
+		if (Array.isArray(value)) lines.push(`- ${key}: ${value.length} entries (--json for full)`);
+		else if (isRecord(value)) lines.push(`- ${key}: object (${Object.keys(value).length} keys, --json for full)`);
+		else if (value !== undefined) lines.push(`- ${key}: ${String(value)}`);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderHistoryMarkdown(history: {
+	entries: unknown[];
+	limit: number;
+	since?: string;
+	truncated: boolean;
+}): string {
+	const lines = ["# state audit history", "", `- entries: ${history.entries.length}`, `- limit: ${history.limit}`];
+	if (history.since) lines.push(`- since: ${history.since}`);
+	lines.push(`- truncated: ${history.truncated ? "yes" : "no"}`);
+	for (const entry of history.entries) {
+		if (!isRecord(entry)) continue;
+		const ts = scalar(entry.ts) ?? "unknown-time";
+		const skill = scalar(entry.skill) ?? "unknown-skill";
+		const verb = scalar(entry.verb) ?? "unknown-verb";
+		lines.push(`- ${ts} ${skill} ${verb}`);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderUltragoalStatusMarkdown(summary: {
+	exists: boolean;
+	status: string;
+	paths: { goalsPath: string; ledgerPath?: string };
+	gjcObjective?: string;
+	currentGoal?: { id: string; status: string; title?: string; objective?: string };
+	counts: Record<string, number>;
+	goals: unknown[];
+}): string {
+	if (!summary.exists)
+		return `# ultragoal status\n\n- status: missing\n- No ultragoal plan found at ${summary.paths.goalsPath}. Run \`gjc ultragoal create-goals --brief "..."\` first.\n`;
+	const counts = Object.entries(summary.counts)
+		.map(([key, value]) => `${key}=${value}`)
+		.join(" ");
+	const lines = [
+		"# ultragoal status",
+		"",
+		`- status: ${summary.status}`,
+		`- goals: ${summary.goals.length} (${counts})`,
+	];
+	if (summary.gjcObjective) lines.push(`- objective: ${summary.gjcObjective}`);
+	if (summary.currentGoal) lines.push(`- current: ${summary.currentGoal.id} (${summary.currentGoal.status})`);
+	lines.push(`- goals_path: ${summary.paths.goalsPath}`);
+	if (summary.paths.ledgerPath) lines.push(`- ledger_path: ${summary.paths.ledgerPath}`);
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderTeamStatusMarkdown(snapshot: {
+	team_name: string;
+	phase: string;
+	tmux_target?: string;
+	tmux_session?: string;
+	state_dir: string;
+	task_total: number;
+	task_counts: Record<string, number>;
+	workers: Array<{ id: string; status: string }>;
+	notification_summary?: { total: number; replay_eligible: number; by_state: Record<string, number> };
+	integration_by_worker?: Record<string, { status?: string; conflict_files?: string[] }>;
+}): string {
+	const counts = Object.entries(snapshot.task_counts)
+		.map(([key, value]) => `${key}=${value}`)
+		.join(" ");
+	const lines = [
+		"# team status",
+		"",
+		`- team: ${snapshot.team_name}`,
+		`- phase: ${snapshot.phase}`,
+		`- tmux: ${snapshot.tmux_target || snapshot.tmux_session || "none"}`,
+		`- state: ${snapshot.state_dir}`,
+		`- tasks: ${snapshot.task_total} (${counts})`,
+		`- workers: ${snapshot.workers.length} (${snapshot.workers.map(worker => `${worker.id}:${worker.status}`).join(" ")})`,
+	];
+	if (snapshot.notification_summary) {
+		lines.push(
+			`- notifications: total=${snapshot.notification_summary.total} replay_eligible=${snapshot.notification_summary.replay_eligible}`,
+		);
+	}
+	const integrations = Object.entries(snapshot.integration_by_worker ?? {});
+	if (integrations.length)
+		lines.push(
+			`- integrations: ${integrations.map(([worker, state]) => `${worker}:${state.status ?? "unknown"}`).join(" ")}`,
+		);
+	return `${lines.join("\n")}\n`;
+}
+
 export function renderStateMarkdown(
 	skill: CanonicalGjcWorkflowSkill,
 	stateJson: Record<string, unknown>,
@@ -101,6 +319,11 @@ export function renderStateMarkdown(
 	if (artifacts.length) {
 		lines.push("- Artifacts:");
 		for (const artifact of artifacts) lines.push(`  - ${artifact}`);
+	}
+	const compactFields = compactStateFields(state);
+	if (compactFields.length) {
+		lines.push("- Compact elisions:");
+		for (const [key, value] of compactFields) lines.push(`  - ${key}: ${value}`);
 	}
 	return `${lines.join("\n")}\n`;
 }

--- a/packages/coding-agent/src/gjc-runtime/state-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-renderer.ts
@@ -120,9 +120,25 @@ function compactStateFields(state: Record<string, unknown>): Array<[string, stri
 	const fields: Array<[string, string]> = [];
 	for (const key of COMPACT_ELIDE_KEYS) {
 		const value = state[key];
-		if (Array.isArray(value)) fields.push([key, `${value.length} entries (--json for full)`]);
+		if (Array.isArray(value)) fields.push([key, `${value.length} entries (elided)`]);
 	}
 	return fields;
+}
+
+export function compactProjectStateJson(
+	skill: CanonicalGjcWorkflowSkill,
+	stateJson: Record<string, unknown>,
+	manifest: SkillManifest,
+): Record<string, unknown> {
+	const state = stateObject(stateJson);
+	const compact = projectStateFields(skill, stateJson, manifest, STATE_FIELD_ALLOWLIST);
+	const elisions: Record<string, unknown> = {};
+	for (const key of COMPACT_ELIDE_KEYS) {
+		const value = state[key];
+		if (Array.isArray(value)) elisions[key] = { type: "array", count: value.length, pointer: `/${key}` };
+	}
+	if (Object.keys(elisions).length) compact.elided = elisions;
+	return compact;
 }
 
 export function projectStateFields(

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -24,7 +24,16 @@ import {
 } from "../skill-state/workflow-state-contract";
 import { renderStateGraph, type StateGraphFormat } from "./state-graph";
 import { migrateAndPersistLegacyState } from "./state-migrations";
-import { renderStateMarkdown } from "./state-renderer";
+import {
+	buildStateStatusSummary,
+	projectStateFields,
+	renderContractMarkdown,
+	renderHistoryMarkdown,
+	renderStateMarkdown,
+	renderStateStatusLine,
+	STATE_FIELD_ALLOWLIST,
+	type StateProjectionField,
+} from "./state-renderer";
 import {
 	type GenericHardPruneTarget,
 	hardPrune,
@@ -84,10 +93,22 @@ const FLAGS_WITH_VALUES = new Set([
 	"--format",
 	"--older-than",
 	"--status",
+	"--fields",
+	"--since",
+	"--limit",
 ]);
-const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate"]);
-const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate"]);
-const VERB_SPECIFIC_FLAGS = new Set(["--skill", "--format", "--older-than", "--status"]);
+const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate", "status"]);
+const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate", "--compact", "--history"]);
+const VERB_SPECIFIC_FLAGS = new Set([
+	"--skill",
+	"--format",
+	"--older-than",
+	"--status",
+	"--fields",
+	"--since",
+	"--limit",
+	"--history",
+]);
 
 function flagName(arg: string): string | undefined {
 	if (!arg.startsWith("--")) return undefined;
@@ -125,7 +146,7 @@ function assertKnownFlags(args: readonly string[], parsed: ParsedInvocation): vo
 }
 
 interface ParsedInvocation {
-	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "migrate";
+	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "migrate" | "status";
 	positionalSkill?: string;
 }
 
@@ -311,6 +332,82 @@ async function writeJsonAtomic(
 	});
 }
 
+function parseFieldsFlag(args: readonly string[]): StateProjectionField[] | undefined {
+	const raw = flagValue(args, "--fields");
+	if (raw === undefined) return undefined;
+	const allowed = new Set<string>(STATE_FIELD_ALLOWLIST);
+	const fields = raw
+		.split(",")
+		.map(field => field.trim())
+		.filter(Boolean);
+	const unknown = fields.filter(field => !allowed.has(field));
+	if (unknown.length) {
+		throw new StateCommandError(
+			2,
+			`unknown --fields value(s): ${unknown.join(", ")}. Allowed fields: ${STATE_FIELD_ALLOWLIST.join(", ")}`,
+		);
+	}
+	return fields as StateProjectionField[];
+}
+
+function parseLimitFlag(args: readonly string[], defaultLimit = 50): number {
+	const raw = flagValue(args, "--limit");
+	if (raw === undefined) return defaultLimit;
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 500) {
+		throw new StateCommandError(2, "gjc state --limit requires an integer from 1 to 500");
+	}
+	return parsed;
+}
+
+function parseSinceFlag(args: readonly string[]): string | undefined {
+	const raw = flagValue(args, "--since")?.trim();
+	if (!raw) return undefined;
+	const duration = raw.match(/^(\d+)(m|h|d)$/);
+	if (duration) {
+		const amount = Number(duration[1]);
+		const unit = duration[2];
+		const multiplier = unit === "m" ? 60_000 : unit === "h" ? 3_600_000 : 86_400_000;
+		return new Date(Date.now() - amount * multiplier).toISOString();
+	}
+	if (Number.isNaN(Date.parse(raw)))
+		throw new StateCommandError(2, "gjc state --since requires an ISO timestamp or duration like 30m, 6h, 7d");
+	return new Date(raw).toISOString();
+}
+
+async function readAuditWindow(
+	cwd: string,
+	args: readonly string[],
+): Promise<{ entries: unknown[]; limit: number; since?: string; truncated: boolean }> {
+	const limit = parseLimitFlag(args);
+	const since = parseSinceFlag(args);
+	const auditPath = path.join(cwd, ".gjc", "state", "audit.jsonl");
+	let raw = "";
+	try {
+		raw = await fs.readFile(auditPath, "utf-8");
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code !== "ENOENT") throw error;
+	}
+	const selected: unknown[] = [];
+	let matched = 0;
+	const lines = raw.split(/\r?\n/).filter(line => line.trim().length > 0);
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index];
+		let entry: unknown;
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (since && isPlainObject(entry) && typeof entry.ts === "string" && Date.parse(entry.ts) < Date.parse(since))
+			break;
+		matched += 1;
+		if (selected.length < limit) selected.push(entry);
+	}
+	return { entries: selected.reverse(), limit, ...(since ? { since } : {}), truncated: matched > limit };
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -487,20 +584,58 @@ async function handleRead(
 ): Promise<StateCommandResult> {
 	const selectors = await resolveSelectors(args, cwd, positionalSkill);
 	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.sessionId));
+	const fields = parseFieldsFlag(args);
 	if (mode) {
 		const filePath = modeStateFile(cwd, mode, selectors.sessionId);
 		const existing = await readWorkflowStateJson(cwd, mode, selectors.sessionId);
 		const envelope = { skill: mode, state: existing, storage_path: filePath };
+		const manifest = getSkillManifest(mode);
+		if (fields) {
+			const projected = projectStateFields(mode, envelope, manifest, fields);
+			return {
+				status: 0,
+				stdout: hasFlag(args, "--json")
+					? `${JSON.stringify(projected, null, 2)}\n`
+					: renderStateMarkdown(mode, projected, manifest),
+			};
+		}
 		return {
 			status: 0,
 			stdout: hasFlag(args, "--json")
 				? `${JSON.stringify(envelope, null, 2)}\n`
-				: renderStateMarkdown(mode, envelope, getSkillManifest(mode)),
+				: renderStateMarkdown(mode, envelope, manifest),
 		};
 	}
 	const filePath = activeStateFile(cwd, selectors.sessionId);
 	const existing = await readJsonFile(filePath);
 	return { status: 0, stdout: `${JSON.stringify(existing ?? {}, null, 2)}\n` };
+}
+
+async function handleStatus(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const selectors = await resolveSelectors(args, cwd, positionalSkill);
+	const mode = selectors.mode ?? (await inferModeFromActiveState(cwd, selectors.sessionId));
+	if (!mode) {
+		throw new StateCommandError(
+			2,
+			"gjc state status requires --mode <skill>, positional <skill>, input.skill, or an active workflow in .gjc/state/skill-active-state.json",
+		);
+	}
+	const filePath = modeStateFile(cwd, mode, selectors.sessionId);
+	const existing = await readWorkflowStateJson(cwd, mode, selectors.sessionId);
+	const summary = buildStateStatusSummary(
+		mode,
+		{ skill: mode, state: existing, storage_path: filePath },
+		getSkillManifest(mode),
+		filePath,
+	);
+	return {
+		status: 0,
+		stdout: hasFlag(args, "--json") ? `${JSON.stringify(summary, null, 2)}\n` : renderStateStatusLine(summary),
+	};
 }
 
 async function handleWrite(
@@ -780,7 +915,12 @@ async function handleContract(
 		throw new StateCommandError(2, "gjc state contract requires --mode <skill>, positional <skill>, or input.skill");
 	}
 	const payload = { skill: mode, contract: describeWorkflowStateContract(mode) };
-	return { status: 0, stdout: `${JSON.stringify(payload, null, 2)}\n` };
+	return {
+		status: 0,
+		stdout: hasFlag(args, "--json")
+			? `${JSON.stringify(payload, null, 2)}\n`
+			: renderContractMarkdown(mode, payload.contract),
+	};
 }
 
 function parseNonNegativeIntegerFlag(args: readonly string[], flag: string): number | undefined {
@@ -809,6 +949,13 @@ async function handleGraph(
 	_cwd: string,
 	positionalSkill: string | undefined,
 ): Promise<StateCommandResult> {
+	if (hasFlag(args, "--history")) {
+		const history = await readAuditWindow(_cwd, args);
+		return {
+			status: 0,
+			stdout: hasFlag(args, "--json") ? `${JSON.stringify(history, null, 2)}\n` : renderHistoryMarkdown(history),
+		};
+	}
 	const rawSkill = flagValue(args, "--skill")?.trim() || positionalSkill?.trim() || "all";
 	if (rawSkill !== "all") assertKnownMode(rawSkill);
 	const format = flagValue(args, "--format")?.trim() || "ascii";
@@ -918,6 +1065,8 @@ export async function runNativeStateCommand(args: string[], cwd = process.cwd())
 				return await handleClear(args, cwd, parsed.positionalSkill);
 			case "contract":
 				return await handleContract(args, cwd, parsed.positionalSkill);
+			case "status":
+				return await handleStatus(args, cwd, parsed.positionalSkill);
 			case "handoff":
 				return await handleHandoff(args, cwd, parsed.positionalSkill);
 			case "graph":

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -18,6 +18,7 @@ import {
 } from "../skill-state/workflow-hud";
 import {
 	buildWorkflowStateReceipt,
+	type AuditEntry,
 	canonicalWorkflowSkill,
 	describeWorkflowStateContract,
 	type WorkflowStateReceipt,
@@ -36,11 +37,16 @@ import {
 } from "./state-renderer";
 import { validateWorkflowStateEnvelope } from "./state-validation";
 import {
+	appendAuditEntry,
+	beginWorkflowTransactionJournal,
+	completeWorkflowTransactionJournal,
+	detectWorkflowEnvelopeIntegrityMismatch,
 	type GenericHardPruneTarget,
 	hardPrune,
 	type StateWriterAuditContext,
 	softDelete,
-	writeJsonAtomic as writeStateJsonAtomic,
+	updateWorkflowTransactionJournal,
+	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
 import { getSkillManifest, isKnownWorkflowState, isValidTransition, typedArgsFor } from "./workflow-manifest";
 
@@ -351,16 +357,51 @@ async function readJsonValue(filePath: string): Promise<unknown | null> {
 	}
 }
 
+async function warnAndAuditOutOfBandIfNeeded(
+	cwd: string,
+	filePath: string,
+	skill: CanonicalGjcWorkflowSkill,
+	mutationId?: string,
+): Promise<string | undefined> {
+	const mismatch = await detectWorkflowEnvelopeIntegrityMismatch(filePath);
+	if (!mismatch) return undefined;
+	const message = `WARNING: workflow mode-state out-of-band edit detected for ${skill}: ${filePath} expected sha256 ${mismatch.expected} but found ${mismatch.actual}`;
+	await appendAuditEntry(cwd, {
+		ts: new Date().toISOString(),
+		skill,
+		category: "state",
+		verb: "out_of_band_detected",
+		owner: "gjc-state-cli",
+		mutation_id: mutationId ?? `${skill}:out-of-band:${new Date().toISOString()}`,
+		forced: false,
+		paths: [filePath],
+		expected_sha256: mismatch.expected,
+		actual_sha256: mismatch.actual,
+	} as AuditEntry);
+	return message;
+}
+
 async function writeJsonAtomic(
 	cwd: string,
 	filePath: string,
 	value: unknown,
 	verb: "write" | "clear" | "handoff" = "write",
-): Promise<void> {
-	await writeStateJsonAtomic(filePath, value, {
+	options?: { skill?: CanonicalGjcWorkflowSkill; mutationId?: string },
+): Promise<string | undefined> {
+	const warning = options?.skill
+		? await warnAndAuditOutOfBandIfNeeded(cwd, filePath, options.skill, options.mutationId)
+		: undefined;
+	await writeWorkflowEnvelopeAtomic(filePath, value, {
 		cwd,
-		audit: { category: "state", verb, owner: "gjc-state-cli" },
+		audit: {
+			category: "state",
+			verb,
+			owner: "gjc-state-cli",
+			skill: options?.skill,
+			mutationId: options?.mutationId,
+		},
 	});
+	return warning;
 }
 
 function parseFieldsFlag(args: readonly string[]): StateProjectionField[] | undefined {
@@ -689,6 +730,7 @@ async function handleWrite(
 	const existingRaw = await readJsonValue(filePath);
 	const existing = isPlainObject(existingRaw) ? existingRaw : null;
 	const nowIsoStr = nowIso();
+	const mutationId = `${mode}:${nowIsoStr}`;
 	const receipt = buildWorkflowStateReceipt({
 		cwd,
 		skill: mode,
@@ -696,6 +738,7 @@ async function handleWrite(
 		command: `gjc state ${mode} write`,
 		sessionId,
 		nowIso: nowIsoStr,
+		mutationId,
 	});
 	if (existingRaw !== null && !isPlainObject(existingRaw)) {
 		throw new StateCommandError(2, `existing state for ${mode} must be a JSON object before write`);
@@ -754,7 +797,7 @@ async function handleWrite(
 	const validation = validateWorkflowStateEnvelope(mode, merged);
 	if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
 
-	await writeJsonAtomic(cwd, filePath, merged, "write");
+	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, merged, "write", { skill: mode, mutationId });
 
 	const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
 	const active = merged.active !== false;
@@ -763,6 +806,7 @@ async function handleWrite(
 	return {
 		status: 0,
 		stdout: `${JSON.stringify({ skill: mode, state: merged, receipt }, null, 2)}\n`,
+		...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
 	};
 }
 
@@ -788,7 +832,7 @@ async function handleClear(
 		current_phase: "complete",
 		updated_at: nowIso(),
 	};
-	await writeJsonAtomic(cwd, filePath, cleared, "clear");
+	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, cleared, "clear", { skill: mode });
 
 	await syncWorkflowSkillState({
 		cwd,
@@ -800,8 +844,11 @@ async function handleClear(
 		phase: "complete",
 		payload: cleared,
 	});
-
-	return { status: 0, stdout: `${JSON.stringify(cleared, null, 2)}\n` };
+	return {
+		status: 0,
+		stdout: `${JSON.stringify(cleared, null, 2)}\n`,
+		...(outOfBandWarning ? { stderr: `${outOfBandWarning}\n` } : {}),
+	};
 }
 
 /**
@@ -859,6 +906,7 @@ async function handleHandoff(
 	const existingCallee = (await readJsonFile(calleePath)) ?? {};
 
 	const handoffAt = nowIso();
+	const mutationId = `${caller}:handoff:${callee}:${handoffAt}`;
 	const callerReceipt = buildWorkflowStateReceipt({
 		cwd,
 		skill: caller,
@@ -866,6 +914,7 @@ async function handleHandoff(
 		command: `gjc state ${caller} handoff --to ${callee}`,
 		sessionId,
 		nowIso: handoffAt,
+		mutationId,
 	});
 	const calleeReceipt = buildWorkflowStateReceipt({
 		cwd,
@@ -874,6 +923,7 @@ async function handleHandoff(
 		command: `gjc state ${caller} handoff --to ${callee}`,
 		sessionId,
 		nowIso: handoffAt,
+		mutationId,
 	});
 
 	const calleeInitial = initialPhaseForSkill(callee);
@@ -902,6 +952,14 @@ async function handleHandoff(
 		receipt: callerReceipt,
 	};
 
+	await beginWorkflowTransactionJournal({
+		cwd,
+		mutationId,
+		caller,
+		callee,
+		paths: [calleePath, callerPath, activeStateFile(cwd, sessionId)],
+	});
+
 	// Atomic write order (architecture blocker AR-3): mode-state files first,
 	// then a single atomic active-state mutation per file (session before root)
 	// via applyHandoffToActiveState. The single-write transaction prevents the
@@ -909,8 +967,18 @@ async function handleHandoff(
 	// and write order keeps the session-scoped source of truth ahead of the
 	// root aggregate. strict:true on the active-state read tolerates ENOENT
 	// only; corrupt JSON / IO failures propagate as non-zero CLI status.
-	await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff");
-	await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff");
+	const warnings = [
+		await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff", { skill: callee, mutationId }),
+		await updateWorkflowTransactionJournal(cwd, mutationId, { steps: ["callee-mode-state"] }).then(() => undefined),
+		await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", { skill: caller, mutationId }),
+		await updateWorkflowTransactionJournal(cwd, mutationId, {
+			steps: ["callee-mode-state", "caller-mode-state"],
+		}).then(() => undefined),
+	].filter((warning): warning is string => typeof warning === "string");
+	for (const warning of warnings) process.stderr.write(`${warning}\n`);
+	if (process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER === mutationId) {
+		throw new StateCommandError(1, `injected handoff failure after caller write for ${mutationId}`);
+	}
 	await applyHandoffToActiveState({
 		cwd,
 		nowIso: handoffAt,
@@ -944,6 +1012,10 @@ async function handleHandoff(
 			receipt: calleeReceipt,
 		},
 	});
+	await updateWorkflowTransactionJournal(cwd, mutationId, {
+		steps: ["callee-mode-state", "caller-mode-state", "active-state"],
+	});
+	await completeWorkflowTransactionJournal(cwd, mutationId);
 
 	return {
 		status: 0,

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -17,8 +17,8 @@ import {
 	buildUltragoalHudSummary,
 } from "../skill-state/workflow-hud";
 import {
-	buildWorkflowStateReceipt,
 	type AuditEntry,
+	buildWorkflowStateReceipt,
 	canonicalWorkflowSkill,
 	describeWorkflowStateContract,
 	type WorkflowStateReceipt,
@@ -27,6 +27,7 @@ import { renderStateGraph, type StateGraphFormat } from "./state-graph";
 import { migrateAndPersistLegacyState } from "./state-migrations";
 import {
 	buildStateStatusSummary,
+	compactProjectStateJson,
 	projectStateFields,
 	renderContractMarkdown,
 	renderHistoryMarkdown,
@@ -197,7 +198,7 @@ function parsePositionalArgs(args: readonly string[]): ParsedInvocation {
 	const first = positional[0];
 	const second = positional[1];
 	if (first && ACTION_NAMES.has(first)) {
-		return { action: first as ParsedInvocation["action"] };
+		return { action: first as ParsedInvocation["action"], positionalSkill: second };
 	}
 	if (first && second && ACTION_NAMES.has(second)) {
 		return { action: second as ParsedInvocation["action"], positionalSkill: first };
@@ -361,7 +362,7 @@ async function warnAndAuditOutOfBandIfNeeded(
 	cwd: string,
 	filePath: string,
 	skill: CanonicalGjcWorkflowSkill,
-	mutationId?: string,
+	options?: { mutationId?: string; forced?: boolean },
 ): Promise<string | undefined> {
 	const mismatch = await detectWorkflowEnvelopeIntegrityMismatch(filePath);
 	if (!mismatch) return undefined;
@@ -372,8 +373,8 @@ async function warnAndAuditOutOfBandIfNeeded(
 		category: "state",
 		verb: "out_of_band_detected",
 		owner: "gjc-state-cli",
-		mutation_id: mutationId ?? `${skill}:out-of-band:${new Date().toISOString()}`,
-		forced: false,
+		mutation_id: options?.mutationId ?? `${skill}:out-of-band:${new Date().toISOString()}`,
+		forced: options?.forced ?? false,
 		paths: [filePath],
 		expected_sha256: mismatch.expected,
 		actual_sha256: mismatch.actual,
@@ -386,11 +387,23 @@ async function writeJsonAtomic(
 	filePath: string,
 	value: unknown,
 	verb: "write" | "clear" | "handoff" = "write",
-	options?: { skill?: CanonicalGjcWorkflowSkill; mutationId?: string },
+	options?: {
+		skill?: CanonicalGjcWorkflowSkill;
+		mutationId?: string;
+		force?: boolean;
+		fromPhase?: string;
+		toPhase?: string;
+	},
 ): Promise<string | undefined> {
 	const warning = options?.skill
-		? await warnAndAuditOutOfBandIfNeeded(cwd, filePath, options.skill, options.mutationId)
+		? await warnAndAuditOutOfBandIfNeeded(cwd, filePath, options.skill, {
+				mutationId: options.mutationId,
+				forced: options.force ?? false,
+			})
 		: undefined;
+	if (warning && !options?.force) {
+		throw new StateCommandError(2, `${warning}; use --force to overwrite tampered mode-state`);
+	}
 	await writeWorkflowEnvelopeAtomic(filePath, value, {
 		cwd,
 		audit: {
@@ -399,6 +412,9 @@ async function writeJsonAtomic(
 			owner: "gjc-state-cli",
 			skill: options?.skill,
 			mutationId: options?.mutationId,
+			fromPhase: options?.fromPhase,
+			toPhase: options?.toPhase,
+			forced: options?.force ?? false,
 		},
 	});
 	return warning;
@@ -671,6 +687,15 @@ async function handleRead(
 					: renderStateMarkdown(mode, projected, manifest),
 			};
 		}
+		if (hasFlag(args, "--compact")) {
+			const compact = compactProjectStateJson(mode, envelope, manifest);
+			return {
+				status: 0,
+				stdout: hasFlag(args, "--json")
+					? `${JSON.stringify(compact, null, 2)}\n`
+					: renderStateMarkdown(mode, envelope, manifest),
+			};
+		}
 		return {
 			status: 0,
 			stdout: hasFlag(args, "--json")
@@ -797,7 +822,13 @@ async function handleWrite(
 	const validation = validateWorkflowStateEnvelope(mode, merged);
 	if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
 
-	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, merged, "write", { skill: mode, mutationId });
+	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, merged, "write", {
+		skill: mode,
+		mutationId,
+		force: forced,
+		fromPhase,
+		toPhase,
+	});
 
 	const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
 	const active = merged.active !== false;
@@ -832,7 +863,12 @@ async function handleClear(
 		current_phase: "complete",
 		updated_at: nowIso(),
 	};
-	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, cleared, "clear", { skill: mode });
+	const outOfBandWarning = await writeJsonAtomic(cwd, filePath, cleared, "clear", {
+		skill: mode,
+		force: hasFlag(args, "--force"),
+		fromPhase: typeof existing.current_phase === "string" ? existing.current_phase : undefined,
+		toPhase: "complete",
+	});
 
 	await syncWorkflowSkillState({
 		cwd,
@@ -967,10 +1003,23 @@ async function handleHandoff(
 	// and write order keeps the session-scoped source of truth ahead of the
 	// root aggregate. strict:true on the active-state read tolerates ENOENT
 	// only; corrupt JSON / IO failures propagate as non-zero CLI status.
+	const force = hasFlag(args, "--force");
 	const warnings = [
-		await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff", { skill: callee, mutationId }),
+		await writeJsonAtomic(cwd, calleePath, mergedCalleeState, "handoff", {
+			skill: callee,
+			mutationId,
+			force,
+			fromPhase: typeof existingCallee.current_phase === "string" ? existingCallee.current_phase : undefined,
+			toPhase: calleeInitial,
+		}),
 		await updateWorkflowTransactionJournal(cwd, mutationId, { steps: ["callee-mode-state"] }).then(() => undefined),
-		await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", { skill: caller, mutationId }),
+		await writeJsonAtomic(cwd, callerPath, mergedCallerState, "handoff", {
+			skill: caller,
+			mutationId,
+			force,
+			fromPhase: typeof existingCaller.current_phase === "string" ? existingCaller.current_phase : undefined,
+			toPhase: "handoff",
+		}),
 		await updateWorkflowTransactionJournal(cwd, mutationId, {
 			steps: ["callee-mode-state", "caller-mode-state"],
 		}).then(() => undefined),
@@ -1343,13 +1392,20 @@ async function handleMigrate(
 		);
 	}
 	const filePath = modeStateFile(cwd, mode, selectors.sessionId);
+	const mismatchWarning = await warnAndAuditOutOfBandIfNeeded(cwd, filePath, mode, {
+		forced: hasFlag(args, "--force"),
+	});
 	const result = await migrateAndPersistLegacyState({
 		cwd,
 		skill: mode,
 		statePath: filePath,
 		sessionId: selectors.sessionId,
 	});
-	return { status: 0, stdout: `${JSON.stringify({ skill: mode, ...result }, null, 2)}\n` };
+	return {
+		status: 0,
+		stdout: `${JSON.stringify({ skill: mode, ...result, integrity_mismatch: Boolean(mismatchWarning) }, null, 2)}\n`,
+		...(mismatchWarning ? { stderr: `${mismatchWarning}\n` } : {}),
+	};
 }
 
 export async function runNativeStateCommand(args: string[], cwd = process.cwd()): Promise<StateCommandResult> {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -98,8 +98,28 @@ const FLAGS_WITH_VALUES = new Set([
 	"--since",
 	"--limit",
 ]);
-const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate", "status"]);
-const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate", "--compact", "--history", "--force"]);
+const ACTION_NAMES = new Set([
+	"read",
+	"write",
+	"clear",
+	"contract",
+	"handoff",
+	"graph",
+	"prune",
+	"gc",
+	"migrate",
+	"status",
+]);
+const BOOLEAN_FLAGS = new Set([
+	"--json",
+	"--replace",
+	"--hard",
+	"--dry-run",
+	"--migrate",
+	"--compact",
+	"--history",
+	"--force",
+]);
 const VERB_SPECIFIC_FLAGS = new Set([
 	"--skill",
 	"--format",
@@ -147,7 +167,7 @@ function assertKnownFlags(args: readonly string[], parsed: ParsedInvocation): vo
 }
 
 interface ParsedInvocation {
-	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "migrate" | "status";
+	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "gc" | "migrate" | "status";
 	positionalSkill?: string;
 }
 
@@ -980,6 +1000,170 @@ function statusFromFile(value: unknown): string | undefined {
 	return undefined;
 }
 
+interface RetentionCandidate {
+	path: string;
+	relativePath: string;
+	category: string;
+	mtimeMs: number;
+	policy: { keep?: number; maxAgeDays?: number };
+}
+
+interface GcSummary {
+	skill: CanonicalGjcWorkflowSkill | "all";
+	dry_run: boolean;
+	eligible: string[];
+	pruned: string[];
+	counts: Record<string, number>;
+}
+
+function categoryForStateRelativePath(relativePath: string): string | undefined {
+	const normalized = relativePath.split(path.sep).join("/");
+	if (normalized === "audit.jsonl") return undefined;
+	if (normalized === SKILL_ACTIVE_STATE_FILE || normalized.endsWith(`/${SKILL_ACTIVE_STATE_FILE}`)) return undefined;
+	if (normalized.startsWith("active/") || normalized.includes("/active/")) return undefined;
+	if (
+		/^[^/]+-state\.json$/.test(normalized) ||
+		(normalized.includes("/sessions/") && /\/[^/]+-state\.json$/.test(normalized))
+	)
+		return undefined;
+	if (normalized.startsWith("artifacts/") || normalized.includes("/artifacts/")) return "artifact";
+	if (
+		normalized.startsWith("logs/") ||
+		normalized.includes("/logs/") ||
+		normalized.endsWith(".log") ||
+		normalized.endsWith(".jsonl")
+	)
+		return "log";
+	if (normalized.startsWith("reports/") || normalized.includes("/reports/")) return "report";
+	if (normalized.startsWith("ledgers/") || normalized.includes("/ledgers/")) return "ledger";
+	if (normalized.startsWith("agents/") || normalized.includes("/agents/")) return "agents";
+	if (normalized.startsWith("force/") || normalized.includes("/force/")) return "force";
+	if (
+		normalized.startsWith("prune/") ||
+		normalized.includes("/prune/") ||
+		normalized.startsWith("delete/") ||
+		normalized.includes("/delete/")
+	)
+		return "prune/delete";
+	if (normalized.startsWith("transactions/") || normalized.includes("/transactions/")) return "prune/delete";
+	return undefined;
+}
+
+async function collectRetentionCandidates(
+	cwd: string,
+	skills: readonly CanonicalGjcWorkflowSkill[],
+): Promise<RetentionCandidate[]> {
+	const stateRoot = path.join(cwd, ".gjc", "state");
+	const policies = new Map<string, { keep?: number; maxAgeDays?: number }>();
+	for (const skill of skills) {
+		for (const policy of getSkillManifest(skill).retention) {
+			const existing = policies.get(policy.category);
+			policies.set(policy.category, {
+				keep: Math.max(existing?.keep ?? 0, policy.keep ?? 0) || undefined,
+				maxAgeDays:
+					existing?.maxAgeDays === undefined
+						? policy.maxAgeDays
+						: policy.maxAgeDays === undefined
+							? existing.maxAgeDays
+							: Math.max(existing.maxAgeDays, policy.maxAgeDays),
+			});
+		}
+	}
+	const candidates: RetentionCandidate[] = [];
+	async function visit(dir: string): Promise<void> {
+		let entries: string[];
+		try {
+			entries = await fs.readdir(dir);
+		} catch (error) {
+			const err = error as NodeJS.ErrnoException;
+			if (err.code === "ENOENT") return;
+			throw error;
+		}
+		for (const entry of entries) {
+			const filePath = path.join(dir, entry);
+			const stat = await fs.stat(filePath);
+			if (stat.isDirectory()) {
+				await visit(filePath);
+				continue;
+			}
+			if (!stat.isFile()) continue;
+			const relativePath = path.relative(stateRoot, filePath);
+			const category = categoryForStateRelativePath(relativePath);
+			if (!category) continue;
+			const policy = policies.get(category);
+			if (!policy) continue;
+			candidates.push({ path: filePath, relativePath, category, mtimeMs: stat.mtimeMs, policy });
+		}
+	}
+	await visit(stateRoot);
+	return candidates;
+}
+
+function selectRetentionEligible(candidates: readonly RetentionCandidate[]): RetentionCandidate[] {
+	const now = Date.now();
+	const byCategory = new Map<string, RetentionCandidate[]>();
+	for (const candidate of candidates) {
+		const list = byCategory.get(candidate.category) ?? [];
+		list.push(candidate);
+		byCategory.set(candidate.category, list);
+	}
+	const eligible = new Set<RetentionCandidate>();
+	for (const list of byCategory.values()) {
+		list.sort((a, b) => b.mtimeMs - a.mtimeMs || a.relativePath.localeCompare(b.relativePath));
+		for (let index = 0; index < list.length; index += 1) {
+			const candidate = list[index];
+			const keep = candidate.policy.keep ?? 0;
+			if (keep > 0 && index < keep) continue;
+			if (candidate.policy.maxAgeDays !== undefined) {
+				const maxAgeMs = candidate.policy.maxAgeDays * 24 * 60 * 60 * 1000;
+				if (now - candidate.mtimeMs < maxAgeMs) continue;
+			}
+			if (candidate.policy.keep !== undefined || candidate.policy.maxAgeDays !== undefined) eligible.add(candidate);
+		}
+	}
+	return [...eligible].sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+async function buildGcSummary(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+	dryRun: boolean,
+): Promise<GcSummary> {
+	const rawSkill =
+		flagValue(args, "--skill")?.trim() || flagValue(args, "--mode")?.trim() || positionalSkill?.trim() || "all";
+	if (rawSkill !== "all") assertKnownMode(rawSkill);
+	const skills = rawSkill === "all" ? CANONICAL_GJC_WORKFLOW_SKILLS : [rawSkill as CanonicalGjcWorkflowSkill];
+	const eligible = selectRetentionEligible(await collectRetentionCandidates(cwd, skills));
+	const counts: Record<string, number> = {};
+	for (const candidate of eligible) counts[candidate.category] = (counts[candidate.category] ?? 0) + 1;
+	const targets: GenericHardPruneTarget[] = eligible.map(candidate => ({
+		path: candidate.path,
+		category: candidate.category,
+	}));
+	let pruned: string[] = [];
+	if (!dryRun && targets.length > 0) {
+		const eligiblePaths = new Set(eligible.map(candidate => path.resolve(candidate.path)));
+		pruned = await hardPrune(targets, context => eligiblePaths.has(path.resolve(context.path)), {
+			cwd,
+			audit: {
+				cwd,
+				skill: rawSkill,
+				category: "prune",
+				verb: "gc",
+				owner: "gjc-state-cli",
+			},
+		});
+	}
+	return {
+		skill: rawSkill as CanonicalGjcWorkflowSkill | "all",
+		dry_run: dryRun,
+		eligible: eligible.map(candidate => candidate.relativePath),
+		pruned: pruned.map(filePath => path.relative(path.join(cwd, ".gjc", "state"), filePath)),
+		counts,
+	};
+}
+
 async function handleGraph(
 	args: readonly string[],
 	_cwd: string,
@@ -1064,6 +1248,15 @@ async function handlePrune(
 	return { status: 0, stdout: `${JSON.stringify({ skill: mode, hard: false, soft_deleted: deleted }, null, 2)}\n` };
 }
 
+async function handleGc(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const summary = await buildGcSummary(args, cwd, positionalSkill, hasFlag(args, "--dry-run"));
+	return { status: 0, stdout: `${JSON.stringify(summary, null, 2)}\n` };
+}
+
 async function handleMigrate(
 	args: readonly string[],
 	cwd: string,
@@ -1109,6 +1302,8 @@ export async function runNativeStateCommand(args: string[], cwd = process.cwd())
 				return await handleGraph(args, cwd, parsed.positionalSkill);
 			case "prune":
 				return await handlePrune(args, cwd, parsed.positionalSkill);
+			case "gc":
+				return await handleGc(args, cwd, parsed.positionalSkill);
 			case "migrate":
 				return await handleMigrate(args, cwd, parsed.positionalSkill);
 			default:

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -34,6 +34,7 @@ import {
 	STATE_FIELD_ALLOWLIST,
 	type StateProjectionField,
 } from "./state-renderer";
+import { validateWorkflowStateEnvelope } from "./state-validation";
 import {
 	type GenericHardPruneTarget,
 	hardPrune,
@@ -41,7 +42,7 @@ import {
 	softDelete,
 	writeJsonAtomic as writeStateJsonAtomic,
 } from "./state-writer";
-import { getSkillManifest, typedArgsFor } from "./workflow-manifest";
+import { getSkillManifest, isKnownWorkflowState, isValidTransition, typedArgsFor } from "./workflow-manifest";
 
 /**
  * Native implementation of the `gjc state read|write|clear` command surface.
@@ -98,7 +99,7 @@ const FLAGS_WITH_VALUES = new Set([
 	"--limit",
 ]);
 const ACTION_NAMES = new Set(["read", "write", "clear", "contract", "handoff", "graph", "prune", "migrate", "status"]);
-const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate", "--compact", "--history"]);
+const BOOLEAN_FLAGS = new Set(["--json", "--replace", "--hard", "--migrate", "--compact", "--history", "--force"]);
 const VERB_SPECIFIC_FLAGS = new Set([
 	"--skill",
 	"--format",
@@ -313,6 +314,16 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown> |
 			return parsed as Record<string, unknown>;
 		}
 		return null;
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return null;
+		throw new StateCommandError(1, `failed to read ${filePath}: ${err.message}`);
+	}
+}
+
+async function readJsonValue(filePath: string): Promise<unknown | null> {
+	try {
+		return JSON.parse(await fs.readFile(filePath, "utf-8"));
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException;
 		if (err.code === "ENOENT") return null;
@@ -607,7 +618,8 @@ async function handleRead(
 		};
 	}
 	const filePath = activeStateFile(cwd, selectors.sessionId);
-	const existing = await readJsonFile(filePath);
+	const existingRaw = await readJsonValue(filePath);
+	const existing = isPlainObject(existingRaw) ? existingRaw : null;
 	return { status: 0, stdout: `${JSON.stringify(existing ?? {}, null, 2)}\n` };
 }
 
@@ -654,7 +666,8 @@ async function handleWrite(
 		);
 
 	const filePath = modeStateFile(cwd, mode, sessionId);
-	const existing = await readJsonFile(filePath);
+	const existingRaw = await readJsonValue(filePath);
+	const existing = isPlainObject(existingRaw) ? existingRaw : null;
 	const nowIsoStr = nowIso();
 	const receipt = buildWorkflowStateReceipt({
 		cwd,
@@ -664,6 +677,9 @@ async function handleWrite(
 		sessionId,
 		nowIso: nowIsoStr,
 	});
+	if (existingRaw !== null && !isPlainObject(existingRaw)) {
+		throw new StateCommandError(2, `existing state for ${mode} must be a JSON object before write`);
+	}
 	const existingPayload = existing ?? {};
 	const innerState = (payload.state as Record<string, unknown> | undefined) ?? {};
 	const incomingPhase =
@@ -686,6 +702,10 @@ async function handleWrite(
 			delete merged.state;
 		}
 	}
+	const preDefaultValidation = validateWorkflowStateEnvelope(mode, merged);
+	if (!preDefaultValidation.valid) {
+		throw new StateCommandError(2, preDefaultValidation.error ?? `invalid ${mode} state envelope`);
+	}
 	merged.skill = mode;
 	if (incomingPhase) {
 		merged.current_phase = incomingPhase;
@@ -698,6 +718,22 @@ async function handleWrite(
 	merged.updated_at = nowIsoStr;
 	merged.receipt = receipt;
 	if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
+
+	const fromPhase = typeof existingPayload.current_phase === "string" ? existingPayload.current_phase : undefined;
+	const toPhase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
+	const forced = hasFlag(args, "--force");
+	if (fromPhase && toPhase && isKnownWorkflowState(mode, fromPhase) && isKnownWorkflowState(mode, toPhase)) {
+		if (!isValidTransition(mode, fromPhase, toPhase) && !forced) {
+			throw new StateCommandError(
+				2,
+				`invalid ${mode} phase transition from ${fromPhase} to ${toPhase}; use --force to bypass`,
+			);
+		}
+	}
+
+	const validation = validateWorkflowStateEnvelope(mode, merged);
+	if (!validation.valid) throw new StateCommandError(2, validation.error ?? `invalid ${mode} state envelope`);
+
 	await writeJsonAtomic(cwd, filePath, merged, "write");
 
 	const phase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;

--- a/packages/coding-agent/src/gjc-runtime/state-validation.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-validation.ts
@@ -1,0 +1,37 @@
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+
+export interface StateValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function typeName(value: unknown): string {
+	if (Array.isArray(value)) return "array";
+	if (value === null) return "null";
+	return typeof value;
+}
+
+export function validateWorkflowStateEnvelope(skill: CanonicalGjcWorkflowSkill, state: unknown): StateValidationResult {
+	if (!isPlainObject(state)) {
+		return { valid: false, error: `state for ${skill} must be a JSON object, got ${typeName(state)}` };
+	}
+
+	if ("skill" in state && state.skill !== skill) {
+		return { valid: false, error: `state skill must match selected mode ${skill}` };
+	}
+	if ("active" in state && typeof state.active !== "boolean") {
+		return { valid: false, error: `state.active must be a boolean when present, got ${typeName(state.active)}` };
+	}
+	if ("current_phase" in state && typeof state.current_phase !== "string") {
+		return {
+			valid: false,
+			error: `state.current_phase must be a string when present, got ${typeName(state.current_phase)}`,
+		};
+	}
+
+	return { valid: true };
+}

--- a/packages/coding-agent/src/gjc-runtime/state-validation.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-validation.ts
@@ -32,6 +32,18 @@ export function validateWorkflowStateEnvelope(skill: CanonicalGjcWorkflowSkill, 
 			error: `state.current_phase must be a string when present, got ${typeName(state.current_phase)}`,
 		};
 	}
+	if ("version" in state && typeof state.version !== "number") {
+		return { valid: false, error: `state.version must be a number when present, got ${typeName(state.version)}` };
+	}
+	if ("updated_at" in state && typeof state.updated_at !== "string") {
+		return {
+			valid: false,
+			error: `state.updated_at must be a string when present, got ${typeName(state.updated_at)}`,
+		};
+	}
+	if ("receipt" in state && state.receipt !== undefined && !isPlainObject(state.receipt)) {
+		return { valid: false, error: `state.receipt must be an object when present, got ${typeName(state.receipt)}` };
+	}
 
 	return { valid: true };
 }

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
@@ -19,9 +19,21 @@ import {
  * supplied mutation context. No lockfiles are used; isolation is by atomic rename,
  * append, O_EXCL creates, conditional deletes, per-entry active-state files,
  * and derived active-state snapshots.
+ * Transaction journals are per mutation id under `.gjc/state/transactions/`;
+ * they are recovery evidence only, never global locks or waiters, so stale
+ * journals do not block unrelated state reads or writes.
  */
 
-export type WriterCategory = "state" | "artifact" | "ledger" | "log" | "report" | "agents" | "prune" | "force";
+export type WriterCategory =
+	| "state"
+	| "artifact"
+	| "ledger"
+	| "log"
+	| "report"
+	| "agents"
+	| "prune"
+	| "force"
+	| "transaction";
 
 export interface StateWriterReceiptContext {
 	cwd?: string;
@@ -43,6 +55,24 @@ export interface StateWriterAuditContext {
 	fromPhase?: string;
 	toPhase?: string;
 	forced?: boolean;
+}
+
+export interface WorkflowEnvelopeIntegrityMismatch {
+	path: string;
+	expected: string;
+	actual: string;
+}
+
+export interface WorkflowTransactionJournal {
+	version: 1;
+	mutation_id: string;
+	status: "pending" | "committed";
+	created_at: string;
+	updated_at: string;
+	caller?: CanonicalGjcWorkflowSkill;
+	callee?: CanonicalGjcWorkflowSkill;
+	paths: string[];
+	steps: string[];
 }
 
 export interface StateWriterOptions {
@@ -127,6 +157,68 @@ function tempPathFor(filePath: string): string {
 
 function jsonText(value: unknown): string {
 	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function canonicalizeJson(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalizeJson);
+	if (!value || typeof value !== "object") return value;
+	const out: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+		const v = (value as Record<string, unknown>)[key];
+		if (v !== undefined) out[key] = canonicalizeJson(v);
+	}
+	return out;
+}
+
+function withoutReceiptChecksum(value: unknown): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const clone: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+	if (clone.receipt && typeof clone.receipt === "object" && !Array.isArray(clone.receipt)) {
+		const receipt = { ...(clone.receipt as Record<string, unknown>) };
+		delete receipt.content_sha256;
+		clone.receipt = receipt;
+	}
+	return clone;
+}
+
+export function workflowEnvelopeContentSha256(value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalizeJson(withoutReceiptChecksum(value))))
+		.digest("hex");
+}
+
+export function stampWorkflowEnvelopeChecksum<T>(value: T, filePath: string, computedAt = new Date().toISOString()): T {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const envelope = { ...(value as Record<string, unknown>) };
+	const receipt =
+		envelope.receipt && typeof envelope.receipt === "object" && !Array.isArray(envelope.receipt)
+			? { ...(envelope.receipt as Record<string, unknown>) }
+			: {};
+	envelope.receipt = {
+		...receipt,
+		content_sha256: {
+			algorithm: "sha256",
+			value: workflowEnvelopeContentSha256(envelope),
+			covered_path: filePath,
+			computed_at: computedAt,
+		},
+	};
+	return envelope as T;
+}
+
+export async function detectWorkflowEnvelopeIntegrityMismatch(
+	filePath: string,
+): Promise<WorkflowEnvelopeIntegrityMismatch | undefined> {
+	const current = await readJsonIfPresent(filePath);
+	if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
+	const receipt = (current as Record<string, unknown>).receipt;
+	if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) return undefined;
+	const checksum = (receipt as Record<string, unknown>).content_sha256;
+	if (!checksum || typeof checksum !== "object" || Array.isArray(checksum)) return undefined;
+	const expected = (checksum as Record<string, unknown>).value;
+	if (typeof expected !== "string" || !expected) return undefined;
+	const actual = workflowEnvelopeContentSha256(current);
+	return actual === expected ? undefined : { path: filePath, expected, actual };
 }
 
 function safeString(value: unknown): string {
@@ -254,6 +346,18 @@ export async function writeJsonAtomic(
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
 	await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
+	await maybeAudit(filePath, options);
+	return filePath;
+}
+
+export async function writeWorkflowEnvelopeAtomic(
+	targetPath: string,
+	value: unknown,
+	options?: StateWriterOptions,
+): Promise<string> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	const withReceipt = withWorkflowReceipt(value, buildReceipt(options));
+	await atomicWrite(filePath, jsonText(stampWorkflowEnvelopeChecksum(withReceipt, filePath)));
 	await maybeAudit(filePath, options);
 	return filePath;
 }
@@ -554,4 +658,61 @@ export async function appendAuditEntry(cwd: string, entry: AuditEntry): Promise<
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
 	return filePath;
+}
+
+function transactionJournalPath(cwd: string, mutationId: string): string {
+	return path.join(path.resolve(cwd), ".gjc", "state", "transactions", `${encodePathSegment(mutationId)}.json`);
+}
+
+export async function readWorkflowTransactionJournal(
+	cwd: string,
+	mutationId: string,
+): Promise<WorkflowTransactionJournal | undefined> {
+	return (await readJsonIfPresent(transactionJournalPath(cwd, mutationId))) as WorkflowTransactionJournal | undefined;
+}
+
+export async function beginWorkflowTransactionJournal(input: {
+	cwd: string;
+	mutationId: string;
+	caller?: CanonicalGjcWorkflowSkill;
+	callee?: CanonicalGjcWorkflowSkill;
+	paths: string[];
+}): Promise<string> {
+	const now = new Date().toISOString();
+	const journal: WorkflowTransactionJournal = {
+		version: 1,
+		mutation_id: input.mutationId,
+		status: "pending",
+		created_at: now,
+		updated_at: now,
+		caller: input.caller,
+		callee: input.callee,
+		paths: input.paths,
+		steps: [],
+	};
+	try {
+		return await createJsonNoClobber(transactionJournalPath(input.cwd, input.mutationId), journal, {
+			cwd: input.cwd,
+		});
+	} catch (error) {
+		if (error instanceof AlreadyExistsError) return error.path;
+		throw error;
+	}
+}
+
+export async function updateWorkflowTransactionJournal(
+	cwd: string,
+	mutationId: string,
+	patch: Partial<WorkflowTransactionJournal>,
+): Promise<string> {
+	const filePath = transactionJournalPath(cwd, mutationId);
+	const current = ((await readJsonIfPresent(filePath)) ?? {}) as WorkflowTransactionJournal;
+	const next = { ...current, ...patch, updated_at: new Date().toISOString() } as WorkflowTransactionJournal;
+	await atomicWrite(filePath, jsonText(next));
+	return filePath;
+}
+
+export async function completeWorkflowTransactionJournal(cwd: string, mutationId: string): Promise<void> {
+	await updateWorkflowTransactionJournal(cwd, mutationId, { status: "committed" });
+	await atomicRemove(transactionJournalPath(cwd, mutationId)).catch(() => false);
 }

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import { renderUltragoalStatusMarkdown } from "./state-renderer";
 import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
 
 export type UltragoalGjcGoalMode = "aggregate" | "per-story";
@@ -899,11 +900,7 @@ async function readBrief(cwd: string, args: readonly string[]): Promise<string> 
 
 function renderStatus(summary: UltragoalStatusSummary, json: boolean): string {
 	if (json) return `${JSON.stringify(summary, null, 2)}\n`;
-	if (!summary.exists) {
-		return `No ultragoal plan found at ${summary.paths.goalsPath}. Run \`gjc ultragoal create-goals --brief "..."\` first.\n`;
-	}
-	const current = summary.currentGoal ? ` Current: ${summary.currentGoal.id} (${summary.currentGoal.status}).` : "";
-	return `Ultragoal ${summary.status}: ${summary.counts.complete}/${summary.goals.length} complete.${current}\n`;
+	return renderUltragoalStatusMarkdown(summary);
 }
 
 function renderCompleteHandoff(

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -144,6 +144,15 @@
       },
       {
         "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "force",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
           "kickoff"
         ],
         "name": "quick",
@@ -340,10 +349,15 @@
       {
         "id": "final",
         "terminal": true
+      },
+      {
+        "id": "handoff",
+        "terminal": true
       }
     ],
     "terminalStates": [
-      "final"
+      "final",
+      "handoff"
     ],
     "transitions": [
       {
@@ -370,6 +384,31 @@
         "from": "adr",
         "to": "final",
         "verb": "write-artifact"
+      },
+      {
+        "from": "planner",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "architect",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "critic",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "revision",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "adr",
+        "to": "handoff",
+        "verb": "handoff"
       }
     ],
     "typedArgs": [
@@ -449,6 +488,15 @@
           "write"
         ],
         "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "force",
         "type": "boolean"
       },
       {
@@ -651,12 +699,17 @@
       {
         "id": "cancelled",
         "terminal": true
+      },
+      {
+        "id": "handoff",
+        "terminal": true
       }
     ],
     "terminalStates": [
       "complete",
       "failed",
-      "cancelled"
+      "cancelled",
+      "handoff"
     ],
     "transitions": [
       {
@@ -698,6 +751,21 @@
         "from": "awaiting_integration",
         "to": "complete",
         "verb": "shutdown"
+      },
+      {
+        "from": "starting",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "running",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "awaiting_integration",
+        "to": "handoff",
+        "verb": "handoff"
       }
     ],
     "typedArgs": [
@@ -777,6 +845,15 @@
           "write"
         ],
         "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "force",
         "type": "boolean"
       },
       {
@@ -1025,11 +1102,16 @@
       {
         "id": "complete",
         "terminal": true
+      },
+      {
+        "id": "handoff",
+        "terminal": true
       }
     ],
     "terminalStates": [
       "failed",
-      "complete"
+      "complete",
+      "handoff"
     ],
     "transitions": [
       {
@@ -1066,6 +1148,26 @@
         "from": "failed",
         "to": "active",
         "verb": "complete-goals"
+      },
+      {
+        "from": "goal-planning",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "pending",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "active",
+        "to": "handoff",
+        "verb": "handoff"
+      },
+      {
+        "from": "blocked",
+        "to": "handoff",
+        "verb": "handoff"
       }
     ],
     "typedArgs": [
@@ -1145,6 +1247,15 @@
           "write"
         ],
         "name": "replace",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "write",
+          "clear",
+          "handoff"
+        ],
+        "name": "force",
         "type": "boolean"
       },
       {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -81,6 +81,7 @@ const COMMON_TYPED_ARGS: TypedArgSpec[] = [
 		appliesToVerbs: ["handoff"],
 	},
 	{ name: "replace", type: "boolean", appliesToVerbs: ["write"] },
+	{ name: "force", type: "boolean", appliesToVerbs: ["write", "clear", "handoff"] },
 ];
 
 function verb(name: string, surface: WorkflowVerb["surface"]): WorkflowVerb {
@@ -170,14 +171,19 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 	}),
 	ralplan: manifest({
 		skill: "ralplan",
-		states: ["planner", "architect", "critic", "revision", "adr", "final"],
-		terminalStates: ["final"],
+		states: ["planner", "architect", "critic", "revision", "adr", "final", "handoff"],
+		terminalStates: ["final", "handoff"],
 		transitions: [
 			{ from: "planner", to: "architect", verb: "write-artifact" },
 			{ from: "architect", to: "critic", verb: "write-artifact" },
 			{ from: "critic", to: "revision", verb: "write-artifact" },
 			{ from: "revision", to: "adr", verb: "write-artifact" },
 			{ from: "adr", to: "final", verb: "write-artifact" },
+			{ from: "planner", to: "handoff", verb: "handoff" },
+			{ from: "architect", to: "handoff", verb: "handoff" },
+			{ from: "critic", to: "handoff", verb: "handoff" },
+			{ from: "revision", to: "handoff", verb: "handoff" },
+			{ from: "adr", to: "handoff", verb: "handoff" },
 		],
 		verbs: [...stateVerbs(), ...flagVerbs(["kickoff", "write-artifact"]), ...plannedVerbs(PLANNED_ADMIN_VERBS)],
 		typedArgs: [
@@ -204,8 +210,8 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 	}),
 	ultragoal: manifest({
 		skill: "ultragoal",
-		states: ["goal-planning", "pending", "active", "blocked", "failed", "complete"],
-		terminalStates: ["failed", "complete"],
+		states: ["goal-planning", "pending", "active", "blocked", "failed", "complete", "handoff"],
+		terminalStates: ["failed", "complete", "handoff"],
 		transitions: [
 			{ from: "goal-planning", to: "pending", verb: "create-goals" },
 			{ from: "pending", to: "active", verb: "complete-goals" },
@@ -214,6 +220,10 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{ from: "active", to: "complete", verb: "checkpoint" },
 			{ from: "blocked", to: "active", verb: "checkpoint" },
 			{ from: "failed", to: "active", verb: "complete-goals" },
+			{ from: "goal-planning", to: "handoff", verb: "handoff" },
+			{ from: "pending", to: "handoff", verb: "handoff" },
+			{ from: "active", to: "handoff", verb: "handoff" },
+			{ from: "blocked", to: "handoff", verb: "handoff" },
 		],
 		verbs: [
 			...stateVerbs(),
@@ -281,8 +291,8 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 	}),
 	team: manifest({
 		skill: "team",
-		states: ["starting", "running", "awaiting_integration", "complete", "failed", "cancelled"],
-		terminalStates: ["complete", "failed", "cancelled"],
+		states: ["starting", "running", "awaiting_integration", "complete", "failed", "cancelled", "handoff"],
+		terminalStates: ["complete", "failed", "cancelled", "handoff"],
 		transitions: [
 			{ from: "starting", to: "running", verb: "start" },
 			{ from: "starting", to: "failed", verb: "start" },
@@ -292,6 +302,9 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{ from: "running", to: "cancelled", verb: "shutdown" },
 			{ from: "awaiting_integration", to: "running", verb: "resume" },
 			{ from: "awaiting_integration", to: "complete", verb: "shutdown" },
+			{ from: "starting", to: "handoff", verb: "handoff" },
+			{ from: "running", to: "handoff", verb: "handoff" },
+			{ from: "awaiting_integration", to: "handoff", verb: "handoff" },
 		],
 		verbs: [
 			...stateVerbs(),
@@ -377,7 +390,12 @@ export function getSkillManifest(skill: CanonicalGjcWorkflowSkill): SkillManifes
 	return WORKFLOW_MANIFEST[skill];
 }
 
+export function isKnownWorkflowState(skill: CanonicalGjcWorkflowSkill, state: string): boolean {
+	return WORKFLOW_MANIFEST[skill].states.some(entry => entry.id === state);
+}
+
 export function isValidTransition(skill: CanonicalGjcWorkflowSkill, from: string, to: string): boolean {
+	if (from === to) return true;
 	return WORKFLOW_MANIFEST[skill].transitions.some(transition => transition.from === from && transition.to === to);
 }
 

--- a/packages/coding-agent/src/skill-state/workflow-state-contract.ts
+++ b/packages/coding-agent/src/skill-state/workflow-state-contract.ts
@@ -9,6 +9,13 @@ export const WORKFLOW_STATE_RECEIPT_FRESH_MS = 30 * 60 * 1000;
 export type WorkflowStateMutationOwner = "gjc-state-cli" | "gjc-runtime" | "gjc-hook";
 export type WorkflowStateReceiptStatus = "fresh" | "stale";
 
+export interface WorkflowStateContentChecksum {
+	algorithm: "sha256";
+	value: string;
+	covered_path: string;
+	computed_at: string;
+}
+
 export interface WorkflowStateReceipt {
 	version: 1;
 	skill: CanonicalGjcWorkflowSkill;
@@ -25,6 +32,7 @@ export interface WorkflowStateReceipt {
 	to_phase?: string;
 	forced?: boolean;
 	paths?: string[];
+	content_sha256?: WorkflowStateContentChecksum;
 }
 
 export interface AuditEntry {

--- a/packages/coding-agent/test/gjc-runtime/state-concurrency-fuzz.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-concurrency-fuzz.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	AlreadyExistsError,
+	appendJsonl,
+	createJsonNoClobber,
+	rebuildActiveSnapshot,
+	writeActiveEntry,
+} from "@gajae-code/coding-agent/gjc-runtime/state-writer";
+import type { SkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
+
+const tempRoots: string[] = [];
+const WORKER_COUNT = 8;
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-state-concurrency-fuzz-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+let priorSessionId: string | undefined;
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+});
+
+async function readJson<T>(filePath: string): Promise<T> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as T;
+}
+
+describe("gjc state no-lock concurrency fuzz", () => {
+	it("preserves all per-skill active entries when concurrent writers rebuild the derived snapshot", async () => {
+		const root = await tempDir();
+		const nowIso = new Date("2026-06-03T00:00:00.000Z").toISOString();
+		const skills = Array.from({ length: WORKER_COUNT }, (_, index) => `fuzz-skill-${index}`);
+
+		await Promise.all(
+			skills.map(async (skill, index) => {
+				await writeActiveEntry(
+					root,
+					undefined,
+					skill,
+					{
+						skill,
+						active: true,
+						phase: `phase-${index}`,
+						updated_at: nowIso,
+						session_id: `session-${index}`,
+					},
+					{ cwd: root },
+				);
+				await rebuildActiveSnapshot(root, undefined, { cwd: root });
+			}),
+		);
+
+		await rebuildActiveSnapshot(root, undefined, { cwd: root });
+		const snapshot = await readJson<SkillActiveState>(path.join(root, ".gjc", "state", "skill-active-state.json"));
+		const activeSkills = snapshot.active_skills ?? [];
+		const bySkill = new Map(activeSkills.map(entry => [entry.skill, entry]));
+
+		expect(activeSkills).toHaveLength(WORKER_COUNT);
+		for (const [index, skill] of skills.entries()) {
+			expect(bySkill.get(skill)).toMatchObject({
+				skill,
+				active: true,
+				phase: `phase-${index}`,
+				session_id: `session-${index}`,
+			});
+		}
+	});
+
+	it("allows exactly one O_EXCL claim winner when workers race the same team claim file", async () => {
+		const root = await tempDir();
+		const claimPath = ".gjc/state/team/claims/shared-task.json";
+		const attempts = await Promise.all(
+			Array.from({ length: WORKER_COUNT }, async (_, index) => {
+				try {
+					await createJsonNoClobber(
+						claimPath,
+						{
+							task_id: "shared-task",
+							worker_id: `worker-${index}`,
+							claimed_at: `2026-06-03T00:00:0${index}.000Z`,
+						},
+						{ cwd: root },
+					);
+					return { ok: true as const, worker: `worker-${index}` };
+				} catch (error) {
+					if (error instanceof AlreadyExistsError) return { ok: false as const, alreadyExists: true };
+					throw error;
+				}
+			}),
+		);
+
+		const winners = attempts.filter(result => result.ok);
+		const losers = attempts.filter(result => !result.ok && result.alreadyExists);
+		expect(winners).toHaveLength(1);
+		expect(losers).toHaveLength(WORKER_COUNT - 1);
+
+		const claim = await readJson<Record<string, unknown>>(path.join(root, claimPath));
+		expect(claim.worker_id).toBe(winners[0]?.worker);
+	});
+
+	it("keeps concurrent audit JSONL appends complete and parseable", async () => {
+		const root = await tempDir();
+		const auditPath = ".gjc/state/audit.jsonl";
+		const ids = Array.from({ length: WORKER_COUNT }, (_, index) => `audit-${index}`);
+
+		await Promise.all(
+			ids.map((id, index) =>
+				appendJsonl(
+					auditPath,
+					{ id, event: "concurrency-fuzz", worker_id: `worker-${index}`, at: `2026-06-03T00:00:0${index}.000Z` },
+					{ cwd: root },
+				),
+			),
+		);
+
+		const raw = await fs.readFile(path.join(root, auditPath), "utf-8");
+		const lines = raw.trimEnd().split("\n");
+		const parsed = lines.map(line => JSON.parse(line) as Record<string, unknown>);
+		const seenIds = new Set(parsed.map(entry => entry.id));
+
+		expect(lines).toHaveLength(WORKER_COUNT);
+		for (const id of ids) expect(seenIds.has(id)).toBe(true);
+		for (const entry of parsed) expect(entry.event).toBe("concurrency-fuzz");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -328,7 +328,7 @@ describe("gjc state handoff", () => {
 
 			// Step 2: R -> U.
 			const step2 = await runNativeStateCommand(
-				["handoff", "--mode", "ralplan", "--to", "ultragoal", "--json"],
+				["handoff", "--mode", "ralplan", "--to", "ultragoal", "--json", "--force"],
 				cwd,
 			);
 			expect(step2.status).toBe(0);

--- a/packages/coding-agent/test/gjc-runtime/state-integrity.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-integrity.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runNativeStateCommand } from "../../src/gjc-runtime/state-runtime";
+import { writeJsonAtomic } from "../../src/gjc-runtime/state-writer";
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-integrity-"));
+	const priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+	try {
+		await fn(dir);
+	} finally {
+		if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+}
+
+async function readAuditEntries(cwd: string): Promise<Array<Record<string, unknown>>> {
+	const raw = await fs.readFile(path.join(cwd, ".gjc/state/audit.jsonl"), "utf-8");
+	return raw
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("gjc state integrity", () => {
+	it("detects out-of-band edits on the next mode-state write and audits evidence", async () => {
+		await withTempCwd(async cwd => {
+			const first = await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "planner" })],
+				cwd,
+			);
+			expect(first.status).toBe(0);
+			const statePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			const stamped = await readJson(statePath);
+			expect((stamped.receipt as Record<string, unknown>)?.content_sha256).toMatchObject({ algorithm: "sha256" });
+
+			stamped.tampered = true;
+			await fs.writeFile(statePath, `${JSON.stringify(stamped, null, 2)}\n`, "utf-8");
+
+			const second = await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "continue" })],
+				cwd,
+			);
+			expect(second.status).toBe(0);
+			expect(second.stderr).toContain("out-of-band edit detected");
+			const entries = await readAuditEntries(cwd);
+			const mismatch = entries.find(entry => entry.verb === "out_of_band_detected");
+			expect(mismatch).toMatchObject({ skill: "ralplan", category: "state", owner: "gjc-state-cli" });
+			expect(typeof mismatch?.expected_sha256).toBe("string");
+			expect(typeof mismatch?.actual_sha256).toBe("string");
+		});
+	});
+
+	it("does not checksum generic non-envelope JSON written by the shared writer", async () => {
+		await withTempCwd(async cwd => {
+			await writeJsonAtomic(
+				path.join(cwd, ".gjc/state/team/tasks/task-1.json"),
+				{ id: "task-1", status: "open" },
+				{ cwd },
+			);
+			const task = await readJson(path.join(cwd, ".gjc/state/team/tasks/task-1.json"));
+			expect(task.receipt).toBeUndefined();
+			expect(task.content_sha256).toBeUndefined();
+		});
+	});
+
+	it("handoff writes and removes its per-mutation journal on success", async () => {
+		await withTempCwd(async cwd => {
+			await runNativeStateCommand(
+				["write", "--mode", "deep-interview", "--input", JSON.stringify({ current_phase: "interviewing" })],
+				cwd,
+			);
+			const result = await runNativeStateCommand(["handoff", "--mode", "deep-interview", "--to", "ralplan"], cwd);
+			expect(result.status).toBe(0);
+			const entries = await fs.readdir(path.join(cwd, ".gjc/state/transactions")).catch(() => [] as string[]);
+			expect(entries).toEqual([]);
+		});
+	});
+
+	it("an injected mid-handoff failure leaves a same-mutation journal while unrelated writes still proceed", async () => {
+		await withTempCwd(async cwd => {
+			await runNativeStateCommand(
+				["write", "--mode", "deep-interview", "--input", JSON.stringify({ current_phase: "interviewing" })],
+				cwd,
+			);
+			process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER = "__never__";
+			const originalNow = Date.prototype.toISOString;
+			Date.prototype.toISOString = () => "2026-06-03T00:00:00.000Z";
+			process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER = "deep-interview:handoff:ralplan:2026-06-03T00:00:00.000Z";
+			try {
+				const failed = await runNativeStateCommand(["handoff", "--mode", "deep-interview", "--to", "ralplan"], cwd);
+				expect(failed.status).toBe(1);
+			} finally {
+				Date.prototype.toISOString = originalNow;
+				delete process.env.GJC_STATE_HANDOFF_FAIL_AFTER_CALLER;
+			}
+
+			const journals = await fs.readdir(path.join(cwd, ".gjc/state/transactions"));
+			expect(journals).toHaveLength(1);
+			const journal = await readJson(path.join(cwd, ".gjc/state/transactions", journals[0]));
+			expect(journal).toMatchObject({
+				status: "pending",
+				mutation_id: "deep-interview:handoff:ralplan:2026-06-03T00:00:00.000Z",
+			});
+
+			Date.prototype.toISOString = () => "2026-06-03T00:00:00.000Z";
+			try {
+				const recovered = await runNativeStateCommand(
+					["handoff", "--mode", "deep-interview", "--to", "ralplan"],
+					cwd,
+				);
+				expect(recovered.status).toBe(0);
+			} finally {
+				Date.prototype.toISOString = originalNow;
+			}
+			const remainingAfterRecovery = await fs.readdir(path.join(cwd, ".gjc/state/transactions"));
+			expect(remainingAfterRecovery).toEqual([]);
+
+			await fs.writeFile(
+				path.join(cwd, ".gjc/state/transactions/orphan-unrelated.json"),
+				`${JSON.stringify({ version: 1, mutation_id: "orphan", status: "pending", paths: ["/elsewhere"] })}\n`,
+			);
+			const write = await runNativeStateCommand(
+				["write", "--mode", "ultragoal", "--input", JSON.stringify({ current_phase: "goal-planning" })],
+				cwd,
+			);
+			expect(write.status).toBe(0);
+			expect(await readJson(path.join(cwd, ".gjc/state/ultragoal-state.json"))).toMatchObject({
+				skill: "ultragoal",
+			});
+		});
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-integrity.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-integrity.test.ts
@@ -31,7 +31,7 @@ async function readAuditEntries(cwd: string): Promise<Array<Record<string, unkno
 }
 
 describe("gjc state integrity", () => {
-	it("detects out-of-band edits on the next mode-state write and audits evidence", async () => {
+	it("blocks out-of-band edits on the next mode-state write unless forced", async () => {
 		await withTempCwd(async cwd => {
 			const first = await runNativeStateCommand(
 				["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "planner" })],
@@ -45,14 +45,22 @@ describe("gjc state integrity", () => {
 			stamped.tampered = true;
 			await fs.writeFile(statePath, `${JSON.stringify(stamped, null, 2)}\n`, "utf-8");
 
-			const second = await runNativeStateCommand(
+			const rejected = await runNativeStateCommand(
 				["write", "--mode", "ralplan", "--input", JSON.stringify({ verdict: "continue" })],
 				cwd,
 			);
-			expect(second.status).toBe(0);
-			expect(second.stderr).toContain("out-of-band edit detected");
+			expect(rejected.status).not.toBe(0);
+			expect(rejected.stderr).toContain("out-of-band edit detected");
+			expect((await readJson(statePath)).tampered).toBe(true);
+
+			const forced = await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--force", "--input", JSON.stringify({ verdict: "continue" })],
+				cwd,
+			);
+			expect(forced.status).toBe(0);
+			expect(forced.stderr).toContain("out-of-band edit detected");
 			const entries = await readAuditEntries(cwd);
-			const mismatch = entries.find(entry => entry.verb === "out_of_band_detected");
+			const mismatch = entries.find(entry => entry.verb === "out_of_band_detected" && entry.forced === true);
 			expect(mismatch).toMatchObject({ skill: "ralplan", category: "state", owner: "gjc-state-cli" });
 			expect(typeof mismatch?.expected_sha256).toBe("string");
 			expect(typeof mismatch?.actual_sha256).toBe("string");

--- a/packages/coding-agent/test/gjc-runtime/state-retention-gc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-retention-gc.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-state-retention-gc-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+let priorSessionId: string | undefined;
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+});
+
+async function writeFileWithAge(
+	root: string,
+	relativePath: string,
+	ageDays: number,
+	content = "{}\n",
+): Promise<string> {
+	const filePath = path.join(root, ".gjc", "state", relativePath);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, "utf-8");
+	const when = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
+	await fs.utimes(filePath, when, when);
+	return filePath;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ENOENT";
+	}
+}
+
+describe("native gjc state retention gc", () => {
+	it("dry-runs and prunes only manifest-retention eligible state files", async () => {
+		const root = await tempDir();
+		const oldLog = await writeFileWithAge(root, "logs/old.jsonl", 45, '{"old":true}\n');
+		const freshLog = await writeFileWithAge(root, "logs/fresh.jsonl", 1, '{"fresh":true}\n');
+		const oldReport = await writeFileWithAge(root, "reports/old.json", 45);
+		const currentState = await writeFileWithAge(
+			root,
+			"team-state.json",
+			45,
+			JSON.stringify({ skill: "team", active: true }),
+		);
+		const currentSnapshot = await writeFileWithAge(
+			root,
+			"skill-active-state.json",
+			45,
+			JSON.stringify({ active: true }),
+		);
+		const audit = await writeFileWithAge(root, "audit.jsonl", 120, '{"category":"state"}\n');
+
+		const dryRun = await runNativeStateCommand(["gc", "--skill", "team", "--dry-run"], root);
+		expect(dryRun.status).toBe(0);
+		const dryRunJson = JSON.parse(dryRun.stdout ?? "{}") as {
+			dry_run: boolean;
+			eligible: string[];
+			pruned: string[];
+		};
+		expect(dryRunJson.dry_run).toBe(true);
+		expect(dryRunJson.eligible).toEqual(["logs/old.jsonl", "reports/old.json"]);
+		expect(dryRunJson.pruned).toEqual([]);
+		expect(await exists(oldLog)).toBe(true);
+		expect(await exists(oldReport)).toBe(true);
+
+		const gc = await runNativeStateCommand(["gc", "--skill", "team"], root);
+		expect(gc.status).toBe(0);
+		const gcJson = JSON.parse(gc.stdout ?? "{}") as { pruned: string[] };
+		expect(gcJson.pruned).toEqual(["logs/old.jsonl", "reports/old.json"]);
+		expect(await exists(oldLog)).toBe(false);
+		expect(await exists(oldReport)).toBe(false);
+		expect(await exists(freshLog)).toBe(true);
+		expect(await exists(currentState)).toBe(true);
+		expect(await exists(currentSnapshot)).toBe(true);
+		expect(await exists(audit)).toBe(true);
+
+		const auditLines = (await fs.readFile(path.join(root, ".gjc", "state", "audit.jsonl"), "utf-8"))
+			.trim()
+			.split(/\r?\n/)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		expect(auditLines.some(entry => entry.category === "prune" && entry.verb === "gc")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readWorkflowStateJson, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-token-thrift-"));
+	tempRoots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	for (const root of tempRoots.splice(0)) await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("GJC state token thrift", () => {
+	it("elides large arrays in default read while --json and readWorkflowStateJson stay full", async () => {
+		const root = await tempDir();
+		const payload = {
+			current_phase: "interviewing",
+			rounds: [
+				{ n: 1, transcript: "full" },
+				{ n: 2, transcript: "full" },
+			],
+			ontology_snapshots: [{ id: "o1" }],
+			architect_findings: [{ finding: "large" }],
+			new_requirements: [{ text: "keep" }],
+			ci_gates: [{ name: "gate" }],
+			research_findings: [{ source: "paper" }],
+		};
+		await runNativeStateCommand(
+			["write", "--mode", "deep-interview", "--session-id", "", "--input", JSON.stringify(payload)],
+			root,
+		);
+
+		const markdown = await runNativeStateCommand(["read", "--mode", "deep-interview", "--session-id", ""], root);
+		expect(markdown.status).toBe(0);
+		expect(markdown.stdout).toContain("rounds: 2 entries (--json for full)");
+		expect(markdown.stdout).toContain("ontology_snapshots: 1 entries (--json for full)");
+		expect(markdown.stdout).not.toContain("transcript");
+
+		const json = await runNativeStateCommand(
+			["read", "--mode", "deep-interview", "--session-id", "", "--json"],
+			root,
+		);
+		expect(json.status).toBe(0);
+		const parsed = JSON.parse(json.stdout ?? "{}");
+		const raw = await readWorkflowStateJson(root, "deep-interview");
+		expect(parsed.state).toEqual(raw);
+		expect(parsed.state.rounds).toEqual(payload.rounds);
+	});
+
+	it("projects requested fields in requested order", async () => {
+		const root = await tempDir();
+		await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "approval", run_id: "r1" })],
+			root,
+		);
+
+		const result = await runNativeStateCommand(
+			["read", "--mode", "ralplan", "--fields", "phase,next,run_id", "--json"],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(Object.keys(parsed)).toEqual(["phase", "next", "run_id"]);
+		expect(parsed.phase).toBe("approval");
+		expect(parsed.run_id).toBe("r1");
+	});
+
+	it("prints state status as one line", async () => {
+		const root = await tempDir();
+		await runNativeStateCommand(
+			["write", "--mode", "deep-interview", "--input", JSON.stringify({ current_phase: "interviewing" })],
+			root,
+		);
+
+		const result = await runNativeStateCommand(["status", "deep-interview"], root);
+		expect(result.status).toBe(0);
+		expect(result.stdout?.trim().split("\n")).toHaveLength(1);
+		expect(result.stdout).toContain("deep-interview: phase=interviewing");
+		expect(result.stdout).toContain("next=");
+	});
+
+	it("windows audit history with --limit", async () => {
+		const root = await tempDir();
+		for (let index = 0; index < 5; index += 1) {
+			await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: `phase-${index}` })],
+				root,
+			);
+		}
+
+		const result = await runNativeStateCommand(["graph", "--history", "--limit", "2", "--json"], root);
+		expect(result.status).toBe(0);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.entries).toHaveLength(2);
+		expect(parsed.limit).toBe(2);
+		expect(parsed.truncated).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
 });
 
 describe("GJC state token thrift", () => {
-	it("elides large arrays in default read while --json and readWorkflowStateJson stay full", async () => {
+	it("elides large arrays only for --compact while plain --json and readWorkflowStateJson stay full", async () => {
 		const root = await tempDir();
 		const payload = {
 			current_phase: "interviewing",
@@ -36,11 +36,23 @@ describe("GJC state token thrift", () => {
 			root,
 		);
 
-		const markdown = await runNativeStateCommand(["read", "--mode", "deep-interview", "--session-id", ""], root);
-		expect(markdown.status).toBe(0);
-		expect(markdown.stdout).toContain("rounds: 2 entries (--json for full)");
-		expect(markdown.stdout).toContain("ontology_snapshots: 1 entries (--json for full)");
-		expect(markdown.stdout).not.toContain("transcript");
+		const compactMarkdown = await runNativeStateCommand(
+			["read", "--mode", "deep-interview", "--session-id", "", "--compact"],
+			root,
+		);
+		expect(compactMarkdown.status).toBe(0);
+		expect(compactMarkdown.stdout).toContain("rounds: 2 entries (elided)");
+		expect(compactMarkdown.stdout).toContain("ontology_snapshots: 1 entries (elided)");
+		expect(compactMarkdown.stdout).not.toContain("transcript");
+
+		const compactJson = await runNativeStateCommand(
+			["read", "--mode", "deep-interview", "--session-id", "", "--compact", "--json"],
+			root,
+		);
+		expect(compactJson.status).toBe(0);
+		const parsedCompact = JSON.parse(compactJson.stdout ?? "{}");
+		expect(parsedCompact.rounds).toBeUndefined();
+		expect(parsedCompact.elided.rounds).toEqual({ type: "array", count: 2, pointer: "/rounds" });
 
 		const json = await runNativeStateCommand(
 			["read", "--mode", "deep-interview", "--session-id", "", "--json"],
@@ -83,6 +95,52 @@ describe("GJC state token thrift", () => {
 		expect(result.stdout?.trim().split("\n")).toHaveLength(1);
 		expect(result.stdout).toContain("deep-interview: phase=interviewing");
 		expect(result.stdout).toContain("next=");
+	});
+
+	it("resolves explicit skill for both status positional forms", async () => {
+		const root = await tempDir();
+		await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ current_phase: "planner" })],
+			root,
+		);
+		const actionFirst = await runNativeStateCommand(["status", "ralplan"], root);
+		const skillFirst = await runNativeStateCommand(["ralplan", "status"], root);
+		expect(actionFirst.status).toBe(0);
+		expect(skillFirst.status).toBe(0);
+		expect(actionFirst.stdout).toContain("ralplan: phase=planner");
+		expect(skillFirst.stdout).toContain("ralplan: phase=planner");
+	});
+
+	it("rejects wrong typed consumed scalars while preserving extension fields", async () => {
+		const root = await tempDir();
+		const wrongVersion = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ version: "1", current_phase: "planner" })],
+			root,
+		);
+		expect(wrongVersion.status).not.toBe(0);
+		expect(wrongVersion.stderr).toContain("state.version must be a number");
+
+		const wrongUpdatedAt = await runNativeStateCommand(
+			["write", "--mode", "ralplan", "--input", JSON.stringify({ updated_at: 123, current_phase: "planner" })],
+			root,
+		);
+		expect(wrongUpdatedAt.status).not.toBe(0);
+		expect(wrongUpdatedAt.stderr).toContain("state.updated_at must be a string");
+
+		const extension = await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"ralplan",
+				"--input",
+				JSON.stringify({ current_phase: "planner", rounds: [{ n: 1 }], topology: { free: ["form"] } }),
+			],
+			root,
+		);
+		expect(extension.status).toBe(0);
+		const parsed = JSON.parse(extension.stdout ?? "{}");
+		expect(parsed.state.rounds).toEqual([{ n: 1 }]);
+		expect(parsed.state.topology).toEqual({ free: ["form"] });
 	});
 
 	it("windows audit history with --limit", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-state-write-hardening-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+let priorSessionId: string | undefined;
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+});
+
+function stateFrom(stdout: string | undefined): Record<string, unknown> {
+	const parsed = JSON.parse(stdout ?? "{}");
+	return parsed.state as Record<string, unknown>;
+}
+
+async function writeState(root: string, mode: string, state: Record<string, unknown>, extra: string[] = []) {
+	return runNativeStateCommand(["write", "--mode", mode, "--input", JSON.stringify(state), "--json", ...extra], root);
+}
+
+describe("gjc state write hardening", () => {
+	it("allows a valid manifest transition", async () => {
+		const root = await tempDir();
+		await writeState(root, "ralplan", { current_phase: "planner" });
+		const result = await writeState(root, "ralplan", { current_phase: "architect" });
+		expect(result.status).toBe(0);
+		expect(stateFrom(result.stdout).current_phase).toBe("architect");
+	});
+
+	it("rejects a known-bad jump", async () => {
+		const root = await tempDir();
+		await writeState(root, "ralplan", { current_phase: "planner" });
+		const result = await writeState(root, "ralplan", { current_phase: "final" });
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("invalid ralplan phase transition from planner to final");
+	});
+
+	it("allows --force to bypass a known-bad jump", async () => {
+		const root = await tempDir();
+		await writeState(root, "ralplan", { current_phase: "planner" });
+		const result = await writeState(root, "ralplan", { current_phase: "final" }, ["--force"]);
+		expect(result.status).toBe(0);
+		expect(stateFrom(result.stdout).current_phase).toBe("final");
+	});
+
+	it.each([
+		["ralplan", "planner"],
+		["ultragoal", "active"],
+		["team", "running"],
+	])("allows %s handoff writes without --force", async (mode, fromPhase) => {
+		const root = await tempDir();
+		await writeState(root, mode, { current_phase: fromPhase });
+		const result = await writeState(root, mode, { current_phase: "handoff" });
+		expect(result.status).toBe(0);
+		expect(stateFrom(result.stdout).current_phase).toBe("handoff");
+	});
+
+	it("allows unknown legacy target phases", async () => {
+		const root = await tempDir();
+		await writeState(root, "ralplan", { current_phase: "planner" });
+		const result = await writeState(root, "ralplan", { current_phase: "legacy-custom" });
+		expect(result.status).toBe(0);
+		expect(stateFrom(result.stdout).current_phase).toBe("legacy-custom");
+	});
+
+	it("allows seeds with no prior phase", async () => {
+		const root = await tempDir();
+		const result = await writeState(root, "ralplan", { current_phase: "final" });
+		expect(result.status).toBe(0);
+		expect(stateFrom(result.stdout).current_phase).toBe("final");
+	});
+
+	it("rejects non-object existing state before write", async () => {
+		const root = await tempDir();
+		const stateDir = path.join(root, ".gjc", "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await fs.writeFile(path.join(stateDir, "ralplan-state.json"), JSON.stringify([]));
+		const result = await writeState(root, "ralplan", { current_phase: "planner" });
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("existing state for ralplan must be a JSON object");
+	});
+
+	it("rejects wrong-typed active and current_phase", async () => {
+		const root = await tempDir();
+		const badActive = await writeState(root, "ralplan", { active: "yes" });
+		expect(badActive.status).not.toBe(0);
+		expect(badActive.stderr).toContain("state.active must be a boolean");
+
+		const badPhase = await writeState(root, "ralplan", { current_phase: 12 });
+		expect(badPhase.status).not.toBe(0);
+		expect(badPhase.stderr).toContain("state.current_phase must be a string");
+	});
+
+	it("preserves free-form extension fields through write", async () => {
+		const root = await tempDir();
+		const extension = {
+			current_phase: "interviewing",
+			rounds: [{ id: "r1", arbitrary: { ok: true } }],
+			topology: { nodes: ["a"] },
+			ontology_snapshots: [{ any: "shape" }],
+			architect_findings: [{ severity: "WATCH", extra: 1 }],
+			new_requirements: ["keep"],
+			ci_gates: { custom: ["gate"] },
+			research_findings: [{ source: "x" }],
+			extension_field: { nested: true },
+		};
+		const result = await writeState(root, "deep-interview", extension);
+		expect(result.status).toBe(0);
+		const written = stateFrom(result.stdout);
+		expect(written.rounds).toEqual(extension.rounds);
+		expect(written.topology).toEqual(extension.topology);
+		expect(written.ontology_snapshots).toEqual(extension.ontology_snapshots);
+		expect(written.architect_findings).toEqual(extension.architect_findings);
+		expect(written.new_requirements).toEqual(extension.new_requirements);
+		expect(written.ci_gates).toEqual(extension.ci_gates);
+		expect(written.research_findings).toEqual(extension.research_findings);
+		expect(written.extension_field).toEqual(extension.extension_field);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -1309,8 +1309,7 @@ describe("native gjc team runtime", () => {
 		expect(commandSource).toContain("monitorGjcTeam(teamName)");
 		expect(commandSource).toContain("listGjcTeams()");
 		expect(commandSource).toContain("formatTaskCounts(snapshot.task_counts)");
-		expect(commandSource).toContain("formatIntegrationSummary(snapshot)");
-		expect(commandSource).toContain("formatNotificationSummary(snapshot)");
+		expect(commandSource).toContain("renderTeamStatusMarkdown(snapshot)");
 
 		const runtimeSource = await Bun.file(path.join(import.meta.dir, "../../src/gjc-runtime/team-runtime.ts")).text();
 		for (const disallowedGitStrategy of ['"-X"', '"--strategy-option"', "-X theirs", "-X ours"]) {


### PR DESCRIPTION
Implements approved consensus plan `state-hardening-token-thrift-v2` (deep-interview perspective: state-model hardening + token-leak reduction), on the merged #198/#199 foundation.

**Token-thrift:** `gjc state read --fields/--compact` projection (plain `--json` + `readWorkflowStateJson` stay lossless); `gjc state status <skill>` one-liner; compact markdown for `state contract`/`ultragoal status`/`team status`; audit `--since/--limit` windowing.

**Hardening:** lenient transition enforcement (`handoff` pseudo-state, only known-bad jumps rejected, `--force` bypass, seeds/migrations/legacy pass); additive schema validation (extension bodies preserved); retention/GC (`gjc state gc`, never deletes current files); out-of-band checksum that BLOCKS tampered mode-state writes unless `--force` (audited); per-mutation-id handoff journal (no-lock preserved); 8-way concurrency fuzz test.

**Verification:** tsc 0; 212 gjc tests pass; G1/G3/G4 gates pass; architect final review APPROVE (all lanes CLEAR, 0 HIGH/CRITICAL) after a BLOCK→fix→re-review cycle.

deep-interview → ralplan consensus → ultragoal execution.
