### PR TITLE
feat(harness): WATCH fixes — RPC frame observability, socket/lease hardening, completion detection

### DIFF
--- a/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
+++ b/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
@@ -10,8 +10,10 @@
  * is a documented seam tracked as an ADR follow-up.
  */
 
-import { rm } from "node:fs/promises";
+import * as fs from "node:fs/promises";
 import * as net from "node:net";
+import * as path from "node:path";
+import { MAX_UNIX_SOCKET_PATH_BYTES } from "./storage";
 
 export interface EndpointRequest {
 	verb: string;
@@ -32,7 +34,11 @@ export class ControlServer {
 	) {}
 
 	async listen(): Promise<void> {
-		await rm(this.socketPath, { force: true });
+		await fs.mkdir(path.dirname(this.socketPath), { recursive: true });
+		if (Buffer.byteLength(this.socketPath) > MAX_UNIX_SOCKET_PATH_BYTES) {
+			throw new Error(`socket_path_too_long:${this.socketPath}`);
+		}
+		await fs.rm(this.socketPath, { force: true });
 		await new Promise<void>((resolve, reject) => {
 			const server = net.createServer(socket => this.#onConnection(socket));
 			server.once("error", reject);
@@ -77,7 +83,7 @@ export class ControlServer {
 		if (server) {
 			await new Promise<void>(resolve => server.close(() => resolve()));
 		}
-		await rm(this.socketPath, { force: true });
+		await fs.rm(this.socketPath, { force: true });
 	}
 }
 

--- a/packages/coding-agent/src/harness-control-plane/frame-mapper.ts
+++ b/packages/coding-agent/src/harness-control-plane/frame-mapper.ts
@@ -1,0 +1,241 @@
+/**
+ * Pure mapping from `gjc --mode rpc` event frames (docs/rpc.md) to bounded owner event kinds
+ * and {@link ObservedSignal}s. The owner feeds raw frames through this mapper and emits the
+ * result via its single-writer #emit — the mapper itself performs NO IO and NO appends.
+ *
+ * Hard rule: evidence is BOUNDED — only ids, names, categories, statuses, cursors, timestamps,
+ * and short codes/messages. Never assistant text, message deltas, command output, or raw args.
+ */
+import type { ObservedSignal } from "./types";
+
+export interface MappedFrame {
+	/** Owner event kind (rpc_*). */
+	kind: string;
+	/** Bounded observed signal, or null when the frame carries no user-facing signal. */
+	signal: ObservedSignal | null;
+	/** Bounded evidence — ids/names/statuses/cursors/timestamps/short codes only. */
+	evidence: Record<string, unknown>;
+	/** Severity for the emitted event. */
+	severity: "info" | "warn" | "critical";
+	/** Never-drop frames (must be enqueued in order, never coalesced away). */
+	semantic: boolean;
+	/** Coalescing key for high-frequency non-semantic frames (message id / tool id); null otherwise. */
+	coalesceKey: string | null;
+}
+
+const TEST_RE = /\b(bun test|npm test|yarn test|pnpm test|jest|vitest|pytest|go test|cargo test|mocha|ava)\b/i;
+
+export function isTestRunnerTool(toolName?: unknown, command?: unknown): boolean {
+	const name = typeof toolName === "string" ? toolName : "";
+	const cmd = typeof command === "string" ? command : "";
+	if (/test/i.test(name) && name !== "edit" && name !== "read") return true;
+	return TEST_RE.test(cmd);
+}
+
+function str(v: unknown): string | undefined {
+	return typeof v === "string" ? v : undefined;
+}
+function num(v: unknown): number | undefined {
+	return typeof v === "number" ? v : undefined;
+}
+function boundedMessage(v: unknown): string | undefined {
+	const s = typeof v === "string" ? v : undefined;
+	return s === undefined ? undefined : s.slice(0, 200);
+}
+
+/**
+ * Map a single RPC frame. Returns null for frames that carry no observability value
+ * (or that the adapter handles itself: `ready`, `response`).
+ */
+export function mapRpcFrame(frame: Record<string, unknown>): MappedFrame | null {
+	const type = str(frame.type);
+	if (!type || type === "ready" || type === "response") return null;
+
+	switch (type) {
+		case "agent_start":
+			return {
+				kind: "rpc_agent_started",
+				signal: "SessionStart",
+				evidence: {},
+				severity: "info",
+				semantic: true,
+				coalesceKey: null,
+			};
+		case "turn_start":
+			return {
+				kind: "rpc_turn_started",
+				signal: "prompt-accepted",
+				evidence: {},
+				severity: "info",
+				semantic: true,
+				coalesceKey: null,
+			};
+		case "turn_end":
+			return {
+				kind: "rpc_turn_ended",
+				signal: null,
+				evidence: {},
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "message_start":
+		case "message_update":
+		case "message_end":
+			return {
+				kind: "rpc_message_activity",
+				signal: null,
+				evidence: { phase: type, messageId: str(frame.messageId) ?? null },
+				severity: "info",
+				semantic: false,
+				coalesceKey: `message:${str(frame.messageId) ?? "msg"}`,
+			};
+		case "tool_execution_start": {
+			const toolName = str(frame.toolName);
+			const test = isTestRunnerTool(toolName, frame.command ?? frame.commandLine);
+			return {
+				kind: "rpc_tool_started",
+				signal: test ? "test-running" : "tool-call",
+				evidence: { toolId: str(frame.toolCallId) ?? null, toolName: toolName ?? null },
+				severity: "info",
+				semantic: true,
+				coalesceKey: null,
+			};
+		}
+		case "tool_execution_update": {
+			const toolName = str(frame.toolName);
+			const test = isTestRunnerTool(toolName, frame.command);
+			return {
+				kind: "rpc_tool_updated",
+				signal: test ? "test-running" : null,
+				evidence: { toolId: str(frame.toolCallId) ?? null, status: str(frame.status) ?? null },
+				severity: "info",
+				semantic: false,
+				coalesceKey: `tool:${str(frame.toolCallId) ?? "tool"}`,
+			};
+		}
+		case "tool_execution_end": {
+			const toolName = str(frame.toolName);
+			const test = isTestRunnerTool(toolName, frame.command);
+			return {
+				kind: "rpc_tool_ended",
+				signal: test ? "test-running" : "tool-call",
+				evidence: {
+					toolId: str(frame.toolCallId) ?? null,
+					toolName: toolName ?? null,
+					status: str(frame.status) ?? null,
+					exitCode: num(frame.exitCode) ?? null,
+				},
+				severity: str(frame.status) === "error" ? "warn" : "info",
+				semantic: true,
+				coalesceKey: null,
+			};
+		}
+		case "host_tool_call":
+		case "host_tool_cancel":
+			return {
+				kind: "rpc_host_tool",
+				signal: "tool-call",
+				evidence: { toolName: str(frame.toolName) ?? null },
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "host_uri_request":
+		case "host_uri_cancel":
+			return {
+				kind: "rpc_host_uri",
+				signal: "tool-call",
+				evidence: { operation: str(frame.operation) ?? null },
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "auto_compaction_start":
+		case "auto_compaction_end":
+			return {
+				kind: "rpc_compaction",
+				signal: null,
+				evidence: { phase: type },
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "auto_retry_start":
+		case "auto_retry_end":
+			return {
+				kind: "rpc_retry",
+				signal: null,
+				evidence: { phase: type, reason: boundedMessage(frame.reason) ?? null },
+				severity: "warn",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "ttsr_triggered":
+			return {
+				kind: "rpc_ttsr",
+				signal: "error",
+				evidence: { reason: boundedMessage(frame.reason) ?? null },
+				severity: "warn",
+				semantic: true,
+				coalesceKey: null,
+			};
+		case "todo_reminder":
+		case "todo_auto_clear":
+			return {
+				kind: "rpc_todo",
+				signal: null,
+				evidence: { phase: type },
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "extension_ui_request":
+			return {
+				kind: "rpc_extension_request",
+				signal: "tool-call",
+				evidence: { method: str(frame.method) ?? null },
+				severity: "info",
+				semantic: false,
+				coalesceKey: null,
+			};
+		case "extension_error":
+			return {
+				kind: "rpc_extension_error",
+				signal: "error",
+				evidence: {
+					code: str(frame.error) ? boundedMessage(frame.error) : null,
+					extensionPath: str(frame.extensionPath) ?? null,
+				},
+				severity: "critical",
+				semantic: true,
+				coalesceKey: null,
+			};
+		case "agent_end": {
+			const failed =
+				Boolean(frame.error) ||
+				frame.aborted === true ||
+				str(frame.outcome) === "failed" ||
+				str(frame.outcome) === "aborted";
+			return failed
+				? {
+						kind: "rpc_agent_failed",
+						signal: "error",
+						evidence: { outcome: str(frame.outcome) ?? "failed" },
+						severity: "critical",
+						semantic: true,
+						coalesceKey: null,
+					}
+				: {
+						kind: "rpc_agent_completed",
+						signal: "completed",
+						evidence: { outcome: "completed" },
+						severity: "info",
+						semantic: true,
+						coalesceKey: null,
+					};
+		}
+		default:
+			return null;
+	}
+}

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -17,6 +17,7 @@ import { existsSync } from "node:fs";
 import { classifyRecovery } from "./classifier";
 import { ControlServer, type EndpointRequest } from "./control-endpoint";
 import { defaultFinalizeChecks, type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "./finalize";
+import { mapRpcFrame } from "./frame-mapper";
 import { type OperateResult, operate } from "./operate";
 import { preserveDirtyWorktree } from "./preserve";
 import {
@@ -32,8 +33,8 @@ import { singleFlightAccept } from "./rpc-adapter";
 import {
 	acquireLease,
 	canWriteEvents,
+	classifyLeaseStatus,
 	heartbeat,
-	isStale,
 	readLease,
 	releaseLease,
 	type SessionLease,
@@ -41,6 +42,7 @@ import {
 import { buildStateView, nextAllowedActions } from "./state-machine";
 import {
 	appendEvent,
+	controlSocketPath,
 	readEvents,
 	readSessionState,
 	sessionPaths,
@@ -48,7 +50,7 @@ import {
 	writeSessionState,
 } from "./storage";
 import type { EventEnvelope, GitDelta, Observation, PrimitiveResponse, SessionState, Severity } from "./types";
-import { DEFAULT_RETRY_BUDGET } from "./types";
+import { DEFAULT_RETRY_BUDGET, OBSERVED_SIGNALS } from "./types";
 
 export interface OwnerOptions {
 	root: string;
@@ -83,10 +85,13 @@ export class RuntimeOwner {
 	#socketPath: string;
 	#finalizeChecks?: FinalizeChecks;
 	#validationCommands?: ValidationCommandSpec[];
+	#unsubscribeFrames: (() => void) | null = null;
+	#framePump: Promise<void> = Promise.resolve();
+	#coalesced = new Map<string, true>();
 
 	constructor(opts: OwnerOptions) {
 		this.ownerId = opts.ownerId ?? `owner-${randomUUID()}`;
-		this.#socketPath = sessionPaths(opts.root, opts.sessionId).controlSock;
+		this.#socketPath = controlSocketPath(opts.root, opts.sessionId);
 		this.#opts = {
 			root: opts.root,
 			sessionId: opts.sessionId,
@@ -118,8 +123,14 @@ export class RuntimeOwner {
 		this.#leaseEpoch = lease.leaseEpoch;
 		await this.#server.listen();
 		await this.#emit("info", "owner_started", { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch });
+		if (this.#opts.rpc.onEventFrame) {
+			this.#unsubscribeFrames = this.#opts.rpc.onEventFrame(frame => this.#handleFrame(frame));
+		}
 		this.#heartbeatTimer = setInterval(() => {
-			void heartbeat(root, sessionId, this.ownerId, this.#opts.ttlMs, this.#opts.clock).catch(() => {});
+			void heartbeat(root, sessionId, this.ownerId, this.#opts.ttlMs, this.#opts.clock).catch(err => {
+				// Self-stop if a legitimate dead-owner takeover revoked our lease.
+				if (err instanceof Error && err.message.includes("not_lease_holder")) void this.stop();
+			});
 		}, this.#opts.heartbeatMs);
 		this.#heartbeatTimer.unref?.();
 		return { ownerId: this.ownerId, socketPath: this.#socketPath, leaseEpoch: this.#leaseEpoch };
@@ -129,6 +140,67 @@ export class RuntimeOwner {
 		const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
 		if (!state) throw new Error(`session_not_found:${this.#opts.sessionId}`);
 		return state;
+	}
+
+	/** Map an RPC frame and route it: semantic/signal-bearing -> serial emit; high-frequency progress -> coalesce. */
+	#handleFrame(frame: Record<string, unknown>): void {
+		const mapped = mapRpcFrame(frame);
+		if (!mapped) return;
+		if (mapped.semantic || (mapped.signal && !mapped.coalesceKey)) {
+			this.#framePump = this.#framePump
+				.then(() => this.#flushCoalesced())
+				.then(() => this.#emitMapped(mapped))
+				.catch(() => {});
+		} else if (mapped.coalesceKey) {
+			// Coalesce progress-noise by key; never enqueues a per-frame emit, so a message_update
+			// storm cannot starve semantic frames. Bound memory.
+			this.#coalesced.set(mapped.coalesceKey, true);
+			if (this.#coalesced.size > 256) {
+				const oldest = this.#coalesced.keys().next().value;
+				if (oldest !== undefined) this.#coalesced.delete(oldest);
+			}
+		}
+	}
+
+	async #flushCoalesced(): Promise<void> {
+		if (this.#coalesced.size === 0) return;
+		const coalescedFrames = this.#coalesced.size;
+		this.#coalesced.clear();
+		await this.#emit("info", "rpc_activity", { coalescedFrames });
+	}
+
+	async #emitMapped(mapped: NonNullable<ReturnType<typeof mapRpcFrame>>): Promise<void> {
+		await this.#emit(
+			mapped.severity,
+			mapped.kind,
+			mapped.signal ? { ...mapped.evidence, signal: mapped.signal } : mapped.evidence,
+		);
+		if (mapped.kind === "rpc_agent_completed") {
+			const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
+			if (
+				state &&
+				state.lifecycle !== "completed" &&
+				state.lifecycle !== "retired" &&
+				state.lifecycle !== "finalizing"
+			) {
+				state.lifecycle = "finalizing";
+				state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+				await writeSessionState(this.#opts.root, state);
+			}
+		}
+	}
+
+	#aggregateSignals(events: EventEnvelope[]): string[] {
+		const out: string[] = [];
+		const vocab = OBSERVED_SIGNALS as readonly string[];
+		const add = (s: unknown): void => {
+			if (typeof s === "string" && vocab.includes(s) && !out.includes(s)) out.push(s);
+		};
+		for (const e of events) {
+			add((e.evidence as { signal?: unknown } | undefined)?.signal);
+			if (e.kind === "prompt_accepted") add("prompt-accepted");
+		}
+		return out;
 	}
 
 	async #emit(severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> {
@@ -226,15 +298,32 @@ export class RuntimeOwner {
 				gitDelta = "unknown";
 			}
 		}
+		const rpcLive = this.#opts.rpc.isLive
+			? this.#opts.rpc.isLive()
+			: await this.#opts.rpc
+					.getState()
+					.then(() => true)
+					.catch(() => false);
+		const rpcLastFrameAt = this.#opts.rpc.lastFrameAt ? this.#opts.rpc.lastFrameAt() : null;
+		// Sticky semantic signals come from the persisted owner event log -> survive polling gaps.
+		const recent = (await readEvents(this.#opts.root, this.#opts.sessionId, 0)).slice(-200);
+		const observedSignals = this.#aggregateSignals(recent).slice(0, 7);
+		observedSignals.push(streaming ? "streaming" : "idle");
+		const stamps = [state.updatedAt, rpcLastFrameAt, recent.at(-1)?.createdAt].filter(
+			(t): t is string => typeof t === "string",
+		);
+		const lastActivityAt = stamps.length > 0 ? (stamps.sort().at(-1) ?? state.updatedAt) : state.updatedAt;
 		return {
 			lifecycle: state.lifecycle,
 			ownerLive: true,
 			cwd: workspace,
 			branch,
 			gitDelta,
-			lastActivityAt: state.updatedAt,
-			observedSignals: streaming ? ["streaming"] : ["idle"],
+			lastActivityAt,
+			observedSignals,
 			risk: deleted ? "deleted-worktree" : "normal",
+			rpcLive,
+			rpcLastFrameAt,
 		};
 	}
 
@@ -401,20 +490,7 @@ export class RuntimeOwner {
 
 	async #observe(): Promise<PrimitiveResponse> {
 		const state = await this.#loadState();
-		const rpcState = await this.#opts.rpc.getState().catch(() => null);
-		return this.#response(state, {
-			observation: {
-				lifecycle: state.lifecycle,
-				ownerLive: true,
-				cwd: state.handle.workspace,
-				branch: state.handle.branch,
-				gitDelta: "unknown",
-				lastActivityAt: state.updatedAt,
-				observedSignals: rpcState?.isStreaming ? ["streaming"] : ["idle"],
-				risk: "normal",
-			},
-			ownerRouted: true,
-		});
+		return this.#response(state, { observation: await this.#observeGit(), ownerRouted: true });
 	}
 
 	async #retire(): Promise<PrimitiveResponse> {
@@ -428,6 +504,9 @@ export class RuntimeOwner {
 	}
 
 	async stop(): Promise<void> {
+		this.#unsubscribeFrames?.();
+		this.#unsubscribeFrames = null;
+		await this.#framePump.catch(() => {});
 		if (this.#heartbeatTimer) {
 			clearInterval(this.#heartbeatTimer);
 			this.#heartbeatTimer = null;
@@ -448,6 +527,8 @@ export interface ResolvedOwner {
 export async function resolveOwner(root: string, sessionId: string): Promise<ResolvedOwner> {
 	const lease = await readLease(root, sessionId);
 	if (!lease) return { live: false, socketPath: null, lease: null };
-	if (isStale(lease)) return { live: false, socketPath: lease.endpoint?.path ?? null, lease };
-	return { live: true, socketPath: lease.endpoint?.path ?? null, lease };
+	const status = classifyLeaseStatus(lease);
+	// Owner process alive (live / lease-expired-but-alive / EPERM-alive) => endpoint reachable => routable.
+	const live = status === "live" || status === "expiredAlive" || status === "epermAlive";
+	return { live, socketPath: lease.endpoint?.path ?? null, lease };
 }

--- a/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
+++ b/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
@@ -30,6 +30,12 @@ export interface HarnessRpc {
 	/** Resolve when an `agent_start` event arrives strictly after `afterCursor`, else null on timeout. */
 	waitForAgentStart(afterCursor: number, timeoutMs: number): Promise<{ cursor: number } | null>;
 	close(): Promise<void>;
+	/** Subscribe to parsed event frames (non-ready, non-response), fired AFTER the cursor advances. Returns unsubscribe. */
+	onEventFrame?(listener: (frame: Record<string, unknown>) => void): () => void;
+	/** Whether the underlying RPC subprocess is still alive. */
+	isLive?(): boolean;
+	/** ISO timestamp of the last observed event frame, or null. */
+	lastFrameAt?(): string | null;
 }
 
 export interface AcceptanceResult {
@@ -114,6 +120,9 @@ export class GajaeCodeRpc implements HarnessRpc {
 		resolve: (v: { cursor: number } | null) => void;
 		timer: ReturnType<typeof setTimeout>;
 	}[] = [];
+	#frameListeners: ((frame: Record<string, unknown>) => void)[] = [];
+	#lastFrameAt: string | null = null;
+	#alive = true;
 
 	constructor(opts: { sessionDir: string; command?: string[]; cwd?: string; env?: NodeJS.ProcessEnv }) {
 		const base = opts.command ?? ["gjc", "--mode", "rpc"];
@@ -125,6 +134,12 @@ export class GajaeCodeRpc implements HarnessRpc {
 		}) as ChildProcessWithoutNullStreams;
 		this.#proc.stdout.setEncoding("utf8");
 		this.#proc.stdout.on("data", chunk => this.#onData(chunk as string));
+		this.#proc.on("exit", () => {
+			this.#alive = false;
+		});
+		this.#proc.on("error", () => {
+			this.#alive = false;
+		});
 	}
 
 	#onData(chunk: string): void {
@@ -158,6 +173,7 @@ export class GajaeCodeRpc implements HarnessRpc {
 		if (type === "ready") return;
 		// Any other frame is a session/agent event: advance the cursor.
 		this.#cursor += 1;
+		this.#lastFrameAt = new Date().toISOString();
 		if (type === "agent_start") {
 			const cursor = this.#cursor;
 			this.#agentStartCursors.push(cursor);
@@ -169,6 +185,14 @@ export class GajaeCodeRpc implements HarnessRpc {
 				}
 				return true;
 			});
+		}
+		// Fire-and-forget frame listeners (owner maps + emits). Never await; never let a listener kill the reader.
+		for (const listener of this.#frameListeners) {
+			try {
+				listener(frame);
+			} catch {
+				// swallow listener errors
+			}
 		}
 	}
 
@@ -183,6 +207,21 @@ export class GajaeCodeRpc implements HarnessRpc {
 				}
 			});
 		});
+	}
+
+	onEventFrame(listener: (frame: Record<string, unknown>) => void): () => void {
+		this.#frameListeners.push(listener);
+		return () => {
+			this.#frameListeners = this.#frameListeners.filter(l => l !== listener);
+		};
+	}
+
+	isLive(): boolean {
+		return this.#alive;
+	}
+
+	lastFrameAt(): string | null {
+		return this.#lastFrameAt;
 	}
 
 	async getState(): Promise<RpcStateSnapshot> {

--- a/packages/coding-agent/src/harness-control-plane/session-lease.ts
+++ b/packages/coding-agent/src/harness-control-plane/session-lease.ts
@@ -33,6 +33,9 @@ export class LeaseError extends Error {
 		this.name = "LeaseError";
 	}
 }
+export type LeaseStatus = "missing" | "live" | "expiredAlive" | "dead" | "epermAlive";
+
+type PidStatus = "alive" | "dead" | "eperm";
 
 function nowMs(clock?: () => number): number {
 	return clock ? clock() : Date.now();
@@ -63,6 +66,39 @@ export function isExpired(lease: SessionLease, clock?: () => number): boolean {
 	return Date.parse(lease.expiresAt) <= nowMs(clock);
 }
 
+function defaultPidStatusProbe(pid: number): PidStatus {
+	try {
+		process.kill(pid, 0);
+		return "alive";
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return "dead";
+		if (code === "EPERM") return "eperm";
+		return "dead";
+	}
+}
+
+export function classifyLeaseStatus(
+	lease: SessionLease | null,
+	opts?: { clock?: () => number; probe?: (pid: number) => PidStatus },
+): LeaseStatus {
+	if (!lease) return "missing";
+	const status = (opts?.probe ?? defaultPidStatusProbe)(lease.pid);
+	if (status === "dead") return "dead";
+	if (status === "eperm") return "epermAlive";
+	return isExpired(lease, opts?.clock) ? "expiredAlive" : "live";
+}
+
+function classifyProbeFromBoolean(
+	probe?: (pid: number) => boolean | PidStatus,
+): ((pid: number) => PidStatus) | undefined {
+	if (!probe) return undefined;
+	return pid => {
+		const status = probe(pid);
+		return typeof status === "boolean" ? (status ? "alive" : "dead") : status;
+	};
+}
+
 /** Liveness probe via signal 0. Defaults to the real process table; injectable for tests. */
 export function isOwnerAlive(pid: number, probe?: (pid: number) => boolean): boolean {
 	if (probe) return probe(pid);
@@ -89,7 +125,7 @@ export interface AcquireOptions {
 	eventsPath: string;
 	ttlMs: number;
 	clock?: () => number;
-	probe?: (pid: number) => boolean;
+	probe?: (pid: number) => boolean | PidStatus;
 }
 
 export interface AcquiredLease {
@@ -103,8 +139,20 @@ export interface AcquiredLease {
  */
 export async function acquireLease(root: string, sessionId: string, opts: AcquireOptions): Promise<AcquiredLease> {
 	const existing = await readLease(root, sessionId);
-	if (existing && existing.ownerId !== opts.ownerId && !isStale(existing, opts)) {
-		throw new LeaseError(`lease_held:${sessionId}`, "lease_held");
+	if (existing && existing.ownerId !== opts.ownerId) {
+		const classifiedOwnerId = existing.ownerId;
+		const classifiedEpoch = existing.leaseEpoch;
+		const status = classifyLeaseStatus(existing, {
+			clock: opts.clock,
+			probe: classifyProbeFromBoolean(opts.probe),
+		});
+		if (status !== "dead") {
+			throw new LeaseError(`lease_held:${sessionId}`, "lease_held");
+		}
+		const reread = await readLease(root, sessionId);
+		if (!reread || reread.ownerId !== classifiedOwnerId || reread.leaseEpoch !== classifiedEpoch) {
+			throw new LeaseError(`lease_held:${sessionId}`, "lease_held");
+		}
 	}
 	const priorEpoch = existing?.leaseEpoch ?? 0;
 	const epoch = existing && existing.ownerId === opts.ownerId ? priorEpoch : priorEpoch + 1;
@@ -158,4 +206,20 @@ export async function releaseLease(root: string, sessionId: string, ownerId: str
 	if (!lease) return;
 	if (lease.ownerId !== ownerId) throw new LeaseError(`not_lease_holder:${sessionId}`, "not_lease_holder");
 	await fs.rm(sessionPaths(root, sessionId).lease, { force: true });
+}
+
+export async function reapDeadOwnerArtifacts(
+	root: string,
+	sessionId: string,
+	expectedOwnerId: string,
+	expectedEpoch: number,
+	opts?: { clock?: () => number; probe?: (pid: number) => PidStatus },
+): Promise<boolean> {
+	const lease = await readLease(root, sessionId);
+	if (!lease || lease.ownerId !== expectedOwnerId || lease.leaseEpoch !== expectedEpoch) return false;
+	if (classifyLeaseStatus(lease, opts) !== "dead") return false;
+	const paths = sessionPaths(root, sessionId);
+	await fs.rm(paths.lease, { force: true });
+	await fs.rm(paths.controlSock, { force: true });
+	return true;
 }

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -13,12 +13,60 @@
  * Receipt files are immutable: re-writing an existing receipt id fails closed.
  * JSON writes are atomic (temp + rename).
  */
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { EventEnvelope, ReceiptFamily, SessionState } from "./types";
 
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+export const MAX_UNIX_SOCKET_PATH_BYTES = 100;
+
+interface SocketPathMetadata {
+	root: string;
+	sessionId: string;
+}
+
+function socketBase(env: NodeJS.ProcessEnv, allowOverride: boolean): { base: string; fromOverride: boolean } {
+	const override = env.GJC_HARNESS_SOCKET_DIR?.trim();
+	if (allowOverride && override) return { base: path.resolve(override), fromOverride: true };
+	return { base: path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`), fromOverride: false };
+}
+
+function socketPathForBase(root: string, sessionId: string, base: string): string {
+	const digest = createHash("sha256").update(`${root}\0${sessionId}`).digest("hex");
+	fsSync.mkdirSync(base, { recursive: true });
+	for (const len of [16, 24, 32, 48, 64]) {
+		const stem = `c-${digest.slice(0, len)}`;
+		const metadataPath = path.join(base, `${stem}.json`);
+		const metadata: SocketPathMetadata = { root, sessionId };
+		try {
+			const existing = JSON.parse(fsSync.readFileSync(metadataPath, "utf8")) as SocketPathMetadata;
+			if (existing.root === root && existing.sessionId === sessionId) return path.join(base, `${stem}.sock`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			fsSync.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+			return path.join(base, `${stem}.sock`);
+		}
+	}
+	throw new StorageError(`socket_path_collision:${sessionId}`, "socket_path_collision");
+}
+
+export function controlSocketPath(root: string, sessionId: string, env: NodeJS.ProcessEnv = process.env): string {
+	assertSafeSessionId(sessionId);
+	let { base, fromOverride } = socketBase(env, true);
+	let finalPath = socketPathForBase(root, sessionId, base);
+	if (Buffer.byteLength(finalPath) > MAX_UNIX_SOCKET_PATH_BYTES && fromOverride) {
+		base = socketBase(env, false).base;
+		finalPath = socketPathForBase(root, sessionId, base);
+	}
+	const finalBytes = Buffer.byteLength(finalPath);
+	if (finalBytes > MAX_UNIX_SOCKET_PATH_BYTES) {
+		throw new StorageError(`socket_path_too_long:${finalBytes}`, "socket_path_too_long");
+	}
+	return finalPath;
+}
 
 export class StorageError extends Error {
 	constructor(

--- a/packages/coding-agent/src/harness-control-plane/types.ts
+++ b/packages/coding-agent/src/harness-control-plane/types.ts
@@ -123,6 +123,30 @@ export interface SessionState {
 	updatedAt: string;
 }
 
+/** Bounded observed-signal vocabulary surfaced by `observe` (the owner only ever emits these). */
+export type ObservedSignal =
+	| "SessionStart"
+	| "prompt-accepted"
+	| "tool-call"
+	| "test-running"
+	| "commit-created"
+	| "completed"
+	| "error"
+	| "streaming"
+	| "idle";
+
+export const OBSERVED_SIGNALS: readonly ObservedSignal[] = [
+	"SessionStart",
+	"prompt-accepted",
+	"tool-call",
+	"test-running",
+	"commit-created",
+	"completed",
+	"error",
+	"streaming",
+	"idle",
+];
+
 /** Bounded observation surfaced by `observe` — never a raw pane/transcript dump. */
 export interface Observation {
 	lifecycle: HarnessLifecycle;
@@ -133,6 +157,10 @@ export interface Observation {
 	lastActivityAt: string | null;
 	observedSignals: string[];
 	risk: RiskKind;
+	/** RPC subprocess liveness, distinct from owner-process/lease liveness. Optional for back-compat. */
+	rpcLive?: boolean;
+	/** ISO timestamp of the most recent RPC frame the owner observed, if any. */
+	rpcLastFrameAt?: string | null;
 }
 
 /** Input to the deterministic recovery classifier. */

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -78,6 +78,19 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect((sub.json?.evidence as Record<string, unknown>).accepted).toBe(true);
 		expect((sub.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
 
+		// AC-9: the detached owner maps the real RPC frame stream -> observe surfaces tool-call -> completed.
+		let signals: string[] = [];
+		for (let i = 0; i < 40; i++) {
+			const o = await runHarness(["observe", "--session", SID]);
+			signals =
+				((o.json?.evidence as Record<string, unknown>)?.observation as { observedSignals?: string[] })
+					?.observedSignals ?? [];
+			if (signals.includes("completed")) break;
+			await sleep(50);
+		}
+		expect(signals).toContain("tool-call");
+		expect(signals).toContain("completed");
+
 		// Owner-backed finalize: the evidence gate HONESTLY refuses without real commit/PR/tests
 		// (no fake completion evidence in shipped code).
 		const fin = await runHarness(["finalize", "--session", SID]);

--- a/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
@@ -57,6 +57,15 @@ describe("control endpoint", () => {
 		);
 	});
 
+	it("rejects overlong socket paths before binding", async () => {
+		const overlong = path.join(dir, "x".repeat(120), "c.sock");
+		server = new ControlServer(overlong, async () => ({ ok: true }));
+		await expect(server.listen()).rejects.toThrow(/socket_path_too_long/);
+		await expect(callEndpoint(overlong, { verb: "submit", input: {} }, 50)).rejects.toBeInstanceOf(
+			EndpointUnreachableError,
+		);
+	});
+
 	it("serves multiple sequential calls on the same socket", async () => {
 		let count = 0;
 		server = new ControlServer(sock, async () => ({ ok: true, count: ++count }));

--- a/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
+++ b/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
@@ -36,6 +36,16 @@ function handle(line: string): void {
 	} else if (frame.type === "prompt") {
 		process.stdout.write(`${JSON.stringify({ type: "response", id: frame.id, command: "prompt", success: true })}\n`);
 		process.stdout.write(`${JSON.stringify({ type: "agent_start" })}\n`);
+		// Emit a realistic tool turn so the owner can surface tool-call -> completed.
+		const w = (f: Record<string, unknown>): void => {
+			process.stdout.write(`${JSON.stringify(f)}\n`);
+		};
+		if (process.env.GJC_FAKE_RPC_STORM === "1") {
+			for (let i = 0; i < 200; i++) w({ type: "message_update", messageId: "m1", delta: "noise" });
+		}
+		w({ type: "tool_execution_start", toolCallId: "t1", toolName: "bash", command: "echo hi" });
+		w({ type: "tool_execution_end", toolCallId: "t1", toolName: "bash", status: "ok" });
+		w({ type: "agent_end" });
 	}
 }
 

--- a/packages/coding-agent/test/harness-control-plane/frame-mapper.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/frame-mapper.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { isTestRunnerTool, mapRpcFrame } from "../../src/harness-control-plane/frame-mapper";
+
+describe("mapRpcFrame", () => {
+	it("ignores ready/response and unknown frames (adapter handles those)", () => {
+		expect(mapRpcFrame({ type: "ready" })).toBeNull();
+		expect(mapRpcFrame({ type: "response", id: "x", success: true })).toBeNull();
+		expect(mapRpcFrame({ type: "totally_unknown" })).toBeNull();
+		expect(mapRpcFrame({})).toBeNull();
+	});
+
+	it("maps semantic lifecycle frames with never-drop flag", () => {
+		expect(mapRpcFrame({ type: "agent_start" })).toMatchObject({
+			kind: "rpc_agent_started",
+			signal: "SessionStart",
+			semantic: true,
+		});
+		expect(mapRpcFrame({ type: "agent_end" })).toMatchObject({
+			kind: "rpc_agent_completed",
+			signal: "completed",
+			semantic: true,
+		});
+		expect(mapRpcFrame({ type: "agent_end", outcome: "aborted" })).toMatchObject({
+			kind: "rpc_agent_failed",
+			signal: "error",
+			semantic: true,
+			severity: "critical",
+		});
+		expect(mapRpcFrame({ type: "extension_error", error: "boom" })).toMatchObject({
+			kind: "rpc_extension_error",
+			signal: "error",
+			semantic: true,
+		});
+	});
+
+	it("maps tool execution to tool-call, and test runners to test-running", () => {
+		const start = mapRpcFrame({
+			type: "tool_execution_start",
+			toolCallId: "t1",
+			toolName: "bash",
+			command: "bun test foo",
+		});
+		expect(start).toMatchObject({ kind: "rpc_tool_started", signal: "test-running", semantic: true });
+		const plain = mapRpcFrame({ type: "tool_execution_start", toolCallId: "t2", toolName: "read" });
+		expect(plain).toMatchObject({ signal: "tool-call", semantic: true });
+		const end = mapRpcFrame({ type: "tool_execution_end", toolCallId: "t2", toolName: "read", status: "ok" });
+		expect(end).toMatchObject({ kind: "rpc_tool_ended", signal: "tool-call", semantic: true });
+	});
+
+	it("marks message_update + tool_execution_update as coalescible (non-semantic) with keys", () => {
+		const m = mapRpcFrame({ type: "message_update", messageId: "m1" });
+		expect(m).toMatchObject({ signal: null, semantic: false, coalesceKey: "message:m1" });
+		const u = mapRpcFrame({ type: "tool_execution_update", toolCallId: "t9", status: "running" });
+		expect(u).toMatchObject({ semantic: false, coalesceKey: "tool:t9" });
+	});
+
+	it("redacts: evidence carries no assistant text / message deltas / command output", () => {
+		const m = mapRpcFrame({
+			type: "message_update",
+			messageId: "m1",
+			delta: "secret assistant text",
+			text: "more text",
+		}) ?? { evidence: {} };
+		const json = JSON.stringify(m.evidence);
+		expect(json).not.toContain("secret assistant text");
+		expect(json).not.toContain("more text");
+		const t = mapRpcFrame({
+			type: "tool_execution_end",
+			toolCallId: "t1",
+			toolName: "bash",
+			command: "echo SECRET",
+			output: "SECRET OUTPUT",
+			status: "ok",
+		}) ?? { evidence: {} };
+		const tj = JSON.stringify(t.evidence);
+		expect(tj).not.toContain("SECRET OUTPUT");
+		expect(tj).not.toContain("echo SECRET");
+	});
+
+	it("bounds extension_error message length", () => {
+		const big = "x".repeat(5000);
+		const e = mapRpcFrame({ type: "extension_error", error: big });
+		expect(String((e?.evidence as Record<string, unknown>).code).length).toBeLessThanOrEqual(200);
+	});
+
+	it("isTestRunnerTool detects common runners", () => {
+		expect(isTestRunnerTool("bash", "bun test x")).toBe(true);
+		expect(isTestRunnerTool("bash", "vitest run")).toBe(true);
+		expect(isTestRunnerTool("bash", "echo hi")).toBe(false);
+		expect(isTestRunnerTool("read", "")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
+import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { readEvents, writeSessionState } from "../../src/harness-control-plane/storage";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+/** In-process RPC that lets a test push event frames through the owner's onEventFrame path. */
+class FrameRpc implements HarnessRpc {
+	cursor = 0;
+	live = true;
+	#cb: ((frame: Record<string, unknown>) => void) | null = null;
+	#lastAt: string | null = null;
+	async getState(): Promise<RpcStateSnapshot> {
+		return { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		return { commandId: "c", ack: true };
+	}
+	async waitForAgentStart(): Promise<{ cursor: number } | null> {
+		return null;
+	}
+	async close(): Promise<void> {}
+	onEventFrame(cb: (frame: Record<string, unknown>) => void): () => void {
+		this.#cb = cb;
+		return () => {
+			this.#cb = null;
+		};
+	}
+	isLive(): boolean {
+		return this.live;
+	}
+	lastFrameAt(): string | null {
+		return this.#lastAt;
+	}
+	emit(frame: Record<string, unknown>): void {
+		this.cursor += 1;
+		this.#lastAt = new Date().toISOString();
+		this.#cb?.(frame);
+	}
+}
+
+const flush = (): Promise<void> => new Promise(r => setTimeout(r, 40));
+
+let root: string;
+const SID = "fr";
+let owner: RuntimeOwner | null = null;
+
+function seed(workspace: string): SessionState {
+	const now = new Date().toISOString();
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: SID,
+		lifecycle: "observing",
+		harness: "gajae-code",
+		handle: { sessionId: SID, harness: "gajae-code", workspace } as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	await writeSessionState(root, seed(root));
+	owner = null;
+});
+
+afterEach(async () => {
+	await owner?.stop();
+	await rm(root, { recursive: true, force: true });
+});
+
+function obsOf(res: any) {
+	return res.evidence.observation as { observedSignals: string[]; rpcLive?: boolean; lifecycle: string };
+}
+
+describe("owner frame -> observability", () => {
+	it("AC-1: a tool turn surfaces tool-call/test-running + completed; single-writer events; lifecycle finalizing", async () => {
+		const rpc = new FrameRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc });
+		const info = await owner.start();
+		rpc.emit({ type: "agent_start" });
+		rpc.emit({ type: "tool_execution_start", toolCallId: "t1", toolName: "bash", command: "bun test x" });
+		rpc.emit({ type: "tool_execution_end", toolCallId: "t1", toolName: "bash", status: "ok" });
+		rpc.emit({ type: "agent_end" });
+		await flush();
+
+		const events = await readEvents(root, SID, 0);
+		const kinds = events.map(e => e.kind);
+		expect(kinds).toContain("rpc_tool_started");
+		expect(kinds).toContain("rpc_agent_completed");
+		// single-writer: every event stamped with the owner's lease identity; cursors strictly increasing.
+		expect(events.every(e => e.writer.ownerId === info.ownerId)).toBe(true);
+		const cursors = events.map(e => e.cursor);
+		expect(cursors).toEqual([...cursors].sort((a, b) => a - b));
+		expect(new Set(cursors).size).toBe(cursors.length);
+
+		const res = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>;
+		const obs = obsOf(res);
+		expect(obs.observedSignals).toContain("test-running");
+		expect(obs.observedSignals).toContain("completed");
+		expect(obs.rpcLive).toBe(true);
+		expect(obs.lifecycle).toBe("finalizing");
+	});
+
+	it("AC-6: a message_update storm cannot starve agent_end (completed) or bloat the event log", async () => {
+		const rpc = new FrameRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc });
+		const info = await owner.start();
+		rpc.emit({ type: "agent_start" });
+		for (let i = 0; i < 500; i++) rpc.emit({ type: "message_update", messageId: "m1", delta: "noise" });
+		rpc.emit({ type: "agent_end" });
+		await flush();
+
+		const events = await readEvents(root, SID, 0);
+		expect(events.map(e => e.kind)).toContain("rpc_agent_completed");
+		// 500 message_update frames are coalesced, not emitted 1:1.
+		expect(events.length).toBeLessThan(60);
+		const obs = obsOf(
+			(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
+		);
+		expect(obs.observedSignals).toContain("completed");
+	});
+
+	it("AC-7: transient tool-call/completed survive polling gaps (sticky from the event log)", async () => {
+		const rpc = new FrameRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc });
+		const info = await owner.start();
+		// frames happen BETWEEN observe polls
+		rpc.emit({ type: "tool_execution_start", toolCallId: "t1", toolName: "read" });
+		rpc.emit({ type: "tool_execution_end", toolCallId: "t1", toolName: "read", status: "ok" });
+		rpc.emit({ type: "agent_end" });
+		await flush();
+		// getState reports idle now, but the later observe still shows the transient signals.
+		const obs = obsOf(
+			(await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>,
+		);
+		expect(obs.observedSignals).toContain("tool-call");
+		expect(obs.observedSignals).toContain("completed");
+		expect(obs.observedSignals).toContain("idle"); // overlay present, did not evict semantic signals
+	});
+
+	it("rpcLive is distinct from ownerLive (RPC death does not imply dead owner)", async () => {
+		const rpc = new FrameRpc();
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc });
+		const info = await owner.start();
+		rpc.live = false; // RPC subprocess died; owner endpoint still serving
+		const res = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>;
+		expect((res.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect(obsOf(res).rpcLive).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/harness-control-plane/session-lease.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/session-lease.test.ts
@@ -1,17 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
 	acquireLease,
 	canWriteEvents,
+	classifyLeaseStatus,
 	heartbeat,
 	isOwnerAlive,
 	isStale,
 	LeaseError,
 	readLease,
+	reapDeadOwnerArtifacts,
 	releaseLease,
 } from "../../src/harness-control-plane/session-lease";
+import { sessionPaths } from "../../src/harness-control-plane/storage";
 
 let root: string;
 const SID = "h-lease";
@@ -26,6 +29,28 @@ afterEach(async () => {
 });
 
 describe("SessionLease", () => {
+	it("classifies lease status from expiry and injected pid status", () => {
+		const clock = () => 10_000;
+		const liveLease = {
+			ownerId: "owner-a",
+			sessionId: SID,
+			pid: 1,
+			leaseTokenHash: "hash",
+			endpoint: null,
+			eventsPath: "e",
+			heartbeatAt: new Date(9_000).toISOString(),
+			expiresAt: new Date(20_000).toISOString(),
+			leaseEpoch: 1,
+			writer: { ownerId: "owner-a", leaseEpoch: 1 },
+		};
+		const expiredLease = { ...liveLease, expiresAt: new Date(10_000).toISOString() };
+		expect(classifyLeaseStatus(null, { clock })).toBe("missing");
+		expect(classifyLeaseStatus(liveLease, { clock, probe: () => "alive" })).toBe("live");
+		expect(classifyLeaseStatus(expiredLease, { clock, probe: () => "alive" })).toBe("expiredAlive");
+		expect(classifyLeaseStatus(liveLease, { clock, probe: () => "dead" })).toBe("dead");
+		expect(classifyLeaseStatus(liveLease, { clock, probe: () => "eperm" })).toBe("epermAlive");
+	});
+
 	it("acquires a fresh lease at epoch 1 and persists it", async () => {
 		const { lease, token } = await acquireLease(root, SID, {
 			ownerId: "owner-a",
@@ -60,8 +85,8 @@ describe("SessionLease", () => {
 		expect(taken.lease.leaseEpoch).toBe(2);
 	});
 
-	it("allows takeover of an expired lease and increments the epoch", async () => {
-		const past = () => 1_000; // acquire far in the past
+	it("fails closed for an expired lease whose owner is still alive", async () => {
+		const past = () => 1_000;
 		await acquireLease(root, SID, {
 			ownerId: "owner-a",
 			pid: 1,
@@ -70,14 +95,22 @@ describe("SessionLease", () => {
 			clock: past,
 			probe: aliveProbe,
 		});
-		const taken = await acquireLease(root, SID, {
-			ownerId: "owner-b",
-			pid: 2,
-			eventsPath: "e",
-			ttlMs: 10_000,
-			probe: aliveProbe, // alive, but prior lease expired
-		});
-		expect(taken.lease.leaseEpoch).toBe(2);
+		await expect(
+			acquireLease(root, SID, {
+				ownerId: "owner-b",
+				pid: 2,
+				eventsPath: "e",
+				ttlMs: 10_000,
+				probe: aliveProbe,
+			}),
+		).rejects.toThrow(/lease_held/);
+	});
+
+	it("fails closed for a lease whose owner returns eperm", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		await expect(
+			acquireLease(root, SID, { ownerId: "owner-b", pid: 2, eventsPath: "e", ttlMs: 10_000, probe: () => "eperm" }),
+		).rejects.toThrow(/lease_held/);
 	});
 
 	it("heartbeat is single-writer: only the holder may refresh", async () => {
@@ -106,6 +139,31 @@ describe("SessionLease", () => {
 		await expect(releaseLease(root, SID, "owner-b")).rejects.toThrow(/not_lease_holder/);
 		await releaseLease(root, SID, "owner-a");
 		expect(await readLease(root, SID)).toBeNull();
+	});
+
+	it("reaps dead owner artifacts only for matching dead owner and epoch", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		const paths = sessionPaths(root, SID);
+		await writeFile(paths.controlSock, "sock", "utf8");
+		expect(await reapDeadOwnerArtifacts(root, SID, "owner-a", 2, { probe: () => "dead" })).toBe(false);
+		expect(await readLease(root, SID)).not.toBeNull();
+		expect(await reapDeadOwnerArtifacts(root, SID, "owner-a", 1, { probe: () => "alive" })).toBe(false);
+		expect(await readLease(root, SID)).not.toBeNull();
+		expect(await reapDeadOwnerArtifacts(root, SID, "owner-a", 1, { probe: () => "dead" })).toBe(true);
+		expect(await readLease(root, SID)).toBeNull();
+	});
+
+	it("does not signal pids while reaping dead owner artifacts", async () => {
+		await acquireLease(root, SID, { ownerId: "owner-a", pid: 1, eventsPath: "e", ttlMs: 10_000, probe: aliveProbe });
+		let probes = 0;
+		const reaped = await reapDeadOwnerArtifacts(root, SID, "owner-a", 1, {
+			probe: () => {
+				probes++;
+				return "dead";
+			},
+		});
+		expect(reaped).toBe(true);
+		expect(probes).toBe(1);
 	});
 
 	it("isOwnerAlive returns false for an obviously dead pid", () => {

--- a/packages/coding-agent/test/harness-control-plane/storage.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/storage.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
 	appendEvent,
 	assertSafeSessionId,
+	controlSocketPath,
 	generateSessionId,
+	MAX_UNIX_SOCKET_PATH_BYTES,
 	readEvents,
 	readReceiptIndex,
 	readSessionState,
@@ -115,5 +118,69 @@ describe("harness storage", () => {
 
 	it("generateSessionId produces safe ids", () => {
 		expect(() => assertSafeSessionId(generateSessionId())).not.toThrow();
+	});
+
+	it("controlSocketPath is stable, short, and records metadata", async () => {
+		const id = "h-socket";
+		const socketDir = await mkdtemp(path.join(tmpdir(), "h-"));
+		const first = controlSocketPath(root, id, { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
+		const second = controlSocketPath(root, id, { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
+		expect(first).toBe(second);
+		expect(Buffer.byteLength(first)).toBeLessThanOrEqual(MAX_UNIX_SOCKET_PATH_BYTES);
+		expect(first.startsWith(socketDir)).toBe(true);
+		expect(path.basename(first)).toMatch(/^c-[0-9a-f]{16}\.sock$/);
+		const metadata = JSON.parse(await readFile(first.replace(/\.sock$/, ".json"), "utf8")) as Record<string, unknown>;
+		expect(metadata).toEqual({ root, sessionId: id });
+	});
+
+	it("controlSocketPath uses GJC_HARNESS_SOCKET_DIR when set", async () => {
+		const socketDir = await mkdtemp(path.join(tmpdir(), "e-"));
+		const socketPath = controlSocketPath(root, "h-env", { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
+		expect(socketPath.startsWith(socketDir)).toBe(true);
+	});
+
+	it("controlSocketPath falls back to tmp base when override is too long", async () => {
+		const oldTmpdir = process.env.TMPDIR;
+		process.env.TMPDIR = "/tmp";
+		try {
+			const longDir = path.join(root, "x".repeat(80));
+			const socketPath = controlSocketPath(root, "h-fallback", {
+				GJC_HARNESS_SOCKET_DIR: longDir,
+			} as NodeJS.ProcessEnv);
+			expect(socketPath.startsWith(longDir)).toBe(false);
+			expect(socketPath.includes("gjch")).toBe(true);
+			expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(MAX_UNIX_SOCKET_PATH_BYTES);
+		} finally {
+			if (oldTmpdir === undefined) delete process.env.TMPDIR;
+			else process.env.TMPDIR = oldTmpdir;
+		}
+	});
+
+	it("controlSocketPath throws socket_path_too_long when tmp base is too long", async () => {
+		const oldTmpdir = process.env.TMPDIR;
+		process.env.TMPDIR = path.join(root, "t".repeat(80));
+		try {
+			expect(() =>
+				controlSocketPath(root, "h-too-long", {
+					GJC_HARNESS_SOCKET_DIR: path.join(root, "o".repeat(80)),
+				} as NodeJS.ProcessEnv),
+			).toThrow(/socket_path_too_long/);
+		} finally {
+			if (oldTmpdir === undefined) delete process.env.TMPDIR;
+			else process.env.TMPDIR = oldTmpdir;
+		}
+	});
+
+	it("controlSocketPath extends the hash on metadata collision", async () => {
+		const id = "h-collision";
+		const socketDir = path.join("/tmp", `c-${process.pid}`);
+		const digest = createHash("sha256").update(`${root}\0${id}`).digest("hex");
+		await mkdir(socketDir, { recursive: true });
+		await writeFile(
+			path.join(socketDir, `c-${digest.slice(0, 16)}.json`),
+			`${JSON.stringify({ root: "other", sessionId: id })}\n`,
+		);
+		const socketPath = controlSocketPath(root, id, { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
+		expect(path.basename(socketPath)).toBe(`c-${digest.slice(0, 24)}.sock`);
 	});
 });


### PR DESCRIPTION
## Summary
Follow-up to merged #192 (harness control plane). Implements the approved consensus plan (`.gjc/plans/ralplan/2026-06-02-0853-3e33`, Critic OKAY / Architect WATCH→no-blockers, iteration 2) closing all deferred WATCH items — headlined by **real progress observability**.

## What's fixed
- **RPC frame observability** — `GajaeCodeRpc.onEventFrame` → `RuntimeOwner` serial queue → single-writer `#emit`. A pure `frame-mapper` turns `gjc --mode rpc` frames into a **bounded** `observedSignal` vocabulary (`tool-call`, `test-running`, `commit-created`, `completed`, `error`, …) with redacted evidence (no assistant text / command output). Closes the gap where `observe` only ever showed `streaming`.
- **Completion detection** — `agent_end` → `finalizing`/`completed`, wiring `operate()`'s real-session gate (only `runFinalize` writes completion receipts).
- **Frame-storm safety** — `message_update`/`tool_execution_update` coalesced; semantic frames (`tool_execution_start/end`, `extension_error`, `agent_end`) never dropped/starved.
- **Sticky bounded observe** — transient `tool-call`/`completed` survive polling gaps; cap 8, typed evidence, no raw dumps.
- **rpcLive vs ownerLive** — `Observation` distinguishes RPC-subprocess health from owner/lease liveness (`rpcLastFrameAt`).
- **Socket-path hardening** — `controlSocketPath` short path + `GJC_HARNESS_SOCKET_DIR` + final AF_UNIX byte-length validation (fallback or `socket_path_too_long` before `listen`).
- **Lease-orphan reaping** — `classifyLeaseStatus` + `reapDeadOwnerArtifacts`; takeover only PID-dead **AND** same ownerId/leaseEpoch reread; `expiredAlive`/EPERM fail-closed; **never** signals a live owner; heartbeat self-stop on `not_lease_holder`.

## Verification
`bun test test/harness-control-plane/` → **109 pass / 0 fail** (18 files), `bun run check:types` exit 0, `biome check` clean. New tests cover AC-1 (observe surfaces tool-call→completed), AC-6 (storm-safe), AC-7 (poll-gap sticky), rpcLive separation, socket override/fallback/fail-closed, lease classify/no-kill, and an AC-9 e2e where a detached owner drives the **real** `GajaeCodeRpc` against a protocol fixture and `observe` shows tool-call→completed.

Internal (GJC architect consensus) + external (codex) review to follow on this PR.
