### PR TITLE
fix(agent): resolve round-2 steer/retry review findings

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -880,6 +880,17 @@ export class Agent {
 		this.#steeringQueue = [...messages, ...this.#steeringQueue];
 	}
 
+	/** Snapshot the follow-up queue without mutating it. */
+	snapshotFollowUp(): AgentMessage[] {
+		return this.#followUpQueue.slice();
+	}
+
+	/** Restore previously snapshotted follow-up messages ahead of any newly queued ones. */
+	restoreFollowUp(messages: AgentMessage[]): void {
+		if (messages.length === 0) return;
+		this.#followUpQueue = [...messages, ...this.#followUpQueue];
+	}
+
 	#dequeueSteeringMessages(): AgentMessage[] {
 		if (this.#steeringMode === "one-at-a-time") {
 			if (this.#steeringQueue.length > 0) {

--- a/packages/agent/test/agent-steering-queue.test.ts
+++ b/packages/agent/test/agent-steering-queue.test.ts
@@ -56,4 +56,32 @@ describe("Agent steering queue introspection", () => {
 		agent.restoreSteering([]);
 		expect(agent.snapshotSteering()).toHaveLength(1);
 	});
+
+	it("snapshots follow-ups without mutating the queue", () => {
+		const agent = new Agent();
+		agent.followUp(userMessage("a"));
+		agent.followUp(userMessage("b"));
+
+		const snap = agent.snapshotFollowUp();
+		expect(snap).toHaveLength(2);
+		expect(agent.hasQueuedMessages()).toBe(true);
+		expect(agent.snapshotFollowUp()).toHaveLength(2);
+	});
+
+	it("restores snapshotted follow-ups ahead of newly queued messages", () => {
+		const agent = new Agent();
+		agent.followUp(userMessage("a"));
+		const snap = agent.snapshotFollowUp();
+
+		agent.clearFollowUpQueue();
+		expect(agent.hasQueuedMessages()).toBe(false);
+
+		agent.followUp(userMessage("b"));
+		agent.restoreFollowUp(snap);
+
+		const after = agent.snapshotFollowUp();
+		expect(after).toHaveLength(2);
+		expect(after[0]).toMatchObject({ content: "a" });
+		expect(after[1]).toMatchObject({ content: "b" });
+	});
 });

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -685,7 +685,12 @@ export class EventController {
 	}
 
 	async #handleAutoRetryStart(event: Extract<AgentSessionEvent, { type: "auto_retry_start" }>): Promise<void> {
-		this.ctx.retryEscapeHandler = this.ctx.editor.onEscape;
+		// Preserve the ORIGINAL editor Escape handler across repeated retry
+		// starts: auto_retry_end only fires at final success/failure, so a
+		// second auto_retry_start must not snapshot the prior retry handler.
+		if (!this.ctx.retryEscapeHandler) {
+			this.ctx.retryEscapeHandler = this.ctx.editor.onEscape;
+		}
 		let escPressed = false;
 		this.ctx.editor.onEscape = () => {
 			if (!escPressed) {
@@ -698,14 +703,17 @@ export class EventController {
 			}
 		};
 		this.ctx.statusContainer.clear();
+		// Stop any prior retry loader/timer before installing a new one.
+		this.ctx.retryLoader?.stop();
+		this.#clearRetryCountdown();
 		const reason = friendlyRetryReason(event.errorMessage);
 		const attemptLabel = event.unbounded ? `attempt ${event.attempt}` : `${event.attempt}/${event.maxAttempts}`;
-		const escHint = event.unbounded ? "esc to retry now" : "esc to cancel";
 		const reasonSuffix = reason ? ` — ${reason}` : "";
 		const deadline = Date.now() + event.delayMs;
 		const buildMessage = () => {
 			const remainingSeconds = Math.max(0, Math.round((deadline - Date.now()) / 1000));
-			return `Retrying (${attemptLabel})${reasonSuffix}, next in ${remainingSeconds}s… (${escHint})`;
+			// First Esc retries immediately; a second Esc cancels.
+			return `Retrying (${attemptLabel})${reasonSuffix}, next in ${remainingSeconds}s… (esc to retry now)`;
 		};
 		const retryLoader = new Loader(
 			this.ctx.ui,
@@ -715,7 +723,6 @@ export class EventController {
 			getSymbolTheme().spinnerFrames,
 		);
 		this.ctx.retryLoader = retryLoader;
-		this.#clearRetryCountdown();
 		this.ctx.retryCountdownTimer = setInterval(() => {
 			retryLoader.setMessage(buildMessage());
 		}, 1000);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -568,6 +568,14 @@ export class InputController {
 			this.ctx.retryLoader.stop();
 			this.ctx.retryLoader = undefined;
 		}
+		if (this.ctx.retryCountdownTimer) {
+			clearInterval(this.ctx.retryCountdownTimer);
+			this.ctx.retryCountdownTimer = undefined;
+		}
+		if (this.ctx.retryEscapeHandler) {
+			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
+			this.ctx.retryEscapeHandler = undefined;
+		}
 		this.ctx.statusContainer.clear();
 		this.ctx.statusLine.dispose();
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7255,17 +7255,25 @@ export class AgentSession {
 		if (/anthropic stream envelope error:/i.test(err)) {
 			return this.#isTransientEnvelopeErrorMessage(err) ? "transient" : "terminal";
 		}
-		// Structured provider HTTP status is usually authoritative, but providers
-		// may derive errorStatus from broad message parsing. Classify text first so
-		// deterministic terminal copy still surfaces, while retry/rate-limit copy
-		// like "rate limit error: 400 requests/min" is not terminalized as HTTP 400.
+		const explicitStatus = this.#extractExplicitHttpStatusFromErrorMessage(err);
+		const structuredStatus = message.errorStatus;
+		const terminalStatus = explicitStatus ?? structuredStatus;
+		const isTerminalHttp4xx =
+			terminalStatus !== undefined &&
+			terminalStatus >= 400 &&
+			terminalStatus < 500 &&
+			terminalStatus !== 408 &&
+			terminalStatus !== 425 &&
+			terminalStatus !== 429;
 		if (this.#isTerminalErrorMessage(err)) return "terminal";
 		if (isUsageLimitError(err)) return "usage_limit";
-		if (this.#isTransientErrorMessage(err)) return "transient";
-		const status = message.errorStatus ?? this.#extractExplicitHttpStatusFromErrorMessage(err);
-		if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429) {
+		// Explicit HTTP/status wording is authoritative. Structured provider status
+		// is also authoritative except for rate-limit copy where providers may have
+		// parsed an incidental quota number such as "400 requests per minute".
+		if (isTerminalHttp4xx && (explicitStatus !== undefined || !/rate.?limit|too many requests/i.test(err))) {
 			return "terminal";
 		}
+		if (this.#isTransientErrorMessage(err)) return "transient";
 		return "unknown";
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -106,7 +106,6 @@ export interface ForkContextSeedOptions {
 
 import { MacOSPowerAssertion } from "@gajae-code/natives";
 import {
-	extractHttpStatusFromError,
 	extractRetryHint,
 	isEnoent,
 	isUnexpectedSocketCloseMessage,
@@ -7230,6 +7229,16 @@ export class AgentSession {
 		);
 	}
 
+	#extractExplicitHttpStatusFromErrorMessage(errorMessage: string): number | undefined {
+		// Parse only explicit HTTP/status wording. Do not treat generic
+		// `error: 400` as an HTTP status because rate-limit copy can say
+		// "rate limit error: 400 requests per minute".
+		const match = /\b(?:http(?:\s+status)?|status(?:[\s_-]+code)?)(?:\s+|[:=]\s*)(\d{3})\b/i.exec(errorMessage);
+		if (!match) return undefined;
+		const status = Number(match[1]);
+		return Number.isFinite(status) && status >= 100 && status <= 599 ? status : undefined;
+	}
+
 	/**
 	 * Ordered retry classification: overflow (compaction) -> terminal (surface)
 	 * -> usage_limit (rotation) -> transient (retry) -> unknown (retry).
@@ -7246,16 +7255,17 @@ export class AgentSession {
 		if (/anthropic stream envelope error:/i.test(err)) {
 			return this.#isTransientEnvelopeErrorMessage(err) ? "transient" : "terminal";
 		}
-		// HTTP status is the most reliable terminal signal: a 4xx client error
-		// (other than 408/425 timeout and 429 rate limit) will not succeed on
-		// retry, so surface it instead of looping forever as "unknown".
-		const status = message.errorStatus ?? extractHttpStatusFromError({ message: err });
-		if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429) {
-			return "terminal";
-		}
+		// Structured provider HTTP status is usually authoritative, but providers
+		// may derive errorStatus from broad message parsing. Classify text first so
+		// deterministic terminal copy still surfaces, while retry/rate-limit copy
+		// like "rate limit error: 400 requests/min" is not terminalized as HTTP 400.
 		if (this.#isTerminalErrorMessage(err)) return "terminal";
 		if (isUsageLimitError(err)) return "usage_limit";
 		if (this.#isTransientErrorMessage(err)) return "transient";
+		const status = message.errorStatus ?? this.#extractExplicitHttpStatusFromErrorMessage(err);
+		if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429) {
+			return "terminal";
+		}
 		return "unknown";
 	}
 
@@ -8448,6 +8458,8 @@ export class AgentSession {
 		const previousFallbackSelectedMCPToolNames = previousSessionFile
 			? this.#getSessionDefaultSelectedMCPToolNames(previousSessionFile)
 			: undefined;
+		const previousAgentSteeringQueue = this.agent.snapshotSteering();
+		const previousAgentFollowUpQueue = this.agent.snapshotFollowUp();
 
 		this.#steeringMessages = [];
 		this.#followUpMessages = [];
@@ -8465,6 +8477,12 @@ export class AgentSession {
 				this.#didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			const fallbackSelectedMCPToolNames = this.#getSessionDefaultSelectedMCPToolNames(sessionPath);
 			await this.#restoreMCPSelectionsForSessionContext(sessionContext, { fallbackSelectedMCPToolNames });
+
+			// The target session is loaded and MCP selections are restored: the
+			// switch is committed far enough to discard pre-switch delivery queues.
+			// Clear before session_switch hooks, so messages enqueued by hooks belong
+			// to the new session and remain deliverable.
+			this.agent.clearAllQueues();
 
 			// Emit session_switch event to hooks
 			if (this.#extensionRunner) {
@@ -8530,10 +8548,6 @@ export class AgentSession {
 			if (switchingToDifferentSession) {
 				this.#resetHindsightConversationTrackingIfHindsight();
 			}
-			// Clear the agent delivery queues only once the switch has committed,
-			// so a rollback (catch) leaves them intact alongside the restored UI
-			// queues instead of silently dropping queued messages.
-			this.agent.clearAllQueues();
 			this.#reconnectToAgent();
 			return true;
 		} catch (error) {
@@ -8564,6 +8578,9 @@ export class AgentSession {
 			this.#followUpMessages = previousFollowUpMessages;
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
+			this.agent.clearAllQueues();
+			this.agent.restoreSteering(previousAgentSteeringQueue);
+			this.agent.restoreFollowUp(previousAgentFollowUpQueue);
 			if (previousModel) {
 				this.agent.setModel(previousModel);
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -106,6 +106,7 @@ export interface ForkContextSeedOptions {
 
 import { MacOSPowerAssertion } from "@gajae-code/natives";
 import {
+	extractHttpStatusFromError,
 	extractRetryHint,
 	isEnoent,
 	isUnexpectedSocketCloseMessage,
@@ -7224,7 +7225,7 @@ export class AgentSession {
 		// Errors that will never succeed on retry (auth/permission, malformed
 		// request, unknown/unsupported model). These surface immediately rather
 		// than retry forever.
-		return /\b(401|402|403|404|413|422)\b|unauthorized|forbidden|authentication_error|permission_error|permission denied|invalid api key|invalid_request_error|invalid request|bad request|bad_request|validation_error|unprocessable|payload too large|payment required|insufficient_quota|insufficient credits|missing required (parameter|field)|invalid schema|invalid tool_choice|unsupported (parameter|value|model)|model_not_found|no such model|unknown model|does not (exist|support)|request was aborted|request aborted|the user aborted/i.test(
+		return /unauthorized|forbidden|authentication_error|permission_error|permission denied|invalid api key|invalid_request_error|invalid request|bad request|bad_request|validation_error|unprocessable|payload too large|payment required|insufficient_quota|insufficient credits|missing required (parameter|field)|invalid schema|invalid tool_choice|unsupported (parameter|value|model)|model_not_found|no such model|unknown model|does not (exist|support)|request was aborted|request aborted|the user aborted/i.test(
 			errorMessage,
 		);
 	}
@@ -7244,6 +7245,13 @@ export class AgentSession {
 		// variant; any other envelope failure is structural and must surface.
 		if (/anthropic stream envelope error:/i.test(err)) {
 			return this.#isTransientEnvelopeErrorMessage(err) ? "transient" : "terminal";
+		}
+		// HTTP status is the most reliable terminal signal: a 4xx client error
+		// (other than 408/425 timeout and 429 rate limit) will not succeed on
+		// retry, so surface it instead of looping forever as "unknown".
+		const status = message.errorStatus ?? extractHttpStatusFromError({ message: err });
+		if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429) {
+			return "terminal";
 		}
 		if (this.#isTerminalErrorMessage(err)) return "terminal";
 		if (isUsageLimitError(err)) return "usage_limit";
@@ -8445,7 +8453,6 @@ export class AgentSession {
 		this.#followUpMessages = [];
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
-		this.agent.clearAllQueues();
 
 		try {
 			await this.sessionManager.setSessionFile(sessionPath);
@@ -8523,6 +8530,10 @@ export class AgentSession {
 			if (switchingToDifferentSession) {
 				this.#resetHindsightConversationTrackingIfHindsight();
 			}
+			// Clear the agent delivery queues only once the switch has committed,
+			// so a rollback (catch) leaves them intact alongside the restored UI
+			// queues instead of silently dropping queued messages.
+			this.agent.clearAllQueues();
 			this.#reconnectToAgent();
 			return true;
 		} catch (error) {

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -15,6 +15,7 @@ import type { Rule } from "@gajae-code/coding-agent/capability/rule";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { TtsrManager } from "@gajae-code/coding-agent/export/ttsr";
+import type { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
@@ -299,6 +300,51 @@ describe("AgentSession concurrent prompt guard", () => {
 
 		expect(mock.calls).toHaveLength(0);
 		expect(session.queuedMessageCount).toBe(1);
+	});
+
+	it("keeps session_switch hook-queued steering deliverable after clearing pre-switch queues", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+		});
+		const currentSessionManager = SessionManager.create(tempDir, tempDir);
+		const targetSessionManager = SessionManager.create(tempDir, tempDir);
+		targetSessionManager.appendMessage({ role: "user", content: "target session", timestamp: Date.now() });
+		await targetSessionManager.flush();
+		const targetSessionFile = targetSessionManager.getSessionFile();
+		await targetSessionManager.close();
+		if (!targetSessionFile) throw new Error("Expected target session file");
+
+		const settings = Settings.isolated();
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-switch-hook.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models-switch-hook.yml"));
+		const extensionRunner = {
+			hasHandlers: vi.fn(() => false),
+			emit: vi.fn(async (event: { type: string }) => {
+				if (event.type === "session_switch") {
+					await session.sendUserMessage("queued by switch hook", { deliverAs: "steer" });
+				}
+			}),
+		} as unknown as ExtensionRunner;
+
+		session = new AgentSession({
+			agent,
+			sessionManager: currentSessionManager,
+			settings,
+			modelRegistry,
+			extensionRunner,
+		});
+		await session.steer("pre-switch steering");
+		expect(session.getQueuedMessages().steering).toEqual(["pre-switch steering"]);
+		expect(agent.snapshotSteering()).toHaveLength(1);
+
+		expect(await session.switchSession(targetSessionFile)).toBe(true);
+
+		expect(session.getQueuedMessages().steering).toEqual(["queued by switch hook"]);
+		expect(agent.snapshotSteering()).toHaveLength(1);
 	});
 
 	// Regression: a subscriber that fires the next prompt synchronously from the

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -4,6 +4,7 @@ import { scheduler } from "node:timers/promises";
 import { Agent } from "@gajae-code/agent-core";
 import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
@@ -16,7 +17,7 @@ type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
 
 function lastAssistant(session: AgentSession): AssistantMessage {
 	const message = session.agent.state.messages.at(-1);
-	if (!message || message.role !== "assistant") {
+	if (message?.role !== "assistant") {
 		throw new Error("Expected trailing assistant message");
 	}
 	return message as AssistantMessage;
@@ -76,6 +77,63 @@ describe("AgentSession resilient retry", () => {
 			"retry.maxDelayMs": 10,
 			"retry.maxRetries": 1,
 			...options.settingsOverrides,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		return new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+	}
+
+	function buildStatusErrorSession(options: {
+		errorMessage: string;
+		errorStatus: number;
+		recoveredContent?: string;
+	}): AgentSession {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, opts) => {
+				calls++;
+				if (calls > 1 && options.recoveredContent) {
+					return createMockModel({ responses: [{ content: [options.recoveredContent] }] }).stream(
+						requestedModel,
+						context,
+						opts,
+					);
+				}
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: requestedModel.api,
+						provider: requestedModel.provider,
+						model: requestedModel.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage: options.errorMessage,
+						errorStatus: options.errorStatus,
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "error", reason: "error", error: message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxDelayMs": 10,
+			"retry.maxRetries": 1,
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
 		return new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
@@ -288,6 +346,59 @@ describe("AgentSession resilient retry", () => {
 
 		expect(retryStartEvents).toHaveLength(0);
 		expect(lastAssistant(session).stopReason).toBe("error");
+	});
+
+	it("surfaces explicit status-code 4xx errors without retrying", async () => {
+		session = buildSession({ responses: [{ throw: "provider returned status code 400 for malformed payload" }] });
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("trigger status-code 400");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(lastAssistant(session).stopReason).toBe("error");
+	});
+
+	it("retries rate-limit text with incidental 4xx numbers even when provider status extraction says 400", async () => {
+		session = buildStatusErrorSession({
+			errorMessage: "rate limit error: 400 requests per minute",
+			errorStatus: 400,
+			recoveredContent: "recovered after rate-limit retry",
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = track(session);
+
+		await session.prompt("trigger misleading rate limit status");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true });
+		expect(lastAssistant(session).stopReason).toBe("stop");
+	});
+
+	it("does not terminalize retryable explicit HTTP statuses", async () => {
+		for (const [status, message] of [
+			[408, "HTTP 408 request timeout"],
+			[425, "HTTP 425 too early retry your request"],
+			[429, "HTTP 429 rate limit exceeded"],
+			[503, "HTTP 503 service unavailable"],
+		] as const) {
+			if (session) {
+				await session.dispose();
+				session = undefined;
+			}
+			session = buildSession({ responses: [{ throw: message }, { content: [`recovered ${status}`] }] });
+			vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+			const { retryStartEvents } = track(session);
+
+			await session.prompt(`trigger retryable HTTP ${status}`);
+			await session.waitForIdle();
+
+			expect(retryStartEvents).toHaveLength(1);
+			expect(lastAssistant(session).stopReason).toBe("stop");
+		}
 	});
 
 	it("emits auto_retry_end when a retry ends on a terminal error", async () => {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -348,6 +348,44 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).stopReason).toBe("error");
 	});
 
+	it("surfaces explicit HTTP 400 messages even when text contains transient substrings", async () => {
+		for (const errorMessage of [
+			"HTTP 400: provider returned error",
+			"HTTP 400: max 500 tool calls exceeded",
+			"HTTP 400: request timed out during validation",
+		] as const) {
+			if (session) {
+				await session.dispose();
+				session = undefined;
+			}
+			session = buildSession({ responses: [{ throw: errorMessage }] });
+			vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+			const { retryStartEvents } = track(session);
+
+			await session.prompt(`trigger explicit terminal 400: ${errorMessage}`);
+			await session.waitForIdle();
+
+			expect(retryStartEvents).toHaveLength(0);
+			expect(lastAssistant(session).stopReason).toBe("error");
+		}
+	});
+
+	it("surfaces structured HTTP 400 even when text contains transient substrings", async () => {
+		session = buildStatusErrorSession({
+			errorMessage: "provider returned error",
+			errorStatus: 400,
+			recoveredContent: "should not retry",
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("trigger structured terminal 400");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(lastAssistant(session).stopReason).toBe("error");
+	});
+
 	it("surfaces explicit status-code 4xx errors without retrying", async () => {
 		session = buildSession({ responses: [{ throw: "provider returned status code 400 for malformed payload" }] });
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -276,6 +276,20 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).stopReason).toBe("error");
 	});
 
+	it("surfaces numeric HTTP 4xx (status context) without retrying", async () => {
+		// No "bad request" keyword — relies on HTTP-status extraction so a bare
+		// numeric 4xx is treated terminal instead of looping as "unknown".
+		session = buildSession({ responses: [{ throw: "HTTP 400: malformed request payload" }] });
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("trigger numeric 400");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(lastAssistant(session).stopReason).toBe("error");
+	});
+
 	it("emits auto_retry_end when a retry ends on a terminal error", async () => {
 		// First a transient error (retries), then a terminal 401 that must not
 		// retry — the retry session must emit a terminal auto_retry_end.


### PR DESCRIPTION
Round-2 + round-3 review remediation for the steer-on-interrupt / resilient-retry / retry-observability feature after #202/#204.

## Round-2 fixes
- **HTTP-status terminal classification** (`agent-session.ts`): provider HTTP statuses and explicit text HTTP/status-code 4xx client errors surface immediately, except 408/425/429 which remain retryable.
- **switchSession rollback** (`agent-session.ts`): queue clearing no longer happens before a fallible switch can rollback.
- **Retry UI cleanup** (`event-controller.ts`, `input-controller.ts`): Esc hint matches behavior (`esc to retry now`), repeated `auto_retry_start` does not leak stale loader/timer/handler state, and background mode clears retry countdown + restores Esc handler.

## Round-3 fixes
- **Rate-limit/status precedence**: classifier now classifies deterministic terminal text, usage-limit, and transient/rate-limit text before applying terminal status-derived 4xx. This prevents broad provider status extraction from terminalizing messages like `rate limit error: 400 requests per minute`, while preserving explicit `HTTP 400` / `status code 400` terminal behavior.
- **Narrow text status parser**: text-only status extraction only accepts explicit HTTP/status wording, not generic `error: NNN`.
- **switchSession hook queue consistency**: Agent delivery queues are snapshotted, pre-switch queues are cleared only after target load/MCP restore commits, clearing happens before `session_switch` hooks, and snapshots restore on rollback. Messages enqueued by `session_switch` hooks stay visible and deliverable.
- **Agent follow-up queue snapshots**: added follow-up snapshot/restore helpers to match existing steering helpers.

## Verification
- `bun biome check --write packages/agent/src/agent.ts packages/agent/test/agent-steering-queue.test.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-concurrent.test.ts`
- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/agent-session-steer-interrupt.test.ts packages/coding-agent/test/agent-session-manual-retry.test.ts packages/coding-agent/test/agent-session-concurrent.test.ts packages/agent/test/agent-steering-queue.test.ts` — 57 pass
- `bun test packages/coding-agent/test/event-controller-retry.test.ts packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/interactive-mode-status.test.ts packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/task/progress-events.test.ts packages/coding-agent/test/sdk-custom-tools.test.ts` — 106 pass
- `(cd packages/agent && bun run check)`
- `(cd packages/coding-agent && bun run check:types)`