### PR TITLE
Add xAI OAuth login provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added xAI to the `/login` API-key provider catalog so users can store xAI credentials with `login xai` in addition to `XAI_API_KEY`.
+- Added xAI to the `/login` provider catalog as a Grok OAuth login with PKCE, refresh-token storage, and mocked login/refresh coverage.
 
 ## [0.2.4] - 2026-06-02
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added xAI to the `/login` API-key provider catalog so users can store xAI credentials with `login xai` in addition to `XAI_API_KEY`.
+
 ## [0.2.4] - 2026-06-02
 
 ### Added

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1063,14 +1063,15 @@ The quickest way to authenticate:
 bunx @gajae-code/ai login              # interactive provider selection
 bunx @gajae-code/ai login anthropic    # login to specific provider
 bunx @gajae-code/ai login vllm         # store vLLM API key (or placeholder for local no-auth)
+bunx @gajae-code/ai login xai          # store an xAI API key
 bunx @gajae-code/ai list               # list available providers
 ```
 
-Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key.
+Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key; `/login xai` stores a pasted xAI API key rather than browser OAuth credentials.
 
 `login` supports OAuth providers (Anthropic, OpenAI code provider, GitHub Copilot, Gemini CLI, Antigravity) and API-key onboarding flows.
 
-For the current API-key onboarding flows, the library covers Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, Qwen Portal, and Ollama Cloud. Ollama remains the local runtime integration; set `OLLAMA_API_KEY` only when your local or self-hosted deployment enforces bearer auth.
+For the current API-key onboarding flows, the library covers xAI, Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, Qwen Portal, and Ollama Cloud. Ollama remains the local runtime integration; set `OLLAMA_API_KEY` only when your local or self-hosted deployment enforces bearer auth.
 
 ### Programmatic OAuth
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1014,6 +1014,7 @@ Several providers support OAuth authentication (some also support static API key
 - **Google Gemini CLI** (Gemini 2.0/2.5 via Google Cloud Code Assist; free tier or paid subscription)
 - **Antigravity** (Free Gemini 3, Anthropic model, GPT-OSS via Google Cloud)
 - **Qwen Portal** (Qwen OAuth token or API key)
+- **xAI** (Grok OAuth login via xAI account)
 
 For paid Cloud Code Assist subscriptions, set `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` to your project ID.
 
@@ -1063,15 +1064,15 @@ The quickest way to authenticate:
 bunx @gajae-code/ai login              # interactive provider selection
 bunx @gajae-code/ai login anthropic    # login to specific provider
 bunx @gajae-code/ai login vllm         # store vLLM API key (or placeholder for local no-auth)
-bunx @gajae-code/ai login xai          # store an xAI API key
+bunx @gajae-code/ai login xai          # sign in with xAI/Grok OAuth
 bunx @gajae-code/ai list               # list available providers
 ```
 
-Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key; `/login xai` stores a pasted xAI API key rather than browser OAuth credentials.
+Credentials are saved to `agent.db` in the agent directory. `/login qianfan` opens the Qianfan console and stores the pasted API key; `/login xai` opens xAI/Grok OAuth login and stores refreshable OAuth credentials.
 
-`login` supports OAuth providers (Anthropic, OpenAI code provider, GitHub Copilot, Gemini CLI, Antigravity) and API-key onboarding flows.
+`login` supports OAuth providers (Anthropic, OpenAI code provider, GitHub Copilot, Gemini CLI, Antigravity, xAI) and API-key onboarding flows.
 
-For the current API-key onboarding flows, the library covers xAI, Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, Qwen Portal, and Ollama Cloud. Ollama remains the local runtime integration; set `OLLAMA_API_KEY` only when your local or self-hosted deployment enforces bearer auth.
+For the current API-key onboarding flows, the library covers Together, Moonshot, Qianfan, NVIDIA, NanoGPT, Hugging Face, Venice, Xiaomi, vLLM, LiteLLM, Cloudflare AI Gateway, Qwen Portal, and Ollama Cloud. Ollama remains the local runtime integration; set `OLLAMA_API_KEY` only when your local or self-hosted deployment enforces bearer auth.
 
 ### Programmatic OAuth
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1486,9 +1486,11 @@ export class AuthStorage {
 			}
 			case "xai": {
 				const { loginXai } = await import("./utils/oauth/xai");
-				const apiKey = await loginXai(ctrl);
-				await saveApiKeyCredential(apiKey);
-				return;
+				credentials = await loginXai({
+					...ctrl,
+					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
+				});
+				break;
 			}
 			case "fireworks": {
 				const { loginFireworks } = await import("./utils/oauth/fireworks");
@@ -1643,6 +1645,13 @@ export class AuthStorage {
 			}
 		}
 		const newCredential: OAuthCredential = { type: "oauth", ...credentials };
+		if (provider === "xai") {
+			const existingOAuthCredentials = this.#getCredentialsForProvider(provider).filter(
+				(credential): credential is OAuthCredential => credential.type === "oauth",
+			);
+			await this.set(provider, [...existingOAuthCredentials, newCredential]);
+			return;
+		}
 		await this.#upsertOAuthCredential(provider, newCredential);
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1484,6 +1484,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "xai": {
+				const { loginXai } = await import("./utils/oauth/xai");
+				const apiKey = await loginXai(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "fireworks": {
 				const { loginFireworks } = await import("./utils/oauth/fireworks");
 				const apiKey = await loginFireworks(ctrl);

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -110,6 +110,7 @@ Providers:
   tavily            Tavily
   zai               Z.AI (GLM Coding Plan)
   deepseek          DeepSeek
+  xai               xAI
   nanogpt           NanoGPT
   minimax-code      MiniMax Coding Plan (International)
   minimax-code-cn   MiniMax Coding Plan (China)

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -315,6 +315,11 @@ export async function refreshOAuthToken(
 			newCredentials = await refreshCursorToken(credentials.refresh);
 			break;
 		}
+		case "xai": {
+			const { refreshXaiToken } = await import("./xai");
+			newCredentials = await refreshXaiToken(credentials.refresh);
+			break;
+		}
 		case "kilo":
 		case "perplexity":
 		case "huggingface":
@@ -326,7 +331,6 @@ export async function refreshOAuthToken(
 		case "nvidia":
 		case "nanogpt":
 		case "synthetic":
-		case "xai":
 		case "together":
 		case "litellm":
 		case "lm-studio":

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -61,6 +61,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "xai",
+		name: "xAI",
+		available: true,
+	},
+	{
 		id: "fireworks",
 		name: "Fireworks",
 		available: true,
@@ -321,6 +326,7 @@ export async function refreshOAuthToken(
 		case "nvidia":
 		case "nanogpt":
 		case "synthetic":
+		case "xai":
 		case "together":
 		case "litellm":
 		case "lm-studio":

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -48,6 +48,7 @@ export type OAuthProvider =
 	| "venice"
 	| "vercel-ai-gateway"
 	| "vllm"
+	| "xai"
 	| "xiaomi"
 	| "zenmux"
 	| "zai";

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,15 @@
+/** xAI login flow (API key paste against https://api.x.ai/v1). */
+import { createApiKeyLogin } from "./api-key-login";
+
+export const loginXai = createApiKeyLogin({
+	providerLabel: "xAI",
+	authUrl: "https://console.x.ai/team/default/api-keys",
+	instructions: "Create or copy your xAI API key",
+	promptMessage: "Paste your xAI API key",
+	placeholder: "xai-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "xAI",
+		modelsUrl: "https://api.x.ai/v1/models",
+	},
+});

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,15 +1,210 @@
-/** xAI login flow (API key paste against https://api.x.ai/v1). */
-import { createApiKeyLogin } from "./api-key-login";
+/** xAI OAuth flow (Grok account login). */
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
+import { generatePKCE } from "./pkce";
+import type { OAuthController, OAuthCredentials } from "./types";
 
-export const loginXai = createApiKeyLogin({
-	providerLabel: "xAI",
-	authUrl: "https://console.x.ai/team/default/api-keys",
-	instructions: "Create or copy your xAI API key",
-	promptMessage: "Paste your xAI API key",
-	placeholder: "xai-...",
-	validation: {
-		kind: "models-endpoint",
-		provider: "xAI",
-		modelsUrl: "https://api.x.ai/v1/models",
-	},
-});
+const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_OAUTH_CALLBACK_PORT = 56121;
+const XAI_OAUTH_CALLBACK_PATH = "/callback";
+const XAI_OAUTH_REFRESH_SKEW_MS = 2 * 60 * 1000;
+const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+
+interface XaiDiscovery {
+	authorizationEndpoint: string;
+	tokenEndpoint: string;
+}
+
+interface XaiDiscoveryPayload {
+	authorization_endpoint?: unknown;
+	token_endpoint?: unknown;
+}
+
+interface XaiTokenPayload {
+	access_token?: unknown;
+	refresh_token?: unknown;
+	expires_in?: unknown;
+	id_token?: unknown;
+	token_type?: unknown;
+}
+
+interface XaiJwtPayload {
+	sub?: unknown;
+	email?: unknown;
+	[key: string]: unknown;
+}
+
+function requestSignal(signal: AbortSignal | undefined): AbortSignal {
+	const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+function validateXaiEndpoint(rawUrl: string): string {
+	const parsed = new URL(rawUrl);
+	const host = parsed.hostname.toLowerCase();
+	if (parsed.protocol !== "https:" || (host !== "x.ai" && !host.endsWith(".x.ai"))) {
+		throw new Error(`xAI OAuth discovery returned an unexpected endpoint: ${rawUrl}`);
+	}
+	return parsed.toString();
+}
+
+export async function discoverXaiOAuthEndpoints(signal?: AbortSignal): Promise<XaiDiscovery> {
+	const response = await fetch(XAI_OAUTH_DISCOVERY_URL, {
+		headers: { Accept: "application/json" },
+		signal: requestSignal(signal),
+	});
+	if (!response.ok) {
+		throw new Error(`xAI OAuth discovery failed: ${response.status} ${await response.text()}`);
+	}
+
+	const payload = (await response.json()) as XaiDiscoveryPayload;
+	if (typeof payload.authorization_endpoint !== "string" || typeof payload.token_endpoint !== "string") {
+		throw new Error("xAI OAuth discovery response missing authorization/token endpoints");
+	}
+
+	return {
+		authorizationEndpoint: validateXaiEndpoint(payload.authorization_endpoint),
+		tokenEndpoint: validateXaiEndpoint(payload.token_endpoint),
+	};
+}
+
+function decodeJwtPayload(token: string): XaiJwtPayload | undefined {
+	const parts = token.split(".");
+	const payload = parts[1];
+	if (parts.length !== 3 || !payload) return undefined;
+	try {
+		return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as XaiJwtPayload;
+	} catch {
+		return undefined;
+	}
+}
+
+function getTokenIdentity(accessToken: string, idToken: string | undefined): { accountId?: string; email?: string } {
+	const payload = (idToken ? decodeJwtPayload(idToken) : undefined) ?? decodeJwtPayload(accessToken);
+	const accountId = typeof payload?.sub === "string" && payload.sub.length > 0 ? payload.sub : undefined;
+	const email =
+		typeof payload?.email === "string" && payload.email.length > 0 ? payload.email.toLowerCase() : undefined;
+	return { accountId, email };
+}
+
+async function postXaiToken(
+	tokenEndpoint: string,
+	body: Record<string, string>,
+	signal?: AbortSignal,
+): Promise<XaiTokenPayload> {
+	const response = await fetch(tokenEndpoint, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams(body).toString(),
+		signal: requestSignal(signal),
+	});
+	if (!response.ok) {
+		throw new Error(`xAI token request failed: ${response.status} ${await response.text()}`);
+	}
+	return (await response.json()) as XaiTokenPayload;
+}
+
+function credentialsFromTokenPayload(payload: XaiTokenPayload, refreshFallback = ""): OAuthCredentials {
+	if (typeof payload.access_token !== "string" || payload.access_token.length === 0) {
+		throw new Error("xAI token response did not include an access token");
+	}
+	const refresh =
+		typeof payload.refresh_token === "string" && payload.refresh_token.length > 0
+			? payload.refresh_token
+			: refreshFallback;
+	if (!refresh) {
+		throw new Error("xAI token response did not include a refresh token");
+	}
+	const expiresIn =
+		typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in) ? payload.expires_in : 3600;
+	const idToken = typeof payload.id_token === "string" ? payload.id_token : undefined;
+	const { accountId, email } = getTokenIdentity(payload.access_token, idToken);
+	return {
+		refresh,
+		access: payload.access_token,
+		expires: Date.now() + expiresIn * 1000 - XAI_OAUTH_REFRESH_SKEW_MS,
+		accountId,
+		email,
+	};
+}
+
+export class XaiOAuthFlow extends OAuthCallbackFlow {
+	#verifier = "";
+	#discovery: XaiDiscovery | undefined;
+
+	constructor(ctrl: OAuthController) {
+		super(ctrl, {
+			preferredPort: XAI_OAUTH_CALLBACK_PORT,
+			callbackPath: XAI_OAUTH_CALLBACK_PATH,
+			callbackHostname: "127.0.0.1",
+			callbackBindHostname: "127.0.0.1",
+			redirectUri: `http://127.0.0.1:${XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`,
+		} satisfies OAuthCallbackFlowOptions);
+	}
+
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
+		const pkce = await generatePKCE();
+		this.#verifier = pkce.verifier;
+		this.#discovery = await discoverXaiOAuthEndpoints(this.ctrl.signal);
+		const params = new URLSearchParams({
+			response_type: "code",
+			client_id: XAI_OAUTH_CLIENT_ID,
+			redirect_uri: redirectUri,
+			scope: XAI_OAUTH_SCOPE,
+			code_challenge: pkce.challenge,
+			code_challenge_method: "S256",
+			state,
+			nonce: crypto.randomUUID(),
+		});
+		return {
+			url: `${this.#discovery.authorizationEndpoint}?${params.toString()}`,
+			instructions:
+				"Complete xAI/Grok login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted.",
+		};
+	}
+
+	async exchangeToken(code: string, _state: string, redirectUri: string): Promise<OAuthCredentials> {
+		if (!this.#verifier) {
+			throw new Error("xAI OAuth PKCE verifier was not initialized");
+		}
+		const discovery = this.#discovery ?? (await discoverXaiOAuthEndpoints(this.ctrl.signal));
+		const tokenPayload = await postXaiToken(
+			discovery.tokenEndpoint,
+			{
+				grant_type: "authorization_code",
+				client_id: XAI_OAUTH_CLIENT_ID,
+				code,
+				redirect_uri: redirectUri,
+				code_verifier: this.#verifier,
+			},
+			this.ctrl.signal,
+		);
+		return credentialsFromTokenPayload(tokenPayload);
+	}
+}
+
+export async function loginXai(ctrl: OAuthController): Promise<OAuthCredentials> {
+	return new XaiOAuthFlow(ctrl).login();
+}
+
+export async function refreshXaiToken(refreshToken: string, signal?: AbortSignal): Promise<OAuthCredentials> {
+	if (!refreshToken) {
+		throw new Error("xAI credentials are expired and do not include a refresh token");
+	}
+	const discovery = await discoverXaiOAuthEndpoints(signal);
+	const tokenPayload = await postXaiToken(
+		discovery.tokenEndpoint,
+		{
+			grant_type: "refresh_token",
+			client_id: XAI_OAUTH_CLIENT_ID,
+			refresh_token: refreshToken,
+		},
+		signal,
+	);
+	return credentialsFromTokenPayload(tokenPayload, refreshToken);
+}

--- a/packages/ai/test/oauth-xai.test.ts
+++ b/packages/ai/test/oauth-xai.test.ts
@@ -5,18 +5,63 @@ import * as path from "node:path";
 
 import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
 import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
-import type { OAuthController, OAuthCredentials } from "../src/utils/oauth/types";
-import { loginXai } from "../src/utils/oauth/xai";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+import {
+	discoverXaiOAuthEndpoints,
+	XAI_OAUTH_CLIENT_ID,
+	XAI_OAUTH_DISCOVERY_URL,
+	XAI_OAUTH_SCOPE,
+	XaiOAuthFlow,
+} from "../src/utils/oauth/xai";
 import { withEnv } from "./helpers";
 
 const originalFetch = global.fetch;
 const SUPPRESS_XAI_ENV = { XAI_API_KEY: undefined } as const;
+const AUTHORIZATION_ENDPOINT = "https://auth.x.ai/oauth2/authorize";
+const TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token";
 
-function makeController(paste: string): OAuthController {
-	return {
-		onAuth: () => {},
-		onPrompt: async () => paste,
-	};
+function discoveryResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			issuer: "https://auth.x.ai",
+			authorization_endpoint: AUTHORIZATION_ENDPOINT,
+			token_endpoint: TOKEN_ENDPOINT,
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function tokenResponse(accessToken: string, refreshToken: string, accountId: string, email: string): Response {
+	return new Response(
+		JSON.stringify({
+			access_token: accessToken,
+			refresh_token: refreshToken,
+			id_token: jwt({ sub: accountId, email }),
+			expires_in: 3600,
+			token_type: "Bearer",
+		}),
+		{ status: 200, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function jwt(payload: Record<string, unknown>): string {
+	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.`;
+}
+
+async function dispatchLocalCallback(callbackUrl: string): Promise<void> {
+	const url = new URL(callbackUrl);
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			await originalFetch(url.toString());
+			return;
+		} catch (error) {
+			lastError = error;
+			await Bun.sleep(10);
+		}
+	}
+	throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 describe("xAI OAuth login provider", () => {
@@ -50,72 +95,156 @@ describe("xAI OAuth login provider", () => {
 		});
 	});
 
-	it("validates against GET /v1/models and returns the trimmed key on 200", async () => {
-		const calls: Array<{ url: string; method?: string; auth?: string | null }> = [];
-		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-			const headers = new Headers(init?.headers ?? {});
-			calls.push({ url, method: init?.method, auth: headers.get("authorization") });
-			return new Response(JSON.stringify({ object: "list", data: [{ id: "grok-4", object: "model" }] }), {
-				status: 200,
-				headers: { "Content-Type": "application/json" },
-			});
+	it("discovers xAI OAuth endpoints from the official issuer", async () => {
+		const fetchMock = vi.fn(async () => discoveryResponse());
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(discoverXaiOAuthEndpoints()).resolves.toEqual({
+			authorizationEndpoint: AUTHORIZATION_ENDPOINT,
+			tokenEndpoint: TOKEN_ENDPOINT,
 		});
-		global.fetch = fetchMock as unknown as typeof fetch;
-
-		const key = await loginXai(makeController("  xai-valid-key  "));
-
-		expect(key).toBe("xai-valid-key");
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(calls[0]?.url).toBe("https://api.x.ai/v1/models");
-		expect(calls[0]?.method ?? "GET").toBe("GET");
-		expect(calls[0]?.auth).toBe("Bearer xai-valid-key");
+		expect(fetchMock).toHaveBeenCalledWith(XAI_OAUTH_DISCOVERY_URL, expect.any(Object));
 	});
 
-	it("rejects an empty paste before touching the network", async () => {
-		const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
-		global.fetch = fetchMock as unknown as typeof fetch;
-
-		await expect(loginXai(makeController("   "))).rejects.toThrow(/API key is required/i);
-		expect(fetchMock).not.toHaveBeenCalled();
-	});
-
-	it("throws a validation error when /v1/models returns 401", async () => {
+	it("rejects OAuth discovery endpoints outside x.ai", async () => {
 		const fetchMock = vi.fn(
-			async () => new Response("invalid api key", { status: 401, headers: { "Content-Type": "text/plain" } }),
+			async () =>
+				new Response(
+					JSON.stringify({
+						authorization_endpoint: "https://evil.example/oauth2/authorize",
+						token_endpoint: TOKEN_ENDPOINT,
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
 		);
 		global.fetch = fetchMock as unknown as typeof fetch;
 
-		await expect(loginXai(makeController("xai-bad-key"))).rejects.toThrow(/xAI.*401.*invalid api key/i);
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await expect(discoverXaiOAuthEndpoints()).rejects.toThrow(/unexpected endpoint/i);
 	});
 
-	it("stores xAI login credentials as a reusable api-key credential", async () => {
-		if (!store || !authStorage) throw new Error("test setup failed");
-		const fetchMock = vi.fn(async () => new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 }));
+	it("builds a PKCE browser authorization URL", async () => {
+		const fetchMock = vi.fn(async () => discoveryResponse());
 		global.fetch = fetchMock as unknown as typeof fetch;
+		const flow = new XaiOAuthFlow({ onAuth: () => {}, onPrompt: async () => "" });
+		expect(flow.redirectUri).toBe("http://127.0.0.1:56121/callback");
+
+		const { url } = await flow.generateAuthUrl("state-123", "http://127.0.0.1:56121/callback");
+		const authUrl = new URL(url);
+
+		expect(authUrl.origin + authUrl.pathname).toBe(AUTHORIZATION_ENDPOINT);
+		expect(authUrl.searchParams.get("response_type")).toBe("code");
+		expect(authUrl.searchParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+		expect(authUrl.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:56121/callback");
+		expect(authUrl.searchParams.get("scope")).toBe(XAI_OAUTH_SCOPE);
+		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(authUrl.searchParams.get("code_challenge")?.length).toBeGreaterThan(20);
+		expect(authUrl.searchParams.get("state")).toBe("state-123");
+		expect(authUrl.searchParams.get("nonce")?.length).toBeGreaterThan(20);
+	});
+
+	it("exchanges an authorization code for refreshable OAuth credentials", async () => {
+		let tokenBody = "";
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === XAI_OAUTH_DISCOVERY_URL) return discoveryResponse();
+			if (url === TOKEN_ENDPOINT) {
+				tokenBody = String(init?.body ?? "");
+				return tokenResponse("access-token", "refresh-token", "account-123", "User@Example.com");
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+		const flow = new XaiOAuthFlow({ onAuth: () => {}, onPrompt: async () => "" });
+		await flow.generateAuthUrl("state-123", "http://127.0.0.1:56121/callback");
+
+		const credentials = await flow.exchangeToken("auth-code", "state-123", "http://127.0.0.1:56121/callback");
+		const tokenParams = new URLSearchParams(tokenBody);
+
+		expect(tokenParams.get("grant_type")).toBe("authorization_code");
+		expect(tokenParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+		expect(tokenParams.get("code")).toBe("auth-code");
+		expect(tokenParams.get("redirect_uri")).toBe("http://127.0.0.1:56121/callback");
+		expect(tokenParams.get("code_verifier")?.length).toBeGreaterThan(20);
+		expect(credentials).toMatchObject({
+			access: "access-token",
+			refresh: "refresh-token",
+			accountId: "account-123",
+			email: "user@example.com",
+		});
+		expect(credentials.expires).toBeGreaterThan(Date.now());
+	});
+
+	it("stores xAI login credentials as refreshable OAuth credentials", async () => {
+		if (!store || !authStorage) throw new Error("test setup failed");
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === XAI_OAUTH_DISCOVERY_URL) return discoveryResponse();
+			if (url === TOKEN_ENDPOINT) {
+				expect(String(init?.body ?? "")).toContain("grant_type=authorization_code");
+				return tokenResponse("access-login", "refresh-login", "account-login", "login@example.com");
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+		await authStorage.set("xai", { type: "api_key", key: "legacy-api-key" });
 
 		await authStorage.login("xai", {
-			onAuth: () => {},
-			onPrompt: async () => "  xai-stored-key  ",
+			onAuth: info => {
+				const authUrl = new URL(info.url);
+				const redirectUri = authUrl.searchParams.get("redirect_uri");
+				const state = authUrl.searchParams.get("state");
+				if (!redirectUri || !state) throw new Error("missing redirect_uri/state");
+				queueMicrotask(() => {
+					void dispatchLocalCallback(`${redirectUri}?code=login-code&state=${state}`);
+				});
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: () => new Promise<string>(() => {}),
 		});
 
 		const credentials = store.listAuthCredentials("xai");
 		expect(credentials).toHaveLength(1);
-		expect(credentials[0]?.credential).toEqual({ type: "api_key", key: "xai-stored-key" });
-		expect(store.getApiKey("xai")).toBe("xai-stored-key");
+		expect(credentials[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: "access-login",
+			refresh: "refresh-login",
+			accountId: "account-login",
+			email: "login@example.com",
+		});
 		await withEnv(SUPPRESS_XAI_ENV, async () => {
-			expect(await authStorage?.getApiKey("xai", "session-xai-login")).toBe("xai-stored-key");
+			expect(await authStorage?.getApiKey("xai", "session-xai-login")).toBe("access-login");
 		});
 	});
 
-	it("treats xAI OAuth-shaped credentials as static bearer credentials during refresh", async () => {
+	it("refreshes expired xAI OAuth credentials with the refresh token", async () => {
+		let tokenBody = "";
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === XAI_OAUTH_DISCOVERY_URL) return discoveryResponse();
+			if (url === TOKEN_ENDPOINT) {
+				tokenBody = String(init?.body ?? "");
+				return tokenResponse("access-rotated", "refresh-rotated", "account-rotated", "rotated@example.com");
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
 		const credentials: OAuthCredentials = {
-			access: "xai-access",
-			refresh: "xai-refresh",
-			expires: Date.now() + 60_000,
+			access: "access-old",
+			refresh: "refresh-old",
+			expires: Date.now() - 60_000,
 		};
 
-		await expect(refreshOAuthToken("xai", credentials)).resolves.toBe(credentials);
+		const refreshed = await refreshOAuthToken("xai", credentials);
+		const tokenParams = new URLSearchParams(tokenBody);
+
+		expect(tokenParams.get("grant_type")).toBe("refresh_token");
+		expect(tokenParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+		expect(tokenParams.get("refresh_token")).toBe("refresh-old");
+		expect(refreshed).toMatchObject({
+			access: "access-rotated",
+			refresh: "refresh-rotated",
+			accountId: "account-rotated",
+			email: "rotated@example.com",
+		});
 	});
 });

--- a/packages/ai/test/oauth-xai.test.ts
+++ b/packages/ai/test/oauth-xai.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
+import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
+import type { OAuthController, OAuthCredentials } from "../src/utils/oauth/types";
+import { loginXai } from "../src/utils/oauth/xai";
+import { withEnv } from "./helpers";
+
+const originalFetch = global.fetch;
+const SUPPRESS_XAI_ENV = { XAI_API_KEY: undefined } as const;
+
+function makeController(paste: string): OAuthController {
+	return {
+		onAuth: () => {},
+		onPrompt: async () => paste,
+	};
+}
+
+describe("xAI OAuth login provider", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore | undefined;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-xai-oauth-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store);
+	});
+
+	afterEach(async () => {
+		global.fetch = originalFetch;
+		vi.restoreAllMocks();
+		store?.close();
+		store = undefined;
+		authStorage = undefined;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("registers xAI as an available login provider", () => {
+		expect(getOAuthProviders().find(provider => provider.id === "xai")).toEqual({
+			id: "xai",
+			name: "xAI",
+			available: true,
+		});
+	});
+
+	it("validates against GET /v1/models and returns the trimmed key on 200", async () => {
+		const calls: Array<{ url: string; method?: string; auth?: string | null }> = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			const headers = new Headers(init?.headers ?? {});
+			calls.push({ url, method: init?.method, auth: headers.get("authorization") });
+			return new Response(JSON.stringify({ object: "list", data: [{ id: "grok-4", object: "model" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const key = await loginXai(makeController("  xai-valid-key  "));
+
+		expect(key).toBe("xai-valid-key");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(calls[0]?.url).toBe("https://api.x.ai/v1/models");
+		expect(calls[0]?.method ?? "GET").toBe("GET");
+		expect(calls[0]?.auth).toBe("Bearer xai-valid-key");
+	});
+
+	it("rejects an empty paste before touching the network", async () => {
+		const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(loginXai(makeController("   "))).rejects.toThrow(/API key is required/i);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("throws a validation error when /v1/models returns 401", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response("invalid api key", { status: 401, headers: { "Content-Type": "text/plain" } }),
+		);
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(loginXai(makeController("xai-bad-key"))).rejects.toThrow(/xAI.*401.*invalid api key/i);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("stores xAI login credentials as a reusable api-key credential", async () => {
+		if (!store || !authStorage) throw new Error("test setup failed");
+		const fetchMock = vi.fn(async () => new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 }));
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await authStorage.login("xai", {
+			onAuth: () => {},
+			onPrompt: async () => "  xai-stored-key  ",
+		});
+
+		const credentials = store.listAuthCredentials("xai");
+		expect(credentials).toHaveLength(1);
+		expect(credentials[0]?.credential).toEqual({ type: "api_key", key: "xai-stored-key" });
+		expect(store.getApiKey("xai")).toBe("xai-stored-key");
+		await withEnv(SUPPRESS_XAI_ENV, async () => {
+			expect(await authStorage?.getApiKey("xai", "session-xai-login")).toBe("xai-stored-key");
+		});
+	});
+
+	it("treats xAI OAuth-shaped credentials as static bearer credentials during refresh", async () => {
+		const credentials: OAuthCredentials = {
+			access: "xai-access",
+			refresh: "xai-refresh",
+			expires: Date.now() + 60_000,
+		};
+
+		await expect(refreshOAuthToken("xai", credentials)).resolves.toBe(credentials);
+	});
+});

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -69,6 +69,7 @@ const CALLBACK_PORTS: Record<string, number> = {
 	"google-gemini-cli": 8085,
 	"google-antigravity": 51121,
 	"gitlab-duo": 8080,
+	xai: 56121,
 };
 
 function getTokenFilePath(): string {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -57,12 +57,13 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 
-const CALLBACK_SERVER_PROVIDERS = new Set<OAuthProvider>([
+const CALLBACK_SERVER_PROVIDERS = new Set<string>([
 	"anthropic",
 	"openai-codex",
 	"gitlab-duo",
 	"google-gemini-cli",
 	"google-antigravity",
+	"xai",
 ]);
 
 const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";


### PR DESCRIPTION
## Summary
- Add xAI to the `/login` provider catalog as a real xAI/Grok OAuth provider, not an API-key paste flow.
- Implement xAI OIDC discovery, fixed localhost PKCE callback (`127.0.0.1:56121/callback`), authorization-code exchange, refresh-token rotation, endpoint host validation, and account/email extraction.
- Store xAI logins as refreshable OAuth credentials, superseding any legacy xAI API-key row so stale API keys do not win after OAuth login.
- Wire refresh dispatch, TUI manual redirect fallback, auth-broker remote callback port forwarding, README, changelog, and mocked OAuth tests.

## Verification
- `bun test packages/ai/test/oauth-xai.test.ts` — passed (7 pass, 0 fail, 29 expect() calls)
- `bun test packages/ai/test/oauth-deepseek.test.ts` — passed (7 pass, 0 fail, 15 expect() calls)
- `bun test packages/ai/test/*oauth*.test.ts` — passed (38 pass, 0 fail, 121 expect() calls)
- `bun --cwd=packages/ai run check` — passed
- `bun --cwd=packages/coding-agent run check` — passed
- `git diff --check` — passed
- xAI OIDC discovery probe — passed (`status: 200`, authorize/token/device endpoints present, `refresh_token` grant present, `S256` PKCE present)
- Final architect review lane — CLEAR / CLEAR / CLEAR, APPROVE, no blockers
- Final QA/red-team lane — passed, no blockers

## Notes
- Automated tests mock xAI network calls; no live xAI token exchange and no secrets in test output.
- This supersedes the earlier API-key implementation on the same branch after the requirement was clarified to be OAuth.
- Target branch: `dev`.