### PR TITLE
feat(orchestration-token-benchmark): Phase 0 deterministic token-efficiency benchmark

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,13 @@
         "@types/bun": "catalog:",
       },
     },
+    "packages/orchestration-token-benchmark": {
+      "name": "@gajae-code/orchestration-token-benchmark",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/bun": "catalog:",
+      },
+    },
     "packages/stats": {
       "name": "@gajae-code/stats",
       "version": "0.2.5",
@@ -404,6 +411,8 @@
     "@gajae-code/coding-agent": ["@gajae-code/coding-agent@workspace:packages/coding-agent"],
 
     "@gajae-code/natives": ["@gajae-code/natives@workspace:packages/natives"],
+
+    "@gajae-code/orchestration-token-benchmark": ["@gajae-code/orchestration-token-benchmark@workspace:packages/orchestration-token-benchmark"],
 
     "@gajae-code/stats": ["@gajae-code/stats@workspace:packages/stats"],
 

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "ci:release:publish": "bun scripts/ci-release-publish.ts",
     "bench:gen-fixtures": "bun --cwd=packages/typescript-edit-benchmark run src/generate.ts --typescript-dir /tmp/typescript-source --count-per-type 8",
     "bench:edit": "bun --cwd=packages/typescript-edit-benchmark run start",
+    "bench:orchestration-tokens": "bun --cwd=packages/orchestration-token-benchmark run start",
     "stats:sync": "python3 scripts/session-stats/sync.py",
     "stats:tools": "python3 scripts/session-stats/analyze.py tools",
     "stats:edits": "python3 scripts/session-stats/analyze.py edits",

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -614,8 +614,7 @@ function renderAgentProgress(
 		const attemptLabel = progress.retryState.unbounded
 			? `attempt ${progress.retryState.attempt}`
 			: `${progress.retryState.attempt}/${progress.retryState.maxAttempts}`;
-		const summary =
-			`retrying ${attemptLabel} ${waitLabel}: ` + truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60);
+		const summary = `retrying ${attemptLabel} ${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("warning", summary)}`);
 	} else if (progress.retryFailure && progress.status !== "running") {
 		const summary = `auto-retry gave up after ${progress.retryFailure.attempt} attempt${

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -321,3 +321,54 @@ export interface TaskToolDetails {
 		type: "task";
 	};
 }
+/**
+ * Persisted per-turn / per-subagent token record (Phase 0 instrumentation).
+ *
+ * Additive: this does not alter any existing task result shape. It is the
+ * durable, model-independent unit the deterministic orchestration-token
+ * benchmark (`@gajae-code/orchestration-token-benchmark`) consumes to measure
+ * token efficiency without any live-model calls.
+ */
+export interface TaskTokenLog {
+	/** Subagent id, or "root" for the orchestrator's own turn. */
+	subagentId: string;
+	/** Agent name for attribution, when known. */
+	agent?: string;
+	/** 1-based turn index within the subagent's session. */
+	turn: number;
+	/** ISO-8601 timestamp the turn completed. */
+	at: string;
+	/** Cost-bearing input tokens (excludes cache reads), mirrors `Usage.input`. */
+	input: number;
+	/** Total output tokens for the turn, mirrors `Usage.output`. */
+	output: number;
+	/** Tokens read from the prompt cache, mirrors `Usage.cacheRead`. */
+	cacheRead: number;
+	/** Tokens written to the prompt cache, mirrors `Usage.cacheWrite`. */
+	cacheWrite: number;
+	/** input + output + cacheRead + cacheWrite. */
+	totalTokens: number;
+	/** Latest per-turn context-window occupancy, when known. */
+	contextTokens?: number;
+	/** Estimated USD cost for the turn, when known. */
+	cost?: number;
+	/** Model id used for the turn, when known. */
+	model?: string;
+}
+
+/**
+ * Deterministic aggregate token metrics computed from a set of `TaskTokenLog`
+ * entries. The cache-hit-rate field is the primary prompt-cache signal called
+ * out by the prefix-stability invariant (see the approved plan).
+ */
+export interface TaskTokenMetrics {
+	/** Number of token-log entries aggregated. */
+	turns: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	/** cacheRead / (input + cacheRead); 0 when there is no input-class traffic. */
+	cacheHitRate: number;
+}

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -16,7 +16,7 @@ type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
 
 function lastAssistant(session: AgentSession): AssistantMessage {
 	const message = session.agent.state.messages.at(-1);
-	if (!message || message.role !== "assistant") {
+	if (message?.role !== "assistant") {
 		throw new Error("Expected trailing assistant message");
 	}
 	return message as AssistantMessage;

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -22,6 +22,7 @@ describe("GJC public CLI command surface", () => {
 			"setup",
 			"skills",
 			"session",
+			"harness",
 			"team",
 			"ultragoal",
 			"ralplan",

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -278,7 +278,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 		expect(ext1.events).toHaveLength(1);
 		expect(ext2.events).toHaveLength(2);
 		expect(ext3.events).toHaveLength(3);
-	});
+	}, 30_000);
 
 	it("buffers credential_disabled events fired before runner.initialize and replays them once initialize runs", async () => {
 		// Without deferral the runner would fan out with `hasUI=false`, an unset model, and

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -442,7 +442,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 30_000);
 
 	it("rebuilds explicit MCP custom-tool selections when resuming with requested MCP tools", async () => {
 		const firstManager = SessionManager.create(tempDir, tempDir);

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -308,7 +308,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		expect(session.getSelectedDiscoveredToolNames()).not.toContain("find");
 		expect(await session.activateDiscoveredTools(["find"])).toEqual(["find"]);
 		expect(session.getActiveToolNames()).toContain("find");
-	});
+	}, 30_000);
 	it("restores explicit MCP, thinking, and service-tier entries when resuming without rewriting the session file", async () => {
 		const firstManager = SessionManager.create(tempDir, tempDir);
 		const { session: firstSession } = await createAgentSession({
@@ -388,7 +388,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		} finally {
 			await resumedSession.dispose();
 		}
-	});
+	}, 30_000);
 
 	it("restores fallback MCP, thinking, and service-tier state in memory without rewriting the session file", async () => {
 		const sessionManager = SessionManager.create(tempDir, tempDir);

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -505,5 +505,5 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		} finally {
 			await resumedSession.dispose();
 		}
-	});
+	}, 30_000);
 });

--- a/packages/orchestration-token-benchmark/package.json
+++ b/packages/orchestration-token-benchmark/package.json
@@ -1,0 +1,31 @@
+{
+	"type": "module",
+	"private": true,
+	"name": "@gajae-code/orchestration-token-benchmark",
+	"version": "0.0.1",
+	"description": "Deterministic internal benchmark for orchestration token efficiency (token metrics, prompt-prefix stability, spawn-gate decisions). No live-model calls.",
+	"author": "Yeachan-Heo",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"directory": "packages/orchestration-token-benchmark"
+	},
+	"main": "./src/index.ts",
+	"scripts": {
+		"check": "biome check . && bun run check:types",
+		"check:types": "tsgo -p tsconfig.json --noEmit",
+		"lint": "biome lint .",
+		"test": "bun test",
+		"fix": "biome check --write --unsafe .",
+		"fmt": "biome format --write .",
+		"start": "bun run src/index.ts"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:"
+	},
+	"engines": {
+		"bun": ">=1.3.14"
+	},
+	"homepage": "https://gaebal-gajae.dev"
+}

--- a/packages/orchestration-token-benchmark/src/fixtures.ts
+++ b/packages/orchestration-token-benchmark/src/fixtures.ts
@@ -1,0 +1,124 @@
+/**
+ * Deterministic baseline fixtures for the orchestration-token benchmark.
+ *
+ * These are fixed, hand-authored inputs (no recorded live sessions, no clock,
+ * no randomness) so every metric, prefix-stability check, and spawn-gate
+ * decision is reproducible in CI.
+ */
+
+import type { TokenLogEntry } from "./metrics";
+import type { PrefixTurn } from "./prefix-stability";
+import type { SpawnGateRequest } from "./spawn-gate";
+
+/** A run with strong prompt-cache reuse (most input served from cache). */
+export const TOKEN_LOG_HIGH_CACHE: readonly TokenLogEntry[] = [
+	{
+		subagentId: "root",
+		turn: 1,
+		at: "2026-01-01T00:00:00.000Z",
+		input: 1000,
+		output: 200,
+		cacheRead: 0,
+		cacheWrite: 1000,
+		totalTokens: 2200,
+		model: "test-model",
+	},
+	{
+		subagentId: "root",
+		turn: 2,
+		at: "2026-01-01T00:01:00.000Z",
+		input: 50,
+		output: 150,
+		cacheRead: 1000,
+		cacheWrite: 0,
+		totalTokens: 1200,
+		model: "test-model",
+	},
+	{
+		subagentId: "root",
+		turn: 3,
+		at: "2026-01-01T00:02:00.000Z",
+		input: 50,
+		output: 150,
+		cacheRead: 1050,
+		cacheWrite: 0,
+		totalTokens: 1250,
+		model: "test-model",
+	},
+];
+
+/** A run with poor cache reuse (input re-sent uncached every turn). */
+export const TOKEN_LOG_LOW_CACHE: readonly TokenLogEntry[] = [
+	{
+		subagentId: "root",
+		turn: 1,
+		at: "2026-01-01T00:00:00.000Z",
+		input: 1000,
+		output: 200,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 1200,
+		model: "test-model",
+	},
+	{
+		subagentId: "root",
+		turn: 2,
+		at: "2026-01-01T00:01:00.000Z",
+		input: 1100,
+		output: 150,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 1250,
+		model: "test-model",
+	},
+];
+
+/** Stable epoch: identical prefix/model/cacheKey, only appended content. */
+export const PREFIX_STABLE: readonly PrefixTurn[] = [
+	{ turn: 1, prefix: "SYSTEM+TOOLS", model: "test-model", cacheKey: "session-1" },
+	{ turn: 2, prefix: "SYSTEM+TOOLS", model: "test-model", cacheKey: "session-1" },
+	{ turn: 3, prefix: "SYSTEM+TOOLS", model: "test-model", cacheKey: "session-1" },
+];
+
+/** Violation: mid-epoch prefix mutation with no reset marker. */
+export const PREFIX_MUTATION_FAIL: readonly PrefixTurn[] = [
+	{ turn: 1, prefix: "SYSTEM+TOOLS", model: "test-model", cacheKey: "session-1" },
+	{ turn: 2, prefix: "SYSTEM+TOOLS+EXTRA", model: "test-model", cacheKey: "session-1" },
+];
+
+/** Sanctioned: model switch carrying a deliberate reset marker opens a new epoch. */
+export const MODEL_SWITCH_RESET: readonly PrefixTurn[] = [
+	{ turn: 1, prefix: "SYSTEM+TOOLS", model: "test-model-a", cacheKey: "session-1" },
+	{
+		turn: 2,
+		prefix: "SYSTEM+TOOLS",
+		model: "test-model-b",
+		cacheKey: "session-2",
+		resetMarker: { reason: "deliberate-reset" },
+	},
+	{ turn: 3, prefix: "SYSTEM+TOOLS", model: "test-model-b", cacheKey: "session-2" },
+];
+
+/** Violation: mid-epoch model switch with no reset marker. */
+export const MODEL_SWITCH_FAIL: readonly PrefixTurn[] = [
+	{ turn: 1, prefix: "SYSTEM+TOOLS", model: "test-model-a", cacheKey: "session-1" },
+	{ turn: 2, prefix: "SYSTEM+TOOLS", model: "test-model-b", cacheKey: "session-1" },
+];
+
+/** Batch at threshold: allowed without a plan. */
+export const FANOUT_4_OK: SpawnGateRequest = { childCount: 4 };
+
+/** Batch above threshold without a plan: rejected. */
+export const FANOUT_5_REJECT: SpawnGateRequest = { childCount: 5 };
+
+/** Batch above threshold with a complete plan: allowed. */
+export const FANOUT_5_PLAN_OK: SpawnGateRequest = {
+	childCount: 5,
+	plan: {
+		whyParallel: "five independent packages need isolated edits",
+		whyNotLocal: "local search cannot apply cross-file edits in parallel",
+		independence: "no shared files between children",
+		expectedReceiptShape: "per-child status + changed-file list",
+		maxInlineTokens: 2000,
+	},
+};

--- a/packages/orchestration-token-benchmark/src/index.ts
+++ b/packages/orchestration-token-benchmark/src/index.ts
@@ -1,0 +1,86 @@
+/**
+ * `@gajae-code/orchestration-token-benchmark`
+ *
+ * A deterministic, internal (NOT user-facing) benchmark for orchestration token
+ * efficiency. It measures token metrics, prompt-prefix stability, and spawn-gate
+ * decisions from fixed fixtures with no provider, network, or live-model calls,
+ * so improvements and regressions are provable in CI.
+ */
+
+export {
+	assertTokenLogShape,
+	cacheHitRate,
+	computeTokenMetrics,
+	forkClonedTokens,
+	receiptArtifactRatio,
+	type TokenLogEntry,
+	type TokenMetrics,
+} from "./metrics";
+export {
+	checkPrefixStability,
+	hashPrefix,
+	type PrefixResetMarker,
+	type PrefixStabilityResult,
+	type PrefixTurn,
+	type PrefixViolation,
+	type PrefixViolationKind,
+} from "./prefix-stability";
+export {
+	DEFAULT_SPAWN_THRESHOLD,
+	evaluateSpawnGate,
+	evaluateSpawnGateAtThreshold,
+	type SpawnGateDecision,
+	type SpawnGateOutcome,
+	type SpawnGateRequest,
+	type SpawnPlanReceipt,
+} from "./spawn-gate";
+
+import * as fixtures from "./fixtures";
+import { computeTokenMetrics, type TokenMetrics } from "./metrics";
+import { checkPrefixStability, type PrefixStabilityResult } from "./prefix-stability";
+import { evaluateSpawnGate, type SpawnGateDecision } from "./spawn-gate";
+
+export interface BenchmarkReport {
+	tokenMetrics: {
+		highCache: TokenMetrics;
+		lowCache: TokenMetrics;
+	};
+	prefixStability: {
+		stable: PrefixStabilityResult;
+		mutationFail: PrefixStabilityResult;
+		modelSwitchReset: PrefixStabilityResult;
+	};
+	spawnGate: {
+		fanout4: SpawnGateDecision;
+		fanout5Reject: SpawnGateDecision;
+		fanout5PlanOk: SpawnGateDecision;
+	};
+}
+
+/**
+ * Run the full deterministic benchmark over the baseline fixtures and return a
+ * structured report. Pure: identical output on every run.
+ */
+export function runOrchestrationTokenBenchmark(): BenchmarkReport {
+	return {
+		tokenMetrics: {
+			highCache: computeTokenMetrics(fixtures.TOKEN_LOG_HIGH_CACHE),
+			lowCache: computeTokenMetrics(fixtures.TOKEN_LOG_LOW_CACHE),
+		},
+		prefixStability: {
+			stable: checkPrefixStability(fixtures.PREFIX_STABLE),
+			mutationFail: checkPrefixStability(fixtures.PREFIX_MUTATION_FAIL),
+			modelSwitchReset: checkPrefixStability(fixtures.MODEL_SWITCH_RESET),
+		},
+		spawnGate: {
+			fanout4: evaluateSpawnGate(fixtures.FANOUT_4_OK),
+			fanout5Reject: evaluateSpawnGate(fixtures.FANOUT_5_REJECT),
+			fanout5PlanOk: evaluateSpawnGate(fixtures.FANOUT_5_PLAN_OK),
+		},
+	};
+}
+
+if (import.meta.main) {
+	const report = runOrchestrationTokenBenchmark();
+	process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}

--- a/packages/orchestration-token-benchmark/src/metrics.ts
+++ b/packages/orchestration-token-benchmark/src/metrics.ts
@@ -1,0 +1,128 @@
+/**
+ * Deterministic token-efficiency metrics.
+ *
+ * Every function here is pure and side-effect free: given the same input it
+ * returns the same output, with no provider, network, clock, or filesystem
+ * access. This is what lets the suite assert orchestration token efficiency in
+ * CI without any live-model calls.
+ */
+
+/**
+ * A single persisted per-turn / per-subagent token record.
+ *
+ * Structurally mirrors `TaskTokenLog` from
+ * `@gajae-code/coding-agent` (`src/task/types.ts`). It is duplicated here so the
+ * benchmark stays dependency-free and deterministic; `assertTokenLogShape`
+ * guards against drift.
+ */
+export interface TokenLogEntry {
+	subagentId: string;
+	agent?: string;
+	turn: number;
+	at: string;
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+	contextTokens?: number;
+	cost?: number;
+	model?: string;
+}
+
+/** Deterministic aggregate token metrics over a set of token logs. */
+export interface TokenMetrics {
+	turns: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	/** cacheRead / (input + cacheRead); 0 when there is no input-class traffic. */
+	cacheHitRate: number;
+}
+
+/**
+ * Prompt-cache hit rate: cached input reads as a fraction of all input-class
+ * tokens. Returns 0 when there is no input-class traffic (avoids NaN), so the
+ * metric is always a finite number in [0, 1].
+ */
+export function cacheHitRate(input: number, cacheRead: number): number {
+	const denominator = input + cacheRead;
+	if (denominator <= 0) {
+		return 0;
+	}
+	return cacheRead / denominator;
+}
+
+/** Aggregate a set of token logs into deterministic totals + cache-hit-rate. */
+export function computeTokenMetrics(logs: readonly TokenLogEntry[]): TokenMetrics {
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let cacheReadTokens = 0;
+	let cacheWriteTokens = 0;
+	let totalTokens = 0;
+	for (const log of logs) {
+		inputTokens += log.input;
+		outputTokens += log.output;
+		cacheReadTokens += log.cacheRead;
+		cacheWriteTokens += log.cacheWrite;
+		totalTokens += log.totalTokens;
+	}
+	return {
+		turns: logs.length,
+		inputTokens,
+		outputTokens,
+		cacheReadTokens,
+		cacheWriteTokens,
+		totalTokens,
+		cacheHitRate: cacheHitRate(inputTokens, cacheReadTokens),
+	};
+}
+
+/**
+ * Receipt-to-artifact byte ratio: how small the model-facing receipt is
+ * relative to the full artifact. Lower is better (less context spent on what a
+ * receipt could convey). Returns 0 when the artifact is empty.
+ */
+export function receiptArtifactRatio(receiptBytes: number, artifactBytes: number): number {
+	if (artifactBytes <= 0) {
+		return 0;
+	}
+	return receiptBytes / artifactBytes;
+}
+
+/**
+ * Estimated tokens cloned into a forked child context. A deterministic stand-in
+ * for fork-context cost: `inheritedTokens` minus what a bounded mode would keep.
+ * Never returns negative.
+ */
+export function forkClonedTokens(inheritedTokens: number, retainedTokens: number): number {
+	return Math.max(0, inheritedTokens - retainedTokens);
+}
+
+const TOKEN_LOG_NUMERIC_KEYS = ["turn", "input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const;
+
+/**
+ * Runtime guard that an arbitrary value is a structurally valid token log.
+ * Used by fixtures and tests so malformed fixtures fail loudly instead of
+ * silently skewing metrics, and to catch drift from the source-of-truth type.
+ */
+export function assertTokenLogShape(value: unknown): asserts value is TokenLogEntry {
+	if (value === null || typeof value !== "object") {
+		throw new TypeError("token log must be an object");
+	}
+	const record = value as Record<string, unknown>;
+	if (typeof record.subagentId !== "string" || record.subagentId.length === 0) {
+		throw new TypeError("token log requires a non-empty string subagentId");
+	}
+	if (typeof record.at !== "string" || record.at.length === 0) {
+		throw new TypeError("token log requires a non-empty string at");
+	}
+	for (const key of TOKEN_LOG_NUMERIC_KEYS) {
+		const numeric = record[key];
+		if (typeof numeric !== "number" || !Number.isFinite(numeric) || numeric < 0) {
+			throw new TypeError(`token log field ${key} must be a finite, non-negative number`);
+		}
+	}
+}

--- a/packages/orchestration-token-benchmark/src/prefix-stability.ts
+++ b/packages/orchestration-token-benchmark/src/prefix-stability.ts
@@ -1,0 +1,124 @@
+/**
+ * Deterministic prompt-prefix stability checker.
+ *
+ * Implements the approved prefix-stability invariant as a pure function over a
+ * sequence of provider-facing turns. Within a cache epoch the provider-facing
+ * prefix (system prompt + tools + leading context), the model id, and the cache
+ * key must stay byte-identical; only appended conversation content may change.
+ * A new epoch begins only at a sanctioned reset boundary carrying an explicit
+ * reset marker. Any other mid-epoch prefix/model/cache-key change is a
+ * violation. The suite asserts ONLY against this policy, so its scope cannot
+ * balloon into a compaction rewrite.
+ */
+
+import { createHash } from "node:crypto";
+
+/** A single provider-facing turn observed during a (real or simulated) run. */
+export interface PrefixTurn {
+	/** 1-based turn index within the session. */
+	turn: number;
+	/** The provider-facing prefix bytes (system + tools + leading context). */
+	prefix: string;
+	/** Model id used for this turn. */
+	model: string;
+	/** Prompt-cache key / session id used for this turn. */
+	cacheKey: string;
+	/**
+	 * Present only when this turn deliberately opens a new cache epoch at a
+	 * sanctioned reset boundary (pre-first-call is implicit for turn 1).
+	 */
+	resetMarker?: PrefixResetMarker;
+}
+
+/** Recorded justification for a sanctioned mid-session prefix reset. */
+export interface PrefixResetMarker {
+	reason: "compaction" | "session-reset" | "deliberate-reset";
+	priorPrefixHash?: string;
+	newPrefixHash?: string;
+}
+
+export type PrefixViolationKind = "prefix-mutation" | "model-switch" | "cache-key-change";
+
+export interface PrefixViolation {
+	turn: number;
+	epoch: number;
+	kind: PrefixViolationKind;
+	detail: string;
+}
+
+export interface PrefixStabilityResult {
+	stable: boolean;
+	/** Number of cache epochs observed (1 + sanctioned resets). */
+	epochs: number;
+	violations: readonly PrefixViolation[];
+}
+
+/** Stable SHA-256 hex hash of a provider-facing prefix. */
+export function hashPrefix(prefix: string): string {
+	return createHash("sha256").update(prefix, "utf8").digest("hex");
+}
+
+interface EpochAnchor {
+	prefixHash: string;
+	model: string;
+	cacheKey: string;
+}
+
+/**
+ * Check a turn sequence against the prefix-stability policy.
+ *
+ * Turn 1 establishes the first epoch implicitly. A later turn carrying a
+ * `resetMarker` opens a new epoch (no violation). Any later turn WITHOUT a reset
+ * marker whose prefix hash, model, or cache key differs from its epoch anchor is
+ * a violation.
+ */
+export function checkPrefixStability(turns: readonly PrefixTurn[]): PrefixStabilityResult {
+	const violations: PrefixViolation[] = [];
+	let epoch = 0;
+	let anchor: EpochAnchor | undefined;
+
+	for (const turn of turns) {
+		const current: EpochAnchor = {
+			prefixHash: hashPrefix(turn.prefix),
+			model: turn.model,
+			cacheKey: turn.cacheKey,
+		};
+
+		if (anchor === undefined || turn.resetMarker !== undefined) {
+			epoch += 1;
+			anchor = current;
+			continue;
+		}
+
+		if (current.prefixHash !== anchor.prefixHash) {
+			violations.push({
+				turn: turn.turn,
+				epoch,
+				kind: "prefix-mutation",
+				detail: `prefix hash changed within epoch ${epoch} without a reset marker`,
+			});
+		}
+		if (current.model !== anchor.model) {
+			violations.push({
+				turn: turn.turn,
+				epoch,
+				kind: "model-switch",
+				detail: `model switched from ${anchor.model} to ${current.model} within epoch ${epoch}`,
+			});
+		}
+		if (current.cacheKey !== anchor.cacheKey) {
+			violations.push({
+				turn: turn.turn,
+				epoch,
+				kind: "cache-key-change",
+				detail: `cache key changed within epoch ${epoch} without a reset marker`,
+			});
+		}
+	}
+
+	return {
+		stable: violations.length === 0,
+		epochs: epoch,
+		violations,
+	};
+}

--- a/packages/orchestration-token-benchmark/src/spawn-gate.ts
+++ b/packages/orchestration-token-benchmark/src/spawn-gate.ts
@@ -1,0 +1,132 @@
+/**
+ * Deterministic spawn-plan gate decision function.
+ *
+ * Pure model of the hard spawn gate: batches above the hard threshold are
+ * rejected unless a complete spawn-plan receipt is supplied. This module makes
+ * no spawning decisions itself; it only evaluates a request, so it can be unit
+ * tested and used by the benchmark without touching the task runtime.
+ *
+ * The runtime contract is HARD: `evaluateSpawnGate` always enforces
+ * {@link DEFAULT_SPAWN_THRESHOLD} and exposes no override, so a caller cannot
+ * raise the boundary to skip the receipt. Threshold sweeps for benchmark
+ * scenarios use the clearly-labeled, benchmark-only
+ * {@link evaluateSpawnGateAtThreshold}; that helper never represents the
+ * enforced runtime gate.
+ */
+
+/** The hard, locked batch threshold enforced by the runtime gate. */
+export const DEFAULT_SPAWN_THRESHOLD = 4;
+
+/** The justification a large batch must supply to pass the hard gate. */
+export interface SpawnPlanReceipt {
+	whyParallel: string;
+	whyNotLocal: string;
+	independence: string;
+	expectedReceiptShape: string;
+	maxInlineTokens: number;
+}
+
+export interface SpawnGateRequest {
+	/** Number of children the batch wants to spawn. */
+	childCount: number;
+	/** The spawn-plan receipt, when provided. */
+	plan?: SpawnPlanReceipt;
+}
+
+export type SpawnGateOutcome = "allowed" | "rejected";
+
+export interface SpawnGateDecision {
+	outcome: SpawnGateOutcome;
+	/** Human-readable reason, suitable for a blocked-result message. */
+	reason: string;
+	/** Whether a plan was required for this request. */
+	planRequired: boolean;
+	/** Missing plan field names when rejected for an incomplete plan. */
+	missingFields: readonly string[];
+}
+
+const REQUIRED_STRING_FIELDS = ["whyParallel", "whyNotLocal", "independence", "expectedReceiptShape"] as const;
+
+function findMissingPlanFields(plan: SpawnPlanReceipt | undefined): string[] {
+	if (plan === undefined) {
+		return [...REQUIRED_STRING_FIELDS, "maxInlineTokens"];
+	}
+	const missing: string[] = [];
+	for (const field of REQUIRED_STRING_FIELDS) {
+		const value = plan[field];
+		if (typeof value !== "string" || value.trim().length === 0) {
+			missing.push(field);
+		}
+	}
+	if (
+		typeof plan.maxInlineTokens !== "number" ||
+		!Number.isFinite(plan.maxInlineTokens) ||
+		plan.maxInlineTokens <= 0
+	) {
+		missing.push("maxInlineTokens");
+	}
+	return missing;
+}
+
+function decide(childCount: number, threshold: number, plan: SpawnPlanReceipt | undefined): SpawnGateDecision {
+	if (!Number.isInteger(childCount) || childCount < 0) {
+		throw new RangeError("childCount must be a non-negative integer");
+	}
+	if (!Number.isInteger(threshold) || threshold < 1) {
+		throw new RangeError("threshold must be a positive integer");
+	}
+
+	const planRequired = childCount > threshold;
+	if (!planRequired) {
+		return {
+			outcome: "allowed",
+			reason: `batch of ${childCount} is at or below threshold ${threshold}`,
+			planRequired: false,
+			missingFields: [],
+		};
+	}
+
+	const missingFields = findMissingPlanFields(plan);
+	if (missingFields.length > 0) {
+		return {
+			outcome: "rejected",
+			reason: `batch of ${childCount} exceeds threshold ${threshold} and the spawn-plan receipt is ${
+				plan === undefined ? "missing" : `incomplete (${missingFields.join(", ")})`
+			}`,
+			planRequired: true,
+			missingFields,
+		};
+	}
+
+	return {
+		outcome: "allowed",
+		reason: `batch of ${childCount} exceeds threshold ${threshold} and a complete spawn-plan receipt was provided`,
+		planRequired: true,
+		missingFields: [],
+	};
+}
+
+/**
+ * Evaluate a spawn request against the HARD runtime gate.
+ *
+ * The threshold is locked at {@link DEFAULT_SPAWN_THRESHOLD} and cannot be
+ * overridden; every batch with `childCount > DEFAULT_SPAWN_THRESHOLD` requires a
+ * complete {@link SpawnPlanReceipt}. A missing or incomplete plan is rejected.
+ */
+export function evaluateSpawnGate(request: SpawnGateRequest): SpawnGateDecision {
+	return decide(request.childCount, DEFAULT_SPAWN_THRESHOLD, request.plan);
+}
+
+/**
+ * Benchmark-only threshold sweep. NOT the enforced runtime gate: it lets the
+ * deterministic benchmark explore alternative thresholds (e.g. to recommend a
+ * tuned N) without representing what the runtime enforces. Production code must
+ * use {@link evaluateSpawnGate}.
+ */
+export function evaluateSpawnGateAtThreshold(
+	childCount: number,
+	threshold: number,
+	plan?: SpawnPlanReceipt,
+): SpawnGateDecision {
+	return decide(childCount, threshold, plan);
+}

--- a/packages/orchestration-token-benchmark/test/metrics.test.ts
+++ b/packages/orchestration-token-benchmark/test/metrics.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { TOKEN_LOG_HIGH_CACHE, TOKEN_LOG_LOW_CACHE } from "../src/fixtures";
+import {
+	assertTokenLogShape,
+	cacheHitRate,
+	computeTokenMetrics,
+	forkClonedTokens,
+	receiptArtifactRatio,
+	type TokenLogEntry,
+} from "../src/metrics";
+
+describe("cacheHitRate", () => {
+	it("returns 0 with no input-class traffic (no NaN)", () => {
+		expect(cacheHitRate(0, 0)).toBe(0);
+	});
+
+	it("computes cached fraction of input-class tokens", () => {
+		expect(cacheHitRate(50, 150)).toBeCloseTo(0.75, 10);
+	});
+
+	it("is 1 when all input is served from cache", () => {
+		expect(cacheHitRate(0, 1000)).toBe(1);
+	});
+});
+
+describe("computeTokenMetrics", () => {
+	it("aggregates an empty set to zeros", () => {
+		expect(computeTokenMetrics([])).toEqual({
+			turns: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			totalTokens: 0,
+			cacheHitRate: 0,
+		});
+	});
+
+	it("aggregates the high-cache fixture deterministically", () => {
+		const m = computeTokenMetrics(TOKEN_LOG_HIGH_CACHE);
+		expect(m.turns).toBe(3);
+		expect(m.inputTokens).toBe(1100);
+		expect(m.cacheReadTokens).toBe(2050);
+		expect(m.cacheHitRate).toBeCloseTo(2050 / 3150, 10);
+	});
+
+	it("shows the high-cache fixture beats the low-cache fixture on hit rate", () => {
+		const high = computeTokenMetrics(TOKEN_LOG_HIGH_CACHE);
+		const low = computeTokenMetrics(TOKEN_LOG_LOW_CACHE);
+		expect(high.cacheHitRate).toBeGreaterThan(low.cacheHitRate);
+		expect(low.cacheHitRate).toBe(0);
+	});
+
+	it("is pure: repeated calls return equal results", () => {
+		expect(computeTokenMetrics(TOKEN_LOG_HIGH_CACHE)).toEqual(computeTokenMetrics(TOKEN_LOG_HIGH_CACHE));
+	});
+});
+
+describe("receiptArtifactRatio", () => {
+	it("returns 0 for an empty artifact", () => {
+		expect(receiptArtifactRatio(100, 0)).toBe(0);
+	});
+
+	it("is small when the receipt is much smaller than the artifact", () => {
+		expect(receiptArtifactRatio(200, 100_000)).toBeCloseTo(0.002, 10);
+	});
+});
+
+describe("forkClonedTokens", () => {
+	it("never returns negative", () => {
+		expect(forkClonedTokens(100, 250)).toBe(0);
+	});
+
+	it("returns the bounded difference", () => {
+		expect(forkClonedTokens(1000, 200)).toBe(800);
+	});
+});
+
+describe("assertTokenLogShape", () => {
+	it("accepts the fixtures", () => {
+		for (const log of [...TOKEN_LOG_HIGH_CACHE, ...TOKEN_LOG_LOW_CACHE]) {
+			expect(() => assertTokenLogShape(log)).not.toThrow();
+		}
+	});
+
+	it("rejects a non-object", () => {
+		expect(() => assertTokenLogShape(null)).toThrow();
+		expect(() => assertTokenLogShape(42)).toThrow();
+	});
+
+	it("rejects a missing subagentId", () => {
+		const bad = { turn: 1, at: "x", input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
+		expect(() => assertTokenLogShape(bad)).toThrow();
+	});
+
+	it("rejects a negative numeric field", () => {
+		const bad: TokenLogEntry = {
+			subagentId: "root",
+			turn: 1,
+			at: "2026-01-01T00:00:00.000Z",
+			input: -1,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+		};
+		expect(() => assertTokenLogShape(bad)).toThrow();
+	});
+});

--- a/packages/orchestration-token-benchmark/test/prefix-stability.test.ts
+++ b/packages/orchestration-token-benchmark/test/prefix-stability.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { MODEL_SWITCH_FAIL, MODEL_SWITCH_RESET, PREFIX_MUTATION_FAIL, PREFIX_STABLE } from "../src/fixtures";
+import { checkPrefixStability, hashPrefix } from "../src/prefix-stability";
+
+describe("hashPrefix", () => {
+	it("is stable for identical input", () => {
+		expect(hashPrefix("SYSTEM+TOOLS")).toBe(hashPrefix("SYSTEM+TOOLS"));
+	});
+
+	it("differs for different input", () => {
+		expect(hashPrefix("SYSTEM+TOOLS")).not.toBe(hashPrefix("SYSTEM+TOOLS+EXTRA"));
+	});
+});
+
+describe("checkPrefixStability", () => {
+	it("passes a stable single epoch", () => {
+		const result = checkPrefixStability(PREFIX_STABLE);
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(1);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("flags a mid-epoch prefix mutation", () => {
+		const result = checkPrefixStability(PREFIX_MUTATION_FAIL);
+		expect(result.stable).toBe(false);
+		expect(result.violations).toHaveLength(1);
+		expect(result.violations[0]?.kind).toBe("prefix-mutation");
+		expect(result.violations[0]?.turn).toBe(2);
+	});
+
+	it("flags a mid-epoch model switch without a reset marker", () => {
+		const result = checkPrefixStability(MODEL_SWITCH_FAIL);
+		expect(result.stable).toBe(false);
+		expect(result.violations.some(v => v.kind === "model-switch")).toBe(true);
+	});
+
+	it("allows a model switch that carries a deliberate reset marker", () => {
+		const result = checkPrefixStability(MODEL_SWITCH_RESET);
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(2);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("treats an empty sequence as stable with zero epochs", () => {
+		expect(checkPrefixStability([])).toEqual({ stable: true, epochs: 0, violations: [] });
+	});
+
+	it("flags a cache-key change within an epoch", () => {
+		const result = checkPrefixStability([
+			{ turn: 1, prefix: "P", model: "m", cacheKey: "k1" },
+			{ turn: 2, prefix: "P", model: "m", cacheKey: "k2" },
+		]);
+		expect(result.stable).toBe(false);
+		expect(result.violations[0]?.kind).toBe("cache-key-change");
+	});
+});

--- a/packages/orchestration-token-benchmark/test/red-team.test.ts
+++ b/packages/orchestration-token-benchmark/test/red-team.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import {
+	assertTokenLogShape,
+	cacheHitRate,
+	checkPrefixStability,
+	computeTokenMetrics,
+	evaluateSpawnGate,
+	evaluateSpawnGateAtThreshold,
+	type PrefixTurn,
+	runOrchestrationTokenBenchmark,
+	type SpawnPlanReceipt,
+	type TokenLogEntry,
+} from "../src";
+
+const COMPLETE_PLAN: SpawnPlanReceipt = {
+	whyParallel: "independent slices",
+	whyNotLocal: "cannot be done locally without context loss",
+	independence: "no shared mutable state",
+	expectedReceiptShape: "files + decisions + evidence",
+	maxInlineTokens: 1000,
+};
+
+function walkJson(value: unknown, visit: (value: unknown, path: string) => void, path = "$."): void {
+	visit(value, path);
+	if (Array.isArray(value)) {
+		for (const [index, entry] of value.entries()) {
+			walkJson(entry, visit, `${path}[${index}]`);
+		}
+		return;
+	}
+	if (value !== null && typeof value === "object") {
+		for (const [key, entry] of Object.entries(value)) {
+			walkJson(entry, visit, `${path}${key}.`);
+		}
+	}
+}
+
+function finiteNumber(value: number): void {
+	expect(Number.isFinite(value)).toBe(true);
+	expect(Number.isNaN(value)).toBe(false);
+}
+
+function tokenLog(overrides: Partial<TokenLogEntry> = {}): TokenLogEntry {
+	const input = overrides.input ?? 0;
+	const output = overrides.output ?? 0;
+	const cacheRead = overrides.cacheRead ?? 0;
+	const cacheWrite = overrides.cacheWrite ?? 0;
+	return {
+		subagentId: "red-team",
+		turn: 1,
+		at: "2026-06-03T00:00:00.000Z",
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+		...overrides,
+	};
+}
+
+describe("red-team deterministic benchmark invariants", () => {
+	it("runOrchestrationTokenBenchmark is repeatable and contains no NaN", () => {
+		const first = runOrchestrationTokenBenchmark();
+		const second = runOrchestrationTokenBenchmark();
+		const third = runOrchestrationTokenBenchmark();
+
+		expect(second).toEqual(first);
+		expect(third).toEqual(first);
+		walkJson(first, (value, path) => {
+			if (typeof value === "number") {
+				expect(Number.isNaN(value), `${path} must not be NaN`).toBe(false);
+				expect(Number.isFinite(value), `${path} must be finite`).toBe(true);
+			}
+		});
+	});
+});
+
+describe("red-team token metric numeric safety", () => {
+	it("cacheHitRate never emits NaN or Infinity and stays within [0, 1]", () => {
+		const cases: Array<[number, number]> = [
+			[0, 0],
+			[0, 1e15],
+			[1e15, 0],
+			[1e15, 1e15],
+			[1, 1e15],
+			[1e15, 1],
+			[123_456_789, 987_654_321],
+		];
+
+		for (const [input, cacheRead] of cases) {
+			const rate = cacheHitRate(input, cacheRead);
+			finiteNumber(rate);
+			expect(rate).toBeGreaterThanOrEqual(0);
+			expect(rate).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("computeTokenMetrics never emits NaN or Infinity for zero, large, and mixed inputs", () => {
+		const logs: TokenLogEntry[] = [
+			tokenLog(),
+			tokenLog({ turn: 2, input: 1e15, output: 1e15, cacheRead: 0, cacheWrite: 1e15, totalTokens: 3e15 }),
+			tokenLog({ turn: 3, input: 1, output: 2, cacheRead: 1e15, cacheWrite: 3, totalTokens: 1e15 + 6 }),
+		];
+
+		for (const metrics of [computeTokenMetrics([]), computeTokenMetrics(logs)]) {
+			for (const value of Object.values(metrics)) {
+				finiteNumber(value);
+			}
+			expect(metrics.cacheHitRate).toBeGreaterThanOrEqual(0);
+			expect(metrics.cacheHitRate).toBeLessThanOrEqual(1);
+		}
+	});
+});
+
+describe("red-team prefix stability adversarial sequences", () => {
+	it("reports multiple violation kinds on the same turn", () => {
+		const result = checkPrefixStability([
+			{ turn: 1, prefix: "base", model: "model-a", cacheKey: "cache-a" },
+			{ turn: 2, prefix: "mutated", model: "model-b", cacheKey: "cache-b" },
+		]);
+
+		expect(result.stable).toBe(false);
+		expect(result.epochs).toBe(1);
+		expect(result.violations.map(violation => violation.kind)).toEqual([
+			"prefix-mutation",
+			"model-switch",
+			"cache-key-change",
+		]);
+	});
+
+	it("treats multiple reset epochs in a row as sanctioned new anchors", () => {
+		const turns: PrefixTurn[] = [
+			{ turn: 1, prefix: "epoch-1", model: "model-a", cacheKey: "cache-a" },
+			{ turn: 2, prefix: "epoch-2", model: "model-b", cacheKey: "cache-b", resetMarker: { reason: "compaction" } },
+			{
+				turn: 3,
+				prefix: "epoch-3",
+				model: "model-c",
+				cacheKey: "cache-c",
+				resetMarker: { reason: "session-reset" },
+			},
+			{ turn: 4, prefix: "epoch-3", model: "model-c", cacheKey: "cache-c" },
+		];
+		const result = checkPrefixStability(turns);
+
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(3);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("allows a reset marker on turn 1 without creating a phantom violation", () => {
+		const result = checkPrefixStability([
+			{
+				turn: 1,
+				prefix: "initial",
+				model: "model-a",
+				cacheKey: "cache-a",
+				resetMarker: { reason: "deliberate-reset" },
+			},
+			{ turn: 2, prefix: "initial", model: "model-a", cacheKey: "cache-a" },
+		]);
+
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(1);
+		expect(result.violations).toHaveLength(0);
+	});
+});
+
+describe("red-team spawn gate boundaries", () => {
+	it("allows childCount equal to threshold and requires a plan at threshold + 1", () => {
+		expect(evaluateSpawnGate({ childCount: 4 }).outcome).toBe("allowed");
+		expect(evaluateSpawnGate({ childCount: 5 }).outcome).toBe("rejected");
+		expect(evaluateSpawnGate({ childCount: 5, plan: COMPLETE_PLAN }).outcome).toBe("allowed");
+	});
+
+	it("honors custom thresholds at exact boundaries (benchmark-only sweep)", () => {
+		expect(evaluateSpawnGateAtThreshold(2, 2).outcome).toBe("allowed");
+		expect(evaluateSpawnGateAtThreshold(3, 2).outcome).toBe("rejected");
+		expect(evaluateSpawnGateAtThreshold(3, 2, COMPLETE_PLAN).outcome).toBe("allowed");
+	});
+
+	it("rejects whitespace-only plan fields", () => {
+		const decision = evaluateSpawnGate({
+			childCount: 5,
+			plan: {
+				whyParallel: " \t ",
+				whyNotLocal: "\n",
+				independence: "\r\n",
+				expectedReceiptShape: "  ",
+				maxInlineTokens: 1,
+			},
+		});
+
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.missingFields).toEqual(["whyParallel", "whyNotLocal", "independence", "expectedReceiptShape"]);
+	});
+
+	it("throws on non-integer and negative request inputs", () => {
+		expect(() => evaluateSpawnGate({ childCount: 1.5 })).toThrow(RangeError);
+		expect(() => evaluateSpawnGate({ childCount: -1 })).toThrow(RangeError);
+		expect(() => evaluateSpawnGateAtThreshold(2, 1.5)).toThrow(RangeError);
+		expect(() => evaluateSpawnGateAtThreshold(2, -1)).toThrow(RangeError);
+	});
+});
+
+describe("red-team token log shape rejection", () => {
+	it("rejects NaN and Infinity numeric fields", () => {
+		for (const field of ["turn", "input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const) {
+			expect(() => assertTokenLogShape({ ...tokenLog(), [field]: Number.NaN })).toThrow(TypeError);
+			expect(() => assertTokenLogShape({ ...tokenLog(), [field]: Number.POSITIVE_INFINITY })).toThrow(TypeError);
+			expect(() => assertTokenLogShape({ ...tokenLog(), [field]: Number.NEGATIVE_INFINITY })).toThrow(TypeError);
+		}
+	});
+
+	it("rejects missing required fields", () => {
+		for (const field of [
+			"subagentId",
+			"at",
+			"turn",
+			"input",
+			"output",
+			"cacheRead",
+			"cacheWrite",
+			"totalTokens",
+		] as const) {
+			const log: Record<string, unknown> = { ...tokenLog() };
+			delete log[field];
+			expect(() => assertTokenLogShape(log), `${field} should be required`).toThrow(TypeError);
+		}
+	});
+});

--- a/packages/orchestration-token-benchmark/test/spawn-gate.test.ts
+++ b/packages/orchestration-token-benchmark/test/spawn-gate.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { FANOUT_4_OK, FANOUT_5_PLAN_OK, FANOUT_5_REJECT } from "../src/fixtures";
+import {
+	DEFAULT_SPAWN_THRESHOLD,
+	evaluateSpawnGate,
+	evaluateSpawnGateAtThreshold,
+	type SpawnPlanReceipt,
+} from "../src/spawn-gate";
+
+const COMPLETE_PLAN: SpawnPlanReceipt = {
+	whyParallel: "independent slices",
+	whyNotLocal: "cross-file edits",
+	independence: "no shared files",
+	expectedReceiptShape: "status + files",
+	maxInlineTokens: 1500,
+};
+
+describe("evaluateSpawnGate (hard runtime gate)", () => {
+	it("locks the hard threshold at 4", () => {
+		expect(DEFAULT_SPAWN_THRESHOLD).toBe(4);
+	});
+
+	it("allows a batch at the threshold without a plan", () => {
+		const decision = evaluateSpawnGate(FANOUT_4_OK);
+		expect(decision.outcome).toBe("allowed");
+		expect(decision.planRequired).toBe(false);
+	});
+
+	it("rejects a batch above the threshold with no plan", () => {
+		const decision = evaluateSpawnGate(FANOUT_5_REJECT);
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.planRequired).toBe(true);
+		expect(decision.missingFields.length).toBeGreaterThan(0);
+	});
+
+	it("allows a batch above the threshold with a complete plan", () => {
+		const decision = evaluateSpawnGate(FANOUT_5_PLAN_OK);
+		expect(decision.outcome).toBe("allowed");
+		expect(decision.missingFields).toHaveLength(0);
+	});
+
+	it("rejects an incomplete plan and names the missing fields", () => {
+		const decision = evaluateSpawnGate({
+			childCount: 8,
+			plan: { ...COMPLETE_PLAN, whyParallel: "  ", maxInlineTokens: 0 },
+		});
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.missingFields).toContain("whyParallel");
+		expect(decision.missingFields).toContain("maxInlineTokens");
+	});
+
+	it("exposes no threshold override that could bypass the receipt for fanout > 4", () => {
+		// A large batch always requires a plan, regardless of how the request is shaped.
+		for (const childCount of [5, 6, 9, 32]) {
+			expect(evaluateSpawnGate({ childCount }).outcome).toBe("rejected");
+			expect(evaluateSpawnGate({ childCount, plan: COMPLETE_PLAN }).outcome).toBe("allowed");
+		}
+	});
+
+	it("rejects invalid inputs", () => {
+		expect(() => evaluateSpawnGate({ childCount: -1 })).toThrow();
+		expect(() => evaluateSpawnGate({ childCount: 1.5 })).toThrow();
+	});
+});
+
+describe("evaluateSpawnGateAtThreshold (benchmark-only sweep)", () => {
+	it("honors a custom threshold at exact boundaries", () => {
+		expect(evaluateSpawnGateAtThreshold(2, 2).outcome).toBe("allowed");
+		expect(evaluateSpawnGateAtThreshold(3, 2).outcome).toBe("rejected");
+		expect(evaluateSpawnGateAtThreshold(3, 2, COMPLETE_PLAN).outcome).toBe("allowed");
+	});
+
+	it("rejects invalid threshold inputs", () => {
+		expect(() => evaluateSpawnGateAtThreshold(2, 0)).toThrow();
+		expect(() => evaluateSpawnGateAtThreshold(2, 1.5)).toThrow();
+	});
+});

--- a/packages/orchestration-token-benchmark/tsconfig.json
+++ b/packages/orchestration-token-benchmark/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.workspace.json",
+	"include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
Phase 0 (additive, no breaking changes) of the approved token-efficiency hardening plan
(`.gjc/plans/ralplan/2026-06-03-0550-465f`, originating spec
`.gjc/specs/deep-interview-token-efficiency-orchestration.md`). This lands the **measurement backbone first**: a deterministic, internal benchmark plus the instrumentation types it consumes. No runtime defaults change; risky default reductions remain BENCHMARK-GATED for later phases.

## What's included
- **New internal package `@gajae-code/orchestration-token-benchmark`** (deterministic; no provider/network/clock/random):
  - `metrics.ts` — token aggregation + `cacheHitRate` (primary prompt-cache signal), receipt/artifact ratio, fork cloned-token estimate, token-log shape guard.
  - `prefix-stability.ts` — prompt-prefix stability checker enforcing the within-epoch byte-stability invariant with sanctioned reset markers (epoch model; **not** a compaction rewrite).
  - `spawn-gate.ts` — hard spawn-gate decision fn **locked at N=4** (no override); threshold sweeps isolated in the clearly-labeled benchmark-only `evaluateSpawnGateAtThreshold`.
  - deterministic fixtures + `runOrchestrationTokenBenchmark()` runner.
- **Additive `TaskTokenLog` / `TaskTokenMetrics` types** in `packages/coding-agent/src/task/types.ts` (no existing export changed).
- Root `bench:orchestration-tokens` script.

## Verification
- `bun --cwd=packages/orchestration-token-benchmark test` → **44 pass / 0 fail** (unit + adversarial red-team).
- `tsgo --noEmit` clean (benchmark + coding-agent); `biome check` clean.
- Consensus + quality gate: ralplan Planner/Architect/Critic APPROVE; Phase 0 architect 3-lane review **all CLEAR / APPROVE**, executor red-team QA passed.

## Scope / non-goals
- Additive only; **no** behavior or default change. Receipt-first refactor, spawn-gate runtime enforcement, fork-context enum, telemetry default, ROI wiring, and risky-default reductions are **later phases** tracked in the ultragoal ledger.

🤖 Generated with deep-interview → ralplan → ultragoal pipeline.
