### PR TITLE
feat: add subagent pause resume steer controls

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -203,13 +203,15 @@ function buildAgentEndEvent(
 	messages: AgentMessage[],
 	telemetry: AgentTelemetry | undefined,
 	stepCount: number,
+	stopReason: "completed" | "paused" = "completed",
 ): Extract<AgentEvent, { type: "agent_end" }> {
-	if (!telemetry) return { type: "agent_end", messages };
+	const base = { type: "agent_end" as const, messages, stopReason };
+	if (!telemetry) return base;
 	const snapshot = telemetry.collector.snapshot({ stepCount });
 	if (telemetry.collector.markRunEnded()) {
 		fireOnRunEnd(telemetry, snapshot.summary, snapshot.coverage);
 	}
-	return { type: "agent_end", messages, telemetry: snapshot.summary, coverage: snapshot.coverage };
+	return { ...base, telemetry: snapshot.summary, coverage: snapshot.coverage };
 }
 
 /**
@@ -585,11 +587,26 @@ async function runLoopBody(
 
 			stream.push({ type: "turn_end", message, toolResults });
 
-			pendingMessages = steeringMessagesFromExecution ?? ((await config.getSteeringMessages?.()) || []);
+			if (steeringMessagesFromExecution && steeringMessagesFromExecution.length > 0) {
+				pendingMessages = steeringMessagesFromExecution;
+				continue;
+			}
+			pendingMessages = (await config.getSteeringMessages?.()) || [];
+			if (pendingMessages.length > 0) continue;
+			if (config.shouldPause?.()) {
+				stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count, "paused"));
+				stream.end(newMessages);
+				return;
+			}
 		}
 
 		// Agent would stop here. Check for follow-up messages.
 		await config.onBeforeYield?.();
+		if (config.shouldPause?.()) {
+			stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count, "paused"));
+			stream.end(newMessages);
+			return;
+		}
 		const followUpMessages = (await config.getFollowUpMessages?.()) || [];
 		if (followUpMessages.length > 0) {
 			// Set as pending so inner loop processes them

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -99,6 +99,8 @@ export interface AgentOptions {
 	 * - "wait": defer steering until the current turn completes
 	 */
 	interruptMode?: "immediate" | "wait";
+	/** Cooperative pause checkpoint passed through to AgentLoopConfig.shouldPause. */
+	shouldPause?: AgentLoopConfig["shouldPause"];
 
 	/**
 	 * API format for Kimi Code provider: "openai" or "anthropic" (default: "anthropic")
@@ -309,6 +311,7 @@ export class Agent {
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
+	#shouldPause?: AgentLoopConfig["shouldPause"];
 	#telemetry?: AgentLoopConfig["telemetry"];
 	#appendOnlyContext?: AppendOnlyContextManager;
 
@@ -371,6 +374,7 @@ export class Agent {
 		this.#getToolChoice = opts.getToolChoice;
 		this.#onAssistantMessageEvent = opts.onAssistantMessageEvent;
 		this.#onHarmonyLeak = opts.onHarmonyLeak;
+		this.#shouldPause = opts.shouldPause;
 		this.beforeToolCall = opts.beforeToolCall;
 		this.afterToolCall = opts.afterToolCall;
 		this.#telemetry = opts.telemetry;
@@ -623,6 +627,10 @@ export class Agent {
 
 	setOnBeforeYield(fn: (() => Promise<void> | void) | undefined): void {
 		this.#onBeforeYield = fn;
+	}
+
+	setShouldPause(fn: AgentLoopConfig["shouldPause"] | undefined): void {
+		this.#shouldPause = fn;
 	}
 
 	emitExternalEvent(event: AgentEvent) {
@@ -1195,6 +1203,10 @@ export class Agent {
 			onBeforeYield: async () => {
 				if (this.#activeRunId !== runId) return;
 				await this.#onBeforeYield?.();
+			},
+			shouldPause: () => {
+				if (this.#activeRunId !== runId) return false;
+				return this.#shouldPause?.() === true;
 			},
 			telemetry: this.#telemetry,
 		};

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -133,6 +133,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
 	/**
+	 * Cooperative pause checkpoint evaluated at safe loop boundaries.
+	 *
+	 * Called after completed tool execution has been emitted and before the loop
+	 * polls steering/follow-up queues or schedules another assistant response.
+	 * Returning true ends the current loop with `agent_end.stopReason === "paused"`
+	 * without aborting any in-flight model or tool work.
+	 */
+	shouldPause?: () => boolean;
+	/**
 	 * Hook fired right before the loop would exit.
 	 *
 	 * Called when the agent has no more tool calls and no steering messages,
@@ -458,6 +467,8 @@ export type AgentEvent =
 	| {
 			type: "agent_end";
 			messages: AgentMessage[];
+			/** Indicates whether the loop ended normally or suspended at a pause checkpoint. */
+			stopReason?: "completed" | "paused";
 			/** Present iff `AgentTelemetryConfig` was supplied on this run. */
 			telemetry?: AgentRunSummary;
 			coverage?: AgentRunCoverage;

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -226,6 +226,111 @@ describe("agentLoop with AgentMessage", () => {
 		expect(contexts[1]?.index).toBe(1);
 	});
 
+	it("pauses at the safe boundary after a tool call without aborting the tool", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		let abortSeen = false;
+		let toolCompleted = false;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				abortSeen = signal?.aborted ?? false;
+				toolCompleted = true;
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		let pauseChecks = 0;
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }] },
+				{ content: ["should not be requested after pause"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			shouldPause: () => {
+				pauseChecks += 1;
+				return toolCompleted;
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		const agentEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "agent_end" }> => event.type === "agent_end",
+		);
+		expect(toolCompleted).toBe(true);
+		expect(abortSeen).toBe(false);
+		expect(pauseChecks).toBeGreaterThan(0);
+		expect(agentEnd?.stopReason).toBe("paused");
+	});
+
+	it("processes queued steering before honoring a pause request", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		let steeringDelivered = false;
+		let pauseRequested = false;
+		let steeringPolls = 0;
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }] },
+				{ content: ["ack steer"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			shouldPause: () => pauseRequested,
+			getSteeringMessages: async () => {
+				steeringPolls += 1;
+				if (steeringPolls === 1 || pauseRequested || steeringDelivered) return [];
+				steeringDelivered = true;
+				pauseRequested = true;
+				return [createUserMessage("steer before pause")];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		const agentEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "agent_end" }> => event.type === "agent_end",
+		);
+		const messages = await stream.result();
+		expect(messages.some(message => message.role === "user" && message.content === "steer before pause")).toBe(true);
+		expect(
+			messages.some(
+				message =>
+					message.role === "assistant" &&
+					message.content[0]?.type === "text" &&
+					message.content[0].text === "ack steer",
+			),
+		).toBe(true);
+		expect(agentEnd?.stopReason).toBe("paused");
+	});
+
 	it("should handle tool calls and results", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		const executed: string[] = [];

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -10,7 +10,7 @@ const DEFAULT_MAX_RUNNING_JOBS = 15;
 export interface AsyncJob {
 	id: string;
 	type: "bash" | "task";
-	status: "running" | "completed" | "failed" | "cancelled";
+	status: "running" | "completed" | "failed" | "cancelled" | "paused";
 	startTime: number;
 	label: string;
 	abortController: AbortController;
@@ -35,6 +35,64 @@ export interface AsyncJobMetadata {
 		description?: string;
 		assignment?: string;
 	};
+}
+
+/**
+ * Typed outcome a subagent task run may produce. A `paused` outcome is
+ * non-terminal and non-delivering: the run suspended at a safe boundary and the
+ * subagent can be resumed from its persisted sessionFile. `completed` always
+ * wins a race with a late pause because the run returns it once it has actually
+ * finished.
+ */
+export type SubagentRunOutcome = { kind: "completed"; text: string } | { kind: "paused"; note?: string };
+
+/** Canonical lifecycle of a subagent across pause/resume cycles. */
+export type SubagentLifecycle = "running" | "paused" | "queued" | "completed" | "failed" | "cancelled";
+
+/**
+ * Live, executor-owned control handle for a RUNNING subagent. Registered when a
+ * subagent run starts and removed on pause/terminal so a paused subagent retains
+ * no live `AgentSession` reference (leak-free).
+ */
+export interface SubagentLiveHandle {
+	/** Request a cooperative safe-boundary pause (never aborts the in-flight tool). */
+	requestPause(): void;
+	/** Inject a steering message into the live session. */
+	injectMessage(content: string, deliverAs: "steer" | "followUp" | "nextTurn"): Promise<void>;
+}
+
+/**
+ * Canonical, stable-id-keyed record for a subagent. Survives `AsyncJob`
+ * eviction so resume stays addressable by subagent id, and is the single source
+ * of truth for control-plane status and identity.
+ */
+export interface SubagentRecord {
+	subagentId: string;
+	ownerId?: string;
+	/** Current live/last AsyncJob id; null while queued with no active job. */
+	currentJobId: string | null;
+	historicalJobIds: string[];
+	status: SubagentLifecycle;
+	sessionFile: string | null;
+	/** False for ephemeral sessions (no persistent artifacts dir). */
+	resumable: boolean;
+	queued?: { ownerId?: string; seq: number; message?: string; createdAt: number };
+}
+
+/** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
+export interface ResumeDescriptor {
+	subagentId: string;
+	ownerId?: string;
+	data: unknown;
+}
+
+/** A pending resume awaiting a free concurrency slot. */
+interface ResumeQueueEntry {
+	subagentId: string;
+	ownerId?: string;
+	seq: number;
+	message?: string;
+	createdAt: number;
 }
 
 export interface AsyncJobManagerOptions {
@@ -160,6 +218,12 @@ export class AsyncJobManager {
 	readonly #retentionMs: number;
 	#deliveryLoop: Promise<void> | undefined;
 	#disposed = false;
+	readonly #subagentRecords = new Map<string, SubagentRecord>();
+	readonly #liveHandles = new Map<string, SubagentLiveHandle>();
+	readonly #resumeQueue: ResumeQueueEntry[] = [];
+	#resumeSeq = 0;
+	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
+	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
 
 	#filterJobs(jobs: Iterable<AsyncJob>, filter?: AsyncJobFilter): AsyncJob[] {
 		const ownerId = filter?.ownerId;
@@ -184,7 +248,7 @@ export class AsyncJobManager {
 			jobId: string;
 			signal: AbortSignal;
 			reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
-		}) => Promise<string>,
+		}) => Promise<string | SubagentRunOutcome>,
 		options?: AsyncJobRegisterOptions,
 	): string {
 		if (this.#disposed) {
@@ -227,20 +291,38 @@ export class AsyncJobManager {
 		};
 		job.promise = (async () => {
 			try {
-				const text = await run({ jobId: id, signal: abortController.signal, reportProgress });
+				const result = await run({ jobId: id, signal: abortController.signal, reportProgress });
+				const outcome: SubagentRunOutcome =
+					typeof result === "string" ? { kind: "completed", text: result } : result;
 				if (job.status === "cancelled") {
-					job.resultText = text;
+					job.resultText = outcome.kind === "completed" ? outcome.text : outcome.note;
 					this.#scheduleEviction(id);
+					this.#markRecordTerminal(id, "cancelled");
+					this.#drainResumeQueue();
+					return;
+				}
+				if (outcome.kind === "paused") {
+					// Sole canonical writer of the running -> paused transition. No
+					// delivery and no eviction scheduling: a paused subagent stays
+					// listed and resumable from its sessionFile.
+					job.status = "paused";
+					if (outcome.note) job.resultText = outcome.note;
+					this.#markRecordPaused(id);
+					this.#drainResumeQueue();
 					return;
 				}
 				job.status = "completed";
-				job.resultText = text;
-				this.#enqueueDelivery(id, text);
+				job.resultText = outcome.text;
+				this.#enqueueDelivery(id, outcome.text);
 				this.#scheduleEviction(id);
+				this.#markRecordTerminal(id, "completed");
+				this.#drainResumeQueue();
 			} catch (error) {
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
 					this.#scheduleEviction(id);
+					this.#markRecordTerminal(id, "cancelled");
+					this.#drainResumeQueue();
 					return;
 				}
 				const errorText = error instanceof Error ? error.message : String(error);
@@ -248,6 +330,8 @@ export class AsyncJobManager {
 				job.errorText = errorText;
 				this.#enqueueDelivery(id, errorText);
 				this.#scheduleEviction(id);
+				this.#markRecordTerminal(id, "failed");
+				this.#drainResumeQueue();
 			}
 		})();
 
@@ -264,11 +348,214 @@ export class AsyncJobManager {
 		const job = this.#jobs.get(id);
 		if (!job) return false;
 		if (filter?.ownerId && job.ownerId !== filter.ownerId) return false;
+		if (job.status === "paused") {
+			// Paused jobs have no running promise to abort; transition directly.
+			// The session file is kept, so the record stays resumable by id.
+			job.status = "cancelled";
+			this.#markRecordTerminal(id, "cancelled");
+			this.#scheduleEviction(id);
+			this.#drainResumeQueue();
+			return true;
+		}
 		if (job.status !== "running") return false;
 		job.status = "cancelled";
 		job.abortController.abort();
 		this.#scheduleEviction(id);
 		return true;
+	}
+
+	// ── Subagent control plane (pause / resume / steer support) ──────────
+
+	/** Register or replace the canonical record for a subagent. */
+	registerSubagentRecord(record: SubagentRecord): void {
+		this.#subagentRecords.set(record.subagentId, record);
+	}
+
+	getSubagentRecord(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {
+		const rec = this.#subagentRecords.get(subagentId.trim());
+		if (!rec) return undefined;
+		if (filter?.ownerId && rec.ownerId !== filter.ownerId) return undefined;
+		return rec;
+	}
+
+	getSubagentRecords(filter?: AsyncJobFilter): SubagentRecord[] {
+		const ownerId = filter?.ownerId;
+		const out: SubagentRecord[] = [];
+		for (const rec of this.#subagentRecords.values()) {
+			if (ownerId && rec.ownerId !== ownerId) continue;
+			out.push(rec);
+		}
+		return out;
+	}
+
+	registerLiveHandle(subagentId: string, handle: SubagentLiveHandle): void {
+		this.#liveHandles.set(subagentId, handle);
+	}
+
+	getLiveHandle(subagentId: string): SubagentLiveHandle | undefined {
+		return this.#liveHandles.get(subagentId);
+	}
+
+	removeLiveHandle(subagentId: string): void {
+		this.#liveHandles.delete(subagentId);
+	}
+
+	/** Install the TaskTool-owned resume runner. Returns the new job id, or undefined on failure. */
+	setResumeRunner(
+		runner: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined,
+	): void {
+		this.#resumeRunner = runner;
+	}
+
+	registerResumeDescriptor(descriptor: ResumeDescriptor): void {
+		this.#resumeDescriptors.set(descriptor.subagentId, descriptor);
+	}
+
+	getResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): ResumeDescriptor | undefined {
+		const descriptor = this.#resumeDescriptors.get(subagentId.trim());
+		if (!descriptor) return undefined;
+		if (filter?.ownerId && descriptor.ownerId !== filter.ownerId) return undefined;
+		return descriptor;
+	}
+
+	#recordByJobId(jobId: string): SubagentRecord | undefined {
+		for (const rec of this.#subagentRecords.values()) {
+			if (rec.currentJobId === jobId) return rec;
+		}
+		return undefined;
+	}
+
+	#markRecordPaused(jobId: string): void {
+		const rec = this.#recordByJobId(jobId);
+		if (rec) {
+			rec.status = "paused";
+			this.#liveHandles.delete(rec.subagentId);
+		}
+	}
+
+	#markRecordTerminal(jobId: string, status: "completed" | "failed" | "cancelled"): void {
+		const rec = this.#recordByJobId(jobId);
+		if (!rec) return;
+		rec.status = status;
+		this.#liveHandles.delete(rec.subagentId);
+	}
+
+	/** Request a graceful safe-boundary pause of a running subagent. */
+	pauseSubagent(
+		subagentId: string,
+		filter?: AsyncJobFilter,
+	): { ok: boolean; status?: SubagentLifecycle; reason?: string } {
+		const rec = this.getSubagentRecord(subagentId, filter);
+		if (!rec) return { ok: false, reason: "not_found" };
+		if (rec.status !== "running") return { ok: false, status: rec.status, reason: "not_running" };
+		const handle = this.#liveHandles.get(rec.subagentId);
+		if (!handle) return { ok: false, status: rec.status, reason: "no_live_handle" };
+		handle.requestPause();
+		return { ok: true, status: rec.status };
+	}
+
+	/** Resume a non-running subagent from its sessionFile, optionally injecting a message first. */
+	resumeSubagent(
+		subagentId: string,
+		filter?: AsyncJobFilter,
+		message?: string,
+	): { ok: boolean; status?: SubagentLifecycle; jobId?: string; queued?: boolean; reason?: string } {
+		const rec = this.getSubagentRecord(subagentId, filter);
+		if (!rec) return { ok: false, reason: "not_found" };
+		if (rec.status === "running") return { ok: false, status: "running", reason: "already_running" };
+		if (rec.status === "queued") {
+			if (message !== undefined && rec.queued) {
+				rec.queued.message = message;
+				const queued = this.#resumeQueue.find(entry => entry.subagentId === rec.subagentId);
+				if (queued) queued.message = message;
+				return { ok: true, queued: true, status: "queued" };
+			}
+			return { ok: false, status: "queued", reason: "already_queued" };
+		}
+		if (!rec.resumable || !rec.sessionFile) return { ok: false, reason: "context_unavailable" };
+		if (!this.#resumeRunner) return { ok: false, reason: "no_runner" };
+		if (this.getRunningJobs().length >= this.#maxRunningJobs) {
+			const seq = ++this.#resumeSeq;
+			rec.status = "queued";
+			rec.queued = { ownerId: rec.ownerId, seq, message, createdAt: Date.now() };
+			this.#resumeQueue.push({
+				subagentId: rec.subagentId,
+				ownerId: rec.ownerId,
+				seq,
+				message,
+				createdAt: rec.queued.createdAt,
+			});
+			return { ok: true, queued: true, status: "queued" };
+		}
+		return this.#startResume(rec, message);
+	}
+
+	#startResume(
+		rec: SubagentRecord,
+		message?: string,
+	): { ok: boolean; status?: SubagentLifecycle; jobId?: string; reason?: string } {
+		const prevJobId = rec.currentJobId;
+		const newJobId = this.#resumeRunner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));
+		if (!newJobId) return { ok: false, reason: "resume_failed" };
+		if (prevJobId && prevJobId !== newJobId) rec.historicalJobIds.push(prevJobId);
+		rec.currentJobId = newJobId;
+		rec.status = this.#jobs.get(newJobId)?.status ?? "running";
+		rec.queued = undefined;
+		return { ok: true, status: rec.status, jobId: newJobId };
+	}
+
+	/** Drain queued resumes (FIFO by seq) while concurrency slots are available. */
+	#drainResumeQueue(): void {
+		if (this.#resumeQueue.length === 0) return;
+		this.#resumeQueue.sort((a, b) => a.seq - b.seq);
+		while (this.#resumeQueue.length > 0 && this.getRunningJobs().length < this.#maxRunningJobs) {
+			const entry = this.#resumeQueue.shift();
+			if (!entry) return;
+			const rec = this.#subagentRecords.get(entry.subagentId);
+			if (rec?.status !== "queued") continue;
+			this.#startResume(rec, entry.message);
+		}
+	}
+
+	/** Cancel a subagent by stable id across running/paused/queued states (keeps the session file). */
+	cancelSubagent(subagentId: string, filter?: AsyncJobFilter): boolean {
+		const rec = this.getSubagentRecord(subagentId, filter);
+		if (!rec) return false;
+		if (rec.status === "running" && rec.currentJobId) return this.cancel(rec.currentJobId, filter);
+		if (rec.status === "paused") {
+			if (rec.currentJobId) {
+				const job = this.#jobs.get(rec.currentJobId);
+				if (job && job.status === "paused") {
+					job.status = "cancelled";
+					this.#scheduleEviction(rec.currentJobId);
+				}
+			}
+			rec.status = "cancelled";
+			this.#liveHandles.delete(rec.subagentId);
+			this.#drainResumeQueue();
+			return true;
+		}
+		if (rec.status === "queued") {
+			const idx = this.#resumeQueue.findIndex(e => e.subagentId === rec.subagentId);
+			if (idx !== -1) this.#resumeQueue.splice(idx, 1);
+			rec.status = "cancelled";
+			rec.queued = undefined;
+			return true;
+		}
+		return false;
+	}
+
+	#purgeOwnerSubagentState(ownerId?: string): void {
+		for (let i = this.#resumeQueue.length - 1; i >= 0; i--) {
+			if (!ownerId || this.#resumeQueue[i].ownerId === ownerId) this.#resumeQueue.splice(i, 1);
+		}
+		for (const [sid, rec] of this.#subagentRecords) {
+			if (!ownerId || rec.ownerId === ownerId) {
+				this.#liveHandles.delete(sid);
+				this.#resumeDescriptors.delete(sid);
+				this.#subagentRecords.delete(sid);
+			}
+		}
 	}
 
 	getJob(id: string): AsyncJob | undefined {
@@ -451,6 +738,7 @@ export class AsyncJobManager {
 				}
 			}
 		}
+		this.#purgeOwnerSubagentState(ownerId);
 	}
 
 	getDeliveryState(filter?: AsyncJobFilter): AsyncJobDeliveryState {
@@ -588,6 +876,10 @@ export class AsyncJobManager {
 		this.#watchedJobs.clear();
 		this.#outputState.clear();
 		this.#ownerCleanups.clear();
+		this.#subagentRecords.clear();
+		this.#liveHandles.clear();
+		this.#resumeDescriptors.clear();
+		this.#resumeQueue.length = 0;
 		return drained;
 	}
 

--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -1,11 +1,11 @@
-Lists, inspects, awaits, or cancels detached task subagents.
+Lists, inspects, awaits, pauses, resumes, steers, or cancels detached task subagents.
 
 Task launches return immediately. Use this tool when you need direct control over those running subagents. Prefer `subagent` for task subagents; generic `job` remains available for non-subagent jobs and compatibility fallback access.
 
 # Operations
 
 ## `action: "list"`
-Snapshot your visible detached subagents.
+Snapshot your visible detached subagents, including `running`, `paused`, `queued`, and terminal subagents when retained.
 
 ## `action: "inspect"`
 Inspect selected subagents by `ids`; omit `ids` to inspect current running subagents. Terminal subagents include final output when retained.
@@ -16,6 +16,36 @@ Wait for selected subagents by `ids`; omit `ids` to wait for current running sub
 - Await timeout only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
 - On timeout, inspect progress and keep doing independent work. Never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 
+## `action: "pause"`
+Request a graceful safe-boundary pause for selected subagents by `ids`.
+- Non-running subagents are a no-op and return their current status snapshot.
+- A paused subagent keeps its session context and can be resumed later.
+
+## `action: "resume"`
+Resume selected non-running subagents by `ids`.
+- Optional `message` is delivered into the resumed run.
+- Running subagents are a no-op and return their current status snapshot.
+- Terminal subagents require `message` to start a follow-up resume run; without `message`, the tool returns the current snapshot with guidance.
+- `paused` subagents resume from saved context; `queued` subagents are already waiting for capacity.
+
+## `action: "steer"`
+Send a non-empty `message` to selected subagents by `ids`.
+- Running subagents receive the message through their live handle.
+- Optional `pause: true` requests a safe-boundary pause after steering a running subagent.
+- `pause` only matters while the target is running.
+- Non-active subagents (`paused`, `queued`, or terminal) automatically resume with the message; `pause` is ignored for these targets.
+
 ## `action: "cancel"`
-Stop selected running subagents by `ids`.
+Stop selected subagents by `ids`, including running, paused, or queued subagents.
 - Use only when the subagent has actually failed, gone off-track, or become unrecoverably wrong; an await timeout alone is never a cancellation reason.
+- Cancellation keeps the subagent session file for possible later context recovery.
+
+# Statuses
+
+- `running` — currently executing.
+- `paused` — stopped at a safe boundary with resumable context.
+- `queued` — resume requested and waiting for execution capacity.
+- `completed` — finished successfully.
+- `failed` — finished with an error.
+- `cancelled` — stopped by cancellation.
+- `not_found` — no visible subagent matches the requested id.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -327,6 +327,8 @@ export interface CreateAgentSessionOptions {
 	forkContextSeed?: ForkContextSeed;
 	/** Optional provider state override. Fork-context children should omit this by default. */
 	providerSessionState?: Map<string, ProviderSessionState>;
+	/** Cooperative pause checkpoint passed through to Agent. */
+	shouldPause?: () => boolean;
 }
 
 /** Result from createAgentSession */
@@ -1797,6 +1799,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			requestMaxRetries: retrySettings.requestMaxRetries,
 			streamMaxRetries: retrySettings.streamMaxRetries,
 			kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
+			shouldPause: options.shouldPause,
 			preferWebsockets: preferOpenAICodexWebsockets,
 			getToolContext: tc => toolContextStore.getContext(tc),
 			getApiKey: async provider => {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -9,6 +9,7 @@ import type { AgentEvent, AgentIdentity, AgentTelemetryConfig, ThinkingLevel } f
 import { recordHandoff, resolveTelemetry } from "@gajae-code/agent-core";
 import { type JsonSchemaValidationIssue, validateJsonSchemaValue } from "@gajae-code/ai/utils/schema";
 import { logger, prompt, untilAborted } from "@gajae-code/utils";
+import { AsyncJobManager } from "../async";
 import { ModelRegistry } from "../config/model-registry";
 import { resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
 import type { PromptTemplate } from "../config/prompt-templates";
@@ -112,6 +113,9 @@ export interface ExecutorOptions {
 	index: number;
 	id: string;
 	modelOverride?: string | string[];
+	runMode?: "initial" | "resume" | "message";
+	resumeMessage?: string;
+	subagentId?: string;
 	/**
 	 * Active model selector of the parent session, used as an auth-aware fallback
 	 * if the resolved subagent model has no working credentials. See #985.
@@ -550,8 +554,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	}
 
 	// Set up artifact paths and write input file upfront if artifacts dir provided
-	let subtaskSessionFile: string | undefined;
-	if (options.artifactsDir) {
+	let subtaskSessionFile: string | undefined = options.sessionFile ?? undefined;
+	if (!subtaskSessionFile && options.artifactsDir) {
 		subtaskSessionFile = path.join(options.artifactsDir, `${id}.jsonl`);
 	}
 
@@ -617,6 +621,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let activeSession: AgentSession | null = null;
 	let unsubscribe: (() => void) | null = null;
 	let yieldCalled = false;
+	let pauseRequested = false;
+	let paused = false;
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
 	const accumulatedUsage = {
@@ -1006,6 +1012,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						}
 					}
 				}
+				paused = (event as { stopReason?: string }).stopReason === "paused";
 				flushProgress = true;
 				break;
 		}
@@ -1193,10 +1200,27 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					localProtocolOptions: options.localProtocolOptions,
 					telemetry: subagentTelemetry,
 					forkContextSeed: options.forkContextSeed,
+					shouldPause: () => pauseRequested,
 				}),
 			);
 
 			activeSession = session;
+			const liveSubagentId = options.subagentId ?? id;
+			const manager = AsyncJobManager.instance();
+			if (manager) {
+				manager.registerLiveHandle(liveSubagentId, {
+					requestPause: () => {
+						pauseRequested = true;
+					},
+					injectMessage: async (content, deliverAs) => {
+						if (deliverAs === "nextTurn") {
+							await session.prompt(content, { attribution: "agent" });
+							return;
+						}
+						await session.sendUserMessage(content, { deliverAs });
+					},
+				});
+			}
 
 			// Emit lifecycle start event
 			if (options.eventBus) {
@@ -1354,13 +1378,24 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					);
 				}
 			}
-			await awaitAbortable(session.prompt(task, { attribution: "agent" }));
-			await awaitAbortable(session.waitForIdle());
+			const runMode = options.runMode ?? "initial";
+			if (runMode === "message") {
+				await awaitAbortable(session.prompt(options.resumeMessage ?? "", { attribution: "agent" }));
+				await awaitAbortable(session.waitForIdle());
+			} else if (runMode === "resume") {
+				await awaitAbortable(
+					session.prompt("Continue from the paused subagent session state.", { attribution: "agent" }),
+				);
+				await awaitAbortable(session.waitForIdle());
+			} else {
+				await awaitAbortable(session.prompt(task, { attribution: "agent" }));
+				await awaitAbortable(session.waitForIdle());
+			}
 
 			const reminderToolChoice = buildNamedToolChoice("yield", session.model);
 
 			let retryCount = 0;
-			while (!yieldCalled && retryCount < MAX_YIELD_RETRIES && !abortSignal.aborted) {
+			while (!paused && !yieldCalled && retryCount < MAX_YIELD_RETRIES && !abortSignal.aborted) {
 				// Skip reminders when the model returned a terminal error (e.g.
 				// rate-limit cap hit, auth failure). Re-prompting would just
 				// hit the same wall, multiplying the failure noise without
@@ -1390,7 +1425,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			await awaitAbortable(session.waitForIdle());
-			if (!yieldCalled && !abortSignal.aborted) {
+			if (!paused && !yieldCalled && !abortSignal.aborted) {
 				exitCode = 0;
 			}
 
@@ -1405,6 +1440,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				} else if (lastAssistant.stopReason === "error") {
 					exitCode = 1;
 					error ??= lastAssistant.errorMessage || "Subagent failed";
+				}
+				if (paused) {
+					exitCode = 0;
+					error = undefined;
 				}
 			}
 		} catch (err) {
@@ -1421,6 +1460,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (exitCode === 0) exitCode = 1;
 			}
 			sessionAbortController.abort();
+			AsyncJobManager.instance()?.removeLiveHandle(options.subagentId ?? id);
 			if (unsubscribe) {
 				try {
 					unsubscribe();
@@ -1527,7 +1567,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? yieldAbortReason
 				: (done.abortReason ?? (signal?.aborted ? resolveSignalAbortReason() : resolveAbortReasonText()))
 		: undefined;
-	progress.status = wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
+	progress.status = paused ? "paused" : wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
 	scheduleProgress(true);
 
 	// Emit lifecycle end event after finalization so yield status is reflected
@@ -1537,7 +1577,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			agent: agent.name,
 			agentSource: agent.source,
 			description: options.description,
-			status: progress.status as "completed" | "failed" | "aborted",
+			status: progress.status as "completed" | "failed" | "aborted" | "paused",
 			sessionFile: subtaskSessionFile,
 			index,
 		});
@@ -1564,6 +1604,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,
+		paused,
 		usage: hasUsage ? accumulatedUsage : undefined,
 		outputPath,
 		extractedToolData: progress.extractedToolData,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -65,6 +65,18 @@ import {
 	type WorktreeBaseline,
 } from "./worktree";
 
+interface TaskResumeDescriptor {
+	toolCallId: string;
+	params: TaskParams;
+	task: TaskItem & { id: string };
+	sessionFile: string | null;
+	forkContextSeed?: ForkContextSeed;
+	agentSource: AgentDefinition["source"];
+}
+
+function isTaskResumeDescriptor(value: unknown): value is TaskResumeDescriptor {
+	return typeof value === "object" && value !== null && "task" in value && "params" in value;
+}
 function renderSubagentUserPrompt(assignment: string, simpleMode: TaskSimpleMode): string {
 	return prompt.render(subagentUserPromptTemplate, {
 		assignment: assignment.trim(),
@@ -416,6 +428,50 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		};
 
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
+		if (typeof manager.setResumeRunner === "function") {
+			manager.setResumeRunner((_subagentId, message, resumeDescriptor) => {
+				const descriptor = isTaskResumeDescriptor(resumeDescriptor?.data) ? resumeDescriptor.data : undefined;
+				if (!descriptor) return undefined;
+				const forkSeeds = descriptor.forkContextSeed
+					? new Map([[descriptor.task.id, descriptor.forkContextSeed]])
+					: undefined;
+				return manager.register(
+					"task",
+					descriptor.task.id,
+					async ({ signal: runSignal }) => {
+						const result = await this.#executeSync(
+							descriptor.toolCallId,
+							{ ...descriptor.params, tasks: [descriptor.task] },
+							runSignal,
+							undefined,
+							[descriptor.task.id],
+							forkSeeds,
+							{
+								runMode: message ? "message" : "resume",
+								resumeMessage: message,
+								sessionFiles: new Map([[descriptor.task.id, descriptor.sessionFile]]),
+							},
+						);
+						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
+						const singleResult = result.details?.results[0];
+						return singleResult?.paused ? { kind: "paused" } : finalText;
+					},
+					{
+						id: `${descriptor.task.id}-resume-${Snowflake.next()}`,
+						ownerId: this.session.getAgentId?.() ?? undefined,
+						metadata: {
+							subagent: {
+								id: descriptor.task.id,
+								agent: descriptor.params.agent,
+								agentSource: descriptor.agentSource,
+								description: descriptor.task.description,
+								assignment: descriptor.task.assignment.trim(),
+							},
+						},
+					},
+				);
+			});
+		}
 		const semaphore = new Semaphore(maxConcurrency);
 		const buildForkContextSeedForTask = async (task: TaskItem): Promise<ForkContextSeed | undefined> => {
 			if (task.inheritContext !== true) return undefined;
@@ -431,6 +487,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			});
 		};
 		const frozenForkSeeds = new Map<string, ForkContextSeed>();
+		const parentSessionFileForBatch = this.session.getSessionFile();
+		const batchArtifactsDir = parentSessionFileForBatch ? parentSessionFileForBatch.slice(0, -6) : null;
 
 		for (let i = 0; i < taskItems.length; i++) {
 			const taskItem = taskItems[i];
@@ -449,6 +507,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const singleParams: TaskParams = { ...params, tasks: [taskItem] };
 			const label = uniqueId;
 			try {
+				const subtaskSessionFile = batchArtifactsDir ? path.join(batchArtifactsDir, `${uniqueId}.jsonl`) : null;
 				const jobId = manager.register(
 					"task",
 					label,
@@ -478,15 +537,20 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								undefined,
 								[uniqueId],
 								frozenForkSeeds,
+								{
+									sessionFiles: new Map([[uniqueId, subtaskSessionFile]]),
+								},
 							);
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 							const singleResult = result.details?.results[0];
 							if (progress) {
-								progress.status = singleResult?.aborted
-									? "aborted"
-									: (singleResult?.exitCode ?? 0) === 0
-										? "completed"
-										: "failed";
+								progress.status = singleResult?.paused
+									? "paused"
+									: singleResult?.aborted
+										? "aborted"
+										: (singleResult?.exitCode ?? 0) === 0
+											? "completed"
+											: "failed";
 								progress.durationMs = singleResult?.durationMs ?? Math.max(0, Date.now() - startedAt);
 								progress.tokens = singleResult?.tokens ?? 0;
 								progress.contextTokens = singleResult?.contextTokens;
@@ -516,6 +580,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 									failedJobs > 0 || failedSchedules.length > 0 ? "failed" : "completed",
 									`Background task batch complete: ${completedJobs}/${taskItems.length} finished.`,
 								);
+							}
+							if (singleResult?.paused) {
+								return { kind: "paused" };
 							}
 							return finalText;
 						} catch (error) {
@@ -568,6 +635,31 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					},
 				);
 				startedJobs.push({ jobId, taskId: taskItem.id });
+				if (typeof manager.registerResumeDescriptor === "function") {
+					manager.registerResumeDescriptor({
+						subagentId: uniqueId,
+						ownerId: this.session.getAgentId?.() ?? undefined,
+						data: {
+							toolCallId: _toolCallId,
+							params,
+							task: { ...taskItem, id: uniqueId },
+							sessionFile: subtaskSessionFile,
+							forkContextSeed: frozenForkSeed,
+							agentSource: fallbackAgentSource,
+						} satisfies TaskResumeDescriptor,
+					});
+				}
+				if (typeof manager.registerSubagentRecord === "function") {
+					manager.registerSubagentRecord({
+						subagentId: uniqueId,
+						ownerId: this.session.getAgentId?.() ?? undefined,
+						currentJobId: jobId,
+						historicalJobIds: [],
+						status: manager.getJob(jobId)?.status ?? "running",
+						sessionFile: subtaskSessionFile,
+						resumable: !!batchArtifactsDir,
+					});
+				}
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				failedSchedules.push(`${taskItem.id}: ${message}`);
@@ -637,6 +729,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
 		preAllocatedIds?: string[],
 		prebuiltForkContextSeeds?: ReadonlyMap<string, ForkContextSeed>,
+		executionOverrides?: {
+			runMode?: "initial" | "resume" | "message";
+			resumeMessage?: string;
+			sessionFiles?: ReadonlyMap<string, string | null>;
+		},
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
 		const { agents, projectAgentsDir } = await discoverAgents(this.session.cwd);
@@ -996,8 +1093,17 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				});
 			};
 
-			const runTask = async (task: (typeof tasksWithUniqueIds)[number], index: number) => {
+			const runTask = async (
+				task: (typeof tasksWithUniqueIds)[number],
+				index: number,
+				overrides?: {
+					runMode?: "initial" | "resume" | "message";
+					resumeMessage?: string;
+					sessionFile?: string | null;
+				},
+			) => {
 				const forkContextSeed = prebuiltForkContextSeeds?.get(task.id) ?? (await buildForkContextSeed(task));
+				const taskSessionFile = overrides?.sessionFile ?? executionOverrides?.sessionFiles?.get(task.id) ?? null;
 				if (!isIsolated) {
 					return runSubprocess({
 						cwd: this.session.cwd,
@@ -1008,12 +1114,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						description: task.description,
 						index,
 						id: task.id,
+						runMode: overrides?.runMode ?? executionOverrides?.runMode,
+						resumeMessage: overrides?.resumeMessage ?? executionOverrides?.resumeMessage,
+						subagentId: task.id,
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
-						sessionFile,
+						sessionFile: taskSessionFile,
 						persistArtifacts: !!artifactsDir,
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,
@@ -1063,12 +1172,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						description: task.description,
 						index,
 						id: task.id,
+						runMode: overrides?.runMode ?? executionOverrides?.runMode,
+						resumeMessage: overrides?.resumeMessage ?? executionOverrides?.resumeMessage,
+						subagentId: task.id,
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
-						sessionFile,
+						sessionFile: taskSessionFile,
 						persistArtifacts: !!artifactsDir,
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -47,6 +47,8 @@ function getStatusIcon(status: AgentProgress["status"], theme: Theme, spinnerFra
 			return formatStatusIcon("error", theme);
 		case "aborted":
 			return formatStatusIcon("aborted", theme);
+		case "paused":
+			return formatStatusIcon("pending", theme);
 	}
 }
 

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -53,7 +53,7 @@ export interface SubagentLifecyclePayload {
 	agent: string;
 	agentSource: AgentSource;
 	description?: string;
-	status: "started" | "completed" | "failed" | "aborted";
+	status: "started" | "completed" | "failed" | "aborted" | "paused";
 	sessionFile?: string;
 	index: number;
 }
@@ -192,7 +192,7 @@ export interface AgentProgress {
 	id: string;
 	agent: string;
 	agentSource: AgentSource;
-	status: "pending" | "running" | "completed" | "failed" | "aborted";
+	status: "pending" | "running" | "completed" | "failed" | "aborted" | "paused";
 	task: string;
 	assignment?: string;
 	description?: string;
@@ -279,6 +279,7 @@ export interface SingleResult {
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;
+	paused?: boolean;
 	/** Aggregated usage from the subprocess, accumulated incrementally from message_end events. */
 	usage?: Usage;
 	/** Output path for the task result */
@@ -315,7 +316,7 @@ export interface TaskToolDetails {
 	outputPaths?: string[];
 	progress?: AgentProgress[];
 	async?: {
-		state: "running" | "completed" | "failed";
+		state: "running" | "paused" | "queued" | "completed" | "failed";
 		jobId: string;
 		type: "task";
 	};

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -1,7 +1,7 @@
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
-import { type AsyncJob, AsyncJobManager } from "../async";
+import { type AsyncJob, AsyncJobManager, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
 import type { AgentSource } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
@@ -16,14 +16,26 @@ const MAX_LIST_LIMIT = 50;
 const TEXT_PREVIEW_WIDTH = 12_000;
 
 const subagentSchema = z.object({
-	action: z.enum(["list", "inspect", "await", "cancel"]).describe("subagent control action"),
+	action: z
+		.enum(["list", "inspect", "await", "cancel", "pause", "resume", "steer"])
+		.describe("subagent control action"),
 	ids: z.array(z.string()).optional().describe("subagent ids or backing job ids"),
+	message: z.string().optional().describe("message to deliver when resuming or steering a subagent"),
+	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
 	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
 	limit: z.number().min(1).max(MAX_LIST_LIMIT).optional().describe("maximum subagents to return"),
 });
 
 type SubagentParams = z.infer<typeof subagentSchema>;
-type SubagentStatus = "running" | "completed" | "failed" | "cancelled" | "not_found" | "already_completed";
+type SubagentStatus =
+	| "running"
+	| "paused"
+	| "queued"
+	| "completed"
+	| "failed"
+	| "cancelled"
+	| "not_found"
+	| "already_completed";
 
 export interface SubagentSnapshot {
 	id: string;
@@ -77,17 +89,17 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const limit = Math.min(MAX_LIST_LIMIT, Math.max(1, Math.floor(params.limit ?? DEFAULT_LIST_LIMIT)));
 
 		if (params.action === "list") {
-			const jobs = this.#listSubagentJobs(manager, ownerFilter, limit);
-			return this.#buildResult(manager, jobs, { title: "Subagents" });
+			const records = this.#listSubagentRecords(manager, ownerFilter, limit);
+			return this.#buildRecordResult(manager, records, { title: "Subagents" });
 		}
 
 		if (params.action === "inspect") {
-			const jobs = params.ids?.length
-				? this.#visibleJobsByIds(manager, params.ids, ownerId)
-				: manager.getRunningJobs(ownerFilter).filter(isSubagentJob);
-			return this.#buildResult(manager, jobs, {
+			const records = params.ids?.length
+				? this.#visibleRecordsByIds(manager, params.ids, ownerFilter)
+				: this.#runningRecords(manager, ownerFilter);
+			return this.#buildRecordResult(manager, records, {
 				title: "Subagent inspection",
-				notFoundIds: this.#notFoundIds(manager, params.ids ?? [], ownerId),
+				notFoundIds: this.#notFoundRecordIds(manager, params.ids ?? [], ownerFilter),
 			});
 		}
 
@@ -98,46 +110,146 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			}
 			const snapshots: SubagentSnapshot[] = [];
 			for (const id of ids) {
-				const job = this.#findVisibleJob(manager, id, ownerId);
-				if (!job) {
+				const record = this.#findVisibleRecord(manager, id, ownerFilter);
+				if (!record) {
 					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
-				if (job.status !== "running") {
-					snapshots.push({ ...this.#snapshot(job), status: "already_completed" });
-					continue;
-				}
-				manager.cancel(job.id, ownerFilter);
-				snapshots.push(this.#snapshot(manager.getJob(job.id) ?? job));
+				const cancelled = manager.cancelSubagent(record.subagentId, ownerFilter);
+				if (!cancelled && record.currentJobId) manager.cancel(record.currentJobId, ownerFilter);
+				const updated = this.#findVisibleRecord(manager, id, ownerFilter) ?? record;
+				snapshots.push(this.#recordSnapshot(manager, updated));
 			}
 			return this.#buildSnapshotResult(snapshots, "Subagent cancellation");
 		}
 
-		return this.#awaitSubagents(manager, params, ownerId, ownerFilter, signal, onUpdate);
+		if (params.action === "pause") {
+			const ids = params.ids ?? [];
+			if (ids.length === 0) {
+				throw new ToolError("`pause` requires at least one subagent id.");
+			}
+			const snapshots: SubagentSnapshot[] = [];
+			for (const id of ids) {
+				const record = this.#findVisibleRecord(manager, id, ownerFilter);
+				if (!record) {
+					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					continue;
+				}
+				const result = manager.pauseSubagent(record.subagentId, ownerFilter);
+				if (!result.ok && result.reason === "not_found") {
+					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					continue;
+				}
+				snapshots.push(
+					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
+				);
+			}
+			return this.#buildSnapshotResult(snapshots, "Subagent pause");
+		}
+
+		if (params.action === "resume") {
+			const ids = params.ids ?? [];
+			if (ids.length === 0) {
+				throw new ToolError("`resume` requires at least one subagent id.");
+			}
+			const snapshots: SubagentSnapshot[] = [];
+			for (const id of ids) {
+				const record = this.#findVisibleRecord(manager, id, ownerFilter);
+				if (!record) {
+					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					continue;
+				}
+				if (record.status === "running") {
+					snapshots.push(this.#recordSnapshot(manager, record));
+					continue;
+				}
+				if (params.message === undefined && isTerminalStatus(record.status)) {
+					snapshots.push({
+						...this.#recordSnapshot(manager, record),
+						guidance:
+							"This subagent is terminal. Provide `message` to start a follow-up resume run from its saved context.",
+					});
+					continue;
+				}
+				const result = manager.resumeSubagent(record.subagentId, ownerFilter, params.message);
+				if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
+				if (!result.ok && result.reason === "not_found") {
+					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					continue;
+				}
+				snapshots.push(
+					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
+				);
+			}
+			return this.#buildSnapshotResult(snapshots, "Subagent resume");
+		}
+
+		if (params.action === "steer") {
+			const ids = params.ids ?? [];
+			const message = params.message;
+			if (ids.length === 0) {
+				throw new ToolError("`steer` requires at least one subagent id.");
+			}
+			if (message === undefined || message.trim() === "") {
+				throw new ToolError("`steer` requires a non-empty message.");
+			}
+			const snapshots: SubagentSnapshot[] = [];
+			for (const id of ids) {
+				const record = this.#findVisibleRecord(manager, id, ownerFilter);
+				if (!record) {
+					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					continue;
+				}
+				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
+				if (record.status === "running") {
+					const handle = manager.getLiveHandle(record.subagentId);
+					if (!handle) throw new ToolError(`Subagent ${record.subagentId} has no live handle.`);
+					await handle.injectMessage(message, "steer");
+					if (params.pause === true) manager.pauseSubagent(record.subagentId, ownerFilter);
+				} else {
+					const result = manager.resumeSubagent(record.subagentId, ownerFilter, message);
+					if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
+					if (!result.ok && result.reason === "not_found") {
+						snapshots.push(
+							this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."),
+						);
+						continue;
+					}
+				}
+				snapshots.push(
+					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
+				);
+			}
+			return this.#buildSnapshotResult(snapshots, "Subagent steer");
+		}
+
+		return this.#awaitSubagents(manager, params, ownerFilter, signal, onUpdate);
 	}
 
 	async #awaitSubagents(
 		manager: AsyncJobManager,
 		params: SubagentParams,
-		ownerId: string | undefined,
 		ownerFilter: { ownerId: string } | undefined,
 		signal: AbortSignal | undefined,
 		onUpdate: AgentToolUpdateCallback<SubagentToolDetails> | undefined,
 	): Promise<AgentToolResult<SubagentToolDetails>> {
-		const jobs = params.ids?.length
-			? this.#visibleJobsByIds(manager, params.ids, ownerId)
-			: manager.getRunningJobs(ownerFilter).filter(isSubagentJob);
-		const notFoundIds = this.#notFoundIds(manager, params.ids ?? [], ownerId);
-		if (jobs.length === 0) {
+		const records = params.ids?.length
+			? this.#visibleRecordsByIds(manager, params.ids, ownerFilter)
+			: this.#runningRecords(manager, ownerFilter);
+		const notFoundIds = this.#notFoundRecordIds(manager, params.ids ?? [], ownerFilter);
+		if (records.length === 0) {
 			const missing = notFoundIds.map(id =>
 				this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."),
 			);
 			return this.#buildSnapshotResult(missing, "Subagent await");
 		}
 
-		const runningJobs = jobs.filter(job => job.status === "running");
+		const runningJobs = records
+			.filter(record => record.status === "running" && record.currentJobId)
+			.map(record => manager.getJob(record.currentJobId!))
+			.filter((job): job is AsyncJob => job !== undefined);
 		if (runningJobs.length === 0) {
-			return this.#buildResult(manager, jobs, { title: "Subagent await", notFoundIds });
+			return this.#buildRecordResult(manager, records, { title: "Subagent await", notFoundIds });
 		}
 
 		const timeoutMs = Math.min(
@@ -148,10 +260,10 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		manager.watchJobs(watchedJobIds);
 		const progressTimer = onUpdate
 			? setInterval(() => {
-					onUpdate(this.#progressResult(manager, jobs));
+					onUpdate(this.#progressResult(manager, records));
 				}, 500)
 			: undefined;
-		onUpdate?.(this.#progressResult(manager, jobs));
+		onUpdate?.(this.#progressResult(manager, records));
 
 		let timedOut = false;
 		try {
@@ -176,70 +288,124 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (progressTimer) clearInterval(progressTimer);
 		}
 
-		return this.#buildResult(manager, jobs, { title: "Subagent await", notFoundIds, timedOut });
+		return this.#buildRecordResult(manager, records, { title: "Subagent await", notFoundIds, timedOut });
 	}
 
-	#listSubagentJobs(
+	#mergedRecords(
 		manager: AsyncJobManager,
 		ownerFilter: { ownerId: string } | undefined,
 		limit: number,
-	): AsyncJob[] {
-		const running = manager.getRunningJobs(ownerFilter).filter(isSubagentJob);
-		const recent = manager.getRecentJobs(limit, ownerFilter).filter(isSubagentJob);
-		const jobs = [...running, ...recent];
-		return this.#dedupeJobs(jobs).slice(0, limit);
-	}
-
-	#visibleJobsByIds(manager: AsyncJobManager, ids: string[], ownerId: string | undefined): AsyncJob[] {
-		const jobs: AsyncJob[] = [];
-		for (const id of ids) {
-			const job = this.#findVisibleJob(manager, id, ownerId);
-			if (job) jobs.push(job);
+	): SubagentRecord[] {
+		const merged = [...manager.getSubagentRecords(ownerFilter)];
+		const known = new Set(merged.map(record => record.subagentId));
+		const jobs = [...manager.getRunningJobs(ownerFilter), ...manager.getRecentJobs(limit, ownerFilter)].filter(
+			isSubagentJob,
+		);
+		for (const job of jobs) {
+			const subagentId = job.metadata?.subagent?.id ?? job.id;
+			if (known.has(subagentId)) continue;
+			known.add(subagentId);
+			merged.push(this.#jobToRecord(job));
 		}
-		return this.#dedupeJobs(jobs);
-	}
-
-	#findVisibleJob(manager: AsyncJobManager, id: string, ownerId: string | undefined): AsyncJob | undefined {
-		const trimmedId = id.trim();
-		if (!trimmedId) return undefined;
-		const direct = manager.getJob(trimmedId);
-		if (direct && isSubagentJob(direct) && (!ownerId || direct.ownerId === ownerId)) return direct;
-		return manager
-			.getAllJobs(ownerId ? { ownerId } : undefined)
-			.find(job => isSubagentJob(job) && job.metadata?.subagent?.id === trimmedId);
-	}
-
-	#notFoundIds(manager: AsyncJobManager, ids: string[], ownerId: string | undefined): string[] {
-		return ids.filter(id => !this.#findVisibleJob(manager, id, ownerId));
-	}
-
-	#dedupeJobs(jobs: AsyncJob[]): AsyncJob[] {
-		const seen = new Set<string>();
-		return jobs.filter(job => {
-			if (seen.has(job.id)) return false;
-			seen.add(job.id);
-			return true;
+		merged.sort((a, b) => {
+			const aJob = a.currentJobId ? manager.getJob(a.currentJobId) : undefined;
+			const bJob = b.currentJobId ? manager.getJob(b.currentJobId) : undefined;
+			return (bJob?.startTime ?? 0) - (aJob?.startTime ?? 0);
 		});
+		return merged.slice(0, limit);
 	}
 
-	#progressResult(manager: AsyncJobManager, jobs: AsyncJob[]): AgentToolResult<SubagentToolDetails> {
+	#listSubagentRecords(
+		manager: AsyncJobManager,
+		ownerFilter: { ownerId: string } | undefined,
+		limit: number,
+	): SubagentRecord[] {
+		return this.#mergedRecords(manager, ownerFilter, limit);
+	}
+
+	#runningRecords(manager: AsyncJobManager, ownerFilter: { ownerId: string } | undefined): SubagentRecord[] {
+		return this.#mergedRecords(manager, ownerFilter, MAX_LIST_LIMIT).filter(record => record.status === "running");
+	}
+
+	/** Synthesize a record from a subagent job that has no registered SubagentRecord (backward compat). */
+	#jobToRecord(job: AsyncJob): SubagentRecord {
 		return {
-			content: [{ type: "text", text: "" }],
-			details: { subagents: this.#snapshots(manager, jobs) },
+			subagentId: job.metadata?.subagent?.id ?? job.id,
+			ownerId: job.ownerId,
+			currentJobId: job.id,
+			historicalJobIds: [],
+			status: job.status,
+			sessionFile: null,
+			resumable: false,
 		};
 	}
 
-	#buildResult(
+	#findSubagentJob(manager: AsyncJobManager, id: string, ownerId: string | undefined): AsyncJob | undefined {
+		const direct = manager.getJob(id);
+		if (direct && isSubagentJob(direct) && (!ownerId || direct.ownerId === ownerId)) return direct;
+		return manager
+			.getAllJobs(ownerId ? { ownerId } : undefined)
+			.find(job => isSubagentJob(job) && job.metadata?.subagent?.id === id);
+	}
+
+	#visibleRecordsByIds(
 		manager: AsyncJobManager,
-		jobs: AsyncJob[],
+		ids: string[],
+		ownerFilter: { ownerId: string } | undefined,
+	): SubagentRecord[] {
+		const records: SubagentRecord[] = [];
+		const seen = new Set<string>();
+		for (const id of ids) {
+			const record = this.#findVisibleRecord(manager, id, ownerFilter);
+			if (!record || seen.has(record.subagentId)) continue;
+			seen.add(record.subagentId);
+			records.push(record);
+		}
+		return records;
+	}
+
+	#findVisibleRecord(
+		manager: AsyncJobManager,
+		id: string,
+		ownerFilter: { ownerId: string } | undefined,
+	): SubagentRecord | undefined {
+		const trimmedId = id.trim();
+		if (!trimmedId) return undefined;
+		const direct = manager.getSubagentRecord(trimmedId, ownerFilter);
+		if (direct) return direct;
+		const byJobId = manager.getSubagentRecords(ownerFilter).find(record => record.currentJobId === trimmedId);
+		if (byJobId) return byJobId;
+		const job = this.#findSubagentJob(manager, trimmedId, ownerFilter?.ownerId);
+		return job ? this.#jobToRecord(job) : undefined;
+	}
+
+	#notFoundRecordIds(manager: AsyncJobManager, ids: string[], ownerFilter: { ownerId: string } | undefined): string[] {
+		return ids.filter(id => !this.#findVisibleRecord(manager, id, ownerFilter));
+	}
+
+	#progressResult(manager: AsyncJobManager, records: SubagentRecord[]): AgentToolResult<SubagentToolDetails> {
+		return {
+			content: [{ type: "text", text: "" }],
+			details: { subagents: this.#recordSnapshots(manager, records) },
+		};
+	}
+
+	#buildRecordResult(
+		manager: AsyncJobManager,
+		records: SubagentRecord[],
 		options: { title: string; notFoundIds?: string[]; timedOut?: boolean },
 	): AgentToolResult<SubagentToolDetails> {
-		const snapshots = this.#snapshots(manager, jobs, options.timedOut);
+		const snapshots = this.#recordSnapshots(manager, records, options.timedOut);
 		for (const id of options.notFoundIds ?? []) {
 			snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 		}
 		manager.acknowledgeDeliveries(
-			snapshots.filter(s => s.status !== "running" && s.status !== "not_found").map(s => s.jobId),
+			snapshots
+				.filter(
+					s =>
+						s.status !== "running" && s.status !== "paused" && s.status !== "queued" && s.status !== "not_found",
+				)
+				.map(s => s.jobId),
 		);
 		return this.#buildSnapshotResult(snapshots, options.title);
 	}
@@ -263,8 +429,29 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		};
 	}
 
-	#snapshots(manager: AsyncJobManager, jobs: AsyncJob[], timedOut = false): SubagentSnapshot[] {
-		return jobs.map(job => this.#snapshot(manager.getJob(job.id) ?? job, timedOut));
+	#recordSnapshots(manager: AsyncJobManager, records: SubagentRecord[], timedOut = false): SubagentSnapshot[] {
+		return records.map(record => this.#recordSnapshot(manager, record, timedOut));
+	}
+
+	#recordSnapshot(manager: AsyncJobManager, record: SubagentRecord, timedOut = false): SubagentSnapshot {
+		const job = record.currentJobId ? manager.getJob(record.currentJobId) : undefined;
+		if (job) {
+			return {
+				...this.#snapshot(job, timedOut),
+				id: record.subagentId,
+				jobId: record.currentJobId ?? job.id,
+				status: record.status,
+			};
+		}
+		return {
+			id: record.subagentId,
+			jobId: record.currentJobId ?? record.subagentId,
+			status: record.status,
+			label: "subagent",
+			agent: "unknown",
+			agentSource: "bundled",
+			durationMs: 0,
+		};
 	}
 
 	#snapshot(job: AsyncJob, timedOut = false): SubagentSnapshot {
@@ -301,6 +488,10 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			guidance,
 		};
 	}
+}
+
+function isTerminalStatus(status: SubagentStatus): boolean {
+	return status === "completed" || status === "failed" || status === "cancelled";
 }
 
 function isSubagentJob(job: AsyncJob): boolean {

--- a/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
+++ b/packages/coding-agent/test/async/job-manager-resume-queue.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "bun:test";
+import { AsyncJobManager, type SubagentRunOutcome } from "@gajae-code/coding-agent/async/job-manager";
+
+/** Build a manager that records every delivered completion. */
+function makeManager(opts?: { maxRunningJobs?: number; retentionMs?: number }) {
+	const completions: Array<{ jobId: string; text: string }> = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: async (jobId, text) => {
+			completions.push({ jobId, text });
+		},
+		maxRunningJobs: opts?.maxRunningJobs,
+		retentionMs: opts?.retentionMs,
+	});
+	return { manager, completions };
+}
+
+/** Spawn a controllable subagent whose single boundary can pause or complete. */
+function spawnControllable(manager: AsyncJobManager, subagentId: string, ownerId?: string) {
+	let pauseRequested = false;
+	const gate = Promise.withResolvers<void>();
+	const jobId = manager.register(
+		"task",
+		subagentId,
+		async (): Promise<string | SubagentRunOutcome> => {
+			await gate.promise; // wait for the test to reach the boundary
+			if (pauseRequested) return { kind: "paused" };
+			return { kind: "completed", text: `${subagentId} done` };
+		},
+		{
+			id: subagentId,
+			ownerId,
+			metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+		},
+	);
+	manager.registerSubagentRecord({
+		subagentId,
+		ownerId,
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	});
+	manager.registerLiveHandle(subagentId, {
+		requestPause() {
+			pauseRequested = true;
+		},
+		async injectMessage() {},
+	});
+	return { jobId, release: () => gate.resolve() };
+}
+
+/** A resume runner that re-spawns a subagent which completes immediately. */
+function installResumeRunner(manager: AsyncJobManager) {
+	manager.setResumeRunner((subagentId, message) => {
+		const rec = manager.getSubagentRecord(subagentId);
+		return manager.register(
+			"task",
+			subagentId,
+			async (): Promise<SubagentRunOutcome> => ({
+				kind: "completed",
+				text: message ? `resumed:${message}` : `resumed:${subagentId}`,
+			}),
+			{
+				id: `${subagentId}-r`,
+				ownerId: rec?.ownerId,
+				metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+			},
+		);
+	});
+}
+
+describe("AsyncJobManager subagent pause/resume/queue", () => {
+	test("paused outcome does not deliver and is exempt from eviction (AC1/AC7/AC8)", async () => {
+		const { manager, completions } = makeManager({ retentionMs: 30 });
+		const a = spawnControllable(manager, "A");
+		expect(manager.pauseSubagent("A").ok).toBe(true);
+		a.release();
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+
+		expect(manager.getSubagentRecord("A")?.status).toBe("paused");
+		expect(manager.getJob(a.jobId)?.status).toBe("paused");
+		expect(completions).toHaveLength(0); // held subagent never delivers
+
+		await Bun.sleep(120); // past retention
+		expect(manager.getJob(a.jobId)?.status).toBe("paused"); // not evicted
+		expect(manager.getSubagentRecord("A")).toBeDefined();
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("resume rehydrates a paused subagent and delivers exactly once (AC2/AC8)", async () => {
+		const { manager, completions } = makeManager();
+		installResumeRunner(manager);
+		const a = spawnControllable(manager, "A");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+		expect(completions).toHaveLength(0);
+
+		const res = manager.resumeSubagent("A");
+		expect(res.ok).toBe(true);
+		expect(res.queued).toBeFalsy();
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+
+		const rec = manager.getSubagentRecord("A");
+		expect(rec?.status).toBe("completed");
+		expect(rec?.historicalJobIds).toContain(a.jobId); // old job archived
+		expect(completions).toHaveLength(1); // exactly once
+		expect(completions[0].text).toBe("resumed:A");
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("resume with a message passes it through (AC3/AC5)", async () => {
+		const { manager, completions } = makeManager();
+		installResumeRunner(manager);
+		const a = spawnControllable(manager, "A");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+
+		manager.resumeSubagent("A", undefined, "do the new thing");
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+		expect(completions[0]?.text).toBe("resumed:do the new thing");
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("steer updates an already queued resume message (AC5/AC6)", async () => {
+		const { manager, completions } = makeManager({ maxRunningJobs: 1 });
+		installResumeRunner(manager);
+		const a = spawnControllable(manager, "A");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+		const b = spawnControllable(manager, "B");
+
+		expect(manager.resumeSubagent("A", undefined, "old").queued).toBe(true);
+		expect(manager.resumeSubagent("A", undefined, "new").queued).toBe(true);
+		b.release();
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+
+		expect(completions.map(c => c.text).sort()).toEqual(["B done", "resumed:new"]);
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("resume uses manager-owned descriptors after the runner is replaced", async () => {
+		const { manager } = makeManager();
+		const a = spawnControllable(manager, "A");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+		manager.registerResumeDescriptor({ subagentId: "A", data: { marker: "old-descriptor" } });
+		let seenDescriptor: unknown;
+		manager.setResumeRunner((_subagentId, _message, descriptor) => {
+			seenDescriptor = descriptor?.data;
+			return manager.register(
+				"task",
+				"A",
+				async (): Promise<SubagentRunOutcome> => ({ kind: "completed", text: "resumed descriptor" }),
+				{ id: "A-r", metadata: { subagent: { id: "A", agent: "executor", agentSource: "bundled" } } },
+			);
+		});
+
+		expect(manager.resumeSubagent("A").ok).toBe(true);
+		await manager.waitForAll();
+		expect(seenDescriptor).toEqual({ marker: "old-descriptor" });
+		expect(manager.getSubagentRecord("A")?.status).toBe("completed");
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("resume queues when at the concurrency limit and drains FIFO (AC6)", async () => {
+		const { manager, completions } = makeManager({ maxRunningJobs: 1 });
+		installResumeRunner(manager);
+
+		const a = spawnControllable(manager, "A"); // running, fills the single slot
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll(); // A paused, slot free
+		expect(manager.getSubagentRecord("A")?.status).toBe("paused");
+
+		const b = spawnControllable(manager, "B"); // running, fills the slot again
+		const resume = manager.resumeSubagent("A");
+		expect(resume.queued).toBe(true);
+		expect(manager.getSubagentRecord("A")?.status).toBe("queued");
+
+		b.release(); // B completes -> drain -> A resumes
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+
+		expect(manager.getSubagentRecord("A")?.status).toBe("completed");
+		expect(manager.getSubagentRecord("B")?.status).toBe("completed");
+		expect(completions.map(c => c.text).sort()).toEqual(["B done", "resumed:A"]);
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("cancelSubagent on a paused subagent marks cancelled but keeps the record (AC10)", async () => {
+		const { manager } = makeManager();
+		const a = spawnControllable(manager, "A");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+
+		expect(manager.cancelSubagent("A")).toBe(true);
+		const rec = manager.getSubagentRecord("A");
+		expect(rec?.status).toBe("cancelled");
+		expect(rec?.sessionFile).toBe("/tmp/A.jsonl"); // file reference kept (resumable by id)
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("resume of a non-resumable subagent returns context_unavailable (AC10)", async () => {
+		const { manager } = makeManager();
+		manager.registerSubagentRecord({
+			subagentId: "E",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "completed",
+			sessionFile: null,
+			resumable: false,
+		});
+		const res = manager.resumeSubagent("E");
+		expect(res.ok).toBe(false);
+		expect(res.reason).toBe("context_unavailable");
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("pause after completion is a no-op (completion wins) (AC8)", async () => {
+		const { manager, completions } = makeManager();
+		const a = spawnControllable(manager, "A");
+		a.release(); // no pause requested -> completes
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 500 });
+
+		expect(manager.getSubagentRecord("A")?.status).toBe("completed");
+		const res = manager.pauseSubagent("A");
+		expect(res.ok).toBe(false);
+		expect(res.reason).toBe("not_running");
+		expect(completions).toHaveLength(1);
+		await manager.dispose({ timeoutMs: 500 });
+	});
+
+	test("owner cleanup purges records, live handles, and queued resumes (AC9)", async () => {
+		const { manager } = makeManager({ maxRunningJobs: 1 });
+		installResumeRunner(manager);
+		const a = spawnControllable(manager, "A", "owner-1");
+		manager.pauseSubagent("A");
+		a.release();
+		await manager.waitForAll();
+
+		manager.runOwnerCleanups({ ownerId: "owner-1" });
+		expect(manager.getSubagentRecord("A")).toBeUndefined();
+		expect(manager.getLiveHandle("A")).toBeUndefined();
+		await manager.dispose({ timeoutMs: 500 });
+	});
+});

--- a/packages/coding-agent/test/task/executor-pause-resume.test.ts
+++ b/packages/coding-agent/test/task/executor-pause-resume.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentEvent } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { AsyncJobManager } from "../../src/async/job-manager";
+import { Settings } from "../../src/config/settings";
+import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "../../src/session/agent-session";
+import { runSubprocess } from "../../src/task/executor";
+import type { AgentDefinition } from "../../src/task/types";
+import { EventBus } from "../../src/utils/event-bus";
+
+function assistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createPauseSession(options: CreateAgentSessionOptions, subagentId: string): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const state = { messages: [] as AssistantMessage[] };
+	let prompts = 0;
+	const emit = (event: AgentEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+	const session = {
+		state,
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: {
+			appendSessionInit: () => {},
+		},
+		getActiveToolNames: () => ["yield"],
+		setActiveToolsByName: async (_toolNames: string[]) => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (_text: string, _promptOptions?: PromptOptions) => {
+			prompts += 1;
+			AsyncJobManager.instance()?.getLiveHandle(subagentId)?.requestPause();
+			const message = assistantMessage("paused output");
+			state.messages.push(message);
+			emit({ type: "message_end", message });
+			emit({
+				type: "agent_end",
+				messages: [message],
+				stopReason: options.shouldPause?.() === true ? "paused" : "completed",
+			});
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
+		abort: async () => {},
+		dispose: async () => {},
+		get promptCount() {
+			return prompts;
+		},
+	};
+	return session as unknown as AgentSession;
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: {} as unknown as LoadExtensionsResult,
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+describe("runSubprocess pause/resume integration", () => {
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		const manager = AsyncJobManager.instance();
+		if (manager) await manager.dispose({ timeoutMs: 100 });
+		AsyncJobManager.setInstance(undefined);
+	});
+
+	it("wires live pause requests into Agent shouldPause and returns a paused result without aborting", async () => {
+		const subagentId = "stable-subagent-id";
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		let session: AgentSession | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			const actualOptions = options ?? {};
+			capturedOptions = actualOptions;
+			session = createPauseSession(actualOptions, subagentId);
+			return createSessionResult(session);
+		});
+		const agent: AgentDefinition = {
+			name: "executor",
+			description: "test executor",
+			systemPrompt: "test",
+			source: "bundled",
+		};
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "do paused work",
+			index: 0,
+			id: subagentId,
+			subagentId,
+			settings: Settings.isolated(),
+			modelRegistry: {
+				refresh: async () => {},
+			} as unknown as import("../../src/config/model-registry").ModelRegistry,
+			enableLsp: false,
+		});
+
+		expect(capturedOptions?.shouldPause?.()).toBe(true);
+		expect(result.paused).toBe(true);
+		expect(result.aborted).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.error).toBeUndefined();
+		expect(manager.getLiveHandle(subagentId)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -186,4 +186,130 @@ describe("SubagentTool", () => {
 		expect(manager.getJob("job-cancel")?.status).toBe("cancelled");
 		await manager.dispose({ timeoutMs: 100 });
 	});
+
+	it("pause requests a running registered subagent and returns a running snapshot", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		let pauseRequested = false;
+		manager.registerSubagentRecord({
+			subagentId: "0-Pause",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Pause.jsonl",
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-Pause", {
+			requestPause() {
+				pauseRequested = true;
+			},
+			async injectMessage() {},
+		});
+
+		const result = await tool.execute("subagent-pause", { action: "pause", ids: ["0-Pause"] });
+
+		expect(pauseRequested).toBe(true);
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(getText(result)).toContain("0-Pause");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("resume starts a paused subagent through the manager runner", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		manager.setResumeRunner(subagentId =>
+			manager.register("task", subagentId, async () => "resumed", {
+				id: "job-resumed",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+			}),
+		);
+		manager.registerSubagentRecord({
+			subagentId: "0-Resume",
+			ownerId: "0-Main",
+			currentJobId: "job-paused",
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/0-Resume.jsonl",
+			resumable: true,
+		});
+
+		const result = await tool.execute("subagent-resume", { action: "resume", ids: ["0-Resume"] });
+
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.jobId).toBe("job-resumed");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("steer running injects a message and optionally requests pause", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		let injected: string | undefined;
+		let pauseRequested = false;
+		manager.registerSubagentRecord({
+			subagentId: "0-Steer",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Steer.jsonl",
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-Steer", {
+			requestPause() {
+				pauseRequested = true;
+			},
+			async injectMessage(content) {
+				injected = content;
+			},
+		});
+
+		const result = await tool.execute("subagent-steer", {
+			action: "steer",
+			ids: ["0-Steer"],
+			message: "tighten scope",
+			pause: true,
+		});
+
+		expect(injected).toBe("tighten scope");
+		expect(pauseRequested).toBe(true);
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("steer non-active auto-resumes with message and ignores pause flag", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		let resumedMessage: string | undefined;
+		manager.setResumeRunner((subagentId, message) => {
+			resumedMessage = message;
+			return manager.register("task", subagentId, async () => "resumed", {
+				id: "job-auto-resumed",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+			});
+		});
+		manager.registerSubagentRecord({
+			subagentId: "0-Auto",
+			ownerId: "0-Main",
+			currentJobId: "job-completed",
+			historicalJobIds: [],
+			status: "completed",
+			sessionFile: "/tmp/0-Auto.jsonl",
+			resumable: true,
+		});
+
+		const result = await tool.execute("subagent-steer-auto", {
+			action: "steer",
+			ids: ["0-Auto"],
+			message: "follow up",
+			pause: true,
+		});
+
+		expect(resumedMessage).toBe("follow up");
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.jobId).toBe("job-auto-resumed");
+		await manager.dispose({ timeoutMs: 100 });
+	});
 });


### PR DESCRIPTION
## Summary
- Add canonical subagent records, live handles, cooperative pause, resume queueing, and manager-owned resume descriptors.
- Add subagent tool actions for pause/resume/steer with paused/queued status surfaces and docs.
- Add generic agent-loop pause checkpoints plus executor resume/message modes and durable steer-before-pause handling.

## Verification
- bun test packages/agent/test/agent-loop.test.ts packages/coding-agent/test/async/job-manager-resume-queue.test.ts packages/coding-agent/test/task/executor-pause-resume.test.ts packages/coding-agent/test/async-job-manager.test.ts packages/coding-agent/test/tools/subagent.test.ts packages/coding-agent/test/tool-discovery/subagent.test.ts packages/coding-agent/test/task/subagent-lsp.test.ts packages/coding-agent/test/task/executor-subagent-reminders.test.ts packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts packages/coding-agent/test/task-fork-context.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts
- bun run check:ts
- bun run lint:ts
- OPENAI_API_KEY=env-openai-key bun run test:ts

## Quality gate
- Architect final review: CLEAR/CLEAR/CLEAR, APPROVE.
- Executor QA/red-team: passed.
- Ultragoal G001 checkpointed complete with strict quality gate.