### PR TITLE
Render deep interview prompts readably

### DIFF
--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -1,0 +1,366 @@
+import { type Component, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
+import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
+
+interface RoundQuestionModel {
+	kind: "round-question";
+	round: string;
+	component?: string;
+	targeting?: string;
+	mode?: string;
+	whyNow?: string;
+	ambiguity?: string;
+	question: string;
+}
+
+interface TopologyQuestionModel {
+	kind: "topology-question";
+	context?: string;
+	components: Array<{ name: string; description: string }>;
+	question: string;
+}
+
+interface ProgressDimension {
+	name: string;
+	score: string;
+	weight: string;
+	weighted: string;
+	gap: string;
+}
+
+interface ProgressModel {
+	kind: "progress";
+	round: string;
+	dimensions: ProgressDimension[];
+	ambiguity?: string;
+	topology?: string;
+	ontology?: string;
+	nextTarget?: string;
+	status?: string;
+	extra?: string;
+}
+
+interface ThresholdModel {
+	kind: "threshold";
+	threshold: string;
+	source: string;
+	rest: string;
+}
+
+type DeepInterviewModel = RoundQuestionModel | TopologyQuestionModel | ProgressModel | ThresholdModel;
+
+function normalizeText(text: string): string {
+	return text.trim().replaceAll("\r\n", "\n");
+}
+
+function stripMarkdownEmphasis(value: string): string {
+	return value.replace(/\*\*/g, "").replace(/^"|"$/g, "").trim();
+}
+
+function parseRoundQuestion(text: string): RoundQuestionModel | null {
+	const normalized = normalizeText(text);
+	const lines = normalized.split("\n");
+	const headerIndex = lines.findIndex(line => /^Round\s+\d+\s+\|/i.test(line.trim()));
+	if (headerIndex < 0) return null;
+	const headerLine = lines[headerIndex]?.trim() ?? "";
+	const body = lines
+		.slice(headerIndex + 1)
+		.join("\n")
+		.trim();
+	if (!body) return null;
+
+	const componentMatch =
+		/^Round\s+(\d+)\s+\|\s+Component:\s*(.*?)\s+\|\s+Targeting:\s*(.*?)\s+\|\s+Why now:\s*(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(
+			headerLine,
+		);
+	if (componentMatch) {
+		return {
+			kind: "round-question",
+			round: componentMatch[1] ?? "?",
+			component: componentMatch[2]?.trim(),
+			targeting: componentMatch[3]?.trim(),
+			whyNow: componentMatch[4]?.trim(),
+			ambiguity: componentMatch[5]?.trim(),
+			question: body,
+		};
+	}
+
+	const targetingMatch =
+		/^Round\s+(\d+)\s+\|\s+Targeting:\s*(.*?)\s+\|\s+Why now:\s*(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(
+			headerLine,
+		);
+	if (targetingMatch) {
+		return {
+			kind: "round-question",
+			round: targetingMatch[1] ?? "?",
+			targeting: targetingMatch[2]?.trim(),
+			whyNow: targetingMatch[3]?.trim(),
+			ambiguity: targetingMatch[4]?.trim(),
+			question: body,
+		};
+	}
+
+	const modeMatch = /^Round\s+(\d+)\s+\|\s+(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(headerLine);
+	if (modeMatch) {
+		return {
+			kind: "round-question",
+			round: modeMatch[1] ?? "?",
+			mode: modeMatch[2]?.trim(),
+			ambiguity: modeMatch[3]?.trim(),
+			question: body,
+		};
+	}
+
+	return null;
+}
+
+function parseTopologyQuestion(text: string): TopologyQuestionModel | null {
+	const normalized = normalizeText(text);
+	const lines = normalized.split("\n");
+	const headerIndex = lines.findIndex(line =>
+		/^Round\s+0\s+\|\s+Topology confirmation\s+\|\s+Ambiguity:\s+not scored yet/i.test(line.trim()),
+	);
+	if (headerIndex < 0) {
+		return null;
+	}
+	const components: TopologyQuestionModel["components"] = [];
+	const contextLines: string[] = [];
+	const questionLines: string[] = [];
+	let inQuestion = false;
+	for (const line of lines.slice(headerIndex + 1)) {
+		const trimmed = line.trim();
+		const component = /^\s*\d+\.\s+([^:]+):\s+(.+)$/.exec(line);
+		if (component) {
+			components.push({ name: component[1]?.trim() ?? "", description: component[2]?.trim() ?? "" });
+			continue;
+		}
+		if (/\?$/.test(trimmed)) inQuestion = true;
+		if (!trimmed) continue;
+		if (inQuestion) questionLines.push(trimmed);
+		else contextLines.push(trimmed);
+	}
+	return {
+		kind: "topology-question",
+		context: contextLines.join("\n") || undefined,
+		components,
+		question: questionLines.join("\n"),
+	};
+}
+
+function splitMarkdownTableRow(line: string): string[] {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return [];
+	return trimmed
+		.slice(1, -1)
+		.split("|")
+		.map(cell => stripMarkdownEmphasis(cell));
+}
+
+function parseProgress(text: string): ProgressModel | null {
+	const normalized = normalizeText(text);
+	const roundMatch = /^Round\s+(\d+)\s+complete\./i.exec(normalized);
+	if (!roundMatch) return null;
+
+	const lines = normalized.split("\n");
+	const dimensions: ProgressDimension[] = [];
+	const extraLines: string[] = [];
+	let ambiguity: string | undefined;
+	let topology: string | undefined;
+	let ontology: string | undefined;
+	let nextTarget: string | undefined;
+	let status: string | undefined;
+
+	for (const [index, line] of lines.entries()) {
+		if (index === 0) continue;
+		const trimmed = line.trim();
+		const cells = splitMarkdownTableRow(line);
+		if (cells.length >= 5) {
+			const [name = "", score = "", weight = "", weighted = "", gap = ""] = cells;
+			if (/^-+$/.test(name) || /^Dimension$/i.test(name)) continue;
+			if (/^Ambiguity$/i.test(name)) {
+				ambiguity = weighted || score || gap;
+				continue;
+			}
+			dimensions.push({ name, score, weight, weighted, gap });
+			continue;
+		}
+		const topologyMatch = /^\*\*Topology:\*\*\s*(.+)$/.exec(trimmed);
+		if (topologyMatch) {
+			topology = topologyMatch[1]?.trim();
+			continue;
+		}
+		const ontologyMatch = /^\*\*Ontology:\*\*\s*(.+)$/.exec(trimmed);
+		if (ontologyMatch) {
+			ontology = ontologyMatch[1]?.trim();
+			continue;
+		}
+		const nextTargetMatch = /^\*\*Next target:\*\*\s*(.+)$/.exec(trimmed);
+		if (nextTargetMatch) {
+			nextTarget = nextTargetMatch[1]?.trim();
+			continue;
+		}
+		if (/^(Clarity threshold met!|Focusing next question on:)/i.test(trimmed)) {
+			status = trimmed;
+			continue;
+		}
+		if (trimmed) extraLines.push(trimmed);
+	}
+
+	if (dimensions.length === 0 && !ambiguity && !topology && !ontology && !nextTarget) return null;
+	return {
+		kind: "progress",
+		round: roundMatch[1] ?? "?",
+		dimensions,
+		ambiguity,
+		topology,
+		ontology,
+		nextTarget,
+		status,
+		extra: extraLines.join("\n") || undefined,
+	};
+}
+
+function parseThreshold(text: string): ThresholdModel | null {
+	const normalized = normalizeText(text);
+	const match = /^Deep Interview threshold:\s*(.*?)\s*\(source:\s*(.*?)\)\s*$/im.exec(normalized.split("\n")[0] ?? "");
+	if (!match) return null;
+	return {
+		kind: "threshold",
+		threshold: match[1]?.trim() ?? "",
+		source: match[2]?.trim() ?? "",
+		rest: normalized.split("\n").slice(1).join("\n").trim(),
+	};
+}
+
+function parseDeepInterview(text: string): DeepInterviewModel | null {
+	return parseProgress(text) ?? parseTopologyQuestion(text) ?? parseRoundQuestion(text) ?? parseThreshold(text);
+}
+
+function addLabel(container: Container, label: string, value: string | undefined, uiTheme: Theme): void {
+	if (!value) return;
+	container.addChild(new Spacer(1));
+	container.addChild(new Text(uiTheme.fg("accent", uiTheme.bold(label)), 0, 0));
+	container.addChild(
+		new Markdown(value, 2, 0, getMarkdownTheme(), { color: (text: string) => uiTheme.fg("toolOutput", text) }),
+	);
+}
+
+function renderPipeSummary(title: string, value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	return (
+		value
+			.split("|")
+			.map(part => part.trim())
+			.filter(Boolean)
+			.map(part => `- ${part}`)
+			.join("\n") || title
+	);
+}
+
+function renderModel(model: DeepInterviewModel, uiTheme: Theme): Component {
+	const container = new Container();
+	if (model.kind === "round-question") {
+		const meta = [
+			`Round ${model.round}`,
+			model.ambiguity ? `Ambiguity ${model.ambiguity.replace(/%$/, "")}%` : undefined,
+		]
+			.filter(Boolean)
+			.join(" · ");
+		container.addChild(new Text(uiTheme.fg("toolTitle", uiTheme.bold(`Deep Interview · ${meta}`)), 0, 0));
+		addLabel(container, "Component", model.component, uiTheme);
+		addLabel(container, "Mode", model.mode, uiTheme);
+		addLabel(container, "Target", model.targeting, uiTheme);
+		addLabel(container, "Why now", model.whyNow, uiTheme);
+		addLabel(container, "Question", model.question, uiTheme);
+		return container;
+	}
+
+	if (model.kind === "topology-question") {
+		container.addChild(
+			new Text(uiTheme.fg("toolTitle", uiTheme.bold("Deep Interview · Round 0 · Topology confirmation")), 0, 0),
+		);
+		addLabel(container, "Ambiguity", "Not scored yet", uiTheme);
+		addLabel(container, "Reading", model.context, uiTheme);
+		if (model.components.length > 0) {
+			const components = model.components
+				.map((component, index) => `${index + 1}. **${component.name}**\n   ${component.description}`)
+				.join("\n\n");
+			addLabel(container, "Components", components, uiTheme);
+		}
+		addLabel(container, "Question", model.question, uiTheme);
+		return container;
+	}
+
+	if (model.kind === "progress") {
+		container.addChild(
+			new Text(uiTheme.fg("toolTitle", uiTheme.bold(`Deep Interview · Round ${model.round} complete`)), 0, 0),
+		);
+		addLabel(container, "Ambiguity", model.ambiguity, uiTheme);
+		if (model.dimensions.length > 0) {
+			container.addChild(new Spacer(1));
+			container.addChild(new Text(uiTheme.fg("accent", uiTheme.bold("Clarity")), 0, 0));
+			for (const dimension of model.dimensions) {
+				const body = [`Score ${dimension.score} · weight ${dimension.weight} · weighted ${dimension.weighted}`];
+				if (dimension.gap) body.push(/^clear$/i.test(dimension.gap) ? "Clear" : `Gap: ${dimension.gap}`);
+				addLabel(container, dimension.name, body.join("\n"), uiTheme);
+			}
+		}
+		addLabel(container, "Topology", renderPipeSummary("Topology", model.topology), uiTheme);
+		addLabel(container, "Ontology", renderPipeSummary("Ontology", model.ontology), uiTheme);
+		addLabel(container, "Next target", model.nextTarget, uiTheme);
+		addLabel(container, "Status", model.status, uiTheme);
+		addLabel(container, "Additional details", model.extra, uiTheme);
+		return container;
+	}
+
+	container.addChild(new Text(uiTheme.fg("toolTitle", uiTheme.bold("Deep Interview · Started")), 0, 0));
+	addLabel(container, "Threshold", `${model.threshold} · source: ${model.source}`, uiTheme);
+	addLabel(container, "Details", model.rest, uiTheme);
+	return container;
+}
+
+export function renderDeepInterviewAssistantText(text: string, uiTheme: Theme): Component | null {
+	const model = parseDeepInterview(text);
+	if (!model || model.kind === "round-question" || model.kind === "topology-question") return null;
+	return renderModel(model, uiTheme);
+}
+
+export function renderDeepInterviewAskQuestion(question: string, uiTheme: Theme): Component | null {
+	const model = parseTopologyQuestion(question) ?? parseRoundQuestion(question);
+	if (!model) return null;
+	return renderModel(model, uiTheme);
+}
+
+export function formatDeepInterviewSelectorPrompt(question: string): string | null {
+	const model = parseTopologyQuestion(question) ?? parseRoundQuestion(question);
+	if (!model) return null;
+	if (model.kind === "topology-question") {
+		const componentLines =
+			model.components.length > 0
+				? [
+						"Components:",
+						...model.components.map(
+							(component, index) => `${index + 1}. ${component.name} — ${component.description}`,
+						),
+					]
+				: [];
+		return [
+			"Deep Interview · Round 0 · Topology confirmation",
+			"Ambiguity: not scored yet",
+			model.context ? `Reading:\n${model.context}` : undefined,
+			...componentLines,
+			model.question ? `Question:\n${model.question}` : undefined,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join("\n\n");
+	}
+	return [
+		`Deep Interview · Round ${model.round}${model.ambiguity ? ` · Ambiguity ${model.ambiguity.replace(/%$/, "")}%` : ""}`,
+		model.component ? `Component: ${model.component}` : undefined,
+		model.mode ? `Mode: ${model.mode}` : undefined,
+		model.targeting ? `Target: ${model.targeting}` : undefined,
+		model.whyNow ? `Why now: ${model.whyNow}` : undefined,
+		model.question,
+	]
+		.filter((line): line is string => Boolean(line))
+		.join("\n");
+}

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, ImageContent, Usage } from "@gajae-code/ai";
 import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@gajae-code/tui";
 import { formatNumber } from "@gajae-code/utils";
 import { settings } from "../../config/settings";
+import { renderDeepInterviewAssistantText } from "../../deep-interview/render-middleware";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { isSilentAbort } from "../../session/messages";
 import { resolveImageOptions } from "../../tools/render-utils";
@@ -153,7 +154,10 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.#contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, getMarkdownTheme()));
+				const text = content.text.trim();
+				this.#contentContainer.addChild(
+					renderDeepInterviewAssistantText(text, theme) ?? new Markdown(text, 1, 0, getMarkdownTheme()),
+				);
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -28,6 +28,7 @@ import {
 } from "@gajae-code/tui";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { formatDeepInterviewSelectorPrompt, renderDeepInterviewAskQuestion } from "../deep-interview/render-middleware";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { getMarkdownTheme, type Theme, theme } from "../modes/theme/theme";
 import askDescription from "../prompts/tools/ask.md" with { type: "text" };
@@ -454,9 +455,10 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		) => {
 			const optionLabels = q.options.map(o => o.label);
 			try {
+				const displayQuestion = formatDeepInterviewSelectorPrompt(q.question) ?? q.question;
 				const { selectedOptions, customInput, navigation, cancelled, timedOut } = await askSingleQuestion(
 					ui,
-					q.question,
+					displayQuestion,
 					optionLabels,
 					q.multi ?? false,
 					{
@@ -659,7 +661,10 @@ export const askToolRenderer = {
 				container.addChild(
 					new Text(` ${uiTheme.fg("dim", qBranch)} ${uiTheme.fg("dim", `[${q.id}]`)}${metaStr}`, 0, 0),
 				);
-				container.addChild(new Markdown(q.question, 3, 0, mdTheme, accentStyle));
+				container.addChild(
+					renderDeepInterviewAskQuestion(q.question, uiTheme) ??
+						new Markdown(q.question, 3, 0, mdTheme, accentStyle),
+				);
 
 				const qOptions = q.options;
 				if (qOptions?.length) {
@@ -688,7 +693,10 @@ export const askToolRenderer = {
 		if (args.multi) meta.push("multi");
 		if (args.options?.length) meta.push(`options:${args.options.length}`);
 		container.addChild(new Text(`${label}${formatMeta(meta, uiTheme)}`, 0, 0));
-		container.addChild(new Markdown(args.question, 1, 0, mdTheme, accentStyle));
+		container.addChild(
+			renderDeepInterviewAskQuestion(args.question, uiTheme) ??
+				new Markdown(args.question, 1, 0, mdTheme, accentStyle),
+		);
 
 		const options = args.options;
 		if (options?.length) {
@@ -752,7 +760,10 @@ export const askToolRenderer = {
 				container.addChild(
 					new Text(` ${uiTheme.fg("dim", branch)} ${statusIcon} ${uiTheme.fg("dim", `[${r.id}]`)}`, 0, 0),
 				);
-				container.addChild(new Markdown(r.question, 3, 0, mdTheme, accentStyle));
+				container.addChild(
+					renderDeepInterviewAskQuestion(r.question, uiTheme) ??
+						new Markdown(r.question, 3, 0, mdTheme, accentStyle),
+				);
 
 				const answerLines: string[] = [];
 				for (let j = 0; j < r.selectedOptions.length; j++) {
@@ -795,7 +806,10 @@ export const askToolRenderer = {
 		const header = renderStatusLine({ icon: hasSelection ? "success" : "warning", title: "Ask" }, uiTheme);
 		const container = new Container();
 		container.addChild(new Text(header, 0, 0));
-		container.addChild(new Markdown(details.question, 1, 0, mdTheme, accentStyle));
+		container.addChild(
+			renderDeepInterviewAskQuestion(details.question, uiTheme) ??
+				new Markdown(details.question, 1, 0, mdTheme, accentStyle),
+		);
 
 		const answerLines: string[] = [];
 		if (details.selectedOptions && details.selectedOptions.length > 0) {

--- a/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
+++ b/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function renderAssistantText(text: string): string {
+	const component = new AssistantMessageComponent(createAssistantMessage(text));
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+	await Settings.init({ inMemory: true });
+});
+
+describe("deep-interview assistant render middleware", () => {
+	it("renders progress tables as readable sections", () => {
+		const raw = [
+			"Round 3 complete.",
+			"",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.80 | 0.40 | 0.32 | Clear |",
+			"| Constraints | 0.65 | 0.30 | 0.20 | Mobile/Desktop boundaries are still unresolved |",
+			"| Success Criteria | 0.55 | 0.30 | 0.17 | Approval completion criteria are not yet testable |",
+			"| **Ambiguity** | | | **38%** | |",
+			"",
+			"**Topology:** Targeted Review UI | Active: 4 | Deferred: 0 | Next rotation after: review-ui",
+			"**Ontology:** 6 entities | Stability: 75% | New: 1 | Changed: 0 | Stable: 5",
+			"**Next target:** Review UI / Success Criteria — approval criteria remain unclear",
+		].join("\n");
+
+		const rendered = renderAssistantText(raw);
+
+		expect(rendered).toContain("Deep Interview · Round 3 complete");
+		expect(rendered).toContain("Ambiguity");
+		expect(rendered).toContain("38%");
+		expect(rendered).toContain("Constraints");
+		expect(rendered).toContain("Gap: Mobile/Desktop boundaries are still unresolved");
+		expect(rendered).toContain("Next target");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("| Dimension | Score | Weight | Weighted | Gap |");
+	});
+
+	it("preserves unstructured progress lines instead of dropping them", () => {
+		const raw = [
+			"Round 4 complete.",
+			"",
+			"Matched entities: User→User, Task→Task",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.90 | 0.40 | 0.36 | Clear |",
+			"| Constraints | 0.70 | 0.30 | 0.21 | Export limits still need clarification |",
+			"| Success Criteria | 0.60 | 0.30 | 0.18 | Approval evidence is not fully testable |",
+			"| **Ambiguity** | | | **25%** | |",
+			"",
+			"Clarity threshold met! Ready to proceed.",
+		].join("\n");
+
+		const rendered = renderAssistantText(raw);
+
+		expect(rendered).toContain("Additional details");
+		expect(rendered).toContain("Matched entities: User→User, Task→Task");
+		expect(rendered).toContain("Status");
+		expect(rendered).toContain("Clarity threshold met! Ready to proceed.");
+	});
+});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1029,3 +1029,115 @@ describe("AskTool multi-question navigation", () => {
 		expect(editor).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("AskTool deep-interview rendering middleware", () => {
+	it("uses a readable selector prompt while preserving raw question details", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 3 | Component: Review UI | Targeting: Success Criteria | Why now: the approval criteria are not yet testable | Ambiguity: 38%",
+			"",
+			"What exact conditions must be satisfied before a reviewer can approve an item?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		const result = await tool.execute(
+			"call-deep-interview",
+			{
+				questions: [
+					{
+						id: "round-3",
+						question: rawQuestion,
+						options: [{ label: "Condition A" }, { label: "Condition B" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(select).toHaveBeenCalledTimes(1);
+		const prompt = select.mock.calls[0]?.[0] ?? "";
+		expect(prompt).toContain("Deep Interview · Round 3 · Ambiguity 38%");
+		expect(prompt).toContain("Component: Review UI");
+		expect(prompt).toContain("Target: Success Criteria");
+		expect(prompt).toContain("Why now: the approval criteria are not yet testable");
+		expect(prompt).toContain("What exact conditions must be satisfied before a reviewer can approve an item?");
+		expect(result.details?.question).toBe(rawQuestion);
+	});
+
+	it("recognizes topology questions even when the agent prepends an intro", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Starting deep interview. I'll show a clarity score after each answer.",
+			"",
+			'**Your idea:** "Refresh the GJC UX"',
+			"**Project type:** brownfield",
+			"",
+			"Round 0 | Topology confirmation | Ambiguity: not scored yet",
+			"",
+			"I'm currently reading the scope as these 2 top-level components.",
+			"1. Brand and theme system: red-claw/GJC default theme and semantic color separation.",
+			"2. Tool card UX: readability of ask/approval cards and tool output styling.",
+			"",
+			"Is that topology right? Should any component be added, removed, merged, split, or explicitly deferred?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-deep-interview-topology",
+			{
+				questions: [
+					{
+						id: "round-0",
+						question: rawQuestion,
+						options: [{ label: "Looks right" }, { label: "Revise it" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const prompt = select.mock.calls[0]?.[0] ?? "";
+		expect(prompt).toContain("Deep Interview · Round 0 · Topology confirmation");
+		expect(prompt).toContain("Ambiguity: not scored yet");
+		expect(prompt).toContain("Reading:");
+		expect(prompt).toContain("I'm currently reading the scope as these 2 top-level components.");
+		expect(prompt).toContain("1. Brand and theme system — red-claw/GJC default theme and semantic color separation.");
+		expect(prompt).toContain("Question:");
+		expect(prompt).not.toContain("Context:");
+		expect(prompt).not.toContain('**Your idea:** "Refresh the GJC UX"');
+		expect(prompt).not.toContain("Round 0 | Topology confirmation");
+	});
+
+	it("renders round questions as structured cards in history", async () => {
+		const theme = await getThemeByName("red-claw");
+		expect(theme).toBeDefined();
+		const rawQuestion = [
+			"Round 2 | Component: Export | Targeting: Constraints | Why now: output boundaries are unclear | Ambiguity: 42%",
+			"",
+			"Which export formats are in scope?",
+		].join("\n");
+
+		const rendered = askToolRenderer.renderCall(
+			{
+				question: rawQuestion,
+				options: [{ label: "CSV" }, { label: "PDF" }],
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+		);
+		const renderedText = stripAnsi(rendered.render(100).join("\n"));
+
+		expect(renderedText).toContain("Deep Interview · Round 2 · Ambiguity 42%");
+		expect(renderedText).toContain("Component");
+		expect(renderedText).toContain("Export");
+		expect(renderedText).toContain("Why now");
+		expect(renderedText).toContain("Question");
+		expect(renderedText).not.toContain("Round 2 | Component:");
+	});
+});


### PR DESCRIPTION
## Summary
- Add a display-only deep-interview render middleware for threshold, Round 0 topology, round questions, and progress reports
- Route ask selector/history and assistant progress text through the middleware while preserving raw question/details payloads
- Add regression tests for selector formatting, structured ask cards, progress table rendering, and unstructured progress line preservation

## Verification
- bun test packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
- bun run check (packages/coding-agent)