### PR TITLE
feat(models): upgrade defaults to Claude Opus 4.8 and GPT-5.5

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -4,6 +4,8 @@
 const COPILOT_PREMIUM_MULTIPLIERS: Record<string, number> = {
 	"github-copilot/claude-haiku-4.5": 0.33,
 	"github-copilot/claude-opus-4.6": 3,
+	"github-copilot/claude-opus-4.7": 3,
+	"github-copilot/claude-opus-4.8": 3,
 	"github-copilot/gpt-4o": 0,
 	"github-copilot/gpt-5.4-mini": 0.33,
 	"github-copilot/grok-code-fast-1": 0.25,

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -50,9 +50,12 @@ const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> 
 
 const COPILOT_GENERATED_LIMITS: Record<string, { contextWindow: number; maxTokens: number }> = {
 	"claude-opus-4.6": { contextWindow: 168000, maxTokens: 32000 },
+	"claude-opus-4.7": { contextWindow: 168000, maxTokens: 32000 },
+	"claude-opus-4.8": { contextWindow: 168000, maxTokens: 32000 },
 	"gpt-5.2": { contextWindow: 272000, maxTokens: 128000 },
 	"gpt-5.4": { contextWindow: 272000, maxTokens: 128000 },
 	"gpt-5.4-mini": { contextWindow: 272000, maxTokens: 128000 },
+	"gpt-5.5": { contextWindow: 272000, maxTokens: 128000 },
 	"grok-code-fast-1": { contextWindow: 192000, maxTokens: 64000 },
 };
 
@@ -307,9 +310,13 @@ export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 }
 
 /**
- * Returns true for Anthropic models with Opus 4.7 API restrictions:
+ * Returns true for Anthropic Opus models 4.7+ that enforce the modern API
+ * restrictions:
  * - Sampling parameters (temperature/top_p/top_k) return 400 error
  * - Thinking content is omitted by default (needs display: "summarized")
+ *
+ * Applies to Opus 4.7, 4.8, and any future Opus 4.x release (the upstream
+ * Anthropic policy is "Opus 4.7+", inherited by all later 4.x models).
  */
 export function hasOpus47ApiRestrictions(modelId: string): boolean {
 	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -458,6 +458,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic.claude-opus-4-8": {
+			"id": "anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Anthropic Haiku 4.5 (AU)",
@@ -497,6 +522,31 @@
 			"cost": {
 				"input": 16.5,
 				"output": 82.5,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"au.anthropic.claude-opus-4-8": {
+			"id": "au.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
@@ -920,8 +970,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
+				"input": 5.5,
+				"output": 27.5,
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
@@ -945,10 +995,35 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"eu.anthropic.claude-opus-4-8": {
+			"id": "eu.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1020,10 +1095,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
+				"input": 3.3,
+				"output": 16.5,
+				"cacheRead": 0.33,
+				"cacheWrite": 4.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
@@ -1055,7 +1130,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Anthropic Haiku 4.5 (Global)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1153,6 +1228,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"global.anthropic.claude-opus-4-8": {
+			"id": "global.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Anthropic Sonnet 4 (Global)",
@@ -1180,7 +1280,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Anthropic Sonnet 4.5 (Global)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1205,7 +1305,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6",
+			"name": "Anthropic Sonnet 4.6 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1271,6 +1371,31 @@
 		"jp.anthropic.claude-opus-4-7": {
 			"id": "jp.anthropic.claude-opus-4-7",
 			"name": "Anthropic Opus 4.7 (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"jp.anthropic.claude-opus-4-8": {
+			"id": "jp.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (JP)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -2281,6 +2406,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"us.anthropic.claude-opus-4-8": {
+			"id": "us.anthropic.claude-opus-4-8",
+			"name": "Anthropic Opus 4.8 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"us.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Anthropic Sonnet 4 (US)",
@@ -2949,6 +3099,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",
@@ -3445,6 +3620,31 @@
 		"anthropic/claude-opus-4-7": {
 			"id": "anthropic/claude-opus-4-7",
 			"name": "Anthropic Opus 4.7",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-opus-4-8": {
+			"id": "anthropic/claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
 			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
@@ -5329,7 +5529,7 @@
 	"github-copilot": {
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5339,13 +5539,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
-			"contextWindow": 144000,
-			"maxTokens": 32000,
+			"contextWindow": 200000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5358,7 +5558,7 @@
 		},
 		"claude-opus-4.5": {
 			"id": "claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5368,12 +5568,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 160000,
+			"contextWindow": 200000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5396,10 +5596,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 168000,
 			"maxTokens": 32000,
@@ -5425,25 +5625,26 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 144000,
-			"maxTokens": 64000,
+			"contextWindow": 168000,
+			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
+			"premiumMultiplier": 3,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
 		},
-		"claude-sonnet-4": {
-			"id": "claude-sonnet-4",
-			"name": "Anthropic Sonnet 4",
+		"claude-opus-4.8": {
+			"id": "claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5453,10 +5654,39 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 168000,
+			"maxTokens": 32000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"premiumMultiplier": 3,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"claude-sonnet-4": {
+			"id": "claude-sonnet-4",
+			"name": "Anthropic Sonnet 4 (latest)",
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 216000,
 			"maxTokens": 16000,
@@ -5471,7 +5701,7 @@
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5481,12 +5711,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
-			"contextWindow": 144000,
+			"contextWindow": 200000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5509,10 +5739,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5531,15 +5761,15 @@
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5551,11 +5781,16 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
-			"name": "Gemini 3 Flash",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5565,9 +5800,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 3,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5635,12 +5870,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5672,12 +5907,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5705,9 +5940,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5780,7 +6015,7 @@
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
-			"name": "GPT-5-mini",
+			"name": "GPT-5 Mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5790,9 +6025,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 264000,
@@ -5930,9 +6165,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -5948,7 +6183,7 @@
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
-			"name": "GPT-5.2-OpenAI code",
+			"name": "GPT-5.2 OpenAI code",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5958,9 +6193,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -5976,7 +6211,7 @@
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
-			"name": "GPT-5.3-OpenAI code",
+			"name": "GPT-5.3 OpenAI code",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5986,9 +6221,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6014,9 +6249,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6032,7 +6267,7 @@
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6042,9 +6277,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6053,6 +6288,34 @@
 				"User-Agent": "opencode/1.3.15"
 			},
 			"premiumMultiplier": 0.33,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4-nano": {
+			"id": "gpt-5.4-nano",
+			"name": "GPT-5.4 nano",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 1.25,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -6071,12 +6334,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -6115,6 +6378,39 @@
 				"supportsReasoningEffort": false
 			},
 			"premiumMultiplier": 0.25,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"raptor-mini": {
+			"id": "raptor-mini",
+			"name": "Raptor mini",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -6376,6 +6672,56 @@
 		"duo-chat-opus-4-6": {
 			"id": "duo-chat-opus-4-6",
 			"name": "Duo Chat Opus 4.6",
+			"api": "anthropic-messages",
+			"provider": "gitlab-duo",
+			"baseUrl": "https://cloud.gitlab.com/ai/v1/proxy/anthropic/",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"duo-chat-opus-4-7": {
+			"id": "duo-chat-opus-4-7",
+			"name": "Duo Chat Opus 4.7",
+			"api": "anthropic-messages",
+			"provider": "gitlab-duo",
+			"baseUrl": "https://cloud.gitlab.com/ai/v1/proxy/anthropic/",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"duo-chat-opus-4-8": {
+			"id": "duo-chat-opus-4-8",
+			"name": "Duo Chat Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "gitlab-duo",
 			"baseUrl": "https://cloud.gitlab.com/ai/v1/proxy/anthropic/",
@@ -8452,7 +8798,7 @@
 			"cost": {
 				"input": 1,
 				"output": 3,
-				"cacheRead": 0,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -8471,7 +8817,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -8495,7 +8841,7 @@
 			"cost": {
 				"input": 0.075,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.0375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -8580,6 +8926,367 @@
 		}
 	},
 	"huggingface": {
+		"aisingapore/Gemma-SEA-LION-v4-27B-IT": {
+			"id": "aisingapore/Gemma-SEA-LION-v4-27B-IT",
+			"name": "aisingapore/Gemma-SEA-LION-v4-27B-IT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"aisingapore/Qwen-SEA-LION-v4-32B-IT": {
+			"id": "aisingapore/Qwen-SEA-LION-v4-32B-IT",
+			"name": "aisingapore/Qwen-SEA-LION-v4-32B-IT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"allenai/Olmo-3-7B-Instruct": {
+			"id": "allenai/Olmo-3-7B-Instruct",
+			"name": "allenai/Olmo-3-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"alpindale/WizardLM-2-8x22B": {
+			"id": "alpindale/WizardLM-2-8x22B",
+			"name": "alpindale/WizardLM-2-8x22B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"baidu/ERNIE-4.5-VL-424B-A47B-Base-PT": {
+			"id": "baidu/ERNIE-4.5-VL-424B-A47B-Base-PT",
+			"name": "baidu/ERNIE-4.5-VL-424B-A47B-Base-PT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/aya-expanse-32b": {
+			"id": "CohereLabs/aya-expanse-32b",
+			"name": "CohereLabs/aya-expanse-32b",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/aya-vision-32b": {
+			"id": "CohereLabs/aya-vision-32b",
+			"name": "CohereLabs/aya-vision-32b",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/c4ai-command-a-03-2025": {
+			"id": "CohereLabs/c4ai-command-a-03-2025",
+			"name": "CohereLabs/c4ai-command-a-03-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/c4ai-command-r-08-2024": {
+			"id": "CohereLabs/c4ai-command-r-08-2024",
+			"name": "CohereLabs/c4ai-command-r-08-2024",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/c4ai-command-r7b-arabic-02-2025": {
+			"id": "CohereLabs/c4ai-command-r7b-arabic-02-2025",
+			"name": "CohereLabs/c4ai-command-r7b-arabic-02-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/command-a-reasoning-08-2025": {
+			"id": "CohereLabs/command-a-reasoning-08-2025",
+			"name": "CohereLabs/command-a-reasoning-08-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/command-a-translate-08-2025": {
+			"id": "CohereLabs/command-a-translate-08-2025",
+			"name": "CohereLabs/command-a-translate-08-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/command-a-vision-07-2025": {
+			"id": "CohereLabs/command-a-vision-07-2025",
+			"name": "CohereLabs/command-a-vision-07-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/tiny-aya-earth": {
+			"id": "CohereLabs/tiny-aya-earth",
+			"name": "CohereLabs/tiny-aya-earth",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/tiny-aya-global": {
+			"id": "CohereLabs/tiny-aya-global",
+			"name": "CohereLabs/tiny-aya-global",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"CohereLabs/tiny-aya-water": {
+			"id": "CohereLabs/tiny-aya-water",
+			"name": "CohereLabs/tiny-aya-water",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepcogito/cogito-671b-v2.1": {
+			"id": "deepcogito/cogito-671b-v2.1",
+			"name": "deepcogito/cogito-671b-v2.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepcogito/cogito-671b-v2.1-FP8": {
+			"id": "deepcogito/cogito-671b-v2.1-FP8",
+			"name": "deepcogito/cogito-671b-v2.1-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-Prover-V2-671B": {
+			"id": "deepseek-ai/DeepSeek-Prover-V2-671B",
+			"name": "deepseek-ai/DeepSeek-Prover-V2-671B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek-ai/DeepSeek-R1": {
 			"id": "deepseek-ai/DeepSeek-R1",
 			"name": "DeepSeek R1",
@@ -8604,6 +9311,158 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek-ai/DeepSeek-R1-0528": {
+			"id": "deepseek-ai/DeepSeek-R1-0528",
+			"name": "deepseek-ai/DeepSeek-R1-0528",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Llama-8B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Qwen-7B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V3": {
+			"id": "deepseek-ai/DeepSeek-V3",
+			"name": "deepseek-ai/DeepSeek-V3",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V3-0324": {
+			"id": "deepseek-ai/DeepSeek-V3-0324",
+			"name": "deepseek-ai/DeepSeek-V3-0324",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek-ai/DeepSeek-V3.1": {
 			"id": "deepseek-ai/DeepSeek-V3.1",
 			"name": "DeepSeek V3.1",
@@ -8623,6 +9482,316 @@
 			"contextWindow": 131072,
 			"maxTokens": 8192
 		},
+		"deepseek-ai/DeepSeek-V3.1-Terminus": {
+			"id": "deepseek-ai/DeepSeek-V3.1-Terminus",
+			"name": "deepseek-ai/DeepSeek-V3.1-Terminus",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V3.2": {
+			"id": "deepseek-ai/DeepSeek-V3.2",
+			"name": "deepseek-ai/DeepSeek-V3.2",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V3.2-Exp": {
+			"id": "deepseek-ai/DeepSeek-V3.2-Exp",
+			"name": "deepseek-ai/DeepSeek-V3.2-Exp",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V4-Flash": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash",
+			"name": "deepseek-ai/DeepSeek-V4-Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"deepseek-ai/DeepSeek-V4-Pro": {
+			"id": "deepseek-ai/DeepSeek-V4-Pro",
+			"name": "deepseek-ai/DeepSeek-V4-Pro",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"EssentialAI/rnj-1-instruct": {
+			"id": "EssentialAI/rnj-1-instruct",
+			"name": "EssentialAI/rnj-1-instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"google/gemma-3-27b-it": {
+			"id": "google/gemma-3-27b-it",
+			"name": "Gemma-3-27B-IT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"google/gemma-3n-E4B-it": {
+			"id": "google/gemma-3n-E4B-it",
+			"name": "google/gemma-3n-E4B-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"google/gemma-4-26B-A4B-it": {
+			"id": "google/gemma-4-26B-A4B-it",
+			"name": "google/gemma-4-26B-A4B-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"google/gemma-4-31B-it": {
+			"id": "google/gemma-4-31B-it",
+			"name": "google/gemma-4-31B-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"inclusionAI/Ling-2.6-1T": {
+			"id": "inclusionAI/Ling-2.6-1T",
+			"name": "inclusionAI/Ling-2.6-1T",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"katanemo/Arch-Router-1.5B": {
+			"id": "katanemo/Arch-Router-1.5B",
+			"name": "katanemo/Arch-Router-1.5B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Llama-3.1-70B-Instruct": {
+			"id": "meta-llama/Llama-3.1-70B-Instruct",
+			"name": "meta-llama/Llama-3.1-70B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Llama-3.1-8B-Instruct": {
+			"id": "meta-llama/Llama-3.1-8B-Instruct",
+			"name": "meta-llama/Llama-3.1-8B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Llama-3.2-1B-Instruct": {
+			"id": "meta-llama/Llama-3.2-1B-Instruct",
+			"name": "meta-llama/Llama-3.2-1B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Llama-3.3-70B-Instruct": {
+			"id": "meta-llama/Llama-3.3-70B-Instruct",
+			"name": "meta-llama/Llama-3.3-70B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 			"name": "Llama 3.3 70B Instruct Turbo",
@@ -8641,6 +9810,291 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192
+		},
+		"meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+			"id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+			"name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Llama-Guard-4-12B": {
+			"id": "meta-llama/Llama-Guard-4-12B",
+			"name": "meta-llama/Llama-Guard-4-12B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Meta-Llama-3-70B-Instruct": {
+			"id": "meta-llama/Meta-Llama-3-70B-Instruct",
+			"name": "meta-llama/Meta-Llama-3-70B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"meta-llama/Meta-Llama-3-8B-Instruct": {
+			"id": "meta-llama/Meta-Llama-3-8B-Instruct",
+			"name": "meta-llama/Meta-Llama-3-8B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"MiniMaxAI/MiniMax-M1-80k": {
+			"id": "MiniMaxAI/MiniMax-M1-80k",
+			"name": "MiniMaxAI/MiniMax-M1-80k",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"MiniMaxAI/MiniMax-M2": {
+			"id": "MiniMaxAI/MiniMax-M2",
+			"name": "MiniMaxAI/MiniMax-M2",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"MiniMaxAI/MiniMax-M2.1": {
+			"id": "MiniMaxAI/MiniMax-M2.1",
+			"name": "MiniMaxAI/MiniMax-M2.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"MiniMaxAI/MiniMax-M2.5": {
+			"id": "MiniMaxAI/MiniMax-M2.5",
+			"name": "MiniMaxAI/MiniMax-M2.5",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"MiniMaxAI/MiniMax-M2.7": {
+			"id": "MiniMaxAI/MiniMax-M2.7",
+			"name": "MiniMaxAI/MiniMax-M2.7",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"moonshotai/Kimi-K2-Instruct": {
+			"id": "moonshotai/Kimi-K2-Instruct",
+			"name": "moonshotai/Kimi-K2-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"moonshotai/Kimi-K2-Instruct-0905": {
+			"id": "moonshotai/Kimi-K2-Instruct-0905",
+			"name": "moonshotai/Kimi-K2-Instruct-0905",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"moonshotai/Kimi-K2-Thinking": {
+			"id": "moonshotai/Kimi-K2-Thinking",
+			"name": "moonshotai/Kimi-K2-Thinking",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"moonshotai/Kimi-K2.5": {
+			"id": "moonshotai/Kimi-K2.5",
+			"name": "moonshotai/Kimi-K2.5",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"moonshotai/Kimi-K2.6": {
+			"id": "moonshotai/Kimi-K2.6",
+			"name": "moonshotai/Kimi-K2.6",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"NousResearch/Hermes-2-Pro-Llama-3-8B": {
+			"id": "NousResearch/Hermes-2-Pro-Llama-3-8B",
+			"name": "NousResearch/Hermes-2-Pro-Llama-3-8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -8665,6 +10119,1156 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"openai/gpt-oss-20b": {
+			"id": "openai/gpt-oss-20b",
+			"name": "GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-oss-safeguard-20b": {
+			"id": "openai/gpt-oss-safeguard-20b",
+			"name": "Safety GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"pearl-ai/Gemma-4-31B-it-pearl": {
+			"id": "pearl-ai/Gemma-4-31B-it-pearl",
+			"name": "pearl-ai/Gemma-4-31B-it-pearl",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-72B-Instruct": {
+			"id": "Qwen/Qwen2.5-72B-Instruct",
+			"name": "Qwen/Qwen2.5-72B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-7B-Instruct": {
+			"id": "Qwen/Qwen2.5-7B-Instruct",
+			"name": "Qwen/Qwen2.5-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-Coder-32B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-32B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-Coder-3B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-3B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-Coder-7B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-7B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen2.5-VL-72B-Instruct": {
+			"id": "Qwen/Qwen2.5-VL-72B-Instruct",
+			"name": "Qwen/Qwen2.5-VL-72B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-14B": {
+			"id": "Qwen/Qwen3-14B",
+			"name": "Qwen/Qwen3-14B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-235B-A22B": {
+			"id": "Qwen/Qwen3-235B-A22B",
+			"name": "Qwen/Qwen3-235B-A22B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
+			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+			"name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
+			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+			"name": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-32B": {
+			"id": "Qwen/Qwen3-32B",
+			"name": "Qwen/Qwen3-32B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-4B-Instruct-2507": {
+			"id": "Qwen/Qwen3-4B-Instruct-2507",
+			"name": "Qwen/Qwen3-4B-Instruct-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-4B-Thinking-2507": {
+			"id": "Qwen/Qwen3-4B-Thinking-2507",
+			"name": "Qwen/Qwen3-4B-Thinking-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-8B": {
+			"id": "Qwen/Qwen3-8B",
+			"name": "Qwen/Qwen3-8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Coder-30B-A3B-Instruct": {
+			"id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+			"name": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+			"name": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+			"name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Coder-Next": {
+			"id": "Qwen/Qwen3-Coder-Next",
+			"name": "Qwen/Qwen3-Coder-Next",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Next-80B-A3B-Instruct": {
+			"id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+			"name": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-Next-80B-A3B-Thinking": {
+			"id": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+			"name": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
+			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-VL-235B-A22B-Thinking": {
+			"id": "Qwen/Qwen3-VL-235B-A22B-Thinking",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Thinking",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-VL-30B-A3B-Instruct": {
+			"id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+			"name": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-VL-30B-A3B-Thinking": {
+			"id": "Qwen/Qwen3-VL-30B-A3B-Thinking",
+			"name": "Qwen/Qwen3-VL-30B-A3B-Thinking",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3-VL-8B-Instruct": {
+			"id": "Qwen/Qwen3-VL-8B-Instruct",
+			"name": "Qwen/Qwen3-VL-8B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.5-122B-A10B": {
+			"id": "Qwen/Qwen3.5-122B-A10B",
+			"name": "Qwen/Qwen3.5-122B-A10B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.5-27B": {
+			"id": "Qwen/Qwen3.5-27B",
+			"name": "Qwen/Qwen3.5-27B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.5-35B-A3B": {
+			"id": "Qwen/Qwen3.5-35B-A3B",
+			"name": "Qwen/Qwen3.5-35B-A3B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.5-397B-A17B": {
+			"id": "Qwen/Qwen3.5-397B-A17B",
+			"name": "Qwen/Qwen3.5-397B-A17B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.5-9B": {
+			"id": "Qwen/Qwen3.5-9B",
+			"name": "Qwen/Qwen3.5-9B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.6-27B": {
+			"id": "Qwen/Qwen3.6-27B",
+			"name": "Qwen/Qwen3.6-27B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/Qwen3.6-35B-A3B": {
+			"id": "Qwen/Qwen3.6-35B-A3B",
+			"name": "Qwen/Qwen3.6-35B-A3B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Qwen/QwQ-32B": {
+			"id": "Qwen/QwQ-32B",
+			"name": "Qwen/QwQ-32B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Sao10K/L3-70B-Euryale-v2.1": {
+			"id": "Sao10K/L3-70B-Euryale-v2.1",
+			"name": "Sao10K/L3-70B-Euryale-v2.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Sao10K/L3-8B-Lunaris-v1": {
+			"id": "Sao10K/L3-8B-Lunaris-v1",
+			"name": "Sao10K/L3-8B-Lunaris-v1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"Sao10K/L3-8B-Stheno-v3.2": {
+			"id": "Sao10K/L3-8B-Stheno-v3.2",
+			"name": "Sao10K/L3-8B-Stheno-v3.2",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun-ai/Step-3.5-Flash": {
+			"id": "stepfun-ai/Step-3.5-Flash",
+			"name": "stepfun-ai/Step-3.5-Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"swiss-ai/Apertus-70B-Instruct-2509": {
+			"id": "swiss-ai/Apertus-70B-Instruct-2509",
+			"name": "swiss-ai/Apertus-70B-Instruct-2509",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"swiss-ai/Apertus-8B-Instruct-2509": {
+			"id": "swiss-ai/Apertus-8B-Instruct-2509",
+			"name": "swiss-ai/Apertus-8B-Instruct-2509",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"utter-project/EuroLLM-22B-Instruct-2512": {
+			"id": "utter-project/EuroLLM-22B-Instruct-2512",
+			"name": "utter-project/EuroLLM-22B-Instruct-2512",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/AutoGLM-Phone-9B-Multilingual": {
+			"id": "zai-org/AutoGLM-Phone-9B-Multilingual",
+			"name": "zai-org/AutoGLM-Phone-9B-Multilingual",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4-32B-0414": {
+			"id": "zai-org/GLM-4-32B-0414",
+			"name": "zai-org/GLM-4-32B-0414",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.5": {
+			"id": "zai-org/GLM-4.5",
+			"name": "zai-org/GLM-4.5",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.5-Air": {
+			"id": "zai-org/GLM-4.5-Air",
+			"name": "zai-org/GLM-4.5-Air",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.5V": {
+			"id": "zai-org/GLM-4.5V",
+			"name": "zai-org/GLM-4.5V",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.5V-FP8": {
+			"id": "zai-org/GLM-4.5V-FP8",
+			"name": "zai-org/GLM-4.5V-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.6": {
+			"id": "zai-org/GLM-4.6",
+			"name": "zai-org/GLM-4.6",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.6-FP8": {
+			"id": "zai-org/GLM-4.6-FP8",
+			"name": "zai-org/GLM-4.6-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.6V": {
+			"id": "zai-org/GLM-4.6V",
+			"name": "zai-org/GLM-4.6V",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.6V-Flash": {
+			"id": "zai-org/GLM-4.6V-Flash",
+			"name": "zai-org/GLM-4.6V-Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.6V-FP8": {
+			"id": "zai-org/GLM-4.6V-FP8",
+			"name": "zai-org/GLM-4.6V-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.7": {
+			"id": "zai-org/GLM-4.7",
+			"name": "zai-org/GLM-4.7",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.7-Flash": {
+			"id": "zai-org/GLM-4.7-Flash",
+			"name": "zai-org/GLM-4.7-Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-4.7-FP8": {
+			"id": "zai-org/GLM-4.7-FP8",
+			"name": "zai-org/GLM-4.7-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-5": {
+			"id": "zai-org/GLM-5",
+			"name": "zai-org/GLM-5",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-5.1": {
+			"id": "zai-org/GLM-5.1",
+			"name": "zai-org/GLM-5.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"zai-org/GLM-5.1-FP8": {
+			"id": "zai-org/GLM-5.1-FP8",
+			"name": "zai-org/GLM-5.1-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		}
 	},
 	"kilo": {
@@ -9490,6 +12094,44 @@
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
 			"name": "Anthropic: Anthropic Opus 4.7 (Fast) ($$$$)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic: Anthropic Opus 4.8 (new)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"anthropic/claude-opus-4.8-fast": {
+			"id": "anthropic/claude-opus-4.8-fast",
+			"name": "Anthropic: Anthropic Opus 4.8 (Fast) ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10394,6 +13036,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek/deepseek-v4-flash:discounted": {
+			"id": "deepseek/deepseek-v4-flash:discounted",
+			"name": "DeepSeek: DeepSeek V4 Flash (>40% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
 			"name": "DeepSeek: DeepSeek V4 Flash (free)",
@@ -10436,6 +13097,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"deepseek/deepseek-v4-pro:discounted": {
+			"id": "deepseek/deepseek-v4-pro:discounted",
+			"name": "DeepSeek: DeepSeek V4 Pro (>80% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"eleutherai/llemma_7b": {
 			"id": "eleutherai/llemma_7b",
@@ -12179,6 +14859,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax: MiniMax M3 (new)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
 			"name": "Mistral: Codestral 2508",
@@ -12958,7 +15657,7 @@
 		},
 		"nex-agi/deepseek-v3.1-nex-n1": {
 			"id": "nex-agi/deepseek-v3.1-nex-n1",
-			"name": "Nex AGI: DeepSeek V3.1 Nex N1",
+			"name": "Nex AGI: DeepSeek V3.1 Nex N1 (retires Jun 8)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -12977,7 +15676,7 @@
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
-			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B",
+			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13372,7 +16071,7 @@
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
-			"name": "OpenAI: GPT-4 Turbo (older v1106)",
+			"name": "OpenAI: GPT-4 Turbo (older v1106) ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13411,7 +16110,7 @@
 		},
 		"openai/gpt-4-turbo-preview": {
 			"id": "openai/gpt-4-turbo-preview",
-			"name": "OpenAI: GPT-4 Turbo Preview",
+			"name": "OpenAI: GPT-4 Turbo Preview ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13748,7 +16447,7 @@
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
-			"name": "OpenAI: GPT-5 Image",
+			"name": "OpenAI: GPT-5 Image ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13824,7 +16523,7 @@
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
-			"name": "OpenAI: GPT-5 Pro",
+			"name": "OpenAI: GPT-5 Pro ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13982,7 +16681,7 @@
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
-			"name": "OpenAI: GPT-5.2 Chat",
+			"name": "OpenAI: GPT-5.2 Chat (retires Aug 10)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14469,7 +17168,7 @@
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
-			"name": "OpenAI: o3 Deep Research",
+			"name": "OpenAI: o3 Deep Research ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14696,6 +17395,25 @@
 		"openrouter/free": {
 			"id": "openrouter/free",
 			"name": "Free Models Router",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"openrouter/fusion": {
+			"id": "openrouter/fusion",
+			"name": "OpenRouter: Fusion",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15308,7 +18026,7 @@
 		},
 		"qwen/qwen3-30b-a3b": {
 			"id": "qwen/qwen3-30b-a3b",
-			"name": "Qwen: Qwen3 30B A3B",
+			"name": "Qwen: Qwen3 30B A3B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16060,6 +18778,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"qwen/qwen3.7-plus": {
+			"id": "qwen/qwen3.7-plus",
+			"name": "Qwen: Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
 			"name": "Qwen: QwQ 32B",
@@ -16195,7 +18932,7 @@
 		},
 		"sao10k/l3-euryale-70b": {
 			"id": "sao10k/l3-euryale-70b",
-			"name": "Sao10k: Llama 3 Euryale 70B v2.1",
+			"name": "Sao10k: Llama 3 Euryale 70B v2.1 (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16326,9 +19063,47 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"stealth/claude-opus-4.8": {
+			"id": "stealth/claude-opus-4.8",
+			"name": "Stealth: Anthropic Opus 4.8 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
 			"name": "Stealth: Anthropic Sonnet 4.6 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stealth/qwen3.6-plus": {
+			"id": "stealth/qwen3.6-plus",
+			"name": "Stealth: Qwen3.6 Plus (50% off)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16367,6 +19142,44 @@
 		"stepfun/step-3.5-flash:free": {
 			"id": "stepfun/step-3.5-flash:free",
 			"name": "StepFun: Step 3.5 Flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "StepFun: Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun/step-3.7-flash:free": {
+			"id": "stepfun/step-3.7-flash:free",
+			"name": "StepFun: Step 3.7 Flash (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34147,6 +36960,31 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "anthropic-messages",
+			"provider": "minimax",
+			"baseUrl": "https://api.minimax.io/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"minimax-cn": {
@@ -34312,6 +37150,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "anthropic-messages",
+			"provider": "minimax-cn",
+			"baseUrl": "https://api.minimaxi.com/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -34548,6 +37411,37 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "minimax-code",
+			"baseUrl": "https://api.minimax.io/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -34801,6 +37695,37 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "minimax-code-cn",
+			"baseUrl": "https://api.minimaxi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"mistral": {
@@ -34825,6 +37750,25 @@
 		},
 		"devstral-2512": {
 			"id": "devstral-2512",
+			"name": "Devstral 2",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
+		"devstral-latest": {
+			"id": "devstral-latest",
 			"name": "Devstral 2",
 			"api": "openai-completions",
 			"provider": "mistral",
@@ -35280,6 +38224,25 @@
 			},
 			"contextWindow": 8000,
 			"maxTokens": 8000
+		},
+		"open-mistral-nemo": {
+			"id": "open-mistral-nemo",
+			"name": "Open Mistral Nemo",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 128000
 		},
 		"open-mixtral-8x22b": {
 			"id": "open-mixtral-8x22b",
@@ -50948,6 +53911,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"stepfun-ai/step-3.7-flash": {
+			"id": "stepfun-ai/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
 			"name": "solar-10.7b-instruct",
@@ -52973,9 +55961,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.08,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -52997,9 +55985,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.2,
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0.0145,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -53054,6 +56042,31 @@
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -53303,6 +56316,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
 			"name": "Anthropic Sonnet 4",
@@ -53376,6 +56414,30 @@
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
 				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"deepseek-v4-flash-free": {
@@ -54267,6 +57329,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"mimo-v2.5-free": {
+			"id": "mimo-v2.5-free",
+			"name": "MiMo V2.5 Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"minimax-m2.1": {
 			"id": "minimax-m2.1",
 			"name": "MiniMax M2.1",
@@ -54643,13 +57730,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55189,6 +58276,56 @@
 				"maxLevel": "high"
 			}
 		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic: Anthropic Opus 4.8",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"anthropic/claude-opus-4.8-fast": {
+			"id": "anthropic/claude-opus-4.8-fast",
+			"name": "Anthropic: Anthropic Opus 4.8 (Fast)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Anthropic Sonnet 4",
@@ -55668,8 +58805,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2288,
-				"output": 0.9144,
+				"input": 0.20020000000000002,
+				"output": 0.8000999999999999,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -55831,13 +58968,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.252,
-				"output": 0.378,
+				"input": 0.2288,
+				"output": 0.3432,
 				"cacheRead": 0.0252,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55879,13 +59016,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.02,
+				"input": 0.0983,
+				"output": 0.1966,
+				"cacheRead": 0.019700000000000002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -57079,6 +60216,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax: MiniMax M3",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 512000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
 			"name": "Mistral: Codestral 2508",
@@ -57713,13 +60875,38 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"moonshotai/kimi-k2.6:free": {
+			"id": "moonshotai/kimi-k2.6:free",
+			"name": "MoonshotAI: Kimi K2.6 (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -58616,11 +61803,11 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 32000
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -58636,7 +61823,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -58686,11 +61873,11 @@
 			"cost": {
 				"input": 0.25,
 				"output": 2,
-				"cacheRead": 0.03,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 128000,
+			"maxTokens": 100000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "medium",
@@ -58740,7 +61927,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 32000
+			"maxTokens": 16384
 		},
 		"openai/gpt-5.2-codex": {
 			"id": "openai/gpt-5.2-codex",
@@ -59115,13 +62302,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
+				"input": 0.029,
 				"output": 0.14,
 				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -59876,13 +63063,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14950000000000002,
-				"output": 1.495,
-				"cacheRead": 0.055,
+				"input": 0.09999999999999999,
+				"output": 0.09999999999999999,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -59924,13 +63111,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
+				"input": 0.0428,
+				"output": 0.1716,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 131072,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -60512,13 +63699,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13899999999999998,
+				"input": 0.14,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61016,6 +64203,34 @@
 				"maxLevel": "high"
 			}
 		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "StepFun: Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 1.15,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"compat": {
+				"supportsToolChoice": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 preview",
@@ -61027,13 +64242,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06599999999999999,
-				"output": 0.26,
-				"cacheRead": 0.029,
+				"input": 0.063,
+				"output": 0.21,
+				"cacheRead": 0.020999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61660,8 +64875,8 @@
 			],
 			"cost": {
 				"input": 0.125,
-				"output": 0.84,
-				"cacheRead": 0.024999999999999998,
+				"output": 0.85,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -62760,6 +65975,56 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Anthropic Opus 4.8",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"claude-opus-4-8-fast": {
+			"id": "claude-opus-4-8-fast",
+			"name": "anthropic-opus-4-8-fast",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63975,6 +67240,34 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"mistral-31-24b": {
 			"id": "mistral-31-24b",
 			"name": "Venice Medium",
@@ -64411,6 +67704,28 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"qwen-3-7-plus": {
+			"id": "qwen-3-7-plus",
+			"name": "qwen-3-7-plus",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -64932,22 +68247,27 @@
 		},
 		"alibaba/qwen-3-235b": {
 			"id": "alibaba/qwen-3-235b",
-			"name": "Qwen3 235B A22b Instruct 2507",
+			"name": "Qwen3 235B A22B",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.2,
+				"input": 0.22,
+				"output": 0.88,
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 40000
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen-3-30b": {
 			"id": "alibaba/qwen-3-30b",
@@ -65053,7 +68373,7 @@
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -65064,7 +68384,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen3-coder-30b-a3b": {
 			"id": "alibaba/qwen3-coder-30b-a3b",
@@ -65189,6 +68514,49 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3-next-80b-a3b-instruct": {
+			"id": "alibaba/qwen3-next-80b-a3b-instruct",
+			"name": "Qwen3 Next 80B A3B Instruct",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768
+		},
+		"alibaba/qwen3-next-80b-a3b-thinking": {
+			"id": "alibaba/qwen3-next-80b-a3b-thinking",
+			"name": "Qwen3 Next 80B A3B Thinking",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -65338,6 +68706,31 @@
 				"cacheWrite": 1.5625
 			},
 			"contextWindow": 991000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3.7-plus": {
+			"id": "alibaba/qwen3.7-plus",
+			"name": "Qwen 3.7 Plus",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.08,
+				"cacheWrite": 0.5
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -65595,6 +68988,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Anthropic Sonnet 4",
@@ -65791,17 +69209,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.77,
-				"output": 0.77,
-				"cacheRead": 0,
+				"input": 0.27,
+				"output": 1.12,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 16384
+			"maxTokens": 163840
 		},
 		"deepseek/deepseek-v3.1": {
 			"id": "deepseek/deepseek-v3.1",
-			"name": "DeepSeek-V3.1",
+			"name": "DeepSeek V3.1",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -65879,7 +69297,8 @@
 			"provider": "vercel-ai-gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.62,
@@ -66262,19 +69681,24 @@
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.39999999999999997,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -66652,7 +70076,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.6,
@@ -66710,6 +70135,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131100,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -66873,6 +70323,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"mistral/mistral-nemo": {
+			"id": "mistral/mistral-nemo",
+			"name": "Mistral Nemo 12B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.02,
+				"output": 0.04,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"mistral/mistral-small": {
 			"id": "mistral/mistral-small",
@@ -67083,6 +70552,30 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 262000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3-super-120b-a12b": {
+			"id": "nvidia/nemotron-3-super-120b-a12b",
+			"name": "Nemotron 3 Super",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.65,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -67851,13 +71344,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.5,
-				"cacheRead": 0,
+				"input": 0.35,
+				"output": 0.75,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 131000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -68119,6 +71612,50 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"stepfun/step-3.5-flash": {
+			"id": "stepfun/step-3.5-flash",
+			"name": "Step 3.5 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.09,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0.02
+			},
+			"contextWindow": 262114,
+			"maxTokens": 262114
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 1.15,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -68962,7 +72499,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 1.4,

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -126,14 +126,14 @@ function catalogDescriptor(
  * OpenAI code provider) are handled separately because they require different config shapes.
  */
 export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
-	descriptor("anthropic", "claude-sonnet-4-6", config => anthropicModelManagerOptions(config)),
+	descriptor("anthropic", "claude-opus-4-8", config => anthropicModelManagerOptions(config)),
 	catalogDescriptor(
 		"alibaba-coding-plan",
 		"qwen3.5-plus",
 		config => alibabaCodingPlanModelManagerOptions(config),
 		catalog("Alibaba Coding Plan", ["ALIBABA_CODING_PLAN_API_KEY"]),
 	),
-	descriptor("openai", "gpt-5.4", config => openaiModelManagerOptions(config)),
+	descriptor("openai", "gpt-5.5", config => openaiModelManagerOptions(config)),
 	descriptor("groq", "openai/gpt-oss-120b", config => groqModelManagerOptions(config)),
 	catalogDescriptor(
 		"huggingface",
@@ -174,23 +174,23 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => nanoGptModelManagerOptions(config),
 		catalog("NanoGPT", ["NANO_GPT_API_KEY"]),
 	),
-	descriptor("opencode-zen", "claude-sonnet-4-6", config => opencodeZenModelManagerOptions(config)),
+	descriptor("opencode-zen", "claude-opus-4-8", config => opencodeZenModelManagerOptions(config)),
 	descriptor("opencode-go", "kimi-k2.5", config => opencodeGoModelManagerOptions(config)),
 	catalogDescriptor(
 		"openrouter",
-		"openai/gpt-5.4",
+		"openai/gpt-5.5",
 		config => openrouterModelManagerOptions(config),
 		catalog("OpenRouter", ["OPENROUTER_API_KEY"], { allowUnauthenticated: true }),
 	),
 	catalogDescriptor(
 		"kilo",
-		"anthropic/claude-sonnet-4.5",
+		"anthropic/claude-opus-4.8",
 		config => kiloModelManagerOptions(config),
 		catalog("Kilo Gateway", ["KILO_API_KEY"], { allowUnauthenticated: true }),
 	),
 	catalogDescriptor(
 		"vercel-ai-gateway",
-		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-opus-4.8",
 		config => vercelAiGatewayModelManagerOptions(config),
 		catalog("Vercel AI Gateway", ["VERCEL_AI_GATEWAY_API_KEY"], { allowUnauthenticated: true }),
 	),
@@ -209,7 +209,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 	),
 	catalogDescriptor(
 		"cloudflare-ai-gateway",
-		"claude-sonnet-4-5",
+		"anthropic/claude-opus-4-8",
 		config => cloudflareAiGatewayModelManagerOptions(config),
 		catalog("Cloudflare AI Gateway", ["CLOUDFLARE_AI_GATEWAY_API_KEY"]),
 	),
@@ -239,7 +239,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 	),
 	catalogDescriptor(
 		"litellm",
-		"claude-opus-4-6",
+		"claude-opus-4-8",
 		config => litellmModelManagerOptions(config),
 		catalog("LiteLLM", ["LITELLM_API_KEY"], { allowUnauthenticated: true }),
 	),
@@ -276,7 +276,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 	),
 	catalogDescriptor(
 		"zenmux",
-		"anthropic/claude-opus-4.6",
+		"anthropic/claude-opus-4.8",
 		config => zenmuxModelManagerOptions(config),
 		catalog("ZenMux", ["ZENMUX_API_KEY"]),
 	),
@@ -296,13 +296,13 @@ export const DEFAULT_MODEL_PER_PROVIDER: Record<KnownProvider, string> = {
 	...Object.fromEntries(PROVIDER_DESCRIPTORS.map(d => [d.providerId, d.defaultModel])),
 	// Providers not in PROVIDER_DESCRIPTORS (special auth or no standard discovery)
 	"alibaba-coding-plan": "qwen3.5-plus",
-	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
+	"amazon-bedrock": "us.anthropic.claude-opus-4-8",
 	"google-antigravity": "gemini-3-pro-high",
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-vertex": "gemini-3-pro-preview",
 	minimax: "MiniMax-M2.5",
 	"minimax-code": "MiniMax-M2.5",
 	"minimax-code-cn": "MiniMax-M2.5",
-	"openai-codex": "gpt-5.4",
+	"openai-codex": "gpt-5.5",
 	"gitlab-duo": "duo-chat-sonnet-4-5",
 } as Record<KnownProvider, string>;

--- a/packages/ai/src/providers/gitlab-duo.ts
+++ b/packages/ai/src/providers/gitlab-duo.ts
@@ -28,6 +28,26 @@ export type GitLabModelMapping = {
 };
 
 export const MODEL_MAPPINGS: Record<string, GitLabModelMapping> = {
+	"duo-chat-opus-4-8": {
+		provider: "anthropic",
+		model: "claude-opus-4-8",
+		name: "Duo Chat Opus 4.8",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	},
+	"duo-chat-opus-4-7": {
+		provider: "anthropic",
+		model: "claude-opus-4-7",
+		name: "Duo Chat Opus 4.7",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	},
 	"duo-chat-opus-4-6": {
 		provider: "anthropic",
 		model: "claude-opus-4-6",

--- a/packages/ai/test/zenmux-provider.test.ts
+++ b/packages/ai/test/zenmux-provider.test.ts
@@ -26,9 +26,9 @@ describe("zenmux provider support", () => {
 	test("registers built-in descriptor and default model", () => {
 		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "zenmux");
 		expect(descriptor).toBeDefined();
-		expect(descriptor?.defaultModel).toBe("anthropic/claude-opus-4.6");
+		expect(descriptor?.defaultModel).toBe("anthropic/claude-opus-4.8");
 		expect(descriptor?.catalogDiscovery?.envVars).toContain("ZENMUX_API_KEY");
-		expect(DEFAULT_MODEL_PER_PROVIDER.zenmux).toBe("anthropic/claude-opus-4.6");
+		expect(DEFAULT_MODEL_PER_PROVIDER.zenmux).toBe("anthropic/claude-opus-4.8");
 	});
 
 	test("registers ZenMux in OAuth provider selector", () => {

--- a/packages/coding-agent/src/priority.json
+++ b/packages/coding-agent/src/priority.json
@@ -10,6 +10,11 @@
 		"mini"
 	],
 	"slow": [
+		"opus-4.8",
+		"opus-4-8",
+		"opus-4.7",
+		"opus-4-7",
+		"gpt-5.5",
 		"gpt-5.4",
 		"gpt-5.3-codex",
 		"gpt-5.3",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -331,7 +331,7 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const opusVariants = registry.getCanonicalVariants("claude-opus-4-7");
+			const opusVariants = registry.getCanonicalVariants("claude-opus-4-8");
 			const haikuVariants = registry.getCanonicalVariants("claude-haiku-4-5");
 
 			expect(opusVariants.some(variant => variant.selector === "demo/anthropic/claude-opus-latest")).toBe(true);


### PR DESCRIPTION
Upgrades GJC defaults to the 2026-06-02 frontier model lineup.

## Provider default model changes
| provider | before | after |
|---|---|---|
| anthropic | claude-sonnet-4-6 | claude-opus-4-8 |
| openai | gpt-5.4 | gpt-5.5 |
| openai-codex | gpt-5.4 | gpt-5.5 |
| amazon-bedrock | us.anthropic.claude-opus-4-6-v1 | us.anthropic.claude-opus-4-8 |
| litellm | claude-opus-4-6 | claude-opus-4-8 |
| zenmux | anthropic/claude-opus-4.6 | anthropic/claude-opus-4.8 |
| openrouter | openai/gpt-5.4 | openai/gpt-5.5 |
| kilo | anthropic/claude-sonnet-4.5 | anthropic/claude-opus-4.8 |
| vercel-ai-gateway | anthropic/claude-sonnet-4-6 | anthropic/claude-opus-4.8 |
| cloudflare-ai-gateway | claude-sonnet-4-5 | anthropic/claude-opus-4-8 |
| opencode-zen | claude-sonnet-4-6 | claude-opus-4-8 |

## Other changes
- model-thinking: add Opus 4.7/4.8 and GPT-5.5 Copilot limit entries; docstring update on `hasOpus47ApiRestrictions` (semver gate already covers 4.8).
- gitlab-duo: add `duo-chat-opus-4-8` and `duo-chat-opus-4-7` mappings.
- generate-models: add Opus 4.7/4.8 Copilot premium multipliers (3x).
- priority.json: promote Opus 4.8/4.7 and GPT-5.5 to the head of the slow tier.
- models.json: regenerated. models.dev already publishes Opus 4.8 — 36 new entries picked up across all gateway/cloud providers.
- tests: update zenmux default lockdown and `claude-opus-latest` canonical variant test to Opus 4.8.

## Verification
- `bun check` (TS): pass across all packages
- `bun lint:ts`: pass
- G002 gate / visible-definitions / rebrand-inventory / gjc-ui-redesign: pass
- Targeted model tests (225 across 15 files): pass

## Out of scope
- Sonnet 4.7/4.8: not announced by Anthropic as of 2026-06-02.
- GitLab Duo default kept at `duo-chat-sonnet-4-5` since GitLab has not exposed Opus 4.7/4.8 in Duo Chat yet. Mappings are in place for when they do.