### PR TITLE
Keep harness owners resident across detach

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -110,6 +110,7 @@ interface OwnerSpawnResult {
 	runtime: "tmux" | "detached" | "manual";
 	tmuxSessionName: string | null;
 	fallbackReason: string | null;
+	blockerReason: string | null;
 }
 
 function shellQuote(value: string): string {
@@ -292,14 +293,16 @@ export default class Harness extends Command {
 	/** Spawn the owner daemon. Prefer a tmux-resident owner, then explicitly fall back to detached. */
 	async #spawnDetachedOwner(root: string, sessionId: string, cwd: string): Promise<OwnerSpawnResult> {
 		const tmux = this.#startTmuxResidentOwner(root, sessionId, cwd);
-		if (tmux.started) {
+		if (tmux.started && (await this.#waitForOwner(root, sessionId))) {
 			return {
-				live: await this.#waitForOwner(root, sessionId),
+				live: true,
 				runtime: "tmux",
 				tmuxSessionName: tmux.sessionName,
 				fallbackReason: null,
+				blockerReason: null,
 			};
 		}
+		const fallbackReason = tmux.started ? "tmux new-session exited 0 but owner did not become live" : tmux.reason;
 		const cmd = this.#buildOwnerCommand(sessionId);
 		const child = Bun.spawn(cmd, {
 			cwd,
@@ -309,11 +312,13 @@ export default class Harness extends Command {
 			stdin: "ignore",
 		});
 		child.unref();
+		const live = await this.#waitForOwner(root, sessionId);
 		return {
-			live: await this.#waitForOwner(root, sessionId),
+			live,
 			runtime: "detached",
 			tmuxSessionName: null,
-			fallbackReason: tmux.reason,
+			fallbackReason,
+			blockerReason: live ? null : "detached-owner-not-live",
 		};
 	}
 
@@ -364,11 +369,13 @@ export default class Harness extends Command {
 		let ownerLive = false;
 		let ownerRuntime: OwnerSpawnResult["runtime"] = "manual";
 		let ownerFallbackReason: string | null = null;
+		let ownerBlockerReason: string | null = null;
 		if (input.detach === true) {
 			const ownerSpawn = await this.#spawnDetachedOwner(root, sessionId, workspace);
 			ownerLive = ownerSpawn.live;
-			ownerRuntime = ownerLive ? ownerSpawn.runtime : "manual";
+			ownerRuntime = ownerSpawn.runtime;
 			ownerFallbackReason = ownerSpawn.fallbackReason;
+			ownerBlockerReason = ownerSpawn.blockerReason;
 			handle.viewportHandle = {
 				kind: "event-monitor",
 				tmuxSessionName: ownerSpawn.tmuxSessionName,
@@ -390,13 +397,27 @@ export default class Harness extends Command {
 				await writeSessionState(root, state);
 			}
 		}
+		if (ownerBlockerReason) {
+			state.lifecycle = "blocked";
+			state.blockers = [...state.blockers, ownerBlockerReason];
+			state.handle = handle;
+			state.updatedAt = nowIso();
+			await writeSessionState(root, state);
+		}
 		writeJson(
-			buildResponse(state, ownerLive, {
-				handle,
-				ownerRuntime,
-				...(ownerFallbackReason ? { ownerFallbackReason } : {}),
-			}),
+			buildResponse(
+				state,
+				ownerLive,
+				{
+					handle,
+					ownerRuntime,
+					...(ownerFallbackReason ? { ownerFallbackReason } : {}),
+					...(ownerBlockerReason ? { reason: ownerBlockerReason } : {}),
+				},
+				!ownerBlockerReason,
+			),
 		);
+		if (ownerBlockerReason) process.exitCode = 1;
 	}
 
 	/** Returns true if a live owner handled the verb (response already printed). */

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -11,6 +11,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { resolveGjcTmuxCommand, sanitizeTmuxToken } from "../gjc-runtime/tmux-common";
 import { classifyRecovery } from "../harness-control-plane/classifier";
 import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
 import { RuntimeOwner, resolveOwner } from "../harness-control-plane/owner";
@@ -102,6 +103,21 @@ function resolveRetryBudget(input: Record<string, unknown>): RetryBudget {
 		return { ...DEFAULT_RETRY_BUDGET, ...(supplied as Partial<RetryBudget>) };
 	}
 	return { ...DEFAULT_RETRY_BUDGET };
+}
+
+interface OwnerSpawnResult {
+	live: boolean;
+	runtime: "tmux" | "detached" | "manual";
+	tmuxSessionName: string | null;
+	fallbackReason: string | null;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function deterministicHarnessTmuxSessionName(sessionId: string): string {
+	return `gajae_code_harness_${sanitizeTmuxToken(sessionId)}`;
 }
 
 async function loadState(root: string, sessionId: string): Promise<SessionState> {
@@ -228,12 +244,63 @@ export default class Harness extends Command {
 		process.exit(0);
 	}
 
-	/** Spawn the detached owner daemon and poll until it holds the lease. */
-	async #spawnDetachedOwner(root: string, sessionId: string, cwd: string): Promise<boolean> {
+	#buildOwnerCommand(sessionId: string): string[] {
 		const argv1 = process.argv[1];
-		const cmd = argv1
+		return argv1
 			? [process.execPath, argv1, "harness", "__owner", "--session", sessionId]
 			: [process.execPath, "harness", "__owner", "--session", sessionId];
+	}
+
+	async #waitForOwner(root: string, sessionId: string): Promise<boolean> {
+		for (let i = 0; i < 100; i++) {
+			if ((await resolveOwner(root, sessionId)).live) return true;
+			await new Promise(r => setTimeout(r, 50));
+		}
+		return false;
+	}
+
+	#startTmuxResidentOwner(
+		root: string,
+		sessionId: string,
+		cwd: string,
+	): { started: boolean; sessionName: string; reason: string | null } {
+		const tmuxCommand = resolveGjcTmuxCommand();
+		if (Bun.which(tmuxCommand) === null) {
+			return {
+				started: false,
+				sessionName: deterministicHarnessTmuxSessionName(sessionId),
+				reason: "tmux-unavailable",
+			};
+		}
+		const sessionName = deterministicHarnessTmuxSessionName(sessionId);
+		const envAssignments = [`GJC_HARNESS_STATE_ROOT=${shellQuote(root)}`];
+		if (process.env.GJC_HARNESS_RPC_COMMAND) {
+			envAssignments.push(`GJC_HARNESS_RPC_COMMAND=${shellQuote(process.env.GJC_HARNESS_RPC_COMMAND)}`);
+		}
+		const ownerCommand = this.#buildOwnerCommand(sessionId).map(shellQuote).join(" ");
+		const shellCommand = `exec env ${envAssignments.join(" ")} ${ownerCommand}`;
+		const created = Bun.spawnSync([tmuxCommand, "new-session", "-d", "-s", sessionName, "-c", cwd, shellCommand], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: process.env,
+		});
+		if (created.exitCode === 0) return { started: true, sessionName, reason: null };
+		const stderr = created.stderr.toString().trim();
+		return { started: false, sessionName, reason: stderr || "tmux-start-failed" };
+	}
+
+	/** Spawn the owner daemon. Prefer a tmux-resident owner, then explicitly fall back to detached. */
+	async #spawnDetachedOwner(root: string, sessionId: string, cwd: string): Promise<OwnerSpawnResult> {
+		const tmux = this.#startTmuxResidentOwner(root, sessionId, cwd);
+		if (tmux.started) {
+			return {
+				live: await this.#waitForOwner(root, sessionId),
+				runtime: "tmux",
+				tmuxSessionName: tmux.sessionName,
+				fallbackReason: null,
+			};
+		}
+		const cmd = this.#buildOwnerCommand(sessionId);
 		const child = Bun.spawn(cmd, {
 			cwd,
 			env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
@@ -242,11 +309,12 @@ export default class Harness extends Command {
 			stdin: "ignore",
 		});
 		child.unref();
-		for (let i = 0; i < 100; i++) {
-			if ((await resolveOwner(root, sessionId)).live) return true;
-			await new Promise(r => setTimeout(r, 50));
-		}
-		return false;
+		return {
+			live: await this.#waitForOwner(root, sessionId),
+			runtime: "detached",
+			tmuxSessionName: null,
+			fallbackReason: tmux.reason,
+		};
 	}
 
 	async #start(root: string, input: Record<string, unknown>): Promise<void> {
@@ -294,8 +362,18 @@ export default class Harness extends Command {
 		};
 		await writeSessionState(root, state);
 		let ownerLive = false;
+		let ownerRuntime: OwnerSpawnResult["runtime"] = "manual";
+		let ownerFallbackReason: string | null = null;
 		if (input.detach === true) {
-			ownerLive = await this.#spawnDetachedOwner(root, sessionId, workspace);
+			const ownerSpawn = await this.#spawnDetachedOwner(root, sessionId, workspace);
+			ownerLive = ownerSpawn.live;
+			ownerRuntime = ownerLive ? ownerSpawn.runtime : "manual";
+			ownerFallbackReason = ownerSpawn.fallbackReason;
+			handle.viewportHandle = {
+				kind: "event-monitor",
+				tmuxSessionName: ownerSpawn.tmuxSessionName,
+				viewOnly: true,
+			};
 			if (ownerLive) {
 				const resolved = await resolveOwner(root, sessionId);
 				handle.processHandle = {
@@ -312,7 +390,13 @@ export default class Harness extends Command {
 				await writeSessionState(root, state);
 			}
 		}
-		writeJson(buildResponse(state, ownerLive, { handle, ownerRuntime: ownerLive ? "detached" : "manual" }));
+		writeJson(
+			buildResponse(state, ownerLive, {
+				handle,
+				ownerRuntime,
+				...(ownerFallbackReason ? { ownerFallbackReason } : {}),
+			}),
+		);
 	}
 
 	/** Returns true if a live owner handled the verb (response already printed). */

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -254,7 +254,15 @@ export default class Harness extends Command {
 
 	async #waitForOwner(root: string, sessionId: string): Promise<boolean> {
 		for (let i = 0; i < 100; i++) {
-			if ((await resolveOwner(root, sessionId)).live) return true;
+			const owner = await resolveOwner(root, sessionId);
+			if (owner.live && owner.socketPath) {
+				try {
+					await callEndpoint(owner.socketPath, { verb: "observe", input: { sessionId } }, 250);
+					return true;
+				} catch (error) {
+					if (!(error instanceof EndpointUnreachableError)) throw error;
+				}
+			}
 			await new Promise(r => setTimeout(r, 50));
 		}
 		return false;
@@ -302,7 +310,9 @@ export default class Harness extends Command {
 				blockerReason: null,
 			};
 		}
-		const fallbackReason = tmux.started ? "tmux new-session exited 0 but owner did not become live" : tmux.reason;
+		const fallbackReason = tmux.started
+			? "tmux new-session exited 0 but owner endpoint did not become routable"
+			: tmux.reason;
 		const cmd = this.#buildOwnerCommand(sessionId);
 		const child = Bun.spawn(cmd, {
 			cwd,

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { resolveOwner } from "../../src/harness-control-plane/owner";
@@ -12,6 +12,40 @@ const FAKE_RPC = path.join(import.meta.dir, "fixtures", "fake-rpc.ts");
 
 let root: string;
 let workspace: string;
+let tmuxCommand: string;
+
+async function createFakeTmuxBin(rootDir: string, options: { failNewSession?: boolean } = {}): Promise<string> {
+	const binDir = path.join(rootDir, ".test-bin");
+	const tmuxPath = path.join(binDir, "tmux");
+	const logPath = path.join(rootDir, "tmux.log");
+	await mkdir(binDir, { recursive: true });
+	await Bun.write(
+		tmuxPath,
+		`#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(logPath)}
+case "$1" in
+  new-session)
+    ${options.failNewSession ? "echo tmux new-session failed >&2; exit 9" : ""}
+    cwd="$PWD"
+    for ((i=1; i<=$#; i++)); do
+      if [ "\${!i}" = "-c" ]; then
+        next=$((i + 1))
+        cwd="\${!next}"
+      fi
+    done
+    cmd="\${@: -1}"
+    (cd "$cwd" && bash -lc "$cmd") >/dev/null 2>&1 &
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+	);
+	await chmod(tmuxPath, 0o755);
+	return tmuxPath;
+}
 
 async function runHarness(args: string[]): Promise<{ code: number; json: Record<string, unknown> | null }> {
 	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
@@ -21,6 +55,7 @@ async function runHarness(args: string[]): Promise<{ code: number; json: Record<
 			GJC_HARNESS_STATE_ROOT: root,
 			// Drive the REAL GajaeCodeRpc against a protocol fixture (no shipped fake seam).
 			GJC_HARNESS_RPC_COMMAND: JSON.stringify(["bun", FAKE_RPC]),
+			GJC_TMUX_COMMAND: tmuxCommand,
 		},
 		stdout: "pipe",
 		stderr: "pipe",
@@ -42,6 +77,7 @@ beforeEach(async () => {
 	// Short paths keep the AF_UNIX socket path under the sun_path limit.
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
+	tmuxCommand = await createFakeTmuxBin(root);
 });
 
 afterEach(async () => {
@@ -63,15 +99,18 @@ afterEach(async () => {
 });
 
 describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
-	it("spawns a background owner; submit + finalize route to it cross-process; retire stops it", async () => {
+	it("spawns a tmux-resident owner; submit + finalize route to it cross-process; retire stops it", async () => {
 		const started = await runHarness([
 			"start",
 			"--input",
 			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true }),
 		]);
 		expect(started.code).toBe(0);
-		expect((started.json?.evidence as Record<string, unknown>).ownerRuntime).toBe("detached");
+		const evidence = started.json?.evidence as Record<string, unknown>;
+		expect(evidence.ownerRuntime).toBe("tmux");
 		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		const handle = evidence.handle as { viewportHandle?: { tmuxSessionName?: string | null } };
+		expect(handle.viewportHandle?.tmuxSessionName).toBe(`gajae_code_harness_${SID}`);
 
 		// A separate stateless CLI invocation re-grabs and drives the background session.
 		const sub = await runHarness(["submit", "--session", SID, "--input", JSON.stringify({ prompt: "go" })]);
@@ -109,5 +148,22 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 			after = await resolveOwner(root, SID);
 		}
 		expect(after.live).toBe(false);
+	}, 60_000);
+
+	it("falls back explicitly when tmux cannot start", async () => {
+		tmuxCommand = await createFakeTmuxBin(root, { failNewSession: true });
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true }),
+		]);
+		expect(started.code).toBe(0);
+		const evidence = started.json?.evidence as Record<string, unknown>;
+		expect(evidence.ownerRuntime).toBe("detached");
+		expect(evidence.ownerFallbackReason).toContain("tmux new-session failed");
+		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+
+		const ret = await runHarness(["retire", "--session", SID]);
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
 	}, 60_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -13,6 +13,7 @@ const FAKE_RPC = path.join(import.meta.dir, "fixtures", "fake-rpc.ts");
 let root: string;
 let workspace: string;
 let tmuxCommand: string;
+let rpcCommandEnv: string;
 
 async function createFakeTmuxBin(
 	rootDir: string,
@@ -57,7 +58,7 @@ async function runHarness(args: string[]): Promise<{ code: number; json: Record<
 			...process.env,
 			GJC_HARNESS_STATE_ROOT: root,
 			// Drive the REAL GajaeCodeRpc against a protocol fixture (no shipped fake seam).
-			GJC_HARNESS_RPC_COMMAND: JSON.stringify(["bun", FAKE_RPC]),
+			GJC_HARNESS_RPC_COMMAND: rpcCommandEnv,
 			GJC_TMUX_COMMAND: tmuxCommand,
 		},
 		stdout: "pipe",
@@ -81,6 +82,7 @@ beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
 	tmuxCommand = await createFakeTmuxBin(root);
+	rpcCommandEnv = JSON.stringify(["bun", FAKE_RPC]);
 });
 
 afterEach(async () => {
@@ -163,7 +165,7 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect(started.code).toBe(0);
 		const evidence = started.json?.evidence as Record<string, unknown>;
 		expect(evidence.ownerRuntime).toBe("detached");
-		expect(evidence.ownerFallbackReason).toBe("tmux new-session exited 0 but owner did not become live");
+		expect(evidence.ownerFallbackReason).toBe("tmux new-session exited 0 but owner endpoint did not become routable");
 		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
 		expect(evidence.ownerRuntime).not.toBe("manual");
 
@@ -171,6 +173,41 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
 	}, 60_000);
 
+	it("blocks start when tmux ghosts and detached owner endpoint is not routable", async () => {
+		tmuxCommand = await createFakeTmuxBin(root, { skipOwnerLaunch: true });
+		const originalRpcCommandEnv = rpcCommandEnv;
+		rpcCommandEnv = "{";
+		try {
+			const started = await runHarness([
+				"start",
+				"--input",
+				JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true }),
+			]);
+			expect(started.code).toBe(1);
+			expect(started.json?.ok).toBe(false);
+			const state = started.json?.state as Record<string, unknown>;
+			const evidence = started.json?.evidence as Record<string, unknown>;
+			expect(state.lifecycle).toBe("blocked");
+			expect(state.ownerLive).toBe(false);
+			expect(state.blockers).toContain("detached-owner-not-live");
+			expect(evidence.ownerRuntime).toBe("detached");
+			expect(evidence.reason).toBe("detached-owner-not-live");
+
+			const submit = await runHarness(["submit", "--session", SID, "--input", JSON.stringify({ prompt: "go" })]);
+			expect(submit.code).toBe(1);
+			expect(submit.json?.ok).toBe(false);
+			expect((submit.json?.state as Record<string, unknown>).ownerLive).toBe(false);
+			expect((submit.json?.evidence as Record<string, unknown>).accepted).toBe(false);
+			expect((submit.json?.evidence as Record<string, unknown>).reason).toBe("owner-not-live");
+			expect(submit.json?.nextAllowedActions).toContainEqual({
+				verb: "submit",
+				available: false,
+				reason: "owner-not-live",
+			});
+		} finally {
+			rpcCommandEnv = originalRpcCommandEnv;
+		}
+	}, 60_000);
 	it("falls back explicitly when tmux cannot start", async () => {
 		tmuxCommand = await createFakeTmuxBin(root, { failNewSession: true });
 		const started = await runHarness([

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -14,7 +14,10 @@ let root: string;
 let workspace: string;
 let tmuxCommand: string;
 
-async function createFakeTmuxBin(rootDir: string, options: { failNewSession?: boolean } = {}): Promise<string> {
+async function createFakeTmuxBin(
+	rootDir: string,
+	options: { failNewSession?: boolean; skipOwnerLaunch?: boolean } = {},
+): Promise<string> {
 	const binDir = path.join(rootDir, ".test-bin");
 	const tmuxPath = path.join(binDir, "tmux");
 	const logPath = path.join(rootDir, "tmux.log");
@@ -34,7 +37,7 @@ case "$1" in
       fi
     done
     cmd="\${@: -1}"
-    (cd "$cwd" && bash -lc "$cmd") >/dev/null 2>&1 &
+    ${options.skipOwnerLaunch ? "exit 0" : '(cd "$cwd" && bash -lc "$cmd") >/dev/null 2>&1 &'}
     exit 0
     ;;
   *)
@@ -148,6 +151,24 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 			after = await resolveOwner(root, SID);
 		}
 		expect(after.live).toBe(false);
+	}, 60_000);
+
+	it("falls back explicitly when tmux exits zero without launching the owner", async () => {
+		tmuxCommand = await createFakeTmuxBin(root, { skipOwnerLaunch: true });
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true }),
+		]);
+		expect(started.code).toBe(0);
+		const evidence = started.json?.evidence as Record<string, unknown>;
+		expect(evidence.ownerRuntime).toBe("detached");
+		expect(evidence.ownerFallbackReason).toBe("tmux new-session exited 0 but owner did not become live");
+		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect(evidence.ownerRuntime).not.toBe("manual");
+
+		const ret = await runHarness(["retire", "--session", SID]);
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
 	}, 60_000);
 
 	it("falls back explicitly when tmux cannot start", async () => {


### PR DESCRIPTION
## Summary
- Keep `gjc harness start --detach` owners resident in a deterministic tmux session when tmux is available.
- Preserve an explicit detached fallback with `ownerFallbackReason` when tmux startup is unavailable or fails.
- Extend the detached-owner CLI regression test to cover tmux-resident ownership and explicit fallback evidence.

## Root cause / owner question
Native/detach launch created non-tmux owners that could vanish outside a resident runtime. Prompt acceptance must therefore require `ownerLive` plus concrete prompt evidence such as `prompt-accepted`, `tool-call`, `streaming`, or completed output; launch logs alone are insufficient. Deleted `/tmp` worktrees must be treated as invalid owner/workspace state and killed or recreated rather than reused.

Closes #210

## Verification
- `bun run check:ts` — passed
- `bun test packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts` — passed (`2 pass`, `0 fail`, `18 expect() calls`)
