### PR TITLE
Fix deep-interview ask prompt scrolling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept deep-interview ask options visible for long prompts by adding an opt-in scrollable selector title panel with selector-local `PageUp`/`PageDown` prompt scrolling, while leaving normal ask dialogs and global keybinding configuration unchanged.
+
 ## [0.2.5] - 2026-06-02
 
 ### Added

--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -1,0 +1,366 @@
+import { type Component, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
+import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
+
+interface RoundQuestionModel {
+	kind: "round-question";
+	round: string;
+	component?: string;
+	targeting?: string;
+	mode?: string;
+	whyNow?: string;
+	ambiguity?: string;
+	question: string;
+}
+
+interface TopologyQuestionModel {
+	kind: "topology-question";
+	context?: string;
+	components: Array<{ name: string; description: string }>;
+	question: string;
+}
+
+interface ProgressDimension {
+	name: string;
+	score: string;
+	weight: string;
+	weighted: string;
+	gap: string;
+}
+
+interface ProgressModel {
+	kind: "progress";
+	round: string;
+	dimensions: ProgressDimension[];
+	ambiguity?: string;
+	topology?: string;
+	ontology?: string;
+	nextTarget?: string;
+	status?: string;
+	extra?: string;
+}
+
+interface ThresholdModel {
+	kind: "threshold";
+	threshold: string;
+	source: string;
+	rest: string;
+}
+
+type DeepInterviewModel = RoundQuestionModel | TopologyQuestionModel | ProgressModel | ThresholdModel;
+
+function normalizeText(text: string): string {
+	return text.trim().replaceAll("\r\n", "\n");
+}
+
+function stripMarkdownEmphasis(value: string): string {
+	return value.replace(/\*\*/g, "").replace(/^"|"$/g, "").trim();
+}
+
+function parseRoundQuestion(text: string): RoundQuestionModel | null {
+	const normalized = normalizeText(text);
+	const lines = normalized.split("\n");
+	const headerIndex = lines.findIndex(line => /^Round\s+\d+\s+\|/i.test(line.trim()));
+	if (headerIndex < 0) return null;
+	const headerLine = lines[headerIndex]?.trim() ?? "";
+	const body = lines
+		.slice(headerIndex + 1)
+		.join("\n")
+		.trim();
+	if (!body) return null;
+
+	const componentMatch =
+		/^Round\s+(\d+)\s+\|\s+Component:\s*(.*?)\s+\|\s+Targeting:\s*(.*?)\s+\|\s+Why now:\s*(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(
+			headerLine,
+		);
+	if (componentMatch) {
+		return {
+			kind: "round-question",
+			round: componentMatch[1] ?? "?",
+			component: componentMatch[2]?.trim(),
+			targeting: componentMatch[3]?.trim(),
+			whyNow: componentMatch[4]?.trim(),
+			ambiguity: componentMatch[5]?.trim(),
+			question: body,
+		};
+	}
+
+	const targetingMatch =
+		/^Round\s+(\d+)\s+\|\s+Targeting:\s*(.*?)\s+\|\s+Why now:\s*(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(
+			headerLine,
+		);
+	if (targetingMatch) {
+		return {
+			kind: "round-question",
+			round: targetingMatch[1] ?? "?",
+			targeting: targetingMatch[2]?.trim(),
+			whyNow: targetingMatch[3]?.trim(),
+			ambiguity: targetingMatch[4]?.trim(),
+			question: body,
+		};
+	}
+
+	const modeMatch = /^Round\s+(\d+)\s+\|\s+(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(headerLine);
+	if (modeMatch) {
+		return {
+			kind: "round-question",
+			round: modeMatch[1] ?? "?",
+			mode: modeMatch[2]?.trim(),
+			ambiguity: modeMatch[3]?.trim(),
+			question: body,
+		};
+	}
+
+	return null;
+}
+
+function parseTopologyQuestion(text: string): TopologyQuestionModel | null {
+	const normalized = normalizeText(text);
+	const lines = normalized.split("\n");
+	const headerIndex = lines.findIndex(line =>
+		/^Round\s+0\s+\|\s+Topology confirmation\s+\|\s+Ambiguity:\s+not scored yet/i.test(line.trim()),
+	);
+	if (headerIndex < 0) {
+		return null;
+	}
+	const components: TopologyQuestionModel["components"] = [];
+	const contextLines: string[] = [];
+	const questionLines: string[] = [];
+	let inQuestion = false;
+	for (const line of lines.slice(headerIndex + 1)) {
+		const trimmed = line.trim();
+		const component = /^\s*\d+\.\s+([^:]+):\s+(.+)$/.exec(line);
+		if (component) {
+			components.push({ name: component[1]?.trim() ?? "", description: component[2]?.trim() ?? "" });
+			continue;
+		}
+		if (/\?$/.test(trimmed)) inQuestion = true;
+		if (!trimmed) continue;
+		if (inQuestion) questionLines.push(trimmed);
+		else contextLines.push(trimmed);
+	}
+	return {
+		kind: "topology-question",
+		context: contextLines.join("\n") || undefined,
+		components,
+		question: questionLines.join("\n"),
+	};
+}
+
+function splitMarkdownTableRow(line: string): string[] {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return [];
+	return trimmed
+		.slice(1, -1)
+		.split("|")
+		.map(cell => stripMarkdownEmphasis(cell));
+}
+
+function parseProgress(text: string): ProgressModel | null {
+	const normalized = normalizeText(text);
+	const roundMatch = /^Round\s+(\d+)\s+complete\./i.exec(normalized);
+	if (!roundMatch) return null;
+
+	const lines = normalized.split("\n");
+	const dimensions: ProgressDimension[] = [];
+	const extraLines: string[] = [];
+	let ambiguity: string | undefined;
+	let topology: string | undefined;
+	let ontology: string | undefined;
+	let nextTarget: string | undefined;
+	let status: string | undefined;
+
+	for (const [index, line] of lines.entries()) {
+		if (index === 0) continue;
+		const trimmed = line.trim();
+		const cells = splitMarkdownTableRow(line);
+		if (cells.length >= 5) {
+			const [name = "", score = "", weight = "", weighted = "", gap = ""] = cells;
+			if (/^-+$/.test(name) || /^Dimension$/i.test(name)) continue;
+			if (/^Ambiguity$/i.test(name)) {
+				ambiguity = weighted || score || gap;
+				continue;
+			}
+			dimensions.push({ name, score, weight, weighted, gap });
+			continue;
+		}
+		const topologyMatch = /^\*\*Topology:\*\*\s*(.+)$/.exec(trimmed);
+		if (topologyMatch) {
+			topology = topologyMatch[1]?.trim();
+			continue;
+		}
+		const ontologyMatch = /^\*\*Ontology:\*\*\s*(.+)$/.exec(trimmed);
+		if (ontologyMatch) {
+			ontology = ontologyMatch[1]?.trim();
+			continue;
+		}
+		const nextTargetMatch = /^\*\*Next target:\*\*\s*(.+)$/.exec(trimmed);
+		if (nextTargetMatch) {
+			nextTarget = nextTargetMatch[1]?.trim();
+			continue;
+		}
+		if (/^(Clarity threshold met!|Focusing next question on:)/i.test(trimmed)) {
+			status = trimmed;
+			continue;
+		}
+		if (trimmed) extraLines.push(trimmed);
+	}
+
+	if (dimensions.length === 0 && !ambiguity && !topology && !ontology && !nextTarget) return null;
+	return {
+		kind: "progress",
+		round: roundMatch[1] ?? "?",
+		dimensions,
+		ambiguity,
+		topology,
+		ontology,
+		nextTarget,
+		status,
+		extra: extraLines.join("\n") || undefined,
+	};
+}
+
+function parseThreshold(text: string): ThresholdModel | null {
+	const normalized = normalizeText(text);
+	const match = /^Deep Interview threshold:\s*(.*?)\s*\(source:\s*(.*?)\)\s*$/im.exec(normalized.split("\n")[0] ?? "");
+	if (!match) return null;
+	return {
+		kind: "threshold",
+		threshold: match[1]?.trim() ?? "",
+		source: match[2]?.trim() ?? "",
+		rest: normalized.split("\n").slice(1).join("\n").trim(),
+	};
+}
+
+function parseDeepInterview(text: string): DeepInterviewModel | null {
+	return parseProgress(text) ?? parseTopologyQuestion(text) ?? parseRoundQuestion(text) ?? parseThreshold(text);
+}
+
+function addLabel(container: Container, label: string, value: string | undefined, uiTheme: Theme): void {
+	if (!value) return;
+	container.addChild(new Spacer(1));
+	container.addChild(new Text(uiTheme.fg("accent", uiTheme.bold(label)), 0, 0));
+	container.addChild(
+		new Markdown(value, 2, 0, getMarkdownTheme(), { color: (text: string) => uiTheme.fg("toolOutput", text) }),
+	);
+}
+
+function renderPipeSummary(title: string, value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	return (
+		value
+			.split("|")
+			.map(part => part.trim())
+			.filter(Boolean)
+			.map(part => `- ${part}`)
+			.join("\n") || title
+	);
+}
+
+function renderModel(model: DeepInterviewModel, uiTheme: Theme): Component {
+	const container = new Container();
+	if (model.kind === "round-question") {
+		const meta = [
+			`Round ${model.round}`,
+			model.ambiguity ? `Ambiguity ${model.ambiguity.replace(/%$/, "")}%` : undefined,
+		]
+			.filter(Boolean)
+			.join(" · ");
+		container.addChild(new Text(uiTheme.fg("toolTitle", uiTheme.bold(`Deep Interview · ${meta}`)), 0, 0));
+		addLabel(container, "Component", model.component, uiTheme);
+		addLabel(container, "Mode", model.mode, uiTheme);
+		addLabel(container, "Target", model.targeting, uiTheme);
+		addLabel(container, "Why now", model.whyNow, uiTheme);
+		addLabel(container, "Question", model.question, uiTheme);
+		return container;
+	}
+
+	if (model.kind === "topology-question") {
+		container.addChild(
+			new Text(uiTheme.fg("toolTitle", uiTheme.bold("Deep Interview · Round 0 · Topology confirmation")), 0, 0),
+		);
+		addLabel(container, "Ambiguity", "Not scored yet", uiTheme);
+		addLabel(container, "Reading", model.context, uiTheme);
+		if (model.components.length > 0) {
+			const components = model.components
+				.map((component, index) => `${index + 1}. **${component.name}**\n   ${component.description}`)
+				.join("\n\n");
+			addLabel(container, "Components", components, uiTheme);
+		}
+		addLabel(container, "Question", model.question, uiTheme);
+		return container;
+	}
+
+	if (model.kind === "progress") {
+		container.addChild(
+			new Text(uiTheme.fg("toolTitle", uiTheme.bold(`Deep Interview · Round ${model.round} complete`)), 0, 0),
+		);
+		addLabel(container, "Ambiguity", model.ambiguity, uiTheme);
+		if (model.dimensions.length > 0) {
+			container.addChild(new Spacer(1));
+			container.addChild(new Text(uiTheme.fg("accent", uiTheme.bold("Clarity")), 0, 0));
+			for (const dimension of model.dimensions) {
+				const body = [`Score ${dimension.score} · weight ${dimension.weight} · weighted ${dimension.weighted}`];
+				if (dimension.gap) body.push(/^clear$/i.test(dimension.gap) ? "Clear" : `Gap: ${dimension.gap}`);
+				addLabel(container, dimension.name, body.join("\n"), uiTheme);
+			}
+		}
+		addLabel(container, "Topology", renderPipeSummary("Topology", model.topology), uiTheme);
+		addLabel(container, "Ontology", renderPipeSummary("Ontology", model.ontology), uiTheme);
+		addLabel(container, "Next target", model.nextTarget, uiTheme);
+		addLabel(container, "Status", model.status, uiTheme);
+		addLabel(container, "Additional details", model.extra, uiTheme);
+		return container;
+	}
+
+	container.addChild(new Text(uiTheme.fg("toolTitle", uiTheme.bold("Deep Interview · Started")), 0, 0));
+	addLabel(container, "Threshold", `${model.threshold} · source: ${model.source}`, uiTheme);
+	addLabel(container, "Details", model.rest, uiTheme);
+	return container;
+}
+
+export function renderDeepInterviewAssistantText(text: string, uiTheme: Theme): Component | null {
+	const model = parseDeepInterview(text);
+	if (!model || model.kind === "round-question" || model.kind === "topology-question") return null;
+	return renderModel(model, uiTheme);
+}
+
+export function renderDeepInterviewAskQuestion(question: string, uiTheme: Theme): Component | null {
+	const model = parseTopologyQuestion(question) ?? parseRoundQuestion(question);
+	if (!model) return null;
+	return renderModel(model, uiTheme);
+}
+
+export function formatDeepInterviewSelectorPrompt(question: string): string | null {
+	const model = parseTopologyQuestion(question) ?? parseRoundQuestion(question);
+	if (!model) return null;
+	if (model.kind === "topology-question") {
+		const componentLines =
+			model.components.length > 0
+				? [
+						"Components:",
+						...model.components.map(
+							(component, index) => `${index + 1}. ${component.name} — ${component.description}`,
+						),
+					]
+				: [];
+		return [
+			"Deep Interview · Round 0 · Topology confirmation",
+			"Ambiguity: not scored yet",
+			model.context ? `Reading:\n${model.context}` : undefined,
+			...componentLines,
+			model.question ? `Question:\n${model.question}` : undefined,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join("\n\n");
+	}
+	return [
+		`Deep Interview · Round ${model.round}${model.ambiguity ? ` · Ambiguity ${model.ambiguity.replace(/%$/, "")}%` : ""}`,
+		model.component ? `Component: ${model.component}` : undefined,
+		model.mode ? `Mode: ${model.mode}` : undefined,
+		model.targeting ? `Target: ${model.targeting}` : undefined,
+		model.whyNow ? `Why now: ${model.whyNow}` : undefined,
+		model.question,
+	]
+		.filter((line): line is string => Boolean(line))
+		.join("\n");
+}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -116,6 +116,12 @@ export interface ExtensionUIDialogOptions {
 	 * hint; non-TUI bridges (RPC, ACP) drop it and do not serialize it.
 	 */
 	wrapFocused?: boolean;
+	/**
+	 * For interactive TUI select dialogs, cap the title/prompt area to this
+	 * many rows and let PageUp/PageDown scroll that prompt locally. This is a
+	 * select-only rendering hint; non-TUI bridges drop it and do not serialize it.
+	 */
+	scrollTitleRows?: number;
 }
 
 /** Raw terminal input listener for extensions. */

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, ImageContent, Usage } from "@gajae-code/ai";
 import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@gajae-code/tui";
 import { formatNumber } from "@gajae-code/utils";
 import { settings } from "../../config/settings";
+import { renderDeepInterviewAssistantText } from "../../deep-interview/render-middleware";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { isSilentAbort } from "../../session/messages";
 import { resolveImageOptions } from "../../tools/render-utils";
@@ -153,7 +154,10 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.#contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, getMarkdownTheme()));
+				const text = content.text.trim();
+				this.#contentContainer.addChild(
+					renderDeepInterviewAssistantText(text, theme) ?? new Markdown(text, 1, 0, getMarkdownTheme()),
+				);
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -39,6 +39,7 @@ export interface HookSelectorOptions {
 	 * byte-identical to the previous implementation for all consumers.
 	 */
 	wrapFocused?: boolean;
+	scrollTitleRows?: number;
 }
 
 class OutlinedList extends Container {
@@ -60,6 +61,57 @@ class OutlinedList extends Container {
 			return `${borderColor(theme.boxSharp.vertical)}${fitted}${padding(pad)}${borderColor(theme.boxSharp.vertical)}`;
 		});
 		return [horizontal, ...content, horizontal];
+	}
+}
+
+class ScrollableTitle extends Container {
+	#markdown: Markdown;
+	#maxRows: number;
+	#scrollOffset = 0;
+	#lastMaxScrollOffset = 0;
+
+	constructor(title: string, maxRows: number) {
+		super();
+		this.#maxRows = Math.max(1, Math.floor(maxRows));
+		this.#markdown = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+	}
+
+	setText(text: string): void {
+		this.#markdown.setText(text);
+		this.#scrollOffset = 0;
+		this.invalidate();
+	}
+
+	scrollBy(rows: number): void {
+		if (rows === 0) return;
+		const nextOffset = Math.max(0, Math.min(this.#lastMaxScrollOffset, this.#scrollOffset + rows));
+		if (nextOffset === this.#scrollOffset) return;
+		this.#scrollOffset = nextOffset;
+		this.invalidate();
+	}
+
+	render(width: number): string[] {
+		const lines = this.#markdown.render(width);
+		const maxScrollOffset = Math.max(0, lines.length - this.#maxRows);
+		this.#lastMaxScrollOffset = maxScrollOffset;
+		this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScrollOffset));
+
+		const visibleLines = lines.slice(this.#scrollOffset, this.#scrollOffset + this.#maxRows);
+		if (maxScrollOffset === 0 || visibleLines.length === 0) {
+			return visibleLines;
+		}
+
+		const indicator =
+			this.#scrollOffset === 0
+				? theme.fg("dim", " PgDn↓")
+				: this.#scrollOffset >= maxScrollOffset
+					? theme.fg("dim", " PgUp↑")
+					: theme.fg("dim", " PgUp/PgDn↕");
+		const lastIndex = visibleLines.length - 1;
+		const availableWidth = Math.max(1, width - visibleWidth(indicator));
+		const fittedLine = truncateToWidth(visibleLines[lastIndex] ?? "", availableWidth);
+		visibleLines[lastIndex] = `${fittedLine}${indicator}`;
+		return visibleLines;
 	}
 }
 
@@ -199,7 +251,8 @@ export class HookSelectorComponent extends Container {
 	#focusAwareList: FocusAwareList | undefined;
 	#onSelectCallback: (option: string) => void;
 	#onCancelCallback: () => void;
-	#titleComponent: Markdown;
+	#titleComponent: Markdown | ScrollableTitle;
+	#scrollableTitle: ScrollableTitle | undefined;
 	#baseTitle: string;
 	#countdown: CountdownTimer | undefined;
 	#onLeftCallback: (() => void) | undefined;
@@ -207,6 +260,7 @@ export class HookSelectorComponent extends Container {
 	#onExternalEditorCallback: (() => void) | undefined;
 	#wrapFocused: boolean;
 	#outline: boolean;
+	#scrollTitleRows: number | undefined;
 	constructor(
 		title: string,
 		options: string[],
@@ -231,7 +285,14 @@ export class HookSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 
-		this.#titleComponent = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+		const scrollTitleRows = opts?.scrollTitleRows === undefined ? undefined : Math.max(1, Math.floor(opts.scrollTitleRows));
+		this.#scrollTitleRows = scrollTitleRows;
+		if (scrollTitleRows === undefined) {
+			this.#titleComponent = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+		} else {
+			this.#scrollableTitle = new ScrollableTitle(title, scrollTitleRows);
+			this.#titleComponent = this.#scrollableTitle;
+		}
 		this.addChild(this.#titleComponent);
 		this.addChild(new Spacer(1));
 
@@ -319,6 +380,14 @@ export class HookSelectorComponent extends Container {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 
+		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageUp")) {
+			this.#scrollableTitle?.scrollBy(-this.#scrollTitleRows);
+			return;
+		}
+		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageDown")) {
+			this.#scrollableTitle?.scrollBy(this.#scrollTitleRows);
+			return;
+		}
 		if (matchesKey(keyData, "up") || keyData === "k") {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			this.#updateList();

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -590,6 +590,13 @@ export class ExtensionUiController {
 			dialogOptions?.signal,
 		);
 		const maxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
+		const requestedTitleRows = dialogOptions?.scrollTitleRows;
+		const selectorChromeRows = 7;
+		const availableTitleRows = this.ctx.ui.terminal.rows - maxVisible - selectorChromeRows;
+		const scrollTitleRows =
+			requestedTitleRows === undefined
+				? undefined
+				: Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,
 			options,
@@ -624,6 +631,7 @@ export class ExtensionUiController {
 				tui: this.ctx.ui,
 				outline: dialogOptions?.outline,
 				wrapFocused: dialogOptions?.wrapFocused,
+				scrollTitleRows,
 				maxVisible,
 			},
 		);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -85,6 +85,7 @@ export interface AskToolDetails {
 
 const OTHER_OPTION = "Other (type your own)";
 const RECOMMENDED_SUFFIX = " (Recommended)";
+const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = 12;
 
 function getDoneOptionLabel(): string {
 	return `${theme.status.success} Done selecting`;
@@ -139,6 +140,7 @@ interface AskSingleQuestionOptions {
 	signal?: AbortSignal;
 	initialSelection?: Pick<SelectionResult, "selectedOptions" | "customInput">;
 	navigation?: NavigationControls;
+	scrollTitleRows?: number;
 }
 
 interface UIContext {
@@ -151,6 +153,7 @@ interface UIContext {
 			signal?: AbortSignal;
 			outline?: boolean;
 			wrapFocused?: boolean;
+			scrollTitleRows?: number;
 			onTimeout?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
@@ -172,7 +175,7 @@ async function askSingleQuestion(
 	multi: boolean,
 	options: AskSingleQuestionOptions = {},
 ): Promise<SelectionResult> {
-	const { recommended, timeout, signal, initialSelection, navigation } = options;
+	const { recommended, timeout, signal, initialSelection, navigation, scrollTitleRows } = options;
 	const doneLabel = getDoneOptionLabel();
 	let selectedOptions = [...(initialSelection?.selectedOptions ?? [])];
 	let customInput = initialSelection?.customInput;
@@ -188,15 +191,18 @@ async function askSingleQuestion(
 			timeoutTriggered = true;
 		};
 		let navigationAction: "back" | "forward" | undefined;
-		const helpText = navigation
+		const baseHelpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
+		const helpText =
+			scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  PgUp/PgDn scroll question`;
 		const dialogOptions = {
 			initialIndex,
 			timeout,
 			signal,
 			outline: true,
 			wrapFocused: true,
+			scrollTitleRows,
 			onTimeout,
 			helpText,
 			onLeft: navigation?.allowBack
@@ -455,7 +461,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		) => {
 			const optionLabels = q.options.map(o => o.label);
 			try {
-				const displayQuestion = formatDeepInterviewSelectorPrompt(q.question) ?? q.question;
+				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
+				const displayQuestion = deepInterviewPrompt ?? q.question;
 				const { selectedOptions, customInput, navigation, cancelled, timedOut } = await askSingleQuestion(
 					ui,
 					displayQuestion,
@@ -467,6 +474,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						signal,
 						initialSelection: options?.previous,
 						navigation: options?.navigation,
+						scrollTitleRows:
+							deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
 					},
 				);
 				return { optionLabels, selectedOptions, customInput, navigation, cancelled, timedOut };

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -28,6 +28,7 @@ import {
 } from "@gajae-code/tui";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { formatDeepInterviewSelectorPrompt, renderDeepInterviewAskQuestion } from "../deep-interview/render-middleware";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { getMarkdownTheme, type Theme, theme } from "../modes/theme/theme";
 import askDescription from "../prompts/tools/ask.md" with { type: "text" };
@@ -454,9 +455,10 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		) => {
 			const optionLabels = q.options.map(o => o.label);
 			try {
+				const displayQuestion = formatDeepInterviewSelectorPrompt(q.question) ?? q.question;
 				const { selectedOptions, customInput, navigation, cancelled, timedOut } = await askSingleQuestion(
 					ui,
-					q.question,
+					displayQuestion,
 					optionLabels,
 					q.multi ?? false,
 					{
@@ -659,7 +661,10 @@ export const askToolRenderer = {
 				container.addChild(
 					new Text(` ${uiTheme.fg("dim", qBranch)} ${uiTheme.fg("dim", `[${q.id}]`)}${metaStr}`, 0, 0),
 				);
-				container.addChild(new Markdown(q.question, 3, 0, mdTheme, accentStyle));
+				container.addChild(
+					renderDeepInterviewAskQuestion(q.question, uiTheme) ??
+						new Markdown(q.question, 3, 0, mdTheme, accentStyle),
+				);
 
 				const qOptions = q.options;
 				if (qOptions?.length) {
@@ -688,7 +693,10 @@ export const askToolRenderer = {
 		if (args.multi) meta.push("multi");
 		if (args.options?.length) meta.push(`options:${args.options.length}`);
 		container.addChild(new Text(`${label}${formatMeta(meta, uiTheme)}`, 0, 0));
-		container.addChild(new Markdown(args.question, 1, 0, mdTheme, accentStyle));
+		container.addChild(
+			renderDeepInterviewAskQuestion(args.question, uiTheme) ??
+				new Markdown(args.question, 1, 0, mdTheme, accentStyle),
+		);
 
 		const options = args.options;
 		if (options?.length) {
@@ -752,7 +760,10 @@ export const askToolRenderer = {
 				container.addChild(
 					new Text(` ${uiTheme.fg("dim", branch)} ${statusIcon} ${uiTheme.fg("dim", `[${r.id}]`)}`, 0, 0),
 				);
-				container.addChild(new Markdown(r.question, 3, 0, mdTheme, accentStyle));
+				container.addChild(
+					renderDeepInterviewAskQuestion(r.question, uiTheme) ??
+						new Markdown(r.question, 3, 0, mdTheme, accentStyle),
+				);
 
 				const answerLines: string[] = [];
 				for (let j = 0; j < r.selectedOptions.length; j++) {
@@ -795,7 +806,10 @@ export const askToolRenderer = {
 		const header = renderStatusLine({ icon: hasSelection ? "success" : "warning", title: "Ask" }, uiTheme);
 		const container = new Container();
 		container.addChild(new Text(header, 0, 0));
-		container.addChild(new Markdown(details.question, 1, 0, mdTheme, accentStyle));
+		container.addChild(
+			renderDeepInterviewAskQuestion(details.question, uiTheme) ??
+				new Markdown(details.question, 1, 0, mdTheme, accentStyle),
+		);
 
 		const answerLines: string[] = [];
 		if (details.selectedOptions && details.selectedOptions.length > 0) {

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -67,7 +67,7 @@ const BASELINE_OUTLINED_RENDER_80_STRIPPED = [
 
 function renderStripped(
 	width: number,
-	opts: { outline?: boolean; wrapFocused?: boolean; initialIndex?: number; maxVisible?: number },
+	opts: { outline?: boolean; wrapFocused?: boolean; scrollTitleRows?: number; initialIndex?: number; maxVisible?: number },
 	options: string[] = [BASELINE_LONG_FOCUSED, BASELINE_LONG_NON_FOCUSED, BASELINE_SHORT],
 ): string {
 	const component = new HookSelectorComponent(
@@ -278,5 +278,62 @@ describe("HookSelectorComponent", () => {
 		// The truncated row must not contain text from the far end of the
 		// label — it is still one-line behavior.
 		expect(nonFocusedLines[0]).not.toContain("hotel golf");
+	});
+	it("caps scrollable title rows while keeping options and help visible", () => {
+		const title = Array.from({ length: 10 }, (_, index) => `Prompt row ${index + 1}`).join("\n\n");
+		const component = new HookSelectorComponent(
+			title,
+			["answer-a", "answer-b"],
+			() => {},
+			() => {},
+			{
+				outline: true,
+				wrapFocused: true,
+				scrollTitleRows: 3,
+				maxVisible: 2,
+				helpText: "up/down navigate  enter select  esc cancel  PgUp/PgDn scroll question",
+			},
+		);
+
+		const rendered = Bun.stripANSI(component.render(88).join("\n"));
+		const titleRows = rendered.split("\n").filter(line => line.includes("Prompt row"));
+
+		expect(titleRows.length).toBeLessThanOrEqual(3);
+		expect(rendered).toContain("answer-a");
+		expect(rendered).toContain("answer-b");
+		expect(rendered).toContain("PgUp/PgDn scroll question");
+		expect(rendered).toContain("PgDn");
+	});
+
+	it("uses selector-local PageUp/PageDown for title scrolling without moving option focus", () => {
+		const title = Array.from({ length: 8 }, (_, index) => `Question segment ${index + 1}`).join("\n\n");
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			title,
+			["first-choice", "second-choice"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ outline: true, wrapFocused: true, scrollTitleRows: 2, maxVisible: 2 },
+		);
+
+		const initial = Bun.stripANSI(component.render(56).join("\n"));
+		expect(initial).toContain("Question segment 1");
+		expect(initial).not.toContain("Question segment 8");
+		expect(initial).toContain("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[6~");
+		const afterPageDown = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterPageDown).not.toContain("Question segment 1");
+		expect(afterPageDown).toContain("Question segment 8");
+		expect(afterPageDown).toContain("first-choice");
+
+		component.handleInput("\n");
+		expect(selected).toBe("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[5~");
+		const afterPageUp = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterPageUp).toContain("Question segment 1");
 	});
 });

--- a/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
+++ b/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function renderAssistantText(text: string): string {
+	const component = new AssistantMessageComponent(createAssistantMessage(text));
+	return Bun.stripANSI(component.render(100).join("\n"));
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+	await Settings.init({ inMemory: true });
+});
+
+describe("deep-interview assistant render middleware", () => {
+	it("renders progress tables as readable sections", () => {
+		const raw = [
+			"Round 3 complete.",
+			"",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.80 | 0.40 | 0.32 | Clear |",
+			"| Constraints | 0.65 | 0.30 | 0.20 | Mobile/Desktop boundaries are still unresolved |",
+			"| Success Criteria | 0.55 | 0.30 | 0.17 | Approval completion criteria are not yet testable |",
+			"| **Ambiguity** | | | **38%** | |",
+			"",
+			"**Topology:** Targeted Review UI | Active: 4 | Deferred: 0 | Next rotation after: review-ui",
+			"**Ontology:** 6 entities | Stability: 75% | New: 1 | Changed: 0 | Stable: 5",
+			"**Next target:** Review UI / Success Criteria — approval criteria remain unclear",
+		].join("\n");
+
+		const rendered = renderAssistantText(raw);
+
+		expect(rendered).toContain("Deep Interview · Round 3 complete");
+		expect(rendered).toContain("Ambiguity");
+		expect(rendered).toContain("38%");
+		expect(rendered).toContain("Constraints");
+		expect(rendered).toContain("Gap: Mobile/Desktop boundaries are still unresolved");
+		expect(rendered).toContain("Next target");
+		expect(rendered).not.toContain("┌");
+		expect(rendered).not.toContain("| Dimension | Score | Weight | Weighted | Gap |");
+	});
+
+	it("preserves unstructured progress lines instead of dropping them", () => {
+		const raw = [
+			"Round 4 complete.",
+			"",
+			"Matched entities: User→User, Task→Task",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.90 | 0.40 | 0.36 | Clear |",
+			"| Constraints | 0.70 | 0.30 | 0.21 | Export limits still need clarification |",
+			"| Success Criteria | 0.60 | 0.30 | 0.18 | Approval evidence is not fully testable |",
+			"| **Ambiguity** | | | **25%** | |",
+			"",
+			"Clarity threshold met! Ready to proceed.",
+		].join("\n");
+
+		const rendered = renderAssistantText(raw);
+
+		expect(rendered).toContain("Additional details");
+		expect(rendered).toContain("Matched entities: User→User, Task→Task");
+		expect(rendered).toContain("Status");
+		expect(rendered).toContain("Clarity threshold met! Ready to proceed.");
+	});
+});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -26,9 +26,12 @@ function createContext(args: {
 			timeout?: number;
 			signal?: AbortSignal;
 			outline?: boolean;
+			wrapFocused?: boolean;
+			scrollTitleRows?: number;
 			onTimeout?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
+			helpText?: string;
 		},
 	) => Promise<string | undefined>;
 	editor?: (
@@ -1065,6 +1068,63 @@ describe("AskTool deep-interview rendering middleware", () => {
 		expect(prompt).toContain("Why now: the approval criteria are not yet testable");
 		expect(prompt).toContain("What exact conditions must be satisfied before a reviewer can approve an item?");
 		expect(result.details?.question).toBe(rawQuestion);
+	});
+
+	it("opts deep-interview selector prompts into local prompt scrolling", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 4 | Component: Selector UI | Targeting: Readability | Why now: long prompts hide answers | Ambiguity: 44%",
+			"",
+			"What evidence proves the answer options remain visible while the question scrolls?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-deep-interview-scroll",
+			{
+				questions: [
+					{
+						id: "round-4",
+						question: rawQuestion,
+						options: [{ label: "Visible options" }, { label: "Scrollable prompt" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const dialogOptions = select.mock.calls[0]?.[2];
+		expect(dialogOptions?.scrollTitleRows).toBe(12);
+		expect(dialogOptions?.helpText).toContain("PgUp/PgDn scroll question");
+	});
+
+	it("leaves non-deep-interview selector prompts without scroll-title opt-in", async () => {
+		const tool = new AskTool(createSession());
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-normal-ask",
+			{
+				questions: [
+					{
+						id: "normal",
+						question: "Which ordinary option should be selected?",
+						options: [{ label: "A" }, { label: "B" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const dialogOptions = select.mock.calls[0]?.[2];
+		expect(dialogOptions?.scrollTitleRows).toBeUndefined();
+		expect(dialogOptions?.helpText).not.toContain("PgUp/PgDn scroll question");
 	});
 
 	it("recognizes topology questions even when the agent prepends an intro", async () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1029,3 +1029,115 @@ describe("AskTool multi-question navigation", () => {
 		expect(editor).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("AskTool deep-interview rendering middleware", () => {
+	it("uses a readable selector prompt while preserving raw question details", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 3 | Component: Review UI | Targeting: Success Criteria | Why now: the approval criteria are not yet testable | Ambiguity: 38%",
+			"",
+			"What exact conditions must be satisfied before a reviewer can approve an item?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		const result = await tool.execute(
+			"call-deep-interview",
+			{
+				questions: [
+					{
+						id: "round-3",
+						question: rawQuestion,
+						options: [{ label: "Condition A" }, { label: "Condition B" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(select).toHaveBeenCalledTimes(1);
+		const prompt = select.mock.calls[0]?.[0] ?? "";
+		expect(prompt).toContain("Deep Interview · Round 3 · Ambiguity 38%");
+		expect(prompt).toContain("Component: Review UI");
+		expect(prompt).toContain("Target: Success Criteria");
+		expect(prompt).toContain("Why now: the approval criteria are not yet testable");
+		expect(prompt).toContain("What exact conditions must be satisfied before a reviewer can approve an item?");
+		expect(result.details?.question).toBe(rawQuestion);
+	});
+
+	it("recognizes topology questions even when the agent prepends an intro", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Starting deep interview. I'll show a clarity score after each answer.",
+			"",
+			'**Your idea:** "Refresh the GJC UX"',
+			"**Project type:** brownfield",
+			"",
+			"Round 0 | Topology confirmation | Ambiguity: not scored yet",
+			"",
+			"I'm currently reading the scope as these 2 top-level components.",
+			"1. Brand and theme system: red-claw/GJC default theme and semantic color separation.",
+			"2. Tool card UX: readability of ask/approval cards and tool output styling.",
+			"",
+			"Is that topology right? Should any component be added, removed, merged, split, or explicitly deferred?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-deep-interview-topology",
+			{
+				questions: [
+					{
+						id: "round-0",
+						question: rawQuestion,
+						options: [{ label: "Looks right" }, { label: "Revise it" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const prompt = select.mock.calls[0]?.[0] ?? "";
+		expect(prompt).toContain("Deep Interview · Round 0 · Topology confirmation");
+		expect(prompt).toContain("Ambiguity: not scored yet");
+		expect(prompt).toContain("Reading:");
+		expect(prompt).toContain("I'm currently reading the scope as these 2 top-level components.");
+		expect(prompt).toContain("1. Brand and theme system — red-claw/GJC default theme and semantic color separation.");
+		expect(prompt).toContain("Question:");
+		expect(prompt).not.toContain("Context:");
+		expect(prompt).not.toContain('**Your idea:** "Refresh the GJC UX"');
+		expect(prompt).not.toContain("Round 0 | Topology confirmation");
+	});
+
+	it("renders round questions as structured cards in history", async () => {
+		const theme = await getThemeByName("red-claw");
+		expect(theme).toBeDefined();
+		const rawQuestion = [
+			"Round 2 | Component: Export | Targeting: Constraints | Why now: output boundaries are unclear | Ambiguity: 42%",
+			"",
+			"Which export formats are in scope?",
+		].join("\n");
+
+		const rendered = askToolRenderer.renderCall(
+			{
+				question: rawQuestion,
+				options: [{ label: "CSV" }, { label: "PDF" }],
+			},
+			{ expanded: true, isPartial: false },
+			theme!,
+		);
+		const renderedText = stripAnsi(rendered.render(100).join("\n"));
+
+		expect(renderedText).toContain("Deep Interview · Round 2 · Ambiguity 42%");
+		expect(renderedText).toContain("Component");
+		expect(renderedText).toContain("Export");
+		expect(renderedText).toContain("Why now");
+		expect(renderedText).toContain("Question");
+		expect(renderedText).not.toContain("Round 2 | Component:");
+	});
+});


### PR DESCRIPTION
## Summary
- add an opt-in `scrollTitleRows` selector dialog hint for interactive TUI selects
- keep deep-interview ask options/help visible by rendering a scrollable prompt/title panel in `HookSelectorComponent`
- enable selector-local `PageUp`/`PageDown` prompt scrolling only for recognized deep-interview ask prompts, with focused regression coverage and changelog entry

## Testing
- bun test packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/tools/ask.test.ts
- bun test packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
- LSP diagnostics: `packages/coding-agent/src/extensibility/extensions/types.ts`
- LSP diagnostics: `packages/coding-agent/src/modes/components/hook-selector.ts`
- LSP diagnostics: `packages/coding-agent/src/modes/controllers/extension-ui-controller.ts`
- LSP diagnostics: `packages/coding-agent/src/tools/ask.ts`
