### PR TITLE
Fix deep-interview ask prompt scrolling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Clarified that `gjc team` requires an existing tmux-backed leader session from `gjc --tmux`, with actionable help, docs, and failure text.
+- Kept deep-interview ask options visible for long prompts by adding an opt-in scrollable selector title panel with selector-local `PageUp`/`PageDown` prompt scrolling, while leaving normal ask dialogs and global keybinding configuration unchanged.
 
 ## [0.2.5] - 2026-06-02
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -116,6 +116,12 @@ export interface ExtensionUIDialogOptions {
 	 * hint; non-TUI bridges (RPC, ACP) drop it and do not serialize it.
 	 */
 	wrapFocused?: boolean;
+	/**
+	 * For interactive TUI select dialogs, cap the title/prompt area to this
+	 * many rows and let PageUp/PageDown scroll that prompt locally. This is a
+	 * select-only rendering hint; non-TUI bridges drop it and do not serialize it.
+	 */
+	scrollTitleRows?: number;
 }
 
 /** Raw terminal input listener for extensions. */

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -39,6 +39,7 @@ export interface HookSelectorOptions {
 	 * byte-identical to the previous implementation for all consumers.
 	 */
 	wrapFocused?: boolean;
+	scrollTitleRows?: number;
 }
 
 class OutlinedList extends Container {
@@ -60,6 +61,57 @@ class OutlinedList extends Container {
 			return `${borderColor(theme.boxSharp.vertical)}${fitted}${padding(pad)}${borderColor(theme.boxSharp.vertical)}`;
 		});
 		return [horizontal, ...content, horizontal];
+	}
+}
+
+class ScrollableTitle extends Container {
+	#markdown: Markdown;
+	#maxRows: number;
+	#scrollOffset = 0;
+	#lastMaxScrollOffset = 0;
+
+	constructor(title: string, maxRows: number) {
+		super();
+		this.#maxRows = Math.max(1, Math.floor(maxRows));
+		this.#markdown = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+	}
+
+	setText(text: string): void {
+		this.#markdown.setText(text);
+		this.#scrollOffset = 0;
+		this.invalidate();
+	}
+
+	scrollBy(rows: number): void {
+		if (rows === 0) return;
+		const nextOffset = Math.max(0, Math.min(this.#lastMaxScrollOffset, this.#scrollOffset + rows));
+		if (nextOffset === this.#scrollOffset) return;
+		this.#scrollOffset = nextOffset;
+		this.invalidate();
+	}
+
+	render(width: number): string[] {
+		const lines = this.#markdown.render(width);
+		const maxScrollOffset = Math.max(0, lines.length - this.#maxRows);
+		this.#lastMaxScrollOffset = maxScrollOffset;
+		this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScrollOffset));
+
+		const visibleLines = lines.slice(this.#scrollOffset, this.#scrollOffset + this.#maxRows);
+		if (maxScrollOffset === 0 || visibleLines.length === 0) {
+			return visibleLines;
+		}
+
+		const indicator =
+			this.#scrollOffset === 0
+				? theme.fg("dim", " PgDn↓")
+				: this.#scrollOffset >= maxScrollOffset
+					? theme.fg("dim", " PgUp↑")
+					: theme.fg("dim", " PgUp/PgDn↕");
+		const lastIndex = visibleLines.length - 1;
+		const availableWidth = Math.max(1, width - visibleWidth(indicator));
+		const fittedLine = truncateToWidth(visibleLines[lastIndex] ?? "", availableWidth);
+		visibleLines[lastIndex] = `${fittedLine}${indicator}`;
+		return visibleLines;
 	}
 }
 
@@ -199,7 +251,8 @@ export class HookSelectorComponent extends Container {
 	#focusAwareList: FocusAwareList | undefined;
 	#onSelectCallback: (option: string) => void;
 	#onCancelCallback: () => void;
-	#titleComponent: Markdown;
+	#titleComponent: Markdown | ScrollableTitle;
+	#scrollableTitle: ScrollableTitle | undefined;
 	#baseTitle: string;
 	#countdown: CountdownTimer | undefined;
 	#onLeftCallback: (() => void) | undefined;
@@ -207,6 +260,7 @@ export class HookSelectorComponent extends Container {
 	#onExternalEditorCallback: (() => void) | undefined;
 	#wrapFocused: boolean;
 	#outline: boolean;
+	#scrollTitleRows: number | undefined;
 	constructor(
 		title: string,
 		options: string[],
@@ -231,7 +285,14 @@ export class HookSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 
-		this.#titleComponent = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+		const scrollTitleRows = opts?.scrollTitleRows === undefined ? undefined : Math.max(1, Math.floor(opts.scrollTitleRows));
+		this.#scrollTitleRows = scrollTitleRows;
+		if (scrollTitleRows === undefined) {
+			this.#titleComponent = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });
+		} else {
+			this.#scrollableTitle = new ScrollableTitle(title, scrollTitleRows);
+			this.#titleComponent = this.#scrollableTitle;
+		}
 		this.addChild(this.#titleComponent);
 		this.addChild(new Spacer(1));
 
@@ -319,6 +380,14 @@ export class HookSelectorComponent extends Container {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 
+		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageUp")) {
+			this.#scrollableTitle?.scrollBy(-this.#scrollTitleRows);
+			return;
+		}
+		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageDown")) {
+			this.#scrollableTitle?.scrollBy(this.#scrollTitleRows);
+			return;
+		}
 		if (matchesKey(keyData, "up") || keyData === "k") {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			this.#updateList();

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -285,7 +285,8 @@ export class HookSelectorComponent extends Container {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 
-		const scrollTitleRows = opts?.scrollTitleRows === undefined ? undefined : Math.max(1, Math.floor(opts.scrollTitleRows));
+		const scrollTitleRows =
+			opts?.scrollTitleRows === undefined ? undefined : Math.max(1, Math.floor(opts.scrollTitleRows));
 		this.#scrollTitleRows = scrollTitleRows;
 		if (scrollTitleRows === undefined) {
 			this.#titleComponent = new Markdown(title, 1, 0, getMarkdownTheme(), { color: t => theme.fg("accent", t) });

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -590,6 +590,13 @@ export class ExtensionUiController {
 			dialogOptions?.signal,
 		);
 		const maxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
+		const requestedTitleRows = dialogOptions?.scrollTitleRows;
+		const selectorChromeRows = 7;
+		const availableTitleRows = this.ctx.ui.terminal.rows - maxVisible - selectorChromeRows;
+		const scrollTitleRows =
+			requestedTitleRows === undefined
+				? undefined
+				: Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,
 			options,
@@ -624,6 +631,7 @@ export class ExtensionUiController {
 				tui: this.ctx.ui,
 				outline: dialogOptions?.outline,
 				wrapFocused: dialogOptions?.wrapFocused,
+				scrollTitleRows,
 				maxVisible,
 			},
 		);

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -594,9 +594,7 @@ export class ExtensionUiController {
 		const selectorChromeRows = 7;
 		const availableTitleRows = this.ctx.ui.terminal.rows - maxVisible - selectorChromeRows;
 		const scrollTitleRows =
-			requestedTitleRows === undefined
-				? undefined
-				: Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
+			requestedTitleRows === undefined ? undefined : Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,
 			options,

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -85,6 +85,7 @@ export interface AskToolDetails {
 
 const OTHER_OPTION = "Other (type your own)";
 const RECOMMENDED_SUFFIX = " (Recommended)";
+const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = 12;
 
 function getDoneOptionLabel(): string {
 	return `${theme.status.success} Done selecting`;
@@ -139,6 +140,7 @@ interface AskSingleQuestionOptions {
 	signal?: AbortSignal;
 	initialSelection?: Pick<SelectionResult, "selectedOptions" | "customInput">;
 	navigation?: NavigationControls;
+	scrollTitleRows?: number;
 }
 
 interface UIContext {
@@ -151,6 +153,7 @@ interface UIContext {
 			signal?: AbortSignal;
 			outline?: boolean;
 			wrapFocused?: boolean;
+			scrollTitleRows?: number;
 			onTimeout?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
@@ -172,7 +175,7 @@ async function askSingleQuestion(
 	multi: boolean,
 	options: AskSingleQuestionOptions = {},
 ): Promise<SelectionResult> {
-	const { recommended, timeout, signal, initialSelection, navigation } = options;
+	const { recommended, timeout, signal, initialSelection, navigation, scrollTitleRows } = options;
 	const doneLabel = getDoneOptionLabel();
 	let selectedOptions = [...(initialSelection?.selectedOptions ?? [])];
 	let customInput = initialSelection?.customInput;
@@ -188,15 +191,18 @@ async function askSingleQuestion(
 			timeoutTriggered = true;
 		};
 		let navigationAction: "back" | "forward" | undefined;
-		const helpText = navigation
+		const baseHelpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
+		const helpText =
+			scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  PgUp/PgDn scroll question`;
 		const dialogOptions = {
 			initialIndex,
 			timeout,
 			signal,
 			outline: true,
 			wrapFocused: true,
+			scrollTitleRows,
 			onTimeout,
 			helpText,
 			onLeft: navigation?.allowBack
@@ -455,7 +461,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		) => {
 			const optionLabels = q.options.map(o => o.label);
 			try {
-				const displayQuestion = formatDeepInterviewSelectorPrompt(q.question) ?? q.question;
+				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
+				const displayQuestion = deepInterviewPrompt ?? q.question;
 				const { selectedOptions, customInput, navigation, cancelled, timedOut } = await askSingleQuestion(
 					ui,
 					displayQuestion,
@@ -467,6 +474,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						signal,
 						initialSelection: options?.previous,
 						navigation: options?.navigation,
+						scrollTitleRows:
+							deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
 					},
 				);
 				return { optionLabels, selectedOptions, customInput, navigation, cancelled, timedOut };

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -194,8 +194,7 @@ async function askSingleQuestion(
 		const baseHelpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
-		const helpText =
-			scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  PgUp/PgDn scroll question`;
+		const helpText = scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  PgUp/PgDn scroll question`;
 		const dialogOptions = {
 			initialIndex,
 			timeout,
@@ -474,8 +473,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						signal,
 						initialSelection: options?.previous,
 						navigation: options?.navigation,
-						scrollTitleRows:
-							deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
+						scrollTitleRows: deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
 					},
 				);
 				return { optionLabels, selectedOptions, customInput, navigation, cancelled, timedOut };

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -67,7 +67,7 @@ const BASELINE_OUTLINED_RENDER_80_STRIPPED = [
 
 function renderStripped(
 	width: number,
-	opts: { outline?: boolean; wrapFocused?: boolean; initialIndex?: number; maxVisible?: number },
+	opts: { outline?: boolean; wrapFocused?: boolean; scrollTitleRows?: number; initialIndex?: number; maxVisible?: number },
 	options: string[] = [BASELINE_LONG_FOCUSED, BASELINE_LONG_NON_FOCUSED, BASELINE_SHORT],
 ): string {
 	const component = new HookSelectorComponent(
@@ -278,5 +278,62 @@ describe("HookSelectorComponent", () => {
 		// The truncated row must not contain text from the far end of the
 		// label — it is still one-line behavior.
 		expect(nonFocusedLines[0]).not.toContain("hotel golf");
+	});
+	it("caps scrollable title rows while keeping options and help visible", () => {
+		const title = Array.from({ length: 10 }, (_, index) => `Prompt row ${index + 1}`).join("\n\n");
+		const component = new HookSelectorComponent(
+			title,
+			["answer-a", "answer-b"],
+			() => {},
+			() => {},
+			{
+				outline: true,
+				wrapFocused: true,
+				scrollTitleRows: 3,
+				maxVisible: 2,
+				helpText: "up/down navigate  enter select  esc cancel  PgUp/PgDn scroll question",
+			},
+		);
+
+		const rendered = Bun.stripANSI(component.render(88).join("\n"));
+		const titleRows = rendered.split("\n").filter(line => line.includes("Prompt row"));
+
+		expect(titleRows.length).toBeLessThanOrEqual(3);
+		expect(rendered).toContain("answer-a");
+		expect(rendered).toContain("answer-b");
+		expect(rendered).toContain("PgUp/PgDn scroll question");
+		expect(rendered).toContain("PgDn");
+	});
+
+	it("uses selector-local PageUp/PageDown for title scrolling without moving option focus", () => {
+		const title = Array.from({ length: 8 }, (_, index) => `Question segment ${index + 1}`).join("\n\n");
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			title,
+			["first-choice", "second-choice"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ outline: true, wrapFocused: true, scrollTitleRows: 2, maxVisible: 2 },
+		);
+
+		const initial = Bun.stripANSI(component.render(56).join("\n"));
+		expect(initial).toContain("Question segment 1");
+		expect(initial).not.toContain("Question segment 8");
+		expect(initial).toContain("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[6~");
+		const afterPageDown = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterPageDown).not.toContain("Question segment 1");
+		expect(afterPageDown).toContain("Question segment 8");
+		expect(afterPageDown).toContain("first-choice");
+
+		component.handleInput("\n");
+		expect(selected).toBe("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[5~");
+		const afterPageUp = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterPageUp).toContain("Question segment 1");
 	});
 });

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -67,7 +67,13 @@ const BASELINE_OUTLINED_RENDER_80_STRIPPED = [
 
 function renderStripped(
 	width: number,
-	opts: { outline?: boolean; wrapFocused?: boolean; scrollTitleRows?: number; initialIndex?: number; maxVisible?: number },
+	opts: {
+		outline?: boolean;
+		wrapFocused?: boolean;
+		scrollTitleRows?: number;
+		initialIndex?: number;
+		maxVisible?: number;
+	},
 	options: string[] = [BASELINE_LONG_FOCUSED, BASELINE_LONG_NON_FOCUSED, BASELINE_SHORT],
 ): string {
 	const component = new HookSelectorComponent(

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -26,9 +26,12 @@ function createContext(args: {
 			timeout?: number;
 			signal?: AbortSignal;
 			outline?: boolean;
+			wrapFocused?: boolean;
+			scrollTitleRows?: number;
 			onTimeout?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
+			helpText?: string;
 		},
 	) => Promise<string | undefined>;
 	editor?: (
@@ -1065,6 +1068,63 @@ describe("AskTool deep-interview rendering middleware", () => {
 		expect(prompt).toContain("Why now: the approval criteria are not yet testable");
 		expect(prompt).toContain("What exact conditions must be satisfied before a reviewer can approve an item?");
 		expect(result.details?.question).toBe(rawQuestion);
+	});
+
+	it("opts deep-interview selector prompts into local prompt scrolling", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 4 | Component: Selector UI | Targeting: Readability | Why now: long prompts hide answers | Ambiguity: 44%",
+			"",
+			"What evidence proves the answer options remain visible while the question scrolls?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-deep-interview-scroll",
+			{
+				questions: [
+					{
+						id: "round-4",
+						question: rawQuestion,
+						options: [{ label: "Visible options" }, { label: "Scrollable prompt" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const dialogOptions = select.mock.calls[0]?.[2];
+		expect(dialogOptions?.scrollTitleRows).toBe(12);
+		expect(dialogOptions?.helpText).toContain("PgUp/PgDn scroll question");
+	});
+
+	it("leaves non-deep-interview selector prompts without scroll-title opt-in", async () => {
+		const tool = new AskTool(createSession());
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-normal-ask",
+			{
+				questions: [
+					{
+						id: "normal",
+						question: "Which ordinary option should be selected?",
+						options: [{ label: "A" }, { label: "B" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const dialogOptions = select.mock.calls[0]?.[2];
+		expect(dialogOptions?.scrollTitleRows).toBeUndefined();
+		expect(dialogOptions?.helpText).not.toContain("PgUp/PgDn scroll question");
 	});
 
 	it("recognizes topology questions even when the agent prepends an intro", async () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1077,7 +1077,10 @@ describe("AskTool deep-interview rendering middleware", () => {
 			"",
 			"What evidence proves the answer options remain visible while the question scrolls?",
 		].join("\n");
-		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const select = vi.fn(
+			async (_prompt: string, options: string[], _dialogOptions?: { scrollTitleRows?: number; helpText?: string }) =>
+				options[0],
+		);
 		const context = createContext({ select });
 
 		await tool.execute(
@@ -1103,7 +1106,10 @@ describe("AskTool deep-interview rendering middleware", () => {
 
 	it("leaves non-deep-interview selector prompts without scroll-title opt-in", async () => {
 		const tool = new AskTool(createSession());
-		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const select = vi.fn(
+			async (_prompt: string, options: string[], _dialogOptions?: { scrollTitleRows?: number; helpText?: string }) =>
+				options[0],
+		);
 		const context = createContext({ select });
 
 		await tool.execute(


### PR DESCRIPTION
## Summary
- add an opt-in `scrollTitleRows` hint for interactive TUI select dialogs
- keep deep-interview ask options visible by rendering a bounded scrollable prompt/title panel in `HookSelectorComponent`
- enable selector-local `PageUp`/`PageDown` prompt scrolling only for recognized deep-interview ask prompts
- fix the new ask tests so package type-checks pass cleanly

## Scope guard
- fresh PR from the latest `dev`
- excludes already-merged deep-interview render-middleware work
- keeps the fix limited to ask-prompt scrolling, its focused tests, and the changelog note

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/tools/ask.test.ts`
- `bun test packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts`
