### PR TITLE
Fix harness observe after completed owner exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added runtime-enforced Ultragoal executor QA/red-team evidence matrices for completion checkpoints, with plan-first contract coverage, user-surface evidence, adversarial cases, artifact references, scoped Executor red-team guidance, and focused rejection tests for shallow or contradictory QA evidence.
 ### Fixed
 
+- Made `gjc harness observe` preserve completed RPC owner evidence after the owner exits, including a `completedOwnerExited` diagnostic and durable terminal-result cursor.
 - Clarified that `gjc team` requires an existing tmux-backed leader session from `gjc --tmux`, with actionable help, docs, and failure text.
 - Kept deep-interview ask options visible for long prompts by adding an opt-in scrollable selector title panel with selector-local `PageUp`/`PageDown` prompt scrolling, while leaving normal ask dialogs and global keybinding configuration unchanged.
 

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -27,6 +27,7 @@ import {
 } from "../harness-control-plane/storage";
 import {
 	DEFAULT_RETRY_BUDGET,
+	type EventEnvelope,
 	type GitDelta,
 	type Harness as HarnessKind,
 	type Observation,
@@ -77,23 +78,58 @@ function gitDeltaFor(workspace: string): { gitDelta: GitDelta; branch: string | 
 	}
 }
 
-/** Owner liveness — always false in the foundation build (RuntimeOwner is M3). */
+/** Fallback liveness after owner routing failed: no reachable owner handled this CLI call. */
 function ownerLiveFor(_state: SessionState): boolean {
 	return false;
 }
 
-function buildObservation(state: SessionState, ownerLive: boolean): Observation {
+function pushUnique(out: string[], value: unknown): void {
+	if (typeof value === "string" && !out.includes(value)) out.push(value);
+}
+
+function completedTerminalEvent(events: EventEnvelope[]): {
+	cursor: number;
+	createdAt: string;
+	kind: string;
+} | null {
+	for (const event of [...events].reverse()) {
+		const signal = (event.evidence as { signal?: unknown } | undefined)?.signal;
+		if (event.kind === "rpc_agent_completed" || signal === "completed") {
+			return { cursor: event.cursor, createdAt: event.createdAt, kind: event.kind };
+		}
+	}
+	return null;
+}
+
+async function buildObservation(
+	root: string,
+	state: SessionState,
+	ownerLive: boolean,
+): Promise<{
+	observation: Observation;
+	completedTerminalEvent: { cursor: number; createdAt: string; kind: string } | null;
+}> {
 	const workspace = state.handle.workspace;
 	const { gitDelta, branch, deleted } = gitDeltaFor(workspace);
+	const events = await readEvents(root, state.sessionId, 0);
+	const observedSignals = ["SessionStart"];
+	for (const event of events.slice(-200)) {
+		pushUnique(observedSignals, (event.evidence as { signal?: unknown } | undefined)?.signal);
+	}
+	const terminalEvent = completedTerminalEvent(events);
+	const lastEventAt = events.at(-1)?.createdAt;
 	return {
-		lifecycle: state.lifecycle,
-		ownerLive,
-		cwd: workspace,
-		branch: branch ?? state.handle.branch,
-		gitDelta,
-		lastActivityAt: state.updatedAt,
-		observedSignals: ["SessionStart"],
-		risk: deleted ? "deleted-worktree" : "normal",
+		observation: {
+			lifecycle: state.lifecycle,
+			ownerLive,
+			cwd: workspace,
+			branch: branch ?? state.handle.branch,
+			gitDelta,
+			lastActivityAt: lastEventAt ?? state.updatedAt,
+			observedSignals,
+			risk: deleted ? "deleted-worktree" : "normal",
+		},
+		completedTerminalEvent: terminalEvent,
 	};
 }
 
@@ -455,8 +491,16 @@ export default class Harness extends Command {
 		if (await this.#tryOwnerRoute(root, sessionId, "observe", { ...input, sessionId })) return;
 		const state = await loadState(root, sessionId);
 		const ownerLive = ownerLiveFor(state);
-		const observation = buildObservation(state, ownerLive);
-		writeJson(buildResponse(state, ownerLive, { observation, readOnly: !ownerLive }));
+		const { observation, completedTerminalEvent } = await buildObservation(root, state, ownerLive);
+		writeJson(
+			buildResponse(state, ownerLive, {
+				observation,
+				readOnly: !ownerLive,
+				...(completedTerminalEvent && !ownerLive
+					? { completedOwnerExited: true, terminalResult: completedTerminalEvent }
+					: {}),
+			}),
+		);
 	}
 
 	async #classify(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
@@ -466,7 +510,7 @@ export default class Harness extends Command {
 		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
 		if (sessionId) {
 			stateView = await loadState(root, sessionId);
-			if (!observation) observation = buildObservation(stateView, ownerLiveFor(stateView));
+			if (!observation) observation = (await buildObservation(root, stateView, ownerLiveFor(stateView))).observation;
 		}
 		if (!observation) throw new Error("classify_requires_observation_or_session");
 		const full: Observation = {
@@ -531,7 +575,7 @@ export default class Harness extends Command {
 		const sessionId = requireSessionId(input, flagSession);
 		if (await this.#tryOwnerRoute(root, sessionId, "retire", { ...input, sessionId })) return;
 		const state = await loadState(root, sessionId);
-		const observation = buildObservation(state, ownerLiveFor(state));
+		const { observation } = await buildObservation(root, state, ownerLiveFor(state));
 		if (observation.gitDelta === "dirty" || observation.gitDelta === "unknown") {
 			writeJson(
 				buildResponse(

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { appendEvent, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -84,6 +85,44 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation).toHaveProperty("gitDelta");
 		expect(res.json.evidence.observation).toHaveProperty("risk");
 		expect(res.json.evidence.observation).not.toHaveProperty("pane");
+	});
+
+	it("observe exposes durable completion evidence after the owner has exited", async () => {
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		expect(state).toBeTruthy();
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "finalizing";
+		state.updatedAt = "2026-06-03T00:00:00.000Z";
+		await writeSessionState(root, state);
+		await appendEvent(root, sessionId, {
+			eventId: "evt-completed",
+			cursor: 1,
+			createdAt: "2026-06-03T00:00:01.000Z",
+			severity: "info",
+			kind: "rpc_agent_completed",
+			state: { sessionId, lifecycle: "finalizing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { signal: "completed", outcome: "completed" },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+		});
+
+		const res = runHarness(["observe", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.ownerLive).toBe(false);
+		expect(res.json.state.lifecycle).toBe("finalizing");
+		expect(res.json.evidence.readOnly).toBe(true);
+		expect(res.json.evidence.completedOwnerExited).toBe(true);
+		expect(res.json.evidence.terminalResult).toEqual({
+			cursor: 1,
+			createdAt: "2026-06-03T00:00:01.000Z",
+			kind: "rpc_agent_completed",
+		});
+		expect(res.json.evidence.observation.observedSignals).toContain("completed");
+		expect(res.json.evidence.observation.lastActivityAt).toBe("2026-06-03T00:00:01.000Z");
 	});
 
 	it("submit is blocked (accepted:false, owner-not-live) and never echoed-as-accepted", () => {


### PR DESCRIPTION
## Summary
- preserve event-log-derived completed signals in no-owner `gjc harness observe` responses
- expose `completedOwnerExited` plus a durable terminal-result cursor when the owner is gone after `rpc_agent_completed`
- add regression coverage for completed owner exit fallback observe

Fixes #227.

## Validation
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/harness-control-plane/cli.test.ts packages/coding-agent/test/harness-control-plane/owner-frames.test.ts packages/coding-agent/test/harness-control-plane/owner.test.ts`