### PR TITLE
fix(coding-agent): persist model across session handoffs

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5188,6 +5188,9 @@ export class AgentSession {
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
 		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+		if (this.model) {
+			this.sessionManager.appendModelChange(`${this.model.provider}/${this.model.id}`);
+		}
 		this.sessionManager.appendServiceTierChange(this.serviceTier ?? null);
 		if (nextDiscoverySessionToolNames) {
 			await this.#applyActiveToolsByName(nextDiscoverySessionToolNames, { persistMCPSelection: false });
@@ -5979,6 +5982,11 @@ export class AgentSession {
 			this.#pendingNextTurnMessages = [];
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#todoReminderCount = 0;
+			if (model) {
+				this.sessionManager.appendModelChange(`${model.provider}/${model.id}`);
+			}
+			this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+			this.sessionManager.appendServiceTierChange(this.serviceTier ?? null);
 
 			// Inject the handoff document as a custom message
 			const handoffContent = createHandoffContext(handoffText);

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -105,6 +105,12 @@ describe("AgentSession handoff", () => {
 		).toHaveLength(0);
 	});
 
+	it("persists active model when starting a new session", async () => {
+		const created = await session.newSession();
+		expect(created).toBe(true);
+		expect(sessionManager.buildSessionContext().models.default).toBe("anthropic/claude-sonnet-4-5");
+	});
+
 	it("does not run auto-compaction after handoff turn completes", async () => {
 		const handoffText = "## Goal\nContinue from here";
 		const generateHandoffSpy = vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue(handoffText);
@@ -193,6 +199,7 @@ describe("AgentSession handoff", () => {
 			parentSession?: string;
 			customType?: string;
 			display?: boolean;
+			model?: string;
 		};
 		const handoffEntries = (await Bun.file(handoffSessionFile).text())
 			.trim()
@@ -211,6 +218,9 @@ describe("AgentSession handoff", () => {
 			handoffEntries.some(
 				entry => entry.type === "custom_message" && entry.customType === "handoff" && entry.display,
 			),
+		).toBe(true);
+		expect(
+			handoffEntries.some(entry => entry.type === "model_change" && entry.model === "anthropic/claude-sonnet-4-5"),
 		).toBe(true);
 
 		const previousSessionText = await Bun.file(previousSessionFile).text();


### PR DESCRIPTION
## Summary
- Persist the active model when starting a new session so continuation sessions do not fall back to settings/defaults.
- Persist model/thinking/service-tier metadata in generated handoff sessions before injecting handoff context.
- Add regression coverage for new-session and handoff session model_change entries.

## Validation
- bun test packages/coding-agent/test/agent-session-handoff.test.ts packages/coding-agent/test/tools/skill.test.ts packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
- bun run check:ts

Fixes #228