### PR TITLE
Fix harness vanished owner lifecycle state

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -87,11 +87,13 @@ function pushUnique(out: string[], value: unknown): void {
 	if (typeof value === "string" && !out.includes(value)) out.push(value);
 }
 
-function completedTerminalEvent(events: EventEnvelope[]): {
+interface CompletedTerminalEvent {
 	cursor: number;
 	createdAt: string;
 	kind: string;
-} | null {
+}
+
+function completedTerminalEvent(events: EventEnvelope[]): CompletedTerminalEvent | null {
 	for (const event of [...events].reverse()) {
 		const signal = (event.evidence as { signal?: unknown } | undefined)?.signal;
 		if (event.kind === "rpc_agent_completed" || signal === "completed") {
@@ -107,7 +109,7 @@ async function buildObservation(
 	ownerLive: boolean,
 ): Promise<{
 	observation: Observation;
-	completedTerminalEvent: { cursor: number; createdAt: string; kind: string } | null;
+	completedTerminalEvent: CompletedTerminalEvent | null;
 }> {
 	const workspace = state.handle.workspace;
 	const { gitDelta, branch, deleted } = gitDeltaFor(workspace);
@@ -133,9 +135,13 @@ async function buildObservation(
 	};
 }
 
-function needsVanishedOwnerBlock(state: SessionState, observation: Observation): boolean {
+function needsVanishedOwnerBlock(
+	state: SessionState,
+	observation: Observation,
+	completedTerminal: CompletedTerminalEvent | null,
+): boolean {
 	if (observation.ownerLive || state.lifecycle !== "observing") return false;
-	if (observation.observedSignals.includes("completed")) return false;
+	if (completedTerminal || observation.observedSignals.includes("completed")) return false;
 	return observation.observedSignals.some(
 		signal => signal === "prompt-accepted" || signal === "tool-call" || signal === "streaming",
 	);
@@ -145,8 +151,9 @@ async function markVanishedOwnerBlocked(
 	root: string,
 	state: SessionState,
 	observation: Observation,
+	completedTerminal: CompletedTerminalEvent | null,
 ): Promise<SessionState> {
-	if (!needsVanishedOwnerBlock(state, observation)) return state;
+	if (!needsVanishedOwnerBlock(state, observation, completedTerminal)) return state;
 	const blocker = `owner-vanished:${observation.gitDelta}`;
 	state.lifecycle = "blocked";
 	state.blockers = state.blockers.includes(blocker) ? state.blockers : [...state.blockers, blocker];
@@ -515,8 +522,8 @@ export default class Harness extends Command {
 		let state = await loadState(root, sessionId);
 		const ownerLive = ownerLiveFor(state);
 		const { observation, completedTerminalEvent } = await buildObservation(root, state, ownerLive);
-		const vanishedOwnerBlock = needsVanishedOwnerBlock(state, observation);
-		state = await markVanishedOwnerBlocked(root, state, observation);
+		const vanishedOwnerBlock = needsVanishedOwnerBlock(state, observation, completedTerminalEvent);
+		state = await markVanishedOwnerBlocked(root, state, observation, completedTerminalEvent);
 		writeJson(
 			buildResponse(state, ownerLive, {
 				observation: { ...observation, lifecycle: state.lifecycle },
@@ -539,9 +546,14 @@ export default class Harness extends Command {
 		if (sessionId) {
 			stateView = await loadState(root, sessionId);
 			if (!observation) {
-				const built = (await buildObservation(root, stateView, ownerLiveFor(stateView))).observation;
-				observation = built;
-				stateView = await markVanishedOwnerBlocked(root, stateView, built);
+				const built = await buildObservation(root, stateView, ownerLiveFor(stateView));
+				observation = built.observation;
+				stateView = await markVanishedOwnerBlocked(
+					root,
+					stateView,
+					built.observation,
+					built.completedTerminalEvent,
+				);
 			}
 		}
 		if (!observation) throw new Error("classify_requires_observation_or_session");
@@ -638,8 +650,8 @@ export default class Harness extends Command {
 	async #recoverWithoutOwner(root: string, sessionId: string, input: Record<string, unknown>): Promise<void> {
 		const budget = resolveRetryBudget(input);
 		let state = await loadState(root, sessionId);
-		const { observation } = await buildObservation(root, state, false);
-		state = await markVanishedOwnerBlocked(root, state, observation);
+		const { observation, completedTerminalEvent } = await buildObservation(root, state, false);
+		state = await markVanishedOwnerBlocked(root, state, observation, completedTerminalEvent);
 		const decision = classifyRecovery({
 			observation: { ...observation, lifecycle: state.lifecycle },
 			retryBudget: budget,

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -127,10 +127,32 @@ async function buildObservation(
 			gitDelta,
 			lastActivityAt: lastEventAt ?? state.updatedAt,
 			observedSignals,
-			risk: deleted ? "deleted-worktree" : "normal",
+			risk: deleted ? "deleted-worktree" : !ownerLive && gitDelta === "dirty" ? "vanished-dirty" : "normal",
 		},
 		completedTerminalEvent: terminalEvent,
 	};
+}
+
+function needsVanishedOwnerBlock(state: SessionState, observation: Observation): boolean {
+	if (observation.ownerLive || state.lifecycle !== "observing") return false;
+	if (observation.observedSignals.includes("completed")) return false;
+	return observation.observedSignals.some(
+		signal => signal === "prompt-accepted" || signal === "tool-call" || signal === "streaming",
+	);
+}
+
+async function markVanishedOwnerBlocked(
+	root: string,
+	state: SessionState,
+	observation: Observation,
+): Promise<SessionState> {
+	if (!needsVanishedOwnerBlock(state, observation)) return state;
+	const blocker = `owner-vanished:${observation.gitDelta}`;
+	state.lifecycle = "blocked";
+	state.blockers = state.blockers.includes(blocker) ? state.blockers : [...state.blockers, blocker];
+	state.updatedAt = nowIso();
+	await writeSessionState(root, state);
+	return state;
 }
 
 function resolveRetryBudget(input: Record<string, unknown>): RetryBudget {
@@ -250,6 +272,7 @@ export default class Harness extends Command {
 	): Promise<void> {
 		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
 		if (sessionId && (await this.#tryOwnerRoute(root, sessionId, verb, { ...input, sessionId }))) return;
+		if (verb === "recover" && sessionId) return this.#recoverWithoutOwner(root, sessionId, input);
 		return this.#pending(root, verb, input, flagSession);
 	}
 
@@ -489,13 +512,18 @@ export default class Harness extends Command {
 	async #observe(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
 		const sessionId = requireSessionId(input, flagSession);
 		if (await this.#tryOwnerRoute(root, sessionId, "observe", { ...input, sessionId })) return;
-		const state = await loadState(root, sessionId);
+		let state = await loadState(root, sessionId);
 		const ownerLive = ownerLiveFor(state);
 		const { observation, completedTerminalEvent } = await buildObservation(root, state, ownerLive);
+		const vanishedOwnerBlock = needsVanishedOwnerBlock(state, observation);
+		state = await markVanishedOwnerBlocked(root, state, observation);
 		writeJson(
 			buildResponse(state, ownerLive, {
-				observation,
+				observation: { ...observation, lifecycle: state.lifecycle },
 				readOnly: !ownerLive,
+				...(vanishedOwnerBlock
+					? { ownerVanished: true, blockerReason: `owner-vanished:${observation.gitDelta}` }
+					: {}),
 				...(completedTerminalEvent && !ownerLive
 					? { completedOwnerExited: true, terminalResult: completedTerminalEvent }
 					: {}),
@@ -510,7 +538,11 @@ export default class Harness extends Command {
 		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
 		if (sessionId) {
 			stateView = await loadState(root, sessionId);
-			if (!observation) observation = (await buildObservation(root, stateView, ownerLiveFor(stateView))).observation;
+			if (!observation) {
+				const built = (await buildObservation(root, stateView, ownerLiveFor(stateView))).observation;
+				observation = built;
+				stateView = await markVanishedOwnerBlocked(root, stateView, built);
+			}
 		}
 		if (!observation) throw new Error("classify_requires_observation_or_session");
 		const full: Observation = {
@@ -525,7 +557,12 @@ export default class Harness extends Command {
 		};
 		const decision = classifyRecovery({ observation: full, retryBudget: budget });
 		if (stateView) {
-			writeJson(buildResponse(stateView, ownerLiveFor(stateView), { decision, observation: full }));
+			writeJson(
+				buildResponse(stateView, ownerLiveFor(stateView), {
+					decision,
+					observation: { ...full, lifecycle: stateView.lifecycle },
+				}),
+			);
 			return;
 		}
 		// Pure classify without a session: synthesize a minimal state view.
@@ -596,6 +633,31 @@ export default class Harness extends Command {
 		state.updatedAt = nowIso();
 		await writeSessionState(root, state);
 		writeJson(buildResponse(state, false, { retired: true }));
+	}
+
+	async #recoverWithoutOwner(root: string, sessionId: string, input: Record<string, unknown>): Promise<void> {
+		const budget = resolveRetryBudget(input);
+		let state = await loadState(root, sessionId);
+		const { observation } = await buildObservation(root, state, false);
+		state = await markVanishedOwnerBlocked(root, state, observation);
+		const decision = classifyRecovery({
+			observation: { ...observation, lifecycle: state.lifecycle },
+			retryBudget: budget,
+		});
+		writeJson(
+			buildResponse(
+				state,
+				false,
+				{
+					pending: false,
+					reason: "owner-not-live",
+					decision,
+					observation: { ...observation, lifecycle: state.lifecycle },
+				},
+				false,
+			),
+		);
+		process.exitCode = 1;
 	}
 
 	async #pending(

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -153,6 +153,56 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation.lastActivityAt).toBe("2026-06-03T00:00:01.000Z");
 	});
 
+	it("observe treats terminal rpc_agent_completed kind without completed signal as completed owner exit", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		expect(state).toBeTruthy();
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "observing";
+		state.updatedAt = "2026-06-03T00:00:00.000Z";
+		await writeSessionState(root, state);
+		await appendSignal(sessionId, 1, "prompt-accepted");
+		await appendSignal(sessionId, 2, "tool-call");
+		await appendSignal(sessionId, 3, "streaming");
+		await appendEvent(root, sessionId, {
+			eventId: "evt-completed-without-signal",
+			cursor: 4,
+			createdAt: "2026-06-03T00:00:04.000Z",
+			severity: "info",
+			kind: "rpc_agent_completed",
+			state: { sessionId, lifecycle: "finalizing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { outcome: "completed" },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+		});
+
+		const res = runHarness(["observe", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.ownerLive).toBe(false);
+		expect(res.json.state.lifecycle).toBe("observing");
+		expect(res.json.state.blockers).not.toContain("owner-vanished:clean");
+		expect(res.json.evidence.ownerVanished).toBeUndefined();
+		expect(res.json.evidence.blockerReason).toBeUndefined();
+		expect(res.json.evidence.completedOwnerExited).toBe(true);
+		expect(res.json.evidence.terminalResult).toEqual({
+			cursor: 4,
+			createdAt: "2026-06-03T00:00:04.000Z",
+			kind: "rpc_agent_completed",
+		});
+		expect(res.json.evidence.observation.observedSignals).toEqual(
+			expect.arrayContaining(["prompt-accepted", "tool-call", "streaming"]),
+		);
+		expect(res.json.evidence.observation.observedSignals).not.toContain("completed");
+
+		const persisted = await readSessionState(root, sessionId);
+		expect(persisted?.lifecycle).toBe("observing");
+		expect(persisted?.blockers).not.toContain("owner-vanished:clean");
+	});
+
 	it("observe marks vanished owner after prompt/tool activity instead of silently observing clean worktree", async () => {
 		await initCleanGitWorkspace();
 		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { appendEvent, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
@@ -52,6 +52,34 @@ function assertContract(res: any): void {
 
 function action(res: any, verb: string) {
 	return (res.nextAllowedActions as any[]).find(a => a.verb === verb);
+}
+
+function git(args: string[]): void {
+	const proc = Bun.spawnSync(["git", ...args], { cwd: workspace, stdout: "pipe", stderr: "pipe" });
+	if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || `git ${args.join(" ")} failed`);
+}
+
+async function initCleanGitWorkspace(): Promise<void> {
+	git(["init"]);
+	git(["config", "user.email", "test@example.com"]);
+	git(["config", "user.name", "Test User"]);
+	await writeFile(path.join(workspace, "README.md"), "fixture\n", "utf8");
+	git(["add", "README.md"]);
+	git(["commit", "-m", "init"]);
+}
+
+async function appendSignal(sessionId: string, cursor: number, signal: string): Promise<void> {
+	await appendEvent(root, sessionId, {
+		eventId: `evt-${signal}-${cursor}`,
+		cursor,
+		createdAt: `2026-06-03T00:00:0${cursor}.000Z`,
+		severity: "info",
+		kind: `rpc_${signal.replaceAll("-", "_")}`,
+		state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+		evidence: { signal },
+		nextAllowedActions: [],
+		writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+	});
 }
 
 describe("gjc harness CLI (foundation)", () => {
@@ -125,6 +153,67 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation.lastActivityAt).toBe("2026-06-03T00:00:01.000Z");
 	});
 
+	it("observe marks vanished owner after prompt/tool activity instead of silently observing clean worktree", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		expect(state).toBeTruthy();
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "observing";
+		state.updatedAt = "2026-06-03T00:00:00.000Z";
+		await writeSessionState(root, state);
+		await appendSignal(sessionId, 1, "prompt-accepted");
+		await appendSignal(sessionId, 2, "tool-call");
+		await appendSignal(sessionId, 3, "streaming");
+
+		const res = runHarness(["observe", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.ownerLive).toBe(false);
+		expect(res.json.state.lifecycle).toBe("blocked");
+		expect(res.json.state.blockers).toContain("owner-vanished:clean");
+		expect(res.json.evidence.ownerVanished).toBe(true);
+		expect(res.json.evidence.blockerReason).toBe("owner-vanished:clean");
+		expect(res.json.evidence.observation.lifecycle).toBe("blocked");
+		expect(res.json.evidence.observation.gitDelta).toBe("clean");
+		expect(res.json.evidence.observation.observedSignals).toEqual(
+			expect.arrayContaining(["prompt-accepted", "tool-call", "streaming"]),
+		);
+		expect(action(res.json, "recover").available).toBe(true);
+
+		const persisted = await readSessionState(root, sessionId);
+		expect(persisted?.lifecycle).toBe("blocked");
+		expect(persisted?.blockers).toContain("owner-vanished:clean");
+	});
+
+	it("recover without owner classifies vanished clean sessions instead of returning pending-only", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		expect(state).toBeTruthy();
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "observing";
+		state.updatedAt = "2026-06-03T00:00:00.000Z";
+		await writeSessionState(root, state);
+		await appendSignal(sessionId, 1, "prompt-accepted");
+		await appendSignal(sessionId, 2, "tool-call");
+
+		const res = runHarness(["recover", "--session", sessionId]);
+
+		expect(res.code).toBe(1);
+		assertContract(res.json);
+		expect(res.json.evidence.pending).toBe(false);
+		expect(res.json.evidence.reason).toBe("owner-not-live");
+		expect(res.json.evidence.decision.classification).toBe("restart-clean");
+		expect(res.json.evidence.decision.requiredReceiptFamily).toBe("vanish");
+		expect(res.json.evidence.observation.lifecycle).toBe("blocked");
+		expect(res.json.state.lifecycle).toBe("blocked");
+		expect(res.json.state.blockers).toContain("owner-vanished:clean");
+	});
+
 	it("submit is blocked (accepted:false, owner-not-live) and never echoed-as-accepted", () => {
 		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
 		const sessionId = started.json.evidence.handle.sessionId as string;
@@ -158,13 +247,13 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(String(res.json.evidence.reason)).toContain("retire-blocked");
 	});
 
-	it("owner-runtime verbs report an honest pending milestone", () => {
+	it("non-recover owner-runtime verbs report an honest pending milestone", () => {
 		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
 		const sessionId = started.json.evidence.handle.sessionId as string;
-		const res = runHarness(["recover", "--session", sessionId]);
+		const res = runHarness(["validate", "--session", sessionId]);
 		expect(res.code).toBe(1);
 		expect(res.json.ok).toBe(false);
 		expect(res.json.evidence.pending).toBe(true);
-		expect(typeof res.json.evidence.milestone).toBe("string");
+		expect(res.json.evidence.verb).toBe("validate");
 	});
 });


### PR DESCRIPTION
Fixes #237

## Summary
- Mark owner-vanished observing sessions as blocked when prompt/tool/streaming activity exists and no terminal completion was recorded.
- Surface vanished-owner evidence in observe responses, including blocker reason and updated observation lifecycle.
- Make ownerless recover return an explicit classification/evidence response instead of pending-only for vanished-owner sessions.
- Add CLI regression coverage for the vanished-owner/observing/clean path and ownerless recover classification.

## Validation
- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/harness-control-plane/cli.test.ts`
- `bun run check:ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*