### PR TITLE
feat(gjc): state-model v3 — CI gates (A), handoff token-thrift (B), command-ref proof-spike (C), read-only doctor (H)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,33 @@ jobs:
               fi
               echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
 
+   # Branch protection must add the always-present `gjc-state-gates` status as required.
+   gjc-state-gates:
+      name: gjc-state-gates
+      runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+      timeout-minutes: 15
+      env:
+         GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+         GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      steps:
+         - uses: actions/checkout@v4
+           with:
+              fetch-depth: 0
+         - uses: actions/setup-node@v4
+           with:
+              node-version: "24"
+         - uses: oven-sh/setup-bun@v2
+           with:
+              bun-version: "1.3"
+         - name: Cache bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+         - run: bun install --frozen-lockfile
+         - name: Run GJC state gates
+           run: bun scripts/ci-gjc-state-gates.ts
+
    # Fast lint + type check (no Rust, no native build needed)
    check:
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
    # Branch protection must add the always-present `gjc-state-gates` status as required.
    gjc-state-gates:
       name: gjc-state-gates
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       timeout-minutes: 15
       env:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -66,3 +66,30 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Run affected path checks and tests
         run: bun scripts/ci-dev-affected.ts
+
+  # Branch protection must add the always-present `gjc-state-gates` status as required.
+  gjc-state-gates:
+    name: gjc-state-gates
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    timeout-minutes: 15
+    env:
+      GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+      GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - run: bun install --frozen-lockfile
+      - name: Run GJC state gates
+        run: bun scripts/ci-gjc-state-gates.ts

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -70,6 +70,7 @@ jobs:
   # Branch protection must add the always-present `gjc-state-gates` status as required.
   gjc-state-gates:
     name: gjc-state-gates
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     timeout-minutes: 15
     env:

--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -12,6 +12,7 @@ export default class State extends Command {
 		'$ gjc state ralplan write --input \'{"phase":"approval","active":true}\' --json',
 		"$ gjc state team contract",
 		"$ gjc state deep-interview handoff --to ralplan --json",
+		"$ gjc state doctor --skill ralplan --json",
 	];
 
 	async run(): Promise<void> {

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -49,6 +49,8 @@ Restricted read-only role agents (`planner`, `architect`, and `critic`) must pas
 
 After a role agent persists a stage artifact, its model-facing response to the caller SHOULD be receipt-only: return the `gjc ralplan --write --json` receipt (`run_id`, `path`, `stage`, `stage_n`, `sha256`, `created_at`) plus the minimal verdict/status fields the caller needs for routing, and do **not** paste the full persisted markdown back into the parent conversation. Downstream reviewers should receive the artifact path/receipt and read the persisted file themselves when they actually need the body. This preserves the audit trail while preventing Planner/Architect/Critic verdict bodies from being duplicated into the main-agent context.
 
+RECEIPT-ONLY guideline: role agents (`planner`, `architect`, and `critic`) persist durable outputs via `gjc ralplan --write` and return ONLY the receipt fields (`run_id`, `path`, `sha256`) plus verdict/status routing fields; include `stage` and `stage_n` when available, and never return the full persisted body.
+
 This skill runs GJC planning in consensus mode for the provided arguments.
 
 The consensus workflow:

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -549,10 +549,14 @@ async function handleSpecWrite(args: readonly string[], cwd: string): Promise<De
 	}
 
 	const stdout = resolved.json
-		? `${JSON.stringify(summary, null, 2)}\n`
+		? `${JSON.stringify(summary)}\n`
 		: [
-				`Persisted deep-interview ${persisted.stage} spec at ${persisted.path}.`,
-				shouldHandoff ? "Handed off deep-interview to ralplan (deliberate)." : undefined,
+				`deep-interview spec_path=${persisted.path}`,
+				`sha=${persisted.sha256}`,
+				`state_path=${persisted.statePath}`,
+				shouldHandoff
+					? `handoff=ralplan run_id=${summary.handoff?.run_id ?? ""} state_path=${summary.handoff?.state_path ?? ""}`
+					: undefined,
 				"",
 			]
 				.filter((line): line is string => Boolean(line))
@@ -591,14 +595,14 @@ export async function runNativeDeepInterviewCommand(
 			idea: resolved.idea,
 			language: resolved.language,
 			state_path: statePath,
-			handoff: "Run `/skill:deep-interview` inside the GJC agent to drive the Socratic interview loop.",
+			handoff: "/skill:deep-interview",
 		};
 		const stdout = resolved.json
-			? `${JSON.stringify(summary, null, 2)}\n`
+			? `${JSON.stringify(summary)}\n`
 			: [
-					`Seeded deep-interview ${resolved.resolution} run at ${statePath}.`,
-					`Threshold: ${(resolved.threshold * 100).toFixed(0)}% (source: ${resolved.thresholdSource}).`,
-					"Run `/skill:deep-interview` inside the GJC agent to execute the interview.",
+					`deep-interview seed state_path=${statePath}`,
+					`resolution=${resolved.resolution} threshold=${resolved.threshold} threshold_source=${resolved.thresholdSource}`,
+					"handoff=/skill:deep-interview",
 					"",
 				].join("\n");
 		return { status: 0, stdout };

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -162,6 +162,8 @@ interface DeepInterviewSpecWriteSummary {
 	slug: string;
 	path: string;
 	sha256: string;
+	spec_path: string;
+	sha: string;
 	created_at: string;
 	state_path: string;
 	handoff?: {
@@ -512,6 +514,8 @@ async function handleSpecWrite(args: readonly string[], cwd: string): Promise<De
 		slug: persisted.slug,
 		path: persisted.path,
 		sha256: persisted.sha256,
+		spec_path: persisted.path,
+		sha: persisted.sha256,
 		created_at: persisted.createdAt,
 		state_path: persisted.statePath,
 	};

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -447,20 +447,17 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 		task: resolved.task,
 		state_path: statePath,
 		run_id: runId,
-		handoff: "Run `/skill:ralplan` inside the GJC agent to drive the Planner / Architect / Critic consensus loop.",
+		handoff: "/skill:ralplan",
 	};
 	const stdout = resolved.json
-		? `${JSON.stringify(summary, null, 2)}\n`
+		? `${JSON.stringify(summary)}\n`
 		: [
-				`Seeded ralplan ${summary.mode} run (${resolved.interactive ? "interactive" : "automated"}) at ${statePath}.`,
-				`Active run_id: ${runId}`,
-				resolved.architectKind ? `Architect: ${resolved.architectKind}` : undefined,
-				resolved.criticKind ? `Critic: ${resolved.criticKind}` : undefined,
-				"Run `/skill:ralplan` inside the GJC agent to execute the consensus loop.",
+				`ralplan seed run_id=${runId}`,
+				`state_path=${statePath}`,
+				`mode=${mode} interactive=${resolved.interactive} architect=${summary.architect} critic=${summary.critic}`,
+				"handoff=/skill:ralplan",
 				"",
-			]
-				.filter((line): line is string => Boolean(line))
-				.join("\n");
+			].join("\n");
 	return { status: 0, stdout };
 }
 

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1356,17 +1356,24 @@ async function handleHandoff(
 
 	return {
 		status: 0,
-		stdout: `${JSON.stringify(
-			{
-				from: caller,
-				to: callee,
-				handoff_at: handoffAt,
-				caller_state: mergedCallerState,
-				callee_state: mergedCalleeState,
+		stdout: `${JSON.stringify({
+			from: caller,
+			to: callee,
+			handoff_at: handoffAt,
+			phases: {
+				from: mergedCallerState.current_phase,
+				to: mergedCalleeState.current_phase,
 			},
-			null,
-			2,
-		)}\n`,
+			receipts: {
+				from: callerReceipt,
+				to: calleeReceipt,
+			},
+			paths: {
+				from: callerPath,
+				to: calleePath,
+				active_state: activeStateFile(cwd, sessionId),
+			},
+		})}\n`,
 	};
 }
 

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -116,6 +116,7 @@ const ACTION_NAMES = new Set([
 	"gc",
 	"migrate",
 	"status",
+	"doctor",
 ]);
 const BOOLEAN_FLAGS = new Set([
 	"--json",
@@ -174,7 +175,18 @@ function assertKnownFlags(args: readonly string[], parsed: ParsedInvocation): vo
 }
 
 interface ParsedInvocation {
-	action: "read" | "write" | "clear" | "contract" | "handoff" | "graph" | "prune" | "gc" | "migrate" | "status";
+	action:
+		| "read"
+		| "write"
+		| "clear"
+		| "contract"
+		| "handoff"
+		| "graph"
+		| "prune"
+		| "gc"
+		| "migrate"
+		| "status"
+		| "doctor";
 	positionalSkill?: string;
 }
 
@@ -356,6 +368,282 @@ async function readJsonValue(filePath: string): Promise<unknown | null> {
 		if (err.code === "ENOENT") return null;
 		throw new StateCommandError(1, `failed to read ${filePath}: ${err.message}`);
 	}
+}
+
+type DoctorProblemType = "orphan_journal" | "checksum_mismatch" | "schema_violation" | "stale_active_state";
+
+interface DoctorProblem {
+	type: DoctorProblemType;
+	skill?: CanonicalGjcWorkflowSkill;
+	path: string;
+	message: string;
+	fixCommand: string;
+}
+
+interface DoctorSummary {
+	ok: boolean;
+	root: string;
+	summary: {
+		skills_scanned: number;
+		files_scanned: number;
+		journals_scanned: number;
+		findings_total: number;
+		by_kind: Record<DoctorProblemType, number>;
+	};
+	problems: DoctorProblem[];
+}
+
+async function readRawJson(filePath: string): Promise<{ exists: boolean; value?: unknown; error?: string }> {
+	try {
+		return { exists: true, value: JSON.parse(await fs.readFile(filePath, "utf-8")) };
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return { exists: false };
+		return { exists: true, error: err.message };
+	}
+}
+
+async function listJsonFiles(dir: string): Promise<string[]> {
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dir);
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return [];
+		throw error;
+	}
+	return entries
+		.filter(entry => entry.endsWith(".json"))
+		.sort()
+		.map(entry => path.join(dir, entry));
+}
+
+function doctorProblem(
+	type: DoctorProblemType,
+	pathValue: string,
+	message: string,
+	fixCommand: string,
+	skill?: CanonicalGjcWorkflowSkill,
+): DoctorProblem {
+	return skill
+		? { type, skill, path: pathValue, message, fixCommand }
+		: { type, path: pathValue, message, fixCommand };
+}
+
+function activeEntryDir(cwd: string, sessionId: string | undefined): string {
+	return path.join(stateDirFor(cwd, sessionId), "active");
+}
+
+function skillFromActiveValue(value: unknown): string | undefined {
+	return isPlainObject(value) && typeof value.skill === "string" ? value.skill : undefined;
+}
+
+function activeFlag(value: unknown): boolean {
+	return isPlainObject(value) && value.active !== false;
+}
+
+async function collectDoctorSummary(
+	cwd: string,
+	skill: CanonicalGjcWorkflowSkill | undefined,
+	sessionId: string | undefined,
+): Promise<DoctorSummary> {
+	const root = path.join(cwd, ".gjc", "state");
+	const skills = skill ? [skill] : [...CANONICAL_GJC_WORKFLOW_SKILLS];
+	const problems: DoctorProblem[] = [];
+	let filesScanned = 0;
+	let journalsScanned = 0;
+
+	for (const currentSkill of skills) {
+		const filePath = modeStateFile(cwd, currentSkill, sessionId);
+		const raw = await readRawJson(filePath);
+		if (!raw.exists) continue;
+		filesScanned += 1;
+		if (raw.error) {
+			problems.push(
+				doctorProblem(
+					"schema_violation",
+					filePath,
+					`mode-state JSON is unreadable: ${raw.error}`,
+					`gjc state ${currentSkill} migrate`,
+					currentSkill,
+				),
+			);
+			continue;
+		}
+		const validation = validateWorkflowStateEnvelope(currentSkill, raw.value);
+		if (!validation.valid) {
+			problems.push(
+				doctorProblem(
+					"schema_violation",
+					filePath,
+					validation.error ?? `invalid ${currentSkill} state envelope`,
+					`gjc state ${currentSkill} migrate`,
+					currentSkill,
+				),
+			);
+		}
+		const mismatch = await detectWorkflowEnvelopeIntegrityMismatch(filePath);
+		if (mismatch) {
+			problems.push(
+				doctorProblem(
+					"checksum_mismatch",
+					filePath,
+					`expected sha256 ${mismatch.expected} but found ${mismatch.actual}`,
+					`gjc state ${currentSkill} migrate`,
+					currentSkill,
+				),
+			);
+		}
+	}
+
+	const journalFiles = await listJsonFiles(path.join(root, "transactions"));
+	for (const journalPath of journalFiles) {
+		journalsScanned += 1;
+		const raw = await readRawJson(journalPath);
+		const value = raw.value;
+		const status = isPlainObject(value) && typeof value.status === "string" ? value.status : undefined;
+		const paths =
+			isPlainObject(value) && Array.isArray(value.paths) ? value.paths.filter(p => typeof p === "string") : [];
+		const hasLiveMutation = status === "pending" && paths.some(filePath => path.resolve(filePath).startsWith(root));
+		if (!hasLiveMutation) {
+			problems.push(
+				doctorProblem(
+					"orphan_journal",
+					journalPath,
+					"transaction journal has no matching live mutation",
+					"gjc state prune --hard",
+				),
+			);
+		}
+	}
+
+	const inspectActiveScope = async (scopeSessionId: string | undefined): Promise<void> => {
+		const snapshotPath = activeStateFile(cwd, scopeSessionId);
+		const snapshot = await readRawJson(snapshotPath);
+		if (snapshot.exists) filesScanned += 1;
+		const entryFiles = await listJsonFiles(activeEntryDir(cwd, scopeSessionId));
+		const entrySkills = new Set<string>();
+		for (const entryPath of entryFiles) {
+			filesScanned += 1;
+			const entry = await readRawJson(entryPath);
+			const entrySkill = skillFromActiveValue(entry.value) ?? path.basename(entryPath, ".json");
+			entrySkills.add(entrySkill);
+			const canonical = canonicalWorkflowSkill(entrySkill);
+			if (canonical && !skills.includes(canonical)) continue;
+			const statePath = canonical
+				? modeStateFile(cwd, canonical, scopeSessionId)
+				: path.join(root, `${entrySkill}-state.json`);
+			const state = await readRawJson(statePath);
+			if (activeFlag(entry.value) && (!state.exists || !activeFlag(state.value))) {
+				problems.push(
+					doctorProblem(
+						"stale_active_state",
+						entryPath,
+						`active entry for ${entrySkill} does not match a live active mode-state`,
+						canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+						canonical ?? undefined,
+					),
+				);
+			}
+		}
+		if (isPlainObject(snapshot.value)) {
+			const activeSkills = Array.isArray(snapshot.value.active_skills) ? snapshot.value.active_skills : [];
+			for (const entry of activeSkills) {
+				const entrySkill = skillFromActiveValue(entry);
+				if (!entrySkill) continue;
+				const canonical = canonicalWorkflowSkill(entrySkill);
+				if (canonical && !skills.includes(canonical)) continue;
+				if (activeFlag(entry) && !entrySkills.has(entrySkill)) {
+					problems.push(
+						doctorProblem(
+							"stale_active_state",
+							snapshotPath,
+							`active snapshot lists ${entrySkill} but no raw per-skill active entry exists`,
+							canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+							canonical ?? undefined,
+						),
+					);
+				}
+			}
+		}
+	};
+
+	await inspectActiveScope(sessionId);
+	if (!sessionId) {
+		const sessionsDir = path.join(root, "sessions");
+		let sessions: string[] = [];
+		try {
+			const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+			sessions = entries
+				.filter(entry => entry.isDirectory())
+				.map(entry => entry.name)
+				.sort();
+		} catch (error) {
+			const err = error as NodeJS.ErrnoException;
+			if (err.code !== "ENOENT") throw error;
+		}
+		for (const rawSession of sessions) await inspectActiveScope(decodeURIComponent(rawSession));
+	}
+
+	problems.sort(
+		(a, b) =>
+			a.type.localeCompare(b.type) || (a.skill ?? "").localeCompare(b.skill ?? "") || a.path.localeCompare(b.path),
+	);
+	const byKind: Record<DoctorProblemType, number> = {
+		orphan_journal: 0,
+		checksum_mismatch: 0,
+		schema_violation: 0,
+		stale_active_state: 0,
+	};
+	for (const problem of problems) byKind[problem.type] += 1;
+	return {
+		ok: problems.length === 0,
+		root,
+		summary: {
+			skills_scanned: skills.length,
+			files_scanned: filesScanned,
+			journals_scanned: journalsScanned,
+			findings_total: problems.length,
+			by_kind: byKind,
+		},
+		problems,
+	};
+}
+
+function renderDoctorText(summary: DoctorSummary): string {
+	const lines = [
+		`ok: ${summary.ok}`,
+		`root: ${summary.root}`,
+		`skills_scanned: ${summary.summary.skills_scanned}`,
+		`files_scanned: ${summary.summary.files_scanned}`,
+		`journals_scanned: ${summary.summary.journals_scanned}`,
+		`findings_total: ${summary.summary.findings_total}`,
+		`counts: ${Object.entries(summary.summary.by_kind)
+			.map(([kind, count]) => `${kind}=${count}`)
+			.join(", ")}`,
+	];
+	for (const problem of summary.problems) {
+		lines.push(
+			`finding: kind=${problem.type} skill=${problem.skill ?? "-"} path=${problem.path} message=${problem.message} fix=${problem.fixCommand}`,
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+async function handleDoctor(
+	args: readonly string[],
+	cwd: string,
+	positionalSkill: string | undefined,
+): Promise<StateCommandResult> {
+	const rawSkill = flagValue(args, "--skill")?.trim() || flagValue(args, "--mode")?.trim() || positionalSkill?.trim();
+	if (rawSkill) assertKnownMode(rawSkill);
+	const sessionId = flagValue(args, "--session-id")?.trim() || undefined;
+	if (sessionId) assertSafePathComponent(sessionId, "session-id");
+	const summary = await collectDoctorSummary(cwd, rawSkill as CanonicalGjcWorkflowSkill | undefined, sessionId);
+	return {
+		status: summary.ok ? 0 : 1,
+		stdout: hasFlag(args, "--json") ? `${JSON.stringify(summary, null, 2)}\n` : renderDoctorText(summary),
+	};
 }
 
 async function warnAndAuditOutOfBandIfNeeded(
@@ -1424,6 +1712,8 @@ export async function runNativeStateCommand(args: string[], cwd = process.cwd())
 				return await handleContract(args, cwd, parsed.positionalSkill);
 			case "status":
 				return await handleStatus(args, cwd, parsed.positionalSkill);
+			case "doctor":
+				return await handleDoctor(args, cwd, parsed.positionalSkill);
 			case "handoff":
 				return await handleHandoff(args, cwd, parsed.positionalSkill);
 			case "graph":

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1236,15 +1236,14 @@ function renderCompleteHandoff(
 	result: { plan: UltragoalPlan; goal?: UltragoalGoal; allComplete: boolean },
 	json: boolean,
 ): string {
-	if (json) return `${JSON.stringify(result, null, 2)}\n`;
-	if (result.allComplete) return "All ultragoal goals are complete.\n";
-	if (!result.goal) return "No schedulable ultragoal goal found.\n";
+	if (json) return `${JSON.stringify(result)}\n`;
+	if (result.allComplete) return "ultragoal complete all=true\n";
+	if (!result.goal) return "ultragoal next-action=none\n";
 	return [
-		`Ultragoal handoff: ${result.goal.id} — ${result.goal.title}`,
-		`Objective: ${result.goal.objective}`,
-		`GJC objective: ${result.plan.gjcObjective}`,
-		'Call goal({"op":"get"}); call goal({"op":"create","objective":"<printed objective>"}) only if no active GJC goal exists, then keep the GJC goal active while this Ultragoal story is verified and checkpointed.',
-		'Before checkpointing complete, obtain a passing architectReview (architecture/product/code CLEAR + APPROVE) and executorQa (e2e/red-team passed with contractCoverage, surfaceEvidence, adversarialCases, and artifactRefs matrix evidence), then checkpoint with --quality-gate-json and a fresh active goal snapshot; record blockers instead of completing on any finding, plan/code mismatch, shallow evidence, or missing artifact link; call goal({"op":"complete"}) only after the final aggregate receipt exists.',
+		`ultragoal next-action=execute-goal goal-id=${result.goal.id}`,
+		`objective=${result.goal.objective}`,
+		`gjc-objective=${result.plan.gjcObjective}`,
+		"checkpoint requires=architectReview:CLEAR+APPROVE,executorQa:passed",
 		"",
 	].join("\n");
 }
@@ -1290,7 +1289,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 				});
 				return {
 					status: 0,
-					stdout: json ? `${JSON.stringify(plan, null, 2)}\n` : `Checkpointed ${goalId} as ${status}.\n`,
+					stdout: json ? `${JSON.stringify(plan)}\n` : `ultragoal checkpoint goal-id=${goalId} status=${status}\n`,
 				};
 			}
 			case "steer": {

--- a/packages/coding-agent/src/gjc-runtime/workflow-command-ref.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-command-ref.ts
@@ -1,0 +1,239 @@
+import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/active-state";
+
+export type CommandRefVisibility = "public" | "hidden" | "planned";
+export type CommandRefIncludeWhen = "implemented-only" | "planned";
+
+export interface CommandRefCommand {
+	tokens: string[];
+	rendered: string;
+	visibility: CommandRefVisibility;
+	includeWhen: CommandRefIncludeWhen;
+	note?: string;
+}
+
+export interface CommandRefExample {
+	label?: string;
+	bytes: string;
+}
+
+export interface CommandRefBridge {
+	from: string;
+	to: string;
+	rendered: string;
+}
+
+export interface CommandRefBlock {
+	skill: CanonicalGjcWorkflowSkill;
+	blockId: string;
+	sourcePath: string;
+	renderOrder: number;
+	markers: {
+		start: string;
+		end: string;
+	};
+	commands: CommandRefCommand[];
+	examples: CommandRefExample[];
+	aliasesAndBridges: CommandRefBridge[];
+	notes: string[];
+}
+
+export interface RenderedCommandRefBlock {
+	skill: CanonicalGjcWorkflowSkill;
+	blockId: string;
+	markers: CommandRefBlock["markers"];
+	bytes: string;
+}
+
+const skillPath = (skill: CanonicalGjcWorkflowSkill): string =>
+	`packages/coding-agent/src/defaults/gjc/skills/${skill}/SKILL.md`;
+
+const stateWrite = (skill: CanonicalGjcWorkflowSkill): CommandRefCommand => ({
+	tokens: ["gjc", "state", skill, "write", "--input", `'{"current_phase":"handoff"}'`, "--json"],
+	rendered: `gjc state ${skill} write --input '{"current_phase":"handoff"}' --json`,
+	visibility: "public",
+	includeWhen: "implemented-only",
+	note: "Marks the workflow ready for the skill-tool chain guard.",
+});
+
+const stateHandoff = (
+	skill: CanonicalGjcWorkflowSkill,
+	targets: readonly CanonicalGjcWorkflowSkill[],
+): CommandRefCommand => ({
+	tokens: ["gjc", "state", skill, "handoff", "--to", `<${targets.join("|")}>`, "--json"],
+	rendered: `gjc state ${skill} handoff --to <${targets.join("|")}> --json`,
+	visibility: "public",
+	includeWhen: "implemented-only",
+	note: "Bridge command run in-process by the skill tool after slash-skill dispatch.",
+});
+
+export const WORKFLOW_COMMAND_REF_BLOCKS: readonly CommandRefBlock[] = [
+	{
+		skill: "deep-interview",
+		blockId: "state",
+		sourcePath: skillPath("deep-interview"),
+		renderOrder: 10,
+		markers: {
+			start: "<!-- gjc:cmdref:start state -->",
+			end: "<!-- gjc:cmdref:end state -->",
+		},
+		commands: [
+			stateWrite("deep-interview"),
+			{
+				tokens: [
+					"gjc",
+					"deep-interview",
+					"--write",
+					"--stage",
+					"final",
+					"--slug",
+					"{slug}",
+					"--spec",
+					"<markdown-or-path>",
+					"--deliberate",
+					"--json",
+				],
+				rendered:
+					"gjc deep-interview --write --stage final --slug {slug} --spec <markdown-or-path> --deliberate --json",
+				visibility: "public",
+				includeWhen: "implemented-only",
+				note: "Sanctioned deliberate deep-interview to ralplan bridge.",
+			},
+		],
+		examples: [
+			{
+				label: "handoff state write",
+				bytes: '```\ngjc state deep-interview write --input \'{"current_phase":"handoff"}\' --json\n```',
+			},
+			{
+				label: "deliberate bridge",
+				bytes: "```\ngjc \\\ndeep-interview --write --stage final --slug {slug} --spec <markdown-or-path> --deliberate --json\n```",
+			},
+		],
+		aliasesAndBridges: [
+			{
+				from: "deep-interview",
+				to: "ralplan",
+				rendered:
+					"gjc deep-interview --write --stage final --slug {slug} --spec <markdown-or-path> --deliberate --json",
+			},
+		],
+		notes: [
+			"Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, persist the final spec and mark deep-interview ready for handoff.",
+		],
+	},
+	{
+		skill: "ralplan",
+		blockId: "state",
+		sourcePath: skillPath("ralplan"),
+		renderOrder: 10,
+		markers: { start: "<!-- gjc:cmdref:start state -->", end: "<!-- gjc:cmdref:end state -->" },
+		commands: [stateWrite("ralplan"), stateHandoff("ralplan", ["team", "ultragoal"])],
+		examples: [
+			{
+				label: "handoff state write",
+				bytes: '```\ngjc state ralplan write --input \'{"current_phase":"handoff"}\' --json\n```',
+			},
+		],
+		aliasesAndBridges: [
+			{ from: "ralplan", to: "team|ultragoal", rendered: "gjc state ralplan handoff --to <team|ultragoal> --json" },
+		],
+		notes: [
+			"Before invoking `/skill:team` or `/skill:ultragoal`, mark ralplan ready for handoff so the skill tool's chain guard permits the transition.",
+		],
+	},
+	{
+		skill: "ultragoal",
+		blockId: "state",
+		sourcePath: skillPath("ultragoal"),
+		renderOrder: 10,
+		markers: { start: "<!-- gjc:cmdref:start state -->", end: "<!-- gjc:cmdref:end state -->" },
+		commands: [stateWrite("ultragoal"), stateHandoff("ultragoal", ["ralplan", "deep-interview"])],
+		examples: [
+			{
+				label: "handoff state write",
+				bytes: '```\ngjc state ultragoal write --input \'{"current_phase":"handoff"}\' --json\n```',
+			},
+		],
+		aliasesAndBridges: [
+			{
+				from: "ultragoal",
+				to: "ralplan|deep-interview",
+				rendered: "gjc state ultragoal handoff --to <ralplan|deep-interview> --json",
+			},
+		],
+		notes: [
+			"When the aggregate ultragoal is complete OR the user requests return to planning/clarification, mark ultragoal ready for handoff.",
+		],
+	},
+	{
+		skill: "team",
+		blockId: "state",
+		sourcePath: skillPath("team"),
+		renderOrder: 10,
+		markers: { start: "<!-- gjc:cmdref:start state -->", end: "<!-- gjc:cmdref:end state -->" },
+		commands: [stateWrite("team"), stateHandoff("team", ["ralplan", "deep-interview", "ultragoal"])],
+		examples: [
+			{
+				label: "handoff state write",
+				bytes: '```\ngjc state team write --input \'{"current_phase":"handoff"}\' --json\n```',
+			},
+		],
+		aliasesAndBridges: [
+			{
+				from: "team",
+				to: "ralplan|deep-interview|ultragoal",
+				rendered: "gjc state team handoff --to <ralplan|deep-interview|ultragoal> --json",
+			},
+		],
+		notes: [
+			"When the team task-set completes OR the user requests return to planning/persistence, mark team ready for handoff.",
+		],
+	},
+] as const;
+
+export function listCommandRefBlocks(skill?: CanonicalGjcWorkflowSkill): CommandRefBlock[] {
+	const blocks =
+		skill === undefined
+			? WORKFLOW_COMMAND_REF_BLOCKS
+			: WORKFLOW_COMMAND_REF_BLOCKS.filter(block => block.skill === skill);
+	return [...blocks].sort(
+		(a, b) => a.skill.localeCompare(b.skill) || a.renderOrder - b.renderOrder || a.blockId.localeCompare(b.blockId),
+	);
+}
+
+export function renderCommandRefBlock(skill: CanonicalGjcWorkflowSkill, blockId = "state"): RenderedCommandRefBlock {
+	const block = WORKFLOW_COMMAND_REF_BLOCKS.find(item => item.skill === skill && item.blockId === blockId);
+	if (block === undefined) throw new Error(`Unknown command-reference block: ${skill}/${blockId}`);
+
+	const lines: string[] = [];
+	lines.push(block.markers.start);
+	lines.push(`### Generated command reference: ${block.blockId}`);
+	lines.push("");
+	for (const note of block.notes) lines.push(note);
+	lines.push("");
+	lines.push("Commands:");
+	for (const command of block.commands.filter(
+		item => item.visibility === "public" && item.includeWhen === "implemented-only",
+	)) {
+		lines.push(`- \`${command.rendered}\``);
+		if (command.note !== undefined) lines.push(`  - ${command.note}`);
+	}
+	lines.push("");
+	lines.push("Examples:");
+	for (const example of block.examples) {
+		if (example.label !== undefined) lines.push(`- ${example.label}:`);
+		lines.push(example.bytes);
+	}
+	lines.push("");
+	lines.push("Aliases and bridges:");
+	for (const bridge of block.aliasesAndBridges) lines.push(`- ${bridge.from} -> ${bridge.to}: \`${bridge.rendered}\``);
+	lines.push(block.markers.end);
+	lines.push("");
+
+	return { skill, blockId: block.blockId, markers: block.markers, bytes: lines.join("\n") };
+}
+
+export function isCanonicalGjcWorkflowSkill(value: string): value is CanonicalGjcWorkflowSkill {
+	return (CANONICAL_GJC_WORKFLOW_SKILLS as readonly string[]).includes(value);
+}

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -78,7 +78,8 @@
           "write",
           "clear",
           "contract",
-          "handoff"
+          "handoff",
+          "doctor"
         ],
         "enumValues": [
           "deep-interview",
@@ -96,6 +97,7 @@
           "clear",
           "contract",
           "handoff",
+          "doctor",
           "kickoff",
           "write-spec",
           "write-artifact"
@@ -149,6 +151,26 @@
           "handoff"
         ],
         "name": "force",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "skill",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "name": "json",
         "type": "boolean"
       },
       {
@@ -265,6 +287,10 @@
       },
       {
         "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "doctor",
         "surface": "state-action"
       },
       {
@@ -426,7 +452,8 @@
           "write",
           "clear",
           "contract",
-          "handoff"
+          "handoff",
+          "doctor"
         ],
         "enumValues": [
           "deep-interview",
@@ -444,6 +471,7 @@
           "clear",
           "contract",
           "handoff",
+          "doctor",
           "kickoff",
           "write-spec",
           "write-artifact"
@@ -497,6 +525,26 @@
           "handoff"
         ],
         "name": "force",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "skill",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "name": "json",
         "type": "boolean"
       },
       {
@@ -602,6 +650,10 @@
       },
       {
         "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "doctor",
         "surface": "state-action"
       },
       {
@@ -783,7 +835,8 @@
           "write",
           "clear",
           "contract",
-          "handoff"
+          "handoff",
+          "doctor"
         ],
         "enumValues": [
           "deep-interview",
@@ -801,6 +854,7 @@
           "clear",
           "contract",
           "handoff",
+          "doctor",
           "kickoff",
           "write-spec",
           "write-artifact"
@@ -854,6 +908,26 @@
           "handoff"
         ],
         "name": "force",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "skill",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "name": "json",
         "type": "boolean"
       },
       {
@@ -1008,6 +1082,10 @@
       },
       {
         "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "doctor",
         "surface": "state-action"
       },
       {
@@ -1196,7 +1274,8 @@
           "write",
           "clear",
           "contract",
-          "handoff"
+          "handoff",
+          "doctor"
         ],
         "enumValues": [
           "deep-interview",
@@ -1214,6 +1293,7 @@
           "clear",
           "contract",
           "handoff",
+          "doctor",
           "kickoff",
           "write-spec",
           "write-artifact"
@@ -1267,6 +1347,26 @@
           "handoff"
         ],
         "name": "force",
+        "type": "boolean"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "enumValues": [
+          "deep-interview",
+          "ralplan",
+          "ultragoal",
+          "team"
+        ],
+        "name": "skill",
+        "type": "enum"
+      },
+      {
+        "appliesToVerbs": [
+          "doctor"
+        ],
+        "name": "json",
         "type": "boolean"
       },
       {
@@ -1442,6 +1542,10 @@
       },
       {
         "name": "handoff",
+        "surface": "state-action"
+      },
+      {
+        "name": "doctor",
         "surface": "state-action"
       },
       {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -64,7 +64,7 @@ const AGENTS_RETENTION: RetentionPolicy = { category: "agents" };
 const PRUNE_RETENTION: RetentionPolicy = { category: "prune/delete", maxAgeDays: 30 };
 const FORCE_RETENTION: RetentionPolicy = { category: "force", maxAgeDays: 90 };
 
-const STATE_VERBS = ["read", "write", "clear", "contract", "handoff"] as const;
+const STATE_VERBS = ["read", "write", "clear", "contract", "handoff", "doctor"] as const;
 const PLANNED_ADMIN_VERBS = ["graph", "prune", "migrate", "force-overwrite"] as const;
 
 const COMMON_TYPED_ARGS: TypedArgSpec[] = [
@@ -82,6 +82,8 @@ const COMMON_TYPED_ARGS: TypedArgSpec[] = [
 	},
 	{ name: "replace", type: "boolean", appliesToVerbs: ["write"] },
 	{ name: "force", type: "boolean", appliesToVerbs: ["write", "clear", "handoff"] },
+	{ name: "skill", type: "enum", enumValues: [...CANONICAL_GJC_WORKFLOW_SKILLS], appliesToVerbs: ["doctor"] },
+	{ name: "json", type: "boolean", appliesToVerbs: ["doctor"] },
 ];
 
 function verb(name: string, surface: WorkflowVerb["surface"]): WorkflowVerb {

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -138,7 +138,12 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 				{ triggerTurn: false },
 			);
 
-			const summary = args ? `Handed off to /skill:${skill.name} ${args}.` : `Handed off to /skill:${skill.name}.`;
+			const summary = JSON.stringify({
+				callee: skill.name,
+				path: skill.filePath,
+				args: args || undefined,
+				lineCount: built.details.lineCount,
+			});
 			return {
 				content: [{ type: "text", text: summary }],
 				details: {

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -21,7 +21,7 @@ describe("native gjc ralplan runtime — consensus handoff", () => {
 		const root = await tempDir();
 		const result = await runNativeRalplanCommand(["--interactive", "--deliberate", "make state native"], root);
 		expect(result.status).toBe(0);
-		expect(result.stdout).toContain("Seeded ralplan deliberate run (interactive)");
+		expect(result.stdout).toContain("ralplan seed run_id=");
 		const state = JSON.parse(await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8"));
 		expect(state.mode).toBe("deliberate");
 		expect(state.interactive).toBe(true);

--- a/packages/coding-agent/test/gjc-runtime/skill-command-ref.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/skill-command-ref.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { renderCommandRefBlock } from "@gajae-code/coding-agent/gjc-runtime/workflow-command-ref";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "@gajae-code/coding-agent/skill-state/active-state";
+
+interface FileSnapshot {
+	bytes: Buffer;
+	mtimeMs: number;
+}
+
+const repoRoot = process.cwd();
+const skillFiles = CANONICAL_GJC_WORKFLOW_SKILLS.map(skill =>
+	path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", skill, "SKILL.md"),
+);
+
+async function snapshotSkillFiles(): Promise<Map<string, FileSnapshot>> {
+	const snapshots = new Map<string, FileSnapshot>();
+	for (const file of skillFiles) {
+		const stat = await fs.stat(file);
+		snapshots.set(file, { bytes: await fs.readFile(file), mtimeMs: stat.mtimeMs });
+	}
+	return snapshots;
+}
+
+async function expectSkillFilesUnchanged(before: Map<string, FileSnapshot>): Promise<void> {
+	for (const file of skillFiles) {
+		const prior = before.get(file);
+		expect(prior, file).toBeDefined();
+		if (!prior) continue;
+		const stat = await fs.stat(file);
+		const bytes = await fs.readFile(file);
+		expect(bytes.equals(prior?.bytes ?? Buffer.alloc(0)), file).toBe(true);
+		expect(stat.mtimeMs, file).toBe(prior?.mtimeMs);
+	}
+}
+
+async function runBun(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(["bun", ...args], { cwd: repoRoot, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { stdout, stderr, exitCode };
+}
+
+describe("workflow command-reference proof spike", () => {
+	it("renders deterministic command-reference blocks", () => {
+		const first = renderCommandRefBlock("ralplan");
+		const second = renderCommandRefBlock("ralplan");
+		expect(first).toEqual(second);
+		expect(first.bytes).toContain("<!-- gjc:cmdref:start state -->");
+		expect(first.bytes).toContain("gjc state ralplan write --input");
+		expect(first.bytes.endsWith("\n")).toBe(true);
+	});
+
+	it("reports byte-equal or gap status without mutating SKILL.md files", async () => {
+		const before = await snapshotSkillFiles();
+		const result = await runBun(["scripts/generate-gjc-skill-command-refs.ts", "--check", "--json"]);
+		await expectSkillFilesUnchanged(before);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const parsed = JSON.parse(result.stdout) as {
+			results: Array<{ skill: string; blockId: string; status: string; reason?: string }>;
+		};
+		expect(parsed.results).toHaveLength(CANONICAL_GJC_WORKFLOW_SKILLS.length);
+		for (const item of parsed.results) {
+			expect([...CANONICAL_GJC_WORKFLOW_SKILLS] as string[]).toContain(item.skill);
+			expect(item.blockId).toBe("state");
+			expect(["BYTE-EQUAL", "GAP"]).toContain(item.status);
+		}
+		expect(
+			parsed.results.every(item => item.status === "GAP" && item.reason === "unmarked / not yet generated"),
+		).toBe(true);
+	});
+
+	it("prints per-skill token budget report", async () => {
+		const result = await runBun(["scripts/audit-skill-token-budget.ts", "--json"]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const parsed = JSON.parse(result.stdout) as {
+			skills: Array<{ skill: string; bytes: number; approxTokens: number; sections: unknown[] }>;
+		};
+		expect(parsed.skills).toHaveLength(CANONICAL_GJC_WORKFLOW_SKILLS.length);
+		for (const item of parsed.skills) {
+			expect([...CANONICAL_GJC_WORKFLOW_SKILLS] as string[]).toContain(item.skill);
+			expect(item.bytes).toBeGreaterThan(0);
+			expect(item.approxTokens).toBeGreaterThan(0);
+			expect(Array.isArray(item.sections)).toBe(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-state-doctor-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+let priorSessionId: string | undefined;
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+async function snapshotFiles(root: string): Promise<Map<string, { bytes: Buffer; mtimeMs: number }>> {
+	const out = new Map<string, { bytes: Buffer; mtimeMs: number }>();
+	async function visit(dir: string): Promise<void> {
+		let entries: string[];
+		try {
+			entries = await fs.readdir(dir);
+		} catch (error) {
+			const err = error as NodeJS.ErrnoException;
+			if (err.code === "ENOENT") return;
+			throw error;
+		}
+		for (const entry of entries.sort()) {
+			const filePath = path.join(dir, entry);
+			const stat = await fs.stat(filePath);
+			if (stat.isDirectory()) {
+				await visit(filePath);
+			} else if (stat.isFile()) {
+				out.set(path.relative(root, filePath), { bytes: await fs.readFile(filePath), mtimeMs: stat.mtimeMs });
+			}
+		}
+	}
+	await visit(root);
+	return out;
+}
+
+function expectUnchanged(
+	before: Map<string, { bytes: Buffer; mtimeMs: number }>,
+	after: Map<string, { bytes: Buffer; mtimeMs: number }>,
+): void {
+	expect([...after.keys()].sort()).toEqual([...before.keys()].sort());
+	for (const [relativePath, beforeFile] of before) {
+		const afterFile = after.get(relativePath);
+		expect(afterFile, relativePath).toBeDefined();
+		expect(afterFile?.bytes.equals(beforeFile.bytes), relativePath).toBe(true);
+		expect(afterFile?.mtimeMs, relativePath).toBe(beforeFile.mtimeMs);
+	}
+}
+
+async function runDoctorUnchanged(
+	root: string,
+	args: string[],
+): Promise<Awaited<ReturnType<typeof runNativeStateCommand>>> {
+	const before = await snapshotFiles(path.join(root, ".gjc"));
+	const result = await runNativeStateCommand(args, root);
+	const after = await snapshotFiles(path.join(root, ".gjc"));
+	expectUnchanged(before, after);
+	return result;
+}
+
+async function writeStampedState(root: string, skill: string, value: Record<string, unknown>): Promise<string> {
+	const result = await runNativeStateCommand(
+		["write", "--mode", skill, "--input", JSON.stringify(value), "--replace"],
+		root,
+	);
+	expect(result.status).toBe(0);
+	return path.join(root, ".gjc", "state", `${skill}-state.json`);
+}
+
+describe("gjc state doctor", () => {
+	it("reports clean state with zero exit and deterministic JSON summary", async () => {
+		const root = await tempDir();
+		const statePath = await writeStampedState(root, "deep-interview", {
+			active: true,
+			current_phase: "interviewing",
+		});
+		expect(statePath).toContain("deep-interview-state.json");
+		await writeJson(path.join(root, ".gjc", "state", "audit.jsonl"), { seeded: true });
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--json"]);
+		expect(result.status).toBe(0);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed).toMatchObject({ ok: true, problems: [] });
+		expect(parsed.summary.by_kind).toEqual({
+			orphan_journal: 0,
+			checksum_mismatch: 0,
+			schema_violation: 0,
+			stale_active_state: 0,
+		});
+	});
+
+	it("detects orphan transaction journals and prints the hard prune fix command", async () => {
+		const root = await tempDir();
+		const journalPath = path.join(root, ".gjc", "state", "transactions", "orphan.json");
+		await writeJson(journalPath, { version: 1, mutation_id: "orphan", status: "committed", paths: [] });
+		await writeJson(path.join(root, ".gjc", "state", "audit.jsonl"), { seeded: true });
+
+		const text = await runDoctorUnchanged(root, ["doctor"]);
+		expect(text.status).toBe(1);
+		expect(text.stdout).toContain("kind=orphan_journal");
+		expect(text.stdout).toContain("fix=gjc state prune --hard");
+
+		const json = await runDoctorUnchanged(root, ["doctor", "--json"]);
+		const parsed = JSON.parse(json.stdout ?? "{}");
+		expect(parsed.ok).toBe(false);
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({ type: "orphan_journal", path: journalPath, fixCommand: "gjc state prune --hard" }),
+		]);
+	});
+
+	it("detects checksum mismatches and prints the migrate fix command", async () => {
+		const root = await tempDir();
+		const statePath = await writeStampedState(root, "ralplan", {
+			active: true,
+			current_phase: "planner",
+		});
+		const state = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		state.current_phase = "critic";
+		await writeJson(statePath, state);
+		await writeJson(path.join(root, ".gjc", "state", "audit.jsonl"), { seeded: true });
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.summary.skills_scanned).toBe(1);
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "checksum_mismatch",
+				skill: "ralplan",
+				path: statePath,
+				fixCommand: "gjc state ralplan migrate",
+			}),
+		]);
+	});
+
+	it("detects schema violations and prints the migrate fix command", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ultragoal-state.json");
+		await writeJson(statePath, { skill: "ultragoal", version: "one", active: "yes", current_phase: 7 });
+		await writeJson(path.join(root, ".gjc", "state", "audit.jsonl"), { seeded: true });
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "schema_violation",
+				skill: "ultragoal",
+				path: statePath,
+				fixCommand: "gjc state ultragoal migrate",
+			}),
+		]);
+	});
+
+	it("detects stale active-state from raw snapshot and per-skill active entries", async () => {
+		const root = await tempDir();
+		const stateRoot = path.join(root, ".gjc", "state");
+		const activeEntryPath = path.join(stateRoot, "active", "team.json");
+		await writeJson(activeEntryPath, { skill: "team", active: true, phase: "running" });
+		await writeJson(path.join(stateRoot, "skill-active-state.json"), {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			active_skills: [{ skill: "ralplan", active: true, phase: "planner" }],
+		});
+		await writeJson(path.join(stateRoot, "audit.jsonl"), { seeded: true });
+
+		const text = await runDoctorUnchanged(root, ["doctor"]);
+		expect(text.status).toBe(1);
+		expect(text.stdout).toContain("kind=stale_active_state");
+		expect(text.stdout).toContain("fix=gjc state team clear");
+		expect(text.stdout).toContain("fix=gjc state ralplan clear");
+
+		const json = await runDoctorUnchanged(root, ["doctor", "--json"]);
+		const parsed = JSON.parse(json.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "ralplan",
+				path: path.join(stateRoot, "skill-active-state.json"),
+				fixCommand: "gjc state ralplan clear",
+			}),
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "team",
+				path: activeEntryPath,
+				fixCommand: "gjc state team clear",
+			}),
+		]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { Skill } from "@gajae-code/coding-agent/extensibility/skills";
+import { runNativeDeepInterviewCommand } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { createUltragoalPlan, runNativeUltragoalCommand } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@gajae-code/coding-agent/session/messages";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
+
+const roots: string[] = [];
+
+async function tempDir(prefix = "gjc-handoff-thrift-"): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	roots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+	delete process.env.GJC_SESSION_ID;
+});
+
+function scrub(text: string): string {
+	return text
+		.replaceAll(/\/var\/folders\/[^\n"]+/g, "/tmp/SCRUBBED")
+		.replaceAll(/\/private\/var\/[^\n"]+/g, "/tmp/SCRUBBED")
+		.replaceAll(/\/tmp\/gjc-[^\n"]+/g, "/tmp/SCRUBBED")
+		.replaceAll(/[0-9a-f]{64}/g, "<sha256>")
+		.replaceAll(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g, "<iso>");
+}
+
+function assertKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+	for (const key of keys) expect(value, `missing ${key}`).toHaveProperty(key);
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, JSON.stringify(value, null, 2));
+}
+
+function passingQualityGate(): string {
+	return JSON.stringify({
+		architectReview: {
+			architectureStatus: "CLEAR",
+			productStatus: "CLEAR",
+			codeStatus: "CLEAR",
+			recommendation: "APPROVE",
+			evidence: "reviewed",
+			commands: ["architect-review"],
+			blockers: [],
+		},
+		executorQa: {
+			status: "passed",
+			e2eStatus: "passed",
+			redTeamStatus: "passed",
+			evidence: "qa passed",
+			e2eCommands: ["bun test:e2e"],
+			redTeamCommands: ["bun test:red-team"],
+			blockers: [],
+		},
+		iteration: {
+			status: "passed",
+			evidence: "complete",
+			fullRerun: true,
+			rerunCommands: ["bun test:e2e"],
+			blockers: [],
+		},
+	});
+}
+
+async function makeSkill(name: string, content: string): Promise<Skill> {
+	const dir = await tempDir(`skill-tool-${name}-`);
+	const filePath = path.join(dir, "SKILL.md");
+	await fs.writeFile(filePath, content);
+	return { name, description: `${name} skill`, filePath, baseDir: dir, source: "test", content };
+}
+
+describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
+	it("goldens and asserts every preserved consumer key field", async () => {
+		delete process.env.GJC_SESSION_ID;
+		const root = await tempDir();
+
+		const ralplanReceipt = await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "2", "--artifact", "# Final", "--run-id", "run-b", "--json"],
+			root,
+		);
+		expect(ralplanReceipt.status).toBe(0);
+		const ralplanReceiptPayload = JSON.parse(ralplanReceipt.stdout ?? "{}") as Record<string, unknown>;
+		assertKeys(ralplanReceiptPayload, [
+			"run_id",
+			"path",
+			"stage",
+			"stage_n",
+			"sha256",
+			"created_at",
+			"pending_approval_path",
+		]);
+		expect(scrub(ralplanReceipt.stdout ?? "")).toMatchInlineSnapshot(`
+			"{
+			  "run_id": "run-b",
+			  "path": "/tmp/SCRUBBED",
+			  "stage": "final",
+			  "stage_n": 2,
+			  "sha256": "<sha256>",
+			  "created_at": "<iso>",
+			  "pending_approval_path": "/tmp/SCRUBBED"
+			}
+			"
+			`);
+
+		const ralplanSeed = await runNativeRalplanCommand(["--json", "scope the work"], root);
+		expect(ralplanSeed.status).toBe(0);
+		expect(scrub(ralplanSeed.stdout ?? "")).toMatchInlineSnapshot(`
+			"{"skill":"ralplan","mode":"short","interactive":false,"architect":"default","critic":"default","task":"scope the work","state_path":"/tmp/SCRUBBED","run_id":"run-b","handoff":"/skill:ralplan"}
+			"
+			`);
+
+		const deepSeed = await runNativeDeepInterviewCommand(["--json", "clarify this idea"], root);
+		expect(deepSeed.status).toBe(0);
+		const deepSeedPayload = JSON.parse(deepSeed.stdout ?? "{}") as Record<string, unknown>;
+		assertKeys(deepSeedPayload, ["state_path", "handoff"]);
+		expect(deepSeedPayload.handoff).toBe("/skill:deep-interview");
+		expect(scrub(deepSeed.stdout ?? "")).toMatchInlineSnapshot(`
+			"{"skill":"deep-interview","resolution":"standard","threshold":0.05,"threshold_source":"/Users/bellman/.gjc/agent/config.yml","idea":"clarify this idea","state_path":"/tmp/SCRUBBED","handoff":"/skill:deep-interview"}
+			"
+			`);
+
+		const deepWrite = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "matrix", "--spec", "# Spec", "--deliberate", "--json"],
+			root,
+		);
+		expect(deepWrite.status).toBe(0);
+		const deepWritePayload = JSON.parse(deepWrite.stdout ?? "{}") as Record<string, unknown>;
+		assertKeys(deepWritePayload, ["path", "sha256", "state_path", "handoff"]);
+		expect(deepWritePayload.path).toBe(deepWritePayload.path);
+		expect(deepWritePayload.sha256).toBeTruthy();
+		const handoff = deepWritePayload.handoff as Record<string, unknown>;
+		assertKeys(handoff, ["to", "run_id", "state_path"]);
+		expect(scrub(deepWrite.stdout ?? "")).toMatchInlineSnapshot(`
+			"{"skill":"deep-interview","stage":"final","slug":"matrix","path":"/tmp/SCRUBBED","sha256":"<sha256>","created_at":"<iso>","state_path":"/tmp/SCRUBBED","handoff":{"to":"ralplan","mode":"deliberate","state_path":"/tmp/SCRUBBED","run_id":"run-b"}}
+			"
+			`);
+
+		await writeJson(path.join(root, ".gjc/state/deep-interview-state.json"), {
+			skill: "deep-interview",
+			version: 1,
+			active: true,
+			current_phase: "interviewing",
+		});
+		const stateHandoff = await runNativeStateCommand(
+			["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+			root,
+		);
+		expect(stateHandoff.status).toBe(0);
+		const statePayload = JSON.parse(stateHandoff.stdout ?? "{}") as Record<string, unknown>;
+		assertKeys(statePayload, ["from", "to", "handoff_at", "phases", "receipts", "paths"]);
+		expect(scrub(stateHandoff.stdout ?? "")).toMatchInlineSnapshot(`
+			"{"from":"deep-interview","to":"ralplan","handoff_at":"<iso>","phases":{"from":"handoff","to":"planner"},"receipts":{"from":{"version":1,"skill":"deep-interview","owner":"gjc-state-cli","command":"gjc state deep-interview handoff --to ralplan","state_path":"/tmp/SCRUBBED","storage_path":"/tmp/SCRUBBED","mutated_at":"<iso>","fresh_until":"<iso>","status":"fresh","mutation_id":"deep-interview:handoff:ralplan:<iso>"},"to":{"version":1,"skill":"ralplan","owner":"gjc-state-cli","command":"gjc state deep-interview handoff --to ralplan","state_path":"/tmp/SCRUBBED","storage_path":"/tmp/SCRUBBED","mutated_at":"<iso>","fresh_until":"<iso>","status":"fresh","mutation_id":"deep-interview:handoff:ralplan:<iso>"}},"paths":{"from":"/tmp/SCRUBBED","to":"/tmp/SCRUBBED","active_state":"/tmp/SCRUBBED"}}
+			"
+			`);
+
+		await createUltragoalPlan({ cwd: root, brief: "Ship the compact output" });
+		const ultragoalHandoff = await runNativeUltragoalCommand(["complete-goals"], root);
+		expect(ultragoalHandoff.status).toBe(0);
+		expect(ultragoalHandoff.stdout).toContain("objective=");
+		expect(ultragoalHandoff.stdout).toContain("next-action=execute-goal");
+		expect(scrub(ultragoalHandoff.stdout ?? "")).toMatchInlineSnapshot(`
+			"ultragoal next-action=execute-goal goal-id=G001
+			objective=Ship the compact output
+			gjc-objective=Complete the durable ultragoal plan in .gjc/ultragoal/goals.json, including later accepted/appended stories, under the original brief constraints; use .gjc/ultragoal/ledger.jsonl as the audit trail.
+			checkpoint requires=architectReview:CLEAR+APPROVE,executorQa:passed
+			"
+			`);
+		const checkpoint = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"blocked",
+				"--evidence",
+				"waiting",
+				"--quality-gate-json",
+				passingQualityGate(),
+			],
+			root,
+		);
+		expect(checkpoint.status).toBe(0);
+		expect(checkpoint.stdout).toContain("goal-id=G001");
+		expect(checkpoint.stdout).toContain("status=blocked");
+		expect(checkpoint.stdout).toMatchInlineSnapshot(`
+		  "ultragoal checkpoint goal-id=G001 status=blocked
+		  "
+		`);
+
+		const skill = await makeSkill("ralplan", "---\nname: ralplan\n---\n# Ralplan\nBody");
+		const captured: Array<{ message: { customType: string; content: unknown }; options?: unknown }> = [];
+		const session: ToolSession = {
+			cwd: root,
+			hasUI: false,
+			skills: [skill],
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+			sendCustomMessage: async (message, options) => {
+				captured.push({ message, options });
+			},
+		};
+		const tool = SkillTool.createIf(session)!;
+		const skillResult = await tool.execute("call", { name: "ralplan", args: "review" });
+		const skillPayload = JSON.parse(
+			skillResult.content[0]?.type === "text" ? skillResult.content[0].text : "{}",
+		) as Record<string, unknown>;
+		assertKeys(skillPayload, ["callee", "path", "args", "lineCount"]);
+		expect(captured[0]?.message.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(captured[0]?.message.content).toContain("# Ralplan");
+		expect(scrub(skillResult.content[0]?.type === "text" ? skillResult.content[0].text : "")).toMatchInlineSnapshot(
+			`"{"callee":"ralplan","path":"/tmp/SCRUBBED","args":"review","lineCount":2}"`,
+		);
+	});
+
+	it("documents the ralplan receipt-only guideline for role agents", async () => {
+		const skillDoc = await fs.readFile(
+			path.join(process.cwd(), "packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md"),
+			"utf-8",
+		);
+		expect(skillDoc).toContain("RECEIPT-ONLY guideline");
+		expect(skillDoc).toContain("planner");
+		expect(skillDoc).toContain("architect");
+		expect(skillDoc).toContain("critic");
+		expect(skillDoc).toContain("gjc ralplan --write");
+		expect(skillDoc).toContain("run_id");
+		expect(skillDoc).toContain("path");
+		expect(skillDoc).toContain("sha256");
+		expect(skillDoc).toContain("verdict/status");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -120,13 +120,16 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			"
 			`);
 
-		const deepSeed = await runNativeDeepInterviewCommand(["--json", "clarify this idea"], root);
+		const deepSeed = await runNativeDeepInterviewCommand(
+			["--standard", "--threshold", "0.05", "--threshold-source", "flag:explicit", "--json", "clarify this idea"],
+			root,
+		);
 		expect(deepSeed.status).toBe(0);
 		const deepSeedPayload = JSON.parse(deepSeed.stdout ?? "{}") as Record<string, unknown>;
 		assertKeys(deepSeedPayload, ["state_path", "handoff"]);
 		expect(deepSeedPayload.handoff).toBe("/skill:deep-interview");
 		expect(scrub(deepSeed.stdout ?? "")).toMatchInlineSnapshot(`
-			"{"skill":"deep-interview","resolution":"standard","threshold":0.05,"threshold_source":"/Users/bellman/.gjc/agent/config.yml","idea":"clarify this idea","state_path":"/tmp/SCRUBBED","handoff":"/skill:deep-interview"}
+			"{"skill":"deep-interview","resolution":"standard","threshold":0.05,"threshold_source":"flag:explicit","idea":"clarify this idea","state_path":"/tmp/SCRUBBED","handoff":"/skill:deep-interview"}
 			"
 			`);
 

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -136,13 +136,15 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 		);
 		expect(deepWrite.status).toBe(0);
 		const deepWritePayload = JSON.parse(deepWrite.stdout ?? "{}") as Record<string, unknown>;
-		assertKeys(deepWritePayload, ["path", "sha256", "state_path", "handoff"]);
-		expect(deepWritePayload.path).toBe(deepWritePayload.path);
-		expect(deepWritePayload.sha256).toBeTruthy();
+		assertKeys(deepWritePayload, ["path", "sha256", "spec_path", "sha", "state_path", "handoff"]);
+		expect(deepWritePayload.spec_path).toBe(deepWritePayload.path);
+		expect(deepWritePayload.sha).toBe(deepWritePayload.sha256);
+		expect(deepWritePayload.spec_path).toBeTruthy();
+		expect(deepWritePayload.sha).toBeTruthy();
 		const handoff = deepWritePayload.handoff as Record<string, unknown>;
 		assertKeys(handoff, ["to", "run_id", "state_path"]);
 		expect(scrub(deepWrite.stdout ?? "")).toMatchInlineSnapshot(`
-			"{"skill":"deep-interview","stage":"final","slug":"matrix","path":"/tmp/SCRUBBED","sha256":"<sha256>","created_at":"<iso>","state_path":"/tmp/SCRUBBED","handoff":{"to":"ralplan","mode":"deliberate","state_path":"/tmp/SCRUBBED","run_id":"run-b"}}
+			"{"skill":"deep-interview","stage":"final","slug":"matrix","path":"/tmp/SCRUBBED","sha256":"<sha256>","spec_path":"/tmp/SCRUBBED","sha":"<sha256>","created_at":"<iso>","state_path":"/tmp/SCRUBBED","handoff":{"to":"ralplan","mode":"deliberate","state_path":"/tmp/SCRUBBED","run_id":"run-b"}}
 			"
 			`);
 

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -156,8 +156,8 @@ describe("SkillTool", () => {
 		const result = await tool!.execute("call-1", { name: "ultragoal", args: "go" });
 		const firstBlock = result.content[0];
 		expect(firstBlock?.type).toBe("text");
-		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain("Handed off");
-		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain("ultragoal");
+		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain('"callee":"ultragoal"');
+		expect(firstBlock?.type === "text" ? firstBlock.text : "").toContain('"args":"go"');
 		expect(result.details?.name).toBe("ultragoal");
 		expect(result.details?.args).toBe("go");
 

--- a/scripts/audit-skill-token-budget.ts
+++ b/scripts/audit-skill-token-budget.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { listCommandRefBlocks } from "../packages/coding-agent/src/gjc-runtime/workflow-command-ref";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../packages/coding-agent/src/skill-state/active-state";
+
+interface SectionBudget {
+	blockId: string;
+	bytes: number;
+	approxTokens: number;
+}
+
+interface SkillBudget {
+	skill: string;
+	sourcePath: string;
+	bytes: number;
+	approxTokens: number;
+	sections: SectionBudget[];
+}
+
+const repoRoot = path.join(import.meta.dir, "..");
+const skillsRoot = path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills");
+
+function usage(): never {
+	console.error("Usage: bun scripts/audit-skill-token-budget.ts [--json]");
+	process.exit(2);
+}
+
+function approxTokens(text: string): number {
+	return Math.ceil(Buffer.byteLength(text) / 4);
+}
+
+function markerBlock(content: string, start: string, end: string): string | undefined {
+	const startIndex = content.indexOf(start);
+	if (startIndex < 0) return undefined;
+	const endIndex = content.indexOf(end, startIndex + start.length);
+	if (endIndex < 0) return undefined;
+	return content.slice(startIndex, endIndex + end.length + (content[endIndex + end.length] === "\n" ? 1 : 0));
+}
+
+export function auditSkillTokenBudget(): SkillBudget[] {
+	return CANONICAL_GJC_WORKFLOW_SKILLS.map(skill => {
+		const sourcePath = path.join(skillsRoot, skill, "SKILL.md");
+		const content = fs.readFileSync(sourcePath, "utf8");
+		const sections = listCommandRefBlocks(skill).flatMap(block => {
+			const existing = markerBlock(content, block.markers.start, block.markers.end);
+			if (existing === undefined) return [];
+			return [{ blockId: block.blockId, bytes: Buffer.byteLength(existing), approxTokens: approxTokens(existing) }];
+		});
+		return {
+			skill,
+			sourcePath: path.relative(repoRoot, sourcePath),
+			bytes: Buffer.byteLength(content),
+			approxTokens: approxTokens(content),
+			sections,
+		};
+	});
+}
+
+function main(): void {
+	const args = process.argv.slice(2);
+	const json = args.includes("--json");
+	if (args.some(arg => arg !== "--json")) usage();
+	const report = auditSkillTokenBudget();
+	if (json) {
+		console.log(JSON.stringify({ skills: report }, null, 2));
+		return;
+	}
+	console.log("GJC bundled skill token budget (approx. 1 token ~= 4 bytes)");
+	console.log("Skill            Bytes   Approx tokens   Marked sections");
+	console.log("---------------  ------  --------------  ---------------");
+	for (const item of report) {
+		const sections = item.sections.length === 0 ? "none" : item.sections.map(section => `${section.blockId}:${section.bytes}B/${section.approxTokens}t`).join(", ");
+		console.log(`${item.skill.padEnd(15)}  ${String(item.bytes).padStart(6)}  ${String(item.approxTokens).padStart(14)}  ${sections}`);
+	}
+	const totalBytes = report.reduce((sum, item) => sum + item.bytes, 0);
+	console.log(`Total            ${String(totalBytes).padStart(6)}  ${String(approxTokens("x".repeat(totalBytes))).padStart(14)}`);
+}
+
+main();

--- a/scripts/ci-gjc-state-gates.ts
+++ b/scripts/ci-gjc-state-gates.ts
@@ -32,9 +32,11 @@ const boundedGateCommands = [
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-graph.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-read-markdown.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts"],
-	["bun", "test", "packages/coding-agent/test/deep-interview-mutation-guard.test.ts"],
-	["bun", "test", "packages/coding-agent/test/gjc-skill-state-hooks.test.ts"],
-	["bun", "test", "packages/coding-agent/test/skill-active-state.test.ts"],
+	// Lane H read-only doctor: imports only the native-free state-runtime module.
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-doctor.test.ts"],
+	// NOTE: deep-interview-mutation-guard, gjc-skill-state-hooks, and skill-active-state
+	// load the @gajae-code/natives addon transitively via the tool/hook runtime, so they
+	// run in the heavier "Affected path validation" job rather than this native-free gate.
 ];
 
 async function changedFiles(): Promise<string[]> {

--- a/scripts/ci-gjc-state-gates.ts
+++ b/scripts/ci-gjc-state-gates.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+import { $ } from "bun";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..");
+
+const relevantPathPrefixes = [
+	"packages/coding-agent/",
+	".github/workflows/dev-ci.yml",
+	".github/workflows/ci.yml",
+	"scripts/ci-gjc-state-gates.ts",
+	"scripts/verify-gjc-state-writers.ts",
+	"scripts/generate-gjc-workflow-manifest.ts",
+	"scripts/verify-gjc-skill-docs.ts",
+	"scripts/verify-g002-gates.ts",
+	"package.json",
+	"bun.lock",
+	"tsconfig.json",
+	"tsconfig.base.json",
+	"tsconfig.tools.json",
+];
+
+const boundedGateCommands = [
+	["bun", "scripts/verify-gjc-state-writers.ts", "--fail"],
+	["bun", "scripts/generate-gjc-workflow-manifest.ts", "--check"],
+	["bun", "scripts/verify-gjc-skill-docs.ts", "--fail"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-runtime.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-handoff.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-receipts.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-integrity.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-graph.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-read-markdown.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts"],
+	["bun", "test", "packages/coding-agent/test/deep-interview-mutation-guard.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-skill-state-hooks.test.ts"],
+	["bun", "test", "packages/coding-agent/test/skill-active-state.test.ts"],
+];
+
+async function changedFiles(): Promise<string[]> {
+	if (process.env.GITHUB_EVENT_NAME === "pull_request" && process.env.GITHUB_BASE_SHA) {
+		await $`git fetch --no-tags --depth=1 origin ${process.env.GITHUB_BASE_SHA}`.cwd(repoRoot).nothrow();
+		const result = await $`git diff --name-only ${process.env.GITHUB_BASE_SHA} HEAD`.cwd(repoRoot).quiet();
+		return result.stdout.toString().split("\n").filter(Boolean);
+	}
+
+	if (process.env.GITHUB_EVENT_BEFORE && !/^0+$/.test(process.env.GITHUB_EVENT_BEFORE)) {
+		await $`git fetch --no-tags --depth=1 origin ${process.env.GITHUB_EVENT_BEFORE}`.cwd(repoRoot).nothrow();
+		const result = await $`git diff --name-only ${process.env.GITHUB_EVENT_BEFORE} HEAD`.cwd(repoRoot).quiet();
+		return result.stdout.toString().split("\n").filter(Boolean);
+	}
+
+	console.log("gjc-state-gates: no comparable base SHA found; running bounded gates.");
+	return ["packages/coding-agent/"];
+}
+
+function isRelevant(file: string): boolean {
+	return relevantPathPrefixes.some(prefix => file === prefix || file.startsWith(prefix));
+}
+
+const files = await changedFiles();
+const relevantFiles = files.filter(isRelevant);
+
+if (relevantFiles.length === 0) {
+	console.log("gjc-state-gates: no relevant paths changed; gate commands skipped.");
+	console.log(`gjc-state-gates: inspected ${files.length} changed path(s).`);
+	process.exit(0);
+}
+
+console.log("gjc-state-gates: relevant paths changed; running bounded gates.");
+for (const file of relevantFiles) {
+	console.log(`gjc-state-gates: relevant ${file}`);
+}
+
+for (const command of boundedGateCommands) {
+	console.log(`gjc-state-gates: running ${command.join(" ")}`);
+	await $`${command}`.cwd(repoRoot);
+}
+
+console.log("gjc-state-gates: bounded gates passed.");

--- a/scripts/generate-gjc-skill-command-refs.ts
+++ b/scripts/generate-gjc-skill-command-refs.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { listCommandRefBlocks, renderCommandRefBlock } from "../packages/coding-agent/src/gjc-runtime/workflow-command-ref";
+
+interface CommandRefCheckResult {
+	skill: string;
+	blockId: string;
+	sourcePath: string;
+	status: "BYTE-EQUAL" | "GAP";
+	reason?: string;
+	currentBytes?: number;
+	renderedBytes: number;
+	firstMismatchOffset?: number;
+}
+
+const repoRoot = path.join(import.meta.dir, "..");
+
+function usage(): never {
+	console.error("Usage: bun scripts/generate-gjc-skill-command-refs.ts [--check] [--strict] [--json]");
+	process.exit(2);
+}
+
+function parseArgs(): { strict: boolean; json: boolean } {
+	const args = process.argv.slice(2);
+	let strict = false;
+	let json = false;
+	for (const arg of args) {
+		if (arg === "--check") continue;
+		if (arg === "--strict") {
+			strict = true;
+			continue;
+		}
+		if (arg === "--json") {
+			json = true;
+			continue;
+		}
+		usage();
+	}
+	return { strict, json };
+}
+
+function markerBlock(content: string, start: string, end: string): string | undefined {
+	const startIndex = content.indexOf(start);
+	if (startIndex < 0) return undefined;
+	const endIndex = content.indexOf(end, startIndex + start.length);
+	if (endIndex < 0) return undefined;
+	return content.slice(startIndex, endIndex + end.length + (content[endIndex + end.length] === "\n" ? 1 : 0));
+}
+
+function firstMismatchOffset(a: string, b: string): number | undefined {
+	const max = Math.min(a.length, b.length);
+	for (let i = 0; i < max; i++) {
+		if (a.charCodeAt(i) !== b.charCodeAt(i)) return i;
+	}
+	return a.length === b.length ? undefined : max;
+}
+
+export function checkSkillCommandRefs(): CommandRefCheckResult[] {
+	return listCommandRefBlocks().map(block => {
+		const sourcePath = path.join(repoRoot, block.sourcePath);
+		const current = fs.readFileSync(sourcePath, "utf8");
+		const rendered = renderCommandRefBlock(block.skill, block.blockId).bytes;
+		const existing = markerBlock(current, block.markers.start, block.markers.end);
+		const relative = path.relative(repoRoot, sourcePath);
+		if (existing === undefined) {
+			return {
+				skill: block.skill,
+				blockId: block.blockId,
+				sourcePath: relative,
+				status: "GAP",
+				reason: "unmarked / not yet generated",
+				renderedBytes: Buffer.byteLength(rendered),
+			};
+		}
+		if (existing === rendered) {
+			return {
+				skill: block.skill,
+				blockId: block.blockId,
+				sourcePath: relative,
+				status: "BYTE-EQUAL",
+				currentBytes: Buffer.byteLength(existing),
+				renderedBytes: Buffer.byteLength(rendered),
+			};
+		}
+		return {
+			skill: block.skill,
+			blockId: block.blockId,
+			sourcePath: relative,
+			status: "GAP",
+			reason: "marked block is not byte-equal to rendered model",
+			currentBytes: Buffer.byteLength(existing),
+			renderedBytes: Buffer.byteLength(rendered),
+			firstMismatchOffset: firstMismatchOffset(existing, rendered),
+		};
+	});
+}
+
+function main(): void {
+	const { strict, json } = parseArgs();
+	const results = checkSkillCommandRefs();
+	if (json) {
+		console.log(JSON.stringify({ results }, null, 2));
+	} else {
+		console.log("GJC skill command-ref proof spike (read-only)");
+		for (const result of results) {
+			const suffix = result.status === "BYTE-EQUAL" ? "" : ` (${result.reason ?? "gap"})`;
+			console.log(`${result.skill}/${result.blockId}: ${result.status}${suffix} rendered=${result.renderedBytes}B${result.currentBytes === undefined ? "" : ` current=${result.currentBytes}B`}`);
+		}
+		const gaps = results.filter(result => result.status === "GAP").length;
+		console.log(`Summary: ${results.length - gaps} byte-equal, ${gaps} gap(s).`);
+	}
+	if (strict && results.some(result => result.status !== "BYTE-EQUAL")) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## gjc `.gjc` state-model v3 — CI enforcement, handoff token-thrift, read-only doctor, command-ref proof-spike

Follow-on to v1 (#198/#199) and v2 (#203, merged). v3 scope = components **A + B + C + H** (D/E/F/G/I deferred to v4). Built on the merged v2 baseline.

### Lanes

**H — read-only `gjc state doctor`** (`state-runtime.ts`, `workflow-manifest.ts`)
- New `doctor [--skill <name>] [--json]` action: pure validators over raw file reads (`validateWorkflowStateEnvelope`, `detectWorkflowEnvelopeIntegrityMismatch`). No writes, no mutation, no mtime/byte changes, no stale-detection writer calls. `doctor` verb added to the manifest + regenerated G3 projection.
- Tests: `test/gjc-runtime/state-doctor.test.ts`.

**A — required `gjc-state-gates` CI job** (`.github/workflows/dev-ci.yml`, `ci.yml`, `scripts/ci-gjc-state-gates.ts`)
- Always-present required status in every protected workflow with internal path-detection no-op success (no workflow-level `paths:` skip), explicit timeout, bounded test list (excludes tmux/team/worktree/native/Rust).
- Runner executes G1 (`verify-gjc-state-writers`), G3 (`generate-gjc-workflow-manifest --check`), G4 (`verify-gjc-skill-docs`) + bounded state tests. Closes the gap where prior PRs only ran "Affected path validation".

**B — handoff/inject token-thrift + receipt-only guideline** (`ultragoal-runtime.ts`, `ralplan-runtime.ts`, `deep-interview-runtime.ts`, `tools/skill.ts`, `ralplan/SKILL.md`)
- Compacted model-facing payloads while **preserving every named key field** (ralplan receipt run_id/path/stage/stage_n/sha256/created_at/pending_approval_path; deep-interview spec_path/sha/state_path/run_id/handoff target; ultragoal objective/next-action/checkpoint; skill-tool callee/path/args/lineCount). No prompt-body or raw-API truncation. Golden snapshots + per-field assertions.
- Appended receipt-only guideline to `ralplan/SKILL.md` (+2 lines; no role-agent prompt surgery).
- Tests: `test/gjc-runtime/state-handoff-thrift.test.ts`, updated `ralplan-runtime.test.ts`, `tools/skill.test.ts`.

**C — command-ref proof-spike (check-only, ZERO SKILL.md byte change)** (`workflow-command-ref.ts`, `scripts/generate-gjc-skill-command-refs.ts`, `scripts/audit-skill-token-budget.ts`)
- Command-ref metadata model + generator + byte-equality check + token-budget audit. Generator runs check-only (reports GAP, exits 0 — content switch deferred to v4 since the manifest models verbs, not hand-authored CLI shapes). No SKILL.md content changed by this lane.
- Tests: `test/gjc-runtime/skill-command-ref.test.ts`.

### Verification (local, current dev base)
- `tsc --noEmit`: clean (0 errors)
- `scripts/ci-gjc-state-gates.ts`: exit 0 — G1/G3/G4 + bounded tests all green
- New v3 tests: 10 pass / 198 expect / 8 snapshots
- biome: clean on all 13 changed source/json files
- SKILL.md delta: ralplan +2 only (B guideline); C zero-byte confirmed
- Token audit: deep-interview ~13.8K, total ~29.3K tokens

Deferred to v4: D (audit rollup), E (hierarchical statecharts), F (versioned migration), G (tamper recovery/`gjc state repair`), I (manifest-driven TUI).
