### PR TITLE
feat(ralplan): persisted-Planner run-state flags + consensus orchestration

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -52,7 +52,7 @@ After a role agent persists a stage artifact, its model-facing response to the c
 This skill runs GJC planning in consensus mode for the provided arguments.
 
 The consensus workflow:
-1. **Planner** creates initial plan and a compact **RALPLAN-DR summary** before review, then persists the stage with `gjc ralplan --write --stage planner --stage_n 1 --artifact "..."`:
+1. **Planner** creates the initial plan and a compact **RALPLAN-DR summary** before review. Launch the Planner ONCE per run as a detached, resumable subagent (await it before the Architect) and record its returned subagent id as the run's persisted Planner id; persist the stage with `gjc ralplan --write --stage planner --stage_n 1 --artifact "..." --planner-id <id> --planner-resumable <true|false>` (see **Persisted Planner** below):
    - After persistence, return only the receipt/path plus compact planning status; do not paste the full plan markdown back to the caller unless explicitly requested.
    - Principles (3-5)
    - Decision Drivers (top 3)
@@ -66,7 +66,7 @@ The consensus workflow:
    - The Critic agent/subagent must persist its evaluation with `gjc ralplan --write --stage critic --stage_n <N> --artifact "..." --json`, then return the receipt/path plus compact verdict/status (`OKAY`/`ITERATE`/`REJECT`) instead of pasting the full evaluation body.
 5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
    a. Collect Architect + Critic feedback
-   b. Revise the plan with Planner
+   b. Revise the plan by resuming the SAME persisted Planner subagent with consolidated Architect + Critic feedback (see **Persisted Planner** below); fall back to a fresh Planner spawn only per the fallback routing table
    c. Return to Architect review
       - Persist each Planner revision with `gjc ralplan --write --stage revision --stage_n <N> --artifact "..." --json` before re-review, then pass the receipt/path forward instead of duplicating the full revision markdown in the parent conversation.
    d. Return to Critic evaluation
@@ -87,6 +87,33 @@ The consensus workflow:
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent Task calls in the same parallel batch. Always await the Architect result before issuing the Critic Task.
 
 Follow the Plan skill's full documentation for consensus mode details.
+
+### Persisted Planner (consensus loop)
+
+The Planner is a **same-session persisted subagent**: launched detached once, awaited before the Architect, then **resumed** with consolidated Architect + Critic feedback on every re-review pass instead of being re-spawned. The Architect and Critic stay **fresh, independent spawns each pass** so their verdicts remain reproducible from their pass artifacts alone. Do NOT modify the subagent control surface; this orchestration uses the existing `subagent` resume/steer controls only.
+
+**Persistence boundary:** this is same-parent, active-session continuity only. Resumability depends on the in-memory subagent record (and a persistent parent session — an in-memory parent yields `resumable:false`), not just a session file. The `.gjc` run-state record is an audit/routing hint, NOT a durable cross-process subagent registry. After a process restart, a missing record, or any unavailable/failed resume, use the fresh Planner fallback.
+
+**Resume routing table** (per re-review pass, when resuming the persisted Planner id):
+
+| Resume outcome | Action |
+|---|---|
+| `running` | `steer`/inject the consolidated feedback to the same id, then await — do NOT fresh-spawn |
+| `queued` | retain/update the queued message or await the same id — do NOT fresh-spawn just because it is queued |
+| `context_unavailable`, `not_found`, `no_runner`, `resume_failed` | fresh Planner spawn for that pass; record the fallback metadata |
+| terminal (`completed`/`failed`/`cancelled`) + revision message | resume the same id when context is available; otherwise use the fresh fallback above |
+
+**Recording persisted-Planner metadata** (audit/routing only — never claim `subagent list` proves resumability, since the snapshot does not expose `resumable`). Ride these optional flags on the normal `--write` for the planner/revision stage of the pass:
+
+```
+gjc ralplan --write --stage revision --stage_n <N> --artifact "..." \
+  --planner-id <id> --planner-resumable <true|false> \
+  --fallback-reason <context_unavailable|not_found|no_runner|resume_failed|process_restart|missing_record> \
+  --fallback-attempted-id <id> --fallback-stage-n <N> \
+  --fallback-receipt-path <fresh-planner-stage-artifact-path> --json
+```
+
+Set `--planner-resumable true` only when the parent session is provably persistent; set/record `false` after an observed `context_unavailable`; otherwise omit it (unknown). Fallback flags are recorded only when a fresh-spawn fallback actually occurs: a fallback record requires `--fallback-reason` **together with** `--fallback-attempted-id` and `--fallback-stage-n` (the failed id and the pass it failed on), while `--fallback-receipt-path` (the fresh Planner's stage artifact) is optional.
 
 ## Pre-Execution Gate
 

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -39,6 +39,17 @@ const KNOWN_CRITIC_KINDS = new Set(["openai-code"]);
 
 const PATH_COMPONENT_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]{0,63}$/;
 
+const SUBAGENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+
+const KNOWN_FALLBACK_REASONS = new Set([
+	"context_unavailable",
+	"not_found",
+	"no_runner",
+	"resume_failed",
+	"process_restart",
+	"missing_record",
+]);
+
 class RalplanCommandError extends Error {
 	constructor(
 		public readonly exitStatus: number,
@@ -57,6 +68,12 @@ const VALUE_FLAGS = new Set([
 	"--session-id",
 	"--architect",
 	"--critic",
+	"--planner-id",
+	"--planner-resumable",
+	"--fallback-reason",
+	"--fallback-attempted-id",
+	"--fallback-stage-n",
+	"--fallback-receipt-path",
 ]);
 
 function flagValue(args: readonly string[], flag: string): string | undefined {
@@ -171,6 +188,151 @@ async function persistActiveRunId(cwd: string, sessionId: string | undefined, ru
 	}
 	if (existing.run_id === runId) return;
 	existing.run_id = runId;
+	if (typeof existing.skill !== "string") existing.skill = "ralplan";
+	if (typeof existing.active !== "boolean") existing.active = true;
+	existing.updated_at = new Date().toISOString();
+	await writeJsonAtomic(statePath, existing, {
+		cwd,
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
+	});
+}
+
+/* --------------------------- planner run-state --------------------------- */
+
+interface PlannerStateUpdate {
+	subagentId?: string;
+	resumable?: boolean;
+	fallbackReason?: string;
+	fallbackAttemptedId?: string;
+	fallbackStageN?: number;
+	fallbackReceiptPath?: string;
+}
+
+function parseBooleanFlag(raw: string, flag: string): boolean {
+	if (raw === "true") return true;
+	if (raw === "false") return false;
+	throw new RalplanCommandError(2, `invalid ${flag}: ${raw}. Expected "true" or "false".`);
+}
+
+function assertSubagentId(value: string, label: string): void {
+	if (!SUBAGENT_ID_RE.test(value)) {
+		throw new RalplanCommandError(2, `invalid ${label}: ${value}`);
+	}
+}
+
+function plannerFlagValue(args: readonly string[], flag: string): string | undefined {
+	const value = flagValue(args, flag);
+	if (value === undefined && hasFlag(args, flag)) {
+		throw new RalplanCommandError(2, `missing value for ${flag}.`);
+	}
+	return value;
+}
+
+/**
+ * Parse the optional persisted-Planner metadata flags that may ride alongside a
+ * `--write`. Returns `undefined` when none are present so existing writes are
+ * unaffected. Throws `RalplanCommandError` on any malformed value. This records
+ * a same-session audit/routing hint, not a durable subagent registry.
+ */
+function parsePlannerStateArgs(args: readonly string[]): PlannerStateUpdate | undefined {
+	const subagentId = plannerFlagValue(args, "--planner-id");
+	const resumableRaw = plannerFlagValue(args, "--planner-resumable");
+	const fallbackReason = plannerFlagValue(args, "--fallback-reason");
+	const fallbackAttemptedId = plannerFlagValue(args, "--fallback-attempted-id");
+	const fallbackStageNRaw = plannerFlagValue(args, "--fallback-stage-n");
+	const fallbackReceiptPath = plannerFlagValue(args, "--fallback-receipt-path");
+
+	const anyPresent = [
+		subagentId,
+		resumableRaw,
+		fallbackReason,
+		fallbackAttemptedId,
+		fallbackStageNRaw,
+		fallbackReceiptPath,
+	].some(value => value !== undefined);
+	if (!anyPresent) return undefined;
+
+	const update: PlannerStateUpdate = {};
+
+	if (subagentId !== undefined) {
+		assertSubagentId(subagentId, "--planner-id");
+		update.subagentId = subagentId;
+	}
+	if (resumableRaw !== undefined) {
+		update.resumable = parseBooleanFlag(resumableRaw, "--planner-resumable");
+	}
+
+	const anyFallback = [fallbackReason, fallbackAttemptedId, fallbackStageNRaw, fallbackReceiptPath].some(
+		value => value !== undefined,
+	);
+	if (anyFallback) {
+		if (!fallbackReason) {
+			throw new RalplanCommandError(2, "--fallback-reason is required when recording planner fallback metadata.");
+		}
+		if (!KNOWN_FALLBACK_REASONS.has(fallbackReason)) {
+			throw new RalplanCommandError(
+				2,
+				`invalid --fallback-reason: ${fallbackReason}. Expected one of: ${[...KNOWN_FALLBACK_REASONS].join(", ")}.`,
+			);
+		}
+		update.fallbackReason = fallbackReason;
+		if (fallbackAttemptedId === undefined) {
+			throw new RalplanCommandError(
+				2,
+				"--fallback-attempted-id is required when recording planner fallback metadata.",
+			);
+		}
+		assertSubagentId(fallbackAttemptedId, "--fallback-attempted-id");
+		update.fallbackAttemptedId = fallbackAttemptedId;
+		if (fallbackStageNRaw === undefined) {
+			throw new RalplanCommandError(2, "--fallback-stage-n is required when recording planner fallback metadata.");
+		}
+		update.fallbackStageN = parseStageN(fallbackStageNRaw);
+		if (fallbackReceiptPath !== undefined) {
+			if (fallbackReceiptPath.trim() === "") {
+				throw new RalplanCommandError(2, "--fallback-receipt-path must not be empty.");
+			}
+			update.fallbackReceiptPath = fallbackReceiptPath;
+		}
+	}
+
+	return update;
+}
+
+/** Snake-case projection of a PlannerStateUpdate for state JSON + receipts. Omitted fields stay absent — an unknown `planner_resumable` is encoded by omission, never literal null. */
+function plannerStatePayload(update: PlannerStateUpdate): Record<string, unknown> {
+	const payload: Record<string, unknown> = {};
+	if (update.subagentId !== undefined) payload.planner_subagent_id = update.subagentId;
+	if (update.resumable !== undefined) payload.planner_resumable = update.resumable;
+	if (update.fallbackReason !== undefined) payload.planner_fallback_reason = update.fallbackReason;
+	if (update.fallbackAttemptedId !== undefined) payload.planner_fallback_attempted_id = update.fallbackAttemptedId;
+	if (update.fallbackStageN !== undefined) payload.planner_fallback_stage_n = update.fallbackStageN;
+	if (update.fallbackReceiptPath !== undefined) payload.planner_fallback_receipt_path = update.fallbackReceiptPath;
+	return payload;
+}
+
+/**
+ * Merge persisted-Planner metadata into the ralplan run-state JSON. Same-session
+ * audit/routing hint only — it records what the caller has already proven and is
+ * NOT a durable cross-process subagent registry.
+ */
+async function applyPlannerStateUpdate(
+	cwd: string,
+	sessionId: string | undefined,
+	update: PlannerStateUpdate,
+): Promise<void> {
+	const statePath = ralplanStatePath(cwd, sessionId);
+	let existing: Record<string, unknown> = {};
+	try {
+		const raw = await fs.readFile(statePath, "utf-8");
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			existing = parsed as Record<string, unknown>;
+		}
+	} catch {
+		// fresh state; fall through to create
+	}
+	Object.assign(existing, plannerStatePayload(update));
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
 	if (typeof existing.active !== "boolean") existing.active = true;
 	existing.updated_at = new Date().toISOString();
@@ -296,8 +458,12 @@ async function syncRalplanHud(options: {
 }
 
 async function handleArtifactWrite(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
+	const plannerState = parsePlannerStateArgs(args);
 	const resolved = await resolveArtifactArgs(args, cwd);
 	const persisted = await persistArtifact(resolved, cwd);
+	if (plannerState) {
+		await applyPlannerStateUpdate(cwd, resolved.sessionId, plannerState);
+	}
 	await syncRalplanHud({
 		cwd,
 		sessionId: resolved.sessionId,
@@ -315,6 +481,7 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 		created_at: persisted.createdAt,
 	};
 	if (persisted.pendingApprovalPath) payload.pending_approval_path = persisted.pendingApprovalPath;
+	if (plannerState) payload.planner_state = plannerStatePayload(plannerState);
 	const stdout = resolved.json
 		? `${JSON.stringify(payload, null, 2)}\n`
 		: `Persisted ralplan ${persisted.stage} stage ${persisted.stageN} at ${persisted.path}.\n`;

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -301,3 +301,299 @@ describe("native gjc ralplan runtime — --write artifact path", () => {
 		expect(writePayload.run_id).toBe(handoffPayload.run_id);
 	});
 });
+
+describe("native gjc ralplan runtime — persisted Planner state", () => {
+	const statePath = (root: string) => path.join(root, ".gjc", "state", "ralplan-state.json");
+
+	async function readState(root: string): Promise<Record<string, unknown>> {
+		const raw = await fs.readFile(statePath(root), "utf-8");
+		return JSON.parse(raw) as Record<string, unknown>;
+	}
+
+	it("records planner id + resumable into run state and echoes planner_state", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Plan",
+				"--run-id",
+				"pp-run",
+				"--planner-id",
+				"0-Planner",
+				"--planner-resumable",
+				"true",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.planner_state).toEqual({
+			planner_subagent_id: "0-Planner",
+			planner_resumable: true,
+		});
+		const state = await readState(root);
+		expect(state.planner_subagent_id).toBe("0-Planner");
+		expect(state.planner_resumable).toBe(true);
+		expect(state.run_id).toBe("pp-run");
+	});
+
+	it("accepts --planner-resumable false", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"2",
+				"--artifact",
+				"# Rev",
+				"--run-id",
+				"pp-false",
+				"--planner-resumable",
+				"false",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const state = await readState(root);
+		expect(state.planner_resumable).toBe(false);
+	});
+
+	it("omits planner fields when no planner flags are supplied (existing writes unaffected)", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "plain", "--json"],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.planner_state).toBeUndefined();
+		const state = await readState(root);
+		expect("planner_subagent_id" in state).toBe(false);
+		expect("planner_resumable" in state).toBe(false);
+	});
+
+	it("records fallback metadata together with a fresh planner id", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"3",
+				"--artifact",
+				"# Rev",
+				"--run-id",
+				"pp-fb",
+				"--planner-id",
+				"1-PlannerFresh",
+				"--fallback-reason",
+				"context_unavailable",
+				"--fallback-attempted-id",
+				"0-PlannerOld",
+				"--fallback-stage-n",
+				"3",
+				"--fallback-receipt-path",
+				".gjc/plans/ralplan/pp-fb/stage-03-revision.md",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const state = await readState(root);
+		expect(state.planner_fallback_reason).toBe("context_unavailable");
+		expect(state.planner_fallback_attempted_id).toBe("0-PlannerOld");
+		expect(state.planner_fallback_stage_n).toBe(3);
+		expect(state.planner_fallback_receipt_path).toBe(".gjc/plans/ralplan/pp-fb/stage-03-revision.md");
+		expect(state.planner_subagent_id).toBe("1-PlannerFresh");
+	});
+
+	it("rejects invalid --planner-resumable with exit 2", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"x",
+				"--run-id",
+				"bad-bool",
+				"--planner-resumable",
+				"yes",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("invalid --planner-resumable");
+	});
+
+	it("rejects invalid --planner-id with exit 2", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"x",
+				"--run-id",
+				"bad-id",
+				"--planner-id",
+				"bad id!",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("invalid --planner-id");
+	});
+
+	it("rejects unknown --fallback-reason with exit 2", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"2",
+				"--artifact",
+				"x",
+				"--run-id",
+				"bad-reason",
+				"--fallback-reason",
+				"because",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("invalid --fallback-reason");
+	});
+
+	it("requires --fallback-reason when other fallback flags are present", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"2",
+				"--artifact",
+				"x",
+				"--run-id",
+				"missing-reason",
+				"--fallback-attempted-id",
+				"0-Old",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("--fallback-reason is required");
+	});
+
+	it("does not persist an artifact when planner flags are invalid (fail-fast)", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Plan",
+				"--run-id",
+				"no-side-effect",
+				"--planner-resumable",
+				"maybe",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		const filePath = path.join(root, ".gjc", "plans", "ralplan", "no-side-effect", "stage-01-planner.md");
+		await expect(fs.readFile(filePath, "utf-8")).rejects.toThrow();
+	});
+
+	it("requires --fallback-attempted-id alongside --fallback-reason", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"2",
+				"--artifact",
+				"x",
+				"--run-id",
+				"fb-missing-id",
+				"--fallback-reason",
+				"context_unavailable",
+				"--fallback-stage-n",
+				"2",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("--fallback-attempted-id is required");
+	});
+
+	it("requires --fallback-stage-n alongside --fallback-reason", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"revision",
+				"--stage_n",
+				"2",
+				"--artifact",
+				"x",
+				"--run-id",
+				"fb-missing-stage",
+				"--fallback-reason",
+				"context_unavailable",
+				"--fallback-attempted-id",
+				"0-Old",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("--fallback-stage-n is required");
+	});
+
+	it("rejects a planner flag supplied without a value (missing value at EOF)", async () => {
+		const root = await tempDir();
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Plan",
+				"--run-id",
+				"eof-flag",
+				"--planner-id",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("missing value for --planner-id");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **same-session persisted Planner** to the ralplan consensus loop: the Planner is launched once as a detached, resumable subagent and **resumed** with consolidated Architect+Critic feedback on each re-review pass, while the **Architect and Critic stay fresh and independent every pass** so their verdicts remain reproducible from their stage artifacts alone.

This is the consensus-approved minimal first increment from deep-interview → ralplan (run `2026-06-03-0603-ea1a`). The GO basis is **convergence quality** (less re-explaining to the Planner); cost/cache is a Planner-only, cache-TTL-dependent bonus.

## What changed (3 files, no control-surface changes)

- **`ralplan-runtime.ts`** — new optional flags on `gjc ralplan --write` that record same-session audit/routing hints into `ralplan-state.json` via the sanctioned `writeJsonAtomic`:
  - `--planner-id`, `--planner-resumable <true|false>`, `--fallback-reason`, `--fallback-attempted-id`, `--fallback-stage-n`, `--fallback-receipt-path`
  - Validation is **fail-fast** (parsed before any artifact write), rejects missing flag values, and requires a complete fallback triple (`reason` + `attempted-id` + `stage-n`). Unknown `planner_resumable` is encoded by **omission**, never literal null.
- **`ralplan/SKILL.md`** — orchestration: launch the Planner detached once + await before Architect; resume the same id per re-review pass; fresh Architect/Critic each pass; a **resume fallback routing table** (`running`→steer+await, `queued`→await, `context_unavailable`/`not_found`/`no_runner`/`resume_failed`→fresh spawn); and an explicit **same-session persistence boundary** (audit/routing hint, not cross-process recovery).
- **tests** — 12 new cases covering happy path, resumable true/false, fallback metadata, all rejection paths, fail-fast no-artifact, and back-compat.

**No changes** to the subagent control surface (`subagent.ts` / `job-manager.ts` / `executor.ts`).

## Persistence boundary (honest scope)

Same-parent, active-session continuity only. Resumability depends on the in-memory subagent record (and a persistent parent session — in-memory parents are `resumable:false`), not just a session file. The `.gjc` run-state record is an audit/routing hint, not a durable cross-process registry; restart/missing-record/failed-resume falls back to a fresh Planner.

## Verification

- `bun test test/gjc-runtime/` → **215 pass / 0 fail** (29 in `ralplan-runtime.test.ts`).
- `tsgo --noEmit` typecheck: clean. `biome check`: clean.
- `verify-gjc-skill-docs`, `verify-gjc-state-writers`: pass. `generate-gjc-workflow-manifest`: no drift.
- **Architect review** (re-review): architecture / product / code all **CLEAR**, recommendation **APPROVE**, 0 blockers.
- **Executor QA + red-team** (real CLI surface via `bun src/cli.ts ralplan --write …`): **passed** — 4/4 contract obligations covered, 6/6 adversarial cases rejected with clear messages, fail-fast (no artifact on invalid flags) confirmed, back-compat preserved.

## Provenance

deep-interview spec `.gjc/specs/deep-interview-ralplan-persisted-planner.md` → ralplan consensus plan `.gjc/plans/ralplan/2026-06-03-0603-ea1a/stage-02-final.md` (Architect CLEAR/APPROVE + Critic OKAY).
