### PR TITLE
Fix clipboard image path paste placeholders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Started the GJC backend bridge foundation with a shared agent-wire protocol module, event envelopes, RPC command scope matrix, UI request broker, typed unsupported UI results, a guarded `--mode bridge` handshake surface, and RPC mode dispatch refactored onto the shared command dispatcher.
 - Documented the experimental `--mode bridge` protocol in `docs/bridge.md` and the `GJC_BRIDGE_*` environment variables in `docs/environment-variables.md` (TLS-mandatory startup, bearer auth, coarse command scopes with a `prompt` floor, single live `AgentSession` per process, bounded event-stream replay with `reset`, and the semantic-not-pixel UI capability matrix), and added bridge event-stream/idempotency regression tests plus a docs-conformance check that pins the docs against the protocol version, scope/command catalog, negotiated capabilities/frame types, and unsupported UI surfaces. The bridge protocol/SDK are experimental (`BRIDGE_PROTOCOL_VERSION` 1) and may change in additive, version-negotiated ways.
 
+### Fixed
+
+- Render terminal-pasted clipboard image temp paths as compact `[image N]` prompt placeholders while attaching the image payload, instead of inserting raw `/var/folders/.../clipboard-*.png` path text.
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,4 +1,5 @@
 import { Editor, type KeyId, matchesKey, parseKittySequence } from "@gajae-code/tui";
+import { BracketedPasteHandler } from "@gajae-code/tui/bracketed-paste";
 import type { AppKeybinding } from "../../config/keybindings";
 
 type ConfigurableEditorAction = Extract<
@@ -63,6 +64,8 @@ export class CustomEditor extends Editor {
 	onCopyPrompt?: () => void;
 	/** Called when the configured image-paste shortcut is pressed. */
 	onPasteImage?: () => Promise<boolean>;
+	/** Called before bracketed paste content is inserted. Return true to consume it. */
+	onPasteText?: (text: string) => boolean | Promise<boolean>;
 	/** Called when the configured dequeue shortcut is pressed. */
 	onDequeue?: () => void;
 	/** Called when Caps Lock is pressed. */
@@ -73,6 +76,7 @@ export class CustomEditor extends Editor {
 	#actionKeys = new Map<ConfigurableEditorAction, KeyId[]>(
 		Object.entries(DEFAULT_ACTION_KEYS).map(([action, keys]) => [action as ConfigurableEditorAction, [...keys]]),
 	);
+	#pasteHandler = new BracketedPasteHandler();
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
@@ -108,6 +112,24 @@ export class CustomEditor extends Editor {
 		this.#customKeyHandlers.clear();
 	}
 
+	#handleBracketedPaste(pasteContent: string, remaining: string): void {
+		const pasteResult = this.onPasteText?.(pasteContent);
+		const applyPasteResult = (handled: boolean | undefined) => {
+			if (!handled) {
+				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
+			}
+			if (remaining.length > 0) {
+				this.handleInput(remaining);
+			}
+		};
+
+		if (pasteResult instanceof Promise) {
+			void pasteResult.then(applyPasteResult, () => applyPasteResult(false));
+		} else {
+			applyPasteResult(pasteResult);
+		}
+	}
+
 	handleInput(data: string): void {
 		const parsed = parseKittySequence(data);
 		if (parsed && (parsed.modifier & 64) !== 0 && this.onCapsLock) {
@@ -116,6 +138,15 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
+		if (this.onPasteText) {
+			const paste = this.#pasteHandler.process(data);
+			if (paste.handled) {
+				if (paste.pasteContent !== undefined) {
+					this.#handleBracketedPaste(paste.pasteContent, paste.remaining);
+				}
+				return;
+			}
+		}
 		// Intercept configured image paste (async - fires and handles result)
 		if (this.#matchesAction(data, "app.clipboard.pasteImage") && this.onPasteImage) {
 			void this.onPasteImage();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -77,6 +77,8 @@ export class CustomEditor extends Editor {
 		Object.entries(DEFAULT_ACTION_KEYS).map(([action, keys]) => [action as ConfigurableEditorAction, [...keys]]),
 	);
 	#pasteHandler = new BracketedPasteHandler();
+	#pasteDecisionPending = false;
+	#pendingPasteInput: string[] = [];
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
@@ -112,18 +114,29 @@ export class CustomEditor extends Editor {
 		this.#customKeyHandlers.clear();
 	}
 
+	#drainPendingPasteInput(initialInput?: string): void {
+		if (initialInput && initialInput.length > 0) {
+			this.handleInput(initialInput);
+		}
+		while (!this.#pasteDecisionPending) {
+			const nextInput = this.#pendingPasteInput.shift();
+			if (nextInput === undefined) break;
+			this.handleInput(nextInput);
+		}
+	}
+
 	#handleBracketedPaste(pasteContent: string, remaining: string): void {
-		const pasteResult = this.onPasteText?.(pasteContent);
 		const applyPasteResult = (handled: boolean | undefined) => {
 			if (!handled) {
 				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
 			}
-			if (remaining.length > 0) {
-				this.handleInput(remaining);
-			}
+			this.#pasteDecisionPending = false;
+			this.#drainPendingPasteInput(remaining);
 		};
+		const pasteResult = this.onPasteText?.(pasteContent);
 
 		if (pasteResult instanceof Promise) {
+			this.#pasteDecisionPending = true;
 			void pasteResult.then(applyPasteResult, () => applyPasteResult(false));
 		} else {
 			applyPasteResult(pasteResult);
@@ -131,6 +144,11 @@ export class CustomEditor extends Editor {
 	}
 
 	handleInput(data: string): void {
+		if (this.#pasteDecisionPending) {
+			this.#pendingPasteInput.push(data);
+			return;
+		}
+
 		const parsed = parseKittySequence(data);
 		if (parsed && (parsed.modifier & 64) !== 0 && this.onCapsLock) {
 			// Caps Lock is modifier bit 64

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import type { AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
@@ -13,7 +14,7 @@ import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../sessio
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
-import { ensureSupportedImageInput } from "../../utils/image-loading";
+import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
@@ -22,6 +23,8 @@ interface Expandable {
 }
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+const CLIPBOARD_TEMP_IMAGE_FILE_PATTERN = /^clipboard-\d{4}-\d{2}-\d{2}-\d{6}-[A-Za-z0-9]+\.(?:png|jpe?g|gif|webp)$/i;
+const MACOS_CLIPBOARD_TEMP_DIR_PATTERN = /^\/var\/folders\/[^/]+\/[^/]+\/T$/;
 
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
@@ -132,6 +135,7 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
 		);
 		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
+		this.ctx.editor.onPasteText = text => this.handleTextPaste(text);
 		this.ctx.editor.setActionKeys("app.tools.expand", this.ctx.keybindings.getKeys("app.tools.expand"));
 		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
@@ -602,6 +606,55 @@ export class InputController {
 		process.kill(0, "SIGTSTP");
 	}
 
+	handleTextPaste(text: string): boolean | Promise<boolean> {
+		const imagePath = this.#getPastedImagePathCandidate(text);
+		return imagePath ? this.#attachPastedImagePath(imagePath) : false;
+	}
+
+	async #attachPastedImagePath(imagePath: string): Promise<boolean> {
+		try {
+			const image = await loadImageInput({
+				path: imagePath,
+				cwd: this.ctx.sessionManager.getCwd(),
+				autoResize: this.ctx.settings.get("images.autoResize"),
+			});
+			if (!image) {
+				this.ctx.showStatus("Unsupported pasted clipboard image file");
+				return true;
+			}
+
+			this.ctx.pendingImages.push({
+				type: "image",
+				data: image.data,
+				mimeType: image.mimeType,
+			});
+			this.ctx.editor.insertText(`${this.#nextImagePlaceholder()} `);
+			this.ctx.showStatus(`Attached image: ${path.basename(image.resolvedPath)}`, { dim: true });
+			this.ctx.ui.requestRender();
+			return true;
+		} catch (error) {
+			if (error instanceof ImageInputTooLargeError) {
+				this.ctx.showStatus(error.message);
+				return true;
+			}
+			this.ctx.showStatus("Failed to attach pasted clipboard image");
+			return true;
+		}
+	}
+
+	#getPastedImagePathCandidate(text: string): string | undefined {
+		const resolvedPath = path.resolve(text.trim());
+		const parentDir = path.dirname(resolvedPath);
+		const isClipboardTempPath =
+			(parentDir === "/tmp" || MACOS_CLIPBOARD_TEMP_DIR_PATTERN.test(parentDir)) &&
+			CLIPBOARD_TEMP_IMAGE_FILE_PATTERN.test(path.basename(resolvedPath));
+		return isClipboardTempPath ? resolvedPath : undefined;
+	}
+
+	#nextImagePlaceholder(): string {
+		return `[image ${this.ctx.pendingImages.length}]`;
+	}
+
 	async handleImagePaste(): Promise<boolean> {
 		try {
 			const image = await readImageFromClipboard();
@@ -616,7 +669,7 @@ export class InputController {
 					this.ctx.showStatus(`Unsupported clipboard image format: ${image.mimeType}`);
 					return false;
 				}
-				if (settings.get("images.autoResize")) {
+				if (this.ctx.settings.get("images.autoResize")) {
 					try {
 						const resized = await resizeImage({
 							type: "image",
@@ -634,10 +687,7 @@ export class InputController {
 					data: imageData.data,
 					mimeType: imageData.mimeType,
 				});
-				// Insert placeholder at cursor like Anthropic model does
-				const imageNum = this.ctx.pendingImages.length;
-				const placeholder = `[Image #${imageNum}]`;
-				this.ctx.editor.insertText(`${placeholder} `);
+				this.ctx.editor.insertText(`${this.#nextImagePlaceholder()} `);
 				this.ctx.ui.requestRender();
 				return true;
 			}

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -37,3 +37,29 @@ describe("CustomEditor temporary model selector keybinding", () => {
 		expect(onSelectModelTemporary).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("CustomEditor bracketed paste interception", () => {
+	it("lets coding-agent consume pasted content before the base editor stores it", async () => {
+		const editor = createEditor();
+		const onPasteText = vi.fn(() => true);
+		editor.onPasteText = onPasteText;
+
+		editor.handleInput("\x1b[200~/tmp/clipboard-2026-06-04-120441-CAC144E7.png\x1b[201~");
+		await Bun.sleep(0);
+
+		expect(onPasteText).toHaveBeenCalledWith("/tmp/clipboard-2026-06-04-120441-CAC144E7.png");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("falls back to normal paste handling when coding-agent does not consume it", async () => {
+		const editor = createEditor();
+		const onPasteText = vi.fn(() => false);
+		editor.onPasteText = onPasteText;
+
+		editor.handleInput("\x1b[200~hello\x1b[201~");
+		await Bun.sleep(0);
+
+		expect(onPasteText).toHaveBeenCalledWith("hello");
+		expect(editor.getText()).toBe("hello");
+	});
+});

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -62,4 +62,38 @@ describe("CustomEditor bracketed paste interception", () => {
 		expect(onPasteText).toHaveBeenCalledWith("hello");
 		expect(editor.getText()).toBe("hello");
 	});
+
+	it("keeps later input behind a pending async consumed paste", async () => {
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+
+		editor.handleInput("before ");
+		editor.handleInput("\x1b[200~/tmp/clipboard-2026-06-04-120441-CAC144E7.png\x1b[201~");
+		editor.handleInput("after");
+
+		expect(editor.getText()).toBe("before ");
+
+		pasteDecision.resolve(true);
+		await Bun.sleep(0);
+
+		expect(editor.getText()).toBe("before after");
+	});
+
+	it("replays async unconsumed paste before later input", async () => {
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+
+		editor.handleInput("before ");
+		editor.handleInput("\x1b[200~middle \x1b[201~");
+		editor.handleInput("after");
+
+		expect(editor.getText()).toBe("before ");
+
+		pasteDecision.resolve(false);
+		await Bun.sleep(0);
+
+		expect(editor.getText()).toBe("before middle after");
+	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import { InputController } from "../src/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "../src/modes/types";
 
@@ -16,6 +17,7 @@ type FakeEditor = {
 	onHistorySearch?: () => void;
 	onShowHotkeys?: () => void;
 	onPasteImage?: () => Promise<boolean>;
+	onPasteText?: (text: string) => boolean | Promise<boolean>;
 	onCopyPrompt?: () => void;
 	onExpandTools?: () => void;
 	onToggleThinking?: () => void;
@@ -25,6 +27,7 @@ type FakeEditor = {
 	onSubmit?: (text: string) => void | Promise<void>;
 	setText(text: string): void;
 	getText(): string;
+	insertText(text: string): void;
 	addToHistory(text: string): void;
 	setActionKeys(action: string, keys: string[]): void;
 	setCustomKeyHandler(key: string, handler: () => void): void;
@@ -42,12 +45,16 @@ async function createContext() {
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBashCommand = vi.fn(async () => {});
+	const showStatus = vi.fn();
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
 		},
 		getText() {
 			return editorText;
+		},
+		insertText(text: string) {
+			editorText += text;
 		},
 		addToHistory: vi.fn(),
 		setActionKeys,
@@ -78,6 +85,17 @@ async function createContext() {
 			},
 		} as InteractiveModeContext["keybindings"],
 		pendingImages: [],
+		settings: {
+			get(path: string) {
+				if (path === "images.autoResize") return false;
+				return undefined;
+			},
+		} as unknown as InteractiveModeContext["settings"],
+		sessionManager: {
+			getCwd() {
+				return "/";
+			},
+		} as unknown as InteractiveModeContext["sessionManager"],
 		locallySubmittedUserSignatures: new Set<string>(),
 		isKnownSlashCommand: () => false,
 		recordLocalSubmission(this: InteractiveModeContext, text: string, imageCount = 0) {
@@ -123,6 +141,7 @@ async function createContext() {
 		updateEditorBorderColor: vi.fn(),
 		handleBashCommand,
 		showWarning: vi.fn(),
+		showStatus,
 		hasActiveBtw: vi.fn(() => false),
 	} as unknown as InteractiveModeContext;
 
@@ -136,6 +155,7 @@ async function createContext() {
 			prompt,
 			updatePendingMessagesDisplay,
 			handleBashCommand,
+			showStatus,
 		},
 	};
 }
@@ -218,6 +238,43 @@ describe("InputController keybinding setup", () => {
 		await expect(controller.handleFollowUp()).rejects.toThrow("queue full");
 
 		expect(ctx.locallySubmittedUserSignatures.has("queued during stream\u00000")).toBe(false);
+	});
+});
+
+describe("InputController pasted clipboard image paths", () => {
+	const RED_1X1_PNG_BASE64 =
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+	it("attaches terminal-pasted clipboard temp images and inserts a compact placeholder", async () => {
+		const imagePath = `/tmp/clipboard-2026-06-04-120441-${process.pid.toString(36)}CAC144E7.png`;
+		await Bun.write(imagePath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
+		try {
+			const { InputController, ctx, editor, spies } = await createContext();
+			const controller = new InputController(ctx);
+
+			controller.setupKeyHandlers();
+			const handled = await editor.onPasteText?.(`${imagePath}\n`);
+
+			expect(handled).toBe(true);
+			expect(editor.getText()).toBe("[image 1] ");
+			expect(ctx.pendingImages).toHaveLength(1);
+			expect(ctx.pendingImages[0]?.mimeType).toBe("image/png");
+			expect(spies.showStatus).toHaveBeenCalledWith(`Attached image: ${imagePath.split("/").at(-1)}`, { dim: true });
+		} finally {
+			await fs.rm(imagePath, { force: true });
+		}
+	});
+
+	it("leaves ordinary pasted text for the editor", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const handled = await editor.onPasteText?.("/tmp/not-a-clipboard-image.png");
+
+		expect(handled).toBe(false);
+		expect(editor.getText()).toBe("");
+		expect(ctx.pendingImages).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
Fixes #241.

## What
- Intercepts bracketed paste content before raw temp paths are inserted into the prompt.
- Detects terminal-pasted clipboard image temp paths from `/tmp` and macOS `/var/folders/.../T`, attaches the image payload, and inserts compact `[image N]` placeholders.
- Keeps ordinary pasted text on the existing editor path and updates the clipboard image shortcut placeholder format to match.

## Testing
- `bun test packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## Notes
- `bun run install:dev` initially installed dependencies but failed during defaults setup because local native addon files were not built; `bun run build:native` resolved the local test environment.