### PR TITLE
feat(coding-agent): consume queued steer on Esc instead of stalling

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -30,8 +30,17 @@ function isExpandable(obj: unknown): obj is Expandable {
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
-	#abortInteractive(): Promise<void> {
-		return this.ctx.session.abort({ timeoutMs: INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS, cause: "user_interrupt" });
+	/** Set while a first Esc is silently consuming a queued steer (abort +
+	 *  steer-on-interrupt continue). A second Esc within that window does a real
+	 *  abort instead of consuming the steer again. */
+	#steerConsumePending = false;
+
+	#abortInteractive(options?: { silent?: boolean }): Promise<void> {
+		return this.ctx.session.abort({
+			timeoutMs: INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS,
+			cause: "user_interrupt",
+			silent: options?.silent,
+		});
 	}
 
 	setupKeyHandlers(): void {
@@ -73,7 +82,22 @@ export class InputController {
 				this.ctx.isPythonMode = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isStreaming) {
-				void this.#abortInteractive();
+				if (this.ctx.session.hasQueuedSteering && !this.#steerConsumePending) {
+					// First Esc with a queued steer: silently consume it and
+					// auto-continue via steer-on-interrupt instead of stalling on
+					// "Operation aborted".
+					this.#steerConsumePending = true;
+					void this.#abortInteractive({ silent: true }).finally(() => {
+						this.#steerConsumePending = false;
+					});
+				} else if (this.#steerConsumePending) {
+					// Second Esc before the steer-continue lands: drop the still-queued
+					// steer (restoring its text to the editor) and do a real abort.
+					this.#steerConsumePending = false;
+					this.restoreQueuedMessagesToEditor({ abort: true });
+				} else {
+					void this.#abortInteractive();
+				}
 			} else if (!this.ctx.editor.getText().trim()) {
 				// Double-interrupt with empty editor triggers /tree, /branch, or nothing based on setting
 				const action = settings.get("doubleEscapeAction");

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -975,10 +975,9 @@ export class AgentSession {
 	/** One-shot flag armed by `abort({ silent: true })` (e.g. Esc consuming a
 	 *  queued steer). Consumed in #handleAgentEvent to stamp `SILENT_ABORT_MARKER`
 	 *  on the resulting aborted assistant `message_end` so the interrupt does not
-	 *  surface a red "Operation aborted" line; cleared in `abort` as a safety net
-	 *  when the abort produces no aborted message_end. */
+	 *  surface a red "Operation aborted" line; cleared by a later non-silent abort
+	 *  or by `abort`'s safety net when no aborted message_end is produced. */
 	#silentAbortPending = false;
-
 	/** Monotonic counter for `enqueueCustomMessageDisplay` tag generation;
 	 *  combined with `Date.now()` so tags stay unique even across rapid
 	 *  same-tick enqueues. */
@@ -5097,6 +5096,8 @@ export class AgentSession {
 	}): Promise<void> {
 		if (options?.silent) {
 			this.#silentAbortPending = true;
+		} else {
+			this.#silentAbortPending = false;
 		}
 		this.abortRetry();
 		this.#promptGeneration++;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -972,6 +972,13 @@ export class AgentSession {
 	 *  without producing an aborted message_end). */
 	#planCompactAbortPending = false;
 
+	/** One-shot flag armed by `abort({ silent: true })` (e.g. Esc consuming a
+	 *  queued steer). Consumed in #handleAgentEvent to stamp `SILENT_ABORT_MARKER`
+	 *  on the resulting aborted assistant `message_end` so the interrupt does not
+	 *  surface a red "Operation aborted" line; cleared in `abort` as a safety net
+	 *  when the abort produces no aborted message_end. */
+	#silentAbortPending = false;
+
 	/** Monotonic counter for `enqueueCustomMessageDisplay` tag generation;
 	 *  combined with `Date.now()` so tags stay unique even across rapid
 	 *  same-tick enqueues. */
@@ -1644,10 +1651,11 @@ export class AgentSession {
 			event.type === "message_end" &&
 			event.message.role === "assistant" &&
 			event.message.stopReason === "aborted" &&
-			this.#planCompactAbortPending
+			(this.#planCompactAbortPending || this.#silentAbortPending)
 		) {
 			(event.message as AssistantMessage).errorMessage = SILENT_ABORT_MARKER;
 			this.#planCompactAbortPending = false;
+			this.#silentAbortPending = false;
 		}
 
 		// Deobfuscate assistant message content for display emission — the LLM echoes back
@@ -4978,6 +4986,13 @@ export class AgentSession {
 		return this.#steeringMessages.length + this.#followUpMessages.length + this.#pendingNextTurnMessages.length;
 	}
 
+	/** Whether the agent has queued steering messages that a `user_interrupt`
+	 *  abort would resume into (steer-on-interrupt). Drives the Esc-on-steer UX:
+	 *  the first Esc consumes the steer and auto-continues, a second Esc aborts. */
+	get hasQueuedSteering(): boolean {
+		return this.agent.hasQueuedSteering();
+	}
+
 	/** Get pending messages (read-only). Returns the public text-only view;
 	 *  internal `{text, tag?}` records are mapped to `.text` so callers
 	 *  (`updatePendingMessagesDisplay`, `restoreQueuedMessagesToEditor`) see
@@ -5074,7 +5089,15 @@ export class AgentSession {
 			| "handoff"
 			| "tool_abort"
 			| "internal";
+		/** Suppress the "Operation aborted" line on the resulting aborted message
+		 *  by stamping `SILENT_ABORT_MARKER`. Used when Esc consumes a queued steer
+		 *  and resumes via steer-on-interrupt, so the interrupt reads as a quiet
+		 *  hand-off rather than a failure. */
+		silent?: boolean;
 	}): Promise<void> {
+		if (options?.silent) {
+			this.#silentAbortPending = true;
+		}
 		this.abortRetry();
 		this.#promptGeneration++;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
@@ -5114,6 +5137,10 @@ export class AgentSession {
 		// block runs, but nested prompt setup/finalizers may still be unwinding. Without this,
 		// a subsequent prompt() can incorrectly observe the session as busy after an abort.
 		this.#resetInFlight();
+		// Safety net: clear the silent-abort flag if it was never consumed (the
+		// abort produced no aborted assistant message_end to stamp). Prevents the
+		// marker from leaking onto a later, unrelated abort.
+		this.#silentAbortPending = false;
 		// Safety net: if the agent loop aborted without producing an assistant
 		// message (e.g. failed before the first stream), the in-flight yield was
 		// never resolved or rejected by the normal message_end path. Reject it now

--- a/packages/coding-agent/test/agent-session-silent-abort.test.ts
+++ b/packages/coding-agent/test/agent-session-silent-abort.test.ts
@@ -132,6 +132,29 @@ describe("AgentSession silent-abort marker stamping", () => {
 		expect(session.isPlanCompactAbortPending).toBe(false);
 	});
 
+	it("does not let a pending silent abort silence a later real abort", async () => {
+		fixture = await createSessionWithObfuscator();
+		const { session } = fixture;
+		const waitForIdleGate = Promise.withResolvers<void>();
+		vi.spyOn(session.agent, "waitForIdle").mockImplementation(() => waitForIdleGate.promise);
+
+		const silentAbort = session.abort({ silent: true });
+		await Promise.resolve();
+
+		const realAbort = session.abort();
+		await Promise.resolve();
+
+		const message = makeAbortedAssistantMessage();
+		session.agent.emitExternalEvent({ type: "message_end", message });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(message.errorMessage).toBeUndefined();
+
+		waitForIdleGate.resolve();
+		await Promise.all([silentAbort, realAbort]);
+	});
+
 	it("A3: flag set + non-aborted message_end does NOT consume the flag", async () => {
 		fixture = await createSessionWithObfuscator();
 		const { session } = fixture;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -64,7 +64,7 @@ function createContext(): {
 	};
 } {
 	let editorText = "";
-	const abort = vi.fn();
+	const abort = vi.fn(() => Promise.resolve());
 	const abortBash = vi.fn();
 	const abortEval = vi.fn();
 	const addMessageToChat = vi.fn();
@@ -113,6 +113,7 @@ function createContext(): {
 			isBashRunning: false,
 			isEvalRunning: false,
 			queuedMessageCount: 0,
+			hasQueuedSteering: false,
 			messages: [],
 			extensionRunner: undefined,
 			abort,
@@ -309,5 +310,35 @@ describe("InputController escape behavior", () => {
 		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.abort).toHaveBeenCalledTimes(1);
+	});
+
+	it("silently consumes a queued steer on the first Esc instead of a loud abort", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+	});
+
+	it("does a real abort on the second Esc while a steer consume is still pending", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.(); // first: silent steer consume
+		editor.onEscape?.(); // second: real abort, dropping the steer to the editor
+
+		expect(spies.abort).toHaveBeenCalledTimes(2);
+		expect(spies.abort.mock.calls[0]?.[0]).toMatchObject({ silent: true });
+		expect(spies.abort.mock.calls[1]?.[0]?.silent).toBeUndefined();
+		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

Revises Esc behavior while the agent is streaming **with a queued steer message**.

- **Before:** Esc did a loud abort (`Operation aborted`) before the existing steer-on-interrupt continue resumed — it looked like the operation died even though it kept going.
- **After:** the first Esc with a queued steer performs a **silent** abort (reusing the existing `SILENT_ABORT_MARKER` suppression path), so the steer is consumed and the agent **auto-continues quietly**. A **second Esc** does a real, visible abort.

During the brief steer-consume window, the second Esc restores the still-queued steer text back into the editor so nothing the user typed is lost.

## Changes

- `AgentSession.abort` gains a `silent` option, backed by a one-shot `#silentAbortPending` flag stamped onto the resulting aborted `message_end` (same mechanism as the plan→compact transition).
- `AgentSession` exposes a `hasQueuedSteering` getter (`agent.hasQueuedSteering()`).
- `InputController`'s streaming Esc branch routes first-press (silent steer consume) vs. second-press (real abort).

## Tests

- Extended `test/input-controller-escape.test.ts` with two cases: silent consume on first Esc, loud abort on second Esc.
- Related suites pass (input-controller, agent-session steer-interrupt / silent-abort, event-controller abort render, keybindings-escape, abort-timeout). Typecheck clean; biome formatted.