### PR TITLE
feat(task): receipt-first task results + central sanitizer + verified agent:// resolver

### DIFF
--- a/packages/coding-agent/src/internal-urls/agent-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/agent-protocol.ts
@@ -11,6 +11,7 @@
  * - agent://<id>/<path> - JSON extraction via path form
  * - agent://<id>?q=<query> - JSON extraction via query form
  */
+import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
@@ -18,6 +19,55 @@ import { applyQuery, pathToQuery } from "./json-query";
 import { artifactsDirsFromRegistry } from "./registry-helpers";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 
+interface AgentOutputMetadata {
+	id: string;
+	kind: "agent-output";
+	sizeBytes: number;
+	lineCount: number;
+	sha256: string;
+	createdAt: string;
+}
+
+function isAgentOutputMetadata(value: unknown, outputId: string): value is AgentOutputMetadata {
+	if (!value || typeof value !== "object") return false;
+	const meta = value as Record<string, unknown>;
+	return (
+		meta.id === outputId &&
+		meta.kind === "agent-output" &&
+		typeof meta.sizeBytes === "number" &&
+		typeof meta.lineCount === "number" &&
+		typeof meta.sha256 === "string" &&
+		typeof meta.createdAt === "string"
+	);
+}
+
+async function verifyAgentOutputMetadata(outputId: string, foundPath: string, bytes: Buffer): Promise<void> {
+	const metaPath = `${foundPath}.meta.json`;
+	let metaRaw: string;
+	try {
+		metaRaw = await Bun.file(metaPath).text();
+	} catch (err) {
+		if (isEnoent(err)) return;
+		throw err;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(metaRaw);
+	} catch {
+		throw new Error(`agent://${outputId} malformed metadata`);
+	}
+	if (!isAgentOutputMetadata(parsed, outputId)) {
+		throw new Error(`agent://${outputId} malformed metadata`);
+	}
+	const stat = await fs.stat(foundPath);
+	if (stat.size !== parsed.sizeBytes || bytes.byteLength !== parsed.sizeBytes) {
+		throw new Error(`agent://${outputId} size mismatch`);
+	}
+	const sha256 = createHash("sha256").update(bytes).digest("hex");
+	if (sha256 !== parsed.sha256) {
+		throw new Error(`agent://${outputId} hash mismatch`);
+	}
+}
 /**
  * Handler for agent:// URLs.
  *
@@ -88,7 +138,9 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			throw new Error(`Not found: ${outputId}\nAvailable: ${availableStr}`);
 		}
 
-		const rawContent = await Bun.file(foundPath).text();
+		const rawBytes = Buffer.from(await Bun.file(foundPath).arrayBuffer());
+		await verifyAgentOutputMetadata(outputId, foundPath, rawBytes);
+		const rawContent = rawBytes.toString("utf8");
 		const notes: string[] = [];
 		let content = rawContent;
 		let contentType: InternalResource["contentType"] = "text/markdown";

--- a/packages/coding-agent/src/prompts/tools/task-summary.md
+++ b/packages/coding-agent/src/prompts/tools/task-summary.md
@@ -5,15 +5,9 @@
 <agent id="{{id}}" agent="{{agent}}">
 <status>{{status}}</status>
 {{#if meta}}<meta lines="{{meta.lineCount}}" size="{{meta.charSize}}" />{{/if}}
-{{#if truncated}}
-<preview full-path="agent://{{id}}">
-{{preview}}
-</preview>
-{{else}}
-<result>
-{{preview}}
-</result>
-{{/if}}
+<synopsis ref="agent://{{id}}">
+{{synopsis}}
+</synopsis>
 </agent>
 {{#unless @last}}
 ---

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -4,6 +4,8 @@
  * Runs each subagent on the main thread and forwards AgentEvents for progress tracking.
  */
 
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentTelemetryConfig, ThinkingLevel } from "@gajae-code/agent-core";
 import { recordHandoff, resolveTelemetry } from "@gajae-code/agent-core";
@@ -1536,18 +1538,39 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 	// Write output artifact (input and jsonl already written in real-time)
 	// Compute output metadata for agent:// URL integration
-	let outputMeta: { lineCount: number; charCount: number } | undefined;
+	let outputMeta: { lineCount: number; charCount: number; byteSize?: number; sha256?: string } | undefined;
 	let outputPath: string | undefined;
 	if (options.artifactsDir) {
-		outputPath = path.join(options.artifactsDir, `${id}.md`);
+		const candidateOutputPath = path.join(options.artifactsDir, `${id}.md`);
 		try {
-			await Bun.write(outputPath, rawOutput);
+			await Bun.write(candidateOutputPath, rawOutput);
+			const byteSize = Buffer.byteLength(rawOutput, "utf8");
+			const lineCount = rawOutput.split("\n").length;
+			const sha256 = createHash("sha256").update(rawOutput).digest("hex");
+			const createdAt = new Date().toISOString();
+			await Bun.write(
+				`${candidateOutputPath}.meta.json`,
+				JSON.stringify({ id, kind: "agent-output", sizeBytes: byteSize, lineCount, sha256, createdAt }, null, 2),
+			);
+			outputPath = candidateOutputPath;
 			outputMeta = {
-				lineCount: rawOutput.split("\n").length,
+				lineCount,
 				charCount: rawOutput.length,
+				byteSize,
+				sha256,
 			};
 		} catch {
-			// Non-fatal
+			// Output or metadata write failed: never advertise an unverifiable
+			// artifact. Best-effort remove any orphaned `.md`/sidecar so a later
+			// agent:// read cannot serve unverified content. Non-fatal.
+			outputPath = undefined;
+			outputMeta = undefined;
+			try {
+				await fs.rm(candidateOutputPath, { force: true });
+				await fs.rm(`${candidateOutputPath}.meta.json`, { force: true });
+			} catch {
+				// best-effort cleanup; ignore
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -134,8 +134,6 @@ export {
 	buildTaskReceipt,
 	findRawTaskLeakKeys,
 	sanitizeTaskToolDetails,
-	TASK_PREVIEW_MAX_BYTES,
-	TASK_PREVIEW_MAX_LINES,
 } from "./receipt";
 export type {
 	AgentDefinition,
@@ -1344,13 +1342,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				}
 			}
 
-			// Collect output paths (artifacts already written by executor in real-time)
-			const outputPaths: string[] = [];
 			const patchPaths: string[] = [];
 			for (const result of results) {
-				if (result.outputPath) {
-					outputPaths.push(result.outputPath);
-				}
 				if (result.patchPath) {
 					patchPaths.push(result.patchPath);
 				}
@@ -1446,7 +1439,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								"<system-notification>Patches were not applied and must be handled manually.</system-notification>";
 							const patchList =
 								patchPaths.length > 0
-									? `\n\nPatch artifacts:\n${patchPaths.map(patch => `- ${patch}`).join("\n")}`
+									? `\n\nPatch artifacts: ${patchPaths.length} preserved for internal merge recovery.`
 									: "";
 							mergeSummary = `\n\n${notification}${patchList}`;
 						}
@@ -1509,8 +1502,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					agent: r.agent,
 					status,
 					id: r.id,
-					preview: r.preview,
-					truncated: r.previewTruncated,
+					synopsis: r.preview,
 					meta: r.outputRef
 						? {
 								lineCount: r.outputRef.lineCount,
@@ -1520,7 +1512,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				};
 			});
 
-			const outputIds = receipts.filter(r => r.outputRef).map(r => r.outputRef!.uri);
 			const summary = prompt.render(taskSummaryTemplate, {
 				successCount,
 				totalCount: results.length,
@@ -1528,7 +1519,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				hasCancelledNote: aborted && cancelledCount > 0,
 				duration: formatDuration(totalDuration),
 				summaries,
-				outputIds,
 				agentName,
 				mergeSummary,
 			});
@@ -1545,7 +1535,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				results: receipts,
 				totalDurationMs: totalDuration,
 				usage: hasAggregatedUsage ? aggregatedUsage : undefined,
-				outputPaths,
 			};
 			assertNoRawTaskFields(details, "task.return.details");
 			return {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -48,6 +48,7 @@ import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
+import { assertNoRawTaskFields, buildTaskReceipt } from "./receipt";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import {
@@ -127,6 +128,15 @@ export { loadBundledAgents as BUNDLED_AGENTS } from "./agents";
 export { discoverCommands, expandCommand, getCommand } from "./commands";
 export { discoverAgents, getAgent } from "./discovery";
 export { AgentOutputManager } from "./output-manager";
+export type { TaskResultReceipt } from "./receipt";
+export {
+	assertNoRawTaskFields,
+	buildTaskReceipt,
+	findRawTaskLeakKeys,
+	sanitizeTaskToolDetails,
+	TASK_PREVIEW_MAX_BYTES,
+	TASK_PREVIEW_MAX_LINES,
+} from "./receipt";
 export type {
 	AgentDefinition,
 	AgentProgress,
@@ -548,7 +558,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 									? "paused"
 									: singleResult?.aborted
 										? "aborted"
-										: (singleResult?.exitCode ?? 0) === 0
+										: singleResult?.status === "completed"
 											? "completed"
 											: "failed";
 								progress.durationMs = singleResult?.durationMs ?? Math.max(0, Date.now() - startedAt);
@@ -556,8 +566,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								progress.contextTokens = singleResult?.contextTokens;
 								progress.contextWindow = singleResult?.contextWindow;
 								progress.cost = singleResult?.usage?.cost.total ?? 0;
-								progress.extractedToolData = singleResult?.extractedToolData;
-								progress.retryFailure = singleResult?.retryFailure;
+								progress.extractedToolData = undefined;
+								progress.retryFailure = singleResult?.retryFailure
+									? {
+											attempt: singleResult.retryFailure.attempt,
+											errorMessage: singleResult.retryFailure.errorSummary,
+										}
+									: undefined;
 								progress.retryState = undefined;
 							}
 							completedJobs += 1;
@@ -1487,41 +1502,25 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const successCount = results.filter(r => r.exitCode === 0 && !r.error && !r.aborted).length;
 			const totalDuration = Date.now() - startTime;
 
-			const summaries = results.map(r => {
-				const status = r.aborted
-					? "cancelled"
-					: r.exitCode === 0 && r.error
-						? "merge failed"
-						: r.exitCode === 0
-							? "completed"
-							: `failed (exit ${r.exitCode})`;
-				const output = r.output.trim() || r.stderr.trim() || "(no output)";
-				const outputCharCount = r.outputMeta?.charCount ?? output.length;
-				const fullOutputThreshold = 5000;
-				let preview = output;
-				let truncated = false;
-				if (outputCharCount > fullOutputThreshold) {
-					const slice = output.slice(0, fullOutputThreshold);
-					const lastNewline = slice.lastIndexOf("\n");
-					preview = lastNewline >= 0 ? slice.slice(0, lastNewline) : slice;
-					truncated = true;
-				}
+			const receipts = results.map(buildTaskReceipt);
+			const summaries = receipts.map(r => {
+				const status = r.status === "merge_failed" ? "merge failed" : r.status;
 				return {
 					agent: r.agent,
 					status,
 					id: r.id,
-					preview,
-					truncated,
-					meta: r.outputMeta
+					preview: r.preview,
+					truncated: r.previewTruncated,
+					meta: r.outputRef
 						? {
-								lineCount: r.outputMeta.lineCount,
-								charSize: formatBytes(r.outputMeta.charCount),
+								lineCount: r.outputRef.lineCount,
+								charSize: formatBytes(r.outputRef.sizeBytes),
 							}
 						: undefined,
 				};
 			});
 
-			const outputIds = results.filter(r => !r.aborted || r.output.trim()).map(r => `agent://${r.id}`);
+			const outputIds = receipts.filter(r => r.outputRef).map(r => r.outputRef!.uri);
 			const summary = prompt.render(taskSummaryTemplate, {
 				successCount,
 				totalCount: results.length,
@@ -1541,15 +1540,17 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				await fs.rm(tempArtifactsDir, { recursive: true, force: true });
 			}
 
+			const details: TaskToolDetails = {
+				projectAgentsDir,
+				results: receipts,
+				totalDurationMs: totalDuration,
+				usage: hasAggregatedUsage ? aggregatedUsage : undefined,
+				outputPaths,
+			};
+			assertNoRawTaskFields(details, "task.return.details");
 			return {
 				content: [{ type: "text", text: summary }],
-				details: {
-					projectAgentsDir,
-					results: results,
-					totalDurationMs: totalDuration,
-					usage: hasAggregatedUsage ? aggregatedUsage : undefined,
-					outputPaths,
-				},
+				details,
 			};
 		} catch (err) {
 			return {

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,0 +1,227 @@
+import type { SingleResult, TaskToolDetails } from "./types";
+
+export const TASK_PREVIEW_MAX_BYTES = 2000;
+export const TASK_PREVIEW_MAX_LINES = 12;
+
+export interface TaskResultReceipt {
+	index: number;
+	id: string;
+	agent: string;
+	agentSource: SingleResult["agentSource"];
+	task: string;
+	assignment?: string;
+	description?: string;
+	status: "completed" | "failed" | "aborted" | "merge_failed" | "paused";
+	exitCode: number;
+	aborted?: boolean;
+	paused?: boolean;
+	truncated: boolean;
+	durationMs: number;
+	tokens: number;
+	contextTokens?: number;
+	contextWindow?: number;
+	modelOverride?: string | string[];
+	usage?: SingleResult["usage"];
+	cost?: number;
+	patchPath?: string;
+	branchName?: string;
+	retryFailure?: { attempt: number; errorSummary: string };
+	errorSummary?: string;
+	abortSummary?: string;
+	preview: string;
+	previewTruncated: boolean;
+	outputRef?: { uri: string; sizeBytes: number; lineCount: number; sha256?: string };
+	outputUnavailable?: boolean;
+	review?: {
+		overallCorrectness?: string;
+		findingCount: number;
+		findings?: Array<{ severity?: string; summary: string }>;
+	};
+	extractedToolCounts?: Record<string, number>;
+}
+
+const BANNED_RAW_TASK_KEYS = new Set([
+	"output",
+	"stderr",
+	"extractedToolData",
+	"resultText",
+	"errorText",
+	"artifactPayload",
+	"rawResult",
+	"rawResults",
+	"rawNestedResults",
+	"fullOutput",
+	"full_result",
+	"toolOutput",
+	"toolResultRaw",
+	"stdout",
+	"rawOutput",
+	"recentOutput",
+	"currentToolArgs",
+	"inflightTaskDetails",
+]);
+
+function truncateText(value: string | undefined, maxChars: number): string | undefined {
+	if (!value) return undefined;
+	return value.length > maxChars ? value.slice(0, maxChars) : value;
+}
+
+function boundedPreview(value: string): { preview: string; truncated: boolean } {
+	const lines = value.split("\n");
+	let preview = lines.slice(0, TASK_PREVIEW_MAX_LINES).join("\n");
+	let truncated = lines.length > TASK_PREVIEW_MAX_LINES;
+	while (Buffer.byteLength(preview, "utf8") > TASK_PREVIEW_MAX_BYTES) {
+		preview = preview.slice(0, Math.max(0, preview.length - 1));
+		truncated = true;
+	}
+	return { preview, truncated };
+}
+
+function getStatus(raw: SingleResult): TaskResultReceipt["status"] {
+	if (raw.paused) return "paused";
+	if (raw.aborted) return "aborted";
+	if (raw.exitCode === 0 && raw.error) return "merge_failed";
+	if (raw.exitCode !== 0 || raw.error) return "failed";
+	return "completed";
+}
+
+function buildReview(raw: SingleResult): TaskResultReceipt["review"] | undefined {
+	const data = raw.extractedToolData;
+	if (!data) return undefined;
+	const yields = Array.isArray(data.yield) ? data.yield : [];
+	const reviewYield = yields
+		.map(item => (item && typeof item === "object" ? (item as { data?: unknown }).data : undefined))
+		.findLast(item => item && typeof item === "object" && "overall_correctness" in item) as
+		| { overall_correctness?: unknown }
+		| undefined;
+	const rawFindings = Array.isArray(data.report_finding) ? data.report_finding : [];
+	const findings = rawFindings.slice(0, 20).map(item => {
+		const value = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+		const severity =
+			typeof value.severity === "string"
+				? value.severity
+				: typeof value.priority === "string"
+					? value.priority
+					: undefined;
+		const summaryValue = value.summary ?? value.title ?? value.message ?? value.body ?? "finding";
+		return { severity, summary: truncateText(String(summaryValue), 200) ?? "finding" };
+	});
+	if (!reviewYield && findings.length === 0) return undefined;
+	return {
+		overallCorrectness:
+			typeof reviewYield?.overall_correctness === "string" ? reviewYield.overall_correctness : undefined,
+		findingCount: rawFindings.length,
+		findings: findings.length > 0 ? findings : undefined,
+	};
+}
+
+export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
+	const sourceOutput = raw.output.trim() ? raw.output : raw.stderr;
+	const { preview, truncated: previewTruncated } = boundedPreview(sourceOutput.trim() || "(no output)");
+	const extractedToolCounts = raw.extractedToolData
+		? Object.fromEntries(
+				Object.entries(raw.extractedToolData).map(([tool, values]) => [
+					tool,
+					Array.isArray(values) ? values.length : 0,
+				]),
+			)
+		: undefined;
+	const outputRef = raw.outputMeta
+		? {
+				uri: `agent://${raw.id}`,
+				sizeBytes: raw.outputMeta.byteSize ?? Buffer.byteLength(raw.output, "utf8"),
+				lineCount: raw.outputMeta.lineCount,
+				sha256: raw.outputMeta.sha256,
+			}
+		: undefined;
+	return {
+		index: raw.index,
+		id: raw.id,
+		agent: raw.agent,
+		agentSource: raw.agentSource,
+		task: raw.task,
+		assignment: raw.assignment,
+		description: raw.description,
+		status: getStatus(raw),
+		exitCode: raw.exitCode,
+		aborted: raw.aborted,
+		paused: raw.paused,
+		truncated: raw.truncated,
+		durationMs: raw.durationMs,
+		tokens: raw.tokens,
+		contextTokens: raw.contextTokens,
+		contextWindow: raw.contextWindow,
+		modelOverride: raw.modelOverride,
+		usage: raw.usage,
+		cost: raw.usage?.cost.total,
+		patchPath: raw.patchPath,
+		branchName: raw.branchName,
+		retryFailure: raw.retryFailure
+			? { attempt: raw.retryFailure.attempt, errorSummary: truncateText(raw.retryFailure.errorMessage, 300) ?? "" }
+			: undefined,
+		errorSummary: truncateText(raw.error, 300),
+		abortSummary: truncateText(raw.abortReason, 300),
+		preview,
+		previewTruncated: previewTruncated || raw.truncated,
+		outputRef,
+		outputUnavailable: outputRef ? undefined : true,
+		review: buildReview(raw),
+		extractedToolCounts,
+	};
+}
+
+/**
+ * Raw, pre-sanitization task details: the internal shape produced during task
+ * execution, where `results` are full `SingleResult` objects. The public
+ * `TaskToolDetails` exposes only receipts.
+ */
+export interface RawTaskToolDetails {
+	projectAgentsDir: string | null;
+	results: SingleResult[];
+	totalDurationMs: number;
+	usage?: TaskToolDetails["usage"];
+	outputPaths?: string[];
+	async?: TaskToolDetails["async"];
+}
+
+/** Central converter from raw task details to receipt-only public details. */
+export function sanitizeTaskToolDetails(raw: RawTaskToolDetails): TaskToolDetails {
+	return {
+		projectAgentsDir: raw.projectAgentsDir,
+		results: raw.results.map(buildTaskReceipt),
+		totalDurationMs: raw.totalDurationMs,
+		usage: raw.usage,
+		outputPaths: raw.outputPaths,
+		async: raw.async,
+	};
+}
+
+export function findRawTaskLeakKeys(value: unknown): string[] {
+	const found = new Set<string>();
+	const seen = new WeakSet<object>();
+	const visit = (current: unknown) => {
+		if (!current || typeof current !== "object") return;
+		if (seen.has(current)) return;
+		seen.add(current);
+		if (Array.isArray(current)) {
+			for (const item of current) visit(item);
+			return;
+		}
+		for (const [key, child] of Object.entries(current)) {
+			// Banned keys only leak when they carry text or structure. A numeric
+			// value (e.g. the `output` token count on a canonical `Usage` record,
+			// whose shape is `input/output/cacheRead/cacheWrite/totalTokens`) is safe.
+			if (BANNED_RAW_TASK_KEYS.has(key) && typeof child !== "number") found.add(key);
+			visit(child);
+		}
+	};
+	visit(value);
+	return [...found].sort();
+}
+
+export function assertNoRawTaskFields(value: unknown, surface: string): void {
+	const keys = findRawTaskLeakKeys(value);
+	if (keys.length > 0) {
+		throw new Error(`${surface} contains raw task fields: ${keys.join(", ")}`);
+	}
+}

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,8 +1,5 @@
 import type { SingleResult, TaskToolDetails } from "./types";
 
-export const TASK_PREVIEW_MAX_BYTES = 2000;
-export const TASK_PREVIEW_MAX_LINES = 12;
-
 export interface TaskResultReceipt {
 	index: number;
 	id: string;
@@ -23,7 +20,6 @@ export interface TaskResultReceipt {
 	modelOverride?: string | string[];
 	usage?: SingleResult["usage"];
 	cost?: number;
-	patchPath?: string;
 	branchName?: string;
 	retryFailure?: { attempt: number; errorSummary: string };
 	errorSummary?: string;
@@ -66,15 +62,21 @@ function truncateText(value: string | undefined, maxChars: number): string | und
 	return value.length > maxChars ? value.slice(0, maxChars) : value;
 }
 
-function boundedPreview(value: string): { preview: string; truncated: boolean } {
-	const lines = value.split("\n");
-	let preview = lines.slice(0, TASK_PREVIEW_MAX_LINES).join("\n");
-	let truncated = lines.length > TASK_PREVIEW_MAX_LINES;
-	while (Buffer.byteLength(preview, "utf8") > TASK_PREVIEW_MAX_BYTES) {
-		preview = preview.slice(0, Math.max(0, preview.length - 1));
-		truncated = true;
+function buildSafeSynopsis(raw: SingleResult, outputRef: TaskResultReceipt["outputRef"]): string {
+	const status = getStatus(raw);
+	if (raw.retryFailure) {
+		return `Task ${status}; retry stopped after attempt ${raw.retryFailure.attempt}.`;
 	}
-	return { preview, truncated };
+	if (raw.abortReason) {
+		return `Task ${status}; abort reason recorded.`;
+	}
+	if (raw.error) {
+		return `Task ${status}; error recorded.`;
+	}
+	if (outputRef) {
+		return `Task ${status}; output stored in ${outputRef.uri} (${outputRef.lineCount} lines, ${outputRef.sizeBytes} bytes).`;
+	}
+	return `Task ${status}; output artifact unavailable.`;
 }
 
 function getStatus(raw: SingleResult): TaskResultReceipt["status"] {
@@ -116,16 +118,6 @@ function buildReview(raw: SingleResult): TaskResultReceipt["review"] | undefined
 }
 
 export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
-	const sourceOutput = raw.output.trim() ? raw.output : raw.stderr;
-	const { preview, truncated: previewTruncated } = boundedPreview(sourceOutput.trim() || "(no output)");
-	const extractedToolCounts = raw.extractedToolData
-		? Object.fromEntries(
-				Object.entries(raw.extractedToolData).map(([tool, values]) => [
-					tool,
-					Array.isArray(values) ? values.length : 0,
-				]),
-			)
-		: undefined;
 	const outputRef = raw.outputMeta
 		? {
 				uri: `agent://${raw.id}`,
@@ -133,6 +125,15 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 				lineCount: raw.outputMeta.lineCount,
 				sha256: raw.outputMeta.sha256,
 			}
+		: undefined;
+	const preview = buildSafeSynopsis(raw, outputRef);
+	const extractedToolCounts = raw.extractedToolData
+		? Object.fromEntries(
+				Object.entries(raw.extractedToolData).map(([tool, values]) => [
+					tool,
+					Array.isArray(values) ? values.length : 0,
+				]),
+			)
 		: undefined;
 	return {
 		index: raw.index,
@@ -154,15 +155,14 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		modelOverride: raw.modelOverride,
 		usage: raw.usage,
 		cost: raw.usage?.cost.total,
-		patchPath: raw.patchPath,
 		branchName: raw.branchName,
 		retryFailure: raw.retryFailure
-			? { attempt: raw.retryFailure.attempt, errorSummary: truncateText(raw.retryFailure.errorMessage, 300) ?? "" }
+			? { attempt: raw.retryFailure.attempt, errorSummary: "Retry failure recorded." }
 			: undefined,
-		errorSummary: truncateText(raw.error, 300),
-		abortSummary: truncateText(raw.abortReason, 300),
+		errorSummary: raw.error ? "Error recorded." : undefined,
+		abortSummary: raw.abortReason ? "Abort reason recorded." : undefined,
 		preview,
-		previewTruncated: previewTruncated || raw.truncated,
+		previewTruncated: false,
 		outputRef,
 		outputUnavailable: outputRef ? undefined : true,
 		review: buildReview(raw),
@@ -180,7 +180,6 @@ export interface RawTaskToolDetails {
 	results: SingleResult[];
 	totalDurationMs: number;
 	usage?: TaskToolDetails["usage"];
-	outputPaths?: string[];
 	async?: TaskToolDetails["async"];
 }
 
@@ -191,7 +190,6 @@ export function sanitizeTaskToolDetails(raw: RawTaskToolDetails): TaskToolDetail
 		results: raw.results.map(buildTaskReceipt),
 		totalDurationMs: raw.totalDurationMs,
 		usage: raw.usage,
-		outputPaths: raw.outputPaths,
 		async: raw.async,
 	};
 }

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -6,12 +6,13 @@
  */
 import path from "node:path";
 import type { Component } from "@gajae-code/tui";
-import { Container, Text } from "@gajae-code/tui";
+import { Text } from "@gajae-code/tui";
 import { formatNumber } from "@gajae-code/utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import {
 	formatBadge,
+	formatBytes,
 	formatDuration,
 	formatMoreItems,
 	formatStatusIcon,
@@ -27,8 +28,9 @@ import {
 	type SubmitReviewDetails,
 } from "../tools/review";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
+import type { TaskResultReceipt } from "./receipt";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
-import type { AgentProgress, SingleResult, TaskParams, TaskToolDetails } from "./types";
+import type { AgentProgress, TaskParams, TaskToolDetails } from "./types";
 
 /**
  * Get status icon for agent state.
@@ -137,21 +139,6 @@ function formatTaskId(id: string): string {
 	const indices = parsed.map(match => match![1]).join(".");
 	const labels = parsed.map(match => match![2]).join(">");
 	return `${indices} ${labels}`;
-}
-
-const MISSING_YIELD_WARNING_PREFIX = "SYSTEM WARNING: Subagent exited without calling yield tool";
-
-function extractMissingYieldWarning(output: string): { warning?: string; rest: string } {
-	const lines = output.split("\n");
-	const firstLine = lines[0]?.trim() ?? "";
-	if (!firstLine.startsWith(MISSING_YIELD_WARNING_PREFIX)) {
-		return { rest: output };
-	}
-	const rest = lines
-		.slice(1)
-		.join("\n")
-		.replace(/^\s*\n+/, "");
-	return { warning: firstLine, rest };
 }
 
 function buildTreePrefix(ancestors: boolean[], theme: Theme): string {
@@ -804,35 +791,24 @@ function renderFindings(
 /**
  * Render final result for a single agent.
  */
-function renderAgentResult(result: SingleResult, isLast: boolean, expanded: boolean, theme: Theme): string[] {
+function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded: boolean, theme: Theme): string[] {
 	const lines: string[] = [];
 	const prefix = isLast ? theme.fg("dim", theme.tree.last) : theme.fg("dim", theme.tree.branch);
 	const continuePrefix = isLast ? "   " : `${theme.fg("dim", theme.tree.vertical)}  `;
 
-	const { warning: missingCompleteWarning, rest: outputWithoutWarning } = extractMissingYieldWarning(result.output);
-	const aborted = result.aborted ?? false;
-	const mergeFailed = !aborted && result.exitCode === 0 && !!result.error;
-	const success = !aborted && result.exitCode === 0 && !result.error;
-	const needsWarning = Boolean(missingCompleteWarning) && success;
-	const icon = aborted
-		? theme.status.aborted
-		: needsWarning
-			? theme.status.warning
-			: success
-				? theme.status.success
+	const success = result.status === "completed";
+	const mergeFailed = result.status === "merge_failed";
+	const aborted = result.status === "aborted";
+	const icon = success
+		? theme.status.success
+		: aborted
+			? theme.status.aborted
+			: mergeFailed
+				? theme.status.warning
 				: theme.status.error;
-	const iconColor = needsWarning ? "warning" : success ? "success" : mergeFailed ? "warning" : "error";
-	const statusText = aborted
-		? "aborted"
-		: needsWarning
-			? "warning"
-			: success
-				? "done"
-				: mergeFailed
-					? "merge failed"
-					: "failed";
+	const iconColor = success ? "success" : mergeFailed ? "warning" : "error";
+	const statusText = mergeFailed ? "merge failed" : success ? "done" : result.status;
 
-	// Main status line: id: description [status] · stats · ⟨agent⟩
 	const description = result.description?.trim();
 	const displayId = formatTaskId(result.id);
 	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
@@ -847,121 +823,64 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 			tokens: result.tokens,
 			contextTokens: result.contextTokens,
 			contextWindow: result.contextWindow,
-			cost: result.usage?.cost.total ?? 0,
+			cost: result.cost ?? result.usage?.cost.total ?? 0,
 		},
 		theme,
 	);
 	statusLine += `${theme.sep.dot}${theme.fg("dim", formatDuration(result.durationMs))}`;
-
-	if (result.truncated) {
+	if (result.truncated || result.previewTruncated) {
 		statusLine += ` ${theme.fg("warning", "[truncated]")}`;
 	}
-
 	lines.push(statusLine);
 
 	lines.push(...renderTaskSection(result.assignment ?? result.task, continuePrefix, expanded, theme));
 
-	if (aborted && result.abortReason) {
-		lines.push(
-			`${continuePrefix}${theme.fg("error", theme.status.aborted)} ${theme.fg("dim", truncateToWidth(replaceTabs(result.abortReason), 80))}`,
-		);
-	}
-	// Check for review result (yield with review schema + report_finding)
-	const completeData = result.extractedToolData?.yield as Array<{ data: unknown }> | undefined;
-	const reportFindingData = normalizeReportFindings(result.extractedToolData?.report_finding);
-
-	// Extract review verdict from yield tool's data field if it matches SubmitReviewDetails
-	const reviewData = completeData
-		?.map(c => c.data as SubmitReviewDetails)
-		.filter(d => d && typeof d === "object" && "overall_correctness" in d);
-	const submitReviewData = reviewData && reviewData.length > 0 ? reviewData : undefined;
-
-	if (submitReviewData && submitReviewData.length > 0) {
-		// Use combined review renderer
-		const summary = submitReviewData[submitReviewData.length - 1];
-		const findings = reportFindingData;
-		lines.push(...renderReviewResult(summary, findings, continuePrefix, expanded, theme));
-		return lines;
-	}
-	if (reportFindingData.length > 0) {
-		const hasCompleteData = completeData && completeData.length > 0;
-		const message = hasCompleteData
-			? "Review verdict missing expected fields"
-			: "Review incomplete (yield not called)";
-		lines.push(`${continuePrefix}${theme.fg("warning", theme.status.warning)} ${theme.fg("dim", message)}`);
-		lines.push(`${continuePrefix}${formatFindingSummary(reportFindingData, theme)}`);
-		lines.push(...renderFindings(reportFindingData, continuePrefix, expanded, theme));
-		return lines;
-	}
-
-	// Check for extracted tool data with custom renderers (skip review tools)
-	let hasCustomRendering = false;
-	const deferredToolLines: string[] = [];
-	if (result.extractedToolData) {
-		for (const [toolName, dataArray] of Object.entries(result.extractedToolData)) {
-			// Skip review tools - handled above
-			if (toolName === "yield" || toolName === "report_finding") continue;
-
-			const handler = subprocessToolRegistry.getHandler(toolName);
-			if (handler?.renderFinal && (dataArray as unknown[]).length > 0) {
-				const isTaskTool = toolName === "task";
-				const component = handler.renderFinal(dataArray as unknown[], theme, expanded);
-				const target = isTaskTool ? deferredToolLines : lines;
-				if (!isTaskTool) {
-					hasCustomRendering = true;
-					target.push(`${continuePrefix}${theme.fg("dim", `Tool: ${toolName}`)}`);
-				}
-				if (component instanceof Text) {
-					// Prefix each line with continuePrefix
-					const text = component.getText();
-					for (const line of text.split("\n")) {
-						target.push(`${continuePrefix}${line}`);
-					}
-				} else if (component instanceof Container) {
-					// For containers, render each child
-					for (const child of (component as Container).children) {
-						if (child instanceof Text) {
-							target.push(`${continuePrefix}${child.getText()}`);
-						}
-					}
+	if (result.review) {
+		if (result.review.overallCorrectness) {
+			lines.push(`${continuePrefix}${theme.fg("dim", `Review: ${result.review.overallCorrectness}`)}`);
+		}
+		if (result.review.findingCount > 0) {
+			lines.push(`${continuePrefix}${theme.fg("dim", `${result.review.findingCount} findings`)}`);
+			if (expanded && result.review.findings) {
+				for (const finding of result.review.findings) {
+					const severity = finding.severity ? `${finding.severity}: ` : "";
+					lines.push(`${continuePrefix}${theme.fg("dim", `- ${severity}${finding.summary}`)}`);
 				}
 			}
 		}
+	} else {
+		lines.push(...renderOutputSection(result.preview, continuePrefix, expanded, theme, 3, 12));
+		if (result.previewTruncated) {
+			lines.push(`${continuePrefix}${theme.fg("warning", "Preview truncated; read outputRef for full artifact.")}`);
+		}
 	}
 
-	if (hasCustomRendering && missingCompleteWarning) {
+	if (result.outputRef) {
 		lines.push(
-			`${continuePrefix}${theme.fg("warning", theme.status.warning)} ${theme.fg(
+			`${continuePrefix}${theme.fg(
 				"dim",
-				truncateToWidth(missingCompleteWarning, 80),
+				`Output: ${result.outputRef.uri} (${formatBytes(result.outputRef.sizeBytes)}, ${result.outputRef.lineCount} lines)`,
 			)}`,
 		);
+	} else if (result.outputUnavailable) {
+		lines.push(`${continuePrefix}${theme.fg("dim", "Output artifact unavailable")}`);
 	}
 
-	// Fallback to output preview if no custom rendering
-	if (!hasCustomRendering) {
-		lines.push(
-			...renderOutputSection(outputWithoutWarning, continuePrefix, expanded, theme, 3, 12, missingCompleteWarning),
-		);
-	}
-
-	if (deferredToolLines.length > 0) {
-		lines.push(...deferredToolLines);
-	}
-
-	if (result.patchPath && !aborted && result.exitCode === 0) {
+	if (result.patchPath && success) {
 		lines.push(`${continuePrefix}${theme.fg("dim", `Patch: ${result.patchPath}`)}`);
-	} else if (result.branchName && !aborted && result.exitCode === 0) {
+	} else if (result.branchName && success) {
 		lines.push(`${continuePrefix}${theme.fg("dim", `Branch: ${result.branchName}`)}`);
 	}
-
-	// Error message
-	if (result.error && (!success || mergeFailed) && (!aborted || result.error !== result.abortReason)) {
+	if (result.abortSummary) {
 		lines.push(
-			`${continuePrefix}${theme.fg(mergeFailed ? "warning" : "error", truncateToWidth(replaceTabs(result.error), 70))}`,
+			`${continuePrefix}${theme.fg("error", theme.status.aborted)} ${theme.fg("dim", truncateToWidth(replaceTabs(result.abortSummary), 80))}`,
 		);
 	}
-
+	if (result.errorSummary && (!success || mergeFailed)) {
+		lines.push(
+			`${continuePrefix}${theme.fg(mergeFailed ? "warning" : "error", truncateToWidth(replaceTabs(result.errorSummary), 70))}`,
+		);
+	}
 	return lines;
 }
 
@@ -1009,9 +928,9 @@ export function renderResult(
 					lines.push(...renderAgentResult(res, isLast, expanded, theme));
 				});
 
-				const abortedCount = details.results.filter(r => r.aborted).length;
-				const mergeFailedCount = details.results.filter(r => !r.aborted && r.exitCode === 0 && r.error).length;
-				const successCount = details.results.filter(r => !r.aborted && r.exitCode === 0 && !r.error).length;
+				const abortedCount = details.results.filter(r => r.status === "aborted").length;
+				const mergeFailedCount = details.results.filter(r => r.status === "merge_failed").length;
+				const successCount = details.results.filter(r => r.status === "completed").length;
 				const failCount = details.results.length - successCount - mergeFailedCount - abortedCount;
 				let summary = `${theme.fg("dim", "Total:")} `;
 				if (abortedCount > 0) {

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -850,9 +850,6 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 		}
 	} else {
 		lines.push(...renderOutputSection(result.preview, continuePrefix, expanded, theme, 3, 12));
-		if (result.previewTruncated) {
-			lines.push(`${continuePrefix}${theme.fg("warning", "Preview truncated; read outputRef for full artifact.")}`);
-		}
 	}
 
 	if (result.outputRef) {
@@ -866,9 +863,7 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 		lines.push(`${continuePrefix}${theme.fg("dim", "Output artifact unavailable")}`);
 	}
 
-	if (result.patchPath && success) {
-		lines.push(`${continuePrefix}${theme.fg("dim", `Patch: ${result.patchPath}`)}`);
-	} else if (result.branchName && success) {
+	if (result.branchName && success) {
 		lines.push(`${continuePrefix}${theme.fg("dim", `Branch: ${result.branchName}`)}`);
 	}
 	if (result.abortSummary) {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Usage } from "@gajae-code/ai";
 import { $env } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import type { TaskResultReceipt } from "./receipt";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import type { NestedRepoPatch } from "./worktree";
 
@@ -304,13 +305,13 @@ export interface SingleResult {
 		errorMessage: string;
 	};
 	/** Output metadata for agent:// URL integration */
-	outputMeta?: { lineCount: number; charCount: number };
+	outputMeta?: { lineCount: number; charCount: number; byteSize?: number; sha256?: string };
 }
 
 /** Tool details for TUI rendering */
 export interface TaskToolDetails {
 	projectAgentsDir: string | null;
-	results: SingleResult[];
+	results: TaskResultReceipt[];
 	totalDurationMs: number;
 	/** Aggregated usage across all subagents. */
 	usage?: Usage;

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -315,7 +315,6 @@ export interface TaskToolDetails {
 	totalDurationMs: number;
 	/** Aggregated usage across all subagents. */
 	usage?: Usage;
-	outputPaths?: string[];
 	progress?: AgentProgress[];
 	async?: {
 		state: "running" | "paused" | "queued" | "completed" | "failed";

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -3,15 +3,15 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { prompt } from "@gajae-code/utils";
 import { AgentProtocolHandler } from "../../src/internal-urls/agent-protocol";
+import taskSummaryTemplate from "../../src/prompts/tools/task-summary.md" with { type: "text" };
 import {
 	assertNoRawTaskFields,
 	buildTaskReceipt,
 	findRawTaskLeakKeys,
 	type RawTaskToolDetails,
 	sanitizeTaskToolDetails,
-	TASK_PREVIEW_MAX_BYTES,
-	TASK_PREVIEW_MAX_LINES,
 } from "../../src/task/receipt";
 import type { SingleResult, TaskToolDetails } from "../../src/task/types";
 
@@ -63,10 +63,8 @@ afterEach(async () => {
 });
 
 describe("task result receipts", () => {
-	it("buildTaskReceipt omits banned keys, bounds preview, and exposes outputRef when metadata is present", () => {
-		const output = Array.from({ length: TASK_PREVIEW_MAX_LINES + 5 }, (_, i) => `line ${i} ${"x".repeat(300)}`).join(
-			"\n",
-		);
+	it("buildTaskReceipt omits banned keys, omits raw output, and exposes outputRef when metadata is present", () => {
+		const output = Array.from({ length: 17 }, (_, i) => `line ${i} ${"x".repeat(300)}`).join("\n");
 		const sha256 = createHash("sha256").update(output).digest("hex");
 		const receipt = buildTaskReceipt(
 			makeRaw({
@@ -86,9 +84,9 @@ describe("task result receipts", () => {
 			}),
 		);
 
-		expect(receipt.previewTruncated).toBe(true);
-		expect(Buffer.byteLength(receipt.preview)).toBeLessThanOrEqual(TASK_PREVIEW_MAX_BYTES);
-		expect(receipt.preview.split("\n").length).toBeLessThanOrEqual(TASK_PREVIEW_MAX_LINES);
+		expect(receipt.previewTruncated).toBe(false);
+		expect(receipt.preview).toContain("agent://9-Agent");
+		expect(receipt.preview).not.toContain("line 0");
 		expect(receipt.outputRef).toEqual({
 			uri: "agent://9-Agent",
 			sizeBytes: Buffer.byteLength(output),
@@ -130,16 +128,19 @@ describe("task result receipts", () => {
 	});
 
 	it("sanitizeTaskToolDetails maps raw results to receipts and preserves usage", () => {
-		const raw: RawTaskToolDetails = {
+		const raw = {
 			projectAgentsDir: null,
 			results: [makeRaw()],
 			totalDurationMs: 10,
 			usage: CANONICAL_USAGE,
-		};
+			outputPaths: ["/tmp/LEAK_SENTINEL_DO_NOT_DIGEST/0-Test.md"],
+		} as RawTaskToolDetails & { outputPaths: string[] };
 		const sanitized = sanitizeTaskToolDetails(raw);
 		expect(sanitized.usage).toBe(CANONICAL_USAGE);
-		expect(sanitized.results[0]?.preview).toBe("hello\nworld");
+		expect(sanitized.results[0]?.preview).toBe("Task completed; output artifact unavailable.");
 		expect(findRawTaskLeakKeys(sanitized)).toEqual([]);
+		expect("outputPaths" in sanitized).toBe(false);
+		expect(JSON.stringify(sanitized)).not.toContain("/tmp/");
 	});
 
 	it("does not flag numeric output token counts on a canonical Usage record", () => {
@@ -149,16 +150,69 @@ describe("task result receipts", () => {
 		expect(() => assertNoRawTaskFields(receipt, "receipt")).not.toThrow();
 	});
 
-	it("keeps the full raw output out of the receipt, exposing only a bounded preview", () => {
+	it("keeps raw output, stderr, error text, and filesystem paths out of public receipts", () => {
 		const sentinel = "LEAK_SENTINEL_DO_NOT_DIGEST";
-		const bigOutput = `head line\n${sentinel}${"A".repeat(64 * 1024)}`;
-		const receipt = buildTaskReceipt(makeRaw({ output: bigOutput }));
-		expect(Buffer.byteLength(receipt.preview)).toBeLessThanOrEqual(TASK_PREVIEW_MAX_BYTES);
+		const secretPath = `/tmp/${sentinel}/0-Test.md`;
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				output: `stdout ${sentinel}`,
+				stderr: `stderr ${sentinel}`,
+				error: `error ${sentinel}`,
+				abortReason: `abort ${sentinel}`,
+				retryFailure: { attempt: 2, errorMessage: `retry ${sentinel}` },
+				outputPath: secretPath,
+				patchPath: secretPath.replace(/\.md$/, ".patch"),
+			}),
+		);
+
 		const serialized = JSON.stringify(receipt);
-		expect(serialized.length).toBeLessThan(bigOutput.length);
-		// The bulk 64KB run never survives beyond the bounded preview budget.
-		expect(serialized).not.toContain("A".repeat(TASK_PREVIEW_MAX_BYTES + 1));
+		expect(serialized).not.toContain(sentinel);
+		expect(serialized).not.toContain(secretPath);
+		expect(serialized).not.toContain("/tmp/");
+		expect(serialized).not.toContain("stdout");
+		expect(serialized).not.toContain("stderr");
+		expect(receipt.preview).toBe("Task merge_failed; retry stopped after attempt 2.");
+		expect(receipt.errorSummary).toBe("Error recorded.");
+		expect(receipt.abortSummary).toBe("Abort reason recorded.");
+		expect(receipt.retryFailure?.errorSummary).toBe("Retry failure recorded.");
 		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
+	it("renders task-summary with synopsis refs and without raw payloads or paths", () => {
+		const sentinel = "LEAK_SENTINEL_DO_NOT_DIGEST";
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				id: "7-Agent",
+				output: `raw ${sentinel}`,
+				stderr: `stderr ${sentinel}`,
+				outputPath: `/tmp/${sentinel}/7-Agent.md`,
+				outputMeta: { lineCount: 2, charCount: 64, byteSize: 64, sha256: "f".repeat(64) },
+			}),
+		);
+		const rendered = prompt.render(taskSummaryTemplate, {
+			successCount: 1,
+			totalCount: 1,
+			cancelledCount: 0,
+			hasCancelledNote: false,
+			duration: "10ms",
+			summaries: [
+				{
+					agent: receipt.agent,
+					status: receipt.status,
+					id: receipt.id,
+					synopsis: receipt.preview,
+					meta: { lineCount: receipt.outputRef?.lineCount, charSize: "64 B" },
+				},
+			],
+		});
+
+		expect(rendered).toContain('<synopsis ref="agent://7-Agent">');
+		expect(rendered).not.toContain("<preview");
+		expect(rendered).not.toContain("<result>");
+		expect(rendered).not.toContain(sentinel);
+		expect(rendered).not.toContain("/tmp/");
+		expect(rendered).not.toContain("raw ");
+		expect(rendered).not.toContain("stderr");
 	});
 });
 

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentProtocolHandler } from "../../src/internal-urls/agent-protocol";
+import {
+	assertNoRawTaskFields,
+	buildTaskReceipt,
+	findRawTaskLeakKeys,
+	type RawTaskToolDetails,
+	sanitizeTaskToolDetails,
+	TASK_PREVIEW_MAX_BYTES,
+	TASK_PREVIEW_MAX_LINES,
+} from "../../src/task/receipt";
+import type { SingleResult, TaskToolDetails } from "../../src/task/types";
+
+const CANONICAL_USAGE = {
+	input: 1,
+	output: 2,
+	cacheRead: 3,
+	cacheWrite: 4,
+	totalTokens: 10,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const tempDirs: string[] = [];
+
+mock.module("../../src/internal-urls/registry-helpers", () => ({
+	artifactsDirsFromRegistry: () => tempDirs,
+}));
+
+function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "0-Test",
+		agent: "executor",
+		agentSource: "bundled",
+		task: "do work",
+		assignment: "assignment",
+		description: "description",
+		exitCode: 0,
+		output: "hello\nworld",
+		stderr: "",
+		truncated: false,
+		durationMs: 10,
+		tokens: 20,
+		...overrides,
+	};
+}
+
+async function makeTempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "receipt-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop()!;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("task result receipts", () => {
+	it("buildTaskReceipt omits banned keys, bounds preview, and exposes outputRef when metadata is present", () => {
+		const output = Array.from({ length: TASK_PREVIEW_MAX_LINES + 5 }, (_, i) => `line ${i} ${"x".repeat(300)}`).join(
+			"\n",
+		);
+		const sha256 = createHash("sha256").update(output).digest("hex");
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				id: "9-Agent",
+				output,
+				outputPath: "/tmp/9-Agent.md",
+				outputMeta: {
+					lineCount: output.split("\n").length,
+					charCount: output.length,
+					byteSize: Buffer.byteLength(output),
+					sha256,
+				},
+				extractedToolData: {
+					yield: [{ data: { overall_correctness: "patch is correct" } }],
+					report_finding: [{ severity: "medium", summary: "finding summary" }],
+				},
+			}),
+		);
+
+		expect(receipt.previewTruncated).toBe(true);
+		expect(Buffer.byteLength(receipt.preview)).toBeLessThanOrEqual(TASK_PREVIEW_MAX_BYTES);
+		expect(receipt.preview.split("\n").length).toBeLessThanOrEqual(TASK_PREVIEW_MAX_LINES);
+		expect(receipt.outputRef).toEqual({
+			uri: "agent://9-Agent",
+			sizeBytes: Buffer.byteLength(output),
+			lineCount: output.split("\n").length,
+			sha256,
+		});
+		expect(receipt.outputUnavailable).toBeUndefined();
+		expect(receipt.review?.overallCorrectness).toBe("patch is correct");
+		expect(receipt.review?.findingCount).toBe(1);
+		expect(receipt.extractedToolCounts).toEqual({ yield: 1, report_finding: 1 });
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
+	it("buildTaskReceipt marks output unavailable when no artifact metadata is present", () => {
+		const receipt = buildTaskReceipt(makeRaw());
+		expect(receipt.outputRef).toBeUndefined();
+		expect(receipt.outputUnavailable).toBe(true);
+	});
+
+	it("detects raw leak keys and allows sanitized receipt details without sentinel", () => {
+		const leaky = {
+			results: [
+				{
+					output: "LEAK_SENTINEL_DO_NOT_DIGEST",
+					stderr: "LEAK_SENTINEL_DO_NOT_DIGEST",
+					extractedToolData: { yield: [{ data: "LEAK_SENTINEL_DO_NOT_DIGEST" }] },
+				},
+			],
+		};
+		expect(findRawTaskLeakKeys(leaky)).toEqual(["extractedToolData", "output", "stderr"]);
+		expect(() => assertNoRawTaskFields(leaky, "sentinel.surface")).toThrow(
+			/sentinel\.surface.*extractedToolData.*output.*stderr/,
+		);
+
+		const sanitized: TaskToolDetails = { projectAgentsDir: null, results: [], totalDurationMs: 0 };
+		expect(findRawTaskLeakKeys(sanitized)).toEqual([]);
+		expect(JSON.stringify(sanitized)).not.toContain("LEAK_SENTINEL_DO_NOT_DIGEST");
+		expect(() => assertNoRawTaskFields(sanitized, "clean.surface")).not.toThrow();
+	});
+
+	it("sanitizeTaskToolDetails maps raw results to receipts and preserves usage", () => {
+		const raw: RawTaskToolDetails = {
+			projectAgentsDir: null,
+			results: [makeRaw()],
+			totalDurationMs: 10,
+			usage: CANONICAL_USAGE,
+		};
+		const sanitized = sanitizeTaskToolDetails(raw);
+		expect(sanitized.usage).toBe(CANONICAL_USAGE);
+		expect(sanitized.results[0]?.preview).toBe("hello\nworld");
+		expect(findRawTaskLeakKeys(sanitized)).toEqual([]);
+	});
+
+	it("does not flag numeric output token counts on a canonical Usage record", () => {
+		const receipt = buildTaskReceipt(makeRaw({ usage: CANONICAL_USAGE }));
+		expect(receipt.usage?.output).toBe(2);
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+		expect(() => assertNoRawTaskFields(receipt, "receipt")).not.toThrow();
+	});
+
+	it("keeps the full raw output out of the receipt, exposing only a bounded preview", () => {
+		const sentinel = "LEAK_SENTINEL_DO_NOT_DIGEST";
+		const bigOutput = `head line\n${sentinel}${"A".repeat(64 * 1024)}`;
+		const receipt = buildTaskReceipt(makeRaw({ output: bigOutput }));
+		expect(Buffer.byteLength(receipt.preview)).toBeLessThanOrEqual(TASK_PREVIEW_MAX_BYTES);
+		const serialized = JSON.stringify(receipt);
+		expect(serialized.length).toBeLessThan(bigOutput.length);
+		// The bulk 64KB run never survives beyond the bounded preview budget.
+		expect(serialized).not.toContain("A".repeat(TASK_PREVIEW_MAX_BYTES + 1));
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+});
+
+describe("agent protocol metadata verification", () => {
+	async function writeOutput(id: string, content: string): Promise<string> {
+		const dir = await makeTempDir();
+		const file = path.join(dir, `${id}.md`);
+		const sha256 = createHash("sha256").update(content).digest("hex");
+		await Bun.write(file, content);
+		await Bun.write(
+			`${file}.meta.json`,
+			JSON.stringify({
+				id,
+				kind: "agent-output",
+				sizeBytes: Buffer.byteLength(content),
+				lineCount: content.split("\n").length,
+				sha256,
+				createdAt: new Date().toISOString(),
+			}),
+		);
+		return file;
+	}
+
+	async function resolve(id: string) {
+		return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never);
+	}
+
+	it("resolves matching metadata and rejects hash and size mismatches", async () => {
+		const file = await writeOutput("verify", "verified content");
+		await expect(resolve("verify")).resolves.toMatchObject({ content: "verified content" });
+
+		const meta = JSON.parse(await Bun.file(`${file}.meta.json`).text());
+		await Bun.write(`${file}.meta.json`, JSON.stringify({ ...meta, sha256: "0".repeat(64) }));
+		await expect(resolve("verify")).rejects.toThrow(/hash mismatch/);
+
+		await Bun.write(`${file}.meta.json`, JSON.stringify({ ...meta, sizeBytes: meta.sizeBytes + 1 }));
+		await expect(resolve("verify")).rejects.toThrow(/size mismatch/);
+	});
+
+	it("preserves legacy behavior when the sidecar is absent", async () => {
+		const file = await writeOutput("legacy", "legacy content");
+		await fs.rm(`${file}.meta.json`);
+		await expect(resolve("legacy")).resolves.toMatchObject({ content: "legacy content" });
+	});
+});

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
-import type { AgentProgress, SingleResult, TaskToolDetails } from "@gajae-code/coding-agent/task";
+import type { AgentProgress, TaskResultReceipt, TaskToolDetails } from "@gajae-code/coding-agent/task";
 import { taskToolRenderer } from "@gajae-code/coding-agent/task/render";
 
 // Defends the live-rendering contract for the `task` tool: while a Level-1
@@ -35,7 +35,7 @@ describe("task renderer: nested live rendering", () => {
 		};
 	}
 
-	function makeCompletedSubResult(id: string, description: string): SingleResult {
+	function makeCompletedSubResult(id: string, description: string): TaskResultReceipt {
 		return {
 			index: 0,
 			id,
@@ -44,12 +44,14 @@ describe("task renderer: nested live rendering", () => {
 			task: "sub assignment",
 			assignment: "sub assignment",
 			description,
+			status: "completed",
 			exitCode: 0,
-			output: "sub-final-output",
-			stderr: "",
 			truncated: false,
 			durationMs: 500,
 			tokens: 200,
+			preview: "sub-final-output",
+			previewTruncated: false,
+			outputUnavailable: true,
 		};
 	}
 


### PR DESCRIPTION
## Token-efficiency program — PR1 of 10

Part of the Critic-approved corrected plan; follows merged PR #211 (Phase 0 deterministic benchmark).

### What
Makes task-tool results receipt-first so raw subagent output is no longer the persisted/model-facing payload, and adds integrity verification to the active agent:// resolver.

- New central module packages/coding-agent/src/task/receipt.ts: TaskResultReceipt, buildTaskReceipt, sanitizeTaskToolDetails (+ RawTaskToolDetails), recursive findRawTaskLeakKeys / assertNoRawTaskFields guards.
- TaskToolDetails.results is now TaskResultReceipt[]: status, ids, tokens/cost, bounded preview (2000B / 12 lines), verified agent:// outputRef (uri+size+lines+sha256) or outputUnavailable, and a bounded review summary. Raw output/stderr/extractedToolData no longer reach returned content/details. SingleResult remains the internal execution/merge shape.
- Executor writes a ${id}.md.meta.json sidecar (sizeBytes/lineCount/sha256), advertises the artifact ref only when both writes succeed, and cleans up orphaned files on failure.
- Active agent:// resolver verifies size + SHA-256 against the sidecar and fails closed (hash/size/malformed) before returning content or JSON extraction; legacy fallback preserved when no sidecar exists.
- Renderer final-result path reads receipts; live progress rendering unchanged.

### Scope
PR1 only. Live-progress sanitization, ACP/RPC/print/bridge, async/job/subagent tools, generic artifact:// metadata, lifecycle resolver, and the strict receipt-vs-legacy distinction are sequenced into later PRs in the same program (not deferred).

### Verification
- tsgo (packages/coding-agent): clean
- biome check (changed files): clean
- bun test test/task test/internal-urls: 124 pass / 0 fail (incl. new receipt/sanitizer/leak-scan, resolver integrity, canonical-Usage no-false-positive, full-output-not-leaked regression tests)
- Architect 3-lane review: architecture/product/code all CLEAR, APPROVE, no blockers
- Executor red-team QA: resolver integrity, recursive/cyclic leak detection, usage.output exemption, UTF-8/boundary cases all hold