### PR TITLE
feat(internal-urls): lifecycle agent/artifact resolver hardening

### DIFF
--- a/packages/coding-agent/src/internal-urls/agent-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/agent-protocol.ts
@@ -83,6 +83,12 @@ export class AgentProtocolHandler implements ProtocolHandler {
 		if (!outputId) {
 			throw new Error("agent:// URL requires an output ID: agent://<id>");
 		}
+		// Output IDs address a single file inside a session artifacts dir. Reject
+		// path separators / traversal so a crafted id cannot escape the dir via
+		// path.join(dir, `${outputId}.md`).
+		if (outputId.includes("/") || outputId.includes("\\") || outputId.includes("..")) {
+			throw new Error(`agent://${outputId} invalid id: path separators are not allowed`);
+		}
 
 		const urlPath = url.pathname;
 		const queryParam = url.searchParams.get("q");
@@ -99,7 +105,7 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			throw new Error("No session - agent outputs unavailable");
 		}
 
-		let foundPath: string | undefined;
+		const candidatePaths: string[] = [];
 		let anyDirExists = false;
 		const availableIds = new Set<string>();
 
@@ -114,18 +120,17 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			const candidate = path.join(dir, `${outputId}.md`);
 			try {
 				await fs.stat(candidate);
-				foundPath = candidate;
-				break;
+				candidatePaths.push(candidate);
 			} catch (err) {
 				if (!isEnoent(err)) throw err;
-				try {
-					const files = await fs.readdir(dir);
-					for (const f of files) {
-						if (f.endsWith(".md")) availableIds.add(f.replace(/\.md$/, ""));
-					}
-				} catch {
-					// Listing failures are non-fatal; continue searching.
+			}
+			try {
+				const files = await fs.readdir(dir);
+				for (const f of files) {
+					if (f.endsWith(".md")) availableIds.add(f.replace(/\.md$/, ""));
 				}
+			} catch {
+				// Listing failures are non-fatal; continue searching.
 			}
 		}
 
@@ -133,11 +138,15 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			throw new Error("No artifacts directory found");
 		}
 
-		if (!foundPath) {
+		if (candidatePaths.length === 0) {
 			const availableStr = availableIds.size > 0 ? [...availableIds].join(", ") : "none";
 			throw new Error(`Not found: ${outputId}\nAvailable: ${availableStr}`);
 		}
+		if (candidatePaths.length > 1) {
+			throw new Error(`agent://${outputId} ambiguous id: ${candidatePaths.length} matching outputs`);
+		}
 
+		const foundPath = candidatePaths[0]!;
 		const rawBytes = Buffer.from(await Bun.file(foundPath).arrayBuffer());
 		await verifyAgentOutputMetadata(outputId, foundPath, rawBytes);
 		const rawContent = rawBytes.toString("utf8");

--- a/packages/coding-agent/src/internal-urls/artifact-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/artifact-protocol.ts
@@ -34,7 +34,7 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error("No session - artifacts unavailable");
 		}
 
-		let foundPath: string | undefined;
+		const candidatePaths: string[] = [];
 		let anyDirExists = false;
 		const availableIds = new Set<string>();
 
@@ -47,14 +47,11 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 				if (isEnoent(err)) continue;
 				throw err;
 			}
-			const match = files.find(f => f.startsWith(`${id}.`));
-			if (match) {
-				foundPath = path.join(dir, match);
-				break;
-			}
 			for (const f of files) {
+				if (f.endsWith(".meta.json")) continue;
 				const m = f.match(/^(\d+)\./);
 				if (m) availableIds.add(m[1]);
+				if (f.startsWith(`${id}.`)) candidatePaths.push(path.join(dir, f));
 			}
 		}
 
@@ -62,12 +59,16 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error("No artifacts directory found");
 		}
 
-		if (!foundPath) {
+		if (candidatePaths.length === 0) {
 			const sorted = [...availableIds].sort((a, b) => Number(a) - Number(b));
 			const availableStr = sorted.length > 0 ? sorted.join(", ") : "none";
 			throw new Error(`Artifact ${id} not found. Available: ${availableStr}`);
 		}
+		if (candidatePaths.length > 1) {
+			throw new Error(`artifact://${id} ambiguous id: ${candidatePaths.length} matching artifacts`);
+		}
 
+		const foundPath = candidatePaths[0]!;
 		const content = await Bun.file(foundPath).text();
 		return {
 			url: url.href,

--- a/packages/coding-agent/test/task/lifecycle-resolver.test.ts
+++ b/packages/coding-agent/test/task/lifecycle-resolver.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentProtocolHandler } from "../../src/internal-urls/agent-protocol";
+import { ArtifactProtocolHandler } from "../../src/internal-urls/artifact-protocol";
+import { buildTaskReceipt, findRawTaskLeakKeys } from "../../src/task/receipt";
+import type { SingleResult, TaskToolDetails } from "../../src/task/types";
+
+const registeredDirs: string[] = [];
+const LEAK_SENTINEL = "LEAK_SENTINEL_DO_NOT_DIGEST";
+
+mock.module("../../src/internal-urls/registry-helpers", () => ({
+	artifactsDirsFromRegistry: () => registeredDirs,
+}));
+
+async function makeTempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lifecycle-resolver-test-"));
+	registeredDirs.push(dir);
+	return dir;
+}
+
+async function writeAgentOutput(dir: string, id: string, content: string): Promise<string> {
+	const file = path.join(dir, `${id}.md`);
+	const bytes = Buffer.from(content, "utf8");
+	await Bun.write(file, bytes);
+	await Bun.write(
+		`${file}.meta.json`,
+		JSON.stringify({
+			id,
+			kind: "agent-output",
+			sizeBytes: bytes.byteLength,
+			lineCount: content.split("\n").length,
+			sha256: createHash("sha256").update(bytes).digest("hex"),
+			createdAt: new Date().toISOString(),
+		}),
+	);
+	return file;
+}
+
+function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "0-Test",
+		agent: "executor",
+		agentSource: "bundled",
+		task: "do work",
+		assignment: "assignment",
+		description: "description",
+		exitCode: 0,
+		output: "receipt preview",
+		stderr: "",
+		truncated: false,
+		durationMs: 10,
+		tokens: 20,
+		...overrides,
+	};
+}
+
+function resolveAgent(id: string) {
+	return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never);
+}
+
+function resolveArtifact(id: string) {
+	return new ArtifactProtocolHandler().resolve(new URL(`artifact://${id}`) as never);
+}
+
+afterEach(async () => {
+	while (registeredDirs.length > 0) {
+		const dir = registeredDirs.pop()!;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("lifecycle resolver hardening", () => {
+	it("resolves a registered resumed-session agent output only through explicit agent:// with metadata verification", async () => {
+		const dir = await makeTempDir();
+		const content = "full resumed output\nkept outside default receipt";
+		const file = await writeAgentOutput(dir, "18-Resume", content);
+		const raw = makeRaw({
+			id: "18-Resume",
+			output: content,
+			outputPath: file,
+			outputMeta: {
+				lineCount: content.split("\n").length,
+				charCount: content.length,
+				byteSize: Buffer.byteLength(content),
+				sha256: createHash("sha256").update(content).digest("hex"),
+			},
+		});
+
+		const receipt = buildTaskReceipt(raw);
+		expect(receipt.outputRef?.uri).toBe("agent://18-Resume");
+		expect(receipt.preview).toBe("Task completed; output stored in agent://18-Resume (2 lines, 48 bytes).");
+		expect(receipt.outputRef).toMatchObject({ sizeBytes: Buffer.byteLength(content), lineCount: 2 });
+		await expect(resolveAgent("18-Resume")).resolves.toMatchObject({ content });
+
+		await Bun.write(`${file}.meta.json`, JSON.stringify({ id: "18-Resume", kind: "agent-output" }));
+		await expect(resolveAgent("18-Resume")).rejects.toThrow(/malformed metadata/);
+	});
+
+	it("fails closed instead of serving a first match when two sessions contain the same agent output id", async () => {
+		const first = await makeTempDir();
+		const second = await makeTempDir();
+		await writeAgentOutput(first, "42-Collision", `first ${LEAK_SENTINEL}`);
+		await writeAgentOutput(second, "42-Collision", "second verified content");
+
+		await expect(resolveAgent("42-Collision")).rejects.toThrow(/ambiguous id/);
+	});
+
+	it("fails closed instead of serving a first numeric-prefix artifact match across sessions", async () => {
+		const first = await makeTempDir();
+		const second = await makeTempDir();
+		await Bun.write(path.join(first, "7.bash.log"), `first ${LEAK_SENTINEL}`);
+		await Bun.write(path.join(second, "7.eval.log"), "second content");
+
+		await expect(resolveArtifact("7")).rejects.toThrow(/ambiguous id/);
+	});
+
+	it("keeps export/replay default task details receipt-only for persisted task result shapes", async () => {
+		const dir = await makeTempDir();
+		const fullOutput = `small preview\n${"A".repeat(8192)}`;
+		const file = await writeAgentOutput(dir, "3-Export", fullOutput);
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				id: "3-Export",
+				output: fullOutput,
+				outputPath: file,
+				outputMeta: {
+					lineCount: fullOutput.split("\n").length,
+					charCount: fullOutput.length,
+					byteSize: Buffer.byteLength(fullOutput),
+					sha256: createHash("sha256").update(fullOutput).digest("hex"),
+				},
+			}),
+		);
+		const persisted = {
+			type: "toolResult",
+			toolName: "task",
+			content: [{ type: "text", text: "Task completed. Full output: agent://3-Export" }],
+			details: { projectAgentsDir: null, results: [receipt], totalDurationMs: 10 } satisfies TaskToolDetails,
+		};
+
+		expect(findRawTaskLeakKeys(persisted.details)).toEqual([]);
+		expect(JSON.stringify(persisted.details)).not.toContain(LEAK_SENTINEL);
+		expect(JSON.stringify(persisted.details)).not.toContain("A".repeat(2001));
+	});
+
+	it("resolves a nested task receipt outputRef through its registered .md sidecar", async () => {
+		const dir = await makeTempDir();
+		const nestedContent = "nested full artifact";
+		const file = await writeAgentOutput(dir, "6-Parent.0-Nested", nestedContent);
+		const nestedReceipt = buildTaskReceipt(
+			makeRaw({
+				id: "6-Parent.0-Nested",
+				output: nestedContent,
+				outputPath: file,
+				outputMeta: {
+					lineCount: 1,
+					charCount: nestedContent.length,
+					byteSize: Buffer.byteLength(nestedContent),
+					sha256: createHash("sha256").update(nestedContent).digest("hex"),
+				},
+			}),
+		);
+
+		expect(nestedReceipt.outputRef?.uri).toBe("agent://6-Parent.0-Nested");
+		await expect(resolveAgent("6-Parent.0-Nested")).resolves.toMatchObject({ content: nestedContent });
+	});
+
+	it("preserves PR1 legacy missing-sidecar behavior but fails closed for tampered sidecars", async () => {
+		const dir = await makeTempDir();
+		const file = await writeAgentOutput(dir, "9-Legacy", "legacy content");
+		await fs.rm(`${file}.meta.json`);
+		await expect(resolveAgent("9-Legacy")).resolves.toMatchObject({ content: "legacy content" });
+
+		await writeAgentOutput(dir, "10-Tampered", "tampered content");
+		await Bun.write(`${path.join(dir, "10-Tampered.md")}.meta.json`, JSON.stringify({ id: "different" }));
+		await expect(resolveAgent("10-Tampered")).rejects.toThrow(/malformed metadata/);
+	});
+
+	it("rejects agent:// ids containing path separators or traversal", async () => {
+		await makeTempDir();
+		const malicious = (rawHost: string) =>
+			new AgentProtocolHandler().resolve({
+				rawHost,
+				hostname: rawHost,
+				pathname: "",
+				searchParams: new URLSearchParams(),
+				href: `agent://${rawHost}`,
+			} as never);
+		await expect(malicious("../../etc/passwd")).rejects.toThrow(/invalid id/);
+		await expect(malicious("..")).rejects.toThrow(/invalid id/);
+		await expect(malicious("a/b")).rejects.toThrow(/invalid id/);
+	});
+});


### PR DESCRIPTION
## Token-efficiency program — PR2 of 10 (stacked on PR1 #246)

> Base is the PR1 branch `feat/token-receipt-first-sanitizer`; retarget to `dev` after PR1 merges. PR2 reuses PR1's receipt/sidecar/hash-size contracts.

### What
Lifecycle hardening of the `agent` and `artifact` internal-URL resolvers so explicit artifact retrieval is reliable and integrity-checked across resumed/replay/export/nested/stats/offline modes.

- Both resolvers now collect all matching candidates across registered session dirs and **fail closed with a bounded `ambiguous id`** error instead of silently serving the first match (cross-session id-collision). PR1 sidecar hash/size verification still runs before any full content; single-match + legacy sidecar-absent reads preserved.
- `artifact` resolver excludes `*.meta.json` siblings from candidate matching and the diagnostic id list.
- `agent` resolver rejects ids containing path separators / `..` (traversal guard).
- Confirmed (no code change needed): resumed-session artifact dirs are already discoverable via the registry; replay/export/stats/offline default task views are already receipt-only because PR1 made persisted `TaskToolDetails.results` receipts.

### Scope
Generic `artifact` sidecar hashing and any non-task raw channels remain later-PR scope.

### Verification
- tsgo clean; biome clean
- new `test/task/lifecycle-resolver.test.ts` (resumed resolution, collision fail-closed for both schemes, export/replay receipt-only, nested receipt resolution, tampered/legacy sidecar, traversal guard)
- `bun test test/task/lifecycle-resolver.test.ts test/task/receipt.test.ts test/internal-urls` = 65 pass / 0 fail
- Architect review: no blockers; flagged WATCH items (traversal guard, sidecar-id diagnostic) addressed in this PR with tests.