### PR TITLE
fix(ultragoal): decompose create-goals briefs via @goal delimiter

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -50,12 +50,38 @@ Use `goal({"op":"get"})` snapshots inside Ultragoal for ledger reconciliation. T
 
 ## Create goals
 
-1. Run one of:
+1. Decide on the brief. To produce **multiple** stories, separate them with a reserved `@goal:` delimiter line; the title follows on the same line and the objective is everything beneath it until the next delimiter:
+
+   ```text
+   Shared brief constraints / context go here (optional preamble).
+
+   @goal: Parse the intake CSVs
+   Ingest reviewer CSVs from the watch dir, validate headers, and reject
+   malformed rows with a per-row reason. Objectives can span multiple lines
+   and contain `code`, "quotes", or commands — no escaping needed.
+
+   @goal: Normalize records
+   Map raw rows onto the canonical schema and dedupe by record id.
+
+   @goal: Export the audit report
+   Emit an audit-ready report covering every accepted and rejected row.
+   ```
+
+   Delimiter contract:
+   - A `@goal` line is a story boundary **only** when it starts at column 0 (no leading whitespace) and the character right after `@goal` is `:`, whitespace (space or tab), or end-of-line. So `@goal: Title`, `@goal Title`, and a bare `@goal` line all open a story.
+   - `@goalish`, `@goals:`, `@goal-foo`, `@goal.foo`, `@goal/foo`, and any indented or mid-line `@goal` are ordinary objective text, not delimiters. To keep a literal `@goal` line inside an objective, indent it.
+   - A title-only block (no body) uses the title as its objective. An empty title borrows the first body line as the title. A block with **neither** title nor body is rejected — `create-goals` errors instead of writing a placeholder goal.
+   - **Preamble** (any text before the first `@goal` delimiter) is global context/constraints only; it is retained in the brief but is **not** turned into a goal. Every executable story needs its own `@goal` block.
+   - With **no** `@goal` delimiter anywhere, the whole brief becomes a single goal `G001` (unchanged legacy behavior).
+
+   Stories become `G001`, `G002`, … in order.
+
+2. Run one of:
    - `gjc ultragoal create-goals --brief "<brief>"`
    - `gjc ultragoal create-goals --brief-file <path>`
    - `cat <brief> | gjc ultragoal create-goals --from-stdin`
    - `gjc ultragoal create-goals --gjc-goal-mode per-story --brief "<brief>"` only when one GJC goal context per story is explicitly preferred
-2. Inspect `.gjc/ultragoal/goals.json` and refine if needed.
+3. Inspect `.gjc/ultragoal/goals.json` and refine if needed.
 
 ## Complete goals
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -474,13 +474,57 @@ export function buildUltragoalHudSummary(
 	});
 }
 
-function titleFromBrief(brief: string): string {
-	const firstLine = brief
+function clampTitle(title: string): string {
+	return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+}
+
+function firstNonEmptyLine(text: string): string | undefined {
+	return text
 		.split(/\r?\n/)
 		.map(line => line.trim())
 		.find(line => line.length > 0);
+}
+
+function titleFromBrief(brief: string): string {
+	const firstLine = firstNonEmptyLine(brief);
 	if (!firstLine) return "Complete ultragoal brief";
-	return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
+	return clampTitle(firstLine);
+}
+
+// A reserved, column-0 (unindented) `@goal` line opens a story. The character
+// right after `@goal` must be `:`, whitespace, or end-of-line, so `@goalish`,
+// `@goals:`, `@goal-foo`, `@goal.foo`, and `@goal/foo` are ordinary objective
+// text, and indented or mid-line `@goal:` is never a delimiter.
+const GOAL_DELIMITER = /^@goal(?::|\s+|$)\s*(.*)$/;
+
+interface ParsedGoal {
+	title: string;
+	objective: string;
+}
+
+function parseGoalsFromBrief(brief: string): ParsedGoal[] {
+	const sections: { title: string; body: string[] }[] = [];
+	let current: { title: string; body: string[] } | undefined;
+	for (const line of brief.split(/\r?\n/)) {
+		const match = GOAL_DELIMITER.exec(line);
+		if (match) {
+			current = { title: match[1].trim(), body: [] };
+			sections.push(current);
+			continue;
+		}
+		current?.body.push(line);
+	}
+	if (sections.length === 0) {
+		return [{ title: titleFromBrief(brief), objective: brief.trim() }];
+	}
+	return sections.map((section, index) => {
+		const body = section.body.join("\n").trim();
+		const title = section.title || firstNonEmptyLine(body) || "";
+		if (!title && !body) {
+			throw new Error(`ultragoal @goal block ${index + 1} has no title or objective`);
+		}
+		return { title: clampTitle(title), objective: body || title };
+	});
 }
 
 export async function createUltragoalPlan(input: {
@@ -491,21 +535,23 @@ export async function createUltragoalPlan(input: {
 	const brief = input.brief.trim();
 	if (!brief) throw new Error("ultragoal brief is required");
 	const now = new Date().toISOString();
+	// Parse the untrimmed brief so the raw-line delimiter contract holds: a
+	// leading-indented `@goal` on the first line must stay objective text rather
+	// than being promoted to column 0 by trimming.
+	const goals: UltragoalGoal[] = parseGoalsFromBrief(input.brief).map((goal, index) => ({
+		id: `G${String(index + 1).padStart(3, "0")}`,
+		title: goal.title,
+		objective: goal.objective,
+		status: "pending",
+		createdAt: now,
+		updatedAt: now,
+	}));
 	const plan: UltragoalPlan = {
 		version: 1,
 		brief,
 		gjcGoalMode: input.gjcGoalMode ?? "aggregate",
 		gjcObjective: DEFAULT_ULTRAGOAL_OBJECTIVE,
-		goals: [
-			{
-				id: "G001",
-				title: titleFromBrief(brief),
-				objective: brief,
-				status: "pending",
-				createdAt: now,
-				updatedAt: now,
-			},
-		],
+		goals,
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -1264,7 +1310,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					createdPlan: true,
 					stdout: json
 						? `${JSON.stringify(plan, null, 2)}\n`
-						: `Created ultragoal plan with ${plan.goals.length} goal at ${getUltragoalPaths(cwd).goalsPath}.\n`,
+						: `Created ultragoal plan with ${plan.goals.length} goal${plan.goals.length === 1 ? "" : "s"} at ${getUltragoalPaths(cwd).goalsPath}.\n`,
 				};
 			}
 			case "complete-goals":

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -6,6 +6,7 @@ import {
 	validateCompletionReceipt,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
+	buildUltragoalHudSummary,
 	checkpointUltragoalGoal,
 	createUltragoalPlan,
 	getUltragoalStatus,
@@ -1018,5 +1019,223 @@ describe("native GJC ultragoal runtime", () => {
 		expect(result.status).toBe(1);
 		expect(result.stderr).toContain("checkpoint --status must be");
 		expect(status.goals[0]?.status).toBe("pending");
+	});
+});
+
+describe("ultragoal @goal decomposition", () => {
+	async function goalsFileExists(root: string): Promise<boolean> {
+		return await Bun.file(path.join(root, ".gjc", "ultragoal", "goals.json")).exists();
+	}
+
+	it("keeps a no-sigil brief as a single goal (backward compatible)", async () => {
+		const root = await tempDir();
+		const brief = "Ship the native fix\nwith a second line";
+		const plan = await createUltragoalPlan({ cwd: root, brief });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]).toMatchObject({ id: "G001", status: "pending" });
+		expect(plan.goals[0]?.objective).toBe(brief.trim());
+	});
+
+	it("trims a whitespace-padded no-sigil brief", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "\n\n  Only one goal here  \n\n" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.objective).toBe("Only one goal here");
+	});
+
+	it("splits multiple @goal blocks into ordered goals", async () => {
+		const root = await tempDir();
+		const brief = [
+			"@goal: Parse CSVs",
+			"Ingest and validate rows.",
+			"Reject malformed rows.",
+			"",
+			"@goal: Normalize records",
+			"Map onto the canonical schema.",
+			"",
+			"@goal: Export report",
+			"Emit the audit report.",
+		].join("\n");
+		const plan = await createUltragoalPlan({ cwd: root, brief });
+		expect(plan.goals.map(goal => goal.id)).toEqual(["G001", "G002", "G003"]);
+		expect(plan.goals.map(goal => goal.title)).toEqual(["Parse CSVs", "Normalize records", "Export report"]);
+		expect(plan.goals[0]?.objective).toBe("Ingest and validate rows.\nReject malformed rows.");
+		expect(plan.goals[2]?.objective).toBe("Emit the audit report.");
+	});
+
+	it("accepts @goal without a colon", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal First story\nDo the thing.\n\n@goal Second story\nDo the next thing.",
+		});
+		expect(plan.goals.map(goal => goal.title)).toEqual(["First story", "Second story"]);
+	});
+
+	it("treats @goal-adjacent tokens as objective text, not delimiters", async () => {
+		const root = await tempDir();
+		const brief = [
+			"@goal: Real story",
+			"@goalish is not a delimiter",
+			"@goals: also not one",
+			"@goal-foo @goal.foo @goal/foo stay in the body",
+		].join("\n");
+		const plan = await createUltragoalPlan({ cwd: root, brief });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.title).toBe("Real story");
+		expect(plan.goals[0]?.objective).toContain("@goalish is not a delimiter");
+		expect(plan.goals[0]?.objective).toContain("@goals: also not one");
+		expect(plan.goals[0]?.objective).toContain("@goal-foo @goal.foo @goal/foo stay in the body");
+	});
+
+	it("keeps a leading-indented first @goal line as objective text, not a delimiter", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "    @goal: Indented first line\nfollow-up detail" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.id).toBe("G001");
+		expect(plan.goals[0]?.objective).toBe("@goal: Indented first line\nfollow-up detail");
+	});
+
+	it("parses @goal:Title with no space after the colon", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal:First\nbody one\n\n@goal:Second\nbody two" });
+		expect(plan.goals.map(goal => goal.title)).toEqual(["First", "Second"]);
+	});
+
+	it("derives the title from the body for a bare @goal line", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal\nBare delimiter story\nmore detail" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.title).toBe("Bare delimiter story");
+		expect(plan.goals[0]?.objective).toBe("Bare delimiter story\nmore detail");
+	});
+
+	it("treats a tab after @goal as a boundary", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal\tTabbed title\nbody" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.title).toBe("Tabbed title");
+	});
+
+	it("keeps an indented @goal line inside the objective", async () => {
+		const root = await tempDir();
+		const brief = "@goal: Story\nUse a literal like:\n    @goal: not a real delimiter\ndone.";
+		const plan = await createUltragoalPlan({ cwd: root, brief });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.objective).toContain("    @goal: not a real delimiter");
+	});
+
+	it("keeps a mid-line @goal reference inside the objective", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: Story\nThe sigil is @goal: when at column zero.",
+		});
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.objective).toBe("The sigil is @goal: when at column zero.");
+	});
+
+	it("uses the title as the objective for a title-only block", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal: Just a title" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]).toMatchObject({ title: "Just a title", objective: "Just a title" });
+	});
+
+	it("derives the title from the first body line when the title is empty", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal:\nDerived title line\nmore detail" });
+		expect(plan.goals[0]?.title).toBe("Derived title line");
+		expect(plan.goals[0]?.objective).toBe("Derived title line\nmore detail");
+	});
+
+	it("clamps long titles to 80 characters", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: `@goal: ${"T".repeat(120)}\nbody` });
+		const title = plan.goals[0]?.title ?? "";
+		expect(title).toHaveLength(80);
+		expect(title.endsWith("...")).toBe(true);
+	});
+
+	it("rejects an empty @goal block without writing goals.json", async () => {
+		const adjacent = await tempDir();
+		await expect(createUltragoalPlan({ cwd: adjacent, brief: "@goal:\n@goal: Second\nbody" })).rejects.toThrow(
+			"has no title or objective",
+		);
+		expect(await goalsFileExists(adjacent)).toBe(false);
+
+		const trailing = await tempDir();
+		await expect(createUltragoalPlan({ cwd: trailing, brief: "@goal: First\nbody\n@goal:" })).rejects.toThrow(
+			"has no title or objective",
+		);
+		expect(await goalsFileExists(trailing)).toBe(false);
+	});
+
+	it("excludes preamble from goals but retains it in the brief", async () => {
+		const root = await tempDir();
+		const brief = "Global constraints: be fast.\n\n@goal: Only story\nDo the work.";
+		const plan = await createUltragoalPlan({ cwd: root, brief });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]).toMatchObject({ title: "Only story", objective: "Do the work." });
+		expect(plan.brief).toContain("Global constraints: be fast.");
+	});
+
+	it("pluralizes the create-goals summary by goal count", async () => {
+		const single = await tempDir();
+		const one = await runNativeUltragoalCommand(["create-goals", "--brief", "One story only"], single);
+		expect(one.stdout).toContain("with 1 goal at");
+		expect(one.stdout).not.toContain("with 1 goals");
+
+		const multi = await tempDir();
+		const three = await runNativeUltragoalCommand(
+			["create-goals", "--brief", "@goal: A\nfirst\n@goal: B\nsecond\n@goal: C\nthird"],
+			multi,
+		);
+		expect(three.stdout).toContain("with 3 goals at");
+	});
+
+	it("reflects a multi-goal plan in the HUD summary", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: Parse\nstep one\n@goal: Normalize\nstep two\n@goal: Export\nstep three",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const summary = await getUltragoalStatus(root);
+		const hud = buildUltragoalHudSummary(summary);
+		const serialized = JSON.stringify(hud);
+		expect(serialized).toContain("0/3");
+		expect(serialized).toContain("G001:Parse");
+		expect(summary.status).toBe("active");
+	});
+
+	it("schedules each @goal story in order through the existing API", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: Parse\nstep one\n@goal: Normalize\nstep two\n@goal: Export\nstep three",
+		});
+
+		const first = await startNextUltragoalGoal({ cwd: root });
+		expect(first.goal?.id).toBe("G001");
+		expect(first.goal?.objective).toBe("step one");
+
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first story verified",
+			gjcGoalJson: goalSnapshot(created.gjcObjective),
+			qualityGateJson: passingQualityGate(),
+		});
+
+		const second = await startNextUltragoalGoal({ cwd: root });
+		expect(second.goal?.id).toBe("G002");
+		expect(second.goal?.status).toBe("active");
+		expect(second.allComplete).toBe(false);
+
+		const status = await getUltragoalStatus(root);
+		expect(status.counts.complete).toBe(1);
+		expect(status.currentGoal?.id).toBe("G002");
 	});
 });


### PR DESCRIPTION
## Problem
`gjc ultragoal create-goals` always collapsed any brief into a single goal `G001` — `createUltragoalPlan` hardcoded one goal with the whole brief as its objective. There was no decomposition logic at all, so multi-story briefs could never become multiple goals.

## Change
Add a deterministic, escaping-free **`@goal:` delimiter** brief format:

- A `@goal` line opens a story **only** at column 0 (no leading whitespace) when followed by `:`, whitespace, or end-of-line. `@goalish`, `@goals:`, `@goal-foo`, indented/mid-line `@goal:` stay objective text.
- Stories become `G001..G00N` in order; the objective is the lines beneath the delimiter.
- **No delimiter anywhere ⇒ unchanged single-goal behavior** (backward compatible).
- Title-only blocks use the title as objective; empty-title blocks derive the title from the first body line; truly-empty `@goal:` blocks are **rejected before any state write**. Titles clamp to 80 chars.
- Preamble before the first `@goal:` is global context (kept in `plan.brief`), not a goal.
- `create-goals` stdout pluralizes (`1 goal` / `3 goals`).

Also rewrites the ultragoal `SKILL.md` "Create goals" section to document the contract with a worked multi-goal example.

## Why a delimiter (not JSON/YAML)
A goal's only author-supplied fields are `title` + `objective`, both free-text prose; objectives routinely contain code/quotes/multi-paragraph text — exactly where LLM-generated JSON breaks on escaping. The delimiter needs zero escaping and is deterministic. (Revisit a validated schema only if structured per-goal metadata like dependencies is ever needed.)

## Wiring verified (HUD + existing API)
Both HUD paths (`commands/ultragoal.ts` command sync and `state-runtime.ts` state sync) and the status renderer were already generic over goal count, so multi-goal flows through unchanged:
- HUD chips render `goals 0/3` and `current G001:<title>`.
- `complete-goals` scheduling iterates `G001 → G002 → …` via the existing `startNextUltragoalGoal`/`chooseNextGoal`.

## Tests
21 new cases in `ultragoal-runtime.test.ts`: parsing variants, false-positive guards, indented/mid-line literals, empty-block rejection (no `goals.json` written), preamble exclusion, title clamping, CLI pluralization, multi-goal HUD summary, and cross-goal scheduling.

## Verification
- `bun test test/gjc-runtime/ultragoal-runtime.test.ts test/gjc-runtime/goal-mode-request.test.ts` → **60 pass**
- `bun run check:types` (tsgo) → clean
- biome → clean
- Live CLI run from source confirmed 3-goal decomposition + status render.

## Process
Planned via ralplan consensus (Planner → Architect → Critic, 2 passes to APPROVE) and an architect implementation review (BLOCK → fixes → CLEAR/CLEAR/CLEAR APPROVE).
