### PR TITLE
feat(subagent): receipt-first list/inspect/await + verbosity + verified output refs

### DIFF
--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -2,19 +2,22 @@ Lists, inspects, awaits, pauses, resumes, steers, or cancels detached task subag
 
 Task launches return immediately. Use this tool when you need direct control over those running subagents. Prefer `subagent` for task subagents; generic `job` remains available for non-subagent jobs and compatibility fallback access.
 
+`verbosity` controls output size: `receipt` (default) returns status metadata plus a single <=280-character result/error preview and an `agent://<id>` output ref when available; `preview` returns <=2000 characters; `full` returns <=12000 characters and requires explicit `ids`.
+
 # Operations
 
 ## `action: "list"`
-Snapshot your visible detached subagents, including `running`, `paused`, `queued`, and terminal subagents when retained.
+Snapshot your visible detached subagents, including `running`, `paused`, `queued`, and terminal subagents when retained. Output is receipt-only by default; use `verbosity: "preview"` for a bounded preview or inspect explicit `ids` with `verbosity: "full"` when fuller retained text is necessary.
 
 ## `action: "inspect"`
-Inspect selected subagents by `ids`; omit `ids` to inspect current running subagents. Terminal subagents include final output when retained.
+Inspect selected subagents by `ids`; omit `ids` to inspect current running subagents. Terminal subagents return receipt-only output by default, with an `agent://<id>` ref when a verified output artifact is available. `verbosity: "full"` requires explicit `ids`.
 
 ## `action: "await"`
 Wait for selected subagents by `ids`; omit `ids` to wait for current running subagents.
 - Always set `timeout_ms` when the result is not immediately required forever.
 - Await timeout only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
 - On timeout, inspect progress and keep doing independent work. Never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.
+- Completed results are receipt-first by default: bounded preview plus `agent://<id>` output ref when available, not full retained output.
 
 ## `action: "pause"`
 Request a graceful safe-boundary pause for selected subagents by `ids`.

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -1,7 +1,9 @@
+import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, type SubagentRecord } from "../async";
+import { artifactsDirsFromRegistry } from "../internal-urls/registry-helpers";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
 import type { AgentSource } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
@@ -13,7 +15,9 @@ const DEFAULT_AWAIT_TIMEOUT_MS = 30_000;
 const MAX_AWAIT_TIMEOUT_MS = 60 * 60 * 1000;
 const DEFAULT_LIST_LIMIT = 10;
 const MAX_LIST_LIMIT = 50;
-const TEXT_PREVIEW_WIDTH = 12_000;
+const RECEIPT_PREVIEW_WIDTH = 280;
+const PREVIEW_WIDTH = 2_000;
+const FULL_PREVIEW_WIDTH = 12_000;
 
 const subagentSchema = z.object({
 	action: z
@@ -24,6 +28,12 @@ const subagentSchema = z.object({
 	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
 	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
 	limit: z.number().min(1).max(MAX_LIST_LIMIT).optional().describe("maximum subagents to return"),
+	verbosity: z
+		.enum(["receipt", "preview", "full"])
+		.optional()
+		.describe(
+			"output verbosity: receipt (default, <=280-char receipt preview), preview (<=2000 chars), or full (<=12000 chars; requires explicit ids)",
+		),
 });
 
 type SubagentParams = z.infer<typeof subagentSchema>;
@@ -49,6 +59,9 @@ export interface SubagentSnapshot {
 	durationMs: number;
 	resultText?: string;
 	errorText?: string;
+	resultPreview?: string;
+	outputRef?: string;
+	truncated?: boolean;
 	guidance?: string;
 }
 
@@ -87,19 +100,26 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const ownerId = this.session.getAgentId?.() ?? undefined;
 		const ownerFilter = ownerId ? { ownerId } : undefined;
 		const limit = Math.min(MAX_LIST_LIMIT, Math.max(1, Math.floor(params.limit ?? DEFAULT_LIST_LIMIT)));
+		const verbosity = params.verbosity ?? "receipt";
+		if (verbosity === "full" && (params.action === "list" || !params.ids?.length)) {
+			throw new ToolError(
+				"`verbosity=full` cannot be used with `list` and requires explicit `ids` so broad inspection cannot inline retained subagent output.",
+			);
+		}
 
 		if (params.action === "list") {
 			const records = this.#listSubagentRecords(manager, ownerFilter, limit);
-			return this.#buildRecordResult(manager, records, { title: "Subagents" });
+			return await this.#buildRecordResult(manager, records, { title: "Subagents", verbosity });
 		}
 
 		if (params.action === "inspect") {
 			const records = params.ids?.length
 				? this.#visibleRecordsByIds(manager, params.ids, ownerFilter)
 				: this.#runningRecords(manager, ownerFilter);
-			return this.#buildRecordResult(manager, records, {
+			return await this.#buildRecordResult(manager, records, {
 				title: "Subagent inspection",
 				notFoundIds: this.#notFoundRecordIds(manager, params.ids ?? [], ownerFilter),
+				verbosity,
 			});
 		}
 
@@ -108,19 +128,26 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (ids.length === 0) {
 				throw new ToolError("`cancel` requires at least one subagent id.");
 			}
-			const snapshots: SubagentSnapshot[] = [];
+			const records: SubagentRecord[] = [];
+			const missing: SubagentSnapshot[] = [];
 			for (const id of ids) {
 				const record = this.#findVisibleRecord(manager, id, ownerFilter);
 				if (!record) {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
 				const cancelled = manager.cancelSubagent(record.subagentId, ownerFilter);
 				if (!cancelled && record.currentJobId) manager.cancel(record.currentJobId, ownerFilter);
-				const updated = this.#findVisibleRecord(manager, id, ownerFilter) ?? record;
-				snapshots.push(this.#recordSnapshot(manager, updated));
+				records.push(this.#findVisibleRecord(manager, id, ownerFilter) ?? record);
 			}
-			return this.#buildSnapshotResult(snapshots, "Subagent cancellation");
+			const verifiedOutputIds = await this.#verifiedOutputIds(records);
+			return this.#buildSnapshotResult(
+				[
+					...records.map(record => this.#recordSnapshot(manager, record, false, verbosity, verifiedOutputIds)),
+					...missing,
+				],
+				"Subagent cancellation",
+			);
 		}
 
 		if (params.action === "pause") {
@@ -128,23 +155,29 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (ids.length === 0) {
 				throw new ToolError("`pause` requires at least one subagent id.");
 			}
-			const snapshots: SubagentSnapshot[] = [];
+			const records: SubagentRecord[] = [];
+			const missing: SubagentSnapshot[] = [];
 			for (const id of ids) {
 				const record = this.#findVisibleRecord(manager, id, ownerFilter);
 				if (!record) {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
 				const result = manager.pauseSubagent(record.subagentId, ownerFilter);
 				if (!result.ok && result.reason === "not_found") {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
-				snapshots.push(
-					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
-				);
+				records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 			}
-			return this.#buildSnapshotResult(snapshots, "Subagent pause");
+			const verifiedOutputIds = await this.#verifiedOutputIds(records);
+			return this.#buildSnapshotResult(
+				[
+					...records.map(record => this.#recordSnapshot(manager, record, false, verbosity, verifiedOutputIds)),
+					...missing,
+				],
+				"Subagent pause",
+			);
 		}
 
 		if (params.action === "resume") {
@@ -152,36 +185,50 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (ids.length === 0) {
 				throw new ToolError("`resume` requires at least one subagent id.");
 			}
-			const snapshots: SubagentSnapshot[] = [];
+			const records: SubagentRecord[] = [];
+			const missing: SubagentSnapshot[] = [];
+			const terminalGuidanceIds = new Set<string>();
+			const verifiedOutputIds = await this.#verifiedOutputIds(this.#visibleRecordsByIds(manager, ids, ownerFilter));
 			for (const id of ids) {
 				const record = this.#findVisibleRecord(manager, id, ownerFilter);
 				if (!record) {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
 				if (record.status === "running") {
-					snapshots.push(this.#recordSnapshot(manager, record));
+					records.push(record);
 					continue;
 				}
 				if (params.message === undefined && isTerminalStatus(record.status)) {
-					snapshots.push({
-						...this.#recordSnapshot(manager, record),
-						guidance:
-							"This subagent is terminal. Provide `message` to start a follow-up resume run from its saved context.",
-					});
+					records.push(record);
+					terminalGuidanceIds.add(record.subagentId);
 					continue;
 				}
 				const result = manager.resumeSubagent(record.subagentId, ownerFilter, params.message);
 				if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
 				if (!result.ok && result.reason === "not_found") {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
-				snapshots.push(
-					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
-				);
+				records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 			}
-			return this.#buildSnapshotResult(snapshots, "Subagent resume");
+
+			return this.#buildSnapshotResult(
+				[
+					...records.map(record => {
+						const snapshot = this.#recordSnapshot(manager, record, false, verbosity, verifiedOutputIds);
+						return terminalGuidanceIds.has(record.subagentId)
+							? {
+									...snapshot,
+									guidance:
+										"This subagent is terminal. Provide `message` to start a follow-up resume run from its saved context.",
+								}
+							: snapshot;
+					}),
+					...missing,
+				],
+				"Subagent resume",
+			);
 		}
 
 		if (params.action === "steer") {
@@ -193,11 +240,13 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (message === undefined || message.trim() === "") {
 				throw new ToolError("`steer` requires a non-empty message.");
 			}
-			const snapshots: SubagentSnapshot[] = [];
+			const records: SubagentRecord[] = [];
+			const missing: SubagentSnapshot[] = [];
+			const verifiedOutputIds = await this.#verifiedOutputIds(this.#visibleRecordsByIds(manager, ids, ownerFilter));
 			for (const id of ids) {
 				const record = this.#findVisibleRecord(manager, id, ownerFilter);
 				if (!record) {
-					snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 					continue;
 				}
 				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
@@ -210,17 +259,19 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 					const result = manager.resumeSubagent(record.subagentId, ownerFilter, message);
 					if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
 					if (!result.ok && result.reason === "not_found") {
-						snapshots.push(
-							this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."),
-						);
+						missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 						continue;
 					}
 				}
-				snapshots.push(
-					this.#recordSnapshot(manager, manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record),
-				);
+				records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 			}
-			return this.#buildSnapshotResult(snapshots, "Subagent steer");
+			return this.#buildSnapshotResult(
+				[
+					...records.map(record => this.#recordSnapshot(manager, record, false, verbosity, verifiedOutputIds)),
+					...missing,
+				],
+				"Subagent steer",
+			);
 		}
 
 		return this.#awaitSubagents(manager, params, ownerFilter, signal, onUpdate);
@@ -249,7 +300,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			.map(record => manager.getJob(record.currentJobId!))
 			.filter((job): job is AsyncJob => job !== undefined);
 		if (runningJobs.length === 0) {
-			return this.#buildRecordResult(manager, records, { title: "Subagent await", notFoundIds });
+			return await this.#buildRecordResult(manager, records, {
+				title: "Subagent await",
+				notFoundIds,
+				verbosity: params.verbosity ?? "receipt",
+			});
 		}
 
 		const timeoutMs = Math.min(
@@ -288,7 +343,12 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (progressTimer) clearInterval(progressTimer);
 		}
 
-		return this.#buildRecordResult(manager, records, { title: "Subagent await", notFoundIds, timedOut });
+		return await this.#buildRecordResult(manager, records, {
+			title: "Subagent await",
+			notFoundIds,
+			timedOut,
+			verbosity: params.verbosity ?? "receipt",
+		});
 	}
 
 	#mergedRecords(
@@ -386,16 +446,23 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 	#progressResult(manager: AsyncJobManager, records: SubagentRecord[]): AgentToolResult<SubagentToolDetails> {
 		return {
 			content: [{ type: "text", text: "" }],
-			details: { subagents: this.#recordSnapshots(manager, records) },
+			details: { subagents: this.#recordSnapshots(manager, records, false, "receipt", new Set()) },
 		};
 	}
 
-	#buildRecordResult(
+	async #buildRecordResult(
 		manager: AsyncJobManager,
 		records: SubagentRecord[],
-		options: { title: string; notFoundIds?: string[]; timedOut?: boolean },
-	): AgentToolResult<SubagentToolDetails> {
-		const snapshots = this.#recordSnapshots(manager, records, options.timedOut);
+		options: { title: string; notFoundIds?: string[]; timedOut?: boolean; verbosity?: SubagentParams["verbosity"] },
+	): Promise<AgentToolResult<SubagentToolDetails>> {
+		const verifiedOutputIds = await this.#verifiedOutputIds(records);
+		const snapshots = this.#recordSnapshots(
+			manager,
+			records,
+			options.timedOut,
+			options.verbosity ?? "receipt",
+			verifiedOutputIds,
+		);
 		for (const id of options.notFoundIds ?? []) {
 			snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 		}
@@ -417,9 +484,13 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (snapshot.jobId !== snapshot.id) lines.push(`Job: ${snapshot.jobId}`);
 			if (snapshot.agent) lines.push(`Agent: ${snapshot.agent} (${snapshot.agentSource})`);
 			if (snapshot.description) lines.push(`Description: ${snapshot.description}`);
+			if (snapshot.outputRef) lines.push(`Output: ${snapshot.outputRef}`);
 			if (snapshot.assignment) lines.push("Assignment:", "```", snapshot.assignment, "```");
-			if (snapshot.resultText) lines.push("Result:", "```", snapshot.resultText, "```");
-			if (snapshot.errorText) lines.push("Error:", "```", snapshot.errorText, "```");
+			if (snapshot.resultPreview) {
+				lines.push(snapshot.errorText ? "Error preview:" : "Result preview:", "```", snapshot.resultPreview, "```");
+				if (snapshot.truncated)
+					lines.push("Preview truncated; use the output ref or explicit ids with `verbosity=full` for more.");
+			}
 			if (snapshot.guidance) lines.push(`Guidance: ${snapshot.guidance}`);
 			lines.push("");
 		}
@@ -429,15 +500,27 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		};
 	}
 
-	#recordSnapshots(manager: AsyncJobManager, records: SubagentRecord[], timedOut = false): SubagentSnapshot[] {
-		return records.map(record => this.#recordSnapshot(manager, record, timedOut));
+	#recordSnapshots(
+		manager: AsyncJobManager,
+		records: SubagentRecord[],
+		timedOut = false,
+		verbosity: SubagentParams["verbosity"] = "receipt",
+		verifiedOutputIds: ReadonlySet<string>,
+	): SubagentSnapshot[] {
+		return records.map(record => this.#recordSnapshot(manager, record, timedOut, verbosity, verifiedOutputIds));
 	}
 
-	#recordSnapshot(manager: AsyncJobManager, record: SubagentRecord, timedOut = false): SubagentSnapshot {
+	#recordSnapshot(
+		manager: AsyncJobManager,
+		record: SubagentRecord,
+		timedOut = false,
+		verbosity: SubagentParams["verbosity"] = "receipt",
+		verifiedOutputIds: ReadonlySet<string>,
+	): SubagentSnapshot {
 		const job = record.currentJobId ? manager.getJob(record.currentJobId) : undefined;
 		if (job) {
 			return {
-				...this.#snapshot(job, timedOut),
+				...this.#snapshot(job, timedOut, verbosity, verifiedOutputIds, record),
 				id: record.subagentId,
 				jobId: record.currentJobId ?? job.id,
 				status: record.status,
@@ -451,29 +534,76 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			agent: "unknown",
 			agentSource: "bundled",
 			durationMs: 0,
+			...(verifiedOutputIds.has(record.subagentId) ? { outputRef: `agent://${record.subagentId}` } : {}),
 		};
 	}
 
-	#snapshot(job: AsyncJob, timedOut = false): SubagentSnapshot {
+	#snapshot(
+		job: AsyncJob,
+		timedOut = false,
+		verbosity: SubagentParams["verbosity"] = "receipt",
+		verifiedOutputIds: ReadonlySet<string>,
+		record?: SubagentRecord,
+	): SubagentSnapshot {
 		const subagent = job.metadata?.subagent;
 		const runningTimeoutGuidance =
 			timedOut && job.status === "running"
 				? "Still running after the await timeout; timeout only bounded this wait and is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong."
 				: undefined;
+		const output = previewJobOutput(job, verbosity);
+		const outputRef = record && verifiedOutputIds.has(record.subagentId) ? `agent://${record.subagentId}` : undefined;
 		return {
 			id: subagent?.id ?? job.id,
 			jobId: job.id,
 			status: job.status,
-			label: sanitizeText(job.label),
+			label: sanitizeText(job.label, RECEIPT_PREVIEW_WIDTH),
 			agent: subagent?.agent ?? "unknown",
 			agentSource: subagent?.agentSource ?? "bundled",
 			durationMs: Math.max(0, Date.now() - job.startTime),
-			...(subagent?.description ? { description: sanitizeText(subagent.description) } : {}),
-			...(subagent?.assignment ? { assignment: sanitizeText(subagent.assignment) } : {}),
-			...(job.resultText ? { resultText: sanitizeText(job.resultText) } : {}),
-			...(job.errorText ? { errorText: sanitizeText(job.errorText) } : {}),
+			...(subagent?.description ? { description: sanitizeText(subagent.description, RECEIPT_PREVIEW_WIDTH) } : {}),
+			...(verbosity === "full" && subagent?.assignment
+				? { assignment: sanitizeText(subagent.assignment, FULL_PREVIEW_WIDTH) }
+				: {}),
+			...(output
+				? {
+						...(output.type === "error" ? { errorText: output.preview } : { resultText: output.preview }),
+						resultPreview: output.preview,
+						truncated: output.truncated,
+					}
+				: {}),
+			...(outputRef ? { outputRef } : {}),
 			...(runningTimeoutGuidance ? { guidance: runningTimeoutGuidance } : {}),
 		};
+	}
+
+	async #verifiedOutputIds(records: SubagentRecord[]): Promise<Set<string>> {
+		const ids = new Set(records.map(record => record.subagentId));
+		const dirs = this.#artifactDirsForRecords(records);
+		const verified = new Set<string>();
+		await Promise.all(
+			[...ids].map(async id => {
+				for (const dir of dirs) {
+					if (await Bun.file(path.join(dir, `${id}.md.meta.json`)).exists()) {
+						verified.add(id);
+						return;
+					}
+				}
+			}),
+		);
+		return verified;
+	}
+
+	#artifactDirsForRecords(records: SubagentRecord[]): string[] {
+		const dirs: string[] = [];
+		for (const record of records) {
+			if (!record.sessionFile) continue;
+			const dir = path.dirname(record.sessionFile);
+			if (!dirs.includes(dir)) dirs.push(dir);
+		}
+		for (const dir of artifactsDirsFromRegistry()) {
+			if (!dirs.includes(dir)) dirs.push(dir);
+		}
+		return dirs;
 	}
 
 	#missingSnapshot(id: string, status: "not_found", guidance: string): SubagentSnapshot {
@@ -498,6 +628,23 @@ function isSubagentJob(job: AsyncJob): boolean {
 	return job.type === "task" && job.metadata?.subagent !== undefined;
 }
 
-function sanitizeText(text: string): string {
-	return truncateToWidth(replaceTabs(text), TEXT_PREVIEW_WIDTH, Ellipsis.Unicode);
+function sanitizeText(text: string, width: number): string {
+	return truncateToWidth(replaceTabs(text), width, Ellipsis.Unicode);
+}
+
+function previewJobOutput(
+	job: AsyncJob,
+	verbosity: SubagentParams["verbosity"] = "receipt",
+): { type: "result" | "error"; preview: string; truncated: boolean } | undefined {
+	const source = job.errorText
+		? { type: "error" as const, text: job.errorText }
+		: job.resultText
+			? { type: "result" as const, text: job.resultText }
+			: undefined;
+	if (!source) return undefined;
+	const width =
+		verbosity === "full" ? FULL_PREVIEW_WIDTH : verbosity === "preview" ? PREVIEW_WIDTH : RECEIPT_PREVIEW_WIDTH;
+	const normalized = replaceTabs(source.text);
+	const preview = truncateToWidth(normalized, width, Ellipsis.Unicode);
+	return { type: source.type, preview, truncated: preview !== normalized };
 }

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { AsyncJobManager } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import { SubagentTool, type ToolSession } from "../../src/tools";
@@ -311,5 +314,152 @@ describe("SubagentTool", () => {
 		expect(result.details?.subagents[0]?.status).toBe("running");
 		expect(result.details?.subagents[0]?.jobId).toBe("job-auto-resumed");
 		await manager.dispose({ timeoutMs: 100 });
+	});
+	it("list and inspect default terminal subagents return receipt previews without bulk output and no unverified ref", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const leak = "LEAK_SENTINEL_DO_NOT_DIGEST";
+		const bulk = `${"a".repeat(300)}${leak}${"b".repeat(64 * 1024)}`;
+		const jobId = manager.register("task", "leaky subagent", async () => bulk, {
+			id: "0-Leaky",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-Leaky", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.registerSubagentRecord({
+			subagentId: "0-Leaky",
+			ownerId: "0-Main",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Leaky.jsonl",
+			resumable: true,
+		});
+		await manager.getJob(jobId)?.promise;
+
+		const listed = await tool.execute("subagent-list-leak", { action: "list" });
+		const inspected = await tool.execute("subagent-inspect-leak", { action: "inspect", ids: ["0-Leaky"] });
+
+		for (const result of [listed, inspected]) {
+			const snapshot = result.details?.subagents[0];
+			expect(snapshot?.resultPreview?.length ?? 0).toBeLessThanOrEqual(281);
+			expect(snapshot?.resultText).toBe(snapshot?.resultPreview);
+			expect(snapshot?.outputRef).toBeUndefined();
+			expect(snapshot?.truncated).toBe(true);
+			expect(getText(result)).not.toContain(leak);
+			expect(getText(result).length).toBeLessThan(2_000);
+		}
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("supports preview and explicit full verbosity bounds without unverified refs", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const bulk = "x".repeat(5_000);
+		const jobId = manager.register("task", "verbose subagent", async () => bulk, {
+			id: "0-Verbose",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-Verbose", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.registerSubagentRecord({
+			subagentId: "0-Verbose",
+			ownerId: "0-Main",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-Verbose.jsonl",
+			resumable: true,
+		});
+		await manager.getJob(jobId)?.promise;
+
+		const preview = await tool.execute("subagent-preview", {
+			action: "inspect",
+			ids: ["0-Verbose"],
+			verbosity: "preview",
+		});
+		expect(preview.details?.subagents[0]?.resultPreview?.length ?? 0).toBeLessThanOrEqual(2_001);
+		expect(preview.details?.subagents[0]?.truncated).toBe(true);
+
+		await expect(tool.execute("subagent-full-bare", { action: "inspect", verbosity: "full" })).rejects.toThrow(
+			"requires explicit `ids`",
+		);
+		await expect(
+			tool.execute("subagent-full-list", { action: "list", ids: ["0-Verbose"], verbosity: "full" }),
+		).rejects.toThrow("cannot be used with `list`");
+
+		const full = await tool.execute("subagent-full", {
+			action: "inspect",
+			ids: ["0-Verbose"],
+			verbosity: "full",
+		});
+		expect(full.details?.subagents[0]?.resultPreview?.length).toBe(5_000);
+		expect(full.details?.subagents[0]?.outputRef).toBeUndefined();
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("await default returns bounded preview with output ref instead of full retained text", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const leak = "LEAK_SENTINEL_DO_NOT_DIGEST";
+		const bulk = `${"a".repeat(300)}${leak}${"b".repeat(64 * 1024)}`;
+		const jobId = manager.register("task", "await leaky subagent", async () => bulk, {
+			id: "0-AwaitLeaky",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-AwaitLeaky", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.registerSubagentRecord({
+			subagentId: "0-AwaitLeaky",
+			ownerId: "0-Main",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/0-AwaitLeaky.jsonl",
+			resumable: true,
+		});
+
+		const result = await tool.execute("subagent-await-leak", {
+			action: "await",
+			ids: ["0-AwaitLeaky"],
+			timeout_ms: 100,
+		});
+
+		const snapshot = result.details?.subagents[0];
+		expect(snapshot?.resultPreview?.length ?? 0).toBeLessThanOrEqual(281);
+		expect(snapshot?.outputRef).toBeUndefined();
+		expect(snapshot?.truncated).toBe(true);
+		expect(getText(result)).not.toContain(leak);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("includes output ref only when an agent output sidecar exists in the subagent artifact dir", async () => {
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "subagent-output-ref-"));
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register("task", "artifact-backed subagent", async () => "artifact backed result", {
+			id: "0-ArtifactBacked",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-ArtifactBacked", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.registerSubagentRecord({
+			subagentId: "0-ArtifactBacked",
+			ownerId: "0-Main",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: path.join(artifactsDir, "0-ArtifactBacked.jsonl"),
+			resumable: true,
+		});
+		await manager.getJob(jobId)?.promise;
+		await Bun.write(path.join(artifactsDir, "0-ArtifactBacked.md"), "artifact backed result");
+		await Bun.write(path.join(artifactsDir, "0-ArtifactBacked.md.meta.json"), "{}");
+
+		const result = await tool.execute("subagent-artifact-backed", {
+			action: "inspect",
+			ids: ["0-ArtifactBacked"],
+		});
+
+		expect(result.details?.subagents[0]?.outputRef).toBe("agent://0-ArtifactBacked");
+		expect(getText(result)).toContain("Output: agent://0-ArtifactBacked");
+		await manager.dispose({ timeoutMs: 100 });
+		await fs.rm(artifactsDir, { recursive: true, force: true });
 	});
 });


### PR DESCRIPTION
## Token-efficiency program — PR3 of 10 (stacked on PR2 #248)

> Base is the PR2 branch; chain is PR1 #246 <- PR2 #248 <- PR3. Retarget to `dev` as predecessors merge.

### What
Stops the `subagent` tool's `list`/`inspect`/`await` from inlining up to 12KB of raw subagent output per agent by default (a second digest channel).

- Adds `verbosity: receipt | preview | full` (default **receipt**). Bounds: receipt <=280 chars, preview <=2000, full <=12000. `full` is rejected for `list` and requires explicit `ids` for every other action.
- All snapshot paths (list/inspect/await/cancel/pause/resume/steer/progress) go through one bounded preview builder; assignment text only at full verbosity.
- Snapshots add an `agent://<id>` output ref **only when the verified `${id}.md.meta.json` sidecar actually exists** (probed once per action across the record session dir + registry dirs) — never advertises a non-resolving ref. Full output is retrieved explicitly via the hash/size-verified resolver from PR1/PR2.
- Updates the bundled subagent prompt doc.

### Verification
- tsgo clean; biome clean
- subagent + tool-discovery suites: 17 pass / 0 fail (receipt-default no-bulk-leak, preview/full bounds, list+full & full-without-ids rejection, output-ref-only-with-real-sidecar)
- Architect 3-lane review: 2 blockers (list+full bypass; output ref from resumable-not-verified) — both fixed in this PR with regression tests and re-verified.
