### PR TITLE
Number deep-interview ask choices

### DIFF
--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -330,6 +330,12 @@ export function renderDeepInterviewAskQuestion(question: string, uiTheme: Theme)
 	return renderModel(model, uiTheme);
 }
 
+export function isDeepInterviewAskQuestion(question: string): boolean {
+	if (parseTopologyQuestion(question) ?? parseRoundQuestion(question)) return true;
+	const normalized = normalizeText(question);
+	return /(?:^|\n)\s*Round\s+\d+\s*\|.*?\bAmbiguity\b/i.test(normalized);
+}
+
 export function formatDeepInterviewSelectorPrompt(question: string): string | null {
 	const model = parseTopologyQuestion(question) ?? parseRoundQuestion(question);
 	if (!model) return null;

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -28,7 +28,11 @@ import {
 } from "@gajae-code/tui";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
-import { formatDeepInterviewSelectorPrompt, renderDeepInterviewAskQuestion } from "../deep-interview/render-middleware";
+import {
+	formatDeepInterviewSelectorPrompt,
+	isDeepInterviewAskQuestion,
+	renderDeepInterviewAskQuestion,
+} from "../deep-interview/render-middleware";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { getMarkdownTheme, type Theme, theme } from "../modes/theme/theme";
 import askDescription from "../prompts/tools/ask.md" with { type: "text" };
@@ -117,6 +121,17 @@ function stripRecommendedSuffix(label: string): string {
 	return label.endsWith(RECOMMENDED_SUFFIX) ? label.slice(0, -RECOMMENDED_SUFFIX.length) : label;
 }
 
+function formatNumberedOptionLabel(label: string, index: number): string {
+	if (/^\s*\d+[.)]\s+/.test(label)) {
+		return label;
+	}
+	return `${index + 1}. ${label}`;
+}
+
+function numberOptionLabels(labels: string[]): string[] {
+	return labels.map(formatNumberedOptionLabel);
+}
+
 // =============================================================================
 // Question Selection Logic
 // =============================================================================
@@ -141,6 +156,7 @@ interface AskSingleQuestionOptions {
 	initialSelection?: Pick<SelectionResult, "selectedOptions" | "customInput">;
 	navigation?: NavigationControls;
 	scrollTitleRows?: number;
+	otherOptionLabel?: string;
 }
 
 interface UIContext {
@@ -231,6 +247,7 @@ async function askSingleQuestion(
 		const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
 		return { input };
 	};
+	const otherOptionLabel = options.otherOptionLabel ?? OTHER_OPTION;
 
 	const promptWithProgress = navigation?.progressText ? `${question} (${navigation.progressText})` : question;
 	if (multi) {
@@ -252,7 +269,7 @@ async function askSingleQuestion(
 			if (!navigation?.allowForward && selected.size > 0) {
 				opts.push(doneLabel);
 			}
-			opts.push(OTHER_OPTION);
+			opts.push(otherOptionLabel);
 
 			const prefix = selected.size > 0 ? `(${selected.size} selected) ` : "";
 			const {
@@ -273,7 +290,7 @@ async function askSingleQuestion(
 			}
 			if (choice === doneLabel) break;
 
-			if (choice === OTHER_OPTION) {
+			if (choice === otherOptionLabel) {
 				if (selectTimedOut) {
 					timedOut = true;
 					break;
@@ -315,7 +332,7 @@ async function askSingleQuestion(
 		selectedOptions = Array.from(selected);
 	} else {
 		const displayLabels = addRecommendedSuffix(optionLabels, recommended);
-		const optionsWithNavigation = [...displayLabels, OTHER_OPTION];
+		const optionsWithNavigation = [...displayLabels, otherOptionLabel];
 
 		let initialIndex = recommended;
 		const previouslySelected = selectedOptions[0];
@@ -344,7 +361,7 @@ async function askSingleQuestion(
 			if (!timedOut) {
 				return { selectedOptions, customInput, timedOut, cancelled: true };
 			}
-		} else if (choice === OTHER_OPTION) {
+		} else if (choice === otherOptionLabel) {
 			if (!selectTimedOut) {
 				const customResult = await promptForCustomInput();
 				if (customResult.input !== undefined) {
@@ -458,25 +475,46 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			q: AskParams["questions"][number],
 			options?: { previous?: QuestionResult; navigation?: NavigationControls },
 		) => {
-			const optionLabels = q.options.map(o => o.label);
+			const rawOptionLabels = q.options.map(o => o.label);
 			try {
 				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
 				const displayQuestion = deepInterviewPrompt ?? q.question;
-				const { selectedOptions, customInput, navigation, cancelled, timedOut } = await askSingleQuestion(
-					ui,
-					displayQuestion,
-					optionLabels,
-					q.multi ?? false,
-					{
-						recommended: q.recommended,
-						timeout: timeout ?? undefined,
-						signal,
-						initialSelection: options?.previous,
-						navigation: options?.navigation,
-						scrollTitleRows: deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
-					},
-				);
-				return { optionLabels, selectedOptions, customInput, navigation, cancelled, timedOut };
+				const shouldNumberOptions = isDeepInterviewAskQuestion(q.question);
+				const optionLabels = shouldNumberOptions ? numberOptionLabels(rawOptionLabels) : rawOptionLabels;
+				const initialSelection =
+					shouldNumberOptions && options?.previous
+						? {
+								...options.previous,
+								selectedOptions: options.previous.selectedOptions.map(selected => {
+									const rawIndex = rawOptionLabels.indexOf(selected);
+									return rawIndex >= 0 ? (optionLabels[rawIndex] ?? selected) : selected;
+								}),
+							}
+						: options?.previous;
+				const {
+					selectedOptions: displaySelectedOptions,
+					customInput,
+					navigation,
+					cancelled,
+					timedOut,
+				} = await askSingleQuestion(ui, displayQuestion, optionLabels, q.multi ?? false, {
+					recommended: q.recommended,
+					timeout: timeout ?? undefined,
+					signal,
+					initialSelection,
+					navigation: options?.navigation,
+					scrollTitleRows: deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
+					otherOptionLabel: shouldNumberOptions
+						? formatNumberedOptionLabel(OTHER_OPTION, optionLabels.length)
+						: undefined,
+				});
+				const selectedOptions = shouldNumberOptions
+					? displaySelectedOptions.map(selected => {
+							const displayIndex = optionLabels.indexOf(selected);
+							return displayIndex >= 0 ? (rawOptionLabels[displayIndex] ?? selected) : selected;
+						})
+					: displaySelectedOptions;
+				return { optionLabels: rawOptionLabels, selectedOptions, customInput, navigation, cancelled, timedOut };
 			} catch (error) {
 				if (error instanceof Error && error.name === "AbortError") {
 					throw new ToolAbortError("Ask input was cancelled");
@@ -668,17 +706,17 @@ export const askToolRenderer = {
 				container.addChild(
 					new Text(` ${uiTheme.fg("dim", qBranch)} ${uiTheme.fg("dim", `[${q.id}]`)}${metaStr}`, 0, 0),
 				);
-				container.addChild(
-					renderDeepInterviewAskQuestion(q.question, uiTheme) ??
-						new Markdown(q.question, 3, 0, mdTheme, accentStyle),
-				);
+				const deepInterviewQuestion = renderDeepInterviewAskQuestion(q.question, uiTheme);
+				container.addChild(deepInterviewQuestion ?? new Markdown(q.question, 3, 0, mdTheme, accentStyle));
 
 				const qOptions = q.options;
 				if (qOptions?.length) {
 					const entries = qOptions.map((opt, j) => {
 						const isLastOpt = j === qOptions.length - 1;
 						const optBranch = isLastOpt ? uiTheme.tree.last : uiTheme.tree.branch;
-						const optLabel = renderInlineMarkdown(opt.label, mdTheme, t => uiTheme.fg("muted", t));
+						const shouldNumberOption = deepInterviewQuestion !== null || isDeepInterviewAskQuestion(q.question);
+						const displayLabel = shouldNumberOption ? formatNumberedOptionLabel(opt.label, j) : opt.label;
+						const optLabel = renderInlineMarkdown(displayLabel, mdTheme, t => uiTheme.fg("muted", t));
 						return {
 							prefix: ` ${uiTheme.fg("dim", continuation)}   ${uiTheme.fg("dim", optBranch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} `,
 							label: optLabel,
@@ -694,23 +732,24 @@ export const askToolRenderer = {
 		if (!args.question) {
 			return new Text(formatErrorMessage("No question provided", uiTheme), 0, 0);
 		}
+		const question = args.question;
 
 		const container = new Container();
 		const meta: string[] = [];
 		if (args.multi) meta.push("multi");
 		if (args.options?.length) meta.push(`options:${args.options.length}`);
 		container.addChild(new Text(`${label}${formatMeta(meta, uiTheme)}`, 0, 0));
-		container.addChild(
-			renderDeepInterviewAskQuestion(args.question, uiTheme) ??
-				new Markdown(args.question, 1, 0, mdTheme, accentStyle),
-		);
+		const deepInterviewQuestion = renderDeepInterviewAskQuestion(question, uiTheme);
+		container.addChild(deepInterviewQuestion ?? new Markdown(question, 1, 0, mdTheme, accentStyle));
 
 		const options = args.options;
 		if (options?.length) {
 			const entries = options.map((opt, i) => {
 				const isLast = i === options.length - 1;
 				const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
-				const optLabel = renderInlineMarkdown(opt.label, mdTheme, t => uiTheme.fg("muted", t));
+				const shouldNumberOption = deepInterviewQuestion !== null || isDeepInterviewAskQuestion(question);
+				const displayLabel = shouldNumberOption ? formatNumberedOptionLabel(opt.label, i) : opt.label;
+				const optLabel = renderInlineMarkdown(displayLabel, mdTheme, t => uiTheme.fg("muted", t));
 				return {
 					prefix: ` ${uiTheme.fg("dim", branch)} ${uiTheme.fg("dim", uiTheme.checkbox.unchecked)} `,
 					label: optLabel,

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1061,6 +1061,7 @@ describe("AskTool deep-interview rendering middleware", () => {
 		);
 
 		expect(select).toHaveBeenCalledTimes(1);
+		expect(select.mock.calls[0]?.[1]).toEqual(["1. Condition A", "2. Condition B", "3. Other (type your own)"]);
 		const prompt = select.mock.calls[0]?.[0] ?? "";
 		expect(prompt).toContain("Deep Interview · Round 3 · Ambiguity 38%");
 		expect(prompt).toContain("Component: Review UI");
@@ -1068,6 +1069,107 @@ describe("AskTool deep-interview rendering middleware", () => {
 		expect(prompt).toContain("Why now: the approval criteria are not yet testable");
 		expect(prompt).toContain("What exact conditions must be satisfied before a reviewer can approve an item?");
 		expect(result.details?.question).toBe(rawQuestion);
+		expect(result.details?.options).toEqual(["Condition A", "Condition B"]);
+		expect(result.details?.selectedOptions).toEqual(["Condition A"]);
+		expect(result.content[0]).toMatchObject({ type: "text", text: "User selected: Condition A" });
+	});
+
+	it("does not double-number pre-numbered deep-interview options", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 6 | Component: Review UI | Targeting: Success Criteria | Why now: answer labels might already be numbered | Ambiguity: 29%",
+			"",
+			"Which acceptance shape should be used?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[1]);
+		const context = createContext({ select });
+
+		const result = await tool.execute(
+			"call-deep-interview-pre-numbered",
+			{
+				questions: [
+					{
+						id: "round-6",
+						question: rawQuestion,
+						options: [{ label: "1. Checklist" }, { label: "2) Scenario" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(select.mock.calls[0]?.[1]).toEqual(["1. Checklist", "2) Scenario", "3. Other (type your own)"]);
+		expect(result.details?.selectedOptions).toEqual(["2) Scenario"]);
+	});
+
+	it("numbers loosely formatted deep-interview questions that are not structurally rendered", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 7 | Component Review UI | Target Success Criteria | Why now option labels must remain scannable | Ambiguity is 34%",
+			"",
+			"What outcome proves the numbering is visible?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[0]);
+		const context = createContext({ select });
+
+		const result = await tool.execute(
+			"call-deep-interview-loose",
+			{
+				questions: [
+					{
+						id: "round-7",
+						question: rawQuestion,
+						options: [{ label: "Numbered choices are visible" }, { label: "Raw answer labels are preserved" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(select.mock.calls[0]?.[0]).toBe(rawQuestion);
+		expect(select.mock.calls[0]?.[1]).toEqual([
+			"1. Numbered choices are visible",
+			"2. Raw answer labels are preserved",
+			"3. Other (type your own)",
+		]);
+		expect(result.details?.selectedOptions).toEqual(["Numbered choices are visible"]);
+	});
+
+	it("accepts the numbered deep-interview free-text option as custom input", async () => {
+		const tool = new AskTool(createSession());
+		const rawQuestion = [
+			"Round 5 | Component: Review UI | Targeting: Constraints | Why now: boundaries are still unclear | Ambiguity: 31%",
+			"",
+			"Which boundary matters most?",
+		].join("\n");
+		const select = vi.fn(async (_prompt: string, options: string[]) => options[2]);
+		const editor = vi.fn(async () => "Use my own boundary");
+		const context = createContext({ select, editor });
+
+		const result = await tool.execute(
+			"call-deep-interview-other",
+			{
+				questions: [
+					{
+						id: "round-5",
+						question: rawQuestion,
+						options: [{ label: "Performance" }, { label: "Security" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(select.mock.calls[0]?.[1]).toEqual(["1. Performance", "2. Security", "3. Other (type your own)"]);
+		expect(editor).toHaveBeenCalledTimes(1);
+		expect(result.details?.selectedOptions).toEqual([]);
+		expect(result.details?.customInput).toBe("Use my own boundary");
 	});
 
 	it("opts deep-interview selector prompts into local prompt scrolling", async () => {
@@ -1204,6 +1306,8 @@ describe("AskTool deep-interview rendering middleware", () => {
 		expect(renderedText).toContain("Export");
 		expect(renderedText).toContain("Why now");
 		expect(renderedText).toContain("Question");
+		expect(renderedText).toContain("1. CSV");
+		expect(renderedText).toContain("2. PDF");
 		expect(renderedText).not.toContain("Round 2 | Component:");
 	});
 });

--- a/scripts/rebrand-inventory.ts
+++ b/scripts/rebrand-inventory.ts
@@ -180,7 +180,25 @@ function rootScriptAllowlistFor(line: string): string | undefined {
 }
 
 function scanLegacyHits(): LegacyHit[] {
-	const roots = ["README.md", "docs", "packages", "python", "scripts", ".gjc", "assets", "package.json", "Cargo.toml", "Dockerfile", "Dockerfile.robogjc", "Dockerfile.dockerignore", "Dockerfile.robogjc.dockerignore"];
+	const roots = [
+		"README.md",
+		"docs",
+		"packages",
+		"python",
+		"scripts",
+		".gjc/skills",
+		".gjc/agents",
+		".gjc/commands",
+		".gjc/rules",
+		".gjc/settings.json",
+		"assets",
+		"package.json",
+		"Cargo.toml",
+		"Dockerfile",
+		"Dockerfile.robogjc",
+		"Dockerfile.dockerignore",
+		"Dockerfile.robogjc.dockerignore",
+	];
 	const files = roots.flatMap(root => {
 		const full = path.join(repoRoot, root);
 		if (!fs.existsSync(full)) return [];


### PR DESCRIPTION
## Summary
- number Deep Interview ask choice labels in the selector and ask-card renderer via middleware only
- preserve the Deep Interview prompt contract and map tool results/details back to original option labels
- cover loose Deep Interview prompt detection, pre-numbered labels, previous-selection restore, and free-text option numbering
- avoid scanning runtime .gjc state in rebrand inventory strict checks

## Verification
- bun test packages/coding-agent/test/tools/ask.test.ts
- bun run check:ts

Rebased cleanly on latest origin/dev (08bcf67).