### PR TITLE
fix(coding-agent): resume agent after auto-compaction instead of stopping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Render terminal-pasted clipboard image temp paths as compact `[image N]` prompt placeholders while attaching the image payload, instead of inserting raw `/var/folders/.../clipboard-*.png` path text.
+- Fixed the interactive agent unexpectedly stopping after automatic context maintenance instead of resuming the in-flight task. Post-compaction continuation now schedules exactly one source per completion (overflow retry → queued messages → synthetic auto-continue prompt), the threshold/handoff auto-continue prompt skips a redundant pre-send compaction check, overflow retry strips only the context-overflow failed turn (never normal/aborted/silent-abort tails), and non-resumable or superseded continuations log a structured reason instead of stranding the session.
 
 ## [0.3.0] - 2026-06-03
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2145,13 +2145,23 @@ export class AgentSession {
 		delayMs?: number;
 		generation?: number;
 		shouldContinue?: () => boolean;
-		onSkip?: () => void;
-		onError?: () => void;
+		onSkip?: (reason: "generation_changed" | "aborted_signal" | "queue_drained") => void;
+		onError?: (error: unknown) => void;
 	}): void {
+		const scheduledGeneration = options?.generation;
+		const signal = this.#postPromptTasksAbortController.signal;
 		this.#schedulePostPromptTask(
 			async () => {
+				if (signal.aborted) {
+					options?.onSkip?.("aborted_signal");
+					return;
+				}
+				if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
+					options?.onSkip?.("generation_changed");
+					return;
+				}
 				if (options?.shouldContinue && !options.shouldContinue()) {
-					options.onSkip?.();
+					options.onSkip?.("queue_drained");
 					return;
 				}
 				try {
@@ -2161,15 +2171,43 @@ export class AgentSession {
 					logger.warn("agent.continue failed after scheduling", {
 						error: error instanceof Error ? error.message : String(error),
 					});
-					options?.onError?.();
+					options?.onError?.(error);
 				}
 			},
-			{
-				delayMs: options?.delayMs,
-				generation: options?.generation,
-				onSkip: options?.onSkip,
-			},
+			{ delayMs: options?.delayMs },
 		);
+	}
+
+	#logCompactionContinuationSkipped(
+		source: "auto_continue_prompt" | "queued_continue" | "overflow_retry",
+		reason: string,
+	): void {
+		logger.warn("Auto-compaction continuation skipped", { source, reason });
+	}
+
+	#logCompactionContinuationError(
+		source: "auto_continue_prompt" | "queued_continue" | "overflow_retry",
+		error: unknown,
+	): void {
+		logger.warn("Auto-compaction continuation failed", {
+			source,
+			reason: error instanceof Error && error.name === "AgentBusyError" ? "queue_drained" : "not_resumable_tail",
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	#isResumableAgentTail(): boolean {
+		const lastMsg = this.agent.state.messages.at(-1);
+		return lastMsg !== undefined && lastMsg.role !== "assistant";
+	}
+
+	#stripOverflowFailedTurnForRetry(): void {
+		const messages = this.agent.state.messages;
+		const lastMsg = messages.at(-1);
+		const contextWindow = this.model?.contextWindow ?? 0;
+		if (lastMsg?.role === "assistant" && isContextOverflow(lastMsg as AssistantMessage, contextWindow)) {
+			this.agent.replaceMessages(messages.slice(0, -1));
+		}
 	}
 
 	#scheduleAutoContinuePrompt(generation: number): void {
@@ -2182,16 +2220,28 @@ export class AgentSession {
 					timestamp: Date.now(),
 				},
 				autoContinuePrompt,
-				{ skipPostPromptRecoveryWait: true },
+				{ skipPostPromptRecoveryWait: true, skipCompactionCheck: true },
 			);
 		};
-		this.#schedulePostPromptTask(
-			async signal => {
+		const scheduledGeneration = generation;
+		const signal = this.#postPromptTasksAbortController.signal;
+		this.#trackPostPromptTask(
+			(async () => {
 				await Promise.resolve();
-				if (signal.aborted) return;
-				await continuePrompt();
-			},
-			{ generation },
+				if (signal.aborted) {
+					this.#logCompactionContinuationSkipped("auto_continue_prompt", "aborted_signal");
+					return;
+				}
+				if (this.#promptGeneration !== scheduledGeneration) {
+					this.#logCompactionContinuationSkipped("auto_continue_prompt", "generation_changed");
+					return;
+				}
+				try {
+					await continuePrompt();
+				} catch (error) {
+					this.#logCompactionContinuationError("auto_continue_prompt", error);
+				}
+			})(),
 		);
 	}
 
@@ -6945,12 +6995,34 @@ export class AgentSession {
 					willRetry: false,
 					skipped: true,
 				});
-				if (!willRetry && this.agent.hasQueuedMessages()) {
+				if (willRetry) {
+					this.#stripOverflowFailedTurnForRetry();
+					if (this.#isResumableAgentTail()) {
+						this.#scheduleAgentContinue({
+							delayMs: 100,
+							generation,
+							onSkip: skipReason => this.#logCompactionContinuationSkipped("overflow_retry", skipReason),
+							onError: error => this.#logCompactionContinuationError("overflow_retry", error),
+						});
+					} else {
+						const tail = this.agent.state.messages.at(-1) as AssistantMessage | undefined;
+						logger.warn("Auto-compaction continuation skipped", {
+							source: "overflow_retry",
+							reason: "not_resumable_tail",
+							role: tail?.role,
+							stopReason: tail?.stopReason,
+						});
+					}
+				} else if (reason !== "idle" && this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({
 						delayMs: 100,
 						generation,
 						shouldContinue: () => this.agent.hasQueuedMessages(),
+						onSkip: skipReason => this.#logCompactionContinuationSkipped("queued_continue", skipReason),
+						onError: error => this.#logCompactionContinuationError("queued_continue", error),
 					});
+				} else if (reason !== "idle" && compactionSettings.autoContinue !== false) {
+					this.#scheduleAutoContinuePrompt(generation);
 				}
 				return;
 			}
@@ -7152,26 +7224,36 @@ export class AgentSession {
 			};
 			await this.#emitSessionEvent({ type: "auto_compaction_end", action, result, aborted: false, willRetry });
 
-			if (!willRetry && reason !== "idle" && compactionSettings.autoContinue !== false) {
-				this.#scheduleAutoContinuePrompt(generation);
-			}
-
 			if (willRetry) {
-				const messages = this.agent.state.messages;
-				const lastMsg = messages[messages.length - 1];
-				if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
-					this.agent.replaceMessages(messages.slice(0, -1));
+				this.#stripOverflowFailedTurnForRetry();
+				if (!this.#isResumableAgentTail()) {
+					const tail = this.agent.state.messages.at(-1) as AssistantMessage | undefined;
+					logger.warn("Auto-compaction continuation skipped", {
+						source: "overflow_retry",
+						reason: "not_resumable_tail",
+						role: tail?.role,
+						stopReason: tail?.stopReason,
+					});
+				} else {
+					this.#scheduleAgentContinue({
+						delayMs: 100,
+						generation,
+						onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
+						onError: error => this.#logCompactionContinuationError("overflow_retry", error),
+					});
 				}
-
-				this.#scheduleAgentContinue({ delayMs: 100, generation });
-			} else if (this.agent.hasQueuedMessages()) {
+			} else if (reason !== "idle" && this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
 				this.#scheduleAgentContinue({
 					delayMs: 100,
 					generation,
 					shouldContinue: () => this.agent.hasQueuedMessages(),
+					onSkip: reason => this.#logCompactionContinuationSkipped("queued_continue", reason),
+					onError: error => this.#logCompactionContinuationError("queued_continue", error),
 				});
+			} else if (reason !== "idle" && compactionSettings.autoContinue !== false) {
+				this.#scheduleAutoContinuePrompt(generation);
 			}
 		} catch (error) {
 			if (autoCompactionSignal.aborted) {

--- a/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getProjectAgentDir, logger, TempDir } from "@gajae-code/utils";
+
+const runtimeSignalStoreKey = "__gjcAutoContinueSignals";
+type RuntimeSignalGlobal = typeof globalThis & { [runtimeSignalStoreKey]?: string[] };
+
+function getRuntimeSignals(): string[] {
+	const globalWithSignals = globalThis as RuntimeSignalGlobal;
+	if (!globalWithSignals[runtimeSignalStoreKey]) globalWithSignals[runtimeSignalStoreKey] = [];
+	return globalWithSignals[runtimeSignalStoreKey];
+}
+
+function assistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: 190000,
+			output: 1000,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 191000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+		...overrides,
+	} as AssistantMessage;
+}
+
+async function advancePostPrompt(ms: number): Promise<void> {
+	await new Promise(resolve => setTimeout(resolve, ms));
+	for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+describe("AgentSession auto-compaction continuation", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	async function createSession(settings: Record<string, unknown> = {}, extensionExtra = "") {
+		tempDir = TempDir.createSync("@pi-auto-compaction-continue-");
+		vi.useRealTimers();
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
+		fs.writeFileSync(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async (event) => {',
+				'\t\treturn { compaction: { summary: "compacted", shortSummary: undefined, firstKeptEntryId: event.preparation.firstKeptEntryId, tokensBefore: event.preparation.tokensBefore, details: {} } };',
+				"\t});",
+				'\tpi.on("auto_compaction_start", async (event) => {',
+				`\t\tconst signals = globalThis.${runtimeSignalStoreKey} ?? (globalThis.${runtimeSignalStoreKey} = []);`,
+				'\t\tsignals.push("compaction:start:" + event.reason);',
+				"\t});",
+				'\tpi.on("auto_compaction_end", async (event) => {',
+				`\t\tconst signals = globalThis.${runtimeSignalStoreKey} ?? (globalThis.${runtimeSignalStoreKey} = []);`,
+				'\t\tsignals.push("compaction:end:" + (event.aborted ? "aborted" : "ok"));',
+				"\t});",
+				extensionExtra,
+				"}",
+			].join("\n"),
+		);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		getRuntimeSignals().length = 0;
+		const extensionsResult = await loadExtensions([extensionPath], tempDir.path());
+		const extensionRunner = new ExtensionRunner(
+			extensionsResult.extensions,
+			extensionsResult.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
+		sessionManager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.autoContinue": true,
+				"contextPromotion.enabled": false,
+				"todo.reminders": false,
+				...settings,
+			}),
+			modelRegistry,
+			extensionRunner,
+		});
+	}
+
+	beforeEach(async () => {
+		await createSession();
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		vi.useRealTimers();
+		getRuntimeSignals().length = 0;
+		vi.restoreAllMocks();
+	});
+
+	async function driveCompaction(message = assistantMessage()) {
+		sessionManager.appendMessage(message);
+		session.agent.emitExternalEvent({ type: "message_end", message });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [message] });
+		for (let i = 0; i < 20; i++) await Promise.resolve();
+		await session.waitForIdle();
+	}
+
+	it("threshold default starts one synthetic auto-continue prompt without re-compacting", async () => {
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		const events: string[] = [];
+		session.subscribe(event => events.push(event.type));
+		await driveCompaction();
+		await advancePostPrompt(50);
+		await session.waitForIdle();
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy.mock.calls[0]?.[0]).toEqual(
+			expect.arrayContaining([expect.objectContaining({ role: "developer", attribution: "agent" })]),
+		);
+		expect(getRuntimeSignals().filter(signal => signal === "compaction:start:threshold")).toHaveLength(1);
+		const endIndex = events.indexOf("auto_compaction_end");
+		expect(events.slice(endIndex + 1)).not.toContain("agent_end");
+		expect(promptSpy.mock.invocationCallOrder[0]).toBeGreaterThan(0);
+	});
+
+	it("overflow with non-resumable tail logs not_resumable_tail and does not continue", async () => {
+		const warnSpy = vi.spyOn(logger, "warn");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		const overflow = assistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
+		});
+		await driveCompaction(overflow);
+		await advancePostPrompt(200);
+		await session.waitForIdle();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(
+			warnSpy.mock.calls.some(call => String(call[0]).includes("Cannot continue from message role: assistant")),
+		).toBe(false);
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Auto-compaction continuation skipped" &&
+					JSON.stringify(call[1]).includes('"source":"overflow_retry"') &&
+					JSON.stringify(call[1]).includes('"reason":"not_resumable_tail"'),
+			),
+		).toBe(true);
+	});
+
+	it("overflow with resumable rebuilt tail strips failed turn and continues once", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.keepRecentTokens": 1 });
+		const warnSpy = vi.spyOn(logger, "warn");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		for (let i = 0; i < 4; i++) {
+			sessionManager.appendMessage({ role: "user", content: `seed user ${i}`, timestamp: Date.now() + i * 2 });
+			sessionManager.appendMessage(assistantMessage({ timestamp: Date.now() + i * 2 + 1 }));
+		}
+		sessionManager.appendMessage({
+			role: "user",
+			content: "latest resumable retry boundary",
+			timestamp: Date.now() + 100,
+		});
+		const overflow = assistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
+			timestamp: Date.now() + 101,
+		});
+		const originalReplaceMessages = session.agent.replaceMessages.bind(session.agent);
+		vi.spyOn(session.agent, "replaceMessages").mockImplementation(messages => {
+			originalReplaceMessages(messages);
+			const tail = session.agent.state.messages.at(-1);
+			if (tail?.role === "assistant" && tail.stopReason === "error") {
+				session.agent.appendMessage({
+					role: "user",
+					content: "latest resumable retry boundary",
+					timestamp: Date.now() + 102,
+				});
+				session.agent.appendMessage(overflow);
+			}
+		});
+		await driveCompaction(overflow);
+		await advancePostPrompt(200);
+		await session.waitForIdle();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Auto-compaction continuation skipped" &&
+					JSON.stringify(call[1]).includes('"reason":"not_resumable_tail"'),
+			),
+		).toBe(false);
+		const tail = session.agent.state.messages.at(-1);
+		expect(tail?.role).not.toBe("assistant");
+		expect(JSON.stringify(tail)).not.toContain("prompt is too long: 1000001 tokens > 1000000 maximum");
+	});
+
+	it("starts synthetic continuation when no generation supersedes it", async () => {
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		await driveCompaction();
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("threshold default with queued message uses queued continuation only", async () => {
+		session.agent.followUp({
+			role: "custom",
+			customType: "test",
+			content: [{ type: "text", text: "Queued" }],
+			display: false,
+			timestamp: Date.now(),
+		});
+		const warnSpy = vi.spyOn(logger, "warn");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		await driveCompaction();
+		await advancePostPrompt(200);
+		await session.waitForIdle();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(warnSpy.mock.calls.some(call => JSON.stringify(call).includes("AgentBusyError"))).toBe(false);
+	});
+
+	it("idle maintenance does not continue", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		await session.runIdleCompaction();
+		await advancePostPrompt(200);
+		await session.waitForIdle();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("autoContinue false without queue does not continue", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.autoContinue": false });
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		await driveCompaction();
+		await advancePostPrompt(200);
+		await session.waitForIdle();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("handoff threshold path schedules hardened auto-continue prompt", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.strategy": "handoff" });
+		vi.spyOn(session, "handoff").mockResolvedValue({ document: "handoff", savedPath: "handoff.md" });
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		await driveCompaction();
+		await advancePostPrompt(50);
+		await session.waitForIdle();
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(getRuntimeSignals()).toContain("compaction:end:ok");
+	});
+});


### PR DESCRIPTION
## Summary

In the interactive TUI the main agent **stopped mid-task after automatic context maintenance ("compaction") instead of continuing**. The continuation machinery lives in the shared `AgentSession`, and the documented contract (docs/compaction.md:97-118) was not honored on the default path. This hardens the post-compaction continuation contract for all consumers.

Root cause (confirmed by reproduction): after a **threshold** compaction the synthetic auto-continue developer prompt was never started; additionally, scheduled continuations could be silently dropped, overflow retry could swallow `agent.continue()`'s assistant-tail throw, and threshold+queued could double-schedule.

## Changes
`packages/coding-agent/src/session/agent-session.ts` (+110/-28):
- **Single-continuation coordinator** in `#runAutoCompaction`: schedule exactly one source per completion — overflow retry → queued messages → synthetic auto-continue prompt — in **both** the skipped-preparation and successful-compaction tails (no double-schedule).
- **Threshold + handoff** auto-continue prompt passes `skipCompactionCheck: true`, so the synthetic prompt no longer re-enters compaction with stale pre-compaction usage.
- **Overflow retry-boundary safety**: `#stripOverflowFailedTurnForRetry` strips only an `isContextOverflow`-matched assistant tail — never a normal / `aborted` / `SILENT_ABORT_MARKER` tail. Non-resumable tails log `not_resumable_tail` instead of silently stranding.
- **Observability**: `#scheduleAgentContinue` emits structured skip reasons (`generation_changed` / `aborted_signal` / `queue_drained`) and `onError`.
- `agent.continue()` global strictness is **preserved** (agent-core unchanged).

New deterministic regression test (no LLM) `packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts` (8 tests): threshold default (one synthetic prompt, no 2nd compaction, no terminal event before continuation), overflow resumable (strip + one continue) and non-resumable (`not_resumable_tail` logged, no swallowed throw), threshold+queued precedence, idle and `autoContinue:false` negatives, and the handoff threshold path.

Plus a CHANGELOG entry.

## Test plan
- `bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts` → 8 pass
- Regression (green): `agent-session-auto-compaction-queue`, `-x-initiator`, `agent-session-handoff`, `agent-session-silent-abort`, `agent-session-compaction`, `silent-abort-print-mode` → 29 pass / 5 skip / 0 fail
- `bun run check:ts` → exit 0
- `bun run lint:ts` → exit 0

## Review
Planned via consensus (Planner → Architect → Critic, APPROVE) and verified through a quality gate: architect 3-lane review **CLEAR / CLEAR / CLEAR + APPROVE, no blockers**; executor QA/red-team lane passed (tail-strip safety, single-continuation in both tails, queued precedence, structured skip logging).
