### PR TITLE
feat(perf): eliminate high-severity resource leaks + runtime owner gauges (perf stage 2)

### DIFF
--- a/packages/coding-agent/src/debug/runtime-gauges.ts
+++ b/packages/coding-agent/src/debug/runtime-gauges.ts
@@ -1,0 +1,20 @@
+/**
+ * Runtime resource owner gauges (Stage 2 observability).
+ *
+ * Reports counts of long-lived runtime owners as plain data so memory/CPU leak
+ * work can see whether owner maps grow without bound across a session. This is
+ * framework-agnostic on purpose: it does not depend on the TUI metrics surface,
+ * so any consumer (debug report, a metrics bridge, a test) can sample it.
+ */
+import { getShellSessionCount } from "../exec/bash-executor";
+
+/**
+ * Current runtime owner counts, keyed by `<owner>.<resource>`. Extend as more
+ * owners (Python kernels, LSP clients, browser tabs, async jobs, streaming
+ * queues) expose count getters.
+ */
+export function getRuntimeResourceCounts(): Record<string, number> {
+	return {
+		"bash.shellSessions": getShellSessionCount(),
+	};
+}

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -5,6 +5,7 @@
  */
 import * as fs from "node:fs/promises";
 import { executeShell, type MinimizerOptions, Shell } from "@gajae-code/natives";
+import { postmortem } from "@gajae-code/utils";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -57,6 +58,30 @@ export interface BashResult {
 
 const shellSessions = new Map<string, Shell>();
 const brokenShellSessions = new Set<string>();
+
+/** Number of persistent shell sessions currently retained (owner gauge). */
+export function getShellSessionCount(): number {
+	return shellSessions.size;
+}
+
+/**
+ * Dispose all persistent shell sessions: abort in-flight work and drop the
+ * strong references so the native shells can be finalized. Healthy persistent
+ * sessions are otherwise retained for the whole process lifetime (MEM-7). This
+ * is registered as a postmortem cleanup so shutdown/signals release native
+ * shell resources, and is also callable directly (e.g. on owner teardown).
+ */
+export async function disposeAllShellSessions(): Promise<void> {
+	// Snapshot and drop strong references up front so concurrent callers cannot
+	// reuse a session that is being torn down, then await every native abort so
+	// shutdown/signal cleanup does not return before resources are released.
+	const sessions = [...shellSessions.values()];
+	shellSessions.clear();
+	brokenShellSessions.clear();
+	await Promise.allSettled(sessions.map(session => session.abort()));
+}
+
+postmortem.register("bash-executor:shell-sessions", () => disposeAllShellSessions());
 
 async function resolveShellCwd(cwd: string | undefined): Promise<string | undefined> {
 	if (!cwd) return undefined;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
-import { executeBash } from "@gajae-code/coding-agent/exec/bash-executor";
+import { getRuntimeResourceCounts } from "@gajae-code/coding-agent/debug/runtime-gauges";
+import {
+	disposeAllShellSessions,
+	executeBash,
+	getShellSessionCount,
+} from "@gajae-code/coding-agent/exec/bash-executor";
 import { DEFAULT_MAX_BYTES } from "@gajae-code/coding-agent/session/streaming-output";
 import * as shellSnapshot from "@gajae-code/coding-agent/utils/shell-snapshot";
 import type { Shell } from "@gajae-code/natives";
@@ -41,6 +46,28 @@ describe("executeBash", () => {
 		const result = await executeBash("exit 7", { cwd: tempDir, timeout: 5000 });
 		expect(result.exitCode).toBe(7);
 		expect(result.cancelled).toBe(false);
+	});
+
+	it("retains then fully disposes persistent shell sessions (MEM-7)", async () => {
+		await disposeAllShellSessions();
+		expect(getShellSessionCount()).toBe(0);
+		await executeBash("echo hi", { cwd: tempDir, timeout: 5000, sessionKey: "leak-test" });
+		expect(getShellSessionCount()).toBeGreaterThanOrEqual(1);
+		// Disposal must await native aborts (not fire-and-forget) so shutdown
+		// cleanup does not return before resources are released.
+		const pending = disposeAllShellSessions();
+		expect(pending).toBeInstanceOf(Promise);
+		await pending;
+		expect(getShellSessionCount()).toBe(0);
+	});
+
+	it("reports the bash shell-session owner count via runtime resource gauges", async () => {
+		await disposeAllShellSessions();
+		expect(getRuntimeResourceCounts()["bash.shellSessions"]).toBe(0);
+		await executeBash("echo hi", { cwd: tempDir, timeout: 5000, sessionKey: "gauge-test" });
+		expect(getRuntimeResourceCounts()["bash.shellSessions"]).toBeGreaterThanOrEqual(1);
+		await disposeAllShellSessions();
+		expect(getRuntimeResourceCounts()["bash.shellSessions"]).toBe(0);
 	});
 
 	it("honors cwd", async () => {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -33,6 +33,7 @@
 		"check:types": "tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"test": "bun test test/*.test.ts",
+		"test:perf": "PI_TUI_PERF_GATES=1 bun test test/perf-gates.test.ts",
 		"fix": "biome check --write --unsafe .",
 		"fmt": "biome format --write ."
 	},

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -62,6 +62,8 @@ export class Loader extends Text {
 			}
 			this.#updateDisplay();
 		}, RENDER_INTERVAL_MS);
+		// Don't let the animation timer keep the event loop alive on its own.
+		this.#intervalId?.unref?.();
 	}
 
 	stop() {

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -24,6 +24,8 @@ export * from "./fuzzy";
 export * from "./keybindings";
 // Kitty keyboard protocol helpers
 export * from "./keys";
+// Renderer/runtime observability metrics (opt-in)
+export * from "./metrics";
 // Mermaid diagram support
 // Input buffering for batch splitting
 export * from "./stdin-buffer";

--- a/packages/tui/src/metrics.ts
+++ b/packages/tui/src/metrics.ts
@@ -1,0 +1,321 @@
+/**
+ * Opt-in renderer/runtime observability counters for the TUI.
+ *
+ * This module is the Stage 1 "observability foundation" surface. It is OFF by
+ * default and only collects data when explicitly enabled, either via the
+ * `PI_TUI_METRICS` environment flag or programmatically (used by the replay
+ * harness and tests). When disabled, every record call is a single boolean
+ * check at the call site, so default runtime overhead is negligible and no
+ * existing render behavior changes.
+ *
+ * It tracks:
+ *  - `#doRender` durations (p50/p95/p99/max/mean) — frame-time histogram.
+ *  - `requestRender` source attribution — which callers ask for renders.
+ *  - Full-redraw cause classification — why a frame fell back to full repaint.
+ *  - Repaint-storm detection — runs of consecutive unexpected full redraws.
+ *  - RSS samples — baseline/peak/last for memory-growth gates.
+ *  - Owner/timer gauges — long-lived resource counts for leak gates.
+ */
+import { performance } from "node:perf_hooks";
+import { $flag } from "@gajae-code/utils";
+
+/** Number of consecutive unexpected full redraws that constitute a "storm". */
+export const REPAINT_STORM_THRESHOLD = 3;
+
+/** Hard cap on retained render-duration samples to keep memory bounded. */
+const MAX_DURATION_SAMPLES = 200_000;
+
+/**
+ * Full-redraw causes that are expected and do not count toward repaint storms.
+ * These are legitimate, unavoidable full repaints (first frame, resize, shrink
+ * clearing). Steady-stream storms come from any other repeated full redraw.
+ */
+function isExpectedFullRedraw(cause: string): boolean {
+	const c = cause.toLowerCase();
+	return (
+		c.startsWith("first render") ||
+		c.includes("width changed") ||
+		c.includes("height changed") ||
+		c.startsWith("clearonshrink") ||
+		c.includes("forced") ||
+		c.includes("force")
+	);
+}
+
+export interface DurationStats {
+	count: number;
+	meanMs: number;
+	p50Ms: number;
+	p95Ms: number;
+	p99Ms: number;
+	maxMs: number;
+}
+
+export interface RssStats {
+	samples: number;
+	baselineBytes: number | null;
+	lastBytes: number | null;
+	peakBytes: number;
+	growthBytes: number;
+	/** RSS sampled after the run + a forced GC (informational). */
+	returnBytes: number | null;
+	/** Heap used at baseline and after the run + forced GC (reclaimable signal). */
+	heapBaselineBytes: number | null;
+	heapReturnBytes: number | null;
+	/** (heapReturn - heapBaseline) / heapBaseline; <= tolerance means heap returned. */
+	returnWithinBaselineFraction: number | null;
+}
+
+export interface HelperStat {
+	count: number;
+	totalMs: number;
+	meanMs: number;
+}
+
+export interface RenderMetricsSnapshot {
+	enabled: boolean;
+	renderCount: number;
+	renderDurations: DurationStats;
+	durationsTruncated: boolean;
+	requestSources: Record<string, number>;
+	fullRedrawCount: number;
+	fullRedrawCauses: Record<string, number>;
+	repaintStorms: number;
+	maxConsecutiveFullRedraws: number;
+	rss: RssStats;
+	ownerGauges: Record<string, number>;
+	timerGauges: Record<string, number>;
+	helperStats: Record<string, HelperStat>;
+}
+
+function emptyDurationStats(): DurationStats {
+	return { count: 0, meanMs: 0, p50Ms: 0, p95Ms: 0, p99Ms: 0, maxMs: 0 };
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const rank = (p / 100) * (sorted.length - 1);
+	const lo = Math.floor(rank);
+	const hi = Math.ceil(rank);
+	if (lo === hi) return sorted[lo];
+	const frac = rank - lo;
+	return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+export class RenderMetrics {
+	#enabled: boolean;
+	#renderCount = 0;
+	#durations: number[] = [];
+	#durationsTruncated = false;
+	#requestSources = new Map<string, number>();
+	#fullRedrawCount = 0;
+	#fullRedrawCauses = new Map<string, number>();
+	#pendingUnexpectedFullRedraw = false;
+	#consecutiveFullRedraws = 0;
+	#maxConsecutiveFullRedraws = 0;
+	#repaintStorms = 0;
+	#rssSamples = 0;
+	#rssBaseline: number | null = null;
+	#rssLast: number | null = null;
+	#rssPeak = 0;
+	#ownerGauges = new Map<string, number>();
+	#timerGauges = new Map<string, number>();
+	#helpers = new Map<string, { count: number; totalMs: number }>();
+	#rssReturn: number | null = null;
+	#heapBaseline: number | null = null;
+	#heapReturn: number | null = null;
+
+	constructor(enabled = $flag("PI_TUI_METRICS")) {
+		this.#enabled = enabled;
+	}
+
+	get enabled(): boolean {
+		return this.#enabled;
+	}
+
+	enable(): void {
+		this.#enabled = true;
+	}
+
+	disable(): void {
+		this.#enabled = false;
+	}
+
+	/** Reset all collected data (keeps the enabled state). */
+	reset(): void {
+		this.#renderCount = 0;
+		this.#durations = [];
+		this.#durationsTruncated = false;
+		this.#requestSources.clear();
+		this.#fullRedrawCount = 0;
+		this.#fullRedrawCauses.clear();
+		this.#pendingUnexpectedFullRedraw = false;
+		this.#consecutiveFullRedraws = 0;
+		this.#maxConsecutiveFullRedraws = 0;
+		this.#repaintStorms = 0;
+		this.#rssSamples = 0;
+		this.#rssBaseline = null;
+		this.#rssLast = null;
+		this.#rssPeak = 0;
+		this.#ownerGauges.clear();
+		this.#timerGauges.clear();
+		this.#helpers.clear();
+		this.#rssReturn = null;
+		this.#heapBaseline = null;
+		this.#heapReturn = null;
+	}
+
+	/** High-resolution clock for timing render passes. Returns 0 when disabled. */
+	now(): number {
+		return this.#enabled ? performance.now() : 0;
+	}
+
+	/** Record that a render was requested, attributed to a caller source. */
+	recordRequest(source = "unknown"): void {
+		if (!this.#enabled) return;
+		this.#requestSources.set(source, (this.#requestSources.get(source) ?? 0) + 1);
+	}
+
+	/** Record one completed `#doRender` pass duration (ms). */
+	recordRender(durationMs: number): void {
+		if (!this.#enabled) return;
+		this.#renderCount += 1;
+		if (this.#durations.length < MAX_DURATION_SAMPLES) {
+			this.#durations.push(durationMs);
+		} else {
+			this.#durationsTruncated = true;
+		}
+
+		// Storm bookkeeping: a render that performed an unexpected full redraw
+		// extends the current run; any other render breaks it.
+		if (this.#pendingUnexpectedFullRedraw) {
+			this.#consecutiveFullRedraws += 1;
+			if (this.#consecutiveFullRedraws > this.#maxConsecutiveFullRedraws) {
+				this.#maxConsecutiveFullRedraws = this.#consecutiveFullRedraws;
+			}
+			if (this.#consecutiveFullRedraws === REPAINT_STORM_THRESHOLD) {
+				this.#repaintStorms += 1;
+			}
+		} else {
+			this.#consecutiveFullRedraws = 0;
+		}
+		this.#pendingUnexpectedFullRedraw = false;
+	}
+
+	/** Record a full-redraw event and classify its cause for storm detection. */
+	recordFullRedraw(cause: string): void {
+		if (!this.#enabled) return;
+		this.#fullRedrawCount += 1;
+		this.#fullRedrawCauses.set(cause, (this.#fullRedrawCauses.get(cause) ?? 0) + 1);
+		if (!isExpectedFullRedraw(cause)) {
+			this.#pendingUnexpectedFullRedraw = true;
+		}
+	}
+
+	/** Sample current RSS. Records baseline on first sample, tracks peak/last. */
+	sampleRss(): number {
+		if (!this.#enabled) return 0;
+		const mem = process.memoryUsage();
+		const rss = mem.rss;
+		this.#rssSamples += 1;
+		if (this.#rssBaseline === null) this.#rssBaseline = rss;
+		if (this.#heapBaseline === null) this.#heapBaseline = mem.heapUsed;
+		this.#rssLast = rss;
+		if (rss > this.#rssPeak) this.#rssPeak = rss;
+		return rss;
+	}
+
+	setOwnerGauge(name: string, value: number): void {
+		if (!this.#enabled) return;
+		this.#ownerGauges.set(name, value);
+	}
+
+	setTimerGauge(name: string, value: number): void {
+		if (!this.#enabled) return;
+		this.#timerGauges.set(name, value);
+	}
+
+	/** Accumulate timing/count for a named render helper (e.g. "renderTree"). */
+	recordHelper(name: string, durationMs: number): void {
+		if (!this.#enabled) return;
+		const cur = this.#helpers.get(name) ?? { count: 0, totalMs: 0 };
+		cur.count += 1;
+		cur.totalMs += durationMs;
+		this.#helpers.set(name, cur);
+	}
+
+	/**
+	 * Force a GC when the runtime exposes one and sample RSS as the post-run
+	 * "return" value used by the memory-leak gate. Callers should drop large
+	 * references before calling so reclaimable memory is actually freed.
+	 */
+	sampleReturn(): number {
+		if (!this.#enabled) return 0;
+		const bunGc = (globalThis as { Bun?: { gc?: (force: boolean) => void } }).Bun?.gc;
+		const nodeGc = (globalThis as { gc?: () => void }).gc;
+		if (typeof bunGc === "function") bunGc(true);
+		else if (typeof nodeGc === "function") nodeGc();
+		const mem = process.memoryUsage();
+		this.#rssReturn = mem.rss;
+		this.#heapReturn = mem.heapUsed;
+		if (this.#rssBaseline === null) this.#rssBaseline = mem.rss;
+		if (this.#heapBaseline === null) this.#heapBaseline = mem.heapUsed;
+		return mem.rss;
+	}
+
+	#durationStats(): DurationStats {
+		if (this.#durations.length === 0) return emptyDurationStats();
+		const sorted = [...this.#durations].sort((a, b) => a - b);
+		const sum = sorted.reduce((acc, v) => acc + v, 0);
+		return {
+			count: sorted.length,
+			meanMs: sum / sorted.length,
+			p50Ms: percentile(sorted, 50),
+			p95Ms: percentile(sorted, 95),
+			p99Ms: percentile(sorted, 99),
+			maxMs: sorted[sorted.length - 1],
+		};
+	}
+
+	#helperStats(): Record<string, HelperStat> {
+		const out: Record<string, HelperStat> = {};
+		for (const [name, v] of this.#helpers) {
+			out[name] = { count: v.count, totalMs: v.totalMs, meanMs: v.count ? v.totalMs / v.count : 0 };
+		}
+		return out;
+	}
+
+	snapshot(): RenderMetricsSnapshot {
+		return {
+			enabled: this.#enabled,
+			renderCount: this.#renderCount,
+			renderDurations: this.#durationStats(),
+			durationsTruncated: this.#durationsTruncated,
+			requestSources: Object.fromEntries(this.#requestSources),
+			fullRedrawCount: this.#fullRedrawCount,
+			fullRedrawCauses: Object.fromEntries(this.#fullRedrawCauses),
+			repaintStorms: this.#repaintStorms,
+			maxConsecutiveFullRedraws: this.#maxConsecutiveFullRedraws,
+			rss: {
+				samples: this.#rssSamples,
+				baselineBytes: this.#rssBaseline,
+				lastBytes: this.#rssLast,
+				peakBytes: this.#rssPeak,
+				growthBytes: this.#rssBaseline === null ? 0 : this.#rssPeak - this.#rssBaseline,
+				returnBytes: this.#rssReturn,
+				heapBaselineBytes: this.#heapBaseline,
+				heapReturnBytes: this.#heapReturn,
+				returnWithinBaselineFraction:
+					this.#heapBaseline && this.#heapReturn !== null
+						? (this.#heapReturn - this.#heapBaseline) / this.#heapBaseline
+						: null,
+			},
+			ownerGauges: Object.fromEntries(this.#ownerGauges),
+			timerGauges: Object.fromEntries(this.#timerGauges),
+			helperStats: this.#helperStats(),
+		};
+	}
+}
+
+/** Shared metrics instance used by the TUI render loop. */
+export const renderMetrics = new RenderMetrics();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { $flag, getDebugLogPath } from "@gajae-code/utils";
 import { isKeyRelease, matchesKey } from "./keys";
+import { renderMetrics } from "./metrics";
 import type { Terminal } from "./terminal";
 import { ImageProtocol, setCellDimensions, setTerminalImageProtocol, TERMINAL } from "./terminal-capabilities";
 import {
@@ -433,6 +434,7 @@ export class TUI extends Container {
 		if (this.#renderTimer) {
 			clearTimeout(this.#renderTimer);
 			this.#renderTimer = undefined;
+			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
 		this.#clearSixelProbeState();
 	}
@@ -619,6 +621,7 @@ export class TUI extends Container {
 		if (this.#renderTimer) {
 			clearTimeout(this.#renderTimer);
 			this.#renderTimer = undefined;
+			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.#previousLines.length > 0) {
@@ -640,11 +643,12 @@ export class TUI extends Container {
 		}
 	}
 
-	requestRender(force = false): void {
+	requestRender(force = false, source = "unknown"): void {
 		if (!this.terminalAvailable) {
 			this.#markTerminalUnavailable();
 			return;
 		}
+		if (renderMetrics.enabled) renderMetrics.recordRequest(source);
 		if (force) {
 			this.#previousLines = [];
 			this.#previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
@@ -656,6 +660,7 @@ export class TUI extends Container {
 			if (this.#renderTimer) {
 				clearTimeout(this.#renderTimer);
 				this.#renderTimer = undefined;
+				if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 			}
 			this.#renderRequested = true;
 			process.nextTick(() => {
@@ -664,7 +669,9 @@ export class TUI extends Container {
 				}
 				this.#renderRequested = false;
 				this.#lastRenderAt = performance.now();
+				const t0 = renderMetrics.now();
 				this.#doRender();
+				if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			});
 			return;
 		}
@@ -681,16 +688,20 @@ export class TUI extends Container {
 		const delay = Math.max(0, TUI.#MIN_RENDER_INTERVAL_MS - elapsed);
 		this.#renderTimer = setTimeout(() => {
 			this.#renderTimer = undefined;
+			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 			if (this.#stopped || !this.#renderRequested) {
 				return;
 			}
 			this.#renderRequested = false;
 			this.#lastRenderAt = performance.now();
+			const t0 = renderMetrics.now();
 			this.#doRender();
+			if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
 			if (this.#renderRequested) {
 				this.#scheduleRender();
 			}
 		}, delay);
+		if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 1);
 	}
 
 	#handleInput(data: string): void {
@@ -1108,7 +1119,9 @@ export class TUI extends Container {
 		};
 
 		// Render all components to get new lines
+		const renderTreeStart = renderMetrics.now();
 		let newLines = this.render(width);
+		if (renderMetrics.enabled) renderMetrics.recordHelper("renderTree", renderMetrics.now() - renderTreeStart);
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
@@ -1130,8 +1143,9 @@ export class TUI extends Container {
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
 
 		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		const fullRender = (clear: boolean, reason = "full render"): void => {
 			this.#fullRedrawCount += 1;
+			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
 			if (clear) buffer += isMultiplexerSession() ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
@@ -1161,6 +1175,7 @@ export class TUI extends Container {
 
 		const multiplexerViewportRepaint = (reason: string): void => {
 			this.#fullRedrawCount += 1;
+			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
 			const nextViewportTop = Math.max(0, newLines.length - height);
 			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
 			let buffer = "\x1b[?2026h";
@@ -1225,14 +1240,14 @@ export class TUI extends Container {
 		// First render - just output everything without clearing (assumes clean screen)
 		if (this.#previousLines.length === 0 && !widthChanged && !heightChanged) {
 			logRedraw("first render");
-			fullRender(false);
+			fullRender(false, "first render");
 			return;
 		}
 
 		// Width changes always need a full re-render because wrapping changes.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-			fullRender(true);
+			fullRender(true, "terminal width changed");
 			return;
 		}
 
@@ -1246,7 +1261,7 @@ export class TUI extends Container {
 			}
 			if (!isTermuxSession() && !isMultiplexerSession()) {
 				logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
-				fullRender(true);
+				fullRender(true, "terminal height changed");
 				return;
 			}
 		}
@@ -1256,7 +1271,7 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			fullRender(true);
+			fullRender(true, "clearOnShrink");
 			return;
 		}
 
@@ -1308,7 +1323,7 @@ export class TUI extends Container {
 					if (isMultiplexerSession() && !useLegacyMultiplexerFullRender()) {
 						multiplexerViewportRepaint(`extraLines > height (${extraLines} > ${height})`);
 					} else {
-						fullRender(true);
+						fullRender(true, "extraLines > height");
 					}
 					return;
 				}
@@ -1347,7 +1362,7 @@ export class TUI extends Container {
 			if (isMultiplexerSession() && !useLegacyMultiplexerFullRender()) {
 				multiplexerViewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
 			} else {
-				fullRender(true);
+				fullRender(true, "firstChanged < viewportTop");
 			}
 			return;
 		}

--- a/packages/tui/test/fixtures/recorded-session.json
+++ b/packages/tui/test/fixtures/recorded-session.json
@@ -1,0 +1,4630 @@
+{
+  "cols": 100,
+  "rows": 30,
+  "turns": [
+    {
+      "userText": "cursor cursor buffer layout",
+      "assistantChunks": [
+        "frame buffer width session layout token ",
+        "layout frame cursor session width token overlay replay ",
+        "diff stream layout layout render token render layout overlay token "
+      ],
+      "outputBlock": [
+        "   0  timer metric timer viewport stream replay gauge diff",
+        "   1  stream viewport viewport session viewport timer frame buffer",
+        "   2  width frame session buffer session width buffer token gauge",
+        "   3  layout metric gauge viewport session cursor width layout timer frame token overlay",
+        "   4  token width stream overlay render viewport layout frame token session session token stream viewport metric render width",
+        "   5  stream gauge cursor frame timer render diff viewport stream overlay diff",
+        "   6  buffer layout frame metric width token stream gauge session frame token replay overlay token",
+        "   7  stream replay replay render replay width layout timer replay buffer gauge stream replay frame metric frame viewport",
+        "   8  viewport token layout buffer layout diff metric frame timer diff overlay",
+        "   9  metric gauge overlay render frame buffer session token",
+        "  10  render viewport buffer viewport frame token layout token frame buffer replay overlay gauge cursor",
+        "  11  width buffer width diff replay overlay layout layout timer stream buffer",
+        "  12  gauge session render replay width metric token metric gauge",
+        "  13  replay frame gauge cursor viewport layout frame layout render width frame render buffer token buffer",
+        "  14  render width render gauge gauge diff gauge replay viewport replay",
+        "  15  replay layout overlay overlay session diff gauge stream metric stream token buffer layout",
+        "  16  overlay frame frame gauge layout overlay token diff metric width cursor viewport timer layout replay",
+        "  17  diff layout buffer layout metric buffer session cursor session session layout metric diff",
+        "  18  buffer gauge replay viewport diff replay cursor buffer diff timer session diff width timer frame timer timer",
+        "  19  session overlay diff diff timer buffer metric overlay diff timer timer timer buffer layout",
+        "  20  frame replay viewport frame viewport width cursor stream render frame gauge metric token",
+        "  21  frame metric buffer buffer viewport stream session buffer token session timer timer metric",
+        "  22  diff gauge diff cursor session cursor replay token metric token gauge stream frame",
+        "  23  replay layout frame render overlay session token viewport cursor",
+        "  24  timer replay token token token gauge metric replay timer cursor frame diff layout token diff",
+        "  25  frame session stream layout metric render session replay cursor timer timer cursor",
+        "  26  diff width buffer render buffer width frame diff session viewport diff timer frame width",
+        "  27  stream timer render gauge replay render overlay gauge replay token gauge frame cursor diff diff timer session",
+        "  28  layout session metric overlay frame buffer gauge replay overlay metric token replay gauge metric viewport",
+        "  29  layout replay metric gauge timer layout viewport token viewport render viewport",
+        "  30  gauge overlay replay width render render frame overlay token token render",
+        "  31  session layout session replay gauge render viewport timer buffer stream frame metric session replay gauge timer token",
+        "  32  width stream viewport frame token layout overlay buffer overlay layout token render diff diff cursor replay",
+        "  33  overlay diff gauge layout buffer diff gauge metric width frame stream layout diff session",
+        "  34  diff viewport token width metric diff render overlay timer overlay layout layout",
+        "  35  metric stream layout replay token cursor token layout token session width diff metric",
+        "  36  diff cursor cursor buffer layout stream stream render cursor metric stream width width buffer timer frame timer",
+        "  37  buffer buffer frame timer overlay stream width timer",
+        "  38  cursor cursor buffer render render overlay replay stream session stream viewport session viewport token",
+        "  39  gauge cursor layout timer frame token token layout buffer token diff",
+        "  40  replay diff width frame buffer buffer timer gauge layout",
+        "  41  session overlay width width token layout width cursor buffer token render metric render token",
+        "  42  timer diff timer cursor layout viewport gauge gauge gauge buffer",
+        "  43  overlay layout frame layout overlay gauge buffer token overlay render diff gauge metric timer diff",
+        "  44  render session cursor viewport render token buffer gauge",
+        "  45  stream replay overlay diff viewport token cursor frame diff buffer metric gauge timer",
+        "  46  buffer token viewport metric render layout width render width session replay",
+        "  47  token cursor buffer width session timer session frame session layout session layout metric metric layout token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff replay session gauge timer",
+      "assistantChunks": [
+        "cursor width timer buffer layout ",
+        "diff render replay replay replay session render gauge gauge "
+      ],
+      "outputBlock": [
+        "   0  render gauge buffer session replay layout viewport overlay render replay token overlay buffer viewport",
+        "   1  cursor token gauge layout viewport session metric width frame frame timer frame viewport frame viewport",
+        "   2  replay buffer replay diff viewport session render frame cursor session cursor viewport diff buffer token width",
+        "   3  metric layout stream replay metric width stream stream metric metric",
+        "   4  metric width metric viewport timer frame render buffer cursor timer",
+        "   5  metric token width session replay buffer frame timer layout replay layout gauge diff",
+        "   6  timer session timer render frame gauge gauge buffer frame",
+        "   7  cursor buffer frame token stream overlay replay frame viewport render render gauge",
+        "   8  gauge viewport gauge stream layout width overlay replay session token",
+        "   9  token timer buffer token diff token session diff timer gauge frame frame render session width",
+        "  10  buffer layout overlay frame frame frame metric cursor buffer session buffer timer overlay cursor",
+        "  11  overlay cursor replay layout token overlay frame width token replay metric token session cursor cursor buffer",
+        "  12  overlay buffer render gauge session width diff session diff layout diff token session gauge",
+        "  13  stream frame session gauge render layout metric viewport layout cursor overlay timer session timer metric session",
+        "  14  token stream buffer stream width overlay session cursor token replay session metric width session session token overlay",
+        "  15  diff cursor stream cursor timer session layout width timer token timer metric frame cursor timer timer metric",
+        "  16  metric metric viewport cursor replay replay diff render",
+        "  17  gauge session gauge stream buffer replay session width gauge metric stream layout stream token",
+        "  18  replay viewport cursor token diff overlay diff width buffer session width diff frame metric",
+        "  19  buffer viewport stream render metric gauge replay buffer metric timer layout layout buffer timer timer render",
+        "  20  cursor cursor width overlay render layout token width layout gauge session layout token gauge stream",
+        "  21  width layout width timer width replay layout token gauge gauge frame session",
+        "  22  frame buffer width stream gauge diff overlay viewport viewport",
+        "  23  stream session token frame overlay diff replay replay token layout stream token",
+        "  24  gauge width stream timer replay viewport buffer buffer frame gauge timer viewport stream",
+        "  25  diff viewport metric render stream timer timer buffer token timer",
+        "  26  session diff buffer overlay buffer viewport metric width gauge token buffer token gauge",
+        "  27  layout layout overlay replay gauge width diff diff cursor cursor frame timer metric",
+        "  28  render viewport stream frame width session render timer",
+        "  29  overlay gauge width cursor frame diff session session timer width timer replay session frame",
+        "  30  stream width metric viewport buffer render metric replay width",
+        "  31  frame replay cursor width overlay replay session layout",
+        "  32  render session gauge metric timer frame diff width overlay diff render overlay layout layout layout",
+        "  33  layout buffer buffer stream layout session buffer viewport timer",
+        "  34  stream overlay diff frame width cursor frame session diff diff render",
+        "  35  session session stream width buffer gauge render render gauge frame stream layout layout replay",
+        "  36  diff diff stream diff buffer gauge width metric overlay timer render layout overlay render overlay cursor",
+        "  37  frame overlay token token width buffer frame stream",
+        "  38  token layout session token diff stream timer frame metric cursor",
+        "  39  gauge viewport gauge viewport cursor overlay viewport render layout cursor",
+        "  40  width render diff metric metric replay timer metric overlay overlay",
+        "  41  buffer diff stream timer buffer metric frame diff timer gauge frame render frame layout layout",
+        "  42  viewport render stream diff viewport cursor layout layout buffer replay render replay metric gauge buffer viewport metric",
+        "  43  timer buffer diff metric viewport render overlay buffer viewport width viewport overlay diff replay frame timer",
+        "  44  diff token token cursor replay frame timer timer gauge render buffer cursor width viewport token buffer",
+        "  45  width timer overlay session timer width gauge gauge stream metric diff cursor metric",
+        "  46  buffer diff render layout stream token buffer render buffer width",
+        "  47  timer width cursor metric metric metric cursor layout replay width",
+        "  48  stream buffer cursor layout buffer buffer replay gauge viewport viewport viewport metric replay frame",
+        "  49  render overlay layout timer viewport diff render frame frame overlay render",
+        "  50  layout session replay gauge frame render token render metric layout render overlay buffer cursor",
+        "  51  render token metric metric metric overlay width render width render viewport token",
+        "  52  replay cursor replay token render timer cursor cursor token session replay buffer",
+        "  53  render gauge token cursor buffer diff stream width metric buffer token viewport session render",
+        "  54  render overlay token frame buffer width session render buffer",
+        "  55  frame overlay render diff stream timer overlay cursor width render render token replay timer cursor layout viewport",
+        "  56  metric frame timer stream viewport timer buffer diff token width overlay diff diff buffer token",
+        "  57  width timer diff buffer diff render metric width gauge metric token buffer",
+        "  58  metric buffer overlay layout width gauge frame cursor width metric timer diff"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout render timer gauge stream replay",
+      "assistantChunks": [
+        "viewport layout width token layout timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout frame render stream buffer",
+      "assistantChunks": [
+        "diff frame token gauge session buffer ",
+        "layout diff cursor diff stream cursor frame "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor diff cursor cursor layout",
+      "assistantChunks": [
+        "overlay layout diff token overlay overlay session stream metric ",
+        "buffer buffer layout viewport width timer ",
+        "session buffer gauge width diff viewport token "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay replay render",
+      "assistantChunks": [
+        "gauge viewport overlay gauge overlay width "
+      ],
+      "toolLines": [
+        "  | cursor stream diff width cursor",
+        "  | gauge stream diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream buffer gauge",
+      "assistantChunks": [
+        "diff viewport render viewport viewport token replay timer ",
+        "stream timer token layout "
+      ],
+      "toolLines": [
+        "  | layout width metric frame gauge layout render",
+        "  | buffer session buffer timer cursor token"
+      ],
+      "resizeTo": {
+        "cols": 74,
+        "rows": 33
+      },
+      "idleTicks": 1
+    },
+    {
+      "userText": "width viewport frame width viewport",
+      "assistantChunks": [
+        "overlay gauge render viewport ",
+        "frame token viewport frame ",
+        "session token timer token replay buffer token width overlay viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session session timer cursor frame replay render",
+      "assistantChunks": [
+        "render render width metric session viewport cursor width replay cursor "
+      ],
+      "toolLines": [
+        "  | diff session viewport gauge session"
+      ],
+      "resizeTo": {
+        "cols": 88,
+        "rows": 30
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout replay width stream",
+      "assistantChunks": [
+        "cursor overlay session overlay stream gauge "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport session overlay overlay",
+      "assistantChunks": [
+        "frame layout replay overlay render stream diff frame timer timer viewport ",
+        "layout width token frame overlay stream token buffer session "
+      ],
+      "toolLines": [
+        "  | token metric cursor token overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width timer viewport token replay",
+      "assistantChunks": [
+        "gauge session buffer replay layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge diff replay",
+      "assistantChunks": [
+        "cursor metric metric gauge cursor buffer ",
+        "stream overlay token render token stream cursor layout ",
+        "replay gauge cursor width "
+      ],
+      "toolLines": [
+        "  | overlay stream buffer token frame diff width",
+        "  | overlay metric layout frame",
+        "  | session session token replay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer gauge buffer render buffer metric",
+      "assistantChunks": [
+        "token replay buffer replay diff overlay render ",
+        "diff diff cursor buffer render frame width overlay token width ",
+        "timer cursor width cursor metric "
+      ],
+      "toolLines": [
+        "  | frame token stream replay width width",
+        "  | viewport viewport frame diff session stream render",
+        "  | session timer frame render timer viewport"
+      ],
+      "outputBlock": [
+        "   0  buffer viewport replay metric token cursor metric replay session frame buffer token viewport viewport frame",
+        "   1  replay stream token metric token viewport token timer width frame cursor stream diff diff replay session",
+        "   2  layout buffer frame gauge buffer timer viewport gauge overlay stream overlay render token gauge token",
+        "   3  token width token buffer diff buffer frame render layout overlay buffer viewport stream stream gauge buffer",
+        "   4  gauge stream layout frame width overlay token session",
+        "   5  diff buffer width replay replay gauge token replay buffer timer viewport replay timer layout width viewport",
+        "   6  stream layout render replay stream frame session layout",
+        "   7  render gauge overlay session diff replay buffer metric width replay stream timer replay",
+        "   8  overlay replay metric gauge layout layout gauge buffer",
+        "   9  replay buffer metric render metric width replay frame buffer diff cursor width stream",
+        "  10  buffer timer cursor frame viewport overlay diff buffer render width stream token token replay cursor overlay metric",
+        "  11  overlay frame width overlay diff replay session gauge stream diff replay token",
+        "  12  viewport cursor replay overlay width buffer width token cursor viewport layout frame cursor token metric diff",
+        "  13  metric cursor overlay stream viewport viewport viewport metric viewport token metric layout width layout render diff session",
+        "  14  cursor timer stream token token layout layout diff frame gauge width token session",
+        "  15  diff metric cursor token layout cursor timer stream",
+        "  16  diff viewport viewport layout token width render overlay token layout render metric",
+        "  17  diff buffer cursor buffer replay overlay cursor frame buffer layout layout frame render metric stream overlay gauge",
+        "  18  timer frame gauge frame layout replay metric buffer render",
+        "  19  layout gauge gauge frame metric token replay session",
+        "  20  replay overlay session session gauge width timer layout stream session frame",
+        "  21  buffer overlay diff timer gauge diff timer frame token buffer replay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge stream viewport",
+      "assistantChunks": [
+        "metric metric frame diff token overlay frame stream overlay ",
+        "timer diff timer cursor gauge viewport width replay render diff stream ",
+        "timer render render width width "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width token metric token",
+      "assistantChunks": [
+        "render render width gauge ",
+        "session frame overlay session token ",
+        "viewport frame gauge layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream layout buffer",
+      "assistantChunks": [
+        "stream stream token layout viewport viewport frame timer session replay diff ",
+        "timer diff layout width layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay diff timer width diff token diff",
+      "assistantChunks": [
+        "stream gauge session replay session frame overlay buffer gauge render "
+      ],
+      "toolLines": [
+        "  | width timer diff",
+        "  | gauge cursor buffer layout replay viewport"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token cursor frame",
+      "assistantChunks": [
+        "timer cursor metric buffer metric replay overlay buffer replay overlay ",
+        "session width session cursor "
+      ],
+      "outputBlock": [
+        "   0  stream cursor metric replay stream token cursor layout stream width",
+        "   1  timer timer width buffer timer timer replay render gauge render",
+        "   2  render frame width frame token overlay layout gauge",
+        "   3  metric frame render render token render metric replay overlay layout render buffer viewport metric gauge",
+        "   4  buffer diff layout diff width diff metric viewport width render cursor replay",
+        "   5  cursor layout overlay viewport gauge overlay width timer overlay metric diff diff metric viewport metric",
+        "   6  width layout render frame frame overlay stream token timer",
+        "   7  gauge width overlay token diff viewport stream buffer buffer token viewport",
+        "   8  width session overlay gauge width session overlay render token diff timer metric gauge metric width",
+        "   9  metric frame buffer token width buffer token diff overlay session stream layout gauge",
+        "  10  session width buffer gauge token cursor overlay replay session overlay token",
+        "  11  viewport stream gauge session render metric viewport frame cursor render session buffer frame layout",
+        "  12  metric token metric metric token diff metric width buffer frame timer overlay token cursor session cursor layout",
+        "  13  gauge layout buffer frame metric width metric viewport cursor cursor",
+        "  14  stream layout token metric replay width gauge token",
+        "  15  render layout session stream timer replay buffer overlay replay replay session session layout replay",
+        "  16  width metric layout diff frame replay cursor width token token frame",
+        "  17  metric overlay session buffer replay replay frame diff stream replay frame gauge timer gauge width replay viewport",
+        "  18  render gauge buffer cursor metric cursor frame metric cursor width stream gauge buffer replay",
+        "  19  gauge replay session diff session token viewport token replay token token cursor cursor session gauge viewport layout",
+        "  20  buffer timer overlay gauge metric layout replay frame viewport gauge render token diff overlay timer",
+        "  21  cursor metric width session session render session metric width",
+        "  22  frame session stream width replay viewport layout stream width cursor",
+        "  23  replay token frame replay gauge stream replay width gauge layout cursor overlay timer token timer gauge cursor",
+        "  24  width buffer stream stream session timer token render width timer",
+        "  25  diff width cursor token token diff metric overlay layout replay",
+        "  26  session gauge frame width token replay viewport session width replay replay layout stream frame",
+        "  27  overlay width layout metric layout render width viewport session",
+        "  28  metric cursor diff metric replay metric buffer render viewport buffer diff",
+        "  29  viewport overlay stream overlay buffer viewport replay gauge cursor width timer buffer render token buffer layout",
+        "  30  viewport stream replay session frame layout gauge stream",
+        "  31  overlay session diff width overlay render timer render timer cursor gauge cursor",
+        "  32  overlay replay frame layout stream replay width diff token width diff",
+        "  33  diff frame timer frame overlay token diff overlay gauge width width replay session",
+        "  34  render layout diff cursor stream stream render frame frame diff overlay buffer gauge viewport layout stream",
+        "  35  diff stream cursor gauge gauge cursor stream diff overlay metric",
+        "  36  render timer replay render cursor session token stream overlay metric frame render cursor width render render metric",
+        "  37  replay frame render width render width overlay timer overlay diff replay overlay metric diff timer",
+        "  38  render metric token token buffer buffer frame metric timer metric",
+        "  39  diff viewport cursor metric gauge replay frame gauge diff",
+        "  40  cursor token render session stream gauge viewport gauge stream",
+        "  41  metric cursor replay width token metric replay buffer buffer metric diff cursor timer frame viewport buffer",
+        "  42  buffer timer metric timer layout width viewport layout",
+        "  43  width overlay buffer overlay diff session diff metric replay width frame gauge buffer render"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge cursor layout session width",
+      "assistantChunks": [
+        "render metric gauge stream render width gauge "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff token layout cursor",
+      "assistantChunks": [
+        "width gauge render stream ",
+        "buffer render viewport width session diff viewport timer viewport "
+      ],
+      "toolLines": [
+        "  | metric buffer session frame session viewport buffer"
+      ],
+      "outputBlock": [
+        "   0  stream layout timer overlay replay timer cursor stream width replay render diff",
+        "   1  width cursor gauge gauge layout token width viewport",
+        "   2  token replay metric metric stream timer stream layout overlay render render",
+        "   3  replay diff stream replay replay session render timer viewport gauge stream stream diff buffer replay",
+        "   4  render cursor width metric stream buffer session render",
+        "   5  frame buffer replay overlay gauge layout width cursor width session gauge render cursor gauge overlay",
+        "   6  viewport cursor replay stream layout buffer gauge token buffer gauge",
+        "   7  timer buffer replay frame buffer width session diff layout frame stream overlay cursor",
+        "   8  metric metric width layout frame overlay timer session token gauge gauge buffer",
+        "   9  metric layout metric token overlay buffer token metric metric token session overlay frame gauge metric",
+        "  10  token render replay buffer timer timer diff render replay stream viewport token viewport frame",
+        "  11  replay replay frame gauge session metric cursor token timer timer buffer cursor diff cursor cursor",
+        "  12  session timer gauge diff viewport viewport overlay metric frame",
+        "  13  render stream overlay buffer session viewport metric buffer cursor",
+        "  14  cursor frame width diff timer gauge layout token replay token token buffer render",
+        "  15  frame layout token session gauge cursor replay cursor stream render timer layout token session token",
+        "  16  frame buffer gauge stream gauge metric cursor frame viewport width buffer layout gauge replay timer gauge buffer",
+        "  17  render viewport render width viewport replay width buffer diff replay diff replay timer",
+        "  18  overlay overlay overlay cursor buffer cursor session replay session stream layout diff buffer session",
+        "  19  token viewport gauge viewport overlay buffer stream cursor layout metric stream gauge stream session viewport replay render",
+        "  20  overlay session viewport replay overlay diff timer metric width gauge cursor replay",
+        "  21  metric render viewport gauge cursor width overlay buffer",
+        "  22  metric gauge diff replay cursor frame layout frame diff timer timer",
+        "  23  stream frame viewport diff timer cursor buffer frame replay diff frame timer overlay layout overlay",
+        "  24  session cursor render viewport viewport token gauge token render",
+        "  25  session diff timer frame gauge viewport layout metric viewport render width gauge layout replay",
+        "  26  frame layout metric stream width gauge gauge session layout viewport replay replay cursor viewport diff width",
+        "  27  cursor render width viewport gauge overlay gauge token metric stream buffer stream overlay",
+        "  28  render layout gauge gauge session overlay token diff layout token",
+        "  29  overlay replay session session timer metric width metric diff token replay render buffer gauge layout metric viewport",
+        "  30  diff frame frame buffer viewport cursor session replay stream",
+        "  31  token frame width metric overlay replay diff cursor",
+        "  32  replay stream diff viewport timer session frame replay",
+        "  33  replay replay stream gauge cursor timer gauge session token diff session width diff session timer",
+        "  34  render session render stream gauge token session width timer cursor buffer frame timer stream metric layout",
+        "  35  frame metric metric gauge metric token diff render timer render cursor token",
+        "  36  overlay width overlay token overlay token stream render cursor render token gauge",
+        "  37  cursor viewport timer viewport overlay layout gauge metric session session frame buffer diff gauge session metric",
+        "  38  buffer replay gauge timer stream metric width overlay cursor buffer render timer layout viewport replay",
+        "  39  metric diff timer width gauge gauge overlay session stream timer stream width viewport render",
+        "  40  buffer viewport session timer session stream timer viewport width",
+        "  41  render overlay viewport viewport stream metric session width cursor timer width overlay session replay cursor timer",
+        "  42  replay timer viewport width layout overlay token width replay timer metric cursor timer viewport frame frame",
+        "  43  frame width token overlay replay replay timer replay overlay buffer",
+        "  44  viewport replay overlay replay diff token stream gauge cursor render overlay gauge diff render diff cursor",
+        "  45  viewport stream replay session width viewport session buffer token frame",
+        "  46  metric stream session width timer timer session replay diff layout buffer timer metric frame diff layout",
+        "  47  token layout token buffer layout replay diff stream diff viewport frame session stream",
+        "  48  width cursor gauge layout diff session cursor session",
+        "  49  overlay buffer viewport frame buffer metric gauge diff buffer viewport metric stream",
+        "  50  stream frame frame overlay overlay buffer buffer metric viewport width buffer cursor overlay",
+        "  51  diff buffer render replay layout width token replay gauge timer",
+        "  52  frame overlay session replay diff render metric replay stream token gauge render render stream"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "render cursor gauge width diff frame",
+      "assistantChunks": [
+        "gauge replay stream frame stream timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge cursor buffer render",
+      "assistantChunks": [
+        "cursor render diff buffer metric stream metric cursor stream layout stream "
+      ],
+      "outputBlock": [
+        "   0  diff buffer gauge cursor session width width metric cursor timer layout width",
+        "   1  width viewport stream layout cursor replay timer gauge layout gauge diff metric gauge timer render",
+        "   2  metric viewport replay width buffer overlay viewport render gauge buffer",
+        "   3  diff viewport replay diff buffer metric viewport width overlay gauge cursor width metric width diff",
+        "   4  gauge layout gauge render timer metric session gauge",
+        "   5  diff diff buffer timer token layout viewport stream frame",
+        "   6  viewport render viewport session stream overlay gauge frame replay timer frame buffer",
+        "   7  replay overlay width buffer replay width gauge cursor overlay cursor timer stream stream metric render",
+        "   8  viewport viewport replay session viewport cursor token viewport token timer viewport timer session session replay cursor",
+        "   9  buffer buffer metric layout replay cursor metric token viewport stream token cursor render metric",
+        "  10  session cursor width token metric frame diff layout viewport metric cursor diff frame layout",
+        "  11  stream overlay frame frame token stream session diff width metric render",
+        "  12  metric layout render replay diff cursor metric session viewport token render cursor",
+        "  13  width width frame diff metric token gauge timer",
+        "  14  metric viewport gauge stream metric token render width viewport overlay layout",
+        "  15  layout diff gauge width gauge session stream replay",
+        "  16  stream stream diff render token overlay width render gauge session metric render",
+        "  17  overlay replay viewport gauge replay session viewport replay gauge diff stream buffer stream metric",
+        "  18  session cursor gauge render viewport gauge viewport diff token viewport stream width render session metric",
+        "  19  replay timer gauge metric replay overlay render layout stream session viewport",
+        "  20  session frame session replay timer overlay width stream",
+        "  21  session frame stream session viewport diff viewport token",
+        "  22  buffer replay frame metric viewport width token metric timer",
+        "  23  frame viewport width session cursor frame overlay gauge width token token diff replay",
+        "  24  token stream replay session session viewport width frame replay layout diff layout timer",
+        "  25  overlay overlay session stream gauge buffer layout frame viewport",
+        "  26  render width width buffer frame width layout diff stream session metric cursor gauge gauge width timer buffer",
+        "  27  cursor cursor gauge width replay timer viewport render session session frame buffer stream overlay timer",
+        "  28  token width layout width cursor frame buffer frame width width metric diff diff timer",
+        "  29  gauge diff gauge buffer replay frame session timer buffer replay",
+        "  30  overlay frame replay timer layout replay frame layout overlay",
+        "  31  stream overlay render width overlay render stream layout gauge gauge viewport stream stream buffer viewport overlay",
+        "  32  cursor layout token gauge render stream cursor width",
+        "  33  token gauge replay replay render overlay session layout stream metric",
+        "  34  layout layout layout cursor buffer metric layout token layout metric",
+        "  35  gauge token metric session metric diff frame token render session",
+        "  36  diff width width stream token render diff cursor replay replay overlay width cursor timer diff",
+        "  37  token layout viewport timer buffer token timer viewport viewport render",
+        "  38  viewport width overlay session render gauge session overlay layout",
+        "  39  gauge frame render buffer stream layout session stream stream replay session render",
+        "  40  timer timer token stream replay gauge diff layout session frame stream session layout layout layout",
+        "  41  frame cursor overlay diff replay overlay render token viewport",
+        "  42  gauge session buffer session timer timer buffer gauge replay frame frame gauge frame diff diff"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "stream viewport session layout layout frame",
+      "assistantChunks": [
+        "viewport gauge render token layout ",
+        "gauge timer stream metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay token diff metric buffer stream",
+      "assistantChunks": [
+        "gauge overlay viewport buffer stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor frame diff layout viewport replay",
+      "assistantChunks": [
+        "frame render render gauge gauge ",
+        "frame gauge frame stream replay ",
+        "width overlay stream layout timer stream replay width viewport frame gauge "
+      ],
+      "toolLines": [
+        "  | buffer token overlay",
+        "  | overlay overlay replay session frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream stream timer replay viewport",
+      "assistantChunks": [
+        "session stream diff stream session buffer render session ",
+        "session session layout buffer gauge overlay cursor session cursor session ",
+        "diff width cursor stream "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay render timer render token",
+      "assistantChunks": [
+        "token stream diff layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width viewport layout frame overlay stream",
+      "assistantChunks": [
+        "overlay timer replay stream frame diff replay layout viewport ",
+        "replay layout timer viewport gauge "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric timer width",
+      "assistantChunks": [
+        "stream buffer width viewport width token cursor ",
+        "render metric session buffer layout buffer stream replay gauge ",
+        "width gauge gauge replay gauge layout session viewport timer width width "
+      ],
+      "toolLines": [
+        "  | timer frame cursor cursor buffer",
+        "  | metric buffer layout frame timer cursor"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token gauge render replay frame",
+      "assistantChunks": [
+        "render timer stream overlay frame "
+      ],
+      "toolLines": [
+        "  | stream gauge width viewport"
+      ],
+      "outputBlock": [
+        "   0  stream stream replay overlay frame metric token width buffer buffer metric token timer",
+        "   1  token session render viewport gauge stream session width width width buffer token diff viewport timer timer session",
+        "   2  diff render metric overlay gauge metric frame session replay token",
+        "   3  width frame stream timer layout cursor layout stream session width",
+        "   4  width render stream buffer diff buffer stream diff viewport layout timer token buffer metric",
+        "   5  render session frame stream metric width layout metric buffer metric replay",
+        "   6  viewport gauge metric session token timer viewport stream metric stream gauge cursor width gauge",
+        "   7  render metric gauge metric metric gauge token layout session",
+        "   8  replay gauge cursor overlay buffer width diff frame layout viewport gauge stream cursor",
+        "   9  overlay timer timer buffer frame frame timer gauge render gauge cursor layout",
+        "  10  gauge render token overlay width replay metric timer width diff cursor gauge width gauge layout token",
+        "  11  session token diff overlay replay session stream token replay width timer cursor viewport diff stream session",
+        "  12  timer width width gauge token gauge overlay overlay buffer width layout frame metric diff metric replay render",
+        "  13  frame stream frame session gauge diff buffer viewport render diff width",
+        "  14  metric layout token cursor replay timer diff stream session layout layout gauge metric render",
+        "  15  buffer layout overlay width viewport diff session render",
+        "  16  buffer cursor gauge timer overlay overlay cursor gauge render diff overlay frame session",
+        "  17  token gauge timer cursor frame metric layout timer",
+        "  18  layout frame render replay width buffer buffer layout cursor cursor",
+        "  19  frame layout metric overlay viewport timer session viewport buffer stream session",
+        "  20  frame cursor buffer metric replay overlay overlay replay gauge metric frame frame",
+        "  21  timer render gauge stream replay token stream render frame token",
+        "  22  diff width width gauge session buffer width overlay frame cursor session",
+        "  23  viewport layout viewport stream timer diff width timer width cursor token gauge",
+        "  24  overlay session buffer gauge stream metric layout render metric metric gauge timer overlay",
+        "  25  buffer gauge replay buffer replay viewport cursor metric width gauge",
+        "  26  viewport layout session diff replay layout layout metric",
+        "  27  session stream token frame gauge gauge viewport frame frame session overlay",
+        "  28  cursor width viewport render render timer width buffer",
+        "  29  gauge overlay stream diff cursor overlay timer frame viewport gauge diff timer render render cursor render",
+        "  30  token token timer gauge frame diff frame frame session width gauge buffer gauge diff token",
+        "  31  session stream timer viewport overlay stream diff render replay frame cursor replay width timer gauge frame buffer",
+        "  32  buffer buffer overlay render replay layout buffer cursor token session session metric layout",
+        "  33  stream width cursor stream layout layout frame stream overlay stream",
+        "  34  token metric token width token cursor layout frame timer gauge replay render layout",
+        "  35  diff gauge overlay width frame metric timer overlay metric timer",
+        "  36  cursor metric frame overlay session viewport stream render stream session",
+        "  37  gauge gauge session gauge overlay token diff gauge",
+        "  38  viewport buffer token session gauge replay gauge token width viewport width",
+        "  39  token diff metric overlay frame timer metric diff timer buffer timer cursor stream render",
+        "  40  buffer timer buffer gauge session gauge render session token buffer metric",
+        "  41  replay gauge diff buffer stream buffer layout layout",
+        "  42  frame buffer diff viewport replay diff buffer overlay render render viewport render render session diff diff",
+        "  43  stream frame gauge diff session token layout cursor cursor session viewport render token metric width gauge",
+        "  44  metric timer timer session viewport diff width timer timer layout layout stream token",
+        "  45  metric overlay stream width stream metric session render replay metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay cursor viewport gauge render",
+      "assistantChunks": [
+        "session stream width diff frame timer token buffer buffer timer replay ",
+        "layout cursor timer timer replay layout session stream diff width ",
+        "layout replay gauge token gauge cursor "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "stream viewport gauge",
+      "assistantChunks": [
+        "frame gauge stream width stream frame render ",
+        "replay cursor token render session metric diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric diff cursor",
+      "assistantChunks": [
+        "width stream diff render layout overlay "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session token overlay buffer",
+      "assistantChunks": [
+        "timer frame metric gauge layout width session render stream frame session ",
+        "width gauge timer metric render layout cursor buffer width frame "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric gauge session",
+      "assistantChunks": [
+        "replay session stream cursor token "
+      ],
+      "outputBlock": [
+        "   0  width buffer cursor stream timer timer layout diff stream token replay gauge token render buffer diff",
+        "   1  metric stream metric diff render stream metric cursor stream overlay session buffer viewport",
+        "   2  cursor diff metric render stream timer buffer cursor width frame cursor",
+        "   3  viewport replay cursor timer viewport layout cursor buffer viewport frame token diff metric cursor render diff frame",
+        "   4  metric frame width replay render replay cursor overlay metric token",
+        "   5  frame frame cursor viewport stream overlay cursor diff",
+        "   6  frame gauge width viewport replay frame stream render gauge buffer metric gauge metric gauge buffer width",
+        "   7  token token frame stream cursor replay metric session session width viewport viewport frame session metric frame cursor",
+        "   8  width diff token render timer cursor viewport viewport metric buffer",
+        "   9  frame layout cursor timer viewport buffer token diff layout metric buffer layout render token stream render",
+        "  10  layout cursor stream replay buffer gauge diff width layout token diff stream timer",
+        "  11  viewport width render layout viewport overlay cursor buffer gauge viewport stream session layout timer frame frame",
+        "  12  render stream frame session gauge layout replay gauge gauge frame",
+        "  13  replay render diff width cursor buffer diff gauge gauge width buffer token render layout stream session",
+        "  14  replay viewport session stream token width stream layout",
+        "  15  session overlay metric token frame metric timer gauge gauge gauge",
+        "  16  width diff layout viewport diff render session session overlay frame stream timer stream cursor",
+        "  17  timer frame replay cursor diff buffer gauge buffer cursor layout width gauge gauge frame",
+        "  18  diff replay viewport diff buffer timer width render token buffer",
+        "  19  diff timer replay layout stream token diff layout token render",
+        "  20  stream diff gauge layout diff session viewport render overlay cursor",
+        "  21  timer render replay frame overlay cursor timer overlay diff frame replay",
+        "  22  timer render timer timer gauge session overlay replay width metric width token overlay viewport",
+        "  23  timer timer gauge gauge viewport replay buffer timer viewport stream token layout",
+        "  24  cursor stream diff token overlay cursor gauge render",
+        "  25  cursor viewport stream timer timer timer frame render gauge session diff stream diff overlay",
+        "  26  buffer frame stream layout buffer overlay cursor session diff overlay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay gauge replay timer viewport layout",
+      "assistantChunks": [
+        "metric token timer gauge session width metric overlay ",
+        "width gauge replay session metric timer timer replay frame token token ",
+        "layout timer overlay token replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric render replay",
+      "assistantChunks": [
+        "replay diff stream session layout buffer metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token gauge gauge render layout overlay width",
+      "assistantChunks": [
+        "buffer replay layout replay width gauge render ",
+        "diff viewport frame stream diff timer ",
+        "layout token gauge stream cursor layout "
+      ],
+      "resizeTo": {
+        "cols": 73,
+        "rows": 24
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge diff stream stream diff metric",
+      "assistantChunks": [
+        "gauge viewport viewport frame diff viewport diff cursor replay replay ",
+        "replay frame metric layout stream timer width ",
+        "metric viewport width session frame token "
+      ],
+      "toolLines": [
+        "  | render frame gauge buffer",
+        "  | cursor layout replay layout layout buffer diff",
+        "  | buffer diff viewport replay token session"
+      ],
+      "outputBlock": [
+        "   0  cursor replay layout diff diff gauge cursor cursor metric width timer session viewport width viewport",
+        "   1  cursor diff render replay frame diff token stream diff viewport viewport width width",
+        "   2  gauge gauge overlay viewport stream gauge render viewport render width gauge render gauge cursor",
+        "   3  replay stream diff width metric buffer timer diff cursor",
+        "   4  gauge width session replay token layout gauge overlay cursor session viewport timer render overlay frame",
+        "   5  token diff render cursor overlay stream metric render render stream viewport",
+        "   6  timer metric cursor session session stream gauge overlay overlay stream frame session",
+        "   7  cursor diff diff frame frame viewport frame stream layout width buffer cursor gauge replay",
+        "   8  stream cursor metric buffer replay frame viewport timer diff stream viewport frame frame render",
+        "   9  width replay layout session layout width metric width overlay frame frame token diff session cursor buffer",
+        "  10  metric viewport stream replay gauge gauge token stream",
+        "  11  render overlay viewport replay token stream width replay diff",
+        "  12  viewport cursor layout cursor token buffer diff layout layout diff render replay frame",
+        "  13  layout session frame replay layout viewport stream overlay metric cursor session stream overlay width token gauge",
+        "  14  session cursor viewport gauge stream session token replay stream render token buffer metric render",
+        "  15  token overlay timer gauge token width metric gauge overlay session frame timer width token session",
+        "  16  token gauge overlay buffer frame viewport timer gauge replay buffer",
+        "  17  timer metric token replay metric replay gauge render overlay session diff timer metric buffer render viewport token",
+        "  18  replay replay gauge width render viewport replay stream token timer stream overlay",
+        "  19  stream render width gauge frame timer cursor gauge stream frame buffer layout diff stream",
+        "  20  frame buffer timer gauge overlay viewport viewport session replay layout diff timer",
+        "  21  cursor timer layout viewport cursor timer overlay timer metric width buffer gauge frame timer token",
+        "  22  replay width render timer session metric buffer cursor layout frame width cursor cursor diff gauge overlay diff",
+        "  23  gauge timer overlay width session layout cursor cursor render session session buffer layout",
+        "  24  metric render metric token viewport token replay timer diff layout cursor viewport token token",
+        "  25  cursor viewport buffer token width render gauge width frame diff overlay overlay overlay overlay stream frame replay",
+        "  26  gauge timer render buffer cursor diff layout buffer timer buffer stream frame replay frame diff",
+        "  27  buffer buffer session timer frame session timer render session layout render viewport frame cursor layout layout",
+        "  28  replay stream render render viewport replay replay frame width replay overlay gauge stream buffer replay gauge overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render timer render layout render token",
+      "assistantChunks": [
+        "buffer token layout gauge gauge viewport layout ",
+        "metric token overlay metric gauge token metric token token metric token ",
+        "replay token buffer metric buffer token gauge replay width render "
+      ],
+      "toolLines": [
+        "  | token viewport viewport replay render buffer",
+        "  | layout metric overlay cursor diff viewport",
+        "  | timer render token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge width stream",
+      "assistantChunks": [
+        "metric width overlay render metric diff ",
+        "frame stream cursor session frame cursor viewport buffer viewport "
+      ],
+      "toolLines": [
+        "  | timer overlay timer stream",
+        "  | gauge layout replay layout",
+        "  | render frame stream replay diff overlay frame"
+      ],
+      "resizeTo": {
+        "cols": 109,
+        "rows": 29
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "render viewport cursor session width layout",
+      "assistantChunks": [
+        "overlay gauge cursor width stream stream width session viewport gauge ",
+        "stream session layout buffer timer overlay cursor stream ",
+        "frame width gauge layout width overlay viewport render "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge diff gauge width render metric",
+      "assistantChunks": [
+        "render cursor diff metric viewport buffer timer viewport session session ",
+        "overlay width viewport width layout overlay timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge viewport token viewport frame gauge",
+      "assistantChunks": [
+        "metric cursor frame cursor "
+      ],
+      "toolLines": [
+        "  | token replay gauge buffer"
+      ],
+      "resizeTo": {
+        "cols": 88,
+        "rows": 20
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor token diff overlay frame width",
+      "assistantChunks": [
+        "timer token render render session session replay stream timer viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor buffer layout layout replay cursor timer",
+      "assistantChunks": [
+        "token cursor diff render session metric render stream session token ",
+        "frame overlay replay timer session layout frame replay layout render timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge session replay metric stream metric",
+      "assistantChunks": [
+        "diff width stream overlay frame replay replay timer stream timer width "
+      ],
+      "toolLines": [
+        "  | render timer overlay overlay",
+        "  | width gauge token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width token viewport layout",
+      "assistantChunks": [
+        "timer cursor diff overlay layout overlay timer buffer ",
+        "token token viewport diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout viewport frame render session session layout",
+      "assistantChunks": [
+        "cursor layout buffer overlay replay render render overlay gauge overlay "
+      ],
+      "outputBlock": [
+        "   0  frame viewport gauge session replay layout session render overlay render gauge layout timer token viewport frame",
+        "   1  cursor stream replay timer render metric timer replay replay stream gauge timer metric layout stream",
+        "   2  replay replay token viewport frame metric timer diff",
+        "   3  replay cursor overlay metric timer render stream width diff layout diff diff buffer frame",
+        "   4  replay metric gauge token diff stream metric overlay diff stream session viewport",
+        "   5  stream render metric diff timer overlay buffer token stream token",
+        "   6  frame render width gauge layout viewport frame cursor",
+        "   7  frame render token gauge gauge diff viewport render cursor session metric",
+        "   8  overlay gauge overlay frame diff layout gauge token viewport replay token timer layout frame viewport diff metric",
+        "   9  replay timer replay overlay metric viewport replay buffer timer diff metric buffer timer",
+        "  10  stream metric frame width stream token render metric session session stream token replay",
+        "  11  timer metric replay cursor timer render frame frame overlay overlay timer width metric layout diff",
+        "  12  width layout overlay gauge replay diff width viewport render replay viewport diff layout metric",
+        "  13  width diff width buffer buffer gauge timer layout layout frame width frame timer frame layout diff",
+        "  14  width overlay stream overlay width timer metric gauge diff diff viewport",
+        "  15  diff timer viewport width session gauge buffer session cursor overlay layout",
+        "  16  timer gauge cursor timer layout viewport width gauge width session",
+        "  17  cursor stream cursor buffer stream stream token timer frame token diff viewport",
+        "  18  frame layout viewport metric timer metric timer frame timer replay",
+        "  19  token gauge stream diff width session layout layout overlay viewport diff buffer buffer viewport diff metric diff",
+        "  20  replay layout gauge metric session overlay stream token width replay session",
+        "  21  timer cursor render frame timer width timer layout diff diff token diff session viewport overlay",
+        "  22  buffer buffer token gauge diff width session replay cursor layout layout token layout",
+        "  23  buffer gauge layout session session stream render gauge token frame width metric timer",
+        "  24  metric token width render replay width token render gauge diff",
+        "  25  layout metric frame frame buffer width diff stream layout cursor diff cursor frame gauge",
+        "  26  session cursor frame stream diff width width render replay diff metric timer",
+        "  27  replay token render diff gauge render buffer cursor",
+        "  28  buffer viewport cursor stream stream frame render timer",
+        "  29  stream stream render cursor render width gauge viewport width frame width token session",
+        "  30  gauge stream metric stream frame overlay token cursor stream frame viewport metric layout layout diff"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "buffer frame gauge",
+      "assistantChunks": [
+        "token gauge frame viewport session viewport ",
+        "cursor token timer stream stream viewport frame cursor diff token token "
+      ],
+      "toolLines": [
+        "  | replay cursor render width width",
+        "  | diff timer render buffer diff",
+        "  | diff stream width timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge viewport timer width gauge",
+      "assistantChunks": [
+        "viewport viewport cursor replay timer render timer token width viewport stream ",
+        "stream metric diff layout timer gauge token buffer layout session layout ",
+        "overlay replay timer diff "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "metric diff replay stream session width",
+      "assistantChunks": [
+        "cursor timer replay render layout timer stream layout metric width ",
+        "replay layout layout metric frame "
+      ],
+      "toolLines": [
+        "  | replay viewport width width token",
+        "  | token cursor render session diff"
+      ],
+      "outputBlock": [
+        "   0  frame layout token frame buffer diff viewport cursor gauge replay cursor gauge",
+        "   1  metric render timer render session buffer render buffer stream layout metric frame",
+        "   2  render overlay diff session replay render render timer diff gauge cursor render overlay",
+        "   3  viewport stream diff layout stream width stream overlay cursor replay buffer metric viewport diff width",
+        "   4  replay render viewport token replay diff width buffer render viewport buffer timer",
+        "   5  frame gauge render metric metric buffer buffer frame overlay",
+        "   6  width buffer gauge buffer frame cursor overlay render timer overlay replay cursor cursor",
+        "   7  cursor buffer layout layout render render frame stream token width replay render replay cursor gauge stream",
+        "   8  replay timer overlay cursor stream frame token replay replay stream layout",
+        "   9  diff render overlay diff cursor frame gauge layout cursor buffer render diff overlay",
+        "  10  width cursor frame overlay render token diff buffer metric",
+        "  11  layout cursor render metric metric metric viewport session layout timer gauge width buffer stream",
+        "  12  buffer stream frame diff overlay session cursor metric layout token gauge frame replay cursor diff",
+        "  13  viewport timer overlay buffer replay viewport session token metric stream viewport",
+        "  14  metric diff timer replay diff session frame diff render layout cursor",
+        "  15  stream overlay render replay cursor gauge stream diff",
+        "  16  stream frame render width render token timer replay session timer overlay",
+        "  17  cursor width replay overlay timer gauge render frame replay",
+        "  18  frame viewport overlay overlay timer replay cursor timer layout diff diff diff layout stream timer",
+        "  19  viewport frame cursor timer session viewport viewport render frame metric cursor stream",
+        "  20  viewport replay session metric frame viewport gauge width token viewport stream session layout gauge frame viewport width",
+        "  21  cursor replay timer buffer cursor overlay stream timer cursor",
+        "  22  frame token timer frame frame stream width layout stream token",
+        "  23  timer token timer cursor token layout overlay layout buffer buffer cursor",
+        "  24  session session metric width buffer buffer overlay buffer stream timer buffer viewport stream render metric",
+        "  25  diff viewport viewport viewport token session token buffer render gauge",
+        "  26  cursor session diff session render token diff layout viewport cursor timer buffer viewport frame token",
+        "  27  buffer replay overlay layout metric frame layout cursor layout metric gauge render token layout frame replay stream",
+        "  28  replay token buffer overlay replay viewport viewport viewport metric viewport layout frame viewport diff stream",
+        "  29  layout frame frame frame timer timer viewport cursor diff width",
+        "  30  stream layout session metric diff replay overlay viewport replay diff frame layout buffer layout token width render",
+        "  31  frame stream metric gauge viewport replay timer width buffer width metric layout timer layout metric diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge render overlay gauge viewport cursor",
+      "assistantChunks": [
+        "stream viewport session render metric session session gauge ",
+        "frame render viewport overlay ",
+        "diff timer cursor replay overlay "
+      ],
+      "toolLines": [
+        "  | viewport stream viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport metric frame session",
+      "assistantChunks": [
+        "replay gauge metric replay metric metric diff layout replay timer "
+      ],
+      "toolLines": [
+        "  | replay render replay diff buffer frame width",
+        "  | diff stream replay render layout cursor",
+        "  | width gauge timer session token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout replay width width",
+      "assistantChunks": [
+        "buffer frame timer session render render metric cursor frame timer cursor ",
+        "stream metric diff viewport layout "
+      ],
+      "outputBlock": [
+        "   0  render gauge layout replay session cursor timer timer token stream viewport stream overlay layout frame viewport",
+        "   1  buffer overlay render viewport token width diff gauge",
+        "   2  width overlay viewport viewport cursor token session gauge session token width stream",
+        "   3  layout frame cursor render width token session session session",
+        "   4  timer stream session layout diff viewport gauge stream viewport",
+        "   5  replay stream render layout buffer gauge viewport replay diff overlay width gauge width",
+        "   6  frame diff session stream render cursor gauge render width timer diff stream",
+        "   7  timer viewport viewport session width stream gauge frame token overlay width token gauge timer metric timer",
+        "   8  session buffer viewport width overlay render replay viewport",
+        "   9  frame cursor timer gauge diff viewport gauge session frame metric layout width width metric",
+        "  10  stream stream timer stream frame viewport gauge replay layout",
+        "  11  timer cursor diff cursor diff layout token buffer cursor replay",
+        "  12  layout frame gauge timer stream render width gauge stream",
+        "  13  session timer metric viewport buffer metric replay metric cursor width metric cursor width width token stream overlay",
+        "  14  replay render timer replay buffer gauge diff gauge",
+        "  15  timer overlay metric timer session timer overlay session",
+        "  16  layout replay frame stream buffer token stream session stream stream frame",
+        "  17  token token diff metric overlay render viewport gauge metric frame layout width timer",
+        "  18  layout diff metric metric layout frame gauge frame overlay width frame overlay metric layout gauge render",
+        "  19  stream replay overlay cursor buffer timer replay metric layout timer diff",
+        "  20  replay buffer gauge layout gauge diff session width cursor layout layout token",
+        "  21  overlay timer replay cursor frame replay frame viewport frame",
+        "  22  viewport replay stream session metric cursor timer buffer frame",
+        "  23  diff metric stream diff metric timer diff layout stream layout",
+        "  24  frame gauge gauge diff gauge gauge cursor session gauge replay token cursor width token cursor",
+        "  25  metric render gauge token token cursor stream render stream metric replay diff replay token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor stream frame frame",
+      "assistantChunks": [
+        "layout render session timer cursor replay "
+      ],
+      "toolLines": [
+        "  | overlay timer gauge stream",
+        "  | width stream stream viewport",
+        "  | stream layout render layout gauge session overlay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session frame timer",
+      "assistantChunks": [
+        "overlay session viewport metric token frame frame viewport ",
+        "viewport viewport replay stream buffer render timer cursor metric frame "
+      ],
+      "toolLines": [
+        "  | layout viewport layout metric",
+        "  | layout token metric frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token render buffer gauge",
+      "assistantChunks": [
+        "replay overlay diff timer diff token width stream "
+      ],
+      "toolLines": [
+        "  | replay width viewport session frame gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token layout diff",
+      "assistantChunks": [
+        "width frame diff layout cursor ",
+        "metric cursor diff frame render stream buffer layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout stream stream replay diff",
+      "assistantChunks": [
+        "session frame buffer frame stream replay replay timer diff metric ",
+        "gauge frame cursor diff diff replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric overlay metric",
+      "assistantChunks": [
+        "render width width timer layout layout token stream token layout replay ",
+        "session metric token viewport session layout frame cursor token render replay ",
+        "timer metric stream width metric diff gauge viewport width layout token "
+      ],
+      "toolLines": [
+        "  | cursor cursor diff layout"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream token session width",
+      "assistantChunks": [
+        "replay timer replay diff stream cursor token buffer token metric gauge ",
+        "stream token diff replay gauge gauge viewport timer buffer buffer "
+      ],
+      "toolLines": [
+        "  | buffer stream viewport",
+        "  | frame session render overlay diff metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width timer diff layout render stream",
+      "assistantChunks": [
+        "viewport render stream token buffer ",
+        "session cursor metric stream gauge replay session overlay gauge "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge cursor frame metric buffer layout",
+      "assistantChunks": [
+        "timer stream stream stream token token overlay ",
+        "metric gauge frame timer ",
+        "token overlay width gauge stream "
+      ],
+      "toolLines": [
+        "  | diff viewport viewport replay session diff",
+        "  | cursor cursor timer",
+        "  | gauge render stream session"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token timer replay timer replay viewport",
+      "assistantChunks": [
+        "layout layout overlay width frame frame timer ",
+        "session viewport replay gauge buffer token width token render stream "
+      ],
+      "toolLines": [
+        "  | viewport session token layout timer"
+      ],
+      "resizeTo": {
+        "cols": 122,
+        "rows": 20
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "token gauge token token stream render diff",
+      "assistantChunks": [
+        "width frame render replay timer cursor session replay layout overlay timer "
+      ],
+      "toolLines": [
+        "  | buffer viewport gauge timer session gauge overlay",
+        "  | buffer timer diff buffer token",
+        "  | cursor replay layout"
+      ],
+      "outputBlock": [
+        "   0  gauge stream timer session cursor cursor session viewport diff buffer",
+        "   1  buffer cursor gauge overlay replay timer overlay frame",
+        "   2  buffer width gauge replay session viewport diff frame viewport gauge",
+        "   3  render buffer token width diff stream diff metric viewport stream timer metric token session cursor render",
+        "   4  width replay session timer buffer diff session viewport overlay frame replay stream diff session overlay width",
+        "   5  session token session stream buffer timer frame token layout stream timer render buffer layout overlay render",
+        "   6  cursor viewport metric metric viewport replay viewport overlay overlay stream timer diff buffer diff cursor replay metric",
+        "   7  render metric cursor width gauge frame stream render viewport frame layout viewport timer stream session cursor diff",
+        "   8  frame diff overlay cursor timer session diff gauge overlay timer gauge stream stream stream",
+        "   9  gauge metric replay render frame diff metric overlay render cursor render width buffer",
+        "  10  layout stream viewport render gauge gauge viewport cursor frame render replay",
+        "  11  width render overlay viewport token overlay replay cursor session frame buffer gauge",
+        "  12  replay gauge render replay render metric frame buffer token layout frame gauge",
+        "  13  gauge token render replay token stream gauge stream cursor frame overlay frame",
+        "  14  frame session replay buffer timer replay gauge token gauge",
+        "  15  render frame render overlay viewport buffer width width token stream session gauge render viewport session render",
+        "  16  stream token replay stream layout token stream replay viewport cursor session render layout overlay",
+        "  17  cursor replay buffer viewport metric width render viewport",
+        "  18  frame replay stream layout metric frame stream session replay",
+        "  19  timer viewport layout gauge layout token render cursor replay stream metric render cursor metric frame stream viewport",
+        "  20  cursor frame viewport session buffer diff replay viewport stream frame token diff stream frame token",
+        "  21  session frame gauge metric timer stream overlay layout metric metric render replay session layout overlay viewport stream",
+        "  22  overlay overlay layout cursor frame overlay session replay token frame cursor replay",
+        "  23  gauge diff cursor session gauge layout diff token gauge",
+        "  24  width render width replay replay timer token buffer timer",
+        "  25  stream timer timer overlay metric overlay session stream stream cursor layout gauge metric",
+        "  26  diff diff overlay diff buffer token gauge layout session metric diff layout diff token",
+        "  27  gauge gauge metric cursor buffer buffer width frame replay width metric frame cursor timer session token",
+        "  28  metric metric buffer frame replay session viewport viewport render overlay viewport frame buffer timer timer viewport",
+        "  29  width buffer gauge frame frame gauge stream timer width diff timer metric timer width frame",
+        "  30  stream stream cursor frame timer frame diff metric timer gauge buffer frame session gauge buffer",
+        "  31  render viewport gauge render frame token cursor layout stream width stream gauge session diff diff width token",
+        "  32  frame session render viewport session stream buffer metric buffer render stream cursor gauge render overlay",
+        "  33  overlay gauge render width stream cursor width diff gauge frame overlay stream layout diff frame layout",
+        "  34  overlay frame metric timer render width cursor replay render replay replay buffer",
+        "  35  timer viewport timer overlay replay buffer session overlay token",
+        "  36  session diff buffer buffer gauge viewport timer buffer diff",
+        "  37  token overlay stream token token gauge stream width metric replay render",
+        "  38  session width cursor token viewport timer width diff metric frame gauge render session",
+        "  39  session token session render session token width overlay viewport overlay gauge replay overlay render",
+        "  40  viewport overlay cursor cursor render overlay width token layout cursor layout",
+        "  41  session frame token token diff frame frame render cursor layout token",
+        "  42  token width replay diff width frame replay timer render stream gauge width gauge",
+        "  43  timer cursor token render timer stream replay frame buffer render",
+        "  44  cursor frame stream token gauge replay timer overlay stream replay stream timer token replay stream layout",
+        "  45  replay frame buffer timer render gauge session layout timer metric buffer render metric",
+        "  46  stream session layout render overlay timer buffer diff render buffer diff diff buffer width gauge overlay session",
+        "  47  buffer timer replay diff replay viewport width timer viewport timer timer",
+        "  48  width replay stream render replay viewport replay overlay overlay session stream width frame metric",
+        "  49  cursor stream gauge layout buffer width diff session render metric viewport session replay diff",
+        "  50  replay timer diff session cursor buffer stream gauge timer frame overlay stream viewport replay timer",
+        "  51  metric timer stream overlay metric diff render token frame gauge gauge cursor layout width",
+        "  52  gauge render timer render metric replay frame session metric metric session",
+        "  53  gauge metric overlay viewport buffer frame stream stream buffer overlay metric",
+        "  54  cursor replay overlay layout diff gauge token cursor viewport layout token stream stream width cursor viewport stream",
+        "  55  timer render timer buffer diff session width timer buffer token timer diff width layout cursor frame metric",
+        "  56  gauge timer overlay viewport session overlay gauge viewport timer token gauge frame metric frame frame replay",
+        "  57  buffer cursor replay gauge session token cursor overlay viewport buffer overlay replay metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render diff layout",
+      "assistantChunks": [
+        "cursor frame layout frame stream cursor timer metric cursor render diff ",
+        "metric replay token replay "
+      ],
+      "toolLines": [
+        "  | replay overlay session diff token",
+        "  | stream layout viewport",
+        "  | width viewport render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width buffer token layout viewport render",
+      "assistantChunks": [
+        "buffer render buffer replay token overlay token buffer token ",
+        "width render overlay width stream replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric width metric metric viewport",
+      "assistantChunks": [
+        "layout cursor overlay metric gauge ",
+        "render render replay render replay replay diff replay timer session ",
+        "frame metric replay session viewport frame "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay token cursor",
+      "assistantChunks": [
+        "buffer viewport buffer layout stream ",
+        "layout diff gauge buffer frame stream timer "
+      ],
+      "toolLines": [
+        "  | metric gauge render stream replay timer",
+        "  | overlay buffer diff timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer session viewport frame layout",
+      "assistantChunks": [
+        "cursor diff diff overlay timer buffer metric ",
+        "replay width layout timer viewport cursor viewport gauge replay overlay stream ",
+        "layout frame cursor session timer metric token overlay cursor "
+      ],
+      "resizeTo": {
+        "cols": 113,
+        "rows": 27
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge session timer stream replay",
+      "assistantChunks": [
+        "render timer replay timer timer overlay timer overlay ",
+        "token stream token layout "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "timer replay width width gauge frame timer",
+      "assistantChunks": [
+        "layout gauge overlay frame cursor ",
+        "cursor timer render render buffer overlay replay viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render diff session",
+      "assistantChunks": [
+        "metric gauge replay timer layout width token metric ",
+        "render viewport viewport token layout token buffer metric replay layout replay ",
+        "width viewport render cursor frame overlay metric gauge stream frame replay "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport buffer render layout",
+      "assistantChunks": [
+        "width layout cursor replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge session frame timer gauge width buffer",
+      "assistantChunks": [
+        "timer gauge stream width buffer metric render replay frame viewport ",
+        "layout gauge render replay cursor diff buffer session "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer layout stream",
+      "assistantChunks": [
+        "cursor metric session overlay metric replay ",
+        "token stream timer overlay session token ",
+        "metric frame metric replay metric frame frame stream replay buffer stream "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay gauge frame",
+      "assistantChunks": [
+        "render diff viewport diff stream ",
+        "cursor metric overlay cursor replay "
+      ],
+      "toolLines": [
+        "  | stream session cursor replay cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor frame token stream cursor width",
+      "assistantChunks": [
+        "width metric cursor timer frame buffer timer viewport timer "
+      ],
+      "toolLines": [
+        "  | replay stream token metric",
+        "  | metric overlay replay",
+        "  | gauge viewport metric layout metric buffer diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay frame overlay cursor replay",
+      "assistantChunks": [
+        "overlay metric buffer gauge buffer metric metric stream viewport "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session layout token token width metric overlay",
+      "assistantChunks": [
+        "timer overlay render gauge viewport width timer cursor ",
+        "render metric width frame diff overlay frame stream "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "buffer overlay overlay timer",
+      "assistantChunks": [
+        "width diff overlay width timer "
+      ],
+      "toolLines": [
+        "  | frame layout replay",
+        "  | width token timer buffer viewport buffer",
+        "  | metric viewport width replay layout frame diff"
+      ],
+      "outputBlock": [
+        "   0  token buffer frame timer replay frame gauge stream layout session layout",
+        "   1  replay timer stream replay render buffer replay session overlay width timer session token frame layout metric width",
+        "   2  token render diff cursor buffer session gauge buffer replay viewport session cursor timer",
+        "   3  timer overlay frame session metric stream stream render",
+        "   4  cursor token replay stream layout frame overlay width",
+        "   5  token buffer viewport diff session cursor overlay buffer diff replay timer",
+        "   6  cursor timer layout frame stream session stream replay",
+        "   7  replay diff stream render replay cursor width layout token session viewport metric",
+        "   8  buffer gauge render render viewport timer token stream stream metric token timer stream",
+        "   9  session overlay session width frame metric overlay token stream viewport timer metric metric frame",
+        "  10  frame cursor frame stream stream metric layout stream overlay",
+        "  11  cursor token session render gauge overlay render token frame layout cursor timer render stream cursor",
+        "  12  frame layout stream stream viewport metric replay session token timer frame",
+        "  13  replay timer frame cursor token cursor replay width metric overlay replay width",
+        "  14  gauge session overlay cursor replay frame session gauge diff",
+        "  15  replay layout overlay frame diff stream gauge render token",
+        "  16  render timer replay layout stream overlay render diff layout timer render frame render",
+        "  17  timer gauge timer frame frame diff viewport cursor stream layout stream timer width",
+        "  18  cursor layout render width cursor token viewport buffer metric render replay session overlay buffer",
+        "  19  session layout viewport replay session width stream overlay replay diff token overlay replay",
+        "  20  buffer diff overlay metric metric buffer cursor frame",
+        "  21  replay metric cursor session width metric token stream session width diff stream metric render session",
+        "  22  gauge gauge overlay frame stream layout cursor gauge width stream width token layout render diff width",
+        "  23  buffer cursor replay gauge width overlay viewport frame render render",
+        "  24  timer diff timer layout width render replay diff stream layout stream cursor overlay timer overlay timer",
+        "  25  gauge overlay token session stream buffer timer timer metric layout frame stream buffer viewport session gauge replay",
+        "  26  render session layout cursor token viewport cursor metric layout diff layout metric",
+        "  27  token width viewport buffer overlay render metric metric timer timer session replay frame",
+        "  28  token cursor layout overlay gauge frame frame cursor stream timer stream metric render viewport",
+        "  29  stream render stream cursor overlay viewport viewport metric layout viewport render buffer layout",
+        "  30  replay replay session token session render viewport viewport render width frame token overlay frame",
+        "  31  layout cursor timer metric render session render stream render frame frame viewport overlay width cursor",
+        "  32  session cursor timer width metric session buffer cursor buffer replay width layout",
+        "  33  layout width buffer width timer diff diff metric metric diff metric",
+        "  34  gauge width buffer viewport gauge session frame overlay frame",
+        "  35  frame frame buffer session timer viewport layout render frame buffer buffer token",
+        "  36  width frame replay width cursor render timer session metric",
+        "  37  diff token gauge frame render diff session gauge replay stream layout timer",
+        "  38  replay session metric cursor buffer cursor viewport diff width stream token stream",
+        "  39  width overlay overlay timer overlay overlay token metric timer viewport viewport width buffer layout frame",
+        "  40  stream stream buffer replay replay replay viewport width width stream replay",
+        "  41  gauge token diff stream token stream buffer width render width buffer",
+        "  42  buffer token overlay session token timer buffer stream width cursor diff overlay session cursor stream",
+        "  43  stream overlay stream viewport cursor layout token layout frame token frame frame layout diff layout metric",
+        "  44  layout frame session diff cursor replay layout layout width overlay gauge layout width frame timer token timer",
+        "  45  layout replay timer render diff layout viewport width render layout overlay token",
+        "  46  token timer buffer gauge buffer viewport metric frame render session buffer timer",
+        "  47  stream replay session overlay gauge layout gauge layout overlay width diff overlay",
+        "  48  gauge overlay viewport gauge timer width frame cursor stream render frame",
+        "  49  width frame stream replay buffer layout stream diff replay session replay diff replay",
+        "  50  frame stream session timer render cursor session frame session diff timer token width replay session replay",
+        "  51  token width gauge gauge replay stream layout diff overlay",
+        "  52  render viewport frame metric metric buffer replay overlay metric buffer diff width replay buffer session buffer"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout cursor replay timer diff metric",
+      "assistantChunks": [
+        "overlay frame viewport token render ",
+        "session timer render token metric token viewport metric metric metric buffer ",
+        "frame render layout render render stream layout "
+      ],
+      "toolLines": [
+        "  | overlay replay render gauge timer",
+        "  | token render frame cursor token",
+        "  | width frame width frame replay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric replay metric gauge token stream width",
+      "assistantChunks": [
+        "session layout diff timer ",
+        "session gauge session buffer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer overlay token",
+      "assistantChunks": [
+        "width width cursor metric frame render ",
+        "session frame gauge width overlay overlay viewport timer diff token session ",
+        "frame gauge overlay metric layout layout stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge render token",
+      "assistantChunks": [
+        "metric stream layout width timer session layout replay buffer width ",
+        "viewport gauge replay replay "
+      ],
+      "outputBlock": [
+        "   0  metric overlay viewport overlay width gauge token replay",
+        "   1  gauge stream diff stream overlay buffer viewport token session session cursor stream timer",
+        "   2  width render viewport token timer render layout layout cursor stream metric session",
+        "   3  replay buffer gauge cursor timer render width cursor replay",
+        "   4  cursor viewport token overlay frame render frame buffer replay buffer width session session",
+        "   5  frame viewport gauge session metric gauge session replay metric buffer cursor width overlay render metric",
+        "   6  diff session diff cursor width frame session gauge render overlay overlay metric viewport replay layout metric",
+        "   7  cursor buffer width frame frame overlay stream frame buffer",
+        "   8  buffer viewport frame overlay timer cursor frame layout viewport width timer width timer replay frame",
+        "   9  render frame diff session stream token cursor cursor layout token metric replay overlay diff",
+        "  10  render replay diff width layout width width viewport overlay",
+        "  11  stream session metric render replay cursor diff token buffer width token render buffer gauge replay",
+        "  12  token metric token width overlay cursor overlay frame buffer stream viewport cursor render",
+        "  13  viewport render diff layout cursor layout overlay viewport layout session gauge frame token",
+        "  14  buffer token session metric cursor overlay width session frame overlay gauge",
+        "  15  gauge buffer cursor layout width timer session token stream token replay frame diff diff viewport",
+        "  16  frame frame diff stream gauge timer metric width session timer layout",
+        "  17  viewport viewport gauge cursor stream cursor token metric",
+        "  18  render diff cursor render cursor gauge buffer width cursor diff gauge metric viewport replay",
+        "  19  viewport stream replay timer session replay stream gauge timer gauge",
+        "  20  session stream gauge render overlay token token viewport metric",
+        "  21  frame replay gauge diff stream token buffer stream metric session overlay timer",
+        "  22  diff metric metric buffer overlay frame overlay layout gauge stream layout",
+        "  23  timer viewport replay timer layout layout session replay token timer cursor stream gauge session",
+        "  24  session layout replay layout buffer replay metric cursor gauge stream",
+        "  25  replay timer render metric buffer session timer buffer cursor diff frame overlay frame token cursor overlay",
+        "  26  gauge cursor gauge diff token metric replay width session cursor",
+        "  27  buffer frame stream viewport metric render session timer cursor width overlay",
+        "  28  session gauge metric width viewport render replay diff cursor token token timer timer render overlay metric cursor",
+        "  29  layout frame cursor buffer render render metric gauge session diff buffer timer stream metric",
+        "  30  session replay metric frame layout gauge overlay overlay session frame session replay stream viewport timer diff",
+        "  31  overlay gauge cursor buffer frame gauge width metric viewport diff width cursor width",
+        "  32  buffer layout layout overlay frame overlay timer diff layout",
+        "  33  width layout frame layout metric gauge timer render token gauge token gauge",
+        "  34  token buffer replay timer session frame render replay cursor metric replay timer diff stream viewport buffer cursor",
+        "  35  timer buffer viewport gauge viewport cursor timer width viewport timer session gauge cursor",
+        "  36  frame render timer token timer width cursor session buffer",
+        "  37  overlay layout buffer metric frame session token stream",
+        "  38  stream layout replay timer token overlay timer cursor metric metric stream metric metric stream",
+        "  39  viewport buffer replay width render replay layout overlay replay buffer stream replay buffer layout cursor timer render",
+        "  40  viewport metric diff width replay layout render metric render diff token session replay viewport",
+        "  41  token metric layout render token width viewport viewport render buffer frame render diff frame",
+        "  42  metric diff overlay width layout replay viewport gauge replay",
+        "  43  diff timer timer viewport session layout metric frame metric replay buffer stream buffer metric cursor overlay buffer",
+        "  44  viewport metric layout metric viewport render metric gauge buffer width overlay replay diff frame",
+        "  45  stream metric layout buffer cursor stream diff stream frame gauge frame cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge buffer frame frame layout session metric",
+      "assistantChunks": [
+        "layout timer replay overlay overlay width cursor viewport buffer replay render ",
+        "replay frame layout timer frame frame session overlay token stream stream ",
+        "cursor replay overlay replay "
+      ],
+      "toolLines": [
+        "  | stream layout width replay stream viewport token"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay replay replay frame token viewport",
+      "assistantChunks": [
+        "width overlay viewport metric session token overlay metric ",
+        "session buffer render timer render render timer gauge "
+      ],
+      "toolLines": [
+        "  | frame metric width diff stream",
+        "  | overlay gauge viewport token",
+        "  | diff timer frame timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor render viewport stream overlay",
+      "assistantChunks": [
+        "metric overlay overlay session overlay stream stream metric gauge token ",
+        "session replay metric timer overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay frame stream width layout gauge",
+      "assistantChunks": [
+        "timer layout metric gauge token layout stream "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token token diff overlay overlay diff cursor",
+      "assistantChunks": [
+        "render render width cursor ",
+        "buffer session token overlay timer replay layout session layout cursor width "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token stream width stream stream",
+      "assistantChunks": [
+        "width replay frame frame cursor width metric width ",
+        "width overlay layout gauge diff cursor overlay timer ",
+        "metric layout token gauge render metric timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "diff token stream layout frame",
+      "assistantChunks": [
+        "session session overlay session frame stream session gauge ",
+        "frame render layout token "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric stream viewport session",
+      "assistantChunks": [
+        "stream overlay replay timer frame overlay cursor metric render ",
+        "viewport diff replay buffer overlay session overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer buffer cursor",
+      "assistantChunks": [
+        "cursor session timer stream viewport ",
+        "frame diff frame timer overlay ",
+        "token viewport overlay overlay token overlay buffer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay metric token metric",
+      "assistantChunks": [
+        "stream stream replay cursor ",
+        "cursor metric gauge viewport overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout frame width gauge",
+      "assistantChunks": [
+        "buffer replay overlay viewport width metric metric token stream session ",
+        "cursor overlay session viewport ",
+        "timer buffer layout layout cursor diff gauge overlay gauge replay viewport "
+      ],
+      "toolLines": [
+        "  | buffer replay timer cursor session buffer"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay timer metric metric",
+      "assistantChunks": [
+        "metric token stream token token replay overlay session cursor replay "
+      ],
+      "toolLines": [
+        "  | width frame token",
+        "  | session timer replay cursor token stream",
+        "  | session viewport buffer render diff frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout metric stream frame render timer",
+      "assistantChunks": [
+        "stream layout cursor cursor layout token width overlay layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport session frame",
+      "assistantChunks": [
+        "replay buffer session viewport layout buffer width width stream overlay "
+      ],
+      "toolLines": [
+        "  | cursor layout width buffer viewport cursor replay",
+        "  | stream stream timer buffer buffer metric session",
+        "  | viewport layout gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer replay render",
+      "assistantChunks": [
+        "session cursor metric gauge session viewport render layout token overlay viewport ",
+        "diff cursor gauge token width ",
+        "gauge viewport timer session gauge replay frame layout replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer overlay diff metric buffer frame",
+      "assistantChunks": [
+        "diff session token viewport frame replay layout gauge metric stream "
+      ],
+      "toolLines": [
+        "  | overlay frame width timer timer metric diff",
+        "  | diff gauge width gauge",
+        "  | stream stream layout stream cursor render viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout buffer metric frame token timer",
+      "assistantChunks": [
+        "overlay session frame render stream stream stream ",
+        "render session gauge replay gauge replay replay session overlay "
+      ],
+      "toolLines": [
+        "  | session frame viewport width overlay",
+        "  | width metric cursor metric session",
+        "  | timer render layout render replay replay session"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge viewport frame",
+      "assistantChunks": [
+        "replay overlay session stream token viewport layout cursor render cursor session "
+      ],
+      "resizeTo": {
+        "cols": 120,
+        "rows": 25
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "session replay cursor width gauge",
+      "assistantChunks": [
+        "diff stream timer token session stream width overlay replay width overlay ",
+        "replay width replay frame overlay frame diff stream token replay buffer "
+      ],
+      "toolLines": [
+        "  | stream token replay gauge width session",
+        "  | session gauge replay replay session cursor buffer"
+      ],
+      "outputBlock": [
+        "   0  viewport metric gauge metric layout token timer cursor stream render width session render session timer timer render",
+        "   1  render layout viewport gauge stream gauge render session session timer diff",
+        "   2  gauge buffer layout timer frame gauge metric metric frame viewport gauge",
+        "   3  layout overlay width timer frame render render replay stream buffer layout metric",
+        "   4  render token cursor layout buffer token token frame cursor width session",
+        "   5  metric overlay metric stream render overlay layout session diff viewport diff metric session replay cursor viewport stream",
+        "   6  timer layout viewport replay stream frame replay buffer replay overlay",
+        "   7  session token cursor layout replay layout cursor width overlay",
+        "   8  session token render replay width session cursor viewport session metric",
+        "   9  timer metric layout timer session cursor viewport overlay cursor",
+        "  10  buffer timer buffer render cursor timer buffer frame gauge token render buffer render stream",
+        "  11  replay stream stream overlay overlay metric replay session",
+        "  12  viewport layout metric session session frame buffer render render timer gauge width layout",
+        "  13  cursor timer buffer diff viewport cursor buffer stream gauge viewport overlay cursor",
+        "  14  viewport layout viewport viewport overlay metric stream stream viewport overlay token cursor metric width width render",
+        "  15  buffer metric gauge viewport width render session token token stream stream session viewport timer overlay",
+        "  16  token cursor token metric render viewport metric session overlay token",
+        "  17  buffer gauge overlay replay gauge metric stream viewport buffer frame replay replay cursor viewport diff gauge replay",
+        "  18  cursor width session layout buffer token frame viewport cursor buffer width width viewport token",
+        "  19  gauge timer gauge frame buffer token replay replay diff timer timer timer timer timer gauge session",
+        "  20  replay viewport metric metric replay session buffer overlay replay stream layout timer",
+        "  21  width diff metric stream session token render stream cursor frame frame viewport gauge width replay gauge frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width metric render overlay layout gauge metric",
+      "assistantChunks": [
+        "buffer gauge session render width viewport cursor width frame buffer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "render layout cursor frame",
+      "assistantChunks": [
+        "token width render replay gauge cursor token layout buffer gauge session ",
+        "diff token width cursor replay buffer session gauge diff "
+      ],
+      "toolLines": [
+        "  | gauge viewport layout stream width render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "diff gauge session viewport",
+      "assistantChunks": [
+        "overlay timer timer overlay metric gauge stream frame overlay buffer width ",
+        "metric render frame cursor timer width replay stream "
+      ],
+      "toolLines": [
+        "  | metric gauge width metric",
+        "  | layout overlay render",
+        "  | timer metric layout metric stream viewport timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer timer diff diff width",
+      "assistantChunks": [
+        "session timer viewport frame cursor layout ",
+        "overlay metric cursor token render ",
+        "session session gauge frame render width token cursor layout viewport timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout timer layout gauge",
+      "assistantChunks": [
+        "overlay token overlay replay token stream session metric ",
+        "cursor overlay gauge render viewport replay session width token layout cursor ",
+        "session viewport stream timer gauge timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport overlay gauge frame",
+      "assistantChunks": [
+        "render token cursor token gauge cursor ",
+        "metric timer diff timer metric replay stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor stream session",
+      "assistantChunks": [
+        "token stream frame timer replay session width viewport stream ",
+        "width overlay token cursor "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay session buffer cursor viewport viewport",
+      "assistantChunks": [
+        "timer diff render stream session ",
+        "cursor width viewport replay overlay overlay ",
+        "session render replay stream gauge timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream session session viewport cursor gauge",
+      "assistantChunks": [
+        "render frame overlay session replay replay metric cursor render timer frame ",
+        "viewport timer buffer replay diff gauge frame width width width frame ",
+        "frame metric viewport metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge stream render gauge gauge viewport",
+      "assistantChunks": [
+        "buffer frame timer metric stream ",
+        "timer overlay metric frame overlay replay ",
+        "metric diff gauge diff buffer "
+      ],
+      "resizeTo": {
+        "cols": 94,
+        "rows": 38
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay cursor stream viewport frame",
+      "assistantChunks": [
+        "metric width frame render token stream width session ",
+        "buffer metric gauge token ",
+        "token overlay diff session frame token diff frame layout replay "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge gauge render buffer gauge metric buffer",
+      "assistantChunks": [
+        "width overlay diff timer "
+      ],
+      "toolLines": [
+        "  | replay viewport gauge replay width gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric metric overlay",
+      "assistantChunks": [
+        "gauge viewport stream token stream replay width ",
+        "gauge session replay frame cursor diff token viewport viewport ",
+        "viewport replay diff stream gauge session "
+      ],
+      "toolLines": [
+        "  | frame replay viewport replay viewport timer buffer",
+        "  | frame viewport buffer token render frame cursor"
+      ],
+      "outputBlock": [
+        "   0  viewport diff session diff cursor cursor width diff render stream gauge gauge timer replay session",
+        "   1  cursor replay viewport replay frame diff layout render replay",
+        "   2  stream frame cursor metric render gauge diff replay token layout render metric layout render metric",
+        "   3  viewport buffer cursor metric timer viewport metric layout",
+        "   4  overlay diff width buffer cursor layout diff width width gauge gauge replay cursor width diff",
+        "   5  buffer session timer render session frame viewport metric stream timer",
+        "   6  diff stream gauge viewport diff frame gauge layout render metric session replay replay buffer timer overlay",
+        "   7  width replay stream layout replay replay cursor viewport frame frame buffer token",
+        "   8  render token width metric metric layout gauge session replay",
+        "   9  frame timer buffer width overlay frame render cursor cursor metric diff metric cursor token token",
+        "  10  replay diff session buffer gauge metric width render width frame metric gauge diff",
+        "  11  cursor gauge session overlay buffer overlay diff token layout width render width",
+        "  12  diff buffer token layout timer token session token session",
+        "  13  frame overlay gauge replay token frame overlay diff timer timer",
+        "  14  width frame metric timer replay buffer replay timer cursor render overlay replay",
+        "  15  gauge diff overlay replay metric render replay render metric",
+        "  16  stream token stream timer cursor viewport buffer layout render stream cursor metric replay timer width",
+        "  17  stream diff timer gauge width diff token token session diff session token render timer metric",
+        "  18  buffer cursor overlay stream cursor overlay overlay replay buffer cursor",
+        "  19  width frame viewport stream cursor overlay replay layout session layout frame replay",
+        "  20  cursor diff width viewport layout replay width timer buffer token buffer width render cursor token buffer",
+        "  21  width viewport overlay cursor diff diff cursor frame session",
+        "  22  buffer layout frame token stream timer width session layout layout metric",
+        "  23  layout frame buffer frame layout timer metric replay buffer gauge gauge viewport session token viewport timer gauge",
+        "  24  layout timer token viewport timer stream viewport cursor timer metric stream token width metric token buffer",
+        "  25  stream render width metric overlay layout layout buffer width metric render width frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport frame diff metric session gauge frame",
+      "assistantChunks": [
+        "gauge render gauge buffer buffer overlay stream viewport gauge diff width ",
+        "width session timer token stream overlay render buffer frame timer frame "
+      ],
+      "outputBlock": [
+        "   0  session gauge stream timer replay gauge cursor width gauge cursor metric buffer token width diff render",
+        "   1  metric metric buffer frame metric cursor timer timer",
+        "   2  viewport render replay overlay width session buffer render diff buffer session buffer timer buffer",
+        "   3  layout cursor buffer session frame stream gauge overlay viewport width cursor",
+        "   4  gauge gauge width render width layout replay frame buffer buffer diff overlay width replay viewport replay viewport",
+        "   5  gauge replay render token viewport gauge width buffer diff token layout timer cursor",
+        "   6  layout render buffer cursor viewport frame viewport width buffer",
+        "   7  width gauge width replay replay replay width token token",
+        "   8  viewport frame layout session cursor layout stream frame gauge viewport",
+        "   9  overlay render overlay viewport frame frame metric diff viewport replay replay token token gauge diff buffer timer",
+        "  10  viewport cursor gauge replay viewport frame replay buffer",
+        "  11  render metric cursor cursor overlay timer gauge width token layout layout render overlay viewport",
+        "  12  layout overlay timer cursor session render layout buffer viewport token width stream metric buffer",
+        "  13  metric metric diff replay diff buffer frame viewport timer stream diff",
+        "  14  render render width replay metric layout overlay frame session replay stream viewport cursor",
+        "  15  render session frame overlay session replay gauge gauge",
+        "  16  layout buffer width cursor buffer width viewport metric",
+        "  17  render timer render token layout session overlay gauge timer stream viewport render token gauge overlay",
+        "  18  viewport gauge metric token buffer stream diff diff replay overlay diff overlay token",
+        "  19  replay timer stream diff metric width cursor gauge buffer render gauge frame frame diff metric width replay",
+        "  20  gauge frame stream diff replay session width stream session overlay layout token gauge stream gauge metric metric",
+        "  21  layout viewport stream layout buffer metric cursor width cursor metric overlay gauge",
+        "  22  timer cursor overlay metric render session frame diff",
+        "  23  replay gauge stream width replay stream frame timer stream metric viewport stream timer",
+        "  24  stream replay viewport replay timer session gauge layout buffer viewport viewport cursor render metric overlay replay stream",
+        "  25  render render timer stream replay overlay overlay diff cursor gauge token session replay",
+        "  26  overlay metric session gauge cursor diff buffer buffer timer render cursor",
+        "  27  metric session width gauge gauge replay cursor timer layout gauge viewport viewport",
+        "  28  token timer replay replay metric gauge viewport session session layout token",
+        "  29  timer token session buffer replay stream cursor overlay diff viewport token",
+        "  30  gauge buffer diff buffer layout render gauge stream frame session render timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport token width stream",
+      "assistantChunks": [
+        "cursor replay metric cursor viewport replay ",
+        "buffer token diff layout metric frame metric session gauge frame token ",
+        "buffer token token buffer timer timer diff "
+      ],
+      "resizeTo": {
+        "cols": 71,
+        "rows": 22
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "session overlay diff layout",
+      "assistantChunks": [
+        "buffer timer token stream ",
+        "session session overlay replay "
+      ],
+      "outputBlock": [
+        "   0  width overlay frame stream width gauge buffer replay frame render cursor stream stream viewport token width viewport",
+        "   1  gauge gauge replay frame render session metric viewport diff layout session width frame session diff",
+        "   2  timer width buffer render diff metric gauge gauge",
+        "   3  layout timer render buffer viewport viewport width render replay diff buffer viewport layout",
+        "   4  stream viewport gauge layout overlay diff metric render frame gauge replay diff overlay token gauge gauge diff",
+        "   5  width frame token stream buffer session cursor replay cursor overlay",
+        "   6  replay width width width cursor render diff diff replay buffer diff render width",
+        "   7  overlay session render cursor token session session viewport frame render stream metric cursor metric",
+        "   8  overlay render session timer width render cursor frame cursor",
+        "   9  timer metric cursor gauge timer replay diff stream frame diff session token width",
+        "  10  diff timer timer timer cursor token session overlay frame overlay",
+        "  11  session frame stream viewport cursor buffer replay render viewport diff diff session replay session stream",
+        "  12  token frame render session gauge cursor gauge metric viewport buffer width metric",
+        "  13  timer frame gauge cursor layout metric render diff",
+        "  14  metric diff stream replay replay render gauge cursor overlay width metric layout overlay viewport render",
+        "  15  frame cursor diff gauge layout buffer token stream",
+        "  16  stream buffer width diff buffer token timer layout layout render buffer session overlay",
+        "  17  render frame width width buffer metric metric token cursor gauge overlay session overlay session cursor diff",
+        "  18  layout stream render diff replay replay timer gauge viewport timer viewport",
+        "  19  cursor render metric overlay render buffer replay stream buffer layout render render replay gauge render",
+        "  20  diff overlay frame buffer timer stream render timer replay replay render",
+        "  21  stream timer layout gauge stream metric render gauge replay metric session timer stream frame replay overlay viewport",
+        "  22  cursor overlay viewport cursor timer cursor layout timer width viewport replay viewport buffer",
+        "  23  metric render width timer session gauge stream stream frame token",
+        "  24  diff token gauge session frame gauge cursor layout cursor session stream replay width session width",
+        "  25  frame metric stream replay cursor replay diff layout diff session frame render",
+        "  26  layout render render timer frame render stream session timer gauge stream cursor metric layout token",
+        "  27  viewport viewport viewport replay diff width render frame metric width render",
+        "  28  timer gauge cursor render gauge overlay token buffer metric token frame timer",
+        "  29  stream layout timer frame diff timer buffer overlay timer viewport width buffer token session viewport",
+        "  30  width diff render layout timer timer stream metric width width stream token render diff",
+        "  31  diff width frame session replay stream session replay viewport cursor layout render",
+        "  32  frame render diff metric viewport frame buffer replay session replay overlay session stream render",
+        "  33  diff gauge overlay width session render token stream gauge timer",
+        "  34  gauge buffer layout frame metric replay replay buffer layout buffer",
+        "  35  token layout layout frame overlay buffer cursor buffer buffer layout stream",
+        "  36  gauge diff session replay overlay viewport viewport gauge metric stream timer token metric overlay",
+        "  37  replay session gauge token session stream render timer cursor buffer overlay diff timer",
+        "  38  overlay session buffer layout gauge stream gauge stream diff timer",
+        "  39  frame render buffer frame gauge stream width width render stream timer replay overlay stream buffer replay timer",
+        "  40  stream gauge render replay token frame width metric cursor frame replay overlay frame",
+        "  41  width session overlay overlay diff replay width diff replay",
+        "  42  overlay width overlay layout render buffer cursor buffer replay gauge width",
+        "  43  diff frame diff stream layout replay overlay gauge gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token token layout viewport session",
+      "assistantChunks": [
+        "stream session stream token stream ",
+        "frame session stream overlay timer ",
+        "stream metric replay stream replay render "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame buffer stream",
+      "assistantChunks": [
+        "token replay cursor token replay cursor metric overlay ",
+        "session overlay overlay diff ",
+        "token viewport token session "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width gauge frame stream session token timer",
+      "assistantChunks": [
+        "gauge cursor replay metric gauge ",
+        "width stream render render cursor frame "
+      ],
+      "toolLines": [
+        "  | stream session buffer frame render overlay",
+        "  | token viewport cursor render viewport layout frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session buffer render width cursor replay overlay",
+      "assistantChunks": [
+        "cursor viewport layout render buffer ",
+        "metric buffer session viewport frame stream buffer "
+      ],
+      "toolLines": [
+        "  | diff diff cursor buffer",
+        "  | gauge layout diff token viewport",
+        "  | frame layout frame replay render replay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor replay cursor viewport",
+      "assistantChunks": [
+        "buffer buffer stream gauge "
+      ],
+      "toolLines": [
+        "  | timer frame width width buffer replay",
+        "  | timer viewport stream diff width",
+        "  | token viewport overlay cursor render"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport session metric stream metric width",
+      "assistantChunks": [
+        "metric layout width overlay layout diff width gauge viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay timer overlay",
+      "assistantChunks": [
+        "overlay layout cursor gauge diff diff ",
+        "gauge session stream token session buffer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay cursor buffer viewport overlay token viewport",
+      "assistantChunks": [
+        "diff width cursor width width width stream cursor gauge "
+      ],
+      "toolLines": [
+        "  | frame render viewport",
+        "  | buffer render replay token gauge"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "render frame viewport",
+      "assistantChunks": [
+        "render diff render gauge gauge render frame diff overlay diff viewport ",
+        "replay layout stream timer viewport replay replay stream buffer replay replay "
+      ],
+      "toolLines": [
+        "  | stream viewport gauge gauge width token token",
+        "  | token token viewport session viewport timer overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer buffer viewport session cursor",
+      "assistantChunks": [
+        "overlay replay overlay metric gauge frame replay buffer replay stream render ",
+        "layout layout diff metric timer render width viewport overlay buffer ",
+        "session viewport overlay replay overlay timer viewport cursor cursor token "
+      ],
+      "toolLines": [
+        "  | replay viewport frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame diff replay layout viewport buffer cursor",
+      "assistantChunks": [
+        "timer replay token timer stream gauge ",
+        "metric stream layout viewport render overlay ",
+        "layout width render diff overlay replay frame viewport layout session "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor frame stream layout session",
+      "assistantChunks": [
+        "width render width metric session width replay render overlay replay timer ",
+        "overlay viewport token metric stream timer render replay ",
+        "metric session width buffer render timer buffer frame overlay overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric viewport layout replay width",
+      "assistantChunks": [
+        "width overlay viewport diff metric render width "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "buffer viewport buffer stream layout metric",
+      "assistantChunks": [
+        "frame session metric token diff session overlay diff metric ",
+        "replay layout layout timer width metric replay frame token layout session ",
+        "token cursor stream timer token layout "
+      ],
+      "toolLines": [
+        "  | frame width width frame token gauge",
+        "  | overlay width layout buffer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token stream width diff",
+      "assistantChunks": [
+        "gauge gauge session cursor diff viewport layout timer ",
+        "frame diff frame render viewport layout timer timer stream overlay ",
+        "frame overlay viewport width metric diff diff overlay diff replay diff "
+      ],
+      "toolLines": [
+        "  | gauge session token cursor token viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame overlay metric render diff cursor timer",
+      "assistantChunks": [
+        "gauge viewport frame timer gauge render ",
+        "session session metric layout session layout token cursor viewport ",
+        "layout stream buffer render width session viewport cursor replay timer overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream render session viewport",
+      "assistantChunks": [
+        "token session cursor gauge stream viewport viewport replay diff ",
+        "overlay buffer cursor timer buffer replay metric layout layout layout stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream frame frame",
+      "assistantChunks": [
+        "cursor width timer render timer metric ",
+        "width replay layout metric timer viewport buffer buffer timer ",
+        "layout render render width overlay gauge session session "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "metric layout frame",
+      "assistantChunks": [
+        "buffer cursor render viewport ",
+        "diff replay timer frame overlay replay width render metric ",
+        "diff metric stream overlay overlay cursor buffer render "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay token overlay token",
+      "assistantChunks": [
+        "stream token frame width viewport timer ",
+        "diff session width viewport timer token cursor ",
+        "buffer timer session session "
+      ],
+      "outputBlock": [
+        "   0  cursor cursor buffer token frame viewport render cursor metric cursor metric",
+        "   1  width gauge overlay replay token cursor metric overlay session render cursor session",
+        "   2  cursor cursor timer metric gauge width gauge buffer stream replay render layout render",
+        "   3  frame cursor session replay buffer viewport overlay overlay stream viewport width replay stream session",
+        "   4  stream width cursor session token timer viewport buffer overlay width gauge stream width metric cursor",
+        "   5  buffer diff diff token width cursor width viewport frame stream width layout",
+        "   6  render render viewport viewport session frame timer session stream token gauge metric token stream metric viewport",
+        "   7  diff frame width diff layout width timer metric render layout timer timer token",
+        "   8  render layout metric layout token gauge width gauge gauge viewport render session overlay stream token layout",
+        "   9  render viewport stream token session overlay timer replay metric timer render stream overlay metric width metric token",
+        "  10  cursor metric replay timer width session timer render",
+        "  11  frame session gauge layout viewport gauge timer metric",
+        "  12  stream layout session cursor cursor stream overlay timer viewport token",
+        "  13  diff metric diff token metric gauge frame width timer layout stream",
+        "  14  stream gauge buffer metric viewport viewport overlay frame viewport buffer viewport overlay layout token cursor diff",
+        "  15  viewport stream token diff buffer gauge render layout replay overlay metric overlay",
+        "  16  width token timer cursor frame metric render gauge layout gauge buffer width overlay gauge width session overlay",
+        "  17  viewport session buffer layout frame session replay metric session",
+        "  18  diff cursor cursor viewport gauge render width cursor session viewport width render viewport gauge width token",
+        "  19  token diff overlay diff gauge cursor cursor replay viewport metric timer buffer replay stream session",
+        "  20  stream cursor width cursor token metric session timer frame",
+        "  21  gauge width metric token session gauge token gauge timer metric cursor session gauge metric render gauge width"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width viewport diff overlay render buffer session",
+      "assistantChunks": [
+        "layout diff session width overlay gauge stream width buffer diff metric "
+      ],
+      "toolLines": [
+        "  | overlay cursor session",
+        "  | buffer frame width buffer",
+        "  | width timer cursor gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay width overlay diff overlay replay",
+      "assistantChunks": [
+        "layout session timer timer viewport viewport ",
+        "replay buffer replay render "
+      ],
+      "toolLines": [
+        "  | metric replay buffer diff cursor metric",
+        "  | stream frame diff stream session timer cursor"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session layout timer viewport cursor",
+      "assistantChunks": [
+        "token metric layout overlay stream replay render ",
+        "session overlay session layout timer frame overlay overlay overlay render "
+      ],
+      "toolLines": [
+        "  | timer overlay cursor width metric",
+        "  | cursor diff width viewport",
+        "  | session buffer layout gauge viewport"
+      ],
+      "resizeTo": {
+        "cols": 109,
+        "rows": 27
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream timer stream session",
+      "assistantChunks": [
+        "replay frame metric diff viewport "
+      ],
+      "toolLines": [
+        "  | viewport cursor diff stream frame",
+        "  | width render replay overlay stream session",
+        "  | timer buffer buffer viewport replay token gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render width replay diff render frame",
+      "assistantChunks": [
+        "gauge width token gauge stream gauge replay gauge ",
+        "diff frame viewport timer layout overlay gauge ",
+        "buffer session session diff width layout overlay replay metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge frame timer metric layout",
+      "assistantChunks": [
+        "overlay width gauge timer metric session gauge gauge frame "
+      ],
+      "toolLines": [
+        "  | overlay gauge buffer metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout frame metric",
+      "assistantChunks": [
+        "stream replay overlay diff width replay ",
+        "buffer width frame buffer buffer layout cursor replay render "
+      ],
+      "toolLines": [
+        "  | buffer overlay cursor"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session timer metric layout viewport replay render",
+      "assistantChunks": [
+        "overlay diff stream buffer buffer cursor cursor frame viewport cursor gauge "
+      ],
+      "toolLines": [
+        "  | metric width diff layout cursor",
+        "  | viewport overlay width diff render"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge render render viewport layout",
+      "assistantChunks": [
+        "cursor render width stream replay ",
+        "session diff metric cursor replay buffer diff buffer viewport gauge render "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session session layout buffer gauge",
+      "assistantChunks": [
+        "viewport replay timer gauge ",
+        "width width token diff stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame render frame frame metric render",
+      "assistantChunks": [
+        "layout layout render render gauge gauge diff ",
+        "width layout cursor diff frame buffer session metric metric session viewport ",
+        "layout gauge viewport render replay layout metric metric frame "
+      ],
+      "toolLines": [
+        "  | render stream gauge diff replay cursor",
+        "  | viewport replay layout",
+        "  | buffer timer viewport stream session render frame"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay viewport token session stream token",
+      "assistantChunks": [
+        "token session gauge metric timer viewport ",
+        "replay diff token cursor width diff gauge cursor session "
+      ],
+      "toolLines": [
+        "  | diff buffer diff overlay overlay",
+        "  | frame render layout buffer token",
+        "  | timer session gauge replay width layout"
+      ],
+      "outputBlock": [
+        "   0  replay cursor layout render layout layout viewport layout overlay render diff",
+        "   1  token token cursor timer viewport layout diff buffer replay cursor viewport viewport diff replay",
+        "   2  replay width frame buffer gauge frame cursor width cursor metric session replay stream buffer buffer session cursor",
+        "   3  render layout stream overlay cursor frame session session gauge timer layout stream viewport stream",
+        "   4  metric layout width overlay replay cursor buffer token width replay width width replay overlay width",
+        "   5  overlay diff metric gauge stream metric viewport stream layout overlay layout token overlay stream width layout",
+        "   6  gauge buffer width token width metric cursor viewport",
+        "   7  layout render stream buffer width overlay token layout",
+        "   8  token render gauge diff diff layout viewport width session viewport",
+        "   9  cursor viewport viewport replay render layout timer metric diff viewport width gauge replay",
+        "  10  replay frame gauge replay viewport diff session replay frame diff render overlay frame",
+        "  11  buffer render viewport layout token gauge token cursor render metric frame stream token metric buffer stream cursor",
+        "  12  viewport buffer buffer layout stream width gauge session gauge token token",
+        "  13  buffer render cursor frame metric token metric token session viewport frame token",
+        "  14  width cursor layout layout gauge replay render timer layout timer buffer cursor",
+        "  15  metric replay stream viewport render cursor gauge session cursor buffer session render frame render session diff",
+        "  16  width session viewport token gauge session replay overlay viewport render cursor frame timer cursor stream",
+        "  17  token frame token cursor diff stream layout diff",
+        "  18  diff viewport token gauge gauge replay cursor viewport timer render timer token diff",
+        "  19  metric buffer render overlay stream timer width buffer frame replay token cursor",
+        "  20  session metric viewport cursor gauge session timer frame session render stream diff frame",
+        "  21  layout render frame gauge overlay buffer frame layout timer buffer stream diff stream gauge",
+        "  22  cursor timer timer replay width layout gauge replay overlay diff session timer token",
+        "  23  stream width buffer metric metric metric metric replay frame stream layout buffer overlay",
+        "  24  session session layout overlay width render metric session overlay gauge buffer",
+        "  25  width metric overlay session overlay gauge buffer overlay replay viewport overlay token overlay gauge",
+        "  26  layout metric diff frame timer stream frame session gauge layout width buffer layout viewport",
+        "  27  metric render viewport diff diff metric replay diff buffer metric layout buffer",
+        "  28  metric timer buffer timer token token replay buffer viewport metric overlay session buffer buffer metric",
+        "  29  token timer session render replay render viewport layout token width overlay token width token width",
+        "  30  frame timer stream cursor session session frame width overlay token layout",
+        "  31  stream session cursor layout diff timer timer layout token replay buffer frame",
+        "  32  token timer frame stream width buffer replay stream",
+        "  33  render diff overlay stream buffer diff viewport render diff stream token gauge overlay timer width token",
+        "  34  timer overlay render diff frame frame session gauge cursor width metric",
+        "  35  gauge stream cursor overlay gauge stream frame metric width cursor frame overlay layout",
+        "  36  frame viewport gauge viewport token gauge buffer cursor",
+        "  37  render token layout overlay width metric diff render frame diff cursor stream viewport replay buffer",
+        "  38  replay timer render diff diff timer metric layout viewport replay viewport stream replay timer session metric",
+        "  39  width stream viewport buffer cursor width diff token layout gauge overlay cursor stream metric token overlay",
+        "  40  gauge width viewport overlay timer viewport layout gauge viewport stream frame overlay buffer",
+        "  41  replay metric replay replay stream timer width gauge diff timer render",
+        "  42  replay cursor timer timer diff session metric replay stream diff diff",
+        "  43  render width diff viewport metric replay frame cursor session gauge diff width",
+        "  44  render stream replay timer replay buffer overlay layout timer cursor",
+        "  45  width stream session buffer width viewport stream gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream diff token render",
+      "assistantChunks": [
+        "viewport layout cursor gauge cursor width viewport stream timer session "
+      ],
+      "toolLines": [
+        "  | width diff layout stream layout",
+        "  | timer layout session overlay",
+        "  | metric frame viewport gauge replay session"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token cursor cursor layout render buffer render",
+      "assistantChunks": [
+        "overlay metric diff width buffer token "
+      ],
+      "toolLines": [
+        "  | cursor cursor cursor session",
+        "  | render cursor stream replay metric",
+        "  | diff layout viewport"
+      ],
+      "resizeTo": {
+        "cols": 119,
+        "rows": 24
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge metric token render",
+      "assistantChunks": [
+        "overlay metric cursor gauge layout render render gauge session session metric ",
+        "frame session render stream timer overlay token layout "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "render frame stream",
+      "assistantChunks": [
+        "replay layout cursor token layout cursor frame stream "
+      ],
+      "toolLines": [
+        "  | overlay width cursor token replay",
+        "  | viewport overlay gauge layout diff",
+        "  | viewport cursor viewport timer overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor token diff replay buffer metric",
+      "assistantChunks": [
+        "diff frame metric metric ",
+        "stream layout width gauge frame diff cursor stream layout "
+      ],
+      "toolLines": [
+        "  | diff viewport viewport render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout stream metric viewport",
+      "assistantChunks": [
+        "replay overlay replay token overlay stream viewport stream timer layout timer ",
+        "width session metric session ",
+        "metric frame metric token timer layout viewport "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay frame layout token",
+      "assistantChunks": [
+        "layout gauge render layout viewport replay ",
+        "metric session session stream session viewport ",
+        "frame metric gauge render token metric overlay width gauge "
+      ],
+      "toolLines": [
+        "  | layout token cursor width",
+        "  | stream overlay diff layout stream gauge",
+        "  | render token render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "stream gauge buffer render",
+      "assistantChunks": [
+        "layout layout overlay cursor frame metric diff metric ",
+        "replay replay token diff stream stream session timer layout "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width cursor overlay",
+      "assistantChunks": [
+        "render session layout replay metric timer layout session viewport ",
+        "token viewport diff buffer overlay gauge cursor width ",
+        "metric layout frame diff viewport "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session timer overlay",
+      "assistantChunks": [
+        "frame replay replay viewport gauge stream ",
+        "frame timer session timer metric buffer layout "
+      ],
+      "toolLines": [
+        "  | width metric buffer buffer",
+        "  | cursor diff viewport session render",
+        "  | layout replay frame"
+      ],
+      "outputBlock": [
+        "   0  cursor session metric viewport render replay frame buffer buffer viewport layout overlay timer width session",
+        "   1  diff diff replay token replay replay buffer stream frame viewport width metric gauge metric buffer width timer",
+        "   2  cursor stream replay cursor metric stream timer overlay timer render layout cursor token width metric metric",
+        "   3  viewport gauge buffer session timer timer gauge cursor cursor",
+        "   4  stream metric replay timer layout diff token timer width width token timer frame",
+        "   5  overlay viewport replay diff cursor cursor buffer gauge cursor cursor replay gauge gauge buffer",
+        "   6  stream buffer frame diff width stream timer gauge width buffer gauge viewport",
+        "   7  render replay stream gauge diff viewport metric replay overlay viewport width render",
+        "   8  token session metric cursor render layout buffer viewport gauge overlay render stream diff diff",
+        "   9  timer viewport stream viewport metric timer diff render",
+        "  10  replay cursor cursor cursor overlay replay stream metric replay stream token stream replay frame",
+        "  11  buffer buffer diff stream overlay width width overlay layout stream token frame",
+        "  12  token cursor cursor stream gauge metric token replay token diff overlay",
+        "  13  session width cursor width replay width gauge width cursor",
+        "  14  layout metric width metric diff gauge buffer metric stream gauge",
+        "  15  gauge diff token overlay metric layout buffer layout overlay viewport replay metric",
+        "  16  stream frame frame width diff overlay timer layout width cursor token cursor frame viewport viewport buffer",
+        "  17  buffer replay metric metric token viewport metric token",
+        "  18  frame metric viewport session session buffer timer overlay render token",
+        "  19  width overlay gauge replay width metric token metric replay overlay cursor render layout frame width layout",
+        "  20  cursor cursor gauge width timer timer layout gauge timer cursor timer",
+        "  21  gauge frame timer token layout replay token session viewport diff viewport",
+        "  22  token gauge viewport stream timer metric stream timer render overlay layout layout",
+        "  23  viewport session buffer overlay gauge replay width overlay buffer session",
+        "  24  layout viewport render stream layout buffer timer width gauge layout viewport",
+        "  25  session stream width buffer viewport token render replay frame",
+        "  26  replay width render diff viewport render timer buffer timer width viewport metric buffer buffer",
+        "  27  token cursor cursor width viewport layout replay width layout diff viewport session layout viewport gauge",
+        "  28  buffer metric token timer metric buffer render metric gauge session buffer frame session viewport metric",
+        "  29  cursor timer token overlay timer timer viewport session metric layout render width stream gauge replay layout",
+        "  30  token gauge layout stream viewport stream frame diff metric",
+        "  31  cursor stream buffer render render diff replay replay viewport buffer replay",
+        "  32  token cursor timer timer replay timer cursor overlay render viewport stream buffer",
+        "  33  replay frame cursor stream width render token frame metric render gauge",
+        "  34  buffer frame session timer frame stream render overlay layout buffer token viewport gauge frame",
+        "  35  gauge viewport overlay metric cursor metric viewport diff viewport buffer metric render stream layout diff",
+        "  36  token width diff gauge timer stream token render token",
+        "  37  frame stream metric overlay layout stream layout viewport cursor viewport render metric metric overlay width width layout",
+        "  38  token frame layout replay layout layout cursor frame viewport timer diff overlay viewport cursor frame stream cursor",
+        "  39  stream gauge timer cursor gauge width token overlay width metric render",
+        "  40  render render render gauge layout metric frame frame cursor",
+        "  41  session render metric width metric replay width token buffer gauge gauge",
+        "  42  buffer viewport session timer gauge cursor frame buffer",
+        "  43  gauge gauge buffer timer viewport render render session",
+        "  44  render stream metric metric token cursor cursor viewport",
+        "  45  render token frame token overlay viewport metric session",
+        "  46  render diff metric metric frame width width render viewport buffer gauge gauge metric timer overlay timer",
+        "  47  viewport gauge timer buffer token render frame buffer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff cursor stream replay width overlay metric",
+      "assistantChunks": [
+        "viewport layout viewport frame timer frame session overlay overlay render width ",
+        "width viewport session width viewport width layout diff replay ",
+        "layout layout token token buffer frame "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay width cursor token",
+      "assistantChunks": [
+        "token metric viewport buffer gauge token ",
+        "diff replay layout viewport frame frame gauge token "
+      ],
+      "toolLines": [
+        "  | session replay stream overlay gauge replay cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token frame render",
+      "assistantChunks": [
+        "frame overlay gauge stream viewport ",
+        "metric cursor token token token overlay layout timer overlay "
+      ],
+      "toolLines": [
+        "  | stream stream stream diff token stream cursor",
+        "  | timer viewport frame token buffer metric session"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport width gauge",
+      "assistantChunks": [
+        "session gauge diff overlay width session layout metric cursor frame ",
+        "token session stream token layout buffer buffer render gauge frame ",
+        "cursor render frame width viewport viewport metric viewport "
+      ],
+      "toolLines": [
+        "  | render diff token layout"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render stream gauge token buffer diff",
+      "assistantChunks": [
+        "buffer gauge gauge timer timer viewport gauge ",
+        "replay cursor diff width layout cursor viewport timer metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "cursor buffer gauge gauge",
+      "assistantChunks": [
+        "metric session timer buffer width diff overlay ",
+        "overlay session viewport token stream overlay cursor ",
+        "buffer timer layout cursor frame diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer token timer viewport timer layout frame",
+      "assistantChunks": [
+        "stream stream width frame timer buffer cursor timer overlay ",
+        "stream buffer replay buffer render token width layout ",
+        "stream metric replay buffer metric token viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport token session token",
+      "assistantChunks": [
+        "render width session width replay token timer replay ",
+        "layout render width render ",
+        "timer overlay token buffer frame buffer viewport "
+      ],
+      "toolLines": [
+        "  | timer diff layout frame cursor",
+        "  | layout metric frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport diff width timer session render timer",
+      "assistantChunks": [
+        "metric layout buffer stream layout session session frame ",
+        "diff viewport width session "
+      ],
+      "toolLines": [
+        "  | width stream diff token overlay",
+        "  | viewport buffer width replay timer buffer width"
+      ],
+      "outputBlock": [
+        "   0  cursor width buffer diff replay width token metric gauge token cursor timer token stream",
+        "   1  overlay overlay metric width width cursor viewport session gauge render frame width timer token timer render metric",
+        "   2  viewport layout render buffer render token metric stream cursor token session metric overlay diff diff render cursor",
+        "   3  session timer token timer token width width cursor render viewport render token token",
+        "   4  stream gauge diff render overlay width frame token buffer layout buffer render overlay gauge",
+        "   5  timer metric timer frame session gauge render stream diff frame cursor viewport metric layout token",
+        "   6  token frame timer viewport token viewport token metric gauge diff session",
+        "   7  replay layout replay metric metric render gauge gauge stream",
+        "   8  gauge gauge diff overlay width cursor gauge frame stream gauge gauge overlay",
+        "   9  layout stream buffer token gauge viewport frame session diff",
+        "  10  replay stream token width render metric render viewport frame width",
+        "  11  token frame metric render frame buffer overlay gauge cursor replay session render metric replay gauge stream",
+        "  12  frame stream cursor gauge width buffer session layout cursor replay metric render gauge",
+        "  13  replay layout buffer token layout stream replay overlay",
+        "  14  overlay gauge stream gauge viewport render timer session replay metric overlay session cursor",
+        "  15  timer diff overlay frame cursor overlay viewport timer width width width stream cursor",
+        "  16  diff width metric timer metric stream viewport stream frame timer viewport gauge overlay gauge frame buffer gauge",
+        "  17  width render width session viewport layout viewport cursor",
+        "  18  layout overlay viewport replay frame gauge replay layout frame replay stream replay layout session cursor render",
+        "  19  width diff render overlay cursor layout gauge width cursor token metric width width cursor metric frame",
+        "  20  session diff viewport replay render layout buffer session timer frame stream frame timer layout timer gauge overlay",
+        "  21  width buffer timer render session token replay buffer",
+        "  22  session diff buffer overlay viewport overlay stream frame buffer layout width diff overlay diff cursor",
+        "  23  overlay overlay width timer width buffer viewport diff viewport render metric viewport buffer cursor buffer token token",
+        "  24  layout timer gauge render cursor buffer timer token diff frame session buffer",
+        "  25  render diff viewport cursor replay width viewport viewport",
+        "  26  gauge diff buffer metric metric timer cursor overlay width overlay token timer width cursor render layout session",
+        "  27  session layout timer frame buffer layout session gauge frame timer width layout layout viewport",
+        "  28  overlay overlay metric overlay session diff replay frame diff stream render cursor stream",
+        "  29  replay replay metric diff token buffer timer overlay viewport",
+        "  30  overlay buffer viewport buffer buffer token token frame gauge viewport stream diff token metric diff",
+        "  31  gauge stream diff cursor viewport layout stream gauge overlay session render",
+        "  32  stream timer layout render replay session gauge frame token",
+        "  33  width session width metric overlay replay token render token session metric gauge viewport layout cursor",
+        "  34  token layout replay width replay metric viewport frame gauge overlay",
+        "  35  layout token token timer viewport replay replay diff stream metric",
+        "  36  stream overlay diff diff buffer width timer session gauge stream cursor buffer cursor metric",
+        "  37  metric width cursor width gauge metric width cursor buffer timer frame layout token",
+        "  38  viewport viewport replay timer stream timer render stream stream replay layout frame timer session render timer",
+        "  39  width overlay overlay viewport gauge gauge render diff frame cursor gauge replay frame token",
+        "  40  frame overlay token width timer buffer overlay render frame metric frame gauge cursor stream",
+        "  41  buffer gauge timer buffer gauge session viewport overlay overlay timer gauge overlay metric replay timer metric",
+        "  42  overlay metric frame layout width viewport diff token diff stream session render token token session",
+        "  43  frame diff buffer viewport viewport stream overlay stream diff layout",
+        "  44  metric session session width render stream timer buffer token buffer cursor cursor",
+        "  45  buffer buffer gauge timer stream timer viewport overlay layout",
+        "  46  stream render frame stream timer buffer metric diff render buffer token diff timer buffer viewport session",
+        "  47  width token token metric stream token token stream token session session metric width viewport viewport diff",
+        "  48  overlay timer buffer stream replay buffer stream gauge metric overlay gauge replay render layout gauge",
+        "  49  layout viewport diff token cursor timer buffer render frame render gauge cursor cursor token diff viewport viewport",
+        "  50  gauge token diff gauge stream cursor width stream gauge token session replay replay",
+        "  51  token width layout token token render replay buffer",
+        "  52  token viewport diff timer metric viewport metric session timer replay token cursor cursor cursor timer layout diff",
+        "  53  gauge gauge token token cursor gauge viewport stream timer gauge replay",
+        "  54  replay frame render stream gauge timer width overlay overlay timer",
+        "  55  diff gauge timer render render token frame metric overlay overlay render token metric",
+        "  56  stream token timer cursor viewport diff replay gauge gauge token token stream"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff buffer cursor buffer",
+      "assistantChunks": [
+        "viewport diff diff gauge cursor session gauge token layout cursor ",
+        "session replay render metric viewport replay session stream frame "
+      ],
+      "toolLines": [
+        "  | overlay diff frame buffer cursor token width"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame metric overlay token",
+      "assistantChunks": [
+        "session frame metric diff "
+      ],
+      "toolLines": [
+        "  | timer diff layout overlay buffer timer session"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor width layout layout token gauge",
+      "assistantChunks": [
+        "stream cursor metric layout stream render gauge token replay session ",
+        "token diff gauge viewport cursor replay replay width viewport overlay replay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream layout metric overlay render layout",
+      "assistantChunks": [
+        "stream layout replay render width overlay "
+      ],
+      "outputBlock": [
+        "   0  viewport replay diff timer render cursor render timer token replay gauge session overlay metric replay",
+        "   1  session frame viewport diff layout render replay overlay buffer viewport buffer",
+        "   2  frame gauge width token metric overlay overlay cursor",
+        "   3  stream metric layout width frame session layout gauge stream buffer width session stream",
+        "   4  replay metric replay session frame width overlay metric token viewport diff frame diff frame overlay overlay width",
+        "   5  width cursor viewport diff token gauge replay layout stream frame timer",
+        "   6  layout overlay buffer diff diff metric viewport frame layout viewport session diff overlay overlay",
+        "   7  gauge layout token viewport cursor session diff buffer width width timer width",
+        "   8  render viewport metric token metric metric layout width token metric diff buffer viewport buffer",
+        "   9  layout session token overlay frame frame cursor token",
+        "  10  viewport gauge overlay diff metric gauge render cursor width diff metric cursor diff width width",
+        "  11  metric frame token token overlay timer token timer viewport width buffer",
+        "  12  timer overlay viewport overlay render layout metric overlay cursor render buffer render width viewport gauge",
+        "  13  session width gauge token stream buffer token frame timer",
+        "  14  viewport replay width frame metric cursor overlay token overlay gauge timer buffer diff token",
+        "  15  diff stream cursor render overlay metric render stream replay gauge timer width diff token token",
+        "  16  gauge width frame buffer frame overlay overlay layout render gauge metric metric",
+        "  17  width timer viewport timer replay overlay metric width stream stream timer gauge cursor frame session",
+        "  18  gauge buffer replay replay cursor overlay frame viewport stream metric stream timer",
+        "  19  session overlay viewport render viewport layout replay width stream",
+        "  20  timer render frame timer viewport metric render stream metric replay timer width token stream overlay metric",
+        "  21  width viewport overlay frame viewport frame width buffer",
+        "  22  cursor replay session token timer gauge session overlay buffer stream session buffer timer width buffer timer",
+        "  23  render cursor buffer diff overlay replay session diff overlay cursor session overlay stream diff buffer",
+        "  24  replay layout frame session viewport overlay viewport timer overlay stream cursor overlay",
+        "  25  replay diff render overlay session metric replay replay replay token overlay metric cursor",
+        "  26  timer frame render session render metric frame diff session diff render replay cursor render buffer",
+        "  27  width viewport session token timer session frame token token cursor timer diff replay session",
+        "  28  replay viewport token replay viewport cursor layout render buffer viewport buffer cursor",
+        "  29  gauge token gauge width width gauge cursor overlay frame gauge stream",
+        "  30  frame layout gauge token overlay width viewport stream diff timer stream diff replay timer stream",
+        "  31  stream render diff token metric timer diff diff layout token timer cursor replay session diff diff gauge",
+        "  32  stream session overlay overlay viewport token session overlay replay replay cursor session",
+        "  33  viewport token token cursor cursor replay gauge cursor render diff metric width",
+        "  34  viewport timer stream buffer stream metric replay stream replay metric session viewport gauge session",
+        "  35  overlay cursor cursor layout cursor token metric buffer render overlay token",
+        "  36  session timer metric replay session frame gauge metric gauge diff metric",
+        "  37  token stream viewport viewport diff token timer session cursor buffer session frame diff session metric overlay",
+        "  38  frame render metric layout stream buffer cursor render",
+        "  39  width overlay stream token layout layout render timer gauge session",
+        "  40  stream cursor timer replay replay cursor token viewport",
+        "  41  token gauge render frame frame buffer buffer frame width token session",
+        "  42  diff layout gauge width cursor buffer metric session render diff replay gauge gauge buffer layout metric session",
+        "  43  cursor stream viewport viewport diff session diff overlay width token token width cursor diff",
+        "  44  layout stream cursor width replay session overlay metric layout replay buffer stream buffer token",
+        "  45  frame buffer session layout gauge stream cursor cursor cursor layout render stream",
+        "  46  cursor buffer buffer replay width diff timer metric timer render timer render render",
+        "  47  stream width diff frame render overlay overlay cursor buffer token",
+        "  48  viewport session frame timer token render token viewport frame layout overlay metric diff layout layout replay",
+        "  49  timer viewport session overlay render render metric frame",
+        "  50  buffer render gauge stream replay metric session timer session metric session viewport metric render render",
+        "  51  replay buffer gauge cursor stream overlay diff layout width stream frame gauge",
+        "  52  overlay replay replay layout token diff diff frame frame",
+        "  53  viewport gauge timer width gauge metric cursor overlay stream token gauge metric buffer frame render stream width",
+        "  54  buffer buffer timer cursor metric stream layout session render",
+        "  55  metric replay diff timer buffer viewport width replay metric diff width buffer frame session stream timer",
+        "  56  render session gauge metric diff width token width metric diff layout cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render stream diff session timer buffer",
+      "assistantChunks": [
+        "width session viewport gauge "
+      ],
+      "toolLines": [
+        "  | stream buffer overlay cursor diff",
+        "  | width width token replay render viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer gauge replay cursor overlay viewport session",
+      "assistantChunks": [
+        "metric stream stream session gauge frame overlay render gauge ",
+        "metric diff session render frame cursor session metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer metric viewport stream layout",
+      "assistantChunks": [
+        "gauge buffer stream session "
+      ],
+      "outputBlock": [
+        "   0  layout timer viewport replay metric cursor viewport buffer stream stream",
+        "   1  viewport session diff buffer replay width buffer token token render token viewport overlay token token overlay diff",
+        "   2  metric width timer render timer buffer cursor timer cursor",
+        "   3  render diff stream diff diff token token diff token stream layout gauge frame",
+        "   4  token width buffer render metric session frame buffer overlay layout replay render render render",
+        "   5  buffer session render stream buffer layout diff overlay",
+        "   6  replay session viewport session render buffer metric stream viewport timer width replay render gauge",
+        "   7  overlay width diff frame metric cursor viewport render cursor viewport",
+        "   8  overlay cursor timer render overlay width diff layout metric render layout overlay token render width replay",
+        "   9  viewport replay frame stream layout session gauge stream timer stream frame timer stream",
+        "  10  render token timer session viewport metric render timer overlay token session session frame session width stream gauge",
+        "  11  timer stream frame width render session viewport frame replay gauge cursor overlay",
+        "  12  timer token metric replay width frame token render width layout",
+        "  13  viewport token timer render cursor viewport stream render viewport metric replay token width",
+        "  14  width token token session session diff buffer session cursor metric metric metric buffer frame metric buffer layout",
+        "  15  token layout session cursor buffer layout token cursor stream layout",
+        "  16  layout cursor token overlay diff stream session session cursor render metric frame stream buffer cursor",
+        "  17  layout gauge viewport width metric replay layout viewport diff diff session timer",
+        "  18  replay layout viewport width replay buffer render gauge gauge stream stream width buffer",
+        "  19  replay metric overlay metric frame cursor diff replay buffer frame width cursor diff token diff",
+        "  20  cursor buffer metric cursor token session replay viewport replay metric cursor gauge",
+        "  21  stream render diff token metric replay cursor session layout cursor overlay",
+        "  22  render metric replay frame session viewport layout timer metric token render timer buffer metric",
+        "  23  overlay diff overlay timer render overlay metric viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport diff frame layout",
+      "assistantChunks": [
+        "render frame gauge metric metric session ",
+        "cursor frame replay stream buffer ",
+        "diff stream overlay overlay frame width diff gauge width layout viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric metric viewport replay overlay",
+      "assistantChunks": [
+        "gauge cursor timer overlay ",
+        "session gauge layout gauge session timer layout buffer "
+      ],
+      "toolLines": [
+        "  | metric frame frame session",
+        "  | session gauge frame metric metric diff",
+        "  | overlay token token stream frame cursor metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream diff replay",
+      "assistantChunks": [
+        "token frame viewport token buffer buffer stream replay session ",
+        "replay token gauge cursor ",
+        "cursor buffer gauge render width token session timer cursor viewport gauge "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "layout metric width token buffer",
+      "assistantChunks": [
+        "render stream replay session ",
+        "width overlay gauge stream replay gauge gauge ",
+        "gauge gauge gauge stream timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay session render",
+      "assistantChunks": [
+        "cursor diff buffer overlay token metric session "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width gauge metric overlay",
+      "assistantChunks": [
+        "overlay timer stream layout replay gauge diff render diff diff timer ",
+        "overlay gauge width render frame cursor overlay ",
+        "layout buffer viewport layout diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame timer timer gauge metric",
+      "assistantChunks": [
+        "metric metric gauge replay render token ",
+        "frame replay frame metric gauge frame ",
+        "viewport buffer replay replay buffer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session width diff cursor token viewport layout",
+      "assistantChunks": [
+        "layout viewport viewport session token viewport token ",
+        "metric replay render viewport diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width width diff render token session",
+      "assistantChunks": [
+        "token overlay frame token replay ",
+        "layout stream metric gauge cursor frame overlay viewport gauge layout overlay "
+      ],
+      "outputBlock": [
+        "   0  cursor overlay metric buffer cursor layout replay buffer render",
+        "   1  buffer layout viewport overlay timer overlay session width overlay buffer metric diff buffer overlay token layout",
+        "   2  width frame metric token token render width gauge frame overlay gauge metric metric layout metric render",
+        "   3  layout buffer layout viewport overlay cursor replay layout",
+        "   4  metric token metric cursor gauge stream stream layout overlay gauge timer width render",
+        "   5  timer viewport frame cursor cursor overlay gauge diff metric replay buffer diff",
+        "   6  replay metric cursor frame frame render replay metric stream diff width render metric gauge buffer",
+        "   7  frame token metric frame buffer token metric buffer cursor frame stream render width",
+        "   8  frame replay stream stream token viewport timer metric metric buffer render frame",
+        "   9  gauge diff layout layout timer gauge viewport render timer timer",
+        "  10  replay gauge token viewport viewport gauge buffer cursor buffer",
+        "  11  render overlay cursor layout viewport cursor stream timer metric metric viewport metric cursor replay render session layout",
+        "  12  buffer overlay layout diff gauge width overlay diff stream viewport replay",
+        "  13  frame width viewport session width layout replay session cursor replay overlay render stream viewport buffer",
+        "  14  metric session render frame session timer token metric frame",
+        "  15  width session stream viewport diff buffer metric overlay",
+        "  16  layout timer stream render layout metric metric diff timer overlay replay",
+        "  17  buffer viewport cursor gauge timer frame viewport stream replay stream width render overlay width",
+        "  18  overlay token width gauge diff render overlay layout cursor",
+        "  19  overlay frame token buffer buffer buffer viewport layout width viewport timer diff frame",
+        "  20  overlay buffer viewport viewport layout diff viewport session metric token replay stream metric replay",
+        "  21  session render viewport overlay token render diff metric diff",
+        "  22  metric replay overlay stream layout replay frame stream width render stream width overlay buffer",
+        "  23  session token overlay session cursor cursor token metric width buffer",
+        "  24  cursor metric diff stream diff replay timer frame timer viewport token session",
+        "  25  gauge buffer stream cursor token session timer overlay buffer layout replay overlay buffer metric",
+        "  26  layout diff gauge replay cursor layout timer layout timer session viewport diff",
+        "  27  viewport overlay session viewport timer gauge overlay render stream cursor overlay cursor",
+        "  28  diff cursor viewport session session layout buffer render token cursor metric"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "cursor session token cursor",
+      "assistantChunks": [
+        "session diff gauge frame viewport buffer timer gauge metric timer "
+      ],
+      "toolLines": [
+        "  | stream metric cursor render",
+        "  | render width timer overlay session"
+      ],
+      "resizeTo": {
+        "cols": 75,
+        "rows": 21
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer replay timer diff session replay",
+      "assistantChunks": [
+        "gauge timer diff diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width frame stream frame replay",
+      "assistantChunks": [
+        "timer token render buffer diff render stream viewport cursor session replay ",
+        "metric viewport buffer viewport replay metric frame replay stream overlay ",
+        "gauge gauge frame layout metric width overlay frame diff buffer "
+      ],
+      "resizeTo": {
+        "cols": 111,
+        "rows": 24
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "width timer cursor overlay overlay",
+      "assistantChunks": [
+        "gauge session stream gauge layout render width overlay layout render "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay width metric viewport",
+      "assistantChunks": [
+        "timer timer render diff metric layout "
+      ],
+      "outputBlock": [
+        "   0  session width viewport stream replay viewport gauge token",
+        "   1  frame render token token diff timer buffer session timer render session timer frame render",
+        "   2  stream metric width render session layout metric layout frame frame width session viewport",
+        "   3  render cursor width viewport gauge session replay cursor token replay layout cursor overlay viewport cursor gauge overlay",
+        "   4  buffer overlay viewport layout render token buffer buffer session layout token",
+        "   5  timer overlay diff session cursor render diff width stream diff token frame metric",
+        "   6  frame overlay stream frame overlay frame width session",
+        "   7  stream render timer diff frame layout session buffer cursor replay token token render frame stream stream",
+        "   8  width cursor diff cursor viewport render gauge metric token",
+        "   9  stream viewport render frame render layout token width gauge buffer frame width layout stream metric",
+        "  10  viewport width render gauge diff replay token buffer session token viewport frame stream diff overlay token width",
+        "  11  replay diff session width overlay width render session session",
+        "  12  gauge overlay frame frame replay layout gauge stream token",
+        "  13  cursor layout gauge buffer cursor replay render gauge stream session buffer width width layout",
+        "  14  cursor render cursor buffer buffer viewport session diff token gauge viewport buffer width gauge render diff",
+        "  15  cursor timer stream frame stream gauge overlay token frame timer width token render cursor replay viewport session",
+        "  16  cursor diff buffer metric overlay render replay frame frame viewport frame diff token cursor width",
+        "  17  diff cursor token token buffer gauge overlay diff gauge cursor stream layout gauge session stream stream",
+        "  18  gauge buffer session stream diff overlay replay viewport",
+        "  19  diff token render gauge session cursor gauge diff viewport timer cursor render cursor render replay gauge frame",
+        "  20  layout viewport overlay width metric render timer timer width layout token render width",
+        "  21  frame layout metric metric gauge render render stream buffer",
+        "  22  layout buffer replay width metric width frame session width viewport gauge buffer diff gauge",
+        "  23  overlay viewport buffer token diff timer render replay width",
+        "  24  cursor viewport frame replay render diff timer width",
+        "  25  metric stream layout session gauge stream render viewport layout metric",
+        "  26  width session viewport timer stream gauge session overlay",
+        "  27  gauge diff cursor stream overlay token gauge buffer",
+        "  28  buffer diff stream timer replay metric render stream buffer metric",
+        "  29  replay metric frame frame cursor diff stream replay width overlay",
+        "  30  render metric render token layout diff replay diff overlay token replay metric buffer",
+        "  31  stream buffer timer replay layout session metric cursor session diff diff token buffer frame layout",
+        "  32  metric width replay timer width metric diff render frame",
+        "  33  diff width viewport replay cursor replay buffer timer replay frame diff stream metric token metric",
+        "  34  render overlay timer width token width session frame cursor overlay replay metric"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge buffer session overlay cursor layout",
+      "assistantChunks": [
+        "token timer width buffer timer token buffer layout gauge ",
+        "metric timer render width stream overlay "
+      ],
+      "toolLines": [
+        "  | frame width session",
+        "  | timer width width"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer gauge token token",
+      "assistantChunks": [
+        "cursor frame replay replay token layout metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame viewport replay session",
+      "assistantChunks": [
+        "diff viewport buffer session timer metric frame stream overlay layout ",
+        "session diff cursor token timer viewport metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session width stream cursor",
+      "assistantChunks": [
+        "replay render session viewport render viewport viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor render replay cursor",
+      "assistantChunks": [
+        "stream overlay replay render timer timer cursor width session "
+      ],
+      "toolLines": [
+        "  | gauge layout buffer layout overlay buffer",
+        "  | gauge diff buffer token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff render replay stream frame layout",
+      "assistantChunks": [
+        "render replay frame timer overlay session session stream ",
+        "replay replay gauge render frame render ",
+        "diff render token diff metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport replay viewport overlay overlay",
+      "assistantChunks": [
+        "frame viewport render metric "
+      ],
+      "toolLines": [
+        "  | viewport layout session timer",
+        "  | timer gauge diff gauge",
+        "  | stream layout frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width token cursor",
+      "assistantChunks": [
+        "layout overlay replay viewport session stream render viewport ",
+        "timer cursor viewport timer buffer frame viewport diff token ",
+        "buffer timer token metric "
+      ],
+      "outputBlock": [
+        "   0  token overlay gauge replay metric token stream frame timer metric width",
+        "   1  frame gauge width replay stream token buffer render",
+        "   2  layout overlay frame render layout buffer metric replay token buffer metric metric overlay replay width timer",
+        "   3  render render overlay buffer metric gauge viewport token render frame replay replay stream width session render width",
+        "   4  replay stream metric token viewport cursor gauge stream cursor buffer",
+        "   5  viewport width diff gauge frame cursor overlay diff render gauge buffer render metric replay width layout",
+        "   6  timer gauge layout buffer timer timer replay buffer metric width session session cursor",
+        "   7  overlay overlay overlay viewport stream viewport overlay layout render layout viewport cursor overlay overlay viewport",
+        "   8  stream render overlay cursor gauge session metric stream stream session",
+        "   9  metric gauge token render replay render overlay session",
+        "  10  replay overlay layout frame layout render layout overlay cursor token layout metric diff diff width frame",
+        "  11  width diff buffer buffer metric session gauge token timer buffer cursor buffer cursor token",
+        "  12  frame gauge overlay diff layout overlay render diff session viewport",
+        "  13  width layout session cursor frame token viewport viewport gauge session gauge token stream layout width metric",
+        "  14  frame cursor overlay token width diff stream session gauge buffer stream width stream",
+        "  15  cursor diff frame width frame session cursor overlay viewport overlay",
+        "  16  stream gauge stream metric render overlay metric render session timer gauge metric",
+        "  17  frame metric session timer gauge render width gauge frame",
+        "  18  frame metric metric token cursor gauge metric diff gauge",
+        "  19  replay replay metric render render buffer cursor replay render timer session stream render",
+        "  20  timer overlay width viewport session diff width timer layout replay viewport buffer",
+        "  21  width layout overlay diff diff frame timer timer gauge timer timer token diff",
+        "  22  replay token viewport buffer diff cursor viewport render overlay stream width frame cursor gauge frame stream",
+        "  23  render stream width token replay metric diff buffer overlay token",
+        "  24  cursor cursor gauge frame session width gauge width render",
+        "  25  diff render cursor diff stream session frame stream buffer frame render token",
+        "  26  width buffer replay cursor token width render layout metric layout gauge stream token overlay session timer",
+        "  27  render stream frame session layout buffer layout overlay session session width buffer viewport session diff render render",
+        "  28  session buffer metric diff diff metric token buffer replay buffer stream layout stream timer diff gauge stream",
+        "  29  cursor diff diff stream frame timer cursor overlay",
+        "  30  session width session diff diff metric timer frame session frame replay session frame diff diff",
+        "  31  width cursor buffer render overlay gauge render token replay render replay buffer layout metric",
+        "  32  metric frame overlay stream metric replay layout metric gauge width frame render replay",
+        "  33  frame render render buffer gauge session buffer token token layout layout stream metric replay gauge session",
+        "  34  timer cursor buffer frame frame metric viewport token cursor gauge layout",
+        "  35  timer frame replay timer buffer frame metric width overlay layout gauge metric render diff frame stream replay",
+        "  36  layout frame render token metric replay timer token render viewport frame cursor token session metric",
+        "  37  width frame metric viewport cursor render diff cursor buffer width stream token width cursor",
+        "  38  session buffer render session cursor token diff overlay diff diff frame gauge metric replay gauge viewport",
+        "  39  timer session stream replay replay diff viewport metric layout timer layout layout stream token session viewport",
+        "  40  viewport width diff frame layout cursor layout frame cursor overlay buffer diff overlay cursor token width",
+        "  41  timer metric cursor overlay render gauge session gauge session frame token gauge gauge replay",
+        "  42  frame overlay stream render buffer buffer gauge viewport viewport",
+        "  43  frame stream viewport metric diff timer diff cursor render gauge layout token width width viewport"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "cursor frame diff diff render",
+      "assistantChunks": [
+        "metric viewport viewport viewport ",
+        "diff metric session overlay metric gauge width replay "
+      ],
+      "toolLines": [
+        "  | buffer viewport cursor session"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session layout cursor overlay width token frame",
+      "assistantChunks": [
+        "session diff timer layout session cursor overlay diff replay layout ",
+        "buffer buffer viewport replay render overlay timer session layout token ",
+        "layout metric token layout render render timer diff diff token frame "
+      ],
+      "resizeTo": {
+        "cols": 99,
+        "rows": 20
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor frame render session",
+      "assistantChunks": [
+        "session overlay buffer width render buffer diff timer "
+      ],
+      "toolLines": [
+        "  | gauge overlay width replay cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout layout replay buffer replay session",
+      "assistantChunks": [
+        "stream diff render stream gauge buffer cursor timer ",
+        "replay layout replay stream ",
+        "token token layout session render buffer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "render width overlay token session stream",
+      "assistantChunks": [
+        "frame layout stream gauge timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "timer stream cursor render overlay metric",
+      "assistantChunks": [
+        "replay gauge frame cursor gauge session metric diff frame render "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport token metric",
+      "assistantChunks": [
+        "stream width layout overlay viewport ",
+        "viewport token gauge frame layout render layout render render buffer "
+      ],
+      "toolLines": [
+        "  | timer layout session cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay render buffer",
+      "assistantChunks": [
+        "width gauge timer render ",
+        "stream width token width "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout token diff viewport overlay metric viewport",
+      "assistantChunks": [
+        "cursor width metric token cursor "
+      ],
+      "toolLines": [
+        "  | frame overlay replay replay session"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream render session replay buffer",
+      "assistantChunks": [
+        "layout metric stream session layout session render ",
+        "metric session frame metric session metric overlay replay session ",
+        "token diff timer gauge cursor session metric "
+      ],
+      "toolLines": [
+        "  | overlay cursor overlay session",
+        "  | diff token replay",
+        "  | overlay token timer metric token width"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay buffer session buffer metric",
+      "assistantChunks": [
+        "buffer token metric frame frame width "
+      ],
+      "resizeTo": {
+        "cols": 122,
+        "rows": 23
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "token width token viewport token",
+      "assistantChunks": [
+        "stream frame metric timer gauge timer frame "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay metric stream buffer render session session",
+      "assistantChunks": [
+        "gauge metric metric gauge ",
+        "overlay token timer gauge frame "
+      ],
+      "toolLines": [
+        "  | session session stream gauge width width timer"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "session metric timer timer",
+      "assistantChunks": [
+        "gauge overlay stream metric token stream replay session overlay ",
+        "buffer frame overlay diff token width width render render ",
+        "stream gauge buffer metric frame viewport "
+      ],
+      "outputBlock": [
+        "   0  render replay replay render metric session replay metric",
+        "   1  cursor replay frame layout layout diff cursor frame diff token",
+        "   2  session width diff token replay cursor stream token width gauge",
+        "   3  stream width frame stream session layout viewport replay",
+        "   4  width token layout frame token replay replay diff cursor cursor metric timer viewport viewport",
+        "   5  render overlay session cursor layout buffer replay timer frame replay",
+        "   6  token session token render stream buffer token viewport session buffer metric metric replay overlay diff",
+        "   7  frame diff buffer buffer replay metric frame layout render diff cursor buffer",
+        "   8  replay buffer session gauge replay frame overlay timer replay replay replay session viewport diff metric",
+        "   9  metric layout viewport frame stream overlay timer timer cursor gauge stream timer stream token token",
+        "  10  frame session width width gauge buffer stream render session metric",
+        "  11  gauge session metric token gauge stream session session overlay timer timer render timer overlay gauge viewport",
+        "  12  buffer width replay timer buffer token timer overlay session session layout overlay overlay gauge cursor",
+        "  13  frame overlay width token cursor cursor layout cursor session replay overlay gauge render",
+        "  14  session replay width session gauge viewport cursor overlay stream layout viewport timer token gauge",
+        "  15  overlay overlay gauge render stream metric session diff token cursor stream viewport buffer frame",
+        "  16  session frame replay stream buffer cursor session render render stream",
+        "  17  token overlay cursor token session diff width metric token width gauge metric diff render",
+        "  18  token render overlay token gauge width metric timer width gauge render",
+        "  19  timer viewport cursor stream layout render replay cursor cursor metric diff",
+        "  20  stream frame diff replay width replay timer session frame session viewport",
+        "  21  layout stream viewport overlay gauge stream viewport replay layout cursor timer timer cursor render frame timer",
+        "  22  render width viewport cursor metric render frame diff replay metric timer frame diff",
+        "  23  replay token replay layout width stream metric diff timer diff session replay session width gauge",
+        "  24  metric overlay token diff layout overlay overlay session session token cursor stream render width width layout timer"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame replay cursor token",
+      "assistantChunks": [
+        "layout frame replay buffer diff stream buffer ",
+        "replay session replay frame diff layout token stream viewport diff "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "diff stream timer viewport token metric",
+      "assistantChunks": [
+        "diff viewport overlay frame stream viewport stream "
+      ],
+      "toolLines": [
+        "  | render buffer diff cursor render timer frame",
+        "  | frame replay cursor width buffer buffer gauge",
+        "  | gauge viewport stream"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame token overlay",
+      "assistantChunks": [
+        "session timer frame cursor render replay token layout stream session ",
+        "timer frame token frame stream gauge gauge buffer width ",
+        "overlay timer cursor width session metric overlay overlay metric cursor render "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer replay replay",
+      "assistantChunks": [
+        "token replay cursor viewport overlay overlay overlay session timer "
+      ],
+      "toolLines": [
+        "  | gauge buffer viewport buffer stream timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay token stream token",
+      "assistantChunks": [
+        "viewport session width diff ",
+        "timer metric viewport layout diff session "
+      ],
+      "outputBlock": [
+        "   0  viewport session width token viewport token buffer viewport replay replay layout session overlay stream metric token",
+        "   1  token cursor stream cursor buffer session layout render session timer metric timer frame metric replay",
+        "   2  render layout metric layout timer timer timer timer token",
+        "   3  replay frame layout cursor width render gauge overlay timer layout",
+        "   4  diff overlay width stream replay gauge metric stream session frame layout cursor token render replay timer",
+        "   5  layout token buffer overlay width viewport layout token token stream metric buffer timer gauge buffer metric layout",
+        "   6  width layout render overlay replay gauge diff metric overlay layout viewport metric session cursor diff",
+        "   7  buffer session viewport metric diff buffer session metric width timer overlay",
+        "   8  viewport metric stream frame render frame cursor diff render",
+        "   9  overlay layout stream overlay replay frame buffer session width frame layout frame buffer",
+        "  10  token session layout render buffer viewport gauge diff gauge cursor buffer viewport",
+        "  11  replay overlay render timer width viewport token stream",
+        "  12  render overlay timer viewport frame cursor stream overlay frame replay token session token frame replay",
+        "  13  frame overlay buffer frame diff diff session viewport render metric width frame",
+        "  14  gauge render metric width diff buffer session buffer render viewport layout frame overlay frame layout",
+        "  15  diff overlay timer stream frame token width diff render gauge metric gauge render cursor buffer gauge stream",
+        "  16  viewport session diff stream viewport stream overlay stream replay diff replay cursor timer viewport session",
+        "  17  buffer replay replay frame cursor gauge cursor frame cursor metric",
+        "  18  viewport width layout token session timer session width diff buffer frame timer render cursor",
+        "  19  stream gauge cursor buffer render width metric timer session cursor viewport viewport",
+        "  20  session buffer gauge diff width viewport diff replay timer layout overlay metric cursor stream width",
+        "  21  frame diff timer overlay gauge frame timer frame token frame stream frame cursor token",
+        "  22  gauge viewport session layout frame token timer gauge cursor timer token diff width overlay",
+        "  23  width token stream timer replay gauge replay replay buffer diff layout stream stream overlay width replay",
+        "  24  cursor cursor viewport replay stream width buffer timer width metric diff token render",
+        "  25  layout frame metric stream viewport timer width gauge token replay replay replay width token",
+        "  26  cursor overlay session overlay token frame token buffer width metric metric",
+        "  27  viewport replay viewport width overlay token timer metric replay stream",
+        "  28  session stream frame layout metric frame render diff overlay viewport",
+        "  29  gauge replay stream stream render overlay cursor session gauge frame replay",
+        "  30  timer viewport gauge stream session viewport frame viewport frame frame overlay width width cursor",
+        "  31  replay replay buffer stream session diff metric render frame stream session timer diff buffer gauge token",
+        "  32  width diff replay session buffer cursor replay metric timer cursor stream diff metric width stream",
+        "  33  metric width metric timer render session session overlay cursor overlay gauge replay render token stream",
+        "  34  frame cursor cursor metric stream metric timer width",
+        "  35  token metric viewport replay cursor session viewport metric buffer metric token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "metric metric diff buffer timer buffer",
+      "assistantChunks": [
+        "gauge diff session timer layout session gauge token replay render cursor ",
+        "overlay token buffer frame metric buffer diff cursor viewport stream "
+      ],
+      "toolLines": [
+        "  | token replay cursor",
+        "  | buffer cursor layout",
+        "  | timer render diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay buffer gauge viewport metric",
+      "assistantChunks": [
+        "overlay stream session diff token buffer ",
+        "layout frame buffer token session overlay frame stream "
+      ],
+      "outputBlock": [
+        "   0  viewport layout diff session render timer timer replay viewport",
+        "   1  metric gauge overlay replay layout session cursor metric width metric layout session layout width metric viewport replay",
+        "   2  replay replay viewport frame diff overlay render frame cursor timer metric render buffer diff",
+        "   3  diff metric gauge session diff width gauge session metric layout layout buffer",
+        "   4  token metric timer metric buffer layout render token metric width",
+        "   5  timer replay render frame gauge viewport metric cursor",
+        "   6  overlay token render session token overlay frame render cursor",
+        "   7  overlay cursor timer timer session cursor replay timer render diff stream timer width",
+        "   8  cursor token buffer diff width overlay viewport token overlay",
+        "   9  diff stream metric layout session width stream overlay",
+        "  10  overlay token cursor buffer render render gauge token render overlay",
+        "  11  render layout cursor token replay gauge layout gauge diff diff buffer overlay",
+        "  12  stream layout session replay session frame frame metric render overlay token width stream gauge token viewport",
+        "  13  buffer render session timer frame metric metric viewport width render render stream session metric replay buffer",
+        "  14  render layout timer overlay frame stream layout cursor cursor",
+        "  15  layout timer width token layout metric metric replay session frame render cursor frame",
+        "  16  replay viewport gauge frame session diff layout session token replay token timer gauge overlay",
+        "  17  stream overlay gauge replay width metric session overlay render stream diff overlay metric width",
+        "  18  timer overlay buffer replay token layout layout session token render stream diff replay diff viewport buffer diff",
+        "  19  buffer cursor buffer overlay width render frame overlay timer frame overlay",
+        "  20  buffer cursor session timer metric frame layout overlay buffer diff layout buffer overlay",
+        "  21  replay width overlay overlay cursor frame replay stream",
+        "  22  overlay diff session stream cursor stream timer buffer gauge layout replay frame token",
+        "  23  diff frame replay overlay cursor layout render width",
+        "  24  token metric gauge timer diff buffer overlay render",
+        "  25  buffer metric frame metric replay overlay viewport buffer gauge timer diff timer render width session layout frame",
+        "  26  metric viewport token diff cursor render stream cursor session timer frame render",
+        "  27  gauge viewport gauge diff frame layout gauge buffer cursor overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render overlay stream",
+      "assistantChunks": [
+        "session token viewport metric token "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render timer timer metric frame overlay token",
+      "assistantChunks": [
+        "viewport metric timer frame viewport render buffer timer timer render ",
+        "timer token diff overlay timer viewport diff layout token buffer "
+      ],
+      "toolLines": [
+        "  | replay gauge timer"
+      ],
+      "outputBlock": [
+        "   0  viewport buffer token stream gauge stream replay metric token overlay viewport frame token overlay diff stream",
+        "   1  layout frame layout session token stream diff stream timer diff layout diff render cursor metric viewport stream",
+        "   2  render buffer render cursor metric timer buffer frame",
+        "   3  gauge session viewport token overlay session diff overlay overlay render viewport gauge token cursor",
+        "   4  stream cursor metric timer session stream buffer diff gauge diff",
+        "   5  stream width diff render width buffer render layout overlay overlay overlay token",
+        "   6  stream width token frame stream overlay viewport gauge render metric replay overlay",
+        "   7  metric cursor session buffer overlay viewport frame cursor",
+        "   8  stream gauge gauge session metric stream viewport metric diff overlay frame",
+        "   9  viewport buffer width overlay timer session diff token width token overlay diff overlay overlay gauge timer diff",
+        "  10  metric timer layout render render stream replay diff replay timer width token layout layout token frame",
+        "  11  session frame cursor diff render layout gauge viewport gauge replay stream viewport stream overlay",
+        "  12  session session stream timer viewport token render gauge timer layout overlay replay layout gauge stream buffer",
+        "  13  gauge overlay token viewport replay render viewport buffer gauge",
+        "  14  layout timer session timer viewport layout replay overlay overlay layout",
+        "  15  render gauge gauge buffer cursor buffer timer session metric diff",
+        "  16  session diff session width overlay viewport session timer session viewport viewport",
+        "  17  layout replay token overlay viewport frame timer diff buffer overlay cursor layout token",
+        "  18  overlay layout frame render cursor overlay token metric gauge layout width metric session overlay",
+        "  19  viewport token layout cursor stream token buffer stream gauge layout buffer viewport replay timer token overlay buffer",
+        "  20  overlay token cursor width timer layout layout viewport metric layout cursor width replay timer render session",
+        "  21  stream replay metric layout overlay gauge gauge viewport width session overlay cursor timer session width replay",
+        "  22  session session diff width viewport viewport timer gauge render timer stream buffer diff metric",
+        "  23  stream timer width token metric cursor cursor cursor render session timer render session gauge session session",
+        "  24  stream buffer width diff cursor layout metric width overlay layout session token",
+        "  25  viewport buffer render diff buffer diff session session token frame diff buffer timer session frame render overlay",
+        "  26  timer gauge session timer overlay diff token frame cursor timer stream timer gauge",
+        "  27  metric diff token cursor replay render diff token render",
+        "  28  replay stream cursor metric cursor gauge diff layout width replay token replay stream buffer",
+        "  29  gauge viewport timer token gauge metric overlay render token",
+        "  30  metric width layout cursor width buffer render render gauge replay render width viewport session session overlay",
+        "  31  stream session timer stream overlay render session metric timer stream buffer frame session timer",
+        "  32  width overlay cursor cursor replay cursor metric stream render frame diff session diff",
+        "  33  overlay stream viewport metric replay viewport token gauge diff",
+        "  34  cursor token replay buffer token overlay stream viewport overlay replay viewport replay width",
+        "  35  frame diff stream token session buffer layout diff token buffer cursor",
+        "  36  session replay diff stream timer session metric metric overlay layout cursor frame timer layout session session",
+        "  37  timer gauge layout frame diff viewport layout stream width diff render timer render timer",
+        "  38  layout metric buffer viewport token stream session session",
+        "  39  width replay overlay stream width session cursor gauge diff cursor overlay token frame timer",
+        "  40  stream layout width width metric overlay cursor stream frame width",
+        "  41  token gauge cursor width timer stream stream diff frame cursor diff render width",
+        "  42  width replay token gauge buffer buffer layout buffer render timer stream",
+        "  43  metric overlay diff render replay width frame token session metric overlay replay overlay render width layout",
+        "  44  render session frame diff overlay cursor cursor stream timer cursor",
+        "  45  viewport stream frame replay gauge metric width metric session gauge layout",
+        "  46  token gauge frame layout diff frame viewport cursor metric layout",
+        "  47  diff session buffer width session session session cursor",
+        "  48  token cursor cursor session stream session width cursor buffer session gauge layout frame",
+        "  49  width width replay session gauge metric metric width layout cursor timer",
+        "  50  timer replay buffer layout stream token viewport session render gauge diff replay frame gauge gauge layout token",
+        "  51  render diff metric frame layout replay render replay timer frame buffer diff layout timer width",
+        "  52  viewport timer frame replay width replay gauge metric overlay token",
+        "  53  buffer gauge timer timer frame stream frame viewport replay replay diff token width",
+        "  54  replay diff overlay cursor timer render buffer metric width",
+        "  55  replay render buffer session gauge gauge render session token",
+        "  56  token layout session viewport cursor diff render diff diff gauge timer session token render buffer width",
+        "  57  cursor viewport diff timer overlay cursor render stream token buffer timer cursor viewport diff",
+        "  58  replay width render timer frame render timer diff overlay render width"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer overlay diff layout overlay frame",
+      "assistantChunks": [
+        "frame token cursor render cursor token overlay ",
+        "token metric render metric stream timer ",
+        "overlay layout timer layout render frame render overlay buffer replay gauge "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff width gauge frame metric viewport",
+      "assistantChunks": [
+        "gauge timer width overlay viewport ",
+        "cursor buffer buffer timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay stream buffer frame stream",
+      "assistantChunks": [
+        "session gauge stream cursor buffer cursor ",
+        "viewport layout viewport timer render stream "
+      ],
+      "outputBlock": [
+        "   0  stream width replay replay timer diff frame frame",
+        "   1  gauge render token session metric viewport timer overlay timer diff",
+        "   2  token frame buffer timer metric timer width width viewport",
+        "   3  buffer render buffer session replay timer width render gauge render metric stream replay render diff",
+        "   4  gauge width diff layout token layout gauge diff width diff width diff diff layout metric token replay",
+        "   5  stream diff frame layout replay cursor token stream diff render token diff render metric",
+        "   6  timer metric frame replay metric frame viewport layout overlay stream layout",
+        "   7  frame diff replay render layout cursor overlay timer",
+        "   8  metric cursor overlay token replay overlay diff session buffer layout frame viewport stream viewport",
+        "   9  buffer buffer viewport stream gauge buffer width session width replay buffer gauge",
+        "  10  timer viewport metric viewport diff width viewport render",
+        "  11  frame session layout width overlay layout timer viewport diff timer gauge stream",
+        "  12  overlay session stream buffer metric buffer render buffer viewport diff overlay",
+        "  13  replay buffer gauge render stream buffer buffer gauge width cursor layout diff metric stream width replay layout",
+        "  14  frame replay layout buffer buffer session overlay timer diff gauge gauge replay",
+        "  15  frame token frame width replay diff gauge metric render viewport stream cursor timer overlay timer session overlay",
+        "  16  session metric frame metric replay timer cursor replay frame cursor viewport session replay",
+        "  17  session frame metric viewport layout render overlay render session token width stream token overlay gauge cursor metric",
+        "  18  replay width width gauge stream session overlay timer metric token metric replay session render",
+        "  19  metric session buffer cursor token overlay overlay frame gauge frame width diff render diff session overlay metric",
+        "  20  gauge session viewport gauge cursor token timer overlay layout render gauge overlay replay render render stream gauge",
+        "  21  overlay frame token viewport session frame layout render render viewport stream session",
+        "  22  render metric overlay gauge token cursor session replay",
+        "  23  session stream overlay cursor diff frame viewport gauge stream timer metric layout replay metric token",
+        "  24  width frame session gauge gauge stream buffer width cursor token width",
+        "  25  session token overlay timer cursor timer layout overlay session replay cursor replay",
+        "  26  width overlay viewport layout cursor stream timer stream cursor stream overlay stream timer",
+        "  27  overlay cursor timer stream frame layout replay render buffer",
+        "  28  render viewport overlay timer diff layout token timer cursor timer overlay buffer session stream stream cursor diff",
+        "  29  timer gauge cursor buffer session width width render metric timer replay cursor",
+        "  30  render layout cursor viewport diff diff gauge timer frame diff token render cursor replay layout",
+        "  31  replay cursor viewport diff overlay diff token width overlay timer diff buffer cursor",
+        "  32  metric layout replay overlay render metric width timer token session timer frame",
+        "  33  timer timer metric overlay viewport gauge diff replay width token timer metric buffer session",
+        "  34  gauge frame session width render timer gauge render overlay buffer gauge timer metric session replay",
+        "  35  timer viewport cursor buffer render width stream timer width token buffer width render buffer token layout",
+        "  36  stream cursor session buffer diff viewport metric token token render frame session",
+        "  37  stream cursor viewport timer overlay width stream session layout overlay gauge token replay session cursor",
+        "  38  metric token diff timer width width session metric buffer buffer overlay cursor gauge",
+        "  39  cursor frame replay token timer width buffer overlay gauge session metric timer gauge",
+        "  40  layout diff width layout gauge buffer buffer layout stream",
+        "  41  width overlay frame timer token session token frame replay",
+        "  42  layout session render viewport metric buffer stream session timer width session gauge layout buffer",
+        "  43  metric render diff viewport buffer viewport gauge layout diff diff",
+        "  44  layout diff replay cursor stream diff gauge metric stream token timer",
+        "  45  diff session stream token width frame timer width width frame timer gauge render metric stream render",
+        "  46  frame frame viewport overlay replay viewport overlay token gauge layout timer",
+        "  47  frame diff timer gauge gauge replay gauge width render replay",
+        "  48  buffer cursor cursor session metric width buffer diff frame stream",
+        "  49  width render buffer diff viewport metric frame overlay render buffer width",
+        "  50  stream layout timer frame token metric token render viewport replay timer metric width",
+        "  51  width viewport cursor frame render session viewport overlay overlay layout cursor metric replay layout timer",
+        "  52  frame cursor render stream width token width stream gauge session",
+        "  53  overlay buffer render cursor replay cursor session layout token overlay timer cursor timer viewport",
+        "  54  stream stream token cursor stream buffer timer cursor token timer timer buffer",
+        "  55  frame cursor diff metric timer overlay stream token replay width layout layout replay render stream",
+        "  56  layout cursor buffer metric width overlay replay viewport",
+        "  57  viewport cursor metric token layout frame render buffer gauge diff timer metric replay frame cursor token timer",
+        "  58  diff diff frame timer render width diff diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer metric diff",
+      "assistantChunks": [
+        "width metric cursor diff diff overlay width token ",
+        "gauge timer gauge render overlay stream viewport overlay stream replay metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay session session replay metric",
+      "assistantChunks": [
+        "session gauge gauge width metric session frame render ",
+        "width stream token diff diff viewport ",
+        "buffer layout replay viewport render buffer gauge gauge overlay "
+      ],
+      "resizeTo": {
+        "cols": 124,
+        "rows": 28
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport width diff stream gauge overlay",
+      "assistantChunks": [
+        "token timer session gauge replay buffer timer ",
+        "gauge gauge width timer width cursor gauge stream "
+      ],
+      "toolLines": [
+        "  | cursor timer replay render cursor buffer width"
+      ],
+      "resizeTo": {
+        "cols": 74,
+        "rows": 32
+      },
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer token session replay",
+      "assistantChunks": [
+        "timer overlay frame viewport token session metric replay ",
+        "cursor timer frame frame "
+      ],
+      "toolLines": [
+        "  | frame cursor cursor timer width timer cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render timer render cursor gauge gauge cursor",
+      "assistantChunks": [
+        "stream overlay replay token frame buffer layout render cursor overlay ",
+        "metric timer stream frame replay diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer cursor gauge cursor gauge",
+      "assistantChunks": [
+        "render session viewport replay render metric diff timer ",
+        "metric frame width layout overlay layout width diff token metric overlay ",
+        "frame timer stream viewport render layout stream cursor "
+      ],
+      "toolLines": [
+        "  | stream viewport token",
+        "  | viewport render viewport render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width metric width viewport",
+      "assistantChunks": [
+        "layout timer render replay render cursor stream gauge gauge viewport stream "
+      ],
+      "toolLines": [
+        "  | buffer layout replay buffer timer stream stream",
+        "  | gauge token gauge width buffer"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame timer diff gauge",
+      "assistantChunks": [
+        "layout replay stream layout diff render width layout frame frame timer ",
+        "metric replay session token viewport session "
+      ],
+      "toolLines": [
+        "  | session stream buffer session frame",
+        "  | token layout metric frame cursor",
+        "  | render render timer replay gauge replay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport diff layout",
+      "assistantChunks": [
+        "viewport buffer viewport diff buffer gauge buffer layout gauge "
+      ],
+      "outputBlock": [
+        "   0  stream timer gauge buffer render diff session width viewport",
+        "   1  token stream gauge metric stream overlay session replay render viewport render",
+        "   2  buffer timer diff overlay stream session viewport diff diff width render stream gauge buffer",
+        "   3  stream session diff replay overlay diff frame stream layout timer frame width cursor session stream",
+        "   4  replay timer buffer stream stream token layout frame timer frame diff token timer gauge",
+        "   5  metric layout width buffer width stream session token width cursor replay buffer gauge cursor width gauge buffer",
+        "   6  gauge session diff diff timer stream buffer frame render render gauge buffer token gauge viewport timer",
+        "   7  token buffer buffer width stream cursor width stream overlay timer overlay",
+        "   8  width token token width cursor stream token viewport viewport cursor replay session",
+        "   9  viewport session gauge session stream render render cursor diff frame timer",
+        "  10  viewport replay session frame timer metric diff width session frame diff viewport",
+        "  11  diff token token viewport timer stream frame viewport cursor frame layout token overlay stream",
+        "  12  stream width cursor viewport overlay overlay width stream gauge stream diff frame render",
+        "  13  buffer viewport width gauge viewport token buffer layout token frame diff buffer session replay layout",
+        "  14  overlay replay stream token gauge session stream cursor gauge metric frame diff frame viewport render layout",
+        "  15  layout cursor buffer replay session timer stream frame session token metric cursor metric cursor metric viewport metric",
+        "  16  token buffer timer stream overlay render buffer gauge replay overlay timer render render replay replay render overlay",
+        "  17  gauge timer viewport layout token buffer diff width stream width metric",
+        "  18  cursor width width token overlay width diff metric viewport",
+        "  19  diff session overlay viewport stream diff buffer token width gauge render width",
+        "  20  viewport timer layout cursor token frame gauge metric",
+        "  21  viewport stream metric cursor diff session layout buffer cursor token session frame",
+        "  22  stream overlay viewport gauge timer diff token session overlay viewport",
+        "  23  buffer diff metric timer layout diff width render overlay overlay frame buffer metric",
+        "  24  token render layout frame overlay width gauge session overlay",
+        "  25  frame buffer layout width timer stream token timer render cursor stream layout layout metric width diff",
+        "  26  render diff diff diff replay render layout overlay",
+        "  27  replay render gauge frame buffer gauge layout session",
+        "  28  timer replay overlay overlay viewport viewport metric diff stream overlay layout timer metric timer viewport render",
+        "  29  token token token token buffer diff replay replay session session metric width session cursor stream cursor stream",
+        "  30  width diff token stream layout buffer render replay stream buffer gauge viewport diff cursor",
+        "  31  timer session replay overlay replay diff render frame frame timer buffer render width frame render",
+        "  32  buffer metric cursor metric timer metric frame viewport",
+        "  33  layout timer gauge timer width cursor cursor token",
+        "  34  timer token overlay render session stream diff viewport viewport replay timer",
+        "  35  stream width replay cursor cursor diff buffer token overlay width replay viewport width metric layout layout",
+        "  36  overlay layout frame metric viewport width session metric render frame viewport diff replay overlay overlay",
+        "  37  overlay frame timer cursor replay layout gauge layout token cursor",
+        "  38  width frame timer session overlay viewport frame buffer overlay replay token frame session cursor timer metric metric",
+        "  39  timer stream timer overlay token metric session layout timer metric viewport overlay render session overlay stream",
+        "  40  buffer render buffer timer overlay session viewport render",
+        "  41  layout gauge metric session replay cursor metric gauge replay diff timer buffer overlay",
+        "  42  replay stream render metric overlay cursor frame token overlay overlay replay render token token",
+        "  43  token replay timer gauge frame viewport gauge width overlay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token token cursor timer replay diff metric",
+      "assistantChunks": [
+        "timer layout buffer viewport viewport metric render session gauge gauge viewport ",
+        "token viewport render layout diff frame token gauge "
+      ],
+      "toolLines": [
+        "  | metric cursor token cursor session gauge render"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport width cursor stream frame session gauge",
+      "assistantChunks": [
+        "render gauge stream overlay stream replay diff "
+      ],
+      "outputBlock": [
+        "   0  width timer cursor diff token viewport width replay stream",
+        "   1  stream layout replay viewport overlay viewport gauge diff overlay metric",
+        "   2  token gauge buffer frame session gauge metric frame",
+        "   3  layout replay cursor cursor timer overlay overlay metric token metric gauge render",
+        "   4  stream overlay overlay stream viewport token viewport token width diff stream layout render diff gauge replay render",
+        "   5  gauge diff metric replay token metric diff layout frame layout stream",
+        "   6  viewport cursor buffer overlay width viewport replay buffer frame metric replay timer width frame",
+        "   7  cursor layout buffer layout width cursor frame width layout cursor timer buffer frame",
+        "   8  overlay stream width session overlay layout render stream cursor viewport stream overlay",
+        "   9  token metric buffer buffer layout layout viewport token viewport replay replay layout gauge cursor viewport",
+        "  10  cursor replay overlay session timer token cursor viewport width stream viewport viewport viewport stream session",
+        "  11  render replay cursor cursor stream buffer viewport timer token frame layout token viewport replay replay session",
+        "  12  cursor diff gauge token token render timer metric frame overlay",
+        "  13  viewport render buffer width render token buffer gauge token viewport diff session timer",
+        "  14  viewport buffer gauge replay stream token token metric metric",
+        "  15  session render token render buffer viewport viewport width frame timer session cursor stream frame width",
+        "  16  buffer viewport diff frame layout token gauge render metric layout diff layout",
+        "  17  render gauge viewport overlay width buffer session gauge",
+        "  18  session render diff viewport token metric gauge overlay layout stream overlay viewport",
+        "  19  render layout diff frame overlay width gauge buffer cursor timer session token",
+        "  20  diff metric replay width frame width buffer stream session width overlay gauge render viewport overlay session",
+        "  21  width width metric diff timer overlay cursor buffer cursor timer replay",
+        "  22  buffer metric frame frame overlay render buffer buffer timer replay session",
+        "  23  timer viewport diff cursor stream diff buffer replay overlay stream viewport diff render",
+        "  24  width timer viewport replay layout gauge replay cursor cursor",
+        "  25  token session diff frame overlay gauge buffer overlay metric token width overlay cursor render metric token frame",
+        "  26  render token timer token frame buffer session render viewport",
+        "  27  cursor frame replay buffer viewport buffer frame gauge overlay timer gauge gauge frame frame token gauge",
+        "  28  stream metric layout frame buffer render width buffer metric replay viewport session buffer timer metric render viewport",
+        "  29  overlay replay buffer timer render width diff token diff diff",
+        "  30  render session gauge buffer diff layout gauge timer stream width diff buffer session render cursor",
+        "  31  replay diff timer token stream frame cursor layout stream",
+        "  32  diff frame timer width frame viewport token token frame diff diff layout token viewport",
+        "  33  width frame replay gauge buffer token frame metric overlay frame diff token metric cursor gauge",
+        "  34  render layout render cursor viewport overlay token gauge render buffer viewport gauge",
+        "  35  token cursor layout session layout diff overlay render width replay render buffer replay overlay cursor cursor",
+        "  36  stream gauge cursor session stream cursor session diff overlay token width viewport token",
+        "  37  frame timer stream layout timer frame cursor gauge",
+        "  38  session buffer width overlay buffer metric replay replay viewport timer viewport diff stream stream metric",
+        "  39  gauge gauge token diff replay frame cursor stream timer render gauge width metric token render",
+        "  40  overlay gauge gauge token gauge timer gauge layout diff overlay render buffer cursor render",
+        "  41  stream metric diff session width layout overlay session session overlay render replay cursor",
+        "  42  token stream stream replay width layout frame width layout stream frame token layout gauge",
+        "  43  layout frame replay render timer frame stream viewport stream render metric replay timer render session diff frame",
+        "  44  diff cursor layout cursor cursor stream buffer cursor metric width gauge render diff",
+        "  45  replay width cursor session overlay render stream cursor buffer timer overlay session timer metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport overlay frame stream metric overlay",
+      "assistantChunks": [
+        "layout session timer width viewport frame buffer overlay session "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff overlay cursor",
+      "assistantChunks": [
+        "timer token diff frame gauge cursor stream frame token layout ",
+        "frame diff stream buffer buffer width timer session ",
+        "metric session buffer layout frame metric "
+      ],
+      "toolLines": [
+        "  | buffer width frame",
+        "  | cursor gauge render overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token overlay render buffer",
+      "assistantChunks": [
+        "frame overlay width metric layout width ",
+        "buffer frame token buffer viewport width token overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream frame diff stream cursor cursor",
+      "assistantChunks": [
+        "render metric session layout replay layout ",
+        "metric render gauge width layout gauge "
+      ],
+      "toolLines": [
+        "  | viewport layout stream gauge timer viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout timer layout",
+      "assistantChunks": [
+        "buffer overlay metric buffer session viewport ",
+        "replay timer gauge frame session ",
+        "width session buffer viewport replay stream replay buffer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout cursor diff metric render diff",
+      "assistantChunks": [
+        "replay timer cursor session width metric gauge gauge replay "
+      ],
+      "toolLines": [
+        "  | stream render replay viewport"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge cursor timer buffer",
+      "assistantChunks": [
+        "replay overlay diff frame ",
+        "metric gauge render gauge "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay overlay replay overlay metric overlay",
+      "assistantChunks": [
+        "width timer replay overlay layout width overlay ",
+        "replay frame timer gauge layout timer diff stream metric width viewport ",
+        "overlay frame render diff timer render replay frame "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer gauge layout cursor viewport stream",
+      "assistantChunks": [
+        "session viewport buffer timer gauge stream timer overlay ",
+        "stream layout stream layout "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token token cursor gauge stream width diff",
+      "assistantChunks": [
+        "buffer token render layout buffer metric metric diff metric metric ",
+        "gauge session session buffer session ",
+        "stream width buffer width buffer overlay token viewport overlay "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor replay session buffer",
+      "assistantChunks": [
+        "gauge diff overlay token session gauge diff ",
+        "frame buffer width metric buffer viewport session session ",
+        "buffer layout viewport timer token "
+      ],
+      "toolLines": [
+        "  | diff frame replay width session overlay gauge",
+        "  | token gauge token viewport stream timer buffer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer stream buffer metric stream cursor viewport",
+      "assistantChunks": [
+        "viewport frame render gauge ",
+        "buffer diff render replay layout token layout frame stream cursor "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer frame replay gauge",
+      "assistantChunks": [
+        "gauge token cursor frame cursor metric width metric timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout overlay render layout frame frame replay",
+      "assistantChunks": [
+        "diff gauge buffer overlay cursor metric width overlay frame timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer replay diff token stream",
+      "assistantChunks": [
+        "viewport width overlay render overlay frame render viewport frame ",
+        "width timer layout timer timer ",
+        "render width replay metric timer metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge layout timer token",
+      "assistantChunks": [
+        "buffer token overlay token timer overlay timer replay frame frame ",
+        "render session session overlay replay stream "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width layout token render",
+      "assistantChunks": [
+        "render layout buffer buffer gauge token buffer gauge ",
+        "buffer viewport metric overlay render overlay frame token width width overlay ",
+        "layout width render frame buffer "
+      ],
+      "toolLines": [
+        "  | render diff frame",
+        "  | diff stream layout replay cursor"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session overlay replay cursor",
+      "assistantChunks": [
+        "token diff token session ",
+        "render layout render gauge diff gauge overlay ",
+        "stream token width gauge cursor frame diff replay stream "
+      ],
+      "toolLines": [
+        "  | timer cursor gauge viewport"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff timer stream gauge",
+      "assistantChunks": [
+        "gauge width token diff token token buffer ",
+        "replay stream diff width ",
+        "cursor cursor session width timer cursor metric stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay timer frame viewport",
+      "assistantChunks": [
+        "overlay width session frame width ",
+        "layout cursor buffer cursor width diff token buffer ",
+        "token replay metric layout frame timer width replay buffer gauge "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token token viewport timer render viewport",
+      "assistantChunks": [
+        "metric stream session viewport gauge ",
+        "metric timer session gauge width session gauge gauge ",
+        "buffer replay token timer metric overlay cursor "
+      ],
+      "toolLines": [
+        "  | stream buffer replay timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay token cursor buffer diff stream token",
+      "assistantChunks": [
+        "render buffer replay render ",
+        "diff overlay overlay timer timer cursor session render "
+      ],
+      "toolLines": [
+        "  | stream width layout session replay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame cursor gauge",
+      "assistantChunks": [
+        "metric layout gauge gauge session viewport "
+      ],
+      "toolLines": [
+        "  | cursor overlay token frame stream stream layout",
+        "  | viewport cursor frame buffer frame"
+      ],
+      "resizeTo": {
+        "cols": 73,
+        "rows": 22
+      },
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame session stream session",
+      "assistantChunks": [
+        "layout buffer replay width cursor gauge layout timer metric metric ",
+        "gauge stream overlay overlay gauge cursor diff "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width width replay",
+      "assistantChunks": [
+        "gauge width overlay gauge render timer timer ",
+        "metric token width replay session replay cursor gauge gauge gauge "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "metric gauge frame session layout",
+      "assistantChunks": [
+        "viewport metric stream gauge width width "
+      ],
+      "toolLines": [
+        "  | metric timer width overlay viewport",
+        "  | render replay overlay width cursor",
+        "  | timer render buffer width cursor width layout"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "diff token buffer frame",
+      "assistantChunks": [
+        "width frame timer width token width "
+      ],
+      "toolLines": [
+        "  | frame stream session",
+        "  | viewport gauge layout session cursor token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "session viewport frame frame replay metric",
+      "assistantChunks": [
+        "overlay layout render stream ",
+        "frame overlay gauge overlay buffer replay session cursor replay "
+      ],
+      "toolLines": [
+        "  | layout stream timer",
+        "  | diff timer diff session viewport render cursor",
+        "  | cursor session buffer stream layout timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport width metric stream token",
+      "assistantChunks": [
+        "diff overlay width width metric diff diff buffer width layout ",
+        "buffer layout diff frame width "
+      ],
+      "toolLines": [
+        "  | overlay token metric diff render viewport"
+      ],
+      "outputBlock": [
+        "   0  gauge width frame viewport timer frame render replay",
+        "   1  stream cursor session token render width metric stream gauge",
+        "   2  render timer diff frame cursor gauge session buffer metric buffer overlay",
+        "   3  frame render render stream replay cursor diff render replay cursor timer session width token gauge",
+        "   4  timer metric overlay timer stream metric token buffer stream buffer stream",
+        "   5  replay timer frame metric viewport gauge frame render stream overlay diff",
+        "   6  stream replay token render replay timer frame stream diff timer metric timer viewport frame render",
+        "   7  session metric viewport token render width viewport token viewport timer cursor overlay metric stream session token viewport",
+        "   8  token diff stream buffer viewport session stream session session session metric",
+        "   9  buffer render metric session session stream token token diff replay",
+        "  10  overlay render overlay replay viewport frame layout stream layout buffer buffer metric metric layout stream",
+        "  11  gauge layout metric render replay session timer overlay gauge timer diff metric metric",
+        "  12  cursor gauge session render diff token render buffer",
+        "  13  render layout token token metric viewport cursor stream diff metric gauge width render",
+        "  14  overlay cursor viewport timer session session stream cursor replay stream token buffer",
+        "  15  width buffer gauge overlay token viewport diff overlay layout timer layout metric metric metric viewport buffer session",
+        "  16  viewport frame overlay cursor buffer overlay layout viewport",
+        "  17  metric metric render stream gauge session session timer overlay",
+        "  18  timer render stream width width session timer viewport diff timer buffer",
+        "  19  gauge buffer viewport replay overlay session session width",
+        "  20  token gauge viewport buffer token session render render replay overlay stream token stream viewport",
+        "  21  cursor layout render gauge token metric layout cursor buffer buffer gauge",
+        "  22  layout layout viewport width frame viewport gauge token buffer buffer",
+        "  23  layout overlay gauge layout render frame token overlay cursor token diff frame stream metric token token",
+        "  24  width metric frame buffer stream cursor overlay diff metric stream viewport",
+        "  25  timer width metric frame overlay metric metric buffer replay",
+        "  26  session cursor width metric timer buffer token width cursor session diff timer",
+        "  27  session cursor layout frame layout diff cursor stream render",
+        "  28  render replay cursor replay render session token token replay frame gauge",
+        "  29  token diff layout gauge viewport frame token timer frame diff viewport stream overlay gauge width",
+        "  30  overlay frame token viewport metric render gauge buffer gauge render cursor render stream frame overlay overlay",
+        "  31  viewport width layout stream gauge token token stream frame gauge metric width overlay cursor cursor timer",
+        "  32  diff viewport token cursor frame metric cursor replay replay layout overlay timer layout layout frame session frame",
+        "  33  cursor metric layout frame overlay metric overlay layout",
+        "  34  cursor stream timer gauge width overlay token token viewport render token frame diff viewport",
+        "  35  render overlay token width stream frame buffer replay",
+        "  36  timer width replay gauge viewport frame replay replay session",
+        "  37  gauge replay overlay width timer metric gauge replay gauge timer cursor render replay session width metric",
+        "  38  buffer replay diff metric timer cursor viewport render",
+        "  39  replay buffer render replay metric stream gauge gauge overlay token replay viewport viewport metric replay render",
+        "  40  viewport width metric buffer gauge metric gauge width replay",
+        "  41  frame replay stream diff buffer frame timer metric layout",
+        "  42  render width render overlay cursor replay metric width diff layout timer replay",
+        "  43  diff token viewport cursor layout layout timer render metric metric width width timer buffer replay overlay",
+        "  44  session cursor cursor metric width token width gauge timer",
+        "  45  session timer layout render timer overlay gauge timer width replay cursor replay",
+        "  46  width replay stream render token frame timer frame overlay width width gauge gauge overlay viewport metric",
+        "  47  render cursor render gauge render render metric overlay diff width layout gauge buffer layout gauge viewport render",
+        "  48  cursor width diff timer width gauge diff gauge width buffer",
+        "  49  metric diff layout token replay cursor session session gauge overlay layout layout render",
+        "  50  token viewport width cursor stream width layout layout viewport replay overlay timer token",
+        "  51  overlay diff viewport cursor metric cursor width frame stream stream",
+        "  52  frame overlay gauge cursor cursor layout metric replay",
+        "  53  metric metric width metric metric session token stream replay width cursor frame viewport frame frame",
+        "  54  metric metric viewport replay gauge frame diff replay overlay",
+        "  55  gauge metric overlay buffer diff render render session diff",
+        "  56  gauge width viewport gauge replay cursor layout viewport viewport width timer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport layout gauge timer buffer stream",
+      "assistantChunks": [
+        "buffer gauge frame buffer ",
+        "buffer width stream viewport session cursor "
+      ],
+      "toolLines": [
+        "  | session frame session diff buffer timer replay",
+        "  | diff buffer frame layout viewport replay token"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "token viewport render timer diff",
+      "assistantChunks": [
+        "viewport replay viewport width metric diff viewport ",
+        "render session stream replay ",
+        "buffer width replay viewport width stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "width metric viewport overlay stream diff",
+      "assistantChunks": [
+        "frame buffer width metric ",
+        "stream buffer buffer width replay stream width ",
+        "metric stream render layout replay render overlay frame "
+      ],
+      "toolLines": [
+        "  | diff viewport width token gauge session",
+        "  | diff cursor token"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "frame token session gauge stream frame width",
+      "assistantChunks": [
+        "viewport metric diff layout width ",
+        "buffer cursor frame diff stream width layout ",
+        "width render frame frame gauge render metric "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "replay timer frame gauge buffer stream gauge",
+      "assistantChunks": [
+        "stream cursor token overlay session session frame width cursor stream width ",
+        "diff diff replay stream buffer token ",
+        "metric token diff buffer "
+      ],
+      "toolLines": [
+        "  | gauge timer layout viewport diff render stream",
+        "  | layout stream diff viewport cursor",
+        "  | timer diff gauge gauge diff token replay"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "width stream render",
+      "assistantChunks": [
+        "render overlay frame diff frame overlay cursor stream width cursor ",
+        "layout cursor gauge timer stream session session session session token "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout gauge width",
+      "assistantChunks": [
+        "buffer viewport gauge gauge gauge overlay metric ",
+        "viewport buffer session width layout diff width gauge viewport "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render gauge frame cursor session layout token",
+      "assistantChunks": [
+        "render render width cursor timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor session layout cursor session",
+      "assistantChunks": [
+        "token render frame cursor layout render buffer replay ",
+        "session session gauge gauge ",
+        "layout replay metric viewport timer "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "token overlay metric width replay",
+      "assistantChunks": [
+        "cursor metric diff stream session replay cursor timer ",
+        "buffer stream session buffer stream viewport frame ",
+        "width timer gauge render replay timer cursor diff width session buffer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay layout overlay",
+      "assistantChunks": [
+        "overlay stream cursor stream ",
+        "replay gauge buffer width ",
+        "gauge frame viewport stream layout layout width replay layout metric "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor replay render replay stream token",
+      "assistantChunks": [
+        "width cursor viewport diff stream "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "replay timer stream timer overlay replay",
+      "assistantChunks": [
+        "render timer session width metric cursor ",
+        "metric timer gauge replay token diff session "
+      ],
+      "toolLines": [
+        "  | overlay gauge replay timer layout token",
+        "  | stream viewport gauge diff",
+        "  | diff buffer replay replay frame"
+      ],
+      "outputBlock": [
+        "   0  diff render token session metric token replay metric layout layout frame buffer",
+        "   1  replay metric stream session viewport token overlay diff cursor render overlay gauge timer buffer",
+        "   2  frame diff timer timer gauge overlay buffer token token",
+        "   3  render layout width cursor viewport stream buffer diff token diff render stream render render replay render cursor",
+        "   4  gauge overlay diff diff gauge viewport metric width",
+        "   5  stream session width layout frame timer width layout diff overlay layout",
+        "   6  frame session frame timer width diff metric token frame",
+        "   7  buffer buffer render viewport buffer metric overlay token render",
+        "   8  frame cursor buffer frame diff width cursor gauge token viewport",
+        "   9  session cursor buffer render timer layout frame frame render viewport layout metric overlay token diff",
+        "  10  frame overlay overlay metric metric layout buffer session overlay replay token buffer layout timer buffer width",
+        "  11  overlay timer frame metric frame frame render overlay timer gauge render gauge render cursor token frame",
+        "  12  buffer gauge token width overlay gauge session replay overlay width render metric layout gauge cursor replay",
+        "  13  buffer session session render session cursor layout cursor session replay cursor metric session diff cursor render",
+        "  14  buffer session buffer buffer diff gauge render stream",
+        "  15  render metric timer timer overlay viewport frame buffer diff diff gauge token gauge width gauge",
+        "  16  diff metric width render replay replay replay overlay",
+        "  17  timer session diff metric viewport cursor timer metric timer",
+        "  18  overlay diff frame overlay stream diff layout frame render token",
+        "  19  session metric render render token gauge layout gauge width cursor width layout diff layout",
+        "  20  session buffer session stream render frame frame width render frame session frame layout buffer diff token diff",
+        "  21  timer cursor timer session buffer session buffer viewport width overlay replay",
+        "  22  session overlay gauge replay viewport overlay token frame render render stream viewport replay width buffer",
+        "  23  layout gauge viewport buffer timer gauge cursor render cursor stream diff frame",
+        "  24  replay token layout session metric session stream gauge buffer overlay layout viewport viewport frame replay",
+        "  25  frame overlay buffer frame width cursor viewport timer replay viewport metric frame buffer metric",
+        "  26  width replay diff render viewport overlay width replay render stream",
+        "  27  gauge layout viewport cursor width overlay token timer session replay",
+        "  28  render render stream diff width viewport metric render width metric"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge overlay cursor cursor timer stream viewport",
+      "assistantChunks": [
+        "stream stream cursor diff "
+      ],
+      "outputBlock": [
+        "   0  timer stream replay gauge session width viewport replay metric",
+        "   1  render stream token stream token token render cursor width timer session replay replay",
+        "   2  token diff layout width session viewport frame diff diff metric diff timer metric",
+        "   3  layout overlay frame gauge session viewport stream viewport frame",
+        "   4  cursor diff metric metric layout replay timer replay replay",
+        "   5  overlay diff layout buffer stream frame metric viewport width gauge overlay cursor metric",
+        "   6  width overlay diff buffer cursor viewport token gauge overlay metric metric metric replay frame timer",
+        "   7  width diff width viewport token stream gauge replay",
+        "   8  replay token session cursor cursor stream cursor frame frame frame",
+        "   9  session stream render layout cursor render width cursor overlay diff overlay frame layout render gauge render",
+        "  10  width gauge token cursor width stream timer width",
+        "  11  gauge diff token metric render overlay session session frame metric diff token",
+        "  12  stream timer timer diff overlay stream metric diff session",
+        "  13  token frame replay buffer cursor width width overlay buffer diff cursor render layout token",
+        "  14  stream timer width diff viewport metric viewport gauge viewport",
+        "  15  viewport replay stream frame diff session gauge metric layout metric frame overlay buffer buffer timer viewport",
+        "  16  token viewport cursor stream diff session diff viewport token metric layout",
+        "  17  layout overlay layout replay metric timer frame buffer gauge",
+        "  18  render render width session render buffer overlay timer width cursor viewport diff cursor",
+        "  19  gauge timer cursor buffer timer metric session buffer cursor stream layout metric",
+        "  20  session stream overlay render buffer cursor cursor replay width cursor gauge metric",
+        "  21  token session session overlay stream timer session token session metric timer frame gauge",
+        "  22  frame token width gauge buffer diff diff cursor viewport replay",
+        "  23  render buffer diff frame gauge overlay session render gauge layout",
+        "  24  metric token render replay overlay frame diff stream gauge buffer session frame render token viewport",
+        "  25  stream token replay gauge frame session buffer buffer buffer session cursor buffer cursor viewport",
+        "  26  layout session overlay replay render session diff replay session session frame replay render width width",
+        "  27  width gauge cursor session replay frame diff render width buffer diff layout stream cursor metric metric timer",
+        "  28  session frame layout metric buffer viewport metric metric buffer replay diff session replay diff render",
+        "  29  stream diff stream cursor viewport cursor session viewport frame timer viewport replay token",
+        "  30  diff session gauge layout session gauge timer stream",
+        "  31  overlay session token render render replay width frame layout layout",
+        "  32  frame replay overlay diff overlay diff session metric frame viewport stream layout gauge render",
+        "  33  timer stream cursor layout metric width stream buffer cursor viewport viewport viewport render token",
+        "  34  layout width layout buffer render token replay layout",
+        "  35  layout width buffer token layout render token token token width layout replay layout token gauge",
+        "  36  frame cursor replay overlay frame buffer diff width viewport width",
+        "  37  render stream viewport width replay width cursor buffer gauge layout frame width metric gauge replay",
+        "  38  viewport layout metric render viewport cursor viewport layout render",
+        "  39  layout gauge timer width gauge width session replay buffer frame session render frame session viewport cursor session",
+        "  40  buffer overlay buffer buffer token diff frame stream session diff cursor replay session gauge render render render",
+        "  41  metric token metric width token buffer width token replay overlay timer render viewport stream replay",
+        "  42  metric frame frame overlay replay metric stream token render gauge viewport replay replay",
+        "  43  token gauge buffer session layout session buffer timer timer cursor diff frame",
+        "  44  cursor buffer replay token overlay overlay width stream metric layout frame replay timer width frame timer overlay",
+        "  45  cursor stream gauge cursor layout frame viewport gauge buffer timer diff cursor width diff width",
+        "  46  diff cursor overlay timer replay buffer overlay replay metric diff session timer",
+        "  47  metric metric timer frame render token buffer diff diff token",
+        "  48  frame diff frame viewport session viewport stream width",
+        "  49  width token buffer session session buffer render buffer width session gauge metric diff metric metric diff",
+        "  50  overlay replay timer width overlay token cursor diff width cursor",
+        "  51  stream width stream replay stream gauge replay width render",
+        "  52  session width session frame overlay overlay viewport overlay replay render",
+        "  53  metric viewport token buffer cursor layout gauge replay layout buffer timer layout render viewport buffer",
+        "  54  width width layout viewport layout gauge layout render metric token width token metric diff",
+        "  55  viewport overlay render viewport metric layout buffer width frame metric overlay replay session width token render",
+        "  56  replay viewport replay buffer render buffer metric stream viewport buffer replay",
+        "  57  metric overlay viewport session buffer viewport diff viewport diff diff render cursor gauge stream buffer",
+        "  58  width diff stream buffer diff token timer diff width overlay gauge render gauge frame cursor"
+      ],
+      "resizeTo": {
+        "cols": 81,
+        "rows": 34
+      },
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport width frame frame",
+      "assistantChunks": [
+        "width overlay cursor layout overlay session viewport session diff ",
+        "gauge timer frame cursor overlay token overlay token render ",
+        "render timer cursor metric render token cursor gauge render buffer "
+      ],
+      "toolLines": [
+        "  | frame token viewport",
+        "  | metric layout overlay buffer width diff"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "overlay width overlay width buffer metric cursor",
+      "assistantChunks": [
+        "viewport timer width buffer stream ",
+        "gauge timer timer gauge replay replay stream timer render metric "
+      ],
+      "toolLines": [
+        "  | replay metric width layout replay metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "frame width frame frame token width",
+      "assistantChunks": [
+        "overlay layout cursor width "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "cursor render metric",
+      "assistantChunks": [
+        "diff buffer width frame ",
+        "timer width stream timer ",
+        "timer layout diff width token token gauge stream session gauge "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "buffer replay session token",
+      "assistantChunks": [
+        "metric session buffer timer viewport replay token overlay replay layout replay ",
+        "layout overlay metric overlay session ",
+        "diff token timer timer buffer viewport diff diff "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render buffer gauge buffer replay",
+      "assistantChunks": [
+        "overlay layout width buffer overlay token token session cursor timer metric ",
+        "layout token replay viewport render replay replay "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "diff timer stream",
+      "assistantChunks": [
+        "diff frame session metric viewport token buffer ",
+        "metric render timer metric token token metric ",
+        "render gauge width cursor token timer gauge replay token "
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "timer width replay render frame metric",
+      "assistantChunks": [
+        "cursor viewport viewport buffer ",
+        "metric layout token viewport width "
+      ],
+      "toolLines": [
+        "  | token token frame",
+        "  | overlay token replay width diff replay metric",
+        "  | token cursor frame session token buffer"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "render overlay width",
+      "assistantChunks": [
+        "render width width width diff buffer metric render buffer layout viewport "
+      ],
+      "toolLines": [
+        "  | stream width token stream",
+        "  | gauge diff frame viewport gauge metric layout",
+        "  | token render metric"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "gauge overlay session buffer width",
+      "assistantChunks": [
+        "buffer width replay overlay session width metric cursor "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "buffer width replay viewport layout",
+      "assistantChunks": [
+        "diff stream replay session ",
+        "gauge viewport viewport cursor ",
+        "cursor cursor diff diff "
+      ],
+      "toolLines": [
+        "  | frame frame overlay timer overlay buffer overlay"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "layout layout frame",
+      "assistantChunks": [
+        "token stream token render stream render stream buffer viewport ",
+        "token render replay timer width timer session render render width "
+      ],
+      "toolLines": [
+        "  | stream token buffer viewport",
+        "  | render overlay viewport buffer token render diff",
+        "  | metric gauge width"
+      ],
+      "resizeTo": {
+        "cols": 122,
+        "rows": 38
+      },
+      "idleTicks": 1
+    },
+    {
+      "userText": "overlay frame viewport gauge diff session cursor",
+      "assistantChunks": [
+        "session gauge diff frame metric layout gauge ",
+        "render viewport timer render overlay diff gauge metric "
+      ],
+      "toolLines": [
+        "  | buffer width session viewport",
+        "  | metric session diff"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "gauge viewport stream timer",
+      "assistantChunks": [
+        "timer render metric metric overlay render replay buffer "
+      ],
+      "toolLines": [
+        "  | token session frame replay render",
+        "  | timer viewport frame",
+        "  | metric render viewport stream viewport gauge"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "stream diff render frame token",
+      "assistantChunks": [
+        "frame diff buffer buffer diff layout "
+      ],
+      "toolLines": [
+        "  | token session overlay layout frame metric viewport"
+      ],
+      "idleTicks": 1
+    },
+    {
+      "userText": "viewport token cursor viewport metric frame",
+      "assistantChunks": [
+        "render timer buffer token width ",
+        "overlay token session buffer session metric width "
+      ],
+      "toolLines": [
+        "  | width layout token frame"
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "timer metric cursor",
+      "assistantChunks": [
+        "buffer gauge layout width timer "
+      ],
+      "idleTicks": 0
+    },
+    {
+      "userText": "viewport session frame overlay replay replay",
+      "assistantChunks": [
+        "gauge render gauge frame metric buffer ",
+        "width session replay width cursor viewport stream "
+      ],
+      "toolLines": [
+        "  | render buffer session",
+        "  | replay stream frame",
+        "  | width stream buffer render timer replay"
+      ],
+      "idleTicks": 0
+    }
+  ]
+}

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -28,4 +28,35 @@ describe("Loader component", () => {
 		loader.stop();
 		tui.stop();
 	});
+
+	it("unrefs its animation interval so it does not keep the event loop alive", () => {
+		const term = new VirtualTerminal(20, 4);
+		const tui = new TUI(term);
+		let unrefCalled = false;
+		const realSetInterval = globalThis.setInterval;
+		// Shim setInterval to observe that the loader unrefs the timer it creates.
+		globalThis.setInterval = ((handler: (...handlerArgs: unknown[]) => void, timeout?: number, ...args: unknown[]) => {
+			const timer = realSetInterval(handler, timeout, ...args);
+			const realUnref = timer.unref?.bind(timer);
+			timer.unref = () => {
+				unrefCalled = true;
+				return realUnref ? realUnref() : timer;
+			};
+			return timer;
+		}) as typeof globalThis.setInterval;
+		try {
+			const loader = new Loader(
+				tui,
+				text => text,
+				text => text,
+				"Working",
+				["|"],
+			);
+			loader.stop();
+		} finally {
+			globalThis.setInterval = realSetInterval;
+		}
+		tui.stop();
+		expect(unrefCalled).toBe(true);
+	});
 });

--- a/packages/tui/test/metrics-redteam.test.ts
+++ b/packages/tui/test/metrics-redteam.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { REPAINT_STORM_THRESHOLD, RenderMetrics } from "@gajae-code/tui/metrics";
+import { makeRecordedSession, runReplay } from "./replay-harness";
+
+function recordUnexpectedRender(metrics: RenderMetrics, cause = "extraLines > height"): void {
+	metrics.recordFullRedraw(cause);
+	metrics.recordRender(1);
+}
+
+function recordExpectedRender(metrics: RenderMetrics, cause = "terminal width changed"): void {
+	metrics.recordFullRedraw(cause);
+	metrics.recordRender(1);
+}
+
+describe("RenderMetrics red-team coverage", () => {
+	it("keeps disabled record paths zeroed under high-volume no-op calls", () => {
+		const metrics = new RenderMetrics(false);
+
+		for (let i = 0; i < 100_000; i++) {
+			metrics.recordRequest(`source-${i % 17}`);
+			metrics.recordRender(i % 101);
+			metrics.recordFullRedraw(i % 2 === 0 ? "extraLines > height" : "terminal width changed");
+			metrics.setOwnerGauge("owner", i);
+			metrics.setTimerGauge("timer", i);
+		}
+
+		expect(metrics.sampleRss()).toBe(0);
+		const snapshot = metrics.snapshot();
+		expect(snapshot.enabled).toBe(false);
+		expect(snapshot.renderCount).toBe(0);
+		expect(snapshot.renderDurations).toEqual({ count: 0, meanMs: 0, p50Ms: 0, p95Ms: 0, p99Ms: 0, maxMs: 0 });
+		expect(snapshot.durationsTruncated).toBe(false);
+		expect(snapshot.requestSources).toEqual({});
+		expect(snapshot.fullRedrawCount).toBe(0);
+		expect(snapshot.fullRedrawCauses).toEqual({});
+		expect(snapshot.repaintStorms).toBe(0);
+		expect(snapshot.maxConsecutiveFullRedraws).toBe(0);
+		expect(snapshot.rss).toEqual({
+			samples: 0,
+			baselineBytes: null,
+			lastBytes: null,
+			peakBytes: 0,
+			growthBytes: 0,
+			returnBytes: null,
+			heapBaselineBytes: null,
+			heapReturnBytes: null,
+			returnWithinBaselineFraction: null,
+		});
+		expect(snapshot.ownerGauges).toEqual({});
+		expect(snapshot.timerGauges).toEqual({});
+	});
+
+	it("counts storms only for consecutive unexpected full-redraw runs at threshold boundaries", () => {
+		const belowThreshold = new RenderMetrics(true);
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD - 1; i++) recordUnexpectedRender(belowThreshold);
+		let snapshot = belowThreshold.snapshot();
+		expect(snapshot.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD - 1);
+		expect(snapshot.repaintStorms).toBe(0);
+
+		const exactlyThreshold = new RenderMetrics(true);
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD; i++) recordUnexpectedRender(exactlyThreshold);
+		snapshot = exactlyThreshold.snapshot();
+		expect(snapshot.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD);
+		expect(snapshot.repaintStorms).toBe(1);
+
+		const interrupted = new RenderMetrics(true);
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD - 1; i++) recordUnexpectedRender(interrupted, "scrollback overflow");
+		recordExpectedRender(interrupted, "terminal width changed");
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD - 1; i++) recordUnexpectedRender(interrupted, "scrollback overflow");
+		snapshot = interrupted.snapshot();
+		expect(snapshot.fullRedrawCauses["scrollback overflow"]).toBe((REPAINT_STORM_THRESHOLD - 1) * 2);
+		expect(snapshot.fullRedrawCauses["terminal width changed"]).toBe(1);
+		expect(snapshot.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD - 1);
+		expect(snapshot.repaintStorms).toBe(0);
+
+		recordUnexpectedRender(interrupted, "scrollback overflow");
+		snapshot = interrupted.snapshot();
+		expect(snapshot.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD);
+		expect(snapshot.repaintStorms).toBe(1);
+	});
+
+	it("returns zeroed, singleton, and monotonic percentile duration stats at boundaries", () => {
+		const empty = new RenderMetrics(true);
+		expect(empty.snapshot().renderDurations).toEqual({ count: 0, meanMs: 0, p50Ms: 0, p95Ms: 0, p99Ms: 0, maxMs: 0 });
+
+		const single = new RenderMetrics(true);
+		single.recordRender(42);
+		expect(single.snapshot().renderDurations).toEqual({
+			count: 1,
+			meanMs: 42,
+			p50Ms: 42,
+			p95Ms: 42,
+			p99Ms: 42,
+			maxMs: 42,
+		});
+
+		const distributed = new RenderMetrics(true);
+		for (const sample of [1, 2, 3, 4, 5, 50, 75, 100, 150, 200]) distributed.recordRender(sample);
+		const stats = distributed.snapshot().renderDurations;
+		expect(stats.count).toBe(10);
+		expect(stats.p50Ms).toBeLessThanOrEqual(stats.p95Ms);
+		expect(stats.p95Ms).toBeLessThanOrEqual(stats.p99Ms);
+		expect(stats.p99Ms).toBeLessThanOrEqual(stats.maxMs);
+		expect(stats.maxMs).toBe(200);
+	});
+
+	it("preserves replay viewport and scrollback byte-for-byte with metrics under narrow stress", async () => {
+		const fixture = makeRecordedSession(80, 0x5eed, 40, 24);
+		const withMetrics = await runReplay(fixture, { metrics: true });
+		const withoutMetrics = await runReplay(fixture, { metrics: false });
+
+		expect(withMetrics.turns).toBe(80);
+		expect(withoutMetrics.turns).toBe(80);
+		expect(withoutMetrics.finalViewport.join("\n")).toBe(withMetrics.finalViewport.join("\n"));
+		expect(withoutMetrics.scrollback.join("\n")).toBe(withMetrics.scrollback.join("\n"));
+	}, 60000);
+
+	it("tracks RSS samples with non-negative growth, peak at least baseline, and last set", () => {
+		const metrics = new RenderMetrics(true);
+		const samples = [metrics.sampleRss(), metrics.sampleRss(), metrics.sampleRss(), metrics.sampleRss()];
+		const snapshot = metrics.snapshot();
+
+		expect(samples.every(sample => sample > 0)).toBe(true);
+		expect(snapshot.rss.samples).toBe(samples.length);
+		expect(snapshot.rss.baselineBytes).toBe(samples[0]);
+		expect(snapshot.rss.lastBytes).toBe(samples[samples.length - 1]);
+		expect(snapshot.rss.peakBytes).toBeGreaterThanOrEqual(snapshot.rss.baselineBytes ?? 0);
+		expect(snapshot.rss.peakBytes).toBeGreaterThanOrEqual(snapshot.rss.lastBytes ?? 0);
+		expect(snapshot.rss.growthBytes).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/packages/tui/test/metrics.test.ts
+++ b/packages/tui/test/metrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { REPAINT_STORM_THRESHOLD, RenderMetrics } from "@gajae-code/tui/metrics";
+
+describe("RenderMetrics", () => {
+	it("is a no-op when disabled (negligible default overhead)", () => {
+		const m = new RenderMetrics(false);
+		expect(m.enabled).toBe(false);
+		m.recordRequest("input");
+		m.recordRender(5);
+		m.recordFullRedraw("extraLines > height");
+		m.sampleRss();
+		m.setOwnerGauge("o", 3);
+		m.setTimerGauge("t", 1);
+		const s = m.snapshot();
+		expect(s.enabled).toBe(false);
+		expect(s.renderCount).toBe(0);
+		expect(s.fullRedrawCount).toBe(0);
+		expect(Object.keys(s.requestSources)).toHaveLength(0);
+		expect(s.rss.samples).toBe(0);
+		expect(Object.keys(s.ownerGauges)).toHaveLength(0);
+		expect(Object.keys(s.timerGauges)).toHaveLength(0);
+	});
+
+	it("computes duration percentiles when enabled", () => {
+		const m = new RenderMetrics(true);
+		for (let i = 1; i <= 100; i++) m.recordRender(i);
+		const s = m.snapshot();
+		expect(s.renderCount).toBe(100);
+		expect(s.renderDurations.count).toBe(100);
+		expect(s.renderDurations.maxMs).toBe(100);
+		expect(s.renderDurations.p50Ms).toBeGreaterThan(49);
+		expect(s.renderDurations.p50Ms).toBeLessThan(52);
+		expect(s.renderDurations.p95Ms).toBeGreaterThan(93);
+		expect(s.renderDurations.p95Ms).toBeLessThanOrEqual(100);
+	});
+
+	it("attributes request sources", () => {
+		const m = new RenderMetrics(true);
+		m.recordRequest("input");
+		m.recordRequest("input");
+		m.recordRequest("resize");
+		const s = m.snapshot();
+		expect(s.requestSources.input).toBe(2);
+		expect(s.requestSources.resize).toBe(1);
+	});
+
+	it("detects repaint storms from consecutive unexpected full redraws", () => {
+		const m = new RenderMetrics(true);
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD; i++) {
+			m.recordFullRedraw("extraLines > height");
+			m.recordRender(1);
+		}
+		let s = m.snapshot();
+		expect(s.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD);
+		expect(s.repaintStorms).toBe(1);
+		expect(s.fullRedrawCauses["extraLines > height"]).toBe(REPAINT_STORM_THRESHOLD);
+
+		// A normal render with no preceding full redraw breaks the run.
+		m.recordRender(1);
+		s = m.snapshot();
+		expect(s.maxConsecutiveFullRedraws).toBe(REPAINT_STORM_THRESHOLD);
+	});
+
+	it("does not count expected full redraws (resize/width/first) as storms", () => {
+		const m = new RenderMetrics(true);
+		for (let i = 0; i < REPAINT_STORM_THRESHOLD + 2; i++) {
+			m.recordFullRedraw("terminal width changed");
+			m.recordRender(1);
+		}
+		const s = m.snapshot();
+		expect(s.fullRedrawCount).toBe(REPAINT_STORM_THRESHOLD + 2);
+		expect(s.repaintStorms).toBe(0);
+		expect(s.maxConsecutiveFullRedraws).toBe(0);
+	});
+
+	it("tracks RSS baseline/peak/growth and owner/timer gauges", () => {
+		const m = new RenderMetrics(true);
+		const first = m.sampleRss();
+		m.sampleRss();
+		expect(first).toBeGreaterThan(0);
+		m.setOwnerGauge("transcript", 7);
+		m.setTimerGauge("render", 1);
+		const s = m.snapshot();
+		expect(s.rss.samples).toBe(2);
+		expect(s.rss.baselineBytes).not.toBeNull();
+		expect(s.rss.growthBytes).toBeGreaterThanOrEqual(0);
+		expect(s.ownerGauges.transcript).toBe(7);
+		expect(s.timerGauges.render).toBe(1);
+	});
+
+	it("reset clears collected data but keeps enabled state", () => {
+		const m = new RenderMetrics(true);
+		m.recordRender(5);
+		m.recordRequest("input");
+		m.reset();
+		const s = m.snapshot();
+		expect(s.renderCount).toBe(0);
+		expect(Object.keys(s.requestSources)).toHaveLength(0);
+		expect(s.enabled).toBe(true);
+	});
+});

--- a/packages/tui/test/perf-gates.test.ts
+++ b/packages/tui/test/perf-gates.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { $flag } from "@gajae-code/utils";
+import { loadFixture, makeRecordedSession, measureIdleCpuFraction, runReplay } from "./replay-harness";
+
+/**
+ * Performance gates for the runtime/renderer hardening program.
+ *
+ * Stage 1 is the observability foundation: it MEASURES idle CPU, RSS growth,
+ * post-GC heap reclaim, p95 frame time, and repaint storms over a recorded
+ * ~300-turn session. Per the approved measurement-first plan, hard numeric
+ * thresholds are opt-in (`PI_TUI_PERF_GATES=1`) and calibrated before becoming
+ * permanent CI fail gates.
+ *
+ * Two threshold classes:
+ *  - ENFORCED now: gates the current renderer already satisfies (p95 frame time,
+ *    zero steady-stream repaint storms, idle CPU, bounded post-GC heap reclaim).
+ *    These fail the build if a future change regresses them.
+ *  - STAGE-2 TARGETS: the spec's RSS-growth budget. Stage 1 records the baseline;
+ *    enforcement is turned on after Stage 2 (resource-leak elimination) brings the
+ *    measured value under target. Recording (not yet failing) here is deliberate:
+ *    the leak-fix threshold cannot pass before the leak-fix stage runs.
+ */
+export const PERF_GATES = {
+	// Enforced now.
+	renderP95Ms: 8,
+	repaintStormsMax: 0,
+	idleCpuFractionMax: 0.01,
+	// Stage-2 acceptance targets (measured now, enforced after leak elimination).
+	rssGrowthTargetBytes: 50 * 1024 * 1024,
+};
+
+const HARD_GATES = $flag("PI_TUI_PERF_GATES");
+
+describe("performance gates (structural, always on)", () => {
+	it("collects gate metrics incl. helper timing and post-GC heap reclaim; zero storms", async () => {
+		const r = await runReplay(makeRecordedSession(60, 0x2026));
+		expect(r.metrics.renderDurations.count).toBeGreaterThan(0);
+		expect(r.metrics.rss.baselineBytes).not.toBeNull();
+		expect(r.metrics.rss.returnBytes).not.toBeNull();
+		expect(r.metrics.rss.heapBaselineBytes).not.toBeNull();
+		expect(r.metrics.rss.heapReturnBytes).not.toBeNull();
+		expect(r.metrics.rss.returnWithinBaselineFraction).not.toBeNull();
+		expect(r.metrics.helperStats.renderTree?.count ?? 0).toBeGreaterThan(0);
+		expect(r.metrics.repaintStorms).toBe(PERF_GATES.repaintStormsMax);
+	}, 60000);
+
+	it("measures idle CPU as a fraction of one core", async () => {
+		const idle = await measureIdleCpuFraction(400);
+		expect(idle).toBeGreaterThanOrEqual(0);
+		expect(Number.isFinite(idle)).toBe(true);
+	}, 30000);
+});
+
+if (HARD_GATES) {
+	describe("performance gates (hard numeric, opt-in via PI_TUI_PERF_GATES)", () => {
+		it("enforces p95 / repaint-storm / idle-CPU and records RSS-growth + heap-reclaim targets", async () => {
+			const json = await Bun.file(`${import.meta.dir}/fixtures/recorded-session.json`).text();
+			const fixture = loadFixture(json);
+			const r = await runReplay(fixture);
+			expect(r.turns).toBe(300);
+
+			const m = r.metrics;
+			const rssGrowthMB = (m.rss.growthBytes / 1048576).toFixed(1);
+			const heapReturnMB = ((m.rss.heapReturnBytes ?? 0) / 1048576).toFixed(1);
+			// Surface the measured baseline for calibration / Stage-2 tracking.
+			console.log(
+				`[perf-gates] p95=${m.renderDurations.p95Ms.toFixed(2)}ms storms=${m.repaintStorms} ` +
+					`rssGrowth=${rssGrowthMB}MB (target ${PERF_GATES.rssGrowthTargetBytes / 1048576}MB) ` +
+					`heapReturn=${heapReturnMB}MB`,
+			);
+
+			// Enforced gates (current renderer satisfies these).
+			expect(m.renderDurations.p95Ms).toBeLessThan(PERF_GATES.renderP95Ms);
+			expect(m.repaintStorms).toBe(PERF_GATES.repaintStormsMax);
+
+			const idle = await measureIdleCpuFraction(1500);
+			expect(idle).toBeLessThan(PERF_GATES.idleCpuFractionMax);
+
+			// Stage-2 targets: measured and finite now; enforced after leak elimination
+			// (the harness retains the returned 300-turn golden output, so heap reclaim
+			// is recorded, not yet a clean hard gate).
+			expect(Number.isFinite(m.rss.growthBytes)).toBe(true);
+			expect(m.rss.growthBytes).toBeGreaterThan(0);
+			expect(m.rss.heapReturnBytes).not.toBeNull();
+		}, 300000);
+	});
+}

--- a/packages/tui/test/replay-harness.test.ts
+++ b/packages/tui/test/replay-harness.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { makeRecordedSession, runReplay } from "./replay-harness";
+
+describe("replay harness", () => {
+	it("produces metrics and golden output for a recorded session", async () => {
+		const fixture = makeRecordedSession(40, 0x1234, 100, 30);
+		const r = await runReplay(fixture);
+		expect(r.turns).toBe(40);
+		expect(r.metrics.enabled).toBe(true);
+		expect(r.metrics.renderCount).toBeGreaterThan(0);
+		expect(r.metrics.renderDurations.count).toBeGreaterThan(0);
+		expect(r.metrics.rss.baselineBytes).not.toBeNull();
+		expect(r.finalViewport.length).toBeGreaterThan(0);
+		expect(Object.keys(r.metrics.requestSources).some(k => k.startsWith("replay."))).toBe(true);
+	}, 60000);
+
+	it("is deterministic: identical fixture -> identical viewport and scrollback", async () => {
+		const a = await runReplay(makeRecordedSession(30, 0xabcd));
+		const b = await runReplay(makeRecordedSession(30, 0xabcd));
+		expect(b.finalViewport).toEqual(a.finalViewport);
+		expect(b.scrollback).toEqual(a.scrollback);
+	}, 60000);
+
+	it("instrumentation does not change visible output (parity)", async () => {
+		const withMetrics = await runReplay(makeRecordedSession(30, 0x55), { metrics: true });
+		const withoutMetrics = await runReplay(makeRecordedSession(30, 0x55), { metrics: false });
+		expect(withoutMetrics.finalViewport).toEqual(withMetrics.finalViewport);
+		expect(withoutMetrics.scrollback).toEqual(withMetrics.scrollback);
+	}, 60000);
+
+	it("clean append-only streaming produces no repaint storms", async () => {
+		const r = await runReplay(makeRecordedSession(60, 0x99));
+		expect(r.metrics.repaintStorms).toBe(0);
+	}, 60000);
+});

--- a/packages/tui/test/replay-harness.ts
+++ b/packages/tui/test/replay-harness.ts
@@ -1,0 +1,268 @@
+/**
+ * Recorded real-session replay harness (Stage 1 observability foundation).
+ *
+ * Drives a `TUI` over the in-repo `VirtualTerminal` with a scripted, deterministic
+ * session fixture (streamed assistant output, tool blocks, high-output/read-like
+ * blocks, idle gaps, terminal resizes, growing transcript) and collects
+ * renderer/runtime metrics plus golden output. It is a test/bench utility, not
+ * shipped runtime code, so it can enable the otherwise opt-in `renderMetrics`.
+ *
+ * Fixtures are plain data (`ReplayFixture`) so they can be serialized to and
+ * loaded from JSON — the "recorded session" format. A representative fixture is
+ * committed at test/fixtures/recorded-session.json and consumed by the gates.
+ */
+import { performance } from "node:perf_hooks";
+import { TUI } from "@gajae-code/tui";
+import { Text } from "@gajae-code/tui/components/text";
+import { type RenderMetricsSnapshot, renderMetrics } from "@gajae-code/tui/metrics";
+import { VirtualTerminal } from "./virtual-terminal";
+
+export interface ReplayTurn {
+	userText: string;
+	/** Assistant output streamed across one or more chunks. */
+	assistantChunks: string[];
+	/** Optional tool-result lines appended after the assistant turn. */
+	toolLines?: string[];
+	/** Optional high-output / read-like block (e.g. command or file output). */
+	outputBlock?: string[];
+	/** Optional terminal resize applied before this turn (UI churn). */
+	resizeTo?: { cols: number; rows: number };
+	/** Number of idle render cycles (no state change) after the turn. */
+	idleTicks?: number;
+}
+
+export interface ReplayFixture {
+	cols: number;
+	rows: number;
+	turns: ReplayTurn[];
+}
+
+export interface ReplayResult {
+	metrics: RenderMetricsSnapshot;
+	finalViewport: string[];
+	scrollback: string[];
+	writeCount: number;
+	turns: number;
+}
+
+export interface ReplayOptions {
+	/** Collect metrics during the replay (default true). */
+	metrics?: boolean;
+}
+
+/** Deterministic 32-bit PRNG (mulberry32) for reproducible fixtures. */
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+const WORDS = [
+	"render",
+	"buffer",
+	"diff",
+	"stream",
+	"token",
+	"layout",
+	"width",
+	"cursor",
+	"overlay",
+	"viewport",
+	"session",
+	"timer",
+	"gauge",
+	"replay",
+	"metric",
+	"frame",
+];
+
+function sentence(rand: () => number, words: number): string {
+	const out: string[] = [];
+	for (let i = 0; i < words; i++) {
+		out.push(WORDS[Math.floor(rand() * WORDS.length)]);
+	}
+	return out.join(" ");
+}
+
+/**
+ * Build a deterministic ~`turnCount`-turn recorded session fixture that
+ * exercises streamed assistant output, tool blocks, high-output/read-like
+ * output, idle gaps, terminal resizes, and a growing transcript.
+ */
+export function makeRecordedSession(turnCount = 300, seed = 0x9e3779b9, cols = 100, rows = 30): ReplayFixture {
+	const rand = mulberry32(seed);
+	const turns: ReplayTurn[] = [];
+	for (let i = 0; i < turnCount; i++) {
+		const chunkCount = 1 + Math.floor(rand() * 3);
+		const assistantChunks: string[] = [];
+		for (let c = 0; c < chunkCount; c++) {
+			assistantChunks.push(`${sentence(rand, 4 + Math.floor(rand() * 8))} `);
+		}
+		const hasTool = rand() < 0.4;
+		const toolLines = hasTool
+			? Array.from({ length: 1 + Math.floor(rand() * 3) }, () => `  | ${sentence(rand, 3 + Math.floor(rand() * 5))}`)
+			: undefined;
+		// ~15% of turns emit a large read-like / command output block.
+		const hasOutput = rand() < 0.15;
+		const outputBlock = hasOutput
+			? Array.from(
+					{ length: 20 + Math.floor(rand() * 40) },
+					(_unused, n) => `${n.toString().padStart(4)}  ${sentence(rand, 8 + Math.floor(rand() * 10))}`,
+				)
+			: undefined;
+		// ~8% of turns resize the terminal (UI churn / width+height change paths).
+		const hasResize = rand() < 0.08;
+		const resizeTo = hasResize
+			? { cols: 70 + Math.floor(rand() * 60), rows: 20 + Math.floor(rand() * 20) }
+			: undefined;
+		turns.push({
+			userText: sentence(rand, 3 + Math.floor(rand() * 5)),
+			assistantChunks,
+			toolLines,
+			outputBlock,
+			resizeTo,
+			idleTicks: rand() < 0.3 ? 1 : 0,
+		});
+	}
+	return { cols, rows, turns };
+}
+
+/** Serialize a fixture to the recorded-session JSON format. */
+export function serializeFixture(fixture: ReplayFixture): string {
+	return JSON.stringify(fixture, null, 2);
+}
+
+/** Parse a recorded-session JSON string into a fixture (shape-validated). */
+export function loadFixture(json: string): ReplayFixture {
+	const data = JSON.parse(json) as ReplayFixture;
+	if (!data || typeof data.cols !== "number" || typeof data.rows !== "number" || !Array.isArray(data.turns)) {
+		throw new Error("invalid replay fixture: expected { cols, rows, turns[] }");
+	}
+	return data;
+}
+
+/**
+ * Replay a fixture through a TUI over a virtual terminal and return metrics plus
+ * golden output. When `metrics` is true (default), `renderMetrics` is reset,
+ * enabled for the duration, and disabled again afterward so callers always get a
+ * clean, isolated snapshot and global state is restored. A post-replay forced-GC
+ * RSS "return" sample is taken after releasing the transcript so the memory-leak
+ * gate measures reclaimable growth.
+ */
+export async function runReplay(fixture: ReplayFixture, opts: ReplayOptions = {}): Promise<ReplayResult> {
+	const collect = opts.metrics ?? true;
+	if (collect) {
+		renderMetrics.reset();
+		renderMetrics.enable();
+	}
+
+	const term = new VirtualTerminal(fixture.cols, fixture.rows);
+	const tui = new TUI(term);
+	tui.start();
+	if (collect) renderMetrics.sampleRss(); // baseline
+
+	let turnIndex = 0;
+	let componentCount = 0;
+	for (const turn of fixture.turns) {
+		turnIndex += 1;
+		if (collect) renderMetrics.setOwnerGauge("transcript.components", componentCount);
+
+		if (turn.resizeTo) {
+			term.resize(turn.resizeTo.cols, turn.resizeTo.rows);
+			await term.waitForRender();
+		}
+
+		tui.addChild(new Text(`> ${turn.userText}`, 1, 0));
+		componentCount += 1;
+		tui.requestRender(false, "replay.user");
+		await term.waitForRender();
+
+		const stream = new Text("", 1, 0);
+		tui.addChild(stream);
+		componentCount += 1;
+
+		// Stream in two coalesced checkpoints (mid + final) to keep the replay
+		// fast while still exercising the streaming render cadence.
+		let acc = "";
+		const mid = Math.ceil(turn.assistantChunks.length / 2);
+		for (let c = 0; c < turn.assistantChunks.length; c++) {
+			acc += turn.assistantChunks[c];
+			if (c === mid - 1 || c === turn.assistantChunks.length - 1) {
+				stream.setText(acc);
+				tui.requestRender(false, "replay.stream");
+				await term.waitForRender();
+			}
+		}
+
+		if (turn.outputBlock) {
+			tui.addChild(new Text(turn.outputBlock.join("\n"), 1, 0));
+			componentCount += 1;
+			tui.requestRender(false, "replay.output");
+			await term.waitForRender();
+		}
+
+		if (turn.toolLines) {
+			for (const line of turn.toolLines) {
+				tui.addChild(new Text(line, 1, 0));
+				componentCount += 1;
+			}
+			tui.requestRender(false, "replay.tool");
+			await term.waitForRender();
+		}
+
+		for (let t = 0; t < (turn.idleTicks ?? 0); t++) {
+			// Idle gap: no state change, no render request. Used to measure that
+			// the renderer does not perform avoidable work when nothing changed.
+			await term.waitForRender();
+		}
+
+		if (collect) renderMetrics.sampleRss();
+	}
+
+	const finalViewport = await term.flushAndGetViewport();
+	const scrollback = term.getScrollBuffer();
+	const writeCount = term.getWriteLog().length;
+	tui.stop();
+
+	// Release retained transcript/terminal state, then sample post-GC RSS so the
+	// memory-leak/return gate measures reclaimable growth rather than live data.
+	if (collect) {
+		tui.clear();
+		term.reset();
+		renderMetrics.sampleReturn();
+	}
+
+	const metrics = renderMetrics.snapshot();
+	if (collect) renderMetrics.disable();
+
+	return { metrics, finalViewport, scrollback, writeCount, turns: turnIndex };
+}
+
+/**
+ * Measure idle CPU as a fraction of one core over `idleMs` on a quiescent TUI
+ * (rendered once, then no further render requests). Used by the idle-CPU gate.
+ */
+export async function measureIdleCpuFraction(idleMs = 1000): Promise<number> {
+	const term = new VirtualTerminal(100, 30);
+	const tui = new TUI(term);
+	tui.start();
+	tui.addChild(new Text("idle baseline", 1, 0));
+	tui.requestRender(false, "idle.setup");
+	await term.waitForRender();
+	await new Promise<void>(resolve => setTimeout(resolve, 50)); // settle
+
+	const cpu0 = process.cpuUsage();
+	const t0 = performance.now();
+	await new Promise<void>(resolve => setTimeout(resolve, idleMs));
+	const elapsedMs = performance.now() - t0;
+	const cpu = process.cpuUsage(cpu0);
+	tui.stop();
+
+	const cpuMicros = cpu.user + cpu.system;
+	return cpuMicros / (elapsedMs * 1000);
+}


### PR DESCRIPTION
## Stage 2 — Resource-leak elimination (first increment)

PR #2 of the staged runtime/renderer performance program. **Stacked on #250 (Stage 1)** — base branch is `feat/tui-perf-observability`; retarget to `dev` after #250 merges. Builds on Stage 1's measurement foundation.

### Fixes (the two HIGH-severity leaks from the risk map)
- **CPU-1 — loader timer pins the event loop.** `Loader`'s 16ms animation `setInterval` is now `unref()`'d, so an active spinner no longer keeps the event loop alive on its own. Animation behavior unchanged (existing loader test still passes).
- **MEM-7 — persistent shell sessions retained for process lifetime.** `bash-executor`'s `shellSessions` map only deleted entries on broken/error/timeout/cancel; healthy persistent sessions accumulated forever. Adds:
  - `disposeAllShellSessions()` — drops strong refs up front (no reuse-during-teardown), then `await`s every native `Shell.abort()` so cleanup doesn't return before resources are released.
  - `getShellSessionCount()`.
  - `postmortem.register(...)` so shutdown/signals (SIGINT/SIGTERM/SIGHUP/uncaught/unhandled) release native shell resources.

### Observability
- `packages/coding-agent/src/debug/runtime-gauges.ts` — framework-agnostic `getRuntimeResourceCounts()` owner-count surface (`bash.shellSessions`), extensible to Python kernels, LSP clients, browser tabs, async jobs, streaming queues. Deliberately **not** coupled to the TUI metrics surface yet (coding-agent resolves `@gajae-code/tui` to a separate checkout until Stage 1 merges; the `renderMetrics` owner-gauge bridge lands in a follow-up increment).

### Verification
- `@gajae-code/tui`: **420 / 0** (incl. new loader-unref test + render-regressions). typecheck clean.
- `@gajae-code/coding-agent` `bash-executor.test.ts`: **29 / 0** (incl. MEM-7 dispose test asserting disposal returns a settling Promise and reaches count 0, + runtime owner-count test). typecheck clean.
- Architect review: **APPROVE**, all lanes **CLEAR**, 0 blockers (after one round that caught—and I fixed—a fire-and-forget abort in disposal).

### Scope / what remains in the leak-elimination stage
First increment = the two HIGH-severity flagged leaks + the owner-count surface. Follow-up increments: wire remaining runtime owner gauges (py/LSP/browser/async — most already have dispose paths), bridge owner counts into `renderMetrics` after #250 merges, and promote the recorded RSS-growth/heap-reclaim baselines into enforced gates.
