### PR TITLE
feat(telemetry): summary-default for truthy capture env + full-mode warning

### DIFF
--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -283,6 +283,7 @@ export interface AgentTelemetryWarning {
 		| "on_span_end_failed"
 		| "normalize_agent_name_failed"
 		| "normalize_provider_failed"
+		| "full_content_capture_env_active"
 		| "on_telemetry_warning_failed";
 	readonly message: string;
 	readonly error?: unknown;
@@ -322,12 +323,14 @@ export interface AgentTelemetryConfig {
 	/** Override the tracer name passed to `trace.getTracer`. */
 	readonly tracerName?: string;
 	/**
-	 * Capture request/response content. `true` preserves the historical full
-	 * payload capture; `"summary"` emits bounded dashboard-friendly summaries;
-	 * `"full"` emits both summaries and full OTEL message payloads.
+	 * Capture request/response content. Programmatic `true` preserves the
+	 * historical full payload capture because code config is an explicit opt-in;
+	 * `"summary"` emits bounded dashboard-friendly summaries; `"full"` emits
+	 * both summaries and full OTEL message payloads.
 	 *
 	 * Defaults to the value of the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`
-	 * env var (`true`/`1`/`yes` => `"full"`, `"summary"` => `"summary"`).
+	 * env var (`true`/`1`/`yes` => `"summary"`, `"summary"` => `"summary"`,
+	 * `"full"` => `"full"`).
 	 */
 	readonly captureMessageContent?: TelemetryContentCapture;
 	/** Extra attributes merged onto every emitted span. */
@@ -436,13 +439,18 @@ function readContentCaptureEnv(): ResolvedTelemetryContentCapture {
 		return "none";
 	}
 	const normalized = raw.trim().toLowerCase();
-	if (normalized === "summary") {
+	if (normalized === "full") {
+		contentCaptureEnvCache = "full";
+	} else if (normalized === "summary" || normalized === "true" || normalized === "1" || normalized === "yes") {
 		contentCaptureEnvCache = "summary";
 	} else {
-		contentCaptureEnvCache =
-			normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "full" ? "full" : "none";
+		contentCaptureEnvCache = "none";
 	}
 	return contentCaptureEnvCache;
+}
+
+export function resetContentCaptureEnvCacheForTest(): void {
+	contentCaptureEnvCache = undefined;
 }
 
 function resolveContentCapture(value: TelemetryContentCapture | undefined): ResolvedTelemetryContentCapture {

--- a/packages/agent/test/otel.test.ts
+++ b/packages/agent/test/otel.test.ts
@@ -17,6 +17,7 @@ import {
 	PiGenAIAttr,
 	recordHandoff,
 	recordManualChatTelemetry,
+	resetContentCaptureEnvCacheForTest,
 	resolveTelemetry,
 	type TelemetryHookContext,
 } from "@gajae-code/agent-core/telemetry";
@@ -52,6 +53,7 @@ beforeAll(() => {
 
 afterEach(() => {
 	exporter.reset();
+	resetContentCaptureEnvCacheForTest();
 });
 
 afterAll(async () => {
@@ -387,6 +389,130 @@ describe("agent-loop OTEL instrumentation", () => {
 		expect(responseText).toEqual(["hi back"]);
 		expect(chat?.attributes[GenAIAttr.InputMessages]).toBeUndefined();
 		expect(chat?.attributes[GenAIAttr.OutputMessages]).toBeUndefined();
+	});
+
+	it.each([
+		"true",
+		"1",
+		"yes",
+		"summary",
+	])("maps env OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=%s to summary capture", async value => {
+		const before = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+		try {
+			process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = value;
+			resetContentCaptureEnvCacheForTest();
+			const mock = createMockModel({
+				...MOCK_IDENT,
+				responses: [{ content: ["hi back"], stopReason: "stop" }],
+			});
+			const config: AgentLoopConfig = {
+				model: mock.model,
+				convertToLlm: identityConverter,
+				telemetry: {},
+			};
+			const ctx: AgentContext = { systemPrompt: ["sys-instruction"], messages: [], tools: [] };
+			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+			const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+			expect(JSON.parse(chat?.attributes[PiGenAIAttr.ResponseText] as string)).toEqual(["hi back"]);
+			expect(chat?.attributes[GenAIAttr.InputMessages]).toBeUndefined();
+			expect(chat?.attributes[GenAIAttr.OutputMessages]).toBeUndefined();
+			expect(chat?.attributes[GenAIAttr.SystemInstructions]).toBeUndefined();
+		} finally {
+			if (before === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+			else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = before;
+		}
+	});
+
+	it("maps env OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=full to full capture", async () => {
+		const before = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+		try {
+			process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = "full";
+			resetContentCaptureEnvCacheForTest();
+			const mock = createMockModel({
+				...MOCK_IDENT,
+				responses: [{ content: ["hi back"], stopReason: "stop" }],
+			});
+			const config: AgentLoopConfig = {
+				model: mock.model,
+				convertToLlm: identityConverter,
+				telemetry: {},
+			};
+			const ctx: AgentContext = { systemPrompt: ["sys-instruction"], messages: [], tools: [] };
+			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+			const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+			expect(JSON.parse(chat?.attributes[GenAIAttr.InputMessages] as string)).toEqual([
+				{ role: "user", parts: [{ type: "text", content: "hi" }] },
+			]);
+			expect(JSON.parse(chat?.attributes[GenAIAttr.OutputMessages] as string)).toEqual([
+				{ role: "assistant", parts: [{ type: "text", content: "hi back" }], finish_reason: "stop" },
+			]);
+		} finally {
+			if (before === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+			else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = before;
+		}
+	});
+
+	it.each([
+		undefined,
+		"",
+		"none",
+		"false",
+		"garbage",
+	])("maps env OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=%s to none", async value => {
+		const before = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+		try {
+			if (value === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+			else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = value;
+			resetContentCaptureEnvCacheForTest();
+			const mock = createMockModel({
+				...MOCK_IDENT,
+				responses: [{ content: ["hi back"], stopReason: "stop" }],
+			});
+			const config: AgentLoopConfig = {
+				model: mock.model,
+				convertToLlm: identityConverter,
+				telemetry: {},
+			};
+			const ctx: AgentContext = { systemPrompt: ["sys-instruction"], messages: [], tools: [] };
+			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+			const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+			expect(chat?.attributes[PiGenAIAttr.RequestMessages]).toBeUndefined();
+			expect(chat?.attributes[PiGenAIAttr.ResponseText]).toBeUndefined();
+			expect(chat?.attributes[GenAIAttr.InputMessages]).toBeUndefined();
+			expect(chat?.attributes[GenAIAttr.OutputMessages]).toBeUndefined();
+		} finally {
+			if (before === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+			else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = before;
+		}
+	});
+
+	it("keeps explicit captureMessageContent true as full capture even though env truthy maps to summary", async () => {
+		const before = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+		try {
+			process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = "true";
+			resetContentCaptureEnvCacheForTest();
+			const mock = createMockModel({
+				...MOCK_IDENT,
+				responses: [{ content: ["hi back"], stopReason: "stop" }],
+			});
+			const config: AgentLoopConfig = {
+				model: mock.model,
+				convertToLlm: identityConverter,
+				telemetry: { captureMessageContent: true },
+			};
+			const ctx: AgentContext = { systemPrompt: ["sys-instruction"], messages: [], tools: [] };
+			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+			const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+			expect(chat?.attributes[GenAIAttr.InputMessages]).toBeDefined();
+			expect(chat?.attributes[GenAIAttr.OutputMessages]).toBeDefined();
+		} finally {
+			if (before === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+			else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = before;
+		}
 	});
 
 	it("invokes costEstimator and stamps pi.gen_ai.cost.estimated_usd", async () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -31,6 +31,36 @@ import {
 	prompt,
 	Snowflake,
 } from "@gajae-code/utils";
+
+const CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+let hasWarnedFullCapture = false;
+
+export function resetFullCaptureEnvWarningForTest(): void {
+	hasWarnedFullCapture = false;
+}
+
+export function warnIfEnvFullContentCaptureActive(telemetry: AgentTelemetryConfig | undefined): void {
+	if (!telemetry || hasWarnedFullCapture) return;
+	if (telemetry.captureMessageContent !== undefined) return;
+	if (process.env[CONTENT_CAPTURE_ENV]?.trim().toLowerCase() !== "full") return;
+	hasWarnedFullCapture = true;
+	const warning = {
+		code: "full_content_capture_env_active" as const,
+		message:
+			`${CONTENT_CAPTURE_ENV}=full enables full GenAI message content capture. ` +
+			`Use ${CONTENT_CAPTURE_ENV}=summary for bounded telemetry summaries.`,
+	};
+	try {
+		telemetry.onTelemetryWarning?.(warning);
+	} catch (error) {
+		logger.warn("Telemetry warning hook failed", {
+			code: warning.code,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+	logger.warn(warning.message, { code: warning.code });
+}
+
 import { type AsyncJob, AsyncJobManager, isBackgroundJobSupportEnabled } from "./async";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
@@ -1746,6 +1776,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				? undefined
 				: serviceTierSetting;
 
+		warnIfEnvFullContentCaptureActive(options.telemetry);
 		const appendOnlyContext =
 			model && resolveAppendOnlyMode(settings.get("provider.appendOnlyContext"), model.provider)
 				? new AppendOnlyContextManager()

--- a/packages/coding-agent/test/telemetry-full-capture-warning.test.ts
+++ b/packages/coding-agent/test/telemetry-full-capture-warning.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { logger } from "@gajae-code/utils";
+import { resetFullCaptureEnvWarningForTest, warnIfEnvFullContentCaptureActive } from "../src/sdk";
+
+describe("full content capture env warning", () => {
+	const envName = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+
+	afterEach(() => {
+		delete process.env[envName];
+		resetFullCaptureEnvWarningForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("warns once through the telemetry hook and logger when env full capture is active", () => {
+		process.env[envName] = "full";
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const hook = vi.fn();
+
+		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
+		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
+
+		expect(hook).toHaveBeenCalledTimes(1);
+		expect(hook.mock.calls[0]?.[0]).toMatchObject({ code: "full_content_capture_env_active" });
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toContain(`${envName}=full enables full GenAI message content capture`);
+	});
+
+	it("does not warn for env summary capture or explicit programmatic full capture", () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const hook = vi.fn();
+
+		process.env[envName] = "summary";
+		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
+
+		process.env[envName] = "full";
+		warnIfEnvFullContentCaptureActive({ captureMessageContent: true, onTelemetryWarning: hook });
+
+		expect(hook).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Token-efficiency program — PR4 of 10 (stacked on PR3 #251)

> Chain: PR1 #246 <- PR2 #248 <- PR3 #251 <- PR4. Retarget to `dev` as predecessors merge.

### What
Closes the telemetry full-content-capture footgun (findings #7).

- `readContentCaptureEnv()` now maps `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`: `full` => full; `summary|true|1|yes` => **summary**; empty/other => none. Previously `true|1|yes` enabled full payload capture.
- Explicit **programmatic** `captureMessageContent: true` intentionally stays full (a deliberate code opt-in, not the env footgun) — documented in code + tests.
- One-time warning when full capture is active from the env, emitted via `onTelemetryWarning` + winston `logger.warn` (never bare `console.warn`, so it cannot corrupt the TUI), wired at session construction (sdk.ts) and gated once-per-process. No warning for summary or programmatic true.
- Task-result telemetry stays receipt-only via PR1 regardless of mode (summary gates full `gen_ai.*` message/tool payload attributes).

### Verification
- tsgo clean (agent + coding-agent); biome clean
- `otel.test.ts` env-mapping cases = 47 pass; `telemetry-full-capture-warning.test.ts` = 2 pass
- Architect 3-lane + red-team review: **CLEAR/CLEAR/CLEAR, APPROVE, no blockers** (case/whitespace mapping, explicit-wins-no-double-warn, once-per-process, summary omits full payloads all verified).
