### PR TITLE
test(ultragoal): harden @goal delimiter per conservative review

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -492,10 +492,11 @@ function titleFromBrief(brief: string): string {
 }
 
 // A reserved, column-0 (unindented) `@goal` line opens a story. The character
-// right after `@goal` must be `:`, whitespace, or end-of-line, so `@goalish`,
-// `@goals:`, `@goal-foo`, `@goal.foo`, and `@goal/foo` are ordinary objective
-// text, and indented or mid-line `@goal:` is never a delimiter.
-const GOAL_DELIMITER = /^@goal(?::|\s+|$)\s*(.*)$/;
+// right after `@goal` must be `:`, an ASCII space or tab, or end-of-line, so
+// `@goalish`, `@goals:`, `@goal-foo`, `@goal.foo`, `@goal/foo`, a non-breaking
+// space, and indented or mid-line `@goal:` are all ordinary objective text and
+// never delimiters.
+const GOAL_DELIMITER = /^@goal(?::|[ \t]+|$)[ \t]*(.*)$/;
 
 interface ParsedGoal {
 	title: string;

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1117,6 +1117,14 @@ describe("ultragoal @goal decomposition", () => {
 		expect(plan.goals[0]?.title).toBe("Tabbed title");
 	});
 
+	it("does not treat a non-breaking space after @goal as a boundary", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal: Real\n@goal\u00a0NotADelimiter still body" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]?.title).toBe("Real");
+		expect(plan.goals[0]?.objective).toContain("@goal\u00a0NotADelimiter still body");
+	});
+
 	it("keeps an indented @goal line inside the objective", async () => {
 		const root = await tempDir();
 		const brief = "@goal: Story\nUse a literal like:\n    @goal: not a real delimiter\ndone.";
@@ -1237,5 +1245,53 @@ describe("ultragoal @goal decomposition", () => {
 		const status = await getUltragoalStatus(root);
 		expect(status.counts.complete).toBe(1);
 		expect(status.currentGoal?.id).toBe("G002");
+	});
+
+	it("splits CRLF briefs without retaining carriage returns", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: Parse\r\nstep one\r\n\r\n@goal: Normalize\r\nstep two",
+		});
+		expect(plan.goals.map(goal => goal.title)).toEqual(["Parse", "Normalize"]);
+		expect(plan.goals.map(goal => goal.objective)).toEqual(["step one", "step two"]);
+		for (const goal of plan.goals) {
+			expect(goal.title).not.toContain("\r");
+			expect(goal.objective).not.toContain("\r");
+		}
+	});
+
+	it("trims trailing whitespace on delimiter lines", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal: First   \nbody\n@goal   \nSecond body" });
+		expect(plan.goals.map(goal => goal.title)).toEqual(["First", "Second body"]);
+		expect(plan.goals.map(goal => goal.objective)).toEqual(["body", "Second body"]);
+	});
+
+	it("collapses multiple blank lines between stories", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: First\nfirst body\n\n\n\n@goal: Second\nsecond body",
+		});
+		expect(plan.goals.map(goal => goal.id)).toEqual(["G001", "G002"]);
+		expect(plan.goals[0]?.objective).toBe("first body");
+		expect(plan.goals[1]?.objective).toBe("second body");
+	});
+
+	it("ignores a single trailing blank line", async () => {
+		const root = await tempDir();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "@goal: First\nfirst body\n" });
+		expect(plan.goals).toHaveLength(1);
+		expect(plan.goals[0]).toMatchObject({ title: "First", objective: "first body" });
+	});
+
+	it("preserves a very long objective without clamping it", async () => {
+		const root = await tempDir();
+		const longBody = "x".repeat(5000);
+		const plan = await createUltragoalPlan({ cwd: root, brief: `@goal: Long\n${longBody}` });
+		expect(plan.goals[0]?.title).toBe("Long");
+		expect(plan.goals[0]?.objective).toBe(longBody);
+		expect(plan.goals[0]?.objective).toHaveLength(5000);
 	});
 });


### PR DESCRIPTION
## Follow-up to #249

#249 (`@goal` delimiter decomposition) was squash-merged into `dev` before the conservative-review hardening commit landed — the merge auto-deleted the branch, stranding that commit. This PR lands the hardening on top of current `dev`.

## Changes
- **Correctness:** tighten `GOAL_DELIMITER` from `/^@goal(?::|\s+|$)\s*(.*)$/` to `/^@goal(?::|[ \t]+|$)[ \t]*(.*)$/` so the delimiter boundary is exactly the documented `:` / ASCII space-or-tab / end-of-line. `\s` previously accepted Unicode/vertical whitespace (e.g. a non-breaking space after `@goal`), which could false-split a single-blob brief. Code now matches the SKILL contract.
- **Tests (+6):** non-breaking-space guard (not a delimiter), CRLF briefs (no retained `\r`), trailing-whitespace delimiter lines, multiple blank lines between stories, single trailing blank line, very-long-objective preservation (objective not clamped).

## Why
Surfaced by an independent architect (LOW) + critic (test-coverage) review of the merged change. No behavior change for normal ASCII briefs; only removes surprising Unicode-whitespace splitting and locks edge cases.

## Verification
- `bun test test/gjc-runtime/ultragoal-runtime.test.ts test/gjc-runtime/goal-mode-request.test.ts` → **66 pass**
- `bun run check:types` (tsgo) → clean · biome → clean
