### PR TITLE
feat(task): hard runtime spawn gate + reviewer->explore gate

### DIFF
--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -27,10 +27,13 @@ Subagents have no conversation history. Every fact, file path, and direction the
 - `.inheritContext` (optional): `true` requests a sanitized, bounded forked snapshot of the parent conversation for this task. Works only when the global `task.forkContext.enabled` setting is true and the target agent declares `forkContext: allowed`; otherwise the call is rejected. Bundled agents that support it: `executor`, `architect`. Use it when the subagent's value depends on what the parent has already established (architect reviewing code the parent has been discussing; executor continuing a mid-investigation handoff). Skip it for independent work — passing context the child will not use wastes tokens. The child runs under its own agent-specific system prompt and tool surface, so treat seeded tokens as full re-billing rather than a prefix-cache hit.
 {{/if}}
 {{#if customSchemaEnabled}}- `schema`: JTD schema for expected structured output (do not put format rules in assignments){{/if}}
+- `spawnPlan` (optional): required before any batch with more than 4 tasks, and before a reviewer agent spawns `explore`; include whyParallel, whyNotLocal, independence, expectedReceiptShape, and maxInlineTokens.
 {{#if isolationEnabled}}- `isolated`: run in isolated env; use when tasks edit overlapping files{{/if}}
 </parameters>
 
 <rules>
+- HARD runtime gate: calls with more than 4 tasks are rejected before any child launches unless `spawnPlan` is complete.
+- Reviewer->explore gate: a `reviewer` spawning `explore` is rejected before launch unless `spawnPlan` is complete, even for a single task.
 - NEVER assign tasks to run project-wide build/test/lint. Caller verifies after the batch.
 - **Subagents do not verify, lint, or format.** Every assignment MUST instruct the subagent to skip all gates and formatters. You run them once at the end across the union of changed files — avoids redundant runs and racing formatter passes.
 {{#if ircEnabled}}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -51,6 +51,7 @@ import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { assertNoRawTaskFields, buildTaskReceipt } from "./receipt";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
+import { DEFAULT_SPAWN_THRESHOLD, evaluateReviewerExploreGate, evaluateSpawnGate } from "./spawn-gate";
 import {
 	applyNestedPatches,
 	captureBaseline,
@@ -272,6 +273,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly renderResult = renderResult;
 	readonly #discoveredAgents: AgentDefinition[];
 	readonly #blockedAgent: string | undefined;
+	readonly #spawningAgentType: string | undefined;
 
 	get parameters(): TaskToolSchemaInstance {
 		const isolationEnabled = this.session.settings.get("task.isolation.mode") !== "none";
@@ -303,6 +305,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		discoveredAgents: AgentDefinition[],
 	) {
 		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
+		this.#spawningAgentType = $env.PI_BLOCKED_AGENT;
 		this.#discoveredAgents = discoveredAgents;
 	}
 
@@ -371,6 +374,36 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		);
 		if (forkContextValidationError) {
 			return createTaskModeError(forkContextValidationError);
+		}
+
+		const batchGateDecision = evaluateSpawnGate({ childCount: taskItems.length, plan: params.spawnPlan });
+		if (batchGateDecision.outcome === "rejected") {
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task spawn gate rejected this batch: ${batchGateDecision.reason}. Batches with more than ${DEFAULT_SPAWN_THRESHOLD} tasks require spawnPlan fields: ${batchGateDecision.missingFields.join(", ")}.`,
+					},
+				],
+				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
+			};
+		}
+
+		const reviewerExploreDecision = evaluateReviewerExploreGate({
+			spawningAgentType: this.#spawningAgentType,
+			targetAgent: params.agent,
+			plan: params.spawnPlan,
+		});
+		if (reviewerExploreDecision.outcome === "rejected") {
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task spawn gate rejected reviewer->explore: ${reviewerExploreDecision.reason}. Provide spawnPlan fields: ${reviewerExploreDecision.missingFields.join(", ")}.`,
+					},
+				],
+				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
+			};
 		}
 
 		const manager = AsyncJobManager.instance();
@@ -924,6 +957,44 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					projectAgentsDir,
 					results: [],
 					totalDurationMs: 0,
+				},
+			};
+		}
+
+		const batchGateDecision = evaluateSpawnGate({ childCount: tasks.length, plan: params.spawnPlan });
+		if (batchGateDecision.outcome === "rejected") {
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task spawn gate rejected this batch: ${batchGateDecision.reason}. Batches with more than ${DEFAULT_SPAWN_THRESHOLD} tasks require spawnPlan fields: ${batchGateDecision.missingFields.join(", ")}.`,
+					},
+				],
+				details: {
+					projectAgentsDir,
+					results: [],
+					totalDurationMs: Date.now() - startTime,
+				},
+			};
+		}
+
+		const reviewerExploreDecision = evaluateReviewerExploreGate({
+			spawningAgentType: this.#spawningAgentType,
+			targetAgent: agentName,
+			plan: params.spawnPlan,
+		});
+		if (reviewerExploreDecision.outcome === "rejected") {
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task spawn gate rejected reviewer->explore: ${reviewerExploreDecision.reason}. Provide spawnPlan fields: ${reviewerExploreDecision.missingFields.join(", ")}.`,
+					},
+				],
+				details: {
+					projectAgentsDir,
+					results: [],
+					totalDurationMs: Date.now() - startTime,
 				},
 			};
 		}

--- a/packages/coding-agent/src/task/spawn-gate.ts
+++ b/packages/coding-agent/src/task/spawn-gate.ts
@@ -1,0 +1,132 @@
+/** The hard, locked batch threshold enforced by the runtime gate. */
+export const DEFAULT_SPAWN_THRESHOLD = 4;
+
+/** The justification a large batch or reviewer-spawned explorer must supply to pass the hard gate. */
+export interface SpawnPlanReceipt {
+	whyParallel: string;
+	whyNotLocal: string;
+	independence: string;
+	expectedReceiptShape: string;
+	maxInlineTokens: number;
+}
+
+export interface SpawnGateRequest {
+	/** Number of children the batch wants to spawn. */
+	childCount: number;
+	/** The spawn-plan receipt, when provided. */
+	plan?: SpawnPlanReceipt;
+}
+
+export interface ReviewerExploreGateRequest {
+	/** Agent type/name doing the spawning, when known. */
+	spawningAgentType?: string | null;
+	/** Target agent type/name requested by the task call. */
+	targetAgent: string;
+	/** The spawn-plan receipt, when provided. */
+	plan?: SpawnPlanReceipt;
+}
+
+export type SpawnGateOutcome = "allowed" | "rejected";
+
+export interface SpawnGateDecision {
+	outcome: SpawnGateOutcome;
+	/** Human-readable reason, suitable for a blocked-result message. */
+	reason: string;
+	/** Whether a plan was required for this request. */
+	planRequired: boolean;
+	/** Missing plan field names when rejected for an incomplete plan. */
+	missingFields: readonly string[];
+}
+
+const REQUIRED_STRING_FIELDS = ["whyParallel", "whyNotLocal", "independence", "expectedReceiptShape"] as const;
+
+export function findMissingPlanFields(plan: SpawnPlanReceipt | undefined): string[] {
+	if (plan === undefined) {
+		return [...REQUIRED_STRING_FIELDS, "maxInlineTokens"];
+	}
+	const missing: string[] = [];
+	for (const field of REQUIRED_STRING_FIELDS) {
+		const value = plan[field];
+		if (typeof value !== "string" || value.trim().length === 0) {
+			missing.push(field);
+		}
+	}
+	if (
+		typeof plan.maxInlineTokens !== "number" ||
+		!Number.isFinite(plan.maxInlineTokens) ||
+		plan.maxInlineTokens <= 0
+	) {
+		missing.push("maxInlineTokens");
+	}
+	return missing;
+}
+
+export function decide(childCount: number, threshold: number, plan: SpawnPlanReceipt | undefined): SpawnGateDecision {
+	if (!Number.isInteger(childCount) || childCount < 0) {
+		throw new RangeError("childCount must be a non-negative integer");
+	}
+	if (!Number.isInteger(threshold) || threshold < 1) {
+		throw new RangeError("threshold must be a positive integer");
+	}
+
+	const planRequired = childCount > threshold;
+	if (!planRequired) {
+		return {
+			outcome: "allowed",
+			reason: `batch of ${childCount} is at or below threshold ${threshold}`,
+			planRequired: false,
+			missingFields: [],
+		};
+	}
+
+	const missingFields = findMissingPlanFields(plan);
+	if (missingFields.length > 0) {
+		return {
+			outcome: "rejected",
+			reason: `batch of ${childCount} exceeds threshold ${threshold} and the spawn-plan receipt is ${
+				plan === undefined ? "missing" : `incomplete (${missingFields.join(", ")})`
+			}`,
+			planRequired: true,
+			missingFields,
+		};
+	}
+
+	return {
+		outcome: "allowed",
+		reason: `batch of ${childCount} exceeds threshold ${threshold} and a complete spawn-plan receipt was provided`,
+		planRequired: true,
+		missingFields: [],
+	};
+}
+
+export function evaluateSpawnGate(request: SpawnGateRequest): SpawnGateDecision {
+	return decide(request.childCount, DEFAULT_SPAWN_THRESHOLD, request.plan);
+}
+
+export function evaluateReviewerExploreGate(request: ReviewerExploreGateRequest): SpawnGateDecision {
+	if (request.spawningAgentType !== "reviewer" || request.targetAgent !== "explore") {
+		return {
+			outcome: "allowed",
+			reason: "reviewer->explore gate does not apply",
+			planRequired: false,
+			missingFields: [],
+		};
+	}
+
+	const missingFields = findMissingPlanFields(request.plan);
+	if (missingFields.length > 0) {
+		return {
+			outcome: "rejected",
+			reason: `reviewer->explore spawn requires a complete spawn-plan receipt (${missingFields.join(", ")})`,
+			planRequired: true,
+			missingFields,
+		};
+	}
+
+	return {
+		outcome: "allowed",
+		reason: "reviewer->explore spawn has a complete spawn-plan receipt",
+		planRequired: true,
+		missingFields: [],
+	};
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -4,6 +4,7 @@ import { $env } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { TaskResultReceipt } from "./receipt";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
+import type { SpawnPlanReceipt } from "./spawn-gate";
 import type { NestedRepoPatch } from "./worktree";
 
 /** Source of an agent definition */
@@ -60,6 +61,15 @@ export interface SubagentLifecyclePayload {
 }
 
 const assignmentDescription = "per-task instructions; self-contained";
+const spawnPlanSchema = z
+	.object({
+		whyParallel: z.string(),
+		whyNotLocal: z.string(),
+		independence: z.string(),
+		expectedReceiptShape: z.string(),
+		maxInlineTokens: z.number(),
+	})
+	.describe("justification required before spawning more than four tasks or reviewer-spawned explore tasks");
 
 const createTaskItemSchema = (_contextEnabled: boolean) =>
 	z.object({
@@ -83,6 +93,7 @@ const createTaskSchema = (options: { isolationEnabled: boolean; simpleMode: Task
 	let schema = z.object({
 		agent: z.string().describe("agent type"),
 		tasks: z.array(itemSchema).describe("tasks to execute in parallel"),
+		spawnPlan: spawnPlanSchema.optional(),
 	});
 	if (contextEnabled) {
 		schema = schema.extend({
@@ -140,6 +151,7 @@ export interface TaskParams {
 	agent: string;
 	context?: string;
 	schema?: string;
+	spawnPlan?: SpawnPlanReceipt;
 	tasks: TaskItem[];
 	isolated?: boolean;
 }

--- a/packages/coding-agent/test/task/spawn-gate.test.ts
+++ b/packages/coding-agent/test/task/spawn-gate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { toolWireSchema } from "@gajae-code/ai/utils/schema";
+import {
+	DEFAULT_SPAWN_THRESHOLD,
+	evaluateReviewerExploreGate,
+	evaluateSpawnGate,
+	type SpawnPlanReceipt,
+} from "../../src/task/spawn-gate";
+import { getTaskSchema } from "../../src/task/types";
+
+const completePlan: SpawnPlanReceipt = {
+	whyParallel: "Independent file slices can run together.",
+	whyNotLocal: "Local execution would serialize unrelated investigation.",
+	independence: "Each task owns disjoint files and can report independently.",
+	expectedReceiptShape: "Each child returns changed files and evidence.",
+	maxInlineTokens: 1200,
+};
+
+describe("task spawn gate", () => {
+	it("allows batches at or below the hard threshold without a plan", () => {
+		expect(DEFAULT_SPAWN_THRESHOLD).toBe(4);
+		expect(evaluateSpawnGate({ childCount: 4 }).outcome).toBe("allowed");
+	});
+
+	it("rejects a batch above the threshold without a plan", () => {
+		const decision = evaluateSpawnGate({ childCount: 5 });
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.planRequired).toBe(true);
+		expect(decision.missingFields).toEqual([
+			"whyParallel",
+			"whyNotLocal",
+			"independence",
+			"expectedReceiptShape",
+			"maxInlineTokens",
+		]);
+	});
+
+	it("allows a batch above the threshold with a complete plan", () => {
+		const decision = evaluateSpawnGate({ childCount: 5, plan: completePlan });
+		expect(decision.outcome).toBe("allowed");
+		expect(decision.planRequired).toBe(true);
+		expect(decision.missingFields).toEqual([]);
+	});
+
+	it.each([
+		"whyParallel",
+		"whyNotLocal",
+		"independence",
+		"expectedReceiptShape",
+		"maxInlineTokens",
+	] as const)("rejects a batch above the threshold when %s is missing", field => {
+		const plan = { ...completePlan };
+		if (field === "maxInlineTokens") {
+			plan.maxInlineTokens = 0;
+		} else {
+			plan[field] = "";
+		}
+
+		const decision = evaluateSpawnGate({ childCount: 5, plan });
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.missingFields).toContain(field);
+	});
+
+	it("validates childCount", () => {
+		expect(() => evaluateSpawnGate({ childCount: -1 })).toThrow("childCount must be a non-negative integer");
+		expect(() => evaluateSpawnGate({ childCount: 1.5 })).toThrow("childCount must be a non-negative integer");
+	});
+});
+
+describe("reviewer explore spawn gate", () => {
+	it("rejects reviewer->explore without a plan", () => {
+		const decision = evaluateReviewerExploreGate({ spawningAgentType: "reviewer", targetAgent: "explore" });
+		expect(decision.outcome).toBe("rejected");
+		expect(decision.planRequired).toBe(true);
+	});
+
+	it("allows reviewer->explore with a complete plan", () => {
+		const decision = evaluateReviewerExploreGate({
+			spawningAgentType: "reviewer",
+			targetAgent: "explore",
+			plan: completePlan,
+		});
+		expect(decision.outcome).toBe("allowed");
+		expect(decision.planRequired).toBe(true);
+	});
+
+	it("does not gate non-reviewer->explore or reviewer->other", () => {
+		expect(evaluateReviewerExploreGate({ spawningAgentType: "executor", targetAgent: "explore" }).outcome).toBe(
+			"allowed",
+		);
+		expect(evaluateReviewerExploreGate({ spawningAgentType: "reviewer", targetAgent: "executor" }).outcome).toBe(
+			"allowed",
+		);
+	});
+});
+
+describe("task schema spawnPlan", () => {
+	it.each([
+		{ isolationEnabled: true, simpleMode: "default" },
+		{ isolationEnabled: false, simpleMode: "default" },
+		{ isolationEnabled: true, simpleMode: "schema-free" },
+		{ isolationEnabled: false, simpleMode: "schema-free" },
+		{ isolationEnabled: true, simpleMode: "independent" },
+		{ isolationEnabled: false, simpleMode: "independent" },
+	] as const)("accepts spawnPlan in %#", options => {
+		const schema = toolWireSchema({ name: "task", description: "Task", parameters: getTaskSchema(options) });
+		expect((schema.properties as Record<string, unknown> | undefined)?.spawnPlan).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/tools/task-simple-mode.test.ts
+++ b/packages/coding-agent/test/tools/task-simple-mode.test.ts
@@ -23,7 +23,13 @@ const TEST_AGENTS = [
 		blocking: true,
 	},
 ];
-
+const COMPLETE_SPAWN_PLAN = {
+	whyParallel: "Independent test tasks can run together.",
+	whyNotLocal: "Serial local execution would waste coordination time.",
+	independence: "Each task has disjoint acceptance criteria.",
+	expectedReceiptShape: "Each task returns a concise receipt.",
+	maxInlineTokens: 1000,
+};
 type CapturedRegister = {
 	type: "bash" | "task";
 	label: string;
@@ -88,6 +94,93 @@ describe("task.simple", () => {
 		expect(tool.description).not.toContain("- `schema`:");
 	});
 
+	it("keeps spawnPlan available in every simple mode", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+
+		for (const mode of ["default", "schema-free", "independent"] as const) {
+			const tool = await TaskTool.create(createSession({ "task.simple": mode }));
+			const properties = getSchemaProperties(tool);
+			expect(properties.spawnPlan).toBeDefined();
+		}
+	});
+
+	it("rejects a five-task batch before scheduling without spawnPlan", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+		const captured: CapturedRegister[] = [];
+		const manager = {
+			register: (
+				type: "bash" | "task",
+				label: string,
+				_run: (ctx: {
+					jobId: string;
+					signal: AbortSignal;
+					reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+				}) => Promise<string>,
+				options?: AsyncJobRegisterOptions,
+			): string => {
+				captured.push({ type, label, options });
+				return options?.id ?? label;
+			},
+		};
+		AsyncJobManager.setInstance(manager as unknown as AsyncJobManager);
+
+		const tool = await TaskTool.create(createSession());
+		const tasks = Array.from({ length: 5 }, (_, index) => ({
+			id: `Task${index}`,
+			description: `label ${index}`,
+			assignment: `Do work ${index}.`,
+		}));
+		const result = await tool.execute("tool-gated", { agent: "task", tasks } as TaskParams);
+
+		expect(captured).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+		expect(getFirstText(result)).toContain("Task spawn gate rejected this batch");
+	});
+
+	it("allows a five-task batch with complete spawnPlan to schedule", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+		const captured: CapturedRegister[] = [];
+		const manager = {
+			register: (
+				type: "bash" | "task",
+				label: string,
+				_run: (ctx: {
+					jobId: string;
+					signal: AbortSignal;
+					reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+				}) => Promise<string>,
+				options?: AsyncJobRegisterOptions,
+			): string => {
+				captured.push({ type, label, options });
+				return options?.id ?? label;
+			},
+		};
+		AsyncJobManager.setInstance(manager as unknown as AsyncJobManager);
+
+		const tool = await TaskTool.create(createSession());
+		const tasks = Array.from({ length: 5 }, (_, index) => ({
+			id: `Task${index}`,
+			description: `label ${index}`,
+			assignment: `Do work ${index}.`,
+		}));
+		const result = await tool.execute("tool-allowed", {
+			agent: "task",
+			tasks,
+			spawnPlan: COMPLETE_SPAWN_PLAN,
+		} as TaskParams);
+
+		expect(captured).toHaveLength(5);
+		expect(getFirstText(result)).toContain("Started 5 background task jobs");
+	});
 	it("rejects direct schema and context fields when the mode disables them", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
 			agents: TEST_AGENTS,


### PR DESCRIPTION
## Token-efficiency program — PR5 of 10 (stacked on PR4 #255)

> Chain: PR1 #246 <- PR2 #248 <- PR3 #251 <- PR4 #255 <- PR5. Retarget to `dev` as predecessors merge.

### What
Turns task-batch spawn guidance into an enforced runtime contract (findings #1, #6).

- New `task/spawn-gate.ts` ports the **pure** gate logic (`DEFAULT_SPAWN_THRESHOLD=4`, `SpawnPlanReceipt`, `decide`/`findMissingPlanFields`, `evaluateSpawnGate`, `evaluateReviewerExploreGate`). No runtime import of the benchmark package (avoids a circular dep); N=4 matches the benchmark primitive.
- Optional task-level `spawnPlan` (whyParallel, whyNotLocal, independence, expectedReceiptShape, maxInlineTokens) added to every schema variant.
- Enforced **before any child launches** in BOTH paths (detached `execute()` pre-schedule and sync `#executeSync`): batches with >4 children require a complete `spawnPlan`; rejection returns a bounded result with `results: []` and launches no child. Nested batches covered (same execute path).
- `reviewer->explore` spawns require a complete `spawnPlan` regardless of batch size, detected via the existing `PI_BLOCKED_AGENT` agent-type signal (documented best-effort; follow-up: expose agent type on ToolSession).
- Documents the gate in the bundled task tool prompt.

### Verification
- tsgo clean; biome clean
- `spawn-gate.test.ts` (threshold boundary 4-vs-5, each missing field, `maxInlineTokens<=0`, childCount validation, reviewer->explore with/without plan, non-reviewer not gated) + detached scheduling (`5 without plan registers 0 children`, `5 with plan registers 5`) + tool-discovery = 78 pass / 0 fail
- Architect 3-lane + red-team review: **CLEAR/CLEAR/CLEAR, APPROVE, no blockers**.
