### PR TITLE
Improve deep-interview prompt scrolling

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -21,6 +21,22 @@ import { matchesAppExternalEditor, matchesSelectCancel } from "../../modes/utils
 import { CountdownTimer } from "./countdown-timer";
 import { DynamicBorder } from "./dynamic-border";
 
+const SGR_MOUSE_PRESS_PATTERN = /^\x1b\[<(\d+);\d+;\d+M$/;
+const MOUSE_WHEEL_TITLE_SCROLL_ROWS = 3;
+
+function getMouseWheelTitleScrollRows(keyData: string): number {
+	const match = SGR_MOUSE_PRESS_PATTERN.exec(keyData);
+	if (!match) return 0;
+
+	const button = Number.parseInt(match[1] ?? "", 10);
+	if (!Number.isFinite(button) || (button & 64) === 0) return 0;
+
+	const wheelDirection = button & 3;
+	if (wheelDirection === 0) return -MOUSE_WHEEL_TITLE_SCROLL_ROWS;
+	if (wheelDirection === 1) return MOUSE_WHEEL_TITLE_SCROLL_ROWS;
+	return 0;
+}
+
 export interface HookSelectorOptions {
 	tui?: TUI;
 	timeout?: number;
@@ -381,6 +397,13 @@ export class HookSelectorComponent extends Container {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 
+		if (this.#scrollTitleRows !== undefined) {
+			const wheelRows = getMouseWheelTitleScrollRows(keyData);
+			if (wheelRows !== 0) {
+				this.#scrollableTitle?.scrollBy(wheelRows);
+				return;
+			}
+		}
 		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageUp")) {
 			this.#scrollableTitle?.scrollBy(-this.#scrollTitleRows);
 			return;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -25,11 +25,17 @@ import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
+const HOOK_SELECTOR_MOUSE_REPORTING_ENABLE = "\x1b[?1006h\x1b[?1000h";
+const HOOK_SELECTOR_MOUSE_REPORTING_DISABLE = "\x1b[?1000l\x1b[?1006l";
+const HOOK_SELECTOR_CHROME_ROWS = 7;
+const HOOK_SELECTOR_OUTLINE_ROWS = 2;
 
 export class ExtensionUiController {
 	#extensionTerminalInputUnsubscribers = new Set<() => void>();
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
+	#hookSelectorMouseReportingEnabled = false;
+
 	constructor(private ctx: InteractiveModeContext) {}
 
 	/**
@@ -589,12 +595,20 @@ export class ExtensionUiController {
 			() => this.hideHookSelector(),
 			dialogOptions?.signal,
 		);
-		const maxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
 		const requestedTitleRows = dialogOptions?.scrollTitleRows;
-		const selectorChromeRows = 7;
-		const availableTitleRows = this.ctx.ui.terminal.rows - maxVisible - selectorChromeRows;
+		const baseMaxVisible = Math.max(4, Math.min(15, this.ctx.ui.terminal.rows - 12));
+		const scrollOptionRows = Math.max(1, Math.min(baseMaxVisible, options.length));
+		const maxVisible =
+			requestedTitleRows === undefined ? baseMaxVisible : Math.min(15, Math.max(3, scrollOptionRows + 1));
+		const listChromeRows = dialogOptions?.outline === true ? HOOK_SELECTOR_OUTLINE_ROWS : 0;
+		const availableTitleRows =
+			this.ctx.ui.terminal.rows - scrollOptionRows - listChromeRows - HOOK_SELECTOR_CHROME_ROWS;
 		const scrollTitleRows =
 			requestedTitleRows === undefined ? undefined : Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
+		if (scrollTitleRows !== undefined) {
+			this.#enableHookSelectorMouseReporting();
+		}
+
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,
 			options,
@@ -640,10 +654,32 @@ export class ExtensionUiController {
 		attachAbort();
 		return promise;
 	}
+
+	#enableHookSelectorMouseReporting(): void {
+		if (this.#hookSelectorMouseReportingEnabled) return;
+		this.#hookSelectorMouseReportingEnabled = true;
+		this.#writeTerminalControl(HOOK_SELECTOR_MOUSE_REPORTING_ENABLE);
+	}
+
+	#disableHookSelectorMouseReporting(): void {
+		if (!this.#hookSelectorMouseReportingEnabled) return;
+		this.#hookSelectorMouseReportingEnabled = false;
+		this.#writeTerminalControl(HOOK_SELECTOR_MOUSE_REPORTING_DISABLE);
+	}
+
+	#writeTerminalControl(sequence: string): void {
+		try {
+			this.ctx.ui.terminal.write(sequence);
+		} catch {
+			// Terminal teardown can race selector cleanup; normal shutdown restores modes.
+		}
+	}
+
 	/**
 	 * Hide the hook selector.
 	 */
 	hideHookSelector(): void {
+		this.#disableHookSelectorMouseReporting();
 		this.ctx.hookSelector?.dispose();
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.editor);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -85,7 +85,7 @@ export interface AskToolDetails {
 
 const OTHER_OPTION = "Other (type your own)";
 const RECOMMENDED_SUFFIX = " (Recommended)";
-const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = 12;
+const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = Number.MAX_SAFE_INTEGER;
 
 function getDoneOptionLabel(): string {
 	return `${theme.status.success} Done selecting`;
@@ -194,7 +194,8 @@ async function askSingleQuestion(
 		const baseHelpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
-		const helpText = scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  PgUp/PgDn scroll question`;
+		const helpText =
+			scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  wheel/PgUp/PgDn scroll question`;
 		const dialogOptions = {
 			initialIndex,
 			timeout,

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -61,7 +61,7 @@ function createControllerContext() {
 		setFocus: vi.fn(),
 		start: vi.fn(),
 		stop: vi.fn(),
-		terminal: { columns: 120 },
+		terminal: { columns: 120, rows: 30, write: vi.fn() },
 	} as unknown as TestContext["ui"] & {
 		setFocus: ReturnType<typeof vi.fn>;
 		requestRender: ReturnType<typeof vi.fn>;
@@ -358,5 +358,32 @@ describe("ExtensionUiController hook editor abort", () => {
 		const result = await promise;
 		// Result depends on what the editor captured. The key thing is it resolved.
 		expect(result).toBeDefined();
+	});
+
+	it("lets scrollable hook selectors use the available terminal height", async () => {
+		const { ctx, editorContainer, ui } = createControllerContext();
+		const controller = new ExtensionUiController(ctx);
+		const title = Array.from({ length: 40 }, (_, index) => `Prompt row ${index + 1}`).join("\n");
+		const promise = controller.showHookSelector(title, ["Alpha", "Beta", "Gamma"], {
+			outline: true,
+			wrapFocused: true,
+			scrollTitleRows: Number.MAX_SAFE_INTEGER,
+		});
+
+		expect(editorContainer.children).toHaveLength(1);
+		expect(ctx.hookSelector).toBeDefined();
+
+		const rendered = Bun.stripANSI(ctx.hookSelector!.render(80).join("\n"));
+		const lines = rendered.split("\n");
+		expect(lines).toHaveLength(30);
+		expect(rendered).toContain("Prompt row 18");
+		expect(rendered).not.toContain("Prompt row 19");
+		expect(rendered).toContain("Alpha");
+		expect(rendered).toContain("Gamma");
+		expect(ui.terminal.write).toHaveBeenCalledWith("\x1b[?1006h\x1b[?1000h");
+
+		ctx.hookSelector!.handleInput("\n");
+		expect(await promise).toBe("Alpha");
+		expect(ui.terminal.write).toHaveBeenCalledWith("\x1b[?1000l\x1b[?1006l");
 	});
 });

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -297,7 +297,7 @@ describe("HookSelectorComponent", () => {
 				wrapFocused: true,
 				scrollTitleRows: 3,
 				maxVisible: 2,
-				helpText: "up/down navigate  enter select  esc cancel  PgUp/PgDn scroll question",
+				helpText: "up/down navigate  enter select  esc cancel  wheel/PgUp/PgDn scroll question",
 			},
 		);
 
@@ -307,7 +307,7 @@ describe("HookSelectorComponent", () => {
 		expect(titleRows.length).toBeLessThanOrEqual(3);
 		expect(rendered).toContain("answer-a");
 		expect(rendered).toContain("answer-b");
-		expect(rendered).toContain("PgUp/PgDn scroll question");
+		expect(rendered).toContain("wheel/PgUp/PgDn scroll question");
 		expect(rendered).toContain("PgDn");
 	});
 
@@ -341,5 +341,37 @@ describe("HookSelectorComponent", () => {
 		for (let i = 0; i < 8; i++) component.handleInput("\x1b[5~");
 		const afterPageUp = Bun.stripANSI(component.render(56).join("\n"));
 		expect(afterPageUp).toContain("Question segment 1");
+	});
+
+	it("uses mouse wheel events for title scrolling without moving option focus", () => {
+		const title = Array.from({ length: 8 }, (_, index) => `Wheel segment ${index + 1}`).join("\n\n");
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			title,
+			["first-choice", "second-choice"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ outline: true, wrapFocused: true, scrollTitleRows: 2, maxVisible: 2 },
+		);
+
+		const initial = Bun.stripANSI(component.render(56).join("\n"));
+		expect(initial).toContain("Wheel segment 1");
+		expect(initial).not.toContain("Wheel segment 8");
+		expect(initial).toContain("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[<65;10;5M");
+		const afterWheelDown = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterWheelDown).not.toContain("Wheel segment 1");
+		expect(afterWheelDown).toContain("Wheel segment 8");
+		expect(afterWheelDown).toContain("first-choice");
+
+		component.handleInput("\n");
+		expect(selected).toBe("first-choice");
+
+		for (let i = 0; i < 8; i++) component.handleInput("\x1b[<64;10;5M");
+		const afterWheelUp = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterWheelUp).toContain("Wheel segment 1");
 	});
 });

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1100,8 +1100,8 @@ describe("AskTool deep-interview rendering middleware", () => {
 		);
 
 		const dialogOptions = select.mock.calls[0]?.[2];
-		expect(dialogOptions?.scrollTitleRows).toBe(12);
-		expect(dialogOptions?.helpText).toContain("PgUp/PgDn scroll question");
+		expect(dialogOptions?.scrollTitleRows).toBe(Number.MAX_SAFE_INTEGER);
+		expect(dialogOptions?.helpText).toContain("wheel/PgUp/PgDn scroll question");
 	});
 
 	it("leaves non-deep-interview selector prompts without scroll-title opt-in", async () => {
@@ -1130,7 +1130,7 @@ describe("AskTool deep-interview rendering middleware", () => {
 
 		const dialogOptions = select.mock.calls[0]?.[2];
 		expect(dialogOptions?.scrollTitleRows).toBeUndefined();
-		expect(dialogOptions?.helpText).not.toContain("PgUp/PgDn scroll question");
+		expect(dialogOptions?.helpText).not.toContain("scroll question");
 	});
 
 	it("recognizes topology questions even when the agent prepends an intro", async () => {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -34,6 +34,8 @@ export function emergencyTerminalRestore(): void {
 			// This avoids writing escape sequences for non-TUI commands (grep, commit, etc.)
 			process.stdout.write(
 				"\x1b[?2004l" + // Disable bracketed paste
+					"\x1b[?1000l" + // Disable normal mouse reporting
+					"\x1b[?1006l" + // Disable SGR extended mouse reporting
 					"\x1b[?2031l" + // Disable Mode 2031 appearance notifications
 					"\x1b[<u" + // Pop kitty keyboard protocol
 					"\x1b[>4;0m" + // Disable modifyOtherKeys fallback
@@ -572,6 +574,8 @@ export class ProcessTerminal implements Terminal {
 
 		// Disable bracketed paste mode
 		this.#safeWrite("\x1b[?2004l");
+		this.#safeWrite("\x1b[?1000l");
+		this.#safeWrite("\x1b[?1006l");
 
 		// Disable Mode 2031 appearance change notifications
 		this.#safeWrite("\x1b[?2031l");


### PR DESCRIPTION
## Background

Deep-interview questions can be much longer than a normal selector prompt because they include round metadata, targeting/context, ambiguity, topology guidance, and the actual question. The previous local scrolling patch made the question area scrollable with PageUp/PageDown, but the UX still felt off for the original goal:

- scrolling the question with only keyboard paging is awkward during interactive interviews
- the capped prompt height made deep-interview feel smaller than the old full-screen prompt
- long questions still need answers and help text to remain visible while the prompt uses the available terminal space

This PR keeps the selector-local scrolling behavior, adds mouse wheel support, and restores the deep-interview prompt to use the available screen height instead of a fixed 12-row cap.

## Changes

- Enable SGR mouse reporting only while a scrollable hook selector is active, and disable it when the selector closes.
- Teach `HookSelectorComponent` to interpret SGR wheel-up / wheel-down input and scroll the title/question area without moving option focus.
- Keep PageUp/PageDown as fallback prompt scrolling controls.
- Change deep-interview ask prompts from a fixed 12-row title budget to `Number.MAX_SAFE_INTEGER`; the controller clamps that to the actual terminal space available.
- Rework selector sizing so scrollable prompt dialogs reserve rows for:
  - visible options
  - outline borders
  - selector chrome/help/spacers
  - the remaining terminal height for the question body
- Update ask help text to advertise `wheel/PgUp/PgDn scroll question`.
- Add terminal cleanup safety so emergency restore and normal terminal stop disable mouse reporting if it was left enabled.
- Add regression coverage for:
  - mouse-wheel prompt scrolling without changing selected option
  - scrollable selector using available terminal height while keeping options visible
  - deep-interview ask prompts opting into full-height scroll budgeting
  - non-deep-interview ask prompts staying unchanged

## Verification

Ran on a branch rebased onto latest `origin/dev`:

- `bun test packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/tools/ask.test.ts`
- `bun run check:ts`

Note: in the isolated PR worktree, `bun install` and `bun --cwd=packages/natives run build` were needed before focused tests because the native addon was not present in that worktree.