### PR TITLE
Fix harness owner liveness reconciliation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Render terminal-pasted clipboard image temp paths as compact `[image N]` prompt placeholders while attaching the image payload, instead of inserting raw `/var/folders/.../clipboard-*.png` path text.
+- Reconciled `gjc harness` owner liveness after tmux readiness races so fresh live-owner evidence clears stale owner-vanished blockers, re-enables submit, and clean completed owner exits become terminal instead of dirty vanish recovery.
 - Fixed the interactive agent unexpectedly stopping after automatic context maintenance instead of resuming the in-flight task. Post-compaction continuation now schedules exactly one source per completion (overflow retry → queued messages → synthetic auto-continue prompt), the threshold/handoff auto-continue prompt skips a redundant pre-send compaction check, overflow retry strips only the context-overflow failed turn (never normal/aborted/silent-abort tails), and non-resumable or superseded continuations log a structured reason instead of stranding the session.
 
 ## [0.3.0] - 2026-06-03

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -135,6 +135,26 @@ async function buildObservation(
 	};
 }
 
+function isOwnerLivenessBlocker(blocker: string): boolean {
+	return blocker === "detached-owner-not-live" || blocker.startsWith("owner-vanished:");
+}
+
+async function reconcileCompletedOwnerExited(
+	root: string,
+	state: SessionState,
+	observation: Observation,
+	completedTerminal: CompletedTerminalEvent | null,
+): Promise<SessionState> {
+	if (!completedTerminal || observation.ownerLive || observation.gitDelta !== "clean") return state;
+	if (state.lifecycle === "completed" || state.lifecycle === "retired") return state;
+	state.lifecycle = "completed";
+	state.blockers = state.blockers.filter(blocker => !isOwnerLivenessBlocker(blocker));
+	state.updatedAt = nowIso();
+	await writeSessionState(root, state);
+	return state;
+}
+
+
 function needsVanishedOwnerBlock(
 	state: SessionState,
 	observation: Observation,
@@ -474,6 +494,25 @@ export default class Harness extends Command {
 			}
 		}
 		if (ownerBlockerReason) {
+			const resolved = await resolveOwner(root, sessionId);
+			if (resolved.live && resolved.socketPath) {
+				ownerLive = true;
+				ownerBlockerReason = null;
+				handle.processHandle = {
+					kind: "runtime-owner",
+					ownerId: resolved.lease?.ownerId ?? null,
+					pid: resolved.lease?.pid ?? null,
+				};
+				handle.ownerHandle = {
+					leasePath,
+					endpoint: resolved.socketPath,
+					heartbeatAt: resolved.lease?.heartbeatAt ?? null,
+				};
+				state.handle = handle;
+				await writeSessionState(root, state);
+			}
+		}
+		if (ownerBlockerReason) {
 			state.lifecycle = "blocked";
 			state.blockers = [...state.blockers, ownerBlockerReason];
 			state.handle = handle;
@@ -522,6 +561,7 @@ export default class Harness extends Command {
 		let state = await loadState(root, sessionId);
 		const ownerLive = ownerLiveFor(state);
 		const { observation, completedTerminalEvent } = await buildObservation(root, state, ownerLive);
+		state = await reconcileCompletedOwnerExited(root, state, observation, completedTerminalEvent);
 		const vanishedOwnerBlock = needsVanishedOwnerBlock(state, observation, completedTerminalEvent);
 		state = await markVanishedOwnerBlocked(root, state, observation, completedTerminalEvent);
 		writeJson(

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -52,6 +52,27 @@ import {
 import type { EventEnvelope, GitDelta, Observation, PrimitiveResponse, SessionState, Severity } from "./types";
 import { DEFAULT_RETRY_BUDGET, OBSERVED_SIGNALS } from "./types";
 
+function isOwnerLivenessBlocker(blocker: string): boolean {
+	return blocker === "detached-owner-not-live" || blocker.startsWith("owner-vanished:");
+}
+
+function reconcileLiveOwnerState(state: SessionState): { state: SessionState; reconciled: boolean } {
+	const blockers = state.blockers.filter(blocker => !isOwnerLivenessBlocker(blocker));
+	const hadLivenessBlocker = blockers.length !== state.blockers.length;
+	const lifecycle = hadLivenessBlocker && state.lifecycle === "blocked" && blockers.length === 0 ? "observing" : state.lifecycle;
+	if (!hadLivenessBlocker && lifecycle === state.lifecycle) return { state, reconciled: false };
+	return {
+		state: {
+			...state,
+			lifecycle,
+			blockers,
+			updatedAt: new Date().toISOString(),
+		},
+		reconciled: true,
+	};
+}
+
+
 export interface OwnerOptions {
 	root: string;
 	sessionId: string;
@@ -139,6 +160,11 @@ export class RuntimeOwner {
 	async #loadState(): Promise<SessionState> {
 		const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
 		if (!state) throw new Error(`session_not_found:${this.#opts.sessionId}`);
+		const reconciled = reconcileLiveOwnerState(state);
+		if (reconciled.reconciled) {
+			await writeSessionState(this.#opts.root, reconciled.state);
+			return reconciled.state;
+		}
 		return state;
 	}
 

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -173,7 +173,7 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
 	}, 60_000);
 
-	it("blocks start when tmux ghosts and detached owner endpoint is not routable", async () => {
+	it("reports blocked only after detached owner endpoint remains unavailable", async () => {
 		tmuxCommand = await createFakeTmuxBin(root, { skipOwnerLaunch: true });
 		const originalRpcCommandEnv = rpcCommandEnv;
 		rpcCommandEnv = "{";

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -183,7 +183,7 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.code).toBe(0);
 		assertContract(res.json);
 		expect(res.json.state.ownerLive).toBe(false);
-		expect(res.json.state.lifecycle).toBe("observing");
+		expect(res.json.state.lifecycle).toBe("completed");
 		expect(res.json.state.blockers).not.toContain("owner-vanished:clean");
 		expect(res.json.evidence.ownerVanished).toBeUndefined();
 		expect(res.json.evidence.blockerReason).toBeUndefined();
@@ -199,8 +199,45 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation.observedSignals).not.toContain("completed");
 
 		const persisted = await readSessionState(root, sessionId);
-		expect(persisted?.lifecycle).toBe("observing");
+		expect(persisted?.lifecycle).toBe("completed");
 		expect(persisted?.blockers).not.toContain("owner-vanished:clean");
+	});
+
+	it("observe reconciles completed clean owner exit away from stale dirty vanish blocker", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		expect(state).toBeTruthy();
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "blocked";
+		state.blockers = ["owner-vanished:dirty"];
+		state.updatedAt = "2026-06-03T00:00:00.000Z";
+		await writeSessionState(root, state);
+		await appendEvent(root, sessionId, {
+			eventId: "evt-completed-clean",
+			cursor: 1,
+			createdAt: "2026-06-03T00:00:01.000Z",
+			severity: "info",
+			kind: "rpc_agent_completed",
+			state: { sessionId, lifecycle: "finalizing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { outcome: "completed" },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+		});
+
+		const res = runHarness(["observe", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.lifecycle).toBe("completed");
+		expect(res.json.state.blockers).not.toContain("owner-vanished:dirty");
+		expect(res.json.evidence.completedOwnerExited).toBe(true);
+		expect(action(res.json, "recover").available).toBe(false);
+		expect(action(res.json, "recover").reason).toBe("lifecycle-terminal:completed");
+		const persisted = await readSessionState(root, sessionId);
+		expect(persisted?.lifecycle).toBe("completed");
+		expect(persisted?.blockers).toEqual([]);
 	});
 
 	it("observe marks vanished owner after prompt/tool activity instead of silently observing clean worktree", async () => {

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
 import { RuntimeOwner, resolveOwner } from "../../src/harness-control-plane/owner";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
-import { readEvents, writeSessionState } from "../../src/harness-control-plane/storage";
+import { readEvents, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
 import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
 
 class FakeRpc implements HarnessRpc {
@@ -157,6 +157,27 @@ describe("RuntimeOwner (in-process integration)", () => {
 		expect(events.map(e => e.kind)).toContain("prompt_not_accepted");
 		const warn = events.find(e => e.kind === "prompt_not_accepted");
 		expect(warn?.severity).toBe("warn");
+	});
+
+	it("live owner reconcile clears stale vanished blockers and re-enables submit", async () => {
+		const rpc = new FakeRpc();
+		await writeSessionState(root, {
+			...seedState(root),
+			lifecycle: "blocked",
+			blockers: ["owner-vanished:dirty"],
+		});
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 200 });
+		const info = await owner.start();
+
+		const obs = (await callEndpoint(info.socketPath, { verb: "observe", input: {} })) as Record<string, unknown>;
+
+		expect((obs.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect((obs.state as Record<string, unknown>).lifecycle).toBe("observing");
+		expect((obs.state as Record<string, unknown>).blockers).not.toContain("owner-vanished:dirty");
+		expect(obs.nextAllowedActions).toContainEqual({ verb: "submit", available: true });
+		const persisted = await readSessionState(root, SID);
+		expect(persisted?.lifecycle).toBe("observing");
+		expect(persisted?.blockers).not.toContain("owner-vanished:dirty");
 	});
 
 	it("observe is owner-routed and reports ownerLive; retire releases the lease", async () => {


### PR DESCRIPTION
Fixes #261.\n\n## Summary\n- Reconcile live owner state by clearing stale owner liveness blockers and moving unblocked sessions back to observing so submit becomes available.\n- Treat clean completed owner exits as completed terminal evidence instead of vanished/dirty recovery state.\n- Add regression coverage for stale owner-vanished dirty blockers, clean completed owner exits, and detached-owner readiness labelling.\n\n## Verification\n- bun test packages/coding-agent/test/harness-control-plane/cli.test.ts packages/coding-agent/test/harness-control-plane/owner.test.ts packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts\n- bun --cwd=packages/coding-agent run check:types\n- bun --cwd=packages/coding-agent run lint