### PR TITLE
Fix issue #264 dogfood native and telemetry failures

### DIFF
--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -271,20 +271,22 @@ export interface AgentIdentity {
 	readonly description?: string;
 }
 
+export type AgentTelemetryWarningCode =
+	| "resolve_attributes_failed"
+	| "content_serializer_failed"
+	| "on_cost_delta_failed"
+	| "on_chat_usage_failed"
+	| "cost_estimator_failed"
+	| "on_run_end_failed"
+	| "on_span_start_failed"
+	| "on_span_end_failed"
+	| "normalize_agent_name_failed"
+	| "normalize_provider_failed"
+	| "full_content_capture_env_active"
+	| "on_telemetry_warning_failed";
+
 export interface AgentTelemetryWarning {
-	readonly code:
-		| "resolve_attributes_failed"
-		| "content_serializer_failed"
-		| "on_cost_delta_failed"
-		| "on_chat_usage_failed"
-		| "cost_estimator_failed"
-		| "on_run_end_failed"
-		| "on_span_start_failed"
-		| "on_span_end_failed"
-		| "normalize_agent_name_failed"
-		| "normalize_provider_failed"
-		| "full_content_capture_env_active"
-		| "on_telemetry_warning_failed";
+	readonly code: AgentTelemetryWarningCode;
 	readonly message: string;
 	readonly error?: unknown;
 }

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 
 const packageDir = path.join(import.meta.dir, "..");
 const outputPath = path.join(packageDir, "dist", "gjc");
+const nativeDir = path.join(packageDir, "..", "natives", "native");
 
 function shouldAdhocSignDarwinBinary(): boolean {
 	return process.platform === "darwin";
@@ -20,6 +21,11 @@ async function runCommand(command: string[], env: NodeJS.ProcessEnv = Bun.env): 
 	if (exitCode !== 0) {
 		throw new Error(`Command failed with exit code ${exitCode}: ${command.join(" ")}`);
 	}
+}
+async function stageWorkspaceNativeAddons(): Promise<void> {
+	await Array.fromAsync(new Bun.Glob("pi_natives.*.node").scan({ cwd: nativeDir }), async filename => {
+		await Bun.write(path.join(packageDir, "dist", filename), Bun.file(path.join(nativeDir, filename)));
+	});
 }
 
 async function main(): Promise<void> {
@@ -62,6 +68,7 @@ async function main(): Promise<void> {
 				buildEnv,
 			);
 
+			await stageWorkspaceNativeAddons();
 			// Bun 1.3.12 emits a truncated Mach-O signature on darwin builds.
 			if (shouldAdhocSignDarwinBinary()) {
 				await runCommand(["codesign", "--force", "--sign", "-", outputPath]);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3,6 +3,7 @@ import {
 	type AgentEvent,
 	type AgentMessage,
 	type AgentTelemetryConfig,
+	type AgentTelemetryWarning,
 	type AgentTool,
 	AppendOnlyContextManager,
 	INTENT_FIELD,
@@ -49,7 +50,7 @@ export function warnIfEnvFullContentCaptureActive(telemetry: AgentTelemetryConfi
 		message:
 			`${CONTENT_CAPTURE_ENV}=full enables full GenAI message content capture. ` +
 			`Use ${CONTENT_CAPTURE_ENV}=summary for bounded telemetry summaries.`,
-	};
+	} satisfies AgentTelemetryWarning;
 	try {
 		telemetry.onTelemetryWarning?.(warning);
 	} catch (error) {

--- a/packages/coding-agent/test/issue-264-dogfood.test.ts
+++ b/packages/coding-agent/test/issue-264-dogfood.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { AgentTelemetryWarning, AgentTelemetryWarningCode } from "@gajae-code/agent-core";
+
+/** Regression coverage for issue #264 dogfood failures. */
+describe("issue #264 — dogfood build and telemetry boundaries", () => {
+	it("keeps the full-content-capture warning code assignable across package boundaries", () => {
+		const code: AgentTelemetryWarningCode = "full_content_capture_env_active";
+		const warning: AgentTelemetryWarning = {
+			code,
+			message: "full content capture is active",
+		};
+
+		expect(warning.code).toBe("full_content_capture_env_active");
+	});
+
+	it("stages workspace native addons next to the compiled dev binary", async () => {
+		const repoRoot = path.resolve(import.meta.dir, "../../..");
+		const buildScriptPath = path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts");
+		const source = await Bun.file(buildScriptPath).text();
+
+		expect(source).toContain('new Bun.Glob("pi_natives.*.node")');
+		expect(source).toContain('path.join(packageDir, "dist", filename)');
+		expect(source.indexOf("await stageWorkspaceNativeAddons();")).toBeGreaterThan(source.indexOf('"dist/gjc"'));
+	});
+});


### PR DESCRIPTION
Fixes #264.

## Summary
- export `AgentTelemetryWarningCode` and type the coding-agent full-content warning against `AgentTelemetryWarning` so package-boundary checks accept `full_content_capture_env_active`
- stage workspace-built `pi_natives.*.node` files next to `packages/coding-agent/dist/gjc` after the dev compile build
- add regression coverage for the warning-code type boundary and dev build native staging contract

## Verification
- `bun test packages/coding-agent/test/issue-264-dogfood.test.ts packages/coding-agent/test/telemetry-full-capture-warning.test.ts packages/natives/test/issue-823-repro.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run build`
- `./packages/coding-agent/dist/gjc --version`
- `./packages/coding-agent/dist/gjc --help`