### PR TITLE
Fix harness metadata preflight

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -77,6 +77,87 @@ function gitDeltaFor(workspace: string): { gitDelta: GitDelta; branch: string | 
 		return { gitDelta: "unknown", branch, deleted: false };
 	}
 }
+interface HarnessPreflight {
+	ok: boolean;
+	blockers: string[];
+	workspace: string;
+	actualBranch: string | null;
+	declaredBranch: string | null;
+	normalizedIssueOrPr: string | null;
+}
+
+function normalizeIssueOrPr(value: unknown): string | null {
+	if (value === undefined || value === null) return null;
+	if (typeof value === "number") {
+		if (Number.isSafeInteger(value) && value > 0) return String(value);
+		throw new Error(`invalid_issue_or_pr:${value}`);
+	}
+	if (typeof value !== "string") throw new Error("invalid_issue_or_pr:not-string-or-number");
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	const patterns = [
+		/^#?(\d+)$/i,
+		/^(?:pr|pull|issue)[-_#]?(\d+)$/i,
+		/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#(\d+)$/,
+		/^(?:https?:\/\/github\.com\/)?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/(?:pull|issues)\/(\d+)\/?$/i,
+	];
+	for (const pattern of patterns) {
+		const match = trimmed.match(pattern);
+		if (match?.[1]) return match[1];
+	}
+	throw new Error(`invalid_issue_or_pr:${trimmed}`);
+}
+
+function gitOutput(workspace: string, args: string[]): string | null {
+	try {
+		return execFileSync("git", args, {
+			cwd: workspace,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return null;
+	}
+}
+
+function buildPreflight(input: Record<string, unknown>): HarnessPreflight {
+	const workspace = typeof input.workspace === "string" ? input.workspace : process.cwd();
+	const declaredBranch = typeof input.branch === "string" && input.branch.trim() ? input.branch.trim() : null;
+	const blockers: string[] = [];
+	const gitRoot = gitOutput(workspace, ["rev-parse", "--show-toplevel"]);
+	const actualBranch = gitRoot ? gitOutput(workspace, ["rev-parse", "--abbrev-ref", "HEAD"]) : null;
+	let normalizedIssueOrPr: string | null = null;
+
+	if (!gitRoot) blockers.push("workspace-not-git-repo");
+	if (gitRoot && actualBranch === "HEAD") blockers.push("detached-head");
+	if (declaredBranch && actualBranch && actualBranch !== "HEAD" && declaredBranch !== actualBranch) {
+		blockers.push("branch-mismatch");
+	}
+	try {
+		normalizedIssueOrPr = normalizeIssueOrPr(input.issueOrPr ?? input.pr ?? input.issue);
+	} catch (error) {
+		blockers.push(error instanceof Error ? error.message : String(error));
+	}
+
+	return {
+		ok: blockers.length === 0,
+		blockers,
+		workspace,
+		actualBranch: actualBranch === "HEAD" ? null : actualBranch,
+		declaredBranch,
+		normalizedIssueOrPr,
+	};
+}
+
+function startFatalPreflightBlockers(input: Record<string, unknown>, preflight: HarnessPreflight): string[] {
+	const strict = input.strictPreflight === true || typeof input.branch === "string";
+	return preflight.blockers.filter(blocker => {
+		if (blocker === "branch-mismatch") return true;
+		if (blocker.startsWith("invalid_issue_or_pr:")) return true;
+		if (strict && (blocker === "workspace-not-git-repo" || blocker === "detached-head")) return true;
+		return false;
+	});
+}
 
 /** Fallback liveness after owner routing failed: no reachable owner handled this CLI call. */
 function ownerLiveFor(_state: SessionState): boolean {
@@ -154,7 +235,6 @@ async function reconcileCompletedOwnerExited(
 	return state;
 }
 
-
 function needsVanishedOwnerBlock(
 	state: SessionState,
 	observation: Observation,
@@ -224,7 +304,7 @@ export default class Harness extends Command {
 
 	static args = {
 		verb: Args.string({
-			description: "start|submit|observe|classify|recover|validate|finalize|retire|events|monitor|operate",
+			description: "start|preflight|submit|observe|classify|recover|validate|finalize|retire|events|monitor|operate",
 			required: true,
 		}),
 	};
@@ -253,6 +333,8 @@ export default class Harness extends Command {
 			switch (verb) {
 				case "start":
 					return await this.#start(root, input);
+				case "preflight":
+					return this.#preflight(input);
 				case "observe":
 					return await this.#observe(root, input, flags.session);
 				case "classify":
@@ -279,6 +361,20 @@ export default class Harness extends Command {
 			writeJson({ ok: false, error: error instanceof Error ? error.message : String(error), verb });
 			process.exitCode = 1;
 		}
+	}
+
+	#preflight(input: Record<string, unknown>): void {
+		const preflight = buildPreflight(input);
+		writeJson({
+			ok: preflight.ok,
+			evidence: {
+				preflight,
+				guidance: preflight.ok
+					? "workspace metadata is normalized"
+					: "fix blockers before gjc harness start; branch must match the actual checkout and issueOrPr must be numeric or a recognized PR/issue form",
+			},
+		});
+		if (!preflight.ok) process.exitCode = 1;
 	}
 
 	async #finalizeVerb(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
@@ -429,6 +525,21 @@ export default class Harness extends Command {
 			process.exitCode = 1;
 			return;
 		}
+		const preflight = buildPreflight(input);
+		const fatalBlockers = startFatalPreflightBlockers(input, preflight);
+		if (fatalBlockers.length > 0) {
+			writeJson({
+				ok: false,
+				error: "harness_preflight_failed",
+				evidence: {
+					preflight: { ...preflight, blockers: fatalBlockers, ok: false },
+					guidance:
+						"fix blockers before start; run gjc harness preflight with the same input for branch and issue/PR diagnostics",
+				},
+			});
+			process.exitCode = 1;
+			return;
+		}
 		const workspace = typeof input.workspace === "string" ? input.workspace : process.cwd();
 		const sessionId = typeof input.sessionId === "string" ? input.sessionId : generateSessionId();
 		const eventsPath = `${root}/sessions/${sessionId}/events.jsonl`;
@@ -439,9 +550,9 @@ export default class Harness extends Command {
 			harness,
 			repo: typeof input.repo === "string" ? input.repo : null,
 			workspace,
-			branch: typeof input.branch === "string" ? input.branch : null,
+			branch: preflight.declaredBranch ?? preflight.actualBranch,
 			base: typeof input.base === "string" ? input.base : null,
-			issueOrPr: typeof input.issueOrPr === "string" ? input.issueOrPr : null,
+			issueOrPr: preflight.normalizedIssueOrPr,
 			processHandle: { kind: "runtime-owner", ownerId: null, pid: null },
 			rpcHandle: { kind: "rpc-subprocess", pid: null, sessionDir: `${root}/sessions/${sessionId}/gjc-session` },
 			ownerHandle: { leasePath, endpoint: null, heartbeatAt: null },
@@ -526,6 +637,7 @@ export default class Harness extends Command {
 				{
 					handle,
 					ownerRuntime,
+					preflight,
 					...(ownerFallbackReason ? { ownerFallbackReason } : {}),
 					...(ownerBlockerReason ? { reason: ownerBlockerReason } : {}),
 				},

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -59,13 +59,21 @@ function git(args: string[]): void {
 	if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || `git ${args.join(" ")} failed`);
 }
 
+function gitOutput(args: string[]): string {
+	const proc = Bun.spawnSync(["git", ...args], { cwd: workspace, stdout: "pipe", stderr: "pipe" });
+	if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || `git ${args.join(" ")} failed`);
+	return proc.stdout.toString().trim();
+}
+
 async function initCleanGitWorkspace(): Promise<void> {
+	if (await Bun.file(path.join(workspace, ".git")).exists()) return;
 	git(["init"]);
 	git(["config", "user.email", "test@example.com"]);
 	git(["config", "user.name", "Test User"]);
 	await writeFile(path.join(workspace, "README.md"), "fixture\n", "utf8");
 	git(["add", "README.md"]);
 	git(["commit", "-m", "init"]);
+	git(["checkout", "-b", "feature/harness"]);
 }
 
 async function appendSignal(sessionId: string, cursor: number, signal: string): Promise<void> {
@@ -83,6 +91,63 @@ async function appendSignal(sessionId: string, cursor: number, signal: string): 
 }
 
 describe("gjc harness CLI (foundation)", () => {
+	it("preflight rejects a declared branch that differs from the actual checkout", async () => {
+		await initCleanGitWorkspace();
+		const res = runHarness([
+			"preflight",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, branch: "gajae-code-pr-265-review", issueOrPr: "PR-265" }),
+		]);
+		expect(res.code).toBe(1);
+		expect(res.json.ok).toBe(false);
+		expect(res.json.evidence.preflight.blockers).toContain("branch-mismatch");
+		expect(res.json.evidence.preflight.actualBranch).toBe("feature/harness");
+		expect(res.json.evidence.preflight.declaredBranch).toBe("gajae-code-pr-265-review");
+		expect(res.json.evidence.preflight.normalizedIssueOrPr).toBe("265");
+	});
+
+	it("normalizes recognized issueOrPr forms and rejects ambiguous mixed ids", async () => {
+		await initCleanGitWorkspace();
+		for (const issueOrPr of [
+			265,
+			"265",
+			"#265",
+			"PR-265",
+			"pr_265",
+			"Yeachan-Heo/gajae-code#265",
+			"https://github.com/Yeachan-Heo/gajae-code/pull/265",
+		]) {
+			const res = runHarness([
+				"preflight",
+				"--input",
+				JSON.stringify({ harness: "gajae-code", workspace, issueOrPr }),
+			]);
+			expect(res.code).toBe(0);
+			expect(res.json.evidence.preflight.normalizedIssueOrPr).toBe("265");
+		}
+
+		const bad = runHarness([
+			"preflight",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, issueOrPr: "pr-2725-recovery" }),
+		]);
+		expect(bad.code).toBe(1);
+		expect(bad.json.evidence.preflight.blockers).toContain("invalid_issue_or_pr:pr-2725-recovery");
+	});
+
+	it("start persists normalized branch and issueOrPr metadata", async () => {
+		await initCleanGitWorkspace();
+		const branch = gitOutput(["rev-parse", "--abbrev-ref", "HEAD"]);
+		const res = runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, branch, issueOrPr: "owner/repo#266" }),
+		]);
+		expect(res.code).toBe(0);
+		expect(res.json.evidence.handle.branch).toBe(branch);
+		expect(res.json.evidence.handle.issueOrPr).toBe("266");
+		expect(res.json.evidence.preflight.ok).toBe(true);
+	});
 	it("start creates a session and reports submit owner-not-live", () => {
 		const res = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
 		expect(res.code).toBe(0);


### PR DESCRIPTION
Fixes #266.

## Summary
- Adds `gjc harness preflight` to validate harness startup metadata before owner start.
- Normalizes `issueOrPr` / `pr` / `issue` inputs to numeric ids for recognized issue/PR forms.
- Fails `harness start` early for declared-vs-actual branch mismatches and ambiguous PR/issue ids while preserving existing loose start compatibility for non-git temp workspaces.
- Persists normalized branch and issueOrPr metadata in the session handle and surfaces preflight diagnostics in start evidence.

## Verification
- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/harness-control-plane/cli.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/commands/harness.ts packages/coding-agent/test/harness-control-plane/cli.test.ts --no-errors-on-unmatched`

## Notes
This intentionally implements the smallest useful operator-safe fix first. Review-specific finalization remains a follow-up surface.