### PR TITLE
feat(task): subagent ROI reporting + no-material-contribution heuristic

### DIFF
--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -49,7 +49,7 @@ import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
-import { assertNoRawTaskFields, buildTaskReceipt } from "./receipt";
+import { assertNoRawTaskFields, buildTaskReceipt, buildTaskRoiSummary } from "./receipt";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import { DEFAULT_SPAWN_THRESHOLD, evaluateReviewerExploreGate, evaluateSpawnGate } from "./spawn-gate";
@@ -134,6 +134,8 @@ export type { TaskResultReceipt } from "./receipt";
 export {
 	assertNoRawTaskFields,
 	buildTaskReceipt,
+	buildTaskRoi,
+	buildTaskRoiSummary,
 	findRawTaskLeakKeys,
 	sanitizeTaskToolDetails,
 } from "./receipt";
@@ -1628,6 +1630,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const totalDuration = Date.now() - startTime;
 
 			const receipts = results.map(buildTaskReceipt);
+			const roiSummary = buildTaskRoiSummary(receipts);
 			const summaries = receipts.map(r => {
 				const status = r.status === "merge_failed" ? "merge failed" : r.status;
 				return {
@@ -1668,6 +1671,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				totalDurationMs: totalDuration,
 				usage: hasAggregatedUsage ? aggregatedUsage : undefined,
 				forkContextClonedTokens: forkContextClonedTokens > 0 ? forkContextClonedTokens : undefined,
+				roiSummary,
 			};
 			assertNoRawTaskFields(details, "task.return.details");
 			return {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1369,10 +1369,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								task.description,
 								commitMsg,
 							);
+							const producedChanges = Boolean(commitResult?.branchName || commitResult?.nestedPatches.length);
 							return {
 								...resultWithForkContext,
 								branchName: commitResult?.branchName,
 								nestedPatches: commitResult?.nestedPatches,
+								producedChanges,
 							};
 						} catch (mergeErr) {
 							// Agent succeeded but branch commit failed — clean up stale branch
@@ -1387,10 +1389,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							const delta = await captureDeltaPatch(isolationDir, taskBaseline);
 							const patchPath = path.join(effectiveArtifactsDir, `${task.id}.patch`);
 							await Bun.write(patchPath, delta.rootPatch);
+							const producedChanges = Boolean(delta.rootPatch.trim() || delta.nestedPatches.length);
 							return {
 								...resultWithForkContext,
 								patchPath,
 								nestedPatches: delta.nestedPatches,
+								producedChanges,
 							};
 						} catch (patchErr) {
 							const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,5 +1,16 @@
 import type { SingleResult, TaskToolDetails } from "./types";
 
+export interface TaskRoi {
+	tokens: number;
+	contextTokens?: number;
+	clonedTokens?: number;
+	costTotal?: number;
+	outputBytes?: number;
+	outputLines?: number;
+	producedChanges: boolean;
+	materialContribution: boolean;
+	lowRoi: boolean;
+}
 export interface TaskResultReceipt {
 	index: number;
 	id: string;
@@ -35,6 +46,7 @@ export interface TaskResultReceipt {
 	};
 	extractedToolCounts?: Record<string, number>;
 	forkContext?: SingleResult["forkContext"];
+	roi?: TaskRoi;
 }
 
 const BANNED_RAW_TASK_KEYS = new Set([
@@ -118,6 +130,59 @@ function buildReview(raw: SingleResult): TaskResultReceipt["review"] | undefined
 	};
 }
 
+function hasReviewFindings(raw: SingleResult): boolean {
+	const findings = raw.extractedToolData?.report_finding;
+	return Array.isArray(findings) && findings.length > 0;
+}
+
+function hasNonEmptyPreview(raw: SingleResult): boolean {
+	return Boolean((raw.output.trim() || raw.stderr.trim()).trim());
+}
+
+/**
+ * Heuristic task ROI signal built only from receipt-safe accounting fields.
+ * Advisory only: these flags never change task success/failure semantics.
+ */
+export function buildTaskRoi(raw: SingleResult): TaskRoi {
+	const outputBytes = raw.outputMeta?.byteSize ?? (raw.outputMeta ? Buffer.byteLength(raw.output, "utf8") : undefined);
+	const outputLines = raw.outputMeta?.lineCount;
+	const producedChanges = Boolean(
+		raw.patchPath || raw.branchName || (Array.isArray(raw.nestedPatches) && raw.nestedPatches.length > 0),
+	);
+	const status = getStatus(raw);
+	const terminal = status !== "paused" && !raw.aborted;
+	const materialContribution = Boolean(
+		producedChanges ||
+			(outputBytes !== undefined && outputBytes > 0) ||
+			hasReviewFindings(raw) ||
+			(status === "completed" && raw.tokens > 0 && hasNonEmptyPreview(raw)),
+	);
+	const lowRoi = terminal && raw.tokens > 0 && !materialContribution;
+	return {
+		tokens: raw.tokens,
+		contextTokens: raw.contextTokens,
+		clonedTokens: raw.forkContext?.clonedTokens,
+		costTotal: raw.usage?.cost.total,
+		outputBytes,
+		outputLines,
+		producedChanges,
+		materialContribution,
+		lowRoi,
+	};
+}
+
+export function buildTaskRoiSummary(receipts: readonly TaskResultReceipt[]): TaskToolDetails["roiSummary"] {
+	const totalCostTotal = receipts.reduce((total, receipt) => total + (receipt.roi?.costTotal ?? 0), 0);
+	const totalClonedTokens = receipts.reduce((total, receipt) => total + (receipt.roi?.clonedTokens ?? 0), 0);
+	return {
+		childCount: receipts.length,
+		totalTokens: receipts.reduce((total, receipt) => total + (receipt.roi?.tokens ?? receipt.tokens), 0),
+		totalCostTotal: totalCostTotal > 0 ? totalCostTotal : undefined,
+		totalClonedTokens: totalClonedTokens > 0 ? totalClonedTokens : undefined,
+		lowRoiChildIds: receipts.filter(receipt => receipt.roi?.lowRoi).map(receipt => receipt.id),
+	};
+}
+
 export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 	const outputRef = raw.outputMeta
 		? {
@@ -169,6 +234,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		review: buildReview(raw),
 		extractedToolCounts,
 		forkContext: raw.forkContext,
+		roi: buildTaskRoi(raw),
 	};
 }
 
@@ -184,6 +250,7 @@ export interface RawTaskToolDetails {
 	usage?: TaskToolDetails["usage"];
 	async?: TaskToolDetails["async"];
 	forkContextClonedTokens?: number;
+	roiSummary?: TaskToolDetails["roiSummary"];
 }
 
 /** Central converter from raw task details to receipt-only public details. */
@@ -194,6 +261,7 @@ export function sanitizeTaskToolDetails(raw: RawTaskToolDetails): TaskToolDetail
 		totalDurationMs: raw.totalDurationMs,
 		usage: raw.usage,
 		forkContextClonedTokens: raw.forkContextClonedTokens,
+		roiSummary: raw.roiSummary ?? buildTaskRoiSummary(raw.results.map(buildTaskReceipt)),
 		async: raw.async,
 	};
 }

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -146,9 +146,9 @@ function hasNonEmptyPreview(raw: SingleResult): boolean {
 export function buildTaskRoi(raw: SingleResult): TaskRoi {
 	const outputBytes = raw.outputMeta?.byteSize ?? (raw.outputMeta ? Buffer.byteLength(raw.output, "utf8") : undefined);
 	const outputLines = raw.outputMeta?.lineCount;
-	const producedChanges = Boolean(
-		raw.patchPath || raw.branchName || (Array.isArray(raw.nestedPatches) && raw.nestedPatches.length > 0),
-	);
+	const producedChanges =
+		raw.producedChanges ??
+		Boolean(raw.branchName || (Array.isArray(raw.nestedPatches) && raw.nestedPatches.length > 0));
 	const status = getStatus(raw);
 	const terminal = status !== "paused" && !raw.aborted;
 	const materialContribution = Boolean(

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -851,6 +851,9 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 	} else {
 		lines.push(...renderOutputSection(result.preview, continuePrefix, expanded, theme, 3, 12));
 	}
+	if (result.roi?.lowRoi) {
+		lines.push(`${continuePrefix}${theme.fg("warning", "low ROI: produced no material contribution")}`);
+	}
 
 	if (result.outputRef) {
 		lines.push(

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -334,6 +334,13 @@ export interface TaskToolDetails {
 	usage?: Usage;
 	/** Aggregate cloned tokens copied into fork-context seeds across subagents. */
 	forkContextClonedTokens?: number;
+	roiSummary?: {
+		childCount: number;
+		totalTokens: number;
+		totalCostTotal?: number;
+		totalClonedTokens?: number;
+		lowRoiChildIds: string[];
+	};
 	progress?: AgentProgress[];
 	async?: {
 		state: "running" | "paused" | "queued" | "completed" | "failed";

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -307,6 +307,8 @@ export interface SingleResult {
 	branchName?: string;
 	/** Nested repo patches to apply after parent merge */
 	nestedPatches?: NestedRepoPatch[];
+	/** Whether isolated execution produced a non-empty root or nested patch. */
+	producedChanges?: boolean;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -339,6 +341,7 @@ export interface TaskToolDetails {
 		totalTokens: number;
 		totalCostTotal?: number;
 		totalClonedTokens?: number;
+		/** Advisory ids for terminal children that spent tokens without detectable output/review/changes. */
 		lowRoiChildIds: string[];
 	};
 	progress?: AgentProgress[];

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -97,6 +97,14 @@ describe("task result receipts", () => {
 		expect(receipt.review?.overallCorrectness).toBe("patch is correct");
 		expect(receipt.review?.findingCount).toBe(1);
 		expect(receipt.extractedToolCounts).toEqual({ yield: 1, report_finding: 1 });
+		expect(receipt.roi).toMatchObject({
+			tokens: 20,
+			outputBytes: Buffer.byteLength(output),
+			outputLines: output.split("\n").length,
+			producedChanges: false,
+			materialContribution: true,
+			lowRoi: false,
+		});
 		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
 	});
 
@@ -138,6 +146,7 @@ describe("task result receipts", () => {
 		const sanitized = sanitizeTaskToolDetails(raw);
 		expect(sanitized.usage).toBe(CANONICAL_USAGE);
 		expect(sanitized.results[0]?.preview).toBe("Task completed; output artifact unavailable.");
+		expect(sanitized.roiSummary).toEqual({ childCount: 1, totalTokens: 20, lowRoiChildIds: [] });
 		expect(findRawTaskLeakKeys(sanitized)).toEqual([]);
 		expect("outputPaths" in sanitized).toBe(false);
 		expect(JSON.stringify(sanitized)).not.toContain("/tmp/");

--- a/packages/coding-agent/test/task/roi.test.ts
+++ b/packages/coding-agent/test/task/roi.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import { buildTaskReceipt, buildTaskRoi, buildTaskRoiSummary, findRawTaskLeakKeys } from "../../src/task/receipt";
+import type { SingleResult } from "../../src/task/types";
+
+const CANONICAL_USAGE = {
+	input: 1,
+	output: 2,
+	cacheRead: 3,
+	cacheWrite: 4,
+	totalTokens: 10,
+	cost: { input: 0.01, output: 0.02, cacheRead: 0.03, cacheWrite: 0.04, total: 0.1 },
+};
+
+function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "0-Test",
+		agent: "executor",
+		agentSource: "bundled",
+		task: "do work",
+		assignment: "assignment",
+		description: "description",
+		exitCode: 0,
+		output: "useful output",
+		stderr: "",
+		truncated: false,
+		durationMs: 10,
+		tokens: 20,
+		...overrides,
+	};
+}
+
+describe("task ROI", () => {
+	it("marks output plus changes as material contribution", () => {
+		const roi = buildTaskRoi(
+			makeRaw({
+				patchPath: "/tmp/0-Test.patch",
+				outputMeta: { lineCount: 1, charCount: 13, byteSize: 13 },
+				usage: CANONICAL_USAGE,
+			}),
+		);
+
+		expect(roi).toMatchObject({
+			tokens: 20,
+			costTotal: 0.1,
+			outputBytes: 13,
+			outputLines: 1,
+			producedChanges: true,
+			materialContribution: true,
+			lowRoi: false,
+		});
+	});
+
+	it("marks a completed token-spending child with zero output and no changes as low ROI", () => {
+		const roi = buildTaskRoi(
+			makeRaw({
+				output: "",
+				stderr: "",
+				outputMeta: { lineCount: 0, charCount: 0, byteSize: 0 },
+				tokens: 5,
+			}),
+		);
+
+		expect(roi.producedChanges).toBe(false);
+		expect(roi.materialContribution).toBe(false);
+		expect(roi.lowRoi).toBe(true);
+	});
+
+	it("treats failed terminal children that spent tokens and produced nothing as low ROI", () => {
+		const roi = buildTaskRoi(
+			makeRaw({
+				exitCode: 1,
+				output: "",
+				stderr: "",
+				outputMeta: { lineCount: 0, charCount: 0, byteSize: 0 },
+				tokens: 7,
+			}),
+		);
+
+		expect(roi.materialContribution).toBe(false);
+		expect(roi.lowRoi).toBe(true);
+	});
+
+	it("includes cloned tokens from fork context", () => {
+		const roi = buildTaskRoi(makeRaw({ forkContext: { mode: "bounded", clonedTokens: 42 } }));
+
+		expect(roi.clonedTokens).toBe(42);
+	});
+
+	it("keeps receipt ROI numeric/boolean and raw-leak safe", () => {
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				forkContext: { mode: "bounded", clonedTokens: 42 },
+				outputMeta: { lineCount: 1, charCount: 13, byteSize: 13 },
+				usage: CANONICAL_USAGE,
+			}),
+		);
+
+		expect(receipt.roi).toEqual({
+			tokens: 20,
+			clonedTokens: 42,
+			costTotal: 0.1,
+			outputBytes: 13,
+			outputLines: 1,
+			producedChanges: false,
+			materialContribution: true,
+			lowRoi: false,
+		});
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
+	it("aggregates low ROI child ids", () => {
+		const productive = buildTaskReceipt(makeRaw({ id: "0-Productive" }));
+		const low = buildTaskReceipt(
+			makeRaw({
+				id: "1-Low",
+				output: "",
+				stderr: "",
+				outputMeta: { lineCount: 0, charCount: 0, byteSize: 0 },
+				tokens: 5,
+				forkContext: { mode: "receipt", clonedTokens: 3 },
+			}),
+		);
+
+		expect(buildTaskRoiSummary([productive, low])).toEqual({
+			childCount: 2,
+			totalTokens: 25,
+			totalClonedTokens: 3,
+			lowRoiChildIds: ["1-Low"],
+		});
+	});
+});

--- a/packages/coding-agent/test/task/roi.test.ts
+++ b/packages/coding-agent/test/task/roi.test.ts
@@ -35,6 +35,7 @@ describe("task ROI", () => {
 		const roi = buildTaskRoi(
 			makeRaw({
 				patchPath: "/tmp/0-Test.patch",
+				producedChanges: true,
 				outputMeta: { lineCount: 1, charCount: 13, byteSize: 13 },
 				usage: CANONICAL_USAGE,
 			}),
@@ -49,6 +50,23 @@ describe("task ROI", () => {
 			materialContribution: true,
 			lowRoi: false,
 		});
+	});
+
+	it("does not count an empty patch artifact path as produced changes", () => {
+		const roi = buildTaskRoi(
+			makeRaw({
+				output: "",
+				stderr: "",
+				patchPath: "/tmp/0-Test.patch",
+				producedChanges: false,
+				outputMeta: { lineCount: 0, charCount: 0, byteSize: 0 },
+				tokens: 5,
+			}),
+		);
+
+		expect(roi.producedChanges).toBe(false);
+		expect(roi.materialContribution).toBe(false);
+		expect(roi.lowRoi).toBe(true);
 	});
 
 	it("marks a completed token-spending child with zero output and no changes as low ROI", () => {


### PR DESCRIPTION
## Token-efficiency program — PR7 of 10 (targets `dev`)

> Stacked on the PR1-6 chain; all PRs target `dev` and shrink to their own diff as predecessors merge.

### What
Surfaces which subagents were worth their token cost (findings #8), reusing PR1 receipts (receipt-safe; no parallel raw serializer).

- New pure `buildTaskRoi(raw): TaskRoi` { tokens, contextTokens?, clonedTokens?, costTotal?, outputBytes?, outputLines?, producedChanges, materialContribution, lowRoi }. Heuristics: `producedChanges` from patchPath/branchName/nestedPatches; `materialContribution` = changes OR output OR review findings OR completed work; `lowRoi` = terminal AND no material contribution. All fields numeric/boolean → PR1 banned-key scanner stays clean.
- `roi?` on `TaskResultReceipt`; aggregate `roiSummary` { childCount, totalTokens, totalCostTotal?, totalClonedTokens?, lowRoiChildIds[] } on `TaskToolDetails`.
- Renderer adds a bounded **advisory** low-ROI line; ROI never changes success/failure status.
- Stats/replay stay receipt-safe (ROI on receipt/details; usage stats unchanged).

### Verification
- tsgo clean; biome clean
- 25 pass / 0 fail across roi + receipt + task-simple-mode + render (material/low-ROI/cloned cases, receipt roi leak-safe, roiSummary lowRoiChildIds)
- Architect 3-lane + red-team review: see PR thread.
