### PR TITLE
fix(gjc): v4 follow-up — fail-closed on corrupt state across all mutation paths

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -7,7 +7,7 @@ import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { migrateWorkflowState } from "./state-migrations";
-import { appendJsonl, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
+import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
 
 /**
  * Native implementation of `gjc ralplan`.
@@ -179,16 +179,15 @@ async function readActiveRunId(cwd: string, sessionId: string | undefined): Prom
 
 async function persistActiveRunId(cwd: string, sessionId: string | undefined, runId: string): Promise<void> {
 	const statePath = ralplanStatePath(cwd, sessionId);
-	let existing: Record<string, unknown> = {};
-	try {
-		const raw = await fs.readFile(statePath, "utf-8");
-		const parsed = JSON.parse(raw);
-		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-			existing = parsed as Record<string, unknown>;
-		}
-	} catch {
-		// fresh receipt; fall through to create
+	const existingRead = await readExistingStateForMutation(statePath);
+	if (existingRead.kind === "corrupt") {
+		throw new RalplanCommandError(
+			2,
+			`existing ralplan state is corrupt or tampered (${existingRead.error}); refusing to overwrite ${statePath}`,
+		);
 	}
+	let existing: Record<string, unknown> = existingRead.kind === "valid" ? existingRead.value : {};
+
 	if (existing.run_id === runId && existing.version === WORKFLOW_STATE_VERSION) return;
 	existing.run_id = runId;
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
@@ -328,16 +327,14 @@ async function applyPlannerStateUpdate(
 	update: PlannerStateUpdate,
 ): Promise<void> {
 	const statePath = ralplanStatePath(cwd, sessionId);
-	let existing: Record<string, unknown> = {};
-	try {
-		const raw = await fs.readFile(statePath, "utf-8");
-		const parsed = JSON.parse(raw);
-		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-			existing = parsed as Record<string, unknown>;
-		}
-	} catch {
-		// fresh state; fall through to create
+	const existingRead = await readExistingStateForMutation(statePath);
+	if (existingRead.kind === "corrupt") {
+		throw new RalplanCommandError(
+			2,
+			`existing ralplan state is corrupt or tampered (${existingRead.error}); refusing to overwrite ${statePath}`,
+		);
 	}
+	let existing: Record<string, unknown> = existingRead.kind === "valid" ? existingRead.value : {};
 	Object.assign(existing, plannerStatePayload(update));
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
 	if (typeof existing.active !== "boolean") existing.active = true;

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -46,6 +46,7 @@ import {
 	detectWorkflowEnvelopeIntegrityMismatch,
 	type GenericHardPruneTarget,
 	hardPrune,
+	readExistingStateForMutation,
 	type StateWriterAuditContext,
 	softDelete,
 	updateWorkflowTransactionJournal,
@@ -371,23 +372,6 @@ async function readJsonValue(filePath: string): Promise<unknown | null> {
 		if (err.code === "ENOENT") return null;
 		process.stderr.write(`WARNING: failed to read ${filePath}; ignoring corrupt state: ${err.message}\n`);
 		return null;
-	}
-}
-type StrictMutationReadResult =
-	| { kind: "absent" }
-	| { kind: "corrupt"; error: string }
-	| { kind: "valid"; value: Record<string, unknown> };
-
-async function readExistingStateForMutation(filePath: string): Promise<StrictMutationReadResult> {
-	try {
-		const raw = await fs.readFile(filePath, "utf-8");
-		const parsed = JSON.parse(raw);
-		if (isPlainObject(parsed)) return { kind: "valid", value: parsed };
-		return { kind: "corrupt", error: "state file must contain a JSON object" };
-	} catch (error) {
-		const err = error as NodeJS.ErrnoException;
-		if (err.code === "ENOENT") return { kind: "absent" };
-		return { kind: "corrupt", error: err.message };
 	}
 }
 
@@ -1116,9 +1100,12 @@ async function handleWrite(
 	merged.skill = mode;
 	if (incomingPhase) {
 		merged.current_phase = incomingPhase;
-	} else if (typeof merged.current_phase !== "string") {
-		merged.current_phase =
-			typeof existingPayload.current_phase === "string" ? existingPayload.current_phase : initialPhaseForSkill(mode);
+	} else if (typeof merged.current_phase !== "string" || !merged.current_phase.trim()) {
+		const retainedPhase =
+			typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : "";
+		merged.current_phase = retainedPhase || initialPhaseForSkill(mode);
+	} else {
+		merged.current_phase = merged.current_phase.trim();
 	}
 	merged.version = WORKFLOW_STATE_VERSION;
 	if (typeof merged.active !== "boolean") merged.active = true;
@@ -1126,10 +1113,11 @@ async function handleWrite(
 	merged.receipt = receipt;
 	if (sessionId && typeof merged.session_id !== "string") merged.session_id = sessionId;
 
-	const fromPhase = typeof existingPayload.current_phase === "string" ? existingPayload.current_phase : undefined;
-	const toPhase = typeof merged.current_phase === "string" ? merged.current_phase : undefined;
+	const fromPhase =
+		typeof existingPayload.current_phase === "string" ? existingPayload.current_phase.trim() : undefined;
+	const toPhase = merged.current_phase as string;
 	const manifestStates = new Set(getSkillManifest(mode).states.map(state => state.id));
-	if (toPhase && !manifestStates.has(toPhase) && !forced) {
+	if (!manifestStates.has(toPhase) && !forced) {
 		throw new StateCommandError(2, `unknown ${mode} phase "${toPhase}"; use --force to bypass`);
 	}
 	if (fromPhase && toPhase && isKnownWorkflowState(mode, fromPhase) && isKnownWorkflowState(mode, toPhase)) {
@@ -1298,14 +1286,29 @@ async function handleHandoff(
 
 	const callerPath = modeStateFile(cwd, caller, sessionId);
 	const calleePath = modeStateFile(cwd, callee, sessionId);
-	const existingCaller = await readJsonFile(callerPath);
-	if (!existingCaller) {
+	const forced = hasFlag(args, "--force");
+	const callerRead = await readExistingStateForMutation(callerPath);
+	if (callerRead.kind === "corrupt" && !forced) {
+		throw new StateCommandError(
+			2,
+			`existing state for ${caller} is corrupt or tampered (${callerRead.error}); use --force to overwrite`,
+		);
+	}
+	if (callerRead.kind !== "valid") {
 		throw new StateCommandError(
 			2,
 			`gjc state ${caller} handoff: caller is not active (no mode-state file at ${callerPath})`,
 		);
 	}
-	const existingCallee = (await readJsonFile(calleePath)) ?? {};
+	const calleeRead = await readExistingStateForMutation(calleePath);
+	if (calleeRead.kind === "corrupt" && !forced) {
+		throw new StateCommandError(
+			2,
+			`existing state for ${callee} is corrupt or tampered (${calleeRead.error}); use --force to overwrite`,
+		);
+	}
+	const existingCaller = callerRead.value;
+	const existingCallee = calleeRead.kind === "valid" ? calleeRead.value : {};
 
 	const handoffAt = nowIso();
 	const mutationId = `${caller}:handoff:${callee}:${handoffAt}`;

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -132,6 +132,27 @@ export class AlreadyExistsError extends Error {
 	}
 }
 
+export type StrictMutationReadResult =
+	| { kind: "absent" }
+	| { kind: "corrupt"; error: string }
+	| { kind: "valid"; value: Record<string, unknown> };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export async function readExistingStateForMutation(filePath: string): Promise<StrictMutationReadResult> {
+	try {
+		const raw = await fs.readFile(filePath, "utf-8");
+		const parsed = JSON.parse(raw);
+		if (isPlainObject(parsed)) return { kind: "valid", value: parsed };
+		return { kind: "corrupt", error: "state file must contain a JSON object" };
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return { kind: "absent" };
+		return { kind: "corrupt", error: err.message };
+	}
+}
 function isErrno(error: unknown, code: string): boolean {
 	return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code;
 }

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -397,6 +397,49 @@ describe("native gjc ralplan runtime — persisted Planner state", () => {
 		expect("planner_resumable" in state).toBe(false);
 	});
 
+	it("rejects corrupt ralplan state before persisting an active run id", async () => {
+		const root = await tempDir();
+		await fs.mkdir(path.dirname(statePath(root)), { recursive: true });
+		await fs.writeFile(statePath(root), "{broken json", "utf-8");
+
+		const result = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "corrupt", "--json"],
+			root,
+		);
+
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("existing ralplan state is corrupt or tampered");
+		expect(await fs.readFile(statePath(root), "utf-8")).toBe("{broken json");
+	});
+
+	it("rejects corrupt ralplan state before applying planner metadata", async () => {
+		const root = await tempDir();
+		await fs.mkdir(path.dirname(statePath(root)), { recursive: true });
+		await fs.writeFile(statePath(root), "{broken json", "utf-8");
+
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Plan",
+				"--run-id",
+				"corrupt-planner",
+				"--planner-id",
+				"0-Planner",
+				"--json",
+			],
+			root,
+		);
+
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("existing ralplan state is corrupt or tampered");
+		expect(await fs.readFile(statePath(root), "utf-8")).toBe("{broken json");
+	});
+
 	it("records fallback metadata together with a fresh planner id", async () => {
 		const root = await tempDir();
 		const result = await runNativeRalplanCommand(

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -119,6 +119,62 @@ describe("gjc state handoff", () => {
 		});
 	});
 
+	it("bootstraps an absent callee mode-state during handoff", async () => {
+		await withTempCwd(async cwd => {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			const calleePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			await writeJson(callerPath, {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+
+			const result = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+
+			expect(result.status).toBe(0);
+			const callee = await readJson(calleePath);
+			expect(callee?.active).toBe(true);
+			expect(callee?.current_phase).toBe("planner");
+			expect(callee?.handoff_from).toBe("deep-interview");
+		});
+	});
+
+	it("rejects corrupt callee mode-state without --force and overwrites with --force", async () => {
+		await withTempCwd(async cwd => {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			const calleePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			await writeJson(callerPath, {
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+			});
+			await fs.mkdir(path.dirname(calleePath), { recursive: true });
+			await fs.writeFile(calleePath, "{broken json", "utf-8");
+
+			const rejected = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(rejected.status).toBe(2);
+			expect(rejected.stderr).toContain("existing state for ralplan is corrupt or tampered");
+			expect(await fs.readFile(calleePath, "utf-8")).toBe("{broken json");
+
+			const forced = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json", "--force"],
+				cwd,
+			);
+			expect(forced.status).toBe(0);
+			const callee = await readJson(calleePath);
+			expect(callee?.active).toBe(true);
+			expect(callee?.handoff_from).toBe("deep-interview");
+		});
+	});
+
 	it("writes callee mode-state before caller mode-state (HUD-coherent ordering)", async () => {
 		await withTempCwd(async cwd => {
 			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -101,6 +101,31 @@ describe("gjc state write hardening", () => {
 		expect(onDisk.current_phase).toBe("planner");
 	});
 
+	it("defaults blank incoming current_phase to the manifest initial phase", async () => {
+		const root = await tempDir();
+		const result = await writeState(root, "ralplan", { current_phase: "" });
+		expect(result.status).toBe(0);
+		expect(receiptFrom(result.stdout).current_phase).toBe("planner");
+		const onDisk = JSON.parse(await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8"));
+		expect(onDisk.current_phase).toBe("planner");
+	});
+
+	it("defaults retained blank legacy current_phase to the manifest initial phase", async () => {
+		const root = await tempDir();
+		await writeRawState(root, "ralplan", {
+			skill: "ralplan",
+			version: 2,
+			active: true,
+			current_phase: "  ",
+		});
+
+		const result = await writeState(root, "ralplan", { active: true });
+		expect(result.status).toBe(0);
+		expect(receiptFrom(result.stdout).current_phase).toBe("planner");
+		const onDisk = JSON.parse(await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8"));
+		expect(onDisk.current_phase).toBe("planner");
+	});
+
 	it("rejects retained unknown existing phases unless forced", async () => {
 		const root = await tempDir();
 		await writeRawState(root, "ralplan", {


### PR DESCRIPTION
## v4 follow-up: fail-closed on corrupt state across all mutation paths

Follow-up to the merged v4 PR #247. Addresses the remaining architect quality-gate HIGH findings (cycle-3): the write-fail-closed-on-corrupt-state invariant was only enforced on `state write`/`clear`, not on every workflow-state mutation path, and a blank `current_phase` could bypass manifest validation.

### Changes
- Centralize `readExistingStateForMutation` (absent | corrupt | valid; never throws) in `state-writer.ts`; `state-runtime.ts` imports it.
- Blank-phase bypass: `gjc state write` treats a blank/whitespace final `current_phase` as absent → defaults to `initialPhaseForSkill(mode)`, then validates the final phase against the manifest unconditionally (rejects unknown unless `--force`). Reads stay fail-open.
- Handoff: `state handoff` reads caller+callee mode-state via the strict reader; corrupt state fails closed unless `--force` (absent callee still bootstraps).
- Ralplan: `persistActiveRunId` and `applyPlannerStateUpdate` raise `RalplanCommandError` on corrupt existing `ralplan-state.json` instead of silently overwriting; absent/valid unchanged.

### Verification
- tsc clean; biome clean; `scripts/ci-gjc-state-gates.ts` exit 0.
- 99 tests pass / 0 fail across state-runtime, state-write-hardening, state-handoff, state-integrity, ralplan-runtime, state-writer-drift (incl. new corrupt-callee handoff, blank-phase, and corrupt-ralplan-state cases).
