### PR TITLE
test(orchestration-token-benchmark): prefix-stability invariant fixtures

### DIFF
--- a/packages/orchestration-token-benchmark/test/prefix-stability.test.ts
+++ b/packages/orchestration-token-benchmark/test/prefix-stability.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { MODEL_SWITCH_FAIL, MODEL_SWITCH_RESET, PREFIX_MUTATION_FAIL, PREFIX_STABLE } from "../src/fixtures";
-import { checkPrefixStability, hashPrefix } from "../src/prefix-stability";
+import {
+	MODEL_SWITCH_FAIL,
+	MODEL_SWITCH_RESET,
+	PREFIX_MUTATION_FAIL,
+	PREFIX_STABLE,
+	TOKEN_LOG_HIGH_CACHE,
+	TOKEN_LOG_LOW_CACHE,
+} from "../src/fixtures";
+import { computeTokenMetrics } from "../src/metrics";
+import { checkPrefixStability, hashPrefix, type PrefixTurn } from "../src/prefix-stability";
 
 describe("hashPrefix", () => {
 	it("is stable for identical input", () => {
@@ -11,6 +19,23 @@ describe("hashPrefix", () => {
 		expect(hashPrefix("SYSTEM+TOOLS")).not.toBe(hashPrefix("SYSTEM+TOOLS+EXTRA"));
 	});
 });
+
+const APPEND_ONLY_PREFIX = JSON.stringify({
+	systemPrompt: ["You are GJC.", "Use tools deterministically."],
+	tools: [
+		{
+			name: "read",
+			description: "Read a file",
+			parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+		},
+	],
+});
+
+const appendOnlyStableFixture: readonly PrefixTurn[] = [
+	{ turn: 1, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key" },
+	{ turn: 2, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key" },
+	{ turn: 3, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key" },
+];
 
 describe("checkPrefixStability", () => {
 	it("passes a stable single epoch", () => {
@@ -52,5 +77,87 @@ describe("checkPrefixStability", () => {
 		]);
 		expect(result.stable).toBe(false);
 		expect(result.violations[0]?.kind).toBe("cache-key-change");
+	});
+
+	it("append-only-stable: repeated turns preserve prefix hash", () => {
+		const hashes = appendOnlyStableFixture.map(turn => hashPrefix(turn.prefix));
+		const result = checkPrefixStability(appendOnlyStableFixture);
+
+		expect(new Set(hashes).size).toBe(1);
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(1);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("mid-session-mutation.fail: injected prefix mutation reports prefix-mutation", () => {
+		const result = checkPrefixStability([
+			...appendOnlyStableFixture.slice(0, 1),
+			{ turn: 2, prefix: `${APPEND_ONLY_PREFIX}\nMUTATED`, model: "model-a", cacheKey: "session-cache-key" },
+		]);
+
+		expect(result.stable).toBe(false);
+		expect(result.epochs).toBe(1);
+		expect(result.violations).toEqual([expect.objectContaining({ turn: 2, epoch: 1, kind: "prefix-mutation" })]);
+	});
+
+	it("model-switch.fail: model switch without reset marker reports model-switch", () => {
+		const result = checkPrefixStability([
+			{ turn: 1, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key" },
+			{ turn: 2, prefix: APPEND_ONLY_PREFIX, model: "model-b", cacheKey: "session-cache-key" },
+		]);
+
+		expect(result.stable).toBe(false);
+		expect(result.violations).toEqual([expect.objectContaining({ turn: 2, epoch: 1, kind: "model-switch" })]);
+	});
+
+	it("compaction-reset.allowed: declared reset marker creates a new epoch", () => {
+		const compactedPrefix = JSON.stringify({ summary: "prior conversation compacted", prefix: APPEND_ONLY_PREFIX });
+		const result = checkPrefixStability([
+			{ turn: 1, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key" },
+			{
+				turn: 2,
+				prefix: compactedPrefix,
+				model: "model-a",
+				cacheKey: "session-cache-key-after-compaction",
+				resetMarker: {
+					reason: "compaction",
+					priorPrefixHash: hashPrefix(APPEND_ONLY_PREFIX),
+					newPrefixHash: hashPrefix(compactedPrefix),
+				},
+			},
+			{ turn: 3, prefix: compactedPrefix, model: "model-a", cacheKey: "session-cache-key-after-compaction" },
+		]);
+
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(2);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("model-switch-reset.allowed: model switch passes with a declared reset marker", () => {
+		const result = checkPrefixStability([
+			{ turn: 1, prefix: APPEND_ONLY_PREFIX, model: "model-a", cacheKey: "session-cache-key-a" },
+			{
+				turn: 2,
+				prefix: APPEND_ONLY_PREFIX,
+				model: "model-b",
+				cacheKey: "session-cache-key-b",
+				resetMarker: { reason: "deliberate-reset", priorPrefixHash: hashPrefix(APPEND_ONLY_PREFIX) },
+			},
+		]);
+
+		expect(result.stable).toBe(true);
+		expect(result.epochs).toBe(2);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it("cache-hit-primary: cache hit rate and stable prefix are primary signals", () => {
+		const highCache = computeTokenMetrics(TOKEN_LOG_HIGH_CACHE);
+		const lowCache = computeTokenMetrics(TOKEN_LOG_LOW_CACHE);
+		const stablePrefix = checkPrefixStability(appendOnlyStableFixture);
+
+		expect(stablePrefix.stable).toBe(true);
+		expect(highCache.cacheHitRate).toBeGreaterThan(lowCache.cacheHitRate);
+		expect(highCache.cacheHitRate).toBeCloseTo(2050 / 3150, 10);
+		expect(highCache.totalTokens).toBeGreaterThan(lowCache.totalTokens);
 	});
 });


### PR DESCRIPTION
## Token-efficiency program — PR8 of 10 (targets `dev`)

### What
Protects prompt-cache efficiency by adding **deterministic prefix-stability fixtures** over the existing `checkPrefixStability` primitive. **Test-only** — investigation of `AppendOnlyContextManager` demonstrated no real prefix violation, so per the approved plan no speculative runtime fix was made (no compaction redesign).

Named fixtures added:
- `append-only-stable` — repeated turns preserve the prefix hash; no violation
- `mid-session-mutation.fail` — injected prefix mutation ⇒ `prefix-mutation`
- `model-switch.fail` — mid-session model switch w/o reset marker ⇒ `model-switch`
- `compaction-reset.allowed` — declared reset marker starts a new epoch and passes
- `model-switch-reset.allowed` — model switch passes only WITH a declared reset marker
- `cache-hit-primary` — cache-hit / stable-prefix treated as the primary signal, not raw token delta alone

### Verification
- tsgo clean; biome clean
- prefix-stability suite = 14 pass / 0 fail
- Single file changed (benchmark test); no production code touched.
