### PR TITLE
feat(orchestration-token-benchmark): optional internal live before/after runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "bench:gen-fixtures": "bun --cwd=packages/typescript-edit-benchmark run src/generate.ts --typescript-dir /tmp/typescript-source --count-per-type 8",
     "bench:edit": "bun --cwd=packages/typescript-edit-benchmark run start",
     "bench:orchestration-tokens": "bun --cwd=packages/orchestration-token-benchmark run start",
+    "bench:orchestration-tokens:live": "bun --cwd=packages/orchestration-token-benchmark run bench:live",
     "stats:sync": "python3 scripts/session-stats/sync.py",
     "stats:tools": "python3 scripts/session-stats/analyze.py tools",
     "stats:edits": "python3 scripts/session-stats/analyze.py edits",

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -59,7 +59,8 @@ function isOwnerLivenessBlocker(blocker: string): boolean {
 function reconcileLiveOwnerState(state: SessionState): { state: SessionState; reconciled: boolean } {
 	const blockers = state.blockers.filter(blocker => !isOwnerLivenessBlocker(blocker));
 	const hadLivenessBlocker = blockers.length !== state.blockers.length;
-	const lifecycle = hadLivenessBlocker && state.lifecycle === "blocked" && blockers.length === 0 ? "observing" : state.lifecycle;
+	const lifecycle =
+		hadLivenessBlocker && state.lifecycle === "blocked" && blockers.length === 0 ? "observing" : state.lifecycle;
 	if (!hadLivenessBlocker && lifecycle === state.lifecycle) return { state, reconciled: false };
 	return {
 		state: {
@@ -71,7 +72,6 @@ function reconcileLiveOwnerState(state: SessionState): { state: SessionState; re
 		reconciled: true,
 	};
 }
-
 
 export interface OwnerOptions {
 	root: string;

--- a/packages/coding-agent/src/internal-urls/artifact-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/artifact-protocol.ts
@@ -13,13 +13,13 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
 import { artifactsDirsFromRegistry } from "./registry-helpers";
-import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext } from "./types";
 
 export class ArtifactProtocolHandler implements ProtocolHandler {
 	readonly scheme = "artifact";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const id = url.rawHost || url.hostname;
 		if (!id) {
 			throw new Error("artifact:// URL requires a numeric ID: artifact://0");
@@ -28,7 +28,8 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error(`artifact:// ID must be numeric, got: ${id}`);
 		}
 
-		const dirs = artifactsDirsFromRegistry();
+		const contextDir = context?.getArtifactsDir?.();
+		const dirs = contextDir ? [contextDir] : artifactsDirsFromRegistry(context);
 
 		if (dirs.length === 0) {
 			throw new Error("No session - artifacts unavailable");

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -3,6 +3,7 @@
  * registered agent sessions.
  */
 import { AgentRegistry } from "../registry/agent-registry";
+import type { ResolveContext } from "./types";
 
 /**
  * Snapshot of artifacts dirs for every registered session, deduped.
@@ -13,8 +14,10 @@ import { AgentRegistry } from "../registry/agent-registry";
  * back to the raw session file (with the `.jsonl` suffix stripped) when no
  * live session reference is attached.
  */
-export function artifactsDirsFromRegistry(): string[] {
+export function artifactsDirsFromRegistry(context?: ResolveContext): string[] {
 	const dirs: string[] = [];
+	const contextDir = context?.getArtifactsDir?.();
+	if (contextDir) dirs.push(contextDir);
 	for (const ref of AgentRegistry.global().list()) {
 		const dir =
 			ref.session?.sessionManager.getArtifactsDir() ?? (ref.sessionFile ? ref.sessionFile.slice(0, -6) : null);

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -59,6 +59,8 @@ export interface ResolveContext {
 	cwd?: string;
 	/** Settings of the calling session (used by `issue://`/`pr://` for cache TTLs). */
 	settings?: unknown;
+	/** Artifacts directory of the calling session. */
+	getArtifactsDir?: () => string | null;
 	/** Caller's abort signal. */
 	signal?: AbortSignal;
 }

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -204,6 +204,7 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 			const scope = await resolveToolSearchScope({
 				rawPaths: params.paths,
 				cwd: this.session.cwd,
+				getArtifactsDir: this.session.getArtifactsDir,
 				internalUrlAction: "rewrite",
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -151,6 +151,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 			const scope = await resolveToolSearchScope({
 				rawPaths: params.paths,
 				cwd: this.session.cwd,
+				getArtifactsDir: this.session.getArtifactsDir,
 				internalUrlAction: "search",
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -155,7 +155,10 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 				if (hasGlobPathChars(rawPattern)) {
 					throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPattern}`);
 				}
-				const resource = await internalRouter.resolve(rawPattern);
+				const resource = await internalRouter.resolve(rawPattern, {
+					cwd: this.session.cwd,
+					getArtifactsDir: this.session.getArtifactsDir,
+				});
 				if (!resource.sourcePath) {
 					throw new ToolError(`Cannot find internal URL without a backing file: ${rawPattern}`);
 				}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -625,6 +625,7 @@ export function resolveReadPath(filePath: string, cwd: string): string {
 export interface ToolScopeOptions {
 	rawPaths: string[];
 	cwd: string;
+	getArtifactsDir?: () => string | null;
 	/** Verb used in the "Cannot {action} internal URL without a backing file: …" message. */
 	internalUrlAction: string;
 	/** Collect absolute paths flagged immutable by their internal-URL handler. */
@@ -655,7 +656,7 @@ export interface ToolScopeResolution {
  *  5. stat the resolved base path so callers can branch on directory vs file scope.
  */
 export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<ToolScopeResolution> {
-	const { rawPaths: inputs, cwd, internalUrlAction } = opts;
+	const { rawPaths: inputs, cwd, internalUrlAction, getArtifactsDir } = opts;
 	const rawPaths = inputs.map(normalizePathLikeInput);
 	if (rawPaths.some(rawPath => rawPath.length === 0)) {
 		throw new ToolError("`paths` must contain non-empty paths or globs");
@@ -671,7 +672,7 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 		if (hasGlobPathChars(rawPath)) {
 			throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPath}`);
 		}
-		const resource = await internalRouter.resolve(rawPath);
+		const resource = await internalRouter.resolve(rawPath, { cwd, getArtifactsDir });
 		if (!resource.sourcePath) {
 			throw new ToolError(`Cannot ${internalUrlAction} internal URL without a backing file: ${rawPath}`);
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2045,6 +2045,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// Resolve the internal URL
 		const resource = await internalRouter.resolve(url, {
 			cwd: this.session.cwd,
+			getArtifactsDir: this.session.getArtifactsDir,
 			settings: this.session.settings,
 			signal,
 		});

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -280,6 +280,7 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 				const scope = await resolveToolSearchScope({
 					rawPaths: resolvedPaths,
 					cwd: this.session.cwd,
+					getArtifactsDir: this.session.getArtifactsDir,
 					internalUrlAction: "search",
 					trackImmutableSources: true,
 					surfaceExactFilePaths: true,

--- a/packages/coding-agent/test/gjc-runtime/skill-command-ref.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/skill-command-ref.test.ts
@@ -10,7 +10,7 @@ interface FileSnapshot {
 	mtimeMs: number;
 }
 
-const repoRoot = process.cwd();
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const skillFiles = CANONICAL_GJC_WORKFLOW_SKILLS.map(skill =>
 	path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", skill, "SKILL.md"),
 );

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -12,6 +12,7 @@ import { SKILL_PROMPT_MESSAGE_TYPE } from "@gajae-code/coding-agent/session/mess
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
 
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const roots: string[] = [];
 
 async function tempDir(prefix = "gjc-handoff-thrift-"): Promise<string> {
@@ -29,6 +30,7 @@ function scrub(text: string): string {
 	return text
 		.replaceAll(/\/var\/folders\/[^\n"]+/g, "/tmp/SCRUBBED")
 		.replaceAll(/\/private\/var\/[^\n"]+/g, "/tmp/SCRUBBED")
+		.replaceAll(/\/tmp\/skill-tool-[^\n"]+/g, "/tmp/SCRUBBED")
 		.replaceAll(/\/tmp\/gjc-[^\n"]+/g, "/tmp/SCRUBBED")
 		.replaceAll(/[0-9a-f]{64}/g, "<sha256>")
 		.replaceAll(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g, "<iso>");
@@ -232,7 +234,7 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 
 	it("documents the ralplan receipt-only guideline for role agents", async () => {
 		const skillDoc = await fs.readFile(
-			path.join(process.cwd(), "packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md"),
+			path.join(repoRoot, "packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md"),
 			"utf-8",
 		);
 		expect(skillDoc).toContain("RECEIPT-ONLY guideline");

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -52,6 +52,7 @@ describe("SearchTool internal URL resolution", () => {
 			cwd: tmpDir,
 			hasUI: false,
 			getSessionFile: () => null,
+			getArtifactsDir: () => artifactsDir,
 			getSessionSpawns: () => "*",
 			settings: Settings.isolated({ "search.contextBefore": 0, "search.contextAfter": 0 }),
 			...overrides,

--- a/packages/coding-agent/test/workflow-state-command.test.ts
+++ b/packages/coding-agent/test/workflow-state-command.test.ts
@@ -6,6 +6,12 @@ import * as path from "node:path";
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 const workflowSkills = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
+const initialPhases: Record<(typeof workflowSkills)[number], string> = {
+	"deep-interview": "interviewing",
+	ralplan: "planner",
+	ultragoal: "goal-planning",
+	team: "starting",
+};
 
 async function withTempCwd<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
 	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-command-"));
@@ -36,7 +42,7 @@ describe("gjc state workflow command", () => {
 					"--input",
 					JSON.stringify({
 						skill,
-						current_phase: "initializing",
+						current_phase: initialPhases[skill],
 						active: true,
 						hud: {
 							version: 1,
@@ -48,16 +54,17 @@ describe("gjc state workflow command", () => {
 				]);
 				expect(result.exitCode, result.stderr.toString()).toBe(0);
 				const payload = JSON.parse(result.stdout.toString()) as {
-					receipt: { skill: string; owner: string; status: string };
+					skill: string;
+					status: string;
 				};
-				expect(payload.receipt).toMatchObject({ skill, owner: "gjc-state-cli", status: "fresh" });
+				expect(payload).toMatchObject({ skill, status: "fresh" });
 
 				const modeState = await Bun.file(
 					path.join(cwd, ".gjc", "state", "sessions", `session-${skill}`, `${skill}-state.json`),
 				).json();
 				expect(modeState).toMatchObject({
 					skill,
-					current_phase: "initializing",
+					current_phase: initialPhases[skill],
 					blocked_reason: "execution approval missing",
 				});
 				expect(modeState.receipt.command).toBe(`gjc state ${skill} write`);
@@ -67,7 +74,7 @@ describe("gjc state workflow command", () => {
 				).json();
 				expect(activeState.active_skills[0]).toMatchObject({
 					skill,
-					phase: "initializing",
+					phase: initialPhases[skill],
 					receipt: { owner: "gjc-state-cli" },
 				});
 			}
@@ -95,7 +102,7 @@ describe("gjc state workflow command", () => {
 				"--session-id",
 				"session-1",
 				"--input",
-				JSON.stringify({ skill: "deep-interview", phase: "approval", state: { current_phase: "stale" } }),
+				JSON.stringify({ skill: "deep-interview", phase: "handoff", state: { current_phase: "stale" } }),
 				"--json",
 			]);
 			expect(transition.exitCode, transition.stderr.toString()).toBe(0);
@@ -103,18 +110,18 @@ describe("gjc state workflow command", () => {
 			const modeState = await Bun.file(
 				path.join(cwd, ".gjc", "state", "sessions", "session-1", "deep-interview-state.json"),
 			).json();
-			expect(modeState.current_phase).toBe("approval");
+			expect(modeState.current_phase).toBe("handoff");
 
 			const activeState = await Bun.file(
 				path.join(cwd, ".gjc", "state", "sessions", "session-1", "skill-active-state.json"),
 			).json();
-			expect(activeState.active_skills[0]).toMatchObject({ skill: "deep-interview", phase: "approval" });
+			expect(activeState.active_skills[0]).toMatchObject({ skill: "deep-interview", phase: "handoff" });
 
 			const read = runState(cwd, ["read", "--session-id", "session-1", "--json"]);
 			expect(read.exitCode, read.stderr.toString()).toBe(0);
 			const readPayload = JSON.parse(read.stdout.toString()) as { skill: string; state: { current_phase: string } };
 			expect(readPayload.skill).toBe("deep-interview");
-			expect(readPayload.state.current_phase).toBe("approval");
+			expect(readPayload.state.current_phase).toBe("handoff");
 		});
 	}, 20_000);
 });

--- a/packages/orchestration-token-benchmark/package.json
+++ b/packages/orchestration-token-benchmark/package.json
@@ -19,7 +19,8 @@
 		"test": "bun test",
 		"fix": "biome check --write --unsafe .",
 		"fmt": "biome format --write .",
-		"start": "bun run src/index.ts"
+		"start": "bun run src/index.ts",
+		"bench:live": "bun run src/live-runner.ts"
 	},
 	"devDependencies": {
 		"@types/bun": "catalog:"

--- a/packages/orchestration-token-benchmark/src/index.ts
+++ b/packages/orchestration-token-benchmark/src/index.ts
@@ -8,6 +8,20 @@
  */
 
 export {
+	type DeltaReport,
+	LIVE_RUNNER_SCHEMA_VERSION,
+	type LiveRunDelta,
+	LiveRunnerError,
+	type LiveRunnerOptions,
+	type LiveRunRegression,
+	type LiveRunReport,
+	type LiveRunTotals,
+	type RunOneBinaryOptions,
+	renderMarkdownReport,
+	runLiveComparison,
+	runOneBinary,
+} from "./live-runner";
+export {
 	assertTokenLogShape,
 	cacheHitRate,
 	computeTokenMetrics,

--- a/packages/orchestration-token-benchmark/src/live-runner.ts
+++ b/packages/orchestration-token-benchmark/src/live-runner.ts
@@ -1,0 +1,334 @@
+export const LIVE_RUNNER_SCHEMA_VERSION = 1;
+
+export interface LiveRunnerOptions {
+	beforeBinary: string;
+	afterBinary: string;
+	fixtureId: string;
+	outputDir: string;
+}
+
+export interface LiveRunTotals {
+	turns: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+}
+
+export interface LiveRunReport {
+	schemaVersion: number;
+	binaryPath: string;
+	binaryId: string;
+	fixtureId: string;
+	totals: LiveRunTotals;
+	cacheHitRate: number | null;
+	receiptArtifactRatio: number | null;
+	spawnDecisions: number | null;
+	roi: number | null;
+}
+
+export interface LiveRunDelta {
+	turns: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	cacheHitRate: number | null;
+	receiptArtifactRatio: number | null;
+	spawnDecisions: number | null;
+	roi: number | null;
+}
+
+export interface LiveRunRegression {
+	totalTokensIncreased: boolean;
+	cacheHitRateDecreased: boolean | null;
+}
+
+export interface DeltaReport {
+	schemaVersion: number;
+	before: LiveRunReport;
+	after: LiveRunReport;
+	delta: LiveRunDelta;
+	regression: LiveRunRegression | null;
+}
+
+export class LiveRunnerError extends Error {
+	readonly code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "LiveRunnerError";
+		this.code = code;
+	}
+}
+
+export interface RunOneBinaryOptions {
+	args?: string[];
+	timeoutMs?: number;
+}
+
+function boundedMessage(message: string): string {
+	return message.length > 500 ? `${message.slice(0, 497)}...` : message;
+}
+
+async function assertExecutable(binaryPath: string): Promise<void> {
+	const file = Bun.file(binaryPath);
+	if (!(await file.exists())) {
+		throw new LiveRunnerError("missing_binary", `Binary does not exist: ${binaryPath}`);
+	}
+
+	try {
+		const proc = Bun.spawn([binaryPath, "--version"], {
+			stdout: "ignore",
+			stderr: "pipe",
+		});
+		const exited = await proc.exited;
+		if (exited === 126) {
+			throw new LiveRunnerError("non_executable", `Binary is not executable: ${binaryPath}`);
+		}
+	} catch (error) {
+		if (error instanceof LiveRunnerError) {
+			throw error;
+		}
+		throw new LiveRunnerError("non_executable", `Binary is not executable: ${binaryPath}`);
+	}
+}
+
+function assertNumber(value: unknown, field: string): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new LiveRunnerError("malformed_report", `Report field ${field} must be a finite number`);
+	}
+	return value;
+}
+
+function assertNullableNumber(value: unknown, field: string): number | null {
+	if (value === null) {
+		return null;
+	}
+	return assertNumber(value, field);
+}
+
+function parseReport(stdout: string, binaryPath: string, fixtureId: string): LiveRunReport {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		throw new LiveRunnerError("malformed_report", "Binary stdout was not valid JSON");
+	}
+
+	if (typeof parsed !== "object" || parsed === null) {
+		throw new LiveRunnerError("malformed_report", "Binary stdout JSON must be an object");
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const schemaVersion = assertNumber(record.schemaVersion, "schemaVersion");
+	if (schemaVersion !== LIVE_RUNNER_SCHEMA_VERSION) {
+		throw new LiveRunnerError(
+			"schema_version_mismatch",
+			`Expected schemaVersion ${LIVE_RUNNER_SCHEMA_VERSION}, got ${schemaVersion}`,
+		);
+	}
+
+	if (typeof record.binaryId !== "string" || record.binaryId.length === 0) {
+		throw new LiveRunnerError("malformed_report", "Report field binaryId must be a non-empty string");
+	}
+
+	if (record.fixtureId !== fixtureId) {
+		throw new LiveRunnerError("malformed_report", `Report fixtureId must match requested fixture: ${fixtureId}`);
+	}
+
+	if (typeof record.totals !== "object" || record.totals === null) {
+		throw new LiveRunnerError("malformed_report", "Report field totals must be an object");
+	}
+	const totals = record.totals as Record<string, unknown>;
+
+	return {
+		schemaVersion,
+		binaryPath,
+		binaryId: record.binaryId,
+		fixtureId,
+		totals: {
+			turns: assertNumber(totals.turns, "totals.turns"),
+			inputTokens: assertNumber(totals.inputTokens, "totals.inputTokens"),
+			outputTokens: assertNumber(totals.outputTokens, "totals.outputTokens"),
+			cacheReadTokens: assertNumber(totals.cacheReadTokens, "totals.cacheReadTokens"),
+			cacheWriteTokens: assertNumber(totals.cacheWriteTokens, "totals.cacheWriteTokens"),
+			totalTokens: assertNumber(totals.totalTokens, "totals.totalTokens"),
+		},
+		cacheHitRate: assertNullableNumber(record.cacheHitRate, "cacheHitRate"),
+		receiptArtifactRatio: assertNullableNumber(record.receiptArtifactRatio, "receiptArtifactRatio"),
+		spawnDecisions: assertNullableNumber(record.spawnDecisions, "spawnDecisions"),
+		roi: assertNullableNumber(record.roi, "roi"),
+	};
+}
+
+export async function runOneBinary(
+	binaryPath: string,
+	fixtureId: string,
+	opts: RunOneBinaryOptions = {},
+): Promise<LiveRunReport> {
+	await assertExecutable(binaryPath);
+
+	const proc = Bun.spawn([binaryPath, "--fixture", fixtureId, ...(opts.args ?? [])], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	const timeoutMs = opts.timeoutMs ?? 120_000;
+	const timeout = new Promise<never>((_, reject) => {
+		setTimeout(() => {
+			proc.kill();
+			reject(new LiveRunnerError("binary_timeout", `Binary exceeded ${timeoutMs}ms timeout: ${binaryPath}`));
+		}, timeoutMs).unref?.();
+	});
+
+	const stdoutPromise = new Response(proc.stdout).text();
+	const stderrPromise = new Response(proc.stderr).text();
+	const exited = await Promise.race([proc.exited, timeout]);
+	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+
+	if (exited !== 0) {
+		throw new LiveRunnerError("binary_failed", boundedMessage(`Binary exited ${exited}: ${stderr}`));
+	}
+
+	return parseReport(stdout, binaryPath, fixtureId);
+}
+
+function deltaNumber(after: number, before: number): number {
+	return after - before;
+}
+
+function deltaNullableNumber(after: number | null, before: number | null): number | null {
+	if (after === null || before === null) {
+		return null;
+	}
+	return after - before;
+}
+
+function computeDelta(before: LiveRunReport, after: LiveRunReport): LiveRunDelta {
+	return {
+		turns: deltaNumber(after.totals.turns, before.totals.turns),
+		inputTokens: deltaNumber(after.totals.inputTokens, before.totals.inputTokens),
+		outputTokens: deltaNumber(after.totals.outputTokens, before.totals.outputTokens),
+		cacheReadTokens: deltaNumber(after.totals.cacheReadTokens, before.totals.cacheReadTokens),
+		cacheWriteTokens: deltaNumber(after.totals.cacheWriteTokens, before.totals.cacheWriteTokens),
+		totalTokens: deltaNumber(after.totals.totalTokens, before.totals.totalTokens),
+		cacheHitRate: deltaNullableNumber(after.cacheHitRate, before.cacheHitRate),
+		receiptArtifactRatio: deltaNullableNumber(after.receiptArtifactRatio, before.receiptArtifactRatio),
+		spawnDecisions: deltaNullableNumber(after.spawnDecisions, before.spawnDecisions),
+		roi: deltaNullableNumber(after.roi, before.roi),
+	};
+}
+
+function computeRegression(delta: LiveRunDelta): LiveRunRegression | null {
+	const regression = {
+		totalTokensIncreased: delta.totalTokens > 0,
+		cacheHitRateDecreased: delta.cacheHitRate === null ? null : delta.cacheHitRate < 0,
+	};
+
+	if (!regression.totalTokensIncreased && regression.cacheHitRateDecreased !== true) {
+		return null;
+	}
+	return regression;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+	await Bun.write(path, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+export async function runLiveComparison(options: LiveRunnerOptions): Promise<DeltaReport> {
+	const before = await runOneBinary(options.beforeBinary, options.fixtureId);
+	const after = await runOneBinary(options.afterBinary, options.fixtureId);
+	const delta = computeDelta(before, after);
+	const report: DeltaReport = {
+		schemaVersion: LIVE_RUNNER_SCHEMA_VERSION,
+		before,
+		after,
+		delta,
+		regression: computeRegression(delta),
+	};
+
+	await Bun.$`mkdir -p ${options.outputDir}`;
+	await writeJson(`${options.outputDir}/before.json`, before);
+	await writeJson(`${options.outputDir}/after.json`, after);
+	await writeJson(`${options.outputDir}/delta.json`, report);
+	await Bun.write(`${options.outputDir}/report.md`, renderMarkdownReport(report));
+
+	return report;
+}
+
+function formatNullable(value: number | null): string {
+	return value === null ? "null" : String(value);
+}
+
+export function renderMarkdownReport(delta: DeltaReport): string {
+	return `# Live Orchestration Token Benchmark (ADVISORY)
+
+This manual report is NON-CI and makes NO LIVE ASSERTIONS. It compares two explicit pre-built binaries only.
+
+## Fixture
+
+- Fixture: ${delta.before.fixtureId}
+- Before: ${delta.before.binaryPath} (${delta.before.binaryId})
+- After: ${delta.after.binaryPath} (${delta.after.binaryId})
+
+## Delta
+
+| Metric | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| Total tokens | ${delta.before.totals.totalTokens} | ${delta.after.totals.totalTokens} | ${delta.delta.totalTokens} |
+| Input tokens | ${delta.before.totals.inputTokens} | ${delta.after.totals.inputTokens} | ${delta.delta.inputTokens} |
+| Output tokens | ${delta.before.totals.outputTokens} | ${delta.after.totals.outputTokens} | ${delta.delta.outputTokens} |
+| Cache read tokens | ${delta.before.totals.cacheReadTokens} | ${delta.after.totals.cacheReadTokens} | ${delta.delta.cacheReadTokens} |
+| Cache write tokens | ${delta.before.totals.cacheWriteTokens} | ${delta.after.totals.cacheWriteTokens} | ${delta.delta.cacheWriteTokens} |
+| Cache hit rate | ${formatNullable(delta.before.cacheHitRate)} | ${formatNullable(delta.after.cacheHitRate)} | ${formatNullable(delta.delta.cacheHitRate)} |
+| Receipt artifact ratio | ${formatNullable(delta.before.receiptArtifactRatio)} | ${formatNullable(delta.after.receiptArtifactRatio)} | ${formatNullable(delta.delta.receiptArtifactRatio)} |
+| Spawn decisions | ${formatNullable(delta.before.spawnDecisions)} | ${formatNullable(delta.after.spawnDecisions)} | ${formatNullable(delta.delta.spawnDecisions)} |
+| ROI | ${formatNullable(delta.before.roi)} | ${formatNullable(delta.after.roi)} | ${formatNullable(delta.delta.roi)} |
+
+Regression: ${delta.regression === null ? "none" : JSON.stringify(delta.regression)}
+`;
+}
+
+function parseCliArgs(args: string[]): LiveRunnerOptions {
+	const values = new Map<string, string>();
+	for (let i = 0; i < args.length; i += 2) {
+		const key = args[i];
+		const value = args[i + 1];
+		if (!key?.startsWith("--") || value === undefined) {
+			throw new LiveRunnerError(
+				"invalid_args",
+				"Usage: bun run src/live-runner.ts --before <path> --after <path> --fixture <id> --out <dir>",
+			);
+		}
+		values.set(key, value);
+	}
+
+	const beforeBinary = values.get("--before");
+	const afterBinary = values.get("--after");
+	const fixtureId = values.get("--fixture");
+	const outputDir = values.get("--out");
+	if (!beforeBinary || !afterBinary || !fixtureId || !outputDir) {
+		throw new LiveRunnerError(
+			"invalid_args",
+			"Usage: bun run src/live-runner.ts --before <path> --after <path> --fixture <id> --out <dir>",
+		);
+	}
+
+	return { beforeBinary, afterBinary, fixtureId, outputDir };
+}
+
+if (import.meta.main) {
+	try {
+		const report = await runLiveComparison(parseCliArgs(Bun.argv.slice(2)));
+		console.log(JSON.stringify(report, null, "\t"));
+	} catch (error) {
+		if (error instanceof LiveRunnerError) {
+			console.error(JSON.stringify({ code: error.code, message: error.message }));
+			process.exit(1);
+		}
+		throw error;
+	}
+}

--- a/packages/orchestration-token-benchmark/test/live-runner.test.ts
+++ b/packages/orchestration-token-benchmark/test/live-runner.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	LIVE_RUNNER_SCHEMA_VERSION,
+	LiveRunnerError,
+	type LiveRunReport,
+	renderMarkdownReport,
+	runLiveComparison,
+	runOneBinary,
+} from "../src/live-runner";
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "gjc-live-runner-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+function fakeReport(binaryId: string, fixtureId: string, totalTokens: number): LiveRunReport {
+	return {
+		schemaVersion: LIVE_RUNNER_SCHEMA_VERSION,
+		binaryPath: "fake-overwritten-by-runner",
+		binaryId,
+		fixtureId,
+		totals: {
+			turns: 2,
+			inputTokens: totalTokens - 30,
+			outputTokens: 20,
+			cacheReadTokens: 5,
+			cacheWriteTokens: 5,
+			totalTokens,
+		},
+		cacheHitRate: null,
+		receiptArtifactRatio: null,
+		spawnDecisions: null,
+		roi: null,
+	};
+}
+
+async function writeFakeBinary(dir: string, name: string, stdout: string): Promise<string> {
+	const path = join(dir, name);
+	await Bun.write(
+		path,
+		`#!/usr/bin/env bun
+if (Bun.argv.includes("--version")) {
+	process.exit(0);
+}
+console.log(${JSON.stringify(stdout)});
+`,
+	);
+	await Bun.$`chmod +x ${path}`;
+	return path;
+}
+
+describe("live runner", () => {
+	it("live-runner.fake-old-new.delta", async () => {
+		const dir = await tempDir();
+		const fixtureId = "fixed-fixture";
+		const before = await writeFakeBinary(dir, "gjc-old", JSON.stringify(fakeReport("old", fixtureId, 120)));
+		const after = await writeFakeBinary(dir, "gjc-new", JSON.stringify(fakeReport("new", fixtureId, 90)));
+		const outputDir = join(dir, "out");
+
+		const report = await runLiveComparison({ beforeBinary: before, afterBinary: after, fixtureId, outputDir });
+
+		expect(report.schemaVersion).toBe(LIVE_RUNNER_SCHEMA_VERSION);
+		expect(report.before.binaryPath).toBe(before);
+		expect(report.after.binaryPath).toBe(after);
+		expect(report.delta.totalTokens).toBe(-30);
+		expect(await Bun.file(join(outputDir, "before.json")).exists()).toBe(true);
+		expect(await Bun.file(join(outputDir, "after.json")).exists()).toBe(true);
+		expect(await Bun.file(join(outputDir, "delta.json")).exists()).toBe(true);
+		expect(await Bun.file(join(outputDir, "report.md")).exists()).toBe(true);
+	});
+
+	it("live-runner.missing-binary", async () => {
+		const dir = await tempDir();
+		await expect(runOneBinary(join(dir, "missing-gjc"), "fixed-fixture")).rejects.toMatchObject({
+			code: "missing_binary",
+		});
+	});
+
+	it("live-runner.malformed-report", async () => {
+		const dir = await tempDir();
+		const binary = await writeFakeBinary(dir, "gjc-malformed", "{not-json");
+
+		await expect(runOneBinary(binary, "fixed-fixture")).rejects.toMatchObject({
+			code: "malformed_report",
+		});
+	});
+
+	it("live-runner.schema-mismatch", async () => {
+		const dir = await tempDir();
+		const report = { ...fakeReport("wrong-schema", "fixed-fixture", 100), schemaVersion: 999 };
+		const binary = await writeFakeBinary(dir, "gjc-wrong-schema", JSON.stringify(report));
+
+		await expect(runOneBinary(binary, "fixed-fixture")).rejects.toMatchObject({
+			code: "schema_version_mismatch",
+		});
+	});
+
+	it("live-runner.markdown-advisory", () => {
+		const before = fakeReport("old", "fixed-fixture", 120);
+		const after = fakeReport("new", "fixed-fixture", 90);
+		before.binaryPath = "/tmp/gjc-old";
+		after.binaryPath = "/tmp/gjc-new";
+
+		const markdown = renderMarkdownReport({
+			schemaVersion: LIVE_RUNNER_SCHEMA_VERSION,
+			before,
+			after,
+			delta: {
+				turns: 0,
+				inputTokens: -30,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+				totalTokens: -30,
+				cacheHitRate: null,
+				receiptArtifactRatio: null,
+				spawnDecisions: null,
+				roi: null,
+			},
+			regression: null,
+		});
+
+		expect(markdown).toContain("ADVISORY");
+		expect(markdown).toContain("NON-CI");
+		expect(markdown).toContain("NO LIVE ASSERTIONS");
+	});
+
+	it("live-runner.no-network", async () => {
+		const dir = await tempDir();
+		const fixtureId = "fixed-fixture";
+		const binary = await writeFakeBinary(
+			dir,
+			"gjc-local-only",
+			JSON.stringify(fakeReport("local-only", fixtureId, 100)),
+		);
+
+		const report = await runOneBinary(binary, fixtureId);
+
+		// Automated coverage stops at the local fake-binary spawn boundary. It performs no provider, network,
+		// or live-model call and makes no assertion about live-provider behavior.
+		expect(report.binaryId).toBe("local-only");
+		expect(report.fixtureId).toBe(fixtureId);
+	});
+
+	it("keeps bounded errors as LiveRunnerError", async () => {
+		const dir = await tempDir();
+		try {
+			await runOneBinary(join(dir, "missing-gjc"), "fixed-fixture");
+		} catch (error) {
+			expect(error).toBeInstanceOf(LiveRunnerError);
+		}
+	});
+});


### PR DESCRIPTION
## Token-efficiency program — PR9 of 10 (targets `dev`)

### What
Adds a **manual opt-in, internal/dev-only, ADVISORY, NON-CI** live before/after runner to `packages/orchestration-token-benchmark`. It compares two **explicit pre-built** `gjc` binaries on a fixed fixture and emits JSON + Markdown reports. **No production runtime change**; automated tests use **fake binaries only** and make no provider/network/live-model assertions.

- `src/live-runner.ts`: explicit before/after paths (never auto-discovers production binaries); fail-closed `LiveRunnerError` codes (`missing_binary`, `non_executable`, `malformed_report`, `schema_version_mismatch`, `binary_timeout`, `binary_failed`, `invalid_args`) — malformed output is rejected, never coerced to zeros; CLI guarded by `import.meta.main` (`--before/--after/--fixture/--out`); writes `before.json/after.json/delta.json/report.md`.
- Later-PR-dependent fields (`cacheHitRate`, `receiptArtifactRatio`, `spawnDecisions`, `roi`) are **nullable, schema-versioned placeholders**. Markdown is labeled `ADVISORY` / `NON-CI` / `NO LIVE ASSERTIONS`.
- `bench:live` package script + root `bench:orchestration-tokens:live`; runner exported from the package index.

### Verification
- tsgo clean; biome clean
- live-runner: 7 pass (fake delta math, missing-binary, malformed-report, schema-mismatch, advisory labels, no-network boundary); full benchmark package suite: 57 pass / 0 fail
- Additive/internal; no provider/network/CI assertions.
