### PR TITLE
fix(gjc): handoff allows --force over corrupt caller mode-state (v4 cycle-4)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1294,7 +1294,7 @@ async function handleHandoff(
 			`existing state for ${caller} is corrupt or tampered (${callerRead.error}); use --force to overwrite`,
 		);
 	}
-	if (callerRead.kind !== "valid") {
+	if (callerRead.kind === "absent") {
 		throw new StateCommandError(
 			2,
 			`gjc state ${caller} handoff: caller is not active (no mode-state file at ${callerPath})`,
@@ -1307,7 +1307,7 @@ async function handleHandoff(
 			`existing state for ${callee} is corrupt or tampered (${calleeRead.error}); use --force to overwrite`,
 		);
 	}
-	const existingCaller = callerRead.value;
+	const existingCaller = callerRead.kind === "valid" ? callerRead.value : {};
 	const existingCallee = calleeRead.kind === "valid" ? calleeRead.value : {};
 
 	const handoffAt = nowIso();

--- a/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff.test.ts
@@ -175,6 +175,32 @@ describe("gjc state handoff", () => {
 		});
 	});
 
+	it("rejects corrupt caller mode-state without --force and proceeds with --force", async () => {
+		await withTempCwd(async cwd => {
+			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");
+			await fs.mkdir(path.dirname(callerPath), { recursive: true });
+			await fs.writeFile(callerPath, "{broken json", "utf-8");
+
+			const rejected = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+				cwd,
+			);
+			expect(rejected.status).toBe(2);
+			expect(rejected.stderr).toContain("existing state for deep-interview is corrupt or tampered");
+			expect(await fs.readFile(callerPath, "utf-8")).toBe("{broken json");
+
+			const forced = await runNativeStateCommand(
+				["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json", "--force"],
+				cwd,
+			);
+			expect(forced.status).toBe(0);
+			const caller = await readJson(callerPath);
+			expect(caller?.active).toBe(false);
+			const callee = await readJson(path.join(cwd, ".gjc/state/ralplan-state.json"));
+			expect(callee?.handoff_from).toBe("deep-interview");
+		});
+	});
+
 	it("writes callee mode-state before caller mode-state (HUD-coherent ordering)", async () => {
 		await withTempCwd(async cwd => {
 			const callerPath = path.join(cwd, ".gjc/state/deep-interview-state.json");


### PR DESCRIPTION
## v4 follow-up: handoff allows --force over corrupt caller mode-state

Final cycle-4 architect finding from the v4 state-typing hardening (after #247 + #269 merged).

`gjc state handoff` rejected a corrupt caller mode-state even with `--force`: the corrupt-throw was skipped under `--force`, but the subsequent `callerRead.kind !== "valid"` check then threw "caller is not active". This made `--force` unable to recover a corrupt caller, contrary to the "corrupt rejected unless --force" contract.

### Fix
- `handleHandoff` now errors "caller is not active" only when the caller file is **absent**; a **corrupt** caller is rejected unless `--force`, and with `--force` proceeds with empty caller state (overwrite), consistent with the callee path.
- Adds a corrupt-caller handoff regression test (rejected without `--force`, proceeds + demotes caller with `--force`).

### Verification
- `state-handoff` tests pass (incl. new corrupt-caller case); `scripts/ci-gjc-state-gates.ts` exit 0.
- Note: dev currently has unrelated pre-existing tsc errors in `src/sdk.ts` / `test/issue-264-dogfood.test.ts` (not introduced by this PR; this PR only touches `state-runtime.ts` + `state-handoff.test.ts`).
