### PR TITLE
feat(tui): monitor & cron jobs status-bar widget + detail overlay

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -35,6 +35,8 @@ export interface AsyncJobMetadata {
 		description?: string;
 		assignment?: string;
 	};
+	/** True when this bash job was started by the `monitor` tool (vs plain async bash). */
+	monitor?: boolean;
 }
 
 /**
@@ -224,6 +226,12 @@ export class AsyncJobManager {
 	#resumeSeq = 0;
 	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
 	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
+	/**
+	 * Change listeners notified on any mutation that can alter the live job set
+	 * (register, terminal/eviction transitions, dispose). Used by the status-line
+	 * jobs widget / overlay to refresh event-driven without polling.
+	 */
+	readonly #changeListeners = new Set<() => void>();
 
 	#filterJobs(jobs: Iterable<AsyncJob>, filter?: AsyncJobFilter): AsyncJob[] {
 		const ownerId = filter?.ownerId;
@@ -239,6 +247,29 @@ export class AsyncJobManager {
 		this.#onJobComplete = options.onJobComplete;
 		this.#maxRunningJobs = Math.max(1, Math.floor(options.maxRunningJobs ?? DEFAULT_MAX_RUNNING_JOBS));
 		this.#retentionMs = Math.max(0, Math.floor(options.retentionMs ?? DEFAULT_RETENTION_MS));
+	}
+
+	/**
+	 * Subscribe to live-job-set change events. Returns an unsubscribe function.
+	 * Listener errors are isolated so one bad subscriber cannot break others.
+	 */
+	onChange(cb: () => void): () => void {
+		this.#changeListeners.add(cb);
+		return () => {
+			this.#changeListeners.delete(cb);
+		};
+	}
+
+	#notifyChange(): void {
+		for (const cb of this.#changeListeners) {
+			try {
+				cb();
+			} catch (error) {
+				logger.warn("Async job change listener failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
 	}
 
 	register(
@@ -336,6 +367,7 @@ export class AsyncJobManager {
 		})();
 
 		this.#jobs.set(id, job);
+		this.#notifyChange();
 		return id;
 	}
 
@@ -880,6 +912,8 @@ export class AsyncJobManager {
 		this.#liveHandles.clear();
 		this.#resumeDescriptors.clear();
 		this.#resumeQueue.length = 0;
+		this.#notifyChange();
+		this.#changeListeners.clear();
 		return drained;
 	}
 
@@ -909,6 +943,7 @@ export class AsyncJobManager {
 	}
 
 	#scheduleEviction(jobId: string): void {
+		this.#notifyChange();
 		if (this.#retentionMs <= 0) {
 			this.#jobs.delete(jobId);
 			this.#suppressedDeliveries.delete(jobId);
@@ -926,6 +961,7 @@ export class AsyncJobManager {
 			this.#suppressedDeliveries.delete(jobId);
 			this.#watchedJobs.delete(jobId);
 			this.#outputState.delete(jobId);
+			this.#notifyChange();
 		}, this.#retentionMs);
 		timer.unref();
 		this.#evictionTimers.set(jobId, timer);

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -38,6 +38,7 @@ interface AppKeybindings {
 	"app.session.fork": true;
 	"app.session.resume": true;
 	"app.session.observe": true;
+	"app.jobs.open": true;
 	"app.session.togglePath": true;
 	"app.session.toggleSort": true;
 	"app.session.rename": true;
@@ -148,6 +149,11 @@ export const KEYBINDINGS = {
 	"app.session.observe": {
 		defaultKeys: "ctrl+s",
 		description: "Observe subagent sessions",
+	},
+
+	"app.jobs.open": {
+		defaultKeys: "alt+j",
+		description: "Open monitor/cron jobs overlay",
 	},
 	"app.session.togglePath": {
 		defaultKeys: "ctrl+p",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -74,6 +74,7 @@ export type StatusLineSegmentId =
 	| "git"
 	| "pr"
 	| "subagents"
+	| "jobs"
 	| "token_in"
 	| "token_out"
 	| "token_total"

--- a/packages/coding-agent/src/modes/components/jobs-overlay-model.ts
+++ b/packages/coding-agent/src/modes/components/jobs-overlay-model.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure model helpers for the jobs overlay.
+ *
+ * Kept free of UI/Component dependencies so the grouping/ordering and
+ * detail-formatting logic is unit-testable. The selector controller wires these
+ * SelectItem lists into nested SelectLists (list -> detail -> confirm).
+ */
+import type { SelectItem } from "@gajae-code/tui";
+import type { JobsSnapshot } from "../jobs-observer";
+
+export type JobRefKind = "monitor" | "cron";
+
+export interface JobRef {
+	kind: JobRefKind;
+	id: string;
+}
+
+const PROMPT_PREVIEW_MAX = 60;
+
+function preview(text: string, max = PROMPT_PREVIEW_MAX): string {
+	const oneLine = text.replace(/\s+/g, " ").trim();
+	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+/** Compact relative time, e.g. "in 5m", "2m ago", "now". */
+export function formatRelative(targetMs: number | undefined, nowMs = Date.now()): string {
+	if (targetMs === undefined) return "—";
+	const deltaMs = targetMs - nowMs;
+	const abs = Math.abs(deltaMs);
+	const mins = Math.round(abs / 60_000);
+	if (mins < 1) return "now";
+	const unit = mins >= 60 ? `${Math.round(mins / 60)}h` : `${mins}m`;
+	return deltaMs >= 0 ? `in ${unit}` : `${unit} ago`;
+}
+
+/** Parse a list item value back into a job reference. */
+export function parseJobRef(value: string): JobRef | null {
+	const sep = value.indexOf(":");
+	if (sep === -1) return null;
+	const kind = value.slice(0, sep);
+	const id = value.slice(sep + 1);
+	if ((kind === "monitor" || kind === "cron") && id.length > 0) {
+		return { kind, id };
+	}
+	return null;
+}
+
+/**
+ * Build the grouped jobs list: monitors first (newest-first), then crons
+ * (newest-first). The snapshot arrays are already sorted newest-first.
+ */
+export function buildJobsListItems(snapshot: JobsSnapshot): SelectItem[] {
+	const items: SelectItem[] = [];
+	for (const monitor of snapshot.monitors) {
+		items.push({
+			value: `monitor:${monitor.id}`,
+			label: `monitor · ${preview(monitor.label, 40)}`,
+			description: monitor.status,
+			hint: monitor.status === "failed" ? "failed" : undefined,
+		});
+	}
+	for (const cron of snapshot.crons) {
+		items.push({
+			value: `cron:${cron.id}`,
+			label: `cron · ${cron.humanSchedule}`,
+			description: preview(cron.prompt),
+		});
+	}
+	return items;
+}
+
+/**
+ * Build the detail-level items for a job: read-only info rows (value "noop"),
+ * then the destructive action, then a back row. `output` is the bounded monitor
+ * output tail (ignored for cron jobs).
+ */
+export function buildJobDetailItems(snapshot: JobsSnapshot, ref: JobRef, output = ""): SelectItem[] {
+	if (ref.kind === "monitor") {
+		const monitor = snapshot.monitors.find(m => m.id === ref.id);
+		if (!monitor) return [{ value: "back", label: "Back (job no longer present)" }];
+		const lastOutput = output.trim().split("\n").filter(Boolean).slice(-1)[0] ?? "(no output captured)";
+		return [
+			{ value: "noop", label: "Status", description: monitor.status },
+			{ value: "noop", label: "Label", description: preview(monitor.label) },
+			{ value: "noop", label: "Started", description: formatRelative(monitor.startTime) },
+			{ value: "noop", label: "Output", description: preview(lastOutput, 80) },
+			{ value: "action:cancel", label: "Cancel this monitor", hint: "stops the running job" },
+			{ value: "back", label: "Back" },
+		];
+	}
+	const cron = snapshot.crons.find(c => c.id === ref.id);
+	if (!cron) return [{ value: "back", label: "Back (job no longer present)" }];
+	return [
+		{ value: "noop", label: "Schedule", description: `${cron.humanSchedule} (${cron.cronExpression})` },
+		{ value: "noop", label: "Recurring", description: cron.recurring ? "yes" : "no" },
+		{ value: "noop", label: "Next fire", description: formatRelative(cron.nextFireAt) },
+		{ value: "noop", label: "Prompt", description: preview(cron.prompt, 80) },
+		{ value: "action:delete", label: "Delete this cron", hint: "removes the schedule" },
+		{ value: "back", label: "Back" },
+	];
+}
+
+/** Yes/No confirm items for a destructive action. */
+export function buildConfirmItems(actionLabel: string): SelectItem[] {
+	return [
+		{ value: "no", label: `No, keep it` },
+		{ value: "yes", label: `Yes, ${actionLabel}` },
+	];
+}

--- a/packages/coding-agent/src/modes/components/jobs-overlay.ts
+++ b/packages/coding-agent/src/modes/components/jobs-overlay.ts
@@ -1,0 +1,27 @@
+import { Container, type SelectItem, SelectList } from "@gajae-code/tui";
+import { getSelectListTheme } from "../theme/theme";
+import { DynamicBorder } from "./dynamic-border";
+
+/**
+ * Generic single-level selector used by the jobs overlay. The selector
+ * controller mounts a fresh instance per navigation level (list -> detail ->
+ * confirm); focus is placed on the inner SelectList, matching the existing
+ * selector components (e.g. ThemeSelectorComponent).
+ */
+export class JobsSelectorComponent extends Container {
+	#selectList: SelectList;
+
+	constructor(items: SelectItem[], onSelect: (item: SelectItem) => void, onCancel: () => void, maxVisible = 12) {
+		super();
+		this.addChild(new DynamicBorder());
+		this.#selectList = new SelectList(items, maxVisible, getSelectListTheme());
+		this.#selectList.onSelect = onSelect;
+		this.#selectList.onCancel = onCancel;
+		this.addChild(this.#selectList);
+		this.addChild(new DynamicBorder());
+	}
+
+	getSelectList(): SelectList {
+		return this.#selectList;
+	}
+}

--- a/packages/coding-agent/src/modes/components/jobs-overlay.ts
+++ b/packages/coding-agent/src/modes/components/jobs-overlay.ts
@@ -1,6 +1,14 @@
 import { Container, type SelectItem, SelectList } from "@gajae-code/tui";
+import type { JobsSnapshot } from "../jobs-observer";
 import { getSelectListTheme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
+import {
+	buildConfirmItems,
+	buildJobDetailItems,
+	buildJobsListItems,
+	type JobRef,
+	parseJobRef,
+} from "./jobs-overlay-model";
 
 /**
  * Generic single-level selector used by the jobs overlay. The selector
@@ -23,5 +31,142 @@ export class JobsSelectorComponent extends Container {
 
 	getSelectList(): SelectList {
 		return this.#selectList;
+	}
+}
+
+export interface JobsOverlayController {
+	acknowledgeFailures(): void;
+	getSnapshot(): JobsSnapshot;
+	getMonitorOutput(id: string): string;
+	cancelMonitor(id: string): boolean;
+	deleteCron(id: string): boolean;
+}
+
+export interface JobsOverlayCallbacks {
+	close(): void;
+	requestRender(): void;
+}
+
+type JobsOverlayView = "list" | "detail" | "confirm";
+type JobsOverlayAction = "cancel" | "delete";
+
+export class JobsOverlayComponent extends Container {
+	readonly #controller: JobsOverlayController;
+	readonly #callbacks: JobsOverlayCallbacks;
+	#view: JobsOverlayView = "list";
+	#ref: JobRef | undefined;
+	#action: JobsOverlayAction | undefined;
+	#selectList: SelectList | undefined;
+
+	constructor(controller: JobsOverlayController, callbacks: JobsOverlayCallbacks) {
+		super();
+		this.#controller = controller;
+		this.#callbacks = callbacks;
+		this.#controller.acknowledgeFailures();
+		this.#renderList();
+	}
+
+	getFocus(): SelectList {
+		if (!this.#selectList) throw new Error("Jobs overlay has no focusable list");
+		return this.#selectList;
+	}
+
+	handleInput(data: string): void {
+		if (this.#view === "confirm") {
+			const key = data.toLowerCase();
+			if (key === "y") {
+				this.#confirmYes();
+				return;
+			}
+			if (key === "n") {
+				this.#renderDetail();
+				return;
+			}
+		}
+		this.#selectList?.handleInput(data);
+	}
+
+	#replaceList(
+		items: SelectItem[],
+		onSelect: (item: SelectItem) => void,
+		onCancel: () => void,
+		maxVisible = 12,
+	): void {
+		this.clear();
+		this.addChild(new DynamicBorder());
+		this.#selectList = new SelectList(items, maxVisible, getSelectListTheme());
+		this.#selectList.onSelect = onSelect;
+		this.#selectList.onCancel = onCancel;
+		this.addChild(this.#selectList);
+		this.addChild(new DynamicBorder());
+		this.#callbacks.requestRender();
+	}
+
+	#renderList(): void {
+		this.#view = "list";
+		this.#ref = undefined;
+		this.#action = undefined;
+		const snapshot = this.#controller.getSnapshot();
+		const built = buildJobsListItems(snapshot);
+		const items = built.length > 0 ? built : [{ value: "close", label: "No active monitor or cron jobs" }];
+		this.#replaceList(
+			items,
+			item => {
+				const ref = parseJobRef(item.value);
+				if (ref) this.#renderDetail(ref);
+				else this.#callbacks.close();
+			},
+			() => this.#callbacks.close(),
+		);
+	}
+
+	#renderDetail(ref = this.#ref): void {
+		if (!ref) {
+			this.#renderList();
+			return;
+		}
+		this.#view = "detail";
+		this.#ref = ref;
+		this.#action = undefined;
+		const output = ref.kind === "monitor" ? this.#controller.getMonitorOutput(ref.id) : "";
+		const items = buildJobDetailItems(this.#controller.getSnapshot(), ref, output);
+		this.#replaceList(
+			items,
+			item => {
+				if (item.value === "action:cancel") this.#renderConfirm("cancel");
+				else if (item.value === "action:delete") this.#renderConfirm("delete");
+				else if (item.value === "back") this.#renderList();
+			},
+			() => this.#callbacks.close(),
+		);
+	}
+
+	#renderConfirm(action: JobsOverlayAction): void {
+		if (!this.#ref) {
+			this.#renderList();
+			return;
+		}
+		this.#view = "confirm";
+		this.#action = action;
+		const label = action === "cancel" ? "cancel this monitor" : "delete this cron";
+		this.#replaceList(
+			buildConfirmItems(label),
+			item => {
+				if (item.value === "yes") this.#confirmYes();
+				else this.#renderDetail();
+			},
+			() => this.#renderDetail(),
+			4,
+		);
+	}
+
+	#confirmYes(): void {
+		if (!this.#ref || !this.#action) {
+			this.#renderList();
+			return;
+		}
+		if (this.#action === "cancel") this.#controller.cancelMonitor(this.#ref.id);
+		else this.#controller.deleteCron(this.#ref.id);
+		this.#renderList();
 	}
 }

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -694,7 +694,8 @@ export class StatusLineComponent implements Component {
 			}
 		}
 
-		const runningBackgroundJobs = this.session.getAsyncJobSnapshot()?.running.length ?? 0;
+		const runningBackgroundJobs =
+			this.session.getAsyncJobSnapshot()?.running.filter(job => job.metadata?.monitor !== true).length ?? 0;
 		if (runningBackgroundJobs > 0) {
 			const icon = theme.icon.agents ? `${theme.icon.agents} ` : "";
 			const label = `${formatCount("job", runningBackgroundJobs)} running`;

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -11,6 +11,7 @@ import type { AgentSession } from "../../session/agent-session";
 import { readVisibleSkillActiveState, type SkillActiveEntry } from "../../skill-state/active-state";
 import * as git from "../../utils/git";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../utils/session-color";
+import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../jobs-observer";
 import { sanitizeStatusText } from "../shared";
 import { computeNonMessageTokens } from "../utils/context-usage";
 import { renderSkillHudBar } from "./skill-hud/render";
@@ -153,6 +154,7 @@ export class StatusLineComponent implements Component {
 	#autoCompactEnabled: boolean = true;
 	#hookStatuses: Map<string, string> = new Map();
 	#subagentCount: number = 0;
+	#jobs: JobsSnapshot = EMPTY_JOBS_SNAPSHOT;
 	#sessionStartTime: number = Date.now();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
@@ -218,6 +220,10 @@ export class StatusLineComponent implements Component {
 
 	setSubagentCount(count: number): void {
 		this.#subagentCount = count;
+	}
+
+	setJobs(jobs: JobsSnapshot): void {
+		this.#jobs = jobs;
 	}
 
 	setSessionStartTime(time: number): void {
@@ -612,6 +618,7 @@ export class StatusLineComponent implements Component {
 			contextWindow,
 			autoCompactEnabled: this.#autoCompactEnabled,
 			subagentCount: this.#subagentCount,
+			jobs: this.#jobs,
 			sessionStartTime: this.#sessionStartTime,
 			git: {
 				branch: this.#getCurrentBranch(),

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -3,7 +3,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["model", "mode", "git", "pr", "path"],
-		rightSegments: ["session_name", "token_rate", "context_pct", "cost"],
+		rightSegments: ["session_name", "jobs", "token_rate", "context_pct", "cost"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -14,7 +14,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	minimal: {
 		leftSegments: ["path", "git"],
-		rightSegments: ["session_name", "mode", "context_pct"],
+		rightSegments: ["session_name", "jobs", "mode", "context_pct"],
 		separator: "slash",
 		segmentOptions: {
 			path: { abbreviate: true, maxLength: 30 },
@@ -24,7 +24,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	compact: {
 		leftSegments: ["model", "mode", "git", "pr"],
-		rightSegments: ["session_name", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "cost", "context_pct"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: false },
@@ -36,6 +36,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 		leftSegments: ["gajae", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
 		rightSegments: [
 			"session_name",
+			"jobs",
 			"token_in",
 			"token_out",
 			"token_rate",
@@ -59,6 +60,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 		leftSegments: ["gajae", "hostname", "model", "mode", "path", "git", "pr", "session", "subagents"],
 		rightSegments: [
 			"session_name",
+			"jobs",
 			"token_in",
 			"token_out",
 			"cache_read",
@@ -82,7 +84,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	ascii: {
 		// No Nerd Font dependencies
 		leftSegments: ["model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "token_total", "cost", "context_pct"],
 		separator: "ascii",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -94,7 +96,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	custom: {
 		// User-defined - these are just defaults that get overridden
 		leftSegments: ["model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "token_total", "cost", "context_pct"],
 		separator: "slash",
 		segmentOptions: {},
 	},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -270,6 +270,30 @@ const subagentsSegment: StatusLineSegment = {
 	},
 };
 
+const jobsSegment: StatusLineSegment = {
+	id: "jobs",
+	render(ctx) {
+		const { jobs } = ctx;
+		const visible = jobs.activeMonitorCount > 0 || jobs.activeCronCount > 0 || jobs.worstState === "failed";
+		if (!visible) {
+			return { content: "", visible: false };
+		}
+		const parts: string[] = [];
+		if (jobs.activeMonitorCount > 0) {
+			parts.push(withIcon(theme.icon.agents, `${jobs.activeMonitorCount}`));
+		}
+		if (jobs.activeCronCount > 0) {
+			parts.push(withIcon(theme.icon.time, `${jobs.activeCronCount}`));
+		}
+		if (parts.length === 0) {
+			// Nothing active but a failure is unacknowledged — keep a drill-in marker.
+			parts.push(withIcon(theme.icon.warning, "jobs"));
+		}
+		const color: ThemeColor = jobs.worstState === "failed" ? "error" : "statusLineSubagents";
+		return { content: theme.fg(color, parts.join(" ")), visible: true };
+	},
+};
+
 const tokenInSegment: StatusLineSegment = {
 	id: "token_in",
 	render(ctx) {
@@ -521,6 +545,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	git: gitSegment,
 	pr: prSegment,
 	subagents: subagentsSegment,
+	jobs: jobsSegment,
 	token_in: tokenInSegment,
 	token_out: tokenOutSegment,
 	token_total: tokenTotalSegment,

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -1,5 +1,6 @@
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../../config/settings-schema";
 import type { AgentSession } from "../../../session/agent-session";
+import type { JobsSnapshot } from "../../jobs-observer";
 import type { StatusLineSegmentOptions, StatusLineSettings } from "../status-line";
 
 export type {
@@ -42,6 +43,7 @@ export interface SegmentContext {
 	contextWindow: number;
 	autoCompactEnabled: boolean;
 	subagentCount: number;
+	jobs: JobsSnapshot;
 	sessionStartTime: number;
 	git: {
 		branch: string | null;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -170,6 +170,9 @@ export class InputController {
 		for (const key of this.ctx.keybindings.getKeys("app.session.observe")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showSessionObserver());
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.jobs.open")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showJobsOverlay());
+		}
 
 		this.ctx.editor.onChange = (text: string) => {
 			const wasBashMode = this.ctx.isBashMode;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -41,6 +41,14 @@ import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
 import { HistorySearchComponent } from "../components/history-search";
+import { JobsSelectorComponent } from "../components/jobs-overlay";
+import {
+	buildConfirmItems,
+	buildJobDetailItems,
+	buildJobsListItems,
+	type JobRef,
+	parseJobRef,
+} from "../components/jobs-overlay-model";
 import { ModelSelectorComponent, type ModelSelectorSelection } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
@@ -55,6 +63,7 @@ import { ThemeSelectorComponent } from "../components/theme-selector";
 import { ToolExecutionComponent } from "../components/tool-execution";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
+import type { JobsObserver } from "../jobs-observer";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 
 const CALLBACK_SERVER_PROVIDERS = new Set<string>([
@@ -1149,5 +1158,77 @@ export class SelectorController {
 		});
 		this.ctx.ui.setFocus(selector);
 		this.ctx.ui.requestRender();
+	}
+
+	/**
+	 * Jobs overlay: navigate ongoing monitor + cron jobs (Monitors then Crons,
+	 * newest-first), drill into per-type detail, and cancel/delete with a y/N
+	 * confirm. Built from nested SelectLists (list -> detail -> confirm) so focus
+	 * stays on the active SelectList.
+	 */
+	showJobsOverlay(observer: JobsObserver): void {
+		observer.acknowledgeFailures();
+
+		const openConfirm = (ref: JobRef, action: "cancel" | "delete"): void => {
+			this.showSelector(() => {
+				const label = action === "cancel" ? "cancel this monitor" : "delete this cron";
+				const component = new JobsSelectorComponent(
+					buildConfirmItems(label),
+					item => {
+						if (item.value === "yes") {
+							if (action === "cancel") observer.cancelMonitor(ref.id);
+							else observer.deleteCron(ref.id);
+							openList();
+						} else {
+							openDetail(ref);
+						}
+					},
+					() => openDetail(ref),
+					4,
+				);
+				return { component, focus: component.getSelectList() };
+			});
+		};
+
+		const openDetail = (ref: JobRef): void => {
+			this.showSelector(done => {
+				const output = ref.kind === "monitor" ? observer.getMonitorOutput(ref.id) : "";
+				const items = buildJobDetailItems(observer.getSnapshot(), ref, output);
+				const component = new JobsSelectorComponent(
+					items,
+					item => {
+						if (item.value === "action:cancel") openConfirm(ref, "cancel");
+						else if (item.value === "action:delete") openConfirm(ref, "delete");
+						else if (item.value === "back") openList();
+						// "noop" info rows: stay on the detail view.
+					},
+					() => {
+						done();
+						openList();
+					},
+				);
+				return { component, focus: component.getSelectList() };
+			});
+		};
+
+		const openList = (): void => {
+			this.showSelector(done => {
+				const snapshot = observer.getSnapshot();
+				const built = buildJobsListItems(snapshot);
+				const items = built.length > 0 ? built : [{ value: "back", label: "No active monitor or cron jobs" }];
+				const component = new JobsSelectorComponent(
+					items,
+					item => {
+						const ref = parseJobRef(item.value);
+						if (ref) openDetail(ref);
+						else done();
+					},
+					done,
+				);
+				return { component, focus: component.getSelectList() };
+			});
+		};
+
+		openList();
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -41,14 +41,7 @@ import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
 import { HistorySearchComponent } from "../components/history-search";
-import { JobsSelectorComponent } from "../components/jobs-overlay";
-import {
-	buildConfirmItems,
-	buildJobDetailItems,
-	buildJobsListItems,
-	type JobRef,
-	parseJobRef,
-} from "../components/jobs-overlay-model";
+import { JobsOverlayComponent } from "../components/jobs-overlay";
 import { ModelSelectorComponent, type ModelSelectorSelection } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
@@ -1167,68 +1160,23 @@ export class SelectorController {
 	 * stays on the active SelectList.
 	 */
 	showJobsOverlay(observer: JobsObserver): void {
-		observer.acknowledgeFailures();
-
-		const openConfirm = (ref: JobRef, action: "cancel" | "delete"): void => {
-			this.showSelector(() => {
-				const label = action === "cancel" ? "cancel this monitor" : "delete this cron";
-				const component = new JobsSelectorComponent(
-					buildConfirmItems(label),
-					item => {
-						if (item.value === "yes") {
-							if (action === "cancel") observer.cancelMonitor(ref.id);
-							else observer.deleteCron(ref.id);
-							openList();
-						} else {
-							openDetail(ref);
-						}
-					},
-					() => openDetail(ref),
-					4,
-				);
-				return { component, focus: component.getSelectList() };
-			});
+		let overlay: JobsOverlayComponent | undefined;
+		const close = () => {
+			this.ctx.editorContainer.clear();
+			this.ctx.editorContainer.addChild(this.ctx.editor);
+			this.ctx.ui.setFocus(this.ctx.editor);
+			this.ctx.ui.requestRender();
 		};
-
-		const openDetail = (ref: JobRef): void => {
-			this.showSelector(done => {
-				const output = ref.kind === "monitor" ? observer.getMonitorOutput(ref.id) : "";
-				const items = buildJobDetailItems(observer.getSnapshot(), ref, output);
-				const component = new JobsSelectorComponent(
-					items,
-					item => {
-						if (item.value === "action:cancel") openConfirm(ref, "cancel");
-						else if (item.value === "action:delete") openConfirm(ref, "delete");
-						else if (item.value === "back") openList();
-						// "noop" info rows: stay on the detail view.
-					},
-					() => {
-						done();
-						openList();
-					},
-				);
-				return { component, focus: component.getSelectList() };
-			});
-		};
-
-		const openList = (): void => {
-			this.showSelector(done => {
-				const snapshot = observer.getSnapshot();
-				const built = buildJobsListItems(snapshot);
-				const items = built.length > 0 ? built : [{ value: "back", label: "No active monitor or cron jobs" }];
-				const component = new JobsSelectorComponent(
-					items,
-					item => {
-						const ref = parseJobRef(item.value);
-						if (ref) openDetail(ref);
-						else done();
-					},
-					done,
-				);
-				return { component, focus: component.getSelectList() };
-			});
-		};
-
-		openList();
+		overlay = new JobsOverlayComponent(observer, {
+			close,
+			requestRender: () => {
+				if (overlay) this.ctx.ui.setFocus(overlay.getFocus());
+				this.ctx.ui.requestRender();
+			},
+		});
+		this.ctx.editorContainer.clear();
+		this.ctx.editorContainer.addChild(overlay);
+		this.ctx.ui.setFocus(overlay.getFocus());
+		this.ctx.ui.requestRender();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -528,11 +528,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender();
 		});
 
-		// Event-driven monitor/cron jobs widget. Scoped to all background work in
-		// the process so the top-level bar reflects every ongoing monitor + cron job.
+		// Event-driven monitor/cron jobs widget. Scoped to this session's owner so
+		// overlay actions cannot mutate another agent's background work.
 		const jobManager = AsyncJobManager.instance();
 		if (jobManager) {
-			const jobsObserver = new JobsObserver(jobManager, undefined);
+			const jobsObserver = new JobsObserver(jobManager, this.session.getAgentId());
 			this.#jobsObserver = jobsObserver;
 			this.statusLine.setJobs(jobsObserver.getSnapshot());
 			jobsObserver.onChange(() => {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -28,6 +28,7 @@ import {
 } from "@gajae-code/tui";
 import { APP_NAME, adjustHsv, getProjectDir, hsvToRgb, isEnoent, logger, postmortem, prompt } from "@gajae-code/utils";
 import chalk from "chalk";
+import { AsyncJobManager } from "../async";
 import { KeybindingsManager } from "../config/keybindings";
 import { isSettingsInitialized, type Settings, settings } from "../config/settings";
 import { DEFAULT_GJC_DEFINITION_NAMES } from "../defaults/gjc-defaults";
@@ -88,6 +89,7 @@ import { InputController } from "./controllers/input-controller";
 import { SelectorController } from "./controllers/selector-controller";
 import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { TodoCommandController } from "./controllers/todo-command-controller";
+import { JobsObserver } from "./jobs-observer";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { SessionObserverRegistry } from "./session-observer-registry";
 import { interruptHint } from "./shared";
@@ -330,6 +332,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#voicePreviousUseTerminalCursor: boolean | null = null;
 	#resizeHandler?: () => void;
 	#observerRegistry: SessionObserverRegistry;
+	#jobsObserver?: JobsObserver;
 	#eventBus?: EventBus;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#welcomeComponent?: WelcomeComponent;
@@ -524,6 +527,19 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.statusLine.setSubagentCount(this.#observerRegistry.getActiveSubagentCount());
 			this.ui.requestRender();
 		});
+
+		// Event-driven monitor/cron jobs widget. Scoped to all background work in
+		// the process so the top-level bar reflects every ongoing monitor + cron job.
+		const jobManager = AsyncJobManager.instance();
+		if (jobManager) {
+			const jobsObserver = new JobsObserver(jobManager, undefined);
+			this.#jobsObserver = jobsObserver;
+			this.statusLine.setJobs(jobsObserver.getSnapshot());
+			jobsObserver.onChange(() => {
+				this.statusLine.setJobs(jobsObserver.getSnapshot());
+				this.ui.requestRender();
+			});
+		}
 
 		// Load initial todos
 		await this.#loadTodoList();
@@ -1843,6 +1859,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry.dispose();
 		this.#eventController.dispose();
 		this.statusLine.dispose();
+		this.#jobsObserver?.dispose();
 		if (this.#resizeHandler) {
 			process.stdout.removeListener("resize", this.#resizeHandler);
 			this.#resizeHandler = undefined;
@@ -2315,6 +2332,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		this.#selectorController.showSessionObserver(this.#observerRegistry);
+	}
+
+	showJobsOverlay(): void {
+		if (!this.#jobsObserver) {
+			this.showStatus("Background jobs are unavailable in this session");
+			return;
+		}
+		this.#selectorController.showJobsOverlay(this.#jobsObserver);
 	}
 
 	resetObserverRegistry(): void {

--- a/packages/coding-agent/src/modes/jobs-observer.ts
+++ b/packages/coding-agent/src/modes/jobs-observer.ts
@@ -178,9 +178,9 @@ export class JobsObserver {
 		return this.#manager.cancel(id);
 	}
 
-	/** Delete a scheduled cron job. Returns true when removed. */
+	/** Delete a visible scheduled cron job. Returns true when removed. */
 	deleteCron(id: string): boolean {
-		return deleteCronJobById(id);
+		return deleteCronJobById(this.#ownerId, id);
 	}
 
 	/** Bounded tail of a monitor job's captured output (for the detail view). */

--- a/packages/coding-agent/src/modes/jobs-observer.ts
+++ b/packages/coding-agent/src/modes/jobs-observer.ts
@@ -1,0 +1,204 @@
+/**
+ * JobsObserver
+ *
+ * Single, event-driven aggregator over the two background-work sources surfaced
+ * by the status-line jobs widget and the jobs overlay:
+ *  - monitor jobs (bash jobs started by the `monitor` tool, tracked in `AsyncJobManager`)
+ *  - cron jobs (tracked in the cron module's owner-scoped schedule store)
+ *
+ * It subscribes to change hooks on both sources (no polling), debounces bursts
+ * to a microtask, and exposes a precomputed snapshot so the status-line render
+ * loop never scans the underlying stores. A failure latch keeps the widget red
+ * until `acknowledgeFailures()` is called (when the overlay opens), so a failed
+ * job that evicts before the user looks is not silently lost.
+ */
+import type { AsyncJob, AsyncJobManager } from "../async";
+import { deleteCronJobById, listCronSnapshots, onCronChange } from "../tools/cron";
+
+export type JobsWorstState = "none" | "running" | "failed";
+
+export interface MonitorJobView {
+	id: string;
+	label: string;
+	status: AsyncJob["status"];
+	startTime: number;
+}
+
+export interface CronJobView {
+	id: string;
+	humanSchedule: string;
+	cronExpression: string;
+	prompt: string;
+	recurring: boolean;
+	nextFireAt?: number;
+	createdAt: number;
+}
+
+export interface JobsSnapshot {
+	monitors: MonitorJobView[];
+	crons: CronJobView[];
+	activeMonitorCount: number;
+	activeCronCount: number;
+	worstState: JobsWorstState;
+	failedUnacknowledged: boolean;
+}
+
+export const EMPTY_JOBS_SNAPSHOT: JobsSnapshot = {
+	monitors: [],
+	crons: [],
+	activeMonitorCount: 0,
+	activeCronCount: 0,
+	worstState: "none",
+	failedUnacknowledged: false,
+};
+
+export class JobsObserver {
+	readonly #manager: AsyncJobManager;
+	readonly #ownerId: string | undefined;
+	readonly #unsubscribers: Array<() => void> = [];
+	readonly #listeners = new Set<() => void>();
+	#failedUnacknowledged = false;
+	#notifyScheduled = false;
+	#disposed = false;
+	#snapshot: JobsSnapshot = EMPTY_JOBS_SNAPSHOT;
+	readonly #acknowledgedFailedIds = new Set<string>();
+
+	constructor(manager: AsyncJobManager, ownerId: string | undefined) {
+		this.#manager = manager;
+		this.#ownerId = ownerId;
+		this.#unsubscribers.push(manager.onChange(() => this.#onUpstreamChange()));
+		this.#unsubscribers.push(onCronChange(() => this.#onUpstreamChange()));
+		this.#recompute();
+	}
+
+	/** Subscribe to debounced change events. Returns an unsubscribe function. */
+	onChange(cb: () => void): () => void {
+		this.#listeners.add(cb);
+		return () => {
+			this.#listeners.delete(cb);
+		};
+	}
+
+	#onUpstreamChange(): void {
+		if (this.#disposed) return;
+		this.#recompute();
+		if (this.#notifyScheduled) return;
+		this.#notifyScheduled = true;
+		queueMicrotask(() => {
+			this.#notifyScheduled = false;
+			if (this.#disposed) return;
+			this.#emit();
+		});
+	}
+
+	#emit(): void {
+		for (const cb of this.#listeners) {
+			try {
+				cb();
+			} catch {
+				// Listener errors are isolated; a bad subscriber must not break others.
+			}
+		}
+	}
+
+	#listMonitorJobs(): AsyncJob[] {
+		const filter = this.#ownerId ? { ownerId: this.#ownerId } : undefined;
+		return this.#manager.getAllJobs(filter).filter(job => job.type === "bash" && job.metadata?.monitor === true);
+	}
+
+	/**
+	 * Recompute and store the snapshot. Called on construction and on every
+	 * upstream change; the status-line render path only reads the stored
+	 * snapshot (never scans the manager/cron stores).
+	 */
+	#recompute(): void {
+		const monitorJobs = this.#listMonitorJobs();
+		const presentIds = new Set(monitorJobs.map(job => job.id));
+		// Prune acknowledged ids whose jobs have been evicted.
+		for (const id of this.#acknowledgedFailedIds) {
+			if (!presentIds.has(id)) this.#acknowledgedFailedIds.delete(id);
+		}
+		// Sticky failure latch: set when an unacknowledged failed monitor is seen
+		// (including at construction); stays set even after the failed job evicts,
+		// until acknowledgeFailures() clears it.
+		const hasUnacknowledgedFailure = monitorJobs.some(
+			job => job.status === "failed" && !this.#acknowledgedFailedIds.has(job.id),
+		);
+		if (hasUnacknowledgedFailure) this.#failedUnacknowledged = true;
+
+		const activeMonitors = monitorJobs.filter(job => job.status === "running");
+		const cronSnapshots = listCronSnapshots(this.#ownerId);
+		const monitors: MonitorJobView[] = monitorJobs
+			.map(job => ({ id: job.id, label: job.label, status: job.status, startTime: job.startTime }))
+			.sort((a, b) => b.startTime - a.startTime);
+		const crons: CronJobView[] = cronSnapshots
+			.map(snapshot => ({
+				id: snapshot.id,
+				humanSchedule: snapshot.humanSchedule,
+				cronExpression: snapshot.cron_expression,
+				prompt: snapshot.prompt,
+				recurring: snapshot.recurring,
+				nextFireAt: snapshot.nextFireAt,
+				createdAt: snapshot.createdAt,
+			}))
+			.sort((a, b) => b.createdAt - a.createdAt);
+		const worstState: JobsWorstState = this.#failedUnacknowledged
+			? "failed"
+			: activeMonitors.length > 0 || crons.length > 0
+				? "running"
+				: "none";
+		this.#snapshot = {
+			monitors,
+			crons,
+			activeMonitorCount: activeMonitors.length,
+			activeCronCount: crons.length,
+			worstState,
+			failedUnacknowledged: this.#failedUnacknowledged,
+		};
+	}
+
+	/** Return the precomputed snapshot (recomputed on each upstream change). */
+	getSnapshot(): JobsSnapshot {
+		return this.#snapshot;
+	}
+
+	/** Clear the failure latch (called when the user opens the jobs overlay). */
+	acknowledgeFailures(): void {
+		for (const job of this.#listMonitorJobs()) {
+			if (job.status === "failed") this.#acknowledgedFailedIds.add(job.id);
+		}
+		if (!this.#failedUnacknowledged) return;
+		this.#failedUnacknowledged = false;
+		this.#recompute();
+		this.#emit();
+	}
+
+	/** Cancel a running monitor job. Returns true when the job was cancelled. */
+	cancelMonitor(id: string): boolean {
+		return this.#manager.cancel(id);
+	}
+
+	/** Delete a scheduled cron job. Returns true when removed. */
+	deleteCron(id: string): boolean {
+		return deleteCronJobById(id);
+	}
+
+	/** Bounded tail of a monitor job's captured output (for the detail view). */
+	getMonitorOutput(id: string): string {
+		const slice = this.#manager.readOutputSince(id, 0, this.#ownerId ? { ownerId: this.#ownerId } : undefined);
+		return slice?.text ?? "";
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+		for (const unsubscribe of this.#unsubscribers) {
+			try {
+				unsubscribe();
+			} catch {
+				// best-effort teardown
+			}
+		}
+		this.#unsubscribers.length = 0;
+		this.#listeners.clear();
+	}
+}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -249,6 +249,7 @@ export interface InteractiveModeContext {
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): void;
 	showSessionObserver(): void;
+	showJobsOverlay(): void;
 	resetObserverRegistry(): void;
 
 	// Input handling

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -297,7 +297,7 @@ function isUnderProjectGjc(cwd: string, targetPath: string): boolean {
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
-export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "label" | "startTime">;
+export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "label" | "startTime" | "metadata">;
 
 export interface AsyncJobSnapshot {
 	running: AsyncJobSnapshotItem[];
@@ -1485,6 +1485,10 @@ export class AgentSession {
 		return tag;
 	}
 
+	getAgentId(): string | undefined {
+		return this.#agentId;
+	}
+
 	getAsyncJobSnapshot(options?: { recentLimit?: number }): AsyncJobSnapshot | null {
 		const manager = AsyncJobManager.instance();
 		if (!manager) return null;
@@ -1495,6 +1499,7 @@ export class AgentSession {
 			status: job.status,
 			label: job.label,
 			startTime: job.startTime,
+			metadata: job.metadata,
 		}));
 		const recent = manager.getRecentJobs(options?.recentLimit ?? 5, ownerFilter).map(job => ({
 			id: job.id,
@@ -1502,6 +1507,7 @@ export class AgentSession {
 			status: job.status,
 			label: job.label,
 			startTime: job.startTime,
+			metadata: job.metadata,
 		}));
 		const delivery = manager.getDeliveryState(ownerFilter);
 		return { running, recent, delivery };

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -587,6 +587,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "monitors",
+		description: "Open the monitor/cron jobs overlay",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showJobsOverlay();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "tree",
 		description: "Navigate session tree (switch branches)",
 		handleTui: (_command, runtime) => {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -693,7 +693,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					throw error instanceof Error ? error : new Error(String(error));
 				}
 			},
-			{ ownerId },
+			{ ownerId, metadata: { monitor: true } },
 		);
 		currentJobId = jobId;
 		return { jobId, label, commandCwd: prepared.commandCwd };

--- a/packages/coding-agent/src/tools/cron.ts
+++ b/packages/coding-agent/src/tools/cron.ts
@@ -137,6 +137,7 @@ function deleteRecord(ownerId: string | undefined, id: string): boolean {
 	disposeRecord(record);
 	const deleted = state.jobs.delete(id);
 	if (state.jobs.size === 0) schedulesByOwner.delete(key);
+	if (deleted) notifyCronChange();
 	return deleted;
 }
 
@@ -158,6 +159,7 @@ export function clearOwnerSchedules(ownerId: string | undefined): void {
 	state.jobs.clear();
 	state.cleanupRegistered = false;
 	schedulesByOwner.delete(key);
+	notifyCronChange();
 }
 
 /** Reset every owner's schedule store. Test-only. */
@@ -167,6 +169,58 @@ export function resetCronRegistryForTests(): void {
 		clearOwnerSchedules(ownerId);
 	}
 	schedulesByOwner.clear();
+	notifyCronChange();
+}
+
+/** Module-level listeners notified whenever the cron schedule set changes. */
+const cronChangeListeners = new Set<() => void>();
+
+/** Subscribe to cron schedule-set changes. Returns an unsubscribe function. */
+export function onCronChange(cb: () => void): () => void {
+	cronChangeListeners.add(cb);
+	return () => {
+		cronChangeListeners.delete(cb);
+	};
+}
+
+function notifyCronChange(): void {
+	for (const cb of cronChangeListeners) {
+		try {
+			cb();
+		} catch (error) {
+			logger.warn("Cron change listener failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+}
+
+/** Snapshot the scheduled cron jobs for an owner (or all owners when omitted). */
+export function listCronSnapshots(ownerId?: string): CronJobSnapshot[] {
+	const out: CronJobSnapshot[] = [];
+	if (ownerId !== undefined) {
+		const state = schedulesByOwner.get(ownerKey(ownerId));
+		if (state) {
+			for (const record of state.jobs.values()) out.push(record.snapshot);
+		}
+		return out;
+	}
+	for (const state of schedulesByOwner.values()) {
+		for (const record of state.jobs.values()) out.push(record.snapshot);
+	}
+	return out;
+}
+
+/** Delete a scheduled cron job by id across all owners. Returns true when removed. */
+export function deleteCronJobById(id: string): boolean {
+	for (const key of schedulesByOwner.keys()) {
+		const ownerId = key === "__legacy__" ? undefined : key;
+		const state = schedulesByOwner.get(key);
+		if (state?.jobs.has(id)) {
+			return deleteRecord(ownerId, id);
+		}
+	}
+	return false;
 }
 
 const CRON_FIELD_BOUNDS: Array<{ name: string; min: number; max: number }> = [
@@ -448,6 +502,7 @@ function scheduleRecord(ownerId: string | undefined, state: OwnerScheduleState, 
 	});
 	record.snapshot.nextFireAt = fireAt;
 	record.timer = setCronTimeout(() => fireRecord(ownerId, state, record.snapshot.id), fireAt - now);
+	notifyCronChange();
 }
 
 function scheduleExpiry(ownerId: string | undefined, record: CronScheduleRecord): void {

--- a/packages/coding-agent/src/tools/cron.ts
+++ b/packages/coding-agent/src/tools/cron.ts
@@ -211,16 +211,9 @@ export function listCronSnapshots(ownerId?: string): CronJobSnapshot[] {
 	return out;
 }
 
-/** Delete a scheduled cron job by id across all owners. Returns true when removed. */
-export function deleteCronJobById(id: string): boolean {
-	for (const key of schedulesByOwner.keys()) {
-		const ownerId = key === "__legacy__" ? undefined : key;
-		const state = schedulesByOwner.get(key);
-		if (state?.jobs.has(id)) {
-			return deleteRecord(ownerId, id);
-		}
-	}
-	return false;
+/** Delete a scheduled cron job by owner-scoped id. Returns true when removed. */
+export function deleteCronJobById(ownerId: string | undefined, id: string): boolean {
+	return deleteRecord(ownerId, id);
 }
 
 const CRON_FIELD_BOUNDS: Array<{ name: string; min: number; max: number }> = [

--- a/packages/coding-agent/test/issue-953-repro.test.ts
+++ b/packages/coding-agent/test/issue-953-repro.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { SegmentContext } from "../src/modes/components/status-line/segments";
 import { renderSegment } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
 import { initTheme, theme } from "../src/modes/theme/theme";
 
 beforeAll(async () => {
@@ -33,6 +34,7 @@ function createCtx(usage: Partial<SegmentContext["usageStats"]>): SegmentContext
 		contextWindow: 0,
 		autoCompactEnabled: false,
 		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
 		sessionStartTime: Date.now(),
 		git: {
 			branch: null,

--- a/packages/coding-agent/test/jobs-observer.test.ts
+++ b/packages/coding-agent/test/jobs-observer.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AsyncJobManager } from "../src/async/job-manager";
+import { JobsObserver } from "../src/modes/jobs-observer";
+import { CronCreateTool, resetCronRegistryForTests } from "../src/tools/cron";
+import type { ToolSession } from "../src/tools/index";
+
+const OWNER = "0-Main";
+
+function makeManager(): AsyncJobManager {
+	return new AsyncJobManager({ onJobComplete: async () => {} });
+}
+
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+/** A run that stays "running" until the job is cancelled (abort-aware, so dispose settles it). */
+function abortable(signal: AbortSignal): Promise<string> {
+	return new Promise<string>(resolve => {
+		if (signal.aborted) return resolve("aborted");
+		signal.addEventListener("abort", () => resolve("aborted"), { once: true });
+	});
+}
+
+function registerMonitor(manager: AsyncJobManager, label: string, ownerId = OWNER): string {
+	return manager.register("bash", label, async ({ signal }) => abortable(signal), {
+		ownerId,
+		metadata: { monitor: true },
+	});
+}
+
+function createCronSession(): ToolSession {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		getSessionId: () => "test-session",
+		getAgentId: () => OWNER,
+		steer: () => {},
+		sendCustomMessage: async () => {},
+		allocateOutputArtifact: async () => ({}),
+	} as unknown as ToolSession;
+}
+
+afterEach(() => {
+	resetCronRegistryForTests();
+	AsyncJobManager.setInstance(undefined);
+});
+
+describe("JobsObserver", () => {
+	test("AC6 counts active monitor jobs only; ignores plain bash + task jobs", async () => {
+		const manager = makeManager();
+		const observer = new JobsObserver(manager, OWNER);
+
+		registerMonitor(manager, "tail log");
+		manager.register("bash", "plain", async ({ signal }) => abortable(signal), { ownerId: OWNER });
+		manager.register("task", "agent", async ({ signal }) => abortable(signal), { ownerId: OWNER });
+
+		const snapshot = observer.getSnapshot();
+		expect(snapshot.activeMonitorCount).toBe(1);
+		expect(snapshot.monitors.map(m => m.label)).toEqual(["tail log"]);
+		expect(snapshot.worstState).toBe("running");
+
+		observer.dispose();
+		await manager.dispose();
+	});
+
+	test("AC2/AC3 failure latches red until acknowledged; completed/failed not counted active", async () => {
+		const manager = makeManager();
+		const observer = new JobsObserver(manager, OWNER);
+
+		manager.register(
+			"bash",
+			"bad monitor",
+			async () => {
+				throw new Error("boom");
+			},
+			{ ownerId: OWNER, metadata: { monitor: true } },
+		);
+		await flush();
+
+		let snapshot = observer.getSnapshot();
+		expect(snapshot.activeMonitorCount).toBe(0);
+		expect(snapshot.worstState).toBe("failed");
+		expect(snapshot.failedUnacknowledged).toBe(true);
+
+		observer.acknowledgeFailures();
+		snapshot = observer.getSnapshot();
+		expect(snapshot.failedUnacknowledged).toBe(false);
+		expect(snapshot.worstState).toBe("none");
+
+		observer.dispose();
+		await manager.dispose();
+	});
+
+	test("failure already present at construction is latched immediately", async () => {
+		const manager = makeManager();
+		manager.register(
+			"bash",
+			"bad monitor",
+			async () => {
+				throw new Error("boom");
+			},
+			{ ownerId: OWNER, metadata: { monitor: true } },
+		);
+		await flush();
+
+		// Observer constructed AFTER the monitor already failed.
+		const observer = new JobsObserver(manager, OWNER);
+		const snapshot = observer.getSnapshot();
+		expect(snapshot.worstState).toBe("failed");
+		expect(snapshot.failedUnacknowledged).toBe(true);
+
+		observer.dispose();
+		await manager.dispose();
+	});
+
+	test("AC5/AC13 onChange fires (debounced) when a monitor registers", async () => {
+		const manager = makeManager();
+		const observer = new JobsObserver(manager, OWNER);
+		let fires = 0;
+		observer.onChange(() => {
+			fires += 1;
+		});
+
+		registerMonitor(manager, "m1");
+		registerMonitor(manager, "m2");
+		await flush();
+
+		expect(fires).toBeGreaterThanOrEqual(1);
+		observer.dispose();
+		await manager.dispose();
+	});
+
+	test("dispose unsubscribes: no notifications after dispose", async () => {
+		const manager = makeManager();
+		const observer = new JobsObserver(manager, OWNER);
+		let fires = 0;
+		observer.onChange(() => {
+			fires += 1;
+		});
+		observer.dispose();
+
+		registerMonitor(manager, "after dispose");
+		await flush();
+		expect(fires).toBe(0);
+
+		await manager.dispose();
+	});
+
+	test("AC6 cron jobs counted via the cron change hook + listing accessor", async () => {
+		const manager = makeManager();
+		AsyncJobManager.setInstance(manager);
+		const observer = new JobsObserver(manager, OWNER);
+		let fires = 0;
+		observer.onChange(() => {
+			fires += 1;
+		});
+
+		const tool = new CronCreateTool(createCronSession());
+		await tool.execute("call-1", { cron_expression: "*/5 * * * *", prompt: "/review-pr 1", recurring: true });
+		await flush();
+
+		const snapshot = observer.getSnapshot();
+		expect(snapshot.activeCronCount).toBe(1);
+		expect(snapshot.crons[0]?.recurring).toBe(true);
+		expect(snapshot.worstState).toBe("running");
+		expect(fires).toBeGreaterThanOrEqual(1);
+
+		observer.dispose();
+		await manager.dispose();
+	});
+});

--- a/packages/coding-agent/test/jobs-observer.test.ts
+++ b/packages/coding-agent/test/jobs-observer.test.ts
@@ -27,12 +27,12 @@ function registerMonitor(manager: AsyncJobManager, label: string, ownerId = OWNE
 	});
 }
 
-function createCronSession(): ToolSession {
+function createCronSession(ownerId = OWNER): ToolSession {
 	return {
 		cwd: process.cwd(),
 		hasUI: false,
 		getSessionId: () => "test-session",
-		getAgentId: () => OWNER,
+		getAgentId: () => ownerId,
 		steer: () => {},
 		sendCustomMessage: async () => {},
 		allocateOutputArtifact: async () => ({}),
@@ -164,6 +164,36 @@ describe("JobsObserver", () => {
 		expect(snapshot.worstState).toBe("running");
 		expect(fires).toBeGreaterThanOrEqual(1);
 
+		observer.dispose();
+		await manager.dispose();
+	});
+
+	test("deleteCron only removes jobs owned by the observer", async () => {
+		const manager = makeManager();
+		AsyncJobManager.setInstance(manager);
+		const observer = new JobsObserver(manager, OWNER);
+		const ownTool = new CronCreateTool(createCronSession(OWNER));
+		const otherTool = new CronCreateTool(createCronSession("0-Other"));
+
+		const own = await ownTool.execute("own", { cron_expression: "*/5 * * * *", prompt: "own", recurring: true });
+		const other = await otherTool.execute("other", {
+			cron_expression: "*/5 * * * *",
+			prompt: "other",
+			recurring: true,
+		});
+		if (!own.details || !other.details) throw new Error("Expected cron create details");
+		await flush();
+
+		expect(observer.getSnapshot().crons.map(cron => cron.id)).toEqual([own.details.id]);
+		expect(observer.deleteCron(other.details.id)).toBe(false);
+		expect(observer.getSnapshot().crons.map(cron => cron.id)).toEqual([own.details.id]);
+		expect(observer.deleteCron(own.details.id)).toBe(true);
+		await flush();
+		expect(observer.getSnapshot().crons).toHaveLength(0);
+
+		const otherObserver = new JobsObserver(manager, "0-Other");
+		expect(otherObserver.getSnapshot().crons.map(cron => cron.id)).toEqual([other.details.id]);
+		otherObserver.dispose();
 		observer.dispose();
 		await manager.dispose();
 	});

--- a/packages/coding-agent/test/jobs-overlay-model.test.ts
+++ b/packages/coding-agent/test/jobs-overlay-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { JobsOverlayComponent, type JobsOverlayController } from "../src/modes/components/jobs-overlay";
 import {
 	buildConfirmItems,
 	buildJobDetailItems,
@@ -17,6 +18,43 @@ function snapshot(over: Partial<JobsSnapshot> = {}): JobsSnapshot {
 		worstState: "none",
 		failedUnacknowledged: false,
 		...over,
+	};
+}
+
+function makeOverlayController(over: Partial<JobsSnapshot> = {}) {
+	const calls: string[] = [];
+	const controller: JobsOverlayController = {
+		acknowledgeFailures: () => calls.push("ack"),
+		getSnapshot: () => snapshot(over),
+		getMonitorOutput: () => "line one\nlast line\n",
+		cancelMonitor: id => {
+			calls.push(`cancel:${id}`);
+			return true;
+		},
+		deleteCron: id => {
+			calls.push(`delete:${id}`);
+			return true;
+		},
+	};
+	let closed = 0;
+	let renders = 0;
+	const overlay = new JobsOverlayComponent(controller, {
+		close: () => {
+			closed += 1;
+		},
+		requestRender: () => {
+			renders += 1;
+		},
+	});
+	return {
+		overlay,
+		calls,
+		get closed() {
+			return closed;
+		},
+		get renders() {
+			return renders;
+		},
 	};
 }
 
@@ -107,6 +145,65 @@ describe("jobs overlay model", () => {
 		expect(items[0]?.value).toBe("no");
 		expect(items[1]?.value).toBe("yes");
 		expect(items[1]?.label).toContain("delete this cron");
+	});
+
+	test("JobsOverlayComponent closes detail on Escape instead of reopening a stale list", () => {
+		const harness = makeOverlayController({
+			monitors: [{ id: "m1", label: "tail server.log", status: "running", startTime: Date.now() }],
+		});
+
+		harness.overlay.handleInput("\n");
+		expect(harness.overlay.render(100).join("\n")).toContain("Cancel this monitor");
+		harness.overlay.handleInput("\x1b");
+
+		expect(harness.closed).toBe(1);
+		expect(harness.calls).toEqual(["ack"]);
+	});
+
+	test("JobsOverlayComponent confirm accepts y and returns to list", () => {
+		const harness = makeOverlayController({
+			monitors: [{ id: "m1", label: "tail server.log", status: "running", startTime: Date.now() }],
+		});
+
+		harness.overlay.handleInput("\n");
+		harness.overlay.handleInput("\u001b[B");
+		harness.overlay.handleInput("\u001b[B");
+		harness.overlay.handleInput("\u001b[B");
+		harness.overlay.handleInput("\u001b[B");
+		harness.overlay.handleInput("\n");
+		expect(harness.overlay.render(100).join("\n")).toContain("Yes, cancel this monitor");
+		harness.overlay.handleInput("y");
+
+		expect(harness.calls).toEqual(["ack", "cancel:m1"]);
+		expect(harness.overlay.render(100).join("\n")).toContain("monitor · tail server.log");
+	});
+
+	test("JobsOverlayComponent confirm rejects n and Escape", () => {
+		for (const key of ["n", "\x1b"]) {
+			const harness = makeOverlayController({
+				crons: [
+					{
+						id: "c1",
+						humanSchedule: "every 5m",
+						cronExpression: "*/5 * * * *",
+						prompt: "poll deploys",
+						recurring: true,
+						createdAt: Date.now(),
+					},
+				],
+			});
+
+			harness.overlay.handleInput("\n");
+			harness.overlay.handleInput("\u001b[B");
+			harness.overlay.handleInput("\u001b[B");
+			harness.overlay.handleInput("\u001b[B");
+			harness.overlay.handleInput("\u001b[B");
+			harness.overlay.handleInput("\n");
+			harness.overlay.handleInput(key);
+
+			expect(harness.calls).toEqual(["ack"]);
+			expect(harness.overlay.render(100).join("\n")).toContain("Delete this cron");
+		}
 	});
 
 	test("formatRelative renders future/past/unknown", () => {

--- a/packages/coding-agent/test/jobs-overlay-model.test.ts
+++ b/packages/coding-agent/test/jobs-overlay-model.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildConfirmItems,
+	buildJobDetailItems,
+	buildJobsListItems,
+	formatRelative,
+	parseJobRef,
+} from "../src/modes/components/jobs-overlay-model";
+import type { JobsSnapshot } from "../src/modes/jobs-observer";
+
+function snapshot(over: Partial<JobsSnapshot> = {}): JobsSnapshot {
+	return {
+		monitors: [],
+		crons: [],
+		activeMonitorCount: 0,
+		activeCronCount: 0,
+		worstState: "none",
+		failedUnacknowledged: false,
+		...over,
+	};
+}
+
+describe("jobs overlay model", () => {
+	test("AC8 list is grouped Monitors-then-Crons preserving newest-first order", () => {
+		const items = buildJobsListItems(
+			snapshot({
+				monitors: [
+					{ id: "m2", label: "tail b", status: "running", startTime: 2 },
+					{ id: "m1", label: "tail a", status: "failed", startTime: 1 },
+				],
+				crons: [
+					{
+						id: "c2",
+						humanSchedule: "every 5m",
+						cronExpression: "*/5 * * * *",
+						prompt: "p2",
+						recurring: true,
+						createdAt: 2,
+					},
+					{
+						id: "c1",
+						humanSchedule: "at 09:00",
+						cronExpression: "0 9 * * *",
+						prompt: "p1",
+						recurring: false,
+						createdAt: 1,
+					},
+				],
+			}),
+		);
+		expect(items.map(i => i.value)).toEqual(["monitor:m2", "monitor:m1", "cron:c2", "cron:c1"]);
+		// failed monitor carries a failed hint
+		expect(items.find(i => i.value === "monitor:m1")?.hint).toBe("failed");
+	});
+
+	test("parseJobRef parses monitor/cron refs and rejects non-refs", () => {
+		expect(parseJobRef("monitor:abc")).toEqual({ kind: "monitor", id: "abc" });
+		expect(parseJobRef("cron:x")).toEqual({ kind: "cron", id: "x" });
+		expect(parseJobRef("noop")).toBeNull();
+		expect(parseJobRef("back")).toBeNull();
+		expect(parseJobRef("other:1")).toBeNull();
+	});
+
+	test("AC9 monitor detail shows status + last output line and a cancel action", () => {
+		const snap = snapshot({
+			monitors: [{ id: "m1", label: "tail server.log", status: "running", startTime: Date.now() }],
+		});
+		const items = buildJobDetailItems(snap, { kind: "monitor", id: "m1" }, "line one\nlast line\n");
+		const labels = items.map(i => i.label);
+		expect(labels).toContain("Status");
+		expect(items.find(i => i.label === "Output")?.description).toBe("last line");
+		expect(items.some(i => i.value === "action:cancel")).toBe(true);
+		expect(items.at(-1)?.value).toBe("back");
+	});
+
+	test("AC10 cron detail shows schedule/recurring/next-fire/prompt and a delete action", () => {
+		const snap = snapshot({
+			crons: [
+				{
+					id: "c1",
+					humanSchedule: "every 5m",
+					cronExpression: "*/5 * * * *",
+					prompt: "review the PR queue",
+					recurring: true,
+					nextFireAt: Date.now() + 300_000,
+					createdAt: Date.now(),
+				},
+			],
+		});
+		const items = buildJobDetailItems(snap, { kind: "cron", id: "c1" });
+		const labels = items.map(i => i.label);
+		expect(labels).toContain("Schedule");
+		expect(labels).toContain("Recurring");
+		expect(labels).toContain("Next fire");
+		expect(labels).toContain("Prompt");
+		expect(items.some(i => i.value === "action:delete")).toBe(true);
+	});
+
+	test("detail for a missing job degrades to a back row", () => {
+		const items = buildJobDetailItems(snapshot(), { kind: "monitor", id: "ghost" });
+		expect(items).toHaveLength(1);
+		expect(items[0]?.value).toBe("back");
+	});
+
+	test("AC11/AC12 confirm items put the safe (No) option first", () => {
+		const items = buildConfirmItems("delete this cron");
+		expect(items[0]?.value).toBe("no");
+		expect(items[1]?.value).toBe("yes");
+		expect(items[1]?.label).toContain("delete this cron");
+	});
+
+	test("formatRelative renders future/past/unknown", () => {
+		const now = 1_000_000;
+		expect(formatRelative(now + 300_000, now)).toBe("in 5m");
+		expect(formatRelative(now - 120_000, now)).toBe("2m ago");
+		expect(formatRelative(undefined, now)).toBe("—");
+	});
+});

--- a/packages/coding-agent/test/jobs-segment.test.ts
+++ b/packages/coding-agent/test/jobs-segment.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
+import { renderSegment, type SegmentContext } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../src/modes/jobs-observer";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function makeCtx(jobs: JobsSnapshot): SegmentContext {
+	return {
+		session: { state: {} } as unknown as SegmentContext["session"],
+		width: 120,
+		options: {},
+		planMode: null,
+		goalMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		jobs,
+		sessionStartTime: Date.now(),
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+describe("jobs status-line segment", () => {
+	test("AC2 hidden when idle (no active jobs, no failure)", () => {
+		const rendered = renderSegment("jobs", makeCtx(EMPTY_JOBS_SNAPSHOT));
+		expect(rendered.visible).toBe(false);
+		expect(rendered.content).toBe("");
+	});
+
+	test("AC1 shows monitor and cron counts when active", () => {
+		const rendered = renderSegment(
+			"jobs",
+			makeCtx({
+				...EMPTY_JOBS_SNAPSHOT,
+				activeMonitorCount: 2,
+				activeCronCount: 3,
+				worstState: "running",
+			}),
+		);
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("2");
+		expect(rendered.content).toContain("3");
+	});
+
+	test("AC2/AC3 stays visible (red) on unacknowledged failure even with zero active", () => {
+		const rendered = renderSegment(
+			"jobs",
+			makeCtx({
+				...EMPTY_JOBS_SNAPSHOT,
+				worstState: "failed",
+				failedUnacknowledged: true,
+			}),
+		);
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content.length).toBeGreaterThan(0);
+	});
+
+	test("AC4 jobs segment is present in the right side of every preset", () => {
+		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
+			expect(preset.rightSegments, `preset ${name} should include jobs`).toContain("jobs");
+		}
+	});
+});

--- a/packages/coding-agent/test/jobs-segment.test.ts
+++ b/packages/coding-agent/test/jobs-segment.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { StatusLineComponent } from "../src/modes/components/status-line";
 import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
 import { renderSegment, type SegmentContext } from "../src/modes/components/status-line/segments";
 import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../src/modes/jobs-observer";
@@ -33,6 +34,36 @@ function makeCtx(jobs: JobsSnapshot): SegmentContext {
 		git: { branch: null, status: null, pr: null },
 		usage: null,
 	};
+}
+
+function makeStatusLineSession(running: Array<{ id: string; type: "bash" | "task"; metadata?: { monitor?: true } }>) {
+	return {
+		state: { messages: [] },
+		isStreaming: false,
+		getAsyncJobSnapshot: () => ({
+			running: running.map(job => ({
+				...job,
+				status: "running" as const,
+				label: job.id,
+				startTime: Date.now(),
+			})),
+			recent: [],
+			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+		}),
+		getCurrentModel: () => undefined,
+		isFastModeEnabled: () => false,
+		sessionManager: {
+			getSessionName: () => "test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
 }
 
 describe("jobs status-line segment", () => {
@@ -74,5 +105,39 @@ describe("jobs status-line segment", () => {
 		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
 			expect(preset.rightSegments, `preset ${name} should include jobs`).toContain("jobs");
 		}
+	});
+
+	test("status line does not append legacy job count for a monitor already shown in jobs segment", () => {
+		const component = new StatusLineComponent(
+			makeStatusLineSession([{ id: "monitor-1", type: "bash", metadata: { monitor: true } }]),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["jobs"],
+			showSkillHud: false,
+		});
+		component.setJobs({
+			...EMPTY_JOBS_SNAPSHOT,
+			activeMonitorCount: 1,
+			worstState: "running",
+		});
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("1");
+		expect(rendered).not.toContain("job running");
+	});
+
+	test("status line keeps legacy job count for non-monitor background jobs", () => {
+		const component = new StatusLineComponent(makeStatusLineSession([{ id: "task-1", type: "task" }]));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["jobs"],
+			showSkillHud: false,
+		});
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("job running");
 	});
 });

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -9,6 +9,7 @@ import type { StatusLineSegmentId } from "../src/config/settings-schema";
 import { StatusLineComponent } from "../src/modes/components/status-line";
 import type { SegmentContext } from "../src/modes/components/status-line/segments";
 import { renderSegment } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
 import { initTheme, theme } from "../src/modes/theme/theme";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../src/utils/session-color";
 
@@ -57,6 +58,7 @@ function createCtx(overrides?: { pathMaxLength?: number; branch?: string | null 
 		contextWindow: 0,
 		autoCompactEnabled: false,
 		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
 		sessionStartTime: Date.now(),
 		git: {
 			branch: overrides?.branch ?? null,

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { getProjectDir, setProjectDir } from "@gajae-code/utils";
 import type { SegmentContext } from "../src/modes/components/status-line/segments";
 import { renderSegment } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
 
 import { initTheme, theme } from "../src/modes/theme/theme";
 
@@ -44,6 +45,7 @@ function createPathContext(): SegmentContext {
 		contextWindow: 0,
 		autoCompactEnabled: false,
 		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
 		sessionStartTime: Date.now(),
 		git: {
 			branch: null,


### PR DESCRIPTION
## Summary

Adds a component to the default status bar (the rail above the chat composer) that visualizes ongoing **monitor** and **cron** jobs at a glance, and a keyboard/command-opened overlay to navigate into per-job detail and cancel/delete jobs.

Built from the approved consensus plan (`.gjc/plans/ralplan/2026-06-04-1332-9ead/`) and deep-interview spec (`.gjc/specs/deep-interview-monitor-cron-jobs-bar.md`, AC1–AC13).

### Component 1 — bar indicator (AC1–AC6)
- Event-driven (no polling): new `onChange` hooks on `AsyncJobManager` and the cron module fire on every live-set mutation. `JobsObserver` aggregates both, keeps a **stored snapshot** recomputed on change (the segment render reads the snapshot only), and uses a sticky, id-tracked **failure latch** so a failed job that evicts before you look still shows red until you open the overlay (acknowledged).
- New `jobs` status-line segment in **all presets** (right side; nerd glyph / ascii text), hidden when idle, red on failure. Mirrors the existing `subagents` count-segment + observer pattern.
- Monitor jobs are tagged (`metadata.monitor`) so the widget scopes to monitors (not plain async bash).

### Component 2 — detail navigation (AC7–AC13)
- Opened via the **`/monitors`** command and the **`app.jobs.open`** hotkey.
- Nested-`SelectList` overlay: list (grouped **Monitors then Crons**, newest-first) → per-type **detail** (monitor → bounded output tail; cron → schedule + prompt + next-fire) → **y/N confirm** → cancel monitor / delete cron.

### Hotkey decision
The spec requested **Ctrl+J**, but it was **empirically verified** to decode as `enter` (LF `0x0a` == Enter) — indistinguishable from submit. **Ctrl+B** is the editor's cursor-left binding. Per the approved fallback, the default is **`Alt+J`** (decodes distinctly; unused by editor/app bindings) plus the always-available `/monitors` command. The existing text-based `/jobs` command is left untouched.

## Testing
- New unit suites: `jobs-observer.test.ts`, `jobs-segment.test.ts`, `jobs-overlay-model.test.ts` (counts/visibility/color, failure latch incl. construction-time, grouping/ordering, detail items, cancel/delete dispatch).
- `tsc --noEmit` clean for `packages/coding-agent`; `biome check` clean on changed files.
- 75 affected existing tests pass (status-line, async-job-manager/output, monitor-cron-tools, resume-queue) — no regressions.

## Review trail
- Consensus plan: Planner → Architect → Critic (APPROVE, pass 2) under run `2026-06-04-1332-9ead`.
- Implementation architect review: 2 HIGH findings (keybinding conflict, stored-snapshot) resolved; 2 MEDIUM accepted/out-of-scope (top-level cancel scoping is intentional; pre-existing async rail segment).
