### PR TITLE
test(tui): initialize settings in jobs segment status-line tests

### DIFF
--- a/packages/coding-agent/test/jobs-segment.test.ts
+++ b/packages/coding-agent/test/jobs-segment.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { StatusLineComponent } from "../src/modes/components/status-line";
 import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
 import { renderSegment, type SegmentContext } from "../src/modes/components/status-line/segments";
@@ -7,6 +8,10 @@ import { initTheme } from "../src/modes/theme/theme";
 
 beforeAll(async () => {
 	await initTheme();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+});
+afterAll(() => {
+	resetSettingsForTest();
 });
 
 function makeCtx(jobs: JobsSnapshot): SegmentContext {


### PR DESCRIPTION
## 0.3.1 RC dogfood evidence

Candidate: `origin/dev` / `e13b2b7fc4c51844c74a89e2aac8b3ee5b8e7dc3`
Branch: `dogfood-031-rc`

### Command categories and results

| Category | Result |
|---|---:|
| Setup: `bun install --frozen-lockfile` | pass |
| Setup: `bun run build:native` | pass |
| Smoke: `bun run ci:test:smoke` | pass |
| Bridge/RPC/agent-wire + bridge-client focused tests | pass: 71 pass, 13 skip, 0 fail |
| GJC workflow state/receipts/deep-interview/ralplan/ultragoal/state guards | pass: 314 pass, 0 fail |
| Harness control plane / owner lifecycle / liveness | pass: 130 pass, 0 fail |
| Task/subagent spawn gates / receipts / ROI | pass: 136 pass, 0 fail |
| TUI jobs/status-line/editor/input/deep-interview/clipboard/perf | initially failed: 310 pass, 2 fail; after fix: 312 pass, 0 fail |
| Telemetry/crash/runtime diagnostics + orchestration benchmark/default reductions | pass: 116 pass, 0 fail |
| CLI surfaces: `--help`, `skills`, `ultragoal`, `harness`, `state`, `state doctor/read`, `deep-interview`, `ralplan` | pass |
| Safe CLI state/ultragoal commands from `/tmp` | pass |
| Focused check on changed file: Biome check | pass |
| Focused test after commit candidate: `bun test packages/coding-agent/test/jobs-segment.test.ts` | pass: 6 pass, 0 fail |

### Setup prerequisites discovered

- Source checkout requires `bun install --frozen-lockfile`.
- Native addon build is required for this checkout path: `bun run build:native`.
- No unexpected setup contradiction found.

### Release-blocking issue fixed

The changed-surface TUI jobs/status-line test file was not initializing `Settings` before constructing `StatusLineComponent`, causing a reproducible focused test failure:

- `bun test packages/coding-agent/test/jobs-segment.test.ts`
- Failure: `Settings not initialized. Call Settings.init() first.`

This PR initializes in-memory settings in the test `beforeAll` and resets them in `afterAll`. The focused test now passes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*