### PR TITLE
Fix stale workflow state phases

### DIFF
--- a/packages/coding-agent/src/commands/state.ts
+++ b/packages/coding-agent/src/commands/state.ts
@@ -9,7 +9,7 @@ export default class State extends Command {
 		'$ gjc state write --input \'{"state":{"interview_id":"abc"}}\' --mode deep-interview --json',
 		"$ gjc state clear --mode deep-interview",
 		"$ gjc state deep-interview read --json",
-		'$ gjc state ralplan write --input \'{"phase":"approval","active":true}\' --json',
+		'$ gjc state ralplan write --input \'{"phase":"planner","active":true}\' --json',
 		"$ gjc state team contract",
 		"$ gjc state deep-interview handoff --to ralplan --json",
 		"$ gjc state doctor --skill ralplan --json",

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -125,7 +125,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
 ```json
 {
   "active": true,
-  "current_phase": "deep-interview",
+  "current_phase": "interviewing",
   "state": {
     "interview_id": "<uuid>",
     "type": "greenfield|brownfield",

--- a/packages/coding-agent/test/workflow-state-command.test.ts
+++ b/packages/coding-agent/test/workflow-state-command.test.ts
@@ -81,6 +81,28 @@ describe("gjc state workflow command", () => {
 		});
 	}, 30_000);
 
+	it("rejects stale workflow phases without force", async () => {
+		await withTempCwd(async cwd => {
+			for (const { skill, phase } of [
+				{ skill: "deep-interview", phase: "initializing" },
+				{ skill: "ralplan", phase: "approval" },
+			] as const) {
+				const result = runState(cwd, [
+					"write",
+					"--session-id",
+					`session-${skill}-${phase}`,
+					"--input",
+					JSON.stringify({ skill, current_phase: phase, active: true }),
+					"--json",
+				]);
+
+				expect(result.exitCode).toBe(2);
+				expect(result.stderr.toString()).toContain(`unknown ${skill} phase "${phase}"`);
+				expect(result.stderr.toString()).toContain("use --force to bypass");
+			}
+		});
+	}, 20_000);
+
 	it("infers read skill from session context and prefers incoming phase transitions", async () => {
 		await withTempCwd(async cwd => {
 			const initial = runState(cwd, [


### PR DESCRIPTION
Closes #285

## Summary
- Updated the `gjc state` CLI example to use the canonical ralplan `planner` phase instead of stale `approval`.
- Updated bundled deep-interview initialization guidance to use canonical `interviewing` phase.
- Added regression coverage proving stale `initializing`/`approval` phases still fail closed without `--force`.

## Verification
- `bun test packages/coding-agent/test/workflow-state-command.test.ts`
- `bun run check:tools`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`

## Risk notes
- Minimal harness/docs/test-only phase reference changes.
- The manifest-driven phase allowlist remains unchanged, preserving fail-closed behavior for invalid phases unless `--force` is explicitly used.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
