### PR TITLE
Fix ralplan corrupt state fail-open

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -165,16 +165,19 @@ function ralplanStatePath(cwd: string, sessionId: string | undefined): string {
 }
 
 async function readActiveRunId(cwd: string, sessionId: string | undefined): Promise<string | undefined> {
-	try {
-		const raw = await fs.readFile(ralplanStatePath(cwd, sessionId), "utf-8");
-		const parsed = JSON.parse(raw) as { run_id?: unknown };
-		const candidate = typeof parsed.run_id === "string" ? parsed.run_id.trim() : "";
-		if (!candidate) return undefined;
-		assertSafePathComponent(candidate, "run-id");
-		return candidate;
-	} catch {
-		return undefined;
+	const statePath = ralplanStatePath(cwd, sessionId);
+	const existingRead = await readExistingStateForMutation(statePath);
+	if (existingRead.kind === "absent") return undefined;
+	if (existingRead.kind === "corrupt") {
+		throw new RalplanCommandError(
+			2,
+			`existing ralplan state is corrupt or tampered (${existingRead.error}); refusing to overwrite ${statePath}`,
+		);
 	}
+	const candidate = typeof existingRead.value.run_id === "string" ? existingRead.value.run_id.trim() : "";
+	if (!candidate) return undefined;
+	assertSafePathComponent(candidate, "run-id");
+	return candidate;
 }
 
 async function persistActiveRunId(cwd: string, sessionId: string | undefined, runId: string): Promise<void> {

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -44,6 +44,39 @@ describe("native gjc ralplan runtime — consensus handoff", () => {
 		expect(payload.task).toBeUndefined();
 	});
 
+	it("rejects corrupt ralplan state before consensus handoff seeding", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(statePath, "{broken json", "utf-8");
+
+		const result = await runNativeRalplanCommand(["--json", "make state native"], root);
+
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("existing ralplan state is corrupt or tampered");
+		expect(await fs.readFile(statePath, "utf-8")).toBe("{broken json");
+	});
+
+	it("reuses a valid active run id during consensus handoff seeding", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(
+			statePath,
+			JSON.stringify({ skill: "ralplan", active: true, current_phase: "planner", run_id: "existing-run" }),
+			"utf-8",
+		);
+
+		const result = await runNativeRalplanCommand(["--json", "continue existing"], root);
+
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}") as { run_id: string };
+		expect(payload.run_id).toBe("existing-run");
+		const state = JSON.parse(await fs.readFile(statePath, "utf-8")) as { run_id: string; task: string };
+		expect(state.run_id).toBe("existing-run");
+		expect(state.task).toBe("continue existing");
+	});
+
 	it("--architect openai-code seeds the kind into state", async () => {
 		const root = await tempDir();
 		const result = await runNativeRalplanCommand(


### PR DESCRIPTION
Closes #289

## Summary
- Make ralplan active run-id discovery use the mutation-safe state read path.
- Reject corrupt or tampered `ralplan-state.json` before consensus kickoff or artifact write can overwrite it.
- Preserve missing-state creation and valid active-run reuse behavior.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts`
- `gjc ralplan --write` regression via `bun packages/coding-agent/src/cli.ts ralplan --write --stage planner --stage_n 1 --artifact '# Plan' --json` against a corrupt `.gjc/state/ralplan-state.json` (exited 2; state remained unchanged)
- `bun run build:native` (to enable CLI regression in this worktree)
- `bun run check:ts`

## Risk notes
- Minimal runtime change: the old broad catch is replaced with existing strict mutation-read semantics.
- ENOENT remains absence-only and still creates a fresh run.
- Valid `run_id` reuse remains unchanged; corrupt state now fails closed instead of being overwritten.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
