### PR TITLE
Fail closed on corrupt deep-interview state

### DIFF
--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -21,6 +21,7 @@ export default class DeepInterview extends Command {
 		deliberate: Flags.boolean({
 			description: "Shortcut for --write handoff to ralplan in deliberate consensus mode",
 		}),
+		force: Flags.boolean({ description: "Overwrite corrupt existing deep-interview state during --write" }),
 		json: Flags.boolean({ description: "Output JSON" }),
 	};
 	static examples = [

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -7,7 +7,7 @@ import { buildDeepInterviewHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import { runNativeRalplanCommand } from "./ralplan-runtime";
 import { runNativeStateCommand } from "./state-runtime";
-import { appendJsonl, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
+import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
 
 /**
  * Native implementation of `gjc deep-interview`.
@@ -96,16 +96,6 @@ function deepInterviewStatePath(cwd: string, sessionId: string | undefined): str
 	return path.join(stateDirFor(cwd, sessionId), "deep-interview-state.json");
 }
 
-async function readJsonObject(filePath: string): Promise<Record<string, unknown>> {
-	try {
-		const parsed = JSON.parse(await fs.readFile(filePath, "utf-8"));
-		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
-	} catch {
-		// Missing/corrupt state should not prevent the sanctioned persistence CLI from writing a receipt.
-	}
-	return {};
-}
-
 async function resolveSpecContent(rawSpec: string, cwd: string): Promise<string> {
 	const candidate = path.isAbsolute(rawSpec) ? rawSpec : path.resolve(cwd, rawSpec);
 	try {
@@ -145,6 +135,7 @@ export interface ResolvedDeepInterviewSpecWriteArgs {
 	json: boolean;
 	deliberate: boolean;
 	handoff?: "ralplan";
+	force: boolean;
 }
 
 export interface PersistedDeepInterviewSpec {
@@ -299,6 +290,7 @@ async function resolveSpecWriteArgs(args: readonly string[], cwd: string): Promi
 		"--handoff",
 		"--deliberate",
 		"--json",
+		"--force",
 	]);
 	let skipNext = false;
 	for (const arg of args) {
@@ -322,6 +314,7 @@ async function resolveSpecWriteArgs(args: readonly string[], cwd: string): Promi
 		sessionId,
 		json: hasFlag(args, "--json"),
 		deliberate: hasFlag(args, "--deliberate"),
+		force: hasFlag(args, "--force"),
 		handoff: rawHandoff as "ralplan" | undefined,
 	};
 }
@@ -395,6 +388,16 @@ export async function persistDeepInterviewSpec(
 	cwd: string,
 	resolved: ResolvedDeepInterviewSpecWriteArgs,
 ): Promise<PersistedDeepInterviewSpec> {
+	const statePath = deepInterviewStatePath(cwd, resolved.sessionId);
+	const existingRead = await readExistingStateForMutation(statePath);
+	if (existingRead.kind === "corrupt" && !resolved.force) {
+		throw new DeepInterviewCommandError(
+			2,
+			`existing deep-interview state is corrupt or tampered (${existingRead.error}); use --force to overwrite ${statePath}`,
+		);
+	}
+	const existing = existingRead.kind === "valid" ? existingRead.value : {};
+
 	const specPath = path.join(cwd, ".gjc", "specs", `deep-interview-${resolved.slug}.md`);
 	const content = resolved.spec.endsWith("\n") ? resolved.spec : `${resolved.spec}\n`;
 	await writeArtifact(specPath, content, {
@@ -410,8 +413,6 @@ export async function persistDeepInterviewSpec(
 		{ cwd, audit: { category: "ledger", verb: "append", owner: "gjc-runtime", skill: "deep-interview" } },
 	);
 
-	const statePath = deepInterviewStatePath(cwd, resolved.sessionId);
-	const existing = await readJsonObject(statePath);
 	const payload: Record<string, unknown> = {
 		...existing,
 		active: true,
@@ -436,7 +437,13 @@ export async function persistDeepInterviewSpec(
 			sessionId: resolved.sessionId,
 			nowIso: createdAt,
 		},
-		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
+		audit: {
+			category: "state",
+			verb: "write",
+			owner: "gjc-runtime",
+			skill: "deep-interview",
+			forced: resolved.force,
+		},
 	});
 	await syncDeepInterviewHud({
 		cwd,

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -47,6 +47,69 @@ describe("native gjc deep-interview runtime", () => {
 		expect(source).toContain("handoff: Flags.string");
 	});
 
+	it("handles missing, valid, and corrupt deep-interview state during spec persistence", async () => {
+		const missingRoot = await tempDir();
+		const missing = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "missing-state", "--spec", "# Missing", "--json"],
+			missingRoot,
+		);
+		expect(missing.status).toBe(0);
+		const missingState = JSON.parse(
+			await fs.readFile(path.join(missingRoot, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
+		);
+		expect(missingState.spec_slug).toBe("missing-state");
+
+		const validRoot = await tempDir();
+		const validStatePath = path.join(validRoot, ".gjc", "state", "deep-interview-state.json");
+		await fs.mkdir(path.dirname(validStatePath), { recursive: true });
+		await fs.writeFile(
+			validStatePath,
+			`${JSON.stringify({ transcript: [{ question: "q", answer: "a" }], current_phase: "interviewing" })}\n`,
+			"utf-8",
+		);
+		const valid = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "valid-state", "--spec", "# Valid", "--json"],
+			validRoot,
+		);
+		expect(valid.status).toBe(0);
+		const validState = JSON.parse(await fs.readFile(validStatePath, "utf-8"));
+		expect(validState.transcript).toEqual([{ question: "q", answer: "a" }]);
+		expect(validState.spec_slug).toBe("valid-state");
+	});
+
+	it("fails closed on corrupt deep-interview state unless --force is supplied", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "deep-interview-state.json");
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(statePath, '{"current_phase":', "utf-8");
+
+		const rejected = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "corrupt-rejected", "--spec", "# Rejected", "--json"],
+			root,
+		);
+		expect(rejected.status).toBe(2);
+		expect(rejected.stderr).toContain("existing deep-interview state is corrupt or tampered");
+		expect(rejected.stderr).toContain("use --force to overwrite");
+		expect(await fs.readFile(statePath, "utf-8")).toBe('{"current_phase":');
+		await expect(fs.access(path.join(root, ".gjc", "specs", "deep-interview-corrupt-rejected.md"))).rejects.toThrow();
+
+		const forced = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "corrupt-forced", "--spec", "# Forced", "--force", "--json"],
+			root,
+		);
+		expect(forced.status).toBe(0);
+		const forcedState = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(forcedState.spec_slug).toBe("corrupt-forced");
+		expect(forcedState.receipt).toMatchObject({ skill: "deep-interview", owner: "gjc-runtime" });
+		const audit = (await fs.readFile(path.join(root, ".gjc", "state", "audit.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+		expect(
+			audit.some(entry => entry.skill === "deep-interview" && entry.verb === "write" && entry.forced === true),
+		).toBe(true);
+	});
+
 	it("persists a final spec under .gjc/specs through the native CLI/API", async () => {
 		const root = await tempDir();
 		const specPath = path.join(root, "final-spec.md");


### PR DESCRIPTION
Closes #288

## Summary
- Replaced deep-interview spec persistence fail-open JSON reads with the strict mutation reader.
- Corrupt existing `deep-interview-state.json` now fails closed unless `--force` is supplied.
- Added `--force` to the native deep-interview write surface and records forced state writes in audit entries.
- Added focused regression coverage for missing, valid, corrupt-no-force, and corrupt-force state paths.

## Verification
- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts`
- `bun run check:ts`

## Risk notes
- Missing state still initializes normally.
- Valid state continues to merge existing metadata/transcript values.
- Corrupt state no longer writes spec artifacts before the state gate passes, avoiding partial persistence on rejection.
- `--force` overwrites corrupt state with receipt/audit evidence.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*