### PR TITLE
Fix queued steer double Escape race

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -33,9 +33,9 @@ function isExpandable(obj: unknown): obj is Expandable {
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
-	/** Set while a first Esc is silently consuming a queued steer (abort +
-	 *  steer-on-interrupt continue). A second Esc within that window does a real
-	 *  abort instead of consuming the steer again. */
+	/** Set after a first Esc silently consumes a queued steer. Kept until the
+	 *  queued steer is either cancelled by a second Esc or drained by continuation,
+	 *  so abort cleanup going idle cannot turn the second Esc into an idle action. */
 	#steerConsumePending = false;
 
 	#abortInteractive(options?: { silent?: boolean }): Promise<void> {
@@ -52,6 +52,7 @@ export class InputController {
 			Boolean(
 				this.ctx.loadingAnimation ||
 					this.ctx.hasActiveBtw() ||
+					(this.#steerConsumePending && this.ctx.session.hasQueuedSteering) ||
 					this.ctx.session.isStreaming ||
 					this.ctx.session.isCompacting ||
 					this.ctx.session.isGeneratingHandoff ||
@@ -65,6 +66,17 @@ export class InputController {
 		this.ctx.editor.onEscape = () => {
 			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
 				return;
+			}
+			if (this.#steerConsumePending) {
+				if (this.ctx.session.hasQueuedSteering) {
+					// Second Esc before the scheduled steer continuation drains the
+					// queue: restore/drop the queued steer and perform a real abort,
+					// even if abort cleanup already made the session look idle.
+					this.#steerConsumePending = false;
+					this.restoreQueuedMessagesToEditor({ abort: true });
+					return;
+				}
+				this.#steerConsumePending = false;
 			}
 			if (this.ctx.loadingAnimation) {
 				if (this.ctx.cancelPendingSubmission()) {
@@ -90,14 +102,7 @@ export class InputController {
 					// auto-continue via steer-on-interrupt instead of stalling on
 					// "Operation aborted".
 					this.#steerConsumePending = true;
-					void this.#abortInteractive({ silent: true }).finally(() => {
-						this.#steerConsumePending = false;
-					});
-				} else if (this.#steerConsumePending) {
-					// Second Esc before the steer-continue lands: drop the still-queued
-					// steer (restoring its text to the editor) and do a real abort.
-					this.#steerConsumePending = false;
-					this.restoreQueuedMessagesToEditor({ abort: true });
+					void this.#abortInteractive({ silent: true });
 				} else {
 					void this.#abortInteractive();
 				}

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -341,4 +341,24 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort.mock.calls[1]?.[0]?.silent).toBeUndefined();
 		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
 	});
+
+	it("cancels a queued steer on second Esc after silent abort cleanup goes idle", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		spies.clearQueue.mockReturnValue({ steering: ["stop after this"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		(ctx.session as { isStreaming: boolean }).isStreaming = false;
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(2);
+		expect(spies.abort.mock.calls[0]?.[0]).toMatchObject({ silent: true });
+		expect(spies.abort.mock.calls[1]?.[0]?.silent).toBeUndefined();
+		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("stop after this");
+		expect(editor.shouldBypassAutocompleteOnEscape?.()).toBe(false);
+	});
 });


### PR DESCRIPTION
Closes #293

## Summary
- Keep the queued-steer consume marker alive until the queued steer drains or a second Escape cancels it.
- Handle pending steer cancellation before the streaming/idle split so a second Escape after abort cleanup restores/drops the queued steer instead of falling into idle behavior.
- Added an input-controller regression for the race where the first silent abort leaves the session idle before the scheduled continue consumes the queue.

## Verification
- `bun test packages/coding-agent/test/input-controller-escape.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Risk notes
- Minimal TUI input-controller change scoped to Escape handling when a queued steer is pending.
- Preserves fail-closed behavior: second Escape clears the queued steer and performs a real user interrupt rather than auto-continuing.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*