### PR TITLE
Reject inherited context in independent tasks

### DIFF
--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -26,6 +26,7 @@ Subagents have no conversation history. Every fact, file path, and direction the
 {{#if contextEnabled}}
 - `.inheritContext` (optional): fork-context mode for seeding the subagent with sanitized parent conversation. Omit it or set `"none"` for no copied context. `"receipt"` copies a minimal receipt-sized snapshot, `"last-turn"` copies only the latest exchange, `"bounded"` copies the bounded default snapshot, and `"full"` copies a larger snapshot up to the configured/model token cap. Non-`none` modes work only when global `task.forkContext.enabled` is true and the target agent declares `forkContext: allowed`; otherwise the call is rejected. Bundled agents that support it: `executor`, `architect`. Use inherited context only when the subagent's value depends on parent context; cloned tokens are billed to the child as fresh input and surfaced in task receipts as fork-context cloned-token accounting.
 {{/if}}
+{{#if independentMode}}- `.inheritContext`: independent mode cannot inherit parent conversation. Omit it or set `"none"`; any non-`none` value is rejected before scheduling.{{/if}}
 {{#if customSchemaEnabled}}- `schema`: JTD schema for expected structured output (do not put format rules in assignments){{/if}}
 - `spawnPlan` (optional): required before any batch with more than 4 tasks, and before a reviewer agent spawns `explore`; include whyParallel, whyNotLocal, independence, expectedReceiptShape, and maxInlineTokens.
 {{#if isolationEnabled}}- `isolated`: run in isolated env; use when tasks edit overlapping files{{/if}}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -215,6 +215,14 @@ function validateTaskModeParams(simpleMode: TaskSimpleMode, params: TaskParams):
 	if (!customSchemaEnabled && params.schema !== undefined) {
 		disallowedFields.push("schema");
 	}
+	if (!contextEnabled) {
+		const inheritedTaskIds = (params.tasks ?? [])
+			.filter(task => task.inheritContext !== undefined && task.inheritContext !== "none")
+			.map(task => task.id);
+		if (inheritedTaskIds.length > 0) {
+			disallowedFields.push(`inheritContext for task(s) ${inheritedTaskIds.join(", ")}`);
+		}
+	}
 	if (disallowedFields.length === 0) {
 		return undefined;
 	}
@@ -224,10 +232,10 @@ function validateTaskModeParams(simpleMode: TaskSimpleMode, params: TaskParams):
 	}
 
 	if (disallowedFields.length === 1) {
-		return `task.simple is set to independent, so the task tool does not accept \`${disallowedFields[0]}\`. Put everything the subagent needs inside each task assignment.`;
+		return `task.simple is set to independent, so the task tool does not accept ${disallowedFields[0].startsWith("inheritContext") ? disallowedFields[0] : `\`${disallowedFields[0]}\``}. Put everything the subagent needs inside each task assignment.`;
 	}
 
-	return "task.simple is set to independent, so the task tool does not accept `context` or `schema`. Put all required background and output expectations inside each task assignment or the selected agent definition.";
+	return `task.simple is set to independent, so the task tool does not accept ${disallowedFields.map(field => (field.startsWith("inheritContext") ? field : `\`${field}\``)).join(", ")}. Put all required background and output expectations inside each task assignment or the selected agent definition.`;
 }
 
 function getForkContextPolicy(agent: AgentDefinition): ForkContextPolicy {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -81,7 +81,7 @@ const createTaskItemSchema = (_contextEnabled: boolean) =>
 			.enum(["none", "receipt", "last-turn", "bounded", "full"])
 			.optional()
 			.describe(
-				"fork-context mode: none/omitted copies no parent context; receipt copies a minimal receipt-sized snapshot; last-turn copies only the latest exchange; bounded copies the sanitized bounded default; full copies a larger sanitized snapshot up to the configured/model token cap",
+				"fork-context mode: none/omitted copies no parent context; receipt copies a minimal receipt-sized snapshot; last-turn copies only the latest exchange; bounded copies the bounded default snapshot; full copies a larger sanitized snapshot up to the configured/model token cap",
 			),
 	});
 
@@ -91,7 +91,18 @@ export type TaskItem = z.infer<typeof taskItemSchema>;
 
 const createTaskSchema = (options: { isolationEnabled: boolean; simpleMode: TaskSimpleMode }) => {
 	const { contextEnabled, customSchemaEnabled } = getTaskSimpleModeCapabilities(options.simpleMode);
-	const itemSchema = createTaskItemSchema(contextEnabled);
+	let itemSchema = createTaskItemSchema(contextEnabled);
+	if (!contextEnabled) {
+		itemSchema = itemSchema.superRefine((item, ctx) => {
+			if (item.inheritContext !== undefined && item.inheritContext !== "none") {
+				ctx.addIssue({
+					code: "custom",
+					path: ["inheritContext"],
+					message: "Independent tasks cannot inherit parent context; omit inheritContext or set it to none.",
+				});
+			}
+		});
+	}
 
 	let schema = z.object({
 		agent: z.string().describe("agent type"),

--- a/packages/coding-agent/test/task-fork-context.test.ts
+++ b/packages/coding-agent/test/task-fork-context.test.ts
@@ -10,7 +10,7 @@ import { TaskTool } from "../src/task";
 import { getBundledAgent } from "../src/task/agents";
 import * as discoveryModule from "../src/task/discovery";
 import type { AgentDefinition, TaskParams } from "../src/task/types";
-import { taskSchema } from "../src/task/types";
+import { getTaskSchema, taskSchema } from "../src/task/types";
 import type { ToolSession } from "../src/tools";
 import { EventBus } from "../src/utils/event-bus";
 
@@ -241,6 +241,23 @@ describe("fork context policy surface", () => {
 		).toBe(false);
 	});
 
+	test("independent task schema rejects inherited parent context", () => {
+		const independentSchema = getTaskSchema({ isolationEnabled: true, simpleMode: "independent" });
+
+		expect(
+			independentSchema.safeParse({
+				agent: "executor",
+				tasks: [{ id: "ForkSeed", description: "d", assignment: "a", inheritContext: "bounded" }],
+			}).success,
+		).toBe(false);
+		expect(
+			independentSchema.safeParse({
+				agent: "executor",
+				tasks: [{ id: "NoFork", description: "d", assignment: "a", inheritContext: "none" }],
+			}).success,
+		).toBe(true);
+	});
+
 	test("rejects inherited context before scheduling when the global gate is disabled", async () => {
 		mockAgents([createAgent("executor", "allowed")]);
 		const tool = await TaskTool.create(createSession({ "task.forkContext.enabled": false }));
@@ -253,6 +270,27 @@ describe("fork context policy surface", () => {
 		} as TaskParams);
 
 		expect(getFirstText(result)).toContain("task.forkContext.enabled is false");
+		expect(registered).toBe(0);
+	});
+
+	test("rejects inherited context before scheduling in independent simple mode", async () => {
+		mockAgents([createAgent("executor", "allowed")]);
+		const seedBuilder = vi.fn(async () => createSeed());
+		const tool = await TaskTool.create(
+			createSession({ "task.simple": "independent", "task.forkContext.enabled": true }, seedBuilder),
+		);
+		let registered = 0;
+		AsyncJobManager.setInstance({ register: () => `${++registered}` } as unknown as AsyncJobManager);
+
+		const result = await tool.execute("tool-call", {
+			agent: "executor",
+			tasks: [{ id: "ForkSeed", description: "seed", assignment: "Use context.", inheritContext: "bounded" }],
+		} as TaskParams);
+
+		expect(getFirstText(result)).toContain("task.simple is set to independent");
+		expect(getFirstText(result)).toContain("inheritContext for task(s) ForkSeed");
+		expect(result.details?.results).toEqual([]);
+		expect(seedBuilder).not.toHaveBeenCalled();
 		expect(registered).toBe(0);
 	});
 


### PR DESCRIPTION
Closes #297

## Summary
- Reject non-`none` per-task `inheritContext` whenever `task.simple=independent` is active before task scheduling.
- Add independent-mode schema refinement so `inheritContext: "bounded"` is rejected while `none` remains accepted.
- Document independent-mode fork-context behavior in the task tool prompt.

## Verification
- `bun --cwd=packages/coding-agent test test/task-fork-context.test.ts`
- `bun run check:ts`

## Risk notes
- Minimal fail-closed validation change scoped to independent simple mode.
- Default and schema-free context-enabled modes continue to accept and gate fork-context inheritance through existing global/agent policy checks.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*