### PR TITLE
Fix reviewer explore spawn gate

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -319,6 +319,8 @@ export interface CreateAgentSessionOptions {
 	requireYieldTool?: boolean;
 	/** Task recursion depth (for subagent sessions). Default: 0 */
 	taskDepth?: number;
+	/** Current role-agent type/name for nested task sessions. */
+	currentAgentType?: string;
 	/** Parent Hindsight state to alias for subagent memory tools. */
 	parentHindsightSessionState?: HindsightSessionState;
 	/** Pre-allocated agent identity for IRC routing. Default: "0-Main" for top-level, parentTaskPrefix-derived for sub. */
@@ -1189,6 +1191,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			outputSchema: options.outputSchema,
 			requireYieldTool: options.requireYieldTool,
 			taskDepth: options.taskDepth ?? 0,
+			currentAgentType: options.currentAgentType,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
 			getEvalKernelOwnerId: () => evalKernelOwnerId,
 			assertEvalExecutionAllowed: () => session?.assertEvalExecutionAllowed(),

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1191,6 +1191,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					hasUI: false,
 					spawns: spawnsEnv,
 					taskDepth: childDepth,
+					currentAgentType: agent.name,
 					parentHindsightSessionState: options.parentHindsightSessionState,
 					parentTaskPrefix: id,
 					agentId: id,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -358,7 +358,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		discoveredAgents: AgentDefinition[],
 	) {
 		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
-		this.#spawningAgentType = $env.PI_BLOCKED_AGENT;
+		this.#spawningAgentType = session.currentAgentType;
 		this.#discoveredAgents = discoveredAgents;
 	}
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -150,6 +150,8 @@ export interface ToolSession {
 	requireYieldTool?: boolean;
 	/** Task recursion depth (0 = top-level, 1 = first child, etc.) */
 	taskDepth?: number;
+	/** Current role-agent type/name for nested task sessions. */
+	currentAgentType?: string;
 	/** Get session file */
 	getSessionFile: () => string | null;
 	/** Get eval kernel owner ID for session-scoped retained-kernel cleanup. */

--- a/packages/coding-agent/test/tools/task-simple-mode.test.ts
+++ b/packages/coding-agent/test/tools/task-simple-mode.test.ts
@@ -16,6 +16,12 @@ const TEST_AGENTS = [
 		source: "bundled" as const,
 	},
 	{
+		name: "explore",
+		description: "Explore task agent",
+		systemPrompt: "You are an explorer.",
+		source: "bundled" as const,
+	},
+	{
 		name: "reviewer",
 		description: "Reviewer task agent",
 		systemPrompt: "You are a reviewer.",
@@ -36,13 +42,17 @@ type CapturedRegister = {
 	options?: AsyncJobRegisterOptions;
 };
 
-function createSession(overrides: Partial<Record<string, unknown>> = {}): ToolSession {
+function createSession(
+	settingsOverrides: Partial<Record<string, unknown>> = {},
+	sessionOverrides: Partial<ToolSession> = {},
+): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
-		settings: Settings.isolated(overrides),
+		settings: Settings.isolated(settingsOverrides),
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
+		...sessionOverrides,
 	} as unknown as ToolSession;
 }
 
@@ -141,6 +151,82 @@ describe("task.simple", () => {
 		expect(captured).toHaveLength(0);
 		expect(result.details?.results).toEqual([]);
 		expect(getFirstText(result)).toContain("Task spawn gate rejected this batch");
+	});
+
+	it("rejects reviewer spawning explore before scheduling without spawnPlan", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+		const captured: CapturedRegister[] = [];
+		const manager = {
+			register: (
+				type: "bash" | "task",
+				label: string,
+				_run: (ctx: {
+					jobId: string;
+					signal: AbortSignal;
+					reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+				}) => Promise<string>,
+				options?: AsyncJobRegisterOptions,
+			): string => {
+				captured.push({ type, label, options });
+				return options?.id ?? label;
+			},
+		};
+		AsyncJobManager.setInstance(manager as unknown as AsyncJobManager);
+
+		const tool = await TaskTool.create(createSession({}, { currentAgentType: "reviewer" }));
+		const result = await tool.execute("tool-reviewer-explore-gated", {
+			agent: "explore",
+			tasks: [{ id: "Explore", description: "label", assignment: "Explore safely." }],
+		} as TaskParams);
+
+		expect(captured).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+		expect(getFirstText(result)).toContain("Task spawn gate rejected reviewer->explore");
+	});
+
+	it("does not use PI_BLOCKED_AGENT as the reviewer explore gate source", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+		const previous = process.env.PI_BLOCKED_AGENT;
+		process.env.PI_BLOCKED_AGENT = "reviewer";
+		const captured: CapturedRegister[] = [];
+		const manager = {
+			register: (
+				type: "bash" | "task",
+				label: string,
+				_run: (ctx: {
+					jobId: string;
+					signal: AbortSignal;
+					reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+				}) => Promise<string>,
+				options?: AsyncJobRegisterOptions,
+			): string => {
+				captured.push({ type, label, options });
+				return options?.id ?? label;
+			},
+		};
+		AsyncJobManager.setInstance(manager as unknown as AsyncJobManager);
+		try {
+			const tool = await TaskTool.create(createSession({}, { currentAgentType: "executor" }));
+			const result = await tool.execute("tool-executor-explore-allowed", {
+				agent: "explore",
+				tasks: [{ id: "Explore", description: "label", assignment: "Explore safely." }],
+			} as TaskParams);
+
+			expect(captured).toHaveLength(1);
+			expect(getFirstText(result)).toContain("Started 1 background task job");
+		} finally {
+			if (previous === undefined) {
+				delete process.env.PI_BLOCKED_AGENT;
+			} else {
+				process.env.PI_BLOCKED_AGENT = previous;
+			}
+		}
 	});
 
 	it("allows a five-task batch with complete spawnPlan to schedule", async () => {


### PR DESCRIPTION
Closes #296

## Summary
- Thread the actual current role-agent type into subagent ToolSession state.
- Keep PI_BLOCKED_AGENT scoped to self-recursion prevention instead of reviewer->explore gate decisions.
- Add regression coverage that reviewer->explore without spawnPlan rejects before scheduling and that PI_BLOCKED_AGENT no longer falsely drives the gate for unrelated agents.

## Verification
- bun test packages/coding-agent/test/task/spawn-gate.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts
- bun --cwd=packages/coding-agent run check:types

## Risk notes
- Minimal runtime surface change: only subagent session construction now supplies currentAgentType, and TaskTool reads that field for the reviewer->explore hard gate.
- Recursion prevention remains keyed to PI_BLOCKED_AGENT and is unchanged.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*