### PR TITLE
Bound TUI metrics label cardinality

### DIFF
--- a/packages/tui/src/metrics.ts
+++ b/packages/tui/src/metrics.ts
@@ -25,6 +25,28 @@ export const REPAINT_STORM_THRESHOLD = 3;
 /** Hard cap on retained render-duration samples to keep memory bounded. */
 const MAX_DURATION_SAMPLES = 200_000;
 
+/** Hard cap on retained metric label keys; overflow is aggregated under `other`. */
+export const MAX_LABEL_MAP_ENTRIES = 128;
+
+const LABEL_OVERFLOW_KEY = "other";
+
+/**
+ * Normalize full-redraw causes before retaining them as metric labels. Some
+ * render paths include dimensions in debug-facing reason strings; metrics keep
+ * the stable cause class so resize/delete storms cannot create unbounded label
+ * cardinality.
+ */
+function normalizeFullRedrawCause(cause: string): string {
+	const c = cause.toLowerCase();
+	if (c.startsWith("first render")) return "first render";
+	if (c.startsWith("terminal width changed")) return "terminal width changed";
+	if (c.startsWith("terminal height changed")) return "terminal height changed";
+	if (c.startsWith("clearonshrink")) return "clearOnShrink";
+	if (c.startsWith("extralines > height")) return "extraLines > height";
+	if (c.startsWith("firstchanged < viewporttop")) return "firstChanged < viewportTop";
+	return cause;
+}
+
 /**
  * Full-redraw causes that are expected and do not count toward repaint storms.
  * These are legitimate, unavoidable full repaints (first frame, resize, shrink
@@ -40,6 +62,16 @@ function isExpectedFullRedraw(cause: string): boolean {
 		c.includes("forced") ||
 		c.includes("force")
 	);
+}
+
+function retainedLabel<T>(map: Map<string, T>, label: string): string {
+	if (map.has(label) || label === LABEL_OVERFLOW_KEY) return label;
+	return map.size < MAX_LABEL_MAP_ENTRIES - 1 ? label : LABEL_OVERFLOW_KEY;
+}
+
+function incrementCount(map: Map<string, number>, label: string): void {
+	const retained = retainedLabel(map, label);
+	map.set(retained, (map.get(retained) ?? 0) + 1);
 }
 
 export interface DurationStats {
@@ -173,7 +205,7 @@ export class RenderMetrics {
 	/** Record that a render was requested, attributed to a caller source. */
 	recordRequest(source = "unknown"): void {
 		if (!this.#enabled) return;
-		this.#requestSources.set(source, (this.#requestSources.get(source) ?? 0) + 1);
+		incrementCount(this.#requestSources, source);
 	}
 
 	/** Record one completed `#doRender` pass duration (ms). */
@@ -206,8 +238,9 @@ export class RenderMetrics {
 	recordFullRedraw(cause: string): void {
 		if (!this.#enabled) return;
 		this.#fullRedrawCount += 1;
-		this.#fullRedrawCauses.set(cause, (this.#fullRedrawCauses.get(cause) ?? 0) + 1);
-		if (!isExpectedFullRedraw(cause)) {
+		const normalizedCause = normalizeFullRedrawCause(cause);
+		incrementCount(this.#fullRedrawCauses, normalizedCause);
+		if (!isExpectedFullRedraw(normalizedCause)) {
 			this.#pendingUnexpectedFullRedraw = true;
 		}
 	}
@@ -238,10 +271,11 @@ export class RenderMetrics {
 	/** Accumulate timing/count for a named render helper (e.g. "renderTree"). */
 	recordHelper(name: string, durationMs: number): void {
 		if (!this.#enabled) return;
-		const cur = this.#helpers.get(name) ?? { count: 0, totalMs: 0 };
+		const retained = retainedLabel(this.#helpers, name);
+		const cur = this.#helpers.get(retained) ?? { count: 0, totalMs: 0 };
 		cur.count += 1;
 		cur.totalMs += durationMs;
-		this.#helpers.set(name, cur);
+		this.#helpers.set(retained, cur);
 	}
 
 	/**

--- a/packages/tui/test/metrics-redteam.test.ts
+++ b/packages/tui/test/metrics-redteam.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { REPAINT_STORM_THRESHOLD, RenderMetrics } from "@gajae-code/tui/metrics";
+import { MAX_LABEL_MAP_ENTRIES, REPAINT_STORM_THRESHOLD, RenderMetrics } from "@gajae-code/tui/metrics";
 import { makeRecordedSession, runReplay } from "./replay-harness";
 
 function recordUnexpectedRender(metrics: RenderMetrics, cause = "extraLines > height"): void {
@@ -127,5 +127,45 @@ describe("RenderMetrics red-team coverage", () => {
 		expect(snapshot.rss.peakBytes).toBeGreaterThanOrEqual(snapshot.rss.baselineBytes ?? 0);
 		expect(snapshot.rss.peakBytes).toBeGreaterThanOrEqual(snapshot.rss.lastBytes ?? 0);
 		expect(snapshot.rss.growthBytes).toBeGreaterThanOrEqual(0);
+	});
+
+	it("bounds enabled metric label maps and aggregates overflow under other", () => {
+		const metrics = new RenderMetrics(true);
+
+		for (let i = 0; i < MAX_LABEL_MAP_ENTRIES * 4; i++) {
+			metrics.recordRequest(`plugin-source-${i}`);
+			metrics.recordHelper(`helper-${i}`, 2);
+		}
+
+		const snapshot = metrics.snapshot();
+		expect(Object.keys(snapshot.requestSources)).toHaveLength(MAX_LABEL_MAP_ENTRIES);
+		expect(snapshot.requestSources.other).toBe(MAX_LABEL_MAP_ENTRIES * 4 - (MAX_LABEL_MAP_ENTRIES - 1));
+		expect(Object.keys(snapshot.helperStats)).toHaveLength(MAX_LABEL_MAP_ENTRIES);
+		expect(snapshot.helperStats.other).toEqual({
+			count: MAX_LABEL_MAP_ENTRIES * 4 - (MAX_LABEL_MAP_ENTRIES - 1),
+			totalMs: (MAX_LABEL_MAP_ENTRIES * 4 - (MAX_LABEL_MAP_ENTRIES - 1)) * 2,
+			meanMs: 2,
+		});
+	});
+
+	it("normalizes dynamic full-redraw causes before retaining labels", () => {
+		const metrics = new RenderMetrics(true);
+
+		for (let i = 0; i < MAX_LABEL_MAP_ENTRIES * 4; i++) {
+			metrics.recordFullRedraw(`extraLines > height (${i + 1} > ${i % 37})`);
+			metrics.recordFullRedraw(`firstChanged < viewportTop (${i} < ${i + 10})`);
+			metrics.recordFullRedraw(`terminal height changed (${i + 20} -> ${i + 21})`);
+		}
+
+		const snapshot = metrics.snapshot();
+		expect(Object.keys(snapshot.fullRedrawCauses)).toEqual([
+			"extraLines > height",
+			"firstChanged < viewportTop",
+			"terminal height changed",
+		]);
+		expect(snapshot.fullRedrawCauses["extraLines > height"]).toBe(MAX_LABEL_MAP_ENTRIES * 4);
+		expect(snapshot.fullRedrawCauses["firstChanged < viewportTop"]).toBe(MAX_LABEL_MAP_ENTRIES * 4);
+		expect(snapshot.fullRedrawCauses["terminal height changed"]).toBe(MAX_LABEL_MAP_ENTRIES * 4);
+		expect(snapshot.fullRedrawCauses.other).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Closes #299

## Summary
- cap retained TUI metrics label maps at a fixed size and aggregate overflow under `other`
- normalize dynamic full-redraw causes before recording labels
- add red-team regression coverage for high-cardinality metrics paths

## Verification
- `bun --cwd=packages/natives run build`
- `bun test test/metrics-redteam.test.ts test/metrics.test.ts` (from `packages/tui`)
- `bun run check:ts`

## Risk notes
- Low-risk metrics-only change; disabled metrics paths remain no-ops.
- Snapshot label maps now coalesce excess public labels under `other` to keep memory bounded.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*