### PR TITLE
Fix harness hung owner endpoint fallback

### DIFF
--- a/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
+++ b/packages/coding-agent/src/harness-control-plane/control-endpoint.ts
@@ -88,13 +88,16 @@ export class ControlServer {
 }
 
 export class EndpointUnreachableError extends Error {
-	constructor(readonly socketPath: string) {
-		super(`endpoint_unreachable:${socketPath}`);
+	constructor(
+		readonly socketPath: string,
+		readonly reason = "unreachable",
+	) {
+		super(`endpoint_${reason}:${socketPath}`);
 		this.name = "EndpointUnreachableError";
 	}
 }
 
-/** Call the owner's control endpoint. Rejects with {@link EndpointUnreachableError} when no owner listens. */
+/** Call the owner's control endpoint. Rejects with {@link EndpointUnreachableError} when no owner listens or responds. */
 export function callEndpoint(socketPath: string, req: EndpointRequest, timeoutMs = 5_000): Promise<unknown> {
 	return new Promise((resolve, reject) => {
 		const socket = net.connect(socketPath);
@@ -107,7 +110,10 @@ export function callEndpoint(socketPath: string, req: EndpointRequest, timeoutMs
 			socket.destroy();
 			fn();
 		};
-		const timer = setTimeout(() => done(() => reject(new Error(`endpoint_timeout:${socketPath}`))), timeoutMs);
+		const timer = setTimeout(
+			() => done(() => reject(new EndpointUnreachableError(socketPath, "timeout"))),
+			timeoutMs,
+		);
 		socket.setEncoding("utf8");
 		socket.on("connect", () => socket.write(frame(req)));
 		socket.on("data", (chunk: string) => {
@@ -118,16 +124,21 @@ export function callEndpoint(socketPath: string, req: EndpointRequest, timeoutMs
 				done(() => {
 					try {
 						resolve(JSON.parse(line));
-					} catch (error) {
-						reject(error instanceof Error ? error : new Error(String(error)));
+					} catch {
+						reject(new EndpointUnreachableError(socketPath, "bad_frame"));
 					}
 				});
 			}
 		});
 		socket.on("error", (error: NodeJS.ErrnoException) => {
 			done(() => {
-				if (error.code === "ENOENT" || error.code === "ECONNREFUSED") {
-					reject(new EndpointUnreachableError(socketPath));
+				if (
+					error.code === "ENOENT" ||
+					error.code === "ECONNREFUSED" ||
+					error.code === "ECONNRESET" ||
+					error.code === "EPIPE"
+				) {
+					reject(new EndpointUnreachableError(socketPath, error.code.toLowerCase()));
 				} else {
 					reject(error);
 				}

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
+import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
 import { RuntimeOwner } from "../../src/harness-control-plane/owner";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
-import { writeSessionState } from "../../src/harness-control-plane/storage";
+import { acquireLease } from "../../src/harness-control-plane/session-lease";
+import { controlSocketPath, sessionPaths, writeSessionState } from "../../src/harness-control-plane/storage";
 import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -33,6 +35,7 @@ class FakeRpc implements HarnessRpc {
 
 let root: string;
 let owner: RuntimeOwner | null = null;
+let hungServer: net.Server | null = null;
 
 function seed(workspace: string): SessionState {
 	const now = new Date().toISOString();
@@ -100,6 +103,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	await owner?.stop();
+	await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
+	hungServer = null;
 	await rm(root, { recursive: true, force: true });
 });
 
@@ -133,4 +138,37 @@ describe("gjc harness CLI -> live owner routing", () => {
 		expect((evidence.finalize as Record<string, unknown>).completed).toBe(true);
 		expect(state.lifecycle).toBe("completed");
 	}, 30_000);
+
+	it("falls back to bounded observe when a live owner endpoint accepts but never responds", async () => {
+		await owner?.stop();
+		owner = null;
+		const socketPath = controlSocketPath(root, SID);
+		hungServer = net.createServer(socket => {
+			socket.on("data", () => {});
+		});
+		await new Promise<void>((resolve, reject) => {
+			hungServer?.once("error", reject);
+			hungServer?.listen(socketPath, () => {
+				hungServer?.removeListener("error", reject);
+				resolve();
+			});
+		});
+		await acquireLease(root, SID, {
+			ownerId: "hung-owner",
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: socketPath },
+			eventsPath: sessionPaths(root, SID).events,
+			ttlMs: 30_000,
+		});
+
+		const res = await runHarness(["observe", "--session", SID]);
+
+		expect(res.code).toBe(0);
+		expect(res.json?.ok).toBe(true);
+		expect(res.json).toHaveProperty("state");
+		expect(res.json).toHaveProperty("evidence");
+		expect(res.json).toHaveProperty("nextAllowedActions");
+		expect((res.json?.state as Record<string, unknown>).ownerLive).toBe(false);
+		expect((res.json?.evidence as Record<string, unknown>).ownerRouted).toBeUndefined();
+	}, 10_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
+import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
@@ -12,6 +13,7 @@ import {
 let dir: string;
 let sock: string;
 let server: ControlServer | null = null;
+let rawServer: net.Server | null = null;
 
 beforeEach(async () => {
 	// Keep the socket path short (AF_UNIX sun_path limit) by living directly in a temp dir.
@@ -22,6 +24,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	await server?.close();
+	await new Promise<void>(resolve => rawServer?.close(() => resolve()) ?? resolve());
+	rawServer = null;
 	await rm(dir, { recursive: true, force: true });
 });
 
@@ -53,6 +57,40 @@ describe("control endpoint", () => {
 
 	it("rejects with EndpointUnreachableError when no owner is listening", async () => {
 		await expect(callEndpoint(path.join(dir, "absent.sock"), { verb: "submit", input: {} })).rejects.toBeInstanceOf(
+			EndpointUnreachableError,
+		);
+	});
+
+	it("rejects with EndpointUnreachableError when the owner accepts but never responds", async () => {
+		rawServer = net.createServer(socket => {
+			socket.on("data", () => {});
+		});
+		await new Promise<void>((resolve, reject) => {
+			rawServer?.once("error", reject);
+			rawServer?.listen(sock, () => {
+				rawServer?.removeListener("error", reject);
+				resolve();
+			});
+		});
+
+		await expect(callEndpoint(sock, { verb: "observe", input: {} }, 50)).rejects.toBeInstanceOf(
+			EndpointUnreachableError,
+		);
+	});
+
+	it("rejects malformed owner frames as EndpointUnreachableError", async () => {
+		rawServer = net.createServer(socket => {
+			socket.end("not-json\n");
+		});
+		await new Promise<void>((resolve, reject) => {
+			rawServer?.once("error", reject);
+			rawServer?.listen(sock, () => {
+				rawServer?.removeListener("error", reject);
+				resolve();
+			});
+		});
+
+		await expect(callEndpoint(sock, { verb: "observe", input: {} }, 500)).rejects.toBeInstanceOf(
 			EndpointUnreachableError,
 		);
 	});


### PR DESCRIPTION
Closes #292

## Summary
- Classify hung owner endpoint timeouts, malformed frames, ECONNRESET, and EPIPE as `EndpointUnreachableError`.
- Preserve CLI fallback to the universal harness response when a live PID owns a socket that accepts but never responds.
- Add regression coverage for hung and malformed fake owner sockets plus CLI observe fallback.

## Verification
- `bun test packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts`
- `bunx biome check packages/coding-agent/src/harness-control-plane/control-endpoint.ts packages/coding-agent/test/harness-control-plane/control-endpoint.test.ts packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts`
- `bun run check:ts`

## Risk notes
- Minimal endpoint error-classification change; no event-writing or lease-acquisition gates were weakened.
- Fallback paths remain read-only/blocked as before, so an unresponsive live PID cannot create split-brain writes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*