### PR TITLE
Fix task id path traversal

### DIFF
--- a/packages/coding-agent/src/task/id.ts
+++ b/packages/coding-agent/src/task/id.ts
@@ -1,0 +1,33 @@
+export const TASK_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,47}$/;
+export const TASK_ID_DESCRIPTION = "filesystem-safe identifier matching ^[A-Za-z0-9][A-Za-z0-9_-]{0,47}$";
+
+const ALLOCATED_TASK_ID_PATTERN = new RegExp(
+	`^\\d+-${TASK_ID_PATTERN.source.slice(1, -1)}(?:\\.\\d+-${TASK_ID_PATTERN.source.slice(1, -1)})*$`,
+);
+
+export function isValidTaskId(id: string): boolean {
+	return TASK_ID_PATTERN.test(id);
+}
+
+export function getTaskIdValidationError(id: unknown): string | undefined {
+	if (typeof id !== "string") return "Task id must be a string.";
+	if (isValidTaskId(id)) return undefined;
+	return `Task id ${JSON.stringify(id)} is invalid. Use ${TASK_ID_DESCRIPTION}.`;
+}
+
+export function validateTaskId(id: string): string {
+	const error = getTaskIdValidationError(id);
+	if (error) throw new Error(error);
+	return id;
+}
+
+export function isValidAllocatedTaskId(id: string): boolean {
+	return ALLOCATED_TASK_ID_PATTERN.test(id);
+}
+
+export function validateAllocatedTaskId(id: string): string {
+	if (!isValidAllocatedTaskId(id)) {
+		throw new Error(`Allocated task id ${JSON.stringify(id)} is invalid for filesystem artifact paths.`);
+	}
+	return id;
+}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -47,6 +47,7 @@ import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
 import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
+import { getTaskIdValidationError, validateAllocatedTaskId } from "./id";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { assertNoRawTaskFields, buildTaskReceipt, buildTaskRoiSummary } from "./receipt";
@@ -125,10 +126,27 @@ function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
 	target.cost.total += cost.total;
 }
 
+function validateTaskIdsForScheduling(tasks: readonly TaskItem[]): string | undefined {
+	const invalid: string[] = [];
+	for (let i = 0; i < tasks.length; i++) {
+		const error = getTaskIdValidationError(tasks[i]?.id);
+		if (error) invalid.push(`index ${i}: ${error}`);
+	}
+	return invalid.length > 0 ? `Invalid task ids: ${invalid.join(" ")}` : undefined;
+}
+
 // Re-export types and utilities
 export { loadBundledAgents as BUNDLED_AGENTS } from "./agents";
 export { discoverCommands, expandCommand, getCommand } from "./commands";
 export { discoverAgents, getAgent } from "./discovery";
+export {
+	isValidAllocatedTaskId,
+	isValidTaskId,
+	TASK_ID_DESCRIPTION,
+	TASK_ID_PATTERN,
+	validateAllocatedTaskId,
+	validateTaskId,
+} from "./id";
 export { AgentOutputManager } from "./output-manager";
 export type { TaskResultReceipt } from "./receipt";
 export {
@@ -396,10 +414,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const taskItems = params.tasks ?? [];
+		const taskIdValidationError = validateTaskIdsForScheduling(taskItems);
+		if (taskIdValidationError) {
+			return createTaskModeError(taskIdValidationError);
+		}
 		if (taskItems.length === 0) {
 			return this.#executeSync(_toolCallId, params, signal, onUpdate);
 		}
-
 		const agent = getAgent(this.#discoveredAgents, params.agent);
 		if (!agent) {
 			const available =
@@ -603,7 +624,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				continue;
 			}
 
-			const uniqueId = uniqueIds[i];
+			const uniqueId = validateAllocatedTaskId(uniqueIds[i] ?? "");
 			const frozenForkSeed = await buildForkContextSeedForTask(taskItem);
 			if (frozenForkSeed) frozenForkSeeds.set(uniqueId, frozenForkSeed);
 			const singleParams: TaskParams = { ...params, tasks: [taskItem] };
@@ -1185,7 +1206,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					this.session.agentOutputManager ?? new AgentOutputManager(this.session.getArtifactsDir ?? (() => null));
 				uniqueIds = await outputManager.allocateBatch(tasks.map(t => t.id));
 			}
-			const tasksWithUniqueIds = tasks.map((t, i) => ({ ...t, id: uniqueIds[i] }));
+			const tasksWithUniqueIds = tasks.map((t, i) => ({ ...t, id: validateAllocatedTaskId(uniqueIds[i] ?? "") }));
 
 			const availableSkills = [...(this.session.skills ?? [])];
 			// Resolve autoload skills from agent definition against available skills
@@ -1395,7 +1416,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					if (resultWithForkContext.exitCode === 0) {
 						try {
 							const delta = await captureDeltaPatch(isolationDir, taskBaseline);
-							const patchPath = path.join(effectiveArtifactsDir, `${task.id}.patch`);
+							const artifactId = validateAllocatedTaskId(task.id);
+							const patchPath = path.join(effectiveArtifactsDir, `${artifactId}.patch`);
 							await Bun.write(patchPath, delta.rootPatch);
 							const producedChanges = Boolean(delta.rootPatch.trim() || delta.nestedPatches.length);
 							return {

--- a/packages/coding-agent/src/task/output-manager.ts
+++ b/packages/coding-agent/src/task/output-manager.ts
@@ -8,6 +8,7 @@
  * This enables reliable agent:// URL resolution and prevents artifact collisions.
  */
 import * as fs from "node:fs/promises";
+import { validateAllocatedTaskId, validateTaskId } from "./id";
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -73,8 +74,8 @@ export class AgentOutputManager {
 	 */
 	async allocate(id: string): Promise<string> {
 		await this.#ensureInitialized();
-		const prefix = this.#parentPrefix ? `${this.#parentPrefix}.` : "";
-		return `${prefix}${this.#nextId++}-${id}`;
+		const prefix = this.#parentPrefix ? `${validateAllocatedTaskId(this.#parentPrefix)}.` : "";
+		return `${prefix}${this.#nextId++}-${validateTaskId(id)}`;
 	}
 
 	/**
@@ -85,8 +86,8 @@ export class AgentOutputManager {
 	 */
 	async allocateBatch(ids: string[]): Promise<string[]> {
 		await this.#ensureInitialized();
-		const prefix = this.#parentPrefix ? `${this.#parentPrefix}.` : "";
-		return ids.map(id => `${prefix}${this.#nextId++}-${id}`);
+		const prefix = this.#parentPrefix ? `${validateAllocatedTaskId(this.#parentPrefix)}.` : "";
+		return ids.map(id => `${prefix}${this.#nextId++}-${validateTaskId(id)}`);
 	}
 
 	/**

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Usage } from "@gajae-code/ai";
 import { $env } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { isValidTaskId, TASK_ID_DESCRIPTION } from "./id";
 import type { TaskResultReceipt } from "./receipt";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import type { SpawnPlanReceipt } from "./spawn-gate";
@@ -74,7 +75,7 @@ const spawnPlanSchema = z
 
 const createTaskItemSchema = (_contextEnabled: boolean) =>
 	z.object({
-		id: z.string().max(48).describe("camelcase identifier"),
+		id: z.string().max(48).refine(isValidTaskId, TASK_ID_DESCRIPTION).describe("filesystem-safe task identifier"),
 		description: z.string().describe("ui label, not seen by subagent"),
 		assignment: z.string().describe(assignmentDescription),
 		inheritContext: z

--- a/packages/coding-agent/test/task/id.test.ts
+++ b/packages/coding-agent/test/task/id.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager, type AsyncJobRegisterOptions } from "../../src/async";
+import { Settings } from "../../src/config/settings";
+import { isValidAllocatedTaskId, isValidTaskId, TaskTool, validateAllocatedTaskId } from "../../src/task";
+import * as discoveryModule from "../../src/task/discovery";
+import { AgentOutputManager } from "../../src/task/output-manager";
+import type { TaskParams } from "../../src/task/types";
+import { taskSchema } from "../../src/task/types";
+import type { ToolSession } from "../../src/tools";
+
+const TEST_AGENTS = [
+	{
+		name: "task",
+		description: "General-purpose task agent",
+		systemPrompt: "You are a task agent.",
+		source: "bundled" as const,
+	},
+];
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	AsyncJobManager.resetForTests();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated(),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		...overrides,
+	} as unknown as ToolSession;
+}
+
+function getFirstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find(part => part.type === "text")?.text ?? "";
+}
+
+function validParams(id: string): TaskParams {
+	return {
+		agent: "task",
+		tasks: [{ id, description: "label", assignment: "Do work." }],
+	};
+}
+
+describe("task id validation", () => {
+	it("accepts filesystem-safe task ids and allocated prefixes", async () => {
+		for (const id of ["A", "a_b-9", "Z".repeat(48)]) {
+			expect(isValidTaskId(id)).toBe(true);
+			expect(taskSchema.safeParse(validParams(id)).success).toBe(true);
+		}
+
+		const outputManager = new AgentOutputManager(() => null);
+		expect(await outputManager.allocateBatch(["Alpha", "beta_2"])).toEqual(["0-Alpha", "1-beta_2"]);
+		expect(isValidAllocatedTaskId("0-Alpha")).toBe(true);
+		expect(isValidAllocatedTaskId("0-Parent.1-Child_2")).toBe(true);
+	});
+
+	it("rejects path-like, blank, control, unicode separator, and absolute-ish ids in schema", () => {
+		const invalidIds = [
+			"",
+			" ",
+			"../x",
+			"a/b",
+			"a\\b",
+			".",
+			"..",
+			"/abs",
+			"C:\\abs",
+			"a\u0000b",
+			"a\u001fb",
+			"a\u2215b",
+			"ab",
+			"-startsWithDash",
+			"_startsWithUnderscore",
+			"a.b",
+			"x".repeat(49),
+		];
+
+		for (const id of invalidIds) {
+			expect(taskSchema.safeParse(validParams(id)).success, id).toBe(false);
+			expect(isValidTaskId(id), id).toBe(false);
+		}
+	});
+
+	it("rejects invalid task ids before scheduling", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: TEST_AGENTS, projectAgentsDir: null });
+		const registered: string[] = [];
+		AsyncJobManager.setInstance({
+			register: (_type: "bash" | "task", label: string, _run: unknown, options?: AsyncJobRegisterOptions) => {
+				registered.push(options?.id ?? label);
+				return options?.id ?? label;
+			},
+		} as unknown as AsyncJobManager);
+
+		const tool = await TaskTool.create(createSession());
+		const result = await tool.execute("tool-invalid-id", validParams("../x"));
+
+		expect(registered).toEqual([]);
+		expect(getFirstText(result)).toContain("Invalid task ids");
+		expect(getFirstText(result)).toContain("../x");
+	});
+
+	it("prevents allocated id path traversal before artifact writes", async () => {
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-id-artifacts-"));
+		tempDirs.push(artifactsDir);
+		const outsidePath = path.join(path.dirname(artifactsDir), "escape.md");
+		await fs.rm(outsidePath, { force: true });
+
+		expect(() => validateAllocatedTaskId("0-../../escape")).toThrow("Allocated task id");
+		expect(() => validateAllocatedTaskId("0-a/b")).toThrow("Allocated task id");
+		expect(() => validateAllocatedTaskId("0-a\\b")).toThrow("Allocated task id");
+
+		await expect(fs.stat(outsidePath)).rejects.toThrow();
+	});
+});

--- a/packages/coding-agent/test/task/id.test.ts
+++ b/packages/coding-agent/test/task/id.test.ts
@@ -52,7 +52,7 @@ function validParams(id: string): TaskParams {
 
 describe("task id validation", () => {
 	it("accepts filesystem-safe task ids and allocated prefixes", async () => {
-		for (const id of ["A", "a_b-9", "Z".repeat(48)]) {
+		for (const id of ["A", "ab", "a_b-9", "Z".repeat(48)]) {
 			expect(isValidTaskId(id)).toBe(true);
 			expect(taskSchema.safeParse(validParams(id)).success).toBe(true);
 		}
@@ -77,7 +77,6 @@ describe("task id validation", () => {
 			"a\u0000b",
 			"a\u001fb",
 			"a\u2215b",
-			"ab",
 			"-startsWithDash",
 			"_startsWithUnderscore",
 			"a.b",


### PR DESCRIPTION
Closes #286

## Summary
- Add a shared filesystem-safe task id validator with `^[A-Za-z0-9][A-Za-z0-9_-]{0,47}$`.
- Enforce the validator in task schema parsing and again at runtime before scheduling.
- Validate allocated task ids before session/output/patch artifact path construction while preserving numeric prefix allocation.
- Add focused regression coverage for rejected traversal-like ids and allocated-id path safety.

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/task/id.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts packages/coding-agent/test/task-fork-context.test.ts`
- `bun test packages/coding-agent/test/task/id.test.ts packages/coding-agent/test/task/*.test.ts`
- `bun run check:ts`

## Risk
Low. This intentionally narrows task ids to filesystem-safe ASCII identifiers; valid existing ids and allocated prefix behavior remain supported.