### PR TITLE
Fail state migrate on tamper without force

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1783,9 +1783,13 @@ async function handleMigrate(
 		);
 	}
 	const filePath = modeStateFile(cwd, mode, selectors.sessionId);
+	const forced = hasFlag(args, "--force");
 	const mismatchWarning = await warnAndAuditOutOfBandIfNeeded(cwd, filePath, mode, {
-		forced: hasFlag(args, "--force"),
+		forced,
 	});
+	if (mismatchWarning && !forced) {
+		throw new StateCommandError(2, `${mismatchWarning}; use --force to migrate tampered mode-state`);
+	}
 	const result = await migrateAndPersistLegacyState({
 		cwd,
 		skill: mode,

--- a/packages/coding-agent/test/gjc-runtime/state-migration-gate.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-migration-gate.test.ts
@@ -76,4 +76,88 @@ describe("G7 gjc state migration gate", () => {
 			});
 		});
 	});
+
+	it("rejects tampered migrated state without --force and leaves the file untouched", async () => {
+		await withTempCwd(async cwd => {
+			const statePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			const legacy = {
+				current_phase: "planning",
+				extension_field: { nested: true },
+			};
+			const initial = await runNativeStateCommand(
+				["write", "--mode", "ralplan", "--input", JSON.stringify(legacy), "--force"],
+				cwd,
+			);
+			expect(initial.status).toBe(0);
+
+			const stamped = await readJson(statePath);
+			stamped.version = 1;
+			stamped.current_phase = "planning";
+			stamped.tampered = true;
+			await writeJson(statePath, stamped);
+			const before = await fs.readFile(statePath, "utf-8");
+
+			const rejected = await runNativeStateCommand(["ralplan", "migrate", "--json"], cwd);
+
+			expect(rejected.status).toBe(2);
+			expect(rejected.stderr).toContain("out-of-band edit detected");
+			expect(rejected.stderr).toContain("use --force to migrate tampered mode-state");
+			expect(await fs.readFile(statePath, "utf-8")).toBe(before);
+			expect(await readJson(statePath)).toMatchObject({ current_phase: "planning", tampered: true });
+		});
+	});
+
+	it("migrates tampered state with --force and audits the forced mismatch", async () => {
+		await withTempCwd(async cwd => {
+			const statePath = path.join(cwd, ".gjc/state/ralplan-state.json");
+			const legacy = {
+				current_phase: "planning",
+				extension_field: { nested: true },
+			};
+			await writeJson(statePath, {
+				version: 1,
+				skill: "ralplan",
+				active: true,
+				current_phase: "planning",
+				extension_field: legacy.extension_field,
+				receipt: {
+					version: 1,
+					skill: "ralplan",
+					owner: "gjc-state-cli",
+					status: "fresh",
+					command: "gjc state ralplan write",
+					state_path: statePath,
+					storage_path: statePath,
+					mutated_at: "2026-06-05T00:00:00.000Z",
+					fresh_until: "2026-06-05T00:00:00.000Z",
+					mutation_id: "seed",
+				},
+			});
+			const seeded = await runNativeStateCommand(["ralplan", "migrate", "--json", "--force"], cwd);
+			expect(seeded.status).toBe(0);
+
+			const stamped = await readJson(statePath);
+			stamped.version = 1;
+			stamped.current_phase = "planning";
+			stamped.tampered = true;
+			await writeJson(statePath, stamped);
+
+			const forced = await runNativeStateCommand(["ralplan", "migrate", "--json", "--force"], cwd);
+
+			expect(forced.status).toBe(0);
+			expect(forced.stderr).toContain("out-of-band edit detected");
+			const receipt = JSON.parse(forced.stdout ?? "{}") as Record<string, unknown>;
+			expect(receipt).toMatchObject({ skill: "ralplan", migrated: true, integrity_mismatch: true });
+			const persisted = await readJson(statePath);
+			expect(persisted).toMatchObject({ current_phase: "planner", tampered: true });
+			expect(persisted.receipt).toMatchObject({ owner: "gjc-state-cli", status: "fresh" });
+
+			const entries = await readAuditEntries(cwd);
+			const mismatch = entries.find(entry => entry.verb === "out_of_band_detected" && entry.forced === true);
+			expect(mismatch).toMatchObject({ skill: "ralplan", category: "state", owner: "gjc-state-cli" });
+			expect(typeof mismatch?.expected_sha256).toBe("string");
+			expect(typeof mismatch?.actual_sha256).toBe("string");
+			expect(entries.at(-1)).toMatchObject({ skill: "ralplan", category: "state", verb: "migrate" });
+		});
+	});
 });


### PR DESCRIPTION
Closes #294

## Summary
- Fail `gjc state migrate` with status 2 when a stamped mode-state checksum mismatch is detected without `--force`.
- Preserve the tampered file unchanged on rejected migrate attempts.
- Keep forced migrate behavior fail-open with mismatch stderr/receipt signal and audit evidence.
- Add regression coverage for no-force and force tampered migrate paths.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/state-migration-gate.test.ts packages/coding-agent/test/gjc-runtime/state-integrity.test.ts packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts`
- `bun run check:ts`

Note: an initial `bun run test ...` invocation used the repo test script and failed before dependency setup because `node_modules`/native addon artifacts were missing. After `bun install` and `bun --cwd=packages/natives run build`, the focused tests above passed.