### PR TITLE
Fix scoped internal artifact URL resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Made opt-in crash diagnostics create/chmod report directories to `0700` and report files to `0600` so captured command, cwd, and stderr previews are private even under a permissive umask.
+- Scoped `agent://` and `artifact://` resolution to the caller's artifacts directory plus explicitly authorized parent/child tree directories, removed registry-wide live-session lookup/enumeration, and made missing agent-output metadata sidecars fail closed.
 - Render terminal-pasted clipboard image temp paths as compact `[image N]` prompt placeholders while attaching the image payload, instead of inserting raw `/var/folders/.../clipboard-*.png` path text.
 - Reconciled `gjc harness` owner liveness after tmux readiness races so fresh live-owner evidence clears stale owner-vanished blockers, re-enables submit, and clean completed owner exits become terminal instead of dirty vanish recovery.
 - Fixed the interactive agent unexpectedly stopping after automatic context maintenance instead of resuming the in-flight task. Post-compaction continuation now schedules exactly one source per completion (overflow retry → queued messages → synthetic auto-continue prompt), the threshold/handoff auto-continue prompt skips a redundant pre-send compaction check, overflow retry strips only the context-overflow failed turn (never normal/aborted/silent-abort tails), and non-resumable or superseded continuations log a structured reason instead of stranding the session.

--- a/packages/coding-agent/src/internal-urls/agent-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/agent-protocol.ts
@@ -1,10 +1,9 @@
 /**
  * Protocol handler for agent:// URLs.
  *
- * Resolves agent output IDs against the artifacts directories of every active
- * session. Parents and subagents share outputs via this registry: a subagent
- * can read its parent's output IDs because both sessions are registered in
- * the shared context.
+ * Resolves agent output IDs only against artifacts directories explicitly
+ * authorized by the caller's ResolveContext. Parents and subagents can share
+ * outputs by passing their tree's artifacts dir at that API boundary.
  *
  * URL forms:
  * - agent://<id> - Full output content
@@ -16,8 +15,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
 import { applyQuery, pathToQuery } from "./json-query";
-import { artifactsDirsFromRegistry } from "./registry-helpers";
-import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
+import { authorizedArtifactsDirsFromContext } from "./registry-helpers";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext } from "./types";
 
 interface AgentOutputMetadata {
 	id: string;
@@ -47,7 +46,7 @@ async function verifyAgentOutputMetadata(outputId: string, foundPath: string, by
 	try {
 		metaRaw = await Bun.file(metaPath).text();
 	} catch (err) {
-		if (isEnoent(err)) return;
+		if (isEnoent(err)) throw new Error(`agent://${outputId} missing metadata`);
 		throw err;
 	}
 	let parsed: unknown;
@@ -78,7 +77,7 @@ export class AgentProtocolHandler implements ProtocolHandler {
 	readonly scheme = "agent";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const outputId = url.rawHost || url.hostname;
 		if (!outputId) {
 			throw new Error("agent:// URL requires an output ID: agent://<id>");
@@ -99,15 +98,14 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			throw new Error("agent:// URL cannot combine path extraction with ?q=");
 		}
 
-		const dirs = artifactsDirsFromRegistry();
+		const dirs = authorizedArtifactsDirsFromContext(context);
 
 		if (dirs.length === 0) {
 			throw new Error("No session - agent outputs unavailable");
 		}
 
-		const candidatePaths: string[] = [];
+		let foundPath: string | undefined;
 		let anyDirExists = false;
-		const availableIds = new Set<string>();
 
 		for (const dir of dirs) {
 			try {
@@ -120,17 +118,10 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			const candidate = path.join(dir, `${outputId}.md`);
 			try {
 				await fs.stat(candidate);
-				candidatePaths.push(candidate);
+				if (foundPath) throw new Error(`agent://${outputId} ambiguous id in authorized artifacts`);
+				foundPath = candidate;
 			} catch (err) {
 				if (!isEnoent(err)) throw err;
-			}
-			try {
-				const files = await fs.readdir(dir);
-				for (const f of files) {
-					if (f.endsWith(".md")) availableIds.add(f.replace(/\.md$/, ""));
-				}
-			} catch {
-				// Listing failures are non-fatal; continue searching.
 			}
 		}
 
@@ -138,15 +129,10 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			throw new Error("No artifacts directory found");
 		}
 
-		if (candidatePaths.length === 0) {
-			const availableStr = availableIds.size > 0 ? [...availableIds].join(", ") : "none";
-			throw new Error(`Not found: ${outputId}\nAvailable: ${availableStr}`);
-		}
-		if (candidatePaths.length > 1) {
-			throw new Error(`agent://${outputId} ambiguous id: ${candidatePaths.length} matching outputs`);
+		if (!foundPath) {
+			throw new Error(`agent://${outputId} not found`);
 		}
 
-		const foundPath = candidatePaths[0]!;
 		const rawBytes = Buffer.from(await Bun.file(foundPath).arrayBuffer());
 		await verifyAgentOutputMetadata(outputId, foundPath, rawBytes);
 		const rawContent = rawBytes.toString("utf8");

--- a/packages/coding-agent/src/internal-urls/artifact-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/artifact-protocol.ts
@@ -1,8 +1,8 @@
 /**
  * Protocol handler for artifact:// URLs.
  *
- * Resolves artifact IDs against the artifacts directories of every active
- * session. Unlike agent://, artifacts are raw text with no JSON extraction.
+ * Resolves artifact IDs only against artifacts directories explicitly authorized
+ * by the caller's ResolveContext. Unlike agent://, artifacts are raw text.
  *
  * URL form:
  * - artifact://<id> - Full artifact content
@@ -12,7 +12,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
-import { artifactsDirsFromRegistry } from "./registry-helpers";
+import { authorizedArtifactsDirsFromContext } from "./registry-helpers";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext } from "./types";
 
 export class ArtifactProtocolHandler implements ProtocolHandler {
@@ -28,16 +28,14 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error(`artifact:// ID must be numeric, got: ${id}`);
 		}
 
-		const contextDir = context?.getArtifactsDir?.();
-		const dirs = contextDir ? [contextDir] : artifactsDirsFromRegistry(context);
+		const dirs = authorizedArtifactsDirsFromContext(context);
 
 		if (dirs.length === 0) {
 			throw new Error("No session - artifacts unavailable");
 		}
 
-		const candidatePaths: string[] = [];
+		let foundPath: string | undefined;
 		let anyDirExists = false;
-		const availableIds = new Set<string>();
 
 		for (const dir of dirs) {
 			let files: string[];
@@ -50,9 +48,10 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			}
 			for (const f of files) {
 				if (f.endsWith(".meta.json")) continue;
-				const m = f.match(/^(\d+)\./);
-				if (m) availableIds.add(m[1]);
-				if (f.startsWith(`${id}.`)) candidatePaths.push(path.join(dir, f));
+				if (f.startsWith(`${id}.`)) {
+					if (foundPath) throw new Error(`artifact://${id} ambiguous id in authorized artifacts`);
+					foundPath = path.join(dir, f);
+				}
 			}
 		}
 
@@ -60,16 +59,10 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error("No artifacts directory found");
 		}
 
-		if (candidatePaths.length === 0) {
-			const sorted = [...availableIds].sort((a, b) => Number(a) - Number(b));
-			const availableStr = sorted.length > 0 ? sorted.join(", ") : "none";
-			throw new Error(`Artifact ${id} not found. Available: ${availableStr}`);
-		}
-		if (candidatePaths.length > 1) {
-			throw new Error(`artifact://${id} ambiguous id: ${candidatePaths.length} matching artifacts`);
+		if (!foundPath) {
+			throw new Error(`artifact://${id} not found`);
 		}
 
-		const foundPath = candidatePaths[0]!;
 		const content = await Bun.file(foundPath).text();
 		return {
 			url: url.href,

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -1,28 +1,28 @@
 /**
- * Shared helpers for internal-url protocol handlers that resolve IDs against
- * registered agent sessions.
+ * Shared helpers for internal-url protocol handlers that resolve session-scoped
+ * artifact IDs.
  */
-import { AgentRegistry } from "../registry/agent-registry";
+import * as path from "node:path";
 import type { ResolveContext } from "./types";
 
+function addDir(dirs: string[], dir: string | null | undefined): void {
+	if (!dir) return;
+	const normalized = path.resolve(dir);
+	if (!dirs.includes(normalized)) dirs.push(normalized);
+}
+
 /**
- * Snapshot of artifacts dirs for every registered session, deduped.
+ * Snapshot of artifacts dirs explicitly authorized for the calling session.
  *
- * Prefers `sessionManager.getArtifactsDir()` because subagents adopt their
- * parent's `ArtifactManager` and report the parent's dir there; dedup then
- * collapses parent + N subagents (the whole agent tree) to one entry. Falls
- * back to the raw session file (with the `.jsonl` suffix stripped) when no
- * live session reference is attached.
+ * Normal reads are scoped to the caller's artifacts directory. Parent/child
+ * agent tree sharing is allowed only when the caller supplies explicit
+ * authorized directories at the ResolveContext boundary. This intentionally
+ * does not enumerate AgentRegistry.global(); live but unrelated sessions are
+ * not an authorization source.
  */
-export function artifactsDirsFromRegistry(context?: ResolveContext): string[] {
+export function authorizedArtifactsDirsFromContext(context?: ResolveContext): string[] {
 	const dirs: string[] = [];
-	const contextDir = context?.getArtifactsDir?.();
-	if (contextDir) dirs.push(contextDir);
-	for (const ref of AgentRegistry.global().list()) {
-		const dir =
-			ref.session?.sessionManager.getArtifactsDir() ?? (ref.sessionFile ? ref.sessionFile.slice(0, -6) : null);
-		if (!dir) continue;
-		if (!dirs.includes(dir)) dirs.push(dir);
-	}
+	addDir(dirs, context?.getArtifactsDir?.());
+	for (const dir of context?.getAuthorizedArtifactsDirs?.() ?? []) addDir(dirs, dir);
 	return dirs;
 }

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -61,6 +61,8 @@ export interface ResolveContext {
 	settings?: unknown;
 	/** Artifacts directory of the calling session. */
 	getArtifactsDir?: () => string | null;
+	/** Additional artifacts directories explicitly authorized for this caller (for parent/child agent trees). */
+	getAuthorizedArtifactsDirs?: () => readonly string[];
 	/** Caller's abort signal. */
 	signal?: AbortSignal;
 }

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -3,7 +3,6 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, type SubagentRecord } from "../async";
-import { artifactsDirsFromRegistry } from "../internal-urls/registry-helpers";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
 import type { AgentSource } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
@@ -600,9 +599,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			const dir = path.dirname(record.sessionFile);
 			if (!dirs.includes(dir)) dirs.push(dir);
 		}
-		for (const dir of artifactsDirsFromRegistry()) {
-			if (!dirs.includes(dir)) dirs.push(dir);
-		}
+		const sessionDir = this.session.getArtifactsDir?.();
+		if (sessionDir && !dirs.includes(sessionDir)) dirs.push(sessionDir);
 		return dirs;
 	}
 

--- a/packages/coding-agent/test/internal-urls/agent-artifact-scope.test.ts
+++ b/packages/coding-agent/test/internal-urls/agent-artifact-scope.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { InternalUrlRouter } from "@gajae-code/coding-agent/internal-urls";
+import type { ResolveContext } from "@gajae-code/coding-agent/internal-urls/types";
+import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-artifact-scope-"));
+	AgentRegistry.resetGlobalForTests();
+	InternalUrlRouter.resetForTests();
+});
+
+afterEach(async () => {
+	AgentRegistry.resetGlobalForTests();
+	InternalUrlRouter.resetForTests();
+	await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+function contextFor(artifactsDir: string, authorizedArtifactsDirs: readonly string[] = []): ResolveContext {
+	return {
+		cwd: tempDir,
+		getArtifactsDir: () => artifactsDir,
+		getAuthorizedArtifactsDirs: () => authorizedArtifactsDirs,
+	};
+}
+
+async function writeAgentOutput(artifactsDir: string, id: string, content: string): Promise<void> {
+	await fs.mkdir(artifactsDir, { recursive: true });
+	const outputPath = path.join(artifactsDir, `${id}.md`);
+	const bytes = Buffer.byteLength(content, "utf8");
+	await Bun.write(outputPath, content);
+	await Bun.write(
+		`${outputPath}.meta.json`,
+		JSON.stringify(
+			{
+				id,
+				kind: "agent-output",
+				sizeBytes: bytes,
+				lineCount: content.split("\n").length,
+				sha256: createHash("sha256").update(content).digest("hex"),
+				createdAt: "2026-06-05T00:00:00.000Z",
+			},
+			null,
+		),
+	);
+}
+
+async function writeArtifact(artifactsDir: string, id: string, content: string): Promise<void> {
+	await fs.mkdir(artifactsDir, { recursive: true });
+	await Bun.write(path.join(artifactsDir, `${id}.bash.log`), content);
+}
+
+function registerLiveSession(id: string, artifactsDir: string): void {
+	AgentRegistry.global().register({
+		id,
+		displayName: id,
+		kind: "main",
+		session: null,
+		sessionFile: `${artifactsDir}.jsonl`,
+		status: "running",
+	});
+}
+
+describe("agent:// and artifact:// session scoping", () => {
+	it("does not resolve agent:// or artifact:// from unrelated live sessions", async () => {
+		const sessionA = path.join(tempDir, "session-a");
+		const sessionB = path.join(tempDir, "session-b");
+		await writeAgentOutput(sessionA, "0-A", "session A output");
+		await writeAgentOutput(sessionB, "0-B", "session B secret");
+		await writeArtifact(sessionA, "0", "session A artifact");
+		await writeArtifact(sessionB, "1", "session B secret artifact");
+		registerLiveSession("live-a", sessionA);
+		registerLiveSession("live-b", sessionB);
+
+		const router = InternalUrlRouter.instance();
+		await expect(router.resolve("agent://0-A", contextFor(sessionA))).resolves.toMatchObject({
+			content: "session A output",
+		});
+		await expect(router.resolve("artifact://0", contextFor(sessionA))).resolves.toMatchObject({
+			content: "session A artifact",
+		});
+
+		await expect(router.resolve("agent://0-B", contextFor(sessionA))).rejects.toThrow("agent://0-B not found");
+		await expect(router.resolve("artifact://1", contextFor(sessionA))).rejects.toThrow("artifact://1 not found");
+	});
+
+	it("allows explicitly authorized parent/child tree artifacts in both directions", async () => {
+		const parentDir = path.join(tempDir, "parent");
+		const childDir = path.join(tempDir, "child");
+		await writeAgentOutput(parentDir, "0-Parent", "parent output");
+		await writeAgentOutput(childDir, "0-Child", "child output");
+		await writeArtifact(parentDir, "0", "parent artifact");
+		await writeArtifact(childDir, "1", "child artifact");
+
+		const router = InternalUrlRouter.instance();
+		await expect(router.resolve("agent://0-Child", contextFor(parentDir, [childDir]))).resolves.toMatchObject({
+			content: "child output",
+		});
+		await expect(router.resolve("artifact://1", contextFor(parentDir, [childDir]))).resolves.toMatchObject({
+			content: "child artifact",
+		});
+		await expect(router.resolve("agent://0-Parent", contextFor(childDir, [parentDir]))).resolves.toMatchObject({
+			content: "parent output",
+		});
+		await expect(router.resolve("artifact://0", contextFor(childDir, [parentDir]))).resolves.toMatchObject({
+			content: "parent artifact",
+		});
+	});
+
+	it("fails closed without context and does not enumerate scoped IDs", async () => {
+		const sessionA = path.join(tempDir, "session-a");
+		const sessionB = path.join(tempDir, "session-b");
+		await writeAgentOutput(sessionA, "0-A", "session A output");
+		await writeAgentOutput(sessionB, "0-B", "session B output");
+		await writeArtifact(sessionA, "0", "session A artifact");
+		await writeArtifact(sessionB, "1", "session B artifact");
+		registerLiveSession("live-a", sessionA);
+		registerLiveSession("live-b", sessionB);
+
+		const router = InternalUrlRouter.instance();
+		await expect(router.resolve("agent://0-A")).rejects.toThrow("No session - agent outputs unavailable");
+		await expect(router.resolve("artifact://0")).rejects.toThrow("No session - artifacts unavailable");
+
+		try {
+			await router.resolve("agent://missing", contextFor(sessionA));
+			expect.unreachable("agent://missing should reject");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toBe("agent://missing not found");
+			expect(message).not.toContain("0-A");
+			expect(message).not.toContain("0-B");
+			expect(message).not.toContain("Available");
+		}
+
+		try {
+			await router.resolve("artifact://9", contextFor(sessionA));
+			expect.unreachable("artifact://9 should reject");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toBe("artifact://9 not found");
+			expect(message).not.toContain("0");
+			expect(message).not.toContain("1");
+			expect(message).not.toContain("Available");
+		}
+	});
+
+	it("does not treat a missing agent:// metadata sidecar as authorization", async () => {
+		const sessionA = path.join(tempDir, "session-a");
+		await fs.mkdir(sessionA, { recursive: true });
+		await Bun.write(path.join(sessionA, "0-NoMeta.md"), "sidecar-free content");
+
+		await expect(InternalUrlRouter.instance().resolve("agent://0-NoMeta", contextFor(sessionA))).rejects.toThrow(
+			"agent://0-NoMeta missing metadata",
+		);
+	});
+});

--- a/packages/coding-agent/test/task/lifecycle-resolver.test.ts
+++ b/packages/coding-agent/test/task/lifecycle-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -8,16 +8,12 @@ import { ArtifactProtocolHandler } from "../../src/internal-urls/artifact-protoc
 import { buildTaskReceipt, findRawTaskLeakKeys } from "../../src/task/receipt";
 import type { SingleResult, TaskToolDetails } from "../../src/task/types";
 
-const registeredDirs: string[] = [];
+const authorizedDirs: string[] = [];
 const LEAK_SENTINEL = "LEAK_SENTINEL_DO_NOT_DIGEST";
-
-mock.module("../../src/internal-urls/registry-helpers", () => ({
-	artifactsDirsFromRegistry: () => registeredDirs,
-}));
 
 async function makeTempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lifecycle-resolver-test-"));
-	registeredDirs.push(dir);
+	authorizedDirs.push(dir);
 	return dir;
 }
 
@@ -58,17 +54,21 @@ function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
 	};
 }
 
-function resolveAgent(id: string) {
-	return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never);
+function resolveContext(dir = authorizedDirs[0]) {
+	return { getArtifactsDir: () => dir ?? null, getAuthorizedArtifactsDirs: () => authorizedDirs };
 }
 
-function resolveArtifact(id: string) {
-	return new ArtifactProtocolHandler().resolve(new URL(`artifact://${id}`) as never);
+function resolveAgent(id: string, dir?: string) {
+	return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never, resolveContext(dir));
+}
+
+function resolveArtifact(id: string, dir?: string) {
+	return new ArtifactProtocolHandler().resolve(new URL(`artifact://${id}`) as never, resolveContext(dir));
 }
 
 afterEach(async () => {
-	while (registeredDirs.length > 0) {
-		const dir = registeredDirs.pop()!;
+	while (authorizedDirs.length > 0) {
+		const dir = authorizedDirs.pop()!;
 		await fs.rm(dir, { recursive: true, force: true });
 	}
 });
@@ -169,11 +169,11 @@ describe("lifecycle resolver hardening", () => {
 		await expect(resolveAgent("6-Parent.0-Nested")).resolves.toMatchObject({ content: nestedContent });
 	});
 
-	it("preserves PR1 legacy missing-sidecar behavior but fails closed for tampered sidecars", async () => {
+	it("fails closed when the agent output metadata sidecar is absent", async () => {
 		const dir = await makeTempDir();
 		const file = await writeAgentOutput(dir, "9-Legacy", "legacy content");
 		await fs.rm(`${file}.meta.json`);
-		await expect(resolveAgent("9-Legacy")).resolves.toMatchObject({ content: "legacy content" });
+		await expect(resolveAgent("9-Legacy")).rejects.toThrow(/missing metadata/);
 
 		await writeAgentOutput(dir, "10-Tampered", "tampered content");
 		await Bun.write(`${path.join(dir, "10-Tampered.md")}.meta.json`, JSON.stringify({ id: "different" }));

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -25,10 +25,6 @@ const CANONICAL_USAGE = {
 };
 
 const tempDirs: string[] = [];
-
-mock.module("../../src/internal-urls/registry-helpers", () => ({
-	artifactsDirsFromRegistry: () => tempDirs,
-}));
 
 function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
 	return {
@@ -263,7 +259,10 @@ describe("agent protocol metadata verification", () => {
 	}
 
 	async function resolve(id: string) {
-		return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never);
+		return new AgentProtocolHandler().resolve(new URL(`agent://${id}`) as never, {
+			getArtifactsDir: () => tempDirs[0] ?? null,
+			getAuthorizedArtifactsDirs: () => tempDirs,
+		});
 	}
 
 	it("resolves matching metadata and rejects hash and size mismatches", async () => {
@@ -278,9 +277,9 @@ describe("agent protocol metadata verification", () => {
 		await expect(resolve("verify")).rejects.toThrow(/size mismatch/);
 	});
 
-	it("preserves legacy behavior when the sidecar is absent", async () => {
+	it("fails closed when the sidecar is absent", async () => {
 		const file = await writeOutput("legacy", "legacy content");
 		await fs.rm(`${file}.meta.json`);
-		await expect(resolve("legacy")).resolves.toMatchObject({ content: "legacy content" });
+		await expect(resolve("legacy")).rejects.toThrow(/missing metadata/);
 	});
 });


### PR DESCRIPTION
Closes #287

## Summary
- Scope `agent://` and `artifact://` resolution to the caller's artifacts directory plus explicitly authorized parent/child tree directories.
- Remove registry-wide live-session artifact lookup and ID enumeration from normal not-found errors.
- Make missing `agent://` metadata sidecars fail closed, and update receipt/lifecycle tests accordingly.

## Verification
- `bun test packages/coding-agent/test/internal-urls/agent-artifact-scope.test.ts packages/coding-agent/test/internal-urls/local-protocol.test.ts packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts packages/coding-agent/test/task/lifecycle-resolver.test.ts packages/coding-agent/test/task/receipt.test.ts`
- `bun run check:ts`

## Risk notes
- Security hardening intentionally removes legacy missing-sidecar reads for `agent://`; older sidecar-free agent output refs now fail closed.
- Parent/child sharing remains available only through explicit authorized artifacts dirs at the resolve-context boundary.