### PR TITLE
fix(task): honor fork context maxMessages

### DIFF
--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -285,9 +285,14 @@ function requestsForkContext(
 
 function resolveForkSeedParamsForMode(
 	mode: ForkContextMode,
+	configuredMaxMessages: number | undefined,
 	configuredMaxTokens: number,
 	model: Model | undefined,
 ): { maxMessages: number; maxTokens: number } | undefined {
+	const capMessages = (defaultMaxMessages: number): number =>
+		configuredMaxMessages === undefined
+			? defaultMaxMessages
+			: Math.min(defaultMaxMessages, Math.max(0, Math.trunc(configuredMaxMessages)));
 	switch (mode) {
 		case "none":
 			return undefined;
@@ -296,9 +301,9 @@ function resolveForkSeedParamsForMode(
 		case "last-turn":
 			return { maxMessages: 2, maxTokens: 250 };
 		case "bounded":
-			return { maxMessages: 50, maxTokens: 250 };
+			return { maxMessages: capMessages(50), maxTokens: 250 };
 		case "full":
-			return { maxMessages: 500, maxTokens: resolveForkContextMaxTokens(configuredMaxTokens, model) };
+			return { maxMessages: capMessages(500), maxTokens: resolveForkContextMaxTokens(configuredMaxTokens, model) };
 		default:
 			return undefined;
 	}
@@ -601,8 +606,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (!this.session.buildForkContextSeed) {
 				throw new Error("Current session cannot build fork-context seeds.");
 			}
+			const configuredMaxMessages = this.session.settings.has("task.forkContext.maxMessages")
+				? this.session.settings.get("task.forkContext.maxMessages")
+				: undefined;
 			const configuredMaxTokens = this.session.settings.get("task.forkContext.maxTokens");
-			const params = resolveForkSeedParamsForMode(task.inheritContext, configuredMaxTokens, this.session.model);
+			const params = resolveForkSeedParamsForMode(
+				task.inheritContext,
+				configuredMaxMessages,
+				configuredMaxTokens,
+				this.session.model,
+			);
 			if (!params) return undefined;
 			return await this.session.buildForkContextSeed({
 				...params,
@@ -1250,8 +1263,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				if (!this.session.buildForkContextSeed) {
 					throw new Error("Current session cannot build fork-context seeds.");
 				}
+				const configuredMaxMessages = this.session.settings.has("task.forkContext.maxMessages")
+					? this.session.settings.get("task.forkContext.maxMessages")
+					: undefined;
 				const configuredMaxTokens = this.session.settings.get("task.forkContext.maxTokens");
-				const params = resolveForkSeedParamsForMode(task.inheritContext, configuredMaxTokens, this.session.model);
+				const params = resolveForkSeedParamsForMode(
+					task.inheritContext,
+					configuredMaxMessages,
+					configuredMaxTokens,
+					this.session.model,
+				);
 				if (!params) return undefined;
 				return await this.session.buildForkContextSeed({
 					...params,

--- a/packages/coding-agent/test/task-fork-context.test.ts
+++ b/packages/coding-agent/test/task-fork-context.test.ts
@@ -410,6 +410,29 @@ describe("fork context policy surface", () => {
 		expect(renderedPrompt?.join("\n")).toContain("forked snapshot of the parent conversation");
 	});
 
+	test("uses configured maxMessages to cap bounded fork-context seeds", async () => {
+		mockAgents([createAgent("executor", "allowed")]);
+		const seed = createSeed();
+		const seedBuilder = vi.fn(async () => seed);
+		const tool = await TaskTool.create(
+			createSession({ "task.forkContext.enabled": true, "task.forkContext.maxMessages": 3 }, seedBuilder),
+		);
+
+		await executeDetached(tool, {
+			agent: "executor",
+			tasks: [
+				{
+					id: "BoundedForkSeed",
+					description: "seed",
+					assignment: "Use bounded context.",
+					inheritContext: "bounded",
+				},
+			],
+		});
+
+		expect(seedBuilder).toHaveBeenCalledWith({ maxMessages: 3, maxTokens: 250, signal: undefined });
+	});
+
 	test("uses reduced model-window fallback for full fork-context seeds", async () => {
 		mockAgents([createAgent("executor", "allowed")]);
 		const seed = createSeed();
@@ -422,6 +445,22 @@ describe("fork context policy surface", () => {
 		});
 
 		expect(seedBuilder).toHaveBeenCalledWith({ maxMessages: 500, maxTokens: 150, signal: undefined });
+	});
+
+	test("uses configured maxMessages to cap full fork-context seeds", async () => {
+		mockAgents([createAgent("executor", "allowed")]);
+		const seed = createSeed();
+		const seedBuilder = vi.fn(async () => seed);
+		const tool = await TaskTool.create(
+			createSession({ "task.forkContext.enabled": true, "task.forkContext.maxMessages": 7 }, seedBuilder),
+		);
+
+		await executeDetached(tool, {
+			agent: "executor",
+			tasks: [{ id: "FullForkSeed", description: "seed", assignment: "Use full context.", inheritContext: "full" }],
+		});
+
+		expect(seedBuilder).toHaveBeenCalledWith({ maxMessages: 7, maxTokens: 150, signal: undefined });
 	});
 
 	test("freezes inherited context seeds before detached job execution", async () => {


### PR DESCRIPTION
## Summary
- apply task.forkContext.maxMessages as a cap for bounded and full fork-context seeds
- preserve existing default message counts when maxMessages is not explicitly configured
- add regression coverage for reduced bounded and full maxMessages

Closes #302

## Verification
- bun test packages/coding-agent/test/task-fork-context.test.ts
- bun --cwd=packages/coding-agent run check