### PR TITLE
fix: restrict subagent resume steer to one target

### DIFF
--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -25,18 +25,20 @@ Request a graceful safe-boundary pause for selected subagents by `ids`.
 - A paused subagent keeps its session context and can be resumed later.
 
 ## `action: "resume"`
-Resume selected non-running subagents by `ids`.
-- Optional `message` is delivered into the resumed run.
+Resume one subagent by `id` (preferred) or a single-item `ids` array.
+- Optional `message` is delivered into that one resumed run.
 - Running subagents are a no-op and return their current status snapshot.
 - Terminal subagents require `message` to start a follow-up resume run; without `message`, the tool returns the current snapshot with guidance.
 - `paused` subagents resume from saved context; `queued` subagents are already waiting for capacity.
+- Multiple targets are rejected because one global `message` must not broadcast to several subagents.
 
 ## `action: "steer"`
-Send a non-empty `message` to selected subagents by `ids`.
-- Running subagents receive the message through their live handle.
+Send a non-empty `message` to one subagent by `id` (preferred) or a single-item `ids` array.
+- A running subagent receives the message through its live handle.
 - Optional `pause: true` requests a safe-boundary pause after steering a running subagent.
 - `pause` only matters while the target is running.
-- Non-active subagents (`paused`, `queued`, or terminal) automatically resume with the message; `pause` is ignored for these targets.
+- A non-active subagent (`paused`, `queued`, or terminal) automatically resumes with the message; `pause` is ignored for that target.
+- Multiple targets are rejected because one global `message` must not broadcast to several subagents.
 
 ## `action: "cancel"`
 Stop selected subagents by `ids`, including running, paused, or queued subagents.

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -23,6 +23,7 @@ const subagentSchema = z.object({
 		.enum(["list", "inspect", "await", "cancel", "pause", "resume", "steer"])
 		.describe("subagent control action"),
 	ids: z.array(z.string()).optional().describe("subagent ids or backing job ids"),
+	id: z.string().optional().describe("single subagent id or backing job id for resume/steer"),
 	message: z.string().optional().describe("message to deliver when resuming or steering a subagent"),
 	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
 	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
@@ -180,36 +181,27 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 
 		if (params.action === "resume") {
-			const ids = params.ids ?? [];
-			if (ids.length === 0) {
-				throw new ToolError("`resume` requires at least one subagent id.");
-			}
+			const id = this.#singleTargetId(params, "resume");
 			const records: SubagentRecord[] = [];
 			const missing: SubagentSnapshot[] = [];
 			const terminalGuidanceIds = new Set<string>();
-			const verifiedOutputIds = await this.#verifiedOutputIds(this.#visibleRecordsByIds(manager, ids, ownerFilter));
-			for (const id of ids) {
-				const record = this.#findVisibleRecord(manager, id, ownerFilter);
-				if (!record) {
-					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
-					continue;
-				}
-				if (record.status === "running") {
-					records.push(record);
-					continue;
-				}
-				if (params.message === undefined && isTerminalStatus(record.status)) {
-					records.push(record);
-					terminalGuidanceIds.add(record.subagentId);
-					continue;
-				}
+			const record = this.#findVisibleRecord(manager, id, ownerFilter);
+			const verifiedOutputIds = await this.#verifiedOutputIds(record ? [record] : []);
+			if (!record) {
+				missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+			} else if (record.status === "running") {
+				records.push(record);
+			} else if (params.message === undefined && isTerminalStatus(record.status)) {
+				records.push(record);
+				terminalGuidanceIds.add(record.subagentId);
+			} else {
 				const result = manager.resumeSubagent(record.subagentId, ownerFilter, params.message);
 				if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
 				if (!result.ok && result.reason === "not_found") {
 					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
-					continue;
+				} else {
+					records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 				}
-				records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 			}
 
 			return this.#buildSnapshotResult(
@@ -231,23 +223,18 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 
 		if (params.action === "steer") {
-			const ids = params.ids ?? [];
+			const id = this.#singleTargetId(params, "steer");
 			const message = params.message;
-			if (ids.length === 0) {
-				throw new ToolError("`steer` requires at least one subagent id.");
-			}
 			if (message === undefined || message.trim() === "") {
 				throw new ToolError("`steer` requires a non-empty message.");
 			}
 			const records: SubagentRecord[] = [];
 			const missing: SubagentSnapshot[] = [];
-			const verifiedOutputIds = await this.#verifiedOutputIds(this.#visibleRecordsByIds(manager, ids, ownerFilter));
-			for (const id of ids) {
-				const record = this.#findVisibleRecord(manager, id, ownerFilter);
-				if (!record) {
-					missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
-					continue;
-				}
+			const record = this.#findVisibleRecord(manager, id, ownerFilter);
+			const verifiedOutputIds = await this.#verifiedOutputIds(record ? [record] : []);
+			if (!record) {
+				missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
+			} else {
 				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
 				if (record.status === "running") {
 					const handle = manager.getLiveHandle(record.subagentId);
@@ -259,10 +246,12 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 					if (!result.ok && result.reason === "context_unavailable") throw new ToolError("context unavailable");
 					if (!result.ok && result.reason === "not_found") {
 						missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
-						continue;
+					} else {
+						records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 					}
 				}
-				records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
+				if (record.status === "running")
+					records.push(manager.getSubagentRecord(record.subagentId, ownerFilter) ?? record);
 			}
 			return this.#buildSnapshotResult(
 				[
@@ -274,6 +263,25 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 
 		return this.#awaitSubagents(manager, params, ownerFilter, signal, onUpdate);
+	}
+
+	#singleTargetId(params: SubagentParams, action: "resume" | "steer"): string {
+		const id = params.id?.trim();
+		const ids = (params.ids ?? []).map(value => value.trim()).filter(value => value.length > 0);
+		if (id && ids.length > 0) {
+			if (ids.length === 1 && ids[0] === id) return id;
+			throw new ToolError(
+				`\`${action}\` accepts exactly one target; provide \`id\` or a single-item \`ids\`, not both.`,
+			);
+		}
+		if (id) return id;
+		if (ids.length === 1) return ids[0]!;
+		if (ids.length > 1) {
+			throw new ToolError(
+				`\`${action}\` accepts exactly one target because \`message\` is delivered to one subagent.`,
+			);
+		}
+		throw new ToolError(`\`${action}\` requires a single subagent id via \`id\`.`);
 	}
 
 	async #awaitSubagents(

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -245,6 +245,47 @@ describe("SubagentTool", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("resume accepts id and rejects multi-id message broadcast", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const resumed: string[] = [];
+		manager.setResumeRunner(subagentId => {
+			resumed.push(subagentId);
+			return manager.register("task", subagentId, async () => "resumed", {
+				id: `job-${subagentId}`,
+				ownerId: "0-Main",
+				metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+			});
+		});
+		for (const subagentId of ["0-ResumeA", "0-ResumeB"]) {
+			manager.registerSubagentRecord({
+				subagentId,
+				ownerId: "0-Main",
+				currentJobId: null,
+				historicalJobIds: [],
+				status: "paused",
+				sessionFile: `/tmp/${subagentId}.jsonl`,
+				resumable: true,
+			});
+		}
+
+		await expect(
+			tool.execute("subagent-resume-broadcast", {
+				action: "resume",
+				ids: ["0-ResumeA", "0-ResumeB"],
+				message: "resume only one",
+			}),
+		).rejects.toThrow("accepts exactly one target");
+		expect(resumed).toEqual([]);
+
+		const result = await tool.execute("subagent-resume-id", { action: "resume", id: "0-ResumeA" });
+
+		expect(resumed).toEqual(["0-ResumeA"]);
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(result.details?.subagents[0]?.jobId).toBe("job-0-ResumeA");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("steer running injects a message and optionally requests pause", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
@@ -277,6 +318,48 @@ describe("SubagentTool", () => {
 
 		expect(injected).toBe("tighten scope");
 		expect(pauseRequested).toBe(true);
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("steer accepts id and rejects multi-id message broadcast", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const injected: string[] = [];
+		for (const subagentId of ["0-SteerA", "0-SteerB"]) {
+			manager.registerSubagentRecord({
+				subagentId,
+				ownerId: "0-Main",
+				currentJobId: null,
+				historicalJobIds: [],
+				status: "running",
+				sessionFile: `/tmp/${subagentId}.jsonl`,
+				resumable: true,
+			});
+			manager.registerLiveHandle(subagentId, {
+				requestPause() {},
+				async injectMessage(content) {
+					injected.push(`${subagentId}:${content}`);
+				},
+			});
+		}
+
+		await expect(
+			tool.execute("subagent-steer-broadcast", {
+				action: "steer",
+				ids: ["0-SteerA", "0-SteerB"],
+				message: "steer only one",
+			}),
+		).rejects.toThrow("accepts exactly one target");
+		expect(injected).toEqual([]);
+
+		const result = await tool.execute("subagent-steer-id", {
+			action: "steer",
+			id: "0-SteerA",
+			message: "steer one",
+		});
+
+		expect(injected).toEqual(["0-SteerA:steer one"]);
 		expect(result.details?.subagents[0]?.status).toBe("running");
 		await manager.dispose({ timeoutMs: 100 });
 	});


### PR DESCRIPTION
## Summary
- add a single-target `id` contract for `subagent` resume/steer while retaining single-item `ids` compatibility
- reject multi-id resume/steer calls before any message is delivered
- update tool docs and regression tests while preserving bulk `ids[]` behavior for other actions

Closes #303

## Verification
- `bun test test/tools/subagent.test.ts` (from `packages/coding-agent`)
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/tools/subagent.ts packages/coding-agent/test/tools/subagent.test.ts packages/coding-agent/src/prompts/tools/subagent.md`