### PR TITLE
Fix hook selector focused option viewport cap

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -141,11 +141,10 @@ class ScrollableTitle extends Container {
  * `maxVisibleRows`; everything that depends on terminal width is recomputed
  * on each render so resize Just Works.
  *
- * `maxVisibleRows` is a sibling budget before it is a hard cap: surrounding
- * options shrink first so the focused option is never clipped. The single
- * allowed overflow exception is when the focused option's wrapped block
- * alone exceeds the budget — in that case the focused option is rendered
- * fully with zero siblings.
+ * `maxVisibleRows` is a hard viewport budget for every rendered option-list
+ * row. Surrounding options shrink first; if the focused option alone would
+ * exceed the remaining budget, it is compacted to contextual rows plus an
+ * omitted-rows marker so controls stay reachable for untrusted long labels.
  */
 class FocusAwareList extends Container {
 	#options: string[] = [];
@@ -184,19 +183,20 @@ class FocusAwareList extends Container {
 			theme.fg("accent", t),
 		);
 		const focusedWrappedSegments = wrapTextWithAnsi(focusedLabel, availableLabelWidth);
-		const focusedRows = Math.max(1, focusedWrappedSegments.length);
 
-		// Decide whether the position marker is going to be shown. We make a
-		// pessimistic first pass assuming the marker is needed; if the window
-		// ends up covering every option we drop it.
+		// Reserve one row for the option position marker only when the focused
+		// block itself must be compacted. Moderate focused labels keep the legacy
+		// wrap-focused behavior and spend the full viewport on label context.
 		const totalOptions = this.#options.length;
-		const willHaveSiblings = totalOptions > 1;
-		const wouldNeedMarker = willHaveSiblings; // tentative; refined below
-		const markerSlot = wouldNeedMarker ? 1 : 0;
+		const mustCompactFocused = focusedWrappedSegments.length > this.#maxVisibleRows;
+		const positionMarkerSlot = mustCompactFocused && totalOptions > 1 ? 1 : 0;
+		const focusedBudget = Math.max(1, this.#maxVisibleRows - positionMarkerSlot);
+		const focusedSegments = this.#capFocusedSegments(focusedWrappedSegments, focusedBudget, availableLabelWidth);
+		const focusedRows = Math.max(1, focusedSegments.length);
 
-		// Sibling budget. If the focused block alone is over budget, render it
-		// fully with zero siblings (only allowed overflow exception).
-		const siblingBudget = Math.max(0, this.#maxVisibleRows - focusedRows - markerSlot);
+		// Sibling budget. If the focused block consumes the available viewport,
+		// render it with zero siblings and the reserved position marker.
+		const siblingBudget = Math.max(0, this.#maxVisibleRows - focusedRows - positionMarkerSlot);
 
 		// Distribute sibling slots around focus, preferring closest options.
 		const availableAbove = this.#selectedIndex;
@@ -219,8 +219,8 @@ class FocusAwareList extends Container {
 			if (i === this.#selectedIndex) {
 				// Emit focused wrapped rows. Cursor only on row 0; continuation
 				// rows are whitespace-aligned under the label start.
-				for (let r = 0; r < focusedWrappedSegments.length; r++) {
-					const segment = focusedWrappedSegments[r] ?? "";
+				for (let r = 0; r < focusedSegments.length; r++) {
+					const segment = focusedSegments[r] ?? "";
 					rows.push(r === 0 ? styledSelectedPrefix + segment : continuationPrefix + segment);
 				}
 			} else {
@@ -233,11 +233,31 @@ class FocusAwareList extends Container {
 			}
 		}
 
-		if (showMarker) {
+		if (showMarker && rows.length < this.#maxVisibleRows) {
 			rows.push(theme.fg("dim", `  (${this.#selectedIndex + 1}/${totalOptions})`));
 		}
 
 		return this.#outline ? this.#wrapOutline(rows, width) : rows;
+	}
+
+	#capFocusedSegments(segments: string[], maxRows: number, availableLabelWidth: number): string[] {
+		const rows = segments.length > 0 ? segments : [""];
+		const budget = Math.max(1, Math.floor(maxRows));
+		if (rows.length <= budget) return rows;
+
+		if (budget === 1) {
+			return [truncateToWidth(`… ${rows.length - 1} wrapped rows omitted …`, availableLabelWidth)];
+		}
+
+		if (budget === 2) {
+			return [rows[0] ?? "", truncateToWidth(`… ${rows.length - 1} wrapped rows omitted …`, availableLabelWidth)];
+		}
+
+		const tailRows = Math.max(1, Math.floor((budget - 2) / 2));
+		const headRows = Math.max(1, budget - 1 - tailRows);
+		const omittedRows = Math.max(1, rows.length - headRows - tailRows);
+		const marker = truncateToWidth(`… ${omittedRows} wrapped rows omitted …`, availableLabelWidth);
+		return [...rows.slice(0, headRows), marker, ...rows.slice(rows.length - tailRows)];
 	}
 
 	#wrapOutline(rows: string[], width: number): string[] {

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -285,6 +285,52 @@ describe("HookSelectorComponent", () => {
 		// label — it is still one-line behavior.
 		expect(nonFocusedLines[0]).not.toContain("hotel golf");
 	});
+
+	it("caps extremely long focused options to maxVisible rows with an omitted marker", () => {
+		const longLabel = Array.from({ length: 400 }, (_, index) => `token-${index}`).join(" ");
+		const maxVisible = 5;
+		const rendered = renderStripped(28, { outline: true, initialIndex: 1, maxVisible, wrapFocused: true }, [
+			"above option",
+			longLabel,
+			"below option",
+		]);
+		const lines = rendered.split("\n");
+		const innerRows = lines.map(line => stripBorder(line, "│"));
+		const optionRows = innerRows.filter(
+			line =>
+				line.includes("above option") ||
+				line.includes("token-") ||
+				line.includes("wrapped rows omitted") ||
+				line.includes("below option") ||
+				line.includes("(2/3)"),
+		);
+
+		expect(optionRows.length).toBeLessThanOrEqual(maxVisible);
+		expect(rendered).toContain("wrapped rows omit");
+		expect(rendered).toContain("(2/3)");
+		expect(rendered).not.toContain("below option");
+	});
+
+	it("keeps controls reachable when focused option budget leaves one content row", () => {
+		const longLabel = Array.from({ length: 200 }, (_, index) => `word${index}`).join(" ");
+		const rendered = renderStripped(24, { outline: false, initialIndex: 0, maxVisible: 3, wrapFocused: true }, [
+			longLabel,
+			"second choice",
+		]);
+		const lines = rendered.split("\n");
+		const optionRows = lines.filter(
+			line =>
+				line.includes("word") ||
+				line.includes("wrapped rows omitted") ||
+				line.includes("second choice") ||
+				line.includes("(1/2)"),
+		);
+
+		expect(optionRows.length).toBeLessThanOrEqual(3);
+		expect(rendered).toContain("wrapped rows omi");
+		expect(rendered).toContain("(1/2)");
+		expect(rendered).toContain("up/down navigate");
+	});
 	it("caps scrollable title rows while keeping options and help visible", () => {
 		const title = Array.from({ length: 10 }, (_, index) => `Prompt row ${index + 1}`).join("\n\n");
 		const component = new HookSelectorComponent(


### PR DESCRIPTION
## Summary
- cap wrapFocused option rendering to the maxVisible option-list viewport budget
- compact oversized focused labels with contextual rows and an omitted-rows marker
- add regression coverage for huge focused options in outlined and non-outline selectors

Closes #301

## Verification
- bun test packages/coding-agent/test/hook-selector-overflow.test.ts
- bun run check:ts
