### PR TITLE
Fix async paste input queue bounds

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -41,6 +41,11 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
 };
 
+const PASTE_DECISION_TIMEOUT_MS = 5_000;
+const PENDING_PASTE_INPUT_MAX = 64;
+
+type PastePendingClearReason = "timeout" | "queue-limit";
+
 /**
  * Custom editor that handles configurable app-level shortcuts for coding-agent.
  */
@@ -66,6 +71,8 @@ export class CustomEditor extends Editor {
 	onPasteImage?: () => Promise<boolean>;
 	/** Called before bracketed paste content is inserted. Return true to consume it. */
 	onPasteText?: (text: string) => boolean | Promise<boolean>;
+	/** Called when async paste handling drops queued input instead of replaying it. */
+	onPastePendingInputCleared?: (reason: PastePendingClearReason, droppedInputCount: number) => void;
 	/** Called when the configured dequeue shortcut is pressed. */
 	onDequeue?: () => void;
 	/** Called when Caps Lock is pressed. */
@@ -78,6 +85,8 @@ export class CustomEditor extends Editor {
 	);
 	#pasteHandler = new BracketedPasteHandler();
 	#pasteDecisionPending = false;
+	#pasteDecisionToken = 0;
+	#pasteDecisionTimeout: NodeJS.Timeout | undefined;
 	#pendingPasteInput: string[] = [];
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
@@ -114,6 +123,37 @@ export class CustomEditor extends Editor {
 		this.#customKeyHandlers.clear();
 	}
 
+	#clearPasteDecisionTimeout(): void {
+		if (this.#pasteDecisionTimeout) {
+			clearTimeout(this.#pasteDecisionTimeout);
+			this.#pasteDecisionTimeout = undefined;
+		}
+	}
+
+	#clearPendingPasteState(): number {
+		this.#clearPasteDecisionTimeout();
+		this.#pasteDecisionPending = false;
+		this.#pasteDecisionToken += 1;
+		const droppedInputCount = this.#pendingPasteInput.length;
+		this.#pendingPasteInput = [];
+		return droppedInputCount;
+	}
+
+	#startPasteDecisionTimeout(token: number): void {
+		this.#clearPasteDecisionTimeout();
+		this.#pasteDecisionTimeout = setTimeout(() => {
+			if (token !== this.#pasteDecisionToken) return;
+			const droppedInputCount = this.#clearPendingPasteState();
+			this.onPastePendingInputCleared?.("timeout", droppedInputCount);
+		}, PASTE_DECISION_TIMEOUT_MS);
+		this.#pasteDecisionTimeout.unref?.();
+	}
+
+	dispose(): void {
+		this.#clearPendingPasteState();
+		this.#pasteHandler = new BracketedPasteHandler();
+	}
+
 	#drainPendingPasteInput(initialInput?: string): void {
 		if (initialInput && initialInput.length > 0) {
 			this.handleInput(initialInput);
@@ -126,7 +166,9 @@ export class CustomEditor extends Editor {
 	}
 
 	#handleBracketedPaste(pasteContent: string, remaining: string): void {
-		const applyPasteResult = (handled: boolean | undefined) => {
+		const applyPasteResult = (token: number, handled: boolean | undefined) => {
+			if (token !== this.#pasteDecisionToken) return;
+			this.#clearPasteDecisionTimeout();
 			if (!handled) {
 				super.handleInput(`\x1b[200~${pasteContent}\x1b[201~`);
 			}
@@ -136,16 +178,26 @@ export class CustomEditor extends Editor {
 		const pasteResult = this.onPasteText?.(pasteContent);
 
 		if (pasteResult instanceof Promise) {
+			const token = this.#pasteDecisionToken + 1;
+			this.#pasteDecisionToken = token;
 			this.#pasteDecisionPending = true;
-			void pasteResult.then(applyPasteResult, () => applyPasteResult(false));
+			this.#startPasteDecisionTimeout(token);
+			void pasteResult.then(
+				handled => applyPasteResult(token, handled),
+				() => applyPasteResult(token, false),
+			);
 		} else {
-			applyPasteResult(pasteResult);
+			applyPasteResult(this.#pasteDecisionToken, pasteResult);
 		}
 	}
 
 	handleInput(data: string): void {
 		if (this.#pasteDecisionPending) {
 			this.#pendingPasteInput.push(data);
+			if (this.#pendingPasteInput.length > PENDING_PASTE_INPUT_MAX) {
+				const droppedInputCount = this.#clearPendingPasteState();
+				this.onPastePendingInputCleared?.("queue-limit", droppedInputCount);
+			}
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -165,6 +165,12 @@ export class InputController {
 		);
 		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
 		this.ctx.editor.onPasteText = text => this.handleTextPaste(text);
+		this.ctx.editor.onPastePendingInputCleared = (reason, droppedInputCount) => {
+			const reasonText = reason === "timeout" ? "timed out" : "exceeded the input queue limit";
+			this.ctx.showWarning(
+				`Paste handling ${reasonText}; discarded ${droppedInputCount} buffered input event${droppedInputCount === 1 ? "" : "s"}.`,
+			);
+		};
 		this.ctx.editor.setActionKeys("app.tools.expand", this.ctx.keybindings.getKeys("app.tools.expand"));
 		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1860,6 +1860,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#eventController.dispose();
 		this.statusLine.dispose();
 		this.#jobsObserver?.dispose();
+		this.editor.dispose();
 		if (this.#resizeHandler) {
 			process.stdout.removeListener("resize", this.#resizeHandler);
 			this.#resizeHandler = undefined;
@@ -1961,6 +1962,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			nextEditor.setHistoryStorage(this.historyStorage);
 		}
 		nextEditor.setText(previousText);
+		previousEditor.dispose();
 
 		this.editorContainer.clear();
 		this.editor = nextEditor;

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 
@@ -9,6 +9,10 @@ function ctrl(key: string): string {
 function createEditor() {
 	return new CustomEditor(defaultEditorTheme);
 }
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("CustomEditor temporary model selector keybinding", () => {
 	it("triggers the temporary selector from a remapped action key instead of Alt+P", () => {
@@ -95,5 +99,66 @@ describe("CustomEditor bracketed paste interception", () => {
 		await Bun.sleep(0);
 
 		expect(editor.getText()).toBe("before middle after");
+	});
+
+	it("drops queued input and ignores late async paste decisions after timeout", async () => {
+		vi.useFakeTimers();
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		const onPastePendingInputCleared = vi.fn();
+		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+		editor.onPastePendingInputCleared = onPastePendingInputCleared;
+
+		editor.handleInput("before ");
+		editor.handleInput("\x1b[200~middle \x1b[201~");
+		editor.handleInput("after");
+
+		expect(editor.getText()).toBe("before ");
+
+		vi.advanceTimersByTime(5_000);
+		expect(onPastePendingInputCleared).toHaveBeenCalledWith("timeout", 1);
+
+		pasteDecision.resolve(false);
+		await Promise.resolve();
+
+		expect(editor.getText()).toBe("before ");
+	});
+
+	it("bounds the async paste input queue and clears pending state", async () => {
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		const onPastePendingInputCleared = vi.fn();
+		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+		editor.onPastePendingInputCleared = onPastePendingInputCleared;
+
+		editor.handleInput("before ");
+		editor.handleInput("\x1b[200~middle \x1b[201~");
+		for (let index = 0; index < 65; index += 1) {
+			editor.handleInput(`queued-${index} `);
+		}
+
+		expect(onPastePendingInputCleared).toHaveBeenCalledWith("queue-limit", 65);
+		expect(editor.getText()).toBe("before ");
+
+		pasteDecision.resolve(false);
+		await Bun.sleep(0);
+
+		expect(editor.getText()).toBe("before ");
+	});
+
+	it("clears pending async paste state when disposed", async () => {
+		const editor = createEditor();
+		const pasteDecision = Promise.withResolvers<boolean>();
+		editor.onPasteText = vi.fn(() => pasteDecision.promise);
+
+		editor.handleInput("before ");
+		editor.handleInput("\x1b[200~middle \x1b[201~");
+		editor.handleInput("after");
+		editor.dispose();
+
+		pasteDecision.resolve(false);
+		await Bun.sleep(0);
+
+		expect(editor.getText()).toBe("before ");
 	});
 });


### PR DESCRIPTION
Closes #300

## Summary
- bound CustomEditor async paste input buffering and add a timeout
- clear pending paste state on editor disposal and editor replacement/shutdown
- surface a warning when queued paste input is discarded
- add regression coverage for timeout, queue cap, and disposal late-settle behavior

## Verification
- bun test packages/coding-agent/test/custom-editor-keybindings.test.ts
- bun run check:ts