### PR TITLE
Fix telemetry content capture warnings

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Moved the env-driven full message content capture warning into agent-core telemetry resolution so direct `@gajae-code/agent-core` consumers receive `full_content_capture_env_active` when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=full` is used without an explicit `captureMessageContent` override.
+
+### Changed
+
+- Clarified that telemetry `summary` content capture emits bounded real-content snippets in `pi.gen_ai.*` attributes and is not redacted or PII-free.
+
 ## [0.2.4] - 2026-06-02
 
 ### Added

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -55,6 +55,9 @@ export const DEFAULT_TRACER_NAME = "@gajae-code/agent-core";
 
 /** Env var matching the OTEL semconv content-capture toggle. */
 const CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+const FULL_CONTENT_CAPTURE_ENV_WARNING =
+	`${CONTENT_CAPTURE_ENV}=full enables full GenAI message content capture. ` +
+	`Use ${CONTENT_CAPTURE_ENV}=summary for bounded telemetry summaries.`;
 
 const MAX_TELEMETRY_ARRAY_ITEMS = 64;
 const MAX_TELEMETRY_MESSAGE_COUNT = 16;
@@ -327,12 +330,16 @@ export interface AgentTelemetryConfig {
 	/**
 	 * Capture request/response content. Programmatic `true` preserves the
 	 * historical full payload capture because code config is an explicit opt-in;
-	 * `"summary"` emits bounded dashboard-friendly summaries; `"full"` emits
-	 * both summaries and full OTEL message payloads.
+	 * `"summary"` emits bounded dashboard-friendly summaries in
+	 * `pi.gen_ai.request.messages`, `pi.gen_ai.response.text`, and related
+	 * `pi.gen_ai.*` attributes. Summary mode is not redacted or PII-free: text is
+	 * truncated to bounded snippets, not removed. `"full"` emits both summaries
+	 * and full OTEL message payloads.
 	 *
 	 * Defaults to the value of the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`
 	 * env var (`true`/`1`/`yes` => `"summary"`, `"summary"` => `"summary"`,
-	 * `"full"` => `"full"`).
+	 * `"full"` => `"full"`). Env-driven `"full"` capture emits a
+	 * `full_content_capture_env_active` telemetry warning once per process.
 	 */
 	readonly captureMessageContent?: TelemetryContentCapture;
 	/** Extra attributes merged onto every emitted span. */
@@ -420,8 +427,9 @@ export function resolveTelemetry(
 ): AgentTelemetry | undefined {
 	if (!config) return undefined;
 	const tracer = config.tracer ?? trace.getTracer(config.tracerName ?? DEFAULT_TRACER_NAME);
+	const contentCaptureFromEnv = config.captureMessageContent === undefined;
 	const contentCapture = resolveContentCapture(config.captureMessageContent);
-	return {
+	const telemetry = {
 		config,
 		tracer,
 		captureMessageContent: contentCapture === "full",
@@ -430,9 +438,12 @@ export function resolveTelemetry(
 		agent: config.agent,
 		collector: new AgentRunCollector(),
 	};
+	warnIfEnvFullContentCaptureActive(telemetry, contentCaptureFromEnv);
+	return telemetry;
 }
 
 let contentCaptureEnvCache: ResolvedTelemetryContentCapture | undefined;
+let hasWarnedFullContentCaptureEnv = false;
 function readContentCaptureEnv(): ResolvedTelemetryContentCapture {
 	if (contentCaptureEnvCache !== undefined) return contentCaptureEnvCache;
 	const raw = process.env[CONTENT_CAPTURE_ENV];
@@ -453,6 +464,7 @@ function readContentCaptureEnv(): ResolvedTelemetryContentCapture {
 
 export function resetContentCaptureEnvCacheForTest(): void {
 	contentCaptureEnvCache = undefined;
+	hasWarnedFullContentCaptureEnv = false;
 }
 
 function resolveContentCapture(value: TelemetryContentCapture | undefined): ResolvedTelemetryContentCapture {
@@ -460,6 +472,15 @@ function resolveContentCapture(value: TelemetryContentCapture | undefined): Reso
 	if (capture === true || capture === "full") return "full";
 	if (capture === "summary") return "summary";
 	return "none";
+}
+
+function warnIfEnvFullContentCaptureActive(telemetry: AgentTelemetry, contentCaptureFromEnv: boolean): void {
+	if (!contentCaptureFromEnv || telemetry.contentCapture !== "full" || hasWarnedFullContentCaptureEnv) return;
+	hasWarnedFullContentCaptureEnv = true;
+	emitTelemetryWarning(telemetry, {
+		code: "full_content_capture_env_active",
+		message: FULL_CONTENT_CAPTURE_ENV_WARNING,
+	});
 }
 
 /**

--- a/packages/agent/test/__snapshots__/otel.test.ts.snap
+++ b/packages/agent/test/__snapshots__/otel.test.ts.snap
@@ -1,0 +1,20 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`agent-loop OTEL instrumentation captures bounded dashboard summary content when requested: summary request messages include bounded real content 1`] = `
+[
+  {
+    "content": "sys-instruction",
+    "role": "system",
+  },
+  {
+    "content": "hi",
+    "role": "user",
+  },
+]
+`;
+
+exports[`agent-loop OTEL instrumentation captures bounded dashboard summary content when requested: summary response text includes bounded real content 1`] = `
+[
+  "hi back",
+]
+`;

--- a/packages/agent/test/otel.test.ts
+++ b/packages/agent/test/otel.test.ts
@@ -380,13 +380,10 @@ describe("agent-loop OTEL instrumentation", () => {
 		await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
 
 		const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
-		const request = JSON.parse(chat?.attributes[PiGenAIAttr.RequestMessages] as string) as Array<{
-			content: unknown;
-			role: string;
-		}>;
+		const request = JSON.parse(chat?.attributes[PiGenAIAttr.RequestMessages] as string);
 		const responseText = JSON.parse(chat?.attributes[PiGenAIAttr.ResponseText] as string);
-		expect(request.map(message => message.role)).toEqual(["system", "user"]);
-		expect(responseText).toEqual(["hi back"]);
+		expect(request).toMatchSnapshot("summary request messages include bounded real content");
+		expect(responseText).toMatchSnapshot("summary response text includes bounded real content");
 		expect(chat?.attributes[GenAIAttr.InputMessages]).toBeUndefined();
 		expect(chat?.attributes[GenAIAttr.OutputMessages]).toBeUndefined();
 	});
@@ -433,10 +430,11 @@ describe("agent-loop OTEL instrumentation", () => {
 				...MOCK_IDENT,
 				responses: [{ content: ["hi back"], stopReason: "stop" }],
 			});
+			const warnings: unknown[] = [];
 			const config: AgentLoopConfig = {
 				model: mock.model,
 				convertToLlm: identityConverter,
-				telemetry: {},
+				telemetry: { onTelemetryWarning: warning => warnings.push(warning) },
 			};
 			const ctx: AgentContext = { systemPrompt: ["sys-instruction"], messages: [], tools: [] };
 			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
@@ -447,6 +445,13 @@ describe("agent-loop OTEL instrumentation", () => {
 			]);
 			expect(JSON.parse(chat?.attributes[GenAIAttr.OutputMessages] as string)).toEqual([
 				{ role: "assistant", parts: [{ type: "text", content: "hi back" }], finish_reason: "stop" },
+			]);
+			expect(warnings).toEqual([
+				{
+					code: "full_content_capture_env_active",
+					message:
+						"OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=full enables full GenAI message content capture. Use OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=summary for bounded telemetry summaries.",
+				},
 			]);
 		} finally {
 			if (before === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3,7 +3,6 @@ import {
 	type AgentEvent,
 	type AgentMessage,
 	type AgentTelemetryConfig,
-	type AgentTelemetryWarning,
 	type AgentTool,
 	AppendOnlyContextManager,
 	INTENT_FIELD,
@@ -32,35 +31,6 @@ import {
 	prompt,
 	Snowflake,
 } from "@gajae-code/utils";
-
-const CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
-let hasWarnedFullCapture = false;
-
-export function resetFullCaptureEnvWarningForTest(): void {
-	hasWarnedFullCapture = false;
-}
-
-export function warnIfEnvFullContentCaptureActive(telemetry: AgentTelemetryConfig | undefined): void {
-	if (!telemetry || hasWarnedFullCapture) return;
-	if (telemetry.captureMessageContent !== undefined) return;
-	if (process.env[CONTENT_CAPTURE_ENV]?.trim().toLowerCase() !== "full") return;
-	hasWarnedFullCapture = true;
-	const warning = {
-		code: "full_content_capture_env_active" as const,
-		message:
-			`${CONTENT_CAPTURE_ENV}=full enables full GenAI message content capture. ` +
-			`Use ${CONTENT_CAPTURE_ENV}=summary for bounded telemetry summaries.`,
-	} satisfies AgentTelemetryWarning;
-	try {
-		telemetry.onTelemetryWarning?.(warning);
-	} catch (error) {
-		logger.warn("Telemetry warning hook failed", {
-			code: warning.code,
-			error: error instanceof Error ? error.message : String(error),
-		});
-	}
-	logger.warn(warning.message, { code: warning.code });
-}
 
 import { type AsyncJob, AsyncJobManager, isBackgroundJobSupportEnabled } from "./async";
 import { loadCapability } from "./capability";
@@ -1780,7 +1750,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				? undefined
 				: serviceTierSetting;
 
-		warnIfEnvFullContentCaptureActive(options.telemetry);
 		const appendOnlyContext =
 			model && resolveAppendOnlyMode(settings.get("provider.appendOnlyContext"), model.provider)
 				? new AppendOnlyContextManager()

--- a/packages/coding-agent/test/telemetry-full-capture-warning.test.ts
+++ b/packages/coding-agent/test/telemetry-full-capture-warning.test.ts
@@ -1,41 +1,39 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { logger } from "@gajae-code/utils";
-import { resetFullCaptureEnvWarningForTest, warnIfEnvFullContentCaptureActive } from "../src/sdk";
+import { resetContentCaptureEnvCacheForTest, resolveTelemetry } from "@gajae-code/agent-core/telemetry";
 
 describe("full content capture env warning", () => {
 	const envName = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
 
 	afterEach(() => {
 		delete process.env[envName];
-		resetFullCaptureEnvWarningForTest();
+		resetContentCaptureEnvCacheForTest();
 		vi.restoreAllMocks();
 	});
 
-	it("warns once through the telemetry hook and logger when env full capture is active", () => {
+	it("warns once through the telemetry hook when env full capture is active", () => {
 		process.env[envName] = "full";
-		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const hook = vi.fn();
 
-		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
-		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
+		resolveTelemetry({ onTelemetryWarning: hook }, "session-1");
+		resolveTelemetry({ onTelemetryWarning: hook }, "session-1");
 
 		expect(hook).toHaveBeenCalledTimes(1);
-		expect(hook.mock.calls[0]?.[0]).toMatchObject({ code: "full_content_capture_env_active" });
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		expect(warnSpy.mock.calls[0]?.[0]).toContain(`${envName}=full enables full GenAI message content capture`);
+		expect(hook.mock.calls[0]?.[0]).toMatchObject({
+			code: "full_content_capture_env_active",
+			message: `${envName}=full enables full GenAI message content capture. Use ${envName}=summary for bounded telemetry summaries.`,
+		});
 	});
 
 	it("does not warn for env summary capture or explicit programmatic full capture", () => {
-		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const hook = vi.fn();
 
 		process.env[envName] = "summary";
-		warnIfEnvFullContentCaptureActive({ onTelemetryWarning: hook });
+		resolveTelemetry({ onTelemetryWarning: hook }, "session-1");
 
 		process.env[envName] = "full";
-		warnIfEnvFullContentCaptureActive({ captureMessageContent: true, onTelemetryWarning: hook });
+		resetContentCaptureEnvCacheForTest();
+		resolveTelemetry({ captureMessageContent: true, onTelemetryWarning: hook }, "session-1");
 
 		expect(hook).not.toHaveBeenCalled();
-		expect(warnSpy).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Closes #298

## Summary
- move env-driven full content capture warning into agent-core telemetry resolution
- document that summary capture emits bounded real-content snippets, not redacted/PII-free metadata
- snapshot summary capture attributes and update full-warning tests

## Verification
- bun test packages/agent/test/otel.test.ts packages/coding-agent/test/telemetry-full-capture-warning.test.ts
- bun --cwd=packages/agent run check:types
- bun --cwd=packages/coding-agent run check:types
- bun run check:tools packages/agent/src/telemetry.ts packages/agent/test/otel.test.ts packages/agent/CHANGELOG.md packages/coding-agent/src/sdk.ts packages/coding-agent/test/telemetry-full-capture-warning.test.ts packages/agent/test/__snapshots__/otel.test.ts.snap