### PR TITLE
Fix hashline anchors for truncated reads

### DIFF
--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1031,7 +1031,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 
 			const collectedLines = streamResult.lines;
-			if (!rawSelector && maxColumns > 0) {
+			if (!rawSelector && !shouldAddHashLines && maxColumns > 0) {
 				for (let i = 0; i < collectedLines.length; i++) {
 					const { text, wasTruncated } = truncateLine(collectedLines[i], maxColumns);
 					if (wasTruncated) {
@@ -1789,8 +1789,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					// counts in `truncation` keep reflecting the source, not the trimmed
 					// view — column truncation surfaces separately via `.limits()`.
 					const rawSelector = isRawSelector(parsed);
+					const shouldAddHashLines = !rawSelector && displayMode.hashLines;
 					const maxColumns = resolveOutputMaxColumns(this.session.settings);
-					if (!rawSelector && maxColumns > 0) {
+					if (!rawSelector && !shouldAddHashLines && maxColumns > 0) {
 						for (let i = 0; i < collectedLines.length; i++) {
 							const { text, wasTruncated } = truncateLine(collectedLines[i], maxColumns);
 							if (wasTruncated) {
@@ -1824,7 +1825,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						getFileReadCache(this.session).recordContiguous(absolutePath, startLineDisplay, collectedLines);
 					}
 
-					const shouldAddHashLines = !rawSelector && displayMode.hashLines;
 					const shouldAddLineNumbers = rawSelector ? false : shouldAddHashLines ? false : displayMode.lineNumbers;
 					let capturedDisplayContent: { text: string; startLine: number } | undefined;
 					const formatText = (text: string, startNum: number): string => {

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -23,6 +23,7 @@ import {
 	tryRecoverHashlineWithCache,
 } from "@gajae-code/coding-agent/edit";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { ReadTool } from "@gajae-code/coding-agent/tools/read";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -52,6 +53,12 @@ function applyDiff(content: string, diff: string): string {
 
 function applyDiffWithPureInsertAutoDrop(content: string, diff: string): string {
 	return applyHashlineEdits(content, parseHashline(diff), { autoDropPureInsertDuplicates: true }).lines;
+}
+function toolText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
+		.map(part => part.text)
+		.join("\n");
 }
 
 async function withTempDir(fn: (tempDir: string) => Promise<void>): Promise<void> {
@@ -826,6 +833,30 @@ describe("hashline — anchor-stale recovery via read snapshot cache", () => {
 		expect(cache.get("/tmp/file-1.ts")).toBeNull();
 		expect(cache.get("/tmp/file-2.ts")).not.toBeNull();
 		expect(cache.get("/tmp/file-31.ts")).not.toBeNull();
+	});
+
+	it("does not generate anchors from column-truncated read lines", async () => {
+		await withTempDir(async tempDir => {
+			const filePath = path.join(tempDir, "long-line.txt");
+			const longLine = "abcdefghij";
+			await Bun.write(filePath, `${longLine}\nsecond\n`);
+
+			const settings = Settings.isolated({ "tools.outputMaxColumns": 5 });
+			const session = makeHashlineSession(tempDir, settings);
+			const readTool = new ReadTool(session);
+			const readResult = await readTool.execute("read-long-line", { path: `${filePath}:1+1` });
+			const readText = toolText(readResult);
+
+			expect(readText).toContain(`1${computeLineHash(1, longLine)}${outputSep}${longLine}`);
+			expect(readText).not.toContain("abcde…");
+
+			const anchor = `${1}${computeLineHash(1, longLine)}`;
+			await executeHashlineSingle(
+				hashlineExecuteOptions(tempDir, `§long-line.txt\n≔${sameLineRange(anchor)}\nshort\n`, settings, session),
+			);
+
+			expect(await Bun.file(filePath).text()).toBe("short\nsecond\n");
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #336.

## Summary
- Keep hashline read output untruncated when anchors are emitted, so hashes are computed for the exact on-disk line content.
- Preserve existing column truncation for non-hashline read output.
- Add a regression covering a long line with a tight outputMaxColumns setting followed by a hashline edit using the displayed anchor.

## Verification
- bun test packages/coding-agent/test/core/hashline.test.ts
- bun run check:ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*