### PR TITLE
feat(coding-agent): model profiles (--mpreset)

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -168,6 +168,42 @@ The same presets are available inside the TUI:
 
 Presets only write `models.yml` entries that reference documented environment variable names (`MINIMAX_CODE_API_KEY`, `MINIMAX_CODE_CN_API_KEY`, or `ZAI_API_KEY`); they do not store or validate real credentials. The GLM preset aliases (`glm`, `zai`, `z-ai`) write an OpenAI-compatible custom provider named `glm-proxy` and do not replace the first-class `zai` provider.
 
+## Model profiles (`--mpreset`)
+
+Model profiles are optional top-level `profiles:` entries in `~/.gjc/agent/models.yml`. A profile can require provider credentials before activation and can map one or more model roles; omitted roles inherit from the active defaults.
+
+```yaml
+profiles:
+  team-standard:
+    required_providers: [openai, anthropic]
+    model_mapping:
+      default: openai/gpt-5.2
+      executor: anthropic/claude-sonnet-4-6:medium
+      architect: openai/o3:high
+      planner: openai/o3:high
+      critic: openai/o3:high
+```
+
+`model_mapping` keys are role names (`default`, `executor`, `architect`, `planner`, `critic`). Each role maps to exactly one model selector in the form `provider/modelId[:effort]`; comma-separated fallback chains are not supported in a single role value.
+`required_providers` is the aggregate set of providers required across the profile's mapped roles, not a per-role fallback chain.
+
+Built-in profiles are grouped by provider mix and tier:
+
+- `opencode-go-{eco,standard,pro}`
+- `codex-{eco,standard,pro}`
+- `opencode-go-codex-{eco,standard,pro}`
+
+The `eco` tier favors cheaper/faster defaults, `standard` matches normal production defaults (`codex-standard` is the current OpenAI Codex default set), and `pro` raises reasoning for architect, critic, and planner roles. User-defined profiles override built-ins by exact profile name.
+
+Use `gjc --mpreset <name>` to activate a profile for the current session only. Activation hard-blocks when any provider listed in `required_providers` lacks credentials. Add `--default` to persist the selected profile as `modelProfile.default` in `config.yml`, so it applies at startup:
+
+```sh
+gjc --mpreset codex-standard
+gjc --mpreset opencode-go-pro --default
+```
+
+The `/model` command shows a `Profiles` section above model selection. In `/login`, `Add custom provider` is the first option for configuring credentials needed by custom or profile-required providers.
+
 MiniMax's OpenAI-compatible endpoint rejects multiple system messages and emits thinking in `reasoning_content`, so pin the public-safe compatibility fields when hand-authoring a custom provider:
 
 ```yaml

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -17,6 +17,8 @@ export interface Args {
 	smol?: string;
 	slow?: string;
 	plan?: string;
+	mpreset?: string;
+	default?: boolean;
 	apiKey?: string;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -127,6 +129,10 @@ export function parseArgs(args: string[]): Args {
 			result.slow = args[++i];
 		} else if (arg === "--plan" && i + 1 < args.length) {
 			result.plan = args[++i];
+		} else if (arg === "--mpreset" && i + 1 < args.length) {
+			result.mpreset = args[++i];
+		} else if (arg === "--default") {
+			result.default = true;
 		} else if (arg === "--api-key" && i + 1 < args.length) {
 			result.apiKey = args[++i];
 		} else if (arg === "--system-prompt" && i + 1 < args.length) {
@@ -197,6 +203,10 @@ export function parseArgs(args: string[]): Args {
 		} else if (!arg.startsWith("-")) {
 			result.messages.push(arg);
 		}
+	}
+
+	if (result.default && !result.mpreset) {
+		throw new Error("--default requires --mpreset <name>");
 	}
 
 	return result;

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -36,6 +36,12 @@ export default class Index extends Command {
 		plan: Flags.string({
 			description: "Plan model for architectural planning (or GJC_PLAN_MODEL env)",
 		}),
+		mpreset: Flags.string({
+			description: "Model profile preset to activate for this session",
+		}),
+		default: Flags.boolean({
+			description: "Persist --mpreset as the default model profile",
+		}),
 		provider: Flags.string({
 			description: "Provider to use (legacy; prefer --model)",
 		}),
@@ -136,6 +142,8 @@ export default class Index extends Command {
 		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
+		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-standard`,
+		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencode-go-pro --default`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,
 	];
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -1,0 +1,145 @@
+import type { Api, Model } from "@gajae-code/ai";
+import { isAuthenticated, type GjcModelAssignmentTargetId, type ModelRegistry } from "./model-registry";
+import { formatAvailableProfileNames, resolveProfileBindings } from "./model-profiles";
+import { resolveModelRoleValue } from "./model-resolver";
+import type { Settings } from "./settings";
+import type { AgentSession } from "../session/agent-session";
+import type { ThinkingLevel } from "@gajae-code/agent-core";
+
+export interface PrepareModelProfileActivationOptions {
+	session: Pick<AgentSession, "model" | "thinkingLevel" | "sessionId">;
+	modelRegistry: Pick<
+		ModelRegistry,
+		| "getModelProfile"
+		| "getModelProfiles"
+		| "getAvailableModelProfileNames"
+		| "getApiKeyForProvider"
+		| "getAll"
+	>;
+	settings: Pick<Settings, "get">;
+	profileName: string;
+}
+
+export interface PreparedModelProfileActivation {
+	profileName: string;
+	session: Pick<AgentSession, "model" | "thinkingLevel" | "sessionId" | "setModelTemporary">;
+	settings: Pick<Settings, "get" | "override" | "set" | "flush">;
+	previousModel: Model<Api> | undefined;
+	previousThinkingLevel: ThinkingLevel | undefined;
+	previousAgentModelOverrides: Record<string, string>;
+	defaultModel: Model<Api> | undefined;
+	defaultThinkingLevel: ThinkingLevel | undefined;
+	agentModelOverrides: Record<string, string>;
+}
+
+export function formatModelProfileCredentialError(profileName: string, providers: readonly string[]): string {
+	return `Model profile "${profileName}" requires credentials for: ${providers.join(", ")}. Run /login and configure the missing provider(s), then retry.`;
+}
+
+export async function prepareModelProfileActivation(
+	options: PrepareModelProfileActivationOptions,
+): Promise<PreparedModelProfileActivation> {
+	const profile = options.modelRegistry.getModelProfile(options.profileName);
+	if (!profile) {
+		const available = formatAvailableProfileNames(options.modelRegistry.getModelProfiles());
+		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
+	}
+
+	const missingProviders: string[] = [];
+	for (const provider of profile.requiredProviders) {
+		const apiKey = await options.modelRegistry.getApiKeyForProvider(provider, options.session.sessionId);
+		if (!isAuthenticated(apiKey)) {
+			missingProviders.push(provider);
+		}
+	}
+	if (missingProviders.length > 0) {
+		throw new Error(formatModelProfileCredentialError(options.profileName, missingProviders));
+	}
+
+	const availableModels = options.modelRegistry.getAll();
+	const bindings = resolveProfileBindings(profile);
+	const resolvedDefault = bindings.defaultSelector
+		? resolveModelRoleValue(bindings.defaultSelector, availableModels, {
+				settings: options.settings as Settings,
+				modelRegistry: options.modelRegistry,
+			})
+		: undefined;
+	if (bindings.defaultSelector && !resolvedDefault?.model) {
+		throw new Error(`Model profile "${options.profileName}" default selector did not resolve: ${bindings.defaultSelector}`);
+	}
+
+	const agentModelOverrides: Record<string, string> = {};
+	for (const [role, selector] of Object.entries(bindings.agentModelOverrides) as [GjcModelAssignmentTargetId, string][]) {
+		const resolved = resolveModelRoleValue(selector, availableModels, {
+			settings: options.settings as Settings,
+			modelRegistry: options.modelRegistry,
+		});
+		if (!resolved.model) {
+			throw new Error(`Model profile "${options.profileName}" ${role} selector did not resolve: ${selector}`);
+		}
+		agentModelOverrides[role] = selector;
+	}
+
+	return {
+		profileName: options.profileName,
+		session: options.session as PreparedModelProfileActivation["session"],
+		settings: options.settings as PreparedModelProfileActivation["settings"],
+		previousModel: options.session.model,
+		previousThinkingLevel: options.session.thinkingLevel,
+		previousAgentModelOverrides: { ...options.settings.get("task.agentModelOverrides") },
+		defaultModel: resolvedDefault?.model,
+		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
+		agentModelOverrides,
+	};
+}
+
+export async function applyPreparedModelProfileActivation(
+	prepared: PreparedModelProfileActivation,
+	options: { persistDefault?: boolean } = {},
+): Promise<void> {
+	const previousModel = prepared.previousModel;
+	const previousThinkingLevel = prepared.previousThinkingLevel;
+	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
+	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
+	let modelChanged = false;
+	let overridesChanged = false;
+	let defaultChanged = false;
+
+	try {
+		if (prepared.defaultModel) {
+			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel);
+			modelChanged = true;
+		}
+		if (Object.keys(prepared.agentModelOverrides).length > 0) {
+			prepared.settings.override("task.agentModelOverrides", {
+				...prepared.settings.get("task.agentModelOverrides"),
+				...prepared.agentModelOverrides,
+			});
+			overridesChanged = true;
+		}
+		if (options.persistDefault) {
+			prepared.settings.set("modelProfile.default", prepared.profileName);
+			defaultChanged = true;
+			await prepared.settings.flush();
+		}
+	} catch (error) {
+		if (defaultChanged) {
+			prepared.settings.set("modelProfile.default", previousPersistedDefault);
+		}
+		if (overridesChanged) {
+			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
+		}
+		if (modelChanged && previousModel) {
+			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+		}
+		throw error;
+	}
+}
+
+export async function activateModelProfile(
+	options: PrepareModelProfileActivationOptions,
+	applyOptions: { persistDefault?: boolean } = {},
+): Promise<void> {
+	const prepared = await prepareModelProfileActivation(options);
+	await applyPreparedModelProfileActivation(prepared, applyOptions);
+}

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -1,20 +1,20 @@
+import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Api, Model } from "@gajae-code/ai";
-import { isAuthenticated, type GjcModelAssignmentTargetId, type ModelRegistry } from "./model-registry";
-import { formatAvailableProfileNames, resolveProfileBindings } from "./model-profiles";
+import type { AgentSession } from "../session/agent-session";
+import {
+	aggregateModelProfileRequiredProviders,
+	formatAvailableProfileNames,
+	resolveProfileBindings,
+} from "./model-profiles";
+import { type GjcModelAssignmentTargetId, isAuthenticated, type ModelRegistry } from "./model-registry";
 import { resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
-import type { AgentSession } from "../session/agent-session";
-import type { ThinkingLevel } from "@gajae-code/agent-core";
 
 export interface PrepareModelProfileActivationOptions {
 	session: Pick<AgentSession, "model" | "thinkingLevel" | "sessionId">;
 	modelRegistry: Pick<
 		ModelRegistry,
-		| "getModelProfile"
-		| "getModelProfiles"
-		| "getAvailableModelProfileNames"
-		| "getApiKeyForProvider"
-		| "getAll"
+		"getModelProfile" | "getModelProfiles" | "getAvailableModelProfileNames" | "getApiKeyForProvider" | "getAll"
 	>;
 	settings: Pick<Settings, "get">;
 	profileName: string;
@@ -46,7 +46,7 @@ export async function prepareModelProfileActivation(
 	}
 
 	const missingProviders: string[] = [];
-	for (const provider of profile.requiredProviders) {
+	for (const provider of aggregateModelProfileRequiredProviders(profile.requiredProviders, profile)) {
 		const apiKey = await options.modelRegistry.getApiKeyForProvider(provider, options.session.sessionId);
 		if (!isAuthenticated(apiKey)) {
 			missingProviders.push(provider);
@@ -65,11 +65,16 @@ export async function prepareModelProfileActivation(
 			})
 		: undefined;
 	if (bindings.defaultSelector && !resolvedDefault?.model) {
-		throw new Error(`Model profile "${options.profileName}" default selector did not resolve: ${bindings.defaultSelector}`);
+		throw new Error(
+			`Model profile "${options.profileName}" default selector did not resolve: ${bindings.defaultSelector}`,
+		);
 	}
 
 	const agentModelOverrides: Record<string, string> = {};
-	for (const [role, selector] of Object.entries(bindings.agentModelOverrides) as [GjcModelAssignmentTargetId, string][]) {
+	for (const [role, selector] of Object.entries(bindings.agentModelOverrides) as [
+		GjcModelAssignmentTargetId,
+		string,
+	][]) {
 		const resolved = resolveModelRoleValue(selector, availableModels, {
 			settings: options.settings as Settings,
 			modelRegistry: options.modelRegistry,

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -1,0 +1,123 @@
+import type { GjcModelAssignmentTargetId } from "./model-registry";
+import type { ModelsConfig } from "./models-config-schema";
+
+export type ModelProfileRole = GjcModelAssignmentTargetId;
+
+export interface ModelProfileDefinition {
+	name: string;
+	requiredProviders: string[];
+	modelMapping: Partial<Record<ModelProfileRole, string>>;
+	source: "builtin" | "user";
+}
+
+export interface ResolvedProfileBinding {
+	defaultSelector?: string;
+	agentModelOverrides: Partial<Record<Exclude<ModelProfileRole, "default">, string>>;
+}
+
+const profile = (
+	name: string,
+	requiredProviders: string[],
+	modelMapping: Record<ModelProfileRole, string>,
+): ModelProfileDefinition => ({
+	name,
+	requiredProviders,
+	modelMapping,
+	source: "builtin",
+});
+
+export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
+	profile("opencode-go-eco", ["opencode-go"], {
+		default: "opencode-go/deepseek-v4-flash",
+		executor: "opencode-go/qwen3.5-plus",
+		architect: "opencode-go/glm-5",
+		planner: "opencode-go/minimax-m2.5",
+		critic: "opencode-go/kimi-k2.5",
+	}),
+	profile("opencode-go-standard", ["opencode-go"], {
+		default: "opencode-go/kimi-k2.6",
+		executor: "opencode-go/qwen3.6-plus",
+		architect: "opencode-go/glm-5.1",
+		planner: "opencode-go/minimax-m2.7",
+		critic: "opencode-go/deepseek-v4-pro",
+	}),
+	profile("opencode-go-pro", ["opencode-go"], {
+		default: "opencode-go/qwen3.7-max",
+		executor: "opencode-go/kimi-k2.6",
+		architect: "opencode-go/deepseek-v4-pro:high",
+		planner: "opencode-go/glm-5.1:high",
+		critic: "opencode-go/minimax-m2.7:high",
+	}),
+	profile("codex-eco", ["openai-codex"], {
+		default: "openai-codex/gpt-5.4-mini",
+		executor: "openai-codex/gpt-5.4-nano",
+		architect: "openai-codex/gpt-5.4-mini",
+		planner: "openai-codex/gpt-5.4-mini",
+		critic: "openai-codex/gpt-5.4-mini",
+	}),
+	profile("codex-standard", ["openai-codex"], {
+		default: "openai-codex/gpt-5.4:medium",
+		executor: "openai-codex/gpt-5.4:low",
+		architect: "openai-codex/gpt-5.4:xhigh",
+		planner: "openai-codex/gpt-5.4:medium",
+		critic: "openai-codex/gpt-5.4:high",
+	}),
+	profile("codex-pro", ["openai-codex"], {
+		default: "openai-codex/gpt-5.5",
+		executor: "openai-codex/gpt-5.2-codex",
+		architect: "openai-codex/gpt-5.1-codex-max:high",
+		planner: "openai-codex/gpt-5.5:high",
+		critic: "openai-codex/gpt-5.3-codex-spark:high",
+	}),
+	profile("opencode-go-codex-eco", ["opencode-go", "openai-codex"], {
+		default: "opencode-go/deepseek-v4-flash",
+		executor: "opencode-go/qwen3.5-plus",
+		architect: "openai-codex/gpt-5.4-mini",
+		planner: "openai-codex/gpt-5.4-mini",
+		critic: "openai-codex/gpt-5.4-mini",
+	}),
+	profile("opencode-go-codex-standard", ["opencode-go", "openai-codex"], {
+		default: "opencode-go/kimi-k2.6",
+		executor: "opencode-go/qwen3.6-plus",
+		architect: "openai-codex/gpt-5.4",
+		planner: "openai-codex/gpt-5.4",
+		critic: "openai-codex/gpt-5.4",
+	}),
+	profile("opencode-go-codex-pro", ["opencode-go", "openai-codex"], {
+		default: "opencode-go/qwen3.7-max",
+		executor: "opencode-go/kimi-k2.6",
+		architect: "openai-codex/gpt-5.1-codex-max:high",
+		planner: "openai-codex/gpt-5.5:high",
+		critic: "openai-codex/gpt-5.3-codex-spark:high",
+	}),
+];
+
+export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const definition of BUILTIN_MODEL_PROFILES) {
+		profiles.set(definition.name, { ...definition, requiredProviders: [...definition.requiredProviders], modelMapping: { ...definition.modelMapping } });
+	}
+	for (const [name, definition] of Object.entries(userProfiles ?? {})) {
+		profiles.set(name, {
+			name,
+			requiredProviders: [...definition.required_providers],
+			modelMapping: { ...definition.model_mapping },
+			source: "user",
+		});
+	}
+	return profiles;
+}
+
+export function resolveProfileBindings(definition: ModelProfileDefinition): ResolvedProfileBinding {
+	const { default: defaultSelector, executor, architect, planner, critic } = definition.modelMapping;
+	const agentModelOverrides: ResolvedProfileBinding["agentModelOverrides"] = {};
+	if (executor !== undefined) agentModelOverrides.executor = executor;
+	if (architect !== undefined) agentModelOverrides.architect = architect;
+	if (planner !== undefined) agentModelOverrides.planner = planner;
+	if (critic !== undefined) agentModelOverrides.critic = critic;
+	return { defaultSelector, agentModelOverrides };
+}
+
+export function formatAvailableProfileNames(profiles: ReadonlyMap<string, ModelProfileDefinition>): string {
+	return [...profiles.keys()].sort((a, b) => a.localeCompare(b)).join(", ");
+}

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -15,13 +15,40 @@ export interface ResolvedProfileBinding {
 	agentModelOverrides: Partial<Record<Exclude<ModelProfileRole, "default">, string>>;
 }
 
+function parseModelSelectorProvider(selector: string): string | undefined {
+	const slashIdx = selector.indexOf("/");
+	if (slashIdx <= 0) return undefined;
+	return selector.slice(0, slashIdx);
+}
+
+export function deriveModelProfileMappedProviders(definition: Pick<ModelProfileDefinition, "modelMapping">): string[] {
+	const providers = new Set<string>();
+	for (const selector of Object.values(definition.modelMapping)) {
+		if (!selector) continue;
+		const provider = parseModelSelectorProvider(selector);
+		if (provider) providers.add(provider);
+	}
+	return [...providers].sort((a, b) => a.localeCompare(b));
+}
+
+export function aggregateModelProfileRequiredProviders(
+	requiredProviders: readonly string[],
+	definition: Pick<ModelProfileDefinition, "modelMapping">,
+): string[] {
+	const providers = new Set(requiredProviders);
+	for (const provider of deriveModelProfileMappedProviders(definition)) {
+		providers.add(provider);
+	}
+	return [...providers];
+}
+
 const profile = (
 	name: string,
 	requiredProviders: string[],
 	modelMapping: Record<ModelProfileRole, string>,
 ): ModelProfileDefinition => ({
 	name,
-	requiredProviders,
+	requiredProviders: aggregateModelProfileRequiredProviders(requiredProviders, { modelMapping }),
 	modelMapping,
 	source: "builtin",
 });
@@ -95,13 +122,18 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
 	const profiles = new Map<string, ModelProfileDefinition>();
 	for (const definition of BUILTIN_MODEL_PROFILES) {
-		profiles.set(definition.name, { ...definition, requiredProviders: [...definition.requiredProviders], modelMapping: { ...definition.modelMapping } });
+		profiles.set(definition.name, {
+			...definition,
+			requiredProviders: [...definition.requiredProviders],
+			modelMapping: { ...definition.modelMapping },
+		});
 	}
 	for (const [name, definition] of Object.entries(userProfiles ?? {})) {
+		const modelMapping = { ...definition.model_mapping };
 		profiles.set(name, {
 			name,
-			requiredProviders: [...definition.required_providers],
-			modelMapping: { ...definition.model_mapping },
+			requiredProviders: aggregateModelProfileRequiredProviders(definition.required_providers, { modelMapping }),
+			modelMapping,
 			source: "user",
 		});
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -50,6 +50,7 @@ import {
 	type ProviderAuthMode,
 	type ProviderDiscovery,
 } from "./models-config-schema";
+import { type ModelProfileDefinition, mergeModelProfiles } from "./model-profiles";
 import { type Settings, settings } from "./settings";
 
 export type { CanonicalModelIndex, CanonicalModelRecord, CanonicalModelVariant, ModelEquivalenceConfig };
@@ -511,6 +512,7 @@ interface CustomModelsResult {
 	configuredProviders?: Set<string>;
 	equivalence?: ModelEquivalenceConfig;
 	modelBindings?: NonNullable<ModelsConfig["modelBindings"]>;
+	profiles?: ModelsConfig["profiles"];
 	error?: ConfigError;
 	found: boolean;
 }
@@ -954,6 +956,7 @@ export class ModelRegistry {
 	#modelOverrides: Map<string, Map<string, ModelOverride>> = new Map();
 	#equivalenceConfig: ModelEquivalenceConfig | undefined;
 	#configuredModelBindings: NonNullable<ModelsConfig["modelBindings"]> | undefined;
+	#modelProfiles: Map<string, ModelProfileDefinition> = mergeModelProfiles();
 	#modelBindingsTargetSettings: Settings | undefined;
 	#appliedModelBindingRoles = new Set<string>();
 	#appliedAgentModelBindingOverrides = new Set<string>();
@@ -1093,6 +1096,7 @@ export class ModelRegistry {
 			configuredProviders = new Set(),
 			equivalence,
 			modelBindings,
+			profiles,
 			error: configError,
 		} = this.#loadCustomModels();
 		this.#configError = configError;
@@ -1103,6 +1107,7 @@ export class ModelRegistry {
 		this.#modelOverrides = modelOverrides;
 		this.#equivalenceConfig = equivalence;
 		this.#configuredModelBindings = modelBindings;
+		this.#modelProfiles = mergeModelProfiles(profiles);
 
 		this.#addImplicitDiscoverableProviders(configuredProviders);
 		const builtInModels = this.#applyHardcodedModelPolicies(this.#loadBuiltInModels(overrides));
@@ -1343,6 +1348,7 @@ export class ModelRegistry {
 				discoverableProviders: [],
 				configuredProviders: new Set(),
 				error,
+				profiles: undefined,
 				found: true,
 			};
 		} else if (status === "not-found") {
@@ -1353,6 +1359,7 @@ export class ModelRegistry {
 				keylessProviders: new Set(),
 				discoverableProviders: [],
 				configuredProviders: new Set(),
+				profiles: undefined,
 				found: false,
 			};
 		}
@@ -1441,10 +1448,22 @@ export class ModelRegistry {
 			configuredProviders,
 			equivalence: value.equivalence,
 			modelBindings: value.modelBindings,
+			profiles: value.profiles,
 			found: true,
 		};
 	}
 
+	getModelProfiles(): Map<string, ModelProfileDefinition> {
+		return new Map(this.#modelProfiles);
+	}
+
+	getModelProfile(name: string): ModelProfileDefinition | undefined {
+		return this.#modelProfiles.get(name);
+	}
+
+	getAvailableModelProfileNames(): string[] {
+		return [...this.#modelProfiles.keys()].sort((a, b) => a.localeCompare(b));
+	}
 	applyConfiguredModelBindings(targetSettings: Settings): void {
 		this.#modelBindingsTargetSettings = targetSettings;
 		this.#applyConfiguredModelBindingsToTarget();

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -76,6 +76,38 @@ const ModelBindingsSchema = z.object({
 	modelRoles: z.record(z.string(), z.string().min(1)).optional(),
 	agentModelOverrides: z.record(z.string(), z.string().min(1)).optional(),
 });
+export const ProfileRoleSchema = z.enum(["default", "executor", "architect", "planner", "critic"]);
+
+function isValidProfileModelSelector(value: string): boolean {
+	if (value.includes(",")) return false;
+	const slashIdx = value.indexOf("/");
+	if (slashIdx <= 0 || slashIdx === value.length - 1) return false;
+	const provider = value.slice(0, slashIdx);
+	const modelId = value.slice(slashIdx + 1);
+	if (!provider || !modelId) return false;
+	const parts = modelId.split(":");
+	if (parts.length > 2) return false;
+	const [base, suffix] = parts;
+	if (!base) return false;
+	return suffix === undefined || ["minimal", "low", "medium", "high", "xhigh"].includes(suffix);
+}
+
+export const ProfileModelSelectorSchema = z.string().min(1).refine(
+	value => isValidProfileModelSelector(value),
+	{ message: "Expected provider/modelId with optional :effort suffix" },
+);
+
+export const ProfileModelMappingSchema = z.partialRecord(ProfileRoleSchema, ProfileModelSelectorSchema);
+
+export const ProfileDefinitionSchema = z
+	.object({
+		required_providers: z.array(z.string().min(1)).min(1),
+		model_mapping: ProfileModelMappingSchema,
+	})
+	.strict();
+
+export const ProfilesSchema = z.record(z.string().min(1), ProfileDefinitionSchema);
+
 
 const ModelDefinitionSchema = z
 	.object({
@@ -205,7 +237,10 @@ export const ModelsConfigSchema = z
 		providers: z.record(z.string(), ProviderConfigSchema).optional(),
 		modelBindings: ModelBindingsSchema.optional(),
 		equivalence: EquivalenceConfigSchema.optional(),
+		profiles: ProfilesSchema.optional(),
 	})
 	.strict();
 
 export type ModelsConfig = z.infer<typeof ModelsConfigSchema>;
+export type ModelProfileConfig = z.infer<typeof ProfileDefinitionSchema>;
+export type ModelProfilesConfig = z.infer<typeof ProfilesSchema>;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -313,6 +313,16 @@ export const SETTINGS_SCHEMA = {
 	disabledExtensions: { type: "array", default: DEFAULT_DISABLED_EXTENSIONS },
 
 	modelRoles: { type: "record", default: EMPTY_STRING_RECORD },
+	"modelProfile.default": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "model",
+			label: "Default Model Profile",
+			description: "Model profile applied automatically at startup",
+			options: "runtime",
+		},
+	},
 
 	modelTags: { type: "record", default: EMPTY_MODEL_TAGS_RECORD },
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -26,6 +26,7 @@ import { buildInitialMessage } from "./cli/initial-message";
 import { runListModelsCommand } from "./cli/list-models";
 import { selectSession } from "./cli/session-picker";
 import { findConfigFile } from "./config";
+import { activateModelProfile } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedModel } from "./config/model-resolver";
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
@@ -194,9 +195,55 @@ export interface AcpSessionFactoryOptions {
 	sessionDir?: string;
 	authStorage: AuthStorage;
 	modelRegistry: ModelRegistry;
-	parsedArgs: Pick<Args, "apiKey">;
+	parsedArgs: Pick<Args, "apiKey" | "default" | "model" | "mpreset" | "thinking">;
 	rawArgs: string[];
 	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
+}
+
+export async function applyStartupModelProfiles(args: {
+	session: AgentSession;
+	settings: Settings;
+	modelRegistry: ModelRegistry;
+	parsedArgs: Pick<Args, "default" | "model" | "mpreset" | "thinking">;
+	startupModel?: CreateAgentSessionOptions["model"];
+	startupThinkingLevel?: CreateAgentSessionOptions["thinkingLevel"];
+}): Promise<void> {
+	const applyProfile = async (profileName: string, persistDefault: boolean): Promise<void> => {
+		await activateModelProfile(
+			{ session: args.session, modelRegistry: args.modelRegistry, settings: args.settings, profileName },
+			{ persistDefault },
+		);
+	};
+
+	// Capture the explicitly-selected startup model BEFORE profile activation can
+	// override it. startupModel covers the eager path; session.model covers the
+	// deferred `--model <pattern>` path resolved inside createAgentSession.
+	const explicitModel = args.parsedArgs.model ? (args.startupModel ?? args.session.model) : undefined;
+
+	const defaultProfile = args.settings.get("modelProfile.default");
+	if (defaultProfile) {
+		await applyProfile(defaultProfile, false);
+	}
+	if (args.parsedArgs.mpreset) {
+		await applyProfile(args.parsedArgs.mpreset, args.parsedArgs.default === true);
+	}
+
+	// Explicit CLI --model/--thinking must win over any activated profile.
+	if (explicitModel) {
+		await args.session.setModelTemporary(explicitModel, args.startupThinkingLevel ?? args.parsedArgs.thinking);
+	} else if (args.parsedArgs.thinking && args.session.model) {
+		await args.session.setModelTemporary(args.session.model, args.parsedArgs.thinking);
+	}
+}
+
+export async function applyStartupModelProfilesOrExit(args: Parameters<typeof applyStartupModelProfiles>[0]): Promise<void> {
+	try {
+		await applyStartupModelProfiles(args);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		process.stderr.write(`${chalk.red(`Error: ${message}`)}\n`);
+		process.exit(1);
+	}
 }
 
 /**
@@ -224,6 +271,14 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			agentId,
 			hasUI: false,
 			enableMCP: false,
+		});
+		await applyStartupModelProfilesOrExit({
+			session: nextSession,
+			settings: nextSettings,
+			modelRegistry: args.modelRegistry,
+			parsedArgs: args.parsedArgs,
+			startupModel: args.baseOptions.model,
+			startupThinkingLevel: args.baseOptions.thinkingLevel,
 		});
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
@@ -877,6 +932,15 @@ export async function runRootCommand(
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
 		}
+
+		await applyStartupModelProfilesOrExit({
+			session,
+			settings: settingsInstance,
+			modelRegistry,
+			parsedArgs,
+			startupModel: sessionOptions.model,
+			startupThinkingLevel: sessionOptions.thinkingLevel,
+		});
 
 		if (modelFallbackMessage) {
 			notifs.push({ kind: "warn", message: modelFallbackMessage });

--- a/packages/coding-agent/src/modes/components/custom-provider-wizard.ts
+++ b/packages/coding-agent/src/modes/components/custom-provider-wizard.ts
@@ -1,0 +1,268 @@
+import { Container, Input, matchesKey, Spacer, Text, TruncatedText } from "@gajae-code/tui";
+import type { ProviderCompatibility, ProviderSetupInput } from "../../setup/provider-onboarding";
+import { theme } from "../theme/theme";
+import { matchesAppInterrupt } from "../utils/keybinding-matchers";
+import { DynamicBorder } from "./dynamic-border";
+
+export type CustomProviderCredentialSource = "env" | "literal";
+
+type WizardStep = "compatibility" | "provider-id" | "base-url" | "credential-source" | "credential" | "models" | "confirm" | "force-confirm";
+
+interface WizardState {
+	compatibility: ProviderCompatibility;
+	providerId: string;
+	baseUrl: string;
+	credentialSource: CustomProviderCredentialSource;
+	credential: string;
+	models: string;
+}
+
+export type CustomProviderWizardSubmit = ProviderSetupInput;
+
+export class CustomProviderWizardComponent extends Container {
+	#contentContainer: Container;
+	#input: Input | null = null;
+	#step: WizardStep = "compatibility";
+	#selectedIndex = 0;
+	#lastSubmitError: string | null = null;
+	#state: WizardState = {
+		compatibility: "openai",
+		providerId: "",
+		baseUrl: "",
+		credentialSource: "env",
+		credential: "",
+		models: "",
+	};
+	#onSubmit: (input: CustomProviderWizardSubmit) => void;
+	#onCancel: () => void;
+	#onRender: () => void;
+
+	constructor(onSubmit: (input: CustomProviderWizardSubmit) => void, onCancel: () => void, onRender: () => void = () => {}) {
+		super();
+		this.#onSubmit = onSubmit;
+		this.#onCancel = onCancel;
+		this.#onRender = onRender;
+
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new TruncatedText(theme.bold("Add custom provider")));
+		this.addChild(new TruncatedText(theme.fg("muted", "  Configure an OpenAI- or Anthropic-compatible API provider."), 0, 0));
+		this.addChild(new Spacer(1));
+		this.#contentContainer = new Container();
+		this.addChild(this.#contentContainer);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+		this.#renderStep();
+	}
+
+	setSubmitError(error: string): void {
+		this.#lastSubmitError = error;
+		if (error.includes("already exists")) {
+			this.#step = "force-confirm";
+			this.#selectedIndex = 1;
+		}
+		this.#renderStep();
+		this.#onRender();
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesAppInterrupt(keyData)) {
+			if (this.#step === "compatibility") {
+				this.#onCancel();
+				return;
+			}
+			this.#goBack();
+			return;
+		}
+
+		if (this.#input) {
+			if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+				this.#saveInputAndProceed();
+				return;
+			}
+			this.#input.handleInput(keyData);
+			return;
+		}
+
+		if (matchesKey(keyData, "up")) {
+			this.#moveSelection(-1);
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#moveSelection(1);
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			this.#selectCurrentOption();
+		}
+	}
+
+	#renderStep(): void {
+		this.#contentContainer.clear();
+		this.#input = null;
+		switch (this.#step) {
+			case "compatibility":
+				this.#renderCompatibilityStep();
+				break;
+			case "provider-id":
+				this.#renderInputStep("Step 2: Provider id", "Enter a provider id:", this.#state.providerId, "e.g. my-openai-proxy");
+				break;
+			case "base-url":
+				this.#renderInputStep("Step 3: Base URL", "Enter the API base URL:", this.#state.baseUrl, "e.g. https://api.example.com/v1");
+				break;
+			case "credential-source":
+				this.#renderCredentialSourceStep();
+				break;
+			case "credential":
+				this.#renderInputStep(
+					"Step 5: Credential",
+					this.#state.credentialSource === "env" ? "Enter the API key environment variable name:" : "Paste the API key:",
+					this.#state.credential,
+					this.#state.credentialSource === "env" ? "e.g. OPENAI_API_KEY" : "The key will be stored in models.yml and redacted in output.",
+				);
+				break;
+			case "models":
+				this.#renderInputStep("Step 6: Model id(s)", "Enter model ids, comma-separated:", this.#state.models, "e.g. gpt-5, claude-sonnet-4-5");
+				break;
+			case "confirm":
+				this.#renderConfirmStep(false);
+				break;
+			case "force-confirm":
+				this.#renderConfirmStep(true);
+				break;
+		}
+	}
+
+	#renderCompatibilityStep(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("accent", "Step 1: Compatibility")));
+		this.#contentContainer.addChild(new Spacer(1));
+		const options: Array<{ value: ProviderCompatibility; label: string }> = [
+			{ value: "openai", label: "OpenAI-compatible" },
+			{ value: "anthropic", label: "Anthropic-compatible" },
+		];
+		for (let i = 0; i < options.length; i++) this.#addOption(i, options[i]?.label ?? "");
+		this.#addHelp("[↑↓ to navigate, Enter to select, Esc to cancel]");
+	}
+
+	#renderCredentialSourceStep(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("accent", "Step 4: Credential source")));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addOption(0, "Environment variable");
+		this.#addOption(1, "Paste API key");
+		this.#addHelp("[↑↓ to navigate, Enter to select, Esc to go back]");
+	}
+
+	#renderInputStep(title: string, prompt: string, value: string, hint: string): void {
+		this.#contentContainer.addChild(new Text(theme.fg("accent", title)));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#contentContainer.addChild(new Text(prompt, 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#input = new Input();
+		this.#input.setValue(value);
+		this.#contentContainer.addChild(this.#input);
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addHelp(hint);
+		this.#addHelp("[Enter to continue, Esc to go back]");
+	}
+
+	#renderConfirmStep(force: boolean): void {
+		this.#contentContainer.addChild(new Text(theme.fg("accent", force ? "Provider exists — replace it?" : "Confirm custom provider")));
+		this.#contentContainer.addChild(new Spacer(1));
+		if (this.#lastSubmitError) {
+			this.#contentContainer.addChild(new Text(theme.fg(force ? "warning" : "error", this.#lastSubmitError), 0, 0));
+			this.#contentContainer.addChild(new Spacer(1));
+		}
+		this.#contentContainer.addChild(new Text(`Compatibility: ${this.#state.compatibility}`, 0, 0));
+		this.#contentContainer.addChild(new Text(`Provider: ${this.#state.providerId}`, 0, 0));
+		this.#contentContainer.addChild(new Text(`Base URL: ${this.#state.baseUrl}`, 0, 0));
+		this.#contentContainer.addChild(new Text(`Credential: ${this.#state.credentialSource === "env" ? this.#state.credential : "pasted API key"}`, 0, 0));
+		this.#contentContainer.addChild(new Text(`Models: ${this.#state.models}`, 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addOption(0, force ? "Replace existing provider" : "Add provider");
+		this.#addOption(1, "Go back");
+		this.#addHelp("[↑↓ to navigate, Enter to select, Esc to go back]");
+	}
+
+	#addOption(index: number, label: string): void {
+		const selected = index === this.#selectedIndex;
+		const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+		this.#contentContainer.addChild(new Text(`${prefix}${selected ? theme.fg("accent", label) : label}`, 0, 0));
+	}
+
+	#addHelp(text: string): void {
+		this.#contentContainer.addChild(new Text(theme.fg("muted", text), 0, 0));
+	}
+
+	#saveInputAndProceed(): void {
+		const value = this.#input?.getValue().trim() ?? "";
+		if (!value) return;
+		if (this.#step === "provider-id") {
+			this.#state.providerId = value;
+			this.#step = "base-url";
+		} else if (this.#step === "base-url") {
+			this.#state.baseUrl = value;
+			this.#step = "credential-source";
+			this.#selectedIndex = 0;
+		} else if (this.#step === "credential") {
+			this.#state.credential = value;
+			this.#step = "models";
+		} else if (this.#step === "models") {
+			this.#state.models = value;
+			this.#step = "confirm";
+			this.#selectedIndex = 0;
+			this.#lastSubmitError = null;
+		}
+		this.#renderStep();
+		this.#onRender();
+	}
+
+	#selectCurrentOption(): void {
+		if (this.#step === "compatibility") {
+			this.#state.compatibility = this.#selectedIndex === 0 ? "openai" : "anthropic";
+			this.#step = "provider-id";
+		} else if (this.#step === "credential-source") {
+			this.#state.credentialSource = this.#selectedIndex === 0 ? "env" : "literal";
+			this.#state.credential = "";
+			this.#step = "credential";
+		} else if (this.#step === "confirm" || this.#step === "force-confirm") {
+			if (this.#selectedIndex === 0) {
+				this.#onSubmit(this.#buildInput(this.#step === "force-confirm"));
+				return;
+			}
+			this.#step = "models";
+		}
+		this.#renderStep();
+		this.#onRender();
+	}
+
+	#buildInput(force: boolean): CustomProviderWizardSubmit {
+		return {
+			compatibility: this.#state.compatibility,
+			providerId: this.#state.providerId,
+			baseUrl: this.#state.baseUrl,
+			apiKeyEnv: this.#state.credentialSource === "env" ? this.#state.credential : undefined,
+			apiKey: this.#state.credentialSource === "literal" ? this.#state.credential : undefined,
+			models: this.#state.models.split(",").map(model => model.trim()).filter(Boolean),
+			force,
+		};
+	}
+
+	#moveSelection(delta: number): void {
+		const maxIndex = this.#step === "confirm" || this.#step === "force-confirm" || this.#step === "compatibility" || this.#step === "credential-source" ? 1 : 0;
+		this.#selectedIndex = (this.#selectedIndex + delta + maxIndex + 1) % (maxIndex + 1);
+		this.#renderStep();
+		this.#onRender();
+	}
+
+	#goBack(): void {
+		if (this.#step === "provider-id") this.#step = "compatibility";
+		else if (this.#step === "base-url") this.#step = "provider-id";
+		else if (this.#step === "credential-source") this.#step = "base-url";
+		else if (this.#step === "credential") this.#step = "credential-source";
+		else if (this.#step === "models") this.#step = "credential";
+		else if (this.#step === "confirm" || this.#step === "force-confirm") this.#step = "models";
+		this.#selectedIndex = 0;
+		this.#renderStep();
+		this.#onRender();
+	}
+}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -19,6 +19,7 @@ import {
 	resolveModelRoleValue,
 	type ScopedModelSelection,
 } from "../../config/model-resolver";
+import type { ModelProfileDefinition } from "../../config/model-profiles";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
@@ -74,6 +75,12 @@ interface CanonicalModelItem {
 	explicitThinkingLevel?: boolean;
 }
 
+interface ProfileItem {
+	kind: "profile";
+	name: string;
+	profile: ModelProfileDefinition;
+}
+
 type ScopedModelItem = ScopedModelSelection;
 
 interface RoleAssignment {
@@ -102,6 +109,11 @@ export type ModelSelectorSelection =
 			selector: string;
 			preset: ModelAssignmentPreset;
 			assignments: Record<GjcModelAssignmentTargetId, ThinkingLevel>;
+	  }
+	| {
+			kind: "profile";
+			profileName: string;
+			setDefault: boolean;
 	  };
 
 interface PendingThinkingChoice {
@@ -110,7 +122,7 @@ interface PendingThinkingChoice {
 	levels: ThinkingLevel[];
 }
 
-type RoleSelectCallback = (selection: ModelSelectorSelection) => void;
+type RoleSelectCallback = (selection: ModelSelectorSelection) => void | Promise<void>;
 type CancelCallback = () => void;
 
 interface ProviderTabState {
@@ -161,6 +173,7 @@ export class ModelSelectorComponent extends Container {
 	#filteredModels: ModelItem[] = [];
 	#canonicalModels: CanonicalModelItem[] = [];
 	#filteredCanonicalModels: CanonicalModelItem[] = [];
+	#profileItems: ProfileItem[] = [];
 	#selectedIndex: number = 0;
 	#roles = {} as Record<string, RoleAssignment | undefined>;
 	#settings = null as unknown as Settings;
@@ -228,7 +241,11 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#beginActionMenuOrSelect(selectedItem);
+				if (selectedItem.kind === "profile") {
+					this.#beginProfileActionMenu(selectedItem);
+				} else {
+					this.#beginActionMenuOrSelect(selectedItem);
+				}
 			}
 		};
 		this.addChild(this.#searchInput);
@@ -465,11 +482,18 @@ export class ModelSelectorComponent extends Container {
 
 		this.#sortModels(models);
 		this.#sortCanonicalModels(canonicalModels);
+		const profiles = this.#modelRegistry.getModelProfiles?.() ?? new Map();
+		const profileItems = this.#temporaryOnly
+			? []
+			: [...profiles.values()]
+					.sort((a, b) => a.name.localeCompare(b.name))
+					.map(profile => ({ kind: "profile" as const, name: profile.name, profile }));
 
 		this.#allModels = models;
 		this.#filteredModels = models;
 		this.#canonicalModels = canonicalModels;
 		this.#filteredCanonicalModels = canonicalModels;
+		this.#profileItems = profileItems;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, models.length - 1));
 	}
 
@@ -664,20 +688,38 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	#getVisibleProfiles(): ProfileItem[] {
+		return !this.#temporaryOnly && !this.#isCanonicalTab() && this.#getActiveTabId() === ALL_TAB ? this.#profileItems : [];
+	}
+
 	#updateList(): void {
 		this.#listContainer.clear();
 		const isCanonicalTab = this.#isCanonicalTab();
+		const visibleProfiles = this.#getVisibleProfiles();
+		const modelSelectedIndex = Math.max(0, this.#selectedIndex - visibleProfiles.length);
 		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
 
 		const maxVisible = 10;
 		const startIndex = Math.max(
 			0,
-			Math.min(this.#selectedIndex - Math.floor(maxVisible / 2), visibleItems.length - maxVisible),
+			Math.min(modelSelectedIndex - Math.floor(maxVisible / 2), visibleItems.length - maxVisible),
 		);
 		const endIndex = Math.min(startIndex + maxVisible, visibleItems.length);
 
 		const showProvider = this.#getActiveTabId() === ALL_TAB;
 
+		if (visibleProfiles.length > 0) {
+			this.#listContainer.addChild(new Text(theme.fg("muted", "Profiles"), 0, 0));
+			for (let i = 0; i < visibleProfiles.length; i++) {
+				const profile = visibleProfiles[i];
+				if (!profile) continue;
+				const isSelected = i === this.#selectedIndex;
+				const prefix = isSelected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+				const label = isSelected ? theme.fg("accent", profile.name) : profile.name;
+				this.#listContainer.addChild(new Text(`${prefix}${label}`, 0, 0));
+			}
+			this.#listContainer.addChild(new Spacer(1));
+		}
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = visibleItems[i];
@@ -685,7 +727,7 @@ export class ModelSelectorComponent extends Container {
 			const canonicalItem = isCanonicalTab ? (item as CanonicalModelItem) : undefined;
 			const providerItem = isCanonicalTab ? undefined : (item as ModelItem);
 
-			const isSelected = i === this.#selectedIndex;
+			const isSelected = i + visibleProfiles.length === this.#selectedIndex;
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
@@ -742,7 +784,7 @@ export class ModelSelectorComponent extends Container {
 			for (const line of errorLines) {
 				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
-		} else if (visibleItems.length === 0) {
+		} else if (visibleItems.length === 0 && visibleProfiles.length === 0) {
 			const statusMessage = this.#getProviderEmptyStateMessage();
 			this.#listContainer.addChild(
 				new Text(
@@ -751,8 +793,13 @@ export class ModelSelectorComponent extends Container {
 					0,
 				),
 			);
+		} else if (this.#selectedIndex < visibleProfiles.length) {
+			const selectedProfile = visibleProfiles[this.#selectedIndex];
+			if (selectedProfile && this.#pendingActionItem) {
+				this.#renderProfileActionMenu(selectedProfile);
+			}
 		} else {
-			const selected = visibleItems[this.#selectedIndex];
+			const selected = visibleItems[modelSelectedIndex];
 			if (!selected) {
 				return;
 			}
@@ -806,6 +853,20 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	#renderProfileActionMenu(profile: ProfileItem): void {
+		this.#listContainer.addChild(new Spacer(1));
+		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for profile: ${profile.name}`), 0, 0));
+		this.#listContainer.addChild(new Spacer(1));
+		const labels = ["Apply for this session", "Set as default"];
+		for (let i = 0; i < labels.length; i++) {
+			const label = labels[i] ?? "";
+			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			this.#listContainer.addChild(
+				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
+			);
+		}
+	}
+
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
@@ -813,10 +874,11 @@ export class ModelSelectorComponent extends Container {
 		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length + (supportsOpenAICodexPreset(model) ? 1 : 0);
 	}
 
-	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
-		return this.#isCanonicalTab()
-			? this.#filteredCanonicalModels[this.#selectedIndex]
-			: this.#filteredModels[this.#selectedIndex];
+	#getSelectedItem(): ModelItem | CanonicalModelItem | ProfileItem | undefined {
+		const visibleProfiles = this.#getVisibleProfiles();
+		if (this.#selectedIndex < visibleProfiles.length) return visibleProfiles[this.#selectedIndex];
+		const modelIndex = this.#selectedIndex - visibleProfiles.length;
+		return this.#isCanonicalTab() ? this.#filteredCanonicalModels[modelIndex] : this.#filteredModels[modelIndex];
 	}
 
 	handleInput(keyData: string): void {
@@ -836,7 +898,7 @@ export class ModelSelectorComponent extends Container {
 
 		// Up arrow - navigate list (wrap to bottom when at top)
 		if (matchesKey(keyData, "up")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount = this.#getVisibleProfiles().length + (this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length);
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === 0 ? itemCount - 1 : this.#selectedIndex - 1;
 			this.#updateList();
@@ -845,7 +907,7 @@ export class ModelSelectorComponent extends Container {
 
 		// Down arrow - navigate list (wrap to top when at bottom)
 		if (matchesKey(keyData, "down")) {
-			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
+			const itemCount = this.#getVisibleProfiles().length + (this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length);
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === itemCount - 1 ? 0 : this.#selectedIndex + 1;
 			this.#updateList();
@@ -857,7 +919,11 @@ export class ModelSelectorComponent extends Container {
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selectedItem = this.#getSelectedItem();
 			if (selectedItem) {
-				this.#beginActionMenuOrSelect(selectedItem);
+				if (selectedItem.kind === "profile") {
+					this.#beginProfileActionMenu(selectedItem);
+				} else {
+					this.#beginActionMenuOrSelect(selectedItem);
+				}
 			}
 			return;
 		}
@@ -872,6 +938,12 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());
 	}
+	#beginProfileActionMenu(profile: ProfileItem): void {
+		this.#pendingActionItem = profile as unknown as ModelItem;
+		this.#selectedActionIndex = 0;
+		this.#updateList();
+	}
+
 	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
 		if (this.#temporaryOnly) {
 			this.#handleSelect(item, null);
@@ -885,7 +957,7 @@ export class ModelSelectorComponent extends Container {
 	#handleActionMenuInput(keyData: string): void {
 		const item = this.#pendingActionItem;
 		if (!item) return;
-		const actionCount = this.#getActionCount(item.model);
+		const actionCount = (item as unknown as ProfileItem).kind === "profile" ? 2 : this.#getActionCount(item.model);
 		if (matchesKey(keyData, "up")) {
 			this.#selectedActionIndex = this.#selectedActionIndex === 0 ? actionCount - 1 : this.#selectedActionIndex - 1;
 			this.#updateList();
@@ -898,11 +970,16 @@ export class ModelSelectorComponent extends Container {
 		}
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			this.#pendingActionItem = undefined;
-			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
-			if (role) {
-				this.#handleSelect(item, role);
+			if ((item as unknown as ProfileItem).kind === "profile") {
+				const profile = item as unknown as ProfileItem;
+				this.#onSelectCallback({ kind: "profile", profileName: profile.name, setDefault: this.#selectedActionIndex === 1 });
 			} else {
-				this.#handlePresetSelect(item, OPENAI_CODE_PROFILE_PRESET);
+				const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
+				if (role) {
+					this.#handleSelect(item, role);
+				} else {
+					this.#handlePresetSelect(item, OPENAI_CODE_PROFILE_PRESET);
+				}
 			}
 			return;
 		}
@@ -1003,6 +1080,9 @@ export class ModelSelectorComponent extends Container {
 
 	getSearchInput(): Input {
 		return this.#searchInput;
+	}
+	async __testSelectProfile(profileName: string, setDefault: boolean): Promise<void> {
+		await this.#onSelectCallback({ kind: "profile", profileName, setDefault });
 	}
 }
 

--- a/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
+++ b/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
@@ -4,7 +4,7 @@ import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
 import { formatModelOnboardingGuidance } from "../../setup/model-onboarding-guidance";
 import { DynamicBorder } from "./dynamic-border";
 
-export type ProviderOnboardingAction = "oauth-login" | "api-guide";
+export type ProviderOnboardingAction = "custom-provider-wizard" | "oauth-login" | "api-guide";
 
 interface ProviderOnboardingOption {
 	label: string;
@@ -13,6 +13,11 @@ interface ProviderOnboardingOption {
 }
 
 const PROVIDER_ONBOARDING_OPTIONS: ProviderOnboardingOption[] = [
+	{
+		label: "Add custom provider",
+		description: "Configure an OpenAI- or Anthropic-compatible API provider interactively.",
+		action: "custom-provider-wizard",
+	},
 	{
 		label: "Login with OAuth/subscription",
 		description: "Open the interactive OAuth provider selector.",

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -4,6 +4,7 @@ import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
 import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
+import { activateModelProfile } from "../../config/model-profile-activation";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
@@ -30,6 +31,7 @@ import {
 import type { InteractiveModeContext } from "../../modes/types";
 import { type SessionInfo, SessionManager } from "../../session/session-manager";
 import { FileSessionStorage } from "../../session/session-storage";
+import { addApiCompatibleProvider, formatProviderSetupResult } from "../../setup/provider-onboarding";
 import {
 	MODEL_ONBOARDING_API_PROVIDER_COMMAND,
 	MODEL_ONBOARDING_PROVIDER_PRESET_COMMAND,
@@ -37,6 +39,7 @@ import {
 } from "../../setup/model-onboarding-guidance";
 import { isSearchProviderPreference, setPreferredImageProvider, setPreferredSearchProvider } from "../../tools";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { CustomProviderWizardComponent, type CustomProviderWizardSubmit } from "../components/custom-provider-wizard";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
@@ -117,7 +120,9 @@ export class SelectorController {
 			const selector = new ProviderOnboardingSelectorComponent(
 				(action: ProviderOnboardingAction) => {
 					done();
-					if (action === "oauth-login") {
+					if (action === "custom-provider-wizard") {
+						this.showCustomProviderWizard();
+					} else if (action === "oauth-login") {
 						void this.showOAuthSelector("login");
 					} else {
 						this.ctx.showStatus(formatProviderOnboardingCommandGuide());
@@ -129,6 +134,36 @@ export class SelectorController {
 				},
 			);
 			return { component: selector, focus: selector };
+		});
+	}
+
+	showCustomProviderWizard(): void {
+		this.showSelector(done => {
+			let wizard: CustomProviderWizardComponent;
+			const submit = async (input: CustomProviderWizardSubmit): Promise<void> => {
+				try {
+					const result = await addApiCompatibleProvider(input);
+					await this.ctx.session.modelRegistry.refresh("offline");
+					await this.ctx.notifyConfigChanged?.();
+					this.ctx.showStatus(formatProviderSetupResult(result));
+					done();
+					this.ctx.ui.requestRender();
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					wizard.setSubmitError(`Provider setup failed: ${message}`);
+				}
+			};
+			wizard = new CustomProviderWizardComponent(
+				input => {
+					void submit(input);
+				},
+				() => {
+					done();
+					this.ctx.ui.requestRender();
+				},
+				() => this.ctx.ui.requestRender(),
+			);
+			return { component: wizard, focus: wizard };
 		});
 	}
 
@@ -496,6 +531,27 @@ export class SelectorController {
 					try {
 						if (selection.kind === "preset") {
 							await this.#applyModelAssignmentPreset(selection);
+							done();
+							this.ctx.ui.requestRender();
+							return;
+						}
+						if (selection.kind === "profile") {
+							await activateModelProfile(
+								{
+									session: this.ctx.session,
+									modelRegistry: this.ctx.session.modelRegistry,
+									settings: this.ctx.settings,
+									profileName: selection.profileName,
+								},
+								{ persistDefault: selection.setDefault },
+							);
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+							this.ctx.showStatus(
+								selection.setDefault
+									? `Default model profile: ${selection.profileName}`
+									: `Model profile: ${selection.profileName}`,
+							);
 							done();
 							this.ctx.ui.requestRender();
 							return;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -147,6 +147,7 @@ export interface InteractiveModeContext {
 	showStatus(message: string, options?: { dim?: boolean }): void;
 	showError(message: string): void;
 	showWarning(message: string): void;
+	notifyConfigChanged?: () => Promise<void> | void;
 	showNewVersionNotification(newVersion: string): void;
 	clearEditor(): void;
 	updatePendingMessagesDisplay(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -740,7 +740,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 
-			void runtime.ctx.showOAuthSelector("login");
+			runtime.ctx.showProviderOnboarding();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,0 +1,155 @@
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+
+import { applyStartupModelProfiles, createAcpSessionFactory } from "../src/main";
+import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { Settings } from "../src/config/settings";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../src/sdk";
+import type { AgentSession } from "../src/session/agent-session";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+
+function fakeRegistry(profiles: ModelProfileDefinition[]) {
+	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
+	return {
+		getModelProfile: (name: string) => profileMap.get(name),
+		getModelProfiles: () => new Map(profileMap),
+		getAvailableModelProfileNames: () => [...profileMap.keys()].sort(),
+		getApiKeyForProvider: async () => "key",
+		getAll: () => [model("profile-provider", "default"), model("cli-provider", "explicit")],
+	};
+}
+
+function fakeSession(initial = model("initial-provider", "initial")) {
+	return {
+		model: initial as Model | undefined,
+		thinkingLevel: undefined as ThinkingLevel | undefined,
+		sessionId: "session-1",
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+	} as AgentSession & { setModelTemporaryCalls: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> };
+}
+describe("CLI model profile args", () => {
+	test("parses --mpreset with separate value", () => {
+		const parsed = parseArgs(["--mpreset", "codex-standard"]);
+		expect(parsed.mpreset).toBe("codex-standard");
+		expect(parsed.default).toBeUndefined();
+	});
+
+	test("parses --mpreset=value", () => {
+		const parsed = parseArgs(["--mpreset=codex-pro"]);
+		expect(parsed.mpreset).toBe("codex-pro");
+	});
+
+	test("parses --default with --mpreset", () => {
+		const parsed = parseArgs(["--mpreset", "opencode-go-standard", "--default"]);
+		expect(parsed.mpreset).toBe("opencode-go-standard");
+		expect(parsed.default).toBe(true);
+	});
+
+	test("rejects --default without --mpreset", () => {
+		expect(() => parseArgs(["--default"])).toThrow("--default requires --mpreset <name>");
+	});
+});
+
+test("explicit CLI --model/--thinking are reapplied after --mpreset activation", async () => {
+	const session = fakeSession(model("cli-provider", "explicit"));
+	const settings = Settings.isolated();
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: fakeRegistry([
+			{
+				name: "profile-a",
+				requiredProviders: ["profile-provider"],
+				modelMapping: { default: "profile-provider/default:high" },
+				source: "user",
+			},
+		]) as never,
+		parsedArgs: { mpreset: "profile-a", model: "cli-provider/explicit", thinking: ThinkingLevel.Low },
+		startupModel: model("cli-provider", "explicit"),
+		startupThinkingLevel: ThinkingLevel.Low,
+	});
+
+	expect(session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`)).toEqual([
+		"profile-provider/default:high",
+		"cli-provider/explicit:low",
+	]);
+	expect(session.model?.provider).toBe("cli-provider");
+	expect(session.model?.id).toBe("explicit");
+	expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+});
+test("deferred explicit CLI --model is reapplied after --mpreset activation", async () => {
+	const explicitModel = model("cli-provider", "explicit");
+	const session = fakeSession(explicitModel);
+	const settings = Settings.isolated();
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: fakeRegistry([
+			{
+				name: "codex-standard",
+				requiredProviders: ["profile-provider"],
+				modelMapping: { default: "profile-provider/default:high" },
+				source: "user",
+			},
+		]) as never,
+		parsedArgs: { mpreset: "codex-standard", model: "cli-provider/explicit" },
+		startupModel: undefined,
+		startupThinkingLevel: undefined,
+	});
+
+	expect(session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`)).toEqual([
+		"profile-provider/default:high",
+		"cli-provider/explicit:undefined",
+	]);
+	expect(session.setModelTemporaryCalls.at(-1)?.model).toBe(explicitModel);
+	expect(session.model).toBe(explicitModel);
+});
+
+test("ACP session factory applies default profile and --mpreset before returning session", async () => {
+	const settings = Settings.isolated({ "modelProfile.default": "default-profile" });
+	const session = fakeSession();
+	const registry = fakeRegistry([
+		{
+			name: "default-profile",
+			requiredProviders: ["profile-provider"],
+			modelMapping: { default: "profile-provider/default:medium" },
+			source: "user",
+		},
+		{
+			name: "session-profile",
+			requiredProviders: ["cli-provider"],
+			modelMapping: { default: "cli-provider/explicit:high" },
+			source: "user",
+		},
+	]) as never;
+	const createSession = async (): Promise<CreateAgentSessionResult> =>
+		({ session, setToolUIContext: () => {}, extensionsResult: {}, eventBus: {} }) as CreateAgentSessionResult;
+	const factory = createAcpSessionFactory({
+		baseOptions: {} as CreateAgentSessionOptions,
+		settings,
+		authStorage: { setRuntimeApiKey: () => {} } as never,
+		modelRegistry: registry,
+		parsedArgs: { mpreset: "session-profile" },
+		rawArgs: [],
+		createSession,
+	});
+
+	const result = await factory(process.cwd());
+
+	expect(result).toBe(session);
+	expect(session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`)).toEqual([
+		"profile-provider/default:medium",
+		"cli-provider/explicit:high",
+	]);
+});

--- a/packages/coding-agent/test/model-profile-activation-redteam.test.ts
+++ b/packages/coding-agent/test/model-profile-activation-redteam.test.ts
@@ -1,13 +1,13 @@
+import { describe, expect, test } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
-import { describe, expect, test } from "bun:test";
 import { parseArgs } from "../src/cli/args";
 import { activateModelProfile } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { Settings } from "../src/config/settings";
 
 const model = (provider: string, id: string): Model =>
-	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
 
 function fakeRegistry(options?: {
 	missingProviders?: string[];
@@ -68,7 +68,13 @@ function instrumentSettings(settings: Settings) {
 	settings.flush = async () => {
 		flushCount += 1;
 	};
-	return { setCalls, overrideCalls, get flushCount() { return flushCount; } };
+	return {
+		setCalls,
+		overrideCalls,
+		get flushCount() {
+			return flushCount;
+		},
+	};
 }
 
 describe("model profile activation red-team", () => {
@@ -90,9 +96,9 @@ describe("model profile activation red-team", () => {
 			],
 		});
 
-		await expect(activateModelProfile({ session, modelRegistry: registry, settings, profileName: "bad-role" })).rejects.toThrow(
-			'Model profile "bad-role" executor selector did not resolve: provider-b/missing',
-		);
+		await expect(
+			activateModelProfile({ session, modelRegistry: registry, settings, profileName: "bad-role" }),
+		).rejects.toThrow('Model profile "bad-role" executor selector did not resolve: provider-b/missing');
 		expect(session.model?.id).toBe("initial");
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(session.setModelTemporaryCalls).toEqual([]);
@@ -122,8 +128,44 @@ describe("model profile activation red-team", () => {
 			],
 		});
 
-		await expect(activateModelProfile({ session, modelRegistry: registry, settings, profileName: "needs-two" })).rejects.toThrow(
+		await expect(
+			activateModelProfile({ session, modelRegistry: registry, settings, profileName: "needs-two" }),
+		).rejects.toThrow(
 			'Model profile "needs-two" requires credentials for: provider-b. Run /login and configure the missing provider(s), then retry.',
+		);
+		expect(session.model?.id).toBe("initial");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(calls.setCalls).toEqual([]);
+		expect(calls.overrideCalls).toEqual([]);
+		expect(calls.flushCount).toBe(0);
+	});
+
+	test("AUTHZ: underdeclared mapped provider hard-blocks with zero mutation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original" },
+			"modelProfile.default": "old-profile",
+		});
+		const calls = instrumentSettings(settings);
+		const registry = fakeRegistry({
+			missingProviders: ["provider-b"],
+			profiles: [
+				{
+					name: "underdeclared-provider",
+					requiredProviders: ["provider-a"],
+					modelMapping: { default: "provider-a/default", executor: "provider-b/executor" },
+					source: "user",
+				},
+			],
+		});
+
+		await expect(
+			activateModelProfile({ session, modelRegistry: registry, settings, profileName: "underdeclared-provider" }),
+		).rejects.toThrow(
+			'Model profile "underdeclared-provider" requires credentials for: provider-b. Run /login and configure the missing provider(s), then retry.',
 		);
 		expect(session.model?.id).toBe("initial");
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
@@ -151,7 +193,10 @@ describe("model profile activation red-team", () => {
 		});
 
 		await expect(
-			activateModelProfile({ session, modelRegistry: registry, settings, profileName: "bad-default" }, { persistDefault: true }),
+			activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "bad-default" },
+				{ persistDefault: true },
+			),
 		).rejects.toThrow('Model profile "bad-default" default selector did not resolve: provider-a/missing');
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
 		expect(calls.setCalls).toEqual([]);
@@ -200,7 +245,12 @@ describe("model profile activation red-team", () => {
 		});
 
 		await expect(
-			activateModelProfile({ session: fakeSession(), modelRegistry: registry, settings: Settings.isolated(), profileName: "missing" }),
+			activateModelProfile({
+				session: fakeSession(),
+				modelRegistry: registry,
+				settings: Settings.isolated(),
+				profileName: "missing",
+			}),
 		).rejects.toThrow('Unknown model profile "missing". Available profiles: alpha, zeta');
 	});
 
@@ -218,13 +268,22 @@ describe("model profile activation red-team", () => {
 				{
 					name: "session-profile",
 					requiredProviders: [],
-					modelMapping: { default: "provider-a/alternate", executor: "provider-a/architect", architect: "provider-b/executor" },
+					modelMapping: {
+						default: "provider-a/alternate",
+						executor: "provider-a/architect",
+						architect: "provider-b/executor",
+					},
 					source: "user",
 				},
 			],
 		});
 
-		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: settings.get("modelProfile.default")! });
+		await activateModelProfile({
+			session,
+			modelRegistry: registry,
+			settings,
+			profileName: settings.get("modelProfile.default")!,
+		});
 		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "session-profile" });
 		settings.override("task.agentModelOverrides", {
 			...settings.get("task.agentModelOverrides"),

--- a/packages/coding-agent/test/model-profile-activation-redteam.test.ts
+++ b/packages/coding-agent/test/model-profile-activation-redteam.test.ts
@@ -1,0 +1,252 @@
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+import { activateModelProfile } from "../src/config/model-profile-activation";
+import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { Settings } from "../src/config/settings";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+
+function fakeRegistry(options?: {
+	missingProviders?: string[];
+	profiles?: ModelProfileDefinition[];
+	models?: Model[];
+}) {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const profile of options?.profiles ?? []) {
+		profiles.set(profile.name, profile);
+	}
+	const missing = new Set(options?.missingProviders ?? []);
+	const models = options?.models ?? [
+		model("provider-a", "default"),
+		model("provider-a", "alternate"),
+		model("provider-b", "executor"),
+		model("provider-a", "architect"),
+	];
+	return {
+		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfiles: () => new Map(profiles),
+		getAvailableModelProfileNames: () => [...profiles.keys()].sort(),
+		getApiKeyForProvider: async (provider: string) => (missing.has(provider) ? undefined : `key-${provider}`),
+		getAll: () => models,
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	};
+}
+
+function fakeSession(initial = model("provider-a", "initial")) {
+	return {
+		model: initial as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
+		sessionId: "session-1",
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+	};
+}
+
+function instrumentSettings(settings: Settings) {
+	const setCalls: string[] = [];
+	const overrideCalls: string[] = [];
+	let flushCount = 0;
+	const originalSet = settings.set.bind(settings);
+	const originalOverride = settings.override.bind(settings);
+	settings.set = ((path: never, value: never) => {
+		setCalls.push(path);
+		return originalSet(path, value);
+	}) as typeof settings.set;
+	settings.override = ((path: never, value: never) => {
+		overrideCalls.push(path);
+		return originalOverride(path, value);
+	}) as typeof settings.override;
+	settings.flush = async () => {
+		flushCount += 1;
+	};
+	return { setCalls, overrideCalls, get flushCount() { return flushCount; } };
+}
+
+describe("model profile activation red-team", () => {
+	test("ATOMICITY: unresolvable role selector after resolved default throws with zero mutation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original" },
+			"modelProfile.default": "old-profile",
+		});
+		const calls = instrumentSettings(settings);
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "bad-role",
+					requiredProviders: [],
+					modelMapping: { default: "provider-a/default:high", executor: "provider-b/missing" },
+					source: "user",
+				},
+			],
+		});
+
+		await expect(activateModelProfile({ session, modelRegistry: registry, settings, profileName: "bad-role" })).rejects.toThrow(
+			'Model profile "bad-role" executor selector did not resolve: provider-b/missing',
+		);
+		expect(session.model?.id).toBe("initial");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(calls.setCalls).toEqual([]);
+		expect(calls.overrideCalls).toEqual([]);
+		expect(calls.flushCount).toBe(0);
+	});
+
+	test("ATOMICITY: one missing required provider hard-blocks naming only missing providers with zero mutation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original" },
+			"modelProfile.default": "old-profile",
+		});
+		const calls = instrumentSettings(settings);
+		const registry = fakeRegistry({
+			missingProviders: ["provider-b"],
+			profiles: [
+				{
+					name: "needs-two",
+					requiredProviders: ["provider-a", "provider-b"],
+					modelMapping: { default: "provider-a/default", executor: "provider-b/executor" },
+					source: "user",
+				},
+			],
+		});
+
+		await expect(activateModelProfile({ session, modelRegistry: registry, settings, profileName: "needs-two" })).rejects.toThrow(
+			'Model profile "needs-two" requires credentials for: provider-b. Run /login and configure the missing provider(s), then retry.',
+		);
+		expect(session.model?.id).toBe("initial");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(calls.setCalls).toEqual([]);
+		expect(calls.overrideCalls).toEqual([]);
+		expect(calls.flushCount).toBe(0);
+	});
+
+	test("--default failure path does not persist or flush modelProfile.default", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "old-profile" });
+		const calls = instrumentSettings(settings);
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "bad-default",
+					requiredProviders: [],
+					modelMapping: { default: "provider-a/missing" },
+					source: "user",
+				},
+			],
+		});
+
+		await expect(
+			activateModelProfile({ session, modelRegistry: registry, settings, profileName: "bad-default" }, { persistDefault: true }),
+		).rejects.toThrow('Model profile "bad-default" default selector did not resolve: provider-a/missing');
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(calls.setCalls).toEqual([]);
+		expect(calls.overrideCalls).toEqual([]);
+		expect(calls.flushCount).toBe(0);
+	});
+
+	test("session-only activation does not persist model roles, agent overrides, default profile, or models config", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			modelRoles: { default: "provider-a/original-default" },
+			"task.agentModelOverrides": { critic: "provider-a/original-critic" },
+			"modelProfile.default": "old-profile",
+		});
+		const calls = instrumentSettings(settings);
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "session-only",
+					requiredProviders: [],
+					modelMapping: { default: "provider-a/default", executor: "provider-b/executor" },
+					source: "user",
+				},
+			],
+		});
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "session-only" });
+		expect(session.setModelTemporaryCalls).toHaveLength(1);
+		expect(settings.get("modelRoles")).toEqual({ default: "provider-a/original-default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "provider-a/original-critic",
+			executor: "provider-b/executor",
+		});
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(calls.setCalls).toEqual([]);
+		expect(calls.overrideCalls).toEqual(["task.agentModelOverrides"]);
+		expect(calls.flushCount).toBe(0);
+	});
+
+	test("unknown profile name lists available names", async () => {
+		const registry = fakeRegistry({
+			profiles: [
+				{ name: "zeta", requiredProviders: [], modelMapping: {}, source: "user" },
+				{ name: "alpha", requiredProviders: [], modelMapping: {}, source: "user" },
+			],
+		});
+
+		await expect(
+			activateModelProfile({ session: fakeSession(), modelRegistry: registry, settings: Settings.isolated(), profileName: "missing" }),
+		).rejects.toThrow('Unknown model profile "missing". Available profiles: alpha, zeta');
+	});
+
+	test("precedence: default profile then --mpreset session override, explicit role flag wins for that role", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "default-profile" });
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "default-profile",
+					requiredProviders: [],
+					modelMapping: { default: "provider-a/default", executor: "provider-b/executor" },
+					source: "user",
+				},
+				{
+					name: "session-profile",
+					requiredProviders: [],
+					modelMapping: { default: "provider-a/alternate", executor: "provider-a/architect", architect: "provider-b/executor" },
+					source: "user",
+				},
+			],
+		});
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: settings.get("modelProfile.default")! });
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "session-profile" });
+		settings.override("task.agentModelOverrides", {
+			...settings.get("task.agentModelOverrides"),
+			executor: "explicit/executor",
+		});
+
+		expect(session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}`)).toEqual([
+			"provider-a/default",
+			"provider-a/alternate",
+		]);
+		expect(session.model?.id).toBe("alternate");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "explicit/executor",
+			architect: "provider-b/executor",
+		});
+		expect(settings.get("modelProfile.default")).toBe("default-profile");
+	});
+
+	test("CLI rejects --default without --mpreset and parses both --mpreset forms", () => {
+		expect(() => parseArgs(["--default"])).toThrow("--default requires --mpreset <name>");
+		expect(parseArgs(["--mpreset=alpha"]).mpreset).toBe("alpha");
+		expect(parseArgs(["--mpreset", "beta"]).mpreset).toBe("beta");
+		expect(parseArgs(["--mpreset", "gamma", "--default"])).toMatchObject({ mpreset: "gamma", default: true });
+	});
+});

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -1,0 +1,231 @@
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { describe, expect, test } from "bun:test";
+import {
+	activateModelProfile,
+	applyPreparedModelProfileActivation,
+	prepareModelProfileActivation,
+} from "../src/config/model-profile-activation";
+import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { Settings } from "../src/config/settings";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+
+function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelProfileDefinition[] }) {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const profile of options?.profiles ?? [
+		{
+			name: "profile-a",
+			requiredProviders: ["provider-a", "provider-b"],
+			modelMapping: {
+				default: "provider-a/default:high",
+				executor: "provider-b/executor",
+				architect: "provider-a/architect",
+			},
+			source: "user" as const,
+		},
+	]) {
+		profiles.set(profile.name, profile);
+	}
+	const missing = new Set(options?.missingProviders ?? []);
+	return {
+		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfiles: () => new Map(profiles),
+		getAvailableModelProfileNames: () => [...profiles.keys()].sort(),
+		getApiKeyForProvider: async (provider: string) => (missing.has(provider) ? undefined : `key-${provider}`),
+		getAll: () => [
+			model("provider-a", "default"),
+			model("provider-b", "executor"),
+			model("provider-a", "architect"),
+			model("openai-codex", "gpt-5.4"),
+			model("openai-codex", "gpt-5.1-codex-max"),
+			model("openai-codex", "gpt-5.2-codex"),
+			model("openai-codex", "gpt-5.5"),
+			model("openai-codex", "gpt-5.3-codex-spark"),
+		],
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	};
+}
+
+function fakeSession(initial = model("provider-a", "initial")) {
+	return {
+		model: initial as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
+		sessionId: "session-1",
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+	};
+}
+
+describe("model profile activation", () => {
+	test("prepared activation resolves default and agent selectors", async () => {
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: fakeRegistry(),
+			settings: Settings.isolated(),
+			profileName: "profile-a",
+		});
+
+		expect(prepared.defaultModel?.provider).toBe("provider-a");
+		expect(prepared.defaultModel?.id).toBe("default");
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.High);
+		expect(prepared.agentModelOverrides).toEqual({
+			executor: "provider-b/executor",
+			architect: "provider-a/architect",
+		});
+	});
+
+	test("builtin profiles preserve explicit role thinking suffixes in overrides", async () => {
+		const registry = fakeRegistry({ profiles: [...BUILTIN_MODEL_PROFILES] });
+
+		const codexStandard = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: registry,
+			settings: Settings.isolated(),
+			profileName: "codex-standard",
+		});
+		expect(codexStandard.agentModelOverrides).toEqual({
+			executor: "openai-codex/gpt-5.4:low",
+			architect: "openai-codex/gpt-5.4:xhigh",
+			planner: "openai-codex/gpt-5.4:medium",
+			critic: "openai-codex/gpt-5.4:high",
+		});
+
+		const codexPro = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: registry,
+			settings: Settings.isolated(),
+			profileName: "codex-pro",
+		});
+		expect(codexPro.agentModelOverrides.architect).toBe("openai-codex/gpt-5.1-codex-max:high");
+		expect(codexPro.agentModelOverrides.planner).toBe("openai-codex/gpt-5.5:high");
+		expect(codexPro.agentModelOverrides.critic).toBe("openai-codex/gpt-5.3-codex-spark:high");
+	});
+
+	test("session-only changes active model and applies runtime overrides without persisted sets", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "task.agentModelOverrides": { critic: "provider-a/old" } });
+		const setCalls: string[] = [];
+		const originalSet = settings.set.bind(settings);
+		settings.set = ((path: never, value: never) => {
+			setCalls.push(path);
+			return originalSet(path, value);
+		}) as typeof settings.set;
+
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		expect(session.setModelTemporaryCalls).toHaveLength(1);
+		expect(session.model?.id).toBe("default");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "provider-a/old",
+			executor: "provider-b/executor",
+			architect: "provider-a/architect",
+		});
+		expect(setCalls).toEqual([]);
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+	});
+
+	test("--default persists only modelProfile.default and flushes", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		const setCalls: string[] = [];
+		const originalSet = settings.set.bind(settings);
+		settings.set = ((path: never, value: never) => {
+			setCalls.push(path);
+			return originalSet(path, value);
+		}) as typeof settings.set;
+		let flushCount = 0;
+		settings.flush = async () => {
+			flushCount += 1;
+		};
+
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" }, { persistDefault: true });
+
+		expect(setCalls).toEqual(["modelProfile.default"]);
+		expect(settings.get("modelProfile.default")).toBe("profile-a");
+		expect(flushCount).toBe(1);
+	});
+
+	test("missing credentials hard-block before mutation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original" },
+			"modelProfile.default": "old-profile",
+		});
+
+		await expect(
+			activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry({ missingProviders: ["provider-a", "provider-b"] }),
+				settings,
+				profileName: "profile-a",
+			}),
+		).rejects.toThrow(
+			'Model profile "profile-a" requires credentials for: provider-a, provider-b. Run /login and configure the missing provider(s), then retry.',
+		);
+		expect(session.model?.id).toBe("initial");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+	});
+
+	test("unknown profile error lists available profiles", async () => {
+		await expect(
+			prepareModelProfileActivation({
+				session: fakeSession(),
+				modelRegistry: fakeRegistry({
+					profiles: [
+						{ name: "alpha", requiredProviders: [], modelMapping: {}, source: "user" },
+						{ name: "beta", requiredProviders: [], modelMapping: {}, source: "user" },
+					],
+				}),
+				settings: Settings.isolated(),
+				profileName: "missing",
+			}),
+		).rejects.toThrow('Unknown model profile "missing". Available profiles: alpha, beta');
+	});
+
+	test("apply rolls back runtime changes when persistence throws", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "task.agentModelOverrides": { executor: "provider-a/original" } });
+		const prepared = await prepareModelProfileActivation({
+			session,
+			modelRegistry: fakeRegistry(),
+			settings,
+			profileName: "profile-a",
+		});
+		settings.flush = async () => {
+			throw new Error("flush failed");
+		};
+
+		await expect(applyPreparedModelProfileActivation(prepared, { persistDefault: true })).rejects.toThrow("flush failed");
+
+		expect(session.model?.id).toBe("initial");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+	});
+
+	test("precedence composes configured, default, mpreset, and explicit overrides", async () => {
+		const settings = Settings.isolated({ "task.agentModelOverrides": { executor: "configured/executor" } });
+		const session = fakeSession();
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		settings.override("task.agentModelOverrides", {
+			...settings.get("task.agentModelOverrides"),
+			executor: "explicit/executor",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "explicit/executor",
+			architect: "provider-a/architect",
+		});
+	});
+});

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import modelsJson from "@gajae-code/ai/models.json" with { type: "json" };
+import {
+	BUILTIN_MODEL_PROFILES,
+	mergeModelProfiles,
+	resolveProfileBindings,
+	type ModelProfileDefinition,
+} from "@gajae-code/coding-agent/config/model-profiles";
+import { parseModelString } from "@gajae-code/coding-agent/config/model-resolver";
+import { ProfileModelSelectorSchema } from "@gajae-code/coding-agent/config/models-config-schema";
+
+type Role = "default" | "executor" | "architect" | "planner" | "critic";
+
+const roles: Role[] = ["default", "executor", "architect", "planner", "critic"];
+const reviewRoles: Role[] = ["architect", "planner", "critic"];
+const effortRank: Partial<Record<ThinkingLevel, number>> = {
+	[ThinkingLevel.Minimal]: 0,
+	[ThinkingLevel.Low]: 1,
+	[ThinkingLevel.Medium]: 2,
+	[ThinkingLevel.High]: 3,
+	[ThinkingLevel.XHigh]: 4,
+};
+
+function builtIn(name: string): ModelProfileDefinition {
+	const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === name);
+	expect(profile).toBeDefined();
+	return profile as ModelProfileDefinition;
+}
+
+function selectorExists(selector: string): boolean {
+	const parsed = parseModelString(selector);
+	if (!parsed) return false;
+	const providerModels = modelsJson[parsed.provider as keyof typeof modelsJson] as Record<string, unknown> | undefined;
+	return providerModels?.[parsed.id] !== undefined;
+}
+
+function effortOf(selector: string): number {
+	const parsed = parseModelString(selector);
+	return parsed?.thinkingLevel ? (effortRank[parsed.thinkingLevel] ?? 0) : 0;
+}
+
+describe("built-in model profile catalog", () => {
+	test("contains exactly 9 builtins", () => {
+		expect(BUILTIN_MODEL_PROFILES).toHaveLength(9);
+		expect(new Set(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).size).toBe(9);
+	});
+
+	test("required_providers are correct per family", () => {
+		for (const profile of BUILTIN_MODEL_PROFILES) {
+			if (profile.name.startsWith("opencode-go-codex-")) {
+				expect(profile.requiredProviders).toEqual(["opencode-go", "openai-codex"]);
+			} else if (profile.name.startsWith("opencode-go-")) {
+				expect(profile.requiredProviders).toEqual(["opencode-go"]);
+			} else if (profile.name.startsWith("codex-")) {
+				expect(profile.requiredProviders).toEqual(["openai-codex"]);
+			} else {
+				throw new Error(`Unexpected built-in profile ${profile.name}`);
+			}
+		}
+	});
+
+	test("every selector parses with schema validation and exists in models.json", () => {
+		const missing: string[] = [];
+		for (const profile of BUILTIN_MODEL_PROFILES) {
+			for (const role of roles) {
+				const selector = profile.modelMapping[role];
+				expect(selector).toBeDefined();
+				expect(ProfileModelSelectorSchema.safeParse(selector).success).toBe(true);
+				expect(parseModelString(selector ?? "")).toBeDefined();
+				if (selector && !selectorExists(selector)) missing.push(`${profile.name}.${role}=${selector}`);
+			}
+		}
+		expect(missing).toEqual([]);
+	});
+
+	test("*-pro profiles raise effort on architect/planner/critic", () => {
+		for (const profile of BUILTIN_MODEL_PROFILES.filter(candidate => candidate.name.endsWith("-pro"))) {
+			for (const role of reviewRoles) {
+				expect(effortOf(profile.modelMapping[role] ?? "")).toBeGreaterThanOrEqual(effortRank[ThinkingLevel.High] ?? 3);
+			}
+		}
+	});
+
+	test("codex-standard mapping exactly equals OpenAI Code profile preset efforts", () => {
+		const profile = builtIn("codex-standard");
+		const expected: Record<Role, ThinkingLevel> = {
+			default: ThinkingLevel.Medium,
+			executor: ThinkingLevel.Low,
+			architect: ThinkingLevel.XHigh,
+			planner: ThinkingLevel.Medium,
+			critic: ThinkingLevel.High,
+		};
+		for (const role of roles) {
+			const parsed = parseModelString(profile.modelMapping[role] ?? "");
+			expect(parsed?.provider).toBe("openai-codex");
+			expect(parsed?.id).toBe("gpt-5.4");
+			expect(parsed?.thinkingLevel).toBe(expected[role]);
+		}
+	});
+
+	test("user same-name profile overrides builtin via mergeModelProfiles", () => {
+		const merged = mergeModelProfiles({
+			"codex-standard": {
+				required_providers: ["custom"],
+				model_mapping: { default: "custom/model" },
+			},
+		});
+		const profile = merged.get("codex-standard");
+		expect(profile).toEqual({
+			name: "codex-standard",
+			requiredProviders: ["custom"],
+			modelMapping: { default: "custom/model" },
+			source: "user",
+		});
+		expect(resolveProfileBindings(profile as ModelProfileDefinition)).toEqual({
+			defaultSelector: "custom/model",
+			agentModelOverrides: {},
+		});
+	});
+});

--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import {
+	BUILTIN_MODEL_PROFILES,
+	mergeModelProfiles,
+	resolveProfileBindings,
+	type ModelProfileDefinition,
+} from "@gajae-code/coding-agent/config/model-profiles";
+import { ModelsConfigSchema, ProfileModelSelectorSchema } from "@gajae-code/coding-agent/config/models-config-schema";
+
+function issuePaths(error: { issues: Array<{ path: PropertyKey[] }> }): string[] {
+	return error.issues.map(issue => issue.path.join("."));
+}
+
+function profileConfig(modelSelector: string) {
+	return {
+		profiles: {
+			bad: {
+				required_providers: ["provider"],
+				model_mapping: { default: modelSelector },
+			},
+		},
+	};
+}
+
+describe("model profile red-team schema and catalog cases", () => {
+	test("required_providers rejects empty arrays", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: [],
+					model_mapping: { default: "provider/model" },
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(issuePaths(result.error)).toContain("profiles.bad.required_providers");
+		}
+	});
+
+	test("model_mapping accepts a partial one-role mapping", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				partial: {
+					required_providers: ["provider"],
+					model_mapping: { executor: "provider/model" },
+				},
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	test("model_mapping rejects unknown role keys with model_mapping in the path", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: ["provider"],
+					model_mapping: { reviewer: "provider/model" },
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(issuePaths(result.error).some(path => path.includes("profiles.bad.model_mapping.reviewer"))).toBe(true);
+		}
+	});
+
+	test.each([
+		["missing slash", "providermodel"],
+		["empty provider", "/model"],
+		["empty model", "provider/"],
+		["trailing colon", "provider/model:"],
+		["bogus effort", "provider/model:ultra"],
+		["double effort", "provider/model:high:low"],
+	])("selector rejects %s", (_label, selector) => {
+		const result = ModelsConfigSchema.safeParse(profileConfig(selector));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(issuePaths(result.error)).toContain("profiles.bad.model_mapping.default");
+			expect(result.error.issues[0]?.message).toBe("Expected provider/modelId with optional :effort suffix");
+		}
+	});
+
+	test("profile definitions strictly reject extra fields", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: ["provider"],
+					model_mapping: { default: "provider/model" },
+					description: "not part of the public profile schema",
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(issuePaths(result.error)).toContain("profiles.bad");
+		}
+	});
+
+	test("user profile with a duplicate builtin name overrides it and changes source to user", () => {
+		const merged = mergeModelProfiles({
+			"codex-standard": {
+				required_providers: ["custom-provider"],
+				model_mapping: { default: "custom-provider/custom-model" },
+			},
+		});
+
+		expect(merged.get("codex-standard")).toEqual({
+			name: "codex-standard",
+			requiredProviders: ["custom-provider"],
+			modelMapping: { default: "custom-provider/custom-model" },
+			source: "user",
+		});
+	});
+
+	test("resolveProfileBindings on a default-only mapping returns only defaultSelector", () => {
+		const resolved = resolveProfileBindings({
+			name: "default-only",
+			requiredProviders: ["provider"],
+			modelMapping: { default: "provider/model" },
+			source: "user",
+		});
+
+		expect(resolved).toEqual({ defaultSelector: "provider/model", agentModelOverrides: {} });
+	});
+
+	test("resolveProfileBindings preserves effort suffixes verbatim", () => {
+		const resolved = resolveProfileBindings({
+			name: "effort",
+			requiredProviders: ["provider"],
+			modelMapping: {
+				default: "provider/default:medium",
+				executor: "provider/executor:high",
+			},
+			source: "user",
+		});
+
+		expect(resolved.defaultSelector).toBe("provider/default:medium");
+		expect(resolved.agentModelOverrides).toEqual({ executor: "provider/executor:high" });
+	});
+
+	test("mergeModelProfiles with undefined returns exactly the 9 builtins", () => {
+		const merged = mergeModelProfiles(undefined);
+
+		expect(merged.size).toBe(9);
+		expect([...merged.values()]).toEqual(BUILTIN_MODEL_PROFILES);
+	});
+
+	test("every builtin selector satisfies public selector validation", () => {
+		const failures: string[] = [];
+		for (const profile of BUILTIN_MODEL_PROFILES) {
+			for (const [role, selector] of Object.entries(profile.modelMapping)) {
+				if (!ProfileModelSelectorSchema.safeParse(selector).success) failures.push(`${profile.name}.${role}=${selector}`);
+			}
+		}
+
+		expect(failures).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -3,7 +3,6 @@ import {
 	BUILTIN_MODEL_PROFILES,
 	mergeModelProfiles,
 	resolveProfileBindings,
-	type ModelProfileDefinition,
 } from "@gajae-code/coding-agent/config/model-profiles";
 import { ModelsConfigSchema, ProfileModelSelectorSchema } from "@gajae-code/coding-agent/config/models-config-schema";
 
@@ -118,6 +117,17 @@ describe("model profile red-team schema and catalog cases", () => {
 		});
 	});
 
+	test("mergeModelProfiles aggregates underdeclared providers from mappings", () => {
+		const merged = mergeModelProfiles({
+			underdeclared: {
+				required_providers: ["provider-a"],
+				model_mapping: { default: "provider-a/default", executor: "provider-b/executor:high" },
+			},
+		});
+
+		expect(merged.get("underdeclared")?.requiredProviders).toEqual(["provider-a", "provider-b"]);
+	});
+
 	test("resolveProfileBindings on a default-only mapping returns only defaultSelector", () => {
 		const resolved = resolveProfileBindings({
 			name: "default-only",
@@ -148,14 +158,15 @@ describe("model profile red-team schema and catalog cases", () => {
 		const merged = mergeModelProfiles(undefined);
 
 		expect(merged.size).toBe(9);
-		expect([...merged.values()]).toEqual(BUILTIN_MODEL_PROFILES);
+		expect([...merged.values()]).toEqual([...BUILTIN_MODEL_PROFILES]);
 	});
 
 	test("every builtin selector satisfies public selector validation", () => {
 		const failures: string[] = [];
 		for (const profile of BUILTIN_MODEL_PROFILES) {
 			for (const [role, selector] of Object.entries(profile.modelMapping)) {
-				if (!ProfileModelSelectorSchema.safeParse(selector).success) failures.push(`${profile.name}.${role}=${selector}`);
+				if (!ProfileModelSelectorSchema.safeParse(selector).success)
+					failures.push(`${profile.name}.${role}=${selector}`);
 			}
 		}
 

--- a/packages/coding-agent/test/model-profiles-schema.test.ts
+++ b/packages/coding-agent/test/model-profiles-schema.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { resolveProfileBindings } from "@gajae-code/coding-agent/config/model-profiles";
+import { ModelsConfigSchema } from "@gajae-code/coding-agent/config/models-config-schema";
+
+function issuePaths(error: { issues: Array<{ path: PropertyKey[] }> }): string[] {
+	return error.issues.map(issue => issue.path.join("."));
+}
+
+describe("model profile schema", () => {
+	test("config without profiles parses", () => {
+		const result = ModelsConfigSchema.safeParse({ providers: {}, modelBindings: {}, equivalence: {} });
+		expect(result.success).toBe(true);
+	});
+
+	test("full and partial mappings parse", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				full: {
+					required_providers: ["openai-codex"],
+					model_mapping: {
+						default: "openai-codex/gpt-5.4:medium",
+						executor: "openai-codex/gpt-5.4:low",
+						architect: "openai-codex/gpt-5.4:xhigh",
+						planner: "openai-codex/gpt-5.4:medium",
+						critic: "openai-codex/gpt-5.4:high",
+					},
+				},
+				partial: {
+					required_providers: ["opencode-go"],
+					model_mapping: { default: "opencode-go/kimi-k2.6" },
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("unknown model_mapping key is rejected with model_mapping path", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: ["openai-codex"],
+					model_mapping: { reviewer: "openai-codex/gpt-5.4" },
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(issuePaths(result.error).some(path => path.includes("profiles.bad.model_mapping.reviewer"))).toBe(true);
+		}
+	});
+
+	test("invalid selector and bad effort are rejected", () => {
+		const missingSlash = ModelsConfigSchema.safeParse({
+			profiles: { bad: { required_providers: ["x"], model_mapping: { default: "gpt-5.4" } } },
+		});
+		const badEffort = ModelsConfigSchema.safeParse({
+			profiles: { bad: { required_providers: ["x"], model_mapping: { default: "x/model:ultra" } } },
+		});
+		expect(missingSlash.success).toBe(false);
+		expect(badEffort.success).toBe(false);
+		if (!badEffort.success) {
+			expect(badEffort.error.issues[0]?.message).toBe("Expected provider/modelId with optional :effort suffix");
+		}
+	});
+
+	test("comma-chain selectors are rejected with model_mapping path", () => {
+		const commaChain = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: ["provider-a", "provider-b"],
+					model_mapping: { default: "provider-a/model, provider-b/model:high" },
+				},
+			},
+		});
+		const badEffort = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: { required_providers: ["a"], model_mapping: { default: "a/m:bogus" } },
+			},
+		});
+		const badProvider = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: { required_providers: ["a"], model_mapping: { default: "/m" } },
+			},
+		});
+
+		expect(commaChain.success).toBe(false);
+		expect(badEffort.success).toBe(false);
+		expect(badProvider.success).toBe(false);
+		for (const result of [commaChain, badEffort, badProvider]) {
+			if (!result.success) {
+				expect(issuePaths(result.error)).toContain("profiles.bad.model_mapping.default");
+				expect(result.error.issues[0]?.message).toBe("Expected provider/modelId with optional :effort suffix");
+			}
+		}
+	});
+
+	test("resolveProfileBindings preserves single selectors verbatim", () => {
+		const resolved = resolveProfileBindings({
+			name: "single",
+			requiredProviders: ["provider-a"],
+			modelMapping: {
+				default: "provider-a/model:high",
+				executor: "provider-a/executor:low",
+			},
+			source: "user",
+		});
+
+		expect(resolved.defaultSelector).toBe("provider-a/model:high");
+		expect(resolved.agentModelOverrides.executor).toBe("provider-a/executor:low");
+	});
+
+	test("extra profile field is rejected", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				bad: {
+					required_providers: ["openai-codex"],
+					model_mapping: { default: "openai-codex/gpt-5.4" },
+					description: "not allowed",
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) expect(issuePaths(result.error)).toContain("profiles.bad");
+	});
+});

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -1,0 +1,237 @@
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent, type ModelSelectorSelection } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+
+function normalizeRenderedText(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\s+/g, " ").trim();
+}
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+const defaultModel = model("provider-a", "default");
+const alternateModel = model("provider-a", "alternate");
+const flatModel = model("provider-b", "zzz-flat-model");
+
+const userProfile: ModelProfileDefinition = {
+	name: "profile-a",
+	requiredProviders: ["provider-a"],
+	modelMapping: { default: "provider-a/default:high", executor: "provider-a/alternate" },
+	source: "user",
+};
+
+function createRegistry(options: { profiles?: ModelProfileDefinition[]; missingCredentials?: boolean } = {}) {
+	const profiles = new Map((options.profiles ?? [userProfile]).map(profile => [profile.name, profile]));
+	return {
+		refresh: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [defaultModel, alternateModel, flatModel],
+		getAll: () => [defaultModel, alternateModel, flatModel],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		getApiKeyForProvider: async () => (options.missingCredentials ? undefined : "key"),
+		getApiKey: async () => "key",
+	};
+}
+
+function createSelector(
+	onSelect: (selection: ModelSelectorSelection) => void | Promise<void>,
+	options: { profiles?: ModelProfileDefinition[]; temporaryOnly?: boolean } = {},
+) {
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		undefined,
+		Settings.isolated(),
+		createRegistry({ profiles: options.profiles }) as never,
+		[],
+		onSelect,
+		() => {},
+		{ temporaryOnly: options.temporaryOnly },
+	);
+}
+
+async function renderSelector(selector: ModelSelectorComponent): Promise<string> {
+	await Bun.sleep(10);
+	installTestTheme();
+	return normalizeRenderedText(selector.render(240).join("\n"));
+}
+
+function createControllerContext(options: { missingCredentials?: boolean } = {}) {
+	const settings = Settings.isolated({
+		"task.agentModelOverrides": { executor: "provider-a/original-executor" },
+		"modelProfile.default": "old-profile",
+	});
+	const flush = vi.fn(async () => {});
+	settings.flush = flush as typeof settings.flush;
+	const setCalls: Array<{ path: string; value: unknown }> = [];
+	const originalSet = settings.set.bind(settings);
+	settings.set = ((path: never, value: never) => {
+		setCalls.push({ path: path as string, value });
+		return originalSet(path, value);
+	}) as typeof settings.set;
+	const overrideCalls: Array<{ path: string; value: unknown }> = [];
+	const originalOverride = settings.override.bind(settings);
+	settings.override = ((path: never, value: never) => {
+		overrideCalls.push({ path: path as string, value });
+		return originalOverride(path, value);
+	}) as typeof settings.override;
+	const session = {
+		model: alternateModel as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low,
+		sessionId: "session-1",
+		scopedModels: [],
+		modelRegistry: createRegistry(options),
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+	};
+	const ctx = {
+		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+		editor: {},
+		settings,
+		session,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+	};
+	return { ctx, settings, session, flush, setCalls, overrideCalls };
+}
+
+async function selectProfileThroughController(controller: SelectorController, setDefault = false): Promise<void> {
+	controller.showModelSelector();
+	const selector = (controller as unknown as { ctx: { editorContainer: { addChild: ReturnType<typeof vi.fn> } } }).ctx
+		.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+	await Bun.sleep(10);
+	installTestTheme();
+	await selector.__testSelectProfile("profile-a", setDefault);
+	await Bun.sleep(0);
+}
+
+describe("model selector profile red-team", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+
+	test("empty profile catalog omits Profiles section and does not crash", async () => {
+		const selector = createSelector(() => {}, { profiles: [] });
+		const rendered = await renderSelector(selector);
+
+		expect(rendered).not.toContain("Profiles");
+		expect(rendered).toContain("provider-a/default");
+	});
+
+	test("temporary-only mode hides Profiles even when profiles exist", async () => {
+		const selector = createSelector(() => {}, { temporaryOnly: true });
+		const rendered = await renderSelector(selector);
+
+		expect(rendered).not.toContain("Profiles");
+		expect(rendered).not.toContain("profile-a");
+	});
+
+	test("user-overridden profile name appears once", async () => {
+		const builtinProfile: ModelProfileDefinition = { ...userProfile, source: "builtin" };
+		const overriddenProfile: ModelProfileDefinition = { ...userProfile, source: "user" };
+		const selector = createSelector(() => {}, { profiles: [builtinProfile, overriddenProfile] });
+		const rendered = await renderSelector(selector);
+
+		expect(rendered.match(/profile-a/g) ?? []).toHaveLength(1);
+	});
+
+	test("profile actions wire Apply for this session to persistDefault false and Set as default to true", async () => {
+		const selections: ModelSelectorSelection[] = [];
+		const applySelector = createSelector(selection => selections.push(selection));
+		await renderSelector(applySelector);
+		applySelector.handleInput("\n");
+		applySelector.handleInput("\n");
+
+		const defaultSelector = createSelector(selection => selections.push(selection));
+		await renderSelector(defaultSelector);
+		defaultSelector.handleInput("\n");
+		defaultSelector.handleInput("\x1b[B");
+		defaultSelector.handleInput("\n");
+
+		expect(selections).toEqual([
+			{ kind: "profile", profileName: "profile-a", setDefault: false },
+			{ kind: "profile", profileName: "profile-a", setDefault: true },
+		]);
+	});
+
+	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {
+		const sessionOnly = createControllerContext();
+		await selectProfileThroughController(new SelectorController(sessionOnly.ctx as never), false);
+
+		expect(sessionOnly.setCalls).not.toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(sessionOnly.settings.get("modelProfile.default")).toBe("old-profile");
+		expect(sessionOnly.ctx.showStatus).toHaveBeenCalledWith("Model profile: profile-a");
+
+		const persistent = createControllerContext();
+		await selectProfileThroughController(new SelectorController(persistent.ctx as never), true);
+
+		expect(persistent.setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(persistent.flush).toHaveBeenCalledTimes(1);
+		expect(persistent.ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+	});
+
+	test("activation credential error shows error and preserves active model, thinking, overrides, and default", async () => {
+		const { ctx, settings, session, overrideCalls, setCalls } = createControllerContext({ missingCredentials: true });
+		await selectProfileThroughController(new SelectorController(ctx as never), false);
+
+		expect(ctx.showError).toHaveBeenCalledWith(
+			'Model profile "profile-a" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
+		);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(session.model).toBe(alternateModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original-executor" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(overrideCalls).toEqual([]);
+		expect(setCalls).toEqual([]);
+	});
+
+	test("profile names with unusual characters render without breaking the list", async () => {
+		const weirdProfile: ModelProfileDefinition = {
+			...userProfile,
+			name: "Team/Profile: β 🚀 [default] {x}|$",
+		};
+		const selector = createSelector(() => {}, { profiles: [weirdProfile] });
+		const rendered = await renderSelector(selector);
+
+		expect(rendered).toContain("Profiles");
+		expect(rendered).toContain("Team/Profile: β 🚀 [default] {x}|$");
+		expect(rendered).toContain("provider-a/default");
+	});
+
+	test("profiles render above flat model rows", async () => {
+		const selector = createSelector(() => {});
+		const rendered = await renderSelector(selector);
+
+		expect(rendered.indexOf("Profiles")).toBeGreaterThanOrEqual(0);
+		expect(rendered.indexOf("profile-a")).toBeGreaterThan(rendered.indexOf("Profiles"));
+		expect(rendered.indexOf("provider-a/default")).toBeGreaterThan(rendered.indexOf("profile-a"));
+		expect(rendered.indexOf("provider-b/zzz-flat-model")).toBeGreaterThan(rendered.indexOf("profile-a"));
+	});
+});

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -1,0 +1,182 @@
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent, type ModelSelectorSelection } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 } as Model);
+
+function normalizeRenderedText(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\s+/g, " ").trim();
+}
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+const defaultModel = model("provider-a", "default");
+const alternateModel = model("provider-a", "alternate");
+const profile: ModelProfileDefinition = {
+	name: "profile-a",
+	requiredProviders: ["provider-a"],
+	modelMapping: { default: "provider-a/default:high", executor: "provider-a/alternate" },
+	source: "user",
+};
+
+function createRegistry(options: { missingCredentials?: boolean } = {}) {
+	const profiles = new Map([[profile.name, profile]]);
+	return {
+		refresh: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [defaultModel, alternateModel],
+		getAll: () => [defaultModel, alternateModel],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		getApiKeyForProvider: async () => (options.missingCredentials ? undefined : "key"),
+		getApiKey: async () => "key",
+	};
+}
+
+function createSelector(onSelect: (selection: ModelSelectorSelection) => void, options: { temporaryOnly?: boolean } = {}) {
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		undefined,
+		Settings.isolated(),
+		createRegistry() as never,
+		[],
+		onSelect,
+		() => {},
+		options,
+	);
+}
+
+function createControllerContext(options: { missingCredentials?: boolean } = {}) {
+	const settings = Settings.isolated({
+		"task.agentModelOverrides": { executor: "provider-a/original-executor" },
+		"modelProfile.default": "old-profile",
+	});
+	const flush = vi.fn(async () => {});
+	settings.flush = flush as typeof settings.flush;
+	const setCalls: Array<{ path: string; value: unknown }> = [];
+	const originalSet = settings.set.bind(settings);
+	settings.set = ((path: never, value: never) => {
+		setCalls.push({ path: path as string, value });
+		return originalSet(path, value);
+	}) as typeof settings.set;
+	const session = {
+		model: alternateModel as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low,
+		sessionId: "session-1",
+		scopedModels: [],
+		modelRegistry: createRegistry(options),
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+	};
+	const ctx = {
+		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+		editor: {},
+		settings,
+		session,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+	};
+	return { ctx, settings, session, flush, setCalls };
+}
+
+async function selectFirstProfile(controller: SelectorController, setDefault = false): Promise<void> {
+	controller.showModelSelector();
+	const selector = (controller as unknown as { ctx: { editorContainer: { addChild: ReturnType<typeof vi.fn> } } }).ctx.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+	await Bun.sleep(10);
+	installTestTheme();
+	await selector.__testSelectProfile("profile-a", setDefault);
+	await Bun.sleep(0);
+}
+
+describe("model selector profiles", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+
+	test("renders Profiles above model rows", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered.indexOf("Profiles")).toBeGreaterThanOrEqual(0);
+		expect(rendered.indexOf("profile-a")).toBeGreaterThan(rendered.indexOf("Profiles"));
+		expect(rendered.indexOf("provider-a/default")).toBeGreaterThan(rendered.indexOf("profile-a"));
+	});
+
+	test("temporary-only mode hides Profiles", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {}, { temporaryOnly: true });
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toContain("Profiles");
+		expect(rendered).not.toContain("profile-a");
+	});
+
+	test("Apply for this session activates profile through setModelTemporary", async () => {
+		const { ctx, settings, session } = createControllerContext();
+		const controller = new SelectorController(ctx as never);
+		await selectFirstProfile(controller);
+
+		expect(session.setModelTemporaryCalls).toHaveLength(1);
+		expect(session.model).toBe(defaultModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: profile-a");
+	});
+
+	test("Set as default persists and flushes modelProfile.default", async () => {
+		const { ctx, settings, flush, setCalls } = createControllerContext();
+		const controller = new SelectorController(ctx as never);
+		await selectFirstProfile(controller, true);
+
+		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(flush).toHaveBeenCalledTimes(1);
+		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+	});
+
+	test("credential failure shows error and leaves model and overrides unchanged", async () => {
+		const { ctx, settings, session } = createControllerContext({ missingCredentials: true });
+		const controller = new SelectorController(ctx as never);
+		await selectFirstProfile(controller);
+
+		expect(ctx.showError).toHaveBeenCalledWith(
+			'Model profile "profile-a" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
+		);
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(session.model).toBe(alternateModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original-executor" });
+		expect(settings.get("modelProfile.default")).toBe("old-profile");
+	});
+});

--- a/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { CustomProviderWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-provider-wizard";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { ProviderOnboardingSelectorComponent, type ProviderOnboardingAction } from "@gajae-code/coding-agent/modes/components/provider-onboarding-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { addApiCompatibleProvider, type ProviderSetupInput } from "@gajae-code/coding-agent/setup/provider-onboarding";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+
+const originalAgentDir = getAgentDir();
+let tempAgentDir: string | undefined;
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+afterEach(async () => {
+	setAgentDir(originalAgentDir);
+	if (tempAgentDir) {
+		await fs.rm(tempAgentDir, { recursive: true, force: true });
+		tempAgentDir = undefined;
+	}
+});
+
+function visibleText(component: { render(width: number): string[] }): string {
+	return Bun.stripANSI(component.render(180).join("\n"));
+}
+
+function typeText(component: { handleInput(input: string): void }, text: string): void {
+	for (const char of text) component.handleInput(char);
+}
+
+function driveWizard(
+	component: CustomProviderWizardComponent,
+	options?: {
+		providerId?: string;
+		baseUrl?: string;
+		credentialSource?: "env" | "literal";
+		credential?: string;
+		models?: string;
+	},
+): void {
+	component.handleInput("\n");
+	typeText(component, options?.providerId ?? "custom-openai");
+	component.handleInput("\n");
+	typeText(component, options?.baseUrl ?? "https://api.example.com/v1");
+	component.handleInput("\n");
+	if (options?.credentialSource === "literal") component.handleInput("\x1b[B");
+	component.handleInput("\n");
+	typeText(component, options?.credential ?? (options?.credentialSource === "literal" ? "sk-redteam-secret" : "CUSTOM_PROVIDER_KEY"));
+	component.handleInput("\n");
+	typeText(component, options?.models ?? "custom-model");
+	component.handleInput("\n");
+}
+
+async function withRegistry<T>(run: (registry: ModelRegistry, store: SqliteAuthCredentialStore) => Promise<T>): Promise<T> {
+	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-wizard-redteam-"));
+	setAgentDir(tempAgentDir);
+	const store = await SqliteAuthCredentialStore.open(path.join(tempAgentDir, "agent.db"));
+	try {
+		const authStorage = new AuthStorage(store);
+		const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
+		return await run(registry, store);
+	} finally {
+		store.close();
+	}
+}
+
+describe("provider onboarding wizard red-team", () => {
+	it("rejects invalid and non-https non-localhost base URLs while wizard surfaces the error without crashing", async () => {
+		await expect(
+			addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "bad-url",
+				baseUrl: "not a url",
+				apiKeyEnv: "BAD_URL_KEY",
+				models: ["bad-model"],
+			}),
+		).rejects.toThrow("Base URL must be a valid absolute URL");
+
+		await expect(
+			addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "insecure-url",
+				baseUrl: "http://api.example.com/v1",
+				apiKeyEnv: "INSECURE_URL_KEY",
+				models: ["bad-model"],
+			}),
+		).rejects.toThrow("Base URL must use https unless it targets localhost or a loopback address");
+
+		const ctx = createControllerContext({ refresh: async () => undefined } as unknown as ModelRegistry);
+		const controller = new SelectorController(ctx);
+		controller.showCustomProviderWizard();
+		const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+		driveWizard(wizard, { providerId: "insecure-wizard", baseUrl: "http://api.example.com/v1" });
+		wizard.handleInput("\n");
+		await Bun.sleep(20);
+
+		const rendered = visibleText(wizard);
+		expect(rendered).toContain("Provider setup failed");
+		expect(rendered).toContain("Base URL must use https unless it targets localhost or a loopback address");
+	});
+
+	it("rejects empty provider id and empty model lists", async () => {
+		await expect(
+			addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "",
+				baseUrl: "https://api.example.com/v1",
+				apiKeyEnv: "EMPTY_PROVIDER_KEY",
+				models: ["custom-model"],
+			}),
+		).rejects.toThrow("Provider id is required");
+
+		await expect(
+			addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "empty-models",
+				baseUrl: "https://api.example.com/v1",
+				apiKeyEnv: "EMPTY_MODELS_KEY",
+				models: ["", "  ", ","],
+			}),
+		).rejects.toThrow("At least one model id is required");
+	});
+
+	it("requires force for an existing provider and overwrites when force is confirmed", async () => {
+		await withRegistry(async () => {
+			const first: ProviderSetupInput = {
+				compatibility: "openai",
+				providerId: "dupe-provider",
+				baseUrl: "https://api.example.com/v1",
+				apiKeyEnv: "DUPE_PROVIDER_KEY",
+				models: ["old-model"],
+			};
+			await addApiCompatibleProvider(first);
+			await expect(addApiCompatibleProvider({ ...first, models: ["new-model"] })).rejects.toThrow(
+				"Provider 'dupe-provider' already exists. Use --force to replace it.",
+			);
+			const result = await addApiCompatibleProvider({ ...first, models: ["new-model"], force: true });
+			expect(result.modelIds).toEqual(["new-model"]);
+
+			const text = await Bun.file(path.join(tempAgentDir!, "models.yml")).text();
+			expect(text).toContain("new-model");
+			expect(text).not.toContain("old-model");
+		});
+	});
+
+	it("emits env-var and pasted-key credential sources as correct ProviderSetupInput fields", () => {
+		const submissions: ProviderSetupInput[] = [];
+		const envWizard = new CustomProviderWizardComponent(input => submissions.push(input), () => undefined);
+		driveWizard(envWizard, { providerId: "env-provider", credentialSource: "env", credential: "ENV_PROVIDER_KEY" });
+		envWizard.handleInput("\n");
+
+		const literalWizard = new CustomProviderWizardComponent(input => submissions.push(input), () => undefined);
+		driveWizard(literalWizard, { providerId: "literal-provider", credentialSource: "literal", credential: "sk-literal-key" });
+		literalWizard.handleInput("\n");
+
+		expect(submissions).toEqual([
+			expect.objectContaining({ providerId: "env-provider", apiKeyEnv: "ENV_PROVIDER_KEY", apiKey: undefined }),
+			expect.objectContaining({ providerId: "literal-provider", apiKeyEnv: undefined, apiKey: "sk-literal-key" }),
+		]);
+	});
+
+	it("refreshes offline, notifies config change, shows formatted result, and exposes new provider in a subsequent model selector read", async () => {
+		await withRegistry(async registry => {
+			const refreshModes: string[] = [];
+			const originalRefresh = registry.refresh.bind(registry);
+			registry.refresh = async mode => {
+				refreshModes.push(mode);
+				await originalRefresh(mode);
+			};
+			let configChanged = 0;
+			const ctx = createControllerContext(registry, () => {
+				configChanged++;
+			});
+			const controller = new SelectorController(ctx);
+
+			controller.showCustomProviderWizard();
+			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+			driveWizard(wizard, { providerId: "visible-provider", models: "visible-model" });
+			wizard.handleInput("\n");
+			await Bun.sleep(50);
+
+			expect(refreshModes).toContain("offline");
+			expect(configChanged).toBe(1);
+			const status = ctx.statuses.join("\n");
+			expect(status).toContain("Provider 'visible-provider' configured as openai-compatible.");
+			expect(status).toContain("Models: visible-model");
+			expect(status).toContain("API key: CUST…_KEY (environment variable)");
+
+			await registry.refresh("offline");
+			expect(registry.find("visible-provider", "visible-model")).toBeDefined();
+		});
+	});
+
+	it("keeps Add custom provider at index 0 while OAuth and API-guide actions still route", () => {
+		const actions: ProviderOnboardingAction[] = [];
+		const selector = new ProviderOnboardingSelectorComponent(action => actions.push(action), () => undefined);
+		const rendered = visibleText(selector);
+		expect(rendered.indexOf("Add custom provider")).toBeLessThan(rendered.indexOf("Login with OAuth/subscription"));
+		selector.handleInput("\n");
+		expect(actions).toEqual(["custom-provider-wizard"]);
+
+		const ctx = createControllerContext({ refresh: async () => undefined } as unknown as ModelRegistry);
+		const controller = new SelectorController(ctx);
+		const showOAuth = mock(() => undefined);
+		controller.showOAuthSelector = showOAuth as unknown as SelectorController["showOAuthSelector"];
+
+		controller.showProviderOnboarding();
+		let routed = ctx.ui.focused as ProviderOnboardingSelectorComponent;
+		routed.handleInput("\x1b[B");
+		routed.handleInput("\n");
+		expect(showOAuth).toHaveBeenCalledWith("login");
+
+		controller.showProviderOnboarding();
+		routed = ctx.ui.focused as ProviderOnboardingSelectorComponent;
+		routed.handleInput("\x1b[B");
+		routed.handleInput("\x1b[B");
+		routed.handleInput("\n");
+		expect(ctx.statuses.join("\n")).toContain("Custom API-compatible provider setup:");
+	});
+});
+
+function createControllerContext(
+	modelRegistry: Pick<ModelRegistry, "refresh">,
+	notifyConfigChanged?: () => void,
+): InteractiveModeContext & { statuses: string[]; ui: { focused?: unknown; requestRender: () => void; setFocus: (component: unknown) => void } } {
+	const children: unknown[] = [];
+	const editor = {};
+	const statuses: string[] = [];
+	return {
+		ui: {
+			focused: undefined,
+			requestRender: () => undefined,
+			setFocus(component: unknown) {
+				this.focused = component;
+			},
+		},
+		editor,
+		editorContainer: {
+			clear: () => {
+				children.length = 0;
+			},
+			addChild: (child: unknown) => {
+				children.push(child);
+			},
+		},
+		session: { modelRegistry, scopedModels: [] },
+		sessionManager: { getCwd: () => process.cwd() },
+		settings: createSettingsStub(),
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => statuses.push(message),
+		showWarning: (message: string) => statuses.push(message),
+		notifyConfigChanged,
+		statuses,
+	} as unknown as InteractiveModeContext & { statuses: string[]; ui: { focused?: unknown; requestRender: () => void; setFocus: (component: unknown) => void } };
+}
+
+function createSettingsStub(): unknown {
+	return {
+		get(path: string) {
+			if (path === "task.agentModelOverrides") return {};
+			return undefined;
+		},
+		getStorage() {
+			return { getModelUsageOrder: () => undefined };
+		},
+		getModelRole() {
+			return undefined;
+		},
+		setModelRole() {
+			return undefined;
+		},
+	};
+}

--- a/packages/coding-agent/test/provider-onboarding-wizard.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { CustomProviderWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-provider-wizard";
+import { ProviderOnboardingSelectorComponent, type ProviderOnboardingAction } from "@gajae-code/coding-agent/modes/components/provider-onboarding-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+
+const originalAgentDir = getAgentDir();
+let tempAgentDir: string | undefined;
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+afterEach(async () => {
+	setAgentDir(originalAgentDir);
+	if (tempAgentDir) {
+		await fs.rm(tempAgentDir, { recursive: true, force: true });
+		tempAgentDir = undefined;
+	}
+});
+
+function visibleText(component: { render(width: number): string[] }): string {
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+function typeText(component: { handleInput(input: string): void }, text: string): void {
+	for (const char of text) component.handleInput(char);
+}
+
+function driveEnvWizard(component: CustomProviderWizardComponent, options?: { providerId?: string; model?: string }): void {
+	component.handleInput("\n");
+	typeText(component, options?.providerId ?? "custom-openai");
+	component.handleInput("\n");
+	typeText(component, "https://api.example.com/v1");
+	component.handleInput("\n");
+	component.handleInput("\n");
+	typeText(component, "CUSTOM_PROVIDER_KEY");
+	component.handleInput("\n");
+	typeText(component, options?.model ?? "custom-model");
+	component.handleInput("\n");
+}
+
+describe("provider onboarding wizard", () => {
+	it("shows Add custom provider as the first /login onboarding option", () => {
+		const actions: ProviderOnboardingAction[] = [];
+		const selector = new ProviderOnboardingSelectorComponent(action => actions.push(action), () => undefined);
+
+		const rendered = visibleText(selector);
+		expect(rendered.indexOf("Add custom provider")).toBeLessThan(rendered.indexOf("Login with OAuth/subscription"));
+		expect(rendered).toContain("Add API-compatible provider");
+
+		selector.handleInput("\n");
+		expect(actions).toEqual(["custom-provider-wizard"]);
+	});
+
+	it("emits the expected addApiCompatibleProvider input", () => {
+		const submissions: unknown[] = [];
+		const wizard = new CustomProviderWizardComponent(input => submissions.push(input), () => undefined);
+
+		driveEnvWizard(wizard);
+		wizard.handleInput("\n");
+
+		expect(submissions).toEqual([
+			{
+				compatibility: "openai",
+				providerId: "custom-openai",
+				baseUrl: "https://api.example.com/v1",
+				apiKeyEnv: "CUSTOM_PROVIDER_KEY",
+				apiKey: undefined,
+				models: ["custom-model"],
+				force: false,
+			},
+		]);
+	});
+
+	it("requires explicit force confirmation before overwrite", () => {
+		const submissions: unknown[] = [];
+		const wizard = new CustomProviderWizardComponent(input => submissions.push(input), () => undefined);
+
+		driveEnvWizard(wizard);
+		wizard.handleInput("\n");
+		wizard.setSubmitError("Provider setup failed: Provider 'custom-openai' already exists. Use --force to replace it.");
+		wizard.handleInput("\x1b[B");
+		wizard.handleInput("\n");
+
+		expect(submissions).toEqual([
+			expect.objectContaining({ force: false }),
+			expect.objectContaining({ force: true }),
+		]);
+	});
+
+	it("refreshes offline after success and exposes the provider in model selector data without restart", async () => {
+		tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-wizard-"));
+		setAgentDir(tempAgentDir);
+		const store = await SqliteAuthCredentialStore.open(path.join(tempAgentDir, "agent.db"));
+		try {
+			const authStorage = new AuthStorage(store);
+			const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
+			let refreshedMode: string | undefined;
+			const originalRefresh = registry.refresh.bind(registry);
+			registry.refresh = async mode => {
+				refreshedMode = mode;
+				await originalRefresh(mode);
+			};
+			let configChanged = false;
+			const ctx = createControllerContext(registry, () => {
+				configChanged = true;
+			});
+			const controller = new SelectorController(ctx);
+
+			controller.showCustomProviderWizard();
+			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+			driveEnvWizard(wizard, { providerId: "live-provider", model: "live-model" });
+			wizard.handleInput("\n");
+			await Bun.sleep(20);
+
+			expect(refreshedMode).toBe("offline");
+			expect(configChanged).toBe(true);
+			expect(registry.find("live-provider", "live-model")).toBeDefined();
+			expect(ctx.statuses.join("\n")).toContain("Provider 'live-provider' configured");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps OAuth and API guide onboarding actions routed", () => {
+		const ctx = createControllerContext({ refresh: async () => undefined } as unknown as ModelRegistry);
+		const controller = new SelectorController(ctx);
+		const showOAuth = mock(() => undefined);
+		controller.showOAuthSelector = showOAuth as unknown as SelectorController["showOAuthSelector"];
+
+		controller.showProviderOnboarding();
+		let selector = ctx.ui.focused as ProviderOnboardingSelectorComponent;
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		expect(showOAuth).toHaveBeenCalledWith("login");
+
+		controller.showProviderOnboarding();
+		selector = ctx.ui.focused as ProviderOnboardingSelectorComponent;
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		expect(ctx.statuses.join("\n")).toContain("Custom API-compatible provider setup:");
+	});
+});
+
+function createControllerContext(modelRegistry: Pick<ModelRegistry, "refresh">, notifyConfigChanged?: () => void): InteractiveModeContext & { statuses: string[]; ui: { focused?: unknown; requestRender: () => void; setFocus: (component: unknown) => void } } {
+	const children: unknown[] = [];
+	const editor = {};
+	const statuses: string[] = [];
+	return {
+		ui: {
+			focused: undefined,
+			requestRender: () => undefined,
+			setFocus(component: unknown) {
+				this.focused = component;
+			},
+		},
+		editor,
+		editorContainer: {
+			clear: () => {
+				children.length = 0;
+			},
+			addChild: (child: unknown) => {
+				children.push(child);
+			},
+		},
+		session: { modelRegistry },
+		sessionManager: { getCwd: () => process.cwd() },
+		settings: {},
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => statuses.push(message),
+		showWarning: (message: string) => statuses.push(message),
+		notifyConfigChanged,
+		statuses,
+	} as unknown as InteractiveModeContext & { statuses: string[]; ui: { focused?: unknown; requestRender: () => void; setFocus: (component: unknown) => void } };
+}

--- a/packages/coding-agent/test/slash-commands/login.test.ts
+++ b/packages/coding-agent/test/slash-commands/login.test.ts
@@ -9,6 +9,7 @@ type RuntimeHarness = {
 	getWarning: () => string | undefined;
 	getSelectorMode: () => "login" | "logout" | undefined;
 	getSelectorProvider: () => string | undefined;
+	getProviderOnboardingShown: () => boolean;
 };
 
 const createRuntimeHarness = (manualInput: OAuthManualInputManager): RuntimeHarness => {
@@ -16,6 +17,7 @@ const createRuntimeHarness = (manualInput: OAuthManualInputManager): RuntimeHarn
 	let warningMessage: string | undefined;
 	let selectorMode: "login" | "logout" | undefined;
 	let selectorProvider: string | undefined;
+	let providerOnboardingShown = false;
 	const ctx = {
 		oauthManualInput: manualInput,
 		editor: {
@@ -31,6 +33,9 @@ const createRuntimeHarness = (manualInput: OAuthManualInputManager): RuntimeHarn
 			selectorMode = mode;
 			selectorProvider = providerId;
 		},
+		showProviderOnboarding: () => {
+			providerOnboardingShown = true;
+		},
 	} as InteractiveModeContext;
 
 	return {
@@ -42,6 +47,7 @@ const createRuntimeHarness = (manualInput: OAuthManualInputManager): RuntimeHarn
 		getWarning: () => warningMessage,
 		getSelectorMode: () => selectorMode,
 		getSelectorProvider: () => selectorProvider,
+		getProviderOnboardingShown: () => providerOnboardingShown,
 	};
 };
 
@@ -60,14 +66,15 @@ describe("/login slash command", () => {
 		expect(await pending).toBe(callbackUrl);
 	});
 
-	it("opens selector when no args are provided", async () => {
+	it("opens provider onboarding selector when no args are provided", async () => {
 		const manualInput = new OAuthManualInputManager();
 		const harness = createRuntimeHarness(manualInput);
 
 		const handled = await executeBuiltinSlashCommand("/login", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.getSelectorMode()).toBe("login");
+		expect(harness.getProviderOnboardingShown()).toBe(true);
+		expect(harness.getSelectorMode()).toBeUndefined();
 	});
 
 	it("routes /login kagi to direct provider login", async () => {


### PR DESCRIPTION
## Summary
Adds a named **model-profile system** (`--mpreset`) that fills the existing role targets (`default`/`executor`/`architect`/`planner`/`critic`) in one action, with built-in + user-defined profiles, CLI/startup activation, a `/model` Profiles section, and a `/login` custom-provider wizard.

Built via deep-interview → ralplan consensus → ultragoal execution.
- Spec: `.gjc/specs/deep-interview-model-profile-system.md`
- Plan/ADR: `.gjc/plans/ralplan/2026-06-04-1546-3874/` (`stage-02-final.md`)

## What's included
- **Schema** (`models-config-schema.ts`): optional **strict** top-level `profiles:` in `models.yml` (additive; `providers`/`modelBindings`/`equivalence` unchanged). Each role maps to a single `provider/modelId[:effort]`; partial mappings inherit; unknown keys path-pointed errors. `required_providers` aggregates **across roles**.
- **Catalog** (`model-profiles.ts`): 9 code-bundled profiles — `opencode-go` / `codex` / `opencode-go-codex` × `eco`/`standard`/`pro` on native `opencode-go` + `openai-codex` providers. `codex-standard` mirrors `OPENAI_CODE_PROFILE_PRESET`; `*-pro` raises reasoning on architect/critic/planner; user profiles override built-ins by name.
- **Activation** (`model-profile-activation.ts`, `model-registry.ts`, `settings-schema.ts`, `main.ts`, `cli/args.ts`, `commands/launch.ts`): atomic + live. `gjc --mpreset <name>` is session-only (`setModelTemporary` + `settings.override`); `--default` persists `modelProfile.default` via Settings (config.yml) + flush; hard-blocks on missing credentials with **no partial mutation**; explicit `--model`/`--thinking` win precedence; applied at startup incl. ACP sessions.
- **/model** (`model-selector.ts`, `selector-controller.ts`): Profiles section above the model list with Apply / Set as default.
- **/login** (`provider-onboarding-selector.ts`, `custom-provider-wizard.ts`, `builtin-registry.ts`): interactive "Add custom provider" wizard as the first option, reusing `addApiCompatibleProvider()` + offline registry refresh. Flag-based `/provider add` unchanged.
- **Docs**: `docs/models.md` Model profiles section + CLI examples.

## Verification
- 83/83 targeted unit/red-team tests pass across 11 files; LSP diagnostics clean on all changed source files.
- Real CLI transcripts verified: `--default` without `--mpreset` errors; unknown `--mpreset` lists available profiles; `--mpreset codex-eco` hard-blocks on missing `openai-codex` credentials.
- Consensus review (Planner/Architect/Critic) + per-story architect + red-team QA lanes all CLEAR/APPROVE.

## Usage
```sh
gjc --mpreset codex-standard
gjc --mpreset opencode-go-pro --default
```

🤖 Generated with Claude Code
