### PR TITLE
Fix Ultragoal HUD reconciliation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Reconciled native Ultragoal commands with workflow mode-state and the HUD: `gjc ultragoal create-goals`, `complete-goals`, `checkpoint`, steering, review-blocker recording, and status now sync `.gjc/state/ultragoal-state.json` plus `skill-active-state.json` from the durable `.gjc/ultragoal` plan/ledger, clearing stale active HUD chips after all goals complete.
 - Forwarded the parent session id when task subagents validate configured role-agent model overrides, preventing session-scoped OAuth providers from being misread as unauthenticated and falling back to the parent chat model.
 
 ## [0.3.1] - 2026-06-05

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1,11 +1,18 @@
 import * as crypto from "node:crypto";
 import * as path from "node:path";
-import type { WorkflowHudSummary } from "../skill-state/active-state";
+import { syncSkillActiveState, type WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
+import { WORKFLOW_STATE_VERSION, workflowStateStoragePath } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
-import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
+import {
+	appendJsonl,
+	readExistingStateForMutation,
+	writeArtifact,
+	writeJsonAtomic,
+	writeWorkflowEnvelopeAtomic,
+} from "./state-writer";
 
 export type UltragoalGjcGoalMode = "aggregate" | "per-story";
 export type UltragoalGoalStatus =
@@ -473,6 +480,82 @@ export function buildUltragoalHudSummary(
 		latestLedgerEvent: latestLedger,
 		updatedAt: new Date().toISOString(),
 	});
+}
+function currentSessionId(): string | undefined {
+	const sessionId = process.env.GJC_SESSION_ID?.trim();
+	return sessionId || undefined;
+}
+
+function ultragoalModeStateFromSummary(
+	summary: UltragoalStatusSummary,
+	latestLedger?: UltragoalLedgerEvent,
+	existing?: Record<string, unknown>,
+): Record<string, unknown> {
+	const updatedAt = new Date().toISOString();
+	const sessionId = currentSessionId();
+	return {
+		...(existing ?? {}),
+		skill: "ultragoal",
+		version: WORKFLOW_STATE_VERSION,
+		active: summary.exists && summary.status !== "complete",
+		current_phase: summary.status,
+		status: summary.status,
+		active_goal_id: summary.currentGoal?.id,
+		counts: summary.counts,
+		brief_path: summary.paths.briefPath,
+		ledger_path: summary.paths.ledgerPath,
+		goals_path: summary.paths.goalsPath,
+		latest_ledger_event: latestLedger?.event,
+		latest_ledger_event_id: latestLedger?.eventId,
+		updated_at: updatedAt,
+		...(sessionId ? { session_id: sessionId } : {}),
+	};
+}
+
+export async function syncUltragoalWorkflowState(cwd: string): Promise<void> {
+	const summary = await getUltragoalStatus(cwd);
+	const ledger = await readUltragoalLedger(cwd);
+	const latestLedger = ledger.at(-1);
+	if (summary.exists) {
+		const sessionId = currentSessionId();
+		const statePath = workflowStateStoragePath(cwd, "ultragoal", sessionId);
+		const existing = await readExistingStateForMutation(statePath);
+		if (existing.kind === "corrupt") throw new Error(`Cannot sync corrupt ultragoal mode-state: ${existing.error}`);
+		const existingValue = existing.kind === "valid" ? existing.value : undefined;
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			ultragoalModeStateFromSummary(summary, latestLedger, existingValue),
+			{
+				cwd,
+				receipt: { cwd, skill: "ultragoal", owner: "gjc-runtime", command: "gjc ultragoal sync", sessionId },
+				audit: {
+					category: "state",
+					verb: "sync",
+					owner: "gjc-runtime",
+					skill: "ultragoal",
+					fromPhase: typeof existingValue?.current_phase === "string" ? existingValue.current_phase : undefined,
+					toPhase: summary.status,
+				},
+			},
+		);
+	}
+	await syncSkillActiveState({
+		cwd,
+		skill: "ultragoal",
+		active: summary.exists && summary.status !== "complete",
+		phase: summary.status,
+		sessionId: currentSessionId(),
+		hud: buildUltragoalHudSummary(summary, latestLedger),
+		source: "gjc-ultragoal",
+	});
+}
+
+async function syncUltragoalWorkflowStateBestEffort(cwd: string): Promise<void> {
+	try {
+		await syncUltragoalWorkflowState(cwd);
+	} catch {
+		// HUD and mode-state sync are best-effort and must not change command semantics.
+	}
 }
 
 function clampTitle(title: string): string {
@@ -1311,14 +1394,18 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 	try {
 		const command = commandName(args);
 		const json = hasFlag(args, "--json");
+		let result: UltragoalCommandResult;
 		switch (command) {
 			case "status":
-				return { status: 0, stdout: renderStatus(await getUltragoalStatus(cwd), json) };
+				await syncUltragoalWorkflowStateBestEffort(cwd);
+				result = { status: 0, stdout: renderStatus(await getUltragoalStatus(cwd), json) };
+				break;
 			case "create":
 			case "create-goals": {
 				const mode = flagValue(args, "--gjc-goal-mode") === "per-story" ? "per-story" : "aggregate";
 				const plan = await createUltragoalPlan({ cwd, brief: await readBrief(cwd, args), gjcGoalMode: mode });
-				return {
+				await syncUltragoalWorkflowStateBestEffort(cwd);
+				result = {
 					status: 0,
 					createdPlan: true,
 					stdout: json
@@ -1330,16 +1417,17 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 							})
 						: `Created ultragoal plan with ${plan.goals.length} goal${plan.goals.length === 1 ? "" : "s"} at ${getUltragoalPaths(cwd).goalsPath}.\n`,
 				};
+				break;
 			}
-			case "complete-goals":
-				return {
+			case "complete-goals": {
+				const handoff = await startNextUltragoalGoal({ cwd, retryFailed: hasFlag(args, "--retry-failed") });
+				await syncUltragoalWorkflowStateBestEffort(cwd);
+				result = {
 					status: 0,
-					stdout: renderCompleteHandoff(
-						await startNextUltragoalGoal({ cwd, retryFailed: hasFlag(args, "--retry-failed") }),
-						json,
-						cwd,
-					),
+					stdout: renderCompleteHandoff(handoff, json, cwd),
 				};
+				break;
+			}
 			case "checkpoint": {
 				const goalId = flagValue(args, "--goal-id") ?? "";
 				const status = parseGoalStatus(flagValue(args, "--status"));
@@ -1352,8 +1440,9 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 					qualityGateJson: flagValue(args, "--quality-gate-json"),
 				});
+				await syncUltragoalWorkflowStateBestEffort(cwd);
 				const goal = plan.goals.find(item => item.id === goalId);
-				return {
+				result = {
 					status: 0,
 					stdout: json
 						? renderCliWriteReceipt({
@@ -1366,6 +1455,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 							})
 						: `ultragoal checkpoint goal-id=${goalId} status=${status}\n`,
 				};
+				break;
 			}
 			case "steer": {
 				const kind = flagValue(args, "--kind");
@@ -1377,8 +1467,9 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					evidence: flagValue(args, "--evidence") ?? "",
 					rationale: flagValue(args, "--rationale") ?? "",
 				});
+				await syncUltragoalWorkflowStateBestEffort(cwd);
 				const goal = plan.goals.at(-1);
-				return {
+				result = {
 					status: 0,
 					stdout: json
 						? renderCliWriteReceipt({
@@ -1389,6 +1480,7 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 							})
 						: "Accepted add_subgoal steering.\n",
 				};
+				break;
 			}
 			case "record-review-blockers": {
 				const plan = await recordUltragoalReviewBlockers({
@@ -1399,17 +1491,20 @@ export async function runNativeUltragoalCommand(args: string[], cwd = process.cw
 					evidence: flagValue(args, "--evidence") ?? "",
 					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 				});
+				await syncUltragoalWorkflowStateBestEffort(cwd);
 				const goal = plan.goals.at(-1);
-				return {
+				result = {
 					status: 0,
 					stdout: json
 						? renderCliWriteReceipt({ ok: true, goal_id: goal?.id, goals_path: getUltragoalPaths(cwd).goalsPath })
 						: "Recorded review blockers.\n",
 				};
+				break;
 			}
 			default:
 				return { status: 1, stderr: `Unknown gjc ultragoal command: ${command}\n` };
 		}
+		return result;
 	} catch (error) {
 		return { status: 1, stderr: `${error instanceof Error ? error.message : String(error)}\n` };
 	}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -516,40 +516,39 @@ export async function syncUltragoalWorkflowState(cwd: string): Promise<void> {
 	const summary = await getUltragoalStatus(cwd);
 	const ledger = await readUltragoalLedger(cwd);
 	const latestLedger = ledger.at(-1);
-	if (summary.exists) {
-		const sessionId = currentSessionId();
-		const syncModeState = async (targetSessionId: string | undefined): Promise<void> => {
-			const statePath = workflowStateStoragePath(cwd, "ultragoal", targetSessionId);
-			const existing = await readExistingStateForMutation(statePath);
-			if (existing.kind === "corrupt")
-				throw new Error(`Cannot sync corrupt ultragoal mode-state: ${existing.error}`);
-			const existingValue = existing.kind === "valid" ? existing.value : undefined;
-			await writeWorkflowEnvelopeAtomic(
-				statePath,
-				ultragoalModeStateFromSummary(summary, latestLedger, existingValue, targetSessionId),
-				{
+	const sessionId = currentSessionId();
+	const modeStateActive = summary.exists && summary.status !== "complete";
+	const syncModeState = async (targetSessionId: string | undefined): Promise<void> => {
+		const statePath = workflowStateStoragePath(cwd, "ultragoal", targetSessionId);
+		const existing = await readExistingStateForMutation(statePath);
+		if (existing.kind === "corrupt" && modeStateActive)
+			throw new Error(`Cannot sync corrupt ultragoal mode-state: ${existing.error}`);
+		const existingValue = existing.kind === "valid" ? existing.value : undefined;
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			ultragoalModeStateFromSummary(summary, latestLedger, existingValue, targetSessionId),
+			{
+				cwd,
+				receipt: {
 					cwd,
-					receipt: {
-						cwd,
-						skill: "ultragoal",
-						owner: "gjc-runtime",
-						command: "gjc ultragoal sync",
-						sessionId: targetSessionId,
-					},
-					audit: {
-						category: "state",
-						verb: "sync",
-						owner: "gjc-runtime",
-						skill: "ultragoal",
-						fromPhase: typeof existingValue?.current_phase === "string" ? existingValue.current_phase : undefined,
-						toPhase: summary.status,
-					},
+					skill: "ultragoal",
+					owner: "gjc-runtime",
+					command: "gjc ultragoal sync",
+					sessionId: targetSessionId,
 				},
-			);
-		};
-		await syncModeState(undefined);
-		if (sessionId) await syncModeState(sessionId);
-	}
+				audit: {
+					category: "state",
+					verb: "sync",
+					owner: "gjc-runtime",
+					skill: "ultragoal",
+					fromPhase: typeof existingValue?.current_phase === "string" ? existingValue.current_phase : undefined,
+					toPhase: summary.status,
+				},
+			},
+		);
+	};
+	await syncModeState(undefined);
+	if (sessionId) await syncModeState(sessionId);
 	await syncSkillActiveState({
 		cwd,
 		skill: "ultragoal",

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -488,11 +488,11 @@ function currentSessionId(): string | undefined {
 
 function ultragoalModeStateFromSummary(
 	summary: UltragoalStatusSummary,
-	latestLedger?: UltragoalLedgerEvent,
-	existing?: Record<string, unknown>,
+	latestLedger: UltragoalLedgerEvent | undefined,
+	existing: Record<string, unknown> | undefined,
+	sessionId: string | undefined,
 ): Record<string, unknown> {
 	const updatedAt = new Date().toISOString();
-	const sessionId = currentSessionId();
 	return {
 		...(existing ?? {}),
 		skill: "ultragoal",
@@ -518,26 +518,37 @@ export async function syncUltragoalWorkflowState(cwd: string): Promise<void> {
 	const latestLedger = ledger.at(-1);
 	if (summary.exists) {
 		const sessionId = currentSessionId();
-		const statePath = workflowStateStoragePath(cwd, "ultragoal", sessionId);
-		const existing = await readExistingStateForMutation(statePath);
-		if (existing.kind === "corrupt") throw new Error(`Cannot sync corrupt ultragoal mode-state: ${existing.error}`);
-		const existingValue = existing.kind === "valid" ? existing.value : undefined;
-		await writeWorkflowEnvelopeAtomic(
-			statePath,
-			ultragoalModeStateFromSummary(summary, latestLedger, existingValue),
-			{
-				cwd,
-				receipt: { cwd, skill: "ultragoal", owner: "gjc-runtime", command: "gjc ultragoal sync", sessionId },
-				audit: {
-					category: "state",
-					verb: "sync",
-					owner: "gjc-runtime",
-					skill: "ultragoal",
-					fromPhase: typeof existingValue?.current_phase === "string" ? existingValue.current_phase : undefined,
-					toPhase: summary.status,
+		const syncModeState = async (targetSessionId: string | undefined): Promise<void> => {
+			const statePath = workflowStateStoragePath(cwd, "ultragoal", targetSessionId);
+			const existing = await readExistingStateForMutation(statePath);
+			if (existing.kind === "corrupt")
+				throw new Error(`Cannot sync corrupt ultragoal mode-state: ${existing.error}`);
+			const existingValue = existing.kind === "valid" ? existing.value : undefined;
+			await writeWorkflowEnvelopeAtomic(
+				statePath,
+				ultragoalModeStateFromSummary(summary, latestLedger, existingValue, targetSessionId),
+				{
+					cwd,
+					receipt: {
+						cwd,
+						skill: "ultragoal",
+						owner: "gjc-runtime",
+						command: "gjc ultragoal sync",
+						sessionId: targetSessionId,
+					},
+					audit: {
+						category: "state",
+						verb: "sync",
+						owner: "gjc-runtime",
+						skill: "ultragoal",
+						fromPhase: typeof existingValue?.current_phase === "string" ? existingValue.current_phase : undefined,
+						toPhase: summary.status,
+					},
 				},
-			},
-		);
+			);
+		};
+		await syncModeState(undefined);
+		if (sessionId) await syncModeState(sessionId);
 	}
 	await syncSkillActiveState({
 		cwd,

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -175,6 +175,38 @@ async function seedStaleUltragoalWorkflowState(root: string): Promise<void> {
 	);
 }
 
+async function seedStaleUltragoalActiveEntry(root: string): Promise<void> {
+	const stateDir = path.join(root, ".gjc", "state");
+	await fs.mkdir(path.join(stateDir, "active"), { recursive: true });
+	const staleAt = "2026-01-01T00:00:00.000Z";
+	const entry = {
+		skill: "ultragoal",
+		phase: "goal-planning",
+		active: true,
+		updated_at: staleAt,
+		hud: {
+			version: 1,
+			chips: [{ label: "status", value: "goal-planning" }],
+		},
+	};
+	await Bun.write(path.join(stateDir, "active", "ultragoal.json"), JSON.stringify(entry, null, 2));
+	await Bun.write(
+		path.join(stateDir, "skill-active-state.json"),
+		JSON.stringify(
+			{
+				version: 1,
+				active: true,
+				skill: "ultragoal",
+				phase: "goal-planning",
+				updated_at: staleAt,
+				active_skills: [entry],
+			},
+			null,
+			2,
+		),
+	);
+}
+
 function mutateQualityGate(mutator: (gate: Record<string, Record<string, unknown>>) => void): string {
 	const gate = JSON.parse(passingQualityGate()) as Record<string, Record<string, unknown>>;
 	mutator(gate);
@@ -1439,6 +1471,63 @@ describe("ultragoal @goal decomposition", () => {
 		expect(modeState.counts).toMatchObject({ complete: 1, pending: 0, active: 0 });
 		expect(modeState.active_goal_id).toBeUndefined();
 		expect(modeState.receipt).toMatchObject({ skill: "ultragoal", owner: "gjc-runtime" });
+
+		const activeState = await readJsonFile(path.join(root, ".gjc", "state", "skill-active-state.json"));
+		expect(activeState.active).toBe(false);
+		expect(activeState.active_skills).toEqual([]);
+	});
+
+	it("reconciles missing durable plans with stale active mode-state", async () => {
+		const root = await tempDir();
+		await seedStaleUltragoalWorkflowState(root);
+		await seedStaleUltragoalActiveEntry(root);
+
+		const status = await runNativeUltragoalCommand(["status"], root);
+
+		expect(status.status).toBe(0);
+		expect(status.stdout).toContain("No ultragoal plan found");
+		const modeState = await readJsonFile(path.join(root, ".gjc", "state", "ultragoal-state.json"));
+		expect(modeState.active).toBe(false);
+		expect(modeState.current_phase).toBe("missing");
+		expect(modeState.status).toBe("missing");
+		expect(modeState.active_goal_id).toBeUndefined();
+
+		const activeState = await readJsonFile(path.join(root, ".gjc", "state", "skill-active-state.json"));
+		expect(activeState.active).toBe(false);
+		expect(activeState.active_skills).toEqual([]);
+	});
+
+	it("reconciles terminal checkpoints despite corrupt stale mode-state", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship corrupt state reconciliation" });
+		await startNextUltragoalGoal({ cwd: root });
+		await seedStaleUltragoalActiveEntry(root);
+		await fs.mkdir(path.join(root, ".gjc", "state"), { recursive: true });
+		await Bun.write(path.join(root, ".gjc", "state", "ultragoal-state.json"), "{not-json");
+
+		const checkpoint = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"final story verified with targeted regression coverage",
+				"--gjc-goal-json",
+				goalSnapshot(created.gjcObjective),
+				"--quality-gate-json",
+				passingQualityGate(),
+			],
+			root,
+		);
+
+		expect(checkpoint.status).toBe(0);
+		const modeState = await readJsonFile(path.join(root, ".gjc", "state", "ultragoal-state.json"));
+		expect(modeState.active).toBe(false);
+		expect(modeState.current_phase).toBe("complete");
+		expect(modeState.status).toBe("complete");
+		expect(modeState.counts).toMatchObject({ complete: 1, pending: 0, active: 0 });
 
 		const activeState = await readJsonFile(path.join(root, ".gjc", "state", "skill-active-state.json"));
 		expect(activeState.active).toBe(false);

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -124,6 +124,57 @@ function goalSnapshot(objective: string, status = "active", updatedAt = Date.now
 		},
 	});
 }
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+	return (await Bun.file(filePath).json()) as Record<string, unknown>;
+}
+
+async function seedStaleUltragoalWorkflowState(root: string): Promise<void> {
+	const stateDir = path.join(root, ".gjc", "state");
+	await fs.mkdir(stateDir, { recursive: true });
+	const staleAt = "2026-01-01T00:00:00.000Z";
+	await Bun.write(
+		path.join(stateDir, "ultragoal-state.json"),
+		JSON.stringify(
+			{
+				skill: "ultragoal",
+				version: 1,
+				active: true,
+				current_phase: "goal-planning",
+				updated_at: staleAt,
+			},
+			null,
+			2,
+		),
+	);
+	await Bun.write(
+		path.join(stateDir, "skill-active-state.json"),
+		JSON.stringify(
+			{
+				version: 1,
+				active: true,
+				skill: "ultragoal",
+				phase: "goal-planning",
+				updated_at: staleAt,
+				active_skills: [
+					{
+						skill: "ultragoal",
+						phase: "goal-planning",
+						active: true,
+						updated_at: staleAt,
+						hud: {
+							version: 1,
+							chips: [{ label: "status", value: "goal-planning" }],
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+}
+
 function mutateQualityGate(mutator: (gate: Record<string, Record<string, unknown>>) => void): string {
 	const gate = JSON.parse(passingQualityGate()) as Record<string, Record<string, unknown>>;
 	mutator(gate);
@@ -1355,6 +1406,41 @@ describe("ultragoal @goal decomposition", () => {
 		expect(serialized).toContain("0/3");
 		expect(serialized).toContain("G001:Parse");
 		expect(summary.status).toBe("active");
+	});
+
+	it("reconciles completed runs with mode-state and HUD active-state", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship state reconciliation" });
+		await startNextUltragoalGoal({ cwd: root });
+		await seedStaleUltragoalWorkflowState(root);
+
+		const checkpoint = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"final story verified with targeted regression coverage",
+				"--gjc-goal-json",
+				goalSnapshot(created.gjcObjective),
+				"--quality-gate-json",
+				passingQualityGate(),
+			],
+			root,
+		);
+
+		expect(checkpoint.status).toBe(0);
+		const modeState = await readJsonFile(path.join(root, ".gjc", "state", "ultragoal-state.json"));
+		expect(modeState.active).toBe(false);
+		expect(modeState.current_phase).toBe("complete");
+		expect(modeState.status).toBe("complete");
+		expect(modeState.receipt).toMatchObject({ skill: "ultragoal", owner: "gjc-runtime" });
+
+		const activeState = await readJsonFile(path.join(root, ".gjc", "state", "skill-active-state.json"));
+		expect(activeState.active).toBe(false);
+		expect(activeState.active_skills).toEqual([]);
 	});
 
 	it("schedules each @goal story in order through the existing API", async () => {

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1436,6 +1436,8 @@ describe("ultragoal @goal decomposition", () => {
 		expect(modeState.active).toBe(false);
 		expect(modeState.current_phase).toBe("complete");
 		expect(modeState.status).toBe("complete");
+		expect(modeState.counts).toMatchObject({ complete: 1, pending: 0, active: 0 });
+		expect(modeState.active_goal_id).toBeUndefined();
 		expect(modeState.receipt).toMatchObject({ skill: "ultragoal", owner: "gjc-runtime" });
 
 		const activeState = await readJsonFile(path.join(root, ".gjc", "state", "skill-active-state.json"));


### PR DESCRIPTION
Fixes #342.

## Summary
- Reconcile native Ultragoal command flows with `.gjc/state/ultragoal-state.json` and `skill-active-state.json` from the durable `.gjc/ultragoal` plan/ledger.
- Write both root and session-scoped Ultragoal mode-state when applicable.
- Clear stale active HUD entries when all Ultragoal goals are terminal complete/superseded.
- Strengthen regression coverage for a completed Ultragoal run that previously stayed `active: true` / `goal-planning`.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun run check:ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*