### PR TITLE
feat(ultragoal): integrate ai-slop-cleaner as internal sub-skill fragment

### DIFF
--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -7,6 +7,7 @@ import autoResearchGreenfieldFragment from "./gjc/skills/deep-interview/auto-res
 import deepInterviewSkill from "./gjc/skills/deep-interview/SKILL.md" with { type: "text" };
 import ralplanSkill from "./gjc/skills/ralplan/SKILL.md" with { type: "text" };
 import teamSkill from "./gjc/skills/team/SKILL.md" with { type: "text" };
+import aiSlopCleanerFragment from "./gjc/skills/ultragoal/ai-slop-cleaner.md" with { type: "text" };
 import ultragoalSkill from "./gjc/skills/ultragoal/SKILL.md" with { type: "text" };
 
 export const DEFAULT_GJC_DEFINITION_NAMES = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
@@ -91,6 +92,12 @@ const DEFAULT_GJC_DEFINITIONS: readonly DefaultGjcDefinition[] = [
 		parentSkillName: "deep-interview",
 		relativePath: "skill-fragments/deep-interview/auto-answer-uncertain.md",
 		content: autoAnswerUncertainFragment,
+	},
+	{
+		kind: "skill-fragment",
+		parentSkillName: "ultragoal",
+		relativePath: "skill-fragments/ultragoal/ai-slop-cleaner.md",
+		content: aiSlopCleanerFragment,
 	},
 ];
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -161,12 +161,22 @@ gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evid
 
 Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Workers must not run `gjc ultragoal checkpoint`; checkpoint authority stays with the leader after worker tasks are terminal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden goal mutation.
 
+## Internal Ultragoal sub-skill fragments
+
+The completion-gate cleanup sweep is driven by `ai-slop-cleaner`, an internal Ultragoal sub-skill bundled as a `kind: "skill-fragment"` prompt with parent skill `ultragoal` (installed at `skill-fragments/ultragoal/ai-slop-cleaner.md`). It is analogous to deep-interview's auto-research fragment: loaded on demand for one specific hook, never a user-facing skill.
+
+- It is not slash-command discoverable, has no public skill-listing entry, and is never resolvable through `skill://`.
+- It is a read-only detector+reporter over the active story's changed files only: it never edits code, writes files, mutates `.gjc/`, checkpoints, calls goal tools, or spawns workflows.
+- It classifies every finding as blocking or advisory across the full taxonomy (fallback-like masking vs. grounded, duplication, dead code, needless abstraction, boundary violations, UI/design slop, missing tests).
+- The leader and a leader-spawned `executor` own all fixes; the cleaner reruns until zero blocking findings remain. Advisory findings live in the gate report only.
+- Recursion guard: it must not spawn nested `ralplan`/`team`/`deep-interview`/`ultragoal`; broad or architectural findings are handed back to the leader as review blockers.
+
 ## Mandatory completion cleanup and review gate
 
 An ultragoal story cannot be checkpointed `complete` until the active agent has run the quality gate. The gate is plan-first, contract-driven, and surface-based:
 
 1. Run targeted implementation verification for the story.
-2. Run a cleanup/refactor review pass on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
+2. Run the internal ai-slop-cleaner skill fragment as the final cleanup sweep on the story's changed files only, before verification and red-team so only clean code is reviewed. It is a read-only detector that emits an `AI SLOP CLEANUP REPORT`; if there are no relevant edits it still runs and records a passed/no-op report. Every BLOCKING cleaner finding is a completion blocker: the leader spawns an `executor` to fix blocking findings only, then reruns the cleaner until blocking findings are zero. Advisory findings are included in the gate report only and are not written to the Ultragoal ledger. Carry the report through the existing `qualityGate.iteration.evidence` field; do not add a new top-level quality-gate key.
 3. Rerun verification after the cleaner pass.
 4. Delegate an `architect` review covering all three lanes:
    - architecture-side: system boundaries, layering, data/control flow, operational risks.

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/ai-slop-cleaner.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/ai-slop-cleaner.md
@@ -1,0 +1,61 @@
+# Ultragoal AI Slop Cleaner Fragment
+
+You are the AI slop cleaner for the Ultragoal completion gate. This is an internal Ultragoal sub-skill, loaded on demand as a `kind: "skill-fragment"` prompt with parent skill `ultragoal`. It is never user-facing: not slash-command discoverable, no public skill listing entry, and never resolvable through `skill://`.
+
+You are a **read-only detector and reporter**. You never edit code, write files, run formatters, mutate `.gjc/` state, checkpoint, call goal tools, or spawn workflows. You detect slop in the active Ultragoal story's changed files, classify each finding, and emit a report. The Ultragoal leader spawns an `executor` to fix BLOCKING findings; you do not fix anything yourself.
+
+## Scope
+
+- Inspect ONLY the active Ultragoal story's changed-files list. No broad rewrites, no inspection outside that scope, no new dependencies.
+- Allow only narrow supporting reads needed to understand the contracts of changed files; if you need broader context, report that need to the leader instead of expanding scope.
+- If there are no relevant edits, emit a passed/no-op report (`Gate Result: PASS`, `Changed Files Reviewed` listing the files as "no relevant edits").
+- Recursion guard: you are already inside an Ultragoal workflow. Do NOT spawn nested `ralplan`, `team`, `deep-interview`, or `ultragoal` workflows. Broad, ambiguous, cross-layer, or architectural findings are handed to the leader as review blockers, not resolved here.
+
+## Taxonomy
+
+Classify every finding against the full taxonomy:
+
+1. **Fallback-like code** — classify each as **masking fallback slop** or **grounded compatibility/fail-safe fallback**.
+   - Masking signals (blocking): swallowed errors, silent defaults, bypassed validation/tests, untested alternate execution paths, primary-contract suppression.
+   - Grounded signals (advisory): scoped to an external/version/fail-safe boundary, documented rationale, preserved failure evidence, and regression tests covering both primary and fallback behavior.
+2. **Duplication** — repeated logic, copy-paste branches, redundant helpers.
+3. **Dead code** — unused code, unreachable branches, stale flags, debug leftovers.
+4. **Needless abstraction** — pass-through wrappers, speculative indirection, single-use helper layers.
+5. **Boundary violations** — hidden coupling, leaky responsibilities, wrong-layer imports or side effects.
+6. **UI/design slop** — context-sensitive signals, not absolute bans; preserve intentional brand/design-system/accessibility/product rationale. Signals: small Korean body copy (challenge 11-12px; Korean body text generally needs 14px+ unless a dense accessible system supports smaller), gratuitous shadows/depth, repetitive eyebrow+title+description scaffolding and filler/emoji badges, default blue/purple palettes (e.g. #3B82F6) without rationale, over-perfect uniform 3/4-column grids, and extreme "AI demo" gradients.
+7. **Missing tests** — behavior not locked, weak regression coverage, missing edge/failure-mode cases.
+
+## Blocking vs advisory
+
+- **Blocking** if it can mask failures, violate accepted contracts, weaken boundaries, leave changed behavior untested, create maintenance traps, or make later verification unsafe.
+- **Advisory** if it is nice-to-have, stylistic/contextual, or outside safe story scope.
+- Advisory findings stay in the gate report only; they are NOT written to the Ultragoal ledger.
+
+## Report
+
+Emit exactly this text block with these mandated labels:
+
+```text
+AI SLOP CLEANUP REPORT
+======================
+
+Scope: [changed files inspected]
+Mode: read-only detector/report; no edits performed
+Blocking Findings: [none, or numbered findings with file, category, evidence, required executor fix]
+Advisory Findings: [none, or numbered findings with file, category, evidence, why advisory]
+Fallback Findings: [none, or finding -> masking fallback slop / grounded compatibility/fail-safe fallback -> blocking/advisory]
+UI/Design Findings: [none/N/A, or signal -> blocking/advisory -> rationale]
+Missing Test Findings: [none, or gap -> blocking/advisory -> required coverage]
+Recursion Guard: [confirmed no nested ralplan/team/deep-interview/ultragoal spawned; broad findings handed to leader]
+Changed Files Reviewed:
+- [path] - [reviewed / no relevant edits]
+
+Gate Result: PASS | BLOCKED
+Leader Action:
+- PASS: continue to verification, architect review, and executor red-team QA.
+- BLOCKED: spawn executor to fix BLOCKING findings only, then rerun this sweep until Blocking Findings is none.
+Remaining Risks:
+- [none, or advisory/deferred risks]
+```
+
+Port the oh-my-codex taxonomy and report shape, not its editing workflow. Do not instruct yourself to execute cleanup passes — detect and report only.

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -148,7 +148,7 @@ describe("GJC public CLI command surface", () => {
 
 			expect(result.exitCode, stderr).toBe(0);
 			const payload = JSON.parse(stdout) as { written?: number; targetRoot?: string };
-			expect(payload.written).toBe(6);
+			expect(payload.written).toBe(7);
 			expect(payload.targetRoot).toContain(path.join(home, ".gjc", "agent"));
 		} finally {
 			await fs.rm(home, { recursive: true, force: true });

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -51,7 +51,7 @@ afterEach(async () => {
 });
 
 describe("default GJC definitions", () => {
-	it("bundles exactly the four default workflow skills plus deep-interview fragments as installable assets", () => {
+	it("bundles exactly the four default workflow skills plus deep-interview and ultragoal fragments as installable assets", () => {
 		const definitions = getDefaultGjcDefinitions();
 		const workflowDefinitions = definitions.filter(definition => definition.kind === "skill");
 		const fragmentDefinitions = definitions.filter(definition => definition.kind === "skill-fragment");
@@ -60,17 +60,19 @@ describe("default GJC definitions", () => {
 
 		expect(skills).toEqual(expected);
 		expect(workflowDefinitions).toHaveLength(4);
-		expect(definitions).toHaveLength(6);
+		expect(definitions).toHaveLength(7);
 		expect(workflowDefinitions.every(definition => definition.relativePath.startsWith("skills/"))).toBe(true);
 		expect(workflowDefinitions.every(definition => definition.content.includes(definition.name))).toBe(true);
-		expect(fragmentDefinitions).toHaveLength(2);
-		expect(fragmentDefinitions.map(definition => definition.parentSkillName)).toEqual([
+		expect(fragmentDefinitions).toHaveLength(3);
+		expect(fragmentDefinitions.map(definition => definition.parentSkillName).sort()).toEqual([
 			"deep-interview",
 			"deep-interview",
+			"ultragoal",
 		]);
 		expect(fragmentDefinitions.map(definition => definition.relativePath).sort()).toEqual([
 			"skill-fragments/deep-interview/auto-answer-uncertain.md",
 			"skill-fragments/deep-interview/auto-research-greenfield.md",
+			"skill-fragments/ultragoal/ai-slop-cleaner.md",
 		]);
 	});
 
@@ -89,6 +91,83 @@ describe("default GJC definitions", () => {
 			"skill-fragments/deep-interview/auto-research-greenfield.md",
 		]);
 		expect(fragments.every(fragment => fragment.content.includes("read-only architect"))).toBe(true);
+	});
+
+	it("exposes the ultragoal ai-slop-cleaner fragment only through the parent-scoped fragment accessor", () => {
+		const fragments = getEmbeddedDefaultGjcSkillFragments("ultragoal");
+
+		expect(
+			getEmbeddedDefaultGjcSkills()
+				.map(skill => skill.name)
+				.sort(),
+		).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
+		expect(fragments).toHaveLength(1);
+		expect(fragments.map(fragment => fragment.kind)).toEqual(["skill-fragment"]);
+		expect(fragments.map(fragment => fragment.relativePath)).toEqual([
+			"skill-fragments/ultragoal/ai-slop-cleaner.md",
+		]);
+		expect(fragments[0]!.content).toContain("AI SLOP CLEANUP REPORT");
+		expect(fragments[0]!.content).toContain("read-only detector");
+	});
+
+	it("authors the ai-slop-cleaner fragment with the mandated report labels and full taxonomy", () => {
+		const fragment = getEmbeddedDefaultGjcSkillFragments("ultragoal")[0]!;
+		const content = fragment.content;
+
+		for (const label of [
+			"AI SLOP CLEANUP REPORT",
+			"Scope:",
+			"Mode: read-only detector/report; no edits performed",
+			"Blocking Findings",
+			"Advisory Findings",
+			"Fallback Findings",
+			"UI/Design Findings",
+			"Missing Test Findings",
+			"Recursion Guard",
+			"Changed Files Reviewed",
+			"Gate Result: PASS | BLOCKED",
+		]) {
+			expect(content).toContain(label);
+		}
+		for (const taxonomy of [
+			"masking fallback slop",
+			"grounded compatibility/fail-safe fallback",
+			"Fallback-like code",
+			"Duplication",
+			"Dead code",
+			"Needless abstraction",
+			"Boundary violations",
+			"UI/design slop",
+			"Missing tests",
+		]) {
+			expect(content).toContain(taxonomy);
+		}
+	});
+
+	it("wires the ai-slop-cleaner into the ultragoal completion gate before verification and red-team", () => {
+		const ultragoal = getDefaultGjcDefinitions().find(
+			definition => definition.kind === "skill" && definition.name === "ultragoal",
+		);
+		if (!ultragoal) throw new Error("missing bundled ultragoal skill");
+		const content = ultragoal.content;
+
+		const sectionStart = content.indexOf("## Mandatory completion cleanup and review gate");
+		expect(sectionStart).toBeGreaterThanOrEqual(0);
+		const afterStart = content.indexOf("\n## ", sectionStart + 1);
+		const section = content.slice(sectionStart, afterStart === -1 ? undefined : afterStart);
+
+		const cleanerStep = section.indexOf("2. Run the internal ai-slop-cleaner skill fragment");
+		const verifyStep = section.indexOf("3. Rerun verification after the cleaner pass");
+		const architectStep = section.indexOf("4. Delegate an `architect` review");
+		const redTeamStep = section.indexOf("5. Delegate an `executor` QA/red-team lane");
+
+		expect(cleanerStep).toBeGreaterThanOrEqual(0);
+		expect(verifyStep).toBeGreaterThan(cleanerStep);
+		expect(architectStep).toBeGreaterThan(verifyStep);
+		expect(redTeamStep).toBeGreaterThan(architectStep);
+
+		expect(section).toContain("reruns the cleaner until blocking findings are zero");
+		expect(section).toContain("Advisory findings are included in the gate report only");
 	});
 
 	it("keeps the four role agents bundled when project .gjc is absent", async () => {
@@ -298,10 +377,10 @@ Project executor override body.
 		const deepInterviewSkillPath = path.join(targetRoot, "skills", "deep-interview", "SKILL.md");
 		const installedDeepInterview = await Bun.file(deepInterviewSkillPath).text();
 
-		expect(initial.written).toBe(6);
-		expect(initial.total).toBe(6);
+		expect(initial.written).toBe(7);
+		expect(initial.total).toBe(7);
 		expect(initial.skipped).toBe(0);
-		expect(initial.files.filter(file => file.kind === "skill-fragment")).toHaveLength(2);
+		expect(initial.files.filter(file => file.kind === "skill-fragment")).toHaveLength(3);
 
 		const installedResearchFragment = await Bun.file(
 			path.join(targetRoot, "skill-fragments", "deep-interview", "auto-research-greenfield.md"),
@@ -310,15 +389,15 @@ Project executor override body.
 		await Bun.write(deepInterviewSkillPath, "local edit");
 		const skipped = await installDefaultGjcDefinitions({ targetRoot });
 		expect(skipped.written).toBe(0);
-		expect(skipped.skipped).toBe(6);
+		expect(skipped.skipped).toBe(7);
 		expect(await Bun.file(deepInterviewSkillPath).text()).toBe("local edit");
 
 		const check = await installDefaultGjcDefinitions({ targetRoot, check: true });
 		expect(check.different).toBe(1);
-		expect(check.matching).toBe(5);
+		expect(check.matching).toBe(6);
 
 		const forced = await installDefaultGjcDefinitions({ targetRoot, force: true });
-		expect(forced.written).toBe(6);
+		expect(forced.written).toBe(7);
 		expect(await Bun.file(deepInterviewSkillPath).text()).toBe(installedDeepInterview);
 		expect(
 			forced.files.some(file => file.kind === "skill-fragment" && file.parentSkillName === "deep-interview"),
@@ -345,6 +424,30 @@ Project executor override body.
 			await expect(
 				new SkillProtocolHandler().resolve(parseInternalUrl("skill://deep-interview/auto-research-greenfield.md")),
 			).rejects.toThrow("File not found");
+		});
+	});
+
+	it("does not make the ultragoal ai-slop-cleaner fragment reachable as a skill-relative internal URL asset", async () => {
+		await withTempHome(async () => {
+			const repoRoot = await makeTempRoot();
+			await installDefaultGjcDefinitions({ targetRoot: path.join(repoRoot, ".gjc") });
+
+			const skills = await loadSkills({
+				cwd: repoRoot,
+				enabled: true,
+				enablePiProject: true,
+				enablePiUser: false,
+			});
+			const ultragoal = skills.skills.find(skill => skill.name === "ultragoal" && skill.source === "native:project");
+			if (!ultragoal) throw new Error("missing installed ultragoal skill");
+
+			setActiveSkills([ultragoal]);
+			await expect(
+				new SkillProtocolHandler().resolve(parseInternalUrl("skill://ultragoal/ai-slop-cleaner.md")),
+			).rejects.toThrow("File not found");
+			await expect(new SkillProtocolHandler().resolve(parseInternalUrl("skill://ai-slop-cleaner"))).rejects.toThrow(
+				"Unknown skill: ai-slop-cleaner",
+			);
 		});
 	});
 });
@@ -419,37 +522,40 @@ describe("bundled skills CLI", () => {
 		expect(parsed.skills.every(skill => skill.path.startsWith("embedded:gjc/skills/"))).toBe(true);
 		expect(parsed.skills.some(skill => skill.name === "auto-research-greenfield")).toBe(false);
 		expect(parsed.skills.some(skill => skill.name === "auto-answer-uncertain")).toBe(false);
+		expect(parsed.skills.some(skill => skill.name === "ai-slop-cleaner")).toBe(false);
 	});
 
 	it("does not expose embedded fragments through skills read", async () => {
-		const externalRoot = await makeTempRoot();
-		const proc = Bun.spawn(
-			[
-				process.execPath,
-				path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
-				"skills",
-				"read",
-				"auto-research-greenfield",
-				"--json",
-			],
-			{
-				cwd: externalRoot,
-				stdout: "pipe",
-				stderr: "pipe",
-				env: {
-					...process.env,
-					HOME: await makeTempRoot(),
-					PI_NO_TITLE: "1",
-					NO_COLOR: "1",
+		for (const fragmentName of ["auto-research-greenfield", "auto-answer-uncertain", "ai-slop-cleaner"]) {
+			const externalRoot = await makeTempRoot();
+			const proc = Bun.spawn(
+				[
+					process.execPath,
+					path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
+					"skills",
+					"read",
+					fragmentName,
+					"--json",
+				],
+				{
+					cwd: externalRoot,
+					stdout: "pipe",
+					stderr: "pipe",
+					env: {
+						...process.env,
+						HOME: await makeTempRoot(),
+						PI_NO_TITLE: "1",
+						NO_COLOR: "1",
+					},
 				},
-			},
-		);
-		const stdout = await new Response(proc.stdout).text();
-		const stderr = await new Response(proc.stderr).text();
-		const exitCode = await proc.exited;
+			);
+			const stdout = await new Response(proc.stdout).text();
+			const stderr = await new Response(proc.stderr).text();
+			const exitCode = await proc.exited;
 
-		expect(exitCode).not.toBe(0);
-		expect(stdout).toBe("");
-		expect(stderr).toContain("unknown embedded skill");
+			expect(exitCode).not.toBe(0);
+			expect(stdout).toBe("");
+			expect(stderr).toContain("unknown embedded skill");
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Integrates oh-my-codex's `ai-slop-cleaner` as an **internal Ultragoal sub-skill fragment**, mirroring deep-interview's auto-research fragment pattern. It is never user-facing: not slash-command discoverable, absent from the public skill listing, and not resolvable through the skill protocol.

The fragment is a **read-only detector + reporter** (it never edits code). Ultragoal's completion gate runs it as the **final cleanup sweep (step 2) before verification, architect review, and red-team**, so only already-cleaned code is reviewed. The leader spawns an `executor` to fix blocking findings and reruns the sweep until zero blocking findings remain; advisory findings stay in the gate report only.

## Changes

- **New** `packages/coding-agent/src/defaults/gjc/skills/ultragoal/ai-slop-cleaner.md` — read-only detector/reporter, full oh-my-codex taxonomy (fallback-like masking vs. grounded, duplication, dead code, needless abstraction, boundary violations, UI/design slop, missing tests), blocking/advisory classification, the mandated `AI SLOP CLEANUP REPORT` block, changed-files scope, recursion guard.
- `gjc-defaults.ts` — registered as `kind: "skill-fragment"`, parent `ultragoal`; `DEFAULT_GJC_DEFINITION_NAMES` and the public-skill filter are unchanged.
- `ultragoal/SKILL.md` — gate step 2 rewritten as the final cleaner sweep with executor-fixes-blocking + rerun-until-zero-blocking + advisory-in-report-only (via existing `qualityGate.iteration.evidence`); added an "Internal Ultragoal sub-skill fragments" section.
- Tests — definition/fragment count bumps, ultragoal fragment accessor test, fragment-content label test, a section-scoped gate-ordering assertion, and real skill-protocol + CLI non-exposure coverage.

## Provenance

Built through the full GJC pipeline: deep-interview (7 rounds, ambiguity ~4%) → ralplan consensus (2 passes; Architect CLEAR/APPROVE, Critic OKAY) → approved execution via ultragoal.

## Verification

- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/cli-command-surface.test.ts` → 28 pass
- `bun scripts/verify-gjc-skill-docs.ts --fail` → clean
- `bun run check:ts` → clean (biome, node20 baseline, gjc-ui, full typecheck)
- Completion gate: architect all-CLEAR/APPROVE; executor QA/red-team passed (non-exposure adversarially confirmed).
