### PR TITLE
Fix release catalog file prefix regression

### DIFF
--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -60,6 +60,15 @@ describe("built-in model profile catalog", () => {
 		}
 	});
 
+	test("models.json package export is a plain relative path", async () => {
+		const manifest = (await Bun.file(new URL("../../ai/package.json", import.meta.url)).json()) as {
+			exports?: Record<string, { import?: string }>;
+		};
+		const exportTarget = manifest.exports?.["./models.json"]?.import;
+		expect(exportTarget).toBe("./src/models.json");
+		expect(exportTarget).not.toMatch(/^file:(?:file:)+/u);
+	});
+
 	test("every selector parses with schema validation and exists in models.json", () => {
 		const missing: string[] = [];
 		for (const profile of BUILTIN_MODEL_PROFILES) {

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -102,19 +102,24 @@ async function loadWorkspaceVersions(): Promise<Readonly<Record<string, string>>
 	return workspaceVersions;
 }
 
+export function normalizeFileDependencySpec(spec: string): string {
+	if (!spec.startsWith("file:")) return spec;
+	return `file:${spec.replace(/^(?:file:)+/u, "")}`;
+}
+
 function rewriteSrcPath(value: string): string {
 	if (!value.startsWith("./src/")) return value;
 	const rel = value.slice("./src/".length).replace(/\.tsx?$/, "");
 	return `./dist/types/${rel}.d.ts`;
 }
 
-async function resolvePublishDependency(name: string, spec: string): Promise<string> {
-	let resolved = spec;
+export async function resolvePublishDependency(name: string, spec: string): Promise<string> {
+	let resolved = normalizeFileDependencySpec(spec);
 	if (spec === "catalog:" || spec.startsWith("catalog:")) {
 		const catalog = await loadRootCatalog();
 		const catalogEntry = catalog[name];
 		if (catalogEntry === undefined) throw new Error(`Missing catalog version for ${name}`);
-		resolved = catalogEntry;
+		resolved = normalizeFileDependencySpec(catalogEntry);
 	}
 	if (resolved === "workspace:*" || resolved.startsWith("workspace:")) {
 		const versions = await loadWorkspaceVersions();
@@ -122,7 +127,7 @@ async function resolvePublishDependency(name: string, spec: string): Promise<str
 		if (workspaceVersion === undefined) throw new Error(`Missing workspace package version for ${name}`);
 		return workspaceVersion;
 	}
-	return resolved;
+	return normalizeFileDependencySpec(resolved);
 }
 
 async function rewriteDependencyFields(manifest: PackageManifest): Promise<void> {
@@ -231,6 +236,12 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 	if (result.exitCode !== 0) process.exit(result.exitCode ?? 1);
 }
 
-for (const pkg of packages) {
-	await publishPackage(pkg);
+async function main(): Promise<void> {
+	for (const pkg of packages) {
+		await publishPackage(pkg);
+	}
+}
+
+if (import.meta.main) {
+	await main();
 }

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
+import { normalizeFileDependencySpec } from "./ci-release-publish";
 
 interface PackageManifest {
 	name: string;
@@ -33,6 +34,15 @@ describe("unscoped gajae-code package publication", () => {
 		);
 		expect(aliasManifest.bin).toEqual({ gjc: "bin/gjc.js" });
 		expect(aliasManifest.dependencies?.["@gajae-code/coding-agent"]).toBe("catalog:");
+	});
+
+	test("release dependency normalization collapses repeated file prefixes", () => {
+		expect(normalizeFileDependencySpec("file:../packages/ai")).toBe("file:../packages/ai");
+		expect(normalizeFileDependencySpec("file:file:../packages/ai")).toBe("file:../packages/ai");
+		expect(normalizeFileDependencySpec("file:file:file:///tmp/gajae-code/packages/ai")).toBe(
+			"file:///tmp/gajae-code/packages/ai",
+		);
+		expect(normalizeFileDependencySpec("catalog:")).toBe("catalog:");
 	});
 
 	test("release publish order publishes the alias after its scoped dependency", async () => {


### PR DESCRIPTION
## Summary
- Fixes #349.
- Normalizes release-publish dependency specs so repeated `file:` prefixes collapse to a single canonical `file:` prefix.
- Makes the release publish helper import-safe for regression tests.
- Adds regression coverage for both the release dependency canonicalizer and the model catalog `@gajae-code/ai/models.json` export path.

## Root cause
The vulnerable path was release/catalog dependency rewriting: catalog-resolved local file specs could be carried forward with repeated `file:` prefixes, producing module specifiers such as `file:file:file:...` that break Bun module resolution when the model profile catalog imports `@gajae-code/ai/models.json`.

## Verification
- `bun test packages/coding-agent/test/model-profiles-catalog.test.ts scripts/release-publish-order.test.ts`
- `bun run test:release`
- `bun scripts/ci-release-publish.ts --dry-run`
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools -- scripts/ci-release-publish.ts scripts/release-publish-order.test.ts packages/coding-agent/test/model-profiles-catalog.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
