### PR TITLE
Fix OpenAI Codex 5.5 xhigh default drift

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -29,6 +29,8 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH: readonly Effort[] = [
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+const GPT_5_5_DEFAULT_EFFORT = Effort.XHigh;
+
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const CLOUDFLARE_AI_GATEWAY_BASE_URL = "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic";
 
@@ -433,6 +435,17 @@ function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel
 	}
 }
 
+function inferDefaultEffort<TApi extends Api>(model: ApiModel<TApi>, parsedModel: ParsedModel): Effort | undefined {
+	if (
+		parsedModel.family === "openai" &&
+		model.provider === "openai-codex" &&
+		semverEqual(parsedModel.version, "5.5")
+	) {
+		return GPT_5_5_DEFAULT_EFFORT;
+	}
+	return undefined;
+}
+
 function inferModelThinking<TApi extends Api>(model: ApiModel<TApi>): ThinkingConfig {
 	const parsedModel = parseKnownModel(model.id);
 	const efforts = inferSupportedEfforts(parsedModel, model);
@@ -446,6 +459,10 @@ function inferModelThinking<TApi extends Api>(model: ApiModel<TApi>): ThinkingCo
 		minLevel,
 		maxLevel,
 	};
+	const defaultLevel = inferDefaultEffort(model, parsedModel);
+	if (defaultLevel && efforts.includes(defaultLevel)) {
+		config.defaultLevel = defaultLevel;
+	}
 	// Encode explicit levels only when the inferred set has gaps the min..max range cannot represent.
 	const minIndex = THINKING_EFFORTS.indexOf(minLevel);
 	const maxIndex = THINKING_EFFORTS.indexOf(maxLevel);
@@ -466,7 +483,13 @@ function normalizeThinkingConfig(thinking: ThinkingConfig | undefined): Thinking
 function thinkingsEqual(left: ThinkingConfig | undefined, right: ThinkingConfig | undefined): boolean {
 	if (left === right) return true;
 	if (!left || !right) return false;
-	if (left.mode !== right.mode || left.minLevel !== right.minLevel || left.maxLevel !== right.maxLevel) return false;
+	if (
+		left.mode !== right.mode ||
+		left.minLevel !== right.minLevel ||
+		left.maxLevel !== right.maxLevel ||
+		left.defaultLevel !== right.defaultLevel
+	)
+		return false;
 	const leftLevels = left.levels;
 	const rightLevels = right.levels;
 	if (leftLevels === rightLevels) return true;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -53159,7 +53159,8 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "xhigh"
+				"maxLevel": "xhigh",
+				"defaultLevel": "xhigh"
 			},
 			"applyPatchToolType": "freeform",
 			"contextPromotionTarget": "openai-codex/gpt-5.4"

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -304,6 +304,6 @@ export const DEFAULT_MODEL_PER_PROVIDER: Record<KnownProvider, string> = {
 	minimax: "MiniMax-M2.5",
 	"minimax-code": "MiniMax-M2.5",
 	"minimax-code-cn": "MiniMax-M2.5",
-	"openai-codex": "gpt-5.4",
+	"openai-codex": "gpt-5.5",
 	"gitlab-duo": "duo-chat-sonnet-4-5",
 } as Record<KnownProvider, string>;

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { Effort, getBundledModel } from "@gajae-code/ai";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@gajae-code/ai/provider-models";
+
+describe("OpenAI Codex defaults", () => {
+	it("pins provider default to GPT-5.5", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER["openai-codex"]).toBe("gpt-5.5");
+	});
+
+	it("represents GPT-5.5 as the xhigh default effort", () => {
+		const model = getBundledModel("openai-codex", "gpt-5.5");
+
+		expect(model.thinking).toMatchObject({
+			mode: "effort",
+			minLevel: Effort.Low,
+			maxLevel: Effort.XHigh,
+			defaultLevel: Effort.XHigh,
+		});
+		expect(model.contextPromotionTarget).toBe("openai-codex/gpt-5.4");
+	});
+});

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -110,6 +110,17 @@ describe("built-in model profile catalog", () => {
 		}
 	});
 
+	test("codex-pro default is GPT-5.5 xhigh", () => {
+		const profile = builtIn("codex-pro");
+		const parsed = parseModelString(profile.modelMapping.default ?? "");
+
+		expect(parsed?.provider).toBe("openai-codex");
+		expect(parsed?.id).toBe("gpt-5.5");
+		expect(parsed?.thinkingLevel).toBeUndefined();
+		const providerModels = modelsJson["openai-codex"] as Record<string, { thinking?: { defaultLevel?: string } }>;
+		expect(providerModels["gpt-5.5"]?.thinking?.defaultLevel).toBe(ThinkingLevel.XHigh);
+	});
+
 	test("user same-name profile overrides builtin via mergeModelProfiles", () => {
 		const merged = mergeModelProfiles({
 			"codex-standard": {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effort, type Model } from "@gajae-code/ai";
 import {
 	expandRoleAlias,
+	findInitialModel,
 	parseModelPattern,
 	parseModelString,
 	resolveAgentModelPatterns,
@@ -10,6 +11,7 @@ import {
 	resolveModelOverride,
 	resolveModelRoleValue,
 	resolveModelScope,
+	restoreModelFromSession,
 } from "@gajae-code/coding-agent/config/model-resolver";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 
@@ -859,6 +861,72 @@ describe("parseModelString", () => {
 			// Empty string is not a valid thinking level, so colon stays as part of ID
 			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:" });
 		});
+	});
+});
+
+const codexDefaultModels: Model<"anthropic-messages">[] = [
+	{
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		api: "anthropic-messages",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.XHigh },
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000000,
+		maxTokens: 128000,
+	},
+	{
+		id: "gpt-5.5",
+		name: "GPT-5.5",
+		api: "anthropic-messages",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.XHigh, defaultLevel: Effort.XHigh },
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272000,
+		maxTokens: 128000,
+	},
+];
+
+const codexDefaultRegistry = {
+	getAvailable: () => codexDefaultModels,
+	find: (provider: string, id: string) =>
+		codexDefaultModels.find(model => model.provider === provider && model.id === id),
+	getApiKey: async () => "test-key",
+};
+
+describe("OpenAI Codex default resolution", () => {
+	test("fresh startup prefers gpt-5.5 over gpt-5.4 when no persisted default exists", async () => {
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: codexDefaultRegistry,
+		});
+
+		expect(result.model?.provider).toBe("openai-codex");
+		expect(result.model?.id).toBe("gpt-5.5");
+		expect(result.model?.thinking?.defaultLevel).toBe(Effort.XHigh);
+	});
+
+	test("restore fallback keeps visible fallback on gpt-5.5 instead of silently drifting to gpt-5.4", async () => {
+		const result = await restoreModelFromSession(
+			"openai-codex",
+			"missing-gpt",
+			undefined,
+			false,
+			codexDefaultRegistry,
+		);
+
+		expect(result.model?.provider).toBe("openai-codex");
+		expect(result.model?.id).toBe("gpt-5.5");
+		expect(result.fallbackMessage).toBe(
+			"Could not restore model openai-codex/missing-gpt (model no longer exists). Using openai-codex/gpt-5.5.",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
- pin OpenAI Codex provider default resolution to `gpt-5.5` instead of `gpt-5.4`
- mark bundled OpenAI Codex `gpt-5.5` with `defaultLevel: xhigh` so startup/profile selection visibly lands on 5.5 xhigh
- add focused regression coverage for provider defaults, profile catalog representation, fresh startup, and restore fallback behavior

Fixes #348.

## Verification
- `bun test packages/ai/test/openai-codex-default.test.ts packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/model-profiles-catalog.test.ts packages/coding-agent/test/model-profile-activation.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*