### PR TITLE
Fix harness session lookup across cwd

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -448,7 +448,10 @@ export default class Harness extends Command {
 		try {
 			const input = parseInput(flags.input);
 			const sessionId = flags.session ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
-			if (verb !== "start" && sessionId) root = await resolveHarnessSessionRoot(root, sessionId);
+			const expectedWorkspace = typeof input.workspace === "string" ? input.workspace : undefined;
+			if (verb !== "start" && sessionId) {
+				root = await resolveHarnessSessionRoot(root, sessionId, process.env, { expectedWorkspace });
+			}
 			switch (verb) {
 				case "start":
 					return await this.#start(root, input);

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -25,7 +25,9 @@ import {
 	generateSessionId,
 	readEvents,
 	readSessionState,
+	rememberHarnessSessionRoot,
 	resolveHarnessRoot,
+	resolveHarnessSessionRoot,
 	sessionPaths,
 	writeReceiptImmutable,
 	writeSessionState,
@@ -442,9 +444,11 @@ export default class Harness extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Harness);
 		const verb = String(args.verb);
-		const root = resolveHarnessRoot();
+		let root = resolveHarnessRoot();
 		try {
 			const input = parseInput(flags.input);
+			const sessionId = flags.session ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+			if (verb !== "start" && sessionId) root = await resolveHarnessSessionRoot(root, sessionId);
 			switch (verb) {
 				case "start":
 					return await this.#start(root, input);
@@ -688,6 +692,7 @@ export default class Harness extends Command {
 			updatedAt: startedAt,
 		};
 		await writeSessionState(root, state);
+		await rememberHarnessSessionRoot(root, sessionId);
 		let ownerLive = false;
 		let ownerRuntime: OwnerSpawnResult["runtime"] = "manual";
 		let ownerFallbackReason: string | null = null;

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -30,7 +30,29 @@ interface HarnessRootRegistry {
 	roots: HarnessRootRegistryEntry[];
 }
 
-function harnessRootRegistryDir(env: NodeJS.ProcessEnv = process.env): string {
+interface ResolveHarnessSessionRootOptions {
+	expectedWorkspace?: string;
+}
+
+function samePath(left: string, right: string): boolean {
+	return path.resolve(left) === path.resolve(right);
+}
+
+async function ensurePrivateDir(dir: string): Promise<void> {
+	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+	await fs.chmod(dir, 0o700);
+}
+
+function ensurePrivateDirSync(dir: string): void {
+	fsSync.mkdirSync(dir, { recursive: true, mode: 0o700 });
+	fsSync.chmodSync(dir, 0o700);
+}
+
+function sessionMatchesWorkspace(state: SessionState, expectedWorkspace: string): boolean {
+	return samePath(state.handle.workspace, expectedWorkspace);
+}
+
+function harnessRootRegistryDir(_env: NodeJS.ProcessEnv = process.env): string {
 	return path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots");
 }
 
@@ -54,12 +76,22 @@ async function readHarnessRootRegistry(
 	return { sessionId, roots: [] };
 }
 
+async function writeJsonAtomicPrivate(file: string, value: unknown): Promise<void> {
+	await ensurePrivateDir(path.dirname(file));
+	const tmp = `${file}.tmp-${randomBytes(4).toString("hex")}`;
+	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+	await fs.rename(tmp, file);
+	await fs.chmod(file, 0o600);
+}
+
 async function writeHarnessRootRegistry(
 	registry: HarnessRootRegistry,
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
+	const dir = harnessRootRegistryDir(env);
+	await ensurePrivateDir(dir);
 	const file = harnessRootRegistryPath(registry.sessionId, env);
-	await writeJsonAtomic(file, registry);
+	await writeJsonAtomicPrivate(file, registry);
 }
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const MAX_UNIX_SOCKET_PATH_BYTES = 100;
@@ -77,7 +109,7 @@ function socketBase(env: NodeJS.ProcessEnv, allowOverride: boolean): { base: str
 
 function socketPathForBase(root: string, sessionId: string, base: string): string {
 	const digest = createHash("sha256").update(`${root}\0${sessionId}`).digest("hex");
-	fsSync.mkdirSync(base, { recursive: true });
+	ensurePrivateDirSync(base);
 	for (const len of [16, 24, 32, 48, 64]) {
 		const stem = `c-${digest.slice(0, len)}`;
 		const metadataPath = path.join(base, `${stem}.json`);
@@ -87,7 +119,10 @@ function socketPathForBase(root: string, sessionId: string, base: string): strin
 			if (existing.root === root && existing.sessionId === sessionId) return path.join(base, `${stem}.sock`);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-			fsSync.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+			fsSync.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
 			return path.join(base, `${stem}.sock`);
 		}
 	}
@@ -210,14 +245,35 @@ export async function resolveHarnessSessionRoot(
 	root: string,
 	sessionId: string,
 	env: NodeJS.ProcessEnv = process.env,
+	options: ResolveHarnessSessionRootOptions = {},
 ): Promise<string> {
 	assertSafeSessionId(sessionId);
 	const resolvedRoot = path.resolve(root);
-	if ((await readSessionState(resolvedRoot, sessionId)) !== null) return resolvedRoot;
+	const localState = await readSessionState(resolvedRoot, sessionId);
+	if (localState !== null) {
+		if (options.expectedWorkspace && !sessionMatchesWorkspace(localState, options.expectedWorkspace)) {
+			throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
+		}
+		return resolvedRoot;
+	}
+
 	const registry = await readHarnessRootRegistry(sessionId, env);
+	const candidates: { root: string; state: SessionState }[] = [];
 	for (const entry of registry.roots) {
 		const candidate = path.resolve(entry.root);
-		if ((await readSessionState(candidate, sessionId)) !== null) return candidate;
+		const state = await readSessionState(candidate, sessionId);
+		if (state !== null) candidates.push({ root: candidate, state });
+	}
+
+	const matchingCandidates = options.expectedWorkspace
+		? candidates.filter(candidate => sessionMatchesWorkspace(candidate.state, options.expectedWorkspace as string))
+		: candidates;
+	if (matchingCandidates.length === 1) return matchingCandidates[0].root;
+	if (matchingCandidates.length > 1) {
+		throw new StorageError(`ambiguous_harness_session_root:${sessionId}`, "ambiguous_harness_session_root");
+	}
+	if (options.expectedWorkspace && candidates.length > 0) {
+		throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
 	}
 	return resolvedRoot;
 }

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -20,6 +20,47 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { EventEnvelope, ReceiptFamily, SessionState } from "./types";
 
+interface HarnessRootRegistryEntry {
+	root: string;
+	updatedAt: string;
+}
+
+interface HarnessRootRegistry {
+	sessionId: string;
+	roots: HarnessRootRegistryEntry[];
+}
+
+function harnessRootRegistryDir(env: NodeJS.ProcessEnv = process.env): string {
+	return path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots");
+}
+
+function harnessRootRegistryPath(sessionId: string, env: NodeJS.ProcessEnv = process.env): string {
+	assertSafeSessionId(sessionId);
+	return path.join(harnessRootRegistryDir(env), `${sessionId}.json`);
+}
+
+async function readHarnessRootRegistry(
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<HarnessRootRegistry> {
+	const file = harnessRootRegistryPath(sessionId, env);
+	try {
+		const raw = await fs.readFile(file, "utf8");
+		const parsed = JSON.parse(raw) as HarnessRootRegistry;
+		if (parsed.sessionId === sessionId && Array.isArray(parsed.roots)) return parsed;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return { sessionId, roots: [] };
+}
+
+async function writeHarnessRootRegistry(
+	registry: HarnessRootRegistry,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	const file = harnessRootRegistryPath(registry.sessionId, env);
+	await writeJsonAtomic(file, registry);
+}
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const MAX_UNIX_SOCKET_PATH_BYTES = 100;
 
@@ -148,6 +189,37 @@ async function readJson<T>(file: string): Promise<T | null> {
 
 export async function readSessionState(root: string, sessionId: string): Promise<SessionState | null> {
 	return readJson<SessionState>(sessionPaths(root, sessionId).state);
+}
+export async function rememberHarnessSessionRoot(
+	root: string,
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	assertSafeSessionId(sessionId);
+	const resolvedRoot = path.resolve(root);
+	const registry = await readHarnessRootRegistry(sessionId, env);
+	const now = new Date().toISOString();
+	registry.roots = [
+		{ root: resolvedRoot, updatedAt: now },
+		...registry.roots.filter(entry => path.resolve(entry.root) !== resolvedRoot),
+	].slice(0, 8);
+	await writeHarnessRootRegistry(registry, env);
+}
+
+export async function resolveHarnessSessionRoot(
+	root: string,
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+	assertSafeSessionId(sessionId);
+	const resolvedRoot = path.resolve(root);
+	if ((await readSessionState(resolvedRoot, sessionId)) !== null) return resolvedRoot;
+	const registry = await readHarnessRootRegistry(sessionId, env);
+	for (const entry of registry.roots) {
+		const candidate = path.resolve(entry.root);
+		if ((await readSessionState(candidate, sessionId)) !== null) return candidate;
+	}
+	return resolvedRoot;
 }
 
 export async function writeSessionState(root: string, state: SessionState): Promise<void> {

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -42,6 +42,27 @@ function runHarness(args: string[]): HarnessResult {
 	}
 	return { code: proc.exitCode ?? 0, json, raw };
 }
+function runHarnessInCwd(args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): HarnessResult {
+	const proc = Bun.spawnSync(["bun", cliEntry, "harness", ...args], {
+		cwd,
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const raw = proc.stdout.toString().trim();
+	let json: any = null;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		// leave null; assertions will surface the raw output
+	}
+	return { code: proc.exitCode ?? 0, json, raw };
+}
+function harnessEnvWithoutStateRoot(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	delete env.GJC_HARNESS_STATE_ROOT;
+	return env;
+}
 
 function assertContract(res: any): void {
 	expect(res, `expected contract object, got: ${JSON.stringify(res)}`).toBeTruthy();
@@ -178,6 +199,49 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation).toHaveProperty("gitDelta");
 		expect(res.json.evidence.observation).toHaveProperty("risk");
 		expect(res.json.evidence.observation).not.toHaveProperty("pane");
+	});
+
+	it("re-acquires observe and recover by session id across cwd without state-root env", async () => {
+		await initCleanGitWorkspace();
+		const otherCwd = await mkdtemp(path.join(tmpdir(), "harness-cli-other-cwd-"));
+		try {
+			const env = harnessEnvWithoutStateRoot();
+			const started = runHarnessInCwd(
+				["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })],
+				workspace,
+				env,
+			);
+			expect(started.code).toBe(0);
+			const sessionId = started.json.evidence.handle.sessionId as string;
+
+			await appendEvent(path.join(workspace, ".gjc", "state", "harness"), sessionId, {
+				eventId: "evt-cross-cwd-prompt",
+				cursor: 1,
+				createdAt: "2026-06-03T00:00:01.000Z",
+				severity: "info",
+				kind: "prompt_accepted",
+				state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+				evidence: { signal: "prompt-accepted" },
+				nextAllowedActions: [],
+				writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+			});
+
+			const observed = runHarnessInCwd(["observe", "--session", sessionId], otherCwd, env);
+			expect(observed.code).toBe(0);
+			assertContract(observed.json);
+			expect(observed.json.state.sessionId).toBe(sessionId);
+			expect(observed.json.evidence.observation.cwd).toBe(workspace);
+			expect(observed.json.evidence.observation.observedSignals).toContain("prompt-accepted");
+
+			const recovered = runHarnessInCwd(["recover", "--session", sessionId], otherCwd, env);
+			expect(recovered.code).toBe(1);
+			assertContract(recovered.json);
+			expect(recovered.json.state.sessionId).toBe(sessionId);
+			expect(recovered.json.evidence.reason).toBe("owner-exited-after-prompt-acceptance");
+			expect(recovered.json.evidence.observation.cwd).toBe(workspace);
+		} finally {
+			await rm(otherCwd, { recursive: true, force: true });
+		}
 	});
 
 	it("observe exposes durable completion evidence after the owner has exited", async () => {

--- a/packages/coding-agent/test/harness-control-plane/storage.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/storage.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
@@ -12,7 +12,9 @@ import {
 	readEvents,
 	readReceiptIndex,
 	readSessionState,
+	rememberHarnessSessionRoot,
 	resolveHarnessRoot,
+	resolveHarnessSessionRoot,
 	StorageError,
 	sessionPaths,
 	writeReceiptImmutable,
@@ -26,6 +28,7 @@ import {
 } from "../../src/harness-control-plane/types";
 
 let root: string;
+let registrySessionIds: string[] = [];
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-store-"));
@@ -33,6 +36,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	await rm(root, { recursive: true, force: true });
+	for (const id of registrySessionIds) {
+		await rm(path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${id}.json`), { force: true });
+	}
+	registrySessionIds = [];
 });
 
 function state(sessionId: string): SessionState {
@@ -62,6 +69,14 @@ function envelope(cursor: number): EventEnvelope {
 		nextAllowedActions: [],
 		writer: { ownerId: "owner-1", leaseEpoch: 1 },
 	};
+}
+
+function registryPath(sessionId: string): string {
+	return path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${sessionId}.json`);
+}
+
+function mode(bits: number): number {
+	return bits & 0o777;
 }
 
 describe("harness storage", () => {
@@ -182,5 +197,54 @@ describe("harness storage", () => {
 		);
 		const socketPath = controlSocketPath(root, id, { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
 		expect(path.basename(socketPath)).toBe(`c-${digest.slice(0, 24)}.sock`);
+	});
+
+	it("does not pick an arbitrary registered root when explicit session ids collide", async () => {
+		const id = `h-collide-${process.pid}`;
+		registrySessionIds.push(id);
+		const leftRoot = await mkdtemp(path.join(tmpdir(), "h-left-"));
+		const rightRoot = await mkdtemp(path.join(tmpdir(), "h-right-"));
+		try {
+			await writeSessionState(leftRoot, { ...state(id), handle: { ...state(id).handle, workspace: "/repo/left" } });
+			await writeSessionState(rightRoot, {
+				...state(id),
+				handle: { ...state(id).handle, workspace: "/repo/right" },
+			});
+			await rememberHarnessSessionRoot(leftRoot, id);
+			await rememberHarnessSessionRoot(rightRoot, id);
+
+			await expect(resolveHarnessSessionRoot(root, id)).rejects.toThrow(/ambiguous_harness_session_root/);
+			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/left" })).toBe(
+				path.resolve(leftRoot),
+			);
+			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/right" })).toBe(
+				path.resolve(rightRoot),
+			);
+			await expect(
+				resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/missing" }),
+			).rejects.toThrow(/session_workspace_mismatch/);
+		} finally {
+			await rm(leftRoot, { recursive: true, force: true });
+			await rm(rightRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("stores global registry files with private permissions", async () => {
+		const id = `h-private-${process.pid}`;
+		registrySessionIds.push(id);
+		const file = registryPath(id);
+		const dir = path.dirname(file);
+		await rm(dir, { recursive: true, force: true });
+		await rememberHarnessSessionRoot(root, id);
+		const dirStat = await stat(dir);
+		const fileStat = await stat(file);
+		expect(mode(dirStat.mode)).toBe(0o700);
+		expect(mode(fileStat.mode)).toBe(0o600);
+
+		await chmod(dir, 0o775);
+		await chmod(file, 0o664);
+		await rememberHarnessSessionRoot(root, id);
+		expect(mode((await stat(dir)).mode)).toBe(0o700);
+		expect(mode((await stat(file)).mode)).toBe(0o600);
 	});
 });


### PR DESCRIPTION
Fixes #354.

## Summary
- persist a per-user harness session-id to state-root registry when `gjc harness start` creates a session
- re-acquire the stored state root for stateless `--session <id>` verbs when the current cwd default root does not contain the session
- disambiguate same session-id registry collisions by expected workspace so cwd-independent lookup still fails closed for ambiguous/wrong-workspace state
- add regression coverage for starting in one cwd and observing/recovering from another cwd without `GJC_HARNESS_STATE_ROOT`, plus registry collision coverage

## Verification
- `bun install` (fresh checkout had no `node_modules`; unresolved `@gajae-code/*` workspace imports were from missing workspace install, not the harness lookup patch)
- `bun --cwd=packages/natives run build` (fresh checkout had no local `pi_natives.linux-x64-*.node`; required before spawned `bun packages/coding-agent/src/cli.ts ...` can import `@gajae-code/natives` through the CLI entrypoint)
- `bun test packages/coding-agent/test/harness-control-plane/storage.test.ts packages/coding-agent/test/harness-control-plane/cli.test.ts packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts` — 36 pass / 0 fail
