### PR TITLE
fix(gjc): scope stale state doctor fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Included the diagnosed `--session-id` in `gjc state doctor` stale active-state fix commands so session-scoped HUD snapshots can be cleared without accidentally targeting the current session.
+
 ## [0.3.2] - 2026-06-05
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -446,6 +446,13 @@ function skillFromActiveValue(value: unknown): string | undefined {
 function activeFlag(value: unknown): boolean {
 	return isPlainObject(value) && value.active !== false;
 }
+function shellWord(value: string): string {
+	return /^[A-Za-z0-9._-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function stateClearFixCommand(skill: CanonicalGjcWorkflowSkill, sessionId: string | undefined): string {
+	return sessionId ? `gjc state ${skill} clear --session-id ${shellWord(sessionId)}` : `gjc state ${skill} clear`;
+}
 
 async function collectDoctorSummary(
 	cwd: string,
@@ -545,7 +552,7 @@ async function collectDoctorSummary(
 						"stale_active_state",
 						entryPath,
 						`active entry for ${entrySkill} does not match a live active mode-state`,
-						canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+						canonical ? stateClearFixCommand(canonical, scopeSessionId) : "gjc state prune --hard",
 						canonical ?? undefined,
 					),
 				);
@@ -564,7 +571,7 @@ async function collectDoctorSummary(
 							"stale_active_state",
 							snapshotPath,
 							`active snapshot lists ${entrySkill} but no raw per-skill active entry exists`,
-							canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+							canonical ? stateClearFixCommand(canonical, scopeSessionId) : "gjc state prune --hard",
 							canonical ?? undefined,
 						),
 					);

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -208,4 +208,31 @@ describe("gjc state doctor", () => {
 			}),
 		]);
 	});
+
+	it("prints a session-scoped clear command for stale active snapshots in old sessions", async () => {
+		const root = await tempDir();
+		const sessionId = "old-session";
+		const sessionRoot = path.join(root, ".gjc", "state", "sessions", sessionId);
+		const snapshotPath = path.join(sessionRoot, "skill-active-state.json");
+		await writeJson(snapshotPath, {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			phase: "final",
+			session_id: sessionId,
+			active_skills: [{ skill: "ralplan", active: true, phase: "final", session_id: sessionId }],
+		});
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "ralplan",
+				path: snapshotPath,
+				fixCommand: "gjc state ralplan clear --session-id old-session",
+			}),
+		]);
+	});
 });


### PR DESCRIPTION
## Summary
- include the diagnosed `--session-id` in `gjc state doctor` stale active-state clear commands
- shell-quote non-simple session ids in rendered fix commands
- add a regression test for stale session-scoped `skill-active-state.json` snapshots
- add an Unreleased changelog entry

## Problem
`gjc state doctor` scans `.gjc/state/sessions/*` when no session is explicitly selected, but stale active-state findings still suggested `gjc state <skill> clear`. In an agent session that command resolves the current `GJC_SESSION_ID`, so it can clear the wrong session and leave the diagnosed stale HUD entry visible.

## Tests
- `bun test packages/coding-agent/test/gjc-runtime/state-doctor.test.ts`
- `bun --cwd=packages/coding-agent run check`