### PR TITLE
Fix harness session lookup testability

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -448,7 +448,10 @@ export default class Harness extends Command {
 		try {
 			const input = parseInput(flags.input);
 			const sessionId = flags.session ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
-			if (verb !== "start" && sessionId) root = await resolveHarnessSessionRoot(root, sessionId);
+			const expectedWorkspace = typeof input.workspace === "string" ? input.workspace : undefined;
+			if (verb !== "start" && sessionId) {
+				root = await resolveHarnessSessionRoot(root, sessionId, process.env, { expectedWorkspace });
+			}
 			switch (verb) {
 				case "start":
 					return await this.#start(root, input);

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -25,7 +25,9 @@ import {
 	generateSessionId,
 	readEvents,
 	readSessionState,
+	rememberHarnessSessionRoot,
 	resolveHarnessRoot,
+	resolveHarnessSessionRoot,
 	sessionPaths,
 	writeReceiptImmutable,
 	writeSessionState,
@@ -442,9 +444,11 @@ export default class Harness extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Harness);
 		const verb = String(args.verb);
-		const root = resolveHarnessRoot();
+		let root = resolveHarnessRoot();
 		try {
 			const input = parseInput(flags.input);
+			const sessionId = flags.session ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+			if (verb !== "start" && sessionId) root = await resolveHarnessSessionRoot(root, sessionId);
 			switch (verb) {
 				case "start":
 					return await this.#start(root, input);
@@ -688,6 +692,7 @@ export default class Harness extends Command {
 			updatedAt: startedAt,
 		};
 		await writeSessionState(root, state);
+		await rememberHarnessSessionRoot(root, sessionId);
 		let ownerLive = false;
 		let ownerRuntime: OwnerSpawnResult["runtime"] = "manual";
 		let ownerFallbackReason: string | null = null;

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -590,6 +590,9 @@ export default class Harness extends Command {
 		if (process.env.GJC_HARNESS_RPC_COMMAND) {
 			envAssignments.push(`GJC_HARNESS_RPC_COMMAND=${shellQuote(process.env.GJC_HARNESS_RPC_COMMAND)}`);
 		}
+		if (process.env.GJC_HARNESS_TEST_NODE_MODULES) {
+			envAssignments.push(`GJC_HARNESS_TEST_NODE_MODULES=${shellQuote(process.env.GJC_HARNESS_TEST_NODE_MODULES)}`);
+		}
 		const ownerCommand = this.#buildOwnerCommand(sessionId).map(shellQuote).join(" ");
 		const shellCommand = `exec env ${envAssignments.join(" ")} ${ownerCommand}`;
 		const created = Bun.spawnSync([tmuxCommand, "new-session", "-d", "-s", sessionName, "-c", cwd, shellCommand], {
@@ -620,7 +623,13 @@ export default class Harness extends Command {
 		const cmd = this.#buildOwnerCommand(sessionId);
 		const child = Bun.spawn(cmd, {
 			cwd,
-			env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+			env: {
+				...process.env,
+				GJC_HARNESS_STATE_ROOT: root,
+				...(process.env.GJC_HARNESS_TEST_NODE_MODULES
+					? { GJC_HARNESS_TEST_NODE_MODULES: process.env.GJC_HARNESS_TEST_NODE_MODULES }
+					: {}),
+			},
 			stdout: "ignore",
 			stderr: "ignore",
 			stdin: "ignore",

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -22,6 +22,7 @@ import { GajaeCodeRpc } from "../harness-control-plane/rpc-adapter";
 import { classifyLeaseStatus, readLease } from "../harness-control-plane/session-lease";
 import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
 import {
+	canonicalWorkspacePath,
 	generateSessionId,
 	readEvents,
 	readSessionState,
@@ -128,8 +129,12 @@ function gitOutput(workspace: string, args: string[]): string | null {
 	}
 }
 
+function resolveInputWorkspace(input: Record<string, unknown>): string {
+	return canonicalWorkspacePath(typeof input.workspace === "string" ? input.workspace : process.cwd());
+}
+
 function buildPreflight(input: Record<string, unknown>): HarnessPreflight {
-	const workspace = typeof input.workspace === "string" ? input.workspace : process.cwd();
+	const workspace = resolveInputWorkspace(input);
 	const declaredBranch = typeof input.branch === "string" && input.branch.trim() ? input.branch.trim() : null;
 	const blockers: string[] = [];
 	const gitRoot = gitOutput(workspace, ["rev-parse", "--show-toplevel"]);
@@ -448,7 +453,7 @@ export default class Harness extends Command {
 		try {
 			const input = parseInput(flags.input);
 			const sessionId = flags.session ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
-			const expectedWorkspace = typeof input.workspace === "string" ? input.workspace : undefined;
+			const expectedWorkspace = typeof input.workspace === "string" ? resolveInputWorkspace(input) : undefined;
 			if (verb !== "start" && sessionId) {
 				root = await resolveHarnessSessionRoot(root, sessionId, process.env, { expectedWorkspace });
 			}
@@ -671,7 +676,7 @@ export default class Harness extends Command {
 			process.exitCode = 1;
 			return;
 		}
-		const workspace = typeof input.workspace === "string" ? input.workspace : process.cwd();
+		const workspace = resolveInputWorkspace(input);
 		const sessionId = typeof input.sessionId === "string" ? input.sessionId : generateSessionId();
 		const eventsPath = `${root}/sessions/${sessionId}/events.jsonl`;
 		const leasePath = `${root}/sessions/${sessionId}/lease.json`;

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -30,7 +30,29 @@ interface HarnessRootRegistry {
 	roots: HarnessRootRegistryEntry[];
 }
 
-function harnessRootRegistryDir(env: NodeJS.ProcessEnv = process.env): string {
+interface ResolveHarnessSessionRootOptions {
+	expectedWorkspace?: string;
+}
+
+function samePath(left: string, right: string): boolean {
+	return path.resolve(left) === path.resolve(right);
+}
+
+async function ensurePrivateDir(dir: string): Promise<void> {
+	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+	await fs.chmod(dir, 0o700);
+}
+
+function ensurePrivateDirSync(dir: string): void {
+	fsSync.mkdirSync(dir, { recursive: true, mode: 0o700 });
+	fsSync.chmodSync(dir, 0o700);
+}
+
+function sessionMatchesWorkspace(state: SessionState, expectedWorkspace: string): boolean {
+	return samePath(state.handle.workspace, expectedWorkspace);
+}
+
+function harnessRootRegistryDir(_env: NodeJS.ProcessEnv = process.env): string {
 	return path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots");
 }
 
@@ -54,12 +76,22 @@ async function readHarnessRootRegistry(
 	return { sessionId, roots: [] };
 }
 
+async function writeJsonAtomicPrivate(file: string, value: unknown): Promise<void> {
+	await ensurePrivateDir(path.dirname(file));
+	const tmp = `${file}.tmp-${randomBytes(4).toString("hex")}`;
+	await fs.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+	await fs.rename(tmp, file);
+	await fs.chmod(file, 0o600);
+}
+
 async function writeHarnessRootRegistry(
 	registry: HarnessRootRegistry,
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
+	const dir = harnessRootRegistryDir(env);
+	await ensurePrivateDir(dir);
 	const file = harnessRootRegistryPath(registry.sessionId, env);
-	await writeJsonAtomic(file, registry);
+	await writeJsonAtomicPrivate(file, registry);
 }
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const MAX_UNIX_SOCKET_PATH_BYTES = 100;
@@ -77,7 +109,7 @@ function socketBase(env: NodeJS.ProcessEnv, allowOverride: boolean): { base: str
 
 function socketPathForBase(root: string, sessionId: string, base: string): string {
 	const digest = createHash("sha256").update(`${root}\0${sessionId}`).digest("hex");
-	fsSync.mkdirSync(base, { recursive: true });
+	ensurePrivateDirSync(base);
 	for (const len of [16, 24, 32, 48, 64]) {
 		const stem = `c-${digest.slice(0, len)}`;
 		const metadataPath = path.join(base, `${stem}.json`);
@@ -87,7 +119,10 @@ function socketPathForBase(root: string, sessionId: string, base: string): strin
 			if (existing.root === root && existing.sessionId === sessionId) return path.join(base, `${stem}.sock`);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-			fsSync.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+			fsSync.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
 			return path.join(base, `${stem}.sock`);
 		}
 	}
@@ -210,14 +245,35 @@ export async function resolveHarnessSessionRoot(
 	root: string,
 	sessionId: string,
 	env: NodeJS.ProcessEnv = process.env,
+	options: ResolveHarnessSessionRootOptions = {},
 ): Promise<string> {
 	assertSafeSessionId(sessionId);
 	const resolvedRoot = path.resolve(root);
-	if ((await readSessionState(resolvedRoot, sessionId)) !== null) return resolvedRoot;
+	const localState = await readSessionState(resolvedRoot, sessionId);
+	if (localState !== null) {
+		if (options.expectedWorkspace && !sessionMatchesWorkspace(localState, options.expectedWorkspace)) {
+			throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
+		}
+		return resolvedRoot;
+	}
+
 	const registry = await readHarnessRootRegistry(sessionId, env);
+	const candidates: { root: string; state: SessionState }[] = [];
 	for (const entry of registry.roots) {
 		const candidate = path.resolve(entry.root);
-		if ((await readSessionState(candidate, sessionId)) !== null) return candidate;
+		const state = await readSessionState(candidate, sessionId);
+		if (state !== null) candidates.push({ root: candidate, state });
+	}
+
+	const matchingCandidates = options.expectedWorkspace
+		? candidates.filter(candidate => sessionMatchesWorkspace(candidate.state, options.expectedWorkspace as string))
+		: candidates;
+	if (matchingCandidates.length === 1) return matchingCandidates[0].root;
+	if (matchingCandidates.length > 1) {
+		throw new StorageError(`ambiguous_harness_session_root:${sessionId}`, "ambiguous_harness_session_root");
+	}
+	if (options.expectedWorkspace && candidates.length > 0) {
+		throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
 	}
 	return resolvedRoot;
 }

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -20,6 +20,47 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { EventEnvelope, ReceiptFamily, SessionState } from "./types";
 
+interface HarnessRootRegistryEntry {
+	root: string;
+	updatedAt: string;
+}
+
+interface HarnessRootRegistry {
+	sessionId: string;
+	roots: HarnessRootRegistryEntry[];
+}
+
+function harnessRootRegistryDir(env: NodeJS.ProcessEnv = process.env): string {
+	return path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots");
+}
+
+function harnessRootRegistryPath(sessionId: string, env: NodeJS.ProcessEnv = process.env): string {
+	assertSafeSessionId(sessionId);
+	return path.join(harnessRootRegistryDir(env), `${sessionId}.json`);
+}
+
+async function readHarnessRootRegistry(
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<HarnessRootRegistry> {
+	const file = harnessRootRegistryPath(sessionId, env);
+	try {
+		const raw = await fs.readFile(file, "utf8");
+		const parsed = JSON.parse(raw) as HarnessRootRegistry;
+		if (parsed.sessionId === sessionId && Array.isArray(parsed.roots)) return parsed;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return { sessionId, roots: [] };
+}
+
+async function writeHarnessRootRegistry(
+	registry: HarnessRootRegistry,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	const file = harnessRootRegistryPath(registry.sessionId, env);
+	await writeJsonAtomic(file, registry);
+}
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const MAX_UNIX_SOCKET_PATH_BYTES = 100;
 
@@ -148,6 +189,37 @@ async function readJson<T>(file: string): Promise<T | null> {
 
 export async function readSessionState(root: string, sessionId: string): Promise<SessionState | null> {
 	return readJson<SessionState>(sessionPaths(root, sessionId).state);
+}
+export async function rememberHarnessSessionRoot(
+	root: string,
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	assertSafeSessionId(sessionId);
+	const resolvedRoot = path.resolve(root);
+	const registry = await readHarnessRootRegistry(sessionId, env);
+	const now = new Date().toISOString();
+	registry.roots = [
+		{ root: resolvedRoot, updatedAt: now },
+		...registry.roots.filter(entry => path.resolve(entry.root) !== resolvedRoot),
+	].slice(0, 8);
+	await writeHarnessRootRegistry(registry, env);
+}
+
+export async function resolveHarnessSessionRoot(
+	root: string,
+	sessionId: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+	assertSafeSessionId(sessionId);
+	const resolvedRoot = path.resolve(root);
+	if ((await readSessionState(resolvedRoot, sessionId)) !== null) return resolvedRoot;
+	const registry = await readHarnessRootRegistry(sessionId, env);
+	for (const entry of registry.roots) {
+		const candidate = path.resolve(entry.root);
+		if ((await readSessionState(candidate, sessionId)) !== null) return candidate;
+	}
+	return resolvedRoot;
 }
 
 export async function writeSessionState(root: string, state: SessionState): Promise<void> {

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -34,8 +34,12 @@ interface ResolveHarnessSessionRootOptions {
 	expectedWorkspace?: string;
 }
 
+export function canonicalWorkspacePath(workspace: string): string {
+	return path.resolve(workspace);
+}
+
 function samePath(left: string, right: string): boolean {
-	return path.resolve(left) === path.resolve(right);
+	return canonicalWorkspacePath(left) === canonicalWorkspacePath(right);
 }
 
 async function ensurePrivateDir(dir: string): Promise<void> {
@@ -52,7 +56,9 @@ function sessionMatchesWorkspace(state: SessionState, expectedWorkspace: string)
 	return samePath(state.handle.workspace, expectedWorkspace);
 }
 
-function harnessRootRegistryDir(_env: NodeJS.ProcessEnv = process.env): string {
+function harnessRootRegistryDir(env: NodeJS.ProcessEnv = process.env): string {
+	const override = env.GJC_HARNESS_ROOT_REGISTRY_DIR?.trim();
+	if (override) return path.resolve(override);
 	return path.join(os.tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots");
 }
 
@@ -249,30 +255,38 @@ export async function resolveHarnessSessionRoot(
 ): Promise<string> {
 	assertSafeSessionId(sessionId);
 	const resolvedRoot = path.resolve(root);
-	const localState = await readSessionState(resolvedRoot, sessionId);
-	if (localState !== null) {
-		if (options.expectedWorkspace && !sessionMatchesWorkspace(localState, options.expectedWorkspace)) {
-			throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
+	const candidates: { root: string; state: SessionState }[] = [];
+	const seenRoots = new Set<string>();
+	const addCandidate = async (candidateRoot: string): Promise<void> => {
+		const candidate = path.resolve(candidateRoot);
+		if (seenRoots.has(candidate)) return;
+		seenRoots.add(candidate);
+		const state = await readSessionState(candidate, sessionId);
+		if (state !== null) candidates.push({ root: candidate, state });
+	};
+
+	await addCandidate(resolvedRoot);
+	const registry = await readHarnessRootRegistry(sessionId, env);
+	for (const entry of registry.roots) await addCandidate(entry.root);
+
+	if (!options.expectedWorkspace) {
+		if (candidates.some(candidate => candidate.root === resolvedRoot)) return resolvedRoot;
+		if (candidates.length === 1) return candidates[0].root;
+		if (candidates.length > 1) {
+			throw new StorageError(`ambiguous_harness_session_root:${sessionId}`, "ambiguous_harness_session_root");
 		}
 		return resolvedRoot;
 	}
 
-	const registry = await readHarnessRootRegistry(sessionId, env);
-	const candidates: { root: string; state: SessionState }[] = [];
-	for (const entry of registry.roots) {
-		const candidate = path.resolve(entry.root);
-		const state = await readSessionState(candidate, sessionId);
-		if (state !== null) candidates.push({ root: candidate, state });
-	}
-
-	const matchingCandidates = options.expectedWorkspace
-		? candidates.filter(candidate => sessionMatchesWorkspace(candidate.state, options.expectedWorkspace as string))
-		: candidates;
+	const expectedWorkspace = canonicalWorkspacePath(options.expectedWorkspace);
+	const matchingCandidates = candidates.filter(candidate =>
+		sessionMatchesWorkspace(candidate.state, expectedWorkspace),
+	);
 	if (matchingCandidates.length === 1) return matchingCandidates[0].root;
 	if (matchingCandidates.length > 1) {
 		throw new StorageError(`ambiguous_harness_session_root:${sessionId}`, "ambiguous_harness_session_root");
 	}
-	if (options.expectedWorkspace && candidates.length > 0) {
+	if (candidates.length > 0) {
 		throw new StorageError(`session_workspace_mismatch:${sessionId}`, "session_workspace_mismatch");
 	}
 	return resolvedRoot;

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { resolveOwner } from "../../src/harness-control-plane/owner";
 import { readLease } from "../../src/harness-control-plane/session-lease";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -14,6 +15,7 @@ let root: string;
 let workspace: string;
 let tmuxCommand: string;
 let rpcCommandEnv: string;
+let cliEnv: HarnessCliEnv;
 
 async function createFakeTmuxBin(
 	rootDir: string,
@@ -55,7 +57,7 @@ async function runHarness(args: string[]): Promise<{ code: number; json: Record<
 	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
 		cwd: workspace,
 		env: {
-			...process.env,
+			...cliEnv.env,
 			GJC_HARNESS_STATE_ROOT: root,
 			// Drive the REAL GajaeCodeRpc against a protocol fixture (no shipped fake seam).
 			GJC_HARNESS_RPC_COMMAND: rpcCommandEnv,
@@ -81,11 +83,13 @@ beforeEach(async () => {
 	// Short paths keep the AF_UNIX socket path under the sun_path limit.
 	root = await mkdtemp(path.join(tmpdir(), "h"));
 	workspace = await mkdtemp(path.join(tmpdir(), "hw"));
+	cliEnv = createHarnessCliEnv(repoRoot);
 	tmuxCommand = await createFakeTmuxBin(root);
 	rpcCommandEnv = JSON.stringify(["bun", FAKE_RPC]);
 });
 
 afterEach(async () => {
+	cliEnv.cleanup();
 	// Safety net: kill any lingering detached owner.
 	try {
 		const lease = await readLease(root, SID);

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -9,6 +9,7 @@ import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-pla
 import { acquireLease } from "../../src/harness-control-plane/session-lease";
 import { controlSocketPath, sessionPaths, writeSessionState } from "../../src/harness-control-plane/storage";
 import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -36,6 +37,7 @@ class FakeRpc implements HarnessRpc {
 let root: string;
 let owner: RuntimeOwner | null = null;
 let hungServer: net.Server | null = null;
+let cliEnv: HarnessCliEnv;
 
 function seed(workspace: string): SessionState {
 	const now = new Date().toISOString();
@@ -57,7 +59,7 @@ function seed(workspace: string): SessionState {
 async function runHarness(args: string[]): Promise<{ code: number; json: Record<string, unknown> | null }> {
 	const proc = Bun.spawn(["bun", cliEntry, "harness", ...args], {
 		cwd: root,
-		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+		env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: root },
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -89,6 +91,7 @@ const passingFinalizeChecks: FinalizeChecks = {
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "h"));
+	cliEnv = createHarnessCliEnv(repoRoot);
 	await writeSessionState(root, seed(root));
 	owner = new RuntimeOwner({
 		root,
@@ -102,6 +105,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	cliEnv.cleanup();
 	await owner?.stop();
 	await new Promise<void>(resolve => hungServer?.close(() => resolve()) ?? resolve());
 	hungServer = null;

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -1,0 +1,50 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+interface PackageManifest {
+	name?: unknown;
+}
+
+export interface HarnessCliEnv {
+	env: NodeJS.ProcessEnv;
+	cleanup(): void;
+}
+
+function readPackageName(manifestPath: string): string | null {
+	try {
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as PackageManifest;
+		return typeof manifest.name === "string" ? manifest.name : null;
+	} catch {
+		return null;
+	}
+}
+
+export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
+	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
+	const scopeDir = path.join(nodePathRoot, "@gajae-code");
+	fs.mkdirSync(scopeDir, { recursive: true });
+
+	const packagesDir = path.join(repoRoot, "packages");
+	for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const packageDir = path.join(packagesDir, entry.name);
+		const name = readPackageName(path.join(packageDir, "package.json"));
+		if (!name?.startsWith("@gajae-code/")) continue;
+		const unscopedName = name.slice("@gajae-code/".length);
+		fs.symlinkSync(packageDir, path.join(scopeDir, unscopedName), "dir");
+	}
+
+	const existingNodePath = baseEnv.NODE_PATH;
+	const env: NodeJS.ProcessEnv = {
+		...baseEnv,
+		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
+	};
+
+	return {
+		env,
+		cleanup() {
+			fs.rmSync(nodePathRoot, { recursive: true, force: true });
+		},
+	};
+}

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -6,6 +6,13 @@ interface PackageManifest {
 	name?: unknown;
 }
 
+const WORKSPACE_NODE_MODULES_ENV = "GJC_HARNESS_TEST_NODE_MODULES";
+
+interface LinkedWorkspacePackage {
+	name: string;
+	packageDir: string;
+}
+
 export interface HarnessCliEnv {
 	env: NodeJS.ProcessEnv;
 	cleanup(): void;
@@ -20,30 +27,106 @@ function readPackageName(manifestPath: string): string | null {
 	}
 }
 
-export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
-	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
-	const scopeDir = path.join(nodePathRoot, "@gajae-code");
-	fs.mkdirSync(scopeDir, { recursive: true });
-
+function collectWorkspacePackages(repoRoot: string): LinkedWorkspacePackage[] {
 	const packagesDir = path.join(repoRoot, "packages");
+	const packages: LinkedWorkspacePackage[] = [];
 	for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue;
 		const packageDir = path.join(packagesDir, entry.name);
 		const name = readPackageName(path.join(packageDir, "package.json"));
 		if (!name?.startsWith("@gajae-code/")) continue;
-		const unscopedName = name.slice("@gajae-code/".length);
-		fs.symlinkSync(packageDir, path.join(scopeDir, unscopedName), "dir");
+		packages.push({ name, packageDir });
 	}
+	return packages;
+}
+
+function linkWorkspacePackages(scopeDir: string, packages: LinkedWorkspacePackage[]): void {
+	fs.mkdirSync(scopeDir, { recursive: true });
+	for (const pkg of packages) {
+		const unscopedName = pkg.name.slice("@gajae-code/".length);
+		const linkPath = path.join(scopeDir, unscopedName);
+		try {
+			fs.symlinkSync(pkg.packageDir, linkPath, "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+		}
+	}
+}
+
+function createRepoNodeModulesLinks(repoRoot: string, packages: LinkedWorkspacePackage[]): () => void {
+	const nodeModulesDir = path.join(repoRoot, "node_modules");
+	const scopeDir = path.join(nodeModulesDir, "@gajae-code");
+	const markerDir = path.join(nodeModulesDir, ".gjc-harness-test-links");
+	const marker = path.join(markerDir, `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`);
+	fs.mkdirSync(markerDir, { recursive: true });
+	linkWorkspacePackages(scopeDir, packages);
+	fs.writeFileSync(
+		marker,
+		JSON.stringify({ createdAt: new Date().toISOString(), packages: packages.map(pkg => pkg.name) }),
+	);
+	return () => {
+		fs.rmSync(marker, { force: true });
+		// Leave node_modules itself alone: it may be a real install. Remove only links
+		// that still point at this repo's workspace packages and only after this test
+		// process has released its marker. This keeps concurrent test files from
+		// deleting each other's resolver surface.
+		const activeMarkers = fs.existsSync(markerDir)
+			? fs.readdirSync(markerDir).filter(name => name.endsWith(".json"))
+			: [];
+		if (activeMarkers.length > 0) return;
+		for (const pkg of packages) {
+			const unscopedName = pkg.name.slice("@gajae-code/".length);
+			const linkPath = path.join(scopeDir, unscopedName);
+			try {
+				if (
+					fs.lstatSync(linkPath).isSymbolicLink() &&
+					fs.realpathSync(linkPath) === fs.realpathSync(pkg.packageDir)
+				) {
+					fs.rmSync(linkPath, { force: true });
+				}
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			}
+		}
+		fs.rmSync(markerDir, { recursive: true, force: true });
+		try {
+			fs.rmdirSync(scopeDir);
+		} catch (error) {
+			if (
+				(error as NodeJS.ErrnoException).code !== "ENOENT" &&
+				(error as NodeJS.ErrnoException).code !== "ENOTEMPTY"
+			)
+				throw error;
+		}
+		try {
+			fs.rmdirSync(nodeModulesDir);
+		} catch (error) {
+			if (
+				(error as NodeJS.ErrnoException).code !== "ENOENT" &&
+				(error as NodeJS.ErrnoException).code !== "ENOTEMPTY"
+			)
+				throw error;
+		}
+	};
+}
+
+export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
+	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
+	const packages = collectWorkspacePackages(repoRoot);
+	linkWorkspacePackages(path.join(nodePathRoot, "@gajae-code"), packages);
+	const cleanupRepoLinks = createRepoNodeModulesLinks(repoRoot, packages);
 
 	const existingNodePath = baseEnv.NODE_PATH;
 	const env: NodeJS.ProcessEnv = {
 		...baseEnv,
+		[WORKSPACE_NODE_MODULES_ENV]: path.join(repoRoot, "node_modules"),
 		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
 	};
 
 	return {
 		env,
 		cleanup() {
+			cleanupRepoLinks();
 			fs.rmSync(nodePathRoot, { recursive: true, force: true });
 		},
 	};

--- a/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts
@@ -13,6 +13,12 @@ interface LinkedWorkspacePackage {
 	packageDir: string;
 }
 
+interface RepoLinkMarker {
+	createdAt: string;
+	done?: boolean;
+	links: string[];
+}
+
 export interface HarnessCliEnv {
 	env: NodeJS.ProcessEnv;
 	cleanup(): void;
@@ -40,16 +46,29 @@ function collectWorkspacePackages(repoRoot: string): LinkedWorkspacePackage[] {
 	return packages;
 }
 
-function linkWorkspacePackages(scopeDir: string, packages: LinkedWorkspacePackage[]): void {
+function linkWorkspacePackages(scopeDir: string, packages: LinkedWorkspacePackage[]): string[] {
 	fs.mkdirSync(scopeDir, { recursive: true });
+	const createdLinks: string[] = [];
 	for (const pkg of packages) {
 		const unscopedName = pkg.name.slice("@gajae-code/".length);
 		const linkPath = path.join(scopeDir, unscopedName);
 		try {
 			fs.symlinkSync(pkg.packageDir, linkPath, "dir");
+			createdLinks.push(linkPath);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
 		}
+	}
+	return createdLinks;
+}
+
+function readRepoLinkMarker(file: string): RepoLinkMarker | null {
+	try {
+		const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as RepoLinkMarker;
+		return Array.isArray(parsed.links) ? parsed : null;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
 	}
 }
 
@@ -59,29 +78,28 @@ function createRepoNodeModulesLinks(repoRoot: string, packages: LinkedWorkspaceP
 	const markerDir = path.join(nodeModulesDir, ".gjc-harness-test-links");
 	const marker = path.join(markerDir, `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`);
 	fs.mkdirSync(markerDir, { recursive: true });
-	linkWorkspacePackages(scopeDir, packages);
-	fs.writeFileSync(
-		marker,
-		JSON.stringify({ createdAt: new Date().toISOString(), packages: packages.map(pkg => pkg.name) }),
-	);
+	const createdLinks = linkWorkspacePackages(scopeDir, packages);
+	const markerData: RepoLinkMarker = { createdAt: new Date().toISOString(), links: createdLinks };
+	fs.writeFileSync(marker, JSON.stringify(markerData));
 	return () => {
-		fs.rmSync(marker, { force: true });
 		// Leave node_modules itself alone: it may be a real install. Remove only links
-		// that still point at this repo's workspace packages and only after this test
-		// process has released its marker. This keeps concurrent test files from
-		// deleting each other's resolver surface.
-		const activeMarkers = fs.existsSync(markerDir)
-			? fs.readdirSync(markerDir).filter(name => name.endsWith(".json"))
+		// these helpers actually created, and only after every overlapping helper has
+		// marked its marker done. Done markers retain link ownership metadata so the
+		// final cleanup removes links created by earlier helpers without touching
+		// pre-existing workspace-package symlinks.
+		fs.writeFileSync(marker, JSON.stringify({ ...markerData, done: true }));
+		const markerFiles = fs.existsSync(markerDir)
+			? fs
+					.readdirSync(markerDir)
+					.filter(name => name.endsWith(".json"))
+					.map(name => path.join(markerDir, name))
 			: [];
-		if (activeMarkers.length > 0) return;
-		for (const pkg of packages) {
-			const unscopedName = pkg.name.slice("@gajae-code/".length);
-			const linkPath = path.join(scopeDir, unscopedName);
+		const markers = markerFiles.map(file => readRepoLinkMarker(file)).filter(marker => marker !== null);
+		if (markers.some(marker => marker.done !== true)) return;
+		const linksToRemove = new Set(markers.flatMap(marker => marker.links));
+		for (const linkPath of linksToRemove) {
 			try {
-				if (
-					fs.lstatSync(linkPath).isSymbolicLink() &&
-					fs.realpathSync(linkPath) === fs.realpathSync(pkg.packageDir)
-				) {
+				if (fs.lstatSync(linkPath).isSymbolicLink()) {
 					fs.rmSync(linkPath, { force: true });
 				}
 			} catch (error) {
@@ -112,6 +130,7 @@ function createRepoNodeModulesLinks(repoRoot: string, packages: LinkedWorkspaceP
 
 export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv = process.env): HarnessCliEnv {
 	const nodePathRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-node-path-"));
+	const registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-harness-root-registry-"));
 	const packages = collectWorkspacePackages(repoRoot);
 	linkWorkspacePackages(path.join(nodePathRoot, "@gajae-code"), packages);
 	const cleanupRepoLinks = createRepoNodeModulesLinks(repoRoot, packages);
@@ -120,6 +139,7 @@ export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv
 	const env: NodeJS.ProcessEnv = {
 		...baseEnv,
 		[WORKSPACE_NODE_MODULES_ENV]: path.join(repoRoot, "node_modules"),
+		GJC_HARNESS_ROOT_REGISTRY_DIR: registryRoot,
 		NODE_PATH: existingNodePath ? `${nodePathRoot}${path.delimiter}${existingNodePath}` : nodePathRoot,
 	};
 
@@ -128,6 +148,7 @@ export function createHarnessCliEnv(repoRoot: string, baseEnv: NodeJS.ProcessEnv
 		cleanup() {
 			cleanupRepoLinks();
 			fs.rmSync(nodePathRoot, { recursive: true, force: true });
+			fs.rmSync(registryRoot, { recursive: true, force: true });
 		},
 	};
 }

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -42,6 +42,27 @@ function runHarness(args: string[]): HarnessResult {
 	}
 	return { code: proc.exitCode ?? 0, json, raw };
 }
+function runHarnessInCwd(args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): HarnessResult {
+	const proc = Bun.spawnSync(["bun", cliEntry, "harness", ...args], {
+		cwd,
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const raw = proc.stdout.toString().trim();
+	let json: any = null;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		// leave null; assertions will surface the raw output
+	}
+	return { code: proc.exitCode ?? 0, json, raw };
+}
+function harnessEnvWithoutStateRoot(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	delete env.GJC_HARNESS_STATE_ROOT;
+	return env;
+}
 
 function assertContract(res: any): void {
 	expect(res, `expected contract object, got: ${JSON.stringify(res)}`).toBeTruthy();
@@ -178,6 +199,49 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.observation).toHaveProperty("gitDelta");
 		expect(res.json.evidence.observation).toHaveProperty("risk");
 		expect(res.json.evidence.observation).not.toHaveProperty("pane");
+	});
+
+	it("re-acquires observe and recover by session id across cwd without state-root env", async () => {
+		await initCleanGitWorkspace();
+		const otherCwd = await mkdtemp(path.join(tmpdir(), "harness-cli-other-cwd-"));
+		try {
+			const env = harnessEnvWithoutStateRoot();
+			const started = runHarnessInCwd(
+				["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })],
+				workspace,
+				env,
+			);
+			expect(started.code).toBe(0);
+			const sessionId = started.json.evidence.handle.sessionId as string;
+
+			await appendEvent(path.join(workspace, ".gjc", "state", "harness"), sessionId, {
+				eventId: "evt-cross-cwd-prompt",
+				cursor: 1,
+				createdAt: "2026-06-03T00:00:01.000Z",
+				severity: "info",
+				kind: "prompt_accepted",
+				state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+				evidence: { signal: "prompt-accepted" },
+				nextAllowedActions: [],
+				writer: { ownerId: "owner-exited", leaseEpoch: 1 },
+			});
+
+			const observed = runHarnessInCwd(["observe", "--session", sessionId], otherCwd, env);
+			expect(observed.code).toBe(0);
+			assertContract(observed.json);
+			expect(observed.json.state.sessionId).toBe(sessionId);
+			expect(observed.json.evidence.observation.cwd).toBe(workspace);
+			expect(observed.json.evidence.observation.observedSignals).toContain("prompt-accepted");
+
+			const recovered = runHarnessInCwd(["recover", "--session", sessionId], otherCwd, env);
+			expect(recovered.code).toBe(1);
+			assertContract(recovered.json);
+			expect(recovered.json.state.sessionId).toBe(sessionId);
+			expect(recovered.json.evidence.reason).toBe("owner-exited-after-prompt-acceptance");
+			expect(recovered.json.evidence.observation.cwd).toBe(workspace);
+		} finally {
+			await rm(otherCwd, { recursive: true, force: true });
+		}
 	});
 
 	it("observe exposes durable completion evidence after the owner has exited", async () => {

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { appendEvent, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
@@ -116,6 +116,32 @@ async function appendSignal(sessionId: string, cursor: number, signal: string): 
 }
 
 describe("gjc harness CLI (foundation)", () => {
+	it("test CLI env cleanup removes overlapping created links and preserves pre-existing links", async () => {
+		const fakeRepo = await mkdtemp(path.join(tmpdir(), "harness-cli-env-repo-"));
+		try {
+			const packageDir = path.join(fakeRepo, "packages", "ai");
+			await mkdir(packageDir, { recursive: true });
+			await writeFile(path.join(packageDir, "package.json"), JSON.stringify({ name: "@gajae-code/ai" }), "utf8");
+			const linkPath = path.join(fakeRepo, "node_modules", "@gajae-code", "ai");
+
+			const first = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			const second = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
+			first.cleanup();
+			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
+			second.cleanup();
+			expect(await Bun.file(linkPath).exists()).toBe(false);
+
+			await mkdir(path.dirname(linkPath), { recursive: true });
+			await symlink(packageDir, linkPath, "dir");
+			const withPreexistingLink = createHarnessCliEnv(fakeRepo, {} as NodeJS.ProcessEnv);
+			withPreexistingLink.cleanup();
+			expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
+		} finally {
+			await rm(fakeRepo, { recursive: true, force: true });
+		}
+	});
+
 	it("preflight rejects a declared branch that differs from the actual checkout", async () => {
 		await initCleanGitWorkspace();
 		const res = runHarness([
@@ -173,6 +199,36 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.evidence.handle.issueOrPr).toBe("266");
 		expect(res.json.evidence.preflight.ok).toBe(true);
 	});
+
+	it("resolves documented relative workspace sessions across caller cwd changes", async () => {
+		await initCleanGitWorkspace();
+		const siblingCwd = await mkdtemp(path.join(tmpdir(), "harness-cli-other-cwd-"));
+		try {
+			const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace: "." })]);
+			expect(started.code).toBe(0);
+			const sessionId = started.json.state.sessionId;
+			expect(started.json.evidence.handle.workspace).toBe(workspace);
+
+			const observed = runHarnessInCwd(
+				["observe", "--session", sessionId, "--input", JSON.stringify({ workspace: "." })],
+				siblingCwd,
+				{ ...cliEnv.env },
+			);
+			expect(observed.code).toBe(1);
+			expect(observed.json.error).toContain("session_workspace_mismatch");
+
+			const observedFromWorkspace = runHarnessInCwd(
+				["observe", "--session", sessionId, "--input", JSON.stringify({ workspace: "." })],
+				workspace,
+				{ ...cliEnv.env },
+			);
+			expect(observedFromWorkspace.code).toBe(0);
+			expect(observedFromWorkspace.json.evidence.observation.cwd).toBe(workspace);
+		} finally {
+			await rm(siblingCwd, { recursive: true, force: true });
+		}
+	});
+
 	it("start creates a session and reports submit owner-not-live", () => {
 		const res = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
 		expect(res.code).toBe(0);

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -3,19 +3,23 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { appendEvent, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 
 let root: string;
 let workspace: string;
+let cliEnv: HarnessCliEnv;
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-cli-root-"));
 	workspace = await mkdtemp(path.join(tmpdir(), "harness-cli-ws-"));
+	cliEnv = createHarnessCliEnv(repoRoot);
 });
 
 afterEach(async () => {
+	cliEnv.cleanup();
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });
@@ -29,7 +33,7 @@ interface HarnessResult {
 function runHarness(args: string[]): HarnessResult {
 	const proc = Bun.spawnSync(["bun", cliEntry, "harness", ...args], {
 		cwd: workspace,
-		env: { ...process.env, GJC_HARNESS_STATE_ROOT: root },
+		env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: root },
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -59,7 +63,7 @@ function runHarnessInCwd(args: string[], cwd: string, env: NodeJS.ProcessEnv = p
 	return { code: proc.exitCode ?? 0, json, raw };
 }
 function harnessEnvWithoutStateRoot(): NodeJS.ProcessEnv {
-	const env = { ...process.env };
+	const env = { ...cliEnv.env };
 	delete env.GJC_HARNESS_STATE_ROOT;
 	return env;
 }

--- a/packages/coding-agent/test/harness-control-plane/storage.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/storage.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import {
@@ -12,7 +12,9 @@ import {
 	readEvents,
 	readReceiptIndex,
 	readSessionState,
+	rememberHarnessSessionRoot,
 	resolveHarnessRoot,
+	resolveHarnessSessionRoot,
 	StorageError,
 	sessionPaths,
 	writeReceiptImmutable,
@@ -26,6 +28,7 @@ import {
 } from "../../src/harness-control-plane/types";
 
 let root: string;
+let registrySessionIds: string[] = [];
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-store-"));
@@ -33,6 +36,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	await rm(root, { recursive: true, force: true });
+	for (const id of registrySessionIds) {
+		await rm(path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${id}.json`), { force: true });
+	}
+	registrySessionIds = [];
 });
 
 function state(sessionId: string): SessionState {
@@ -62,6 +69,14 @@ function envelope(cursor: number): EventEnvelope {
 		nextAllowedActions: [],
 		writer: { ownerId: "owner-1", leaseEpoch: 1 },
 	};
+}
+
+function registryPath(sessionId: string): string {
+	return path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${sessionId}.json`);
+}
+
+function mode(bits: number): number {
+	return bits & 0o777;
 }
 
 describe("harness storage", () => {
@@ -182,5 +197,54 @@ describe("harness storage", () => {
 		);
 		const socketPath = controlSocketPath(root, id, { GJC_HARNESS_SOCKET_DIR: socketDir } as NodeJS.ProcessEnv);
 		expect(path.basename(socketPath)).toBe(`c-${digest.slice(0, 24)}.sock`);
+	});
+
+	it("does not pick an arbitrary registered root when explicit session ids collide", async () => {
+		const id = `h-collide-${process.pid}`;
+		registrySessionIds.push(id);
+		const leftRoot = await mkdtemp(path.join(tmpdir(), "h-left-"));
+		const rightRoot = await mkdtemp(path.join(tmpdir(), "h-right-"));
+		try {
+			await writeSessionState(leftRoot, { ...state(id), handle: { ...state(id).handle, workspace: "/repo/left" } });
+			await writeSessionState(rightRoot, {
+				...state(id),
+				handle: { ...state(id).handle, workspace: "/repo/right" },
+			});
+			await rememberHarnessSessionRoot(leftRoot, id);
+			await rememberHarnessSessionRoot(rightRoot, id);
+
+			await expect(resolveHarnessSessionRoot(root, id)).rejects.toThrow(/ambiguous_harness_session_root/);
+			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/left" })).toBe(
+				path.resolve(leftRoot),
+			);
+			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/right" })).toBe(
+				path.resolve(rightRoot),
+			);
+			await expect(
+				resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/missing" }),
+			).rejects.toThrow(/session_workspace_mismatch/);
+		} finally {
+			await rm(leftRoot, { recursive: true, force: true });
+			await rm(rightRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("stores global registry files with private permissions", async () => {
+		const id = `h-private-${process.pid}`;
+		registrySessionIds.push(id);
+		const file = registryPath(id);
+		const dir = path.dirname(file);
+		await rm(dir, { recursive: true, force: true });
+		await rememberHarnessSessionRoot(root, id);
+		const dirStat = await stat(dir);
+		const fileStat = await stat(file);
+		expect(mode(dirStat.mode)).toBe(0o700);
+		expect(mode(fileStat.mode)).toBe(0o600);
+
+		await chmod(dir, 0o775);
+		await chmod(file, 0o664);
+		await rememberHarnessSessionRoot(root, id);
+		expect(mode((await stat(dir)).mode)).toBe(0o700);
+		expect(mode((await stat(file)).mode)).toBe(0o600);
 	});
 });

--- a/packages/coding-agent/test/harness-control-plane/storage.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/storage.test.ts
@@ -28,18 +28,18 @@ import {
 } from "../../src/harness-control-plane/types";
 
 let root: string;
-let registrySessionIds: string[] = [];
+let registryRoot: string;
+let registryEnv: NodeJS.ProcessEnv;
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-store-"));
+	registryRoot = await mkdtemp(path.join(tmpdir(), "harness-root-registry-"));
+	registryEnv = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryRoot };
 });
 
 afterEach(async () => {
 	await rm(root, { recursive: true, force: true });
-	for (const id of registrySessionIds) {
-		await rm(path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${id}.json`), { force: true });
-	}
-	registrySessionIds = [];
+	await rm(registryRoot, { recursive: true, force: true });
 });
 
 function state(sessionId: string): SessionState {
@@ -72,7 +72,7 @@ function envelope(cursor: number): EventEnvelope {
 }
 
 function registryPath(sessionId: string): string {
-	return path.join(tmpdir(), `gjch${process.getuid?.() ?? "u"}`, "harness-roots", `${sessionId}.json`);
+	return path.join(registryRoot, `${sessionId}.json`);
 }
 
 function mode(bits: number): number {
@@ -201,7 +201,6 @@ describe("harness storage", () => {
 
 	it("does not pick an arbitrary registered root when explicit session ids collide", async () => {
 		const id = `h-collide-${process.pid}`;
-		registrySessionIds.push(id);
 		const leftRoot = await mkdtemp(path.join(tmpdir(), "h-left-"));
 		const rightRoot = await mkdtemp(path.join(tmpdir(), "h-right-"));
 		try {
@@ -210,18 +209,20 @@ describe("harness storage", () => {
 				...state(id),
 				handle: { ...state(id).handle, workspace: "/repo/right" },
 			});
-			await rememberHarnessSessionRoot(leftRoot, id);
-			await rememberHarnessSessionRoot(rightRoot, id);
+			await rememberHarnessSessionRoot(leftRoot, id, registryEnv);
+			await rememberHarnessSessionRoot(rightRoot, id, registryEnv);
 
-			await expect(resolveHarnessSessionRoot(root, id)).rejects.toThrow(/ambiguous_harness_session_root/);
-			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/left" })).toBe(
+			await expect(resolveHarnessSessionRoot(root, id, registryEnv)).rejects.toThrow(
+				/ambiguous_harness_session_root/,
+			);
+			expect(await resolveHarnessSessionRoot(root, id, registryEnv, { expectedWorkspace: "/repo/left" })).toBe(
 				path.resolve(leftRoot),
 			);
-			expect(await resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/right" })).toBe(
+			expect(await resolveHarnessSessionRoot(root, id, registryEnv, { expectedWorkspace: "/repo/right" })).toBe(
 				path.resolve(rightRoot),
 			);
 			await expect(
-				resolveHarnessSessionRoot(root, id, process.env, { expectedWorkspace: "/repo/missing" }),
+				resolveHarnessSessionRoot(root, id, registryEnv, { expectedWorkspace: "/repo/missing" }),
 			).rejects.toThrow(/session_workspace_mismatch/);
 		} finally {
 			await rm(leftRoot, { recursive: true, force: true });
@@ -229,13 +230,31 @@ describe("harness storage", () => {
 		}
 	});
 
+	it("uses expectedWorkspace registry disambiguation instead of stale local same-session state", async () => {
+		const id = `h-stale-local-${process.pid}`;
+		const registeredRoot = await mkdtemp(path.join(tmpdir(), "h-registered-"));
+		try {
+			await writeSessionState(root, { ...state(id), handle: { ...state(id).handle, workspace: "/repo/stale" } });
+			await writeSessionState(registeredRoot, {
+				...state(id),
+				handle: { ...state(id).handle, workspace: "/repo/expected" },
+			});
+			await rememberHarnessSessionRoot(registeredRoot, id, registryEnv);
+
+			expect(await resolveHarnessSessionRoot(root, id, registryEnv, { expectedWorkspace: "/repo/expected" })).toBe(
+				path.resolve(registeredRoot),
+			);
+		} finally {
+			await rm(registeredRoot, { recursive: true, force: true });
+		}
+	});
+
 	it("stores global registry files with private permissions", async () => {
 		const id = `h-private-${process.pid}`;
-		registrySessionIds.push(id);
 		const file = registryPath(id);
 		const dir = path.dirname(file);
 		await rm(dir, { recursive: true, force: true });
-		await rememberHarnessSessionRoot(root, id);
+		await rememberHarnessSessionRoot(root, id, registryEnv);
 		const dirStat = await stat(dir);
 		const fileStat = await stat(file);
 		expect(mode(dirStat.mode)).toBe(0o700);
@@ -243,7 +262,7 @@ describe("harness storage", () => {
 
 		await chmod(dir, 0o775);
 		await chmod(file, 0o664);
-		await rememberHarnessSessionRoot(root, id);
+		await rememberHarnessSessionRoot(root, id, registryEnv);
 		expect(mode((await stat(dir)).mode)).toBe(0o700);
 		expect(mode((await stat(file)).mode)).toBe(0o600);
 	});


### PR DESCRIPTION
Fixes #354. Supersedes/updates the verification blocker from #357.

## Summary
- keep the #357 storage/session lookup contract intact
- add a harness CLI test helper that gives spawned `bun packages/coding-agent/src/cli.ts ...` processes a test-only `NODE_PATH` bridge to the repo workspace packages
- apply that helper to harness CLI tests that run from temp workspaces or spawn detached/tmux owners, so targeted CLI contract tests no longer depend on pre-existing `node_modules/@gajae-code/*` symlinks in a fresh checkout
- review-blocker follow-up: persist and match harness workspaces by canonical absolute path, disambiguate registered roots before stale local same-session state rejects `expectedWorkspace`, isolate test registry roots, and make test symlink cleanup remove only links it created

## Diagnosis
The targeted harness tests spawn the source CLI from temp cwd values. In this checkout, removing a workspace symlink such as `node_modules/@gajae-code/ai` reproduces the review blocker: Bun aborts before harness code runs with `Cannot find module '@gajae-code/ai' from .../packages/coding-agent/src/cli.ts`. The lookup fix itself is storage-level, but the spawned source CLI needs workspace package resolution before the harness command can execute.

The current review blockers were caused by relative workspace metadata and ambiguous same-session roots escaping the storage-level contract: `workspace:"."` could be persisted verbatim and later matched from a different caller cwd, while a stale local root could reject a correct registered root before registry disambiguation.

## Verification
- `bun test packages/coding-agent/test/harness-control-plane/storage.test.ts packages/coding-agent/test/harness-control-plane/cli.test.ts packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts` — 43 pass / 0 fail
- `bunx biome check packages/coding-agent/src/commands/harness.ts packages/coding-agent/src/harness-control-plane/storage.ts packages/coding-agent/test/harness-control-plane/cli-workspace-env.ts packages/coding-agent/test/harness-control-plane/cli.test.ts packages/coding-agent/test/harness-control-plane/storage.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`
- Red-team review: PASS / no remaining PR #363 blocker
