### PR TITLE
fix(gjc): suspend TUI around contribute-pr worker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Preserved harness owner-vanish evidence after prompt acceptance: no-owner `recover` now either restores a detached owner when a prior endpoint exists or returns a public-safe concrete owner-exit reason plus a vanish receipt, and no-owner `observe`/`events` expose the preserved owner-exit summary.
 
+### Fixed
+
+- Suspended and restored the parent TUI around `/contribute-pr` worker launches and awaited the child exit so the fresh worker no longer races the original input box or leaves terminal state corrupted.
+
 ## [0.3.2] - 2026-06-05
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -38,6 +38,7 @@ import { buildHotkeysMarkdown } from "../../modes/utils/hotkeys-markdown";
 import { buildToolsMarkdown } from "../../modes/utils/tools-markdown";
 import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage } from "../../session/auth-storage";
+import { spawnContributionPrepWorker } from "../../session/contribution-prep";
 import type { NewSessionOptions } from "../../session/session-manager";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
@@ -1252,7 +1253,19 @@ export class CommandController {
 	async handleContributionPrepCommand(customInstructions?: string): Promise<void> {
 		this.ctx.editor.setText("");
 		try {
-			const result = await this.ctx.session.prepareContributionPrep({ customInstructions, spawnWorker: true });
+			const result = await this.ctx.session.prepareContributionPrep({
+				customInstructions,
+				spawnWorker: true,
+				spawn: async (args, cwd, shell) => {
+					this.ctx.ui.stop();
+					try {
+						await spawnContributionPrepWorker(args, cwd, shell);
+					} finally {
+						this.ctx.ui.start();
+						this.ctx.ui.requestRender(true);
+					}
+				},
+			});
 			this.ctx.showStatus(
 				[
 					"Contribution prep artifacts written.",

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -179,6 +179,23 @@ async function writeArtifact(
 	return { path: filePath, description };
 }
 
+export async function spawnContributionPrepWorker(args: string[], cwd: string, shell: boolean): Promise<void> {
+	const child = shell
+		? Bun.spawn({
+				cmd: args,
+				cwd,
+				stdout: "inherit",
+				stderr: "inherit",
+				stdin: "inherit",
+				windowsVerbatimArguments: true,
+			})
+		: Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
+	const exitCode = await child.exited;
+	if (exitCode !== 0) {
+		throw new Error(`contribute-pr worker exited with code ${exitCode}`);
+	}
+}
+
 export function buildContributionPrepWorkerPrompt(manifestPath: string): string {
 	return [
 		"Prepare a maintainer-friendly contribution draft from the redacted context dump.",
@@ -291,22 +308,7 @@ export async function prepareContributionPrep(
 
 	let spawned = false;
 	if (options.spawnWorker) {
-		const spawn =
-			options.spawn ??
-			(async (args, cwd, shell) => {
-				if (shell) {
-					Bun.spawn({
-						cmd: args,
-						cwd,
-						stdout: "inherit",
-						stderr: "inherit",
-						stdin: "inherit",
-						windowsVerbatimArguments: true,
-					});
-					return;
-				}
-				Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
-			});
+		const spawn = options.spawn ?? spawnContributionPrepWorker;
 		const command = resolveGjcCommand();
 		await spawn(
 			[command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`],

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { CommandController } from "@gajae-code/coding-agent/modes/controllers/command-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import type { Subprocess } from "bun";
 
 function createContainer() {
 	return {
@@ -13,6 +14,13 @@ function createContainer() {
 			this.children = [];
 		},
 	};
+}
+
+function createFakeProcess(exitCode = 0): Subprocess {
+	return {
+		pid: 12345,
+		exited: Promise.resolve(exitCode),
+	} as Subprocess;
 }
 
 describe("/handoff command", () => {
@@ -94,7 +102,7 @@ describe("/handoff command", () => {
 			},
 			statusContainer,
 			chatContainer,
-			ui: { requestRender },
+			ui: { requestRender, start: vi.fn(), stop: vi.fn() },
 			editor: { setText: vi.fn() },
 			rebuildChatFromMessages: vi.fn(),
 			statusLine: { invalidate: vi.fn() },
@@ -105,14 +113,69 @@ describe("/handoff command", () => {
 
 		await controller.handleContributionPrepCommand("focus on repro");
 
-		expect(ctx.session.prepareContributionPrep).toHaveBeenCalledWith({
-			customInstructions: "focus on repro",
-			spawnWorker: true,
-		});
+		expect(ctx.session.prepareContributionPrep).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customInstructions: "focus on repro",
+				spawnWorker: true,
+				spawn: expect.any(Function),
+			}),
+		);
 		expect(ctx.rebuildChatFromMessages).not.toHaveBeenCalled();
 		expect(ctx.statusLine.invalidate).not.toHaveBeenCalled();
 		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("Manifest: /tmp/prep/manifest.json"));
 		expect(chatContainer.children).toHaveLength(1);
 		expect(requestRender).toHaveBeenCalled();
+	});
+
+	it("suspends the TUI while the spawned contribute-pr worker owns the terminal", async () => {
+		const spawnCalls: Array<unknown> = [];
+		vi.spyOn(Bun, "spawn").mockImplementation((first: unknown) => {
+			spawnCalls.push(first);
+			return createFakeProcess();
+		});
+
+		const chatContainer = createContainer();
+		const requestRender = vi.fn();
+		const start = vi.fn();
+		const stop = vi.fn();
+		const ctx = {
+			sessionManager: { getEntries: () => [{ type: "message" }, { type: "message" }] },
+			session: {
+				prepareContributionPrep: vi.fn(
+					async (options: {
+						spawn?: (args: string[], cwd: string, shell: boolean) => Promise<void>;
+						customInstructions?: string;
+						spawnWorker?: boolean;
+					}) => {
+						await options.spawn?.(["gjc", "--no-skills", "--", "@/tmp/prep/worker-prompt.md"], "/repo", false);
+						return {
+							manifestPath: "/tmp/prep/manifest.json",
+							workerPromptPath: "/tmp/prep/worker-prompt.md",
+							artifactDir: "/tmp/prep",
+							changedFiles: [],
+							spawned: true,
+						};
+					},
+				),
+			},
+			statusContainer: createContainer(),
+			chatContainer,
+			ui: { requestRender, start, stop },
+			editor: { setText: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			statusLine: { invalidate: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		await controller.handleContributionPrepCommand();
+
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledWith(true);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]).toEqual(["gjc", "--no-skills", "--", "@/tmp/prep/worker-prompt.md"]);
+		expect(ctx.showError).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- suspend the parent TUI while `/contribute-pr` hands the terminal to the spawned worker
- await the spawned worker exit and surface non-zero exits instead of returning immediately
- add a regression test that asserts the TUI stop/start lifecycle around the worker spawn
- add an Unreleased changelog entry

## Verification
- `bun test packages/coding-agent/test/contribution-prep.test.ts packages/coding-agent/test/modes/controllers/handoff-command.test.ts packages/coding-agent/test/changelog.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/session/contribution-prep.ts packages/coding-agent/src/modes/controllers/command-controller.ts packages/coding-agent/test/modes/controllers/handoff-command.test.ts packages/coding-agent/CHANGELOG.md`

## contribute-pr
- Ran `gjc contribute-pr --no-spawn --source-session-id terminal-fix-pr` to generate the contribution-prep manifest/artifacts before drafting the original PR. Artifacts were local runtime state and were not committed.

Supersedes #360, which targeted `main` by mistake.