### PR TITLE
fix(gjc): scope stale state doctor fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Preserved harness owner-vanish evidence after prompt acceptance: no-owner `recover` now either restores a detached owner when a prior endpoint exists or returns a public-safe concrete owner-exit reason plus a vanish receipt, and no-owner `observe`/`events` expose the preserved owner-exit summary.
 
+### Fixed
+
+- Included the diagnosed `--session-id` in `gjc state doctor` stale active-state fix commands so session-scoped HUD snapshots can be cleared without accidentally targeting the current session.
+
 ## [0.3.2] - 2026-06-05
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -447,6 +447,13 @@ function skillFromActiveValue(value: unknown): string | undefined {
 function activeFlag(value: unknown): boolean {
 	return isPlainObject(value) && value.active !== false;
 }
+function shellWord(value: string): string {
+	return /^[A-Za-z0-9._-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function stateClearFixCommand(skill: CanonicalGjcWorkflowSkill, sessionId: string | undefined): string {
+	return sessionId ? `gjc state ${skill} clear --session-id ${shellWord(sessionId)}` : `gjc state ${skill} clear`;
+}
 
 async function collectDoctorSummary(
 	cwd: string,
@@ -546,7 +553,7 @@ async function collectDoctorSummary(
 						"stale_active_state",
 						entryPath,
 						`active entry for ${entrySkill} does not match a live active mode-state`,
-						canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+						canonical ? stateClearFixCommand(canonical, scopeSessionId) : "gjc state prune --hard",
 						canonical ?? undefined,
 					),
 				);
@@ -565,7 +572,7 @@ async function collectDoctorSummary(
 							"stale_active_state",
 							snapshotPath,
 							`active snapshot lists ${entrySkill} but no raw per-skill active entry exists`,
-							canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+							canonical ? stateClearFixCommand(canonical, scopeSessionId) : "gjc state prune --hard",
 							canonical ?? undefined,
 						),
 					);

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -208,4 +208,31 @@ describe("gjc state doctor", () => {
 			}),
 		]);
 	});
+
+	it("prints a session-scoped clear command for stale active snapshots in old sessions", async () => {
+		const root = await tempDir();
+		const sessionId = "old-session";
+		const sessionRoot = path.join(root, ".gjc", "state", "sessions", sessionId);
+		const snapshotPath = path.join(sessionRoot, "skill-active-state.json");
+		await writeJson(snapshotPath, {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			phase: "final",
+			session_id: sessionId,
+			active_skills: [{ skill: "ralplan", active: true, phase: "final", session_id: sessionId }],
+		});
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "ralplan",
+				path: snapshotPath,
+				fixCommand: "gjc state ralplan clear --session-id old-session",
+			}),
+		]);
+	});
 });


### PR DESCRIPTION
## Summary
- include the diagnosed `--session-id` in `gjc state doctor` stale active-state fix commands
- keep session-scoped HUD cleanup from accidentally targeting the current session
- add regression coverage for the session-scoped fix command

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/state-doctor.test.ts packages/coding-agent/test/changelog.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/gjc-runtime/state-runtime.ts packages/coding-agent/test/gjc-runtime/state-doctor.test.ts packages/coding-agent/CHANGELOG.md`

Supersedes #358, which targeted `main` by mistake.