### PR TITLE
fix(gjc): scope stale state doctor fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Preserved harness owner-vanish evidence after prompt acceptance: no-owner `recover` now either restores a detached owner when a prior endpoint exists or returns a public-safe concrete owner-exit reason plus a vanish receipt, and no-owner `observe`/`events` expose the preserved owner-exit summary.
 
+### Fixed
+
+- Included the diagnosed `--session-id` in `gjc state doctor` stale active-state fix commands so session-scoped HUD snapshots can be cleared without accidentally targeting the current session.
+
 ## [0.3.2] - 2026-06-05
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -436,16 +436,29 @@ function doctorProblem(
 		: { type, path: pathValue, message, fixCommand };
 }
 
-function activeEntryDir(cwd: string, sessionId: string | undefined): string {
-	return path.join(stateDirFor(cwd, sessionId), "active");
-}
-
 function skillFromActiveValue(value: unknown): string | undefined {
 	return isPlainObject(value) && typeof value.skill === "string" ? value.skill : undefined;
 }
 
 function activeFlag(value: unknown): boolean {
 	return isPlainObject(value) && value.active !== false;
+}
+function shellWord(value: string): string {
+	return /^[A-Za-z0-9._-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function stateClearFixCommand(skill: CanonicalGjcWorkflowSkill, sessionId: string | undefined): string {
+	return sessionId ? `gjc state ${skill} clear --session-id ${shellWord(sessionId)}` : `gjc state ${skill} clear`;
+}
+
+function decodeDoctorSessionDirName(rawSession: string): string | undefined {
+	try {
+		const decoded = decodeURIComponent(rawSession);
+		if (!PATH_COMPONENT_RE.test(decoded) || decoded.includes("..")) return undefined;
+		return encodeSessionSegment(decoded) === rawSession ? decoded : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 async function collectDoctorSummary(
@@ -523,11 +536,17 @@ async function collectDoctorSummary(
 		}
 	}
 
-	const inspectActiveScope = async (scopeSessionId: string | undefined): Promise<void> => {
-		const snapshotPath = activeStateFile(cwd, scopeSessionId);
+	const inspectActiveScope = async (
+		scopeRoot: string,
+		scopeSessionId: string | undefined,
+		unsafeSessionDir: boolean,
+	): Promise<void> => {
+		const staleFixCommand = (canonical: CanonicalGjcWorkflowSkill): string =>
+			unsafeSessionDir ? "gjc state prune --hard" : stateClearFixCommand(canonical, scopeSessionId);
+		const snapshotPath = path.join(scopeRoot, SKILL_ACTIVE_STATE_FILE);
 		const snapshot = await readRawJson(snapshotPath);
 		if (snapshot.exists) filesScanned += 1;
-		const entryFiles = await listJsonFiles(activeEntryDir(cwd, scopeSessionId));
+		const entryFiles = await listJsonFiles(path.join(scopeRoot, "active"));
 		const entrySkills = new Set<string>();
 		for (const entryPath of entryFiles) {
 			filesScanned += 1;
@@ -536,9 +555,7 @@ async function collectDoctorSummary(
 			entrySkills.add(entrySkill);
 			const canonical = canonicalWorkflowSkill(entrySkill);
 			if (canonical && !skills.includes(canonical)) continue;
-			const statePath = canonical
-				? modeStateFile(cwd, canonical, scopeSessionId)
-				: path.join(root, `${entrySkill}-state.json`);
+			const statePath = path.join(scopeRoot, `${canonical ?? entrySkill}-state.json`);
 			const state = await readRawJson(statePath);
 			if (activeFlag(entry.value) && (!state.exists || !activeFlag(state.value))) {
 				problems.push(
@@ -546,7 +563,7 @@ async function collectDoctorSummary(
 						"stale_active_state",
 						entryPath,
 						`active entry for ${entrySkill} does not match a live active mode-state`,
-						canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+						canonical ? staleFixCommand(canonical) : "gjc state prune --hard",
 						canonical ?? undefined,
 					),
 				);
@@ -565,7 +582,7 @@ async function collectDoctorSummary(
 							"stale_active_state",
 							snapshotPath,
 							`active snapshot lists ${entrySkill} but no raw per-skill active entry exists`,
-							canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+							canonical ? staleFixCommand(canonical) : "gjc state prune --hard",
 							canonical ?? undefined,
 						),
 					);
@@ -574,7 +591,7 @@ async function collectDoctorSummary(
 		}
 	};
 
-	await inspectActiveScope(sessionId);
+	await inspectActiveScope(stateDirFor(cwd, sessionId), sessionId, false);
 	if (!sessionId) {
 		const sessionsDir = path.join(root, "sessions");
 		let sessions: string[] = [];
@@ -588,7 +605,10 @@ async function collectDoctorSummary(
 			const err = error as NodeJS.ErrnoException;
 			if (err.code !== "ENOENT") throw error;
 		}
-		for (const rawSession of sessions) await inspectActiveScope(decodeURIComponent(rawSession));
+		for (const rawSession of sessions) {
+			const decodedSession = decodeDoctorSessionDirName(rawSession);
+			await inspectActiveScope(path.join(sessionsDir, rawSession), decodedSession, decodedSession === undefined);
+		}
 	}
 
 	problems.sort(

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -579,6 +579,17 @@ function activeStateWriterAudit(verb: string) {
 	return { category: "state" as const, verb, owner: "gjc-runtime" as const };
 }
 
+async function readRootActiveEntry(cwd: string, skill: string): Promise<SkillActiveEntry | null> {
+	try {
+		const text = await Bun.file(path.join(cwd, ".gjc", "state", "active", `${encodePathSegment(skill)}.json`)).text();
+		return normalizeEntry(JSON.parse(text));
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return null;
+		return null;
+	}
+}
+
 async function persistActiveEntry(
 	cwd: string,
 	sessionScope: ActiveSessionScope | undefined,
@@ -653,10 +664,20 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 				? { active_subskills: preservedActiveSubskills }
 				: {}),
 	};
-	await persistActiveEntry(options.cwd, undefined, entry);
-	await rebuildActiveState(options.cwd);
+	if (!options.sessionId) {
+		await persistActiveEntry(options.cwd, undefined, entry);
+		await rebuildActiveState(options.cwd);
+		return;
+	}
 
-	if (!options.sessionId) return;
+	const rootEntry = await readRootActiveEntry(options.cwd, options.skill);
+	const rootEntrySessionId = safeString(rootEntry?.session_id).trim();
+	const shouldUpdateRoot = entry.active !== false || rootEntrySessionId === options.sessionId;
+	if (shouldUpdateRoot) {
+		await persistActiveEntry(options.cwd, undefined, entry);
+		await rebuildActiveState(options.cwd);
+	}
+
 	const sessionScope = { sessionId: options.sessionId };
 	await persistActiveEntry(options.cwd, sessionScope, entry);
 	await rebuildActiveState(options.cwd, sessionScope);

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -29,6 +29,17 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 	await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
 async function snapshotFiles(root: string): Promise<Map<string, { bytes: Buffer; mtimeMs: number }>> {
 	const out = new Map<string, { bytes: Buffer; mtimeMs: number }>();
 	async function visit(dir: string): Promise<void> {
@@ -207,5 +218,108 @@ describe("gjc state doctor", () => {
 				fixCommand: "gjc state team clear",
 			}),
 		]);
+	});
+
+	it("prints a session-scoped clear command for stale active snapshots in old sessions", async () => {
+		const root = await tempDir();
+		const sessionId = "old-session";
+		const sessionRoot = path.join(root, ".gjc", "state", "sessions", sessionId);
+		const snapshotPath = path.join(sessionRoot, "skill-active-state.json");
+		await writeJson(snapshotPath, {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			phase: "final",
+			session_id: sessionId,
+			active_skills: [{ skill: "ralplan", active: true, phase: "final", session_id: sessionId }],
+		});
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "ralplan",
+				path: snapshotPath,
+				fixCommand: "gjc state ralplan clear --session-id old-session",
+			}),
+		]);
+	});
+
+	it("executes a session-scoped stale active fix without clearing current-session HUD state", async () => {
+		const root = await tempDir();
+		const stateRoot = path.join(root, ".gjc", "state");
+		const sessionId = "old-session";
+		const sessionRoot = path.join(stateRoot, "sessions", sessionId);
+		const oldSnapshotPath = path.join(sessionRoot, "skill-active-state.json");
+		const currentSnapshotPath = path.join(stateRoot, "skill-active-state.json");
+		const currentEntryPath = path.join(stateRoot, "active", "ralplan.json");
+		await writeJson(oldSnapshotPath, {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			phase: "final",
+			session_id: sessionId,
+			active_skills: [{ skill: "ralplan", active: true, phase: "final", session_id: sessionId }],
+		});
+		const currentModePath = await writeStampedState(root, "ralplan", {
+			active: true,
+			current_phase: "planner",
+		});
+		await writeJson(currentEntryPath, { skill: "ralplan", active: true, phase: "planner" });
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({
+				type: "stale_active_state",
+				skill: "ralplan",
+				path: oldSnapshotPath,
+				fixCommand: "gjc state ralplan clear --session-id old-session",
+			}),
+		]);
+
+		const fix = await runNativeStateCommand(["ralplan", "clear", "--session-id", sessionId], root);
+		expect(fix.status).toBe(0);
+		const fixedOldSnapshot = JSON.parse(await fs.readFile(oldSnapshotPath, "utf-8")) as { active?: boolean };
+		expect(fixedOldSnapshot.active).toBe(false);
+		expect(await fileExists(currentSnapshotPath)).toBe(true);
+		expect(await fileExists(currentEntryPath)).toBe(true);
+		expect(await fileExists(currentModePath)).toBe(true);
+		const afterFix = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(afterFix.status).toBe(0);
+		expect(JSON.parse(afterFix.stdout ?? "{}").problems).toEqual([]);
+	});
+
+	it("does not emit invalid clear commands for hostile encoded session directories", async () => {
+		const root = await tempDir();
+		const stateRoot = path.join(root, ".gjc", "state");
+		const hostileSnapshotPath = path.join(stateRoot, "sessions", "weird%3Bid", "skill-active-state.json");
+		const malformedSnapshotPath = path.join(stateRoot, "sessions", "bad%ZZ", "skill-active-state.json");
+		await writeJson(hostileSnapshotPath, {
+			version: 1,
+			active: true,
+			skill: "ralplan",
+			active_skills: [{ skill: "ralplan", active: true }],
+		});
+		await writeJson(malformedSnapshotPath, {
+			version: 1,
+			active: true,
+			skill: "team",
+			active_skills: [{ skill: "team", active: true }],
+		});
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}") as {
+			problems: Array<{ path: string; fixCommand: string }>;
+		};
+		expect(parsed.problems).toEqual([
+			expect.objectContaining({ path: hostileSnapshotPath, fixCommand: "gjc state prune --hard" }),
+			expect.objectContaining({ path: malformedSnapshotPath, fixCommand: "gjc state prune --hard" }),
+		]);
+		expect(parsed.problems.some(problem => problem.fixCommand.includes("--session-id"))).toBe(false);
+		expect(JSON.stringify(parsed.problems)).not.toContain("weird;id");
 	});
 });


### PR DESCRIPTION
## Summary
- include the diagnosed `--session-id` in stale active-state fix commands for safe old session scopes
- avoid decoding hostile/malformed session directory names into rejected `clear --session-id` commands
- inspect session active-state paths from the actual session directory root so malformed percent-encoding cannot crash doctor
- preserve current/root HUD active entries when clearing an old session-scoped state

## Review follow-up
Addresses the blocker from #366:
- hostile encoded dir such as `weird%3Bid` now gets an executable fallback fix instead of `clear --session-id weird;id`
- malformed percent encoding such as `bad%ZZ` no longer throws
- tests execute the old-session clear command and verify current-session HUD state survives

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/state-doctor.test.ts packages/coding-agent/test/skill-active-state.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/changelog.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/gjc-runtime/state-runtime.ts packages/coding-agent/src/skill-state/active-state.ts packages/coding-agent/test/gjc-runtime/state-doctor.test.ts packages/coding-agent/CHANGELOG.md`

Supersedes #366.