### PR TITLE
Support Opus max reasoning preset

### DIFF
--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -13,6 +13,7 @@ export const ThinkingLevel = {
 	Medium: Effort.Medium,
 	High: Effort.High,
 	XHigh: Effort.XHigh,
+	Max: Effort.Max,
 } as const;
 
 export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -8,6 +8,7 @@ export const enum Effort {
 	Medium = "medium",
 	High = "high",
 	XHigh = "xhigh",
+	Max = "max",
 }
 
 export const THINKING_EFFORTS: readonly Effort[] = [
@@ -16,6 +17,7 @@ export const THINKING_EFFORTS: readonly Effort[] = [
 	Effort.Medium,
 	Effort.High,
 	Effort.XHigh,
+	Effort.Max,
 ];
 
 const DEFAULT_REASONING_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
@@ -25,6 +27,21 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH: readonly Effort[] = [
 	Effort.Medium,
 	Effort.High,
 	Effort.XHigh,
+];
+const DEFAULT_REASONING_EFFORTS_WITH_MAX: readonly Effort[] = [
+	Effort.Minimal,
+	Effort.Low,
+	Effort.Medium,
+	Effort.High,
+	Effort.Max,
+];
+const DEFAULT_REASONING_EFFORTS_WITH_XHIGH_AND_MAX: readonly Effort[] = [
+	Effort.Minimal,
+	Effort.Low,
+	Effort.Medium,
+	Effort.High,
+	Effort.XHigh,
+	Effort.Max,
 ];
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
@@ -283,6 +300,7 @@ export function mapEffortToGoogleThinkingLevel<TApi extends Api>(
 			return "MEDIUM";
 		case Effort.High:
 		case Effort.XHigh:
+		case Effort.Max:
 			return "HIGH";
 	}
 }
@@ -301,10 +319,8 @@ export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 		case Effort.High:
 			return "high";
 		case Effort.XHigh:
-			// Opus 4.7+ introduced a distinct "xhigh" effort level (between "high" and "max").
-			// The Anthropic docs scope this to the Messages API only, so Bedrock Converse and
-			// older adaptive-thinking Opus 4.6 models keep the legacy "max" alias.
-			return anthropicModelHasRealXHighEffort(model) ? "xhigh" : "max";
+		case Effort.Max:
+			return effort === Effort.XHigh ? "xhigh" : "max";
 	}
 }
 
@@ -548,7 +564,10 @@ function inferAnthropicSupportedEfforts<TApi extends Api>(
 		(model.api === "anthropic-messages" || model.api === "bedrock-converse-stream") &&
 		semverGte(parsedModel.version, "4.6")
 	) {
-		return parsedModel.kind === "opus" ? DEFAULT_REASONING_EFFORTS_WITH_XHIGH : DEFAULT_REASONING_EFFORTS;
+		if (parsedModel.kind !== "opus") return DEFAULT_REASONING_EFFORTS;
+		return anthropicModelHasRealXHighEffort(model)
+			? DEFAULT_REASONING_EFFORTS_WITH_XHIGH_AND_MAX
+			: DEFAULT_REASONING_EFFORTS_WITH_MAX;
 	}
 	return inferFallbackEfforts(model);
 }

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2135,7 +2135,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 			// sending unsupported effort strings.
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: true,
-			reasoningEffortMap: { minimal: "high", low: "high", medium: "high", high: "high", xhigh: "max" },
+			reasoningEffortMap: { minimal: "high", low: "high", medium: "high", high: "high", xhigh: "max", max: "max" },
 			maxTokensField: "max_tokens",
 			// DeepSeek V4 thinking mode rejects the `tool_choice` control parameter.
 			// Tool calls still work without it; the API defaults to auto when tools exist.

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -791,6 +791,7 @@ function buildAdditionalModelRequestFields(
 		medium: 8192,
 		high: 16384,
 		xhigh: 32768,
+		max: 32768,
 	};
 	const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[level];
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2001,8 +2001,8 @@ function buildParams(
 				}
 				params.thinking = adaptive as typeof params.thinking;
 				if (effort) {
-					// SDK's OutputConfig.effort type is not yet widened to include the new "xhigh"
-					// level introduced with Anthropic model Opus 4.7. Cast until the SDK catches up.
+					// SDK OutputConfig.effort typings may lag Anthropic's adaptive effort literals.
+					// Cast so newly supported levels can pass through before the SDK catches up.
 					params.output_config = { effort } as typeof params.output_config;
 				}
 			} else {

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -70,7 +70,7 @@ function resolveDeploymentName(model: Model<"azure-openai-responses">, options?:
 
 // Azure OpenAI Responses-specific options
 export interface AzureOpenAIResponsesOptions extends StreamOptions {
-	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	azureApiVersion?: string;
 	azureResourceName?: string;

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -23,7 +23,7 @@ import { toolWireSchema } from "../utils/schema/wire";
 import { transformMessages } from "./transform-messages";
 
 export interface OllamaChatOptions extends StreamOptions {
-	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	toolChoice?: ToolChoice;
 }
 
@@ -95,6 +95,7 @@ function mapReasoning(reasoning: OllamaChatOptions["reasoning"]): boolean | "low
 			return "medium";
 		case "high":
 		case "xhigh":
+		case "max":
 			return "high";
 		default:
 			return undefined;

--- a/packages/ai/src/providers/openai-chat-server-schema.ts
+++ b/packages/ai/src/providers/openai-chat-server-schema.ts
@@ -210,7 +210,7 @@ export const openaiChatRequestSchema = z.object({
 	frequency_penalty: z.number().optional(),
 	logit_bias: z.record(z.string(), z.number()).optional(),
 	user: z.string().optional(),
-	reasoning_effort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).optional(),
+	reasoning_effort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
 	parallel_tool_calls: z.boolean().optional(),
 	service_tier: z.enum(["auto", "default", "flex", "scale", "priority"]).optional(),
 	metadata: z.record(z.string(), z.unknown()).optional(),

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -33,7 +33,14 @@ export type { ParsedRequest };
 type ReasoningEffort = NonNullable<ParsedRequest["options"]["reasoning"]>;
 
 function isReasoningEffort(value: unknown): value is ReasoningEffort {
-	return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+	return (
+		value === "minimal" ||
+		value === "low" ||
+		value === "medium" ||
+		value === "high" ||
+		value === "xhigh" ||
+		value === "max"
+	);
 }
 
 function isServiceTier(value: unknown): value is ResolvedServiceTier {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -73,7 +73,7 @@ import {
 import { transformMessages } from "./transform-messages";
 
 export interface OpenAICodexResponsesOptions extends StreamOptions {
-	reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	reasoningSummary?: "auto" | "concise" | "detailed" | null;
 	textVerbosity?: "low" | "medium" | "high";
 	include?: string[];

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -3,7 +3,7 @@ import { requireSupportedEffort } from "../../model-thinking";
 import type { Api, Model } from "../../types";
 
 export interface ReasoningConfig {
-	effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	summary?: "auto" | "concise" | "detailed";
 }
 

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -1,6 +1,6 @@
 import type { Model, OpenAICompat } from "../types";
 
-type OpenAIReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+type OpenAIReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";
 
 export type ResolvedOpenAICompat = Required<
@@ -162,6 +162,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 					medium: "default",
 					high: "default",
 					xhigh: "default",
+					max: "default",
 				} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
 			: isDeepseekFamily && model.reasoning
 				? ({
@@ -170,6 +171,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 						medium: "high",
 						high: "high",
 						xhigh: "max",
+						max: "max",
 					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
 				: isFireworks
 					? ({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -249,13 +249,13 @@ export function isOpenAICompletionsProgressChunk(chunk: unknown): boolean {
 
 export interface OpenAICompletionsOptions extends StreamOptions {
 	toolChoice?: ToolChoice;
-	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	/** Force-disable reasoning where supported, or request the lowest effort on generic effort endpoints. */
 	disableReasoning?: boolean;
 	serviceTier?: ServiceTier;
 }
 
-type OpenAICompletionsParams = OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+type OpenAICompletionsParams = Omit<OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming, "reasoning_effort"> & {
 	top_k?: number;
 	min_p?: number;
 	repetition_penalty?: number;
@@ -263,6 +263,7 @@ type OpenAICompletionsParams = OpenAI.Chat.Completions.ChatCompletionCreateParam
 	enable_thinking?: boolean;
 	chat_template_kwargs?: { enable_thinking: boolean };
 	reasoning?: { effort?: string } | { enabled: false };
+	reasoning_effort?: OpenAICompletionsOptions["reasoning"];
 	provider?: OpenAICompat["openRouterRouting"];
 	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
 };
@@ -479,7 +480,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					body: params,
 				};
 				const { data, response, request_id } = await client.chat.completions
-					.create(params, { signal: requestSignal })
+					.create(params as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming, { signal: requestSignal })
 					.withResponse();
 				await notifyProviderResponse(options, response, model, request_id);
 				return data;

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -37,7 +37,14 @@ export type { ParsedRequest };
 // ─── narrow guards ──────────────────────────────────────────────────────────
 
 function isReasoningEffort(value: unknown): value is NonNullable<ParsedRequest["options"]["reasoning"]> {
-	return value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+	return (
+		value === "minimal" ||
+		value === "low" ||
+		value === "medium" ||
+		value === "high" ||
+		value === "xhigh" ||
+		value === "max"
+	);
 }
 
 function isServiceTier(value: unknown): value is NonNullable<ParsedRequest["options"]["serviceTier"]> {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -95,7 +95,7 @@ export function normalizeOpenAIResponsesPromptCacheKey(sessionId: string | undef
 
 // OpenAI Responses-specific options
 export interface OpenAIResponsesOptions extends StreamOptions {
-	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ServiceTier;
 	toolChoice?: ToolChoice;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -459,6 +459,7 @@ export const ANTHROPIC_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 32768,
+	max: 65536,
 };
 
 const GOOGLE_THINKING: Record<Effort, number> = {
@@ -467,6 +468,7 @@ const GOOGLE_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 24575,
+	max: 24575,
 };
 
 const BEDROCK_CLAUDE_THINKING: Record<Effort, number> = {
@@ -475,6 +477,7 @@ const BEDROCK_CLAUDE_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 16384,
+	max: 32768,
 };
 
 function resolveBedrockThinkingBudget(

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1029,7 +1029,7 @@ describe("Anthropic request fingerprint alignment", () => {
 				thinking: {
 					mode: "anthropic-adaptive",
 					minLevel: Effort.Minimal,
-					maxLevel: Effort.XHigh,
+					maxLevel: Effort.Max,
 				},
 			},
 			{
@@ -1056,6 +1056,31 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.top_k).toBeUndefined();
 		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
 		expect(payload.output_config).toEqual({ effort: "high" });
+	});
+
+	it("maps Opus max reasoning to Anthropic adaptive max", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-4-7",
+				name: "Claude Opus 4.7",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.Max,
+				},
+			},
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.Max,
+			},
+		)) as { output_config?: { effort?: string } };
+
+		expect(payload.output_config).toEqual({ effort: "max" });
 	});
 
 	it("treats tool prefix helpers as no-ops when prefix is empty", () => {

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -114,20 +114,25 @@ describe("model thinking metadata", () => {
 		expect(opus46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
-			maxLevel: Effort.XHigh,
+			maxLevel: Effort.Max,
+			levels: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.Max],
 		});
 		expect(sonnet46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
 			maxLevel: Effort.High,
 		});
-		// Opus 4.6 has no real xhigh level — pi-ai aliases XHigh to Anthropic's "max".
-		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toBe("max");
-		// Opus 4.7 on Messages API sends the new literal "xhigh" level.
+		// Older Opus adaptive models expose max but not the newer xhigh literal.
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toThrow(/not supported/);
+		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.Max)).toBe("max");
+		// Opus 4.7+ on Messages API exposes both Anthropic's real xhigh and max presets.
 		expect(mapEffortToAnthropicAdaptiveEffort(opus47, Effort.XHigh)).toBe("xhigh");
-		// Bedrock Converse is not the Messages API, so xhigh is not available there yet.
-		expect(mapEffortToAnthropicAdaptiveEffort(opus47Bedrock, Effort.XHigh)).toBe("max");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus47, Effort.Max)).toBe("max");
+		// Bedrock Converse supports max, but not the Messages-only xhigh preset.
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus47Bedrock, Effort.XHigh)).toThrow(/not supported/);
+		expect(mapEffortToAnthropicAdaptiveEffort(opus47Bedrock, Effort.Max)).toBe("max");
 		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.XHigh)).toThrow(/not supported/);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.Max)).toThrow(/not supported/);
 	});
 });
 
@@ -202,7 +207,8 @@ describe("generated model policies", () => {
 		expect(models[1]?.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
-			maxLevel: Effort.XHigh,
+			maxLevel: Effort.Max,
+			levels: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.Max],
 		});
 		expect(models[1]?.cost.cacheRead).toBe(0.5);
 		expect(models[1]?.cost.cacheWrite).toBe(6.25);
@@ -340,6 +346,17 @@ describe("model thinking runtime helpers", () => {
 		expect(clampThinkingLevelForModel(model, Effort.Minimal)).toBe(Effort.Medium);
 		expect(clampThinkingLevelForModel(model, Effort.XHigh)).toBe(Effort.High);
 		expect(clampThinkingLevelForModel(model, Effort.High)).toBe(Effort.High);
+	});
+
+	it("does not clamp unsupported xhigh to max for Opus models without xhigh support", () => {
+		const model = createModel({
+			id: "claude-opus-4.6",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+
+		expect(clampThinkingLevelForModel(model, Effort.XHigh)).toBe(Effort.High);
+		expect(clampThinkingLevelForModel(model, Effort.Max)).toBe(Effort.Max);
 	});
 
 	it('forces "off" for non-reasoning models', () => {

--- a/packages/coding-agent/src/config/model-equivalence.ts
+++ b/packages/coding-agent/src/config/model-equivalence.ts
@@ -42,7 +42,7 @@ interface ResolvedCanonicalModel {
 }
 
 const TRAILING_MARKER_PATTERN =
-	/[-:](?:thinking|customtools|high|low|medium|minimal|xhigh|free|cloud|exacto|nitro|original|optimized|nvfp4|fp8|fp4|bf16|int8|int4)$/i;
+	/[-:](?:thinking|customtools|high|low|medium|minimal|xhigh|max|free|cloud|exacto|nitro|original|optimized|nvfp4|fp8|fp4|bf16|int8|int4)$/i;
 const WRAPPER_PREFIXES = ["duo-chat-"] as const;
 
 let referenceDataCache: CanonicalReferenceData | undefined;

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -16,6 +16,7 @@ const ReasoningEffortMapSchema = z.object({
 	medium: z.string().optional(),
 	high: z.string().optional(),
 	xhigh: z.string().optional(),
+	max: z.string().optional(),
 });
 
 export const OpenAICompatSchema = z.object({
@@ -45,7 +46,7 @@ export const OpenAICompatSchema = z.object({
 	toolStrictMode: z.enum(["all_strict", "none"]).optional(),
 });
 
-const EffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh"]);
+const EffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh", "max"]);
 
 const ThinkingControlModeSchema = z.enum([
 	"effort",
@@ -89,7 +90,7 @@ function isValidProfileModelSelector(value: string): boolean {
 	if (parts.length > 2) return false;
 	const [base, suffix] = parts;
 	if (!base) return false;
-	return suffix === undefined || ["minimal", "low", "medium", "high", "xhigh"].includes(suffix);
+	return suffix === undefined || ["minimal", "low", "medium", "high", "xhigh", "max"].includes(suffix);
 }
 
 export const ProfileModelSelectorSchema = z

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2775,6 +2775,8 @@ export const SETTINGS_SCHEMA = {
 	"thinkingBudgets.high": { type: "number", default: 16384 },
 
 	"thinkingBudgets.xhigh": { type: "number", default: 32768 },
+
+	"thinkingBudgets.max": { type: "number", default: 65536 },
 } as const;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2955,6 +2957,7 @@ export interface ThinkingBudgetsSettings {
 	medium: number;
 	high: number;
 	xhigh: number;
+	max: number;
 }
 
 export interface SttSettings {

--- a/packages/coding-agent/src/modes/shared/agent-wire/command-validation.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/command-validation.ts
@@ -17,7 +17,7 @@ function stringField(value: Record<string, unknown>, key: string): boolean {
 	return typeof value[key] === "string";
 }
 
-const THINKING_LEVELS = new Set(["inherit", "off", "minimal", "low", "medium", "high", "xhigh"]);
+const THINKING_LEVELS = new Set(["inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 const TODO_STATUSES = new Set(["pending", "in_progress", "completed", "abandoned"]);
 
 function optionalBoolean(value: unknown): boolean {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1316,6 +1316,7 @@ export class Theme {
 			case "high":
 				return (str: string) => this.fg("thinkingHigh", str);
 			case "xhigh":
+			case "max":
 				return (str: string) => this.fg("thinkingXhigh", str);
 			default:
 				return (str: string) => this.fg("thinkingOff", str);

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -129,6 +129,7 @@ export type SymbolKey =
 	| "thinking.medium"
 	| "thinking.high"
 	| "thinking.xhigh"
+	| "thinking.max"
 	// Checkboxes
 	| "checkbox.checked"
 	| "checkbox.unchecked"
@@ -292,6 +293,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"thinking.medium": "◒ med",
 	"thinking.high": "◕ high",
 	"thinking.xhigh": "◉ xhigh",
+	"thinking.max": "◉ max",
 	// Checkboxes
 	"checkbox.checked": "☑",
 	"checkbox.unchecked": "☐",
@@ -542,6 +544,7 @@ const NERD_SYMBOLS: SymbolMap = {
 	"thinking.high": "\u{F111} high",
 	// pick: 🧠 xhi | alt:  xhi  xhi
 	"thinking.xhigh": "\u{F06D} xhi",
+	"thinking.max": "\u{F06D} max",
 	// Checkboxes
 	// pick:  | alt:  
 	"checkbox.checked": "\uf14a",
@@ -712,6 +715,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"thinking.medium": "[med]",
 	"thinking.high": "[high]",
 	"thinking.xhigh": "[xhi]",
+	"thinking.max": "[max]",
 	// Checkboxes
 	"checkbox.checked": "[x]",
 	"checkbox.unchecked": "[ ]",
@@ -1488,6 +1492,7 @@ export class Theme {
 			medium: this.#symbols["thinking.medium"],
 			high: this.#symbols["thinking.high"],
 			xhigh: this.#symbols["thinking.xhigh"],
+			max: this.#symbols["thinking.max"],
 		};
 	}
 

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -34,6 +34,11 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 		label: "xhigh",
 		description: "Maximum reasoning (~32k tokens)",
 	},
+	[ThinkingLevel.Max]: {
+		value: ThinkingLevel.Max,
+		label: "max",
+		description: "Opus maximum reasoning",
+	},
 };
 
 const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS]);

--- a/packages/coding-agent/test/model-profiles-schema.test.ts
+++ b/packages/coding-agent/test/model-profiles-schema.test.ts
@@ -34,6 +34,18 @@ describe("model profile schema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	test("max effort selector parses explicitly", () => {
+		const result = ModelsConfigSchema.safeParse({
+			profiles: {
+				opus: {
+					required_providers: ["anthropic"],
+					model_mapping: { default: "anthropic/claude-opus-4.7:max" },
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
 	test("unknown model_mapping key is rejected with model_mapping path", () => {
 		const result = ModelsConfigSchema.safeParse({
 			profiles: {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -267,7 +267,15 @@ describe("parseModelPattern", () => {
 		});
 
 		test("all valid thinking levels work", () => {
-			const levels = ["off", Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] as const;
+			const levels = [
+				"off",
+				Effort.Minimal,
+				Effort.Low,
+				Effort.Medium,
+				Effort.High,
+				Effort.XHigh,
+				Effort.Max,
+			] as const;
 			for (const level of levels) {
 				const result = parseModelPattern(`sonnet:${level}`, allModels);
 				expect(result.model?.id).toBe("claude-sonnet-4-5");

--- a/packages/coding-agent/test/status-line-thinking.test.ts
+++ b/packages/coding-agent/test/status-line-thinking.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { renderSegment } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
+import { initTheme, theme } from "../src/modes/theme/theme";
+import type { SegmentContext } from "../src/modes/components/status-line/segments";
+
+function createCtx(thinkingLevel: ThinkingLevel): SegmentContext {
+	return {
+		session: {
+			state: {
+				model: { id: "claude-opus-4-5", name: "Claude Opus 4.5", thinking: true },
+				thinkingLevel,
+			},
+			isFastModeActive: () => false,
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		options: { model: { showThinkingLevel: true } },
+		planMode: null,
+		goalMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
+		sessionStartTime: Date.now(),
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+beforeAll(async () => {
+	await initTheme();
+});
+describe("status line thinking indicator", () => {
+	it("renders max reasoning with a dedicated theme label", () => {
+		const rendered = renderSegment("model", createCtx(ThinkingLevel.Max));
+
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("Opus 4.5");
+		expect(rendered.content).toContain(theme.thinking.max);
+	});
+});


### PR DESCRIPTION
## Summary
- Add explicit max reasoning support across thinking levels, config schemas, RPC validation, and UI metadata
- Map Opus adaptive thinking so max is distinct while unsupported xhigh is rejected or clamped instead of silently promoted
- Widen provider option/schema paths and OpenAI-compatible reasoning maps for the new preset

Fixes #371

## Verification
- bun test packages/ai/test/model-thinking.test.ts packages/ai/test/anthropic-alignment.test.ts packages/coding-agent/test/model-profiles-schema.test.ts packages/coding-agent/test/model-resolver.test.ts
- bun run check:types (packages/ai)
- bun run check:types (packages/coding-agent)
- bun run check:types (packages/agent)

Note: root bun run check:ts still fails on pre-existing formatting issues in packages/coding-agent/src/session/agent-session.ts and packages/coding-agent/test/harness-control-plane/unattended-lifecycle-redteam.test.ts, unrelated to this branch diff.