### PR TITLE
Route unattended deep-interview asks through workflow gates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Routed unattended deep-interview ask-tool questions through `workflow_gate { kind: "question" }` events, including Round 0 topology and challenge-mode metadata, free-text option/schema shape, headless RPC answers, and synchronous response race handling (#316).
 - Preserved harness owner-vanish evidence after prompt acceptance: no-owner `recover` now either restores a detached owner when a prior endpoint exists or returns a public-safe concrete owner-exit reason plus a vanish receipt, and no-owner `observe`/`events` expose the preserved owner-exit summary.
 
 ## [0.3.2] - 2026-06-05

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -424,6 +424,9 @@ export interface RpcJsonSchema {
 	items?: RpcJsonSchema;
 	minLength?: number;
 	maxLength?: number;
+	minItems?: number;
+	maxItems?: number;
+	uniqueItems?: boolean;
 	minimum?: number;
 	maximum?: number;
 	title?: string;

--- a/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
@@ -138,18 +138,11 @@ export function questionToGate(question: AskGateQuestion): OpenGateInput {
 		stage: "deep-interview",
 		kind: "question",
 		schema,
-		options: [
-			...question.options.map((o, i) => ({
-				value: o.label,
-				label: o.label,
-				description: i === question.recommended ? "recommended" : undefined,
-			})),
-			{
-				value: { other: true },
-				label: GATE_OTHER_OPTION,
-				description: "free-text custom answer",
-			},
-		],
+		options: question.options.map((o, i) => ({
+			value: o.label,
+			label: o.label,
+			description: i === question.recommended ? "recommended" : undefined,
+		})),
 		context: {
 			title: question.question,
 			prompt: question.question,

--- a/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
@@ -110,15 +110,21 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 		required: ["selected"],
 		additionalProperties: false,
 		anyOf: [
-			{ properties: { selected: selectedOnly, other: { const: false } } },
-			{ properties: { selected: selectedOnly }, required: ["selected"] },
 			{
+				type: "object",
+				properties: { selected: selectedOnly, other: { const: false } },
+				required: ["selected"],
+				additionalProperties: false,
+			},
+			{
+				type: "object",
 				properties: {
 					selected: selectedWithOther,
 					other: { const: true },
 					custom: { type: "string", minLength: 1 },
 				},
 				required: ["selected", "other", "custom"],
+				additionalProperties: false,
 			},
 		],
 	};

--- a/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
@@ -63,31 +63,87 @@ export class DeepInterviewGateError extends Error {
 	}
 }
 
-/** Build the `workflow_gate` open-input for one deep-interview question. */
-export function questionToGate(question: AskGateQuestion): OpenGateInput {
-	const labels = question.options.map(o => o.label);
-	const schema: RpcJsonSchema = {
+function deepInterviewQuestionState(questionText: string): Record<string, unknown> {
+	const roundMatch = /^Round\s+(\d+)\s+\|\s+([^|]+?)\s+\|\s+Ambiguity:\s*(.+?)\s*$/im.exec(questionText);
+	const state: Record<string, unknown> = {};
+	if (roundMatch) {
+		const round = Number(roundMatch[1]);
+		if (Number.isFinite(round)) state.round = round;
+		const mode = roundMatch[2]?.trim();
+		if (mode) {
+			state.mode = mode;
+			const normalized = mode.toLowerCase();
+			if (normalized.includes("topology")) state.topology_gate = true;
+			if (/(contrarian|simplifier|ontologist)/u.test(normalized)) state.challenge_mode = normalized;
+		}
+		const ambiguity = roundMatch[3]?.trim();
+		if (ambiguity) state.ambiguity = ambiguity;
+	}
+	if (/Round\s+0\s+\|\s+Topology confirmation/im.test(questionText)) {
+		state.round = 0;
+		state.mode = "Topology confirmation";
+		state.topology_gate = true;
+	}
+	return state;
+}
+
+function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJsonSchema {
+	const multi = question.multi ?? false;
+	const selectedItems: RpcJsonSchema = { type: "string", enum: labels };
+	const selectedBase: RpcJsonSchema = { type: "array", items: selectedItems, uniqueItems: true };
+	const selectedOnly: RpcJsonSchema = {
+		...selectedBase,
+		minItems: 1,
+		...(multi ? {} : { maxItems: 1 }),
+	};
+	const selectedWithOther: RpcJsonSchema = {
+		...selectedBase,
+		...(multi ? {} : { maxItems: 0 }),
+	};
+	return {
 		type: "object",
 		properties: {
-			selected: {
-				type: "array",
-				items: { type: "string", enum: labels },
-			},
+			selected: selectedBase,
 			other: { type: "boolean", description: "set true to provide a free-text answer in `custom`" },
-			custom: { type: "string", description: "free-text answer; required when `other` is true" },
+			custom: { type: "string", minLength: 1, description: "free-text answer; required when `other` is true" },
 		},
 		required: ["selected"],
 		additionalProperties: false,
+		anyOf: [
+			{ properties: { selected: selectedOnly, other: { const: false } } },
+			{ properties: { selected: selectedOnly }, required: ["selected"] },
+			{
+				properties: {
+					selected: selectedWithOther,
+					other: { const: true },
+					custom: { type: "string", minLength: 1 },
+				},
+				required: ["selected", "other", "custom"],
+			},
+		],
 	};
+}
+
+/** Build the `workflow_gate` open-input for one deep-interview question. */
+export function questionToGate(question: AskGateQuestion): OpenGateInput {
+	const labels = question.options.map(o => o.label);
+	const schema = questionAnswerSchema(question, labels);
 	return {
 		stage: "deep-interview",
 		kind: "question",
 		schema,
-		options: question.options.map((o, i) => ({
-			value: o.label,
-			label: o.label,
-			description: i === question.recommended ? "recommended" : undefined,
-		})),
+		options: [
+			...question.options.map((o, i) => ({
+				value: o.label,
+				label: o.label,
+				description: i === question.recommended ? "recommended" : undefined,
+			})),
+			{
+				value: { other: true },
+				label: GATE_OTHER_OPTION,
+				description: "free-text custom answer",
+			},
+		],
 		context: {
 			title: question.question,
 			prompt: question.question,
@@ -96,6 +152,7 @@ export function questionToGate(question: AskGateQuestion): OpenGateInput {
 				multi: question.multi ?? false,
 				options: labels,
 				other_option: GATE_OTHER_OPTION,
+				...deepInterviewQuestionState(question.question),
 			},
 		},
 	};

--- a/packages/coding-agent/src/modes/shared/agent-wire/unattended-session.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/unattended-session.ts
@@ -59,6 +59,7 @@ export class UnattendedSessionControlPlane implements RpcUnattendedControlPlane,
 	#controller: UnattendedRunController | undefined;
 	#broker: WorkflowGateBroker | undefined;
 	readonly #pending = new Map<string, { resolve: (answer: unknown) => void; reject: (err: Error) => void }>();
+	readonly #earlyAnswers = new Map<string, unknown>();
 
 	constructor(private readonly opts: UnattendedSessionOptions) {}
 
@@ -95,7 +96,12 @@ export class UnattendedSessionControlPlane implements RpcUnattendedControlPlane,
 				if (pending) {
 					this.#pending.delete(gate.gate_id);
 					pending.resolve(answer);
+					return;
 				}
+				// A controller may answer synchronously while emitFrame is still on the
+				// stack. Keep the accepted answer so emitGate can still resolve after
+				// openGate returns and the caller starts awaiting.
+				this.#earlyAnswers.set(gate.gate_id, answer);
 			},
 		});
 		return {
@@ -150,9 +156,14 @@ export class UnattendedSessionControlPlane implements RpcUnattendedControlPlane,
 			return Promise.reject(new Error("cannot emit a workflow gate before unattended mode is negotiated"));
 		}
 		const gate = this.#broker.openGate(input);
-		return new Promise<unknown>((resolve, reject) => {
-			this.#pending.set(gate.gate_id, { resolve, reject });
-		});
+		if (this.#earlyAnswers.has(gate.gate_id)) {
+			const answer = this.#earlyAnswers.get(gate.gate_id);
+			this.#earlyAnswers.delete(gate.gate_id);
+			return Promise.resolve(answer);
+		}
+		const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+		this.#pending.set(gate.gate_id, { resolve, reject });
+		return promise;
 	}
 
 	async recover(): Promise<void> {
@@ -160,6 +171,7 @@ export class UnattendedSessionControlPlane implements RpcUnattendedControlPlane,
 	}
 
 	#rejectAllPending(error: Error): void {
+		this.#earlyAnswers.clear();
 		for (const [gateId, pending] of this.#pending) {
 			this.#pending.delete(gateId);
 			pending.reject(error);

--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-schema.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-schema.ts
@@ -25,6 +25,9 @@ const SUPPORTED_KEYWORDS = new Set<keyof RpcJsonSchema>([
 	"items",
 	"minLength",
 	"maxLength",
+	"minItems",
+	"maxItems",
+	"uniqueItems",
 	"minimum",
 	"maximum",
 	"title",
@@ -104,11 +107,14 @@ function walkSchema(schema: RpcJsonSchema, depth: number, path: string): void {
 			throw new WorkflowGateSchemaError(`${meta} at ${path} must be a string`);
 		}
 	}
-	for (const limit of ["minLength", "maxLength"] as const) {
+	for (const limit of ["minLength", "maxLength", "minItems", "maxItems"] as const) {
 		const v = schema[limit];
 		if (v !== undefined && (typeof v !== "number" || !Number.isInteger(v) || v < 0)) {
 			throw new WorkflowGateSchemaError(`${limit} at ${path} must be a non-negative integer`);
 		}
+	}
+	if (schema.uniqueItems !== undefined && typeof schema.uniqueItems !== "boolean") {
+		throw new WorkflowGateSchemaError(`uniqueItems at ${path} must be a boolean`);
 	}
 	for (const limit of ["minimum", "maximum"] as const) {
 		const v = schema[limit];
@@ -262,9 +268,38 @@ function validateValue(schema: RpcJsonSchema, value: unknown, path: string, erro
 			}
 		}
 	}
-	if (Array.isArray(value) && schema.items) {
-		for (let i = 0; i < value.length; i++)
-			validateValue(schema.items as RpcJsonSchema, value[i], `${path}/${i}`, errors);
+	if (Array.isArray(value)) {
+		if (schema.minItems !== undefined && value.length < schema.minItems) {
+			errors.push({
+				path,
+				keyword: "minItems",
+				message: `fewer than ${schema.minItems} items`,
+				expected: schema.minItems,
+			});
+		}
+		if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+			errors.push({
+				path,
+				keyword: "maxItems",
+				message: `more than ${schema.maxItems} items`,
+				expected: schema.maxItems,
+			});
+		}
+		if (schema.uniqueItems) {
+			const seen = new Set<string>();
+			for (const item of value) {
+				const key = canonicalJson(item);
+				if (seen.has(key)) {
+					errors.push({ path, keyword: "uniqueItems", message: "array items must be unique" });
+					break;
+				}
+				seen.add(key);
+			}
+		}
+		if (schema.items) {
+			for (let i = 0; i < value.length; i++)
+				validateValue(schema.items as RpcJsonSchema, value[i], `${path}/${i}`, errors);
+		}
 	}
 	for (const combiner of ["oneOf", "anyOf"] as const) {
 		const branches = schema[combiner];

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1935,6 +1935,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			modelRegistry,
 			taskDepth,
 			toolRegistry,
+			workflowGateToolSession: toolSession,
 			transformContext,
 			onPayload,
 			onResponse,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -209,7 +209,6 @@ import {
 	readVisibleSkillActiveState,
 	syncSkillActiveState,
 } from "../skill-state/active-state";
-
 import { assertDeepInterviewMutationAllowed } from "../skill-state/deep-interview-mutation-guard";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import { resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
@@ -219,9 +218,11 @@ import {
 	type DiscoverableTool,
 	type DiscoverableToolSearchIndex,
 } from "../tool-discovery/tool-index";
+import type { ToolSession } from "../tools";
+import { AskTool } from "../tools/ask";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import type { CheckpointState } from "../tools/checkpoint";
-import { outputMeta } from "../tools/output-meta";
+import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
 import { getLatestTodoPhasesFromEntries, type TodoItem, type TodoPhase } from "../tools/todo-write";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
@@ -347,6 +348,8 @@ export interface AgentSessionConfig {
 	taskDepth?: number;
 	/** Tool registry for LSP and settings */
 	toolRegistry?: Map<string, AgentTool>;
+	/** Tool-session factory context used to lazily attach workflow-gate-only tools. */
+	workflowGateToolSession?: ToolSession;
 	/** Current session pre-LLM message transform pipeline */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/** Provider payload hook used by the active session request path */
@@ -934,6 +937,7 @@ export class AgentSession {
 
 	// Tool registry and prompt builder for extensions
 	#toolRegistry: Map<string, AgentTool>;
+	#workflowGateToolSession: ToolSession | undefined;
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
 	#onResponse: SimpleStreamOptions["onResponse"] | undefined;
@@ -1113,6 +1117,7 @@ export class AgentSession {
 		}
 		this.#validateRetryFallbackChains();
 		this.#toolRegistry = config.toolRegistry ?? new Map();
+		this.#workflowGateToolSession = config.workflowGateToolSession;
 		this.#requestedToolNames = config.requestedToolNames;
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#onPayload = config.onPayload;
@@ -4224,6 +4229,37 @@ export class AgentSession {
 
 	setWorkflowGateEmitter(emitter: WorkflowGateEmitter | undefined): void {
 		this.#workflowGateEmitter = emitter;
+		if (emitter) {
+			this.#ensureWorkflowGateAskTool();
+		}
+	}
+
+	#ensureWorkflowGateAskTool(): void {
+		if (this.#toolRegistry.has("ask")) return;
+		if (!this.#workflowGateToolSession) return;
+
+		const askTool = AskTool.createIf(this.#workflowGateToolSession);
+		if (!askTool) return;
+
+		const wrappedTool = wrapToolWithMetaNotice(askTool as unknown as AgentTool);
+		const finalTool: AgentTool = this.#extensionRunner
+			? new ExtensionToolWrapper(wrappedTool, this.#extensionRunner)
+			: wrappedTool;
+		this.#toolRegistry.set(finalTool.name, finalTool);
+
+		if (!this.getActiveToolNames().includes(finalTool.name)) {
+			const activeTools = [
+				...this.agent.state.tools,
+				this.#wrapToolForDeepInterviewMutationGuard(this.#wrapToolForAcpPermission(finalTool)),
+			];
+			this.agent.setTools(activeTools);
+			this.#invalidateDiscoveryCaches();
+			void this.refreshBaseSystemPrompt().catch(error => {
+				logger.warn("Failed to refresh system prompt after workflow gate ask tool registration", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		}
 	}
 
 	get goalRuntime(): GoalRuntime {

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -426,7 +426,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 	}
 
 	static createIf(session: ToolSession): AskTool | null {
-		return session.hasUI ? new AskTool(session) : null;
+		return session.hasUI || session.getWorkflowGateEmitter?.() ? new AskTool(session) : null;
 	}
 
 	/** Send terminal notification when ask tool is waiting for input */
@@ -443,17 +443,25 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		_onUpdate?: AgentToolUpdateCallback<AskToolDetails>,
 		context?: AgentToolContext,
 	): Promise<AgentToolResult<AskToolDetails>> {
-		// Headless fallback
-		if (!context?.hasUI || !context.ui) {
+		const gateEmitter = this.session.getWorkflowGateEmitter?.();
+		const canUseWorkflowGate = gateEmitter?.isUnattended() === true;
+
+		// Headless fallback: unattended workflow gates are the non-TUI answer path.
+		if (!canUseWorkflowGate && (!context?.hasUI || !context.ui)) {
 			context?.abort();
 			throw new ToolAbortError("Ask tool requires interactive mode");
 		}
 
-		const extensionUi = context.ui;
+		const extensionUi = context?.ui;
 		const ui: UIContext = {
-			select: (prompt, options, dialogOptions) => extensionUi.select(prompt, options, dialogOptions),
-			editor: (title, prefill, dialogOptions, editorOptions) =>
-				extensionUi.editor(title, prefill, dialogOptions, editorOptions),
+			select: (prompt, options, dialogOptions) => {
+				if (!extensionUi) throw new ToolAbortError("Ask tool requires interactive mode");
+				return extensionUi.select(prompt, options, dialogOptions);
+			},
+			editor: (title, prefill, dialogOptions, editorOptions) => {
+				if (!extensionUi) throw new ToolAbortError("Ask tool requires interactive mode");
+				return extensionUi.editor(title, prefill, dialogOptions, editorOptions);
+			},
 		};
 
 		// Determine timeout based on settings and plan mode
@@ -478,10 +486,9 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			options?: { previous?: QuestionResult; navigation?: NavigationControls },
 		) => {
 			const rawOptionLabels = q.options.map(o => o.label);
-			// Unattended (#323/G011): route the question through the workflow-gate
+			// Unattended (#316/#323/G011): route the question through the workflow-gate
 			// emitter instead of the interactive UI; the external agent answers over RPC.
-			const gateEmitter = this.session.getWorkflowGateEmitter?.();
-			if (gateEmitter?.isUnattended()) {
+			if (gateEmitter && canUseWorkflowGate) {
 				const gateQuestion = {
 					id: q.id,
 					question: q.question,
@@ -552,7 +559,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			const { optionLabels, selectedOptions, customInput, cancelled, timedOut } = await askQuestion(q);
 
 			if (!timedOut && (cancelled || (selectedOptions.length === 0 && customInput === undefined))) {
-				context.abort();
+				context?.abort();
 				throw new ToolAbortError("Ask tool was cancelled by the user");
 			}
 			const details: AskToolDetails = {
@@ -604,7 +611,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			} = await askQuestion(q, { previous, navigation });
 
 			if (cancelled && !timedOut) {
-				context.abort();
+				context?.abort();
 				throw new ToolAbortError("Ask tool was cancelled by the user");
 			}
 

--- a/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
+++ b/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
@@ -135,24 +135,27 @@ describe("deep-interview question gates red-team", () => {
 
 	it("marks the recommended option description", () => {
 		const gate = questionToGate(singleQ);
-		expect(gate.options?.map(o => ({ label: o.label, description: o.description }))).toEqual([
-			{ label: "JWT", description: undefined },
-			{ label: "OAuth2", description: "recommended" },
-			{ label: "Session cookies", description: undefined },
-			{ label: "Other (type your own)", description: "free-text custom answer" },
+		expect(gate.options?.map(o => ({ value: o.value, label: o.label, description: o.description }))).toEqual([
+			{ value: "JWT", label: "JWT", description: undefined },
+			{ value: "OAuth2", label: "OAuth2", description: "recommended" },
+			{ value: "Session cookies", label: "Session cookies", description: undefined },
 		]);
+		expect(gate.context?.stage_state).toMatchObject({ other_option: "Other (type your own)" });
 	});
 
-	it("supports zero-option questions as Other-only gates", async () => {
+	it("supports zero-option questions as free-text gates without advertising Other as a selectable option", async () => {
 		const zeroQ: AskGateQuestion = {
 			id: "zero-options",
 			question: "What constraint is missing?",
 			options: [],
 		};
 		const gate = questionToGate(zeroQ);
-		expect(gate.options).toEqual([
-			{ value: { other: true }, label: "Other (type your own)", description: "free-text custom answer" },
-		]);
+		expect(gate.options).toEqual([]);
+		expect(gate.context?.stage_state).toMatchObject({
+			question_id: "zero-options",
+			options: [],
+			other_option: "Other (type your own)",
+		});
 		expect(gate.schema.properties?.selected?.items?.enum).toEqual([]);
 
 		const answer = { selected: [], other: true, custom: "No cloud dependencies" };
@@ -168,6 +171,28 @@ describe("deep-interview question gates red-team", () => {
 			selectedOptions: [],
 			customInput: "No cloud dependencies",
 		});
+	});
+
+	it("keeps generic pick-first unattended consumers safe for zero-option questions", async () => {
+		const zeroQ: AskGateQuestion = {
+			id: "zero-options-generic",
+			question: "What constraint is missing?",
+			options: [],
+		};
+		const gate = questionToGate(zeroQ);
+		const first = gate.options?.[0]?.value;
+		expect(first).toBeUndefined();
+		expect(typeof first).not.toBe("object");
+
+		const genericAnswer =
+			first !== undefined
+				? { selected: [first], other: false }
+				: { selected: [], other: true, custom: "memory-derived answer" };
+		const broker = new WorkflowGateBroker("run-zero-options-generic", new MemoryGateStore());
+		const emitted = broker.openGate(gate);
+		const resolution = await broker.resolve({ gate_id: emitted.gate_id, answer: genericAnswer });
+		expect(resolution.status).toBe("accepted");
+		expect(gateAnswerToResult(zeroQ, genericAnswer).customInput).toBe("memory-derived answer");
 	});
 
 	it("advertises the same schema_hash the broker uses for validation", async () => {

--- a/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
+++ b/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
@@ -134,6 +134,7 @@ describe("deep-interview question gates red-team", () => {
 			{ label: "JWT", description: undefined },
 			{ label: "OAuth2", description: "recommended" },
 			{ label: "Session cookies", description: undefined },
+			{ label: "Other (type your own)", description: "free-text custom answer" },
 		]);
 	});
 
@@ -144,7 +145,9 @@ describe("deep-interview question gates red-team", () => {
 			options: [],
 		};
 		const gate = questionToGate(zeroQ);
-		expect(gate.options).toEqual([]);
+		expect(gate.options).toEqual([
+			{ value: { other: true }, label: "Other (type your own)", description: "free-text custom answer" },
+		]);
 		expect(gate.schema.properties?.selected?.items?.enum).toEqual([]);
 
 		const answer = { selected: [], other: true, custom: "No cloud dependencies" };

--- a/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
+++ b/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
@@ -80,6 +80,11 @@ describe("deep-interview question gates red-team", () => {
 			{ name: "selected not an array", answer: { selected: "JWT" }, keyword: "type" },
 			{ name: "selected item outside enum", answer: { selected: ["Password"] }, keyword: "enum" },
 			{
+				name: "single-select combines option and Other",
+				answer: { selected: ["JWT"], other: true, custom: "Passkeys" },
+				keyword: "anyOf",
+			},
+			{
 				name: "additional unexpected property",
 				answer: { selected: ["JWT"], surprise: true },
 				keyword: "additionalProperties",

--- a/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
+++ b/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
@@ -84,9 +84,30 @@ describe("end-to-end via the broker", () => {
 		// A schema-invalid answer (selected not an array) is rejected, gate stays pending.
 		const bad = await broker.resolve({ gate_id: gate.gate_id, answer: { selected: "OAuth2" } });
 		expect(bad.status).toBe("rejected");
+		// A schema-invalid single-select answer cannot combine a normal option and Other.
+		const combined = await broker.resolve({
+			gate_id: gate.gate_id,
+			answer: { selected: ["JWT"], other: true, custom: "Passkeys" },
+		});
+		expect(combined.status).toBe("rejected");
+		expect(combined.error?.errors.some(e => e.keyword === "anyOf")).toBe(true);
 		// A schema-valid answer is accepted and decodes to the human-path result.
 		const good = await broker.resolve({ gate_id: gate.gate_id, answer: { selected: ["JWT"] } });
 		expect(good.status).toBe("accepted");
 		expect(gateAnswerToResult(singleQ, { selected: ["JWT"] }).selectedOptions).toEqual(["JWT"]);
+	});
+
+	it("accepts single-select normal selection and Other-only paths", async () => {
+		const broker = new WorkflowGateBroker("run-di-valid", new MemoryGateStore());
+		const selectionGate = broker.openGate(questionToGate(singleQ));
+		const selection = await broker.resolve({ gate_id: selectionGate.gate_id, answer: { selected: ["JWT"] } });
+		expect(selection.status).toBe("accepted");
+
+		const otherGate = broker.openGate(questionToGate(singleQ));
+		const other = await broker.resolve({
+			gate_id: otherGate.gate_id,
+			answer: { selected: [], other: true, custom: "Passkeys" },
+		});
+		expect(other.status).toBe("accepted");
 	});
 });

--- a/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
+++ b/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
@@ -30,7 +30,7 @@ describe("questionToGate", () => {
 		const gate = questionToGate(singleQ);
 		expect(gate.stage).toBe("deep-interview");
 		expect(gate.kind).toBe("question");
-		expect(gate.options?.map(o => o.label)).toEqual(["JWT", "OAuth2", "Session cookies"]);
+		expect(gate.options?.map(o => o.label)).toEqual(["JWT", "OAuth2", "Session cookies", "Other (type your own)"]);
 		expect(gate.options?.[0]?.description).toBe("recommended");
 		// schema is the documented subset and accepts {selected, custom?}
 		expect(gate.schema.properties?.selected?.items?.enum).toEqual(["JWT", "OAuth2", "Session cookies"]);

--- a/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
+++ b/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
@@ -30,13 +30,17 @@ describe("questionToGate", () => {
 		const gate = questionToGate(singleQ);
 		expect(gate.stage).toBe("deep-interview");
 		expect(gate.kind).toBe("question");
-		expect(gate.options?.map(o => o.label)).toEqual(["JWT", "OAuth2", "Session cookies", "Other (type your own)"]);
+		expect(gate.options?.map(o => o.label)).toEqual(["JWT", "OAuth2", "Session cookies"]);
 		expect(gate.options?.[0]?.description).toBe("recommended");
 		// schema is the documented subset and accepts {selected, custom?}
 		expect(gate.schema.properties?.selected?.items?.enum).toEqual(["JWT", "OAuth2", "Session cookies"]);
 		expect(gate.schema.properties?.other?.type).toBe("boolean");
 		expect(gate.schema.required).toEqual(["selected"]);
-		expect(gate.context?.stage_state).toMatchObject({ question_id: "q1", multi: false });
+		expect(gate.context?.stage_state).toMatchObject({
+			question_id: "q1",
+			multi: false,
+			other_option: "Other (type your own)",
+		});
 	});
 
 	it("maps a batch", () => {

--- a/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
+++ b/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
@@ -73,4 +73,62 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter (G011 real wiring)", (
 			await session.dispose();
 		}
 	});
+	it("late-registers ask when a headless session receives an unattended workflow gate emitter", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-g011-headless-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			hasUI: false,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+		});
+		try {
+			expect(session.getWorkflowGateEmitter()).toBeUndefined();
+			expect(session.getToolByName("ask")).toBeUndefined();
+
+			const received: OpenGateInput[] = [];
+			const emitter: WorkflowGateEmitter = {
+				isUnattended: () => true,
+				emitGate: input => {
+					received.push(input);
+					return Promise.resolve({ selected: ["JWT"], other: false });
+				},
+			};
+			session.setWorkflowGateEmitter(emitter);
+
+			expect(session.getWorkflowGateEmitter()).toBe(emitter);
+			const askTool = session.getToolByName("ask");
+			expect(askTool).toBeDefined();
+			expect(session.getActiveToolNames()).toContain("ask");
+
+			const ctx = {
+				hasUI: false,
+				abort: () => {},
+			} as unknown as AgentToolContext;
+
+			const result = await askTool!.execute(
+				"call-headless",
+				{ questions: [{ id: "auth", question: "Which auth?", options: [{ label: "JWT" }, { label: "OAuth2" }] }] },
+				undefined,
+				undefined,
+				ctx,
+			);
+
+			expect(received).toHaveLength(1);
+			expect(received[0].options).toEqual([
+				{ value: "JWT", label: "JWT", description: undefined },
+				{ value: "OAuth2", label: "OAuth2", description: undefined },
+			]);
+			expect(JSON.stringify(result.details)).toContain("JWT");
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/tools/ask-unattended-gate.test.ts
+++ b/packages/coding-agent/test/tools/ask-unattended-gate.test.ts
@@ -13,6 +13,13 @@ import { AskTool } from "@gajae-code/coding-agent/tools/ask";
  * gate contract end-to-end.
  */
 
+function createHeadlessContext(): AgentToolContext {
+	return {
+		hasUI: false,
+		abort: () => {},
+	} as unknown as AgentToolContext;
+}
+
 function createContext(): AgentToolContext {
 	let selectCalls = 0;
 	const ctx = {
@@ -75,6 +82,63 @@ describe("ask tool unattended gate emission (G011)", () => {
 		// The decoded answer is surfaced as the tool result.
 		expect(result.content[0]).toMatchObject({ type: "text" });
 		expect(JSON.stringify(result.details)).toContain("OAuth2");
+	});
+
+	it("emits and resolves over workflow_gate without a TUI context", async () => {
+		const emitter = new StubEmitter(() => ({ selected: ["JWT"], other: false }));
+		const tool = new AskTool(createSession(emitter));
+
+		const result = await tool.execute(
+			"call-headless",
+			{ questions: [{ id: "auth", question: "Which auth?", options: [{ label: "JWT" }] }] },
+			undefined,
+			undefined,
+			createHeadlessContext(),
+		);
+
+		expect(emitter.received).toHaveLength(1);
+		expect(result.details).toMatchObject({ selectedOptions: ["JWT"] });
+	});
+
+	it("surfaces Round 0 topology and challenge-mode asks as question gates", async () => {
+		const emitter = new StubEmitter(input => {
+			const options = input.options ?? [];
+			return { selected: [options[0]?.label], other: false };
+		});
+		const tool = new AskTool(createSession(emitter));
+
+		await tool.execute(
+			"call-topology-challenge",
+			{
+				questions: [
+					{
+						id: "topology",
+						question: "Round 0 | Topology confirmation | Ambiguity: not scored yet\nIs that topology right?",
+						options: [{ label: "Looks right" }, { label: "Revise" }],
+					},
+					{
+						id: "contrarian",
+						question: "Round 4 | Contrarian mode | Ambiguity: 38%\nWhat if the opposite were true?",
+						options: [{ label: "Keep assumption" }, { label: "Drop assumption" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			createHeadlessContext(),
+		);
+
+		expect(emitter.received).toHaveLength(2);
+		expect(emitter.received[0].context?.stage_state).toMatchObject({
+			question_id: "topology",
+			round: 0,
+			topology_gate: true,
+		});
+		expect(emitter.received[1].context?.stage_state).toMatchObject({
+			question_id: "contrarian",
+			round: 4,
+			challenge_mode: "contrarian mode",
+		});
 	});
 
 	it("handles a free-text (Other) gate answer", async () => {

--- a/packages/coding-agent/test/unattended-session.test.ts
+++ b/packages/coding-agent/test/unattended-session.test.ts
@@ -53,6 +53,22 @@ describe("UnattendedSessionControlPlane", () => {
 		await expect(pending).resolves.toEqual({ decision: "approve" });
 	});
 
+	it("resolves a synchronously answered emitted gate without losing the answer", async () => {
+		let plane: UnattendedSessionControlPlane;
+		const emitted: RpcWorkflowGate[] = [];
+		plane = new UnattendedSessionControlPlane({
+			runId: "run-sync",
+			emitFrame: gate => {
+				emitted.push(gate);
+				void plane.resolveGate({ gate_id: gate.gate_id, answer: { decision: "approve" } });
+			},
+		});
+		plane.negotiate(DECL);
+
+		await expect(plane.emitGate(approvalGate({ summary: "sync?" }))).resolves.toEqual({ decision: "approve" });
+		expect(emitted).toHaveLength(1);
+	});
+
 	it("bridges a deep-interview question gate end-to-end", async () => {
 		const { plane, emitted } = makePlane();
 		plane.negotiate(DECL);

--- a/packages/coding-agent/test/workflow-gate-schema.test.ts
+++ b/packages/coding-agent/test/workflow-gate-schema.test.ts
@@ -34,6 +34,9 @@ describe("workflow-gate-schema", () => {
 			{ type: "object", additionalProperties: 1 }, // not boolean/object
 			{ type: "string", minLength: -1 }, // negative
 			{ type: "string", maxLength: 1.5 }, // non-integer
+			{ type: "array", minItems: -1 }, // negative
+			{ type: "array", maxItems: 1.5 }, // non-integer
+			{ type: "array", uniqueItems: "yes" }, // non-boolean
 			{ type: "number", minimum: Number.POSITIVE_INFINITY }, // non-finite
 			{ type: "string", title: 5 }, // non-string meta
 		];
@@ -71,6 +74,20 @@ describe("workflow-gate-schema", () => {
 			"additionalProperties",
 		);
 		expect(validateGateAnswer(compiled, "g2", { name: "x", age: -1 })?.errors[0]?.keyword).toBe("minimum");
+	});
+
+	it("validates array minItems, maxItems, and uniqueItems", () => {
+		const compiled = compileGateSchema({
+			type: "array",
+			items: { type: "string", enum: ["a", "b"] },
+			minItems: 1,
+			maxItems: 2,
+			uniqueItems: true,
+		});
+		expect(validateGateAnswer(compiled, "g-array", ["a", "b"])).toBeNull();
+		expect(validateGateAnswer(compiled, "g-array", [])?.errors[0]?.keyword).toBe("minItems");
+		expect(validateGateAnswer(compiled, "g-array", ["a", "b", "a"])?.errors[0]?.keyword).toBe("maxItems");
+		expect(validateGateAnswer(compiled, "g-array", ["a", "a"])?.errors[0]?.keyword).toBe("uniqueItems");
 	});
 
 	it("caches compiled schemas by hash", () => {


### PR DESCRIPTION
## Summary
- Fixes #316 by routing unattended deep-interview ask-tool prompts through `workflow_gate` question events.
- Preserves attended human-path answer decoding while adding headless RPC answer handling.
- Includes Round 0 topology/challenge metadata and stricter question schema validation.

## Tests
- `bun test packages/coding-agent/test/deep-interview-gate-redteam.test.ts packages/coding-agent/test/deep-interview-workflow-gates.test.ts packages/coding-agent/test/tools/ask-unattended-gate.test.ts packages/coding-agent/test/unattended-session.test.ts packages/coding-agent/test/workflow-gate-schema.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Known blockers
- `bun --cwd=packages/coding-agent run check` is blocked by an unrelated pre-existing Biome import-order error in `packages/coding-agent/test/status-line-thinking.test.ts`.
