### PR TITLE
Fix slash command suggestion ordering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved slash command and `skill:*` suggestion ranking so `/team` surfaces the matching skill before weaker fallback candidates.
+
 ### Fixed
 
 - Preserved harness owner-vanish evidence after prompt acceptance: no-owner `recover` now either restores a detached owner when a prior endpoint exists or returns a public-safe concrete owner-exit reason plus a vanish receipt, and no-owner `observe`/`events` expose the preserved owner-exit summary.

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,
 	getKeybindings,
+	getSlashCommandMatchRank,
 	type SlashCommand,
 } from "@gajae-code/tui";
 import { formatKeyHints, type KeybindingsManager } from "../config/keybindings";
@@ -104,6 +105,43 @@ function mergeAutocompleteSuggestions(
 	return { items, prefix: primary.prefix };
 }
 
+function sortSlashCommandSuggestions(
+	suggestions: { items: AutocompleteItem[]; prefix: string } | null,
+	commands: SlashCommand[],
+): { items: AutocompleteItem[]; prefix: string } | null {
+	if (!suggestions) return null;
+	const query = suggestions.prefix.slice(1).toLowerCase();
+	const commandIndexes = new Map(commands.map((command, index) => [command.name, index]));
+	const commandByName = new Map(commands.map(command => [command.name, command]));
+	const items = suggestions.items
+		.map((item, index) => {
+			const command = commandByName.get(item.value);
+			const commandIndex = commandIndexes.get(item.value) ?? index;
+			const lowerName = item.value.toLowerCase();
+			const lowerDesc = command?.description?.toLowerCase() ?? item.description?.toLowerCase() ?? "";
+			const nameScore = fuzzyMatch(query, lowerName) ? fuzzyScore(query, lowerName) : 0;
+			const descScore = fuzzyMatch(query, lowerDesc) ? fuzzyScore(query, lowerDesc) * 0.5 : 0;
+			return {
+				item,
+				index,
+				commandIndex,
+				matchRank: getSlashCommandMatchRank(query, lowerName),
+				priority: command?.priority ?? 0,
+				score: Math.max(nameScore, descScore),
+			};
+		})
+		.sort(
+			(a, b) =>
+				a.matchRank - b.matchRank ||
+				b.priority - a.priority ||
+				b.score - a.score ||
+				a.commandIndex - b.commandIndex ||
+				a.index - b.index,
+		)
+		.map(({ item }) => item);
+	return { ...suggestions, items };
+}
+
 function withoutSkillCommandSuggestions(
 	suggestions: { items: AutocompleteItem[]; prefix: string } | null,
 ): { items: AutocompleteItem[]; prefix: string } | null {
@@ -182,7 +220,10 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
 			);
 			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
-			return mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions);
+			return sortSlashCommandSuggestions(
+				mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),
+				this.#commands,
+			);
 		}
 
 		if (!isSettingsInitialized() || settings.get("emojiAutocomplete")) {
@@ -253,7 +294,10 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null,
 		);
 		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
-		return mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions);
+		return sortSlashCommandSuggestions(
+			mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),
+			this.#commands,
+		);
 	}
 	trySyncInlineReplace(textBeforeCursor: string): { replaceLen: number; insert: string } | null {
 		if (isSettingsInitialized() && !settings.get("emojiAutocomplete")) return null;

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -1,12 +1,7 @@
-import {
-	type AutocompleteItem,
-	type AutocompleteProvider,
-	CombinedAutocompleteProvider,
-	getKeybindings,
-	getSlashCommandMatchRank,
-	type SlashCommand,
-} from "@gajae-code/tui";
-import { formatKeyHints, type KeybindingsManager } from "../config/keybindings";
+import type { AutocompleteItem, AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
+import { CombinedAutocompleteProvider, getKeybindings, getSlashCommandMatchRank } from "@gajae-code/tui";
+import type { KeybindingsManager } from "../config/keybindings";
+import { formatKeyHints } from "../config/keybindings";
 import { isSettingsInitialized, settings } from "../config/settings";
 import { applyEmojiCompletion, getEmojiSuggestions, isEmojiPrefix, tryEmojiInlineReplace } from "./emoji-autocomplete";
 

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -10,6 +10,9 @@ function createProvider() {
 			{ name: "skill:deep-interview", description: "Deep interview" },
 			{ name: "skill:fast", description: "Colliding skill" },
 			{ name: "skill:mode", description: "Mode skill" },
+			{ name: "skill:team", description: "Multi-worker team orchestration" },
+			{ name: "init", description: "Generate team AGENTS.md for current codebase" },
+			{ name: "goal", description: "Toggle team goal mode for this session" },
 		],
 		basePath: "/tmp",
 		keybindings: { getKeys: () => [] } as unknown as KeybindingsManager,
@@ -56,5 +59,21 @@ describe("prompt action skill autocomplete", () => {
 		expect(suggestions?.prefix).toBe("/mode");
 		expect(suggestions?.items.some(item => item.value === "model")).toBe(true);
 		expect(suggestions?.items.some(item => item.value === "skill:mode")).toBe(true);
+	});
+	it("ranks skill word matches before weaker merged slash candidates", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.getSuggestions(["/team"], 0, 5);
+		expect(suggestions?.prefix).toBe("/team");
+		expect(suggestions?.items[0]?.value).toBe("skill:team");
+		expect(suggestions?.items.map(item => item.value)).toEqual(
+			expect.arrayContaining(["init", "goal", "skill:team"]),
+		);
+	});
+
+	it("ranks normalized skill prefixes before weaker merged slash candidates", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.trySyncSlashCompletion("/skill-te");
+		expect(suggestions?.prefix).toBe("/skill-te");
+		expect(suggestions?.items[0]?.value).toBe("skill:team");
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Ranked slash command-name suggestions by stronger prefix/token matches before fuzzy fallback ordering, while keeping priority as an intra-tier tie-breaker.
+
 ## [0.3.1] - 2026-06-05
 
 ### Changed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -147,6 +147,48 @@ function fuzzyScore(query: string, target: string): number {
 	// Base score 40 for subsequence, minus penalty for gaps
 	return Math.max(1, 40 - gaps * 5);
 }
+export function getSlashCommandMatchRank(query: string, commandName: string): number {
+	const normalizedQuery = normalizeSlashCommandText(query);
+	if (normalizedQuery.length === 0) return 4;
+
+	const normalizedName = normalizeSlashCommandText(commandName);
+	if (commandName.toLowerCase().startsWith(query.toLowerCase()) || normalizedName.startsWith(normalizedQuery)) {
+		return 0;
+	}
+
+	const queryTokens = normalizedQuery.split(" ").filter(Boolean);
+	const nameTokens = normalizedName.split(" ").filter(Boolean);
+	if (queryTokens.length === 1 && nameTokens.includes(queryTokens[0]!)) {
+		return 1;
+	}
+
+	if (
+		queryTokens.length > 1 &&
+		queryTokens.every((token, index) => {
+			const nameToken = nameTokens[index];
+			return nameToken ? nameToken.startsWith(token) : false;
+		})
+	) {
+		return 2;
+	}
+
+	if (
+		queryTokens.length === 1 &&
+		nameTokens.some(token => token.startsWith(queryTokens[0]!) || token.includes(queryTokens[0]!))
+	) {
+		return 3;
+	}
+
+	return 4;
+}
+
+function normalizeSlashCommandText(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+		.replace(/\s+/g, " ");
+}
 
 export interface AutocompleteItem {
 	value: string;
@@ -273,12 +315,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					.filter(cmd => {
 						const name = "name" in cmd ? cmd.name : cmd.value;
 						if (!name) return false;
-						// Match name or description
+						// Match name, normalized slash-name aliases, or description.
 						if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
+						if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
 						const desc = cmd.description?.toLowerCase();
 						return desc ? fuzzyMatch(lowerPrefix, desc) : false;
 					})
-					.map(cmd => {
+					.map((cmd, index) => {
 						const name = "name" in cmd ? cmd.name : cmd.value;
 						const lowerName = name?.toLowerCase() ?? "";
 						const lowerDesc = cmd.description?.toLowerCase() ?? "";
@@ -294,11 +337,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 							label: "name" in cmd ? cmd.name : cmd.label,
 							score: Math.max(nameScore, descScore),
 							priority,
+							matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
+							index,
 							...(fullDesc && { description: fullDesc }),
 						};
 					})
-					.sort((a, b) => b.priority - a.priority || b.score - a.score)
-					.map(({ score: _score, priority: _priority, ...rest }) => rest);
+					.sort(
+						(a, b) =>
+							a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index,
+					)
+					.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
 
 				if (matches.length === 0) return null;
 
@@ -815,10 +863,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const name = "name" in cmd ? cmd.name : cmd.value;
 				if (!name) return false;
 				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
+				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
 				const desc = cmd.description?.toLowerCase();
 				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
 			})
-			.map(cmd => {
+			.map((cmd, index) => {
 				const name = "name" in cmd ? cmd.name : cmd.value;
 				const lowerName = name?.toLowerCase() ?? "";
 				const lowerDesc = cmd.description?.toLowerCase() ?? "";
@@ -833,11 +882,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					label: "name" in cmd ? cmd.name : cmd.label,
 					score: Math.max(nameScore, descScore),
 					priority,
+					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
+					index,
 					...(fullDesc && { description: fullDesc }),
-				} as AutocompleteItem & { score: number; priority: number };
+				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };
 			})
-			.sort((a, b) => b.priority - a.priority || b.score - a.score)
-			.map(({ score: _score, priority: _priority, ...rest }) => rest);
+			.sort((a, b) => a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index)
+			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
 
 		if (matches.length === 0) return null;
 		return { items: matches, prefix: textBeforeCursor };

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -255,6 +255,7 @@ describe("trySyncSlashCompletion", () => {
 		expect(result).not.toBeNull();
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
+
 	it("ranks high-priority commands above higher fuzzy scores", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -255,6 +255,22 @@ describe("trySyncSlashCompletion", () => {
 		expect(result).not.toBeNull();
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
+	it("ranks high-priority commands above higher fuzzy scores", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				// Lower priority, but exact-prefix match would normally win on fuzzy score.
+				{ name: "skim", description: "Skim the file", value: "skim" },
+				// Higher priority: pinned regardless of fuzzy score.
+				{ name: "skill:ralplan", description: "Plan the work", value: "skill:ralplan", priority: 100 },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/sk");
+		expect(result).not.toBeNull();
+		const values = result!.items.map(i => i.value);
+		expect(values[0]).toBe("skill:ralplan");
+		expect(values).toContain("skim");
+	});
 
 	it("uses priority as a tie-breaker within the same slash match tier", () => {
 		const provider = new CombinedAutocompleteProvider(

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -256,20 +256,43 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
 
-	it("ranks high-priority commands above higher fuzzy scores", () => {
+	it("uses priority as a tie-breaker within the same slash match tier", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[
-				// Lower priority, but exact-prefix match would normally win on fuzzy score.
-				{ name: "skim", description: "Skim the file", value: "skim" },
-				// Higher priority: pinned regardless of fuzzy score.
-				{ name: "skill:ralplan", description: "Plan the work", value: "skill:ralplan", priority: 100 },
+				{ name: "skill:team", description: "Team orchestration", value: "skill:team", priority: 100 },
+				{ name: "slash:team", description: "Alternate team command", value: "slash:team" },
 			],
 			"/tmp",
 		);
-		const result = provider.trySyncSlashCompletion("/sk");
+		const result = provider.trySyncSlashCompletion("/team");
 		expect(result).not.toBeNull();
-		const values = result!.items.map(i => i.value);
-		expect(values[0]).toBe("skill:ralplan");
-		expect(values).toContain("skim");
+		expect(result!.items.map(i => i.value)).toEqual(["skill:team", "slash:team"]);
+	});
+
+	it("ranks stronger slash text matches above higher-priority fallback matches", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "init", description: "Generate team files", value: "init", priority: 100 },
+				{ name: "skill:team", description: "Team orchestration", value: "skill:team" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/team");
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toEqual(["skill:team", "init"]);
+	});
+
+	it("normalizes separators for structured slash command prefixes", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "init", description: "Initialize skill template", value: "init", priority: 100 },
+				{ name: "skill:team", description: "Team orchestration", value: "skill:team" },
+			],
+			"/tmp",
+		);
+		const dashed = provider.trySyncSlashCompletion("/skill-te");
+		const colon = provider.trySyncSlashCompletion("/skill:te");
+		expect(dashed?.items[0]?.value).toBe("skill:team");
+		expect(colon?.items[0]?.value).toBe("skill:team");
 	});
 });


### PR DESCRIPTION
## What
- Add slash-command-specific ranking so stronger command-name matches beat weaker fuzzy/description fallback suggestions.
- Share the ranking helper with the coding-agent prompt-action provider so merged built-in and `skill:*` suggestions are ordered together.
- Add focused regression coverage for `/team`, separator-normalized `skill-te`/`skill:te`, priority behavior, and exact non-skill shadowing.
- Update package changelogs under `## [Unreleased]`.

## Why
Fixes #374.

This targets the concrete, narrow issue from the maintainer discussion: human-facing CLI/TUI slash command suggestion ordering. The PR follows the normal `dev` branch flow by targeting upstream `dev` from the fork branch `ririnto:fix/slash-command-suggestion-order`.

Maintainer note acknowledged: if the existing maintainer implementation lane lands first, this PR can still serve as focused repro/regression-test coverage for the requested ordering.

## Testing
- `bun test packages/tui/test/autocomplete.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
