### PR TITLE
Support cacheRetention in models.yml

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -56,11 +56,13 @@ providers:
     authHeader: true
     auth: apiKey
     disableStrictTools: false  # set true for Anthropic-compatible endpoints that reject the strict field
+    cacheRetention: short  # none | short | long; model entries and modelOverrides can override this
     discovery:
       type: ollama
     modelOverrides:
       some-model-id:
         name: Renamed model
+        cacheRetention: long
     models:
       - id: some-model-id
         name: Some Model
@@ -76,6 +78,7 @@ providers:
         maxTokens: 16384
         headers:
           X-Model: value
+        cacheRetention: none
         thinking:
           minLevel: low
           maxLevel: xhigh
@@ -240,6 +243,7 @@ providers:
 - `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement
 - `models.yml` is strict: unknown provider/model keys fail validation before provider dispatch, so stale keys such as `requestTransform` or `wireModelId` only work where this document lists them.
 - `discovery.type`: `ollama`, `llama.cpp`, or `lm-studio`
+- `cacheRetention`: `none`, `short`, or `long`; request-time options win over model/modelOverride values, then provider values, then `GJC_CACHE_RETENTION`, then the runtime default. For OpenAI Responses, this controls `prompt_cache_retention` only; it does not disable `prompt_cache_key` when a stable session id exists.
 
 ## OpenAI-compatible proxy configuration
 
@@ -348,7 +352,7 @@ ModelRegistry pipeline (on refresh):
 
 1. Load built-in providers/models from `@gajae-code/ai`.
 2. Load `models.yml` custom config.
-3. Apply provider overrides (`baseUrl`, `headers`, `requestTransform`, `disableStrictTools`) to built-in models.
+3. Apply provider overrides (`baseUrl`, `headers`, `requestTransform`, `disableStrictTools`, `cacheRetention`) to built-in models.
 4. Apply `modelOverrides` (per provider + model id).
 5. Merge custom `models`:
    - same `provider + id` replaces existing

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -425,11 +425,9 @@ function createClient(
 }
 
 function getOpenAIResponsesCacheSessionId(
-	options: Pick<OpenAIResponsesOptions, "cacheRetention" | "sessionId"> | undefined,
+	options: Pick<OpenAIResponsesOptions, "sessionId"> | undefined,
 ): string | undefined {
-	return resolveCacheRetention(options?.cacheRetention) === "none"
-		? undefined
-		: normalizeOpenAIResponsesPromptCacheKey(options?.sessionId);
+	return normalizeOpenAIResponsesPromptCacheKey(options?.sessionId);
 }
 
 function buildParams(
@@ -470,7 +468,7 @@ function buildParams(
 		}
 	}
 
-	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+	const cacheRetention = resolveCacheRetention(options?.cacheRetention ?? model.cacheRetention);
 	const promptCacheKey = getOpenAIResponsesCacheSessionId(options);
 	const params: OpenAIResponsesSamplingParams = {
 		model: model.wireModelId ?? model.id,
@@ -478,9 +476,7 @@ function buildParams(
 		instructions: systemInstructions,
 		stream: true,
 		prompt_cache_key: promptCacheKey,
-		prompt_cache_retention: promptCacheKey
-			? getPromptCacheRetention(resolvedBaseUrl || model.baseUrl, cacheRetention)
-			: undefined,
+		prompt_cache_retention: getPromptCacheRetention(resolvedBaseUrl || model.baseUrl, cacheRetention),
 		store: false,
 		stream_options: model.provider === "openai" ? { include_obfuscation: false } : undefined,
 	};

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -562,7 +562,7 @@ function mapOptionsForApi<TApi extends Api>(
 		maxTokens: options?.maxTokens || Math.min(model.maxTokens, 32000),
 		signal: options?.signal,
 		apiKey: apiKey || options?.apiKey,
-		cacheRetention: options?.cacheRetention,
+		cacheRetention: options?.cacheRetention ?? model.cacheRetention,
 		headers: options?.headers,
 		initiatorOverride: options?.initiatorOverride,
 		maxRetryDelayMs: options?.maxRetryDelayMs,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -888,6 +888,8 @@ export interface Model<TApi extends Api = any> {
 	wireModelId?: string;
 	/** Declarative request shaping for OpenAI-compatible proxy providers. */
 	requestTransform?: ModelRequestTransform;
+	/** Default prompt-cache retention preference for this model when the request omits one. */
+	cacheRetention?: CacheRetention;
 	/** Provider-assigned priority value (lower = higher priority). */
 	priority?: number;
 	/** Canonical thinking capability metadata for this model. */

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -20,6 +20,7 @@ function getHeader(headers: RequestInit["headers"], name: string): string | null
 
 async function captureOpenAIResponseHeaders(
 	options: OpenAIResponsesOptions,
+	modelOverride: Model<"openai-responses"> = model,
 ): Promise<{ sessionId: string | null; clientRequestId: string | null; body: Record<string, unknown> | null }> {
 	const captured = {
 		sessionId: null as string | null,
@@ -67,7 +68,7 @@ async function captureOpenAIResponseHeaders(
 		systemPrompt: ["stable system", "stable durable context"],
 		messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
 	};
-	const stream = streamOpenAIResponses(model, context, { apiKey: "test-key", ...options });
+	const stream = streamOpenAIResponses(modelOverride, context, { apiKey: "test-key", ...options });
 
 	for await (const event of stream) {
 		if (event.type === "done" || event.type === "error") break;
@@ -104,11 +105,52 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
 	});
 
-	it("omits OpenAI session routing headers when cache retention is disabled", async () => {
+	it("keeps prompt_cache_key when cache retention is disabled", async () => {
 		const captured = await captureOpenAIResponseHeaders({ cacheRetention: "none", sessionId: "session-123" });
 
-		expect(captured.sessionId).toBeNull();
-		expect(captured.clientRequestId).toBeNull();
-		expect(captured.body?.prompt_cache_key).toBeUndefined();
+		expect(captured.sessionId).toBe("session-123");
+		expect(captured.clientRequestId).toBe("session-123");
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("uses model cacheRetention for OpenAI Responses retention when request omits cacheRetention", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ authCredentialType: "oauth", sessionId: "session-123" },
+			{ ...model, baseUrl: "https://api.openai.com/v1", cacheRetention: "long" },
+		);
+
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBe("24h");
+	});
+
+	it("lets explicit request cacheRetention win over model cacheRetention", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ cacheRetention: "none", sessionId: "session-123" },
+			{ ...model, cacheRetention: "long" },
+		);
+
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("uses GJC_CACHE_RETENTION when request and model omit cacheRetention", async () => {
+		const previous = Bun.env.GJC_CACHE_RETENTION;
+		Bun.env.GJC_CACHE_RETENTION = "long";
+		try {
+			const captured = await captureOpenAIResponseHeaders(
+				{ authCredentialType: "oauth", sessionId: "session-123" },
+				{ ...model, baseUrl: "https://api.openai.com/v1" },
+			);
+
+			expect(captured.body?.prompt_cache_key).toBe("session-123");
+			expect(captured.body?.prompt_cache_retention).toBe("24h");
+		} finally {
+			if (previous === undefined) {
+				delete Bun.env.GJC_CACHE_RETENTION;
+			} else {
+				Bun.env.GJC_CACHE_RETENTION = previous;
+			}
+		}
 	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import {
 	type Api,
 	type AssistantMessageEventStream,
+	type CacheRetention,
 	type Context,
 	createModelManager,
 	enrichModelThinking,
@@ -240,6 +241,7 @@ interface ProviderValidationConfig {
 	compat?: Model<Api>["compat"];
 	requestTransform?: ModelRequestTransform;
 	disableStrictTools?: boolean;
+	cacheRetention?: CacheRetention;
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
 }
@@ -267,11 +269,12 @@ function validateProviderConfiguration(
 				!config.apiKeyEnv &&
 				!config.disableStrictTools &&
 				!config.requestTransform &&
+				!config.cacheRetention &&
 				!hasModelOverrides &&
 				!config.discovery
 			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "compat", "requestTransform", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "compat", "requestTransform", "cacheRetention", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -384,6 +387,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					compat: providerConfig.compat,
 					requestTransform: providerConfig.requestTransform,
 					disableStrictTools: providerConfig.disableStrictTools,
+					cacheRetention: providerConfig.cacheRetention,
 					modelOverrides: providerConfig.modelOverrides,
 					models: (providerConfig.models ?? []) as ProviderValidationModel[],
 				},
@@ -402,6 +406,7 @@ interface ProviderOverride {
 	compat?: Model<Api>["compat"];
 	transport?: Model<Api>["transport"];
 	requestTransform?: ModelRequestTransform;
+	cacheRetention?: CacheRetention;
 }
 
 const PROVIDER_BASE_URL_ENV_ALIASES: Record<string, readonly string[]> = {
@@ -449,7 +454,10 @@ function resolveProviderBaseUrlFromEnv(provider: string): string | undefined {
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "transport" | "requestTransform">,
+	providerOverride?: Pick<
+		ProviderOverride,
+		"baseUrl" | "headers" | "transport" | "requestTransform" | "cacheRetention"
+	>,
 ): Model<TApi> {
 	if (existing) {
 		return {
@@ -460,6 +468,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 				mergeRequestTransform(existing.requestTransform, model.requestTransform),
 				providerOverride?.requestTransform,
 			),
+			cacheRetention: model.cacheRetention ?? existing.cacheRetention ?? providerOverride?.cacheRetention,
 		};
 	}
 	if (providerOverride) {
@@ -481,6 +490,7 @@ interface DiscoveryProviderConfig {
 	headers?: Record<string, string>;
 	compat?: Model<Api>["compat"];
 	requestTransform?: ModelRequestTransform;
+	cacheRetention?: CacheRetention;
 	discovery: ProviderDiscovery;
 	optional?: boolean;
 }
@@ -678,6 +688,7 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 	if (override.reasoning !== undefined) result.reasoning = override.reasoning;
 	if (override.thinking !== undefined) result.thinking = override.thinking as ThinkingConfig;
 	if (override.input !== undefined) result.input = override.input as ("text" | "image")[];
+	if (override.cacheRetention !== undefined) result.cacheRetention = override.cacheRetention;
 	if (override.contextWindow !== undefined) result.contextWindow = override.contextWindow;
 	if (override.maxTokens !== undefined) result.maxTokens = override.maxTokens;
 	if (override.contextPromotionTarget !== undefined) result.contextPromotionTarget = override.contextPromotionTarget;
@@ -716,6 +727,7 @@ interface CustomModelDefinitionLike {
 	premiumMultiplier?: number;
 	wireModelId?: string;
 	requestTransform?: ModelRequestTransform;
+	cacheRetention?: CacheRetention;
 }
 
 interface CustomModelBuildOptions {
@@ -740,6 +752,7 @@ type CustomModelOverlay = {
 	premiumMultiplier?: number;
 	wireModelId?: string;
 	requestTransform?: ModelRequestTransform;
+	cacheRetention?: CacheRetention;
 	isOAuth?: boolean;
 };
 
@@ -791,6 +804,7 @@ function buildCustomModelOverlay(
 	providerCompat: Model<Api>["compat"] | undefined,
 	providerRequestTransform: ModelRequestTransform | undefined,
 	providerAuth: ProviderAuthMode | undefined,
+	providerCacheRetention: CacheRetention | undefined,
 	modelDef: CustomModelDefinitionLike,
 ): CustomModelOverlay | undefined {
 	const api = modelDef.api ?? providerApi;
@@ -813,6 +827,7 @@ function buildCustomModelOverlay(
 		wireModelId: modelDef.wireModelId,
 		contextPromotionTarget: modelDef.contextPromotionTarget,
 		premiumMultiplier: modelDef.premiumMultiplier,
+		cacheRetention: modelDef.cacheRetention ?? providerCacheRetention,
 		isOAuth: resolveCustomModelIsOAuth(api, providerAuth),
 	};
 }
@@ -913,6 +928,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		contextPromotionTarget: resolvedModel.contextPromotionTarget,
 		wireModelId: resolvedModel.wireModelId,
 		requestTransform: resolvedModel.requestTransform,
+		cacheRetention: resolvedModel.cacheRetention ?? reference?.cacheRetention,
 		premiumMultiplier: resolvedModel.premiumMultiplier,
 		isOAuth: resolvedModel.isOAuth,
 	} as Model<Api>);
@@ -1139,6 +1155,7 @@ export class ModelRegistry {
 				return {
 					...withTransportOverride,
 					compat: mergeCompat(m.compat, providerOverride.compat),
+					cacheRetention: m.cacheRetention ?? providerOverride.cacheRetention,
 				};
 			});
 		});
@@ -1295,6 +1312,7 @@ export class ModelRegistry {
 				requestTransform: providerConfig.requestTransform
 					? mergeRequestTransform(undefined, providerConfig.requestTransform)
 					: undefined,
+				cacheRetention: normalized.cacheRetention ?? providerConfig.cacheRetention,
 			};
 		});
 	}
@@ -1383,7 +1401,8 @@ export class ModelRegistry {
 				providerConfig.compat ||
 				providerConfig.disableStrictTools ||
 				providerConfig.requestTransform ||
-				providerConfig.transport
+				providerConfig.transport ||
+				providerConfig.cacheRetention
 			) {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
@@ -1394,6 +1413,7 @@ export class ModelRegistry {
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					transport: providerConfig.transport,
 					requestTransform: providerConfig.requestTransform,
+					cacheRetention: providerConfig.cacheRetention,
 				});
 			}
 
@@ -1410,6 +1430,7 @@ export class ModelRegistry {
 					headers: providerConfig.headers,
 					compat: providerConfig.compat,
 					requestTransform: providerConfig.requestTransform,
+					cacheRetention: providerConfig.cacheRetention,
 					discovery: providerConfig.discovery,
 					optional: false,
 				});
@@ -2101,13 +2122,16 @@ export class ModelRegistry {
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
 			transport: override.transport ?? baseOverride?.transport,
 			requestTransform: mergeRequestTransform(baseOverride?.requestTransform, override.requestTransform),
+			cacheRetention: override.cacheRetention ?? baseOverride?.cacheRetention,
 		};
 	}
-	#applyProviderTransportOverride<T extends { baseUrl?: string; headers?: Record<string, string> }>(
+	#applyProviderTransportOverride<
+		T extends { baseUrl?: string; headers?: Record<string, string>; cacheRetention?: CacheRetention },
+	>(
 		entry: T,
 		override: Pick<
 			ProviderOverride,
-			"baseUrl" | "headers" | "authHeader" | "apiKey" | "transport" | "requestTransform"
+			"baseUrl" | "headers" | "authHeader" | "apiKey" | "transport" | "requestTransform" | "cacheRetention"
 		>,
 	): T {
 		const headers = mergeAuthHeader(
@@ -2126,6 +2150,7 @@ export class ModelRegistry {
 				(entry as { requestTransform?: ModelRequestTransform }).requestTransform,
 				override.requestTransform,
 			),
+			cacheRetention: entry.cacheRetention ?? override.cacheRetention,
 		};
 	}
 	#applyRuntimeProviderOverrides(models: Model<Api>[]): Model<Api>[] {
@@ -2214,6 +2239,7 @@ export class ModelRegistry {
 					providerCompat,
 					providerConfig.requestTransform,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
+					providerConfig.cacheRetention,
 					modelDef as CustomModelDefinitionLike,
 				);
 				if (!model) continue;
@@ -2575,6 +2601,7 @@ export class ModelRegistry {
 					config.authHeader,
 					config.compat,
 					config.requestTransform,
+					undefined,
 					undefined,
 					modelDef as CustomModelDefinitionLike,
 				);

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -47,6 +47,7 @@ export const OpenAICompatSchema = z.object({
 });
 
 const EffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh", "max"]);
+const CacheRetentionSchema = z.enum(["none", "short", "long"]);
 
 const ThinkingControlModeSchema = z.enum([
 	"effort",
@@ -150,6 +151,7 @@ const ModelDefinitionSchema = z
 		contextPromotionTarget: z.string().min(1).optional(),
 		wireModelId: z.string().min(1).optional(),
 		requestTransform: RequestTransformSchema.optional(),
+		cacheRetention: CacheRetentionSchema.optional(),
 	})
 	.strict();
 
@@ -175,6 +177,7 @@ export const ModelOverrideSchema = z
 		contextPromotionTarget: z.string().min(1).optional(),
 		wireModelId: z.string().min(1).optional(),
 		requestTransform: RequestTransformSchema.optional(),
+		cacheRetention: CacheRetentionSchema.optional(),
 	})
 	.strict();
 
@@ -226,6 +229,7 @@ const ProviderConfigSchema = z
 		 * and `apiKey` must carry the gateway bearer.
 		 */
 		transport: z.literal("pi-native").optional(),
+		cacheRetention: CacheRetentionSchema.optional(),
 	})
 	.strict();
 

--- a/packages/coding-agent/test/model-profiles-schema.test.ts
+++ b/packages/coding-agent/test/model-profiles-schema.test.ts
@@ -12,6 +12,33 @@ describe("model profile schema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	test("provider model and override cacheRetention values parse", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				openai: {
+					cacheRetention: "long",
+					models: [
+						{ id: "custom", api: "openai-responses", baseUrl: "https://example.com/v1", cacheRetention: "short" },
+					],
+					modelOverrides: { "gpt-5-mini": { cacheRetention: "none" } },
+				},
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	// Runtime defaulting treats any non-"long" GJC_CACHE_RETENTION value as short;
+	// config is stricter so typos fail before dispatch.
+	test("invalid cacheRetention config values are rejected", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: { openai: { cacheRetention: "forever" } },
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) expect(issuePaths(result.error)).toContain("providers.openai.cacheRetention");
+	});
+
 	test("full and partial mappings parse", () => {
 		const result = ModelsConfigSchema.safeParse({
 			profiles: {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -252,6 +252,60 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	describe("cache retention config", () => {
+		test("applies provider cacheRetention to bundled provider models", () => {
+			writeRawModelsJson({
+				openai: { cacheRetention: "long" },
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const openaiModel = registry.find("openai", "gpt-5-mini");
+
+			expect(openaiModel?.cacheRetention).toBe("long");
+		});
+
+		test("modelOverrides cacheRetention wins over provider cacheRetention", () => {
+			writeRawModelsJson({
+				openai: {
+					cacheRetention: "long",
+					modelOverrides: {
+						"gpt-5-mini": { cacheRetention: "none" },
+					},
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const overridden = registry.find("openai", "gpt-5-mini");
+			const inherited = registry.find("openai", "gpt-5");
+
+			expect(overridden?.cacheRetention).toBe("none");
+			expect(inherited?.cacheRetention).toBe("long");
+		});
+
+		test("inline custom model cacheRetention wins over provider cacheRetention", () => {
+			writeRawModelsJson({
+				custom: {
+					baseUrl: "https://custom.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-responses",
+					cacheRetention: "long",
+					models: [
+						{
+							id: "fast",
+							cacheRetention: "short",
+						},
+						{ id: "defaulted" },
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+			expect(registry.find("custom", "fast")?.cacheRetention).toBe("short");
+			expect(registry.find("custom", "defaulted")?.cacheRetention).toBe("long");
+		});
+	});
+
 	describe("canonical equivalence", () => {
 		test("groups dotted provider variants under the bundled canonical id", () => {
 			writeRawModelsJson({


### PR DESCRIPTION
## Summary
- add provider/model/modelOverride cacheRetention schema support for models.yml
- propagate config-level retention into model metadata with request-time values taking precedence
- keep OpenAI Responses prompt_cache_key enabled while cacheRetention controls prompt_cache_retention only

Closes #380.

## Validation
- OPENAI_API_KEY= GJC_AUTH_BROKER_URL= GJC_AUTH_BROKER_TOKEN= bun test packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/model-profiles-schema.test.ts packages/ai/test/openai-responses-cache-affinity.test.ts
- OPENAI_API_KEY= GJC_AUTH_BROKER_URL= GJC_AUTH_BROKER_TOKEN= bun --cwd=packages/ai run check && bun --cwd=packages/coding-agent run check:types

Note: full `bun run check:ts` is currently blocked by pre-existing Biome import ordering in `packages/coding-agent/test/status-line-thinking.test.ts`, unrelated to this change.