### PR TITLE
Update generated models schema

### DIFF
--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -632,6 +632,14 @@
 										}
 									},
 									"additionalProperties": false
+								},
+								"cacheRetention": {
+									"type": "string",
+									"enum": [
+										"none",
+										"short",
+										"long"
+									]
 								}
 							},
 							"required": [
@@ -971,6 +979,14 @@
 										}
 									},
 									"additionalProperties": false
+								},
+								"cacheRetention": {
+									"type": "string",
+									"enum": [
+										"none",
+										"short",
+										"long"
+									]
 								}
 							},
 							"additionalProperties": false
@@ -982,6 +998,14 @@
 					"transport": {
 						"type": "string",
 						"const": "pi-native"
+					},
+					"cacheRetention": {
+						"type": "string",
+						"enum": [
+							"none",
+							"short",
+							"long"
+						]
 					}
 				},
 				"additionalProperties": false


### PR DESCRIPTION
## Summary
- Regenerated schemas after cacheRetention model schema changes
- Updated only schemas/models.schema.json

## Validation
- bun run generate-schemas
- bun run check:schemas
- bun test scripts/generate-json-schemas.test.ts

Fixes dev CI run 27059053911.