### PR TITLE
Add Cursor ACP provider for Composer 2.5

### DIFF
--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -26,6 +26,7 @@ const BUILTIN_APIS = new Set<KnownApi>([
 	"google-vertex",
 	"ollama-chat",
 	"cursor-agent",
+	"acp-agent",
 ]);
 
 export type CustomStreamFn = (

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -10,6 +10,7 @@ export * from "./model-thinking";
 export * from "./models";
 export * from "./provider-details";
 export * from "./provider-models";
+export type * from "./providers/acp-agent";
 export * from "./providers/anthropic";
 export * from "./providers/azure-openai-responses";
 export type * from "./providers/cursor";

--- a/packages/ai/src/providers/acp-agent.ts
+++ b/packages/ai/src/providers/acp-agent.ts
@@ -1,0 +1,415 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+import { create } from "@bufbuild/protobuf";
+import type {
+	AssistantMessage,
+	Context,
+	CursorExecHandlerResult,
+	CursorExecHandlers,
+	Model,
+	StreamFunction,
+	StreamOptions,
+	ToolResultMessage,
+} from "../types";
+import { AssistantMessageEventStream } from "../utils/event-stream";
+import {
+	ReadArgsSchema,
+	type ReadResult,
+	ShellArgsSchema,
+	type ShellResult,
+	WriteArgsSchema,
+} from "./cursor/gen/agent_pb";
+
+type AcpConfigValue = string | boolean;
+
+export interface AcpAgentOptions extends StreamOptions {
+	command?: string;
+	args?: string[];
+	cwd?: string;
+	env?: Record<string, string | undefined>;
+	clientCapabilities?: Partial<acp.ClientCapabilities>;
+	defaultConfigOptions?: Record<string, AcpConfigValue>;
+	execHandlers?: CursorExecHandlers;
+}
+
+interface TerminalRecord {
+	output: string;
+	exitCode: number | null;
+	released: boolean;
+	done: Promise<void>;
+}
+
+interface PlainReadResult {
+	content?: string;
+	fileText?: string;
+}
+
+interface PlainShellResult {
+	output?: string;
+	stdout?: string;
+	stderr?: string;
+	exitCode?: number | null;
+}
+
+function emptyUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function messageContentText(content: Context["messages"][number]["content"]): string {
+	if (typeof content === "string") return content;
+	return content
+		.map(item => {
+			if (item.type === "text") return item.text;
+			if (item.type === "image") return `[image: ${item.mimeType}]`;
+			return "";
+		})
+		.filter(Boolean)
+		.join("\n");
+}
+
+function toolResultToText(toolResult: ToolResultMessage): string {
+	return toolResult.content.map(item => (item.type === "text" ? item.text : `[image: ${item.mimeType}]`)).join("\n");
+}
+
+function buildPromptText(context: Context): string {
+	const sections: string[] = [];
+	const systemText = (context.systemPrompt ?? [])
+		.map(entry => entry.trim())
+		.filter(Boolean)
+		.join("\n\n");
+	if (systemText) sections.push(`System:\n${systemText}`);
+	for (const message of context.messages) {
+		if (message.role === "toolResult") {
+			const text = toolResultToText(message);
+			if (text) sections.push(`Tool result (${message.toolName}):\n${text}`);
+			continue;
+		}
+		const text = messageContentText(message.content);
+		if (text) sections.push(`${message.role}:\n${text}`);
+	}
+	return sections.join("\n\n");
+}
+
+function isToolResultMessage(value: unknown): value is ToolResultMessage {
+	return !!value && typeof value === "object" && (value as ToolResultMessage).role === "toolResult";
+}
+
+function splitExecResult<TResult>(result: CursorExecHandlerResult<TResult>): {
+	result?: TResult;
+	toolResult?: ToolResultMessage;
+} {
+	if (isToolResultMessage(result)) {
+		return { toolResult: result };
+	}
+	if (result && typeof result === "object" && "result" in result) {
+		const boxed = result as { result: TResult; toolResult?: ToolResultMessage };
+		return { result: boxed.result, toolResult: boxed.toolResult };
+	}
+	return { result: result as TResult };
+}
+
+function readResultContent(result: ReadResult | PlainReadResult): string {
+	if ("$typeName" in result) {
+		if (result.result.case !== "success") return "";
+		const output = result.result.value.output;
+		if (output.case === "content") return output.value;
+		if (output.case === "data") return new TextDecoder().decode(output.value);
+		return "";
+	}
+	return result.content ?? result.fileText ?? "";
+}
+
+function readRecordFromSplit(
+	result: ReadResult | PlainReadResult | undefined,
+	toolResult: ToolResultMessage | undefined,
+): string {
+	if (result) return readResultContent(result);
+	return toolResult ? toolResultToText(toolResult) : "";
+}
+
+function shellResultRecord(
+	result: ShellResult | PlainShellResult | undefined,
+	toolResult: ToolResultMessage | undefined,
+): {
+	output: string;
+	exitCode: number | null;
+} {
+	if (!result) {
+		return {
+			output: toolResult ? toolResultToText(toolResult) : "",
+			exitCode: toolResult?.isError ? 1 : 0,
+		};
+	}
+	if ("$typeName" in result) {
+		if (result.result.case === "success" || result.result.case === "failure") {
+			const value = result.result.value;
+			const output = value.interleavedOutput ?? [value.stdout, value.stderr].filter(Boolean).join("");
+			return { output, exitCode: value.exitCode };
+		}
+		if (result.result.case === "timeout") {
+			return { output: `Command timed out after ${result.result.value.timeoutMs}ms`, exitCode: 124 };
+		}
+		if (result.result.case === "rejected") {
+			return { output: result.result.value.reason, exitCode: 1 };
+		}
+		if (result.result.case === "spawnError") {
+			return { output: result.result.value.error, exitCode: 1 };
+		}
+		if (result.result.case === "permissionDenied") {
+			return { output: result.result.value.error, exitCode: 1 };
+		}
+		return { output: "", exitCode: 0 };
+	}
+	return {
+		output: result.output ?? [result.stdout, result.stderr].filter(Boolean).join(""),
+		exitCode: result.exitCode ?? 0,
+	};
+}
+
+async function runTerminalCommand(
+	terminal: TerminalRecord,
+	execHandlers: CursorExecHandlers,
+	command: string,
+	cwd: string,
+	terminalId: string,
+): Promise<void> {
+	try {
+		const { result, toolResult } = splitExecResult(
+			await execHandlers.shell?.(
+				create(ShellArgsSchema, {
+					command,
+					workingDirectory: cwd,
+					toolCallId: terminalId,
+				}),
+			),
+		);
+		if (terminal.exitCode === 143) return;
+		const shellResult = shellResultRecord(result, toolResult);
+		terminal.output = shellResult.output;
+		terminal.exitCode = shellResult.exitCode;
+	} catch (error) {
+		if (terminal.exitCode === 143) return;
+		terminal.output = error instanceof Error ? error.message : String(error);
+		terminal.exitCode = 1;
+	}
+}
+
+function createClient(
+	stream: AssistantMessageEventStream,
+	assistant: AssistantMessage,
+	execHandlers: CursorExecHandlers | undefined,
+	terminals: Map<string, TerminalRecord>,
+): acp.Client {
+	return {
+		async sessionUpdate(params) {
+			const update = params.update;
+			if (update.sessionUpdate !== "agent_message_chunk") return;
+			const content = update.content;
+			if (content.type !== "text") return;
+			let contentIndex = assistant.content.length - 1;
+			const last = assistant.content[contentIndex];
+			if (last?.type === "text") {
+				last.text += content.text;
+			} else {
+				assistant.content.push({ type: "text", text: content.text });
+				contentIndex = assistant.content.length - 1;
+				stream.push({ type: "text_start", contentIndex, partial: assistant });
+			}
+			stream.push({ type: "text_delta", contentIndex, delta: content.text, partial: assistant });
+		},
+		async requestPermission(params) {
+			const option = params.options.find(candidate => candidate.kind === "allow_always") ?? params.options[0];
+			if (!option) return { outcome: { outcome: "cancelled" } };
+			return { outcome: { outcome: "selected", optionId: option.optionId } };
+		},
+		async readTextFile(params) {
+			if (!execHandlers?.read) throw new Error("ACP readTextFile requested but no read handler is available");
+			const { result, toolResult } = splitExecResult(
+				await execHandlers.read(
+					create(ReadArgsSchema, {
+						path: params.path,
+						toolCallId: `acp-read-${crypto.randomUUID()}`,
+					}),
+				),
+			);
+			return { content: readRecordFromSplit(result, toolResult) };
+		},
+		async writeTextFile(params) {
+			if (!execHandlers?.write) throw new Error("ACP writeTextFile requested but no write handler is available");
+			const { toolResult } = splitExecResult(
+				await execHandlers.write(
+					create(WriteArgsSchema, {
+						path: params.path,
+						fileText: params.content,
+						toolCallId: `acp-write-${crypto.randomUUID()}`,
+					}),
+				),
+			);
+			if (toolResult?.isError) throw new Error(toolResultToText(toolResult) || "ACP writeTextFile failed");
+			return {};
+		},
+		async createTerminal(params) {
+			if (!execHandlers?.shell) throw new Error("ACP terminal requested but no shell handler is available");
+			const terminalId = `acp-terminal-${crypto.randomUUID()}`;
+			const command = params.args?.length ? [params.command, ...params.args].join(" ") : params.command;
+			const terminal: TerminalRecord = {
+				output: "",
+				exitCode: null,
+				released: false,
+				done: Promise.resolve(),
+			};
+			terminal.done = runTerminalCommand(terminal, execHandlers, command, params.cwd ?? process.cwd(), terminalId);
+			terminals.set(terminalId, terminal);
+			return { terminalId };
+		},
+		async terminalOutput(params) {
+			const terminal = terminals.get(params.terminalId);
+			if (!terminal) throw new Error(`Unknown ACP terminal: ${params.terminalId}`);
+			return {
+				output: terminal.output,
+				truncated: false,
+				exitStatus: terminal.exitCode === null ? null : { exitCode: terminal.exitCode, signal: null },
+			};
+		},
+		async waitForTerminalExit(params) {
+			const terminal = terminals.get(params.terminalId);
+			if (!terminal) throw new Error(`Unknown ACP terminal: ${params.terminalId}`);
+			await terminal.done;
+			return { exitCode: terminal.exitCode ?? 0, signal: null };
+		},
+		async killTerminal(params) {
+			const terminal = terminals.get(params.terminalId);
+			if (terminal) terminal.exitCode = terminal.exitCode ?? 143;
+			return {};
+		},
+		async releaseTerminal(params) {
+			const terminal = terminals.get(params.terminalId);
+			if (terminal) terminal.released = true;
+			return {};
+		},
+	};
+}
+
+function buildClientCapabilities(options: AcpAgentOptions | undefined): acp.ClientCapabilities {
+	return {
+		fs: {
+			readTextFile: true,
+			writeTextFile: true,
+		},
+		terminal: true,
+		...options?.clientCapabilities,
+		_meta: {
+			parameterizedModelPicker: true,
+			...(options?.clientCapabilities?._meta ?? {}),
+		},
+	};
+}
+
+function getDefaultConfigOptions(
+	model: Model<"acp-agent">,
+	options: AcpAgentOptions | undefined,
+): Record<string, AcpConfigValue> | undefined {
+	if (options?.defaultConfigOptions) return options.defaultConfigOptions;
+	if (model.provider === "cursor-acp" && model.id === "composer-2.5") {
+		return {
+			model: "composer-2.5",
+			fast: "false",
+		};
+	}
+	return undefined;
+}
+
+async function applyDefaultConfigOptions(
+	connection: acp.ClientSideConnection,
+	sessionId: string,
+	defaultConfigOptions: Record<string, AcpConfigValue> | undefined,
+): Promise<void> {
+	if (!defaultConfigOptions) return;
+	for (const [configId, value] of Object.entries(defaultConfigOptions)) {
+		await connection.setSessionConfigOption({
+			sessionId,
+			configId,
+			...(typeof value === "boolean" ? { type: "boolean" as const, value } : { value }),
+		});
+	}
+}
+
+function spawnAcpProcess(options: AcpAgentOptions | undefined): ChildProcessWithoutNullStreams {
+	const command = options?.command ?? "cursor-agent";
+	const args = options?.args ?? ["--model", "composer-2.5[fast=false]", "acp"];
+	return spawn(command, args, {
+		cwd: options?.cwd ?? process.cwd(),
+		env: { ...process.env, ...(options?.env ?? {}) },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+}
+
+export const streamAcpAgent: StreamFunction<"acp-agent"> = (
+	model: Model<"acp-agent">,
+	context: Context,
+	options?: AcpAgentOptions,
+): AssistantMessageEventStream => {
+	const stream = new AssistantMessageEventStream();
+
+	(async () => {
+		const startedAt = Date.now();
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "acp-agent",
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "stop",
+			timestamp: startedAt,
+		};
+		let child: ChildProcessWithoutNullStreams | undefined;
+		try {
+			child = spawnAcpProcess(options);
+			const acpStream = acp.ndJsonStream(Writable.toWeb(child.stdin), Readable.toWeb(child.stdout));
+			const terminals = new Map<string, TerminalRecord>();
+			const connection = new acp.ClientSideConnection(
+				() => createClient(stream, assistant, options?.execHandlers, terminals),
+				acpStream,
+			);
+
+			stream.push({ type: "start", partial: assistant });
+			await connection.initialize({
+				protocolVersion: acp.PROTOCOL_VERSION,
+				clientCapabilities: buildClientCapabilities(options),
+				clientInfo: { name: "gjc", version: "0.3.0" },
+			});
+			const session = await connection.newSession({
+				cwd: options?.cwd ?? process.cwd(),
+				mcpServers: [],
+			});
+			await applyDefaultConfigOptions(connection, session.sessionId, getDefaultConfigOptions(model, options));
+			await connection.prompt({
+				sessionId: session.sessionId,
+				prompt: [{ type: "text", text: buildPromptText(context) }],
+			});
+			assistant.content.forEach((content, contentIndex) => {
+				if (content.type === "text") {
+					stream.push({ type: "text_end", contentIndex, content: content.text, partial: assistant });
+				}
+			});
+			assistant.duration = Date.now() - startedAt;
+			stream.push({ type: "done", reason: "stop", message: assistant });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			stream.fail(new Error(`ACP agent provider failed: ${message}`));
+		} finally {
+			child?.kill();
+		}
+	})();
+
+	return stream;
+};

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -9,6 +9,7 @@ import {
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
 } from "./model-thinking";
+import { type AcpAgentOptions, streamAcpAgent } from "./providers/acp-agent";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { CursorOptions } from "./providers/cursor";
@@ -217,6 +218,8 @@ export function stream<TApi extends Api>(
 	} else if (model.api === "bedrock-converse-stream") {
 		// Bedrock doesn't have any API keys instead it sources credentials from standard AWS env variables or from given AWS profile.
 		return streamBedrock(model as Model<"bedrock-converse-stream">, context, (options || {}) as BedrockOptions);
+	} else if (model.api === "acp-agent") {
+		return streamAcpAgent(model as Model<"acp-agent">, context, (options || {}) as AcpAgentOptions);
 	}
 
 	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
@@ -262,6 +265,9 @@ export function stream<TApi extends Api>(
 
 		case "cursor-agent":
 			return streamCursor(model as Model<"cursor-agent">, context, providerOptions as CursorOptions);
+
+		case "acp-agent":
+			return streamAcpAgent(model as Model<"acp-agent">, context, providerOptions as AcpAgentOptions);
 
 		default:
 			throw new Error(`Unhandled API: ${api}`);
@@ -399,6 +405,9 @@ export function streamSimple<TApi extends Api>(
 		return stream(model, context, providerOptions);
 	} else if (model.api === "bedrock-converse-stream") {
 		// Bedrock doesn't have any API keys instead it sources credentials from standard AWS env variables or from given AWS profile.
+		const providerOptions = mapOptionsForApi(model, options, undefined);
+		return stream(model, context, providerOptions);
+	} else if (model.api === "acp-agent") {
 		const providerOptions = mapOptionsForApi(model, options, undefined);
 		return stream(model, context, providerOptions);
 	}
@@ -862,6 +871,14 @@ function mapOptionsForApi<TApi extends Api>(
 				...base,
 				execHandlers,
 				onToolResult,
+			});
+		}
+
+		case "acp-agent": {
+			const execHandlers = options?.cursorExecHandlers ?? options?.execHandlers;
+			return castApi<"acp-agent">({
+				...base,
+				execHandlers,
 			});
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,4 +1,5 @@
 import type { ZodType, z } from "zod/v4";
+import type { AcpAgentOptions } from "./providers/acp-agent";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses";
@@ -42,7 +43,8 @@ export type KnownApi =
 	| "google-gemini-cli"
 	| "google-vertex"
 	| "ollama-chat"
-	| "cursor-agent";
+	| "cursor-agent"
+	| "acp-agent";
 export type Api = KnownApi | (string & {});
 export interface ApiOptionsMap {
 	"anthropic-messages": AnthropicOptions;
@@ -56,6 +58,7 @@ export interface ApiOptionsMap {
 	"google-vertex": GoogleVertexOptions;
 	"ollama-chat": OllamaChatOptions;
 	"cursor-agent": CursorOptions;
+	"acp-agent": AcpAgentOptions;
 }
 // Compile-time exhaustiveness check - this will fail if ApiOptionsMap doesn't have all KnownApi keys
 type _CheckExhaustive =

--- a/packages/ai/test/acp-agent-provider.test.ts
+++ b/packages/ai/test/acp-agent-provider.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { create } from "@bufbuild/protobuf";
+import { streamAcpAgent } from "../src/providers/acp-agent";
+import {
+	ReadResultSchema,
+	ReadSuccessSchema,
+	ShellResultSchema,
+	ShellSuccessSchema,
+} from "../src/providers/cursor/gen/agent_pb";
+import type { Context, Model, ToolResultMessage } from "../src/types";
+
+const fixturePath = join(fileURLToPath(new URL(".", import.meta.url)), "fixtures/fake-acp-agent.ts");
+
+const model: Model<"acp-agent"> = {
+	id: "composer-2.5",
+	name: "Cursor Composer 2.5 ACP",
+	api: "acp-agent",
+	provider: "cursor-acp",
+	baseUrl: "acp://cursor",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 64_000,
+};
+
+const context: Context = {
+	systemPrompt: ["You are a helpful coding agent."],
+	messages: [{ role: "user", content: "Use tools", timestamp: 0 }],
+};
+
+function textToolResult(toolCallId: string, toolName: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("ACP agent provider", () => {
+	it("initializes Cursor-style ACP agents with parameterized model picker and applies default config options", async () => {
+		const result = await streamAcpAgent(model, context, {
+			command: "bun",
+			args: [fixturePath],
+			defaultConfigOptions: {
+				model: "composer-2.5",
+				fast: "false",
+			},
+			clientCapabilities: {
+				_meta: {
+					parameterizedModelPicker: true,
+				},
+			},
+			execHandlers: {
+				async read(args) {
+					return {
+						result: create(ReadResultSchema, {
+							result: {
+								case: "success",
+								value: create(ReadSuccessSchema, {
+									path: args.path,
+									totalLines: 1,
+									fileSize: BigInt("fake-file-content".length),
+									truncated: false,
+									output: { case: "content", value: "fake-file-content" },
+								}),
+							},
+						}),
+						toolResult: textToolResult(args.toolCallId ?? "read", "read", "fake-file-content"),
+					};
+				},
+				async shell(args) {
+					return {
+						result: create(ShellResultSchema, {
+							result: {
+								case: "success",
+								value: create(ShellSuccessSchema, {
+									command: args.command,
+									workingDirectory: args.workingDirectory,
+									exitCode: 0,
+									signal: "",
+									stdout: "fake-shell-output",
+									stderr: "",
+									executionTime: 0,
+								}),
+							},
+						}),
+						toolResult: textToolResult(args.toolCallId ?? "shell", "bash", "fake-shell-output"),
+					};
+				},
+			},
+		}).result();
+
+		const text = result.content.find(item => item.type === "text")?.text;
+		expect(text).toBeDefined();
+		const payload = JSON.parse(text ?? "{}");
+		expect(payload.initialize.clientCapabilities._meta.parameterizedModelPicker).toBe(true);
+		expect(payload.configSets).toContainEqual({
+			sessionId: "fake-session",
+			configId: "model",
+			value: "composer-2.5",
+		});
+		expect(payload.configSets).toContainEqual({
+			sessionId: "fake-session",
+			configId: "fast",
+			value: "false",
+		});
+		expect(payload.promptText).toContain("System:\nYou are a helpful coding agent.");
+		expect(payload.promptText).toContain("user:\nUse tools");
+		expect(payload.readContent).toBe("fake-file-content");
+		expect(payload.shellOutput).toBe("fake-shell-output");
+	});
+
+	it("accepts bare tool result handler returns for ACP file and terminal requests", async () => {
+		const result = await streamAcpAgent(model, context, {
+			command: "bun",
+			args: [fixturePath],
+			defaultConfigOptions: {
+				model: "composer-2.5",
+				fast: "false",
+			},
+			execHandlers: {
+				async read(args) {
+					return textToolResult(args.toolCallId ?? "read", "read", "bare-read-content");
+				},
+				async shell(args) {
+					return textToolResult(args.toolCallId ?? "shell", "bash", "bare-shell-output");
+				},
+			},
+		}).result();
+
+		const text = result.content.find(item => item.type === "text")?.text;
+		expect(text).toBeDefined();
+		const payload = JSON.parse(text ?? "{}");
+		expect(payload.readContent).toBe("bare-read-content");
+		expect(payload.shellOutput).toBe("bare-shell-output");
+	});
+});

--- a/packages/ai/test/fixtures/fake-acp-agent.ts
+++ b/packages/ai/test/fixtures/fake-acp-agent.ts
@@ -1,0 +1,104 @@
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+
+type CapturedState = {
+	initialize?: acp.InitializeRequest;
+	configSets: acp.SetSessionConfigOptionRequest[];
+	promptText?: string;
+	readContent?: string;
+	shellOutput?: string;
+};
+
+const state: CapturedState = {
+	configSets: [],
+};
+
+class FakeAgent implements acp.Agent {
+	async authenticate(_params: acp.AuthenticateRequest): Promise<acp.AuthenticateResponse> {
+		return {};
+	}
+
+	async initialize(params: acp.InitializeRequest): Promise<acp.InitializeResponse> {
+		state.initialize = params;
+		return {
+			protocolVersion: acp.PROTOCOL_VERSION,
+			agentCapabilities: {},
+			agentInfo: { name: "fake-acp-agent", version: "0.0.0" },
+		};
+	}
+
+	async newSession(_params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
+		return {
+			sessionId: "fake-session",
+			configOptions: [
+				{
+					id: "model",
+					name: "Model",
+					type: "select",
+					category: "model",
+					currentValue: "composer-2.5",
+					options: [{ value: "composer-2.5", name: "Composer 2.5" }],
+				},
+				{
+					id: "fast",
+					name: "Fast",
+					type: "select",
+					currentValue: "true",
+					options: [
+						{ value: "false", name: "Off" },
+						{ value: "true", name: "Fast" },
+					],
+				},
+			],
+		};
+	}
+
+	async setSessionConfigOption(
+		params: acp.SetSessionConfigOptionRequest,
+	): Promise<acp.SetSessionConfigOptionResponse> {
+		state.configSets.push(params);
+		return { configOptions: [] };
+	}
+
+	async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+		state.promptText = params.prompt.map(item => (item.type === "text" ? item.text : "")).join("\n");
+		const read = await connection.readTextFile({
+			sessionId: params.sessionId,
+			path: "/tmp/fake-acp.txt",
+		});
+		state.readContent = read.content;
+
+		const terminal = await connection.createTerminal({
+			sessionId: params.sessionId,
+			command: "printf fake-shell",
+			cwd: "/tmp",
+		});
+		const terminalOutput = await terminal.currentOutput();
+		state.shellOutput = terminalOutput.output;
+		await terminal.release();
+
+		await connection.sessionUpdate({
+			sessionId: params.sessionId,
+			update: {
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: JSON.stringify({
+						initialize: state.initialize,
+						configSets: state.configSets,
+						promptText: state.promptText,
+						readContent: state.readContent,
+						shellOutput: state.shellOutput,
+					}),
+				},
+			},
+		});
+		return { stopReason: "end_turn" };
+	}
+
+	async cancel(_params: acp.CancelNotification): Promise<void> {}
+}
+
+let connection: acp.AgentSideConnection;
+const stream = acp.ndJsonStream(Writable.toWeb(process.stdout), Readable.toWeb(process.stdin));
+connection = new acp.AgentSideConnection(() => new FakeAgent(), stream);

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -129,6 +129,7 @@ const ModelDefinitionSchema = z
 				"google-gemini-cli",
 				"ollama-chat",
 				"cursor-agent",
+				"acp-agent",
 			])
 			.optional(),
 		baseUrl: z.string().min(1).optional(),
@@ -210,6 +211,7 @@ const ProviderConfigSchema = z
 				"google-gemini-cli",
 				"ollama-chat",
 				"cursor-agent",
+				"acp-agent",
 			])
 			.optional(),
 		headers: z.record(z.string(), z.string()).optional(),

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -414,6 +414,32 @@ describe("ModelRegistry", () => {
 			expect(variants.some(variant => variant.selector === "ollama/deepseek-v4-pro:cloud")).toBe(true);
 		});
 
+		test("accepts keyless Cursor ACP custom provider models", () => {
+			writeRawModelsJson({
+				"cursor-acp": {
+					baseUrl: "acp://cursor",
+					api: "acp-agent",
+					auth: "none",
+					models: [
+						{
+							id: "composer-2.5",
+							name: "Cursor Composer 2.5 ACP",
+							input: ["text"],
+							contextWindow: 200_000,
+							maxTokens: 64_000,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("cursor-acp", "composer-2.5");
+
+			expect(model?.api).toBe("acp-agent");
+			expect(model?.provider).toBe("cursor-acp");
+			expect(model?.id).toBe("composer-2.5");
+		});
+
 		test("collapses anthropic latest aliases into the best upstream claude family id", () => {
 			writeRawModelsJson({
 				demo: providerConfig("https://demo.example.com/v1", [


### PR DESCRIPTION
## Summary
- add a keyless `acp-agent` transport that launches Cursor ACP directly for Composer 2.5
- advertise the parameterized model picker and apply `composer-2.5` with `fast=false` defaults for `cursor-acp/composer-2.5`
- route ACP file and terminal requests through the existing GJC Cursor exec handlers, with coverage for protobuf and bare tool-result returns

## Test Plan
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/ai/test/acp-agent-provider.test.ts packages/coding-agent/test/model-registry.test.ts --test-name-pattern 'ACP agent provider|accepts keyless Cursor ACP'`

## Notes
- Retargeted to `dev` after #383 was closed for using `main` as the base.
- `cursor-acp/composer-2.5` is intended to avoid the OpenAI-compatible Cursor bridge path, where tool calling is not reliable.
- The ACP client capability includes `_meta.parameterizedModelPicker = true` so Cursor exposes the Composer 2.5 parameterized model configuration.
