### PR TITLE
Add MiniMax M3 model support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added minimax-m3 model support across MiniMax providers.
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -34657,6 +34657,31 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "minimax",
+			"baseUrl": "https://api.minimax.io/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"minimax-cn": {
@@ -34822,6 +34847,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "minimax-cn",
+			"baseUrl": "https://api.minimaxi.com/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -35069,6 +35119,37 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "openai-completions",
+			"provider": "minimax-code",
+			"baseUrl": "https://api.minimax.io/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"minimax-code-cn": {
@@ -35300,6 +35381,37 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "openai-completions",
+			"provider": "minimax-code-cn",
+			"baseUrl": "https://api.minimaxi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -301,9 +301,9 @@ export const DEFAULT_MODEL_PER_PROVIDER: Record<KnownProvider, string> = {
 	"google-antigravity": "gemini-3-pro-high",
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-vertex": "gemini-3-pro-preview",
-	minimax: "MiniMax-M2.5",
-	"minimax-code": "MiniMax-M2.5",
-	"minimax-code-cn": "MiniMax-M2.5",
+	minimax: "minimax-m3",
+	"minimax-code": "minimax-m3",
+	"minimax-code-cn": "minimax-m3",
 	"openai-codex": "gpt-5.5",
 	"gitlab-duo": "duo-chat-sonnet-4-5",
 } as Record<KnownProvider, string>;

--- a/packages/ai/test/issue-385-minimax-m3.test.ts
+++ b/packages/ai/test/issue-385-minimax-m3.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { DEFAULT_MODEL_PER_PROVIDER } from "../src/provider-models/descriptors";
+
+const minimaxProviders = ["minimax", "minimax-cn", "minimax-code", "minimax-code-cn"] as const;
+
+describe("MiniMax M3 support (issue #385)", () => {
+	test("bundles minimax-m3 across first-class MiniMax providers", () => {
+		for (const provider of minimaxProviders) {
+			const model = getBundledModel(provider, "minimax-m3");
+
+			expect(model.id).toBe("minimax-m3");
+			expect(model.provider).toBe(provider);
+			expect(model.contextWindow).toBe(512_000);
+			expect(model.maxTokens).toBe(128_000);
+			expect(model.input).toContain("text");
+			expect(model.input).toContain("image");
+		}
+	});
+
+	test("uses minimax-m3 as the default first-class MiniMax model", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER.minimax).toBe("minimax-m3");
+		expect(DEFAULT_MODEL_PER_PROVIDER["minimax-code"]).toBe("minimax-m3");
+		expect(DEFAULT_MODEL_PER_PROVIDER["minimax-code-cn"]).toBe("minimax-m3");
+	});
+});

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -79,7 +79,7 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
 		providerId: "minimax-code",
 		baseUrl: "https://api.minimax.io/v1",
 		apiKeyEnv: "MINIMAX_CODE_API_KEY",
-		models: ["MiniMax-M2.5"],
+		models: ["minimax-m3"],
 		compat: MINIMAX_OPENAI_COMPAT,
 	},
 	{
@@ -92,7 +92,7 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
 		providerId: "minimax-code-cn",
 		baseUrl: "https://api.minimaxi.com/v1",
 		apiKeyEnv: "MINIMAX_CODE_CN_API_KEY",
-		models: ["MiniMax-M2.5"],
+		models: ["minimax-m3"],
 		compat: MINIMAX_OPENAI_COMPAT,
 	},
 	{

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1215,7 +1215,7 @@ describe("ModelRegistry", () => {
 			await addApiCompatibleProvider({ preset: "zai", modelsPath: presetModelsPath });
 
 			const registry = new ModelRegistry(authStorage, presetModelsPath);
-			const minimax = registry.find("minimax-code", "MiniMax-M2.5");
+			const minimax = registry.find("minimax-code", "minimax-m3");
 			const glm = registry.find("glm-proxy", "glm-4.6");
 
 			expect(minimax?.api).toBe("openai-completions");
@@ -1237,12 +1237,12 @@ describe("ModelRegistry", () => {
 					compat: {
 						extraBody: { source: "proxy" },
 					},
-					models: [{ id: "MiniMax-M2.5" }],
+					models: [{ id: "minimax-m3" }],
 				},
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			const model = registry.find("minimax-code", "MiniMax-M2.5");
+			const model = registry.find("minimax-code", "minimax-m3");
 			const compat = getOpenAICompat(model);
 			expect(compat?.thinkingFormat).toBeUndefined();
 			expect(compat?.reasoningContentField).toBeUndefined();

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -120,7 +120,7 @@ describe("provider onboarding setup core", () => {
 		expect(result.providerId).toBe("minimax-code");
 		expect(result.api).toBe("openai-completions");
 		expect(result.preset).toBe("minimax");
-		expect(result.modelIds).toEqual(["MiniMax-M2.5"]);
+		expect(result.modelIds).toEqual(["minimax-m3"]);
 		expect(formatProviderSetupResult(result)).toContain("MiniMax Coding Plan");
 
 		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
@@ -141,7 +141,7 @@ describe("provider onboarding setup core", () => {
 		expect(parsed.providers["minimax-code"]?.compat?.supportsStore).toBe(false);
 		expect(parsed.providers["minimax-code"]?.compat?.supportsDeveloperRole).toBe(false);
 		expect(parsed.providers["minimax-code"]?.compat?.reasoningContentField).toBe("reasoning_content");
-		expect(parsed.providers["minimax-code"]?.models.map(model => model.id)).toEqual(["MiniMax-M2.5"]);
+		expect(parsed.providers["minimax-code"]?.models.map(model => model.id)).toEqual(["minimax-m3"]);
 	});
 
 	it("adds GLM/zAI through preset aliases with OpenAI-compatible config", async () => {

--- a/packages/coding-agent/test/provider-slash-command.test.ts
+++ b/packages/coding-agent/test/provider-slash-command.test.ts
@@ -123,7 +123,7 @@ describe("provider slash command", () => {
 		expect(parsed.providers["minimax-code"]?.api).toBe("openai-completions");
 		expect(parsed.providers["minimax-code"]?.baseUrl).toBe("https://api.minimax.io/v1");
 		expect(parsed.providers["minimax-code"]?.apiKeyEnv).toBe("MINIMAX_CODE_API_KEY");
-		expect(parsed.providers["minimax-code"]?.models.map(model => model.id)).toEqual(["MiniMax-M2.5"]);
+		expect(parsed.providers["minimax-code"]?.models.map(model => model.id)).toEqual(["minimax-m3"]);
 		expect(parsed.providers["glm-proxy"]?.api).toBe("openai-completions");
 		expect(parsed.providers["glm-proxy"]?.baseUrl).toBe("https://api.z.ai/api/paas/v4");
 		expect(parsed.providers["glm-proxy"]?.apiKeyEnv).toBe("ZAI_API_KEY");


### PR DESCRIPTION
## Summary
- Add `minimax-m3` to the bundled first-class MiniMax provider catalogs (`minimax`, `minimax-cn`, `minimax-code`, `minimax-code-cn`).
- Make MiniMax provider presets select `minimax-m3` by default.
- Add regression coverage for bundled MiniMax M3 catalog entries and preset onboarding.

## Issue
- https://github.com/Yeachan-Heo/gajae-code/issues/385

## Validation
- `bun scripts/generate-json-schemas.ts`
- `OPENAI_API_KEY=env-openai-key bun test packages/ai/test/issue-385-minimax-m3.test.ts packages/coding-agent/test/provider-onboarding.test.ts packages/coding-agent/test/provider-slash-command.test.ts packages/coding-agent/test/model-registry.test.ts`
- `bun scripts/check-visible-definitions.ts && bun scripts/verify-g002-gates.ts && bun scripts/rebrand-inventory.ts --strict && bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun run check:schemas`

Closes https://github.com/Yeachan-Heo/gajae-code/issues/385