### PR TITLE
Fix LSP and MCP lifecycle cleanup

### DIFF
--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -61,6 +61,10 @@ function stopIdleChecker(): void {
 	}
 }
 
+export function isIdleCheckerActiveForTests(): boolean {
+	return idleCheckInterval !== null;
+}
+
 // =============================================================================
 // Client Capabilities
 // =============================================================================
@@ -919,6 +923,9 @@ export async function sendNotification(client: LspClient, method: string, params
  * Shutdown all LSP clients.
  */
 export async function shutdownAll(): Promise<void> {
+	stopIdleChecker();
+	clientLocks.clear();
+	fileOperationLocks.clear();
 	const clientsToShutdown = Array.from(clients.values());
 	clients.clear();
 	await Promise.allSettled(clientsToShutdown.map(client => shutdownClientInstance(client)));

--- a/packages/coding-agent/src/runtime-mcp/client.ts
+++ b/packages/coding-agent/src/runtime-mcp/client.ts
@@ -141,6 +141,8 @@ export async function connectToServer(
 ): Promise<MCPServerConnection> {
 	const timeoutMs = config.timeout ?? CONNECTION_TIMEOUT_MS;
 	let transport: MCPTransport | undefined;
+	const connectAbort = new AbortController();
+	const connectSignal = options?.signal ? AbortSignal.any([options.signal, connectAbort.signal]) : connectAbort.signal;
 
 	const connect = async (): Promise<MCPServerConnection> => {
 		transport = await createTransport(config);
@@ -155,7 +157,7 @@ export async function connectToServer(
 
 		try {
 			const initResult = await initializeConnection(transport, {
-				signal: options?.signal,
+				signal: connectSignal,
 				async onInitialized() {
 					// Open the SSE stream before sending initialized, so server-to-client
 					// requests triggered by on_initialized (e.g. roots/list) are delivered.
@@ -184,13 +186,14 @@ export async function connectToServer(
 			connect(),
 			timeoutMs,
 			`Connection to MCP server "${name}" timed out after ${timeoutMs}ms`,
-			options?.signal,
+			connectSignal,
 		);
 	} catch (error) {
 		// If withTimeout rejected (timeout/abort) while connect() was still pending,
-		// the transport may be alive with an open SSE listener. Close it.
+		// abort initialization and wait for transport cleanup before returning.
+		connectAbort.abort(error);
 		if (transport) {
-			void transport.close().catch(() => {});
+			await transport.close().catch(() => {});
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -152,6 +152,7 @@ export class MCPManager {
 	#connections = new Map<string, MCPServerConnection>();
 	#tools: CustomTool<TSchema, MCPToolDetails>[] = [];
 	#pendingConnections = new Map<string, Promise<MCPServerConnection>>();
+	#pendingConnectionControllers = new Map<string, AbortController>();
 	#pendingToolLoads = new Map<string, Promise<ToolLoadResult>>();
 	#sources = new Map<string, SourceMeta>();
 	#authStorage: AuthStorage | null = null;
@@ -164,6 +165,7 @@ export class MCPManager {
 	#subscribedResources = new Map<string, Set<string>>();
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
+	#disconnectEpochs = new Map<string, number>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
@@ -348,10 +350,14 @@ export class MCPManager {
 			// and falls back to cached/deferred tools.
 			this.#serverConfigs.set(name, config);
 
+			const connectionEpoch = this.#epoch;
+			const connectionAbort = new AbortController();
+			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
 				const resolvedConfig = await this.#resolveAuthConfig(config);
 				return connectToServer(name, resolvedConfig, {
+					signal: connectionAbort.signal,
 					onNotification: (method, params) => {
 						this.#handleServerNotification(name, method, params);
 					},
@@ -360,18 +366,26 @@ export class MCPManager {
 					},
 				});
 			})().then(
-				connection => {
+				async connection => {
 					// Store original config (without resolved tokens) to keep
 					// cache keys stable and avoid leaking rotating credentials.
 					connection.config = config;
-					this.#serverConfigs.set(name, config);
 					if (sources[name]) {
 						connection._source = sources[name];
 					}
-					if (this.#pendingConnections.get(name) === connectionPromise) {
+					const stillPending = this.#pendingConnections.get(name) === connectionPromise;
+					const stillCurrent = this.#epoch === connectionEpoch && this.#serverConfigs.get(name) === config;
+					if (stillPending) {
 						this.#pendingConnections.delete(name);
-						this.#connections.set(name, connection);
+						this.#pendingConnectionControllers.delete(name);
 					}
+					if (!stillPending || !stillCurrent) {
+						connection.transport.onClose = undefined;
+						await connection.transport.close().catch(() => {});
+						throw new Error(`Server "${name}" was disconnected during connection`);
+					}
+					this.#connections.set(name, connection);
+					this.#serverConfigs.set(name, config);
 
 					// Wire auth refresh for HTTP transports so 401s trigger token refresh.
 					if (connection.transport instanceof HttpTransport && config.auth?.type === "oauth") {
@@ -396,6 +410,7 @@ export class MCPManager {
 				error => {
 					if (this.#pendingConnections.get(name) === connectionPromise) {
 						this.#pendingConnections.delete(name);
+						this.#pendingConnectionControllers.delete(name);
 					}
 					throw error;
 				},
@@ -660,13 +675,16 @@ export class MCPManager {
 	 * Disconnect from a specific server.
 	 */
 	async disconnectServer(name: string): Promise<void> {
+		const nextEpoch = (this.#disconnectEpochs.get(name) ?? 0) + 1;
+		this.#disconnectEpochs.set(name, nextEpoch);
+		this.#pendingConnectionControllers.get(name)?.abort(new Error(`MCP server disconnected: ${name}`));
+		this.#pendingConnectionControllers.delete(name);
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
 		this.#sources.delete(name);
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
-
 		const connection = this.#connections.get(name);
 
 		const subscribedUris = this.#subscribedResources.get(name);
@@ -705,6 +723,10 @@ export class MCPManager {
 		const promises = Array.from(this.#connections.values()).map(conn => disconnectServer(conn));
 		await Promise.allSettled(promises);
 
+		for (const controller of this.#pendingConnectionControllers.values()) {
+			controller.abort(new Error("MCP manager disconnected"));
+		}
+		this.#pendingConnectionControllers.clear();
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();
 		this.#pendingReconnections.clear();
@@ -808,14 +830,24 @@ export class MCPManager {
 		reconnectEpoch: number,
 	): Promise<MCPServerConnection> {
 		const resolvedConfig = await this.#resolveAuthConfig(config);
-		const connection = await connectToServer(name, resolvedConfig, {
-			onNotification: (method, params) => {
-				this.#handleServerNotification(name, method, params);
-			},
-			onRequest: (method, params) => {
-				return this.#handleServerRequest(method, params);
-			},
-		});
+		const connectionAbort = new AbortController();
+		this.#pendingConnectionControllers.set(name, connectionAbort);
+		let connection: MCPServerConnection;
+		try {
+			connection = await connectToServer(name, resolvedConfig, {
+				signal: connectionAbort.signal,
+				onNotification: (method, params) => {
+					this.#handleServerNotification(name, method, params);
+				},
+				onRequest: (method, params) => {
+					return this.#handleServerRequest(method, params);
+				},
+			});
+		} finally {
+			if (this.#pendingConnectionControllers.get(name) === connectionAbort) {
+				this.#pendingConnectionControllers.delete(name);
+			}
+		}
 
 		connection.config = config;
 		if (source) connection._source = source;

--- a/packages/coding-agent/src/runtime-mcp/transports/http.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/http.ts
@@ -25,6 +25,8 @@ export class HttpTransport implements MCPTransport {
 	#connected = false;
 	#sessionId: string | null = null;
 	#sseConnection: AbortController | null = null;
+	#streamControllers = new Set<AbortController>();
+	#streamReaders = new Set<Promise<void>>();
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -52,6 +54,15 @@ export class HttpTransport implements MCPTransport {
 		this.#connected = true;
 	}
 
+	#trackReader(promise: Promise<void>, controller?: AbortController): void {
+		if (controller) this.#streamControllers.add(controller);
+		this.#streamReaders.add(promise);
+		void promise.finally(() => {
+			this.#streamReaders.delete(promise);
+			if (controller) this.#streamControllers.delete(controller);
+		});
+	}
+
 	/**
 	 * Start SSE listener for server-initiated messages.
 	 * Resolves once the SSE connection is established (or fails/unsupported).
@@ -61,7 +72,8 @@ export class HttpTransport implements MCPTransport {
 		if (!this.#connected) return;
 		if (this.#sseConnection) return;
 
-		this.#sseConnection = new AbortController();
+		const sseConnection = new AbortController();
+		this.#sseConnection = sseConnection;
 		const headers: Record<string, string> = {
 			Accept: "text/event-stream",
 			...this.config.headers,
@@ -76,10 +88,10 @@ export class HttpTransport implements MCPTransport {
 			response = await fetch(this.config.url, {
 				method: "GET",
 				headers,
-				signal: this.#sseConnection.signal,
+				signal: sseConnection.signal,
 			});
 		} catch (error) {
-			this.#sseConnection = null;
+			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
 			if (error instanceof Error && error.name !== "AbortError") {
 				this.onError?.(error);
 			}
@@ -87,19 +99,20 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {
-			this.#sseConnection = null;
+			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
 			return;
 		}
 
 		// Connection established — read messages in background.
 		// If the stream ends unexpectedly (server restart, network drop),
 		// fire onClose so the manager can trigger reconnection.
-		const signal = this.#sseConnection.signal;
-		void this.#readSSEStream(response.body!, signal).finally(() => {
+		const signal = sseConnection.signal;
+		const reader = this.#readSSEStream(response.body!, signal).finally(() => {
 			const wasConnected = this.#connected;
-			this.#sseConnection = null;
-			if (wasConnected) this.onClose?.();
+			if (this.#sseConnection === sseConnection) this.#sseConnection = null;
+			if (wasConnected && !signal.aborted) this.onClose?.();
 		});
+		this.#trackReader(reader, sseConnection);
 	}
 	async #readSSEStream(body: ReadableStream<Uint8Array>, signal: AbortSignal): Promise<void> {
 		try {
@@ -266,6 +279,8 @@ export class HttpTransport implements MCPTransport {
 		// Re-reading `response.body` after `for await` breaks would lock the
 		// stream a second time and surface as "ReadableStream already has a
 		// controller", so we must not exit the loop early.
+		const drainController = abortController;
+		this.#streamControllers.add(drainController);
 		const drain = async (): Promise<void> => {
 			try {
 				for await (const raw of readSseJson<JsonRpcMessage | JsonRpcMessage[]>(response.body!, operationSignal)) {
@@ -306,10 +321,11 @@ export class HttpTransport implements MCPTransport {
 				}
 			} finally {
 				clearTimeout(timeoutId);
+				this.#streamControllers.delete(drainController);
 			}
 		};
 
-		void drain();
+		this.#trackReader(drain());
 		return promise;
 	}
 
@@ -417,9 +433,13 @@ export class HttpTransport implements MCPTransport {
 			// on the notification response (MCP Streamable HTTP spec). Read them.
 			const contentType = response.headers.get("Content-Type") ?? "";
 			if (contentType.includes("text/event-stream") && response.body) {
-				// Use the SSE connection's signal if available, otherwise read until stream ends
-				const signal = this.#sseConnection?.signal ?? AbortSignal.timeout(this.config.timeout ?? 30000);
-				void this.#readSSEStream(response.body, signal);
+				const streamController = new AbortController();
+				const streamTimeout = AbortSignal.timeout(this.config.timeout ?? 30000);
+				const signals = this.#sseConnection
+					? [this.#sseConnection.signal, streamController.signal, streamTimeout]
+					: [streamController.signal, streamTimeout];
+				const reader = this.#readSSEStream(response.body, AbortSignal.any(signals));
+				this.#trackReader(reader, streamController);
 			} else {
 				await response.body?.cancel();
 			}
@@ -433,14 +453,20 @@ export class HttpTransport implements MCPTransport {
 	}
 
 	async close(): Promise<void> {
-		if (!this.#connected) return;
+		const wasConnected = this.#connected;
 		this.#connected = false;
 
-		// Abort SSE listener
+		// Abort all SSE/background readers and wait for them to settle.
+		for (const controller of this.#streamControllers) {
+			controller.abort();
+		}
 		if (this.#sseConnection) {
 			this.#sseConnection.abort();
 			this.#sseConnection = null;
 		}
+		await Promise.allSettled(Array.from(this.#streamReaders));
+
+		if (!wasConnected && !this.#sessionId) return;
 
 		// Send session termination if we have a session
 		if (this.#sessionId) {

--- a/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
@@ -5,8 +5,7 @@
  * Messages are newline-delimited JSON.
  */
 
-import { getProjectDir, readJsonl, Snowflake } from "@gajae-code/utils";
-import { type Subprocess, spawn } from "bun";
+import { getProjectDir, ptree, readJsonl, Snowflake } from "@gajae-code/utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -22,8 +21,10 @@ import { toJsonRpcError } from "../../runtime-mcp/types";
  * Stdio transport for MCP servers.
  * Spawns a subprocess and communicates via stdin/stdout.
  */
+const CLOSE_WAIT_MS = 1_000;
+
 export class StdioTransport implements MCPTransport {
-	#process: Subprocess<"pipe", "pipe", "pipe"> | null = null;
+	#process: ptree.ChildProcess<"pipe"> | null = null;
 	#pendingRequests = new Map<
 		string | number,
 		{
@@ -57,13 +58,11 @@ export class StdioTransport implements MCPTransport {
 			...this.config.env,
 		};
 
-		this.#process = spawn({
-			cmd: [this.config.command, ...args],
+		this.#process = ptree.spawn([this.config.command, ...args], {
 			cwd: this.config.cwd ?? getProjectDir(),
 			env,
 			stdin: "pipe",
-			stdout: "pipe",
-			stderr: "pipe",
+			stderr: "full",
 		});
 
 		this.#connected = true;
@@ -299,9 +298,11 @@ export class StdioTransport implements MCPTransport {
 		}
 		this.#pendingRequests.clear();
 
-		// Kill subprocess
-		if (this.#process) {
-			this.#process.kill();
+		// Terminate the subprocess tree and keep the handle until exit is observed.
+		const process = this.#process;
+		if (process) {
+			process.kill();
+			await Promise.race([process.exited.catch(() => {}), Bun.sleep(CLOSE_WAIT_MS)]);
 			this.#process = null;
 		}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -178,6 +178,7 @@ import type { Goal, GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
 import { ensureWorkflowSkillActivationState } from "../hooks/skill-state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
+import { shutdownAll as shutdownAllLspClients } from "../lsp/client";
 import { resolveMemoryBackend } from "../memory-backend";
 import type { WorkflowGateEmitter } from "../modes/shared/agent-wire/unattended-session";
 import { getCurrentThemeName, theme } from "../modes/theme/theme";
@@ -202,6 +203,7 @@ import {
 	isMCPToolName,
 	selectDiscoverableMCPToolNamesByServer,
 } from "../runtime-mcp/discoverable-tool-metadata";
+import { MCPManager } from "../runtime-mcp/manager";
 import { deobfuscateSessionContext, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatNoCredentialOnboardingError, formatNoModelOnboardingError } from "../setup/model-onboarding-guidance";
 import {
@@ -3130,6 +3132,14 @@ export class AgentSession {
 				AsyncJobManager.setInstance(undefined);
 			}
 		}
+		const mcpManager = MCPManager.instance();
+		if (mcpManager) {
+			await mcpManager.disconnectAll();
+			if (MCPManager.instance() === mcpManager) {
+				MCPManager.setInstance(undefined);
+			}
+		}
+		await shutdownAllLspClients();
 		const pythonExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
 		if (!pythonExecutionsSettled) {
 			logger.warn(

--- a/packages/coding-agent/test/lsp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/lsp-lifecycle-cleanup.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getActiveClients, isIdleCheckerActiveForTests, setIdleTimeout, shutdownAll } from "../src/lsp/client";
+
+describe("LSP lifecycle cleanup", () => {
+	afterEach(async () => {
+		await shutdownAll();
+	});
+
+	it("shutdownAll stops the idle checker when no clients remain", async () => {
+		setIdleTimeout(60_000);
+		expect(isIdleCheckerActiveForTests()).toBe(true);
+
+		await shutdownAll();
+
+		expect(getActiveClients()).toEqual([]);
+		expect(isIdleCheckerActiveForTests()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import * as mcpClient from "../src/runtime-mcp/client";
+import { MCPManager } from "../src/runtime-mcp/manager";
+import { HttpTransport } from "../src/runtime-mcp/transports/http";
+import type { MCPServerConfig, MCPServerConnection, MCPTransport } from "../src/runtime-mcp/types";
+
+function makeConnection(name: string, close: () => Promise<void> = async () => {}): MCPServerConnection {
+	return {
+		name,
+		config: { type: "stdio", command: "test" },
+		transport: {
+			connected: true,
+			async request() {
+				throw new Error("unused");
+			},
+			async notify() {},
+			close,
+		} satisfies MCPTransport,
+		serverInfo: { name: "test", version: "1.0" },
+		capabilities: { tools: {} },
+	};
+}
+
+describe("MCP lifecycle cleanup", () => {
+	afterEach(() => {
+		mock.restore();
+		MCPManager.resetForTests();
+	});
+
+	it("disconnectServer aborts pending initial connection work", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		let closedLateConnection = false;
+		const release = Promise.withResolvers<MCPServerConnection>();
+		mock.module("../src/runtime-mcp/client", () => ({
+			...mcpClient,
+			connectToServer: (_name: string, _config: MCPServerConfig, options?: { signal?: AbortSignal }) => {
+				capturedSignal = options?.signal;
+				return release.promise;
+			},
+			listTools: async () => [],
+		}));
+		const { MCPManager: MockedManager } = await import("../src/runtime-mcp/manager");
+		const manager = new MockedManager(process.cwd());
+
+		const load = manager.connectServers(
+			{ slow: { type: "stdio", command: "slow", timeout: 10_000 } },
+			{ slow: { provider: "test", providerName: "Test", path: "test", level: "project" } },
+		);
+		await Bun.sleep(0);
+
+		await manager.disconnectServer("slow");
+		expect(capturedSignal?.aborted).toBe(true);
+
+		release.resolve(
+			makeConnection("slow", async () => {
+				closedLateConnection = true;
+			}),
+		);
+		await load;
+		await Bun.sleep(0);
+
+		expect(manager.getConnection("slow")).toBeUndefined();
+		expect(closedLateConnection).toBe(true);
+	});
+
+	it("disconnectAll aborts pending initial connection work", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		const release = Promise.withResolvers<MCPServerConnection>();
+		mock.module("../src/runtime-mcp/client", () => ({
+			...mcpClient,
+			connectToServer: (_name: string, _config: MCPServerConfig, options?: { signal?: AbortSignal }) => {
+				capturedSignal = options?.signal;
+				return release.promise;
+			},
+			listTools: async () => [],
+		}));
+		const { MCPManager: MockedManager } = await import("../src/runtime-mcp/manager");
+		const manager = new MockedManager(process.cwd());
+
+		const load = manager.connectServers(
+			{ slow: { type: "stdio", command: "slow", timeout: 10_000 } },
+			{ slow: { provider: "test", providerName: "Test", path: "test", level: "project" } },
+		);
+		await Bun.sleep(0);
+
+		await manager.disconnectAll();
+		expect(capturedSignal?.aborted).toBe(true);
+
+		release.resolve(makeConnection("slow"));
+		await load;
+		expect(manager.getConnection("slow")).toBeUndefined();
+	});
+
+	it("HttpTransport.close aborts and settles background SSE readers without reconnect", async () => {
+		const originalFetch = globalThis.fetch;
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('data: {"jsonrpc":"2.0","method":"ping"}\n\n'));
+			},
+		});
+		globalThis.fetch = (async () =>
+			new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			})) as unknown as typeof fetch;
+		try {
+			const transport = new HttpTransport({ type: "http", url: "http://example.test/mcp", timeout: 10_000 });
+			let closeEvents = 0;
+			transport.onClose = () => {
+				closeEvents++;
+			};
+			await transport.connect();
+			await transport.startSSEListener();
+
+			await transport.close();
+
+			expect(transport.connected).toBe(false);
+			expect(closeEvents).toBe(1);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});


### PR DESCRIPTION
Closes #388.

## Summary
- switch MCP stdio transport to repository ptree process-tree termination and await close settlement
- abort pending MCP connection work on disconnect/disconnectAll, close stale late connections, and avoid reconnect on intentional close
- track/abort/settle HTTP/SSE reader loops during transport close
- stop LSP idle checker and clear global clients/locks during shutdownAll
- clean process-global MCP/LSP lifecycle state from AgentSession.dispose

## Verification
- bun test packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts packages/coding-agent/test/lsp-lifecycle-cleanup.test.ts
- bun run check:ts
- bun test packages/coding-agent/test (5003 pass, 355 skip, 5 unrelated failures: model-registry env key expected env-openai-key but received ambient OPENAI key; marketplace project-scope temp root resolved /tmp; ultragoal runtime stale/corrupt mode-state reconciliation expectations)

## Follow-up
- A macOS manual process-list smoke check with real MCP/LSP servers would still be useful because the automated regression uses focused fake lifecycle paths rather than Activity Monitor/ps output.