### PR TITLE
test(rpc): real-model unattended lifecycle e2e (#314/#323 final gap)

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -20,6 +20,8 @@ import type {
 	RpcHostToolUpdate,
 	RpcResponse,
 	RpcSessionState,
+	RpcUnattendedAccepted,
+	RpcUnattendedDeclaration,
 	RpcWorkflowGate,
 	RpcWorkflowGateResolution,
 	RpcWorkflowGateResponse,
@@ -338,6 +340,26 @@ export class RpcClient {
 			answer,
 			idempotency_key: idempotencyKey,
 		});
+		return this.#getData(response);
+	}
+
+	/**
+	 * Subscribe to extension UI requests emitted by the server (e.g. select /
+	 * input / editor / confirm). Returns an unsubscribe function.
+	 */
+	onExtensionUiRequest(listener: (req: RpcExtensionUIRequest) => void): () => void {
+		this.#extensionUiListeners.add(listener);
+		return () => {
+			this.#extensionUiListeners.delete(listener);
+		};
+	}
+
+	/**
+	 * Enter unattended mode by declaring budget + scopes + action allowlist.
+	 * Returns the accepted declaration, or rejects (fail-closed) on refusal.
+	 */
+	async negotiateUnattended(declaration: RpcUnattendedDeclaration): Promise<RpcUnattendedAccepted> {
+		const response = await this.#send({ type: "negotiate_unattended", declaration });
 		return this.#getData(response);
 	}
 

--- a/packages/coding-agent/test/rpc-client-workflow-gate-redteam.test.ts
+++ b/packages/coding-agent/test/rpc-client-workflow-gate-redteam.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RpcClient } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+import type { RpcExtensionUIRequest, RpcUnattendedDeclaration } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
+
+const declaration: RpcUnattendedDeclaration = {
+	actor: "redteam-agent",
+	budget: { max_tokens: 100, max_tool_calls: 2, max_wall_time_ms: 1000, max_cost_usd: 1 },
+	scopes: ["prompt", "control"],
+	action_allowlist: ["command.prompt", "command.control"],
+};
+
+async function withFakeServer(source: string, run: (client: RpcClient) => Promise<void>): Promise<void> {
+	const scriptPath = path.join(os.tmpdir(), `gjc-rpc-workflow-gate-redteam-${Date.now()}-${Math.random()}.js`);
+	await Bun.write(scriptPath, source);
+	const client = new RpcClient({ cliPath: scriptPath });
+	try {
+		await run(client);
+	} finally {
+		client.stop();
+		await fs.unlink(scriptPath).catch(() => undefined);
+	}
+}
+
+describe("RpcClient workflow_gate red-team hardening", () => {
+	it("negotiateUnattended fail-closes on object-valued refusal responses", async () => {
+		await withFakeServer(
+			`
+let buffer = "";
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+process.stdin.on("data", chunk => {
+	buffer += chunk.toString("utf8");
+	let index = buffer.indexOf("\\n");
+	while (index !== -1) {
+		const line = buffer.slice(0, index).trim();
+		buffer = buffer.slice(index + 1);
+		if (line) {
+			const frame = JSON.parse(line);
+			write({
+				id: frame.id,
+				type: "response",
+				command: frame.type,
+				success: false,
+				error: { code: "incomplete_budget" },
+			});
+		}
+		index = buffer.indexOf("\\n");
+	}
+});
+`,
+			async client => {
+				await client.start();
+				await expect(client.negotiateUnattended(declaration)).rejects.toThrow(/"incomplete_budget"/);
+			},
+		);
+	});
+
+	it("onExtensionUiRequest unsubscribe stops further delivery", async () => {
+		await withFakeServer(
+			`
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+setTimeout(() => write({ type: "extension_ui_request", id: "ui-1", method: "select", title: "pick", options: ["a", "b"] }), 0);
+setTimeout(() => write({ type: "extension_ui_request", id: "ui-2", method: "select", title: "pick again", options: ["c", "d"] }), 20);
+setInterval(() => {}, 1000);
+`,
+			async client => {
+				const received: RpcExtensionUIRequest[] = [];
+				const { promise, resolve } = Promise.withResolvers<void>();
+				const unsubscribe = client.onExtensionUiRequest(req => {
+					received.push(req);
+					unsubscribe();
+					resolve();
+				});
+				await client.start();
+				await promise;
+				await Bun.sleep(60);
+				expect(received.map(req => req.id)).toEqual(["ui-1"]);
+			},
+		);
+	});
+
+	it("negotiateUnattended sends exactly negotiate_unattended and carries the declaration verbatim", async () => {
+		await withFakeServer(
+			`
+let buffer = "";
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+process.stdin.on("data", chunk => {
+	buffer += chunk.toString("utf8");
+	let index = buffer.indexOf("\\n");
+	while (index !== -1) {
+		const line = buffer.slice(0, index).trim();
+		buffer = buffer.slice(index + 1);
+		if (line) {
+			const frame = JSON.parse(line);
+			write({
+				id: frame.id,
+				type: "response",
+				command: "negotiate_unattended",
+				success: true,
+				data: {
+					run_id: "run-redteam",
+					accepted_at: "2026-06-05T05:00:00.000Z",
+					echoed_type: frame.type,
+					echoed_declaration: frame.declaration,
+				},
+			});
+		}
+		index = buffer.indexOf("\\n");
+	}
+});
+`,
+			async client => {
+				await client.start();
+				const accepted = await client.negotiateUnattended(declaration);
+				expect(accepted).toMatchObject({ echoed_type: "negotiate_unattended", echoed_declaration: declaration });
+			},
+		);
+	});
+
+	it("onExtensionUiRequest delivers confirm method frames for human-UI assertions", async () => {
+		await withFakeServer(
+			`
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+write({ type: "extension_ui_request", id: "ui-confirm", method: "confirm", title: "confirm?", message: "danger" });
+setInterval(() => {}, 1000);
+`,
+			async client => {
+				const { promise, resolve } = Promise.withResolvers<RpcExtensionUIRequest>();
+				client.onExtensionUiRequest(resolve);
+				await client.start();
+				const req = await promise;
+				expect(req.method).toBe("confirm");
+				expect(req.id).toBe("ui-confirm");
+			},
+		);
+	});
+});

--- a/packages/coding-agent/test/rpc-client-workflow-gate.test.ts
+++ b/packages/coding-agent/test/rpc-client-workflow-gate.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { RpcClient } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
-import type { RpcWorkflowGate } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
+import type { RpcExtensionUIRequest, RpcWorkflowGate } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
 
 const gate: RpcWorkflowGate = {
 	type: "workflow_gate",
@@ -119,6 +119,72 @@ process.stdin.on("data", chunk => {
 				await client.start();
 				const resolution = await client.respondGate(gate.gate_id, { decision: "approve" }, "idem-1");
 				expect(resolution).toMatchObject({ gate_id: gate.gate_id, status: "accepted" });
+			},
+		);
+	});
+
+	it("negotiateUnattended sends negotiate_unattended and returns the accepted declaration", async () => {
+		await withFakeServer(
+			`
+let buffer = "";
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+process.stdin.on("data", chunk => {
+	buffer += chunk.toString("utf8");
+	let index = buffer.indexOf("\\n");
+	while (index !== -1) {
+		const line = buffer.slice(0, index).trim();
+		buffer = buffer.slice(index + 1);
+		if (line) {
+			const frame = JSON.parse(line);
+			const d = frame.declaration;
+			write({
+				id: frame.id,
+				type: "response",
+				command: "negotiate_unattended",
+				success: true,
+				data: {
+					run_id: "run-fake",
+					actor: d.actor,
+					budget: d.budget,
+					scopes: d.scopes,
+					action_allowlist: d.action_allowlist,
+					accepted_at: "2026-06-05T05:00:00.000Z",
+				},
+			});
+		}
+		index = buffer.indexOf("\\n");
+	}
+});
+`,
+			async client => {
+				await client.start();
+				const accepted = await client.negotiateUnattended({
+					actor: "hermes",
+					budget: { max_tokens: 100, max_tool_calls: 2, max_wall_time_ms: 1000, max_cost_usd: 1 },
+					scopes: ["prompt"],
+					action_allowlist: ["command.prompt"],
+				});
+				expect(accepted).toMatchObject({ run_id: "run-fake", actor: "hermes", scopes: ["prompt"] });
+			},
+		);
+	});
+
+	it("onExtensionUiRequest delivers extension_ui_request frames to listeners", async () => {
+		await withFakeServer(
+			`
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+write({ type: "extension_ui_request", id: "ui-1", method: "select", title: "pick", options: ["a", "b"] });
+setInterval(() => {}, 1000);
+`,
+			async client => {
+				const { promise, resolve } = Promise.withResolvers<RpcExtensionUIRequest>();
+				client.onExtensionUiRequest(resolve);
+				await client.start();
+				const req = await promise;
+				expect(req.method).toBe("select");
+				expect(req.id).toBe("ui-1");
 			},
 		);
 	});

--- a/packages/coding-agent/test/rpc-live-unattended-e2e.test.ts
+++ b/packages/coding-agent/test/rpc-live-unattended-e2e.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { RpcClient } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+import type {
+	RpcExtensionUIRequest,
+	RpcUnattendedDeclaration,
+	RpcWorkflowGate,
+} from "@gajae-code/coding-agent/modes/rpc/rpc-types";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
+import { e2eApiKey } from "./utilities";
+
+/**
+ * #314/#323 FINAL gap closer: a real model, running unattended over the real
+ * spawned `gjc --mode rpc-ui` server, actually calls the ask tool which emits a
+ * workflow_gate over RPC; a scripted external "memory" agent answers via
+ * workflow_gate_response with zero human input; the turn resumes and completes.
+ *
+ * Prior coverage proves in-process components (#355) and the spawned stdio
+ * transport seam without a model (#391). This is the only test that proves the
+ * headline acceptance with a REAL model.
+ *
+ * CI-safe: the whole describe skips without ANTHROPIC_API_KEY. With a key, ONE
+ * overall deadline bounds the entire flow (no stacking sub-waits, no CI hang),
+ * and the spawned process is always killed in finally.
+ */
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+const OVERALL_DEADLINE_MS = 90_000;
+const BUN_TIMEOUT_MS = 120_000;
+const SELECTED = "Remember Beta";
+const MARKER = "UNATTENDED_GATE_ADVANCED";
+
+const declaration: RpcUnattendedDeclaration = {
+	actor: "memory-agent/live-e2e",
+	budget: { max_tokens: 12_000, max_tool_calls: 8, max_wall_time_ms: OVERALL_DEADLINE_MS, max_cost_usd: 2 },
+	scopes: ["prompt", "control", "message:read"],
+	action_allowlist: ["command.prompt", "command.control", "command.message_read"],
+};
+
+const ASK_PROMPT = [
+	"This is a live unattended lifecycle test. You MUST use the `ask` tool exactly once before any final answer.",
+	'Ask ONE single-select multiple-choice clarifying question with id "memory_choice" and EXACTLY these options:',
+	'- "Remember Alpha"',
+	'- "Remember Beta"',
+	'Set the recommended option to "Remember Beta".',
+	`After the ask tool returns, reply in ONE concise sentence that includes the exact selected option label and the marker ${MARKER}.`,
+	"Do not call any other tool. Do not ask in plain text. Do not finish until the ask tool has returned.",
+].join("\n");
+
+const RETRY_PROMPT = `You did not call the ask tool. You MUST call the \`ask\` tool now with one single-select question id "memory_choice" and options "Remember Alpha" / "Remember Beta", then reply with the selected label and ${MARKER}.`;
+
+const HUMAN_UI_METHODS = new Set(["select", "input", "editor", "confirm"]);
+
+describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("RPC live unattended lifecycle (real model)", () => {
+	let workspace: string;
+	let cliEnv: HarnessCliEnv;
+
+	beforeEach(async () => {
+		workspace = await mkdtemp(path.join(tmpdir(), "rpc-live-e2e-"));
+		cliEnv = createHarnessCliEnv(repoRoot);
+	});
+
+	afterEach(async () => {
+		try {
+			cliEnv.cleanup();
+		} catch {
+			// best-effort temp cleanup (tolerate worktree symlinked node_modules)
+		}
+		await rm(workspace, { recursive: true, force: true });
+	});
+
+	it(
+		"a real model emits a workflow_gate over RPC, an external agent answers it, and the turn advances with zero human UI",
+		async () => {
+			const key = e2eApiKey("ANTHROPIC_API_KEY");
+			const client = new RpcClient({
+				cliPath: cliEntry,
+				cwd: workspace,
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				// Last --mode wins in arg parsing; rpc-ui sets hasUI=true so the ask tool exists.
+				args: ["--mode", "rpc-ui"],
+				env: { ...cliEnv.env, ANTHROPIC_API_KEY: key as string, GJC_HARNESS_STATE_ROOT: workspace },
+			});
+
+			// ONE overall deadline bounds the whole flow; every sub-wait derives from it.
+			const deadlineAt = Date.now() + OVERALL_DEADLINE_MS;
+			const remainingMs = () => Math.max(0, deadlineAt - Date.now());
+			const withDeadline = async <T>(p: Promise<T>, label: string): Promise<T> => {
+				let timer: ReturnType<typeof setTimeout> | undefined;
+				const guard = new Promise<never>((_, reject) => {
+					timer = setTimeout(() => reject(new Error(`overall deadline exceeded at: ${label}`)), remainingMs());
+				});
+				try {
+					return await Promise.race([p, guard]);
+				} finally {
+					if (timer) clearTimeout(timer);
+				}
+			};
+
+			const gates: RpcWorkflowGate[] = [];
+			const uiRequests: RpcExtensionUIRequest[] = [];
+			let answered = 0;
+
+			client.onExtensionUiRequest(req => uiRequests.push(req));
+			// External "memory" agent: answer every received gate over RPC, zero human input.
+			client.onWorkflowGate(gate => {
+				gates.push(gate);
+				void client
+					.respondGate(gate.gate_id, { selected: [SELECTED] }, `ans-${gate.gate_id}`)
+					.then(() => {
+						answered += 1;
+					})
+					.catch(() => {
+						/* surfaced via diagnostics below */
+					});
+			});
+
+			const diagnostics = () =>
+				[
+					`gates=${JSON.stringify(gates.map(g => ({ id: g.gate_id, stage: g.stage, kind: g.kind })))}`,
+					`answered=${answered}`,
+					`uiRequests=${JSON.stringify(uiRequests.map(r => r.method))}`,
+					`stderr=${client.getStderr().slice(-2000)}`,
+				].join("\n");
+
+			try {
+				await withDeadline(client.start(), "client.start");
+
+				const accepted = await withDeadline(client.negotiateUnattended(declaration), "negotiate_unattended");
+				expect(accepted.actor).toBe(declaration.actor);
+				expect(accepted.budget).toEqual(declaration.budget);
+				expect(accepted.scopes).toEqual(declaration.scopes);
+				expect(accepted.action_allowlist).toEqual(declaration.action_allowlist);
+
+				// Turn 1: prompt the model to call ask (emitting a gate).
+				await withDeadline(client.promptAndWait(ASK_PROMPT, undefined, remainingMs()), "prompt#1");
+
+				// No-silent-pass: one stricter retry if the model finished without a gate.
+				if (gates.length === 0) {
+					await withDeadline(client.promptAndWait(RETRY_PROMPT, undefined, remainingMs()), "prompt#retry");
+				}
+				if (gates.length === 0) {
+					throw new Error(`model never emitted a workflow_gate after a retry.\n${diagnostics()}`);
+				}
+
+				// (1) a deep-interview question gate was emitted over RPC
+				const gate = gates[0];
+				expect(gate.stage).toBe("deep-interview");
+				expect(gate.kind).toBe("question");
+				expect(gate.required).toBe(true);
+				expect(gate.options?.map(o => o.value)).toContain(SELECTED);
+				expect(answered, `gate not answered.\n${diagnostics()}`).toBeGreaterThanOrEqual(1);
+
+				// (2) ZERO interactive human UI (gate path, not a human prompt)
+				const humanUi = uiRequests.filter(r => HUMAN_UI_METHODS.has(r.method));
+				expect(humanUi, `unexpected human UI requests.\n${diagnostics()}`).toHaveLength(0);
+
+				// (3) the turn advanced/completed after the answer. Use the model's actual
+				// last assistant text (NOT raw events) so the markers prove the model's
+				// reply, not the echoed prompt.
+				const finalText = (await withDeadline(client.getLastAssistantText(), "get_last_assistant_text")) ?? "";
+				expect(finalText, `final assistant text missing markers.\n${diagnostics()}`).toContain(SELECTED);
+				expect(finalText).toContain(MARKER);
+			} finally {
+				// Always kill the spawned process — no orphan, no hang, even on deadline expiry.
+				try {
+					client.stop();
+				} catch {
+					/* ignore */
+				}
+			}
+		},
+		BUN_TIMEOUT_MS,
+	);
+});


### PR DESCRIPTION
## Why

Final verification gap for the agent-driven RPC workflow lifecycle epic (#314). Prior PRs proved the in-process components (#355) and the spawned **stdio** transport seam without a model (#391). The headline #323 acceptance — a **zero-human, model-driven** unattended run — had no automated test. This adds it.

Planned via **ralplan** consensus (Planner → Architect CLEAR → Critic ITERATE[single-deadline] → revision → Architect CLEAR → Critic OKAY) and executed via **ultragoal** with a clean review gate (architect CLEAR/CLEAR/CLEAR + APPROVE, executor QA passed, zero blockers).

## What

`packages/coding-agent/test/rpc-live-unattended-e2e.test.ts` (new):
- `describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))` — skips cleanly without a key (runs live in keyed CI).
- Spawns the **real** `gjc --mode rpc-ui` server via `createHarnessCliEnv` (pure `rpc` has `hasUI=false` → no ask tool; `rpc-ui` selected via `options.args`, last `--mode` wins).
- `negotiateUnattended` with a complete budget/scopes/action_allowlist; asserts the accepted declaration mirrors it.
- Prompts a real model (`claude-sonnet-4-5`) to call the **ask** tool once → emits a `workflow_gate` over RPC; a scripted external memory agent answers via `respondGate`.
- Asserts: gate `stage=deep-interview`/`kind=question`/options; **zero** interactive human UI (no select/input/editor/confirm); the turn advances with the markers via **`getLastAssistantText()`** (so echoed prompt text can't satisfy it); budget-bounded.
- **One overall 90s deadline** bounds the whole flow (non-stacking sub-waits, Bun timeout 120s); **no-silent-pass** retry + fail-with-diagnostics; `finally` always kills the spawned process.

`rpc-client.ts`: two **additive, default-preserving** seams — `negotiateUnattended()` and `onExtensionUiRequest()`. No `start()`/server behavior change.

Deterministic (no-key) coverage of the new client methods: `rpc-client-workflow-gate.test.ts` (+2 cases) and `rpc-client-workflow-gate-redteam.test.ts` (new): negotiate accepted + fail-closed refusal, extension-UI delivery + unsubscribe, verbatim declaration.

## Testing
- `bun --cwd=packages/coding-agent run check:types` — clean
- `bun test packages/coding-agent/test/rpc-live-unattended-e2e.test.ts packages/coding-agent/test/rpc-client-workflow-gate.test.ts packages/coding-agent/test/rpc-client-workflow-gate-redteam.test.ts` → 9 pass / 1 skip (live e2e w/o key) / 0 fail
- biome clean