### PR TITLE
Fix RPC stdio tests without model secrets

### DIFF
--- a/packages/coding-agent/test/rpc-unattended-stdio.test.ts
+++ b/packages/coding-agent/test/rpc-unattended-stdio.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
@@ -14,8 +14,9 @@ import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane
  *   - emitFrame -> stdout JSON serialization
  *   - the stdin JSONL parse loop routing negotiate_unattended / workflow_gate_response
  *     through the shared dispatcher.
- * No model/API key is needed: negotiation and answering route through the control
- * plane without running the agent loop.
+ * The spawned CLI still performs normal non-interactive startup, so the test
+ * provides an isolated keyless fixture model config instead of depending on
+ * developer or CI provider secrets.
  */
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -23,10 +24,29 @@ const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"
 
 let workspace: string;
 let cliEnv: HarnessCliEnv;
+const fixtureModelsYaml = `providers:
+  rpc-test:
+    auth: none
+    api: openai-responses
+    baseUrl: http://127.0.0.1:9/v1
+    models:
+      - id: rpc-test-model
+        contextWindow: 100000
+        maxTokens: 4096
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+`;
 
 beforeEach(async () => {
 	workspace = await mkdtemp(path.join(tmpdir(), "rpc-stdio-ws-"));
 	cliEnv = createHarnessCliEnv(repoRoot);
+	const agentDir = path.join(workspace, ".gjc", "agent");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(path.join(agentDir, "models.yml"), fixtureModelsYaml);
+	cliEnv.env.GJC_CODING_AGENT_DIR = agentDir;
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Summary
- Fixes dev CI run 27078523672, job 79920057735 failure in `packages/coding-agent/test/rpc-unattended-stdio.test.ts`.
- The stdio tests spawn real `gjc --mode rpc`, which now performs normal non-interactive startup and exits before emitting `ready` when CI has no configured models.
- Adds an isolated per-test `GJC_CODING_AGENT_DIR` with a keyless local fixture `models.yml`, keeping the RPC/unattended fail-closed coverage deterministic without live provider secrets or user config.

## CI failure evidence
- Affected path validation job failed with `expected ready frame, got none`.
- stderr showed: `No models available. Model selection only shows configured providers... Advanced manual config remains available at /home/runner/.gjc/agent/models.yml`.
- The second fail-closed test also failed because the server exited before negotiation/command routing.

## Verification
- `bun install`
- `bun run build:native`
- `bun --cwd=packages/coding-agent test test/rpc-unattended-stdio.test.ts`
- `bun --cwd=packages/coding-agent test test/rpc-unattended-stdio.test.ts test/rpc-workflow-gate.test.ts test/harness-control-plane/rpc-unattended-lifecycle.test.ts test/rpc-live-unattended-regression.test.ts`

Note: an initial `bun run test packages/coding-agent/test/rpc-unattended-stdio.test.ts` invocation used the root script and attempted the broader workspace test set before dependencies/native addon were installed; it failed on missing local workspace modules/native addon, not on the patched test contract.