### PR TITLE
fix: correct MiniMax M3 display casing

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -34660,7 +34660,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "minimax",
 			"baseUrl": "https://api.minimax.io/anthropic",
@@ -34855,7 +34855,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "minimax-cn",
 			"baseUrl": "https://api.minimaxi.com/anthropic",
@@ -35122,7 +35122,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "minimax-code",
 			"baseUrl": "https://api.minimax.io/v1",
@@ -35395,7 +35395,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "minimax-code-cn",
 			"baseUrl": "https://api.minimaxi.com/v1",

--- a/packages/ai/test/issue-385-minimax-m3.test.ts
+++ b/packages/ai/test/issue-385-minimax-m3.test.ts
@@ -23,4 +23,11 @@ describe("MiniMax M3 support (issue #385)", () => {
 		expect(DEFAULT_MODEL_PER_PROVIDER["minimax-code"]).toBe("minimax-m3");
 		expect(DEFAULT_MODEL_PER_PROVIDER["minimax-code-cn"]).toBe("minimax-m3");
 	});
+
+	test("surfaces minimax-m3 with MiniMax-M3 display casing (issue #404)", () => {
+		for (const provider of minimaxProviders) {
+			const model = getBundledModel(provider, "minimax-m3");
+			expect(model.name).toBe("MiniMax-M3");
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #404.

The four bundled `minimax-m3` model entries surfaced their user-facing display name as `MiniMax M3` (with a space), inconsistent with the official `MiniMax-M3` branding and the existing `MiniMax-M2.5` naming convention. This corrects the display casing to `MiniMax-M3` across all first-class MiniMax providers.

## Changes

- `packages/ai/src/models.json`: set `name` to `MiniMax-M3` for the `minimax`, `minimax-cn`, `minimax-code`, and `minimax-code-cn` provider entries.
- `packages/ai/test/issue-385-minimax-m3.test.ts`: added a focused test asserting `model.name === "MiniMax-M3"` for each MiniMax provider (fails with the old `MiniMax M3` value, passes after the fix).

## Verification

- `bun test test/issue-385-minimax-m3.test.ts` — 3 pass, 0 fail
- `bun run build` — success
- `bun run check:schemas` — success