### PR TITLE
Guard Team lane handoffs

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -124,6 +124,15 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 - explain why each lane exists (delivery, verification, specialist support)
 - include an explicit launch hint (`gjc team "<task>"` / `$team "<task>"`) for the coordinated worker run; mention `$ultragoal` as the default durable follow-up/ledger path; mention a later separate Single-owner execution follow-up only when explicitly requested or genuinely needed as a fallback
 - if the ideal role is unavailable, choose the closest role from the roster and say so
+- For multi-worker follow-up execution, do not pass an inline "Split lanes: A..., B..." sentence as the whole team task. `gjc team` rejects ambiguous inline lane splits because they previously caused every worker to receive the same broad task. Use explicit markdown lane sections instead:
+  ```md
+  ### Lane A — Delivery
+  Implement delivery-only changes and evidence.
+
+  ### Lane B — Verification
+  Add focused tests and smoke evidence.
+  ```
+  Explicit `### Lane <id> — <title>` sections are converted into distinct worker-owned initial tasks.
 
 ## Current Runtime Behavior (As Implemented)
 
@@ -134,7 +143,7 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 3. Initialize team state:
    - `.gjc/state/team/<team>/config.json`
    - `.gjc/state/team/<team>/manifest.v2.json`
-   - `.gjc/state/team/<team>/tasks/task-1.json`
+   - `.gjc/state/team/<team>/tasks/task-*.json` (one per explicit lane section, otherwise one worker-owned compatibility task per worker)
    - `.gjc/state/team/<team>/mailbox/worker-1.json`
    - `.gjc/state/team/<team>/workers/<worker>/status.json`
    - `.gjc/state/team/<team>/workers/<worker>/lifecycle.json`

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1673,9 +1673,10 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 		`You are ${worker.id} in gjc team ${config.team_name}.`,
 		`Team state root: ${config.state_root}.`,
 		workspace,
-		`Task: ${config.task}`,
+		`Team brief (context only): ${config.task}`,
+		"Before implementation, claim your worker-owned task and treat the claimed task record as the source of truth. Do not implement directly from the broad team brief.",
 		`Before claiming work, send startup ACK: gjc team api worker-startup-ack --input '{"team_name":"${config.team_name}","worker_id":"${worker.id}","protocol_version":"1"}' --json.`,
-		`Use gjc team api update-worker-status to report task-local activity, then claim-task/transition-task-status with this worker id; record completion_evidence (summary plus a passed command or verified inspection/artifact item) before completed, and do not mutate leader-owned goal state.`,
+		`Use gjc team api update-worker-status to report task-local activity, then claim-task/transition-task-status with this worker id; keep heartbeat current during long work, record completion_evidence (summary plus a passed command or verified inspection/artifact item) before completed, and do not mutate leader-owned goal state.`,
 	].join("\n");
 	const env = [
 		`GJC_TEAM_WORKER=${shellQuote(`${config.team_name}/${worker.id}`)}`,
@@ -1689,7 +1690,80 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 	];
 	return `${env.join(" ")} ${config.worker_command} ${shellQuote(prompt)}`;
 }
+interface GjcTeamInitialLane {
+	label: string;
+	title: string;
+	body: string;
+}
+
+function normalizeLaneId(label: string): string {
+	return `lane-${sanitizeName(label).toLowerCase() || stableHash(label).slice(0, 8)}`;
+}
+
+function parseExplicitTeamLanes(task: string): GjcTeamInitialLane[] {
+	const lines = task.split(/\r?\n/);
+	const lanes: GjcTeamInitialLane[] = [];
+	let current: { label: string; title: string; body: string[] } | null = null;
+	const laneHeading = /^#{2,6}\s+Lane\s+([A-Za-z0-9]+)\s*(?:[—–-]\s*(.+))?\s*$/;
+	const boundaryHeading = /^#{1,6}\s+(?:Integration Owner|Verification Plan|ADR|Approval State)\b/i;
+
+	for (const line of lines) {
+		const match = line.match(laneHeading);
+		if (match) {
+			if (current) lanes.push({ ...current, body: current.body.join("\n").trim() });
+			current = {
+				label: match[1] ?? `${lanes.length + 1}`,
+				title: (match[2] ?? `Lane ${match[1] ?? lanes.length + 1}`).trim(),
+				body: [],
+			};
+			continue;
+		}
+		if (current && boundaryHeading.test(line)) {
+			lanes.push({ ...current, body: current.body.join("\n").trim() });
+			current = null;
+			continue;
+		}
+		if (current) current.body.push(line);
+	}
+	if (current) lanes.push({ ...current, body: current.body.join("\n").trim() });
+	return lanes.filter(lane => lane.body.length > 0 || lane.title.length > 0);
+}
+
+function hasAmbiguousLaneSplitIntent(task: string): boolean {
+	return (
+		/\bsplit\s+lanes?\s*:/i.test(task) || /\blanes?\s*:\s*[A-Z]\b/i.test(task) || /\bLane\s+[A-Z]\s*[—–-]/.test(task)
+	);
+}
+
 function buildInitialTasks(task: string, workers: GjcTeamWorker[]): GjcTeamTask[] {
+	const lanes = parseExplicitTeamLanes(task);
+	if (lanes.length > 0)
+		return lanes.map((lane, index) => {
+			const worker = workers[index % workers.length];
+			if (!worker) throw new Error("team_lane_requires_worker");
+			const laneTitle = `Lane ${lane.label} — ${lane.title}`;
+			const objective = [`${laneTitle}`, lane.body].filter(part => part.trim().length > 0).join("\n\n");
+			return {
+				id: `task-${index + 1}`,
+				subject: laneTitle,
+				description: objective,
+				title: laneTitle,
+				objective,
+				status: "pending",
+				owner: worker.id,
+				lane: normalizeLaneId(lane.label),
+				required_role: worker.role,
+				version: 1,
+				created_at: now(),
+				updated_at: now(),
+			};
+		});
+
+	if (workers.length > 1 && hasAmbiguousLaneSplitIntent(task))
+		throw new Error(
+			"ambiguous_team_lane_split: multi-worker team launch mentions lanes but does not provide explicit markdown lane sections such as `### Lane A — Title`",
+		);
+
 	return workers.map(worker => ({
 		id: `task-${worker.index}`,
 		subject: `Execute team brief (${worker.id})`,
@@ -2456,6 +2530,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		? { sessionName: "dry-run", windowIndex: "0", leaderPaneId: "%dry-run-leader", target: "dry-run:0" }
 		: readCurrentTmuxLeaderContext(tmuxCommand, env);
 	const initialWorkers = buildWorkers(options.workerCount, options.agentType, stateRoot);
+	const initialTasks = buildInitialTasks(options.task, initialWorkers);
 	const workers: GjcTeamWorker[] = [];
 	try {
 		for (const worker of initialWorkers)
@@ -2509,7 +2584,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		updated_at: createdAt,
 	});
 	await writePhase(dir, "starting");
-	for (const task of buildInitialTasks(options.task, config.workers)) await writeTask(dir, task);
+	for (const task of initialTasks) await writeTask(dir, task);
 	await appendEvent(dir, {
 		type: "team_started",
 		message: options.dryRun

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -473,6 +473,84 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).toContain("split-window -v -t %2");
 		expect(tmuxLog).not.toContain("new-session");
 	});
+	it("distributes explicit markdown lane sections into worker-owned initial tasks", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		const snapshot = await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: [
+				"Shared context for the coordinated run.",
+				"",
+				"### Lane A — Schema contract",
+				"Define the durable schema and ID checks.",
+				"",
+				"### Lane B — Verification",
+				"Add focused regression coverage.",
+			].join("\n"),
+			teamName: "lane-distribution-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+
+		const task1 = await readGjcTeamTask("lane-distribution-team", "task-1", cleanupRoot, { PATH: "" });
+		const task2 = await readGjcTeamTask("lane-distribution-team", "task-2", cleanupRoot, { PATH: "" });
+
+		expect(snapshot.task_counts.pending).toBe(2);
+		expect(task1.subject).toBe("Lane A — Schema contract");
+		expect(task1.owner).toBe("worker-1");
+		expect(task1.lane).toBe("lane-a");
+		expect(task1.required_role).toBe("executor");
+		expect(task1.description).toContain("Define the durable schema");
+		expect(task1.description).not.toContain("Add focused regression coverage");
+		expect(task2.subject).toBe("Lane B — Verification");
+		expect(task2.owner).toBe("worker-2");
+		expect(task2.lane).toBe("lane-b");
+		expect(task2.description).toContain("Add focused regression coverage");
+		expect(task2.description).not.toContain("Define the durable schema");
+	});
+
+	it("rejects ambiguous inline lane splits before duplicating broad multi-worker work", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await expect(
+			startGjcTeam({
+				workerCount: 4,
+				agentType: "executor",
+				task: "Implement turn orchestration. Split lanes: A schema, B delivery, C read_turn, D docs/tests.",
+				teamName: "ambiguous-lane-team",
+				cwd: cleanupRoot,
+				dryRun: true,
+				env: { PATH: "" },
+			}),
+		).rejects.toThrow("ambiguous_team_lane_split");
+		expect(await Bun.file(path.join(cleanupRoot, ".gjc", "state", "team", "ambiguous-lane-team")).exists()).toBe(
+			false,
+		);
+	});
+
+	it("rejects ambiguous lane splits before non-dry-run state, worktree, or pane mutation", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+
+		await expect(
+			startGjcTeam({
+				workerCount: 2,
+				agentType: "executor",
+				task: "Implement approved plan. Split lanes: A runtime, B tests.",
+				teamName: "ambiguous-lane-worktree-team",
+				cwd: cleanupRoot,
+				env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+			}),
+		).rejects.toThrow("ambiguous_team_lane_split");
+
+		expect(
+			await Bun.file(path.join(cleanupRoot, ".gjc", "state", "team", "ambiguous-lane-worktree-team")).exists(),
+		).toBe(false);
+		expect(await Bun.file(path.join(cleanupRoot, "tmux-split-count")).exists()).toBe(false);
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
+		expect(tmuxLog).not.toContain("split-window");
+	});
 
 	it("fails outside current tmux before creating team state or worktrees", async () => {
 		cleanupRoot = await createGitRepo();


### PR DESCRIPTION
## Summary

This PR hardens `gjc team` multi-worker launch orchestration so lane-style handoffs are not silently duplicated across workers.

## Why

A previous Team run received a ralplan handoff with separate lanes, but the main orchestration launched it as one broad command:

```bash
gjc team 4:executor "... Split lanes: A ..., B ..., C ..., D ..."
```

Before this change, `gjc team` treated that text as a single plain brief and created one identical `Execute team brief` task per worker. That made every worker eligible to interpret and work on the same broad plan, causing duplicated implementation/testing effort and avoidable compute load in a Rust/TypeScript workspace.

The failure was not the lane plan itself; it was that the Team launch boundary accepted ambiguous lane intent without converting it into worker-owned tasks or failing fast.

## What changed

- Parse explicit markdown lane sections in Team launch briefs:

  ```md
  ### Lane A — Runtime
  Implement runtime-only changes.

  ### Lane B — Verification
  Add focused regression tests.
  ```

- Convert each explicit lane section into its own initial task with:
  - distinct `subject` / `objective`
  - worker ownership
  - `lane` metadata
  - `required_role` metadata
- Reject ambiguous inline lane split prompts for multi-worker launches, e.g.:

  ```text
  Split lanes: A runtime, B verification
  ```

  with `ambiguous_team_lane_split` before state, worktree, or pane mutation.
- Update worker launch instructions so workers treat the claimed task record as the source of truth instead of implementing directly from the broad team brief.
- Update the Team skill guidance to document the accepted markdown lane format and the ambiguous inline rejection behavior.

## Expected behavior

- Structured lane handoffs now become actual lane-owned tasks instead of duplicated broad worker tasks.
- Ambiguous multi-worker lane prompts fail fast and cannot waste compute by fanning out the same work to every worker.
- Existing simple non-lane multi-worker launches remain compatible and still create worker-owned compatibility tasks.

## Verification

```bash
bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
bun --cwd=packages/coding-agent biome check src/gjc-runtime/team-runtime.ts test/gjc-runtime/team-runtime.test.ts src/defaults/gjc/skills/team/SKILL.md
```

The tests cover:

- explicit markdown lane sections becoming distinct worker-owned task records;
- ambiguous inline lane split rejection in dry-run;
- ambiguous inline lane split rejection before non-dry-run state/worktree/pane mutation;
- existing Team runtime behavior continuing to pass.
