### PR TITLE
Fix compiled gjc --tmux relaunch

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -48,6 +48,7 @@ export interface TmuxLaunchContext {
 	currentBranch?: string | null;
 	existingBranchSessionName?: string | null;
 	project?: string | null;
+	diagnosticWriter?: (message: string) => void;
 }
 
 export interface TmuxSpawnResult {
@@ -120,6 +121,16 @@ function isInteractiveRootLaunch(parsed: Args, tty: TtyState): boolean {
 	);
 }
 
+function isBunVirtualPath(value: string | undefined): boolean {
+	return value?.startsWith("/$bunfs/") === true;
+}
+
+function formatTmuxLaunchDiagnostic(stage: string, stderr?: string): string {
+	const detail = stderr?.trim();
+	const suffix = detail ? ` ${detail.slice(0, 240)}` : "";
+	return `gjc --tmux failed after creating tmux session: ${stage}.${suffix}\n`;
+}
+
 function shellQuote(value: string): string {
 	if (value.length === 0) return "''";
 	return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -148,6 +159,9 @@ export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProf
 function resolveCurrentGjcCommand(context: CommandResolutionContext): string[] {
 	const entrypoint = context.argv[1];
 	if (!entrypoint) return ["gjc"];
+	if (isBunVirtualPath(entrypoint)) {
+		return isBunVirtualPath(context.execPath) ? ["gjc"] : [context.execPath];
+	}
 	const resolvedEntrypoint = path.isAbsolute(entrypoint) ? entrypoint : path.resolve(context.cwd, entrypoint);
 	if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs")) {
 		return [context.execPath, resolvedEntrypoint];
@@ -264,10 +278,19 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		});
 		if (profile.failures.length > 0) {
 			cleanupCreatedTmuxSession(plan, spawnSync, options);
-			return false;
+			const failure =
+				profile.failures.find(item => item.command.args.includes("@gjc-profile")) ?? profile.failures[0];
+			(context.diagnosticWriter ?? process.stderr.write.bind(process.stderr))(
+				formatTmuxLaunchDiagnostic("profile tagging failed", failure?.stderr),
+			);
+			return true;
 		}
 	}
 	if (created.exitCode !== 0) return false;
 	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", plan.sessionName], options);
-	return attached.exitCode === 0;
+	if (attached.exitCode === 0) return true;
+	(context.diagnosticWriter ?? process.stderr.write.bind(process.stderr))(
+		formatTmuxLaunchDiagnostic("attach failed", attached.stderr),
+	);
+	return true;
 }

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -62,6 +62,43 @@ describe("default GJC tmux launch", () => {
 			"'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' '--tmux' 'hello world'",
 		);
 	});
+	it("uses a host command for compiled Bun virtual entrypoints", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["gjc", "/$bunfs/root/gjc-linux-x64"],
+			execPath: "/home/me/.local/bin/gjc",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+
+		expect(plan.innerCommand).not.toContain("$bunfs");
+		expect(plan.innerCommand).toContain(`${GJC_TMUX_LAUNCHED_ENV}=1`);
+		expect(plan.innerCommand).toContain("'/home/me/.local/bin/gjc' '--tmux' 'hello world'");
+	});
+
+	it("falls back to gjc when compiled Bun virtual entrypoint has no host exec path", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux"],
+			cwd: "/repo",
+			env: {},
+			argv: ["gjc", "/$bunfs/root/gjc-linux-x64"],
+			execPath: "/$bunfs/root/gjc-linux-x64",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan?.innerCommand).not.toContain("$bunfs");
+		expect(plan?.innerCommand).toContain("'gjc' '--tmux'");
+	});
 
 	it("attaches existing tagged session for matching worktree branch", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
@@ -218,8 +255,9 @@ describe("default GJC tmux launch", () => {
 		expect(calls[0].args[0]).toBe("new-session");
 	});
 
-	it("kills a detached session when required profile tagging fails", () => {
+	it("handles and reports partial launch when required profile tagging fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ tmux: true }),
 			rawArgs: [],
@@ -230,16 +268,50 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
-				if (spawnArgs.includes("@gjc-profile")) return { exitCode: 1 };
+				if (spawnArgs.includes("@gjc-profile")) return { exitCode: 1, stderr: "no server running on /tmp/tmux" };
 				return { exitCode: 0 };
 			},
 		});
 
-		expect(handled).toBe(false);
+		expect(handled).toBe(true);
 		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
 		expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: profile tagging failed.");
+		expect(diagnostics[0].length).toBeLessThan(320);
+	});
+
+	it("handles and reports partial launch when attach fails after profile succeeds", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		expect(diagnostics[0].length).toBeLessThan(320);
 	});
 
 	it("falls through to direct launch when tmux is unavailable", () => {


### PR DESCRIPTION
## Summary

Fixes packaged/compiled `gjc --tmux` so it launches the real GJC executable inside tmux instead of leaking Bun's virtual filesystem path into the tmux command.

In compiled Bun builds, `process.argv[1]` can be a path such as:

```text
/$bunfs/root/gjc-linux-x64
```

That path is valid only inside Bun's embedded filesystem. The previous tmux launcher embedded it into the detached tmux command, so `tmux new-session` could briefly succeed, the inner command immediately died, profile tagging failed with `no server running`, and GJC fell back to direct TUI startup. That made `gjc --tmux` look like it worked while `tmux ls` showed no managed session.

## What changed

- Detect Bun virtual compiled entrypoints before building the tmux inner command.
- Use a host executable command for compiled launches:
  - non-virtual `process.execPath` when usable;
  - otherwise `gjc` as a safe PATH fallback.
- Preserve existing source-mode relaunch behavior for `.ts`, `.js`, and `.mjs` entrypoints.
- Treat post-create profile/attach failures as handled `--tmux` failures instead of silently falling back to direct TUI.
- Emit a bounded stderr diagnostic with a stable prefix:

```text
gjc --tmux failed after creating tmux session:
```

## Why this matters

`gjc --tmux` and GJC-managed tmux sessions are documented/released CLI behavior. The previous behavior was misleading: users could see the TUI and assume tmux worked, but no tmux session existed. This also made `gjc session list` / `tmux ls` appear inconsistent with the launched UI.

## Tests / validation

Ran:

```sh
bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts --no-errors-on-unmatched
bun --cwd=packages/coding-agent run check:types
bun --cwd=packages/coding-agent run build
```

Focused tests now cover:

- compiled virtual `/$bunfs/...` entrypoints do not appear in `innerCommand`;
- fallback to `gjc` when both entrypoint and execPath are virtual;
- source-mode relaunch remains unchanged;
- fake tmux profile failure after `new-session` emits one bounded diagnostic, attempts cleanup, and does not direct-fallback;
- fake tmux attach failure emits one bounded diagnostic and does not direct-fallback.

Packaged binary smoke:

```sh
TERM=xterm-256color GJC_TMUX_SESSION=gajae_code_smoke_attach timeout 5s packages/coding-agent/dist/gjc --tmux
```

Confirmed a real managed tmux session existed while active:

```text
gajae_code_smoke_attach profile=1 attached=0
```

Note: a full package `check` was also attempted and failed only on pre-existing unrelated Biome optional-chain warnings outside these changed files; changed-file Biome check passed.