### PR TITLE
fix(cli): improve grep limit-reached message with actionable text

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.
+
 ## [0.4.1] - 2026-06-07
 
 ### Changed

--- a/packages/coding-agent/src/cli/grep-cli.ts
+++ b/packages/coding-agent/src/cli/grep-cli.ts
@@ -98,7 +98,7 @@ export async function runGrepCommand(cmd: GrepCommandArgs): Promise<void> {
 		console.log(chalk.green(`Files with matches: ${result.filesWithMatches}`));
 		console.log(chalk.green(`Files searched: ${result.filesSearched}`));
 		if (result.limitReached) {
-			console.log(chalk.yellow(`Limit reached: true`));
+			console.log(chalk.yellow(`Result limit reached (${cmd.limit} matches). Use --limit to show more.`));
 		}
 		console.log("");
 


### PR DESCRIPTION
## What
Replace generic `Limit reached: true` CLI output with actionable message showing the current limit and suggesting `--limit`.

## Why
The old message gave users no clue what to do. The new message tells them the limit value and how to change it.

## Testing
Manual run of grep with result cap; confirmed new message renders correctly. CHANGELOG updated.

---
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated