### PR TITLE
chore(ci): add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
    # in that case, so the canary's retention window (see build-native action) is the
    # effective TTL of a cache hit before main rebuilds anyway.
    rust-hash:
+      timeout-minutes: 10
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       outputs:
@@ -105,6 +106,7 @@ jobs:
 
    # Fast lint + type check (no Rust, no native build needed)
    check:
+      timeout-minutes: 15
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
@@ -127,6 +129,7 @@ jobs:
    # Linux x64 baseline + modern: required by `test`, so it runs on every PR
    # unless rust-hash found a cached run. Tags always rebuild for fresh artifacts.
    native_linux:
+      timeout-minutes: 30
       needs: [rust-hash]
       if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
          (startsWith(github.ref, 'refs/tags/v') || needs.rust-hash.outputs.run-id == '') }}
@@ -150,6 +153,7 @@ jobs:
 
    # Remaining platforms only ship in release tags; PRs and main never build them.
    native_release:
+      timeout-minutes: 45
       needs: [rust-hash]
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       strategy:
@@ -238,6 +242,7 @@ jobs:
            run: bun run ci:test:smoke
 
    install_methods:
+      timeout-minutes: 20
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
@@ -284,6 +289,7 @@ jobs:
            run: bun run ci:test:install-methods
 
    release_binary:
+      timeout-minutes: 30
       if: ${{ always() && startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs.native_linux.result == 'success' && needs.native_release.result ==
          'success' && needs.check.result == 'success' }}
@@ -377,6 +383,7 @@ jobs:
               path: ${{ matrix.binary_path }}
 
    release-github:
+      timeout-minutes: 15
       if: ${{ (github.event_name != 'pull_request' ||
          github.event.pull_request.head.repo.full_name == github.repository) &&
          startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
@@ -402,6 +409,7 @@ jobs:
 
 
    release_github_verify:
+      timeout-minutes: 10
       if: ${{ startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs['release-github'].result == 'success' }}
       needs: [release-github]
@@ -420,6 +428,7 @@ jobs:
               HOME="$runtime_dir/home" XDG_DATA_HOME="$runtime_dir/xdg" ./gjc-darwin-arm64 --version
 
    release-npm:
+      timeout-minutes: 15
       if: ${{ (github.event_name != 'pull_request' ||
          github.event.pull_request.head.repo.full_name == github.repository) &&
          startsWith(github.ref, 'refs/tags/v') && !cancelled() &&

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.
 
+### Changed
+
+- Added `timeout-minutes` to all CI workflow jobs to prevent indefinite hangs.
+
 ## [0.4.1] - 2026-06-07
 
 ### Changed


### PR DESCRIPTION
## Add `timeout-minutes` to all CI workflow jobs

Follow-up to #410 / #411 incorporating review feedback.

### Changes

All 11 CI jobs now have explicit `timeout-minutes` to prevent indefinite hangs on self-hosted runners:

| Job | Timeout | Notes |
|-----|---------|-------|
| `rust-hash` | 10m | hash computation + artifact lookup |
| `gjc-state-gates` | 15m | *(existing — unchanged)* |
| `check` | 15m | lint + type check |
| `native_linux` | 30m | Rust cdylib build (baseline + modern) |
| `native_release` | 45m | cross-platform release matrix (arm64, darwin, win32) |
| `test` | 30m | *(existing — unchanged)* |
| `install_methods` | 20m | install method smoke tests |
| `release_binary` | 30m | binary build + smoke per platform |
| `release-github` | 15m | GitHub release + artifact upload |
| `release_github_verify` | 10m | download + verify published binary |
| `release-npm` | 15m | npm publish |

### Fixes from #411 review

- **Complete coverage**: all 11/11 jobs now have timeouts (previously only covered 7/11, missing `native_release` and `release_binary`)
- **CHANGELOG preserved**: existing `### Fixed` entry for grep limit-reached message is retained; new `### Changed` section added separately

### Files changed

- `.github/workflows/ci.yml` — added `timeout-minutes` to 9 jobs (2 already had timeouts)
- `packages/coding-agent/CHANGELOG.md` — added `### Changed` entry under `[Unreleased]`

### Testing

- [x] All 11/11 jobs verified with timeout-minutes
- [x] Existing `gjc-state-gates` (15m) and `test` (30m) timeouts untouched
- [x] CHANGELOG existing `### Fixed` entry preserved
- [x] Only 2 files changed — no scope creep

### PR checklist

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
