### PR TITLE
docs: update extension example README

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -6,7 +6,7 @@ Example extensions for gajae-code.
 
 ```bash
 # Load an extension with --extension flag
-pi --extension examples/extensions/permission-gate.ts
+gjc --extension examples/extensions/permission-gate.ts
 
 # Or copy to extensions directory for auto-discovery
 cp permission-gate.ts ~/.gjc/agent/extensions/
@@ -67,7 +67,7 @@ cp permission-gate.ts ~/.gjc/agent/extensions/
 
 ## Writing Extensions
 
-See [docs/extensions.md](../../docs/extensions.md) for full documentation.
+The examples below show the core extension patterns used by this directory.
 
 ```typescript
 import type { ExtensionAPI } from "@gajae-code/coding-agent";


### PR DESCRIPTION
## What

Updates `packages/coding-agent/examples/extensions/README.md` only:

- replaces the stale `pi --extension ...` usage example with the current public `gjc` command surface
- removes the dead `../../docs/extensions.md` pointer because that target does not exist in current `dev`
- keeps the existing in-file examples as the current extension reference

## Why

Follows the maintainer direction from #413 to take candidate 2 only: one README, one docs/example link-validation target, one focused PR.

## Testing

- [x] direct link/path check for `packages/coding-agent/examples/extensions/README.md`
- [x] `bun run check:tools`
- [x] `bun check`
- [x] `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) - not needed; example README text only per #413

Related: #413

Changelog: not needed; example README text only.