### PR TITLE
chore(ci): add conservative workflow timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
    # in that case, so the canary's retention window (see build-native action) is the
    # effective TTL of a cache hit before main rebuilds anyway.
    rust-hash:
+      timeout-minutes: 15
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       outputs:
@@ -105,6 +106,7 @@ jobs:
 
    # Fast lint + type check (no Rust, no native build needed)
    check:
+      timeout-minutes: 30
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
@@ -127,6 +129,7 @@ jobs:
    # Linux x64 baseline + modern: required by `test`, so it runs on every PR
    # unless rust-hash found a cached run. Tags always rebuild for fresh artifacts.
    native_linux:
+      timeout-minutes: 60
       needs: [rust-hash]
       if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
          (startsWith(github.ref, 'refs/tags/v') || needs.rust-hash.outputs.run-id == '') }}
@@ -150,6 +153,7 @@ jobs:
 
    # Remaining platforms only ship in release tags; PRs and main never build them.
    native_release:
+      timeout-minutes: 90
       needs: [rust-hash]
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       strategy:
@@ -238,6 +242,7 @@ jobs:
            run: bun run ci:test:smoke
 
    install_methods:
+      timeout-minutes: 45
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
@@ -284,6 +289,7 @@ jobs:
            run: bun run ci:test:install-methods
 
    release_binary:
+      timeout-minutes: 60
       if: ${{ always() && startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs.native_linux.result == 'success' && needs.native_release.result ==
          'success' && needs.check.result == 'success' }}
@@ -377,6 +383,7 @@ jobs:
               path: ${{ matrix.binary_path }}
 
    release-github:
+      timeout-minutes: 30
       if: ${{ (github.event_name != 'pull_request' ||
          github.event.pull_request.head.repo.full_name == github.repository) &&
          startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
@@ -402,6 +409,7 @@ jobs:
 
 
    release_github_verify:
+      timeout-minutes: 15
       if: ${{ startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
          needs['release-github'].result == 'success' }}
       needs: [release-github]
@@ -420,6 +428,7 @@ jobs:
               HOME="$runtime_dir/home" XDG_DATA_HOME="$runtime_dir/xdg" ./gjc-darwin-arm64 --version
 
    release-npm:
+      timeout-minutes: 30
       if: ${{ (github.event_name != 'pull_request' ||
          github.event.pull_request.head.repo.full_name == github.repository) &&
          startsWith(github.ref, 'refs/tags/v') && !cancelled() &&

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Added conservative `timeout-minutes` values to all CI workflow jobs to prevent indefinite hangs.
+
 ### Fixed
 
 - Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.


### PR DESCRIPTION
## What

Adds job-level `timeout-minutes` to the CI workflow jobs that did not already have one, using more conservative values than #412:

- `rust-hash`: 15m
- `check`: 30m
- `native_linux`: 60m
- `native_release`: 90m
- `install_methods`: 45m
- `release_binary`: 60m
- `release-github`: 30m
- `release_github_verify`: 15m
- `release-npm`: 30m

Existing timeouts are left as-is:

- `gjc-state-gates`: 15m
- `test`: 30m

No `if:` gates, permissions, action pins, matrices, or release behavior changed.

## Why

Fresh focused follow-up to the REQUEST_CHANGES review on #412. The previous values were considered too tight for cold or slow runners, especially native/release paths. This revision uses larger headroom while still preventing indefinite hangs.

## CI/runtime evidence

Recent successful upstream CI job durations checked via GitHub Actions job API:

| Workflow run | Ref | Relevant observed max |
| --- | --- | --- |
| 27081200935 | tag `v0.4.1` | `native_release` max 10.6m, `native_linux` max 3.3m, `install_methods` 10.6m, `release_binary` max 2.1m |
| 27077656489 | tag `v0.4.0` | `native_release` max 11.3m, `native_linux` max 3.0m, `install_methods` 9.2m, `release_binary` max 2.5m |
| 27004499815 | tag `v0.3.2` | `native_release` max 26.2m, `native_linux` max 11.3m, `install_methods` 9.1m, `release_binary` max 1.9m |
| 27077656120 | `main` | `test` 9.4m, `install_methods` 14.2m, `check` 3.7m |
| 27081200662 | `main` | `test` 11.9m, `install_methods` 9.8m, `check` 3.7m |

Headroom examples from this PR:

- `native_release`: observed max 26.2m -> 90m timeout
- `native_linux`: observed max 11.3m -> 60m timeout
- `install_methods`: observed max 14.2m -> 45m timeout
- `release_binary`: observed max 2.8m -> 60m timeout

Fork PR CI is still expected to skip protected lanes; this evidence is from upstream successful `main`/tag runs.

## Testing

- [x] `.github/workflows/ci.yml` parses as YAML
- [x] parsed job map confirms 11/11 CI jobs have job-level `timeout-minutes`
- [x] `git diff --check`
- [x] `bun run check:tools`
- [x] `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

Follow-up to: #412