### PR TITLE
chore(ci): dedupe release npm node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,13 +433,10 @@ jobs:
          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
            with:
               node-version: "24"
+              registry-url: "https://registry.npmjs.org"
          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
            with:
               bun-version: "1.3"
-         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-           with:
-              node-version: "24"
-              registry-url: "https://registry.npmjs.org"
          - name: Cache bun dependencies
            uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
            with:


### PR DESCRIPTION
## What

Removes the duplicate `actions/setup-node` step from the `release-npm` job in `.github/workflows/ci.yml`.

The job already sets up Node 24 before Bun. This keeps that setup step, moves the npm `registry-url` onto it, and removes the second identical Node 24 setup step.

No `if:` gates, permissions, pinned action SHAs, matrix entries, publish commands, or user-facing behavior changed.

## Why

Small CI cleanup in the audits / optimizations / glitches lane: fewer release-job setup steps, same npm registry configuration.

## Validation

- [x] `.github/workflows/ci.yml` parses as YAML
- [x] parsed `release-npm` job confirms exactly one `actions/setup-node` step remains
- [x] parsed `release-npm` setup-node step keeps `registry-url: https://registry.npmjs.org`
- [x] `git diff --check`
- [x] `bun run check:tools`
- [x] `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) - not needed; CI-only optimization