### PR TITLE
fix(harness): review-only sessions emit terminal verdict + honest monitor (#415)

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -54,6 +54,9 @@ function nowIso(): string {
 	return new Date().toISOString();
 }
 
+/** RPC activity newer than this (relative to wall clock) marks an endpoint gap as transient, not terminal. */
+const RPC_ACTIVITY_RECENT_MS = 60_000;
+
 function parseInput(raw: string | undefined): Record<string, unknown> {
 	if (!raw?.trim()) return {};
 	const parsed = JSON.parse(raw) as unknown;
@@ -241,6 +244,10 @@ interface OwnerExitEvidence {
 	lastSignal: string | null;
 	promptAcceptedSeen: boolean;
 	completedSeen: boolean;
+	/** True only when the owner is genuinely gone (lease missing or process dead). */
+	terminal: boolean;
+	/** ISO timestamp of the most recent RPC-derived owner event, if any. */
+	lastRpcActivityAt: string | null;
 }
 
 async function buildOwnerExitEvidence(root: string, state: SessionState): Promise<OwnerExitEvidence> {
@@ -251,23 +258,30 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 	let lastSignal: string | null = null;
 	let promptAcceptedSeen = false;
 	let completedSeen = false;
+	let lastRpcActivityAt: string | null = null;
 	for (const event of events) {
 		const signal = (event.evidence as { signal?: unknown } | undefined)?.signal;
 		if (typeof signal === "string") lastSignal = signal;
 		if (event.kind === "prompt_accepted" || signal === "prompt-accepted") promptAcceptedSeen = true;
 		if (event.kind === "rpc_agent_completed" || signal === "completed") completedSeen = true;
+		if (event.kind === "rpc_activity" || event.kind.startsWith("rpc_")) lastRpcActivityAt = event.createdAt;
 	}
+	// Recent RPC frames mean the owner is still driving the session even if the control endpoint
+	// did not answer this stateless call — a transient observation gap, not terminal owner loss.
+	const rpcActivityRecent =
+		lastRpcActivityAt !== null && Date.now() - Date.parse(lastRpcActivityAt) <= RPC_ACTIVITY_RECENT_MS;
+	const terminal = !lease || leaseStatus === "dead";
 	let reason = "owner-not-live";
 	if (!lease) {
 		reason = promptAcceptedSeen && !completedSeen ? "owner-exited-after-prompt-acceptance" : "owner-lease-missing";
 	} else if (leaseStatus === "dead") {
 		reason = promptAcceptedSeen && !completedSeen ? "owner-exited-after-prompt-acceptance" : "owner-process-dead";
 	} else if (leaseStatus === "expiredAlive") {
-		reason = "owner-lease-expired";
+		reason = rpcActivityRecent ? "owner-endpoint-observation-gap" : "owner-lease-expired";
 	} else if (leaseStatus === "epermAlive") {
 		reason = "owner-liveness-unknown-permission-denied";
 	} else {
-		reason = "owner-endpoint-unreachable";
+		reason = rpcActivityRecent ? "owner-endpoint-observation-gap" : "owner-endpoint-unreachable";
 	}
 	return {
 		reason,
@@ -281,6 +295,8 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 		lastSignal,
 		promptAcceptedSeen,
 		completedSeen,
+		terminal,
+		lastRpcActivityAt,
 	};
 }
 
@@ -684,6 +700,7 @@ export default class Harness extends Command {
 		const handle: SessionHandle = {
 			sessionId,
 			harness,
+			mode: input.mode === "review" || input.reviewOnly === true ? "review" : "implement",
 			repo: typeof input.repo === "string" ? input.repo : null,
 			workspace,
 			branch: preflight.declaredBranch ?? preflight.actualBranch,

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -54,9 +54,6 @@ function nowIso(): string {
 	return new Date().toISOString();
 }
 
-/** RPC activity newer than this (relative to wall clock) marks an endpoint gap as transient, not terminal. */
-const RPC_ACTIVITY_RECENT_MS = 60_000;
-
 function parseInput(raw: string | undefined): Record<string, unknown> {
 	if (!raw?.trim()) return {};
 	const parsed = JSON.parse(raw) as unknown;
@@ -246,7 +243,9 @@ interface OwnerExitEvidence {
 	completedSeen: boolean;
 	/** True only when the owner is genuinely gone (lease missing or process dead). */
 	terminal: boolean;
-	/** ISO timestamp of the most recent RPC-derived owner event, if any. */
+	/** True when the owner process is provably alive (live lease + fresh heartbeat) but the endpoint did not route. */
+	transient: boolean;
+	/** ISO timestamp of the most recent non-terminal RPC-derived owner event, if any (observability only). */
 	lastRpcActivityAt: string | null;
 }
 
@@ -264,24 +263,28 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 		if (typeof signal === "string") lastSignal = signal;
 		if (event.kind === "prompt_accepted" || signal === "prompt-accepted") promptAcceptedSeen = true;
 		if (event.kind === "rpc_agent_completed" || signal === "completed") completedSeen = true;
-		if (event.kind === "rpc_activity" || event.kind.startsWith("rpc_")) lastRpcActivityAt = event.createdAt;
+		// Terminal completion/failure frames are NOT owner liveness — exclude them from activity.
+		if (event.kind.startsWith("rpc_") && event.kind !== "rpc_agent_completed" && event.kind !== "rpc_agent_failed") {
+			lastRpcActivityAt = event.createdAt;
+		}
 	}
-	// Recent RPC frames mean the owner is still driving the session even if the control endpoint
-	// did not answer this stateless call — a transient observation gap, not terminal owner loss.
-	const rpcActivityRecent =
-		lastRpcActivityAt !== null && Date.now() - Date.parse(lastRpcActivityAt) <= RPC_ACTIVITY_RECENT_MS;
+	// Owner liveness is the lease heartbeat, never RPC frames: a "live" lease means the owner process
+	// is alive and heartbeating within TTL, so a failed endpoint call is a transient observation gap.
+	// Real owner loss (missing/dead lease) stays terminal and keeps its original reason string so
+	// existing consumers that match on the reason continue to escalate.
 	const terminal = !lease || leaseStatus === "dead";
+	const transient = leaseStatus === "live";
 	let reason = "owner-not-live";
 	if (!lease) {
 		reason = promptAcceptedSeen && !completedSeen ? "owner-exited-after-prompt-acceptance" : "owner-lease-missing";
 	} else if (leaseStatus === "dead") {
 		reason = promptAcceptedSeen && !completedSeen ? "owner-exited-after-prompt-acceptance" : "owner-process-dead";
 	} else if (leaseStatus === "expiredAlive") {
-		reason = rpcActivityRecent ? "owner-endpoint-observation-gap" : "owner-lease-expired";
+		reason = "owner-lease-expired";
 	} else if (leaseStatus === "epermAlive") {
 		reason = "owner-liveness-unknown-permission-denied";
 	} else {
-		reason = rpcActivityRecent ? "owner-endpoint-observation-gap" : "owner-endpoint-unreachable";
+		reason = "owner-endpoint-unreachable";
 	}
 	return {
 		reason,
@@ -296,6 +299,7 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 		promptAcceptedSeen,
 		completedSeen,
 		terminal,
+		transient,
 		lastRpcActivityAt,
 	};
 }

--- a/packages/coding-agent/src/harness-control-plane/finalize.ts
+++ b/packages/coding-agent/src/harness-control-plane/finalize.ts
@@ -17,10 +17,13 @@ import {
 	type CompletionEvidence,
 	type ReceiptEnvelope,
 	type ReceiptSubject,
+	type ReviewFailureEvidence,
+	type ReviewVerdictEvidence,
 	type ValidationEvidence,
 	validateReceipt,
 } from "./receipts";
 import { readReceiptIndex, writeReceiptImmutable } from "./storage";
+import { isReviewVerdict, type ReviewVerdict } from "./types";
 
 export interface ValidationCommandSpec {
 	name: string;
@@ -49,6 +52,12 @@ export interface FinalizeOptions {
 	requireTests?: boolean;
 	requireCommit?: boolean;
 	requirePr?: boolean;
+	/** Review-only sessions produce a terminal verdict instead of implementation validation. */
+	reviewOnly?: boolean;
+	/** Operator/loop-supplied terminal review verdict (closed vocabulary). */
+	verdict?: string | null;
+	/** Bounded PR/issue reference for the review target (e.g. "PR-414"). Never resolved from the live repo. */
+	prTarget?: string | null;
 	validationCommands?: ValidationCommandSpec[];
 	checks: FinalizeChecks;
 	clock?: () => number;
@@ -60,6 +69,7 @@ export interface FinalizeResult {
 	validation: { name: string; valid: boolean; exitStatus: number }[];
 	commitHash: string | null;
 	prUrl: string | null;
+	verdict?: ReviewVerdict | null;
 	issueArtifact: string | null;
 	blockers: string[];
 }
@@ -69,6 +79,8 @@ function receiptId(prefix: string): string {
 }
 
 export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult> {
+	if (opts.reviewOnly) return runReviewFinalize(opts);
+
 	const now = () => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
 	const blockers: string[] = [];
 	const validation: FinalizeResult["validation"] = [];
@@ -178,6 +190,77 @@ export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult
 	};
 }
 
+/**
+ * Review-only finalizer: produces a terminal verdict receipt (no implementation validation,
+ * no commit/PR resolution) when a valid verdict is supplied; otherwise writes a durable,
+ * bounded `review-failure` receipt suitable for fallback routing. Never attaches PR metadata
+ * resolved from the live repo, so a review session cannot report stale/unrelated PRs.
+ */
+async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult> {
+	const now = () => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
+	const prTarget = opts.prTarget ?? null;
+	const subject: ReceiptSubject = { workspace: opts.workspace, branch: opts.branch, head: null, commit: null };
+	const baseResult: Omit<FinalizeResult, "completed" | "receiptPath" | "verdict" | "blockers"> = {
+		validation: [],
+		commitHash: null,
+		prUrl: null,
+		issueArtifact: null,
+	};
+
+	if (!isReviewVerdict(opts.verdict)) {
+		const reason = opts.verdict == null ? "review-verdict-missing" : "review-verdict-invalid";
+		const failure: ReviewFailureEvidence = {
+			reason,
+			prTarget,
+			failedAt: now(),
+			fallback: "operator-or-omx-review",
+		};
+		const receipt = buildReceipt<ReviewFailureEvidence>({
+			receiptId: receiptId("revfail"),
+			sessionId: opts.sessionId,
+			family: "review-failure",
+			source: "finalizer",
+			subject,
+			evidence: failure,
+			createdAt: now(),
+			valid: true,
+		});
+		const entry = await writeReceiptImmutable(
+			opts.root,
+			opts.sessionId,
+			"review-failure",
+			receipt.receiptId,
+			receipt,
+		);
+		return { ...baseResult, completed: false, receiptPath: entry.path, verdict: null, blockers: [reason] };
+	}
+
+	const verdict = opts.verdict as ReviewVerdict;
+	const evidence: ReviewVerdictEvidence = {
+		verdict,
+		prTarget,
+		finalizedAt: now(),
+		summaryRef: typeof opts.prTarget === "string" ? `verdict:${verdict}@${opts.prTarget}` : `verdict:${verdict}`,
+	};
+	const receipt = buildReceipt<ReviewVerdictEvidence>({
+		receiptId: receiptId("verdict"),
+		sessionId: opts.sessionId,
+		family: "review-verdict",
+		source: "finalizer",
+		subject,
+		evidence,
+		createdAt: now(),
+	});
+	const outcome = validateReceipt(receipt);
+	const entry = await writeReceiptImmutable(opts.root, opts.sessionId, "review-verdict", receipt.receiptId, receipt);
+	return {
+		...baseResult,
+		completed: outcome.valid,
+		receiptPath: entry.path,
+		verdict,
+		blockers: outcome.valid ? [] : outcome.reasons,
+	};
+}
 function git(workspace: string, args: string[]): string | null {
 	try {
 		return execFileSync("git", args, {

--- a/packages/coding-agent/src/harness-control-plane/finalize.ts
+++ b/packages/coding-agent/src/harness-control-plane/finalize.ts
@@ -192,9 +192,16 @@ export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult
 
 /**
  * Review-only finalizer: produces a terminal verdict receipt (no implementation validation,
- * no commit/PR resolution) when a valid verdict is supplied; otherwise writes a durable,
- * bounded `review-failure` receipt suitable for fallback routing. Never attaches PR metadata
- * resolved from the live repo, so a review session cannot report stale/unrelated PRs.
+ * no commit/PR resolution) when a valid, autonomous verdict is supplied; otherwise writes a
+ * durable, bounded `review-failure` receipt suitable for fallback routing.
+ *
+ * It never *resolves* PR/commit metadata from the live repo; the only PR reference attached is
+ * the session's own declared review target (`prTarget`), so a review session cannot report an
+ * unrelated PR resolved from the current checkout.
+ *
+ * `OWNER_CONFIRMATION_REQUIRED` is a valid verdict but is NOT an autonomous success: it is
+ * recorded durably yet returns `completed: false` with an `owner-confirmation-required` blocker
+ * so downstream routing escalates to a human instead of treating it as merge-ready.
  */
 async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult> {
 	const now = () => new Date(opts.clock ? opts.clock() : Date.now()).toISOString();
@@ -209,12 +216,7 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 
 	if (!isReviewVerdict(opts.verdict)) {
 		const reason = opts.verdict == null ? "review-verdict-missing" : "review-verdict-invalid";
-		const failure: ReviewFailureEvidence = {
-			reason,
-			prTarget,
-			failedAt: now(),
-			fallback: "operator-or-omx-review",
-		};
+		const failure: ReviewFailureEvidence = { reason, prTarget, failedAt: now(), fallback: "operator-or-omx-review" };
 		const receipt = buildReceipt<ReviewFailureEvidence>({
 			receiptId: receiptId("revfail"),
 			sessionId: opts.sessionId,
@@ -223,8 +225,8 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 			subject,
 			evidence: failure,
 			createdAt: now(),
-			valid: true,
 		});
+		const outcome = validateReceipt(receipt);
 		const entry = await writeReceiptImmutable(
 			opts.root,
 			opts.sessionId,
@@ -232,7 +234,8 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 			receipt.receiptId,
 			receipt,
 		);
-		return { ...baseResult, completed: false, receiptPath: entry.path, verdict: null, blockers: [reason] };
+		const blockers = outcome.valid ? [reason] : [reason, ...outcome.reasons];
+		return { ...baseResult, completed: false, receiptPath: entry.path, verdict: null, blockers };
 	}
 
 	const verdict = opts.verdict as ReviewVerdict;
@@ -253,13 +256,11 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 	});
 	const outcome = validateReceipt(receipt);
 	const entry = await writeReceiptImmutable(opts.root, opts.sessionId, "review-verdict", receipt.receiptId, receipt);
-	return {
-		...baseResult,
-		completed: outcome.valid,
-		receiptPath: entry.path,
-		verdict,
-		blockers: outcome.valid ? [] : outcome.reasons,
-	};
+	// A confirmation-required verdict is recorded but never an autonomous success.
+	const humanActionRequired = verdict === "OWNER_CONFIRMATION_REQUIRED";
+	const completed = outcome.valid && !humanActionRequired;
+	const blockers = !outcome.valid ? outcome.reasons : humanActionRequired ? ["owner-confirmation-required"] : [];
+	return { ...baseResult, completed, receiptPath: entry.path, verdict, blockers };
 }
 function git(workspace: string, args: string[]): string | null {
 	try {

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -359,6 +359,14 @@ export class RuntimeOwner {
 
 	async #validate(): Promise<PrimitiveResponse> {
 		const state = await this.#loadState();
+		if (state.handle.mode === "review") {
+			// Review-only sessions do not run implementation validation and never attach PR metadata.
+			state.lifecycle = "validating";
+			state.updatedAt = new Date(this.#opts.clock ? this.#opts.clock() : Date.now()).toISOString();
+			await writeSessionState(this.#opts.root, state);
+			await this.#emit("info", "validated", { count: 0, reviewOnly: true });
+			return this.#response(state, { validation: [], reviewOnly: true });
+		}
 		const checks = this.#finalizeChecks ?? defaultFinalizeChecks(state.handle.workspace);
 		const commit = await checks.resolveCommit();
 		const subject: ReceiptSubject = {
@@ -495,11 +503,15 @@ export class RuntimeOwner {
 		const state = await this.#loadState();
 		const workspace = state.handle.workspace;
 		const checks = this.#finalizeChecks ?? defaultFinalizeChecks(workspace);
+		const reviewOnly = state.handle.mode === "review";
 		const fin = await runFinalize({
 			root: this.#opts.root,
 			sessionId: this.#opts.sessionId,
 			workspace,
 			branch: state.handle.branch ?? "",
+			reviewOnly,
+			verdict: reviewOnly ? (typeof input.verdict === "string" ? input.verdict : null) : undefined,
+			prTarget: reviewOnly ? state.handle.issueOrPr : undefined,
 			requireTests: input.requireTests !== false,
 			requireCommit: input.requireCommit !== false,
 			requirePr: input.requirePr !== false,
@@ -514,6 +526,7 @@ export class RuntimeOwner {
 		await this.#emit(fin.completed ? "info" : "critical", "finalized", {
 			completed: fin.completed,
 			blockers: fin.blockers,
+			...(reviewOnly ? { verdict: fin.verdict ?? null, reviewOnly: true } : {}),
 		});
 		return this.#response(state, { finalize: fin }, fin.completed);
 	}

--- a/packages/coding-agent/src/harness-control-plane/receipts.ts
+++ b/packages/coding-agent/src/harness-control-plane/receipts.ts
@@ -13,7 +13,13 @@
  *   - completion        the finalize gate: receipt-valid + commit + PR/issue + validations
  */
 import { createHash } from "node:crypto";
-import type { GitDelta, ReceiptFamily, RecoveryClassification } from "./types";
+import {
+	type GitDelta,
+	isReviewVerdict,
+	type ReceiptFamily,
+	type RecoveryClassification,
+	type ReviewVerdict,
+} from "./types";
 
 export interface ReceiptSubject {
 	workspace: string;
@@ -144,6 +150,23 @@ export interface CompletionEvidence {
 	blockers: string[];
 }
 
+export interface ReviewVerdictEvidence {
+	verdict: ReviewVerdict;
+	prTarget: string | null;
+	finalizedAt: string;
+	/** Bounded summary code/reference for the verdict; never raw assistant text. */
+	summaryRef: string | null;
+}
+
+export interface ReviewFailureEvidence {
+	/** Machine-actionable reason the review produced no terminal verdict. */
+	reason: string;
+	prTarget: string | null;
+	failedAt: string;
+	/** Routing hint for the operator/fallback path. */
+	fallback: string;
+}
+
 function validateFamily(receipt: ReceiptEnvelope<unknown>): string[] {
 	switch (receipt.family) {
 		case "vanish":
@@ -154,6 +177,10 @@ function validateFamily(receipt: ReceiptEnvelope<unknown>): string[] {
 			return validateValidation(receipt.evidence as ValidationEvidence);
 		case "completion":
 			return validateCompletion(receipt.evidence as CompletionEvidence);
+		case "review-verdict":
+			return validateReviewVerdict(receipt.evidence as ReviewVerdictEvidence);
+		case "review-failure":
+			return validateReviewFailure(receipt.evidence as ReviewFailureEvidence);
 		default:
 			return [`unknown-family:${receipt.family}`];
 	}
@@ -204,6 +231,17 @@ function validateCompletion(e: CompletionEvidence): string[] {
 	}
 	if (Array.isArray(e.blockers) && e.blockers.length > 0) reasons.push("completion-has-blockers");
 	return reasons;
+}
+
+function validateReviewVerdict(e: ReviewVerdictEvidence): string[] {
+	if (!e) return ["review-verdict-missing-evidence"];
+	if (!isReviewVerdict(e.verdict)) return ["review-verdict-not-in-vocabulary"];
+	return [];
+}
+
+function validateReviewFailure(e: ReviewFailureEvidence): string[] {
+	if (!e || typeof e.reason !== "string" || e.reason.length === 0) return ["review-failure-missing-reason"];
+	return [];
 }
 
 /** Classifications that MUST have a valid `vanish` receipt before the action proceeds. */

--- a/packages/coding-agent/src/harness-control-plane/types.ts
+++ b/packages/coding-agent/src/harness-control-plane/types.ts
@@ -11,6 +11,22 @@
 /** Harnesses the control plane can operate. v1 implements `gajae-code` only. */
 export type Harness = "gajae-code" | "codex" | "omx";
 
+/** Operating mode of a session. `implement` builds/changes code; `review` produces a read-only verdict. */
+export type SessionMode = "implement" | "review";
+
+/** Closed vocabulary of terminal review verdicts a review-only session may emit. */
+export type ReviewVerdict = "APPROVE_MERGE_READY" | "REQUEST_CHANGES" | "OWNER_CONFIRMATION_REQUIRED";
+
+export const REVIEW_VERDICTS: readonly ReviewVerdict[] = [
+	"APPROVE_MERGE_READY",
+	"REQUEST_CHANGES",
+	"OWNER_CONFIRMATION_REQUIRED",
+];
+
+export function isReviewVerdict(value: unknown): value is ReviewVerdict {
+	return typeof value === "string" && (REVIEW_VERDICTS as readonly string[]).includes(value);
+}
+
 /** Lifecycle states of an operated session. */
 export type HarnessLifecycle =
 	| "new"
@@ -44,7 +60,13 @@ export type RecoveryClassification =
 	| "human-check";
 
 /** Receipt families persisted under the session storage dir. */
-export type ReceiptFamily = "vanish" | "prompt-acceptance" | "validation" | "completion";
+export type ReceiptFamily =
+	| "vanish"
+	| "prompt-acceptance"
+	| "validation"
+	| "completion"
+	| "review-verdict"
+	| "review-failure";
 
 /** The CLI verbs / primitives exposed by `gjc harness <verb>`. */
 export type HarnessVerb =
@@ -95,6 +117,8 @@ export interface PrimitiveResponse<E = Record<string, unknown>> {
 export interface SessionHandle {
 	sessionId: string;
 	harness: Harness;
+	/** Operating mode; absent on legacy records means `implement`. */
+	mode?: SessionMode;
 	repo: string | null;
 	workspace: string;
 	branch: string | null;

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -591,7 +591,7 @@ describe("gjc harness CLI (foundation)", () => {
 		if (!state) throw new Error("missing seeded state");
 		state.lifecycle = "observing";
 		await writeSessionState(root, state);
-		// A live lease (fresh heartbeat, this test process pid) with recent RPC frames.
+		// A live lease (fresh heartbeat, this test process pid) — the heartbeat is the liveness signal.
 		const nowMs = Date.now();
 		const lease = {
 			ownerId: "owner-live",
@@ -621,11 +621,43 @@ describe("gjc harness CLI (foundation)", () => {
 		const monitored = runHarness(["monitor", "--session", sessionId]);
 		expect(monitored.code).toBe(0);
 		expect(monitored.json.evidence.ownerExit).toMatchObject({
-			reason: "owner-endpoint-observation-gap",
+			// Reason string is unchanged for backward-compatible consumers; the transient distinction
+			// is carried by the additive `terminal`/`transient` fields.
+			reason: "owner-endpoint-unreachable",
 			leaseStatus: "live",
 			terminal: false,
+			transient: true,
 		});
 		expect(monitored.json.evidence.ownerExit.lastRpcActivityAt).toBeTruthy();
+	});
+
+	it("monitor does not treat a terminal completion frame as owner liveness (no transient masking)", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "observing";
+		await writeSessionState(root, state);
+		// No lease (owner gone) plus a recent terminal completion frame.
+		await appendEvent(root, sessionId, {
+			eventId: "evt-rpc-completed",
+			cursor: 1,
+			createdAt: new Date().toISOString(),
+			severity: "info",
+			kind: "rpc_agent_completed",
+			state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { outcome: "completed", signal: "completed" },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-gone", leaseEpoch: 1 },
+		});
+
+		const monitored = runHarness(["monitor", "--session", sessionId]);
+		expect(monitored.code).toBe(0);
+		expect(monitored.json.evidence.ownerExit.terminal).toBe(true);
+		expect(monitored.json.evidence.ownerExit.transient).toBe(false);
+		// Completion frames are excluded from activity, so they cannot fabricate liveness.
+		expect(monitored.json.evidence.ownerExit.lastRpcActivityAt).toBeNull();
 	});
 
 	it("submit is blocked (accepted:false, owner-not-live) and never echoed-as-accepted", () => {

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { appendEvent, readSessionState, writeSessionState } from "../../src/harness-control-plane/storage";
+import {
+	appendEvent,
+	readSessionState,
+	sessionPaths,
+	writeSessionState,
+} from "../../src/harness-control-plane/storage";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
@@ -576,6 +581,51 @@ describe("gjc harness CLI (foundation)", () => {
 			completedSeen: false,
 		});
 		expect(events.json.evidence.events).toHaveLength(1);
+	});
+
+	it("monitor distinguishes a transient endpoint gap from terminal owner loss when RPC activity continues", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		if (!state) throw new Error("missing seeded state");
+		state.lifecycle = "observing";
+		await writeSessionState(root, state);
+		// A live lease (fresh heartbeat, this test process pid) with recent RPC frames.
+		const nowMs = Date.now();
+		const lease = {
+			ownerId: "owner-live",
+			sessionId,
+			pid: process.pid,
+			leaseTokenHash: "0".repeat(64),
+			endpoint: { kind: "unix-socket" as const, path: "/tmp/unreachable.sock" },
+			eventsPath: sessionPaths(root, sessionId).events,
+			heartbeatAt: new Date(nowMs).toISOString(),
+			expiresAt: new Date(nowMs + 30_000).toISOString(),
+			leaseEpoch: 1,
+			writer: { ownerId: "owner-live", leaseEpoch: 1 },
+		};
+		await writeFile(sessionPaths(root, sessionId).lease, `${JSON.stringify(lease, null, 2)}\n`, "utf8");
+		await appendEvent(root, sessionId, {
+			eventId: "evt-rpc-activity",
+			cursor: 1,
+			createdAt: new Date(nowMs).toISOString(),
+			severity: "info",
+			kind: "rpc_activity",
+			state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { coalescedFrames: 3 },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-live", leaseEpoch: 1 },
+		});
+
+		const monitored = runHarness(["monitor", "--session", sessionId]);
+		expect(monitored.code).toBe(0);
+		expect(monitored.json.evidence.ownerExit).toMatchObject({
+			reason: "owner-endpoint-observation-gap",
+			leaseStatus: "live",
+			terminal: false,
+		});
+		expect(monitored.json.evidence.ownerExit.lastRpcActivityAt).toBeTruthy();
 	});
 
 	it("submit is blocked (accepted:false, owner-not-live) and never echoed-as-accepted", () => {

--- a/packages/coding-agent/test/harness-control-plane/finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/finalize.test.ts
@@ -153,6 +153,17 @@ describe("runFinalize (review-only verdict gate)", () => {
 		expect(await readReceiptIndex(root, SID, "review-failure")).toHaveLength(1);
 	});
 
+	it("records OWNER_CONFIRMATION_REQUIRED as a non-success human-action-required state", async () => {
+		const res = await runFinalize({ ...reviewBase(), verdict: "OWNER_CONFIRMATION_REQUIRED", checks: checks() });
+		expect(res.completed).toBe(false);
+		expect(res.verdict).toBe("OWNER_CONFIRMATION_REQUIRED");
+		expect(res.blockers).toEqual(["owner-confirmation-required"]);
+		// The verdict is still durably recorded even though it is not an autonomous success.
+		const verdicts = await readReceiptIndex(root, SID, "review-verdict");
+		expect(verdicts).toHaveLength(1);
+		expect(verdicts[0].valid).toBe(true);
+	});
+
 	it("never blocks review on validation-required-but-none-run", async () => {
 		const res = await runFinalize({
 			...reviewBase(),

--- a/packages/coding-agent/test/harness-control-plane/finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/finalize.test.ts
@@ -101,3 +101,66 @@ describe("runFinalize (evidence gate)", () => {
 		expect(res.issueArtifact).toBe("issue#42-resolved");
 	});
 });
+
+describe("runFinalize (review-only verdict gate)", () => {
+	const reviewBase = () => ({
+		root,
+		sessionId: SID,
+		workspace: "/ws",
+		branch: "gajae-code-pr-414-review",
+		reviewOnly: true as const,
+		prTarget: "PR-414",
+	});
+
+	it("completes with a terminal verdict and no PR/commit/validation metadata", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: "REQUEST_CHANGES",
+			// Stale checks would resolve an unrelated PR/commit; review-only must ignore them.
+			checks: checks({
+				resolveCommit: async () => "stale999",
+				prOrIssue: async () => ({ prUrl: "https://x/pr/59", issueArtifact: null }),
+			}),
+		});
+		expect(res.completed).toBe(true);
+		expect(res.verdict).toBe("REQUEST_CHANGES");
+		expect(res.blockers).toEqual([]);
+		expect(res.prUrl).toBeNull();
+		expect(res.issueArtifact).toBeNull();
+		expect(res.commitHash).toBeNull();
+		expect(res.validation).toEqual([]);
+		const verdicts = await readReceiptIndex(root, SID, "review-verdict");
+		expect(verdicts).toHaveLength(1);
+		expect(verdicts[0].valid).toBe(true);
+		expect(await readReceiptIndex(root, SID, "completion")).toHaveLength(0);
+	});
+
+	it("writes a durable bounded failure receipt when no verdict is supplied", async () => {
+		const res = await runFinalize({ ...reviewBase(), verdict: null, checks: checks() });
+		expect(res.completed).toBe(false);
+		expect(res.verdict).toBeNull();
+		expect(res.blockers).toEqual(["review-verdict-missing"]);
+		expect(res.prUrl).toBeNull();
+		const failures = await readReceiptIndex(root, SID, "review-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0].valid).toBe(true);
+	});
+
+	it("blocks on a verdict outside the closed vocabulary", async () => {
+		const res = await runFinalize({ ...reviewBase(), verdict: "LGTM", checks: checks() });
+		expect(res.completed).toBe(false);
+		expect(res.blockers).toEqual(["review-verdict-invalid"]);
+		expect(await readReceiptIndex(root, SID, "review-failure")).toHaveLength(1);
+	});
+
+	it("never blocks review on validation-required-but-none-run", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: "APPROVE_MERGE_READY",
+			validationCommands: [],
+			checks: checks(),
+		});
+		expect(res.completed).toBe(true);
+		expect(res.blockers).not.toContain("validation-required-but-none-run");
+	});
+});


### PR DESCRIPTION
Closes #415.

## Problem
Review-only GJC harness sessions could not produce a terminal review verdict and could surface stale, unrelated PR metadata (a review of PR #414 reported `prUrl` for PR #59), forcing an OMX fallback to finish the review. `monitor` also reported `owner-endpoint-unreachable` despite a live lease/heartbeat and recent RPC activity.

## Change
- Add a `review` session mode (persisted on the session handle) distinct from the default `implement` mode.
- `runFinalize` gains a review-only path gated on a closed verdict vocabulary (`APPROVE_MERGE_READY` / `REQUEST_CHANGES` / `OWNER_CONFIRMATION_REQUIRED`) instead of implementation validation/commit/PR checks. It never resolves PR/commit metadata from the live repo, so a review session can no longer report a stale/unrelated PR.
- A valid verdict writes a `review-verdict` receipt and completes; a missing/invalid verdict writes a durable, bounded `review-failure` receipt suitable for fallback routing.
- Owner `finalize`/`validate` honor review mode: `validate` becomes a no-op that attaches no validation or PR metadata.
- `monitor` distinguishes a transient endpoint observation gap from terminal owner loss: when the lease is live and recent RPC frames exist, exit evidence reports `owner-endpoint-observation-gap` with `terminal: false` instead of `owner-endpoint-unreachable`.

## Acceptance criteria mapping
- Review-only sessions complete with a terminal verdict without implementation validation — review path in `runFinalize` + owner plumbing.
- `finalize`/`validate` for review-only sessions attach no stale PR metadata — review path skips `prOrIssue`/commit resolution; `validate` short-circuits.
- `monitor` distinguishes transient endpoint observation gaps from terminal owner loss when RPC activity continues — `owner-endpoint-observation-gap` + `terminal` flag in owner-exit evidence.
- A blocked review session emits a durable, bounded failure receipt suitable for fallback routing — new `review-failure` receipt family.

## Verification
- `bun test test/harness-control-plane/` (in `packages/coding-agent`): 160 pass / 0 fail.
- `bun run check:ts` (typecheck + biome + schemas + node20 baseline + gjc-ui): clean.
- New tests: 4 review-only verdict-gate cases in `finalize.test.ts`; 1 monitor observation-gap case in `cli.test.ts`.

Do not merge — opened for review only.