### PR TITLE
fix(harness): recover bootstraps owner for never-started session (#421)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.
+- Fixed a `gjc harness` recovery deadlock where a session created by `start` without `--detach` (persisted as `started` with no owner lease/endpoint) could never get a live owner: `recover` refused to spawn one because no prior endpoint existed, while `start` reported `session-already-exists`. `recover` now bootstraps a fresh owner for a never-started session (no lease, no endpoint, no owner-run evidence) without writing a misleading `vanish` receipt, reported via `bootstrappedOwner: true` (#421).
 
 ## [0.4.1] - 2026-06-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.
-- Fixed a `gjc harness` recovery deadlock where a session created by `start` without `--detach` (persisted as `started` with no owner lease/endpoint) could never get a live owner: `recover` refused to spawn one because no prior endpoint existed, while `start` reported `session-already-exists`. `recover` now bootstraps a fresh owner for a never-started session (no lease, no endpoint, no owner-run evidence) without writing a misleading `vanish` receipt, reported via `bootstrappedOwner: true` (#421).
+- Fixed a `gjc harness` recovery deadlock where a session created by `start` without `--detach` (persisted as `started` with no owner lease/endpoint) could never get a live owner: `recover` refused to spawn one because no prior endpoint existed, while `start` reported `session-already-exists`. `recover` now bootstraps a fresh owner for a never-started session (no lease, no endpoint, no owner-run evidence) without writing a misleading `vanish` receipt, reported via `bootstrappedOwner: true`. Bootstrap is independent of the vanish classifier's `ownerRequired` verdict (nothing has vanished), so a session started in a non-git workspace (git delta `unknown`) is recovered too, while a deleted worktree is still refused (#421).
 
 ## [0.4.1] - 2026-06-07
 

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -983,13 +983,18 @@ export default class Harness extends Command {
 			!beforeExit.endpointPresent &&
 			!beforeExit.promptAcceptedSeen &&
 			!beforeExit.completedSeen &&
-			beforeExit.lastEventKind === null;
+			beforeExit.lastEventKind === null &&
+			observation.risk !== "deleted-worktree";
 		// Bootstrapping a never-started owner is not a vanish, so it needs no vanish receipt.
 		const vanishReceiptId = ownerNeverStarted
 			? null
 			: await writeVanishReceiptForDecision(root, state, observation, decision.classification);
+		// A never-started owner has no in-flight work to preserve, so bootstrapping it does not
+		// depend on the vanish classifier's `ownerRequired` verdict — that gate exists to protect a
+		// vanished owner's worktree. Without this, a session started in a non-git workspace (git
+		// delta `unknown` → classifier `human-check` with `ownerRequired: false`) would stay stuck.
 		const restoredOwner =
-			decision.ownerRequired && (beforeExit.endpointPresent || ownerNeverStarted)
+			ownerNeverStarted || (decision.ownerRequired && beforeExit.endpointPresent)
 				? await this.#spawnDetachedOwner(root, sessionId, state.handle.workspace)
 				: null;
 		if (restoredOwner?.live) {

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -974,9 +974,22 @@ export default class Harness extends Command {
 			observation: { ...observation, lifecycle: state.lifecycle },
 			retryBudget: budget,
 		});
-		const vanishReceiptId = await writeVanishReceiptForDecision(root, state, observation, decision.classification);
+		// A session persisted as `started` whose owner was never spawned (no lease,
+		// no endpoint, no owner-run evidence) is not a vanish — it simply never had
+		// an owner. Bootstrap a fresh owner instead of deadlocking on the missing
+		// prior endpoint (which `start` without `--detach` never records).
+		const ownerNeverStarted =
+			state.lifecycle === "started" &&
+			!beforeExit.endpointPresent &&
+			!beforeExit.promptAcceptedSeen &&
+			!beforeExit.completedSeen &&
+			beforeExit.lastEventKind === null;
+		// Bootstrapping a never-started owner is not a vanish, so it needs no vanish receipt.
+		const vanishReceiptId = ownerNeverStarted
+			? null
+			: await writeVanishReceiptForDecision(root, state, observation, decision.classification);
 		const restoredOwner =
-			decision.ownerRequired && beforeExit.endpointPresent
+			decision.ownerRequired && (beforeExit.endpointPresent || ownerNeverStarted)
 				? await this.#spawnDetachedOwner(root, sessionId, state.handle.workspace)
 				: null;
 		if (restoredOwner?.live) {
@@ -989,7 +1002,7 @@ export default class Harness extends Command {
 				writeJson(
 					buildResponse(state, true, {
 						pending: false,
-						restoredOwner: true,
+						...(ownerNeverStarted ? { bootstrappedOwner: true } : { restoredOwner: true }),
 						decision,
 						observation: { ...observation, lifecycle: state.lifecycle, ownerLive: true },
 						ownerExit: beforeExit,

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -265,4 +265,27 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		const ret = await runHarness(["retire", "--session", SID]);
 		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
 	}, 60_000);
+	it("recover bootstraps a never-started owner even when the workspace is not a git repo (#421)", async () => {
+		// No gitInit: a bare workspace reports git delta `unknown`, so the vanish classifier
+		// returns `human-check` / `ownerRequired: false`. Bootstrap must not be gated on that.
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID }),
+		]);
+		expect(started.code).toBe(0);
+		expect((started.json?.state as Record<string, unknown>).lifecycle).toBe("started");
+
+		const recovered = await runHarness(["recover", "--session", SID]);
+		expect(recovered.code).toBe(0);
+		const evidence = recovered.json?.evidence as Record<string, unknown>;
+		expect(evidence.bootstrappedOwner).toBe(true);
+		expect(evidence.vanishReceiptId).toBeUndefined();
+		expect((evidence.decision as Record<string, unknown>).ownerRequired).toBe(false);
+		expect((recovered.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect((recovered.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
+
+		const ret = await runHarness(["retire", "--session", SID]);
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
+	}, 60_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { resolveOwner } from "../../src/harness-control-plane/owner";
@@ -287,5 +287,42 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 
 		const ret = await runHarness(["retire", "--session", SID]);
 		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
+	}, 60_000);
+	it("recover bootstraps a never-started owner in a dirty worktree without a vanish receipt and preserves the delta (#421)", async () => {
+		gitInit(workspace);
+		// Pre-existing uncommitted work makes the git delta `dirty` (classifier:
+		// restart-preserve-delta, ownerRequired:true). A never-started owner never touched this
+		// work, so bootstrapping it is by-design NOT a vanish — no receipt, no stash/reset.
+		const dirtyFile = path.join(workspace, "uncommitted.txt");
+		await writeFile(dirtyFile, "user-work", "utf8");
+
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID }),
+		]);
+		expect(started.code).toBe(0);
+		expect((started.json?.state as Record<string, unknown>).lifecycle).toBe("started");
+
+		const recovered = await runHarness(["recover", "--session", SID]);
+		expect(recovered.code).toBe(0);
+		const evidence = recovered.json?.evidence as Record<string, unknown>;
+		expect(evidence.bootstrappedOwner).toBe(true);
+		// By design: a never-started owner is not a vanish, so no vanish receipt is written
+		// even though the worktree is dirty.
+		expect(evidence.vanishReceiptId).toBeUndefined();
+		const decision = evidence.decision as Record<string, unknown>;
+		expect(decision.classification).toBe("restart-preserve-delta");
+		expect(decision.ownerRequired).toBe(true);
+		expect((evidence.observation as Record<string, unknown>).gitDelta).toBe("dirty");
+		expect((recovered.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect((recovered.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
+		// The pre-existing uncommitted work is left untouched (never stashed or reset).
+		expect(await readFile(dirtyFile, "utf8")).toBe("user-work");
+
+		const ret = await runHarness(["retire", "--session", SID]);
+		// retire routes to the live owner, which stops cleanly without mutating the worktree.
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
+		expect(await readFile(dirtyFile, "utf8")).toBe("user-work");
 	}, 60_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -11,6 +11,17 @@ const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"
 const SID = "d";
 const FAKE_RPC = path.join(import.meta.dir, "fixtures", "fake-rpc.ts");
 
+function gitInit(dir: string): void {
+	const run = (args: string[]): void => {
+		const r = Bun.spawnSync(["git", ...args], { cwd: dir, stdout: "ignore", stderr: "ignore" });
+		if (r.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed`);
+	};
+	run(["init"]);
+	run(["config", "user.email", "test@example.com"]);
+	run(["config", "user.name", "Test"]);
+	run(["commit", "--allow-empty", "-m", "init"]);
+}
+
 let root: string;
 let workspace: string;
 let tmuxCommand: string;
@@ -224,6 +235,32 @@ describe("gjc harness start --detach (detached owner lifecycle, B1)", () => {
 		expect(evidence.ownerRuntime).toBe("detached");
 		expect(evidence.ownerFallbackReason).toContain("tmux new-session failed");
 		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+
+		const ret = await runHarness(["retire", "--session", SID]);
+		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);
+	}, 60_000);
+	it("recover bootstraps an owner for a started session whose owner was never spawned (#421)", async () => {
+		gitInit(workspace);
+		// start WITHOUT --detach persists a `started` session with no owner lease/endpoint.
+		const started = await runHarness([
+			"start",
+			"--input",
+			JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID }),
+		]);
+		expect(started.code).toBe(0);
+		expect((started.json?.state as Record<string, unknown>).lifecycle).toBe("started");
+		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(false);
+		expect((started.json?.evidence as Record<string, unknown>).ownerRuntime).toBe("manual");
+
+		// recover must bootstrap a fresh owner instead of deadlocking on the missing prior endpoint.
+		const recovered = await runHarness(["recover", "--session", SID]);
+		expect(recovered.code).toBe(0);
+		const evidence = recovered.json?.evidence as Record<string, unknown>;
+		expect(evidence.bootstrappedOwner).toBe(true);
+		expect(evidence.restoredOwner).toBeUndefined();
+		expect(evidence.vanishReceiptId).toBeUndefined();
+		expect((recovered.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect((recovered.json?.state as Record<string, unknown>).lifecycle).toBe("observing");
 
 		const ret = await runHarness(["retire", "--session", SID]);
 		expect((ret.json?.evidence as Record<string, unknown>).retired).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #421.

`gjc harness start` without `--detach` persists a session as `lifecycle: "started"` with **no owner lease or endpoint** (an owner is expected to be started later). Recovery then deadlocked:

- `recover` only spawned/restored an owner when a prior lease endpoint existed (`beforeExit.endpointPresent`), so a never-started owner could **never** be bootstrapped.
- `start` is advised as unavailable with `session-already-exists`.
- `submit`/`operate` require a live owner.

Net result: a started-without-owner session was stuck, even though the contract advertised `recover: available`.

## Change

In `#recoverWithoutOwner` (`packages/coding-agent/src/commands/harness.ts`):

- Detect the **owner-never-started** case: `lifecycle === "started"` AND no lease endpoint AND no owner-run evidence (`!promptAcceptedSeen && !completedSeen && lastEventKind === null`) AND the worktree is not deleted (`risk !== "deleted-worktree"`).
- Bootstrap a fresh owner via the existing detached-owner spawn path for that case. Bootstrap is **independent of the vanish classifier's `ownerRequired` verdict** — that gate only protects a *vanished* owner's worktree, and a never-started owner has no in-flight work to preserve. This also recovers a session started in a non-git workspace (git delta `unknown` -> `human-check` / `ownerRequired: false`).
- A never-started owner is **not** a vanish, so the misleading `vanish` receipt is skipped for the bootstrap path, including in a dirty worktree (the dirty changes are pre-existing user work the owner never touched, so they are left untouched — no stash/reset).
- Success is reported with `bootstrappedOwner: true` (vs `restoredOwner: true` for endpoint restore), keeping evidence honest.

Existing vanished-owner recovery (prompt accepted then owner gone) is unchanged: those sessions have owner-run evidence and continue to preserve vanish receipts without auto-restart. A deleted worktree is still refused.

## Verification

- `bun test packages/coding-agent/test/harness-control-plane/` -> **165 pass, 0 fail** (21 files), including new regression tests:
  - `recover bootstraps an owner for a started session whose owner was never spawned (#421)`
  - `recover bootstraps a never-started owner even when the workspace is not a git repo (#421)`
  - `recover bootstraps a never-started owner in a dirty worktree without a vanish receipt and preserves the delta (#421)`
- `bun --cwd=packages/coding-agent run check` (biome + tsgo) -> clean.

### Environment caveat

This worktree had no installed dependencies and no prebuilt native addon, so the harness CLI tests initially failed with `Failed to load pi_natives native addon`. Bootstrap required `bun install` followed by `bun --cwd=packages/natives run build`. No lockfile changes are included in this PR (`git status` shows only source/test/changelog files).
