### PR TITLE
feat(star-reminder): nudge to star the repo on interactive launch

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1009,6 +1009,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"starReminder.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "GitHub Star Reminder",
+			description: "Show the interactive GitHub star reminder when gh is authenticated",
+		},
+	},
+
 	collapseChangelog: {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -55,6 +55,11 @@ import planModeApprovedPrompt from "../prompts/system/plan-mode-approved.md" wit
 import planModeCompactInstructionsPrompt from "../prompts/system/plan-mode-compact-instructions.md" with {
 	type: "text",
 };
+import {
+	createStarReminderBeforeAgentStartContributor,
+	scheduleLaunchStarReminderAfterFirstRender,
+	starReminderLaunchGate,
+} from "../reminders/star-reminder";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import { HistoryStorage } from "../session/history-storage";
 import type { SessionContext, SessionManager } from "../session/session-manager";
@@ -552,6 +557,27 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#syncEditorMaxHeight();
 		this.isInitialized = true;
 		this.ui.requestRender(true);
+
+		// GitHub star reminder (interactive-only). Register the decline-driven
+		// injection contributor and schedule the launch nudge after the first
+		// render so the networked gh check never blocks startup.
+		const starReminderGate = starReminderLaunchGate({
+			enabled: settings.get("starReminder.enabled"),
+			quiet: startupQuiet,
+		});
+		if (starReminderGate.register) {
+			this.session.registerBeforeAgentStartContributor(
+				createStarReminderBeforeAgentStartContributor({
+					getSessionId: () => this.sessionManager.getSessionId(),
+				}),
+			);
+		}
+		if (starReminderGate.schedule) {
+			scheduleLaunchStarReminderAfterFirstRender({
+				confirm: (title, message) => this.showHookConfirm(title, message),
+				isIdle: () => !this.session.isStreaming && !this.isBackgrounded && !this.hookSelector,
+			});
+		}
 
 		// Initialize hooks with TUI-based UI context
 		await this.initHooksAndCustomTools();

--- a/packages/coding-agent/src/reminders/star-reminder.ts
+++ b/packages/coding-agent/src/reminders/star-reminder.ts
@@ -1,0 +1,422 @@
+/**
+ * GitHub star reminder.
+ *
+ * On interactive launch, if `gh` is authenticated and the GJC repo is not
+ * starred, the user is nudged to star it. Declining switches to a per-session
+ * persuasion message injected at the before-agent-start point until the repo is
+ * starred. Detection is `gh`-only: if `gh` is missing, unauthenticated, offline,
+ * or fails for any non-404 reason, the feature stays completely silent.
+ *
+ * All state lives in a user-global file under the GJC config root and is updated
+ * under a file lock with atomic temp+rename writes and a monotonic merge that
+ * never lets a stale "declined"/"unstarred" write clobber a confirmed star.
+ */
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ImageContent, MessageAttribution } from "@gajae-code/ai";
+import { getConfigRootDir, isEnoent } from "@gajae-code/utils";
+import { withFileLock } from "../config/file-lock";
+import type { CustomMessage } from "../session/messages";
+
+export const STAR_REMINDER_REPO = "Yeachan-Heo/gajae-code";
+export const STAR_REMINDER_CUSTOM_TYPE = "star-reminder";
+export const STARRED_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const GH_TIMEOUT_MS = 5_000;
+
+export interface StarReminderState {
+	declined: boolean;
+	starred: boolean;
+	/** ISO-8601 timestamp of the last authoritative star check, or "" if never. */
+	starredCheckedAt: string;
+}
+
+export type StarCheckStatus = "starred" | "unstarred" | "unavailable";
+
+export interface GhResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	timedOut?: boolean;
+}
+
+export type RunGh = (args: string[], options?: { timeoutMs?: number }) => Promise<GhResult>;
+
+export interface StarReminderDeps {
+	statePath?: string;
+	now?: () => Date;
+	runGh?: RunGh;
+	sleep?: (ms: number) => Promise<void>;
+}
+
+// --------------------------------------------------------------------------
+// State path + defaults
+// --------------------------------------------------------------------------
+
+export function getStarReminderStatePath(): string {
+	return path.join(getConfigRootDir(), "star-reminder.json");
+}
+
+export function defaultStarReminderState(): StarReminderState {
+	return { declined: false, starred: false, starredCheckedAt: "" };
+}
+
+function resolveStatePath(deps?: StarReminderDeps): string {
+	return deps?.statePath ?? getStarReminderStatePath();
+}
+
+function resolveNow(deps?: StarReminderDeps): Date {
+	return deps?.now ? deps.now() : new Date();
+}
+
+function isValidState(value: unknown): value is StarReminderState {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return typeof v.declined === "boolean" && typeof v.starred === "boolean" && typeof v.starredCheckedAt === "string";
+}
+
+// --------------------------------------------------------------------------
+// State IO
+// --------------------------------------------------------------------------
+
+/** Read state without locking. Missing or malformed files return the default. */
+export async function readStarReminderStateUnlocked(statePath?: string): Promise<StarReminderState> {
+	const target = statePath ?? getStarReminderStatePath();
+	try {
+		const raw = await fs.readFile(target, "utf8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (!isValidState(parsed)) return defaultStarReminderState();
+		return { declined: parsed.declined, starred: parsed.starred, starredCheckedAt: parsed.starredCheckedAt };
+	} catch (err) {
+		if (isEnoent(err)) return defaultStarReminderState();
+		// Malformed JSON or any read error -> treat as default; never throw to UI.
+		return defaultStarReminderState();
+	}
+}
+
+/** Whether a stored `starred:true` is still within the 24h cache window. */
+export function isStarredCacheFresh(state: StarReminderState, now: Date = new Date()): boolean {
+	if (!state.starred) return false;
+	const checked = new Date(state.starredCheckedAt).getTime();
+	if (Number.isNaN(checked)) return false;
+	const age = now.getTime() - checked;
+	return age >= 0 && age < STARRED_CACHE_TTL_MS;
+}
+
+async function writeStateAtomic(statePath: string, state: StarReminderState): Promise<void> {
+	await fs.mkdir(path.dirname(statePath), { recursive: true, mode: 0o700 });
+	const temp = `${statePath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
+	try {
+		await fs.writeFile(temp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+		await fs.rename(temp, statePath);
+	} catch (err) {
+		await fs.rm(temp, { force: true }).catch(() => {});
+		throw err;
+	}
+}
+
+/**
+ * Lock-protected read-modify-write. The mutator receives the freshly re-read
+ * state under the lock; callers MUST base monotonic decisions on that value,
+ * not on any snapshot captured before the lock was held.
+ */
+export async function updateStarReminderStateLocked(
+	mutator: (current: StarReminderState) => StarReminderState | Promise<StarReminderState>,
+	deps?: StarReminderDeps,
+): Promise<StarReminderState> {
+	const statePath = resolveStatePath(deps);
+	// The lock file lives next to the state file, so its parent dir must exist
+	// before withFileLock tries to create the (non-recursive) lock directory.
+	await fs.mkdir(path.dirname(statePath), { recursive: true, mode: 0o700 });
+	return withFileLock(statePath, async () => {
+		const current = await readStarReminderStateUnlocked(statePath);
+		const next = await mutator(current);
+		await writeStateAtomic(statePath, next);
+		return next;
+	});
+}
+
+// --------------------------------------------------------------------------
+// Monotonic merge helpers
+// --------------------------------------------------------------------------
+
+/** A successful PUT is authoritative: always record starred and clear declined. */
+export async function recordStarredFromPut(deps?: StarReminderDeps): Promise<StarReminderState> {
+	const checkedAt = resolveNow(deps).toISOString();
+	return updateStarReminderStateLocked(() => ({ declined: false, starred: true, starredCheckedAt: checkedAt }), deps);
+}
+
+/**
+ * Record the result of a fresh `gh` star check performed by this operation.
+ * - "starred": authoritative, clears declined so all reminders stop.
+ * - "unstarred": may downgrade, but only when the current state is not a
+ *   still-fresh confirmed star (which a concurrent process may have just
+ *   written); in that case the fresher confirmation wins.
+ */
+export async function recordFreshStarCheck(
+	status: "starred" | "unstarred",
+	deps?: StarReminderDeps,
+): Promise<StarReminderState> {
+	const now = resolveNow(deps);
+	const checkedAt = now.toISOString();
+	return updateStarReminderStateLocked(current => {
+		if (status === "starred") {
+			return { declined: false, starred: true, starredCheckedAt: checkedAt };
+		}
+		// Preserve a confirmed star that is either still within the cache window
+		// or was written concurrently AFTER this operation's check time. The latter
+		// guards against a stale unstarred observation clobbering a newer star that
+		// another process recorded while we were waiting on the lock.
+		if (current.starred) {
+			const currentChecked = new Date(current.starredCheckedAt).getTime();
+			const newerThanThisCheck = !Number.isNaN(currentChecked) && currentChecked > now.getTime();
+			if (newerThanThisCheck || isStarredCacheFresh(current, now)) {
+				return current;
+			}
+		}
+		return { declined: current.declined, starred: false, starredCheckedAt: checkedAt };
+	}, deps);
+}
+
+/** Record a launch-nudge decline. Never downgrades a confirmed star. */
+export async function recordDeclinedAfterNo(deps?: StarReminderDeps): Promise<StarReminderState> {
+	return updateStarReminderStateLocked(current => {
+		if (current.starred) return current;
+		return { ...current, declined: true };
+	}, deps);
+}
+
+// --------------------------------------------------------------------------
+// gh helpers
+// --------------------------------------------------------------------------
+
+/** Default `gh` runner. Returns an unavailable-style result instead of throwing. */
+export async function runGhDefault(args: string[], options?: { timeoutMs?: number }): Promise<GhResult> {
+	const ghPath = Bun.which("gh");
+	if (!ghPath) {
+		return { exitCode: -1, stdout: "", stderr: "gh not found", timedOut: false };
+	}
+	const timeoutMs = options?.timeoutMs ?? GH_TIMEOUT_MS;
+	let timedOut = false;
+	try {
+		const proc = Bun.spawn([ghPath, ...args], { stdout: "pipe", stderr: "pipe", stdin: "ignore" });
+		const timer = setTimeout(() => {
+			timedOut = true;
+			proc.kill();
+		}, timeoutMs);
+		try {
+			const [stdout, stderr] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			const exitCode = await proc.exited;
+			return { exitCode, stdout, stderr, timedOut };
+		} finally {
+			clearTimeout(timer);
+		}
+	} catch (err) {
+		return { exitCode: -1, stdout: "", stderr: err instanceof Error ? err.message : String(err), timedOut };
+	}
+}
+
+function resolveRunGh(deps?: StarReminderDeps): RunGh {
+	return deps?.runGh ?? runGhDefault;
+}
+
+/** Classify the star state of the repo via `gh api`. */
+export async function checkGhStarred(deps?: StarReminderDeps): Promise<StarCheckStatus> {
+	const runGh = resolveRunGh(deps);
+	const res = await runGh(["api", `user/starred/${STAR_REMINDER_REPO}`], { timeoutMs: GH_TIMEOUT_MS });
+	if (res.timedOut) return "unavailable";
+	if (res.exitCode === 0) return "starred";
+	// A genuine 404 from this endpoint is the unambiguous "not starred" signal.
+	// gh emits "gh: Not Found (HTTP 404)" for that case. Other failures (missing
+	// gh, auth, network, malformed output) must stay silent, so we key strictly
+	// on the explicit HTTP 404 status rather than any "404"/"not found" substring,
+	// which could appear in unrelated error text.
+	if (/http[\s/]?404\b/i.test(res.stderr)) return "unstarred";
+	return "unavailable";
+}
+
+/** Star the repo via `gh api -X PUT`. Returns whether the PUT succeeded. */
+export async function autoStarRepo(deps?: StarReminderDeps): Promise<boolean> {
+	const runGh = resolveRunGh(deps);
+	const res = await runGh(["api", "-X", "PUT", `user/starred/${STAR_REMINDER_REPO}`], { timeoutMs: GH_TIMEOUT_MS });
+	return res.exitCode === 0 && !res.timedOut;
+}
+
+/**
+ * Determine the star state for this session, hitting `gh` only when needed.
+ * A fresh cached star skips `gh`; unstarred and declined states are rechecked.
+ * Authoritative results are persisted via the monotonic helpers.
+ */
+export async function refreshStarStateForSession(deps?: StarReminderDeps): Promise<StarCheckStatus> {
+	const statePath = resolveStatePath(deps);
+	const state = await readStarReminderStateUnlocked(statePath);
+	if (state.starred && isStarredCacheFresh(state, resolveNow(deps))) {
+		return "starred";
+	}
+	const status = await checkGhStarred(deps);
+	if (status === "starred") {
+		await recordFreshStarCheck("starred", deps);
+	} else if (status === "unstarred") {
+		await recordFreshStarCheck("unstarred", deps);
+	}
+	return status;
+}
+
+// --------------------------------------------------------------------------
+// Launch nudge
+// --------------------------------------------------------------------------
+
+export interface StarReminderPromptUI {
+	/** Show a yes/no confirmation. Resolves true when the user accepts. */
+	confirm(title: string, message: string): Promise<boolean>;
+	/** Optional guard; when it returns false the nudge is skipped silently. */
+	isIdle?: () => boolean;
+}
+
+const LAUNCH_PROMPT_TITLE = "Enjoying GJC?";
+const LAUNCH_PROMPT_MESSAGE = `Star ${STAR_REMINDER_REPO} on GitHub to support the project?`;
+
+/**
+ * Run the launch nudge once. Caller is responsible for the `startup.quiet`,
+ * `starReminder.enabled`, and true-interactive gates. All errors are swallowed
+ * so the launch path can never be broken by the reminder.
+ */
+export async function maybeShowLaunchStarReminder(ui: StarReminderPromptUI, deps?: StarReminderDeps): Promise<void> {
+	try {
+		const statePath = resolveStatePath(deps);
+		const state = await readStarReminderStateUnlocked(statePath);
+		// Declined users no longer see the launch prompt; the injection path
+		// handles re-checks for them.
+		if (state.declined) return;
+		if (state.starred && isStarredCacheFresh(state, resolveNow(deps))) return;
+
+		const status = await checkGhStarred(deps);
+		if (status === "starred") {
+			await recordFreshStarCheck("starred", deps);
+			return;
+		}
+		if (status === "unavailable") return;
+
+		// status === "unstarred". Persist this fresh unstarred evidence first so a
+		// stale cached starred:true is downgraded and a subsequent No is recorded as
+		// declined (recordDeclinedAfterNo only preserves a still-starred state).
+		await recordFreshStarCheck("unstarred", deps);
+		if (ui.isIdle && !ui.isIdle()) return;
+		const accepted = await ui.confirm(LAUNCH_PROMPT_TITLE, LAUNCH_PROMPT_MESSAGE);
+		if (accepted) {
+			const ok = await autoStarRepo(deps);
+			if (ok) await recordStarredFromPut(deps);
+			// On PUT failure: stay silent and do not mark starred; a later launch
+			// may prompt again while still not declined.
+			return;
+		}
+		await recordDeclinedAfterNo(deps);
+	} catch {
+		// Never surface star-reminder failures to the user.
+	}
+}
+
+/**
+ * Schedule the launch nudge to run after the first render so the networked
+ * `gh` check never blocks startup. Returns immediately.
+ */
+export function scheduleLaunchStarReminderAfterFirstRender(ui: StarReminderPromptUI, deps?: StarReminderDeps): void {
+	setTimeout(() => {
+		void maybeShowLaunchStarReminder(ui, deps);
+	}, 0);
+}
+
+export interface StarReminderLaunchGateInput {
+	/** The `starReminder.enabled` setting. */
+	enabled: boolean;
+	/** The `startup.quiet` setting. */
+	quiet: boolean;
+}
+
+export interface StarReminderLaunchGate {
+	/** Whether to register the decline-driven injection contributor. */
+	register: boolean;
+	/** Whether to schedule the launch nudge after first render. */
+	schedule: boolean;
+}
+
+/**
+ * Pure decision for interactive wiring. The injection contributor is registered
+ * whenever the feature is enabled; the launch nudge is additionally suppressed
+ * by quiet startup. Centralizing this keeps the interactive gate testable.
+ */
+export function starReminderLaunchGate(input: StarReminderLaunchGateInput): StarReminderLaunchGate {
+	return { register: input.enabled, schedule: input.enabled && !input.quiet };
+}
+
+// --------------------------------------------------------------------------
+// Decline-driven injection
+// --------------------------------------------------------------------------
+
+export interface StarReminderSessionRef {
+	getSessionId(): string | undefined;
+}
+
+export type StarReminderCustomMessage = Pick<
+	CustomMessage,
+	"customType" | "content" | "display" | "details" | "attribution"
+>;
+
+export type InternalBeforeAgentStartContributor = (event: {
+	prompt: string;
+	images?: ImageContent[];
+	sessionId: string | undefined;
+}) => Promise<StarReminderCustomMessage | undefined>;
+
+const PERSUASION_CONTENT =
+	`The user previously declined the launch GitHub-star prompt. At an appropriate moment in this response, ` +
+	`briefly and politely encourage starring https://github.com/${STAR_REMINDER_REPO} to support the project. ` +
+	`Ask at most once and do not be pushy.`;
+
+export function createStarReminderMessage(): StarReminderCustomMessage {
+	const attribution: MessageAttribution = "agent";
+	return {
+		customType: STAR_REMINDER_CUSTOM_TYPE,
+		content: PERSUASION_CONTENT,
+		display: false,
+		attribution,
+	};
+}
+
+/**
+ * Build a before-agent-start contributor that injects the persuasion message
+ * once per logical session id, for declined-and-still-unstarred users only.
+ */
+export function createStarReminderBeforeAgentStartContributor(
+	session: StarReminderSessionRef,
+	deps?: StarReminderDeps,
+): InternalBeforeAgentStartContributor {
+	const injectedSessionIds = new Set<string>();
+	return async event => {
+		try {
+			const state = await readStarReminderStateUnlocked(resolveStatePath(deps));
+			if (!state.declined) return undefined;
+
+			// Without a stable logical session id we cannot enforce once-per-session,
+			// so prefer not injecting at all.
+			const sessionId = session.getSessionId() ?? event.sessionId;
+			if (!sessionId) return undefined;
+			if (injectedSessionIds.has(sessionId)) return undefined;
+
+			// Process each logical session at most once, regardless of outcome:
+			// even when gh is unavailable we must not re-check (and possibly delay)
+			// on every subsequent prompt in the same session.
+			injectedSessionIds.add(sessionId);
+
+			const status = await refreshStarStateForSession(deps);
+			if (status !== "unstarred") return undefined;
+			return createStarReminderMessage();
+		} catch {
+			return undefined;
+		}
+	};
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -822,6 +822,23 @@ function extractPermissionLocations(
  *  rely on the existing text-equality match. */
 type QueuedDisplayEntry = { text: string; tag?: string };
 
+/** A custom message contributed at the before-agent-start point. */
+export type BeforeAgentStartInternalMessage = Pick<
+	CustomMessage,
+	"customType" | "content" | "display" | "details" | "attribution"
+>;
+
+/**
+ * Internal (first-party, non-user-hook) contributor invoked at the active
+ * before-agent-start point alongside the extension runner. Returns an optional
+ * custom message to append to the prompt context. Errors are nonfatal.
+ */
+export type BeforeAgentStartContributor = (event: {
+	prompt: string;
+	images?: ImageContent[];
+	sessionId: string | undefined;
+}) => Promise<BeforeAgentStartInternalMessage | undefined>;
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -922,6 +939,8 @@ export class AgentSession {
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
 	#turnIndex = 0;
+	// First-party internal before-agent-start contributors (not user hooks).
+	#beforeAgentStartContributors: BeforeAgentStartContributor[] = [];
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
@@ -4756,6 +4775,9 @@ export class AgentSession {
 
 			const beforeAgentStartSystemPrompt = await this.#buildSystemPromptForAgentStart(expandedText);
 
+			const promptAttribution: "user" | "agent" | undefined =
+				"attribution" in message ? message.attribution : undefined;
+
 			// Emit before_agent_start extension event
 			if (this.#extensionRunner) {
 				const result = await this.#extensionRunner.emitBeforeAgentStart(
@@ -4764,19 +4786,7 @@ export class AgentSession {
 					beforeAgentStartSystemPrompt,
 				);
 				if (result?.messages) {
-					const promptAttribution: "user" | "agent" | undefined =
-						"attribution" in message ? message.attribution : undefined;
-					for (const msg of result.messages) {
-						messages.push({
-							role: "custom",
-							customType: msg.customType,
-							content: msg.content,
-							display: msg.display,
-							details: msg.details,
-							attribution: msg.attribution ?? promptAttribution ?? (message.role === "user" ? "user" : "agent"),
-							timestamp: Date.now(),
-						});
-					}
+					this.#appendBeforeAgentStartCustomMessages(messages, result.messages, promptAttribution, message.role);
 				}
 
 				if (result?.systemPrompt !== undefined) {
@@ -4786,6 +4796,26 @@ export class AgentSession {
 				}
 			} else {
 				this.agent.setSystemPrompt(beforeAgentStartSystemPrompt);
+			}
+
+			// Invoke first-party internal before-agent-start contributors. These run
+			// alongside the extension runner (not via user-loaded hooks) and append
+			// through the same custom-message attribution path. Errors are nonfatal.
+			if (this.#beforeAgentStartContributors.length > 0) {
+				const contributed: BeforeAgentStartInternalMessage[] = [];
+				for (const contributor of this.#beforeAgentStartContributors) {
+					try {
+						const msg = await contributor({
+							prompt: expandedText,
+							images: options?.images,
+							sessionId: this.sessionId,
+						});
+						if (msg) contributed.push(msg);
+					} catch (err) {
+						logger.debug("before_agent_start contributor failed", { error: String(err) });
+					}
+				}
+				this.#appendBeforeAgentStartCustomMessages(messages, contributed, promptAttribution, message.role);
 			}
 
 			// Bail out if a newer abort/prompt cycle has started since we began setup
@@ -9620,6 +9650,42 @@ export class AgentSession {
 	 */
 	hasExtensionHandlers(eventType: string): boolean {
 		return this.#extensionRunner?.hasHandlers(eventType) ?? false;
+	}
+
+	/**
+	 * Register a first-party internal before-agent-start contributor. Returns an
+	 * unregister function. This is NOT user-facing hook discovery; it is an
+	 * in-core seam invoked alongside the extension runner.
+	 */
+	registerBeforeAgentStartContributor(contributor: BeforeAgentStartContributor): () => void {
+		this.#beforeAgentStartContributors.push(contributor);
+		return () => {
+			const idx = this.#beforeAgentStartContributors.indexOf(contributor);
+			if (idx !== -1) this.#beforeAgentStartContributors.splice(idx, 1);
+		};
+	}
+
+	/**
+	 * Append before-agent-start custom messages (from the extension runner or
+	 * internal contributors) using one shared attribution/defaulting path.
+	 */
+	#appendBeforeAgentStartCustomMessages(
+		target: AgentMessage[],
+		returned: readonly BeforeAgentStartInternalMessage[],
+		promptAttribution: "user" | "agent" | undefined,
+		messageRole: string,
+	): void {
+		for (const msg of returned) {
+			target.push({
+				role: "custom",
+				customType: msg.customType,
+				content: msg.content,
+				display: msg.display,
+				details: msg.details,
+				attribution: msg.attribution ?? promptAttribution ?? (messageRole === "user" ? "user" : "agent"),
+				timestamp: Date.now(),
+			});
+		}
 	}
 
 	/**

--- a/packages/coding-agent/test/interactive-star-reminder.test.ts
+++ b/packages/coding-agent/test/interactive-star-reminder.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	defaultStarReminderState,
+	type GhResult,
+	readStarReminderStateUnlocked,
+	type StarReminderPromptUI,
+	scheduleLaunchStarReminderAfterFirstRender,
+	starReminderLaunchGate,
+} from "@gajae-code/coding-agent/reminders/star-reminder";
+
+const tempDirs: string[] = [];
+
+async function makeStatePath(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-interactive-star-"));
+	tempDirs.push(dir);
+	return path.join(dir, "star-reminder.json");
+}
+
+const notFound = (): GhResult => ({ exitCode: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" });
+const missing = (): GhResult => ({ exitCode: -1, stdout: "", stderr: "gh not found" });
+
+function tick(ms = 30): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("scheduleLaunchStarReminderAfterFirstRender", () => {
+	it("does not run the gh check or prompt synchronously", async () => {
+		const statePath = await makeStatePath();
+		let confirmCalls = 0;
+		let ghCalls = 0;
+		const ui: StarReminderPromptUI = {
+			confirm: async () => {
+				confirmCalls++;
+				return false;
+			},
+		};
+		scheduleLaunchStarReminderAfterFirstRender(ui, {
+			statePath,
+			runGh: async () => {
+				ghCalls++;
+				return notFound();
+			},
+		});
+		// Synchronous: nothing has run yet (deferred to after first render).
+		expect(ghCalls).toBe(0);
+		expect(confirmCalls).toBe(0);
+
+		await tick();
+		expect(ghCalls).toBe(1);
+		expect(confirmCalls).toBe(1);
+		expect((await readStarReminderStateUnlocked(statePath)).declined).toBe(true);
+	});
+
+	it("returns immediately and swallows confirm errors", async () => {
+		const statePath = await makeStatePath();
+		const ui: StarReminderPromptUI = {
+			confirm: async () => {
+				throw new Error("ui boom");
+			},
+		};
+		// Must not throw synchronously.
+		expect(() =>
+			scheduleLaunchStarReminderAfterFirstRender(ui, { statePath, runGh: async () => notFound() }),
+		).not.toThrow();
+		await tick();
+		// The error was swallowed (no throw). The fresh unstarred check was
+		// persisted before the prompt, but the decline write never ran because
+		// confirm threw, so declined stays false.
+		const state = await readStarReminderStateUnlocked(statePath);
+		expect(state.declined).toBe(false);
+		expect(state.starred).toBe(false);
+	});
+
+	it("stays silent when gh is unavailable", async () => {
+		const statePath = await makeStatePath();
+		let confirmCalls = 0;
+		const ui: StarReminderPromptUI = {
+			confirm: async () => {
+				confirmCalls++;
+				return true;
+			},
+		};
+		scheduleLaunchStarReminderAfterFirstRender(ui, { statePath, runGh: async () => missing() });
+		await tick();
+		expect(confirmCalls).toBe(0);
+		expect(await readStarReminderStateUnlocked(statePath)).toEqual(defaultStarReminderState());
+	});
+
+	it("skips silently when the idle guard reports busy", async () => {
+		const statePath = await makeStatePath();
+		let confirmCalls = 0;
+		const ui: StarReminderPromptUI = {
+			confirm: async () => {
+				confirmCalls++;
+				return true;
+			},
+			isIdle: () => false,
+		};
+		scheduleLaunchStarReminderAfterFirstRender(ui, { statePath, runGh: async () => notFound() });
+		await tick();
+		expect(confirmCalls).toBe(0);
+	});
+});
+
+describe("starReminderLaunchGate (interactive wiring)", () => {
+	it("enabled + not quiet -> register and schedule", () => {
+		expect(starReminderLaunchGate({ enabled: true, quiet: false })).toEqual({ register: true, schedule: true });
+	});
+
+	it("enabled + quiet -> register but do not schedule the launch nudge (AC9)", () => {
+		expect(starReminderLaunchGate({ enabled: true, quiet: true })).toEqual({ register: true, schedule: false });
+	});
+
+	it("disabled -> neither register nor schedule", () => {
+		expect(starReminderLaunchGate({ enabled: false, quiet: false })).toEqual({ register: false, schedule: false });
+		expect(starReminderLaunchGate({ enabled: false, quiet: true })).toEqual({ register: false, schedule: false });
+	});
+});

--- a/packages/coding-agent/test/session-star-reminder.test.ts
+++ b/packages/coding-agent/test/session-star-reminder.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	createStarReminderBeforeAgentStartContributor,
+	type GhResult,
+	recordDeclinedAfterNo,
+	STAR_REMINDER_CUSTOM_TYPE,
+} from "@gajae-code/coding-agent/reminders/star-reminder";
+import { AgentSession, type BeforeAgentStartContributor } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+const notFound = (): GhResult => ({ exitCode: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" });
+const starred = (): GhResult => ({ exitCode: 0, stdout: "", stderr: "" });
+
+describe("AgentSession before-agent-start contributor seam", () => {
+	let tempDir: TempDir;
+	let stateDir: string;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-session-star-reminder-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-session-star-state-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) await session.dispose();
+		authStorage?.close();
+		authStorage = undefined;
+		tempDir.removeSync();
+		await fs.rm(stateDir, { recursive: true, force: true });
+	});
+
+	function statePath(): string {
+		return path.join(stateDir, "star-reminder.json");
+	}
+
+	function createSession(contributors: BeforeAgentStartContributor[]) {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }, { content: ["Done"] }, { content: ["Done"] }] })
+				.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+		for (const c of contributors) session.registerBeforeAgentStartContributor(c);
+	}
+
+	function reminderMessages(messages: AgentMessage[]): AgentMessage[] {
+		return messages.filter(m => m.role === "custom" && m.customType === STAR_REMINDER_CUSTOM_TYPE);
+	}
+
+	it("appends a contributor custom message with user attribution for user prompts", async () => {
+		const contributor: BeforeAgentStartContributor = async () => ({
+			customType: STAR_REMINDER_CUSTOM_TYPE,
+			content: "please star",
+			display: false,
+		});
+		createSession([contributor]);
+
+		await session.prompt("hello");
+
+		const injected = reminderMessages(session.messages);
+		expect(injected).toHaveLength(1);
+		const msg = injected[0];
+		if (msg?.role !== "custom") throw new Error("expected custom message");
+		expect(msg.attribution).toBe("user");
+		expect(msg.display).toBe(false);
+	});
+
+	it("is nonfatal when a contributor throws", async () => {
+		const contributor: BeforeAgentStartContributor = async () => {
+			throw new Error("boom");
+		};
+		createSession([contributor]);
+
+		await session.prompt("hello");
+		// The agent still ran and produced its response.
+		expect(session.messages.some(m => m.role === "assistant")).toBe(true);
+		expect(reminderMessages(session.messages)).toHaveLength(0);
+	});
+
+	it("injects the persuasion message once per logical session (AC6)", async () => {
+		await recordDeclinedAfterNo({ statePath: statePath() });
+		const runGh = async () => notFound();
+		const contributor = createStarReminderBeforeAgentStartContributor(
+			{ getSessionId: () => "session-1" },
+			{ statePath: statePath(), runGh },
+		);
+		createSession([contributor]);
+
+		await session.prompt("first");
+		await session.prompt("second");
+
+		expect(reminderMessages(session.messages)).toHaveLength(1);
+	});
+
+	it("re-injects after a new logical session id (/new)", async () => {
+		await recordDeclinedAfterNo({ statePath: statePath() });
+		const runGh = async () => notFound();
+		let currentId = "session-1";
+		const contributor = createStarReminderBeforeAgentStartContributor(
+			{ getSessionId: () => currentId },
+			{ statePath: statePath(), runGh },
+		);
+		createSession([contributor]);
+
+		await session.prompt("first");
+		currentId = "session-2";
+		await session.prompt("after new");
+
+		expect(reminderMessages(session.messages)).toHaveLength(2);
+	});
+
+	it("does not inject once the repo is starred (AC7)", async () => {
+		await recordDeclinedAfterNo({ statePath: statePath() });
+		const runGh = async () => starred();
+		const contributor = createStarReminderBeforeAgentStartContributor(
+			{ getSessionId: () => "session-1" },
+			{ statePath: statePath(), runGh },
+		);
+		createSession([contributor]);
+
+		await session.prompt("first");
+
+		expect(reminderMessages(session.messages)).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/star-reminder.test.ts
+++ b/packages/coding-agent/test/star-reminder.test.ts
@@ -1,0 +1,432 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	autoStarRepo,
+	checkGhStarred,
+	createStarReminderBeforeAgentStartContributor,
+	createStarReminderMessage,
+	defaultStarReminderState,
+	type GhResult,
+	isStarredCacheFresh,
+	maybeShowLaunchStarReminder,
+	readStarReminderStateUnlocked,
+	recordDeclinedAfterNo,
+	recordFreshStarCheck,
+	recordStarredFromPut,
+	refreshStarStateForSession,
+	STAR_REMINDER_CUSTOM_TYPE,
+	STAR_REMINDER_REPO,
+	STARRED_CACHE_TTL_MS,
+	type StarReminderState,
+	updateStarReminderStateLocked,
+} from "@gajae-code/coding-agent/reminders/star-reminder";
+
+const tempDirs: string[] = [];
+
+async function makeStatePath(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-star-reminder-"));
+	tempDirs.push(dir);
+	return path.join(dir, "nested", "star-reminder.json");
+}
+
+interface GhCall {
+	args: string[];
+}
+
+function ghRecorder(handler: (args: string[]) => GhResult) {
+	const calls: GhCall[] = [];
+	const runGh = async (args: string[]): Promise<GhResult> => {
+		calls.push({ args });
+		return handler(args);
+	};
+	return { runGh, calls };
+}
+
+const ok = (stdout = ""): GhResult => ({ exitCode: 0, stdout, stderr: "" });
+const notFound = (): GhResult => ({ exitCode: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" });
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("state IO", () => {
+	it("returns default for a missing file", async () => {
+		const statePath = await makeStatePath();
+		expect(await readStarReminderStateUnlocked(statePath)).toEqual(defaultStarReminderState());
+	});
+
+	it("returns default for malformed JSON without throwing", async () => {
+		const statePath = await makeStatePath();
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(statePath, "{ not json");
+		expect(await readStarReminderStateUnlocked(statePath)).toEqual(defaultStarReminderState());
+	});
+
+	it("returns default for a shape mismatch", async () => {
+		const statePath = await makeStatePath();
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(statePath, JSON.stringify({ declined: "yes" }));
+		expect(await readStarReminderStateUnlocked(statePath)).toEqual(defaultStarReminderState());
+	});
+
+	it("locked write creates the parent dir and writes valid JSON", async () => {
+		const statePath = await makeStatePath();
+		const next: StarReminderState = { declined: true, starred: false, starredCheckedAt: "" };
+		const written = await updateStarReminderStateLocked(() => next, { statePath });
+		expect(written).toEqual(next);
+		const reread = JSON.parse(await fs.readFile(statePath, "utf8"));
+		expect(reread).toEqual(next);
+	});
+});
+
+describe("isStarredCacheFresh (AC8)", () => {
+	const now = new Date("2026-01-02T00:00:00.000Z");
+
+	it("is fresh just under 24h", () => {
+		const checkedAt = new Date(now.getTime() - (STARRED_CACHE_TTL_MS - 1)).toISOString();
+		expect(isStarredCacheFresh({ declined: false, starred: true, starredCheckedAt: checkedAt }, now)).toBe(true);
+	});
+
+	it("is stale at exactly 24h", () => {
+		const checkedAt = new Date(now.getTime() - STARRED_CACHE_TTL_MS).toISOString();
+		expect(isStarredCacheFresh({ declined: false, starred: true, starredCheckedAt: checkedAt }, now)).toBe(false);
+	});
+
+	it("is stale older than 24h", () => {
+		const checkedAt = new Date(now.getTime() - STARRED_CACHE_TTL_MS - 1000).toISOString();
+		expect(isStarredCacheFresh({ declined: false, starred: true, starredCheckedAt: checkedAt }, now)).toBe(false);
+	});
+
+	it("is stale for a malformed timestamp", () => {
+		expect(isStarredCacheFresh({ declined: false, starred: true, starredCheckedAt: "nope" }, now)).toBe(false);
+	});
+
+	it("is never fresh when unstarred", () => {
+		expect(isStarredCacheFresh({ declined: false, starred: false, starredCheckedAt: now.toISOString() }, now)).toBe(
+			false,
+		);
+	});
+});
+
+describe("checkGhStarred classification", () => {
+	it("exit 0 -> starred and uses exact args", async () => {
+		const { runGh, calls } = ghRecorder(() => ok());
+		expect(await checkGhStarred({ runGh })).toBe("starred");
+		expect(calls[0]?.args).toEqual(["api", `user/starred/${STAR_REMINDER_REPO}`]);
+	});
+
+	it("404 -> unstarred", async () => {
+		const { runGh } = ghRecorder(() => notFound());
+		expect(await checkGhStarred({ runGh })).toBe("unstarred");
+	});
+
+	it("missing gh -> unavailable", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: -1, stdout: "", stderr: "gh not found" }));
+		expect(await checkGhStarred({ runGh })).toBe("unavailable");
+	});
+
+	it("auth failure -> unavailable", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: 1, stdout: "", stderr: "gh auth login required" }));
+		expect(await checkGhStarred({ runGh })).toBe("unavailable");
+	});
+
+	it("network failure -> unavailable", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: 1, stdout: "", stderr: "dial tcp: lookup api.github.com" }));
+		expect(await checkGhStarred({ runGh })).toBe("unavailable");
+	});
+
+	it("timeout -> unavailable", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: -1, stdout: "", stderr: "", timedOut: true }));
+		expect(await checkGhStarred({ runGh })).toBe("unavailable");
+	});
+});
+
+describe("autoStarRepo", () => {
+	it("uses exact PUT args and returns true on success", async () => {
+		const { runGh, calls } = ghRecorder(() => ok());
+		expect(await autoStarRepo({ runGh })).toBe(true);
+		expect(calls[0]?.args).toEqual(["api", "-X", "PUT", `user/starred/${STAR_REMINDER_REPO}`]);
+	});
+
+	it("returns false on failure", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: 1, stdout: "", stderr: "boom" }));
+		expect(await autoStarRepo({ runGh })).toBe(false);
+	});
+});
+
+describe("monotonic merge", () => {
+	it("recordStarredFromPut writes starred and clears declined", async () => {
+		const statePath = await makeStatePath();
+		await updateStarReminderStateLocked(() => ({ declined: true, starred: false, starredCheckedAt: "" }), {
+			statePath,
+		});
+		const result = await recordStarredFromPut({ statePath, now: () => new Date("2026-01-01T00:00:00.000Z") });
+		expect(result.starred).toBe(true);
+		expect(result.declined).toBe(false);
+	});
+
+	it("stale declined write cannot overwrite a confirmed star", async () => {
+		const statePath = await makeStatePath();
+		await updateStarReminderStateLocked(
+			() => ({ declined: false, starred: true, starredCheckedAt: new Date().toISOString() }),
+			{ statePath },
+		);
+		const result = await recordDeclinedAfterNo({ statePath });
+		expect(result.starred).toBe(true);
+		expect(result.declined).toBe(false);
+	});
+
+	it("recordDeclinedAfterNo sets declined when not starred", async () => {
+		const statePath = await makeStatePath();
+		const result = await recordDeclinedAfterNo({ statePath });
+		expect(result).toEqual({ declined: true, starred: false, starredCheckedAt: "" });
+	});
+
+	it("fresh unstarred check does not downgrade a still-fresh confirmed star", async () => {
+		const statePath = await makeStatePath();
+		const now = new Date("2026-01-02T00:00:00.000Z");
+		await updateStarReminderStateLocked(
+			() => ({ declined: false, starred: true, starredCheckedAt: now.toISOString() }),
+			{ statePath },
+		);
+		const result = await recordFreshStarCheck("unstarred", { statePath, now: () => now });
+		expect(result.starred).toBe(true);
+	});
+
+	it("fresh unstarred check downgrades a stale star", async () => {
+		const statePath = await makeStatePath();
+		const now = new Date("2026-01-02T00:00:00.000Z");
+		const stale = new Date(now.getTime() - STARRED_CACHE_TTL_MS - 1000).toISOString();
+		await updateStarReminderStateLocked(() => ({ declined: false, starred: true, starredCheckedAt: stale }), {
+			statePath,
+		});
+		const result = await recordFreshStarCheck("unstarred", { statePath, now: () => now });
+		expect(result.starred).toBe(false);
+	});
+
+	it("unstarred check does not clobber a concurrently-newer confirmed star", async () => {
+		const statePath = await makeStatePath();
+		const opTime = new Date("2026-01-02T00:00:00.000Z");
+		// A concurrent process recorded a star AFTER this operation captured its time.
+		const newer = new Date(opTime.getTime() + 5000).toISOString();
+		await updateStarReminderStateLocked(() => ({ declined: false, starred: true, starredCheckedAt: newer }), {
+			statePath,
+		});
+		const result = await recordFreshStarCheck("unstarred", { statePath, now: () => opTime });
+		expect(result.starred).toBe(true);
+	});
+});
+
+describe("refreshStarStateForSession (AC5, AC8)", () => {
+	it("skips gh when starred cache is fresh", async () => {
+		const statePath = await makeStatePath();
+		const now = new Date("2026-01-02T00:00:00.000Z");
+		await updateStarReminderStateLocked(
+			() => ({ declined: false, starred: true, starredCheckedAt: now.toISOString() }),
+			{ statePath },
+		);
+		const { runGh, calls } = ghRecorder(() => ok());
+		expect(await refreshStarStateForSession({ statePath, now: () => now, runGh })).toBe("starred");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rechecks gh when unstarred and records the result", async () => {
+		const statePath = await makeStatePath();
+		const { runGh, calls } = ghRecorder(() => notFound());
+		expect(await refreshStarStateForSession({ statePath, runGh })).toBe("unstarred");
+		expect(calls).toHaveLength(1);
+	});
+});
+
+describe("maybeShowLaunchStarReminder", () => {
+	it("AC2: stays fully silent when gh is unavailable", async () => {
+		const statePath = await makeStatePath();
+		const { runGh } = ghRecorder(() => ({ exitCode: -1, stdout: "", stderr: "gh not found" }));
+		let confirmCalls = 0;
+		await maybeShowLaunchStarReminder(
+			{
+				confirm: async () => {
+					confirmCalls++;
+					return true;
+				},
+			},
+			{ statePath, runGh },
+		);
+		expect(confirmCalls).toBe(0);
+		expect(await readStarReminderStateUnlocked(statePath)).toEqual(defaultStarReminderState());
+	});
+
+	it("Yes path stars the repo (AC3)", async () => {
+		const statePath = await makeStatePath();
+		const { runGh } = ghRecorder(args => (args.includes("PUT") ? ok() : notFound()));
+		await maybeShowLaunchStarReminder({ confirm: async () => true }, { statePath, runGh });
+		const state = await readStarReminderStateUnlocked(statePath);
+		expect(state.starred).toBe(true);
+		expect(state.declined).toBe(false);
+	});
+
+	it("No path records declined and suppresses a later prompt (AC4)", async () => {
+		const statePath = await makeStatePath();
+		const { runGh } = ghRecorder(() => notFound());
+		let confirmCalls = 0;
+		const ui = {
+			confirm: async () => {
+				confirmCalls++;
+				return false;
+			},
+		};
+		await maybeShowLaunchStarReminder(ui, { statePath, runGh });
+		expect((await readStarReminderStateUnlocked(statePath)).declined).toBe(true);
+
+		// Second launch: declined users get no prompt.
+		await maybeShowLaunchStarReminder(ui, { statePath, runGh });
+		expect(confirmCalls).toBe(1);
+	});
+
+	it("does not prompt when already starred and fresh (AC5)", async () => {
+		const statePath = await makeStatePath();
+		const now = new Date("2026-01-02T00:00:00.000Z");
+		await updateStarReminderStateLocked(
+			() => ({ declined: false, starred: true, starredCheckedAt: now.toISOString() }),
+			{ statePath },
+		);
+		const { runGh, calls } = ghRecorder(() => ok());
+		let confirmCalls = 0;
+		await maybeShowLaunchStarReminder(
+			{
+				confirm: async () => {
+					confirmCalls++;
+					return true;
+				},
+			},
+			{ statePath, now: () => now, runGh },
+		);
+		expect(confirmCalls).toBe(0);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("skips silently when the idle guard is false", async () => {
+		const statePath = await makeStatePath();
+		const { runGh } = ghRecorder(() => notFound());
+		let confirmCalls = 0;
+		await maybeShowLaunchStarReminder(
+			{
+				confirm: async () => {
+					confirmCalls++;
+					return true;
+				},
+				isIdle: () => false,
+			},
+			{ statePath, runGh },
+		);
+		expect(confirmCalls).toBe(0);
+	});
+});
+
+describe("decline-driven injection (AC6, AC7)", () => {
+	function sessionRef(id: string | undefined) {
+		return { getSessionId: () => id };
+	}
+
+	it("injects once per logical session for declined + unstarred users", async () => {
+		const statePath = await makeStatePath();
+		await recordDeclinedAfterNo({ statePath });
+		const { runGh } = ghRecorder(() => notFound());
+		const contributor = createStarReminderBeforeAgentStartContributor(sessionRef("session-a"), { statePath, runGh });
+
+		const first = await contributor({ prompt: "hi", sessionId: "session-a" });
+		expect(first?.customType).toBe(STAR_REMINDER_CUSTOM_TYPE);
+		const second = await contributor({ prompt: "again", sessionId: "session-a" });
+		expect(second).toBeUndefined();
+	});
+
+	it("re-injects for a new logical session id", async () => {
+		const statePath = await makeStatePath();
+		await recordDeclinedAfterNo({ statePath });
+		const { runGh } = ghRecorder(() => notFound());
+		let currentId = "session-a";
+		const contributor = createStarReminderBeforeAgentStartContributor(
+			{ getSessionId: () => currentId },
+			{ statePath, runGh },
+		);
+		expect(await contributor({ prompt: "hi", sessionId: currentId })).toBeDefined();
+		currentId = "session-b";
+		expect(await contributor({ prompt: "hi", sessionId: currentId })).toBeDefined();
+	});
+
+	it("does not inject for non-declined users", async () => {
+		const statePath = await makeStatePath();
+		const { runGh } = ghRecorder(() => notFound());
+		const contributor = createStarReminderBeforeAgentStartContributor(sessionRef("session-a"), { statePath, runGh });
+		expect(await contributor({ prompt: "hi", sessionId: "session-a" })).toBeUndefined();
+	});
+
+	it("stops injecting once the repo is starred externally (AC7)", async () => {
+		const statePath = await makeStatePath();
+		await recordDeclinedAfterNo({ statePath });
+		const { runGh } = ghRecorder(() => ok());
+		const contributor = createStarReminderBeforeAgentStartContributor(sessionRef("session-a"), { statePath, runGh });
+		expect(await contributor({ prompt: "hi", sessionId: "session-a" })).toBeUndefined();
+		// External star was recorded.
+		expect((await readStarReminderStateUnlocked(statePath)).starred).toBe(true);
+	});
+
+	it("does not inject without a stable session id", async () => {
+		const statePath = await makeStatePath();
+		await recordDeclinedAfterNo({ statePath });
+		const { runGh } = ghRecorder(() => notFound());
+		const contributor = createStarReminderBeforeAgentStartContributor(sessionRef(undefined), { statePath, runGh });
+		expect(await contributor({ prompt: "hi", sessionId: undefined })).toBeUndefined();
+	});
+});
+
+describe("createStarReminderMessage", () => {
+	it("is a non-displayed agent-attributed custom message", () => {
+		const msg = createStarReminderMessage();
+		expect(msg.customType).toBe(STAR_REMINDER_CUSTOM_TYPE);
+		expect(msg.display).toBe(false);
+		expect(msg.attribution).toBe("agent");
+		expect(typeof msg.content).toBe("string");
+	});
+});
+
+describe("regression fixes", () => {
+	it("non-404 failure containing the digits 404 stays unavailable", async () => {
+		const { runGh } = ghRecorder(() => ({ exitCode: 1, stdout: "", stderr: "dial tcp 10.0.0.404:443: timeout" }));
+		expect(await checkGhStarred({ runGh })).toBe("unavailable");
+	});
+
+	it("stale starred + fresh unstarred + No records declined (AC4)", async () => {
+		const statePath = await makeStatePath();
+		const now = new Date("2026-01-02T00:00:00.000Z");
+		const stale = new Date(now.getTime() - STARRED_CACHE_TTL_MS - 1000).toISOString();
+		await updateStarReminderStateLocked(() => ({ declined: false, starred: true, starredCheckedAt: stale }), {
+			statePath,
+		});
+		const { runGh } = ghRecorder(() => notFound());
+		await maybeShowLaunchStarReminder(
+			{
+				confirm: async () => false,
+			},
+			{ statePath, now: () => now, runGh },
+		);
+		const state = await readStarReminderStateUnlocked(statePath);
+		expect(state.starred).toBe(false);
+		expect(state.declined).toBe(true);
+	});
+
+	it("declined + unavailable gh checks once per session, not per prompt", async () => {
+		const statePath = await makeStatePath();
+		await recordDeclinedAfterNo({ statePath });
+		const { runGh, calls } = ghRecorder(() => ({ exitCode: -1, stdout: "", stderr: "gh not found" }));
+		const contributor = createStarReminderBeforeAgentStartContributor(
+			{ getSessionId: () => "session-a" },
+			{ statePath, runGh },
+		);
+		expect(await contributor({ prompt: "1", sessionId: "session-a" })).toBeUndefined();
+		expect(await contributor({ prompt: "2", sessionId: "session-a" })).toBeUndefined();
+		expect(calls).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

Adds an interactive, `gh`-authenticated GitHub star reminder for `Yeachan-Heo/gajae-code`. On interactive launch, if `gh` is authenticated and the repo is unstarred, the user is nudged to star it. Declining switches to a once-per-session persuasion message injected at the before-agent-start point until the repo is starred. Detection is **gh-only** — if `gh` is missing, unauthenticated, offline, or fails for any non-404 reason, the feature stays completely silent.

## Changes

- **`packages/coding-agent/src/reminders/star-reminder.ts`** (new): state IO at `~/.gjc/star-reminder.json` (via `getConfigRootDir()`) under a file lock with atomic temp+rename and a **monotonic merge** that preserves a confirmed/concurrently-newer star; `gh` detection + strict HTTP-404 classification; `autoStarRepo` via `gh api -X PUT`; 24h cache once starred; launch nudge; once-per-logical-session decline-driven contributor; pure `starReminderLaunchGate` for testable wiring.
- **`agent-session.ts`**: internal `registerBeforeAgentStartContributor` seam + shared `#appendBeforeAgentStartCustomMessages` helper (same attribution path as the extension runner), invoked adjacent to `emitBeforeAgentStart`.
- **`interactive-mode.ts`**: register contributor + schedule the launch nudge **after** `ui.start()` + first render (never blocks startup), gated by `starReminder.enabled` and `startup.quiet`, with an idle guard.
- **`settings-schema.ts`**: new `starReminder.enabled` boolean (default `true`).

## Behavior

- `Yes` → auto-star via `gh api -X PUT user/starred/...`, record starred, never nudge again.
- `No` → suppress the launch nudge; inject a persuasion message once per logical session until starred.
- gh unavailable / already starred / quiet startup → silent (no nudge, no added context).
- Re-check via gh each session while unstarred; cache the starred result for 24h.

## Testing

51 tests across three suites (all passing):
- `star-reminder.test.ts` — gh classification matrix, 24h cache boundaries, monotonic merge, lost-update race, full-silence.
- `session-star-reminder.test.ts` — real `AgentSession.prompt()`: attribution parity, nonfatal contributor, once-per-session, `/new` re-injection, external-star stop.
- `interactive-star-reminder.test.ts` — scheduler deferral/idle/silence + launch-gate truth table.

Produced via deep-interview → ralplan consensus → ultragoal, with a 3-round architect quality gate ending CLEAR/CLEAR/CLEAR + APPROVE.
