### PR TITLE
Keep Ultragoal advancing through multi-stage runs

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -96,11 +96,12 @@ Loop until `gjc ultragoal status` reports all goals complete:
 7. Before any `--status complete` checkpoint, run the mandatory final cleanup/review gate below. In aggregate mode, do **not** call `goal({"op":"complete"})` for intermediate stories; checkpoint each story with a fresh `goal({"op":"get"})` snapshot whose aggregate objective is still `active`. On the final story, use the same fresh active snapshot to create the final aggregate receipt first; only after that receipt exists may `goal({"op":"complete"})` run.
 8. Checkpoint the durable ledger with that fresh active snapshot. Complete checkpoints require `--quality-gate-json`; the runtime hook rejects closure without a clean architect review:
    `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --gjc-goal-json <goal-get-json-or-path> --quality-gate-json <quality-gate-json-or-path>`
+   A successful complete checkpoint is story completion, not automatic run completion. Read the checkpoint output: when it prints `Next ultragoal goal: <id>`, continue that active story under the same aggregate GJC goal; when it prints `All ultragoal goals are complete`, the durable run is terminal. `gjc ultragoal complete-goals` remains the supported manual next-story command if continuation output was missed.
 9. If blocked or failed, checkpoint failure:
    `gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
-11. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
+10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
    `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy GJC goal blocks goal create in this thread>" --gjc-goal-json <goal-get-json-or-path>`
-12. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
+11. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
 
 ## Dynamic steering
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import {
 	computeUltragoalPlanGeneration,
 	getUltragoalPaths,
+	getUltragoalRunCompletionState,
 	hashStructuredValue,
 	readUltragoalLedger,
 	readUltragoalPlan,
@@ -246,7 +247,8 @@ export async function readUltragoalVerificationState(input: {
 			message: "Ultragoal has recorded review blockers; complete blocker work and rerun verification.",
 		};
 	}
-	if (plan.goals.some(goal => goal.status === "blocked" || goal.status === "failed")) {
+	const runState = getUltragoalRunCompletionState(plan);
+	if (runState.incompleteGoals.some(goal => goal.status === "blocked" || goal.status === "failed")) {
 		return {
 			state: "active_dirty_quality_gate",
 			message: "Ultragoal has blocked or failed goals; record blockers or rerun verification.",
@@ -259,7 +261,21 @@ export async function readUltragoalVerificationState(input: {
 			message: "Ultragoal aggregate completion requires a fresh final aggregate receipt.",
 		};
 	}
-	return validateCompletionReceipt({ plan, ledger, goal: receiptTarget.goal, receiptKind: receiptTarget.receiptKind });
+	const receiptDiagnostic = validateCompletionReceipt({
+		plan,
+		ledger,
+		goal: receiptTarget.goal,
+		receiptKind: receiptTarget.receiptKind,
+	});
+	if (receiptDiagnostic.state !== "active_verified_complete") return receiptDiagnostic;
+	if (runState.incompleteGoals.length > 0) {
+		return {
+			state: "active_missing_final_receipt",
+			message: `Ultragoal still has incomplete required goals: ${runState.incompleteGoals.map(goal => goal.id).join(", ")}. Run \`gjc ultragoal complete-goals\` to continue.`,
+			goalId: receiptTarget.goal.id,
+		};
+	}
+	return receiptDiagnostic;
 }
 
 export async function assertCanCompleteCurrentGoal(input: {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -228,18 +228,35 @@ function planSnapshotForReceipt(input: {
 	goal: UltragoalGoal;
 	beforeStatus: UltragoalGoalStatus;
 	targetGoalUpdatedAt: string;
+	receiptKind: UltragoalReceiptKind;
 }): unknown {
+	const targetGoalSnapshot = {
+		...input.goal,
+		status: input.beforeStatus,
+		updatedAt: input.targetGoalUpdatedAt,
+		evidence: undefined,
+		completedAt: undefined,
+		completionVerification: undefined,
+	};
+	const goals =
+		input.receiptKind === "final-aggregate"
+			? input.plan.goals.map(goal => ({
+					...goal,
+					status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
+					updatedAt: goal.id === input.goal.id ? input.targetGoalUpdatedAt : goal.updatedAt,
+					evidence: goal.id === input.goal.id ? undefined : goal.evidence,
+					completedAt: goal.id === input.goal.id ? undefined : goal.completedAt,
+					completionVerification: undefined,
+				}))
+			: [targetGoalSnapshot];
 	return {
-		...input.plan,
-		updatedAt: undefined,
-		goals: input.plan.goals.map(goal => ({
-			...goal,
-			status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
-			updatedAt: goal.id === input.goal.id ? input.targetGoalUpdatedAt : goal.updatedAt,
-			evidence: goal.id === input.goal.id ? undefined : goal.evidence,
-			completedAt: goal.id === input.goal.id ? undefined : goal.completedAt,
-			completionVerification: undefined,
-		})),
+		version: input.plan.version,
+		brief: input.plan.brief,
+		gjcGoalMode: input.plan.gjcGoalMode,
+		gjcObjective: input.plan.gjcObjective,
+		gjcObjectiveAliases: input.plan.gjcObjectiveAliases,
+		createdAt: input.plan.createdAt,
+		goals,
 	};
 }
 
@@ -264,6 +281,7 @@ export function computeUltragoalPlanGeneration(input: {
 			goal: input.goal,
 			beforeStatus: input.beforeStatus,
 			targetGoalUpdatedAt,
+			receiptKind: input.receiptKind,
 		}),
 	);
 	const requiredGoalSetHashBeforeCheckpoint = hashStructuredValue(
@@ -569,6 +587,31 @@ function chooseNextGoal(plan: UltragoalPlan, retryFailed: boolean): UltragoalGoa
 		(retryFailed ? plan.goals.find(goal => goal.status === "failed") : undefined)
 	);
 }
+export interface UltragoalRunCompletionState {
+	requiredGoals: UltragoalGoal[];
+	incompleteGoals: UltragoalGoal[];
+	nextGoal?: UltragoalGoal;
+	allComplete: boolean;
+	hasBlockers: boolean;
+	needsFinalAggregateReceipt: boolean;
+}
+
+export function getUltragoalRunCompletionState(
+	plan: UltragoalPlan,
+	options: { retryFailed?: boolean } = {},
+): UltragoalRunCompletionState {
+	const requiredGoals = requiredUltragoalGoals(plan);
+	const incompleteGoals = requiredGoals.filter(goal => !TERMINAL_OR_SKIPPED_STATUSES.has(goal.status));
+	const nextGoal = chooseNextGoal(plan, options.retryFailed === true);
+	return {
+		requiredGoals,
+		incompleteGoals,
+		nextGoal,
+		allComplete: requiredGoals.length > 0 && incompleteGoals.length === 0,
+		hasBlockers: incompleteGoals.some(goal => goal.status === "blocked" || goal.status === "review_blocked"),
+		needsFinalAggregateReceipt: plan.gjcGoalMode === "aggregate" && incompleteGoals.length === 0,
+	};
+}
 
 export async function startNextUltragoalGoal(input: { cwd: string; retryFailed?: boolean }): Promise<{
 	plan: UltragoalPlan;
@@ -578,7 +621,7 @@ export async function startNextUltragoalGoal(input: { cwd: string; retryFailed?:
 	const plan = await readUltragoalPlan(input.cwd);
 	if (!plan) throw new Error("No ultragoal plan found. Run `gjc ultragoal create-goals --brief ...` first.");
 	const goal = chooseNextGoal(plan, input.retryFailed === true);
-	if (!goal) return { plan, allComplete: plan.goals.every(item => TERMINAL_OR_SKIPPED_STATUSES.has(item.status)) };
+	if (!goal) return { plan, allComplete: getUltragoalRunCompletionState(plan).allComplete };
 	if (goal.status !== "active") {
 		const now = new Date().toISOString();
 		goal.status = "active";
@@ -1171,6 +1214,54 @@ export async function checkpointUltragoalGoal(input: {
 	});
 	return plan;
 }
+export interface UltragoalCheckpointContinuation {
+	plan: UltragoalPlan;
+	checkpointedGoal: UltragoalGoal;
+	nextGoal?: UltragoalGoal;
+	startedNext: boolean;
+	allComplete: boolean;
+	incompleteGoals: UltragoalGoal[];
+}
+
+export async function checkpointAndContinueUltragoalGoal(input: {
+	cwd: string;
+	goalId: string;
+	status: UltragoalGoalStatus;
+	evidence: string;
+	gjcGoalJson?: string;
+	qualityGateJson?: string;
+	advanceNext?: boolean;
+	retryFailed?: boolean;
+}): Promise<UltragoalCheckpointContinuation> {
+	let plan = await checkpointUltragoalGoal(input);
+	const checkpointedGoal = plan.goals.find(goal => goal.id === input.goalId);
+	if (!checkpointedGoal) throw new Error(`No ultragoal goal found for ${input.goalId}.`);
+	if (input.status === "complete" && input.advanceNext === true) {
+		const beforeAdvance = getUltragoalRunCompletionState(plan, { retryFailed: input.retryFailed });
+		if (beforeAdvance.nextGoal && beforeAdvance.nextGoal.status !== "active") {
+			const started = await startNextUltragoalGoal({ cwd: input.cwd, retryFailed: input.retryFailed });
+			plan = started.plan;
+			const afterAdvance = getUltragoalRunCompletionState(plan, { retryFailed: input.retryFailed });
+			return {
+				plan,
+				checkpointedGoal,
+				nextGoal: started.goal,
+				startedNext: Boolean(started.goal),
+				allComplete: afterAdvance.allComplete,
+				incompleteGoals: afterAdvance.incompleteGoals,
+			};
+		}
+	}
+	const state = getUltragoalRunCompletionState(plan, { retryFailed: input.retryFailed });
+	return {
+		plan,
+		checkpointedGoal,
+		nextGoal: state.nextGoal,
+		startedNext: false,
+		allComplete: state.allComplete,
+		incompleteGoals: state.incompleteGoals,
+	};
+}
 
 export async function addUltragoalSubgoal(input: {
 	cwd: string;
@@ -1387,6 +1478,43 @@ function renderCompleteHandoff(
 		"",
 	].join("\n");
 }
+function renderCheckpointContinuation(result: UltragoalCheckpointContinuation, status: UltragoalGoalStatus, json: boolean, cwd: string): string {
+	if (json)
+		return renderCliWriteReceipt({
+			ok: true,
+			goal_id: result.checkpointedGoal.id,
+			status,
+			goals_path: getUltragoalPaths(cwd).goalsPath,
+			completion_receipt_kind: result.checkpointedGoal.completionVerification?.receiptKind,
+			quality_gate_hash: result.checkpointedGoal.completionVerification?.qualityGateHash,
+			all_complete: result.allComplete,
+			next_goal_id: result.nextGoal?.id,
+			next_goal_status: result.nextGoal?.status,
+			started_next: result.startedNext,
+			incomplete_goal_ids: result.incompleteGoals.map(goal => goal.id),
+		});
+	const lines = [`Checkpointed ${result.checkpointedGoal.id} as ${status}.`];
+	if (status === "complete") {
+		if (result.allComplete) {
+			lines.push("All ultragoal goals are complete.");
+		} else if (result.nextGoal) {
+			lines.push(`Next ultragoal goal: ${result.nextGoal.id} — ${result.nextGoal.title}`);
+			lines.push(`Objective: ${result.nextGoal.objective}`);
+			lines.push(`GJC objective: ${result.plan.gjcObjective}`);
+			lines.push(
+				result.startedNext
+					? "The next ultragoal goal is active; continue the current aggregate GJC goal and checkpoint this story when verified."
+					: "Run `gjc ultragoal complete-goals` to activate the next ultragoal story.",
+			);
+		}
+	} else if (status === "failed") {
+		lines.push("Resume failed goals with `gjc ultragoal complete-goals --retry-failed` after the blocker is fixed.");
+	} else if (status === "blocked" || status === "review_blocked") {
+		lines.push("Blocked ultragoal work must be resolved with explicit blocker work or steering before final completion.");
+	}
+	lines.push("");
+	return lines.join("\n");
+}
 
 async function dispatchUltragoalCommand(args: string[], cwd: string): Promise<UltragoalCommandResult> {
 	const help = renderUltragoalHelp(args);
@@ -1427,27 +1555,18 @@ async function dispatchUltragoalCommand(args: string[], cwd: string): Promise<Ul
 				const goalId = flagValue(args, "--goal-id") ?? "";
 				const status = parseGoalStatus(flagValue(args, "--status"));
 				const evidence = flagValue(args, "--evidence") ?? "";
-				const plan = await checkpointUltragoalGoal({
+				const result = await checkpointAndContinueUltragoalGoal({
 					cwd,
 					goalId,
 					status,
 					evidence,
 					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 					qualityGateJson: flagValue(args, "--quality-gate-json"),
+					advanceNext: status === "complete",
 				});
-				const goal = plan.goals.find(item => item.id === goalId);
 				return {
 					status: 0,
-					stdout: json
-						? renderCliWriteReceipt({
-								ok: true,
-								goal_id: goalId,
-								status,
-								goals_path: getUltragoalPaths(cwd).goalsPath,
-								completion_receipt_kind: goal?.completionVerification?.receiptKind,
-								quality_gate_hash: goal?.completionVerification?.qualityGateHash,
-							})
-						: `ultragoal checkpoint goal-id=${goalId} status=${status}\n`,
+					stdout: renderCheckpointContinuation(result, status, json, cwd),
 				};
 			}
 			case "steer": {

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -473,6 +473,7 @@ describe("bundled skills CLI", () => {
 					HOME: await makeTempRoot(),
 					PI_NO_TITLE: "1",
 					NO_COLOR: "1",
+					FORCE_COLOR: undefined,
 				},
 			},
 		);
@@ -508,6 +509,7 @@ describe("bundled skills CLI", () => {
 					HOME: await makeTempRoot(),
 					PI_NO_TITLE: "1",
 					NO_COLOR: "1",
+					FORCE_COLOR: undefined,
 				},
 			},
 		);
@@ -546,6 +548,7 @@ describe("bundled skills CLI", () => {
 						HOME: await makeTempRoot(),
 						PI_NO_TITLE: "1",
 						NO_COLOR: "1",
+						FORCE_COLOR: undefined,
 					},
 				},
 			);

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -7,11 +7,13 @@ import {
 	validateCompletionReceipt,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
+	addUltragoalSubgoal,
 	buildUltragoalHudSummary,
 	checkpointUltragoalGoal,
 	createUltragoalPlan,
 	getUltragoalStatus,
 	readUltragoalLedger,
+	readUltragoalPlan,
 	runNativeUltragoalCommand,
 	startNextUltragoalGoal,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
@@ -528,6 +530,87 @@ describe("native GJC ultragoal runtime", () => {
 
 		expect(plan.goals[0]?.status).toBe("complete");
 		expect(plan.goals[0]?.completionVerification?.receiptKind).toBe("per-goal");
+	});
+	it("continues to next ultragoal goal after checkpointing G001 complete", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Second stage",
+			objective: "Complete the second stage.",
+			evidence: "The regression requires a second required goal.",
+			rationale: "Cover continuation after the first checkpoint.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--gjc-goal-json",
+				goalSnapshot(created.gjcObjective),
+				"--quality-gate-json",
+				passingQualityGate(),
+			],
+			root,
+		);
+		const status = await getUltragoalStatus(root);
+		const ledger = await readUltragoalLedger(root);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("Next ultragoal goal: G002");
+		expect(status.goals[0]).toMatchObject({ id: "G001", status: "complete" });
+		expect(status.goals[1]).toMatchObject({ id: "G002", status: "active" });
+		expect(status.status).toBe("active");
+		expect(ledger.filter(event => event.event === "goal_started" && event.goalId === "G002")).toHaveLength(1);
+	});
+
+	it("keeps per-goal receipt fresh after unrelated next goal starts", async () => {
+		const root = await tempDir();
+		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Second stage",
+			objective: "Complete the second stage.",
+			evidence: "The regression requires a second required goal.",
+			rationale: "Cover receipt freshness after continuation.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--gjc-goal-json",
+				goalSnapshot(created.gjcObjective),
+				"--quality-gate-json",
+				passingQualityGate(),
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const plan = await readUltragoalPlan(root);
+		if (!plan) throw new Error("missing ultragoal plan");
+		const diagnostic = validateCompletionReceipt({
+			plan,
+			ledger: await readUltragoalLedger(root),
+			goal: plan.goals[0]!,
+			receiptKind: "per-goal",
+		});
+
+		expect(plan.goals[1]).toMatchObject({ id: "G002", status: "active" });
+		expect(diagnostic.state).toBe("active_verified_complete");
 	});
 
 	it("treats receipts as stale after target goal mutation", async () => {

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../src/config/skill-settings-defaults";
 import { RequiredOnWriteEnvelopeSchema } from "../src/gjc-runtime/state-schema";
-import { createUltragoalPlan } from "../src/gjc-runtime/ultragoal-runtime";
+import { addUltragoalSubgoal, checkpointUltragoalGoal, createUltragoalPlan, startNextUltragoalGoal } from "../src/gjc-runtime/ultragoal-runtime";
 import {
 	mergeGjcManagedCodexHooksConfig,
 	readGjcManagedCodexHooksStatus,
@@ -43,6 +43,92 @@ describe("GJC native skill-state hooks", () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-hooks-"));
 		return tempDir;
 	}
+
+function ultragoalQualityGate(): string {
+	return JSON.stringify({
+		architectReview: {
+			architectureStatus: "CLEAR",
+			productStatus: "CLEAR",
+			codeStatus: "CLEAR",
+			recommendation: "APPROVE",
+			evidence: "architect reviewed architecture product and code surfaces",
+			commands: ["architect-review"],
+			blockers: [],
+		},
+		executorQa: {
+			status: "passed",
+			e2eStatus: "passed",
+			redTeamStatus: "passed",
+			evidence: "executor ran e2e and red-team verification for the approved contract",
+			e2eCommands: ["bun test:e2e"],
+			redTeamCommands: ["bun test:red-team"],
+			artifactRefs: [
+				{
+					id: "cli-run",
+					kind: "test-report",
+					description: "CLI verification transcript",
+					inlineEvidence: "The CLI test report verified the approved flow and recorded the passing result.",
+				},
+				{
+					id: "adversarial",
+					kind: "failure-mode-test",
+					description: "Adversarial verification report",
+					inlineEvidence: "Adversarial cases covered invalid input, missing state, and repeated operation boundaries.",
+				},
+			],
+			contractCoverage: [
+				{
+					id: "contract",
+					contractRef: "approved-plan",
+					obligation: "The story satisfies the approved contract",
+					status: "covered",
+					surfaceEvidenceRefs: ["surface"],
+					adversarialCaseRefs: ["case"],
+				},
+			],
+			surfaceEvidence: [
+				{
+					id: "surface",
+					contractRef: "approved-plan",
+					surface: "cli",
+					invocation: "Run the focused CLI verification scenario",
+					verdict: "passed",
+					artifactRefs: ["cli-run"],
+				},
+			],
+			adversarialCases: [
+				{
+					id: "case",
+					contractRef: "approved-plan",
+					scenario: "Exercise invalid and repeated command paths",
+					expectedBehavior: "The runtime preserves the durable goal contract",
+					verdict: "passed",
+					artifactRefs: ["adversarial"],
+				},
+			],
+			blockers: [],
+		},
+		iteration: {
+			status: "passed",
+			evidence: "full verification reran cleanly after the implementation pass",
+			fullRerun: true,
+			rerunCommands: ["bun test:e2e", "bun test:red-team"],
+			blockers: [],
+		},
+	});
+}
+
+function goalSnapshot(objective: string, status = "active", updatedAt = Date.now()): string {
+	return JSON.stringify({
+		goal: {
+			threadId: "test-thread",
+			objective,
+			status,
+			createdAt: updatedAt,
+			updatedAt,
+		},
+	});
+}
 
 	it("detects only the public GJC workflow skill surface", () => {
 		expect(detectSkillKeywords("$deep-interview then $team").map(match => match.skill)).toEqual([
@@ -746,6 +832,96 @@ disabledExtensions:
 		expect(String(result.outputJson?.reason ?? "")).toContain("fresh final aggregate receipt");
 	});
 
+	it("Stop blocks verified Ultragoal stories while later required goals remain", async () => {
+		const root = await cwd();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Second stage",
+			objective: "Complete the second stage.",
+			evidence: "The test needs a second required goal.",
+			rationale: "Regression coverage for multi-stage continuation.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first stage verified",
+			gjcGoalJson: goalSnapshot(plan.gjcObjective),
+			qualityGateJson: ultragoalQualityGate(),
+		});
+		await dispatchGjcNativeSkillHook(
+			{
+				hookEventName: "UserPromptSubmit",
+				userPrompt: "$ultragoal plan this",
+				cwd: root,
+				sessionId: "session-ultra-stop-pending",
+				threadId: "thread-ultra-stop-pending",
+			},
+			{ effectiveSkillConfig: testEffectiveSkillConfig },
+		);
+		const statePath = path.join(root, ".gjc", "state", "sessions", "session-ultra-stop-pending", "ultragoal-state.json");
+		const state = await Bun.file(statePath).json();
+		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.goals[0]?.objective }, null, 2));
+
+		const blocked = await dispatchGjcNativeSkillHook({
+			hookEventName: "Stop",
+			cwd: root,
+			sessionId: "session-ultra-stop-pending",
+			threadId: "thread-ultra-stop-pending",
+		});
+
+		expect(blocked.outputJson).toMatchObject({ decision: "block" });
+		expect(String(blocked.outputJson?.reason ?? "")).toContain("G002");
+		expect(String(blocked.outputJson?.reason ?? "")).toContain("complete-goals");
+	});
+
+	it("UserPromptSubmit blocks Ultragoal completion when later required goals remain", async () => {
+		const root = await cwd();
+		const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Second stage",
+			objective: "Complete the second stage.",
+			evidence: "The test needs a second required goal.",
+			rationale: "Regression coverage for multi-stage completion bypass.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first stage verified",
+			gjcGoalJson: goalSnapshot(plan.gjcObjective),
+			qualityGateJson: ultragoalQualityGate(),
+		});
+		await dispatchGjcNativeSkillHook(
+			{
+				hookEventName: "UserPromptSubmit",
+				userPrompt: "$ultragoal plan this",
+				cwd: root,
+				sessionId: "session-ultra-bypass-pending",
+				threadId: "thread-ultra-bypass-pending",
+			},
+			{ effectiveSkillConfig: testEffectiveSkillConfig },
+		);
+		const statePath = path.join(root, ".gjc", "state", "sessions", "session-ultra-bypass-pending", "ultragoal-state.json");
+		const state = await Bun.file(statePath).json();
+		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.goals[0]?.objective }, null, 2));
+
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: 'please call goal({"op":"complete"})',
+			cwd: root,
+			sessionId: "session-ultra-bypass-pending",
+			threadId: "thread-ultra-bypass-pending",
+		});
+
+		expect(result.outputJson).toMatchObject({ decision: "block" });
+		expect(String(result.outputJson?.reason ?? "")).toContain("G002");
+		expect(String(result.outputJson?.reason ?? "")).toContain("complete-goals");
+	});
 	it("UserPromptSubmit includes steer guidance when activating Ultragoal", async () => {
 		const root = await cwd();
 		const result = await dispatchGjcNativeSkillHook(


### PR DESCRIPTION
## Summary

This PR fixes an Ultragoal workflow failure mode where a multi-stage durable run could complete the first story (`G001`) and then stop instead of continuing through the remaining required stages (`G002`, `G003`, etc.).

In real project-management terms, the old behavior was like a project board that lets a worker close ticket 1 of 5 and then go idle, even though tickets 2-5 are still waiting. The board had a completion stamp for the current ticket, but it did not reliably hand off the next ticket or block premature project shutdown.

## Why this work was needed

Ultragoal is meant to be a durable execution ledger, not a one-ticket checklist. When users split work into several stages, the expected behavior is:

1. Start the current stage.
2. Verify it through the strict quality gate.
3. Checkpoint that stage.
4. Continue to the next required stage.
5. Only allow final completion when all required stages are complete and the correct receipt exists.

The runtime previously relied too much on the agent remembering to manually re-run `gjc ultragoal complete-goals` after each checkpoint. That made the system fragile: a clean `G001` receipt could look like a safe stopping point even when the durable plan still had pending required goals.

## What changed

- Added a shared Ultragoal run-completion state helper so runtime and guards can reason about the whole durable run, not only the current story.
- Added checkpoint continuation behavior for successful complete checkpoints:
  - `G001` complete now reports the next required goal when one exists.
  - The next pending goal can be activated through the runtime continuation path.
  - The checkpoint output now clearly tells the agent what to do next.
- Preserved strict quality gates. This does **not** weaken architect review, executor QA, red-team evidence, receipt freshness, or final aggregate receipt requirements.
- Fixed per-goal receipt freshness so starting `G002` does not accidentally stale the already-valid `G001` receipt.
- Strengthened completion/stop guarding so a verified current story cannot be treated as whole-run completion while required goals remain incomplete.
- Updated the bundled Ultragoal skill documentation to explain that a successful checkpoint is story completion, not necessarily durable-run completion.
- Added regression tests for multi-stage continuation, receipt freshness, and hook-level premature stop/completion blocking.
- Hardened bundled skill CLI tests against inherited `FORCE_COLOR` stderr noise in environments that also set `NO_COLOR`.

## What gets better

- Multi-stage Ultragoal runs should keep moving after stage 1 instead of silently stopping.
- Agents receive explicit continuation output such as `Next ultragoal goal: G002`.
- The workflow becomes safer: closing one stage does not masquerade as closing the whole project.
- The durable ledger remains trustworthy because per-story receipts stay scoped to the story they verify.
- Final completion stays conservative: aggregate completion still requires all required goals and a final aggregate receipt.
- Hook behavior now catches the real failure mode earlier by blocking stop/completion attempts while required goals remain.

## Expected behavior after this PR

For a plan with five stages:

1. `G001` is started and verified.
2. `gjc ultragoal checkpoint --goal-id G001 --status complete ...` records the strict quality-gated receipt.
3. The runtime surfaces/activates `G002` instead of letting the run appear finished.
4. Stop or `goal({"op":"complete"})` remains blocked while `G002`-`G005` are still incomplete.
5. Only after the final required stage is cleanly checkpointed does aggregate completion become valid.

## Verification

Passed locally on the PR branch based on `dev`:

```sh
unset GJC_SESSION_ID; bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts
bun scripts/check-visible-definitions.ts
bun scripts/verify-g002-gates.ts
bun scripts/rebrand-inventory.ts --strict
```

Results:

- 128 tests passed across the focused runtime/hook/default-definition tests.
- Visible default workflow surface gate passed.
- G002 gate verification passed.
- Rebrand inventory strict gate passed.

Note: The focused runtime tests intentionally exercise corrupt/stale state reconciliation paths, so they print expected `ultragoal state reconciliation failed: EISDIR...` diagnostics while still passing.
