### PR TITLE
fix(release): default bare binary build to host target

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1102,7 +1102,8 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "context",
 			label: "Auto-Promote Context",
-			description: "Promote to a larger-context model on context overflow instead of compacting (off by default; opt in to enable)",
+			description:
+				"Promote to a larger-context model on context overflow instead of compacting (off by default; opt in to enable)",
 		},
 	},
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1478,7 +1478,12 @@ function renderCompleteHandoff(
 		"",
 	].join("\n");
 }
-function renderCheckpointContinuation(result: UltragoalCheckpointContinuation, status: UltragoalGoalStatus, json: boolean, cwd: string): string {
+function renderCheckpointContinuation(
+	result: UltragoalCheckpointContinuation,
+	status: UltragoalGoalStatus,
+	json: boolean,
+	cwd: string,
+): string {
 	if (json)
 		return renderCliWriteReceipt({
 			ok: true,
@@ -1510,7 +1515,9 @@ function renderCheckpointContinuation(result: UltragoalCheckpointContinuation, s
 	} else if (status === "failed") {
 		lines.push("Resume failed goals with `gjc ultragoal complete-goals --retry-failed` after the blocker is fixed.");
 	} else if (status === "blocked" || status === "review_blocked") {
-		lines.push("Blocked ultragoal work must be resolved with explicit blocker work or steering before final completion.");
+		lines.push(
+			"Blocked ultragoal work must be resolved with explicit blocker work or steering before final completion.",
+		);
 	}
 	lines.push("");
 	return lines.join("\n");

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -4,7 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../src/config/skill-settings-defaults";
 import { RequiredOnWriteEnvelopeSchema } from "../src/gjc-runtime/state-schema";
-import { addUltragoalSubgoal, checkpointUltragoalGoal, createUltragoalPlan, startNextUltragoalGoal } from "../src/gjc-runtime/ultragoal-runtime";
+import {
+	addUltragoalSubgoal,
+	checkpointUltragoalGoal,
+	createUltragoalPlan,
+	startNextUltragoalGoal,
+} from "../src/gjc-runtime/ultragoal-runtime";
 import {
 	mergeGjcManagedCodexHooksConfig,
 	readGjcManagedCodexHooksStatus,
@@ -44,91 +49,92 @@ describe("GJC native skill-state hooks", () => {
 		return tempDir;
 	}
 
-function ultragoalQualityGate(): string {
-	return JSON.stringify({
-		architectReview: {
-			architectureStatus: "CLEAR",
-			productStatus: "CLEAR",
-			codeStatus: "CLEAR",
-			recommendation: "APPROVE",
-			evidence: "architect reviewed architecture product and code surfaces",
-			commands: ["architect-review"],
-			blockers: [],
-		},
-		executorQa: {
-			status: "passed",
-			e2eStatus: "passed",
-			redTeamStatus: "passed",
-			evidence: "executor ran e2e and red-team verification for the approved contract",
-			e2eCommands: ["bun test:e2e"],
-			redTeamCommands: ["bun test:red-team"],
-			artifactRefs: [
-				{
-					id: "cli-run",
-					kind: "test-report",
-					description: "CLI verification transcript",
-					inlineEvidence: "The CLI test report verified the approved flow and recorded the passing result.",
-				},
-				{
-					id: "adversarial",
-					kind: "failure-mode-test",
-					description: "Adversarial verification report",
-					inlineEvidence: "Adversarial cases covered invalid input, missing state, and repeated operation boundaries.",
-				},
-			],
-			contractCoverage: [
-				{
-					id: "contract",
-					contractRef: "approved-plan",
-					obligation: "The story satisfies the approved contract",
-					status: "covered",
-					surfaceEvidenceRefs: ["surface"],
-					adversarialCaseRefs: ["case"],
-				},
-			],
-			surfaceEvidence: [
-				{
-					id: "surface",
-					contractRef: "approved-plan",
-					surface: "cli",
-					invocation: "Run the focused CLI verification scenario",
-					verdict: "passed",
-					artifactRefs: ["cli-run"],
-				},
-			],
-			adversarialCases: [
-				{
-					id: "case",
-					contractRef: "approved-plan",
-					scenario: "Exercise invalid and repeated command paths",
-					expectedBehavior: "The runtime preserves the durable goal contract",
-					verdict: "passed",
-					artifactRefs: ["adversarial"],
-				},
-			],
-			blockers: [],
-		},
-		iteration: {
-			status: "passed",
-			evidence: "full verification reran cleanly after the implementation pass",
-			fullRerun: true,
-			rerunCommands: ["bun test:e2e", "bun test:red-team"],
-			blockers: [],
-		},
-	});
-}
+	function ultragoalQualityGate(): string {
+		return JSON.stringify({
+			architectReview: {
+				architectureStatus: "CLEAR",
+				productStatus: "CLEAR",
+				codeStatus: "CLEAR",
+				recommendation: "APPROVE",
+				evidence: "architect reviewed architecture product and code surfaces",
+				commands: ["architect-review"],
+				blockers: [],
+			},
+			executorQa: {
+				status: "passed",
+				e2eStatus: "passed",
+				redTeamStatus: "passed",
+				evidence: "executor ran e2e and red-team verification for the approved contract",
+				e2eCommands: ["bun test:e2e"],
+				redTeamCommands: ["bun test:red-team"],
+				artifactRefs: [
+					{
+						id: "cli-run",
+						kind: "test-report",
+						description: "CLI verification transcript",
+						inlineEvidence: "The CLI test report verified the approved flow and recorded the passing result.",
+					},
+					{
+						id: "adversarial",
+						kind: "failure-mode-test",
+						description: "Adversarial verification report",
+						inlineEvidence:
+							"Adversarial cases covered invalid input, missing state, and repeated operation boundaries.",
+					},
+				],
+				contractCoverage: [
+					{
+						id: "contract",
+						contractRef: "approved-plan",
+						obligation: "The story satisfies the approved contract",
+						status: "covered",
+						surfaceEvidenceRefs: ["surface"],
+						adversarialCaseRefs: ["case"],
+					},
+				],
+				surfaceEvidence: [
+					{
+						id: "surface",
+						contractRef: "approved-plan",
+						surface: "cli",
+						invocation: "Run the focused CLI verification scenario",
+						verdict: "passed",
+						artifactRefs: ["cli-run"],
+					},
+				],
+				adversarialCases: [
+					{
+						id: "case",
+						contractRef: "approved-plan",
+						scenario: "Exercise invalid and repeated command paths",
+						expectedBehavior: "The runtime preserves the durable goal contract",
+						verdict: "passed",
+						artifactRefs: ["adversarial"],
+					},
+				],
+				blockers: [],
+			},
+			iteration: {
+				status: "passed",
+				evidence: "full verification reran cleanly after the implementation pass",
+				fullRerun: true,
+				rerunCommands: ["bun test:e2e", "bun test:red-team"],
+				blockers: [],
+			},
+		});
+	}
 
-function goalSnapshot(objective: string, status = "active", updatedAt = Date.now()): string {
-	return JSON.stringify({
-		goal: {
-			threadId: "test-thread",
-			objective,
-			status,
-			createdAt: updatedAt,
-			updatedAt,
-		},
-	});
-}
+	function goalSnapshot(objective: string, status = "active", updatedAt = Date.now()): string {
+		return JSON.stringify({
+			goal: {
+				threadId: "test-thread",
+				objective,
+				status,
+				createdAt: updatedAt,
+				updatedAt,
+			},
+		});
+	}
 
 	it("detects only the public GJC workflow skill surface", () => {
 		expect(detectSkillKeywords("$deep-interview then $team").map(match => match.skill)).toEqual([
@@ -861,7 +867,14 @@ disabledExtensions:
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
 		);
-		const statePath = path.join(root, ".gjc", "state", "sessions", "session-ultra-stop-pending", "ultragoal-state.json");
+		const statePath = path.join(
+			root,
+			".gjc",
+			"state",
+			"sessions",
+			"session-ultra-stop-pending",
+			"ultragoal-state.json",
+		);
 		const state = await Bun.file(statePath).json();
 		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.goals[0]?.objective }, null, 2));
 
@@ -906,7 +919,14 @@ disabledExtensions:
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
 		);
-		const statePath = path.join(root, ".gjc", "state", "sessions", "session-ultra-bypass-pending", "ultragoal-state.json");
+		const statePath = path.join(
+			root,
+			".gjc",
+			"state",
+			"sessions",
+			"session-ultra-bypass-pending",
+			"ultragoal-state.json",
+		);
 		const state = await Bun.file(statePath).json();
 		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.goals[0]?.objective }, null, 2));
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -575,6 +575,17 @@
 			},
 			"additionalProperties": false
 		},
+		"starReminder": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"description": "Show the interactive GitHub star reminder when gh is authenticated",
+					"default": true
+				}
+			},
+			"additionalProperties": false
+		},
 		"collapseChangelog": {
 			"type": "boolean",
 			"description": "Show condensed changelog after updates",

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -86,6 +86,16 @@ function parseRequestedTargets(): Set<string> | null {
 	);
 }
 
+function hostDefaultTargets(): BinaryTarget[] {
+	// A bare invocation (no --targets / RELEASE_TARGETS) is a single-host
+	// dogfood build, not a full release. Only the host's platform/arch can be
+	// built here because `embed:native` requires a matching prebuilt addon, and
+	// cross-arch addons are produced per-runner in CI. Default to the host
+	// target instead of every release target so we never demand native addons
+	// for architectures this machine cannot produce.
+	return targets.filter(target => target.platform === process.platform && target.arch === process.arch);
+}
+
 function shouldAdhocSignDarwinBinary(target: BinaryTarget): boolean {
 	return target.platform === "darwin" && process.platform === "darwin";
 }
@@ -182,7 +192,7 @@ async function main(): Promise<void> {
 	const requestedTargets = parseRequestedTargets();
 	const selectedTargets = requestedTargets
 		? targets.filter(target => requestedTargets.has(target.id))
-		: targets;
+		: hostDefaultTargets();
 
 	if (requestedTargets) {
 		const unknownTargets = [...requestedTargets].filter(
@@ -194,7 +204,13 @@ async function main(): Promise<void> {
 	}
 
 	if (selectedTargets.length === 0) {
-		throw new Error("No release targets selected.");
+		if (requestedTargets) {
+			throw new Error("No release targets selected.");
+		}
+		throw new Error(
+			`No release target matches this host (${process.platform}-${process.arch}). ` +
+				`Pass --targets <id> or set RELEASE_TARGETS to build a specific target.`,
+		);
 	}
 
 	await fs.mkdir(binariesDir, { recursive: true });


### PR DESCRIPTION
## Problem

A bare `bun scripts/ci-release-build-binaries.ts` invocation (no `--targets` / `RELEASE_TARGETS`) attempted to build **all 5** release targets. Each target's `embed:native` step requires a prebuilt native addon (`pi_natives.<platform>-<arch>[-variant].node`) to already exist in `packages/natives/native/`. On a single dev host only the host architecture's addon can be produced, so the release-artifact dogfood failed right after building `darwin-arm64` because the `darwin-x64` addon was missing.

## Fix

When no targets are explicitly requested, default to the **host-matching** target instead of every release target. This lets single-host dogfood builds produce real, supported artifacts without demanding native addons for architectures the machine cannot build — and without fabricating missing-arch artifacts.

CI behavior is unchanged: every release matrix job already sets `RELEASE_TARGETS` to exactly one target and downloads only that platform's addon. The empty-selection error now distinguishes the explicit vs. host-default case.

## Verification (darwin-arm64 dev host)

1. `bun install --frozen-lockfile` — ok
2. `bun run build` — ok (built `pi_natives.darwin-arm64.node`)
3. `bun scripts/ci-release-build-binaries.ts` — built `gjc-darwin-arm64` only, completed cleanly
4. Artifact smoke: `gjc-darwin-arm64 --version` → `gjc/0.4.1`; `--smoke-test` → `smoke-test: ok` (exit 0)
5. Targeted tests: `issue-1150-repro.test.ts` + `release-publish-order.test.ts` → 6 pass / 0 fail

## Release hold

Release execution is **held**: no publish, tag, GitHub release, merge to main, or external announcement.