### PR TITLE
fix(tui): prefer stable TMUX_PANE over TTY path in getTerminalId

### DIFF
--- a/packages/tui/src/ttyid.ts
+++ b/packages/tui/src/ttyid.ts
@@ -39,6 +39,13 @@ export function getTtyPath(): string | null {
  * Returns null if no terminal can be identified (e.g., piped input).
  */
 export function getTerminalId(): string | null {
+	// Inside tmux the stdin TTY path is unstable (it tracks the attached
+	// client, not the pane), which spawns duplicate sessions and breaks
+	// /resume. Prefer the stable per-pane TMUX_PANE identifier instead.
+	if (process.env.TMUX && process.env.TMUX_PANE) {
+		return `tmux-${process.env.TMUX_PANE}`;
+	}
+
 	// TTY device path — most reliable, unique per terminal tab
 	if (process.stdin.isTTY) {
 		try {

--- a/packages/tui/test/ttyid.test.ts
+++ b/packages/tui/test/ttyid.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getTerminalId } from "@gajae-code/tui/ttyid";
+
+describe("getTerminalId tmux ordering", () => {
+	const TMUX_KEYS = ["TMUX", "TMUX_PANE", "KITTY_WINDOW_ID", "TERM_SESSION_ID", "WT_SESSION"];
+	let saved: Record<string, string | undefined>;
+	let savedIsTTY: boolean | undefined;
+
+	beforeEach(() => {
+		saved = {};
+		for (const key of TMUX_KEYS) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+		savedIsTTY = process.stdin.isTTY;
+	});
+
+	afterEach(() => {
+		for (const key of TMUX_KEYS) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		Object.defineProperty(process.stdin, "isTTY", { value: savedIsTTY, configurable: true });
+	});
+
+	it("prefers stable TMUX_PANE over the TTY path inside tmux", () => {
+		// Simulate an attached tmux session with a live stdin TTY.
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		process.env.TMUX = "/tmp/tmux-1000/default,123,0";
+		process.env.TMUX_PANE = "%7";
+
+		expect(getTerminalId()).toBe("tmux-%7");
+	});
+
+	it("does not use the tmux pane when TMUX is unset", () => {
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		process.env.TMUX_PANE = "%7";
+
+		// Outside tmux, the lone TMUX_PANE fallback still applies (unchanged behavior).
+		expect(getTerminalId()).toBe("tmux-%7");
+	});
+
+	it("returns null when no terminal can be identified", () => {
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+		expect(getTerminalId()).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #432. Inside tmux, `getTerminalId()` consulted the stdin TTY device path before the multiplexer env vars. That TTY path tracks the **attached client**, not the pane, so it changes across attach/detach and produces a different terminal id for the same pane. The result was duplicate agent sessions and a broken `/resume`.

## Change

In `packages/tui/src/ttyid.ts`, when both `TMUX` and `TMUX_PANE` are set, return the stable per-pane identifier (`tmux-<pane>`) before falling back to the TTY path. Behavior outside tmux is unchanged: the TTY path is still preferred, and the existing env-var fallbacks (kitty, lone `TMUX_PANE`, Terminal.app, Windows Terminal) are untouched.

## Tests

Added `packages/tui/test/ttyid.test.ts` covering ordering:
- Inside tmux (`TMUX` + `TMUX_PANE`, stdin is a TTY) → returns the stable `tmux-<pane>` id, not the TTY path.
- `TMUX` unset → lone `TMUX_PANE` fallback still applies (unchanged behavior).
- No terminal identifiable → returns `null`.

## Verification

- `bun test packages/tui/test/ttyid.test.ts` → 3 pass
- `bun run check:types` (packages/tui) → clean
- `biome check` on changed files → ok
- `bun run build` → succeeds

---
🤖 Generated with gajae-code