### PR TITLE
fix(monitor): stop persistent monitor notification flood after cancel/eviction

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -943,6 +943,21 @@ export class Agent {
 		return this.#followUpQueue.pop();
 	}
 
+	/** Remove queued steering+follow-up messages matching `predicate`, preserving order of the rest. */
+	removeQueuedMessages(predicate: (message: AgentMessage) => boolean): {
+		steering: number;
+		followUp: number;
+		total: number;
+	} {
+		const beforeSteering = this.#steeringQueue.length;
+		const beforeFollowUp = this.#followUpQueue.length;
+		this.#steeringQueue = this.#steeringQueue.filter(m => !predicate(m));
+		this.#followUpQueue = this.#followUpQueue.filter(m => !predicate(m));
+		const steering = beforeSteering - this.#steeringQueue.length;
+		const followUp = beforeFollowUp - this.#followUpQueue.length;
+		return { steering, followUp, total: steering + followUp };
+	}
+
 	clearMessages() {
 		this.#state.messages = [];
 	}

--- a/packages/agent/test/agent-queue-removal.test.ts
+++ b/packages/agent/test/agent-queue-removal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@gajae-code/agent-core";
+
+function custom(content: string, taskId: string) {
+	return {
+		role: "custom" as const,
+		customType: "task-notification",
+		content,
+		display: false,
+		details: { taskId },
+		attribution: "agent" as const,
+		timestamp: Date.now(),
+	};
+}
+
+function user(content: string) {
+	return { role: "user" as const, content, timestamp: Date.now() };
+}
+
+describe("Agent queue predicate removal", () => {
+	it("removeQueuedMessages removes matching steer and follow-up messages while preserving order", () => {
+		const agent = new Agent();
+		agent.steer(user("keep-steer-1"));
+		agent.steer(custom("drop-steer", "bg_1"));
+		agent.steer(user("keep-steer-2"));
+		agent.followUp(custom("drop-follow", "bg_1"));
+		agent.followUp(user("keep-follow-1"));
+		agent.followUp(custom("keep-other", "bg_2"));
+
+		const removed = agent.removeQueuedMessages(
+			m =>
+				m.role === "custom" &&
+				m.customType === "task-notification" &&
+				(m.details as { taskId?: string } | undefined)?.taskId === "bg_1",
+		);
+
+		expect(removed).toEqual({ steering: 1, followUp: 1, total: 2 });
+		expect(agent.snapshotSteering().map(m => (m as ReturnType<typeof custom>).content)).toEqual([
+			"keep-steer-1",
+			"keep-steer-2",
+		]);
+		expect(agent.snapshotFollowUp().map(m => (m as ReturnType<typeof custom>).content)).toEqual([
+			"keep-follow-1",
+			"keep-other",
+		]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a persistent `monitor` notification flood where a cancelled or evicted monitor kept delivering queued `task-notification` follow-ups (surviving process death, log deletion, and `job cancel` returning not-found). Monitors now purge their queued notifications on cancel/terminal/eviction, retain a short tombstone so post-eviction `job cancel` still purges, coalesce rapid duplicate output to the latest state, and close a cancel/trailing-flush race.
+
 ## [0.4.2] - 2026-06-09
 
 ### Changed

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -6,6 +6,7 @@ const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
+const MONITOR_TOMBSTONE_TTL_MS = 5 * 60_000;
 
 export interface AsyncJob {
 	id: string;
@@ -120,6 +121,27 @@ export interface AsyncJobDeliveryState {
 	pendingJobIds: string[];
 }
 
+export interface AsyncJobLifecycleCleanup {
+	onCancel?: (job: AsyncJob) => void;
+	onTerminal?: (job: AsyncJob) => void;
+	onEvict?: (job: AsyncJob) => void;
+	/**
+	 * Idempotent residual cleanup invoked by a post-eviction tombstone purge
+	 * (e.g. a late `job cancel` after the job left the registry). Kept distinct
+	 * from the at-most-once lifecycle phases so a tombstone purge never has to
+	 * re-invoke a phase hook. Must be safe to call repeatedly.
+	 */
+	onTombstonePurge?: (job: AsyncJob) => void;
+}
+
+export interface MonitorTombstone {
+	jobId: string;
+	ownerId?: string;
+	status: AsyncJob["status"];
+	expiresAt: number;
+	purge: () => unknown;
+}
+
 export interface AsyncJobRegisterOptions {
 	id?: string;
 	/** Registry id of the agent that owns this job; used to scope cancelAll. */
@@ -127,6 +149,7 @@ export interface AsyncJobRegisterOptions {
 	/** Structured metadata for tool-specific control surfaces. */
 	metadata?: AsyncJobMetadata;
 	onProgress?: (text: string, details?: Record<string, unknown>) => void | Promise<void>;
+	lifecycle?: AsyncJobLifecycleCleanup;
 }
 
 /**
@@ -214,6 +237,9 @@ export class AsyncJobManager {
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #outputState = new Map<string, AsyncJobOutputState>();
 	readonly #ownerCleanups = new Map<string, Set<() => void>>();
+	readonly #lifecycles = new Map<string, AsyncJobLifecycleCleanup>();
+	readonly #lifecyclePhases = new Map<string, Set<"cancel" | "terminal" | "evict">>();
+	readonly #monitorTombstones = new Map<string, MonitorTombstone>();
 	readonly #outputRetentionBytes = DEFAULT_JOB_OUTPUT_RETENTION_BYTES;
 	readonly #onJobComplete: AsyncJobManagerOptions["onJobComplete"];
 	readonly #maxRunningJobs: number;
@@ -292,6 +318,7 @@ export class AsyncJobManager {
 			);
 		}
 
+		this.#expireMonitorTombstones();
 		const id = this.#resolveJobId(options?.id);
 		this.#suppressedDeliveries.delete(id);
 		const abortController = new AbortController();
@@ -308,6 +335,7 @@ export class AsyncJobManager {
 			ownerId: options?.ownerId,
 			metadata: options?.metadata,
 		};
+		if (options?.lifecycle) this.#lifecycles.set(id, options.lifecycle);
 
 		const reportProgress = async (text: string, details?: Record<string, unknown>): Promise<void> => {
 			if (!options?.onProgress) return;
@@ -325,8 +353,10 @@ export class AsyncJobManager {
 				const result = await run({ jobId: id, signal: abortController.signal, reportProgress });
 				const outcome: SubagentRunOutcome =
 					typeof result === "string" ? { kind: "completed", text: result } : result;
+
 				if (job.status === "cancelled") {
 					job.resultText = outcome.kind === "completed" ? outcome.text : outcome.note;
+					this.#runLifecycle(id, "terminal");
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
@@ -342,20 +372,24 @@ export class AsyncJobManager {
 					this.#drainResumeQueue();
 					return;
 				}
+
 				job.status = "completed";
 				job.resultText = outcome.text;
 				this.#enqueueDelivery(id, outcome.text);
+				this.#runLifecycle(id, "terminal");
 				this.#scheduleEviction(id);
 				this.#markRecordTerminal(id, "completed");
 				this.#drainResumeQueue();
 			} catch (error) {
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
+					this.#runLifecycle(id, "terminal");
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
 					return;
 				}
+				this.#runLifecycle(id, "terminal");
 				const errorText = error instanceof Error ? error.message : String(error);
 				job.status = "failed";
 				job.errorText = errorText;
@@ -381,6 +415,7 @@ export class AsyncJobManager {
 		if (!job) return false;
 		if (filter?.ownerId && job.ownerId !== filter.ownerId) return false;
 		if (job.status === "paused") {
+			this.#runLifecycle(id, "cancel");
 			// Paused jobs have no running promise to abort; transition directly.
 			// The session file is kept, so the record stays resumable by id.
 			job.status = "cancelled";
@@ -390,10 +425,74 @@ export class AsyncJobManager {
 			return true;
 		}
 		if (job.status !== "running") return false;
+		this.#runLifecycle(id, "cancel");
 		job.status = "cancelled";
 		job.abortController.abort();
-		this.#scheduleEviction(id);
 		return true;
+	}
+
+	#runLifecycle(jobId: string, phase: "cancel" | "terminal" | "evict"): void {
+		const fired = this.#lifecyclePhases.get(jobId) ?? new Set<"cancel" | "terminal" | "evict">();
+		if (fired.has(phase)) return;
+		fired.add(phase);
+		this.#lifecyclePhases.set(jobId, fired);
+		const lifecycle = this.#lifecycles.get(jobId);
+		const job = this.#jobs.get(jobId);
+		if (!lifecycle || !job) return;
+		try {
+			if (phase === "cancel") lifecycle.onCancel?.(job);
+			else if (phase === "terminal") lifecycle.onTerminal?.(job);
+			else lifecycle.onEvict?.(job);
+		} catch (error) {
+			logger.warn("Async job lifecycle cleanup failed", {
+				jobId,
+				phase,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	#expireMonitorTombstones(): void {
+		const now = Date.now();
+		for (const [jobId, tombstone] of this.#monitorTombstones) {
+			if (tombstone.expiresAt <= now) this.#monitorTombstones.delete(jobId);
+		}
+	}
+
+	#recordMonitorTombstone(jobId: string): void {
+		const job = this.#jobs.get(jobId);
+		if (!job?.metadata?.monitor) return;
+		const lifecycle = this.#lifecycles.get(jobId);
+		this.#monitorTombstones.set(jobId, {
+			jobId,
+			ownerId: job.ownerId,
+			status: job.status,
+			expiresAt: Date.now() + MONITOR_TOMBSTONE_TTL_MS,
+			purge: () => (lifecycle?.onTombstonePurge ?? lifecycle?.onEvict)?.(job),
+		});
+	}
+
+	getMonitorTombstone(jobId: string, filter?: AsyncJobFilter): MonitorTombstone | undefined {
+		this.#expireMonitorTombstones();
+		const tombstone = this.#monitorTombstones.get(jobId);
+		if (!tombstone) return undefined;
+		if (filter?.ownerId && tombstone.ownerId !== filter.ownerId) return undefined;
+		return tombstone;
+	}
+
+	purgeMonitorTombstone(jobId: string, filter?: AsyncJobFilter): { found: boolean; status?: AsyncJob["status"] } {
+		const tombstone = this.getMonitorTombstone(jobId, filter);
+		if (!tombstone) return { found: false };
+		this.#monitorTombstones.delete(jobId);
+		try {
+			tombstone.purge();
+		} catch (error) {
+			logger.warn("Monitor tombstone purge failed", {
+				jobId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+		return { found: true, status: tombstone.status };
 	}
 
 	// ── Subagent control plane (pause / resume / steer support) ──────────
@@ -836,6 +935,7 @@ export class AsyncJobManager {
 	 */
 	cancelAll(filter?: AsyncJobFilter): void {
 		for (const job of this.getRunningJobs(filter)) {
+			this.#runLifecycle(job.id, "cancel");
 			job.status = "cancelled";
 			job.abortController.abort();
 			this.#scheduleEviction(job.id);
@@ -898,6 +998,17 @@ export class AsyncJobManager {
 		// manager. Errors in cleanup callbacks are logged but never escalated.
 		this.runOwnerCleanups();
 		this.cancelAll();
+		for (const tombstone of this.#monitorTombstones.values()) {
+			try {
+				tombstone.purge();
+			} catch (error) {
+				logger.warn("Monitor tombstone purge failed during dispose", {
+					jobId: tombstone.jobId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+		this.#monitorTombstones.clear();
 		await this.waitForAll();
 		const drained = await this.drainDeliveries({ timeoutMs: options?.timeoutMs ?? 3_000 });
 		this.#clearEvictionTimers();
@@ -945,7 +1056,11 @@ export class AsyncJobManager {
 	#scheduleEviction(jobId: string): void {
 		this.#notifyChange();
 		if (this.#retentionMs <= 0) {
+			this.#recordMonitorTombstone(jobId);
+			this.#runLifecycle(jobId, "evict");
 			this.#jobs.delete(jobId);
+			this.#lifecycles.delete(jobId);
+			this.#lifecyclePhases.delete(jobId);
 			this.#suppressedDeliveries.delete(jobId);
 			this.#watchedJobs.delete(jobId);
 			this.#outputState.delete(jobId);
@@ -957,7 +1072,11 @@ export class AsyncJobManager {
 		}
 		const timer = setTimeout(() => {
 			this.#evictionTimers.delete(jobId);
+			this.#recordMonitorTombstone(jobId);
+			this.#runLifecycle(jobId, "evict");
 			this.#jobs.delete(jobId);
+			this.#lifecycles.delete(jobId);
+			this.#lifecyclePhases.delete(jobId);
 			this.#suppressedDeliveries.delete(jobId);
 			this.#watchedJobs.delete(jobId);
 			this.#outputState.delete(jobId);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1222,6 +1222,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					timestamp: Date.now(),
 				}),
 			sendCustomMessage: (msg, opts) => session.sendCustomMessage(msg, opts),
+			purgeQueuedCustomMessages: predicate => session.purgeQueuedCustomMessages(predicate),
 			peekQueueInvoker: () => session.peekQueueInvoker(),
 			peekStandingResolveHandler: () => session.peekStandingResolveHandler(),
 			setStandingResolveHandler: handler => session.setStandingResolveHandler(handler),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -89,6 +89,15 @@ export interface ForkContextSeedMetadata {
 	skippedReasons: Record<string, number>;
 }
 
+export interface PurgeQueuedCustomMessagesResult {
+	agentSteering: number;
+	agentFollowUp: number;
+	pendingNextTurn: number;
+	displaySteering: number;
+	displayFollowUp: number;
+	totalExecutable: number;
+}
+
 export interface ForkContextSeed {
 	messages: Message[];
 	agentMessages: AgentMessage[];
@@ -5058,6 +5067,10 @@ export class AgentSession {
 		this.#queueHiddenNextTurnMessage(message, true);
 	}
 
+	queueDeferredMessageForTests(message: CustomMessage, triggerTurn = true): void {
+		this.#queueHiddenNextTurnMessage(message, triggerTurn);
+	}
+
 	#queueHiddenNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
 		this.#pendingNextTurnMessages.push(message);
 		if (!triggerTurn) return;
@@ -5228,6 +5241,46 @@ export class AgentSession {
 			message.details,
 			message.attribution ?? "agent",
 		);
+	}
+
+	/** Remove undelivered queued custom messages matching `predicate` from executable queues and tagged display mirrors. */
+	purgeQueuedCustomMessages(predicate: (message: CustomMessage) => boolean): PurgeQueuedCustomMessagesResult {
+		const isMatch = (m: AgentMessage): boolean => m.role === "custom" && predicate(m as CustomMessage);
+		const removedTags = new Set<string>();
+		for (const m of [...this.agent.snapshotSteering(), ...this.agent.snapshotFollowUp()]) {
+			if (isMatch(m)) {
+				const tag = readPendingDisplayTag((m as CustomMessage).details);
+				if (tag) removedTags.add(tag);
+			}
+		}
+		const agentRemoved = this.agent.removeQueuedMessages(isMatch);
+		const beforeNext = this.#pendingNextTurnMessages.length;
+		for (const m of this.#pendingNextTurnMessages) {
+			if (predicate(m)) {
+				const tag = readPendingDisplayTag(m.details);
+				if (tag) removedTags.add(tag);
+			}
+		}
+		this.#pendingNextTurnMessages = this.#pendingNextTurnMessages.filter(m => !predicate(m));
+		const pendingNextTurn = beforeNext - this.#pendingNextTurnMessages.length;
+		let displaySteering = 0;
+		let displayFollowUp = 0;
+		if (removedTags.size > 0) {
+			const beforeS = this.#steeringMessages.length;
+			this.#steeringMessages = this.#steeringMessages.filter(e => !(e.tag && removedTags.has(e.tag)));
+			displaySteering = beforeS - this.#steeringMessages.length;
+			const beforeF = this.#followUpMessages.length;
+			this.#followUpMessages = this.#followUpMessages.filter(e => !(e.tag && removedTags.has(e.tag)));
+			displayFollowUp = beforeF - this.#followUpMessages.length;
+		}
+		return {
+			agentSteering: agentRemoved.steering,
+			agentFollowUp: agentRemoved.followUp,
+			pendingNextTurn,
+			displaySteering,
+			displayFollowUp,
+			totalExecutable: agentRemoved.total + pendingNextTurn,
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -609,6 +609,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			label?: string;
 			ctx?: AgentToolContext;
 			onRawLine?: (line: string, jobId: string) => void;
+			shouldAcceptRawLine?: (jobId: string) => boolean;
+			lifecycle?: import("../async").AsyncJobLifecycleCleanup;
 		} = {},
 	): Promise<{ jobId: string; label: string; commandCwd: string }> {
 		const manager = AsyncJobManager.instance();
@@ -624,12 +626,14 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		let cursorOffset = 0;
 		let lineBuffer = "";
 		const dispatchLines = (chunk: string) => {
+			if (opts.shouldAcceptRawLine?.(currentJobId) === false) return;
 			if (!onRawLine) return;
 			lineBuffer += chunk;
 			let newlineIndex = lineBuffer.indexOf("\n");
 			while (newlineIndex !== -1) {
 				const line = lineBuffer.slice(0, newlineIndex);
 				lineBuffer = lineBuffer.slice(newlineIndex + 1);
+				if (opts.shouldAcceptRawLine?.(currentJobId) === false) return;
 				try {
 					onRawLine(line, currentJobId);
 				} catch (error) {
@@ -642,6 +646,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		};
 		const flushTrailingLine = () => {
 			if (!onRawLine) return;
+			if (opts.shouldAcceptRawLine?.(currentJobId) === false) return;
 			if (lineBuffer.length === 0) return;
 			const remainder = lineBuffer;
 			lineBuffer = "";
@@ -693,7 +698,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					throw error instanceof Error ? error : new Error(String(error));
 				}
 			},
-			{ ownerId, metadata: { monitor: true } },
+			{ ownerId, metadata: { monitor: true }, lifecycle: opts.lifecycle },
 		);
 		currentJobId = jobId;
 		return { jobId, label, commandCwd: prepared.commandCwd };

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -13,7 +13,11 @@ import { LspTool } from "../lsp";
 import type { WorkflowGateEmitter } from "../modes/shared/agent-wire/unattended-session";
 import type { PlanModeState } from "../plan-mode/state";
 import type { AgentRegistry } from "../registry/agent-registry";
-import type { ForkContextSeed, ForkContextSeedOptions } from "../session/agent-session";
+import type {
+	ForkContextSeed,
+	ForkContextSeedOptions,
+	PurgeQueuedCustomMessagesResult,
+} from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
@@ -162,6 +166,8 @@ export interface ToolSession {
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "0-Main", "0-AuthLoader"). */
 	getAgentId?: () => string | null;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
+	/** Purge undelivered queued custom messages matching the predicate. Returns counts. */
+	purgeQueuedCustomMessages?: (predicate: (message: CustomMessage) => boolean) => PurgeQueuedCustomMessagesResult;
 	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Agent registry for IRC routing across live sessions. */
 	agentRegistry?: AgentRegistry;

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -52,7 +52,7 @@ interface JobSnapshot {
 	errorText?: string;
 }
 
-type CancelStatus = "cancelled" | "not_found" | "already_completed";
+type CancelStatus = "cancelled" | "not_found" | "already_completed" | "already_cancelled";
 
 interface CancelOutcome {
 	id: string;
@@ -115,10 +115,20 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 		for (const id of cancelIds) {
 			const existing = manager.getJob(id);
 			if (!existing || (ownerId && existing.ownerId !== ownerId)) {
-				cancelOutcomes.push({ id, status: "not_found", message: `Background job not found: ${id}` });
+				const tombstone = manager.purgeMonitorTombstone(id, ownerFilter);
+				cancelOutcomes.push(
+					tombstone.found
+						? {
+								id,
+								status: tombstone.status === "cancelled" ? "already_cancelled" : "already_completed",
+								message: `Monitor job ${id} already gone; purged queued notifications.`,
+							}
+						: { id, status: "not_found", message: `Background job not found: ${id}` },
+				);
 				continue;
 			}
 			if (existing.status !== "running") {
+				if (existing.metadata?.monitor) manager.purgeMonitorTombstone(id, ownerFilter);
 				cancelOutcomes.push({
 					id,
 					status: "already_completed",

--- a/packages/coding-agent/src/tools/monitor.ts
+++ b/packages/coding-agent/src/tools/monitor.ts
@@ -47,6 +47,7 @@ export interface MonitorToolDetails {
 }
 
 const MONITOR_LABEL_MAX = 120;
+const MAX_PENDING_MONITOR_NOTIFICATIONS = 3;
 
 function buildMonitorLabel(params: MonitorParams): string {
 	const base = `[monitor:${params.kind}] ${params.description}`;
@@ -89,36 +90,116 @@ export class MonitorTool implements AgentTool<typeof monitorSchema, MonitorToolD
 		const ownerId = this.session.getAgentId?.() ?? undefined;
 		const bash = new BashTool(this.session);
 		let deliveredFirstLine = false;
+		const controller = { closed: false };
+		let currentJobId = "";
+		let sequence = 0;
+		let latestLine: string | undefined;
+		let coalescedCount = 0;
+		let flushScheduled = false;
+		// Count of notification *sends* (not live queue depth): once it exceeds the
+		// cap, each new send first purges older queued notifications for this task,
+		// keeping the queue bounded and latest-biased.
+		let pendingNotifications = 0;
+		const isMonitorMessage = (message: { customType?: string; details?: unknown }) =>
+			message.customType === "task-notification" &&
+			(message.details as { taskId?: string } | undefined)?.taskId === currentJobId;
+		const flushLatest = () => {
+			if (!persistent || latestLine === undefined) return;
+			const line = latestLine;
+			const count = coalescedCount;
+			latestLine = undefined;
+			coalescedCount = 0;
+			flushScheduled = false;
+			sendNotification(line, currentJobId, count);
+		};
+		const closeMonitor = (mode: "purge" | "flush") => {
+			// "flush" (natural process exit): deliver the newest pending line so the
+			// final state is never lost, then stop. "purge" (explicit cancel / registry
+			// eviction): drop the queued backlog. Non-persistent monitors keep their one
+			// notification, so they never purge.
+			if (mode === "flush") {
+				flushLatest();
+				controller.closed = true;
+				return;
+			}
+			controller.closed = true;
+			if (!persistent) return;
+			return this.session.purgeQueuedCustomMessages?.(isMonitorMessage);
+		};
+		const sendNotification = (line: string, jobId: string, count: number) => {
+			if (controller.closed) return;
+			const notificationId = `${jobId}:${sequence}`;
+			const suffix = count > 0 ? `\n(+${count} earlier lines)` : "";
+			const content = `<task-notification>\nMonitor task ${jobId} (${params.kind}: ${params.description}) emitted latest state:\n${line}${suffix}\n</task-notification>`;
+			const details = {
+				taskId: jobId,
+				kind: params.kind,
+				description: params.description,
+				monitor: true,
+				notificationId,
+				sequence,
+				coalescedCount: count,
+			};
+			pendingNotifications += 1;
+			if (pendingNotifications > MAX_PENDING_MONITOR_NOTIFICATIONS) {
+				this.session.purgeQueuedCustomMessages?.(
+					m =>
+						m.customType === "task-notification" &&
+						(m.details as { taskId?: string; notificationId?: string } | undefined)?.taskId === jobId &&
+						(m.details as { notificationId?: string } | undefined)?.notificationId !== notificationId,
+				);
+				pendingNotifications = MAX_PENDING_MONITOR_NOTIFICATIONS;
+			}
+			const sendPromise = this.session.sendCustomMessage?.(
+				{ customType: "task-notification", content, display: false, attribution: "agent", details },
+				{ triggerTurn: true, deliverAs: "followUp" },
+			);
+			if (sendPromise) {
+				void sendPromise.catch(error => {
+					logger.warn("Monitor task-notification delivery failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			} else {
+				this.session.steer?.({ customType: "task-notification", content, details });
+			}
+		};
+		const schedulePersistentNotification = (line: string) => {
+			latestLine = line;
+			sequence += 1;
+			coalescedCount += flushScheduled ? 1 : 0;
+			if (flushScheduled) return;
+			flushScheduled = true;
+			queueMicrotask(flushLatest);
+		};
 		const monitorJob = await bash.startMonitorJob(
 			{ command: params.command, timeout: params.timeout },
 			{
 				ownerId,
 				label,
 				ctx: context,
+				shouldAcceptRawLine: () => !controller.closed,
+				lifecycle: {
+					onCancel: () => closeMonitor("purge"),
+					onTerminal: () => closeMonitor("flush"),
+					onEvict: () => closeMonitor("purge"),
+					onTombstonePurge: () => closeMonitor("purge"),
+				},
 				onRawLine: (line, jobId) => {
+					if (controller.closed) return;
+					currentJobId = jobId;
 					if (!persistent && deliveredFirstLine) return;
 					deliveredFirstLine = true;
-					const content = `<task-notification>\nMonitor task ${jobId} (${params.kind}: ${params.description}) emitted:\n${line}\n</task-notification>`;
-					const details = { taskId: jobId, kind: params.kind, description: params.description };
-					const sendPromise = this.session.sendCustomMessage?.(
-						{ customType: "task-notification", content, display: false, attribution: "agent", details },
-						{ triggerTurn: true, deliverAs: "followUp" },
-					);
-					if (sendPromise) {
-						void sendPromise.catch(error => {
-							logger.warn("Monitor task-notification delivery failed", {
-								error: error instanceof Error ? error.message : String(error),
-							});
-						});
-					} else {
-						this.session.steer?.({ customType: "task-notification", content, details });
+					if (persistent) {
+						schedulePersistentNotification(line);
+						return;
 					}
-					if (!persistent) {
-						manager.cancel(jobId, ownerId ? { ownerId } : undefined);
-					}
+					sendNotification(line, jobId, 0);
+					manager.cancel(jobId, ownerId ? { ownerId } : undefined);
 				},
 			},
 		);
+		currentJobId = monitorJob.jobId;
 
 		const startedText = `Monitor started · task ${monitorJob.jobId} · persistent: ${persistent}`;
 

--- a/packages/coding-agent/test/agent-session-custom-message-purge.test.ts
+++ b/packages/coding-agent/test/agent-session-custom-message-purge.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import type { CustomMessage } from "../src/session/messages";
+import { SessionManager } from "../src/session/session-manager";
+
+async function createSession() {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model");
+	const agent = new Agent({ initialState: { model, messages: [], tools: [] } });
+	const authStorage = await AuthStorage.create(":memory:");
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: new ModelRegistry(authStorage),
+	});
+	return { agent, session };
+}
+
+const isTask = (taskId: string) => (m: CustomMessage) =>
+	m.customType === "task-notification" && (m.details as { taskId?: string } | undefined)?.taskId === taskId;
+
+describe("AgentSession purgeQueuedCustomMessages", () => {
+	it("purges executable followUp and steer queues while preserving unrelated order", async () => {
+		const { agent, session } = await createSession();
+		agent.steer({
+			role: "custom",
+			customType: "task-notification",
+			content: "drop steer",
+			display: false,
+			details: { taskId: "bg_1", __pendingDisplayTag: "s1" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		agent.steer({
+			role: "custom",
+			customType: "task-notification",
+			content: "keep steer",
+			display: false,
+			details: { taskId: "bg_2", __pendingDisplayTag: "s2" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		agent.followUp({
+			role: "custom",
+			customType: "task-notification",
+			content: "drop follow",
+			display: false,
+			details: { taskId: "bg_1", __pendingDisplayTag: "f1" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		agent.followUp({
+			role: "custom",
+			customType: "task-notification",
+			content: "keep follow",
+			display: false,
+			details: { taskId: "bg_2", __pendingDisplayTag: "f2" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+
+		const result = session.purgeQueuedCustomMessages(isTask("bg_1"));
+
+		expect(result.agentSteering).toBe(1);
+		expect(result.agentFollowUp).toBe(1);
+		expect(result.totalExecutable).toBe(2);
+		expect(agent.snapshotSteering().map(m => (m as CustomMessage).content)).toEqual(["keep steer"]);
+		expect(agent.snapshotFollowUp().map(m => (m as CustomMessage).content)).toEqual(["keep follow"]);
+	});
+
+	it("purges pending next-turn messages and leaves non-matching messages intact", async () => {
+		const { session } = await createSession();
+		session.queueDeferredMessageForTests(
+			{
+				role: "custom",
+				customType: "task-notification",
+				content: "drop next",
+				display: false,
+				details: { taskId: "bg_1", __pendingDisplayTag: "n1" },
+				attribution: "agent",
+				timestamp: Date.now(),
+			},
+			false,
+		);
+		session.queueDeferredMessageForTests(
+			{
+				role: "custom",
+				customType: "task-notification",
+				content: "keep next",
+				display: false,
+				details: { taskId: "bg_2", __pendingDisplayTag: "n2" },
+				attribution: "agent",
+				timestamp: Date.now(),
+			},
+			false,
+		);
+
+		const result = session.purgeQueuedCustomMessages(isTask("bg_1"));
+
+		expect(result.pendingNextTurn).toBe(1);
+		expect(result.totalExecutable).toBe(1);
+		expect(session.queuedMessageCount).toBe(1);
+	});
+
+	it("removes tagged display mirrors for purged custom messages", async () => {
+		const { agent, session } = await createSession();
+		const tag = session.enqueueCustomMessageDisplay("drop notif", "followUp");
+		agent.followUp({
+			role: "custom",
+			customType: "task-notification",
+			content: "drop notif",
+			display: false,
+			details: { taskId: "bg_1", __pendingDisplayTag: tag },
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		expect(session.getQueuedMessages().followUp).toContain("drop notif");
+
+		const result = session.purgeQueuedCustomMessages(isTask("bg_1"));
+
+		expect(result.agentFollowUp).toBe(1);
+		expect(result.displayFollowUp).toBe(1);
+		expect(session.getQueuedMessages().followUp).not.toContain("drop notif");
+	});
+});

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -374,4 +374,101 @@ describe("AsyncJobManager", () => {
 		await manager.waitForAll();
 		expect(manager.getJob(parentJobId)?.status).toBe("cancelled");
 	});
+	test("retention-zero eviction runs onEvict and records a monitor tombstone", async () => {
+		let evictCount = 0;
+		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		const jobId = manager.register("bash", "monitor", async () => "done", {
+			ownerId: "0-Test",
+			metadata: { monitor: true },
+			lifecycle: {
+				onEvict: () => {
+					evictCount += 1;
+				},
+			},
+		});
+
+		await manager.waitForAll();
+
+		expect(manager.getJob(jobId)).toBeUndefined();
+		expect(evictCount).toBe(1);
+		expect(manager.getMonitorTombstone(jobId, { ownerId: "0-Test" })?.jobId).toBe(jobId);
+		expect(manager.getMonitorTombstone(jobId, { ownerId: "other" })).toBeUndefined();
+	});
+
+	test("purgeMonitorTombstone after eviction returns found and runs purge once", async () => {
+		let evictCount = 0;
+		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		const jobId = manager.register("bash", "monitor", async () => "done", {
+			ownerId: "0-Test",
+			metadata: { monitor: true },
+			lifecycle: {
+				onEvict: () => {
+					evictCount += 1;
+				},
+			},
+		});
+
+		await manager.waitForAll();
+		expect(evictCount).toBe(1);
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "0-Test" })).toEqual({ found: true, status: "completed" });
+		expect(evictCount).toBe(2);
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "0-Test" })).toEqual({ found: false });
+		expect(evictCount).toBe(2);
+	});
+
+	test("tombstone purge uses the dedicated onTombstonePurge hook, not the evict phase", async () => {
+		let evictCount = 0;
+		let tombstonePurgeCount = 0;
+		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		const jobId = manager.register("bash", "monitor", async () => "done", {
+			ownerId: "0-Test",
+			metadata: { monitor: true },
+			lifecycle: {
+				onEvict: () => {
+					evictCount += 1;
+				},
+				onTombstonePurge: () => {
+					tombstonePurgeCount += 1;
+				},
+			},
+		});
+
+		await manager.waitForAll();
+		expect(evictCount).toBe(1);
+		expect(tombstonePurgeCount).toBe(0);
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "0-Test" })).toEqual({ found: true, status: "completed" });
+		// Tombstone purge runs the dedicated idempotent hook and does NOT re-run the evict phase.
+		expect(tombstonePurgeCount).toBe(1);
+		expect(evictCount).toBe(1);
+	});
+
+	test("lifecycle hooks fire at most once per phase", async () => {
+		const phases: string[] = [];
+		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		const jobId = manager.register(
+			"bash",
+			"monitor",
+			async ({ signal }) => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "cancelled";
+			},
+			{
+				metadata: { monitor: true },
+				lifecycle: {
+					onCancel: () => phases.push("cancel"),
+					onTerminal: () => phases.push("terminal"),
+					onEvict: () => phases.push("evict"),
+				},
+			},
+		);
+
+		expect(manager.cancel(jobId)).toBe(true);
+		expect(manager.cancel(jobId)).toBe(false);
+		await manager.waitForAll();
+		manager.purgeMonitorTombstone(jobId);
+
+		expect(phases.filter(p => p === "cancel")).toHaveLength(1);
+		expect(phases.filter(p => p === "terminal")).toHaveLength(1);
+		expect(phases.filter(p => p === "evict")).toHaveLength(2);
+	});
 });

--- a/packages/coding-agent/test/monitor-cron-tools.test.ts
+++ b/packages/coding-agent/test/monitor-cron-tools.test.ts
@@ -39,6 +39,14 @@ function createSession(settings: Settings, options: SessionOptions = {}): ToolSe
 		sendCustomMessage: async (msg: { customType: string; content: string; details?: unknown }) => {
 			options.steered?.push({ customType: msg.customType, content: msg.content, details: msg.details });
 		},
+		purgeQueuedCustomMessages: () => ({
+			agentSteering: 0,
+			agentFollowUp: 0,
+			pendingNextTurn: 0,
+			displaySteering: 0,
+			displayFollowUp: 0,
+			totalExecutable: 0,
+		}),
 		allocateOutputArtifact: async () => ({}),
 	} as unknown as ToolSession;
 }
@@ -178,26 +186,63 @@ describe("MonitorTool", () => {
 		).rejects.toThrow(/Use the `read` tool instead/);
 	});
 
-	it("dispatches one task-notification steer per stdout line", async () => {
+	it("persistent monitor coalesces duplicate executable notifications", async () => {
 		const steered: Array<{ customType: string; content: string; details?: unknown }> = [];
 		const session = createSession(settings, { steered });
 		const tool = MonitorTool.createIf(session)!;
 		const result = expectText(
 			await tool.execute("call", {
-				command: "printf 'alpha\\nbeta\\n'",
+				command: "for i in $(seq 1 20); do printf 'same\\n'; done",
 				kind: "log",
 				description: "line test",
 				persistent: true,
 			}),
 		);
-		expect(result.text).toContain("Monitor started · task");
 		expect(result.text).toContain("persistent: true");
 		await manager.waitForAll();
-		expect(steered.map(entry => entry.customType)).toEqual(["task-notification", "task-notification"]);
-		expect(steered[0]?.content).toContain("alpha");
-		expect(steered[1]?.content).toContain("beta");
+		await Promise.resolve();
+
+		expect(steered.length).toBeLessThanOrEqual(3);
+		expect(steered.at(-1)?.content).toContain("same");
 		const slice = manager.readOutputSince(result.details.taskId, 0, { ownerId: "0-Test" });
-		expect(slice?.text).toContain("alpha\nbeta\n");
+		expect(slice?.text.match(/same\n/g)).toHaveLength(20);
+	});
+
+	it("persistent monitor preserves latest state when cap is full", async () => {
+		const steered: Array<{ customType: string; content: string; details?: unknown }> = [];
+		const session = createSession(settings, { steered });
+		const tool = MonitorTool.createIf(session)!;
+		await tool.execute("call", {
+			command:
+				"for i in $(seq 1 20); do printf '0 passed, 2 pending, 0 failed\\n'; done; printf '0 passed, 0 pending, 2 failed\\n'",
+			kind: "poll",
+			description: "state test",
+			persistent: true,
+		});
+		await manager.waitForAll();
+		await Promise.resolve();
+
+		expect(steered.some(entry => entry.content.includes("0 passed, 0 pending, 2 failed"))).toBe(true);
+		expect(steered.length).toBeLessThanOrEqual(3);
+	});
+
+	it("cancel closes monitor before abort trailing partial flush", async () => {
+		const steered: Array<{ customType: string; content: string; details?: unknown }> = [];
+		const session = createSession(settings, { steered });
+		const tool = MonitorTool.createIf(session)!;
+		const result = expectText(
+			await tool.execute("call", {
+				command: "printf 'partial-without-newline'; sleep 30",
+				kind: "poll",
+				description: "partial test",
+				persistent: true,
+			}),
+		);
+		manager.cancel(result.details.taskId, { ownerId: "0-Test" });
+		await manager.waitForAll();
+		await Promise.resolve();
+
+		expect(steered.some(entry => entry.content.includes("partial-without-newline"))).toBe(false);
 	});
 
 	it("auto-cancels non-persistent monitors after the first stdout-line notification", async () => {

--- a/packages/coding-agent/test/monitor-redteam.test.ts
+++ b/packages/coding-agent/test/monitor-redteam.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async/job-manager";
+import { Settings } from "../src/config/settings";
+import type { CustomMessage } from "../src/session/messages";
+import type { ToolSession } from "../src/tools/index";
+import { JobTool } from "../src/tools/job";
+import { MonitorTool } from "../src/tools/monitor";
+
+type QueuedMessage = { customType: string; content: string; details?: unknown };
+
+function detailsOf(entry: QueuedMessage): { taskId?: string; notificationId?: string; coalescedCount?: number } {
+	return (entry.details ?? {}) as { taskId?: string; notificationId?: string; coalescedCount?: number };
+}
+
+function makeSession(ownerId: string, queue: QueuedMessage[], settings: Settings): ToolSession {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		settings,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getSessionId: () => `session-${ownerId}`,
+		getAgentId: () => ownerId,
+		steer: (msg: { customType: string; content: string; details?: unknown }) => queue.push(msg as QueuedMessage),
+		sendCustomMessage: async (msg: { customType: string; content: string; details?: unknown }) => {
+			queue.push(msg as QueuedMessage);
+		},
+		purgeQueuedCustomMessages: (predicate: (message: CustomMessage) => boolean) => {
+			let removed = 0;
+			for (let i = queue.length - 1; i >= 0; i -= 1) {
+				const candidate = queue[i];
+				if (candidate && predicate(candidate as never)) {
+					queue.splice(i, 1);
+					removed += 1;
+				}
+			}
+			return {
+				agentSteering: 0,
+				agentFollowUp: removed,
+				pendingNextTurn: 0,
+				displaySteering: 0,
+				displayFollowUp: 0,
+				totalExecutable: removed,
+			};
+		},
+		allocateOutputArtifact: async () => ({}),
+	} as unknown as ToolSession;
+}
+
+async function tickMicrotasks(times = 4): Promise<void> {
+	for (let i = 0; i < times; i += 1) await Promise.resolve();
+}
+
+describe("monitor backlog red-team public surfaces", () => {
+	const previousInstance = AsyncJobManager.instance();
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	beforeEach(async () => {
+		settings = await Settings.init();
+		manager = new AsyncJobManager({ retentionMs: 1000, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 200 });
+		AsyncJobManager.setInstance(previousInstance);
+	});
+
+	it("cancel of a persistent monitor purges queued task-notifications and suppresses trailing output", async () => {
+		const queue: QueuedMessage[] = [];
+		const session = makeSession("0-Owner", queue, settings);
+		const monitor = new MonitorTool(session);
+		const job = new JobTool(session);
+		const result = await monitor.execute("call", {
+			command: "printf 'before-cancel\\n'; sleep 30; printf 'after-cancel\\n'",
+			kind: "poll",
+			description: "cancel purge redteam",
+			persistent: true,
+		});
+		const taskId = result.details?.taskId;
+		expect(taskId).toBeString();
+
+		const deadline = Date.now() + 2_000;
+		while (!queue.some(entry => detailsOf(entry).taskId === taskId)) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for initial monitor notification");
+			await Bun.sleep(5);
+		}
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId).length).toBe(1);
+
+		const cancelResult = await job.execute("job", { cancel: [taskId!] });
+		expect(cancelResult.details?.cancelled?.[0]?.status).toBe("cancelled");
+		await manager.waitForAll();
+		await tickMicrotasks();
+
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId)).toHaveLength(0);
+		const jobRecord = manager.getJob(taskId!);
+		const captured = jobRecord?.resultText ?? jobRecord?.errorText ?? "";
+		expect(captured).toContain("before-cancel");
+		expect(captured).not.toContain("after-cancel");
+	});
+
+	it("post-eviction job cancel purges via owner-scoped tombstone and unknown ids stay not_found", async () => {
+		await manager.dispose({ timeoutMs: 200 });
+		manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		const queue: QueuedMessage[] = [];
+		const ownerSession = makeSession("0-Owner", queue, settings);
+		const otherSession = makeSession("9-Other", queue, settings);
+		const monitor = new MonitorTool(ownerSession);
+		const ownerJob = new JobTool(ownerSession);
+		const otherJob = new JobTool(otherSession);
+		const result = await monitor.execute("call", {
+			command: "printf 'retained-line\\n'",
+			kind: "log",
+			description: "tombstone redteam",
+			persistent: true,
+		});
+		const taskId = result.details!.taskId;
+		await manager.waitForAll();
+		await tickMicrotasks();
+		queue.push({ customType: "task-notification", content: "late residual", details: { taskId } });
+		expect(manager.getJob(taskId)).toBeUndefined();
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId).length).toBeGreaterThan(0);
+
+		const wrongOwner = await otherJob.execute("job", { cancel: [taskId] });
+		expect(wrongOwner.details?.cancelled?.[0]?.status).toBe("not_found");
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId).length).toBeGreaterThan(0);
+
+		const ownerCancel = await ownerJob.execute("job", { cancel: [taskId] });
+		expect(ownerCancel.details?.cancelled?.[0]?.status).not.toBe("not_found");
+		expect(ownerCancel.content[0]?.type === "text" ? ownerCancel.content[0].text : "").toContain(
+			"purged queued notifications",
+		);
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId)).toHaveLength(0);
+
+		const unknown = await ownerJob.execute("job", { cancel: ["bg_does_not_exist"] });
+		expect(unknown.details?.cancelled?.[0]?.status).toBe("not_found");
+	});
+
+	it("persistent coalescing keeps newest failed state while bounding pending notifications", async () => {
+		const queue: QueuedMessage[] = [];
+		const session = makeSession("0-Owner", queue, settings);
+		const result = await new MonitorTool(session).execute("call", {
+			command:
+				"for i in $(seq 1 80); do printf '0 passed, 2 pending, 0 failed\\n'; done; printf '0 passed, 0 pending, 2 failed\\n'; exit 7",
+			kind: "poll",
+			description: "coalescing cap redteam",
+			persistent: true,
+		});
+		const taskId = result.details!.taskId;
+		await manager.waitForAll();
+		await tickMicrotasks();
+
+		const entries = queue.filter(entry => detailsOf(entry).taskId === taskId);
+		expect(entries.length).toBeLessThanOrEqual(3);
+		expect(entries.some(entry => entry.content.includes("0 passed, 0 pending, 2 failed"))).toBe(true);
+		expect(entries.some(entry => (detailsOf(entry).coalescedCount ?? 0) > 0)).toBe(true);
+		expect(manager.getJob(taskId)?.status).toBe("failed");
+	});
+
+	it("non-persistent monitor delivers exactly one notification and terminal eviction does not purge it", async () => {
+		const queue: QueuedMessage[] = [];
+		const session = makeSession("0-Owner", queue, settings);
+		const result = await new MonitorTool(session).execute("call", {
+			command: "printf 'first\\nsecond\\n'",
+			kind: "log",
+			description: "non persistent redteam",
+			persistent: false,
+		});
+		const taskId = result.details!.taskId;
+		await manager.waitForAll();
+		await tickMicrotasks();
+
+		const entries = queue.filter(entry => detailsOf(entry).taskId === taskId);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.content).toContain("first");
+		expect(entries[0]?.content).not.toContain("second");
+		expect(manager.getJob(taskId)?.status).toBe("cancelled");
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId)).toHaveLength(1);
+	});
+
+	it("captured AsyncJobManager output is byte-faithful despite notification coalescing", async () => {
+		const queue: QueuedMessage[] = [];
+		const session = makeSession("0-Owner", queue, settings);
+		const expected = "α\nrepeat\nrepeat\nemoji-🙂\n";
+		const result = await new MonitorTool(session).execute("call", {
+			command: "printf 'α\\nrepeat\\nrepeat\\nemoji-🙂\\n'",
+			kind: "log",
+			description: "byte faithful redteam",
+			persistent: true,
+		});
+		const taskId = result.details!.taskId;
+		await manager.waitForAll();
+		await tickMicrotasks();
+
+		const slice = manager.readOutputSince(taskId, 0, { ownerId: "0-Owner" });
+		expect(slice?.text).toBe(expected);
+		expect(Buffer.byteLength(slice?.text ?? "", "utf8")).toBe(Buffer.byteLength(expected, "utf8"));
+		expect(queue.filter(entry => detailsOf(entry).taskId === taskId).length).toBeLessThan(
+			expected.split("\n").length - 1,
+		);
+	});
+
+	it("lifecycle cleanup is at-most-once per phase and tombstone purge is idempotent", async () => {
+		await manager.dispose({ timeoutMs: 200 });
+		manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		const phases: string[] = [];
+		const jobId = manager.register(
+			"bash",
+			"lifecycle monitor",
+			async ({ signal }) => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "cancelled";
+			},
+			{
+				ownerId: "0-Owner",
+				metadata: { monitor: true },
+				lifecycle: {
+					onCancel: () => phases.push("cancel"),
+					onTerminal: () => phases.push("terminal"),
+					onEvict: () => phases.push("evict"),
+				},
+			},
+		);
+
+		expect(manager.cancel(jobId, { ownerId: "9-Other" })).toBe(false);
+		expect(manager.cancel(jobId, { ownerId: "0-Owner" })).toBe(true);
+		expect(manager.cancel(jobId, { ownerId: "0-Owner" })).toBe(false);
+		await manager.waitForAll();
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "9-Other" })).toEqual({ found: false });
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "0-Owner" })).toEqual({
+			found: true,
+			status: "cancelled",
+		});
+		expect(manager.purgeMonitorTombstone(jobId, { ownerId: "0-Owner" })).toEqual({ found: false });
+
+		expect(phases.filter(phase => phase === "cancel")).toHaveLength(1);
+		expect(phases.filter(phase => phase === "terminal")).toHaveLength(1);
+		expect(phases.filter(phase => phase === "evict")).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Problem

A `monitor` tool job started with `persistent: true` enqueues one executable agent follow-up (`task-notification`, `triggerTurn:true`) per stdout line. A duplicate/polling source (e.g. tailing a CI watch loop) builds an unbounded executable backlog that keeps triggering turns **after** the underlying process dies, the async job is cancelled, or the job is evicted — at which point `job cancel` returns `Background job not found`, leaving the user with no way to stop the noise.

## Fix

- **`Agent.removeQueuedMessages(predicate)`** (`packages/agent/src/agent.ts`): narrow public API to remove matching steering + follow-up queue entries, order-preserving, no private-field casts.
- **`AgentSession.purgeQueuedCustomMessages(predicate)`**: purges the executable agent queues plus `#pendingNextTurnMessages` and tagged display mirrors; exposed on `ToolSession` (wired in `sdk.ts`).
- **`AsyncJobManager`**: idempotent lifecycle hooks (`onCancel`/`onTerminal`/`onEvict`, at-most-once per phase), a dedicated idempotent **`onTombstonePurge`** hook, and short-lived **owner-scoped monitor tombstones** (5 min TTL) so a post-eviction `job cancel <taskId>` still purges residual notifications and returns a clear status instead of `not_found`.
- **`MonitorTool` / `startMonitorJob`**: latest-state-preserving coalescing + cap for persistent monitors (newest line always wins; raw `AsyncJobManager` output stays byte-faithful), a `closed`-before-abort flag + `shouldAcceptRawLine` guard closing the cancel/trailing-flush race, **flush** of the newest pending line on natural terminal (final state is never lost) while **cancel/eviction purge** the backlog.
- **`JobTool`**: cancel consults monitor tombstones when the job is gone.

## Tests

New/extended (all FAIL pre-fix, PASS post-fix):
- `packages/agent/test/agent-queue-removal.test.ts`
- `packages/coding-agent/test/agent-session-custom-message-purge.test.ts`
- `packages/coding-agent/test/async-job-manager.test.ts` (lifecycle/tombstone/idempotency)
- `packages/coding-agent/test/monitor-cron-tools.test.ts` (coalescing/raw-fidelity/race)
- `packages/coding-agent/test/monitor-redteam.test.ts` (AC1–AC6 black-box red-team)

`bun test` over the five files: **45 pass / 0 fail**; `tsgo --noEmit` clean for `coding-agent` and `agent`; biome clean.

## Verification / process

Planned via ralplan consensus (Planner → Architect → Critic, run `2026-06-06-1458-a7f5`) and executed via ultragoal with the mandatory quality gate: an executor red-team lane initially caught a real blocker (newest `pending→failed` state was purged on natural terminal), which was fixed (terminal now flushes the final state); architect re-review returned CLEAR/CLEAR/CLEAR + APPROVE and the red-team rerun passed AC1–AC6 cleanly.
