### PR TITLE
fix(cli): help-safe startup and sanitized unavailable-model errors (#438)

### DIFF
--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { extractHttpStatusFromError, getLogsDir } from "@gajae-code/utils";
+import { APP_NAME, extractHttpStatusFromError, getLogsDir } from "@gajae-code/utils";
 import { isCopilotTransientModelError } from "./retry.js";
 import { formatErrorMessageWithRetryAfter } from "./retry-after.js";
 
@@ -26,6 +26,46 @@ type ErrorWithStatus = {
 
 const SENSITIVE_HEADERS = ["authorization", "x-api-key", "api-key", "cookie", "set-cookie", "proxy-authorization"];
 
+/**
+ * Privacy note appended next to a saved raw HTTP request dump. The dump is
+ * sanitized (secrets/thinking redacted) but can still contain prompt content
+ * and request metadata, so we explicitly discourage pasting it into public
+ * channels (issue #438).
+ */
+const RAW_HTTP_REQUEST_PRIVACY_NOTE =
+	"note: this local file is for your own debugging and may contain prompt content or request metadata — review it before sharing and do not paste its contents into public channels (issues, Discord, etc.).";
+
+/**
+ * Patterns that indicate the configured model is unavailable on the provider
+ * (e.g. OpenAI's "The requested model '...' does not exist."). Used to surface
+ * actionable model/provider guidance instead of only a raw 400 + log path.
+ */
+const MODEL_UNAVAILABLE_PATTERNS: readonly RegExp[] = [
+	/\bmodel\b[^\n]*\bdoes not exist\b/i,
+	/\bdoes not exist\b[^\n]*\bmodel\b/i,
+	/\bmodel\b[^\n]*\b(not found|unavailable|not supported|no access|does not have access)\b/i,
+	/\b(unknown|unsupported|invalid)\s+model\b/i,
+];
+
+/** Whether `message` (from a 400 response) signals an unavailable/unknown model. */
+export function isModelUnavailableError(message: string, error: unknown): boolean {
+	if (extractHttpStatusFromError(error) !== 400) return false;
+	return MODEL_UNAVAILABLE_PATTERNS.some(pattern => pattern.test(message));
+}
+
+/** Actionable guidance for selecting an available model/provider. */
+export function formatModelUnavailableGuidance(dump: RawHttpRequestDump | undefined): string {
+	const modelPart = dump?.model ? ` '${dump.model}'` : "";
+	const providerPart = dump?.provider ? ` on provider '${dump.provider}'` : "";
+	return [
+		`The configured model${modelPart}${providerPart} is not available on this account/provider.`,
+		"Pick an available model before retrying:",
+		`  • List available models:  ${APP_NAME} --list-models`,
+		`  • Run with a model:        ${APP_NAME} --model <model>`,
+		`  • Configure a provider:    ${APP_NAME} setup provider`,
+	].join("\n");
+}
+
 export async function appendRawHttpRequestDumpFor400(
 	message: string,
 	error: unknown,
@@ -41,7 +81,7 @@ export async function appendRawHttpRequestDumpFor400(
 
 	try {
 		await Bun.write(filePath, `${JSON.stringify(sanitizedDump, null, 2)}\n`);
-		return `${message}\nraw-http-request=${filePath}`;
+		return `${message}\nraw-http-request=${filePath}\n${RAW_HTTP_REQUEST_PRIVACY_NOTE}`;
 	} catch (writeError) {
 		const writeMessage = writeError instanceof Error ? writeError.message : String(writeError);
 		return `${message}\nraw-http-request-save-failed=${writeMessage}`;
@@ -61,6 +101,9 @@ export async function finalizeErrorMessage(
 		} else if (!message.includes(capturedMessage)) {
 			message = `${message}\n${capturedMessage}`;
 		}
+	}
+	if (isModelUnavailableError(message, error)) {
+		message = `${message}\n\n${formatModelUnavailableGuidance(rawRequestDump)}`;
 	}
 	return appendRawHttpRequestDumpFor400(message, error, rawRequestDump);
 }

--- a/packages/ai/test/http-inspector.test.ts
+++ b/packages/ai/test/http-inspector.test.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
-import { finalizeErrorMessage, type RawHttpRequestDump } from "../src/utils/http-inspector";
+import {
+	finalizeErrorMessage,
+	formatModelUnavailableGuidance,
+	isModelUnavailableError,
+	type RawHttpRequestDump,
+} from "../src/utils/http-inspector";
 
 let previousAgentDir: string | undefined;
 let previousPiConfigDir: string | undefined;
@@ -99,5 +104,64 @@ describe("HTTP 400 request dump sanitization", () => {
 		expect(saved).not.toContain("synthetic-key");
 		expect(saved).toContain("visible text");
 		expect(saved).toContain("[redacted]");
+	});
+});
+
+describe("HTTP 400 error message safety (issue #438)", () => {
+	function unavailableModelDump(): RawHttpRequestDump {
+		return {
+			provider: "openai",
+			api: "openai-responses",
+			model: "codex-mini-latest",
+			method: "POST",
+			url: "https://api.openai.com/v1/responses",
+			body: { model: "codex-mini-latest" },
+		};
+	}
+
+	it("does not encourage pasting the saved raw request log publicly", async () => {
+		await useTempAgentDir();
+		const error = new Error("400 The requested model 'codex-mini-latest' does not exist.");
+		(error as { status?: number }).status = 400;
+
+		const message = await finalizeErrorMessage(error, unavailableModelDump());
+
+		expect(message).toContain("raw-http-request=");
+		expect(message).toMatch(/do not paste/i);
+		expect(message).toMatch(/public channels/i);
+	});
+
+	it("surfaces model/provider selection guidance for unavailable-model 400s", async () => {
+		await useTempAgentDir();
+		const error = new Error("400 The requested model 'codex-mini-latest' does not exist.");
+		(error as { status?: number }).status = 400;
+
+		const message = await finalizeErrorMessage(error, unavailableModelDump());
+
+		expect(message).toContain("not available");
+		expect(message).toContain("gjc --list-models");
+		expect(message).toContain("gjc setup provider");
+		expect(message).toContain("codex-mini-latest");
+	});
+
+	it("detects unavailable-model errors only for 400 responses", () => {
+		const notFound = new Error("The requested model 'codex-mini-latest' does not exist.");
+		(notFound as { status?: number }).status = 400;
+		expect(isModelUnavailableError(notFound.message, notFound)).toBe(true);
+
+		const serverError = new Error("The requested model 'codex-mini-latest' does not exist.");
+		(serverError as { status?: number }).status = 500;
+		expect(isModelUnavailableError(serverError.message, serverError)).toBe(false);
+
+		const rateLimited = new Error("429 rate limit exceeded");
+		(rateLimited as { status?: number }).status = 400;
+		expect(isModelUnavailableError(rateLimited.message, rateLimited)).toBe(false);
+	});
+
+	it("omits model/provider names from guidance when the dump is absent", () => {
+		const guidance = formatModelUnavailableGuidance(undefined);
+		expect(guidance).toContain("not available");
+		expect(guidance).toContain("gjc --list-models");
+		expect(guidance).not.toContain("''");
 	});
 });

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -68,4 +68,57 @@ describe("CLI help load order", () => {
 
 		expect(exitCode).toBe(0);
 	}, 15_000);
+
+	it("renders --help offline without touching the provider/model path (issue #438)", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-help-offline-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+				// Strip provider credentials so any accidental provider call would fail
+				// loudly, and point network at a black hole so help can never reach out.
+				ANTHROPIC_API_KEY: "",
+				ANTHROPIC_OAUTH_TOKEN: "",
+				OPENAI_API_KEY: "",
+				GEMINI_API_KEY: "",
+				GITHUB_TOKEN: "",
+				HTTP_PROXY: "http://127.0.0.1:1",
+				HTTPS_PROXY: "http://127.0.0.1:1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		const combined = `${stdout}\n${stderr}`;
+		// Help text must render.
+		expect(combined).toContain("USAGE");
+		// And must not leak provider/model failures or raw request-log hints.
+		expect(combined).not.toMatch(/does not exist/i);
+		expect(combined).not.toContain("raw-http-request");
+		expect(combined).not.toContain("http-400-requests");
+	}, 15_000);
 });


### PR DESCRIPTION
## Summary

Fixes #438: `gjc --help` / first-run startup could surface a raw `400 The requested model 'codex-mini-latest' does not exist.` error plus a `raw-http-request=...json` log-path hint before setup/help could guide the user, implicitly encouraging users to paste sensitive request dumps publicly.

## Changes

- **Help-safety (acceptance #1):** Added a spawn-based test that runs `gjc --help` with provider credentials stripped and `HTTP(S)_PROXY` pointed at a black hole, asserting help renders (`USAGE` present), exits 0, and never leaks `does not exist` / `raw-http-request` / `http-400-requests`. The existing top-level `--help` path already routes through `showHelp`/`renderRootHelp` without instantiating the launch command or resolving a model; this locks that contract.
- **Unavailable-model guidance (acceptance #2):** `finalizeErrorMessage` now detects 400 responses that signal an unavailable/unknown model and appends clear selection guidance — `gjc --list-models`, `gjc --model <model>`, `gjc setup provider` — including the offending model/provider when known. Detection is 400-only and skips unrelated 400s/other statuses.
- **Sanitized error output (acceptance #3):** The saved-dump line now carries an explicit privacy note that the local file may contain prompt content/request metadata and should not be pasted into public channels.
- **Tests (acceptance #4):** New `http-inspector` unit tests cover the privacy note, the unavailable-model guidance, 400-only detection, and dump-absent guidance; plus the offline help-safety spawn test.

## Testing

- `bun test packages/ai/test/http-inspector.test.ts` — 5 pass
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts` — 2 pass
- `bun run check:types` in `packages/ai` and `packages/coding-agent` — clean
- `biome check` on changed files — clean

(The broader `packages/ai` suite has pre-existing failures in this worktree only because the `pi_natives` native addon isn't built locally; unrelated to this change.)

Closes #438

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
