### PR TITLE
Make help safe before model setup

### DIFF
--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -41,10 +41,10 @@ export async function appendRawHttpRequestDumpFor400(
 
 	try {
 		await Bun.write(filePath, `${JSON.stringify(sanitizedDump, null, 2)}\n`);
-		return `${message}\nraw-http-request=${filePath}`;
+		return `${message}\nHTTP 400 request diagnostics were saved locally at ${filePath}. Review the file before sharing it; do not paste raw request logs publicly.`;
 	} catch (writeError) {
 		const writeMessage = writeError instanceof Error ? writeError.message : String(writeError);
-		return `${message}\nraw-http-request-save-failed=${writeMessage}`;
+		return `${message}\nHTTP 400 request diagnostics could not be saved locally: ${writeMessage}`;
 	}
 }
 
@@ -62,6 +62,7 @@ export async function finalizeErrorMessage(
 			message = `${message}\n${capturedMessage}`;
 		}
 	}
+	message = appendUnavailableModelGuidance(message, error, rawRequestDump, capturedErrorResponse);
 	return appendRawHttpRequestDumpFor400(message, error, rawRequestDump);
 }
 
@@ -96,6 +97,65 @@ export function rewriteCopilotError(errorMessage: string, error: unknown, provid
 		return `GitHub Copilot rejected this model (HTTP 400 model_not_supported) after retries. This is a known intermittent rollout gap for preview models on OAuth clients other than VS Code. Try again in a few seconds, switch to a GA model (gpt-5-mini, gpt-5.2), or run this model from VS Code.`;
 	}
 	return errorMessage;
+}
+
+function appendUnavailableModelGuidance(
+	message: string,
+	error: unknown,
+	dump: RawHttpRequestDump | undefined,
+	capturedErrorResponse: CapturedHttpErrorResponse | undefined,
+): string {
+	if (extractHttpStatusFromError(error) !== 400 || !isUnavailableModelError(message, error, capturedErrorResponse)) {
+		return message;
+	}
+	if (message.includes("gjc --list-models") || message.includes("gjc setup provider")) {
+		return message;
+	}
+
+	const selectedModel = dump?.model ? ` "${dump.model}"` : "";
+	const selectedProvider = dump?.provider ? ` on provider "${dump.provider}"` : "";
+	return [
+		message,
+		`The configured model${selectedModel}${selectedProvider} appears unavailable for this account or endpoint. Run gjc --list-models to see configured models, start with an explicit available model via gjc --model <provider/model>, or run gjc setup provider to configure a provider before retrying.`,
+	].join("\n");
+}
+
+function isUnavailableModelError(
+	message: string,
+	error: unknown,
+	capturedErrorResponse: CapturedHttpErrorResponse | undefined,
+): boolean {
+	const combined = [
+		message,
+		formatCapturedHttpError(capturedErrorResponse),
+		errorCode(error),
+		capturedErrorCode(capturedErrorResponse),
+	]
+		.filter((part): part is string => typeof part === "string" && part.length > 0)
+		.join("\n");
+	return (
+		/\bmodel(?:s)?[_ -]?(?:not[_ -]?(?:found|supported)|unsupported)\b/i.test(combined) ||
+		/\brequested model\b[\s\S]{0,120}\b(?:does not exist|not available|not supported|unavailable|access)\b/i.test(
+			combined,
+		) ||
+		/\b(?:does not exist|not available|not supported|unavailable)\b[\s\S]{0,120}\bmodel\b/i.test(combined)
+	);
+}
+
+function errorCode(error: unknown): string | undefined {
+	if (!isObject(error)) return undefined;
+	const direct = getStringProperty(error, "code");
+	if (direct) return direct;
+	const nested = getObjectProperty(error, "error");
+	return nested ? getStringProperty(nested, "code") : undefined;
+}
+
+function capturedErrorCode(captured: CapturedHttpErrorResponse | undefined): string | undefined {
+	if (!captured) return undefined;
+	const payload = parseCapturedErrorPayload(captured);
+	if (!payload) return undefined;
+	const nested = getObjectProperty(payload, "error");
+	return (nested ? getStringProperty(nested, "code") : undefined) ?? getStringProperty(payload, "code");
 }
 
 function sanitizeDump(dump: RawHttpRequestDump): RawHttpRequestDump {

--- a/packages/ai/test/http-inspector.test.ts
+++ b/packages/ai/test/http-inspector.test.ts
@@ -89,7 +89,7 @@ describe("HTTP 400 request dump sanitization", () => {
 		(error as { status?: number }).status = 400;
 
 		const message = await finalizeErrorMessage(error, dump);
-		const match = /raw-http-request=(.+)$/m.exec(message);
+		const match = /HTTP 400 request diagnostics were saved locally at (.+?)\. Review/m.exec(message);
 		expect(match?.[1]).toBeDefined();
 		const saved = await fs.readFile(match?.[1] ?? "", "utf-8");
 
@@ -99,5 +99,30 @@ describe("HTTP 400 request dump sanitization", () => {
 		expect(saved).not.toContain("synthetic-key");
 		expect(saved).toContain("visible text");
 		expect(saved).toContain("[redacted]");
+	});
+
+	it("adds unavailable-model setup guidance without raw request paste hints", async () => {
+		await useTempAgentDir();
+		const dump: RawHttpRequestDump = {
+			provider: "openai",
+			api: "openai-responses",
+			model: "codex-mini-latest",
+			method: "POST",
+			url: "https://api.openai.com/v1/responses",
+			body: { model: "codex-mini-latest" },
+		};
+		const error = new Error("400 The requested model 'codex-mini-latest' does not exist.");
+		(error as { status?: number; code?: string }).status = 400;
+		(error as { status?: number; code?: string }).code = "model_not_found";
+
+		const message = await finalizeErrorMessage(error, dump);
+
+		expect(message).toContain("gjc --list-models");
+		expect(message).toContain("gjc --model <provider/model>");
+		expect(message).toContain("gjc setup provider");
+		expect(message).toContain("do not paste raw request logs publicly");
+		expect(message).toContain("codex-mini-latest");
+		expect(message).not.toContain("raw-http-request=");
+		expect(message).not.toContain("http-400-requests/*.json");
 	});
 });

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -19,6 +19,7 @@ procmgr.scrubProcessEnv();
  * lightweight CLI runner from pi-utils.
  */
 import { type CliConfig, type CommandEntry, run } from "@gajae-code/utils/cli";
+import { printHelp } from "./cli/help";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -107,15 +108,16 @@ export async function runCli(argv: string[]): Promise<void> {
 		await runSmokeTest();
 		return;
 	}
-	// --help and --version are handled by run() directly, don't rewrite those.
+	// Keep root help fully local/offline: do not load command modules, settings,
+	// model registries, or provider code before help can guide first-run users.
+	if (argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
+		printHelp();
+		return;
+	}
+	// --version is handled by run() directly, don't rewrite it.
 	// Everything else that isn't a known subcommand routes to "launch".
 	const first = argv[0];
-	const runArgv =
-		first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
-			? argv
-			: isSubcommand(first)
-				? argv
-				: ["launch", ...argv];
+	const runArgv = first === "--version" || first === "-v" ? argv : isSubcommand(first) ? argv : ["launch", ...argv];
 	return run({ bin: APP_NAME, version: VERSION, argv: runArgv, commands, help: showHelp });
 }
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -2,10 +2,12 @@
  * CLI argument parsing and help display
  */
 import { type Effort, THINKING_EFFORTS } from "@gajae-code/ai";
-import { APP_NAME, CONFIG_DIR_NAME, logger } from "@gajae-code/utils";
-import chalk from "chalk";
+import { logger } from "@gajae-code/utils";
+
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
+
+export { getExtraHelpText, printHelp } from "./help";
 
 export type Mode = "text" | "json" | "rpc" | "acp" | "rpc-ui" | "bridge";
 
@@ -210,92 +212,4 @@ export function parseArgs(args: string[]): Args {
 	}
 
 	return result;
-}
-
-export function getExtraHelpText(): string {
-	return `${chalk.bold("Environment Variables:")}
-  ${chalk.dim("# Core Providers")}
-  ANTHROPIC_API_KEY          - Anthropic Claude models
-  ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)
-  CLAUDE_CODE_USE_FOUNDRY    - Enable Anthropic Foundry mode (uses Foundry endpoint + mTLS)
-  FOUNDRY_BASE_URL           - Anthropic Foundry base URL (e.g., https://<foundry-host>)
-  ANTHROPIC_FOUNDRY_API_KEY  - Anthropic token used as Authorization: Bearer <token> in Foundry mode
-  ANTHROPIC_CUSTOM_HEADERS   - Extra Foundry headers (e.g., "user-id: USERNAME")
-  CLAUDE_CODE_CLIENT_CERT    - Client certificate (PEM path or inline PEM) for mTLS
-  CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
-  NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
-  OPENAI_API_KEY             - OpenAI GPT models
-  GEMINI_API_KEY             - Google Gemini models
-  GITHUB_TOKEN               - GitHub Copilot (or GH_TOKEN, COPILOT_GITHUB_TOKEN)
-
-  ${chalk.dim("# Additional LLM Providers")}
-  AZURE_OPENAI_API_KEY       - Azure OpenAI models
-  GROQ_API_KEY               - Groq models
-  CEREBRAS_API_KEY           - Cerebras models
-  XAI_API_KEY                - xAI Grok models
-  OPENROUTER_API_KEY         - OpenRouter aggregated models
-  KILO_API_KEY               - Kilo Gateway models
-  MISTRAL_API_KEY            - Mistral models
-  ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
-  MINIMAX_API_KEY            - MiniMax models
-  OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
-  CURSOR_ACCESS_TOKEN        - Cursor AI models
-  AI_GATEWAY_API_KEY         - Vercel AI Gateway
-
-  ${chalk.dim("# Cloud Providers")}
-  AWS_PROFILE                - AWS Bedrock (or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
-  GOOGLE_CLOUD_PROJECT       - Google Vertex AI (requires GOOGLE_CLOUD_LOCATION)
-  GOOGLE_APPLICATION_CREDENTIALS - Service account for Vertex AI
-
-  ${chalk.dim("# Search & Tools")}
-  EXA_API_KEY                - Exa web search
-  BRAVE_API_KEY              - Brave web search
-  PERPLEXITY_API_KEY         - Perplexity web search (API)
-  PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
-  TAVILY_API_KEY             - Tavily web search
-  ANTHROPIC_SEARCH_API_KEY   - Anthropic search provider
-
-  ${chalk.dim("# Configuration")}
-  GJC_CODING_AGENT_DIR       - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
-  GJC_PACKAGE_DIR            - Override package directory (for Nix/Guix store paths)
-  GJC_SMOL_MODEL              - Override smol/fast model (see --smol)
-  GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
-  GJC_PLAN_MODEL              - Override planning model (see --plan)
-  GJC_NO_PTY                  - Disable PTY-based interactive bash execution
-  --tmux                       - Launch interactive startup inside a new tmux session
-  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
-  GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
-  GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
-
-  For complete environment variable reference, see:
-  ${chalk.dim("docs/environment-variables.md")}
-${chalk.bold("Available Tools (default-enabled unless noted):")}
-  read          - Read file contents
-  bash          - Execute bash commands
-  edit          - Edit files with find/replace
-  write         - Write files (creates/overwrites)
-  grep          - Search file contents
-  find          - Find files by glob pattern
-  lsp           - Language server protocol (code intelligence)
-  python        - Execute Python code (requires: ${APP_NAME} setup python)
-  notebook      - Edit Jupyter notebooks
-  inspect_image - Analyze images with a vision model
-  browser       - Browser automation (Puppeteer)
-  task          - Launch sub-agents for parallel tasks
-  todo_write    - Manage todo/task lists
-  web_search    - Search the web
-  ask           - Ask user questions (interactive mode only)
-
-${chalk.bold("Useful Commands:")}
-  ${APP_NAME} --list-models        - List configured provider models
-  ${APP_NAME} --help               - Show this help`;
-}
-
-export function printHelp(): void {
-	process.stdout.write(
-		`${chalk.bold(APP_NAME)} - red-claw AI coding assistant\n\n` +
-			`Run ${APP_NAME} --help for full command and option details.\n` +
-			`Run ${APP_NAME} <command> --help for command-specific help.\n\n` +
-			`${getExtraHelpText()}\n`,
-	);
 }

--- a/packages/coding-agent/src/cli/help.ts
+++ b/packages/coding-agent/src/cli/help.ts
@@ -1,0 +1,99 @@
+/**
+ * Offline-safe root help text.
+ *
+ * This module intentionally avoids importing model registries, tool catalogs, or
+ * provider packages so `gjc --help` can run before setup and without native
+ * addons, credentials, or network access.
+ */
+import { APP_NAME, CONFIG_DIR_NAME } from "@gajae-code/utils";
+import chalk from "chalk";
+
+export function getExtraHelpText(): string {
+	return `${chalk.bold("Environment Variables:")}
+  ${chalk.dim("# Core Providers")}
+  ANTHROPIC_API_KEY          - Anthropic Claude models
+  ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)
+  CLAUDE_CODE_USE_FOUNDRY    - Enable Anthropic Foundry mode (uses Foundry endpoint + mTLS)
+  FOUNDRY_BASE_URL           - Anthropic Foundry base URL (e.g., https://<foundry-host>)
+  ANTHROPIC_FOUNDRY_API_KEY  - Anthropic token used as Authorization: Bearer <token> in Foundry mode
+  ANTHROPIC_CUSTOM_HEADERS   - Extra Foundry headers (e.g., "user-id: USERNAME")
+  CLAUDE_CODE_CLIENT_CERT    - Client certificate (PEM path or inline PEM) for mTLS
+  CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
+  NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
+  OPENAI_API_KEY             - OpenAI GPT models
+  GEMINI_API_KEY             - Google Gemini models
+  GITHUB_TOKEN               - GitHub Copilot (or GH_TOKEN, COPILOT_GITHUB_TOKEN)
+
+  ${chalk.dim("# Additional LLM Providers")}
+  AZURE_OPENAI_API_KEY       - Azure OpenAI models
+  GROQ_API_KEY               - Groq models
+  CEREBRAS_API_KEY           - Cerebras models
+  XAI_API_KEY                - xAI Grok models
+  OPENROUTER_API_KEY         - OpenRouter aggregated models
+  KILO_API_KEY               - Kilo Gateway models
+  MISTRAL_API_KEY            - Mistral models
+  ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
+  MINIMAX_API_KEY            - MiniMax models
+  OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
+  CURSOR_ACCESS_TOKEN        - Cursor AI models
+  AI_GATEWAY_API_KEY         - Vercel AI Gateway
+
+  ${chalk.dim("# Cloud Providers")}
+  AWS_PROFILE                - AWS Bedrock (or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
+  GOOGLE_CLOUD_PROJECT       - Google Vertex AI (requires GOOGLE_CLOUD_LOCATION)
+  GOOGLE_APPLICATION_CREDENTIALS - Service account for Vertex AI
+
+  ${chalk.dim("# Search & Tools")}
+  EXA_API_KEY                - Exa web search
+  BRAVE_API_KEY              - Brave web search
+  PERPLEXITY_API_KEY         - Perplexity web search (API)
+  PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
+  TAVILY_API_KEY             - Tavily web search
+  ANTHROPIC_SEARCH_API_KEY   - Anthropic search provider
+
+  ${chalk.dim("# Configuration")}
+  GJC_CODING_AGENT_DIR       - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  GJC_PACKAGE_DIR            - Override package directory (for Nix/Guix store paths)
+  GJC_SMOL_MODEL              - Override smol/fast model (see --smol)
+  GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
+  GJC_PLAN_MODEL              - Override planning model (see --plan)
+  GJC_NO_PTY                  - Disable PTY-based interactive bash execution
+  --tmux                       - Launch interactive startup inside a new tmux session
+  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
+  GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
+  GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
+
+  For complete environment variable reference, see:
+  ${chalk.dim("docs/environment-variables.md")}
+${chalk.bold("Available Tools (default-enabled unless noted):")}
+  read          - Read file contents
+  bash          - Execute bash commands
+  edit          - Edit files with find/replace
+  write         - Write files (creates/overwrites)
+  grep          - Search file contents
+  find          - Find files by glob pattern
+  lsp           - Language server protocol (code intelligence)
+  python        - Execute Python code (requires: ${APP_NAME} setup python)
+  notebook      - Edit Jupyter notebooks
+  inspect_image - Analyze images with a vision model
+  browser       - Browser automation (Puppeteer)
+  task          - Launch sub-agents for parallel tasks
+  todo_write    - Manage todo/task lists
+  web_search    - Search the web
+  ask           - Ask user questions (interactive mode only)
+
+${chalk.bold("Useful Commands:")}
+  ${APP_NAME} --list-models        - List configured provider models
+  ${APP_NAME} setup provider       - Configure a provider before first use
+  ${APP_NAME} --model <model>      - Start with an explicit available model
+  ${APP_NAME} --help               - Show this help`;
+}
+
+export function printHelp(): void {
+	process.stdout.write(
+		`${chalk.bold(APP_NAME)} - red-claw AI coding assistant\n\n` +
+			`Run ${APP_NAME} --help for full command and option details.\n` +
+			`Run ${APP_NAME} <command> --help for command-specific help.\n\n` +
+			`${getExtraHelpText()}\n`,
+	);
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -53,6 +53,11 @@ import type { LspStartupServerInfo } from "./tools";
 import { getDisplayChangelogEntries, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
+async function printOfflineHelp(): Promise<void> {
+	const { printHelp } = await import("./cli/help");
+	printHelp();
+}
+
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
 	if (!settings.get("startup.checkUpdate")) {
 		return;
@@ -715,13 +720,21 @@ export async function runRootCommand(
 	rawArgs: string[],
 	deps: RunRootCommandDependencies = {},
 ): Promise<void> {
+	const parsedArgs = parsed;
+	if (parsedArgs.help) {
+		await printOfflineHelp();
+		return;
+	}
+	if (parsedArgs.version) {
+		process.stdout.write(`${VERSION}\n`);
+		return;
+	}
+
 	logger.startTiming();
 
 	// Initialize theme early with defaults (CLI commands need symbols)
 	// Will be re-initialized with user preferences later
 	await logger.time("initTheme:initial", initTheme);
-
-	const parsedArgs = parsed;
 	await logger.time("maybeAutoChdir", maybeAutoChdir, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
@@ -729,12 +742,6 @@ export async function runRootCommand(
 	// Create AuthStorage and ModelRegistry upfront
 	const authStorage = await logger.time("discoverModels", deps.discoverAuthStorage ?? discoverAuthStorage);
 	const modelRegistry = new ModelRegistry(authStorage);
-
-	if (parsedArgs.version) {
-		process.stdout.write(`${VERSION}\n`);
-		process.exit(0);
-	}
-
 	if (parsedArgs.listModels !== undefined) {
 		await modelRegistry.refresh("online");
 		const searchPattern = typeof parsedArgs.listModels === "string" ? parsedArgs.listModels : undefined;

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -44,6 +44,12 @@ describe("CLI help load order", () => {
 		await fs.mkdir(home, { recursive: true });
 		await fs.mkdir(xdg, { recursive: true });
 		await fs.mkdir(agentDir, { recursive: true });
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			["modelRoles:", "  default: openai/codex-mini-latest", "modelProfile:", "  default: codex-standard", ""].join(
+				"\n",
+			),
+		);
 
 		const proc = Bun.spawn([process.execPath, cliEntry, "--help"], {
 			cwd: repoRoot,
@@ -55,17 +61,23 @@ describe("CLI help load order", () => {
 				XDG_CONFIG_HOME: xdg,
 				XDG_DATA_HOME: xdg,
 				PI_CODING_AGENT_DIR: agentDir,
+				GJC_CODING_AGENT_DIR: agentDir,
+				OPENAI_API_KEY: "sk-unavailable-model-sentinel",
 				PI_NO_TITLE: "1",
 				NO_COLOR: "1",
 			},
 		});
 
-		const [, , exitCode] = await Promise.all([
+		const [stdout, stderr, exitCode] = await Promise.all([
 			readStream(proc.stdout as ReadableStream<Uint8Array>),
 			readStream(proc.stderr as ReadableStream<Uint8Array>),
 			proc.exited,
 		]);
 
 		expect(exitCode).toBe(0);
+		expect(stdout).toContain("Useful Commands:");
+		expect(stdout).toContain("gjc --help");
+		expect(stderr).not.toContain("codex-mini-latest");
+		expect(stderr).not.toContain("raw-http-request");
 	}, 15_000);
 });


### PR DESCRIPTION
Closes #438

## Summary
- keep root `gjc --help` on an offline-safe help path that does not load model/provider/native startup code
- add setup/model-selection guidance for unavailable model HTTP 400s
- replace raw request dump hints with a local diagnostics privacy warning

## Tests
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts packages/ai/test/http-inspector.test.ts`
- `bun run check:ts`