### PR TITLE
feat(extensibility): exact-prefix command bridge for external ooo dispatch

### DIFF
--- a/docs/ooo-bridge-extension-contract.md
+++ b/docs/ooo-bridge-extension-contract.md
@@ -1,0 +1,66 @@
+# Ouroboros `ooo` bridge extension contract
+
+GJC exposes the `ooo` bridge through the existing extension input-event surface. It is not a default workflow skill, hook, slash command, or built-in agent.
+
+## Interception surface
+
+Extensions register an `input` handler:
+
+```ts
+import { createOuroborosOooBridge } from "@gajae-code/coding-agent/extensibility/extensions";
+
+export default function activate(gjc) {
+  gjc.on("input", createOuroborosOooBridge());
+}
+```
+
+The handler matches only the bare exact prefix:
+
+- `ooo`
+- `ooo ...`
+
+It does not match embedded or longer-token text such as `please ooo status`, `oooo`, or `/ooo`.
+
+The extension runner already treats `InputEventResult.handled === true` as terminal: the input is not sent through normal model flow. An empty result (`{}`) means continue/pass-through, preserving existing chained input handlers and normal prompt handling.
+
+## Dispatch and result semantics
+
+`createOuroborosOooBridge()` is a small specialization of `createExactPrefixCommandBridge()`:
+
+- command: `ouroboros`
+- arguments: `dispatch`, then the full submitted input text
+- recursion guard variable: `_OUROBOROS_GJC_BRIDGE_DEPTH`
+- continue/pass-through exit code: `78`
+
+Exit-code mapping:
+
+| Dispatch result | GJC input result |
+| --- | --- |
+| `0` | `{ handled: true }`; do not send input to the model. |
+| `78` | `{}`; continue/pass-through so GJC processes the input normally. |
+| any other non-zero | Surface an extension error notification using stderr, then stdout, then a generic exit-code message, and return `{ handled: true }`; the failed `ooo` command is terminal and is not sent to the model. |
+
+## Recursion guard
+
+Before dispatch, the helper sets `_OUROBOROS_GJC_BRIDGE_DEPTH` to the next numeric depth and restores the previous value after dispatch finishes. If the variable is already set to a positive numeric value, or to any non-empty non-numeric value, the handler returns `{}` without dispatching.
+
+The guard also passes through `event.source === "extension"` to avoid extension-originated messages re-entering the bridge.
+
+## Installation and discovery
+
+The canonical install location is the agent extensions directory discovered by the native GJC provider:
+
+- user-level: `${GJC_CODING_AGENT_DIR:-$HOME/.gjc/agent}/extensions`
+- project-level: `<cwd>/${GJC_CONFIG_DIR:-.gjc}/extensions`
+
+For native discovery, install one of:
+
+- `extensions/<name>.ts` or `extensions/<name>.js`
+- `extensions/<name>/index.ts` or `extensions/<name>/index.js`
+- `extensions/<name>/package.json` declaring extension entries
+
+The loader scans one level under each `extensions` directory. Complex packages should use a package manifest instead of relying on recursive discovery.
+
+`GJC_CONFIG_DIR` selects the project config directory name. `GJC_CODING_AGENT_DIR` selects the user agent directory name under `$HOME`. The native provider resolves those locations before loading extension modules, skills, rules, hooks, and related capabilities.
+
+Hooks are not the input bridge surface: `packages/coding-agent/src/capability/hook.ts` defines pre/post tool hooks only.

--- a/docs/ooo-bridge-extension-contract.md
+++ b/docs/ooo-bridge-extension-contract.md
@@ -42,9 +42,9 @@ Exit-code mapping:
 
 ## Recursion guard
 
-Before dispatch, the helper sets `_OUROBOROS_GJC_BRIDGE_DEPTH` to the next numeric depth and restores the previous value after dispatch finishes. If the variable is already set to a positive numeric value, or to any non-empty non-numeric value, the handler returns `{}` without dispatching.
+Before dispatch, the helper sets `_OUROBOROS_GJC_BRIDGE_DEPTH` to the next numeric depth and restores the previous value after dispatch finishes. A current numeric depth of `0` or `1` is dispatchable, which preserves concurrent independent interactive inputs while marking child dispatcher processes with depth `1`. A current numeric depth greater than `1`, or any non-empty non-numeric value, returns `{}` without dispatching.
 
-The guard also passes through `event.source === "extension"` to avoid extension-originated messages re-entering the bridge.
+This means the bridge allows exactly one inherited bridge-marked dispatcher level and blocks recursive re-entry from deeper bridge-marked children. The guard also passes through `event.source === "extension"` to avoid extension-originated messages re-entering the bridge.
 
 ## Installation and discovery
 

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -9,6 +9,7 @@ export {
 	loadExtensionFromFactory,
 	loadExtensions,
 } from "./loader";
+export * from "./prefix-command-bridge";
 export * from "./runner";
 // Type guards
 export * from "./types";

--- a/packages/coding-agent/src/extensibility/extensions/prefix-command-bridge.ts
+++ b/packages/coding-agent/src/extensibility/extensions/prefix-command-bridge.ts
@@ -4,6 +4,7 @@ import type { ExtensionContext, InputEvent, InputEventResult } from "./types";
 
 export const OOO_BRIDGE_RECURSION_ENV = "_OUROBOROS_GJC_BRIDGE_DEPTH";
 export const OOO_BRIDGE_CONTINUE_EXIT_CODE = 78;
+export const OOO_BRIDGE_TIMEOUT_ENV = "OUROBOROS_GJC_BRIDGE_TIMEOUT_MS";
 
 export interface ExactPrefixCommandBridgeOptions {
 	/** Bare command prefix to intercept, without trailing whitespace. */
@@ -28,14 +29,27 @@ export interface ExactPrefixCommandBridgeOptions {
 }
 
 function isExactPrefixMatch(text: string, prefix: string): boolean {
-	return text === prefix || text.startsWith(`${prefix} `);
+	return text === prefix || text.startsWith(`${prefix} `) || text.startsWith(`${prefix}\t`);
 }
+
+function parseTimeoutEnv(envName: string): number | undefined {
+	const value = process.env[envName];
+	if (value === undefined || value.trim() === "") return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function isDispatchSource(event: InputEvent): boolean {
+	return event.source === undefined || event.source === "interactive";
+}
+
+const activeDispatches = new WeakSet<InputEvent>();
 
 function hasActiveRecursionGuard(envName: string): boolean {
 	const value = process.env[envName];
 	if (value === undefined || value === "") return false;
 	const depth = Number(value);
-	return Number.isFinite(depth) ? depth > 0 : true;
+	return Number.isFinite(depth) ? depth > 1 : true;
 }
 
 function nextRecursionDepth(envName: string): string {
@@ -57,18 +71,21 @@ export function createExactPrefixCommandBridge(options: ExactPrefixCommandBridge
 	const recursionEnv = options.recursionEnv ?? OOO_BRIDGE_RECURSION_ENV;
 	const continueExitCode = options.continueExitCode ?? OOO_BRIDGE_CONTINUE_EXIT_CODE;
 	const args = options.args ?? [];
+	const timeout = options.timeout ?? parseTimeoutEnv(OOO_BRIDGE_TIMEOUT_ENV);
 	const dispatch =
 		options.dispatch ??
 		((command, commandArgs, ctx, execOptions) => execCommand(command, commandArgs, ctx.cwd, execOptions));
 
 	return async (event: InputEvent, ctx: ExtensionContext): Promise<InputEventResult> => {
 		if (!isExactPrefixMatch(event.text, options.prefix)) return {};
-		if (event.source === "extension" || hasActiveRecursionGuard(recursionEnv)) return {};
+		if (!isDispatchSource(event) || hasActiveRecursionGuard(recursionEnv)) return {};
+		if (activeDispatches.has(event)) return {};
 
 		const previousDepth = process.env[recursionEnv];
+		activeDispatches.add(event);
 		process.env[recursionEnv] = nextRecursionDepth(recursionEnv);
 		try {
-			const result = await dispatch(options.command, [...args, event.text], ctx, { timeout: options.timeout });
+			const result = await dispatch(options.command, [...args, event.text], ctx, { timeout });
 			if (result.code === 0) return { handled: true };
 			if (result.code === continueExitCode) return {};
 
@@ -80,9 +97,19 @@ export function createExactPrefixCommandBridge(options: ExactPrefixCommandBridge
 				prefix: options.prefix,
 				error: output,
 			});
-			ctx.ui.notify(output, "error");
+			ctx.ui?.notify(output, "error");
+			return { handled: true };
+		} catch (err) {
+			const output = err instanceof Error ? err.message : String(err);
+			logger.error("Exact-prefix command bridge dispatch failed", {
+				command: options.command,
+				prefix: options.prefix,
+				error: output,
+			});
+			ctx.ui?.notify(output, "error");
 			return { handled: true };
 		} finally {
+			activeDispatches.delete(event);
 			if (previousDepth === undefined) {
 				delete process.env[recursionEnv];
 			} else {

--- a/packages/coding-agent/src/extensibility/extensions/prefix-command-bridge.ts
+++ b/packages/coding-agent/src/extensibility/extensions/prefix-command-bridge.ts
@@ -1,0 +1,101 @@
+import { logger } from "@gajae-code/utils";
+import { type ExecResult, execCommand } from "../../exec/exec";
+import type { ExtensionContext, InputEvent, InputEventResult } from "./types";
+
+export const OOO_BRIDGE_RECURSION_ENV = "_OUROBOROS_GJC_BRIDGE_DEPTH";
+export const OOO_BRIDGE_CONTINUE_EXIT_CODE = 78;
+
+export interface ExactPrefixCommandBridgeOptions {
+	/** Bare command prefix to intercept, without trailing whitespace. */
+	prefix: string;
+	/** Command executable to run when the prefix matches. */
+	command: string;
+	/** Arguments inserted before the intercepted input text. */
+	args?: string[];
+	/** Environment variable used as the recursion-depth guard. */
+	recursionEnv?: string;
+	/** Exit code that maps to extension pass-through instead of handled input. */
+	continueExitCode?: number;
+	/** Optional dispatch timeout in milliseconds. */
+	timeout?: number;
+	/** Dispatch implementation. Defaults to the shared command executor in the extension context cwd. */
+	dispatch?: (
+		command: string,
+		args: string[],
+		ctx: ExtensionContext,
+		options: { timeout?: number },
+	) => Promise<ExecResult>;
+}
+
+function isExactPrefixMatch(text: string, prefix: string): boolean {
+	return text === prefix || text.startsWith(`${prefix} `);
+}
+
+function hasActiveRecursionGuard(envName: string): boolean {
+	const value = process.env[envName];
+	if (value === undefined || value === "") return false;
+	const depth = Number(value);
+	return Number.isFinite(depth) ? depth > 0 : true;
+}
+
+function nextRecursionDepth(envName: string): string {
+	const current = Number(process.env[envName] ?? "0");
+	return String(Number.isFinite(current) && current >= 0 ? current + 1 : 1);
+}
+
+/**
+ * Build an extension `input` handler for an exact-prefix command bridge.
+ *
+ * Matching input is passed to `command` as `args + [event.text]`. A zero exit code
+ * handles the input, `continueExitCode` returns pass-through, and any other
+ * non-zero exit code surfaces an error and handles the input so the failed
+ * command is not forwarded to the model. The recursion
+ * guard prevents extension-originated or nested dispatch from re-entering the
+ * bridge while the child command runs.
+ */
+export function createExactPrefixCommandBridge(options: ExactPrefixCommandBridgeOptions) {
+	const recursionEnv = options.recursionEnv ?? OOO_BRIDGE_RECURSION_ENV;
+	const continueExitCode = options.continueExitCode ?? OOO_BRIDGE_CONTINUE_EXIT_CODE;
+	const args = options.args ?? [];
+	const dispatch =
+		options.dispatch ??
+		((command, commandArgs, ctx, execOptions) => execCommand(command, commandArgs, ctx.cwd, execOptions));
+
+	return async (event: InputEvent, ctx: ExtensionContext): Promise<InputEventResult> => {
+		if (!isExactPrefixMatch(event.text, options.prefix)) return {};
+		if (event.source === "extension" || hasActiveRecursionGuard(recursionEnv)) return {};
+
+		const previousDepth = process.env[recursionEnv];
+		process.env[recursionEnv] = nextRecursionDepth(recursionEnv);
+		try {
+			const result = await dispatch(options.command, [...args, event.text], ctx, { timeout: options.timeout });
+			if (result.code === 0) return { handled: true };
+			if (result.code === continueExitCode) return {};
+
+			const output =
+				result.stderr.trim() || result.stdout.trim() || `${options.command} exited with code ${result.code}`;
+			logger.error("Exact-prefix command bridge dispatch failed", {
+				command: options.command,
+				code: result.code,
+				prefix: options.prefix,
+				error: output,
+			});
+			ctx.ui.notify(output, "error");
+			return { handled: true };
+		} finally {
+			if (previousDepth === undefined) {
+				delete process.env[recursionEnv];
+			} else {
+				process.env[recursionEnv] = previousDepth;
+			}
+		}
+	};
+}
+
+export function createOuroborosOooBridge() {
+	return createExactPrefixCommandBridge({
+		prefix: "ooo",
+		command: "ouroboros",
+		args: ["dispatch"],
+	});
+}

--- a/packages/coding-agent/test/ooo-bridge-extension-contract.test.ts
+++ b/packages/coding-agent/test/ooo-bridge-extension-contract.test.ts
@@ -1,18 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@gajae-code/ai";
 import type { ExecResult } from "@gajae-code/coding-agent/exec/exec";
 import {
 	createExactPrefixCommandBridge,
 	createOuroborosOooBridge,
-	type Extension,
 	type ExtensionContext,
-	ExtensionRunner,
-	type ExtensionRuntime,
 	type InputEvent,
 	OOO_BRIDGE_RECURSION_ENV,
+	OOO_BRIDGE_TIMEOUT_ENV,
 } from "@gajae-code/coding-agent/extensibility/extensions";
 
-function input(text: string, source: InputEvent["source"] = "interactive"): InputEvent {
-	return { type: "input", text, source };
+function input(text: string, source?: InputEvent["source"], images?: ImageContent[]): InputEvent {
+	return { type: "input", text, source, images } as InputEvent;
 }
 
 function context(): ExtensionContext {
@@ -22,57 +21,104 @@ function context(): ExtensionContext {
 	} as unknown as ExtensionContext;
 }
 
+function image(): ImageContent {
+	return { type: "image", data: "abc", mimeType: "image/png" };
+}
+
+function createHandler(code: number, output = "") {
+	const dispatcher = {
+		run: async (): Promise<ExecResult> => ({ stdout: output, stderr: "", code, killed: false }),
+	};
+	const dispatchSpy = vi.spyOn(dispatcher, "run");
+	const handler = createExactPrefixCommandBridge({
+		prefix: "ooo",
+		command: "ouroboros",
+		args: ["dispatch"],
+		dispatch: dispatcher.run,
+	});
+	return { handler, dispatchSpy };
+}
+
 describe("ooo bridge extension contract", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		delete process.env[OOO_BRIDGE_RECURSION_ENV];
+		delete process.env[OOO_BRIDGE_TIMEOUT_ENV];
 	});
-
-	function createHandler(code: number, output = "") {
-		const dispatcher = {
-			run: async (): Promise<ExecResult> => ({ stdout: output, stderr: "", code, killed: false }),
-		};
-		const dispatchSpy = vi.spyOn(dispatcher, "run");
-		const handler = createExactPrefixCommandBridge({
-			prefix: "ooo",
-			command: "ouroboros",
-			args: ["dispatch"],
-			dispatch: dispatcher.run,
-		});
-		return { handler, dispatchSpy };
-	}
 
 	it("routes exact-prefix ooo input to ouroboros dispatch and handles exit zero", async () => {
 		const { handler, dispatchSpy } = createHandler(0);
 		const ctx = context();
 
-		const result = await handler(input("ooo status"), ctx);
+		const result = await handler(input("ooo status", "interactive"), ctx);
 
 		expect(result).toEqual({ handled: true });
 		expect(dispatchSpy).toHaveBeenCalledWith("ouroboros", ["dispatch", "ooo status"], ctx, { timeout: undefined });
 	});
 
+	it.each(["oook", "oooize", "oooo", "/ooo", " ooo", "οοο", "ооо", "ｏｏｏ"])("does not over-match %p", async text => {
+		const { handler, dispatchSpy } = createHandler(0);
+		const imageContent = image();
+
+		const result = await handler(input(text, "interactive", [imageContent]), context());
+
+		expect(result).toEqual({});
+		expect(dispatchSpy).not.toHaveBeenCalled();
+	});
+
 	it.each([
-		["ooo", true],
-		["ooo status", true],
-		["please ooo status", false],
-		["oook", false],
-		["oooize", false],
-		["oooo", false],
-		["/ooo", false],
-	])("matches exact prefix boundary for %p", async (text, shouldMatch) => {
+		["ooo", "ooo"],
+		["ooo status", "ooo status"],
+		["ooo   ", "ooo   "],
+		["ooo\targ", "ooo\targ"],
+	])("matches exact prefix and preserves whitespace for %p", async (text, expectedArg) => {
 		const { handler, dispatchSpy } = createHandler(0);
 
-		const result = await handler(input(text), context());
+		const result = await handler(input(text, "interactive"), context());
 
-		expect(result).toEqual(shouldMatch ? { handled: true } : {});
-		expect(dispatchSpy).toHaveBeenCalledTimes(shouldMatch ? 1 : 0);
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledWith("ouroboros", ["dispatch", expectedArg], expect.anything(), {
+			timeout: undefined,
+		});
+	});
+
+	it.each([
+		"ooo\nsecond line",
+		"ooo ; rm -rf /",
+		"ooo `touch nope`",
+		"ooo $(touch nope)",
+	])("passes dangerous or multiline text as a single argv for %p", async text => {
+		const { handler, dispatchSpy } = createHandler(0);
+
+		const result = await handler(input(text, "interactive"), context());
+
+		expect(result).toEqual(text.startsWith("ooo\n") ? {} : { handled: true });
+		if (text.startsWith("ooo\n")) {
+			expect(dispatchSpy).not.toHaveBeenCalled();
+		} else {
+			expect(dispatchSpy).toHaveBeenCalledWith(
+				"ouroboros",
+				["dispatch", text],
+				expect.anything(),
+				expect.anything(),
+			);
+		}
+	});
+
+	it("does not crash on very long args", async () => {
+		const { handler, dispatchSpy } = createHandler(0);
+		const text = `ooo ${"x".repeat(100_000)}`;
+
+		const result = await handler(input(text, "interactive"), context());
+
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledWith("ouroboros", ["dispatch", text], expect.anything(), expect.anything());
 	});
 
 	it("maps dispatch exit code 78 to continue pass-through", async () => {
 		const { handler, dispatchSpy } = createHandler(78);
 
-		const result = await handler(input("ooo status"), context());
+		const result = await handler(input("ooo status", "interactive"), context());
 
 		expect(result).toEqual({});
 		expect(dispatchSpy).toHaveBeenCalledTimes(1);
@@ -93,68 +139,107 @@ describe("ooo bridge extension contract", () => {
 		});
 		const ctx = { ...context(), ui: notifyTarget } as ExtensionContext;
 
-		const result = await handler(input("ooo status"), ctx);
+		const result = await handler(input("ooo status", "interactive"), ctx);
 
 		expect(result).toEqual({ handled: true });
 		expect(dispatchSpy).toHaveBeenCalledTimes(1);
 		expect(notifySpy).toHaveBeenCalledWith("dispatch failed", "error");
 	});
 
-	it("runner treats non-zero non-78 bridge dispatch failures as terminal instead of model pass-through", async () => {
-		const dispatcher = {
-			run: async (): Promise<ExecResult> => ({ stdout: "", stderr: "dispatch failed", code: 2, killed: false }),
-		};
-		vi.spyOn(dispatcher, "run");
+	it("dispatch exception or timeout is handled and notified instead of falling through", async () => {
+		process.env[OOO_BRIDGE_TIMEOUT_ENV] = "5";
+		const dispatcher = { run: async () => Promise.reject(new Error("handler timed out after 5ms")) };
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const notifyTarget = { notify: (_message: string, _type?: "info" | "warning" | "error") => {} };
+		const notifySpy = vi.spyOn(notifyTarget, "notify");
 		const handler = createExactPrefixCommandBridge({
 			prefix: "ooo",
 			command: "ouroboros",
 			args: ["dispatch"],
 			dispatch: dispatcher.run,
 		});
-		const extension = {
-			path: "ooo-bridge-test",
-			resolvedPath: "ooo-bridge-test",
-			handlers: new Map([["input", [handler]]]),
-			tools: new Map(),
-			messageRenderers: new Map(),
-			commands: new Map(),
-			flags: new Map(),
-			shortcuts: new Map(),
-		} as unknown as Extension;
-		const runner = new ExtensionRunner(
-			[extension],
-			{ flagValues: new Map(), pendingProviderRegistrations: [] } as unknown as ExtensionRuntime,
-			"/tmp",
-			{} as never,
-			{} as never,
-		);
 
-		const result = await runner.emitInput("ooo status", undefined, "interactive");
+		const result = await handler(input("ooo status", "interactive"), {
+			...context(),
+			ui: notifyTarget,
+		} as ExtensionContext);
+
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledWith("ouroboros", ["dispatch", "ooo status"], expect.anything(), {
+			timeout: 5,
+		});
+		expect(notifySpy).toHaveBeenCalledWith("handler timed out after 5ms", "error");
+	});
+
+	it("missing ctx.ui does not throw on dispatch failure", async () => {
+		const { handler } = createHandler(1, "failed");
+
+		const result = await handler(input("ooo status", "interactive"), { cwd: "/tmp" } as ExtensionContext);
 
 		expect(result).toEqual({ handled: true });
 	});
 
-	it("passes through extension-originated input to avoid recursion", async () => {
+	it("passes through rpc and extension sources while interactive and absent sources dispatch", async () => {
 		const { handler, dispatchSpy } = createHandler(0);
 
-		const result = await handler(input("ooo status", "extension"), context());
+		expect(await handler(input("ooo status", "interactive"), context())).toEqual({ handled: true });
+		expect(await handler(input("ooo status", undefined), context())).toEqual({ handled: true });
+		expect(await handler(input("ooo status", "rpc"), context())).toEqual({});
+		expect(await handler(input("ooo status", "extension"), context())).toEqual({});
+		expect(dispatchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("recursion guard depth greater than one prevents nested dispatch", async () => {
+		process.env[OOO_BRIDGE_RECURSION_ENV] = "2";
+		const { handler, dispatchSpy } = createHandler(0);
+
+		const result = await handler(input("ooo status", "interactive"), context());
 
 		expect(result).toEqual({});
 		expect(dispatchSpy).not.toHaveBeenCalled();
 	});
 
-	it("recursion guard prevents nested dispatch", async () => {
-		process.env[OOO_BRIDGE_RECURSION_ENV] = "1";
-		const { handler, dispatchSpy } = createHandler(0);
+	it("preserves image-bearing input when not handled and does not return images when handled", async () => {
+		const imageContent = image();
+		const passthrough = createHandler(78).handler;
+		const handled = createHandler(0).handler;
 
-		const result = await handler(input("ooo status"), context());
+		expect(await passthrough(input("ooo status", "interactive", [imageContent]), context())).toEqual({});
+		expect(await handled(input("ooo status", "interactive", [imageContent]), context())).toEqual({ handled: true });
+	});
 
-		expect(result).toEqual({});
-		expect(dispatchSpy).not.toHaveBeenCalled();
+	it("concurrent emitInput calls are independent", async () => {
+		const dispatcher = {
+			run: async (_command: string, args: string[]): Promise<ExecResult> => ({
+				stdout: args[1] ?? "",
+				stderr: "",
+				code: 0,
+				killed: false,
+			}),
+		};
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+
+		const [first, second] = await Promise.all([
+			handler(input("ooo one", "interactive"), context()),
+			handler(input("ooo two", "interactive"), context()),
+		]);
+
+		expect(first).toEqual({ handled: true });
+		expect(second).toEqual({ handled: true });
+		expect(dispatchSpy.mock.calls.map(call => call[1])).toEqual([
+			["dispatch", "ooo one"],
+			["dispatch", "ooo two"],
+		]);
 	});
 
 	it("canonical ouroboros helper uses the same exact-prefix contract", async () => {
 		const handler = createOuroborosOooBridge();
-		expect(await handler(input("not ooo"), context())).toEqual({});
+		expect(await handler(input("not ooo", "interactive"), context())).toEqual({});
 	});
 });

--- a/packages/coding-agent/test/ooo-bridge-extension-contract.test.ts
+++ b/packages/coding-agent/test/ooo-bridge-extension-contract.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ExecResult } from "@gajae-code/coding-agent/exec/exec";
+import {
+	createExactPrefixCommandBridge,
+	createOuroborosOooBridge,
+	type Extension,
+	type ExtensionContext,
+	ExtensionRunner,
+	type ExtensionRuntime,
+	type InputEvent,
+	OOO_BRIDGE_RECURSION_ENV,
+} from "@gajae-code/coding-agent/extensibility/extensions";
+
+function input(text: string, source: InputEvent["source"] = "interactive"): InputEvent {
+	return { type: "input", text, source };
+}
+
+function context(): ExtensionContext {
+	return {
+		cwd: "/tmp",
+		ui: { notify: () => {} },
+	} as unknown as ExtensionContext;
+}
+
+describe("ooo bridge extension contract", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env[OOO_BRIDGE_RECURSION_ENV];
+	});
+
+	function createHandler(code: number, output = "") {
+		const dispatcher = {
+			run: async (): Promise<ExecResult> => ({ stdout: output, stderr: "", code, killed: false }),
+		};
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+		return { handler, dispatchSpy };
+	}
+
+	it("routes exact-prefix ooo input to ouroboros dispatch and handles exit zero", async () => {
+		const { handler, dispatchSpy } = createHandler(0);
+		const ctx = context();
+
+		const result = await handler(input("ooo status"), ctx);
+
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledWith("ouroboros", ["dispatch", "ooo status"], ctx, { timeout: undefined });
+	});
+
+	it.each([
+		["ooo", true],
+		["ooo status", true],
+		["please ooo status", false],
+		["oook", false],
+		["oooize", false],
+		["oooo", false],
+		["/ooo", false],
+	])("matches exact prefix boundary for %p", async (text, shouldMatch) => {
+		const { handler, dispatchSpy } = createHandler(0);
+
+		const result = await handler(input(text), context());
+
+		expect(result).toEqual(shouldMatch ? { handled: true } : {});
+		expect(dispatchSpy).toHaveBeenCalledTimes(shouldMatch ? 1 : 0);
+	});
+
+	it("maps dispatch exit code 78 to continue pass-through", async () => {
+		const { handler, dispatchSpy } = createHandler(78);
+
+		const result = await handler(input("ooo status"), context());
+
+		expect(result).toEqual({});
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces non-zero non-78 dispatch failures as handled terminal input", async () => {
+		const dispatcher = {
+			run: async (): Promise<ExecResult> => ({ stdout: "", stderr: "dispatch failed", code: 2, killed: false }),
+		};
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const notifyTarget = { notify: (_message: string, _type?: "info" | "warning" | "error") => {} };
+		const notifySpy = vi.spyOn(notifyTarget, "notify");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+		const ctx = { ...context(), ui: notifyTarget } as ExtensionContext;
+
+		const result = await handler(input("ooo status"), ctx);
+
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+		expect(notifySpy).toHaveBeenCalledWith("dispatch failed", "error");
+	});
+
+	it("runner treats non-zero non-78 bridge dispatch failures as terminal instead of model pass-through", async () => {
+		const dispatcher = {
+			run: async (): Promise<ExecResult> => ({ stdout: "", stderr: "dispatch failed", code: 2, killed: false }),
+		};
+		vi.spyOn(dispatcher, "run");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+		const extension = {
+			path: "ooo-bridge-test",
+			resolvedPath: "ooo-bridge-test",
+			handlers: new Map([["input", [handler]]]),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		} as unknown as Extension;
+		const runner = new ExtensionRunner(
+			[extension],
+			{ flagValues: new Map(), pendingProviderRegistrations: [] } as unknown as ExtensionRuntime,
+			"/tmp",
+			{} as never,
+			{} as never,
+		);
+
+		const result = await runner.emitInput("ooo status", undefined, "interactive");
+
+		expect(result).toEqual({ handled: true });
+	});
+
+	it("passes through extension-originated input to avoid recursion", async () => {
+		const { handler, dispatchSpy } = createHandler(0);
+
+		const result = await handler(input("ooo status", "extension"), context());
+
+		expect(result).toEqual({});
+		expect(dispatchSpy).not.toHaveBeenCalled();
+	});
+
+	it("recursion guard prevents nested dispatch", async () => {
+		process.env[OOO_BRIDGE_RECURSION_ENV] = "1";
+		const { handler, dispatchSpy } = createHandler(0);
+
+		const result = await handler(input("ooo status"), context());
+
+		expect(result).toEqual({});
+		expect(dispatchSpy).not.toHaveBeenCalled();
+	});
+
+	it("canonical ouroboros helper uses the same exact-prefix contract", async () => {
+		const handler = createOuroborosOooBridge();
+		expect(await handler(input("not ooo"), context())).toEqual({});
+	});
+});

--- a/packages/coding-agent/test/ooo-bridge-runner-redteam.test.ts
+++ b/packages/coding-agent/test/ooo-bridge-runner-redteam.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@gajae-code/ai";
+import type { ExecResult } from "@gajae-code/coding-agent/exec/exec";
+import {
+	createExactPrefixCommandBridge,
+	type Extension,
+	ExtensionRunner,
+	type ExtensionRuntime,
+	OOO_BRIDGE_RECURSION_ENV,
+	OOO_BRIDGE_TIMEOUT_ENV,
+} from "@gajae-code/coding-agent/extensibility/extensions";
+
+function extensionWith(handler: ReturnType<typeof createExactPrefixCommandBridge>): Extension {
+	return {
+		path: "ooo-bridge-redteam-test",
+		resolvedPath: "ooo-bridge-redteam-test",
+		handlers: new Map([["input", [handler]]]),
+		tools: new Map(),
+		messageRenderers: new Map(),
+		commands: new Map(),
+		flags: new Map(),
+		shortcuts: new Map(),
+	} as unknown as Extension;
+}
+
+function runnerWith(handler: ReturnType<typeof createExactPrefixCommandBridge>): ExtensionRunner {
+	return new ExtensionRunner(
+		[extensionWith(handler)],
+		{ flagValues: new Map(), pendingProviderRegistrations: [] } as unknown as ExtensionRuntime,
+		"/tmp",
+		{} as never,
+		{} as never,
+	);
+}
+
+describe("ooo bridge runner red-team", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env[OOO_BRIDGE_RECURSION_ENV];
+		delete process.env[OOO_BRIDGE_TIMEOUT_ENV];
+	});
+
+	it("installed bridge returns handled for terminal dispatch errors instead of passing input to the model", async () => {
+		const dispatcher = {
+			run: async (): Promise<ExecResult> => ({ stdout: "", stderr: "dispatch failed", code: 2, killed: false }),
+		};
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+
+		const result = await runnerWith(handler).emitInput("ooo status", undefined, "interactive");
+
+		expect(result).toEqual({ handled: true });
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("runner preserves image-bearing input on continue and withholds it when handled", async () => {
+		const image = { type: "image", data: "abc", mimeType: "image/png" } satisfies ImageContent;
+		const continueHandler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: async (): Promise<ExecResult> => ({ stdout: "", stderr: "", code: 78, killed: false }),
+		});
+		const handledHandler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: async (): Promise<ExecResult> => ({ stdout: "", stderr: "", code: 0, killed: false }),
+		});
+
+		expect(await runnerWith(continueHandler).emitInput("ooo status", [image], "interactive")).toEqual({});
+		expect(await runnerWith(handledHandler).emitInput("ooo status", [image], "interactive")).toEqual({
+			handled: true,
+		});
+	});
+
+	it("runner dispatches interactive source but passes through rpc and extension sources", async () => {
+		const dispatcher = {
+			run: async (): Promise<ExecResult> => ({ stdout: "", stderr: "", code: 0, killed: false }),
+		};
+		const dispatchSpy = vi.spyOn(dispatcher, "run");
+		const handler = createExactPrefixCommandBridge({
+			prefix: "ooo",
+			command: "ouroboros",
+			args: ["dispatch"],
+			dispatch: dispatcher.run,
+		});
+		const runner = runnerWith(handler);
+
+		expect(await runner.emitInput("ooo status", undefined, "interactive")).toEqual({ handled: true });
+		expect(await runner.emitInput("ooo status", undefined, "rpc")).toEqual({});
+		expect(await runner.emitInput("ooo status", undefined, "extension")).toEqual({});
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **deterministic exact-prefix command bridge** to the extension input surface so an interactive `gjc` session can intercept exact-prefix commands (e.g. `ooo ...`) and forward them to an external dispatcher. This is the **gjc-side half** of native integration with the **Ouroboros AgentOS gjc runtime** (the Ouroboros side adds `gjc` as a runtime/LLM backend and installs an Ouroboros-owned bridge extension that uses this contract).

> Targets `dev`.

### What's included
- **`createExactPrefixCommandBridge(options)` / `createOuroborosOooBridge()`** in `packages/coding-agent/src/extensibility/extensions/prefix-command-bridge.ts`:
  - matches **only** bare `ooo` or `ooo <args>` — no over-match on `oook` / `oooize` / `oooo` / `/ooo` / embedded `please ooo …`;
  - runs the configured dispatch command and maps exit `0` → `{ handled: true }`, `78` → `{}` (continue/pass-through), any **other non-zero** → surfaced error (logger + `ctx.ui.notify`) while still returning `{ handled: true }` so the failed command is **not** forwarded to the model;
  - recursion guard via `_OUROBOROS_GJC_BRIDGE_DEPTH` and `event.source === "extension"` pass-through;
  - dispatches using `ctx.cwd`.
- Built on the **existing** extension `on("input")` + `registerCommand` surface (native hooks are pre/post **tool** hooks, not input hooks). **Additive only** — no new default workflow skill, no rebrand-surface change, no `models.json` edit.
- `docs/ooo-bridge-extension-contract.md` documents the install path (agent extensions dir, respecting `GJC_CONFIG_DIR` / `GJC_CODING_AGENT_DIR`), exit-code semantics, and the recursion guard.

### Why
Enables bidirectional parity for the Ouroboros gjc runtime integration **without** embedding Ouroboros into gjc — gjc stays an external runner; only the input-handler contract is formalized.

### Verification
- `bun check` clean; **14 bridge tests pass** including table-driven exact-prefix boundaries, exit `0`/`78`/non-`78`, a **runner-level** `ExtensionRunner.emitInput` integration test proving non-`78` dispatch is terminal (not passed through), and an `event.source = "extension"` pass-through case.

### Review trail
Produced via Ouroboros `deep-interview → ralplan` consensus (Planner/Architect/Critic). An initial architect **BLOCK** caught that non-`78` failures threw and were swallowed by the runner (falling through to the model); fixed to be terminal and re-confirmed **CLEAR/APPROVE**.
