### PR TITLE
fix(models): prefer vision-capable variant over provider order for ambiguous ids

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2325,6 +2325,14 @@ export class ModelRegistry {
 			fallback: 3,
 		};
 		return [...variants].sort((left, right) => {
+			// Prefer vision-capable variants over configured provider order so an
+			// ambiguous canonical id never resolves to a text-only namesake when a
+			// vision-capable variant of the same id is available.
+			const leftVision = left.model.input.includes("image") ? 0 : 1;
+			const rightVision = right.model.input.includes("image") ? 0 : 1;
+			if (leftVision !== rightVision) {
+				return leftVision - rightVision;
+			}
 			const leftProviderRank = providerRank.get(left.model.provider.toLowerCase()) ?? Number.MAX_SAFE_INTEGER;
 			const rightProviderRank = providerRank.get(right.model.provider.toLowerCase()) ?? Number.MAX_SAFE_INTEGER;
 			if (leftProviderRank !== rightProviderRank) {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -246,6 +246,15 @@ function pickPreferredModel(candidates: Model<Api>[], context: ModelPreferenceCo
 			return (aProviderUsage ?? Number.POSITIVE_INFINITY) - (bProviderUsage ?? Number.POSITIVE_INFINITY);
 		}
 
+		// Prefer vision-capable variants over configured provider/registration order
+		// so an ambiguous id never resolves to a text-only namesake when a
+		// vision-capable variant of the same id is available.
+		const aVision = a.input.includes("image") ? 0 : 1;
+		const bVision = b.input.includes("image") ? 0 : 1;
+		if (aVision !== bVision) {
+			return aVision - bVision;
+		}
+
 		const aDeprioritized = context.deprioritizedProviders.has(a.provider);
 		const bDeprioritized = context.deprioritizedProviders.has(b.provider);
 		if (aDeprioritized !== bDeprioritized) {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -546,8 +546,24 @@ describe("ModelRegistry", () => {
 					modelProviderOrder: ["demo", "anthropic"],
 				},
 			});
+			// Both variants are vision-capable, so provider order is the deciding factor.
 			writeRawModelsJson({
-				demo: providerConfig("https://demo.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+				demo: {
+					baseUrl: "https://demo.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "anthropic/claude-sonnet-4.5",
+							name: "anthropic/claude-sonnet-4.5",
+							reasoning: false,
+							input: ["text", "image"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 100000,
+							maxTokens: 8000,
+						},
+					],
+				},
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
@@ -558,6 +574,30 @@ describe("ModelRegistry", () => {
 
 			expect(resolved?.provider).toBe("demo");
 			expect(resolved?.id).toBe("anthropic/claude-sonnet-4.5");
+		});
+
+		test("prefers vision-capable variant over configured provider order", async () => {
+			await Settings.init({
+				inMemory: true,
+				overrides: {
+					modelProviderOrder: ["demo", "anthropic"],
+				},
+			});
+			// demo's variant is text-only and ranked first by provider order, but the
+			// vision-capable bundled variant must win so an ambiguous id never resolves
+			// to a text-only namesake when a vision-capable variant is available.
+			writeRawModelsJson({
+				demo: providerConfig("https://demo.example.com/v1", [{ id: "anthropic/claude-sonnet-4.5" }]),
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const resolved = registry.resolveCanonicalModel("claude-sonnet-4-5", {
+				availableOnly: false,
+				candidates: registry.getAll(),
+			});
+
+			expect(resolved?.input.includes("image")).toBe(true);
+			expect(resolved?.provider).toBe("anthropic");
 		});
 	});
 


### PR DESCRIPTION
## Problem

A custom model that supports vision could be reported/treated as **not** supporting vision when referenced by a bare id.

When a `models.yml` declares the same model id under two providers — e.g. `claude-opus-4-8` under a text-only `openai-completions` proxy and a vision-capable `anthropic-messages` proxy — resolving the **bare id** (model carousel, `/model claude-opus-4-8`, or any non-qualified reference) chose the variant purely by **configured provider order**. If the text-only provider was declared first, gjc resolved to the text-only namesake and treated the model as non-vision, even though a vision-capable variant of the same id was available.

## Fix

Add a vision-capability preference ranked **above** configured provider order in both ambiguous-id resolvers:

- `ModelRegistry.#resolveCanonicalVariant` (`packages/coding-agent/src/config/model-registry.ts`)
- `pickPreferredModel` (`packages/coding-agent/src/config/model-resolver.ts`)

An ambiguous id now resolves to a vision-capable variant whenever one exists. Explicit `provider/id` qualification (e.g. `layofflabs/claude-opus-4-8`) is unchanged and still routes exactly as written.

## Verification

- Bare `claude-opus-4-8` → vision variant (`["text","image"]`); explicit `layofflabs/claude-opus-4-8` → still text-only.
- Updated the provider-order canonical test to use equal-capability variants (provider order remains the tiebreak when capabilities match).
- Added a test asserting vision wins over configured provider order.
- `model-registry.test.ts` and `model-resolver.test.ts` pass; biome clean on changed files.