### PR TITLE
fix(mcp): fail fast on stuck startup without cache

### DIFF
--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -304,6 +304,7 @@ export class MCPManager {
 			config: MCPServerConfig;
 			tracked: TrackedPromise<ToolLoadResult>;
 			toolsPromise: Promise<ToolLoadResult>;
+			connectionAbort: AbortController;
 		};
 
 		const errors = new Map<string, string>();
@@ -424,7 +425,7 @@ export class MCPManager {
 			this.#pendingToolLoads.set(name, toolsPromise);
 
 			const tracked = trackPromise(toolsPromise);
-			connectionTasks.push({ name, config, tracked, toolsPromise });
+			connectionTasks.push({ name, config, tracked, toolsPromise, connectionAbort });
 
 			void toolsPromise
 				.then(async ({ connection, serverTools }) => {
@@ -475,7 +476,19 @@ export class MCPManager {
 
 				const pendingWithoutCache = pendingTasks.filter(task => !cachedTools.has(task.name));
 				if (pendingWithoutCache.length > 0) {
-					await Promise.allSettled(pendingWithoutCache.map(task => task.tracked.promise));
+					for (const task of pendingWithoutCache) {
+						const message = `MCP server connection timed out during startup: ${task.name}`;
+						errors.set(task.name, message);
+						reportedErrors.add(task.name);
+						task.connectionAbort.abort(new Error(message));
+						if (this.#pendingConnections.has(task.name)) this.#pendingConnections.delete(task.name);
+						if (this.#pendingToolLoads.get(task.name) === task.toolsPromise)
+							this.#pendingToolLoads.delete(task.name);
+						this.#pendingConnectionControllers.delete(task.name);
+					}
+					// Do not await these promises here: a misbehaving stdio/MCP transport can ignore
+					// AbortSignal and keep startup blocked indefinitely. The background toolsPromise
+					// handler will clean up if it eventually settles.
 				}
 			}
 

--- a/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
@@ -91,6 +91,32 @@ describe("MCP lifecycle cleanup", () => {
 		expect(manager.getConnection("slow")).toBeUndefined();
 	});
 
+	it("connectServers fails fast when an uncached MCP startup ignores abort", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		mock.module("../src/runtime-mcp/client", () => ({
+			...mcpClient,
+			connectToServer: (_name: string, _config: MCPServerConfig, options?: { signal?: AbortSignal }) => {
+				capturedSignal = options?.signal;
+				return new Promise<MCPServerConnection>(() => {});
+			},
+			listTools: async () => [],
+		}));
+		const { MCPManager: MockedManager } = await import("../src/runtime-mcp/manager");
+		const manager = new MockedManager(process.cwd());
+
+		const startedAt = Date.now();
+		const result = await manager.connectServers(
+			{ stuck: { type: "stdio", command: "stuck", timeout: 10_000 } },
+			{ stuck: { provider: "test", providerName: "Test", path: "test", level: "project" } },
+		);
+
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+		expect(capturedSignal?.aborted).toBe(true);
+		expect(result.tools).toHaveLength(0);
+		expect(result.errors.get("stuck")).toBe("MCP server connection timed out during startup: stuck");
+		expect(manager.getConnectionStatus("stuck")).toBe("disconnected");
+	});
+
 	it("HttpTransport.close aborts and settles background SSE readers without reconnect", async () => {
 		const originalFetch = globalThis.fetch;
 		const stream = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## Summary
- fail fast when an uncached MCP server is still pending after startup timeout
- abort and clear pending connection/tool-load state instead of awaiting a possibly non-settling transport forever
- add regression coverage for an MCP startup promise that ignores abort

## Root cause
Tool-backed GJC startup could silently stall because `connectServers()` raced MCP startup against `STARTUP_TIMEOUT_MS`, but for pending servers without cached tools it then awaited the same pending tool promises again. If a stdio/MCP transport ignored abort or never settled, the entire session startup stayed blocked with no prompt progress.

## Tests
- `bun test packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts`
- `bun test packages/coding-agent/test/mcp-reconnect.test.ts packages/coding-agent/test/mcp-tool-ordering.test.ts packages/coding-agent/test/agent-session-mcp-discovery.test.ts packages/coding-agent/test/sdk-mcp-discovery.test.ts`
- `bun run --cwd packages/coding-agent check:types`
- `bunx biome check packages/coding-agent/src/runtime-mcp/manager.ts packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
