### PR TITLE
fix(agent): reserve max output budget so input packing doesn't fill the whole context window (#442)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Separated a model's total context window from its safe input/prompt-packing budget in the compaction threshold. `effectiveReserveTokens`, `resolveThresholdTokens`, and `shouldCompact` now accept an optional `maxOutputTokens` and reserve at least that completion budget, so a large-output model (e.g. 400K context / 128K max output) caps input near 272K instead of 340K and cannot overflow the total window with reserved output ([#442](https://github.com/Yeachan-Heo/gajae-code/issues/442)).
+
 ## [0.4.0] - 2026-06-06
 
 ### Changed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -203,22 +203,44 @@ export function getLastAssistantUsage(entries: SessionEntry[]): Usage | undefine
 }
 
 /**
- * Effective reserve: at least 15% of context window or the configured floor, whichever is larger.
+ * Effective reserve: the largest of 15% of the context window, the configured floor,
+ * and the model's reserved completion budget (`maxOutputTokens`).
+ *
+ * Reserving `maxOutputTokens` keeps the safe input/prompt-packing budget below the
+ * *total* context window for models whose completion reservation exceeds the 15%
+ * floor (e.g. a 400K-context model with 128K max output reserves 128K, not 60K, so
+ * input is capped near 272K instead of 340K).
  */
-export function effectiveReserveTokens(contextWindow: number, settings: CompactionSettings): number {
-	return Math.max(Math.floor(contextWindow * 0.15), settings.reserveTokens);
+export function effectiveReserveTokens(
+	contextWindow: number,
+	settings: CompactionSettings,
+	maxOutputTokens = 0,
+): number {
+	return Math.max(Math.floor(contextWindow * 0.15), settings.reserveTokens, Math.max(0, maxOutputTokens));
 }
 
 /**
  * Check if compaction should trigger based on context usage.
+ *
+ * `maxOutputTokens` is the model's reserved completion budget; it is excluded from
+ * the safe input budget so prompt + reserved output cannot exceed the total window.
  */
-export function shouldCompact(contextTokens: number, contextWindow: number, settings: CompactionSettings): boolean {
+export function shouldCompact(
+	contextTokens: number,
+	contextWindow: number,
+	settings: CompactionSettings,
+	maxOutputTokens = 0,
+): boolean {
 	if (!settings.enabled || settings.strategy === "off" || contextWindow <= 0) return false;
-	const thresholdTokens = resolveThresholdTokens(contextWindow, settings);
+	const thresholdTokens = resolveThresholdTokens(contextWindow, settings, maxOutputTokens);
 	return contextTokens > thresholdTokens;
 }
 
-export function resolveThresholdTokens(contextWindow: number, settings: CompactionSettings): number {
+export function resolveThresholdTokens(
+	contextWindow: number,
+	settings: CompactionSettings,
+	maxOutputTokens = 0,
+): number {
 	// Fixed token limit takes priority over percentage
 	const thresholdTokens = settings.thresholdTokens;
 	if (typeof thresholdTokens === "number" && Number.isFinite(thresholdTokens) && thresholdTokens > 0) {
@@ -229,7 +251,7 @@ export function resolveThresholdTokens(contextWindow: number, settings: Compacti
 	// Percentage-based threshold
 	const thresholdPercent = settings.thresholdPercent;
 	if (typeof thresholdPercent !== "number" || !Number.isFinite(thresholdPercent) || thresholdPercent <= 0) {
-		return contextWindow - effectiveReserveTokens(contextWindow, settings);
+		return contextWindow - effectiveReserveTokens(contextWindow, settings, maxOutputTokens);
 	}
 	const clampedThresholdPercent = Math.min(99, Math.max(1, thresholdPercent));
 	return Math.floor(contextWindow * (clampedThresholdPercent / 100));

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Improved the grep limit-reached message to show the current limit value and suggest using `--limit` for more results.
+- Passed the active model's `maxTokens` (reserved completion budget) into the auto-compaction threshold and context-usage reserve so prompt packing reserves output for large-window models, keeping the safe input budget below the total context window (e.g. ~272K for a 400K/128K model) instead of filling the whole window ([#442](https://github.com/Yeachan-Heo/gajae-code/issues/442)).
 - Fixed a `gjc harness` recovery deadlock where a session created by `start` without `--detach` (persisted as `started` with no owner lease/endpoint) could never get a live owner: `recover` refused to spawn one because no prior endpoint existed, while `start` reported `session-already-exists`. `recover` now bootstraps a fresh owner for a never-started session (no lease, no endpoint, no owner-run evidence) without writing a misleading `vanish` receipt, reported via `bootstrappedOwner: true`. Bootstrap is independent of the vanish classifier's `ownerRequired` verdict (nothing has vanished), so a session started in a non-git workspace (git delta `unknown`) is recovered too, while a deleted worktree is still refused (#421).
 
 ## [0.4.1] - 2026-06-07

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -197,14 +197,14 @@ export function computeContextBreakdown(
 	if (contextWindow > 0) {
 		const compactionSettings = session.settings.getGroup("compaction") as CompactionSettings;
 		if (compactionSettings.enabled && compactionSettings.strategy !== "off") {
-			const threshold = resolveThresholdTokens(contextWindow, compactionSettings);
+			const threshold = resolveThresholdTokens(contextWindow, compactionSettings, model?.maxTokens ?? 0);
 			autoCompactBufferTokens = Math.max(0, contextWindow - threshold);
 		} else {
 			autoCompactBufferTokens = 0;
 		}
 		// Even when fully disabled, fall back to a sensible reserve floor for display.
 		if (autoCompactBufferTokens === 0 && compactionSettings.enabled) {
-			autoCompactBufferTokens = effectiveReserveTokens(contextWindow, compactionSettings);
+			autoCompactBufferTokens = effectiveReserveTokens(contextWindow, compactionSettings, model?.maxTokens ?? 0);
 		}
 	}
 	autoCompactBufferTokens = Math.min(autoCompactBufferTokens, Math.max(0, contextWindow - usedTokens));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6450,7 +6450,7 @@ export class AgentSession {
 		if (pruneResult) {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
-		if (shouldCompact(contextTokens, contextWindow, compactionSettings)) {
+		if (shouldCompact(contextTokens, contextWindow, compactionSettings, this.model?.maxTokens ?? 0)) {
 			// Try promotion first — if a larger model is available, switch instead of compacting
 			const promoted = await this.#tryContextPromotion(assistantMessage);
 			if (!promoted) {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -9,6 +9,7 @@ import {
 	findCutPoint,
 	getLastAssistantUsage,
 	prepareCompaction,
+	resolveThresholdTokens,
 	shouldCompact,
 } from "@gajae-code/agent-core/compaction/compaction";
 import * as ai from "@gajae-code/ai";
@@ -284,6 +285,37 @@ describe("shouldCompact", () => {
 		};
 
 		expect(shouldCompact(95000, 100000, settings)).toBe(false);
+	});
+
+	it("reserves the model's max output budget so input cannot fill the whole window", () => {
+		// GPT-5.5-like: 400K total window, 128K reserved max output.
+		const settings: CompactionSettings = {
+			enabled: true,
+			reserveTokens: 16384,
+			keepRecentTokens: 20000,
+		};
+
+		// Safe input budget = 400K - max(15%*400K=60K, 16384, 128K) = 400K - 128K = 272K.
+		expect(resolveThresholdTokens(400_000, settings, 128_000)).toBe(272_000);
+		expect(shouldCompact(271_999, 400_000, settings, 128_000)).toBe(false);
+		expect(shouldCompact(272_001, 400_000, settings, 128_000)).toBe(true);
+
+		// Separation guard: the same 300K input must NOT pack against the total window
+		// when output is reserved (would be allowed if budget == total context).
+		expect(shouldCompact(300_000, 400_000, settings, 128_000)).toBe(true);
+		expect(shouldCompact(300_000, 400_000, settings, 0)).toBe(false);
+	});
+
+	it("ignores max output reservation when it is below the percentage/floor reserve", () => {
+		const settings: CompactionSettings = {
+			enabled: true,
+			reserveTokens: 10000,
+			keepRecentTokens: 20000,
+		};
+
+		// 8K max output is smaller than the 15% floor (15K) -> threshold unchanged at 85K.
+		expect(resolveThresholdTokens(100_000, settings, 8_000)).toBe(85_000);
+		expect(resolveThresholdTokens(100_000, settings, 0)).toBe(85_000);
 	});
 });
 


### PR DESCRIPTION
## Summary
Closes #442.

Separates a model's **total context window** from its **safe input/prompt-packing budget**. Previously the auto-compaction threshold treated `contextWindow` (total) as the input budget, reserving only `max(15% * contextWindow, reserveTokens)`. For a model with a large reserved completion budget (e.g. GPT-5.5: 400K total / 128K max output) that floor (60K) is *smaller* than the output reservation, so input could grow to ~340K and overflow the 400K window once 128K of output was requested.

The compaction reserve floor now also reserves the model's max output tokens:

```
effectiveReserve = max(floor(0.15 * contextWindow), reserveTokens, maxOutputTokens)
```

So the safe input budget = `contextWindow - effectiveReserve`. For GPT-5.5 that is **272K** (= 400K − 128K), matching the publicly discussed figure. Model metadata (`contextWindow`) is unchanged and still exposes the true total window.

## Changes
- `packages/agent/src/compaction/compaction.ts`: optional trailing `maxOutputTokens = 0` on `effectiveReserveTokens`, `resolveThresholdTokens`, and `shouldCompact` (fully backward compatible — existing 2/3-arg callers and tests are unaffected).
- `packages/coding-agent/src/session/agent-session.ts`: pass `this.model?.maxTokens` into the auto-compaction `shouldCompact` call.
- `packages/coding-agent/src/modes/utils/context-usage.ts`: pass `model?.maxTokens` into the reserve/threshold used for the context-usage display.
- Tests + changelog entries.

## Acceptance criteria (#442)
- [x] Prompt packing does not fill the entire total window when max output must be reserved.
- [x] Model metadata can still expose the total context window.
- [x] Tests cover a model with large max output reservation so input budget and total context cannot drift together (GPT-5.5-like 400K/128K → threshold 272K; a 300K input compacts when output is reserved but not when it isn't).

## Validation
- `packages/coding-agent/test/compaction.test.ts`: 30 pass / 0 fail (resolved against this branch's `agent-core` source).
- `packages/agent` typecheck: clean.
- New 3-arg call sites typecheck against the updated signatures.

Note: the `thresholdPercent` / fixed `thresholdTokens` paths are explicit user overrides and intentionally keep their existing behavior; only the default/legacy reserve path auto-reserves output.