### PR TITLE
fix(image): align Antigravity image provider config and accept raw-token credentials (#447)

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2639,7 +2639,7 @@ export const SETTINGS_SCHEMA = {
 	},
 	"providers.image": {
 		type: "enum",
-		values: ["auto", "openai", "gemini", "openrouter"] as const,
+		values: ["auto", "openai", "antigravity", "gemini", "openrouter"] as const,
 		default: "auto",
 		ui: {
 			tab: "providers",
@@ -2652,6 +2652,11 @@ export const SETTINGS_SCHEMA = {
 					description: "Priority: GPT model image tool > Antigravity > OpenRouter > Gemini",
 				},
 				{ value: "openai", label: "OpenAI", description: "Uses the active GPT Responses/Codex model" },
+				{
+					value: "antigravity",
+					label: "Antigravity",
+					description: "Requires Antigravity (google-antigravity) OAuth login",
+				},
 				{ value: "gemini", label: "Gemini", description: "Requires GEMINI_API_KEY" },
 				{ value: "openrouter", label: "OpenRouter", description: "Requires OPENROUTER_API_KEY" },
 			],

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -506,7 +506,13 @@ export class SelectorController {
 				}
 				break;
 			case "providers.image":
-				if (value === "auto" || value === "openai" || value === "gemini" || value === "openrouter") {
+				if (
+					value === "auto" ||
+					value === "openai" ||
+					value === "antigravity" ||
+					value === "gemini" ||
+					value === "openrouter"
+				) {
 					setPreferredImageProvider(value);
 				}
 				break;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -867,6 +867,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	if (
 		imageProvider === "auto" ||
 		imageProvider === "openai" ||
+		imageProvider === "antigravity" ||
 		imageProvider === "gemini" ||
 		imageProvider === "openrouter"
 	) {

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -11,6 +11,7 @@ import {
 import {
 	$env,
 	isEnoent,
+	logger,
 	parseImageMetadata,
 	prompt,
 	ptree,
@@ -404,15 +405,51 @@ interface ParsedAntigravityCredentials {
 	projectId: string;
 }
 
-function parseAntigravityCredentials(raw: string): ParsedAntigravityCredentials | null {
-	try {
-		const parsed = JSON.parse(raw) as { token?: string; projectId?: string };
-		if (parsed.token && parsed.projectId) {
-			return { accessToken: parsed.token, projectId: parsed.projectId };
+export function parseAntigravityCredentials(raw: string): ParsedAntigravityCredentials | null {
+	const value = raw.trim();
+	if (!value) return null;
+
+	// Antigravity credentials are normally a structured JSON document
+	// ({ token, projectId }). Some provider configurations instead hand back a
+	// raw OAuth token. Accept both the structured (JSON/object) form and a raw
+	// token, and emit a diagnostic when config is present but unusable so the
+	// image tool fails loudly instead of silently dropping the provider.
+	if (value.startsWith("{")) {
+		let parsed: { token?: unknown; projectId?: unknown; project_id?: unknown };
+		try {
+			parsed = JSON.parse(value) as typeof parsed;
+		} catch {
+			logger.warn("Antigravity image credentials are not valid JSON; skipping image provider", {
+				provider: "google-antigravity",
+			});
+			return null;
 		}
-	} catch {
-		// Invalid JSON
+		const token = typeof parsed.token === "string" ? parsed.token.trim() : "";
+		const projectId =
+			typeof parsed.projectId === "string"
+				? parsed.projectId.trim()
+				: typeof parsed.project_id === "string"
+					? parsed.project_id.trim()
+					: "";
+		if (token && projectId) {
+			return { accessToken: token, projectId };
+		}
+		logger.warn("Antigravity image credentials missing token or projectId; skipping image provider", {
+			provider: "google-antigravity",
+		});
+		return null;
 	}
+
+	// Raw token form: the Antigravity image endpoint requires a project, so a
+	// bare token is only usable when a project id is available from the env.
+	const projectId = ($env.GOOGLE_CLOUD_PROJECT ?? $env.GOOGLE_ANTIGRAVITY_PROJECT_ID ?? "").trim();
+	if (projectId) {
+		return { accessToken: value, projectId };
+	}
+	logger.warn(
+		"Antigravity image credentials are a raw token without a project id; set GOOGLE_CLOUD_PROJECT to enable the image provider",
+		{ provider: "google-antigravity" },
+	);
 	return null;
 }
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -2,9 +2,15 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import type { Model } from "@gajae-code/ai";
 import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { getEnumValues } from "@gajae-code/coding-agent/config/settings-schema";
 import type { CustomToolContext } from "@gajae-code/coding-agent/extensibility/custom-tools";
 import type { ReadonlySessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import { imageGenTool, setPreferredImageProvider } from "@gajae-code/coding-agent/tools/image-gen";
+import {
+	getImageGenToolsWithRegistry,
+	imageGenTool,
+	parseAntigravityCredentials,
+	setPreferredImageProvider,
+} from "@gajae-code/coding-agent/tools/image-gen";
 
 const originalFetch = global.fetch;
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
@@ -190,5 +196,75 @@ describe("imageGenTool", () => {
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
 		expect(requestUrl).toBe("https://api.openai.com/v1/responses");
+	});
+});
+
+describe("antigravity image provider config", () => {
+	it("exposes antigravity as a selectable providers.image value", () => {
+		expect(getEnumValues("providers.image")).toContain("antigravity");
+	});
+});
+
+describe("parseAntigravityCredentials", () => {
+	const originalCloudProject = Bun.env.GOOGLE_CLOUD_PROJECT;
+	const originalAntigravityProject = Bun.env.GOOGLE_ANTIGRAVITY_PROJECT_ID;
+
+	afterEach(() => {
+		if (originalCloudProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
+		else Bun.env.GOOGLE_CLOUD_PROJECT = originalCloudProject;
+		if (originalAntigravityProject === undefined) delete Bun.env.GOOGLE_ANTIGRAVITY_PROJECT_ID;
+		else Bun.env.GOOGLE_ANTIGRAVITY_PROJECT_ID = originalAntigravityProject;
+	});
+
+	it("parses the structured JSON credential form", () => {
+		expect(parseAntigravityCredentials(JSON.stringify({ token: "tok", projectId: "proj-1" }))).toEqual({
+			accessToken: "tok",
+			projectId: "proj-1",
+		});
+	});
+
+	it("accepts the snake_case project_id alias", () => {
+		expect(parseAntigravityCredentials(JSON.stringify({ token: "tok", project_id: "proj-2" }))).toEqual({
+			accessToken: "tok",
+			projectId: "proj-2",
+		});
+	});
+
+	it("returns null for structured credentials missing a projectId", () => {
+		expect(parseAntigravityCredentials(JSON.stringify({ token: "tok" }))).toBeNull();
+	});
+
+	it("returns null for a raw token when no project id is available", () => {
+		delete Bun.env.GOOGLE_CLOUD_PROJECT;
+		delete Bun.env.GOOGLE_ANTIGRAVITY_PROJECT_ID;
+		expect(parseAntigravityCredentials("raw-oauth-token")).toBeNull();
+	});
+
+	it("accepts a raw token when GOOGLE_CLOUD_PROJECT is set", () => {
+		delete Bun.env.GOOGLE_ANTIGRAVITY_PROJECT_ID;
+		Bun.env.GOOGLE_CLOUD_PROJECT = "proj-env";
+		expect(parseAntigravityCredentials("raw-oauth-token")).toEqual({
+			accessToken: "raw-oauth-token",
+			projectId: "proj-env",
+		});
+	});
+
+	it("returns null for malformed JSON and empty input", () => {
+		expect(parseAntigravityCredentials("{not-json")).toBeNull();
+		expect(parseAntigravityCredentials("   ")).toBeNull();
+	});
+});
+
+describe("getImageGenToolsWithRegistry (antigravity)", () => {
+	it("registers the image tool when antigravity is preferred and structured credentials exist", async () => {
+		setPreferredImageProvider("antigravity");
+		const modelRegistry = {
+			getApiKeyForProvider: async () => JSON.stringify({ token: "tok", projectId: "proj-1" }),
+			getApiKey: async () => undefined,
+		} as unknown as ModelRegistry;
+
+		const tools = await getImageGenToolsWithRegistry(modelRegistry);
+		expect(tools).toHaveLength(1);
+		expect(tools[0]).toBe(imageGenTool);
 	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1844,6 +1844,7 @@
 					"enum": [
 						"auto",
 						"openai",
+						"antigravity",
 						"gemini",
 						"openrouter"
 					],


### PR DESCRIPTION
Closes #447.

## Problem
Two related defects could prevent the image-generation tool from registering with an Antigravity configuration:

1. **Provider enum/config drift.** `image-gen.ts` already implements an `antigravity` image provider branch, and the `providers.image` "auto" priority docs list Antigravity — but the `providers.image` settings enum and the acceptance checks in `sdk.ts` / `selector-controller.ts` only allowed `auto | openai | gemini | openrouter`. So `setPreferredImageProvider("antigravity")` was never reachable from settings.
2. **Raw-token parse failure.** `parseAntigravityCredentials` did a bare `JSON.parse` and required `{ token, projectId }`. When `getApiKeyForProvider("google-antigravity")` returned a raw token (or a structured credential using the `project_id` alias), parsing silently returned `null`, dropping the provider — and if Antigravity was the only image-capable credential, the tool failed to register entirely.

## Fix
- Add `"antigravity"` to the `providers.image` enum (`settings-schema.ts`) plus the acceptance checks in `sdk.ts` and `selector-controller.ts`, so the existing `image-gen.ts` antigravity path is reachable and the config is consistent end-to-end.
- Rework `parseAntigravityCredentials` to accept:
  - structured JSON `{ token, projectId }`, including the snake_case `project_id` alias (mirrors `parseGeminiCliCredentials`);
  - a raw OAuth token, usable when a project id is available via `GOOGLE_CLOUD_PROJECT` / `GOOGLE_ANTIGRAVITY_PROJECT_ID` (the Antigravity image endpoint requires a project).
  - When config is present but unusable (invalid JSON, missing projectId, raw token without a project id), it now emits a `logger.warn` diagnostic instead of failing silently — following the issue's "fail loudly, not silently unregister" requirement and the existing `extractGoogleOAuthToken` raw-token precedent.
- Regenerated `schemas/config.schema.json` for the new enum value.

## Decision note (documented for reviewer)
The issue left ambiguous where a project id comes from in the raw-token case. Antigravity's image endpoint requires a `project`, so a bare token alone cannot build a request. I resolved this with the canonical GCP `GOOGLE_CLOUD_PROJECT` env (plus a provider-specific `GOOGLE_ANTIGRAVITY_PROJECT_ID`) rather than inventing a new config surface; a raw token with no resolvable project id is rejected with a clear diagnostic. Happy to adjust if a different project source is preferred.

## Evidence
- `bun test test/tools/image-gen.test.ts` → **11 pass / 0 fail** (8 new cases: enum exposure, all credential parsing forms, raw-token w/ and w/o env project, and antigravity tool registration via `getImageGenToolsWithRegistry`).
- `bun run check:types` → clean.
- `biome check` on all touched files → clean.
- `bun run check:schemas` → clean after regeneration.

No unrelated behavior touched.

---
*Signed-off via GJC harness session `h-2026-06-09-0746-11ff5aab`.*