### PR TITLE
fix(models): mark all Claude Opus 4.8 variants vision-capable

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -234,6 +234,23 @@ function applyCodexPricingFallback(models: readonly Model[]): Model[] {
 	});
 }
 
+// Catalog sources occasionally omit image input for Claude Opus 4.8 variants
+// (e.g. kilo/venice "-fast" entries) even though every Claude Opus model is
+// vision-capable. Correct those so capability advertising stays consistent
+// across providers. Runs after the dynamic merge so it survives regeneration.
+function applyClaudeOpusVisionCorrections(models: readonly Model[]): Model[] {
+	return models.map(model => {
+		const normalizedId = model.id.toLowerCase().replace(/\./g, "-");
+		if (!normalizedId.includes("claude-opus-4-8")) {
+			return model;
+		}
+		if (model.input.includes("image")) {
+			return model;
+		}
+		return { ...model, input: [...model.input, "image"] };
+	});
+}
+
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
 async function getOAuthAccessFromStorage(provider: OAuthProvider): Promise<OAuthAccess | null> {
@@ -387,6 +404,7 @@ async function generateModels() {
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
+	allModels = applyClaudeOpusVisionCorrections(allModels);
 	applyGeneratedModelPolicies(allModels);
 	linkOpenAIPromotionTargets(allModels);
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -9853,7 +9853,8 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -9872,7 +9873,8 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -16768,7 +16770,8 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -63601,7 +63604,8 @@
 			"baseUrl": "https://api.venice.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,

--- a/packages/ai/test/claude-opus-vision.test.ts
+++ b/packages/ai/test/claude-opus-vision.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModels, getBundledProviders } from "../src/models";
+
+/**
+ * Every Claude Opus 4.8 variant is vision-capable. Some upstream catalogs omit
+ * image input (e.g. kilo/venice "-fast" entries); generate-models.ts corrects
+ * these via applyClaudeOpusVisionCorrections so capability advertising stays
+ * consistent across providers.
+ */
+describe("Claude Opus 4.8 vision capability", () => {
+	it("advertises image input for every bundled claude-opus-4.8 variant", () => {
+		const offenders: string[] = [];
+		for (const provider of getBundledProviders()) {
+			for (const model of getBundledModels(provider)) {
+				const normalizedId = model.id.toLowerCase().replace(/\./g, "-");
+				if (!normalizedId.includes("claude-opus-4-8")) continue;
+				if (!model.input.includes("image")) {
+					offenders.push(`${provider}/${model.id}`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Why

Every Claude Opus model is vision-capable, but a few catalog entries advertised Claude Opus 4.8 as **text-only**: `kilo/anthropic/claude-opus-4.8`, `kilo/anthropic/claude-opus-4.8-fast`, `kilo/stealth/claude-opus-4.8`, and `venice/claude-opus-4-8-fast`. That makes gjc treat a vision model as lacking vision.

## What

- Add `applyClaudeOpusVisionCorrections` to `packages/ai/scripts/generate-models.ts`, run after the dynamic merge so the correction **survives regeneration** (matches any id normalizing to `claude-opus-4-8`).
- Apply the same correction to the four affected `models.json` entries (minimal diff: `["text"]` → `["text","image"]`).
- Add `packages/ai/test/claude-opus-vision.test.ts` asserting every bundled `claude-opus-4.8` variant advertises image input.

## Verification

- `bun --cwd=packages/ai run check:types` clean; `biome` clean.
- `bun run check:schemas` passes.
- New regression test + `models-cost` tests pass.
- `models.json` diff is exactly the four entries.

Follow-up to the role-cleanup PR; part of the custom-model capability-parity series.