### PR TITLE
test(input-controller): add missing settings mock for busyStreamingBehavior

### DIFF
--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -99,6 +99,7 @@ function createContext(): {
 	});
 
 	ctx = {
+		settings: { get: () => undefined } as unknown as InteractiveModeContext["settings"],
 		editor: editor as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
 		loadingAnimation: undefined,


### PR DESCRIPTION
## What

The escape-behavior test mock for `InputController` is missing a `settings` property, causing `TypeError: undefined is not an object` when `#busyStreamingBehavior()` calls `this.ctx.settings.get("busyPromptMode")`.

## Why

PR #434 (feat(input): queue prompts submitted while agent is busy) introduced `#busyStreamingBehavior()` which reads `ctx.settings`, but the test mock at line 101 was never updated. The test passed on CI because `--only-failures` skips previously-passing test names, so it was never re-executed after the behavioral change.

## Testing

- `bun test packages/coding-agent/test/input-controller-escape.test.ts` → 12 pass, 0 fail (was 1 fail before)
- `bun run check:ts` → clean
- No behavior change — test-only fix

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)