### PR TITLE
feat(image-gen): hosted image generation for custom proxies via declarative output capability

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -854,6 +854,14 @@ export interface Model<TApi extends Api = any> {
 	baseUrl: string;
 	reasoning: boolean;
 	input: ("text" | "image")[];
+	/**
+	 * Output modalities the model can produce. Defaults to text-only when
+	 * unset. A model that lists `"image"` advertises image-generation support
+	 * (e.g. an OpenAI-compatible `gpt-image` model behind a proxy), which the
+	 * `generate_image` tool uses to route requests without first-party
+	 * provider/id heuristics.
+	 */
+	output?: ("text" | "image")[];
 	cost: {
 		input: number; // $/million tokens
 		output: number; // $/million tokens

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -688,6 +688,7 @@ function applyModelOverride(model: Model<Api>, override: ModelOverride): Model<A
 	if (override.reasoning !== undefined) result.reasoning = override.reasoning;
 	if (override.thinking !== undefined) result.thinking = override.thinking as ThinkingConfig;
 	if (override.input !== undefined) result.input = override.input as ("text" | "image")[];
+	if (override.output !== undefined) result.output = override.output as ("text" | "image")[];
 	if (override.cacheRetention !== undefined) result.cacheRetention = override.cacheRetention;
 	if (override.contextWindow !== undefined) result.contextWindow = override.contextWindow;
 	if (override.maxTokens !== undefined) result.maxTokens = override.maxTokens;
@@ -718,6 +719,7 @@ interface CustomModelDefinitionLike {
 	reasoning?: boolean;
 	thinking?: ThinkingConfig;
 	input?: ("text" | "image")[];
+	output?: ("text" | "image")[];
 	cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow?: number;
 	maxTokens?: number;
@@ -743,6 +745,7 @@ type CustomModelOverlay = {
 	reasoning?: boolean;
 	thinking?: ThinkingConfig;
 	input?: ("text" | "image")[];
+	output?: ("text" | "image")[];
 	cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow?: number;
 	maxTokens?: number;
@@ -818,6 +821,7 @@ function buildCustomModelOverlay(
 		reasoning: modelDef.reasoning,
 		thinking: modelDef.thinking as ThinkingConfig | undefined,
 		input: modelDef.input as ("text" | "image")[] | undefined,
+		output: modelDef.output as ("text" | "image")[] | undefined,
 		cost: modelDef.cost,
 		contextWindow: modelDef.contextWindow,
 		maxTokens: modelDef.maxTokens,
@@ -910,6 +914,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		reference?.cost ??
 		(options.useDefaults ? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } : undefined);
 	const input = resolvedModel.input ?? reference?.input ?? (options.useDefaults ? ["text"] : undefined);
+	const output = resolvedModel.output ?? reference?.output;
 	return enrichModelThinking({
 		id: resolvedModel.id,
 		name: resolvedModel.name ?? (options.useDefaults ? resolvedModel.id : undefined),
@@ -919,6 +924,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		reasoning: resolvedModel.reasoning ?? reference?.reasoning ?? (options.useDefaults ? false : undefined),
 		thinking: resolvedModel.thinking ?? reference?.thinking,
 		input: input as ("text" | "image")[],
+		output: output as ("text" | "image")[] | undefined,
 		cost,
 		contextWindow:
 			resolvedModel.contextWindow ?? reference?.contextWindow ?? (options.useDefaults ? 128000 : undefined),
@@ -1213,6 +1219,7 @@ export class ModelRegistry {
 					reasoning: customModel.reasoning ?? existingModel.reasoning,
 					thinking: customModel.thinking ?? existingModel.thinking,
 					input: customModel.input ?? existingModel.input,
+					output: customModel.output ?? existingModel.output,
 					cost: customModel.cost ?? existingModel.cost,
 					contextWindow: customModel.contextWindow ?? existingModel.contextWindow,
 					maxTokens: customModel.maxTokens ?? existingModel.maxTokens,

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -135,6 +135,7 @@ const ModelDefinitionSchema = z
 		reasoning: z.boolean().optional(),
 		thinking: ModelThinkingSchema.optional(),
 		input: z.array(z.enum(["text", "image"])).optional(),
+		output: z.array(z.enum(["text", "image"])).optional(),
 		cost: z
 			.object({
 				input: z.number(),
@@ -161,6 +162,7 @@ export const ModelOverrideSchema = z
 		reasoning: z.boolean().optional(),
 		thinking: ModelThinkingSchema.optional(),
 		input: z.array(z.enum(["text", "image"])).optional(),
+		output: z.array(z.enum(["text", "image"])).optional(),
 		cost: z
 			.object({
 				input: z.number().optional(),

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -589,12 +589,21 @@ function collectInlineImages(parts: GeminiPart[]): InlineImageData[] {
 	return images;
 }
 
-function isOpenAIHostedImageModel(model: Model | undefined): model is Model {
+export function isOpenAIHostedImageModel(model: Model | undefined): model is Model {
 	if (!model) return false;
-	if (model.provider !== "openai" && model.provider !== "openai-codex") return false;
+	// The hosted image_generation tool is only available over the Responses API.
 	if (model.api !== "openai-responses" && model.api !== "openai-codex-responses") return false;
-	const modelId = model.id.toLowerCase();
-	return modelId.startsWith("gpt-") || modelId === "o3" || modelId.startsWith("o3-");
+	// Declarative capability: any provider (e.g. an OpenAI-compatible proxy
+	// fronting gpt-image) whose model advertises image output can drive
+	// generate_image, routed to the model's own baseUrl with registry auth.
+	if (model.output?.includes("image")) return true;
+	// First-party heuristic: OpenAI/OpenAI code GPT and o3 models generate
+	// images inline through the hosted tool without a declared output modality.
+	if (model.provider === "openai" || model.provider === "openai-codex") {
+		const modelId = model.id.toLowerCase();
+		return modelId.startsWith("gpt-") || modelId === "o3" || modelId.startsWith("o3-");
+	}
+	return false;
 }
 
 function getOpenAIHostedImageProvider(model: Model): ImageProvider {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -264,6 +264,50 @@ describe("ModelRegistry", () => {
 			expect(openaiModel?.cacheRetention).toBe("long");
 		});
 
+		test("propagates declared image output capability for custom models", () => {
+			writeRawModelsJson({
+				layofflabs: {
+					baseUrl: "https://api.layofflabs.com/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-responses",
+					models: [
+						{
+							id: "gpt-5.5",
+							input: ["text", "image"],
+							output: ["text", "image"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 400000,
+							maxTokens: 128000,
+						},
+						{
+							id: "gpt-5.5-text",
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 400000,
+							maxTokens: 128000,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("layofflabs", "gpt-5.5")?.output).toEqual(["text", "image"]);
+			expect(registry.find("layofflabs", "gpt-5.5-text")?.output).toBeUndefined();
+		});
+
+		test("modelOverrides can set image output capability", () => {
+			writeRawModelsJson({
+				openai: {
+					modelOverrides: {
+						"gpt-5-mini": { output: ["text", "image"] },
+					},
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("openai", "gpt-5-mini")?.output).toEqual(["text", "image"]);
+		});
+
 		test("modelOverrides cacheRetention wins over provider cacheRetention", () => {
 			writeRawModelsJson({
 				openai: {

--- a/packages/coding-agent/test/tools/image-gen-capability.test.ts
+++ b/packages/coding-agent/test/tools/image-gen-capability.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@gajae-code/ai";
+import { isOpenAIHostedImageModel } from "@gajae-code/coding-agent/tools/image-gen";
+
+function model<TApi extends Api>(
+	overrides: Partial<Model<TApi>> & Pick<Model<TApi>, "id" | "api" | "provider">,
+): Model<TApi> {
+	return {
+		name: overrides.id,
+		baseUrl: "https://proxy.example/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+		...overrides,
+	} as Model<TApi>;
+}
+
+describe("isOpenAIHostedImageModel", () => {
+	it("accepts first-party OpenAI GPT/o3 Responses models (unchanged)", () => {
+		expect(isOpenAIHostedImageModel(model({ id: "gpt-5.5", api: "openai-responses", provider: "openai" }))).toBe(
+			true,
+		);
+		expect(
+			isOpenAIHostedImageModel(model({ id: "o3", api: "openai-codex-responses", provider: "openai-codex" })),
+		).toBe(true);
+	});
+
+	it("accepts any provider whose Responses model declares image output", () => {
+		expect(
+			isOpenAIHostedImageModel(
+				model({ id: "gpt-5.5", api: "openai-responses", provider: "layofflabs", output: ["text", "image"] }),
+			),
+		).toBe(true);
+	});
+
+	it("rejects a custom Responses model that does not declare image output", () => {
+		expect(isOpenAIHostedImageModel(model({ id: "gpt-5.5", api: "openai-responses", provider: "layofflabs" }))).toBe(
+			false,
+		);
+	});
+
+	it("rejects image output declared over a non-Responses API", () => {
+		expect(
+			isOpenAIHostedImageModel(
+				model({ id: "gpt-image-2", api: "openai-completions", provider: "layofflabs", output: ["text", "image"] }),
+			),
+		).toBe(false);
+	});
+
+	it("rejects a non-GPT first-party model without declared image output", () => {
+		expect(
+			isOpenAIHostedImageModel(model({ id: "text-embedding-3", api: "openai-responses", provider: "openai" })),
+		).toBe(false);
+	});
+
+	it("rejects undefined", () => {
+		expect(isOpenAIHostedImageModel(undefined)).toBe(false);
+	});
+});

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -388,6 +388,16 @@
 										]
 									}
 								},
+								"output": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [
+											"text",
+											"image"
+										]
+									}
+								},
 								"cost": {
 									"type": "object",
 									"properties": {
@@ -732,6 +742,16 @@
 									"additionalProperties": false
 								},
 								"input": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [
+											"text",
+											"image"
+										]
+									}
+								},
+								"output": {
 									"type": "array",
 									"items": {
 										"type": "string",


### PR DESCRIPTION
## Why

Hosted image generation (`generate_image`) was gated to first-party `openai`/`openai-codex` providers by a hardcoded provider/api/id allowlist (`isOpenAIHostedImageModel`). A custom OpenAI-compatible proxy (e.g. `layofflabs` `gpt-5.5` fronting `gpt-image`) could not drive image generation even though it supports it — "gpt-5.5 image generation, like openai/codex".

## What

- Add a declarative `output?: ("text"|"image")[]` modality to the `Model` type (`packages/ai/src/types.ts`) and to the `models.yml` model + override schemas, propagated through every custom-model registry path (build overlay, finalize, `modelOverrides`, custom/bundled merge).
- `isOpenAIHostedImageModel` now accepts **any provider** whose Responses-API model declares `output` includes `image`, routed to the model's own `baseUrl` with registry-resolved auth. The first-party GPT/o3 heuristic is unchanged.
- The hosted `image_generation` tool is Responses-API only, so the gate keeps requiring `openai-responses`/`openai-codex-responses`; a model declaring image output over a non-Responses API is rejected.

## Usage

```yaml
providers:
  layofflabs:
    api: openai-responses
    models:
      - id: gpt-5.5
        input: [text, image]
        output: [text, image]   # now drives generate_image via the proxy
```

## Verification

- `bun --cwd=packages/ai run check:types` and `bun --cwd=packages/coding-agent run check:types` clean (the latter verified by mirroring the type locally due to the shared-`node_modules` worktree symlink; CI resolves the branch standalone).
- `biome` clean.
- New tests: `test/tools/image-gen-capability.test.ts` (gating matrix) and registry `output` propagation tests in `model-registry.test.ts`; full `model-registry` suite passes.

## Scope / follow-up

Completions-only image endpoints (direct OpenAI Images API `/images/generations`) are intentionally out of scope here; this PR enables the Responses-API hosted tool path for custom providers. Part of the custom-model capability-parity series.