### PR TITLE
feat(browser): structured action space (SOTA computer-use adaptation)

### DIFF
--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -2,10 +2,11 @@ Drives a real Chromium tab with full puppeteer access via JS execution.
 
 <instruction>
 - For static web content (articles, docs, issues/PRs, JSON, PDFs, feeds), prefer the `read` tool with a URL — reader-mode text without spinning up a browser. Use this tool when you need JS execution, authentication, or interactive actions.
-- Three actions only:
+- Four actions:
   - `open` — acquire (or reuse) a named tab. `name` defaults to `"main"`. Optional `url` navigates after the tab is ready. Optional `viewport` sets dimensions. Optional `dialogs: "accept" | "dismiss"` auto-handles `alert`/`confirm`/`beforeunload` so navigation/clicks don't hang (default: leave dialogs unhandled — page hangs until caller wires `page.on('dialog', …)`).
   - `close` — release a tab by `name`, or every tab with `all: true`. For spawned-app browsers, set `kill: true` to terminate the process tree (default leaves it running).
   - `run` — execute JS against an existing tab. `code` is the body of an async function with `page`, `browser`, `tab`, `display`, `assert`, `wait` in scope. The function's return value is JSON-stringified into the tool result; multiple `display(value)` calls accumulate text/images.
+  - `act` — run a list of structured `actions` against an existing tab without writing JS (preferred for routine navigation/interaction). Each step is `{ verb, … }`; verbs: `navigate {url, wait_until?}`, `click {id|selector}`, `type {id|selector, text}`, `fill {selector, value}`, `select {selector, values}`, `press {key, selector?}`, `scroll {dx?, dy?}`, `back`, `wait {selector?|ms?}`, `observe {viewport_only?, include_all?}`, `extract {format?}`, `screenshot`. Address elements by the numeric `id` from a prior `observe` (preferred) or a selector. Steps run in order; the tool returns an array of per-step results (observations/extracted content included). Use `run` only when a verb does not cover what you need.
 - Tabs survive across `run` calls and across in-process subagents. Open once, reuse many times.
 - Browser kinds, selected by the `app` field on `open`:
   - default (no `app`) → headless Chromium with stealth patches.
@@ -32,7 +33,7 @@ Drives a real Chromium tab with full puppeteer access via JS execution.
 </instruction>
 
 <critical>
-- You MUST call `open` before `run`. `run` does not implicitly create a tab.
+- You MUST call `open` before `run` or `act`. Neither implicitly creates a tab.
 - You NEVER screenshot just to "see what's on the page" — `tab.observe()` returns structured data with element ids you can act on immediately.
 - After a `tab.goto()` or any navigation, prior element ids from `tab.observe()` are invalidated. Re-observe before referencing them.
 - `code` runs with full Node access. Treat it as your code, not sandboxed code.

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -3,6 +3,7 @@ import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import browserDescription from "../prompts/tools/browser.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
+import { type BrowserActionStep, compileActionSteps } from "./browser/actions";
 import { acquireBrowser, type BrowserHandle, type BrowserKind, type BrowserKindTag } from "./browser/registry";
 import type { Observation, ScreenshotResult } from "./browser/tab-protocol";
 import { acquireTab, dropHeadlessTabs, getTab, releaseAllTabs, releaseTab, runInTab } from "./browser/tab-supervisor";
@@ -24,8 +25,44 @@ const appSchema = z.object({
 	target: z.string().describe("substring to pick a window").optional(),
 });
 
+const actionStepSchema = z.object({
+	verb: z
+		.enum([
+			"navigate",
+			"click",
+			"type",
+			"fill",
+			"select",
+			"press",
+			"scroll",
+			"back",
+			"wait",
+			"observe",
+			"extract",
+			"screenshot",
+		])
+		.describe("structured action verb"),
+	id: z.number().describe("element id from a prior observe").optional(),
+	selector: z.string().describe("css/puppeteer selector").optional(),
+	text: z.string().describe("text to type").optional(),
+	value: z.string().describe("value for fill").optional(),
+	values: z.array(z.string()).describe("option value(s) for select").optional(),
+	url: z.string().describe("url for navigate").optional(),
+	key: z.string().describe("key for press, e.g. Enter").optional(),
+	dx: z.number().describe("horizontal scroll delta").optional(),
+	dy: z.number().describe("vertical scroll delta").optional(),
+	ms: z.number().describe("sleep ms for wait without selector").optional(),
+	format: z.enum(["markdown", "text", "html"]).describe("extract format").optional(),
+	wait_until: z
+		.enum(["load", "domcontentloaded", "networkidle0", "networkidle2"])
+		.describe("navigation wait condition for navigate")
+		.optional(),
+	viewport_only: z.boolean().describe("observe: only viewport elements").optional(),
+	include_all: z.boolean().describe("observe: include non-interactive elements").optional(),
+});
+
 const browserSchema = z.object({
-	action: z.enum(["open", "close", "run"] as const).describe("operation"),
+	action: z.enum(["open", "close", "run", "act"] as const).describe("operation"),
 	name: z.string().describe("tab id (default 'main')").optional(),
 	url: z.string().describe("url to open").optional(),
 	app: appSchema.optional(),
@@ -45,6 +82,7 @@ const browserSchema = z.object({
 		.describe("auto-handle dialogs")
 		.optional(),
 	code: z.string().describe("js body to run in tab").optional(),
+	actions: z.array(actionStepSchema).describe("structured action steps for action 'act'").optional(),
 	timeout: z.number().default(30).describe("timeout in seconds (default 30, max 300)").optional(),
 	all: z.boolean().describe("close every tab").optional(),
 	kill: z.boolean().describe("also kill spawned-app browsers").optional(),
@@ -126,6 +164,8 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 					return await this.#close(name, params, details, signal);
 				case "run":
 					return await this.#run(name, params, details, timeoutMs, signal);
+				case "act":
+					return await this.#act(name, params, details, timeoutMs, signal);
 				default:
 					throw new ToolError(`Unsupported action: ${(params as BrowserParams).action}`);
 			}
@@ -251,6 +291,56 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		}
 		if (!content.length) {
 			content.push({ type: "text", text: `Ran code on tab ${JSON.stringify(name)}` });
+		}
+		const textOnly = content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("\n");
+		details.result = textOnly;
+		return toolResult(details).content(content).done();
+	}
+
+	async #act(
+		name: string,
+		params: BrowserParams,
+		details: BrowserToolDetails,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<BrowserToolDetails>> {
+		const steps = (params.actions ?? []) as BrowserActionStep[];
+		if (steps.length === 0) {
+			throw new ToolError("Missing required parameter 'actions' for action 'act'.");
+		}
+		const tab = getTab(name);
+		if (!tab) {
+			throw new ToolError(`No tab named ${JSON.stringify(name)}. Open it first with action 'open'.`);
+		}
+		details.browser = tab.browser.kind.kind;
+		details.url = tab.info.url;
+
+		// compileActionSteps validates each step and produces injection-safe code
+		// (steps embedded as parsed JSON) for the existing in-tab run worker.
+		let code: string;
+		try {
+			code = compileActionSteps(steps);
+		} catch (error) {
+			throw new ToolError(error instanceof Error ? error.message : String(error));
+		}
+
+		const { displays, returnValue, screenshots } = await runInTab(name, {
+			code,
+			timeoutMs,
+			signal,
+			session: this.session,
+		});
+
+		if (screenshots.length) details.screenshots = screenshots;
+		const content = [...displays];
+		if (returnValue !== undefined) {
+			content.push({ type: "text", text: stringifyReturnValue(returnValue) });
+		}
+		if (!content.length) {
+			content.push({ type: "text", text: `Ran ${steps.length} action(s) on tab ${JSON.stringify(name)}` });
 		}
 		const textOnly = content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")

--- a/packages/coding-agent/src/tools/browser/actions.ts
+++ b/packages/coding-agent/src/tools/browser/actions.ts
@@ -1,0 +1,189 @@
+/**
+ * Structured browser action space.
+ *
+ * Adapts the SOTA computer-use / browser-use pattern: instead of authoring raw
+ * JavaScript for every interaction, the model emits a list of structured verbs
+ * (navigate / click / type / …) that reference elements by the numeric `id`
+ * returned from {@link Observation}. Each verb is compiled onto the existing
+ * in-tab `tab.*` helpers and executed through the same worker `run` path, so the
+ * worker protocol is unchanged and the raw-JS `run` escape hatch still works.
+ */
+
+export type BrowserActionVerb =
+	| "navigate"
+	| "click"
+	| "type"
+	| "fill"
+	| "select"
+	| "press"
+	| "scroll"
+	| "back"
+	| "wait"
+	| "observe"
+	| "extract"
+	| "screenshot";
+
+export interface BrowserActionStep {
+	verb: BrowserActionVerb;
+	/** Element id from a prior `observe` (preferred for click/type). */
+	id?: number;
+	/** CSS / puppeteer selector when not addressing by `id`. */
+	selector?: string;
+	/** Text to type. */
+	text?: string;
+	/** Value for `fill`. */
+	value?: string;
+	/** Option value(s) for `select`. */
+	values?: string[];
+	/** URL for `navigate`. */
+	url?: string;
+	/** Key for `press` (e.g. "Enter"). */
+	key?: string;
+	/** Horizontal scroll delta. */
+	dx?: number;
+	/** Vertical scroll delta. */
+	dy?: number;
+	/** Sleep duration for `wait` when no selector is given. */
+	ms?: number;
+	/** Extract format. */
+	format?: "markdown" | "text" | "html";
+	/** Navigation wait condition for `navigate`. */
+	wait_until?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+	/** Only return interactive/viewport elements for `observe`. */
+	viewport_only?: boolean;
+	include_all?: boolean;
+}
+
+const VERBS: ReadonlySet<BrowserActionVerb> = new Set([
+	"navigate",
+	"click",
+	"type",
+	"fill",
+	"select",
+	"press",
+	"scroll",
+	"back",
+	"wait",
+	"observe",
+	"extract",
+	"screenshot",
+]);
+
+/**
+ * Validate a single step's required fields. Returns an error string, or
+ * `undefined` when the step is well-formed.
+ */
+export function validateActionStep(step: BrowserActionStep, index: number): string | undefined {
+	const where = `actions[${index}] (${step.verb})`;
+	if (!VERBS.has(step.verb)) return `${where}: unknown verb`;
+	switch (step.verb) {
+		case "navigate":
+			if (!step.url?.trim()) return `${where}: 'url' is required`;
+			return undefined;
+		case "click":
+			if (step.id === undefined && !step.selector?.trim()) return `${where}: 'id' or 'selector' is required`;
+			return undefined;
+		case "type":
+			if (step.id === undefined && !step.selector?.trim()) return `${where}: 'id' or 'selector' is required`;
+			if (step.text === undefined) return `${where}: 'text' is required`;
+			return undefined;
+		case "fill":
+			if (!step.selector?.trim()) return `${where}: 'selector' is required`;
+			if (step.value === undefined) return `${where}: 'value' is required`;
+			return undefined;
+		case "select":
+			if (!step.selector?.trim()) return `${where}: 'selector' is required`;
+			if (!step.values?.length) return `${where}: 'values' is required`;
+			return undefined;
+		case "press":
+			if (!step.key?.trim()) return `${where}: 'key' is required`;
+			return undefined;
+		case "scroll":
+			if (step.dx === undefined && step.dy === undefined) return `${where}: 'dx' or 'dy' is required`;
+			return undefined;
+		case "wait":
+			if (!step.selector?.trim() && step.ms === undefined) return `${where}: 'selector' or 'ms' is required`;
+			return undefined;
+		default:
+			// back / observe / extract / screenshot take no required fields
+			return undefined;
+	}
+}
+
+/** Validate the full step list. Throws on the first invalid step. */
+export function validateActionSteps(steps: readonly BrowserActionStep[]): void {
+	if (steps.length === 0) throw new Error("browser 'act' requires a non-empty 'actions' list");
+	for (let i = 0; i < steps.length; i += 1) {
+		const error = validateActionStep(steps[i]!, i);
+		if (error) throw new Error(error);
+	}
+}
+
+/**
+ * Compile structured steps into a JS program for the in-tab `run` worker. Steps
+ * are embedded as parsed JSON (no string interpolation, so values cannot inject
+ * code) and dispatched by a fixed interpreter against the `tab` / `page` helpers.
+ */
+export function compileActionSteps(steps: readonly BrowserActionStep[]): string {
+	validateActionSteps(steps);
+	const stepsLiteral = JSON.stringify(JSON.stringify(steps));
+	return `
+const __steps = JSON.parse(${stepsLiteral});
+const __results = [];
+for (const s of __steps) {
+	switch (s.verb) {
+		case "navigate":
+			await tab.goto(s.url, s.wait_until ? { waitUntil: s.wait_until } : undefined);
+			__results.push({ verb: "navigate", url: s.url });
+			break;
+		case "click":
+			if (s.id !== undefined && s.id !== null) { await (await tab.id(s.id)).click(); }
+			else { await tab.click(s.selector); }
+			__results.push({ verb: "click", id: s.id ?? null, selector: s.selector ?? null });
+			break;
+		case "type":
+			if (s.id !== undefined && s.id !== null) { await (await tab.id(s.id)).type(s.text); }
+			else { await tab.type(s.selector, s.text); }
+			__results.push({ verb: "type", id: s.id ?? null, selector: s.selector ?? null });
+			break;
+		case "fill":
+			await tab.fill(s.selector, s.value);
+			__results.push({ verb: "fill", selector: s.selector });
+			break;
+		case "select":
+			__results.push({ verb: "select", selected: await tab.select(s.selector, ...(s.values || [])) });
+			break;
+		case "press":
+			await tab.press(s.key, s.selector ? { selector: s.selector } : undefined);
+			__results.push({ verb: "press", key: s.key });
+			break;
+		case "scroll":
+			await tab.scroll(s.dx || 0, s.dy || 0);
+			__results.push({ verb: "scroll", dx: s.dx || 0, dy: s.dy || 0 });
+			break;
+		case "back":
+			await page.goBack();
+			__results.push({ verb: "back" });
+			break;
+		case "wait":
+			if (s.selector) { await tab.waitFor(s.selector); }
+			else { await new Promise(r => setTimeout(r, s.ms)); }
+			__results.push({ verb: "wait", selector: s.selector ?? null, ms: s.ms ?? null });
+			break;
+		case "observe":
+			__results.push({ verb: "observe", observation: await tab.observe({ viewportOnly: s.viewport_only === true, includeAll: s.include_all === true }) });
+			break;
+		case "extract":
+			__results.push({ verb: "extract", content: await tab.extract(s.format || "markdown") });
+			break;
+		case "screenshot":
+			await tab.screenshot({});
+			__results.push({ verb: "screenshot" });
+			break;
+		default:
+			throw new Error("Unknown browser action verb: " + s.verb);
+	}
+}
+return __results;
+`;
+}

--- a/packages/coding-agent/test/tools/browser-actions.test.ts
+++ b/packages/coding-agent/test/tools/browser-actions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type BrowserActionStep,
+	compileActionSteps,
+	validateActionStep,
+	validateActionSteps,
+} from "@gajae-code/coding-agent/tools/browser/actions";
+
+describe("validateActionStep", () => {
+	it("requires url for navigate", () => {
+		expect(validateActionStep({ verb: "navigate" }, 0)).toContain("'url' is required");
+		expect(validateActionStep({ verb: "navigate", url: "https://x" }, 0)).toBeUndefined();
+	});
+
+	it("requires id or selector for click", () => {
+		expect(validateActionStep({ verb: "click" }, 0)).toContain("'id' or 'selector'");
+		expect(validateActionStep({ verb: "click", id: 3 }, 0)).toBeUndefined();
+		expect(validateActionStep({ verb: "click", selector: "button" }, 0)).toBeUndefined();
+	});
+
+	it("requires target and text for type", () => {
+		expect(validateActionStep({ verb: "type", id: 1 }, 0)).toContain("'text' is required");
+		expect(validateActionStep({ verb: "type", id: 1, text: "hi" }, 0)).toBeUndefined();
+	});
+
+	it("requires selector + values for select and key for press", () => {
+		expect(validateActionStep({ verb: "select", selector: "select" }, 0)).toContain("'values' is required");
+		expect(validateActionStep({ verb: "select", selector: "select", values: ["a"] }, 0)).toBeUndefined();
+		expect(validateActionStep({ verb: "press" }, 0)).toContain("'key' is required");
+	});
+
+	it("accepts back/observe/extract/screenshot without extra fields", () => {
+		for (const verb of ["back", "observe", "extract", "screenshot"] as const) {
+			expect(validateActionStep({ verb }, 0)).toBeUndefined();
+		}
+	});
+
+	it("rejects an unknown verb", () => {
+		expect(validateActionStep({ verb: "teleport" as BrowserActionStep["verb"] }, 0)).toContain("unknown verb");
+	});
+});
+
+describe("validateActionSteps", () => {
+	it("rejects an empty list", () => {
+		expect(() => validateActionSteps([])).toThrow(/non-empty/);
+	});
+	it("throws on the first invalid step", () => {
+		expect(() => validateActionSteps([{ verb: "navigate", url: "https://x" }, { verb: "click" }])).toThrow(
+			/actions\[1\]/,
+		);
+	});
+});
+
+describe("compileActionSteps", () => {
+	const steps: BrowserActionStep[] = [
+		{ verb: "navigate", url: "https://example.com", wait_until: "domcontentloaded" },
+		{ verb: "click", id: 7 },
+		{ verb: "type", selector: "input[name=q]", text: "hello" },
+		{ verb: "extract", format: "markdown" },
+	];
+
+	it("embeds the steps as injection-safe parsed JSON", () => {
+		const code = compileActionSteps(steps);
+		const match = code.match(/JSON\.parse\((".*?")\)/s);
+		expect(match).not.toBeNull();
+		const literal = match![1]!;
+		// The embedded literal is a JSON string of the steps array; decoding twice
+		// must round-trip to the original steps (proves no code interpolation).
+		const decoded = JSON.parse(JSON.parse(literal));
+		expect(decoded).toEqual(steps);
+	});
+
+	it("wires each verb onto the expected tab/page helper", () => {
+		const code = compileActionSteps([
+			{ verb: "navigate", url: "https://x" },
+			{ verb: "click", id: 1 },
+			{ verb: "type", selector: "i", text: "t" },
+			{ verb: "fill", selector: "i", value: "v" },
+			{ verb: "select", selector: "s", values: ["a"] },
+			{ verb: "press", key: "Enter" },
+			{ verb: "scroll", dy: 100 },
+			{ verb: "back" },
+			{ verb: "wait", selector: "i" },
+			{ verb: "observe" },
+			{ verb: "extract" },
+			{ verb: "screenshot" },
+		]);
+		expect(code).toContain("tab.goto(");
+		expect(code).toContain("tab.id(s.id)");
+		expect(code).toContain("tab.click(s.selector)");
+		expect(code).toContain("tab.type(s.selector, s.text)");
+		expect(code).toContain("tab.fill(s.selector, s.value)");
+		expect(code).toContain("tab.select(s.selector,");
+		expect(code).toContain("tab.press(s.key");
+		expect(code).toContain("tab.scroll(s.dx || 0, s.dy || 0)");
+		expect(code).toContain("page.goBack()");
+		expect(code).toContain("tab.waitFor(s.selector)");
+		expect(code).toContain("tab.observe(");
+		expect(code).toContain("tab.extract(s.format");
+		expect(code).toContain("tab.screenshot(");
+		expect(code.trimStart().startsWith("const __steps")).toBe(true);
+		expect(code.trimEnd().endsWith("return __results;")).toBe(true);
+	});
+
+	it("rejects invalid steps before compiling", () => {
+		expect(() => compileActionSteps([{ verb: "type", id: 1 }])).toThrow(/'text' is required/);
+	});
+
+	it("produces a syntactically valid function body", () => {
+		const code = compileActionSteps(steps);
+		// Wrapping in an async function must parse without SyntaxError.
+		expect(() => new Function("tab", "page", `return (async () => {${code}})()`)).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Why

gjc's browser tool already exposes the browser-use / computer-use **element-reference** pattern (`observe()` returns numbered `id`s), but the only way to act was authoring raw JavaScript via `run`. SOTA browser/computer-use agents expose a **structured action space**, which is more reliable and works for non-coding models.

## What

Add an `act` action that runs a list of structured verbs against an existing tab: `navigate`, `click`, `type`, `fill`, `select`, `press`, `scroll`, `back`, `wait`, `observe {viewport_only?, include_all?}`, `extract {format?}`, `screenshot`.

- New `tools/browser/actions.ts` validates each step and compiles them into injection-safe code — steps are embedded as parsed JSON (no string interpolation), dispatched by a fixed interpreter onto the existing in-tab `tab.*` helpers via the proven `runInTab` worker path. Worker protocol unchanged.
- Elements are addressed by the numeric `id` from a prior `observe` (preferred) or a selector.
- The raw-JS `run` escape hatch is unchanged; `act` is additive.

## Verification

- `bun --cwd=packages/coding-agent run check:types` and `biome` clean.
- `test/tools/browser-actions.test.ts` (12 tests): per-verb validation, empty-list guard, JSON round-trip (injection safety), verb->helper wiring, compiled-code syntactic validity.

Final PR in the custom-model capability-parity / tooling series.
