### PR TITLE
test(harness-cli): resolve workspace with realpathSync on macOS

### DIFF
--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { realpathSync } from "node:fs";
 import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -19,7 +20,7 @@ let cliEnv: HarnessCliEnv;
 
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-cli-root-"));
-	workspace = await mkdtemp(path.join(tmpdir(), "harness-cli-ws-"));
+	workspace = realpathSync(await mkdtemp(path.join(tmpdir(), "harness-cli-ws-")));
 	cliEnv = createHarnessCliEnv(repoRoot);
 });
 


### PR DESCRIPTION
## What

The harness CLI test compares a temp directory path against the workspace path returned by the child process. On macOS, `os.tmpdir()` returns `/var/folders/...` (a symlink), but the child process resolves through the OS to `/private/var/folders/...`, causing a path mismatch.

## Why

`/var` is a symlink to `/private/var` on macOS. The test uses `mkdtemp(path.join(tmpdir(), ...))` which returns the symlinked form, while the harness CLI child process returns the canonical form via OS-level path resolution. The comparison fails:

```
Expected: /var/folders/.../T/harness-cli-ws-XXX
Received: /private/var/folders/.../T/harness-cli-ws-XXX
```

CI does not hit this because the Linux runners have no such symlink.

## Testing

- `bun test packages/coding-agent/test/harness-control-plane/cli.test.ts` → 22 pass, 0 fail (was 1 fail before)
- `biome check` on the changed file → OK
- No behavior change — test-only fix

---

- [x] `bun check` passes (biome clean; pre-existing formatting issues in unrelated files unchanged)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)