### PR TITLE
fix(image): register Antigravity image provider and tolerate raw-token credentials (#447)

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2627,7 +2627,7 @@ export const SETTINGS_SCHEMA = {
 	},
 	"providers.image": {
 		type: "enum",
-		values: ["auto", "openai", "gemini", "openrouter"] as const,
+		values: ["auto", "openai", "gemini", "openrouter", "antigravity"] as const,
 		default: "auto",
 		ui: {
 			tab: "providers",
@@ -2642,6 +2642,7 @@ export const SETTINGS_SCHEMA = {
 				{ value: "openai", label: "OpenAI", description: "Uses the active GPT Responses/Codex model" },
 				{ value: "gemini", label: "Gemini", description: "Requires GEMINI_API_KEY" },
 				{ value: "openrouter", label: "OpenRouter", description: "Requires OPENROUTER_API_KEY" },
+				{ value: "antigravity", label: "Antigravity", description: "Requires login with google-antigravity" },
 			],
 		},
 	},

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -506,7 +506,13 @@ export class SelectorController {
 				}
 				break;
 			case "providers.image":
-				if (value === "auto" || value === "openai" || value === "gemini" || value === "openrouter") {
+				if (
+					value === "auto" ||
+					value === "openai" ||
+					value === "gemini" ||
+					value === "openrouter" ||
+					value === "antigravity"
+				) {
 					setPreferredImageProvider(value);
 				}
 				break;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -868,7 +868,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		imageProvider === "auto" ||
 		imageProvider === "openai" ||
 		imageProvider === "gemini" ||
-		imageProvider === "openrouter"
+		imageProvider === "openrouter" ||
+		imageProvider === "antigravity"
 	) {
 		setPreferredImageProvider(imageProvider);
 	}

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -401,23 +401,39 @@ export function setPreferredImageProvider(provider: ImageProvider | "auto"): voi
 
 interface ParsedAntigravityCredentials {
 	accessToken: string;
-	projectId: string;
+	projectId?: string;
 }
 
 function parseAntigravityCredentials(raw: string): ParsedAntigravityCredentials | null {
 	try {
-		const parsed = JSON.parse(raw) as { token?: string; projectId?: string };
-		if (parsed.token && parsed.projectId) {
-			return { accessToken: parsed.token, projectId: parsed.projectId };
+		const parsed = JSON.parse(raw) as { token?: string; accessToken?: string; projectId?: string };
+		const token = parsed.token ?? parsed.accessToken;
+		if (typeof token === "string" && token.trim().length > 0) {
+			return { accessToken: token.trim(), projectId: parsed.projectId };
 		}
+		// Parsed as JSON but no usable token field.
+		return null;
 	} catch {
-		// Invalid JSON
+		// Not JSON: treat the value as a raw bearer token.
 	}
-	return null;
+	const rawToken = raw.trim();
+	return rawToken.length > 0 ? { accessToken: rawToken } : null;
 }
 
-async function findAntigravityCredentials(modelRegistry: ModelRegistry): Promise<ImageApiKey | null> {
-	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity");
+async function findAntigravityCredentials(
+	modelRegistry: ModelRegistry,
+	sessionId?: string,
+): Promise<ImageApiKey | null> {
+	const oauthAccess = await modelRegistry.authStorage.getOAuthAccess("google-antigravity", sessionId);
+	if (oauthAccess?.accessToken) {
+		return {
+			provider: "antigravity",
+			apiKey: oauthAccess.accessToken,
+			projectId: oauthAccess.projectId,
+		};
+	}
+
+	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity", sessionId);
 	if (!apiKey) return null;
 
 	const parsed = parseAntigravityCredentials(apiKey);
@@ -457,7 +473,7 @@ async function findImageApiKey(
 		if (openAI) return openAI;
 		// Fall through to auto-detect if preferred provider key not found.
 	} else if (preferredImageProvider === "antigravity" && modelRegistry) {
-		const antigravity = await findAntigravityCredentials(modelRegistry);
+		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
 		if (antigravity) return antigravity;
 		// Fall through to auto-detect if preferred provider key not found.
 	} else if (preferredImageProvider === "gemini") {
@@ -477,7 +493,7 @@ async function findImageApiKey(
 	if (openAI) return openAI;
 
 	if (modelRegistry) {
-		const antigravity = await findAntigravityCredentials(modelRegistry);
+		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
 		if (antigravity) return antigravity;
 	}
 
@@ -995,7 +1011,9 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 			if (provider === "antigravity") {
 				if (!apiKey.projectId) {
-					throw new Error("Missing projectId in antigravity credentials");
+					throw new Error(
+						"Antigravity image generation requires a projectId, but the stored google-antigravity credential only contains an access token. Run the google-antigravity login flow again so the projectId is stored, then retry.",
+					);
 				}
 
 				const prompt = assemblePrompt(params);

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -2,9 +2,14 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import type { Model } from "@gajae-code/ai";
 import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { SETTINGS_SCHEMA } from "@gajae-code/coding-agent/config/settings-schema";
 import type { CustomToolContext } from "@gajae-code/coding-agent/extensibility/custom-tools";
 import type { ReadonlySessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import { imageGenTool, setPreferredImageProvider } from "@gajae-code/coding-agent/tools/image-gen";
+import {
+	getImageGenToolsWithRegistry,
+	imageGenTool,
+	setPreferredImageProvider,
+} from "@gajae-code/coding-agent/tools/image-gen";
 
 const originalFetch = global.fetch;
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
@@ -190,5 +195,236 @@ describe("imageGenTool", () => {
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
 		expect(requestUrl).toBe("https://api.openai.com/v1/responses");
+	});
+});
+
+const ANTIGRAVITY_URL = "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse";
+
+function antigravitySseResponse(): Response {
+	const chunk = {
+		response: {
+			candidates: [
+				{
+					content: {
+						role: "model",
+						parts: [{ inlineData: { mimeType: "image/png", data: Buffer.from("fake-png").toString("base64") } }],
+					},
+				},
+			],
+		},
+	};
+	return new Response(`data: ${JSON.stringify(chunk)}\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+const ANTIGRAVITY_MODEL = {
+	api: "google-gemini-cli",
+	provider: "google-antigravity",
+	id: "gemini-3-pro-image",
+	name: "Gemini 3 Pro Image (Antigravity)",
+	baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+} as Model;
+
+function makeAntigravityCtx(modelRegistry: Partial<ModelRegistry>): CustomToolContext {
+	return {
+		sessionManager: {
+			getCwd: () => "/tmp",
+			getSessionId: () => "test-session",
+		} as unknown as ReadonlySessionManager,
+		modelRegistry: modelRegistry as unknown as ModelRegistry,
+		model: ANTIGRAVITY_MODEL,
+		isIdle: () => true,
+		hasQueuedMessages: () => false,
+		abort: () => {},
+	};
+}
+
+describe("providers.image settings schema", () => {
+	it("accepts antigravity and does not include openai-codex", () => {
+		const values = SETTINGS_SCHEMA["providers.image"].values as readonly string[];
+		expect(values).toContain("antigravity");
+		expect(values).not.toContain("openai-codex");
+	});
+});
+
+describe("imageGenTool antigravity provider", () => {
+	it("uses structured getOAuthAccess metadata (access token + projectId) for the request", async () => {
+		setPreferredImageProvider("antigravity");
+		let requestUrl: string | undefined;
+		let authorization: string | undefined;
+		let requestBody: { project?: string } | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+			requestBody = JSON.parse(String(init?.body));
+			return antigravitySseResponse();
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const ctx = makeAntigravityCtx({
+			authStorage: {
+				getOAuthAccess: async () => ({ accessToken: "oauth-token", projectId: "project-1" }),
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () => {
+				throw new Error("getApiKeyForProvider should not be called when OAuth metadata is present");
+			},
+		});
+
+		const result = await imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe(ANTIGRAVITY_URL);
+		expect(authorization).toBe("Bearer oauth-token");
+		expect(requestBody?.project).toBe("project-1");
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
+	it("falls back to JSON-parsed getApiKeyForProvider credentials when OAuth access is absent", async () => {
+		setPreferredImageProvider("antigravity");
+		let authorization: string | undefined;
+		let requestBody: { project?: string } | undefined;
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+			requestBody = JSON.parse(String(init?.body));
+			return antigravitySseResponse();
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const ctx = makeAntigravityCtx({
+			authStorage: {
+				getOAuthAccess: async () => undefined,
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () => JSON.stringify({ token: "json-token", projectId: "project-json" }),
+		});
+
+		const result = await imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(authorization).toBe("Bearer json-token");
+		expect(requestBody?.project).toBe("project-json");
+	});
+
+	it("does not register for malformed JSON credentials without a token field", async () => {
+		setPreferredImageProvider("antigravity");
+
+		const modelRegistry = {
+			authStorage: {
+				getOAuthAccess: async () => undefined,
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () => JSON.stringify({ projectId: "project-without-token" }),
+		} as unknown as ModelRegistry;
+
+		const tools = await getImageGenToolsWithRegistry(modelRegistry, ANTIGRAVITY_MODEL);
+		expect(tools).toHaveLength(0);
+	});
+
+	it("does not register for empty or whitespace antigravity credentials", async () => {
+		setPreferredImageProvider("antigravity");
+
+		for (const credential of ["", "   \n\t  "]) {
+			const modelRegistry = {
+				authStorage: {
+					getOAuthAccess: async () => undefined,
+				} as unknown as ModelRegistry["authStorage"],
+				getApiKeyForProvider: async () => credential,
+			} as unknown as ModelRegistry;
+
+			const tools = await getImageGenToolsWithRegistry(modelRegistry, ANTIGRAVITY_MODEL);
+			expect(tools).toHaveLength(0);
+		}
+	});
+
+	it("accepts JSON credentials with accessToken and honors projectId", async () => {
+		setPreferredImageProvider("antigravity");
+		let authorization: string | undefined;
+		let requestBody: { project?: string } | undefined;
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+			requestBody = JSON.parse(String(init?.body));
+			return antigravitySseResponse();
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const ctx = makeAntigravityCtx({
+			authStorage: {
+				getOAuthAccess: async () => undefined,
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () =>
+				JSON.stringify({ accessToken: "access-token-json", projectId: "project-access" }),
+		});
+
+		const result = await imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(authorization).toBe("Bearer access-token-json");
+		expect(requestBody?.project).toBe("project-access");
+		expect(result.details?.provider).toBe("antigravity");
+	});
+
+	it("registers OAuth access without projectId but fails loudly before fetch", async () => {
+		setPreferredImageProvider("antigravity");
+		let fetchCalled = false;
+		const fetchMock: typeof fetch = (async () => {
+			fetchCalled = true;
+			return antigravitySseResponse();
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const modelRegistry = {
+			authStorage: {
+				getOAuthAccess: async () => ({ accessToken: "oauth-token-without-project" }),
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () => {
+				throw new Error("getApiKeyForProvider should not be called when OAuth access token is present");
+			},
+		} as unknown as ModelRegistry;
+
+		const tools = await getImageGenToolsWithRegistry(modelRegistry, ANTIGRAVITY_MODEL);
+		expect(tools).toHaveLength(1);
+
+		const ctx = makeAntigravityCtx(modelRegistry);
+		await expect(imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			/projectId.*google-antigravity|google-antigravity.*projectId/s,
+		);
+		await expect(imageGenTool.execute("call-2", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(/login/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("registers the tool for a raw-token-only credential but fails loudly without a projectId", async () => {
+		setPreferredImageProvider("antigravity");
+		let fetchCalled = false;
+		const fetchMock: typeof fetch = (async () => {
+			fetchCalled = true;
+			return antigravitySseResponse();
+		}) as unknown as typeof fetch;
+		fetchMock.preconnect = originalFetch.preconnect;
+		global.fetch = fetchMock;
+
+		const modelRegistry = {
+			authStorage: {
+				getOAuthAccess: async () => undefined,
+			} as unknown as ModelRegistry["authStorage"],
+			getApiKeyForProvider: async () => "raw-token",
+		} as unknown as ModelRegistry;
+
+		const tools = await getImageGenToolsWithRegistry(modelRegistry, ANTIGRAVITY_MODEL);
+		expect(tools).toHaveLength(1);
+
+		const ctx = makeAntigravityCtx(modelRegistry);
+		await expect(imageGenTool.execute("call-1", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			/projectId.*google-antigravity|google-antigravity.*projectId/s,
+		);
+		await expect(imageGenTool.execute("call-2", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(/login/);
+		expect(fetchCalled).toBe(false);
 	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1836,7 +1836,8 @@
 						"auto",
 						"openai",
 						"gemini",
-						"openrouter"
+						"openrouter",
+						"antigravity"
 					],
 					"description": "Provider for image generation tool",
 					"default": "auto"


### PR DESCRIPTION
## Summary
Fixes #447. Image generation tool registration failed for the Antigravity provider in two related ways:

1. **Provider enum gap** — `image-gen.ts` supported an `antigravity` image provider, but the `providers.image` enum / runtime preference gates did not, so `providers.image: "antigravity"` was silently dropped.
2. **Raw-token credential parsing** — `findAntigravityCredentials` only accepted a JSON `{token, projectId}` blob from `getApiKeyForProvider`. When the credential resolved to a raw bearer token (api_key / env / config-override forms), `JSON.parse` failed and the image tool was **silently unregistered**.

## Changes
- Add `"antigravity"` to the `providers.image` enum + UI option (`settings-schema.ts`), the startup validation gate (`sdk.ts`), and the live settings handler (`selector-controller.ts`). Regenerated `config.schema.json`.
- Rework Antigravity credential resolution to prefer structured `modelRegistry.authStorage.getOAuthAccess()` (access token **+ projectId**), then JSON `{token|accessToken, projectId}`, then a trimmed raw bearer token. `sessionId` is threaded through both lookup sites.
- Raw-token-only credentials now **keep the tool registered** and fail loudly at execution with an actionable re-login diagnostic (instead of silently dropping the tool).
- Scope is `antigravity` only — `openai-codex` intentionally NOT added.

## Tests
`packages/coding-agent/test/tools/image-gen.test.ts` (11 pass): enum accepts antigravity & excludes openai-codex; OAuth-access path supplies projectId; JSON fallback (`token` and `accessToken`); raw-token-only registers + execute throws diagnostic (substrings `projectId`/`google-antigravity`/`login`) with no network call; malformed/empty credentials do not register; no OpenAI regression.

## Verification
- `bun test packages/coding-agent/test/tools/image-gen.test.ts` → 11 pass / 0 fail
- `bun run check:ts` (biome lint + tsgo typecheck across workspaces + schema check) → clean

Planned via GJC deep-interview → ralplan consensus (Planner/Architect/Critic) → ultragoal execution with architect + adversarial QA gates (both APPROVE / passed).