### PR TITLE
fix(ultragoal): scope pending goal-mode request to producing session (#457)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Fixed a persistent `monitor` notification flood where a cancelled or evicted monitor kept delivering queued `task-notification` follow-ups (surviving process death, log deletion, and `job cancel` returning not-found). Monitors now purge their queued notifications on cancel/terminal/eviction, retain a short tombstone so post-eviction `job cancel` still purges, coalesce rapid duplicate output to the latest state, and close a cancel/trailing-flush race.
+- Fixed `ultragoal` execution leaking across concurrent independent GJC sessions. The runtime `goal-mode-request.json` is now stamped with the producing session's `GJC_SESSION_ID`, and the consumer only activates a request that belongs to the current session (another session's request is left intact instead of being consumed/deleted). Legacy unscoped requests remain consumable for single-session compatibility ([#457](https://github.com/Yeachan-Heo/gajae-code/issues/457)).
 
 ## [0.4.2] - 2026-06-09
 

--- a/packages/coding-agent/src/commands/ultragoal.ts
+++ b/packages/coding-agent/src/commands/ultragoal.ts
@@ -1,6 +1,7 @@
 import { Command } from "@gajae-code/utils/cli";
 import {
 	GJC_SESSION_FILE_ENV,
+	GJC_SESSION_ID_ENV,
 	isUltragoalCreateGoalsInvocation,
 	readUltragoalGjcObjective,
 	writeCurrentSessionGoalModeState,
@@ -28,6 +29,11 @@ export default class Ultragoal extends Command {
 			sessionFile: process.env[GJC_SESSION_FILE_ENV],
 			objective,
 		});
-		await writePendingGoalModeRequest({ cwd, objective, goalsPath });
+		await writePendingGoalModeRequest({
+			cwd,
+			objective,
+			goalsPath,
+			sessionId: process.env[GJC_SESSION_ID_ENV],
+		});
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -25,6 +25,12 @@ export interface PendingGoalModeRequest {
 	objective: string;
 	createdAt: string;
 	goalsPath?: string;
+	/**
+	 * Session id that produced this request (from GJC_SESSION_ID). When present,
+	 * only the originating session may consume it, so concurrent sessions sharing
+	 * the same `.gjc` project state never auto-run each other's ultragoal.
+	 */
+	sessionId?: string;
 }
 
 export type CurrentSessionGoalModeWriteResult =
@@ -77,9 +83,11 @@ export async function writePendingGoalModeRequest(input: {
 	cwd: string;
 	objective: string;
 	goalsPath?: string;
+	sessionId?: string | null;
 }): Promise<PendingGoalModeRequest> {
 	const objective = input.objective.trim();
 	if (!objective) throw new Error("goal objective is required");
+	const sessionId = input.sessionId?.trim();
 	const request: PendingGoalModeRequest = {
 		version: REQUEST_VERSION,
 		kind: "goal_mode_request",
@@ -87,6 +95,7 @@ export async function writePendingGoalModeRequest(input: {
 		objective,
 		createdAt: new Date().toISOString(),
 		goalsPath: input.goalsPath,
+		...(sessionId ? { sessionId } : {}),
 	};
 	const filePath = requestPath(input.cwd);
 	await writeJsonAtomic(filePath, request, {
@@ -162,7 +171,10 @@ export async function writeCurrentSessionGoalModeState(input: {
 	return { status: "updated", goal: state.goal, sessionFile };
 }
 
-export async function consumePendingGoalModeRequest(cwd: string): Promise<PendingGoalModeRequest | null> {
+export async function consumePendingGoalModeRequest(
+	cwd: string,
+	currentSessionId?: string | null,
+): Promise<PendingGoalModeRequest | null> {
 	const filePath = requestPath(cwd);
 	let raw: unknown;
 	try {
@@ -179,6 +191,14 @@ export async function consumePendingGoalModeRequest(cwd: string): Promise<Pendin
 		typeof candidate.objective !== "string" ||
 		candidate.objective.trim().length === 0
 	) {
+		return null;
+	}
+	// Session isolation: a request stamped with an owning session id may only be
+	// consumed by that same session. Leave another session's request untouched
+	// (do not delete it) so its rightful owner can still pick it up. Legacy/unscoped
+	// requests (no sessionId) remain consumable by any session in this cwd.
+	const ownerSessionId = typeof candidate.sessionId === "string" ? candidate.sessionId.trim() : "";
+	if (ownerSessionId && ownerSessionId !== (currentSessionId?.trim() ?? "")) {
 		return null;
 	}
 	await removeFileAudited(filePath, {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1156,7 +1156,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#updateGoalModeStatus();
 			return;
 		}
-		const pendingGoal = goalEnabled ? await consumePendingGoalModeRequest(this.sessionManager.getCwd()) : null;
+		const pendingGoal = goalEnabled
+			? await consumePendingGoalModeRequest(this.sessionManager.getCwd(), this.sessionManager.getSessionId())
+			: null;
 		if (pendingGoal) {
 			await this.#enterGoalMode({ objective: pendingGoal.objective, silent: true });
 			this.#scheduleGoalContinuation();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4372,7 +4372,10 @@ export class AgentSession {
 
 	async #activatePendingGjcGoalModeRequest(): Promise<boolean> {
 		if (!this.settings.get("goal.enabled")) return false;
-		const pendingGoal = await consumePendingGoalModeRequest(this.sessionManager.getCwd());
+		const pendingGoal = await consumePendingGoalModeRequest(
+			this.sessionManager.getCwd(),
+			this.sessionManager.getSessionId(),
+		);
 		if (!pendingGoal) return false;
 		const currentState = this.getGoalModeState();
 		if (currentState?.goal && currentState.goal.status !== "complete" && currentState.goal.status !== "dropped") {

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import {
 	consumePendingGoalModeRequest,
 	GJC_SESSION_FILE_ENV,
+	GJC_SESSION_ID_ENV,
 	isUltragoalCreateGoalsInvocation,
 	readUltragoalGjcObjective,
 	writeCurrentSessionGoalModeState,
@@ -58,6 +59,50 @@ describe("GJC ultragoal goal mode request", () => {
 		expect(request?.objective).toBe("Complete ultragoal");
 		expect(request?.source).toBe("ultragoal");
 		expect(consumedAgain).toBeNull();
+	});
+
+	it("does not let a concurrent session consume another session's pending request", async () => {
+		const root = await tempDir();
+		await writePendingGoalModeRequest({
+			cwd: root,
+			objective: "Complete ultragoal",
+			goalsPath: "goals.json",
+			sessionId: "session-A",
+		});
+
+		// A different, independent session must not pick up session-A's request.
+		const leaked = await consumePendingGoalModeRequest(root, "session-B");
+		expect(leaked).toBeNull();
+
+		// The request is left intact for its rightful owner to consume.
+		const owned = await consumePendingGoalModeRequest(root, "session-A");
+		expect(owned?.objective).toBe("Complete ultragoal");
+		expect(owned?.sessionId).toBe("session-A");
+
+		// Once consumed by the owner it is gone for everyone.
+		expect(await consumePendingGoalModeRequest(root, "session-A")).toBeNull();
+	});
+
+	it("lets the owning session consume its own session-scoped request", async () => {
+		const root = await tempDir();
+		await writePendingGoalModeRequest({
+			cwd: root,
+			objective: "Complete ultragoal",
+			sessionId: "session-A",
+		});
+
+		const owned = await consumePendingGoalModeRequest(root, "session-A");
+		expect(owned?.sessionId).toBe("session-A");
+	});
+
+	it("keeps consuming legacy unscoped requests from any session", async () => {
+		const root = await tempDir();
+		await writePendingGoalModeRequest({ cwd: root, objective: "Complete ultragoal" });
+
+		// No sessionId stamped (legacy/CLI-only producer) → consumable by any session.
+		const request = await consumePendingGoalModeRequest(root, "session-X");
+		expect(request?.objective).toBe("Complete ultragoal");
+		expect(request?.sessionId).toBeUndefined();
 	});
 
 	it("writes goal mode state into the current session file", async () => {
@@ -208,16 +253,21 @@ describe("GJC ultragoal goal mode request", () => {
 		);
 
 		const cliPath = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+
 		const result = Bun.spawnSync(["bun", cliPath, "ultragoal", "create-goals", "--brief", "Ship native goal"], {
 			cwd: root,
-			env: { ...process.env, [GJC_SESSION_FILE_ENV]: sessionFile },
+			env: { ...process.env, [GJC_SESSION_FILE_ENV]: sessionFile, [GJC_SESSION_ID_ENV]: "session-owner" },
 			stdout: "pipe",
 			stderr: "pipe",
 		});
 
 		expect(result.exitCode, result.stderr.toString()).toBe(0);
-		const pending = await consumePendingGoalModeRequest(root);
+		// The pending request is stamped with the producing session and must not
+		// leak into a concurrent independent session sharing the same cwd.
+		expect(await consumePendingGoalModeRequest(root, "other-session")).toBeNull();
+		const pending = await consumePendingGoalModeRequest(root, "session-owner");
 		expect(pending?.objective).toContain(".gjc/ultragoal/goals.json");
+		expect(pending?.sessionId).toBe("session-owner");
 		const entries = (await loadEntriesFromFile(sessionFile)).filter(
 			(entry): entry is SessionEntry => entry.type !== "session",
 		);


### PR DESCRIPTION
## Summary

Fixes #457 — `ultragoal` execution leaking across concurrent independent GJC sessions.

`gjc ultragoal create-goals` writes a pending runtime activation request to a **cwd-scoped** file `.gjc/state/goal-mode-request.json` with no session binding. The interactive session then consumes it to enter goal mode. Because the file is keyed only by project cwd, a second concurrent session sharing the same project would consume session A's pending request and auto-run its ultragoal.

## Fix

- **Producer** (`gjc ultragoal create-goals`): stamp the pending request with the producing session's `GJC_SESSION_ID`.
- **Consumer** (`consumePendingGoalModeRequest`): pass the current session id; only activate a request whose owning session id matches. Another session's request is **left intact** (not consumed/deleted) so its rightful owner can still pick it up.
- **Backward compat**: legacy/unscoped requests (no `sessionId`, e.g. direct CLI use outside a session) remain consumable by any session, preserving single-session behavior.

## Files

- `src/gjc-runtime/goal-mode-request.ts` — `sessionId` on the request; scope-checked consume.
- `src/commands/ultragoal.ts` — stamp `GJC_SESSION_ID`.
- `src/session/agent-session.ts`, `src/modes/interactive-mode.ts` — pass current session id to consumer.
- `test/gjc-runtime/goal-mode-request.test.ts` — regression tests for concurrent-session isolation + end-to-end CLI scoping.

## Verification

- `bun test test/gjc-runtime/goal-mode-request.test.ts` → 12 pass.
- Typecheck (LSP) and biome lint clean on all changed files.
- 4 pre-existing failures in `ultragoal-runtime.test.ts` / `state-handoff-thrift.test.ts` are environment-specific (TMPDIR `/tmp` path + `EISDIR`) and reproduce on the base branch without these changes.