### PR TITLE
fix(tui): fix Korean UTF-8 paste mojibake in terminal input (#454)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Korean (and other multi-byte UTF-8) paste mojibake in terminal input: `StdinBuffer` is now the single raw-stdin decoding boundary using a persistent `StringDecoder`, so multi-byte characters split across stdin read boundaries are reassembled instead of producing U+FFFD. `ProcessTerminal` no longer relies on `process.stdin.setEncoding("utf8")` and forwards raw Buffers; the legacy single-high-byte meta conversion is preserved. (#454)
+
 ## [0.4.0] - 2026-06-06
 
 ### Changed

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -17,6 +17,7 @@
  * MIT License - Copyright (c) 2025 opentui
  */
 import { EventEmitter } from "events";
+import { StringDecoder } from "node:string_decoder";
 
 const ESC = "\x1b";
 const BRACKETED_PASTE_START = "\x1b[200~";
@@ -246,6 +247,13 @@ export type StdinBufferEventMap = {
 /**
  * Buffers stdin input and emits complete sequences via the 'data' event.
  * Handles partial escape sequences that arrive across multiple chunks.
+ *
+ * StdinBuffer is the single raw-stdin decoding boundary: raw terminal bytes
+ * enter via `process()` and decoded string events leave via the 'data' and
+ * 'paste' events. UTF-8 is decoded exactly once here (using a persistent
+ * StringDecoder) so multi-byte characters split across chunk boundaries are
+ * reassembled rather than corrupted into U+FFFD. All downstream parsing
+ * (escape sequences, bracketed paste, Kitty/CSI, OSC/DA1) operates on strings.
  */
 export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	#buffer: string = "";
@@ -254,6 +262,11 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	#pasteMode: boolean = false;
 	#pasteBuffer: string = "";
 	#pendingKittyPrintableCodepoint: number | undefined;
+	// Persistent UTF-8 decoder. Holds an incomplete trailing multi-byte
+	// sequence between chunks so split reads (e.g. a 3-byte Korean syllable
+	// split across two stdin events) reassemble correctly instead of emitting
+	// U+FFFD. Reset on clear()/destroy(); never finalized on normal flush.
+	#decoder = new StringDecoder("utf8");
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
@@ -267,22 +280,38 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			this.#timeout = undefined;
 		}
 
-		// Handle high-byte conversion (for compatibility with parseKeypress)
-		// If buffer has single byte > 127, convert to ESC + (byte - 128)
+		// Decode raw bytes into a string. Buffers come from raw stdin; strings
+		// come from tests or non-terminal callers and are already decoded.
 		let str: string;
+		let decodedFromBuffer = false;
 		if (Buffer.isBuffer(data)) {
+			// Legacy 8-bit meta: an isolated high byte (0x80-0xFF) is treated
+			// as ESC + (byte - 128) for Alt/meta compatibility, BEFORE UTF-8
+			// decoding. This is the one documented exception to UTF-8 boundary
+			// decoding — a lone high byte that is also a valid UTF-8 lead byte
+			// is still read as meta — so such a byte is never fed to the decoder.
 			if (data.length === 1 && data[0]! > 127) {
 				const byte = data[0]! - 128;
 				str = `\x1b${String.fromCharCode(byte)}`;
 			} else {
-				str = data.toString();
+				// Decode through the persistent StringDecoder so a multi-byte
+				// sequence split across chunks (e.g. a 3-byte Korean syllable)
+				// is reassembled instead of emitting U+FFFD.
+				str = this.#decoder.write(data);
+				decodedFromBuffer = true;
 			}
 		} else {
 			str = data;
 		}
 
 		if (str.length === 0 && this.#buffer.length === 0) {
-			this.#emitDataSequence("");
+			// A Buffer that decoded to nothing means the decoder is holding an
+			// incomplete UTF-8 prefix; emit nothing and wait for the completing
+			// bytes. Preserve the historical empty 'data' event for explicit
+			// empty-string input only.
+			if (!decodedFromBuffer) {
+				this.#emitDataSequence("");
+			}
 			return;
 		}
 
@@ -398,6 +427,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#pasteMode = false;
 		this.#pasteBuffer = "";
 		this.#pendingKittyPrintableCodepoint = undefined;
+		// Drop any incomplete multi-byte sequence the decoder is holding so a
+		// stale partial prefix cannot combine with future input. destroy()
+		// resets the decoder by calling clear().
+		this.#decoder = new StringDecoder("utf8");
 	}
 
 	getBuffer(): string {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -123,7 +123,7 @@ export class ProcessTerminal implements Terminal {
 	#modifyOtherKeysActive = false;
 	#modifyOtherKeysTimeout?: Timer;
 	#stdinBuffer?: StdinBuffer;
-	#stdinDataHandler?: (data: string) => void;
+	#stdinDataHandler?: (data: string | Buffer) => void;
 	#dead = false;
 	#writeLogPath = $env.PI_TUI_WRITE_LOG || "";
 	#detachLogPath = $env.PI_TUI_TERMINAL_DETACH_LOG || "";
@@ -165,7 +165,11 @@ export class ProcessTerminal implements Terminal {
 		if (process.stdin.setRawMode) {
 			process.stdin.setRawMode(true);
 		}
-		process.stdin.setEncoding("utf8");
+		// Do NOT setEncoding("utf8"): raw stdin chunks may split a multi-byte
+		// UTF-8 character across reads, and Bun's raw-TTY string decoding does
+		// not reliably reassemble them (issue #454 — Korean paste mojibake).
+		// StdinBuffer is the single decoding boundary and decodes Buffers via a
+		// persistent StringDecoder, so we forward raw Buffers untouched.
 		process.stdin.resume();
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
@@ -420,7 +424,7 @@ export class ProcessTerminal implements Terminal {
 		});
 
 		// Handler that pipes stdin data through the buffer
-		this.#stdinDataHandler = (data: string) => {
+		this.#stdinDataHandler = (data: string | Buffer) => {
 			this.#stdinBuffer!.process(data);
 		};
 	}

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -327,4 +327,113 @@ describe("StdinBuffer", () => {
 			expect(emittedSequences).toEqual([]);
 		});
 	});
+
+	describe("UTF-8 multi-byte decoding (issue #454)", () => {
+		let emittedPaste: string[];
+
+		beforeEach(() => {
+			buffer = new StdinBuffer({ timeout: 10 });
+			emittedSequences = [];
+			buffer.on("data", (sequence: string) => {
+				emittedSequences.push(sequence);
+			});
+			emittedPaste = [];
+			buffer.on("paste", (data: string) => {
+				emittedPaste.push(data);
+			});
+		});
+
+		it("reassembles a Korean syllable split across Buffer chunks", () => {
+			const source = "화면 기록";
+			const bytes = Buffer.from(source, "utf8");
+			// Split inside the first 3-byte syllable (after 2 of 3 bytes).
+			processInput(bytes.subarray(0, 2));
+			expect(emittedSequences).toEqual([]); // decoder holds the partial prefix
+
+			processInput(bytes.subarray(2));
+			expect(emittedSequences.join("")).toBe(source);
+			expect(emittedSequences.join("")).not.toContain("\uFFFD");
+		});
+
+		it("reassembles a bracketed Korean paste split mid-syllable and mid-marker", () => {
+			const content = "화면 기록";
+			const full = Buffer.from(`\x1b[200~${content}\x1b[201~`, "utf8");
+			// Split inside the Korean content and again inside the end marker.
+			const markerStart = Buffer.byteLength("\x1b[200~", "utf8");
+			processInput(full.subarray(0, markerStart + 2)); // mid first syllable
+			processInput(full.subarray(markerStart + 2, full.length - 3)); // mid end marker
+			processInput(full.subarray(full.length - 3));
+
+			expect(emittedPaste).toEqual([content]);
+			expect(emittedPaste.join("")).not.toContain("\uFFFD");
+			expect(emittedSequences).toEqual([]); // no data events during paste
+		});
+
+		it("reassembles a large multi-line Korean paste chunked at awkward byte offsets", () => {
+			const content = Array.from({ length: 40 }, (_, i) => `src/화면/기록-${i}.ts`).join("\n");
+			const full = Buffer.from(`\x1b[200~${content}\x1b[201~`, "utf8");
+			// Feed in fixed 5-byte chunks so most boundaries split a multi-byte char.
+			for (let i = 0; i < full.length; i += 5) {
+				processInput(full.subarray(i, i + 5));
+			}
+			expect(emittedPaste).toEqual([content]);
+			expect(emittedPaste.join("")).not.toContain("\uFFFD");
+		});
+
+		it("reassembles mixed ASCII, Korean, and emoji split inside multi-byte chars", () => {
+			const source = "a화b\u{1f389}c";
+			const bytes = Buffer.from(source, "utf8");
+			// Split inside the 3-byte Korean syllable and inside the 4-byte emoji.
+			const koreanStart = 1; // after "a"
+			const emojiStart = koreanStart + 3 + 1; // after Korean + "b"
+			processInput(bytes.subarray(0, koreanStart + 2));
+			processInput(bytes.subarray(koreanStart + 2, emojiStart + 2));
+			processInput(bytes.subarray(emojiStart + 2));
+
+			expect(emittedSequences.join("")).toBe(source);
+			expect(emittedSequences.join("")).not.toContain("\uFFFD");
+		});
+
+		it("does not emit or corrupt a trailing incomplete sequence on flush", () => {
+			const bytes = Buffer.from("화", "utf8");
+			processInput(bytes.subarray(0, 2));
+			expect(emittedSequences).toEqual([]);
+
+			// Normal flush must not finalize the decoder: held bytes stay held.
+			expect(buffer.flush()).toEqual([]);
+			expect(emittedSequences).toEqual([]);
+
+			// The completing bytes (remainder grouped with following text, as a
+			// real terminal delivers them) still produce the full character.
+			processInput(Buffer.concat([bytes.subarray(2), Buffer.from("x", "utf8")]));
+			expect(emittedSequences.join("")).toBe("화x");
+			expect(emittedSequences.join("")).not.toContain("\uFFFD");
+		});
+
+		it("resets decoder state on clear() so a stale prefix cannot complete", () => {
+			const bytes = Buffer.from("화", "utf8");
+			processInput(bytes.subarray(0, 2));
+			buffer.clear();
+
+			processInput(bytes.subarray(2));
+			expect(emittedSequences.join("")).not.toBe("화");
+		});
+
+		it("resets decoder state on destroy() so a stale prefix cannot complete", () => {
+			const bytes = Buffer.from("화", "utf8");
+			processInput(bytes.subarray(0, 2));
+			buffer.destroy();
+
+			processInput(bytes.subarray(2));
+			expect(emittedSequences.join("")).not.toBe("화");
+		});
+
+		it("preserves legacy single-high-byte meta conversion (ESC + byte-128)", () => {
+			// An isolated high byte is read as Alt/meta, not fed to the UTF-8
+			// decoder. 0xE1 (225) -> ESC + char(97) = ESC + "a".
+			processInput(Buffer.from([0xe1]));
+			expect(emittedSequences).toEqual(["\x1ba"]);
+			expect(emittedSequences.join("")).not.toContain("\uFFFD");
+		});
+	});
 });

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -330,3 +330,75 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		terminal.stop();
 	});
 });
+
+describe("ProcessTerminal raw-Buffer stdin (issue #454)", () => {
+	beforeEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdin, "setRawMode", { value: vi.fn(), configurable: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
+		restoreProperty(process, "platform", processPlatformDescriptor);
+		restoreEnv("WSL_INTEROP", originalWslInterop);
+		restoreEnv("WSL_DISTRO_NAME", originalWslDistroName);
+	});
+
+	function setupTerminal() {
+		const received: string[] = [];
+		vi.spyOn(process, "kill").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		const setEncodingSpy = vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			data => received.push(data),
+			() => {},
+		);
+
+		return { terminal, received, setEncodingSpy };
+	}
+
+	it("does not call setEncoding('utf8') on start", () => {
+		const { terminal, setEncodingSpy } = setupTerminal();
+		expect(setEncodingSpy).not.toHaveBeenCalled();
+		terminal.stop();
+	});
+
+	it("delivers a Korean bracketed paste split mid-syllable from raw Buffers unchanged", () => {
+		const { terminal, received } = setupTerminal();
+
+		const content = "화면 기록";
+		const full = Buffer.from(`\x1b[200~${content}\x1b[201~`, "utf8");
+		const markerStart = Buffer.byteLength("\x1b[200~", "utf8");
+		// Split inside the first Korean syllable and inside the end marker.
+		process.stdin.emit("data", full.subarray(0, markerStart + 2));
+		process.stdin.emit("data", full.subarray(markerStart + 2, full.length - 3));
+		process.stdin.emit("data", full.subarray(full.length - 3));
+
+		// Terminal re-wraps decoded paste content in bracketed markers.
+		expect(received).toContain(`\x1b[200~${content}\x1b[201~`);
+		expect(received.join("")).not.toContain("\uFFFD");
+
+		terminal.stop();
+	});
+
+	it("decodes Buffer-emitted OSC 11 + DA1 protocol responses without leaking to input", () => {
+		const { terminal, received } = setupTerminal();
+
+		process.stdin.emit("data", Buffer.from("\x1b]11;rgb:0000/0000/0000\x07", "utf8"));
+		process.stdin.emit("data", Buffer.from("\x1b[?1;2c", "utf8"));
+
+		expect(terminal.appearance).toBe("dark");
+		expect(received).toEqual([]);
+
+		terminal.stop();
+	});
+});


### PR DESCRIPTION
## Summary
Fixes #454 — Korean (and other multi-byte UTF-8) paste produced mojibake (U+FFFD) in the TUI terminal input.

**Root cause:** `StdinBuffer.process()` decoded each raw stdin Buffer chunk with a naive per-chunk `data.toString()` and kept no decoder state between chunks. When a multi-byte character (Korean syllables are 3 UTF-8 bytes) was split across an OS read boundary, each half decoded independently into U+FFFD. Correctness leaned on Bun's raw-mode TTY `process.stdin.setEncoding("utf8")` reassembling split reads, which is unreliable.

## Fix
- **`StdinBuffer` is now the single raw-stdin decoding boundary** using a persistent `node:string_decoder` `StringDecoder`. Incomplete trailing multi-byte sequences are held until the completing bytes arrive, then emitted as correct codepoints.
- Decoder is **reset on `clear()`/`destroy()`** and is **never finalized on normal `flush()`/timeout**, so a trailing partial is neither dropped nor turned into a premature U+FFFD.
- The **legacy single-high-byte meta conversion** (`ESC + byte-128`) is preserved as the one documented boundary exception (a lone high byte is read as Alt/meta, not fed to the decoder).
- **`ProcessTerminal`** stops calling `setEncoding("utf8")` and forwards raw Buffers; the stdin handler is widened to `string | Buffer`. `drainInput()` stays byte-agnostic, and Kitty/DA1/OSC/Mode 2031 consumers keep receiving decoded string events.

This is distinct from (and leaves intact) the existing NFD→NFC paste normalization, which addresses cursor drift, not byte-level mojibake.

## Tests
- `packages/tui/test/stdin-buffer.test.ts`: split-mid-syllable Korean, bracketed paste split mid-syllable + mid-marker, large multiline paste chunked at awkward offsets, mixed ASCII+Korean+emoji, trailing-incomplete flush (no premature U+FFFD), `clear()`/`destroy()` decoder reset, and legacy meta-byte regression.
- `packages/tui/test/terminal-appearance.test.ts`: `ProcessTerminal` raw-Buffer Korean bracketed paste reaches the input handler unchanged, Buffer-based OSC 11/DA1 protocol responses decode without leaking to input, and `setEncoding` is not called on start.

## Verification
- `bun test` (packages/tui): **447 pass / 0 fail** across 32 files.
- `biome check` on changed files: clean.
- Note: `tsgo`/`tsc` is not installed in this worktree, so the repo's canonical typecheck could not be run here; changes are type-reviewed (handler widened to `string | Buffer` matching `StdinBuffer.process`).

## Plan
Implemented per the approved ralplan consensus plan (Architect CLEAR+APPROVE, Critic APPROVE), run `2026-06-09-0841-711b`.