### PR TITLE
fix(tui): keep btw panel dismissable with Esc (#455)

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -51,6 +51,13 @@ type PastePendingClearReason = "timeout" | "queue-limit";
  */
 export class CustomEditor extends Editor {
 	onEscape?: () => void;
+	/**
+	 * Optional high-priority interrupt consumer. Invoked when the interrupt key
+	 * is pressed, before `onEscape`. Returning `true` consumes the keystroke.
+	 * Used so a transient UI (e.g. the btw panel) stays dismissable even while
+	 * another controller has temporarily installed its own `onEscape` handler.
+	 */
+	onInterruptPriority?: () => boolean;
 	shouldBypassAutocompleteOnEscape?: () => boolean;
 	onClear?: () => void;
 	onExit?: () => void;
@@ -285,10 +292,19 @@ export class CustomEditor extends Editor {
 
 		// Intercept configured interrupt shortcut.
 		// Default behavior keeps autocomplete dismissal, but parent can prioritize global interrupt handling.
-		if (this.#matchesAction(data, "app.interrupt") && this.onEscape) {
+		if (this.#matchesAction(data, "app.interrupt")) {
 			if (!this.isShowingAutocomplete() || this.shouldBypassAutocompleteOnEscape?.()) {
-				this.onEscape();
-				return;
+				// A priority interrupt consumer (e.g. an open btw panel) must win over any
+				// transient onEscape handler other controllers install (auto-compaction,
+				// auto-retry, manual compaction, etc.) so dismissal stays wired regardless
+				// of which handler currently owns onEscape.
+				if (this.onInterruptPriority?.()) {
+					return;
+				}
+				if (this.onEscape) {
+					this.onEscape();
+					return;
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -64,6 +64,11 @@ export class InputController {
 					this.ctx.autoCompactionEscapeHandler ||
 					this.ctx.retryEscapeHandler,
 			);
+		// An open btw panel must stay dismissable with Esc even while another
+		// controller (auto-compaction, auto-retry, manual compaction, etc.) has
+		// temporarily replaced editor.onEscape. This priority hook is never
+		// swapped out, so it always wins for the interrupt key.
+		this.ctx.editor.onInterruptPriority = () => (this.ctx.hasActiveBtw() ? this.ctx.handleBtwEscape() : false);
 		this.ctx.editor.onEscape = () => {
 			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
 				return;

--- a/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
@@ -1,0 +1,162 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { CustomEditor } from "@gajae-code/coding-agent/modes/components/custom-editor";
+import { BtwController } from "@gajae-code/coding-agent/modes/controllers/btw-controller";
+import { InputController } from "@gajae-code/coding-agent/modes/controllers/input-controller";
+import { getEditorTheme, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { Container, type TUI } from "@gajae-code/tui";
+import { setKittyProtocolActive } from "@gajae-code/tui/keys";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const ESC = "\x1b";
+
+interface Harness {
+	editor: CustomEditor;
+	btw: BtwController;
+	btwContainer: Container;
+}
+
+function makeHarness(runEphemeralTurn: () => Promise<unknown>): Harness {
+	const editor = new CustomEditor(getEditorTheme());
+	const btwContainer = new Container();
+	const ui = { requestRender: vi.fn(), onDebug: undefined } as unknown as TUI;
+	const session = {
+		model: { provider: "anthropic", id: "test" },
+		runEphemeralTurn,
+		isStreaming: false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		isCompacting: false,
+		isGeneratingHandoff: false,
+		hasQueuedSteering: false,
+	} as unknown as InteractiveModeContext["session"];
+
+	const btw = new BtwController({
+		ui,
+		btwContainer,
+		session,
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+	} as unknown as InteractiveModeContext);
+
+	const keymap: Record<string, string[]> = { "app.interrupt": ["escape"] };
+	const ctx = {
+		ui,
+		editor,
+		keybindings: { getKeys: (action: string) => keymap[action] ?? [] },
+		session,
+		hasActiveBtw: () => btw.hasActiveRequest(),
+		handleBtwEscape: () => btw.handleEscape(),
+		cancelPendingSubmission: vi.fn(() => false),
+		restoreQueuedMessagesToEditor: vi.fn(),
+	} as unknown as InteractiveModeContext;
+
+	new InputController(ctx).setupKeyHandlers();
+	return { editor, btw, btwContainer };
+}
+
+const pending = () => new Promise<never>(() => {});
+
+async function drain(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("btw panel Esc dismissal (issue #455)", () => {
+	it("dismisses a running btw panel on Esc", async () => {
+		const { editor, btw, btwContainer } = makeHarness(() => pending());
+		await btw.start("Why?");
+		expect(btw.hasActiveRequest()).toBe(true);
+
+		editor.handleInput(ESC);
+
+		expect(btw.hasActiveRequest()).toBe(false);
+		expect(btwContainer.children).toHaveLength(0);
+	});
+
+	it("dismisses a completed btw panel on Esc", async () => {
+		const { editor, btw, btwContainer } = makeHarness(async () => ({
+			replyText: "Answer",
+			assistantMessage: {},
+		}));
+		await btw.start("Why?");
+		await drain();
+		expect(btw.hasActiveRequest()).toBe(true);
+
+		editor.handleInput(ESC);
+
+		expect(btw.hasActiveRequest()).toBe(false);
+		expect(btwContainer.children).toHaveLength(0);
+	});
+
+	it("dismisses an errored btw panel on Esc", async () => {
+		const { editor, btw, btwContainer } = makeHarness(async () => {
+			throw new Error("boom");
+		});
+		await btw.start("Why?");
+		await drain();
+		expect(btw.hasActiveRequest()).toBe(true);
+
+		editor.handleInput(ESC);
+
+		expect(btw.hasActiveRequest()).toBe(false);
+		expect(btwContainer.children).toHaveLength(0);
+	});
+
+	it("dismisses under the kitty keyboard protocol encoding of Esc", async () => {
+		setKittyProtocolActive(true);
+		try {
+			const { editor, btw, btwContainer } = makeHarness(() => pending());
+			await btw.start("Why?");
+
+			editor.handleInput("\x1b[27u");
+
+			expect(btw.hasActiveRequest()).toBe(false);
+			expect(btwContainer.children).toHaveLength(0);
+		} finally {
+			setKittyProtocolActive(false);
+		}
+	});
+
+	// Regression: previously the btw dismiss was wired only through the
+	// input-controller's onEscape handler. Whenever another controller
+	// (auto-compaction, auto-retry, manual compaction, handoff, branch summary,
+	// MCP connect, debug) temporarily replaced editor.onEscape, the btw panel
+	// could no longer be dismissed with Esc.
+	it("stays dismissable while a transient onEscape handler is installed", async () => {
+		const { editor, btw, btwContainer } = makeHarness(() => pending());
+		await btw.start("Why?");
+		expect(btw.hasActiveRequest()).toBe(true);
+
+		// Mimic event-controller/command-controller hijacking onEscape (e.g. an
+		// auto-compaction or auto-retry that begins while the panel is open).
+		let transientHandlerFired = false;
+		editor.onEscape = () => {
+			transientHandlerFired = true;
+		};
+
+		editor.handleInput(ESC);
+
+		expect(btw.hasActiveRequest()).toBe(false);
+		expect(btwContainer.children).toHaveLength(0);
+		expect(transientHandlerFired).toBe(false);
+	});
+
+	it("does not consume Esc when no btw panel is active", async () => {
+		const { editor, btw } = makeHarness(() => pending());
+		expect(btw.hasActiveRequest()).toBe(false);
+
+		let transientHandlerFired = false;
+		editor.onEscape = () => {
+			transientHandlerFired = true;
+		};
+
+		editor.handleInput(ESC);
+
+		expect(transientHandlerFired).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Make the `/btw` panel reliably dismissable with `Esc`.

`CustomEditor` gains an `onInterruptPriority` hook that runs ahead of `onEscape` for the interrupt key and consumes it when a btw panel is active. The input controller wires this hook in `setupKeyHandlers` and it is never swapped out.

## Why

Fixes #455.

The btw Esc-to-dismiss was wired only through the input controller's `editor.onEscape` handler. Several controllers temporarily replace `editor.onEscape` for their own flows — auto-compaction, auto-retry, manual compaction, handoff, branch summary, MCP connect, debug. While any of those handlers owned `onEscape`, an open btw panel could no longer be dismissed with `Esc` (the keystroke went to the transient handler instead). The dedicated priority hook keeps dismissal wired regardless of which handler currently owns `onEscape`.

## Testing

New regression suite `test/modes/controllers/btw-escape-dismiss.test.ts` drives the real `CustomEditor` + `BtwController` + `InputController` and asserts dismissal for:
- running / complete / error panel states
- the kitty keyboard-protocol `Esc` encoding (`ESC [ 27 u`)
- the regression case: a transient `onEscape` handler installed while the panel is open (previously broken)
- no-op when no panel is active (Esc still reaches `onEscape`)

```
bun test test/modes/controllers/btw-escape-dismiss.test.ts   # 6 pass
bun test test/modes/controllers/btw-controller.test.ts        # pass
bun run check:types                                           # clean
biome lint/format on touched files                            # clean
```

---

- [x] `bun check` passes (touched files; pre-existing unrelated biome/test failures elsewhere left untouched)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)