### PR TITLE
test(stats): fix totalPremiumRequests expectation for Anthropic fast mode

### DIFF
--- a/packages/stats/test/priority-premium-requests.test.ts
+++ b/packages/stats/test/priority-premium-requests.test.ts
@@ -84,7 +84,7 @@ describe("priority service-tier premium-request backfill", () => {
 				{ type: "service_tier_change", id: "stc1", timestamp: new Date().toISOString(), serviceTier: "priority" },
 				assistantEntry({ id: "a1", provider: "openai" }),
 				assistantEntry({ id: "a2", provider: "openai-codex" }),
-				// Provider that doesn't honor service_tier — stays at zero.
+				// Direct Anthropic under priority tier counts as fast-mode premium.
 				assistantEntry({ id: "a3", provider: "anthropic" }),
 				{ type: "service_tier_change", id: "stc2", timestamp: new Date().toISOString(), serviceTier: null },
 				assistantEntry({ id: "a4", provider: "openai" }),
@@ -95,7 +95,7 @@ describe("priority service-tier premium-request backfill", () => {
 
 		const overall = await getOverallStats();
 		expect(overall.totalRequests).toBe(4);
-		expect(overall.totalPremiumRequests).toBe(2);
+		expect(overall.totalPremiumRequests).toBe(3);
 	});
 
 	it("preserves an existing non-zero premiumRequests value (Copilot multiplier) even under priority tier", async () => {


### PR DESCRIPTION
## What
Fix incorrect `totalPremiumRequests` assertion in `priority-premium-requests` integration test (2 lines).

## Why
The integration test expected `totalPremiumRequests=2` for a session containing `openai`, `openai-codex`, and `anthropic` requests under the `"priority"` service tier. However, `getPriorityPremiumRequests("priority", "anthropic")` correctly returns `1` (Anthropic fast mode), as confirmed by the existing unit tests in `service-tier-premium-requests.test.ts`:

```ts
it("counts priority on direct Anthropic as one premium request (fast mode)", () => {
    expect(getPriorityPremiumRequests("priority", "anthropic")).toBe(1);
});
```

The integration test comment ("Provider that doesn't honor service_tier — stays at zero") was incorrect for direct Anthropic, which does realize priority tier as fast mode.

## Testing
- `bun test packages/stats/test/priority-premium-requests.test.ts` — 4 pass
- `bun test packages/ai/test/service-tier-premium-requests.test.ts` — 21 pass (unchanged, confirms contract)
- Full stats suite (`bun test packages/stats/test/`) — 33 pass

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)