### PR TITLE
test(ultragoal): isolate GJC_SESSION_ID env in ultragoal-runtime tests

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
@@ -21,6 +21,13 @@ import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-stat
 
 const tempRoots: string[] = [];
 
+let savedSessionId: string | undefined;
+
+beforeEach(() => {
+	savedSessionId = process.env.GJC_SESSION_ID;
+	delete process.env.GJC_SESSION_ID;
+});
+
 async function tempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-ultragoal-runtime-"));
 	tempRoots.push(dir);
@@ -28,6 +35,8 @@ async function tempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+	if (savedSessionId === undefined) delete process.env.GJC_SESSION_ID;
+	else process.env.GJC_SESSION_ID = savedSessionId;
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 


### PR DESCRIPTION
## What
Add `GJC_SESSION_ID` environment variable isolation to `ultragoal-runtime.test.ts` (10 lines added, 1 changed).

## Why
When tests run inside a GJC session, the inherited `GJC_SESSION_ID` env var causes `reconcileUltragoalState` to write session-scoped state (`.gjc/state/sessions/<id>/ultragoal-state.json`) instead of root state (`.gjc/state/ultragoal-state.json`). Three tests that seed stale state at the root path and verify reconciliation updates it correctly would see the stale `active: true` because reconciliation wrote to a different file:

1. `reconciles completed runs with mode-state and HUD active-state` — `modeState.active` expected false, got true
2. `reconciles missing durable plans with stale active mode-state` — same
3. `reconciles terminal checkpoints despite corrupt stale mode-state` — `SyntaxError: Failed to parse JSON` (corrupt state caused EISDIR during atomic write)

The fix adds `beforeEach`/`afterEach` hooks that save, clear, and restore `GJC_SESSION_ID` so each test runs with a clean session environment. This is the same isolation pattern used by the `withSessionId` helper in the same file, applied at the describe level.

## Testing
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts` — **79 pass** (was 76 pass, 3 fail)
- Session-scoped tests still pass (they use `withSessionId` which restores on completion)

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)