### PR TITLE
test(model-registry): isolate OLLAMA_API_KEY env in ollama discovery tests

### DIFF
--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1803,15 +1803,18 @@ describe("ModelRegistry", () => {
 	describe("runtime discovery", () => {
 		test("auto-discovers ollama models without provider config", async () => {
 			using _hook = mockOllamaDiscovery(["phi4-mini"]);
-
-			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			await registry.refresh();
-			const ollamaModels = getModelsForProvider(registry, "ollama");
-			expect(ollamaModels.some(m => m.id === "phi4-mini")).toBe(true);
-			expect(registry.getAvailable().some(m => m.provider === "ollama" && m.id === "phi4-mini")).toBe(true);
-			expect(await registry.getApiKey(ollamaModels[0])).toBe(kNoAuth);
+			const _restoreOllamaKey = unsetEnvForTest("OLLAMA_API_KEY");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				await registry.refresh();
+				const ollamaModels = getModelsForProvider(registry, "ollama");
+				expect(ollamaModels.some(m => m.id === "phi4-mini")).toBe(true);
+				expect(registry.getAvailable().some(m => m.provider === "ollama" && m.id === "phi4-mini")).toBe(true);
+				expect(await registry.getApiKey(ollamaModels[0])).toBe(kNoAuth);
+			} finally {
+				_restoreOllamaKey();
+			}
 		});
-
 		test("discovers ollama-cloud through built-in descriptor flow without regressing local implicit ollama", async () => {
 			authStorage.setRuntimeApiKey("ollama-cloud", "cloud-test-key");
 
@@ -1875,6 +1878,8 @@ describe("ModelRegistry", () => {
 			).toBe(true);
 		});
 		test("discovers ollama models at runtime and treats auth:none providers as available", async () => {
+			const _restoreOllamaKey = unsetEnvForTest("OLLAMA_API_KEY");
+			try {
 			writeRawModelsJson({
 				ollama: {
 					baseUrl: "http://127.0.0.1:11434/v1",
@@ -1913,6 +1918,9 @@ describe("ModelRegistry", () => {
 			const available = registry.getAvailable().filter(m => m.provider === "ollama");
 			expect(available.length).toBe(2);
 			expect(await registry.getApiKey(available[0])).toBe(kNoAuth);
+			} finally {
+				_restoreOllamaKey();
+			}
 		});
 
 		test("normalizes cached ollama completions rows to responses on load", () => {


### PR DESCRIPTION
## What
Add `OLLAMA_API_KEY` environment variable isolation to two ollama discovery tests (8 lines changed, net +8 -0 in test body).

## Why
When `OLLAMA_API_KEY` is set in the process environment (e.g., running inside a development shell with ollama configured), `hasAuth("ollama")` returns `true` via `getEnvApiKey()` and `getApiKey()` returns the real key instead of `kNoAuth`. This causes two test failures that only appear when ollama is configured locally:

1. `auto-discovers ollama models without provider config` — `getApiKey` returns real key instead of `kNoAuth`
2. `discovers ollama models at runtime and treats auth:none providers as available` — same

The fix uses the existing `unsetEnvForTest` helper (same pattern as `OPENAI_API_KEY` cleanup at line 747) to save, clear, and restore `OLLAMA_API_KEY` in the two affected tests.

## Testing
- `bun test packages/coding-agent/test/model-registry.test.ts` — **116 pass** (was 114 pass, 2 fail)
- Tested with `OLLAMA_API_KEY` explicitly set in environment

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)