### PR TITLE
test(system-prompt): mock os.homedir to isolate from real home directory

### DIFF
--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -26,6 +26,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-system-home-"));
 		originalHome = process.env.HOME;
 		process.env.HOME = tempHomeDir;
+		vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
 	});
 
 	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));


### PR DESCRIPTION
## What
Mock `os.homedir()` in `system-prompt-dedup.test.ts` to return the temp home directory (2 lines changed, net +2 -1).

## Why
Bun caches `os.homedir()` on startup. The test sets `process.env.HOME = tempHomeDir` in `beforeEach`, but `loadCapability()` calls `os.homedir()` to resolve user-level paths (`~/.config/opencode/AGENTS.md`). Since the cache returns the real home, the test reads the actual `~/.config/opencode/AGENTS.md` file instead of the empty temp directory, causing:

```
loadProjectContextFiles({ cwd: projectDir }) → expected [] but got [{ path: "/Users/.../.config/opencode/AGENTS.md", ... }]
```

The fix adds `vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir)` to `beforeEach`, matching the established pattern in `gh.test.ts`, `bash-executor.test.ts`, `gjc-plugin-no-surface.test.ts`, and `disabled-extensions.test.ts`.

## Testing
- `bun test packages/coding-agent/test/system-prompt-dedup.test.ts` — **6 pass** (was 5 pass, 1 fail)

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)