### PR TITLE
test(role-info): update stale test expectations after smol/slow role removal

### DIFF
--- a/packages/coding-agent/test/role-info.test.ts
+++ b/packages/coding-agent/test/role-info.test.ts
@@ -11,16 +11,6 @@ describe("getRoleInfo", () => {
 			color: "success",
 			tag: "DEFAULT",
 		});
-		expect(getRoleInfo("smol", settings)).toEqual({
-			name: "Fast",
-			color: "warning",
-			tag: "SMOL",
-		});
-		expect(getRoleInfo("slow", settings)).toEqual({
-			name: "Thinking",
-			color: "accent",
-			tag: "SLOW",
-		});
 	});
 
 	test("returns custom role info from modelTags", () => {
@@ -53,14 +43,14 @@ describe("getRoleInfo", () => {
 	test("configured metadata overrides built-in role info while keeping built-in defaults", () => {
 		const settings = Settings.isolated({
 			modelTags: {
-				smol: { name: "My Smol", color: "success" },
+				default: { name: "My Default", color: "accent" },
 			},
 		});
 
-		expect(getRoleInfo("smol", settings)).toEqual({
-			tag: "SMOL",
-			name: "My Smol",
-			color: "success",
+		expect(getRoleInfo("default", settings)).toEqual({
+			tag: "DEFAULT",
+			name: "My Default",
+			color: "accent",
 		});
 	});
 });


### PR DESCRIPTION
## What
Update `role-info.test.ts` expectations to match the current `MODEL_ROLES` which only contains `default` (5 insertions, 15 deletions).

## Why
The `smol` and `slow` model roles were removed from `MODEL_ROLES`, leaving only `default`. Two test failures resulted:

1. `returns built-in role info` — expected `smol` → `{ name: "Fast", color: "warning", tag: "SMOL" }` and `slow` → `{ name: "Thinking", color: "accent", tag: "SLOW" }` but these are no longer built-in roles, so `getRoleInfo` returns the fallback `{ name: "smol", color: "muted" }`.
2. `configured metadata overrides built-in role info while keeping built-in defaults` — used `smol` in `modelTags` and expected `tag: "SMOL"` from built-in, but `smol` has no built-in entry so `tag` is `undefined`.

Fix: remove `smol`/`slow` assertions from test 1, update test 4 to use `default` (the only remaining built-in role) to verify the override-keeps-tag behavior.

## Testing
- `bun test packages/coding-agent/test/role-info.test.ts` — **4 pass** (was 2 pass, 2 fail)

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)