### PR TITLE
test(compaction): replace stale smol role with default in auth fallback test

### DIFF
--- a/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
@@ -82,7 +82,7 @@ describe("issue #986 compaction auth fallback", () => {
 	}
 
 	it("falls back to an authenticated role model when the current provider returns auth_unavailable", async () => {
-		const { currentModel, fallbackModel } = await createSession({ fallbackModelRole: "smol" });
+		const { currentModel, fallbackModel } = await createSession({ fallbackModelRole: "default" });
 		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => {
 			if (model.provider === currentModel.provider && model.id === currentModel.id) {
 				throw new Error(


### PR DESCRIPTION
## What
Change `fallbackModelRole` from `"smol"` to `"default"` in compaction auth fallback test (1 line changed).

## Why
The `smol` model role was removed from `MODEL_ROLE_IDS` (now only `["default"]`). The compaction candidate loop in `getCompactionModelCandidates` iterates `MODEL_ROLE_IDS` to find fallback models. Since `"smol"` is no longer in that list, the fallback model assigned via `settings.setModelRole("smol", ...)` was never resolved as a candidate. The test hit the exhaustion path instead of the fallback path:

```
Compaction requires usable credentials for openai-codex/gpt-5.4-mini.
```

Fix: use `"default"` as the fallback role, which is in `MODEL_ROLE_IDS` and resolves correctly through `resolveRoleModelFull`.

## Testing
- `bun test packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts` — **2 pass** (was 1 pass, 1 fail)

## Checklist
- [x] One issue per PR
- [x] Targets `dev` branch
- [x] Tested locally
- [x] No production code changes (test-only)