### PR TITLE
chore(biome): fix import-sort and format errors

### DIFF
--- a/packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts
+++ b/packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts
@@ -5,8 +5,8 @@ import {
 	mapAgentSessionEventToAcpSessionUpdates,
 	mapAgentWireEventPayloadToAcpSessionUpdates,
 } from "../../src/modes/acp/acp-event-mapper";
-import { toAgentWireEventPayload } from "../../src/modes/shared/agent-wire/event-envelope";
 import { AGENT_WIRE_EVENT_TYPES } from "../../src/modes/shared/agent-wire/event-contract";
+import { toAgentWireEventPayload } from "../../src/modes/shared/agent-wire/event-envelope";
 import type { AgentSessionEvent } from "../../src/session/agent-session";
 import { EVENT_FIXTURES } from "../agent-wire/fixtures";
 
@@ -88,7 +88,11 @@ describe("ACP canonical payload red-team", () => {
 		for (const type of AGENT_WIRE_EVENT_TYPES) {
 			const fixture = EVENT_FIXTURES[type];
 			expect(
-				mapAgentWireEventPayloadToAcpSessionUpdates(toAgentWireEventPayload(fixture), SESSION_ID, makeParityOptions()),
+				mapAgentWireEventPayloadToAcpSessionUpdates(
+					toAgentWireEventPayload(fixture),
+					SESSION_ID,
+					makeParityOptions(),
+				),
 				type,
 			).toEqual(mapAgentSessionEventToAcpSessionUpdates(fixture, SESSION_ID, makeParityOptions()));
 		}
@@ -97,9 +101,10 @@ describe("ACP canonical payload red-team", () => {
 	it("returns no ACP notifications for every explicit whitelist event type", () => {
 		for (const type of WHITELISTED_EMPTY_EVENT_TYPES) {
 			expect(mapAgentSessionEventToAcpSessionUpdates(EVENT_FIXTURES[type], SESSION_ID), type).toEqual([]);
-			expect(mapAgentWireEventPayloadToAcpSessionUpdates(toAgentWireEventPayload(EVENT_FIXTURES[type]), SESSION_ID), type).toEqual(
-				[],
-			);
+			expect(
+				mapAgentWireEventPayloadToAcpSessionUpdates(toAgentWireEventPayload(EVENT_FIXTURES[type]), SESSION_ID),
+				type,
+			).toEqual([]);
 		}
 	});
 
@@ -117,7 +122,11 @@ describe("ACP canonical payload red-team", () => {
 			"tool_call_update",
 			"tool_call_update",
 		]);
-		expect(updates.map(notification => (notification.update as { toolCallId?: string }).toolCallId)).toEqual(["t1", "t1", "t1"]);
+		expect(updates.map(notification => (notification.update as { toolCallId?: string }).toolCallId)).toEqual([
+			"t1",
+			"t1",
+			"t1",
+		]);
 		expect((updates[1]!.update as { status?: string }).status).toBe("in_progress");
 		expect((updates[2]!.update as { status?: string }).status).toBe("completed");
 	});

--- a/packages/coding-agent/test/agent-wire/command-contract.redteam.test.ts
+++ b/packages/coding-agent/test/agent-wire/command-contract.redteam.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
-import { describe, expect, it } from "bun:test";
 import {
 	dispatchRpcCommand,
 	isRpcCommandType,
@@ -67,7 +67,8 @@ describe("agent-wire command contract red-team", () => {
 		const harnessFiles = sourceFiles(HARNESS_CONTROL_PLANE_DIR);
 		expect(harnessFiles).toContain(join(HARNESS_CONTROL_PLANE_DIR, "owner.ts"));
 
-		const importPattern = /from\s+["'](?:\.\/frame-mapper|.*harness-control-plane\/frame-mapper)["']|import\s*\(["'](?:\.\/frame-mapper|.*harness-control-plane\/frame-mapper)["']\)/;
+		const importPattern =
+			/from\s+["'](?:\.\/frame-mapper|.*harness-control-plane\/frame-mapper)["']|import\s*\(["'](?:\.\/frame-mapper|.*harness-control-plane\/frame-mapper)["']\)/;
 		const offenders = sourceFiles(SRC_ROOT)
 			.filter(path => importPattern.test(readFileSync(path, "utf8")))
 			.map(repoRelative);

--- a/packages/coding-agent/test/agent-wire/event-envelope.redteam.test.ts
+++ b/packages/coding-agent/test/agent-wire/event-envelope.redteam.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { AGENT_WIRE_EVENT_TYPES, AGENT_WIRE_PROTOCOL_VERSION } from "../../src/modes/shared/agent-wire/event-contract";
 import {
-	agentSessionEventType,
 	AgentWireFrameSequencer,
+	agentSessionEventType,
 	BridgeFrameSequencer,
 	toAgentWireEventFrame,
 	toBridgeEventFrame,

--- a/packages/coding-agent/test/agent-wire/event-envelope.test.ts
+++ b/packages/coding-agent/test/agent-wire/event-envelope.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { AGENT_WIRE_EVENT_TYPES, AGENT_WIRE_PROTOCOL_VERSION } from "../../src/modes/shared/agent-wire/event-contract";
 import {
-	agentSessionEventType,
 	AgentWireFrameSequencer,
+	agentSessionEventType,
 	BridgeFrameSequencer,
 	toAgentWireEventFrame,
 	toBridgeEventFrame,

--- a/packages/coding-agent/test/agent-wire/event-observation.redteam.test.ts
+++ b/packages/coding-agent/test/agent-wire/event-observation.redteam.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { AGENT_WIRE_EVENT_TYPES } from "../../src/modes/shared/agent-wire/event-contract";
-import {
-	observeAgentSessionEvent,
-	observeRpcOutboundFrame,
-} from "../../src/modes/shared/agent-wire/event-observation";
+import { observeAgentSessionEvent, observeRpcOutboundFrame } from "../../src/modes/shared/agent-wire/event-observation";
 import { EVENT_FIXTURES } from "./fixtures";
 
 const SECRET_MARKERS = [
@@ -42,7 +39,10 @@ function assertBoundedAndRedacted(observation: unknown) {
 		expect(serialized).not.toContain(marker);
 	}
 
-	const evidence = ((observation as { evidence?: Record<string, unknown> } | null)?.evidence ?? {}) as Record<string, unknown>;
+	const evidence = ((observation as { evidence?: Record<string, unknown> } | null)?.evidence ?? {}) as Record<
+		string,
+		unknown
+	>;
 	for (const [key, value] of Object.entries(evidence)) {
 		if (key === "code" || key === "message") {
 			expect(typeof value === "string" ? value.length : 0).toBeLessThanOrEqual(200);

--- a/packages/coding-agent/test/agent-wire/event-observation.test.ts
+++ b/packages/coding-agent/test/agent-wire/event-observation.test.ts
@@ -93,9 +93,10 @@ describe("agent-wire event observation", () => {
 			expect(observeRpcOutboundFrame({ type: "host_tool_call", id: "h1", toolName: "echo" })?.signal).toBe(
 				"tool-call",
 			);
-			expect(observeRpcOutboundFrame({ type: "host_uri_request", id: "u2", operation: "read", scheme: "db" })?.evidence.scheme).toBe(
-				"db",
-			);
+			expect(
+				observeRpcOutboundFrame({ type: "host_uri_request", id: "u2", operation: "read", scheme: "db" })?.evidence
+					.scheme,
+			).toBe("db");
 			const gate = observeRpcOutboundFrame({ type: "workflow_gate", gate_id: "g1", kind: "approval", stage: "pre" });
 			expect(gate?.semantic).toBe(true);
 			expect(gate?.evidence.gate_id).toBe("g1");

--- a/packages/coding-agent/test/agent-wire/fixtures.ts
+++ b/packages/coding-agent/test/agent-wire/fixtures.ts
@@ -3,8 +3,9 @@
  * Fixtures intentionally embed sensitive-looking raw content (assistant text,
  * raw args, raw command output) so redaction can be asserted by tests.
  */
-import type { AgentSessionEvent } from "../../src/session/agent-session";
+
 import type { AgentWireEventType } from "../../src/modes/shared/agent-wire/event-contract";
+import type { AgentSessionEvent } from "../../src/session/agent-session";
 
 /** A raw secret marker that must NEVER appear in bounded owner evidence. */
 export const RAW_SECRET = "RAW_SECRET_MUST_NOT_LEAK";

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1880,44 +1880,44 @@ describe("ModelRegistry", () => {
 		test("discovers ollama models at runtime and treats auth:none providers as available", async () => {
 			const _restoreOllamaKey = unsetEnvForTest("OLLAMA_API_KEY");
 			try {
-			writeRawModelsJson({
-				ollama: {
-					baseUrl: "http://127.0.0.1:11434/v1",
-					api: "openai-completions",
-					auth: "none",
-					discovery: { type: "ollama" },
-				},
-			});
+				writeRawModelsJson({
+					ollama: {
+						baseUrl: "http://127.0.0.1:11434/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "ollama" },
+					},
+				});
 
-			using _hook = hookFetch(input => {
-				const url = String(input);
-				if (url === "http://127.0.0.1:11434/api/tags") {
-					return new Response(
-						JSON.stringify({
-							models: [{ name: "qwen2.5-coder:7b" }, { model: "llama3.2:3b", name: "llama3.2:3b" }],
-						}),
-						{ status: 200, headers: { "Content-Type": "application/json" } },
-					);
-				}
-				if (url === "http://127.0.0.1:11434/api/show") {
-					return new Response(JSON.stringify({ capabilities: ["completion"] }), {
-						status: 200,
-						headers: { "Content-Type": "application/json" },
-					});
-				}
-				throw new Error(`Unexpected URL: ${url}`);
-			});
+				using _hook = hookFetch(input => {
+					const url = String(input);
+					if (url === "http://127.0.0.1:11434/api/tags") {
+						return new Response(
+							JSON.stringify({
+								models: [{ name: "qwen2.5-coder:7b" }, { model: "llama3.2:3b", name: "llama3.2:3b" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					if (url === "http://127.0.0.1:11434/api/show") {
+						return new Response(JSON.stringify({ capabilities: ["completion"] }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				});
 
-			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			await registry.refresh();
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				await registry.refresh();
 
-			const ollamaModels = getModelsForProvider(registry, "ollama");
-			expect(ollamaModels.some(m => m.id === "qwen2.5-coder:7b")).toBe(true);
-			expect(ollamaModels.some(m => m.id === "llama3.2:3b")).toBe(true);
+				const ollamaModels = getModelsForProvider(registry, "ollama");
+				expect(ollamaModels.some(m => m.id === "qwen2.5-coder:7b")).toBe(true);
+				expect(ollamaModels.some(m => m.id === "llama3.2:3b")).toBe(true);
 
-			const available = registry.getAvailable().filter(m => m.provider === "ollama");
-			expect(available.length).toBe(2);
-			expect(await registry.getApiKey(available[0])).toBe(kNoAuth);
+				const available = registry.getAvailable().filter(m => m.provider === "ollama");
+				expect(available.length).toBe(2);
+				expect(await registry.getApiKey(available[0])).toBe(kNoAuth);
 			} finally {
 				_restoreOllamaKey();
 			}

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -16,8 +16,9 @@
  * Based on code from OpenTUI (https://github.com/anomalyco/opentui)
  * MIT License - Copyright (c) 2025 opentui
  */
-import { EventEmitter } from "events";
+
 import { StringDecoder } from "node:string_decoder";
+import { EventEmitter } from "events";
 
 const ESC = "\x1b";
 const BRACKETED_PASTE_START = "\x1b[200~";


### PR DESCRIPTION
## What

Run `biome check --write` on current `dev` to resolve 9 lint/format issues across test and source files.

## Changes

- Import sort order in agent-wire and acp test files
- Line-width formatting in `model-registry.test.ts`
- Import organization in `stdin-buffer.ts`

## Verification

- `bunx biome check .` → 0 errors
- No functional changes — lint/format only