### PR TITLE
Proposal: restore /copy slash command registration (TUI-only)

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -436,6 +436,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "copy",
+		description: "Copy last agent message to clipboard",
+		subcommands: [
+			{ name: "last", description: "Copy last agent message (default)" },
+			{ name: "code", description: "Copy last code block from last agent message" },
+			{ name: "all", description: "Copy all code blocks from last agent message" },
+			{ name: "cmd", description: "Copy last bash/eval command" },
+		],
+		allowArgs: true,
+		handleTui: (command, runtime) => {
+			runtime.ctx.handleCopyCommand(command.args.trim().toLowerCase() || undefined);
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "session",
 		description: "Session management commands",
 		acpDescription: "Show session information",

--- a/packages/coding-agent/test/slash-commands/copy.test.ts
+++ b/packages/coding-agent/test/slash-commands/copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+
+function createRuntimeHarness() {
+	const setText = vi.fn();
+	const handleCopyCommand = vi.fn();
+
+	return {
+		setText,
+		handleCopyCommand,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				handleCopyCommand,
+			} as InteractiveModeContext,
+			handleBackgroundCommand: () => {},
+		},
+	};
+}
+
+describe("/copy slash command", () => {
+	it("dispatches to handleCopyCommand with no subcommand", async () => {
+		const harness = createRuntimeHarness();
+
+		expect(await executeBuiltinSlashCommand("/copy", harness.runtime)).toBe(true);
+
+		expect(harness.handleCopyCommand).toHaveBeenCalledTimes(1);
+		expect(harness.handleCopyCommand).toHaveBeenCalledWith(undefined);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("passes each documented subcommand through", async () => {
+		for (const sub of ["last", "code", "all", "cmd"]) {
+			const harness = createRuntimeHarness();
+
+			expect(await executeBuiltinSlashCommand(`/copy ${sub}`, harness.runtime)).toBe(true);
+
+			expect(harness.handleCopyCommand).toHaveBeenCalledWith(sub);
+			expect(harness.setText).toHaveBeenCalledWith("");
+		}
+	});
+
+	it("normalizes subcommand casing before dispatch", async () => {
+		const harness = createRuntimeHarness();
+
+		expect(await executeBuiltinSlashCommand("/copy CODE", harness.runtime)).toBe(true);
+
+		expect(harness.handleCopyCommand).toHaveBeenCalledWith("code");
+	});
+});

--- a/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
+++ b/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
@@ -35,7 +35,6 @@ describe("GJC utility extensibility quarantine", () => {
 			"plan",
 			"share",
 			"browser",
-			"copy",
 			"todo",
 			"changelog",
 			"branch",
@@ -49,6 +48,7 @@ describe("GJC utility extensibility quarantine", () => {
 		}
 		expect(registry).toContain(`name: "ssh"`);
 		expect(registry).toContain(`name: "provider"`);
+		expect(registry).toContain(`name: "copy"`);
 		expect(await Bun.file(srcPath("slash-commands", "helpers", "marketplace-manager.ts")).exists()).toBe(false);
 		expect(await Bun.file(srcPath("slash-commands", "marketplace-install-parser.ts")).exists()).toBe(false);
 	});


### PR DESCRIPTION
## What

Restores the `/copy` slash command by registering the existing, still-maintained TUI handler in `BUILTIN_SLASH_COMMAND_REGISTRY`.

- `packages/coding-agent/src/slash-commands/builtin-registry.ts` — add a TUI-only `copy` spec (no `handle`, so the ACP dispatcher keeps skipping it; clipboard access is meaningless in ACP). Dispatches `command.args` (trimmed, lowercased) to `runtime.ctx.handleCopyCommand(...)` and clears the editor, matching the `/dump` / `/session` patterns.
- `packages/coding-agent/test/utility-extensibility-quarantine.test.ts` — remove `"copy"` from the removed-commands list and assert `name: "copy"` is present. **All other quarantine entries stay intact.**
- `packages/coding-agent/test/slash-commands/copy.test.ts` — new dispatch tests following the `/session` harness pattern.

## Why

`handleCopyCommand` (`command-controller.ts:242`) with `last` / `code` / `all` / `cmd` subcommands and its unit tests (`test/modes/controllers/copy-command.test.ts`) are actively maintained in-tree, but the registration was removed by the utility-extensibility quarantine, so `/copy` is unreachable. Users coming from Claude Code expect `/copy` to copy the last assistant response; the only working alternative today is `/dump`, which copies the entire transcript.

Full analysis in #472; original user request in #458.

## Scope note for the maintainer

#458 was closed pending an owner-confirmed command contract, and the quarantine test makes the current removal an explicit product decision. This PR is a concrete proposal artifact for that decision, not a unilateral reversal — if the quarantine of `/copy` stands, close it. The command contract implemented here is exactly the one already shipped in `handleCopyCommand`: `/copy [last|code|all|cmd]`, default `last`.

## Verification

```
bun test test/slash-commands/copy.test.ts test/slash-commands/session.test.ts \
  test/utility-extensibility-quarantine.test.ts test/modes/controllers/copy-command.test.ts
# 14 pass, 0 fail (win32-x64)
```

`bunx biome check` clean on all three changed files.

Closes #472
