### PR TITLE
fix(ralplan): persist role-agent artifacts via CLI, return receipt-only

### DIFF
--- a/packages/coding-agent/src/prompts/agents/architect.md
+++ b/packages/coding-agent/src/prompts/agents/architect.md
@@ -83,4 +83,10 @@ Prioritized concrete actions.
 
 ## Trade-offs
 Table or bullets comparing viable options when relevant.
+
+Persist this full review as the durable artifact via the restricted bash CLI, passing the markdown inline (never a file path, never `/tmp`):
+
+  gjc ralplan --write --stage architect --stage_n <N> --artifact "<full review markdown>" --json
+
+Then return to the caller ONLY the write receipt (`run_id`, `path`, `sha256`, `stage`, `stage_n`) plus the compact verdict (Architectural Status + Code Review Recommendation). Never paste the full review body back into your response — the caller reads the persisted artifact when it needs the full text.
 </output_contract>

--- a/packages/coding-agent/src/prompts/agents/critic.md
+++ b/packages/coding-agent/src/prompts/agents/critic.md
@@ -56,4 +56,10 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 - Risk/Verification Rigor
 
 If not OKAY, list concrete required fixes.
+
+Persist this full evaluation as the durable artifact via the restricted bash CLI, passing the markdown inline (never a file path, never `/tmp`):
+
+  gjc ralplan --write --stage critic --stage_n <N> --artifact "<full evaluation markdown>" --json
+
+Then return to the caller ONLY the write receipt (`run_id`, `path`, `sha256`, `stage`, `stage_n`) plus the compact verdict (OKAY / ITERATE / REJECT). Never paste the full evaluation body back into your response — the caller reads the persisted artifact when it needs the full text.
 </output_contract>

--- a/packages/coding-agent/src/prompts/agents/planner.md
+++ b/packages/coding-agent/src/prompts/agents/planner.md
@@ -18,6 +18,7 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 <constraints>
 - Read-only: never write, edit, format, commit, push, or mutate files.
 - Exception: you may use the restricted `bash` tool only for sanctioned GJC workflow CLI persistence (`gjc ralplan --write ...`) and GJC workflow state read/write/contract commands (`gjc state ...`). For `gjc ralplan --write`, pass the plan markdown inline in `--artifact`, not as a file path. Do not use bash for product-source writes, direct handoffs, state clears, or general shell work.
+- Persist durable plans only through `gjc ralplan --write`. Never write plan files to `/tmp`, the repository, or any other path, and never rely on a file the caller must read back. The CLI is your only persistence channel.
 - Inspect the repository before asking about code facts.
 - Ask only about priorities, tradeoffs, scope decisions, timelines, or preferences that repository inspection cannot resolve.
 - Right-size the step count to the task; do not default to a fixed number of steps.
@@ -42,7 +43,7 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 </success_criteria>
 
 <output_contract>
-Return:
+Build the full plan as a single markdown document containing:
 - Summary
 - In scope / out of scope
 - File-level changes
@@ -50,4 +51,10 @@ Return:
 - Acceptance criteria
 - Verification
 - Risks and mitigations
+
+Persist that markdown as the durable artifact via the restricted bash CLI, passing the plan inline (never a file path, never `/tmp`):
+
+  gjc ralplan --write --stage planner --stage_n <N> --artifact "<full plan markdown>" --json
+
+Then return to the caller ONLY the write receipt (`run_id`, `path`, `sha256`, `stage`, `stage_n`) plus a compact plan summary (<=10 lines). Never paste the full plan body back into your response — the caller reads the persisted artifact when it needs the full text.
 </output_contract>


### PR DESCRIPTION
## Problem

The ralplan consensus loop leaked tokens and improvised an illegal `/tmp` write:

- `planner`/`architect`/`critic` are read-only role agents, but their `<output_contract>` instructed them to **return the full body** to the caller. The planner returned ~78KB of plan markdown into the parent conversation (the token leak).
- Because durable persistence was not mandatory/self-contained, the orchestrator improvised a `/tmp/planner-plan.md` write — which a read-only agent cannot perform.

These agents already have `gjc ralplan --write` and `gjc state` in `bashAllowedPrefixes`, so they *can* persist as read-only; nothing made them do so or stopped them from echoing the body.

## Fix

In the three role-agent prompts (`packages/coding-agent/src/prompts/agents/`):

- **planner.md** — added a constraint that durable plans persist **only** through `gjc ralplan --write` (never `/tmp`, the repo, or any path), and rewrote `<output_contract>` to: build the full plan markdown -> persist inline via `gjc ralplan --write --stage planner ... --json` -> return **only** the receipt (`run_id`, `path`, `sha256`, `stage`, `stage_n`) plus a <=10-line summary, never the full body.
- **architect.md** / **critic.md** — appended the same persist-then-receipt instruction so the whole consensus loop is receipt-only.

No `/tmp` reference existed in the ralplan runtime or SKILL.md; it was orchestrator improvisation, now prevented by making the CLI the agents' sole mandatory persistence channel.

## Verification

- Targeted tests pass: `task-bundled-agent-surface`, `ralplan-runtime`, `default-gjc-definitions`, `state-handoff-thrift` (57 pass, 0 fail), including the "documents the ralplan receipt-only guideline for role agents" assertion.
- `bun run check:ts` green: biome lint (2041 files), Node20 baseline, JSON schemas, GJC-UI/rebrand inventory, and full-workspace typecheck all exit 0.