### PR TITLE
feat(subagent): show awaited sub-agent live streaming status in await panel

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -1,5 +1,5 @@
 import { logger } from "@gajae-code/utils";
-import type { AgentSource } from "../task/types";
+import type { AgentProgress, AgentSource } from "../task/types";
 
 const DELIVERY_RETRY_BASE_MS = 500;
 const DELIVERY_RETRY_MAX_MS = 30_000;
@@ -248,6 +248,7 @@ export class AsyncJobManager {
 	#disposed = false;
 	readonly #subagentRecords = new Map<string, SubagentRecord>();
 	readonly #liveHandles = new Map<string, SubagentLiveHandle>();
+	readonly #subagentProgress = new Map<string, AgentProgress>();
 	readonly #resumeQueue: ResumeQueueEntry[] = [];
 	#resumeSeq = 0;
 	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
@@ -531,6 +532,38 @@ export class AsyncJobManager {
 		this.#liveHandles.delete(subagentId);
 	}
 
+	/**
+	 * Retain the latest live `AgentProgress` for a subagent (deep-cloned so later
+	 * mutation of the live object cannot corrupt retained state). Read by the
+	 * `subagent` await panel; cleared on terminal/cancel/purge/dispose.
+	 *
+	 * Ignored for ids without a canonical `SubagentRecord` (e.g. foreground/inline
+	 * task runs that share the executor path) so the map only holds detached
+	 * subagent progress and never accumulates untracked foreground task state.
+	 */
+	recordSubagentProgress(subagentId: string, progress: AgentProgress): void {
+		if (!this.#subagentRecords.has(subagentId)) return;
+		this.#subagentProgress.set(subagentId, structuredClone(progress));
+	}
+
+	getSubagentProgress(subagentId: string): AgentProgress | undefined {
+		return this.#subagentProgress.get(subagentId);
+	}
+
+	/**
+	 * True only when a live, in-session progress producer exists for this id: a
+	 * canonical registered record with a live handle or an in-memory running job.
+	 * False for `SubagentTool` backward-compat job synthesis and resumed-from-disk
+	 * records, which have no live producer to stream from.
+	 */
+	hasLiveSubagent(subagentId: string, filter?: AsyncJobFilter): boolean {
+		const rec = this.getSubagentRecord(subagentId, filter);
+		if (!rec) return false;
+		if (this.#liveHandles.has(rec.subagentId)) return true;
+		const job = rec.currentJobId ? this.#jobs.get(rec.currentJobId) : undefined;
+		return job?.status === "running";
+	}
+
 	/** Install the TaskTool-owned resume runner. Returns the new job id, or undefined on failure. */
 	setResumeRunner(
 		runner: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined,
@@ -561,6 +594,7 @@ export class AsyncJobManager {
 		if (rec) {
 			rec.status = "paused";
 			this.#liveHandles.delete(rec.subagentId);
+			this.#subagentProgress.delete(rec.subagentId);
 		}
 	}
 
@@ -569,6 +603,7 @@ export class AsyncJobManager {
 		if (!rec) return;
 		rec.status = status;
 		this.#liveHandles.delete(rec.subagentId);
+		this.#subagentProgress.delete(rec.subagentId);
 	}
 
 	/** Request a graceful safe-boundary pause of a running subagent. */
@@ -626,6 +661,9 @@ export class AsyncJobManager {
 		message?: string,
 	): { ok: boolean; status?: SubagentLifecycle; jobId?: string; reason?: string } {
 		const prevJobId = rec.currentJobId;
+		// Clear any retained progress from the previous run so a resumed subagent
+		// never renders the prior run's tool/output as live before it emits again.
+		this.#subagentProgress.delete(rec.subagentId);
 		const newJobId = this.#resumeRunner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));
 		if (!newJobId) return { ok: false, reason: "resume_failed" };
 		if (prevJobId && prevJobId !== newJobId) rec.historicalJobIds.push(prevJobId);
@@ -663,6 +701,7 @@ export class AsyncJobManager {
 			}
 			rec.status = "cancelled";
 			this.#liveHandles.delete(rec.subagentId);
+			this.#subagentProgress.delete(rec.subagentId);
 			this.#drainResumeQueue();
 			return true;
 		}
@@ -671,6 +710,7 @@ export class AsyncJobManager {
 			if (idx !== -1) this.#resumeQueue.splice(idx, 1);
 			rec.status = "cancelled";
 			rec.queued = undefined;
+			this.#subagentProgress.delete(rec.subagentId);
 			return true;
 		}
 		return false;
@@ -685,6 +725,7 @@ export class AsyncJobManager {
 				this.#liveHandles.delete(sid);
 				this.#resumeDescriptors.delete(sid);
 				this.#subagentRecords.delete(sid);
+				this.#subagentProgress.delete(sid);
 			}
 		}
 	}
@@ -1021,6 +1062,7 @@ export class AsyncJobManager {
 		this.#ownerCleanups.clear();
 		this.#subagentRecords.clear();
 		this.#liveHandles.clear();
+		this.#subagentProgress.clear();
 		this.#resumeDescriptors.clear();
 		this.#resumeQueue.length = 0;
 		this.#notifyChange();

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1324,6 +1324,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							progressMap.set(index, {
 								...structuredClone(progress),
 							});
+							AsyncJobManager.instance()?.recordSubagentProgress(task.id, progress);
 							emitProgress();
 						},
 						authStorage: this.session.authStorage,
@@ -1384,6 +1385,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							progressMap.set(index, {
 								...structuredClone(progress),
 							});
+							AsyncJobManager.instance()?.recordSubagentProgress(task.id, progress);
 							emitProgress();
 						},
 						authStorage: this.session.authStorage,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -691,6 +691,20 @@ function renderAgentProgress(
 }
 
 /**
+ * Public wrapper to render a single subagent's live `AgentProgress` for the
+ * `subagent` await panel. Reuses the internal task-progress renderer so the
+ * await panel stays at parity with the inline task panel.
+ */
+export function renderSubagentLiveProgress(
+	progress: AgentProgress,
+	expanded: boolean,
+	theme: Theme,
+	spinnerFrame?: number,
+): string[] {
+	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame);
+}
+
+/**
  * Render review result with combined verdict + findings in tree structure.
  */
 function renderReviewResult(

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -29,6 +29,7 @@ import { resolveToolRenderer } from "./resolve";
 import { searchToolRenderer } from "./search";
 import { searchToolBm25Renderer } from "./search-tool-bm25";
 import { sshToolRenderer } from "./ssh";
+import { subagentToolRenderer } from "./subagent-render";
 import { todoWriteToolRenderer } from "./todo-write";
 import { writeToolRenderer } from "./write";
 
@@ -66,6 +67,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	resolve: resolveToolRenderer as ToolRenderer,
 	search_tool_bm25: searchToolBm25Renderer as ToolRenderer,
 	ssh: sshToolRenderer as ToolRenderer,
+	subagent: subagentToolRenderer as ToolRenderer,
 	task: taskToolRenderer as ToolRenderer,
 	todo_write: todoWriteToolRenderer as ToolRenderer,
 	github: githubToolRenderer as ToolRenderer,

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -1,0 +1,160 @@
+/**
+ * TUI renderer for the `subagent` tool.
+ *
+ * The await panel surfaces each awaited subagent's live streaming status at
+ * parity with the inline `task` panel by reusing `renderSubagentLiveProgress`.
+ * Falls back to a `running, no activity yet` placeholder when a live producer
+ * exists but has not emitted yet, and to a static status line when no live
+ * producer is available (resumed-from-disk or backward-compat records).
+ */
+import type { Component } from "@gajae-code/tui";
+import { Text } from "@gajae-code/tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import { renderSubagentLiveProgress } from "../task/render";
+import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
+import {
+	formatDuration,
+	formatStatusIcon,
+	getPreviewLines,
+	replaceTabs,
+	type ToolUIStatus,
+	truncateToWidth,
+} from "./render-utils";
+import type { SubagentSnapshot, SubagentToolDetails } from "./subagent";
+
+const PREVIEW_LINES_COLLAPSED = 1;
+const PREVIEW_LINES_EXPANDED = 4;
+const PREVIEW_LINE_WIDTH = 80;
+
+function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
+	switch (status) {
+		case "completed":
+		case "already_completed":
+			return "success";
+		case "failed":
+			return "error";
+		case "cancelled":
+		case "not_found":
+			return "warning";
+		case "queued":
+			return "pending";
+		default:
+			return "info";
+	}
+}
+
+function renderSubagentSnapshot(
+	snapshot: SubagentSnapshot,
+	expanded: boolean,
+	theme: Theme,
+	spinnerFrame: number | undefined,
+): string[] {
+	const lines: string[] = [];
+	const icon = formatStatusIcon(
+		statusIconKind(snapshot.status),
+		theme,
+		snapshot.status === "running" ? spinnerFrame : undefined,
+	);
+	const id = theme.fg("muted", snapshot.id);
+	const status = theme.fg("dim", snapshot.status);
+	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
+	lines.push(`${icon} ${id} ${status} ${duration}`);
+
+	// Static receipt fields (parity with the markdown content for non-await actions).
+	if (snapshot.jobId !== snapshot.id) lines.push(`  ${theme.fg("dim", `Job: ${snapshot.jobId}`)}`);
+	if (snapshot.agent && snapshot.agent !== "unknown") {
+		lines.push(`  ${theme.fg("dim", `Agent: ${snapshot.agent} (${snapshot.agentSource})`)}`);
+	}
+	if (snapshot.description) lines.push(`  ${theme.fg("dim", `Description: ${snapshot.description}`)}`);
+	if (snapshot.outputRef) lines.push(`  ${theme.fg("dim", `Output: ${snapshot.outputRef}`)}`);
+	if (snapshot.assignment) {
+		lines.push(`  ${theme.fg("dim", "Assignment:")}`);
+		for (const al of snapshot.assignment.split("\n")) lines.push(`    ${theme.fg("toolOutput", replaceTabs(al))}`);
+	}
+
+	if (snapshot.progress) {
+		// Live streaming panel (full task-panel parity), indented under the header.
+		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, spinnerFrame)) {
+			lines.push(`  ${pl}`);
+		}
+	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
+		lines.push(`  ${theme.fg("dim", "running, no activity yet")}`);
+	}
+
+	const preview = snapshot.errorText?.trim() || snapshot.resultText?.trim();
+	if (preview) {
+		const maxLines = expanded ? PREVIEW_LINES_EXPANDED : PREVIEW_LINES_COLLAPSED;
+		const tone = snapshot.errorText ? "error" : "dim";
+		for (const pl of getPreviewLines(preview, maxLines, PREVIEW_LINE_WIDTH, Ellipsis.Unicode)) {
+			lines.push(`  ${theme.fg(tone, replaceTabs(pl))}`);
+		}
+		if (snapshot.truncated) {
+			lines.push(
+				`  ${theme.fg("dim", "Preview truncated; use the output ref or explicit ids with `verbosity=full` for more.")}`,
+			);
+		}
+	}
+
+	if (snapshot.guidance) lines.push(`  ${theme.fg("dim", snapshot.guidance)}`);
+	return lines;
+}
+
+export const subagentToolRenderer = {
+	inline: true,
+
+	renderCall(_args: unknown, _options: RenderResultOptions, theme: Theme): Component {
+		return new Text(renderStatusLine({ icon: "pending", title: "Subagent" }, theme), 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: SubagentToolDetails },
+		options: RenderResultOptions,
+		theme: Theme,
+	): Component {
+		const subagents = result.details?.subagents ?? [];
+		if (subagents.length === 0) {
+			const fallback = result.content.find(c => c.type === "text")?.text || "No subagents";
+			return new Text(theme.fg("dim", truncateToWidth(fallback, 100)), 0, 0);
+		}
+
+		const runningCount = subagents.filter(s => s.status === "running").length;
+
+		let cached: RenderCache | undefined;
+		return {
+			render(width: number): string[] {
+				const expanded = options.expanded;
+				const spinnerFrame = options.spinnerFrame ?? 0;
+				const key = new Hasher().bool(expanded).u32(width).u32(spinnerFrame).digest();
+				if (cached?.key === key) return cached.lines;
+
+				const header = renderStatusLine(
+					{
+						icon: runningCount > 0 ? "info" : "success",
+						spinnerFrame: runningCount > 0 ? options.spinnerFrame : undefined,
+						title: "Subagent",
+						description:
+							runningCount > 0
+								? `awaiting ${runningCount} of ${subagents.length}`
+								: `${subagents.length} ${subagents.length === 1 ? "subagent" : "subagents"}`,
+					},
+					theme,
+				);
+
+				const lines: string[] = [header];
+				for (const snapshot of subagents) {
+					lines.push(...renderSubagentSnapshot(snapshot, expanded, theme, options.spinnerFrame));
+				}
+
+				const out = lines.map(l => (l.length > 0 ? truncateToWidth(l, width, Ellipsis.Omit) : ""));
+				cached = { key, lines: out };
+				return out;
+			},
+			invalidate() {
+				cached = undefined;
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+};

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -4,7 +4,7 @@ import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
-import type { AgentSource } from "../task/types";
+import type { AgentProgress, AgentSource } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
 import type { ToolSession } from "./index";
 import { replaceTabs } from "./render-utils";
@@ -63,6 +63,10 @@ export interface SubagentSnapshot {
 	outputRef?: string;
 	truncated?: boolean;
 	guidance?: string;
+	/** Live streaming progress for the awaited subagent (await panel only; UI detail). */
+	progress?: AgentProgress;
+	/** True when a live in-session progress producer exists for this subagent. */
+	liveProgressAvailable?: boolean;
 }
 
 export interface SubagentToolDetails {
@@ -322,10 +326,10 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		manager.watchJobs(watchedJobIds);
 		const progressTimer = onUpdate
 			? setInterval(() => {
-					onUpdate(this.#progressResult(manager, records));
+					onUpdate(this.#progressResult(manager, records, true));
 				}, 500)
 			: undefined;
-		onUpdate?.(this.#progressResult(manager, records));
+		onUpdate?.(this.#progressResult(manager, records, true));
 
 		let timedOut = false;
 		try {
@@ -355,6 +359,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			notFoundIds,
 			timedOut,
 			verbosity: params.verbosity ?? "receipt",
+			attachLiveProgress: true,
 		});
 	}
 
@@ -450,17 +455,29 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		return ids.filter(id => !this.#findVisibleRecord(manager, id, ownerFilter));
 	}
 
-	#progressResult(manager: AsyncJobManager, records: SubagentRecord[]): AgentToolResult<SubagentToolDetails> {
+	#progressResult(
+		manager: AsyncJobManager,
+		records: SubagentRecord[],
+		attachLiveProgress = false,
+	): AgentToolResult<SubagentToolDetails> {
 		return {
 			content: [{ type: "text", text: "" }],
-			details: { subagents: this.#recordSnapshots(manager, records, false, "receipt", new Set()) },
+			details: {
+				subagents: this.#recordSnapshots(manager, records, false, "receipt", new Set(), attachLiveProgress),
+			},
 		};
 	}
 
 	async #buildRecordResult(
 		manager: AsyncJobManager,
 		records: SubagentRecord[],
-		options: { title: string; notFoundIds?: string[]; timedOut?: boolean; verbosity?: SubagentParams["verbosity"] },
+		options: {
+			title: string;
+			notFoundIds?: string[];
+			timedOut?: boolean;
+			verbosity?: SubagentParams["verbosity"];
+			attachLiveProgress?: boolean;
+		},
 	): Promise<AgentToolResult<SubagentToolDetails>> {
 		const verifiedOutputIds = await this.#verifiedOutputIds(records);
 		const snapshots = this.#recordSnapshots(
@@ -469,6 +486,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			options.timedOut,
 			options.verbosity ?? "receipt",
 			verifiedOutputIds,
+			options.attachLiveProgress ?? false,
 		);
 		for (const id of options.notFoundIds ?? []) {
 			snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
@@ -513,8 +531,28 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		timedOut = false,
 		verbosity: SubagentParams["verbosity"] = "receipt",
 		verifiedOutputIds: ReadonlySet<string>,
+		attachLiveProgress = false,
 	): SubagentSnapshot[] {
-		return records.map(record => this.#recordSnapshot(manager, record, timedOut, verbosity, verifiedOutputIds));
+		return records.map(record =>
+			this.#recordSnapshot(manager, record, timedOut, verbosity, verifiedOutputIds, attachLiveProgress),
+		);
+	}
+
+	#liveProgressFields(
+		manager: AsyncJobManager,
+		record: SubagentRecord,
+		attachLiveProgress: boolean,
+	): Pick<SubagentSnapshot, "progress" | "liveProgressAvailable"> {
+		if (!attachLiveProgress) return {};
+		const liveProgressAvailable = manager.hasLiveSubagent(record.subagentId);
+		// Only surface progress when a live producer exists; stale/retained progress
+		// for a record with no live producer must degrade to a static snapshot (AC5).
+		if (!liveProgressAvailable) return { liveProgressAvailable: false };
+		const progress = manager.getSubagentProgress(record.subagentId);
+		return {
+			liveProgressAvailable: true,
+			...(progress ? { progress } : {}),
+		};
 	}
 
 	#recordSnapshot(
@@ -523,7 +561,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		timedOut = false,
 		verbosity: SubagentParams["verbosity"] = "receipt",
 		verifiedOutputIds: ReadonlySet<string>,
+		attachLiveProgress = false,
 	): SubagentSnapshot {
+		const liveFields = this.#liveProgressFields(manager, record, attachLiveProgress);
 		const job = record.currentJobId ? manager.getJob(record.currentJobId) : undefined;
 		if (job) {
 			return {
@@ -531,6 +571,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				id: record.subagentId,
 				jobId: record.currentJobId ?? job.id,
 				status: record.status,
+				...liveFields,
 			};
 		}
 		return {
@@ -542,6 +583,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			agentSource: "bundled",
 			durationMs: 0,
 			...(verifiedOutputIds.has(record.subagentId) ? { outputRef: `agent://${record.subagentId}` } : {}),
+			...liveFields,
 		};
 	}
 

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { AsyncJobManager, type SubagentRecord } from "../../src/async";
+import { Settings } from "../../src/config/settings";
+import type { AgentProgress } from "../../src/task/types";
+import { SubagentTool, type ToolSession } from "../../src/tools";
+
+function createSession(agentId = "0-Main"): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getAgentId: () => agentId,
+	} as ToolSession;
+}
+
+function createManager(): AsyncJobManager {
+	const manager = new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 10_000 });
+	AsyncJobManager.setInstance(manager);
+	return manager;
+}
+
+function makeProgress(overrides: Partial<AgentProgress> & Pick<AgentProgress, "id">): AgentProgress {
+	return {
+		index: 0,
+		agent: "executor",
+		agentSource: "bundled",
+		status: "running",
+		task: "assignment",
+		recentTools: [],
+		recentOutput: [],
+		toolCount: 0,
+		tokens: 0,
+		cost: 0,
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+function runningRecord(subagentId: string, jobId: string): SubagentRecord {
+	return {
+		subagentId,
+		ownerId: "0-Main",
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: null,
+		resumable: false,
+	};
+}
+
+describe("subagent await live progress", () => {
+	afterEach(() => {
+		AsyncJobManager.resetForTests();
+	});
+
+	it("surfaces retained progress recorded before await (replay, no new event)", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register(
+			"task",
+			"live subagent",
+			async () => {
+				await Bun.sleep(150);
+				return "done";
+			},
+			{
+				id: "job-live",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Live", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+		// Record progress BEFORE await; no further progress event will fire.
+		manager.recordSubagentProgress(
+			"0-Live",
+			makeProgress({ id: "0-Live", currentTool: "read", recentOutput: ["scanning files"] }),
+		);
+
+		const result = await tool.execute("await", { action: "await", ids: ["0-Live"], timeout_ms: 5 });
+		const snap = result.details?.subagents.find(s => s.id === "0-Live");
+
+		expect(snap?.status).toBe("running");
+		expect(snap?.liveProgressAvailable).toBe(true);
+		expect(snap?.progress?.currentTool).toBe("read");
+		expect(snap?.progress?.recentOutput).toContain("scanning files");
+
+		manager.cancelSubagent("0-Live", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("isolates live progress per subagent id", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobA = manager.register(
+			"task",
+			"a",
+			async () => {
+				await Bun.sleep(150);
+				return "a";
+			},
+			{
+				id: "job-a",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-A", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		const jobB = manager.register(
+			"task",
+			"b",
+			async () => {
+				await Bun.sleep(150);
+				return "b";
+			},
+			{
+				id: "job-b",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-B", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-A", jobA));
+		manager.registerSubagentRecord(runningRecord("0-B", jobB));
+		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "read" }));
+		manager.recordSubagentProgress("0-B", makeProgress({ id: "0-B", currentTool: "bash" }));
+
+		const result = await tool.execute("await", { action: "await", ids: ["0-A", "0-B"], timeout_ms: 5 });
+		const a = result.details?.subagents.find(s => s.id === "0-A");
+		const b = result.details?.subagents.find(s => s.id === "0-B");
+
+		expect(a?.progress?.currentTool).toBe("read");
+		expect(b?.progress?.currentTool).toBe("bash");
+
+		manager.cancelSubagent("0-A", { ownerId: "0-Main" });
+		manager.cancelSubagent("0-B", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("degrades to no live producer when the record is not a live in-session subagent", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		// No registerSubagentRecord -> the tool synthesizes a backward-compat record.
+		manager.register(
+			"task",
+			"synth subagent",
+			async () => {
+				await Bun.sleep(150);
+				return "done";
+			},
+			{
+				id: "job-synth",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Synth", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+
+		const result = await tool.execute("await", { action: "await", ids: ["0-Synth"], timeout_ms: 5 });
+		const snap = result.details?.subagents.find(s => s.id === "0-Synth");
+
+		expect(snap?.status).toBe("running");
+		expect(snap?.progress).toBeUndefined();
+		expect(snap?.liveProgressAvailable).toBe(false);
+
+		manager.cancel("job-synth", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("does not surface retained progress when no live producer exists (stale-progress degrade)", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		// Synthesized backward-compat record (no canonical SubagentRecord) => no live producer.
+		manager.register(
+			"task",
+			"synth stale subagent",
+			async () => {
+				await Bun.sleep(150);
+				return "done";
+			},
+			{
+				id: "job-stale",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Stale", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		// Retained progress exists for the id, but there is no live producer for it.
+		manager.recordSubagentProgress("0-Stale", makeProgress({ id: "0-Stale", currentTool: "should-not-render" }));
+
+		const result = await tool.execute("await", { action: "await", ids: ["0-Stale"], timeout_ms: 5 });
+		const snap = result.details?.subagents.find(s => s.id === "0-Stale");
+
+		expect(snap?.liveProgressAvailable).toBe(false);
+		expect(snap?.progress).toBeUndefined();
+
+		manager.cancel("job-stale", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+});
+
+describe("AsyncJobManager subagent progress retention", () => {
+	afterEach(() => {
+		AsyncJobManager.resetForTests();
+	});
+
+	it("hasLiveSubagent is true for a canonical running record and false for synthesized/absent ids", () => {
+		const manager = createManager();
+		const jobId = manager.register(
+			"task",
+			"live",
+			async ({ signal }) => {
+				while (!signal.aborted) await Bun.sleep(5);
+				throw new Error("cancelled");
+			},
+			{
+				id: "job-live",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Live", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Live", jobId));
+
+		expect(manager.hasLiveSubagent("0-Live")).toBe(true);
+		expect(manager.hasLiveSubagent("0-Absent")).toBe(false);
+
+		manager.cancelSubagent("0-Live", { ownerId: "0-Main" });
+	});
+
+	it("clears retained progress on terminal cleanup (cancel)", async () => {
+		const manager = createManager();
+		const jobId = manager.register(
+			"task",
+			"cleanup",
+			async ({ signal }) => {
+				while (!signal.aborted) await Bun.sleep(5);
+				throw new Error("cancelled");
+			},
+			{
+				id: "job-clean",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Clean", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Clean", jobId));
+		manager.recordSubagentProgress("0-Clean", makeProgress({ id: "0-Clean", currentTool: "read" }));
+		expect(manager.getSubagentProgress("0-Clean")).toBeDefined();
+
+		manager.cancelSubagent("0-Clean", { ownerId: "0-Main" });
+		await manager.getJob(jobId)?.promise;
+
+		expect(manager.getSubagentProgress("0-Clean")).toBeUndefined();
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("ignores progress for ids without a canonical subagent record (foreground task isolation)", () => {
+		const manager = createManager();
+		manager.recordSubagentProgress("0-Foreground", makeProgress({ id: "0-Foreground", currentTool: "read" }));
+		expect(manager.getSubagentProgress("0-Foreground")).toBeUndefined();
+	});
+
+	it("clears retained progress at resume start so a resumed run shows no stale live status", () => {
+		const manager = createManager();
+		const firstJob = manager.register(
+			"task",
+			"resume-1",
+			async () => {
+				await Bun.sleep(200);
+				return "one";
+			},
+			{
+				id: "job-r1",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Resume", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord({
+			subagentId: "0-Resume",
+			ownerId: "0-Main",
+			currentJobId: firstJob,
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/0-Resume.jsonl",
+			resumable: true,
+		});
+		manager.recordSubagentProgress("0-Resume", makeProgress({ id: "0-Resume", currentTool: "old-tool" }));
+		expect(manager.getSubagentProgress("0-Resume")).toBeDefined();
+
+		manager.setResumeRunner(() =>
+			manager.register(
+				"task",
+				"resume-2",
+				async () => {
+					await Bun.sleep(200);
+					return "two";
+				},
+				{
+					id: "job-r2",
+					ownerId: "0-Main",
+					metadata: { subagent: { id: "0-Resume", agent: "executor", agentSource: "bundled" } },
+				},
+			),
+		);
+
+		const result = manager.resumeSubagent("0-Resume", { ownerId: "0-Main" }, "go");
+		expect(result.ok).toBe(true);
+		// Retained progress from the previous run must be gone before the new run emits.
+		expect(manager.getSubagentProgress("0-Resume")).toBeUndefined();
+	});
+
+	it("deep-clones retained progress so later mutation cannot corrupt it", () => {
+		const manager = createManager();
+		manager.registerSubagentRecord(runningRecord("0-Clone", "job-clone"));
+		const live = makeProgress({ id: "0-Clone", recentOutput: ["one"] });
+		manager.recordSubagentProgress("0-Clone", live);
+		live.recentOutput.push("two");
+		live.currentTool = "mutated";
+
+		const retained = manager.getSubagentProgress("0-Clone");
+		expect(retained?.recentOutput).toEqual(["one"]);
+		expect(retained?.currentTool).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -1,0 +1,150 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { Theme } from "../../src/modes/theme/theme";
+import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
+import type { AgentProgress } from "../../src/task/types";
+import type { SubagentSnapshot, SubagentToolDetails } from "../../src/tools/subagent";
+import { subagentToolRenderer } from "../../src/tools/subagent-render";
+
+let theme: Theme;
+
+beforeAll(async () => {
+	theme = (await getThemeByName("red-claw"))!;
+	expect(theme).toBeDefined();
+	setThemeInstance(theme);
+});
+
+function progress(overrides: Partial<AgentProgress> & Pick<AgentProgress, "id">): AgentProgress {
+	return {
+		index: 0,
+		agent: "executor",
+		agentSource: "bundled",
+		status: "running",
+		task: "assignment",
+		recentTools: [],
+		recentOutput: [],
+		toolCount: 0,
+		tokens: 0,
+		cost: 0,
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+function snapshot(overrides: Partial<SubagentSnapshot> & Pick<SubagentSnapshot, "id">): SubagentSnapshot {
+	return {
+		jobId: overrides.id,
+		status: "running",
+		label: "subagent",
+		agent: "executor",
+		agentSource: "bundled",
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+function render(details: SubagentToolDetails): string {
+	const component = subagentToolRenderer.renderResult(
+		{ content: [{ type: "text", text: "" }], details },
+		{ expanded: true, isPartial: true, spinnerFrame: 0 },
+		theme,
+	);
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+describe("subagentToolRenderer", () => {
+	it("renders live progress (current tool + recent output) when present", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Live",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-Live", currentTool: "read", recentOutput: ["scanning the repo"] }),
+				}),
+			],
+		});
+		expect(out).toContain("read");
+		expect(out).toContain("scanning the repo");
+	});
+
+	it("renders the placeholder when a live producer exists but no progress yet", () => {
+		const out = render({
+			subagents: [snapshot({ id: "0-Pending", status: "running", liveProgressAvailable: true })],
+		});
+		expect(out).toContain("running, no activity yet");
+	});
+
+	it("renders static status without a no-activity claim when no live producer", () => {
+		const out = render({
+			subagents: [snapshot({ id: "0-Static", status: "running", liveProgressAvailable: false })],
+		});
+		expect(out).toContain("0-Static");
+		expect(out).not.toContain("running, no activity yet");
+	});
+
+	it("stacks multiple awaited subagents", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-A",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-A", currentTool: "read" }),
+				}),
+				snapshot({
+					id: "0-B",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-B", currentTool: "bash" }),
+				}),
+			],
+		});
+		expect(out).toContain("read");
+		expect(out).toContain("bash");
+	});
+
+	it("preserves static receipt fields for non-await actions (guidance, output ref, description, agent, assignment, truncation)", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Done",
+					jobId: "job-done",
+					status: "completed",
+					agent: "executor",
+					description: "did the thing",
+					assignment: "Do the work carefully.",
+					outputRef: "agent://0-Done",
+					resultText: "final answer",
+					truncated: true,
+					guidance: "This subagent is terminal. Provide `message` to start a follow-up resume run.",
+				}),
+			],
+		});
+		expect(out).toContain("job-done");
+		expect(out).toContain("Agent: executor");
+		expect(out).toContain("did the thing");
+		expect(out).toContain("Assignment:");
+		expect(out).toContain("Do the work carefully.");
+		expect(out).toContain("agent://0-Done");
+		expect(out).toContain("final answer");
+		expect(out).toContain("Preview truncated");
+		expect(out).toContain("terminal");
+	});
+
+	it("intentionally suppresses an unknown agent line (no noisy 'Agent: unknown')", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Missing",
+					status: "not_found",
+					agent: "unknown",
+					guidance: "No visible detached subagent matches this id.",
+				}),
+			],
+		});
+		expect(out).not.toContain("Agent: unknown");
+		expect(out).toContain("No visible detached subagent");
+	});
+
+	it("does not throw on empty subagents", () => {
+		const out = render({ subagents: [] });
+		expect(out).toContain("No subagents");
+	});
+});


### PR DESCRIPTION
## What

When you `await` a detached sub-agent, the await panel now shows that sub-agent's **live streaming status** (current tool, recent output, tokens/cost) at parity with the inline `task` panel — instead of just `running + duration`.

## Why

The live `AgentProgress` already existed and flowed on `TASK_SUBAGENT_PROGRESS_CHANNEL` into the TUI observer overlay, but the `subagent` tool's `await` action never read it, and there was no registered renderer for `subagent` results.

## How

- **Manager retention** (`async/job-manager.ts`): retain the latest deep-cloned `AgentProgress` per detached subagent (`recordSubagentProgress`/`getSubagentProgress`/`hasLiveSubagent`), fed by the existing detached `onProgress` closure in `task/index.ts`. Cleared on terminal/cancel/pause/resume/purge/dispose. Ignores ids without a canonical `SubagentRecord` so foreground task progress is never retained.
- **Await wiring** (`tools/subagent.ts`): the existing 500ms poll reads retained progress (replayable — no in-tool EventBus subscription). `SubagentSnapshot` gains `progress` + `liveProgressAvailable`; progress is surfaced only when a live producer exists (static degrade otherwise, no misleading "no activity" message).
- **Renderer** (`tools/subagent-render.ts`, `task/render.ts`): a `subagent` renderer reuses the task panel via an exported `renderSubagentLiveProgress` wrapper — full-parity live panels stacked per subagent, a `running, no activity yet` placeholder, and full static receipt-field parity (Job/Agent/Description/Output/Assignment/truncation/Guidance) so non-await actions don't regress.

Layering stays clean: the tool reads only `AsyncJobManager`; the TUI-layer `SessionObserverRegistry` is untouched.

## Tests

`subagent-live-progress.test.ts` + `subagent-render.test.ts`: late-await replay, per-id isolation, no-live-producer degrade, foreground-id gating, resume-start clearing, terminal cleanup, clone-on-write, and renderer live/placeholder/static/static-field coverage. All 40 targeted tests pass; `tsc --noEmit`, biome, and workspace `check` are green.

## Review provenance

Planned via ralplan consensus (Architect CLEAR + Critic OKAY) and executed via ultragoal with a strict completion gate: architect 3-lane review CLEAR/CLEAR/CLEAR + APPROVE, executor red-team QA passed (40/40 targeted + 45/45 adversarial), ai-slop-cleaner zero blocking findings.