### PR TITLE
fix(ask): collect Other custom input inline below the option list

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -122,6 +122,19 @@ export interface ExtensionUIDialogOptions {
 	 * select-only rendering hint; non-TUI bridges drop it and do not serialize it.
 	 */
 	scrollTitleRows?: number;
+	/**
+	 * For interactive TUI select dialogs, handle the option with `optionLabel`
+	 * inline: selecting it keeps the title and option list on screen and opens
+	 * a free-text input below the list. Submitting calls `onSubmit` with the
+	 * typed text and resolves the select with `optionLabel`; Escape returns to
+	 * option selection. Non-TUI bridges (RPC, ACP) drop it; callers must keep
+	 * a fallback path for selects that resolve `optionLabel` without invoking
+	 * `onSubmit`.
+	 */
+	customInput?: {
+		optionLabel: string;
+		onSubmit: (text: string) => void;
+	};
 }
 
 /** Raw terminal input listener for extensions. */

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -4,6 +4,7 @@
  */
 import {
 	Container,
+	Editor,
 	Markdown,
 	matchesKey,
 	padding,
@@ -16,8 +17,13 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@gajae-code/tui";
-import { getMarkdownTheme, theme } from "../../modes/theme/theme";
-import { matchesAppExternalEditor, matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
+import { getEditorTheme, getMarkdownTheme, theme } from "../../modes/theme/theme";
+import {
+	matchesAppExternalEditor,
+	matchesAppInterrupt,
+	matchesSelectCancel,
+} from "../../modes/utils/keybinding-matchers";
+import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { CountdownTimer } from "./countdown-timer";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -56,6 +62,17 @@ export interface HookSelectorOptions {
 	 */
 	wrapFocused?: boolean;
 	scrollTitleRows?: number;
+	/**
+	 * Inline free-text entry for the option with this label (e.g. the ask
+	 * tool's "Other (type your own)"). Selecting it keeps the title and option
+	 * list on screen and opens a prompt-style editor below the list instead of
+	 * replacing the whole selector. Enter submits via `onSubmit`; Escape
+	 * returns to option selection.
+	 */
+	customInput?: {
+		optionLabel: string;
+		onSubmit: (text: string) => void;
+	};
 }
 
 class OutlinedList extends Container {
@@ -297,6 +314,12 @@ export class HookSelectorComponent extends Container {
 	#wrapFocused: boolean;
 	#outline: boolean;
 	#scrollTitleRows: number | undefined;
+	#customInput: { optionLabel: string; onSubmit: (text: string) => void } | undefined;
+	#inputArea: Container;
+	#inlineEditor: Editor | undefined;
+	#helpTextComponent: Text;
+	#baseHelpText: string;
+	#tui: TUI | undefined;
 	constructor(
 		title: string,
 		options: string[],
@@ -317,6 +340,8 @@ export class HookSelectorComponent extends Container {
 		this.#onExternalEditorCallback = opts?.onExternalEditor;
 		this.#wrapFocused = opts?.wrapFocused === true;
 		this.#outline = opts?.outline === true;
+		this.#customInput = opts?.customInput;
+		this.#tui = opts?.tui;
 
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
@@ -364,9 +389,12 @@ export class HookSelectorComponent extends Container {
 			this.#listContainer = new Container();
 			this.addChild(this.#listContainer);
 		}
+		this.#inputArea = new Container();
+		this.addChild(this.#inputArea);
 		this.addChild(new Spacer(1));
-		const controlsHint = opts?.helpText ?? "up/down navigate  enter select  esc cancel";
-		this.addChild(new Text(theme.fg("dim", controlsHint), 1, 0));
+		this.#baseHelpText = opts?.helpText ?? "up/down navigate  enter select  esc cancel";
+		this.#helpTextComponent = new Text(theme.fg("dim", this.#baseHelpText), 1, 0);
+		this.addChild(this.#helpTextComponent);
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 
@@ -432,6 +460,10 @@ export class HookSelectorComponent extends Container {
 			this.#scrollableTitle?.scrollBy(this.#scrollTitleRows);
 			return;
 		}
+		if (this.#inlineEditor) {
+			this.#handleInputModeKey(keyData, this.#inlineEditor);
+			return;
+		}
 		if (matchesKey(keyData, "up") || keyData === "k") {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			this.#updateList();
@@ -440,7 +472,12 @@ export class HookSelectorComponent extends Container {
 			this.#updateList();
 		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selected = this.#options[this.#selectedIndex];
-			if (selected) this.#onSelectCallback(selected);
+			if (!selected) return;
+			if (this.#customInput && selected === this.#customInput.optionLabel) {
+				this.#enterInputMode();
+				return;
+			}
+			this.#onSelectCallback(selected);
 		} else if (matchesKey(keyData, "left")) {
 			this.#onLeftCallback?.();
 		} else if (matchesKey(keyData, "right")) {
@@ -449,6 +486,73 @@ export class HookSelectorComponent extends Container {
 			this.#onExternalEditorCallback();
 		} else if (matchesSelectCancel(keyData)) {
 			this.#onCancelCallback();
+		}
+	}
+
+	/** Keys while the inline custom-input editor is open below the option list. */
+	#handleInputModeKey(keyData: string, editor: Editor): void {
+		// Escape backs out to option selection instead of cancelling the dialog,
+		// so a stray Esc never throws away the question context.
+		if (matchesKey(keyData, "escape") || matchesAppInterrupt(keyData)) {
+			this.#exitInputMode();
+			return;
+		}
+		if (matchesAppExternalEditor(keyData)) {
+			void this.#openExternalEditor(editor);
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return")) {
+			this.#customInput?.onSubmit(editor.getText());
+			return;
+		}
+		editor.handleInput(keyData);
+	}
+
+	#enterInputMode(): void {
+		if (this.#inlineEditor) return;
+		// Stop the auto-select countdown for good: the user is actively typing,
+		// matching the old behavior where the separate editor had no timeout.
+		if (this.#countdown) {
+			this.#countdown.dispose();
+			this.#countdown = undefined;
+			this.#titleComponent.setText(this.#baseTitle);
+		}
+		const editor = new Editor(getEditorTheme());
+		editor.setBorderVisible(false);
+		editor.setPromptGutter("> ");
+		editor.disableSubmit = true;
+		this.#inlineEditor = editor;
+		this.#inputArea.addChild(new Spacer(1));
+		this.#inputArea.addChild(editor);
+		const scrollHint = this.#scrollTitleRows === undefined ? "" : "  wheel/PgUp/PgDn scroll question";
+		this.#helpTextComponent.setText(
+			theme.fg("dim", `enter submit  esc back to options  ctrl+g external editor${scrollHint}`),
+		);
+		this.invalidate();
+	}
+
+	#exitInputMode(): void {
+		if (!this.#inlineEditor) return;
+		this.#inlineEditor = undefined;
+		this.#inputArea.clear();
+		this.#helpTextComponent.setText(theme.fg("dim", this.#baseHelpText));
+		this.invalidate();
+	}
+
+	async #openExternalEditor(editor: Editor): Promise<void> {
+		const editorCmd = getEditorCommand();
+		if (!editorCmd || !this.#tui) return;
+
+		const currentText = editor.getExpandedText();
+		try {
+			this.#tui.stop();
+			const result = await openInEditor(editorCmd, currentText);
+			if (result !== null) {
+				editor.setText(result);
+			}
+		} finally {
+			this.#tui.start();
+			this.#tui.requestRender(true);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -29,6 +29,7 @@ const HOOK_SELECTOR_MOUSE_REPORTING_ENABLE = "\x1b[?1006h\x1b[?1000h";
 const HOOK_SELECTOR_MOUSE_REPORTING_DISABLE = "\x1b[?1000l\x1b[?1006l";
 const HOOK_SELECTOR_CHROME_ROWS = 7;
 const HOOK_SELECTOR_OUTLINE_ROWS = 2;
+const HOOK_SELECTOR_INLINE_INPUT_ROWS = 2;
 
 export class ExtensionUiController {
 	#extensionTerminalInputUnsubscribers = new Set<() => void>();
@@ -601,8 +602,11 @@ export class ExtensionUiController {
 		const maxVisible =
 			requestedTitleRows === undefined ? baseMaxVisible : Math.min(15, Math.max(3, scrollOptionRows + 1));
 		const listChromeRows = dialogOptions?.outline === true ? HOOK_SELECTOR_OUTLINE_ROWS : 0;
+		// Reserve rows for the inline custom-input editor so opening it doesn't
+		// push the scrollable title past the viewport into terminal scrollback.
+		const inlineInputRows = dialogOptions?.customInput ? HOOK_SELECTOR_INLINE_INPUT_ROWS : 0;
 		const availableTitleRows =
-			this.ctx.ui.terminal.rows - scrollOptionRows - listChromeRows - HOOK_SELECTOR_CHROME_ROWS;
+			this.ctx.ui.terminal.rows - scrollOptionRows - listChromeRows - inlineInputRows - HOOK_SELECTOR_CHROME_ROWS;
 		const scrollTitleRows =
 			requestedTitleRows === undefined ? undefined : Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
 		if (scrollTitleRows !== undefined) {
@@ -645,6 +649,17 @@ export class ExtensionUiController {
 				wrapFocused: dialogOptions?.wrapFocused,
 				scrollTitleRows,
 				maxVisible,
+				customInput: dialogOptions?.customInput
+					? {
+							optionLabel: dialogOptions.customInput.optionLabel,
+							onSubmit: text => {
+								const optionLabel = dialogOptions.customInput?.optionLabel;
+								this.hideHookSelector();
+								dialogOptions.customInput?.onSubmit(text);
+								finish(optionLabel);
+							},
+						}
+					: undefined,
 			},
 		);
 		this.ctx.editorContainer.clear();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -175,6 +175,7 @@ interface UIContext {
 			onLeft?: () => void;
 			onRight?: () => void;
 			helpText?: string;
+			customInput?: { optionLabel: string; onSubmit: (text: string) => void };
 		},
 	): Promise<string | undefined>;
 	editor(
@@ -194,6 +195,7 @@ async function askSingleQuestion(
 ): Promise<SelectionResult> {
 	const { recommended, timeout, signal, initialSelection, navigation, scrollTitleRows } = options;
 	const doneLabel = getDoneOptionLabel();
+	const otherOptionLabel = options.otherOptionLabel ?? OTHER_OPTION;
 	let selectedOptions = [...(initialSelection?.selectedOptions ?? [])];
 	let customInput = initialSelection?.customInput;
 	let timedOut = false;
@@ -202,11 +204,20 @@ async function askSingleQuestion(
 		prompt: string,
 		optionsToShow: string[],
 		initialIndex?: number,
-	): Promise<{ choice: string | undefined; timedOut: boolean; navigation?: "back" | "forward" }> => {
+	): Promise<{
+		choice: string | undefined;
+		timedOut: boolean;
+		navigation?: "back" | "forward";
+		inlineInput?: string;
+	}> => {
 		let timeoutTriggered = false;
 		const onTimeout = () => {
 			timeoutTriggered = true;
 		};
+		// Inline custom input: the TUI selector keeps the question and option
+		// list on screen and collects the "Other" text below the list, instead
+		// of swapping to a separate editor screen that hides the question.
+		let inlineInput: string | undefined;
 		let navigationAction: "back" | "forward" | undefined;
 		const baseHelpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
@@ -222,6 +233,12 @@ async function askSingleQuestion(
 			scrollTitleRows,
 			onTimeout,
 			helpText,
+			customInput: {
+				optionLabel: otherOptionLabel,
+				onSubmit: (text: string) => {
+					inlineInput = text;
+				},
+			},
 			onLeft: navigation?.allowBack
 				? () => {
 						navigationAction = "back";
@@ -240,16 +257,17 @@ async function askSingleQuestion(
 		if (!timeoutTriggered && choice === undefined && typeof timeout === "number") {
 			timeoutTriggered = Date.now() - startMs >= timeout;
 		}
-		return { choice, timedOut: timeoutTriggered, navigation: navigationAction };
+		return { choice, timedOut: timeoutTriggered, navigation: navigationAction, inlineInput };
 	};
 
+	// Fallback for UI contexts that don't support inline custom input (they
+	// resolve the "Other" label without invoking customInput.onSubmit).
 	const promptForCustomInput = async (): Promise<{ input: string | undefined }> => {
 		const dialogOptions = signal ? { signal } : undefined;
 		const showCustomInput = () => ui.editor("Enter your response:", undefined, dialogOptions, { promptStyle: true });
 		const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
 		return { input };
 	};
-	const otherOptionLabel = options.otherOptionLabel ?? OTHER_OPTION;
 
 	const promptWithProgress = navigation?.progressText ? `${question} (${navigation.progressText})` : question;
 	if (multi) {
@@ -278,6 +296,7 @@ async function askSingleQuestion(
 				choice,
 				timedOut: selectTimedOut,
 				navigation: arrowNavigation,
+				inlineInput,
 			} = await selectOption(`${prefix}${promptWithProgress}`, opts, cursorIndex);
 
 			if (arrowNavigation) {
@@ -297,11 +316,11 @@ async function askSingleQuestion(
 					timedOut = true;
 					break;
 				}
-				const customResult = await promptForCustomInput();
-				if (customResult.input === undefined) {
+				const input = inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input;
+				if (input === undefined) {
 					break;
 				}
-				customInput = customResult.input;
+				customInput = input;
 				break;
 			}
 
@@ -353,6 +372,7 @@ async function askSingleQuestion(
 			choice,
 			timedOut: selectTimedOut,
 			navigation: arrowNavigation,
+			inlineInput,
 		} = await selectOption(promptWithProgress, optionsWithNavigation, initialIndex);
 		timedOut = selectTimedOut;
 
@@ -365,12 +385,12 @@ async function askSingleQuestion(
 			}
 		} else if (choice === otherOptionLabel) {
 			if (!selectTimedOut) {
-				const customResult = await promptForCustomInput();
-				if (customResult.input !== undefined) {
-					customInput = customResult.input;
+				const input = inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input;
+				if (input !== undefined) {
+					customInput = input;
 					selectedOptions = [];
 				}
-				// If editor was dismissed (undefined), keep prior selectedOptions/customInput intact
+				// If input was dismissed (undefined), keep prior selectedOptions/customInput intact
 			}
 		} else {
 			selectedOptions = [stripRecommendedSuffix(choice)];

--- a/packages/coding-agent/test/hook-selector-inline-input.test.ts
+++ b/packages/coding-agent/test/hook-selector-inline-input.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components/hook-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	const themeInstance = await getThemeByName("red-claw");
+	if (!themeInstance) {
+		throw new Error("Failed to load dark theme for tests");
+	}
+	setThemeInstance(themeInstance);
+});
+
+const TITLE = "Deep Interview question body\n\nLong explanation line one\nLong explanation line two";
+const OPTIONS = ["1. Option A", "2. Option B", "3. Other (type your own)"];
+const OTHER = OPTIONS[2]!;
+
+interface Callbacks {
+	selected: string[];
+	cancelled: number;
+	submitted: string[];
+}
+
+function createSelector(opts?: { scrollTitleRows?: number }): {
+	component: HookSelectorComponent;
+	calls: Callbacks;
+} {
+	const calls: Callbacks = { selected: [], cancelled: 0, submitted: [] };
+	const component = new HookSelectorComponent(
+		TITLE,
+		OPTIONS,
+		option => calls.selected.push(option),
+		() => calls.cancelled++,
+		{
+			customInput: {
+				optionLabel: OTHER,
+				onSubmit: text => calls.submitted.push(text),
+			},
+			scrollTitleRows: opts?.scrollTitleRows,
+		},
+	);
+	return { component, calls };
+}
+
+function renderText(component: HookSelectorComponent, width = 80): string {
+	return Bun.stripANSI(component.render(width).join("\n"));
+}
+
+function moveToOther(component: HookSelectorComponent): void {
+	component.handleInput("\x1b[B"); // down
+	component.handleInput("\x1b[B"); // down
+}
+
+describe("HookSelectorComponent inline custom input", () => {
+	it("keeps the title and option list visible after opening the input", () => {
+		const { component, calls } = createSelector();
+		moveToOther(component);
+		component.handleInput("\r");
+
+		const rendered = renderText(component);
+		expect(rendered).toContain("Deep Interview question body");
+		expect(rendered).toContain("1. Option A");
+		expect(rendered).toContain("2. Option B");
+		expect(rendered).toContain("3. Other (type your own)");
+		// The selector must not resolve yet — input mode is internal.
+		expect(calls.selected).toEqual([]);
+		expect(calls.submitted).toEqual([]);
+		expect(calls.cancelled).toBe(0);
+	});
+
+	it("shows input-mode help text and an inline prompt below the options", () => {
+		const { component } = createSelector();
+		const before = renderText(component);
+		expect(before).toContain("enter select");
+
+		moveToOther(component);
+		component.handleInput("\r");
+
+		const after = renderText(component);
+		expect(after).toContain("enter submit  esc back to options");
+		const optionRow = after.indexOf("3. Other");
+		const promptRow = after.indexOf("> ");
+		expect(promptRow).toBeGreaterThan(optionRow);
+	});
+
+	it("submits typed text via onSubmit instead of resolving an option", () => {
+		const { component, calls } = createSelector();
+		moveToOther(component);
+		component.handleInput("\r");
+
+		component.handleInput("h");
+		component.handleInput("i");
+		component.handleInput("\r");
+
+		expect(calls.submitted).toEqual(["hi"]);
+		expect(calls.selected).toEqual([]);
+		expect(calls.cancelled).toBe(0);
+	});
+
+	it("escape returns to option selection without cancelling the dialog", () => {
+		const { component, calls } = createSelector();
+		moveToOther(component);
+		component.handleInput("\r");
+		component.handleInput("x");
+		component.handleInput("\x1b");
+
+		expect(calls.cancelled).toBe(0);
+		const rendered = renderText(component);
+		expect(rendered).not.toContain("esc back to options");
+		expect(rendered).toContain("enter select");
+
+		// Selection mode is fully restored: enter on a normal option resolves it.
+		component.handleInput("\x1b[A"); // up to "2. Option B"
+		component.handleInput("\r");
+		expect(calls.selected).toEqual(["2. Option B"]);
+	});
+
+	it("escape in selection mode still cancels the dialog", () => {
+		const { component, calls } = createSelector();
+		component.handleInput("\x1b");
+		expect(calls.cancelled).toBe(1);
+	});
+
+	it("selecting a regular option resolves immediately without input mode", () => {
+		const { component, calls } = createSelector();
+		component.handleInput("\r");
+		expect(calls.selected).toEqual(["1. Option A"]);
+		expect(calls.submitted).toEqual([]);
+	});
+
+	it("without customInput, selecting the Other label resolves like any option", () => {
+		const selected: string[] = [];
+		const component = new HookSelectorComponent(
+			TITLE,
+			OPTIONS,
+			option => selected.push(option),
+			() => {},
+		);
+		moveToOther(component);
+		component.handleInput("\r");
+		expect(selected).toEqual([OTHER]);
+	});
+
+	it("keeps the question scrollable from input mode when scrollTitleRows is set", () => {
+		const { component } = createSelector({ scrollTitleRows: 2 });
+		moveToOther(component);
+		component.handleInput("\r");
+
+		const before = renderText(component);
+		expect(before).toContain("Deep Interview question body");
+		component.handleInput("\x1b[6~"); // PgDn scrolls the title, not the editor
+		const after = renderText(component);
+		expect(after).not.toContain("Deep Interview question body");
+		expect(after).toContain("esc back to options");
+	});
+});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -32,6 +32,7 @@ function createContext(args: {
 			onLeft?: () => void;
 			onRight?: () => void;
 			helpText?: string;
+			customInput?: { optionLabel: string; onSubmit: (text: string) => void };
 		},
 	) => Promise<string | undefined>;
 	editor?: (
@@ -417,6 +418,69 @@ describe("AskTool custom input", () => {
 		expect(result.details?.customInput).toBe(multilineText);
 		expect(result.details?.selectedOptions).toEqual([]);
 		expect(editor).toHaveBeenCalledTimes(1);
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("uses inline selector input for Other without opening the editor screen", async () => {
+		const tool = new AskTool(createSession());
+		const abort = vi.fn();
+		const editor = vi.fn(async () => "editor text");
+		const questions = [
+			{
+				id: "details",
+				question: "Share details",
+				options: [{ label: "yes" }, { label: "no" }],
+			},
+		];
+		const context = createContext({
+			select: async (_prompt, _options, dialogOptions) => {
+				// Simulate the TUI selector collecting the text inline below the
+				// option list, then resolving with the Other label.
+				expect(dialogOptions?.customInput?.optionLabel).toBe("Other (type your own)");
+				dialogOptions?.customInput?.onSubmit("inline answer");
+				return "Other (type your own)";
+			},
+			editor,
+			abort,
+		});
+
+		const result = await tool.execute("call-inline-single", { questions }, undefined, undefined, context);
+		expect(result.details?.customInput).toBe("inline answer");
+		expect(result.details?.selectedOptions).toEqual([]);
+		expect(editor).not.toHaveBeenCalled();
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("uses inline selector input for Other in multi-select questions", async () => {
+		const tool = new AskTool(createSession());
+		const abort = vi.fn();
+		const editor = vi.fn(async () => "editor text");
+		const questions = [
+			{
+				id: "details",
+				question: "Share details",
+				options: [{ label: "yes" }, { label: "no" }],
+				multi: true,
+			},
+		];
+		let call = 0;
+		const context = createContext({
+			select: async (_prompt, options, dialogOptions) => {
+				call++;
+				if (call === 1) {
+					return options.find(option => option.includes("yes"));
+				}
+				dialogOptions?.customInput?.onSubmit("inline multi answer");
+				return "Other (type your own)";
+			},
+			editor,
+			abort,
+		});
+
+		const result = await tool.execute("call-inline-multi", { questions }, undefined, undefined, context);
+		expect(result.details?.selectedOptions).toEqual(["yes"]);
+		expect(result.details?.customInput).toBe("inline multi answer");
+		expect(editor).not.toHaveBeenCalled();
 		expect(abort).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Problem

In deep-interview (and any `ask` tool) questions, choosing **Other (type your own)** threw away the question screen and replaced it with a bare input screen:

```
Enter your response:
>
```

- The (often long) deep-interview question body disappeared
- The other option labels disappeared too
- Users had to scroll the terminal scrollback to re-read the question while writing their answer — and any keystroke re-rendered the TUI back down to the input position, losing the scroll position

## Fix

Selecting **Other** no longer swaps to a separate editor screen. The selector stays on screen and a prompt-style input opens *inside* it, right below the option list:

```
딥인터뷰 질문 본문

  1. 선택지 A
  2. 선택지 B
❯ 3. Other (type your own)

> 직접 답변 입력…
```

- Question body and option list stay visible; the Other row stays focused so the selected state is visible
- Long questions remain scrollable **in-UI** (mouse wheel / PgUp / PgDn) while typing — no terminal-scrollback dependence
- `Enter` submits, `Shift+Enter` inserts a newline, `Ctrl+G` opens the external editor
- `Esc` now returns to option selection instead of cancelling the whole ask (previously esc from the editor aborted the tool)

## Implementation

- `HookSelectorComponent` gains an opt-in inline custom-input mode (`customInput` option): on selecting the configured option it opens a borderless prompt-gutter `Editor` below the list, switches the help line, and stops the auto-select countdown (matching the old editor screen, which had no timeout)
- `ExtensionUIDialogOptions.customInput` plumbs the option through `showHookSelector`, which reserves rows for the inline editor when budgeting the scrollable title
- The `ask` tool passes `customInput` for both single- and multi-select flows, and keeps the old `ui.editor` screen as a fallback for UI bridges (RPC, ACP) that resolve the Other label without inline-input support

## Tests

- New `hook-selector-inline-input.test.ts` (8 cases): title/options stay visible, inline prompt renders below the options, submit/escape semantics, selection-mode regression guards, in-UI question scrolling from input mode
- New `ask.test.ts` cases: inline path skips the editor screen in single- and multi-select flows
- All existing hook-selector/hook-editor/ask/deep-interview tests pass unchanged (`bun test` 149 pass), `tsgo --noEmit` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)