### PR TITLE
Add TUI paste-image slash command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a TUI-only `/paste-image` slash command, with `/attach-image` as an alias, so terminal clipboard image attachment remains reachable when the terminal intercepts normal paste handling.
+
 ## [0.4.3] - 2026-06-10
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -27,6 +27,14 @@ const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const CLIPBOARD_TEMP_IMAGE_FILE_PATTERN = /^clipboard-\d{4}-\d{2}-\d{2}-\d{6}-[A-Za-z0-9]+\.(?:png|jpe?g|gif|webp)$/i;
 const MACOS_CLIPBOARD_TEMP_DIR_PATTERN = /^\/var\/folders\/[^/]+\/[^/]+\/T$/;
 
+const PASTE_IMAGE_COMMAND_PATTERN = /(?:^|\s)\/(?:paste-image|attach-image)\s*$/;
+
+function stripTrailingPasteImageCommand(text: string): string | undefined {
+	const match = text.match(PASTE_IMAGE_COMMAND_PATTERN);
+	if (!match || match.index === undefined) return undefined;
+	return text.slice(0, match.index).trimEnd();
+}
+
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
@@ -250,6 +258,12 @@ export class InputController {
 			}
 
 			if (!text) return;
+			const pasteImagePrefix = stripTrailingPasteImageCommand(text);
+			if (pasteImagePrefix !== undefined) {
+				this.ctx.editor.setText(pasteImagePrefix ? `${pasteImagePrefix} ` : "");
+				await this.handleImagePaste();
+				return;
+			}
 
 			// Continue shortcuts: "." or "c" sends empty message (agent continues, no visible message)
 			if (text === "." || text === "c") {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -217,6 +217,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "paste-image",
+		aliases: ["attach-image"],
+		description: "Attach image from system clipboard",
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleImagePaste();
+			return commandConsumed();
+		},
+	},
+	{
 		name: "theme",
 		description: "Open theme selector",
 		handleTui: (_command, runtime) => {

--- a/packages/coding-agent/test/gjc-ui-redesign.test.ts
+++ b/packages/coding-agent/test/gjc-ui-redesign.test.ts
@@ -6,7 +6,7 @@ import blueCrabTheme from "../src/modes/theme/defaults/blue-crab.json" with { ty
 import redClawTheme from "../src/modes/theme/defaults/red-claw.json" with { type: "json" };
 import * as themeModule from "../src/modes/theme/theme";
 import { ACP_BUILTIN_SLASH_COMMANDS } from "../src/slash-commands/acp-builtins";
-import { lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
+import { executeBuiltinSlashCommand, lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
 
 describe("GJC red-claw redesign defaults", () => {
 	afterEach(() => {
@@ -81,6 +81,37 @@ describe("GJC red-claw redesign defaults", () => {
 		expect(command?.handleTui).toBeDefined();
 		expect(command?.handle).toBeUndefined();
 		expect(ACP_BUILTIN_SLASH_COMMANDS.map(item => item.name)).not.toContain("theme");
+	});
+
+	it("exposes /paste-image only for TUI clipboard image attachment", () => {
+		const command = lookupBuiltinSlashCommand("paste-image");
+		const alias = lookupBuiltinSlashCommand("attach-image");
+
+		expect(command?.handleTui).toBeDefined();
+		expect(command?.handle).toBeUndefined();
+		expect(alias).toBe(command);
+		expect(ACP_BUILTIN_SLASH_COMMANDS.map(item => item.name)).not.toContain("paste-image");
+		expect(ACP_BUILTIN_SLASH_COMMANDS.map(item => item.name)).not.toContain("attach-image");
+	});
+
+	it("dispatches /paste-image and /attach-image through the TUI image paste handler", async () => {
+		const setText = vi.fn();
+		const handleImagePaste = vi.fn(async () => true);
+		const runtime = {
+			ctx: {
+				editor: { setText },
+				handleImagePaste,
+			},
+			handleBackgroundCommand: vi.fn(),
+		} as unknown as Parameters<typeof executeBuiltinSlashCommand>[1];
+
+		expect(await executeBuiltinSlashCommand("/paste-image", runtime)).toBe(true);
+		expect(await executeBuiltinSlashCommand("/attach-image", runtime)).toBe(true);
+
+		expect(setText).toHaveBeenCalledTimes(2);
+		expect(setText).toHaveBeenNthCalledWith(1, "");
+		expect(setText).toHaveBeenNthCalledWith(2, "");
+		expect(handleImagePaste).toHaveBeenCalledTimes(2);
 	});
 
 	it("keeps public status presets on the GJC identity", () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -278,6 +278,57 @@ describe("InputController pasted clipboard image paths", () => {
 	});
 });
 
+describe("InputController paste-image submit fallback", () => {
+	it("consumes exact /paste-image without prompting the agent", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+		const pasteSpy = vi.spyOn(controller, "handleImagePaste").mockResolvedValue(true);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("/paste-image");
+
+		expect(pasteSpy).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("consumes exact /attach-image without prompting the agent", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+		const pasteSpy = vi.spyOn(controller, "handleImagePaste").mockResolvedValue(true);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("/attach-image");
+
+		expect(pasteSpy).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("preserves existing placeholders when appending another /paste-image", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+		const pasteSpy = vi.spyOn(controller, "handleImagePaste").mockImplementation(async () => {
+			ctx.pendingImages.push({
+				type: "image",
+				data: `image-${ctx.pendingImages.length + 1}`,
+				mimeType: "image/png",
+			});
+			editor.insertText(`[image ${ctx.pendingImages.length}] `);
+			return true;
+		});
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("/paste-image");
+		await editor.onSubmit?.(`${editor.getText()}/paste-image`);
+
+		expect(pasteSpy).toHaveBeenCalledTimes(2);
+		expect(editor.getText()).toBe("[image 1] [image 2] ");
+		expect(ctx.pendingImages).toHaveLength(2);
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+});
+
 describe("InputController shell mode cues", () => {
 	it("marks leading bang input as shell mode without rewriting editor text", async () => {
 		const { InputController, ctx, editor } = await createContext();


### PR DESCRIPTION
## Summary
- add TUI-only `/paste-image` slash command with `/attach-image` alias
- route both commands through the existing `handleImagePaste()` clipboard attachment path
- consume exact or trailing `/paste-image` command text without sending it as a user prompt
- preserve existing draft text/placeholders so repeated `/paste-image` calls can attach multiple clipboard images sequentially

## Tests
- `bun test packages/coding-agent/test/gjc-ui-redesign.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent test`
- `git diff --check`

## Notes
- Built local native addon first with `bun --cwd=packages/natives run build` so the package test suite could load `pi_natives` on darwin-arm64.