### PR TITLE
fix: surface stream idle abort remediation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved provider abort root causes in the final TUI abort label and added a `PI_STREAM_IDLE_TIMEOUT_MS` remediation hint when stream idle watchdogs fire.
+
 ## [0.4.3] - 2026-06-10
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -20,6 +20,7 @@ import type { AgentSessionEvent } from "../../session/agent-session";
 import { isSilentAbort, readPendingDisplayTag } from "../../session/messages";
 import type { ResolveToolDetails } from "../../tools/resolve";
 import { interruptHint } from "../shared";
+import { buildAbortDisplayMessage } from "../utils/abort-message";
 
 type AgentSessionEventKind = AgentSessionEvent["type"];
 
@@ -419,10 +420,10 @@ export class EventController {
 				// controller ran, so reaching this branch implies the abort was NOT a
 				// silent internal transition.
 				const retryAttempt = this.ctx.session.retryAttempt;
-				errorMessage =
-					retryAttempt > 0
-						? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-						: "Operation aborted";
+				errorMessage = buildAbortDisplayMessage({
+					errorMessage: this.ctx.streamingMessage.errorMessage,
+					retryAttempt,
+				});
 				this.ctx.streamingMessage.errorMessage = errorMessage;
 			}
 			if (silentlyAborted || ttsrSilenced) {

--- a/packages/coding-agent/src/modes/utils/abort-message.ts
+++ b/packages/coding-agent/src/modes/utils/abort-message.ts
@@ -1,0 +1,31 @@
+const STREAM_IDLE_TIMEOUT_PATTERN = /\bstream stalled while waiting for the next event\b/i;
+const GENERIC_ABORT_PATTERN = /^Request was aborted\.?$/i;
+
+export function buildAbortDisplayMessage({
+	errorMessage,
+	retryAttempt,
+}: {
+	errorMessage?: string;
+	retryAttempt: number;
+}): string {
+	const baseMessage =
+		retryAttempt > 0
+			? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
+			: "Operation aborted";
+	const cause = normalizeAbortCause(errorMessage);
+	if (!cause) return baseMessage;
+
+	return `${baseMessage}: ${cause}${streamIdleTimeoutHint(cause)}`;
+}
+
+function normalizeAbortCause(errorMessage: string | undefined): string {
+	const trimmed = errorMessage?.trim();
+	if (!trimmed || GENERIC_ABORT_PATTERN.test(trimmed)) return "";
+	return trimmed;
+}
+
+function streamIdleTimeoutHint(cause: string): string {
+	if (!STREAM_IDLE_TIMEOUT_PATTERN.test(cause)) return "";
+	const separator = /[.!?]$/.test(cause) ? " " : ". ";
+	return `${separator}Hint: set PI_STREAM_IDLE_TIMEOUT_MS=300000 for slow reasoning/proxy streams, or PI_STREAM_IDLE_TIMEOUT_MS=0 to disable the watchdog.`;
+}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -27,6 +27,7 @@ import {
 } from "../../session/messages";
 import type { SessionContext } from "../../session/session-manager";
 import { formatBytes, formatDuration } from "../../tools/render-utils";
+import { buildAbortDisplayMessage } from "./abort-message";
 
 type TextBlock = { type: "text"; text: string };
 interface RenderInitialMessagesOptions {
@@ -319,12 +320,10 @@ export class UiHelpers {
 					!isAbortedSilently && (message.stopReason === "aborted" || message.stopReason === "error");
 				const errorMessage = hasErrorStop
 					? message.stopReason === "aborted"
-						? (() => {
-								const retryAttempt = this.ctx.session.retryAttempt;
-								return retryAttempt > 0
-									? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
-									: "Operation aborted";
-							})()
+						? buildAbortDisplayMessage({
+								errorMessage: message.errorMessage,
+								retryAttempt: this.ctx.session.retryAttempt,
+							})
 						: message.errorMessage || "Error"
 					: null;
 

--- a/packages/coding-agent/test/abort-message.test.ts
+++ b/packages/coding-agent/test/abort-message.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { buildAbortDisplayMessage } from "@gajae-code/coding-agent/modes/utils/abort-message";
+
+describe("buildAbortDisplayMessage", () => {
+	it("keeps the legacy generic abort labels when there is no useful cause", () => {
+		expect(buildAbortDisplayMessage({ errorMessage: undefined, retryAttempt: 0 })).toBe("Operation aborted");
+		expect(buildAbortDisplayMessage({ errorMessage: "Request was aborted", retryAttempt: 1 })).toBe(
+			"Aborted after 1 retry attempt",
+		);
+		expect(buildAbortDisplayMessage({ errorMessage: "Request was aborted.", retryAttempt: 2 })).toBe(
+			"Aborted after 2 retry attempts",
+		);
+	});
+
+	it("preserves the provider root cause after retries", () => {
+		expect(buildAbortDisplayMessage({ errorMessage: "fetch failed", retryAttempt: 1 })).toBe(
+			"Aborted after 1 retry attempt: fetch failed",
+		);
+	});
+
+	it("adds a remediation hint for provider stream idle watchdog aborts", () => {
+		expect(
+			buildAbortDisplayMessage({
+				errorMessage: "Anthropic stream stalled while waiting for the next event",
+				retryAttempt: 1,
+			}),
+		).toBe(
+			"Aborted after 1 retry attempt: Anthropic stream stalled while waiting for the next event. Hint: set PI_STREAM_IDLE_TIMEOUT_MS=300000 for slow reasoning/proxy streams, or PI_STREAM_IDLE_TIMEOUT_MS=0 to disable the watchdog.",
+		);
+	});
+});

--- a/packages/coding-agent/test/event-controller-abort-render.test.ts
+++ b/packages/coding-agent/test/event-controller-abort-render.test.ts
@@ -138,4 +138,26 @@ describe("EventController #handleMessageEnd abort labeling", () => {
 		expect(arg.stopReason).toBe("stop");
 		expect(arg.errorMessage).toBeUndefined();
 	});
+	it("C4: provider stream idle abort -> preserves root cause and remediation hint after retry", async () => {
+		const message = makeAssistantMessage({
+			stopReason: "aborted",
+			errorMessage: "Anthropic stream stalled while waiting for the next event",
+		});
+		const { controller, streamingComponent } = createFixture({
+			streamingMessage: message,
+			isTtsrAbortPending: false,
+			retryAttempt: 1,
+		});
+
+		await controller.handleEvent({ type: "message_end", message });
+
+		expect(message.errorMessage).toBe(
+			"Aborted after 1 retry attempt: Anthropic stream stalled while waiting for the next event. Hint: set PI_STREAM_IDLE_TIMEOUT_MS=300000 for slow reasoning/proxy streams, or PI_STREAM_IDLE_TIMEOUT_MS=0 to disable the watchdog.",
+		);
+		expect(streamingComponent.updateContent).toHaveBeenCalledTimes(1);
+		const arg = streamingComponent.updateContent.mock.calls[0]![0] as AssistantMessage;
+		expect(arg).toBe(message);
+		expect(arg.stopReason).toBe("aborted");
+		expect(arg.errorMessage).toContain("PI_STREAM_IDLE_TIMEOUT_MS=300000");
+	});
 });


### PR DESCRIPTION
## Summary
- Preserve provider abort root causes instead of replacing them with only the generic retry-aborted label
- Add an actionable PI_STREAM_IDLE_TIMEOUT_MS hint for provider stream idle watchdog aborts
- Reuse the same abort-label formatter for live and replayed TUI rendering

## Verification
- bun test packages/coding-agent/test/abort-message.test.ts packages/coding-agent/test/event-controller-abort-render.test.ts
- bun --cwd=packages/coding-agent run check