### PR TITLE
Fix Anthropic Fable forced tool_choice 400s

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic requests for Claude Fable/Mythos-style models that support tools but reject forced tool use by omitting forced `tool_choice` while preserving `auto`/`none` choices.
+
 ## [0.4.2] - 2026-06-09
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -881,6 +881,8 @@ function getAnthropicCompat(
 		disableAdaptiveThinking: model.compat?.disableAdaptiveThinking ?? false,
 		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
+		supportsToolChoice: model.compat?.supportsToolChoice ?? true,
+		supportsForcedToolChoice: model.compat?.supportsForcedToolChoice ?? true,
 	};
 }
 
@@ -1682,6 +1684,30 @@ function disableThinkingIfToolChoiceForced(params: MessageCreateParamsStreaming)
 	}
 }
 
+function isForcedAnthropicToolChoice(toolChoice: NonNullable<AnthropicOptions["toolChoice"]>): boolean {
+	if (typeof toolChoice === "string") return toolChoice === "any";
+	if ("function" in toolChoice) return true;
+	if ("name" in toolChoice && typeof toolChoice.name === "string") return true;
+	return toolChoice.type === "tool" || toolChoice.type === "function";
+}
+
+function supportsForcedAnthropicToolChoice(model: Model<"anthropic-messages">): boolean {
+	const compat = model.compat;
+	if (compat?.supportsToolChoice === false || compat?.supportsForcedToolChoice === false) return false;
+
+	// Claude Mythos Preview is documented as accepting tools while rejecting
+	// forced tool use; Claude Fable currently returns the same Anthropic 400.
+	return !/^claude-(?:fable|mythos)(?:-|$)/i.test(model.id);
+}
+
+function shouldSendAnthropicToolChoice(
+	model: Model<"anthropic-messages">,
+	toolChoice: NonNullable<AnthropicOptions["toolChoice"]>,
+): boolean {
+	if (model.compat?.supportsToolChoice === false) return false;
+	return !isForcedAnthropicToolChoice(toolChoice) || supportsForcedAnthropicToolChoice(model);
+}
+
 function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, model: Model<"anthropic-messages">): void {
 	const thinking = params.thinking;
 	if (thinking?.type !== "enabled") return;
@@ -2029,7 +2055,7 @@ function buildParams(
 		(params as ParamsWithSpeed).speed = "fast";
 	}
 
-	if (options?.toolChoice) {
+	if (options?.toolChoice && shouldSendAnthropicToolChoice(model, options.toolChoice)) {
 		if (typeof options.toolChoice === "string") {
 			params.tool_choice = { type: options.toolChoice };
 		} else if (isOAuthToken && options.toolChoice.name) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -805,6 +805,10 @@ export interface AnthropicCompat {
 	disableAdaptiveThinking?: boolean;
 	/** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true. */
 	supportsEagerToolInputStreaming?: boolean;
+	/** Whether the provider accepts the `tool_choice` parameter at all. Default: true. */
+	supportsToolChoice?: boolean;
+	/** Whether `tool_choice` may force a tool (`any` / named `tool`). Default: true except known incompatible Anthropic models. */
+	supportsForcedToolChoice?: boolean;
 	/** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
 	supportsLongCacheRetention?: boolean;
 }

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -57,6 +57,7 @@ type CaptureAnthropicOptions = {
 	temperature?: number;
 	topP?: number;
 	topK?: number;
+	toolChoice?: "auto" | "none" | "any" | { type: "tool"; name: string };
 };
 
 function captureAnthropicPayload(
@@ -75,6 +76,7 @@ function captureAnthropicPayload(
 		temperature: options?.temperature,
 		topP: options?.topP,
 		topK: options?.topK,
+		toolChoice: options?.toolChoice,
 		onPayload: payload => resolve(payload),
 	});
 	return promise;
@@ -323,6 +325,56 @@ describe("Anthropic request fingerprint alignment", () => {
 
 		expect(payload.metadata?.user_id).not.toBe("invalid-user-id");
 		expect(isClaudeCloakingUserId(payload.metadata?.user_id ?? "")).toBe(true);
+	});
+	it("omits forced tool_choice for Anthropic Fable models", async () => {
+		const payload = (await captureAnthropicPayload(
+			{ ...ANTHROPIC_MODEL, id: "claude-fable-5", name: "Claude Fable 5" },
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "resolve",
+						description: "resolve a pending action",
+						parameters: {
+							type: "object",
+							properties: { action: { type: "string" } },
+							required: ["action"],
+						} as TJsonSchema,
+					},
+				],
+			},
+			{ toolChoice: { type: "tool", name: "resolve" } },
+		)) as { tool_choice?: unknown; tools?: unknown[] };
+
+		expect(payload.tool_choice).toBeUndefined();
+		expect(payload.tools).toHaveLength(1);
+	});
+
+	it("keeps non-forced tool_choice for Anthropic Fable models", async () => {
+		const payload = (await captureAnthropicPayload(
+			{ ...ANTHROPIC_MODEL, id: "claude-fable-5", name: "Claude Fable 5" },
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{ toolChoice: "none" },
+		)) as { tool_choice?: unknown };
+
+		expect(payload.tool_choice).toEqual({ type: "none" });
+	});
+
+	it("keeps forced tool_choice for compatible Anthropic models", async () => {
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{ toolChoice: { type: "tool", name: "resolve" } },
+		)) as { tool_choice?: unknown };
+
+		expect(payload.tool_choice).toEqual({ type: "tool", name: "proxy_resolve" });
 	});
 	it("adds additionalProperties false to Anthropic tool object schemas", async () => {
 		const originalNestedSchema = {

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -36,6 +36,7 @@ export const OpenAICompatSchema = z.object({
 	allowsSyntheticReasoningContentForToolCalls: z.boolean().optional(),
 	requiresAssistantContentForToolCalls: z.boolean().optional(),
 	supportsToolChoice: z.boolean().optional(),
+	supportsForcedToolChoice: z.boolean().optional(),
 	disableReasoningOnForcedToolChoice: z.boolean().optional(),
 	disableReasoningOnToolChoice: z.boolean().optional(),
 	thinkingFormat: z.enum(["openai", "openrouter", "zai", "qwen", "qwen-chat-template"]).optional(),

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -131,6 +131,9 @@
 							"supportsToolChoice": {
 								"type": "boolean"
 							},
+							"supportsForcedToolChoice": {
+								"type": "boolean"
+							},
 							"disableReasoningOnForcedToolChoice": {
 								"type": "boolean"
 							},
@@ -521,6 +524,9 @@
 										"supportsToolChoice": {
 											"type": "boolean"
 										},
+										"supportsForcedToolChoice": {
+											"type": "boolean"
+										},
 										"disableReasoningOnForcedToolChoice": {
 											"type": "boolean"
 										},
@@ -876,6 +882,9 @@
 											"type": "boolean"
 										},
 										"supportsToolChoice": {
+											"type": "boolean"
+										},
+										"supportsForcedToolChoice": {
 											"type": "boolean"
 										},
 										"disableReasoningOnForcedToolChoice": {


### PR DESCRIPTION
## Summary
- omit forced Anthropic `tool_choice` for Claude Fable/Mythos-style models that accept tools but reject forced tool use
- preserve non-forced `auto` / `none` tool choices and keep named forcing for compatible Claude models
- add `supportsForcedToolChoice` model compat config, generated schema coverage, and regression tests

## Verification
- `bun test packages/ai/test/anthropic-alignment.test.ts`
- `bun run check` in `packages/ai`
- `bun test packages/coding-agent/test/model-profiles-schema.test.ts packages/coding-agent/test/model-registry.test.ts`
- `bun run check:types` in `packages/coding-agent`
- `bun run check:schemas` in `packages/coding-agent`
- `bunx biome check packages/coding-agent/src/config/models-config-schema.ts schemas/models.schema.json`

## Notes
- Rebased on current `dev` (`e2be0c6`) after #480 was closed for stale-base diff pollution.
- Diff is limited to the intended Anthropic/provider/types/test/changelog/config-schema/generated-schema changes.
- Reproduced from a local request dump where `claude-fable-5` rejected `tool_choice: { type: "tool", name: "proxy_resolve" }` with `tool_choice forces tool use is not compatible with this model`.
- The raw request dump is intentionally not included because it may contain prompt/request metadata.
