### PR TITLE
fix(cursor): keep native exec handlers instance-safe + print last assistant (#484)

### DIFF
--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -161,7 +161,20 @@ function formatMcpToolErrorMessage(toolName: string, availableTools: string[]): 
 }
 
 export class CursorExecHandlers implements ICursorExecHandlers {
-	constructor(private options: CursorExecBridgeOptions) {}
+	constructor(private options: CursorExecBridgeOptions) {
+		// Bind every native handler so methods stay instance-safe when invoked
+		// detached/unbound by the Cursor provider (e.g. `const read = handlers.read`).
+		// Without this, `this.#optionsForCall()` throws "undefined is not an object".
+		this.read = this.read.bind(this);
+		this.ls = this.ls.bind(this);
+		this.grep = this.grep.bind(this);
+		this.write = this.write.bind(this);
+		this.delete = this.delete.bind(this);
+		this.shell = this.shell.bind(this);
+		this.shellStream = this.shellStream.bind(this);
+		this.diagnostics = this.diagnostics.bind(this);
+		this.mcp = this.mcp.bind(this);
+	}
 
 	#optionsForCall(): CursorExecBridgeOptions {
 		return {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -72,7 +72,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// In text mode, output final response
 	if (mode === "text") {
 		const state = session.state;
-		const lastMessage = state.messages[state.messages.length - 1];
+		const lastMessage = state.messages.findLast(message => message.role === "assistant");
 
 		if (lastMessage?.role === "assistant") {
 			const assistantMsg = lastMessage as AssistantMessage;

--- a/packages/coding-agent/test/cursor-exec-handlers.test.ts
+++ b/packages/coding-agent/test/cursor-exec-handlers.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression (#484): CursorExecHandlers native handlers must stay instance-safe
+ * when invoked detached/unbound by the Cursor provider.
+ *
+ * The provider can destructure or rebind handler methods, e.g. `const read = handlers.read`,
+ * and call them without the class instance. Before the constructor binding fix this threw:
+ *   "undefined is not an object (evaluating 'this.#optionsForCall')"
+ */
+import { describe, expect, it } from "bun:test";
+import type { AgentTool } from "@gajae-code/agent";
+import { CursorExecHandlers } from "../src/cursor";
+
+function makeTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		execute: async (_toolCallId: string, args: Record<string, unknown>) => ({
+			content: [{ type: "text" as const, text: `${name}:${JSON.stringify(args)}` }],
+			details: {},
+		}),
+	} as unknown as AgentTool;
+}
+
+function makeHandlers(): CursorExecHandlers {
+	const tools = new Map<string, AgentTool>([
+		["read", makeTool("read")],
+		["search", makeTool("search")],
+		["bash", makeTool("bash")],
+		["write", makeTool("write")],
+		["lsp", makeTool("lsp")],
+	]);
+	return new CursorExecHandlers({ cwd: process.cwd(), tools } as never);
+}
+
+describe("CursorExecHandlers detached invocation (#484)", () => {
+	it("read works when called detached without losing #optionsForCall", async () => {
+		const handlers = makeHandlers();
+		const read = handlers.read;
+		const result = await read({ path: "/tmp/package.json", toolCallId: "c1" });
+		expect(result.role).toBe("toolResult");
+		expect(result.isError).toBeFalsy();
+		expect(result.toolName).toBe("read");
+	});
+
+	it("a representative set of handlers all work detached", async () => {
+		const handlers = makeHandlers();
+		const { read, ls, grep, shell, write, diagnostics } = handlers;
+
+		const calls = [
+			read({ path: "/tmp/a.txt", toolCallId: "r" }),
+			ls({ path: "/tmp", toolCallId: "l" }),
+			grep({ pattern: "foo", path: "/tmp", toolCallId: "g" }),
+			shell({ command: "echo hi", toolCallId: "s" }),
+			write({ path: "/tmp/b.txt", fileText: "x", toolCallId: "w" }),
+			diagnostics({ path: "/tmp/a.ts", toolCallId: "d" }),
+		];
+
+		const results = await Promise.all(calls);
+		for (const result of results) {
+			expect(result.role).toBe("toolResult");
+			expect(result.isError).toBeFalsy();
+		}
+	});
+});

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -6,7 +6,7 @@
  * (and exit with code 1). This test verifies the guard skips silent-abort.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import type { AssistantMessage } from "@gajae-code/ai";
+import type { AssistantMessage, Message, ToolResultMessage } from "@gajae-code/ai";
 import type { AgentSession } from "../src/session/agent-session";
 import { SILENT_ABORT_MARKER } from "../src/session/messages";
 
@@ -32,7 +32,7 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 }
 
 /** Minimal mock of AgentSession for print-mode text output path */
-function createMockSession(messages: AssistantMessage[]): AgentSession {
+function createMockSession(messages: Message[]): AgentSession {
 	return {
 		state: { messages },
 		sessionManager: {
@@ -104,5 +104,51 @@ describe("Print-mode silent-abort regression", () => {
 		expect(stderrText).toContain("Rate limit exceeded");
 		// process.exit(1) SHOULD have been called
 		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+});
+
+function makeToolResultMessage(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "read",
+		content: [{ type: "text", text: "file contents" }],
+		isError: false,
+		timestamp: Date.now(),
+	} as ToolResultMessage;
+}
+
+describe("Print-mode last-assistant output regression (#484)", () => {
+	let stdoutOutput: string[];
+
+	beforeEach(() => {
+		stdoutOutput = [];
+		vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const chunk = args[0];
+			if (typeof chunk === "string" && chunk.length > 0) stdoutOutput.push(chunk);
+			const last = args[args.length - 1];
+			if (typeof last === "function") last();
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("prints last assistant text even when a toolResult trails it", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+
+		const assistantMsg = makeAssistantMessage({
+			content: [{ type: "text", text: "@gajae-code/coding-agent" }],
+		});
+		// Cursor native tool execution can append a toolResult after the assistant reply.
+		const session = createMockSession([assistantMsg, makeToolResultMessage()]);
+		await runPrintMode(session, { mode: "text" });
+
+		const stdoutText = stdoutOutput.join("");
+		expect(stdoutText).toContain("@gajae-code/coding-agent");
 	});
 });


### PR DESCRIPTION
## Summary

Narrow fix for #484: Cursor provider native tool execution fails with a lost `this` binding.

### 1. `CursorExecHandlers` instance-safety (`packages/coding-agent/src/cursor.ts`)
The handler methods call the private `#optionsForCall()`. When the Cursor provider invoked a handler detached/unbound (e.g. `const read = handlers.read; await read(...)`), `this` was lost and execution threw:

```
undefined is not an object (evaluating 'this.#optionsForCall')
```

Fix: bind every native handler (`read`, `ls`, `grep`, `write`, `delete`, `shell`, `shellStream`, `diagnostics`, `mcp`) in the constructor so they stay instance-safe regardless of call site. No behavior beyond binding safety is changed.

### 2. `--print` text output (`packages/coding-agent/src/modes/print-mode.ts`)
Text mode read only the last session message. After Cursor native tool execution, a `toolResult` message can be appended **after** the assistant reply, so `--print` emitted nothing. Fix uses the last assistant message:

```ts
const lastMessage = state.messages.findLast(message => message.role === "assistant");
```

Existing error / silent-abort handling is preserved.

## Tests
- `packages/coding-agent/test/cursor-exec-handlers.test.ts` (new): proves `read` and a representative set (`ls`, `grep`, `shell`, `write`, `diagnostics`) work when called detached (`const read = handlers.read`) without losing `#optionsForCall`.
- `packages/coding-agent/test/silent-abort-print-mode.test.ts`: adds a regression test asserting last-assistant text is printed even when a `toolResult` trails it.

```
bun test test/cursor-exec-handlers.test.ts test/silent-abort-print-mode.test.ts
5 pass / 0 fail
```

Repo-wide `check` (tsgo/biome) not run: those binaries are not available in this worktree environment. Live Cursor auth was not available, so verification is via deterministic unit/regression tests only.

Closes after merge to `dev`.

Refs #484

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
