### PR TITLE
fix(harness): surface owner death before first prompt as a startup blocker (#485)

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -247,6 +247,30 @@ interface OwnerExitEvidence {
 	transient: boolean;
 	/** ISO timestamp of the most recent non-terminal RPC-derived owner event, if any (observability only). */
 	lastRpcActivityAt: string | null;
+	/**
+	 * True when the owner started (reported live) but died before accepting the first prompt.
+	 * This is a startup blocker, not a healthy live gate: callers must recover before submit.
+	 */
+	startupBlocker: boolean;
+	/** Explicit, human-actionable recovery guidance for the surfaced exit reason. */
+	recoveryGuidance: string;
+}
+
+function ownerExitGuidance(reason: string, startupBlocker: boolean): string {
+	if (startupBlocker) {
+		return "owner started and reported live but exited before accepting the first prompt; run `gjc harness recover --session <id>` to respawn the owner, then resubmit the prompt";
+	}
+	switch (reason) {
+		case "owner-exited-after-prompt-acceptance":
+			return "owner exited after accepting a prompt; run `gjc harness recover --session <id>` to preserve in-flight work and classify the vanish before resubmitting";
+		case "owner-lease-expired":
+		case "owner-endpoint-unreachable":
+			return "owner lease is stale or its endpoint did not route; run `gjc harness recover --session <id>` to respawn or take over the owner";
+		case "owner-liveness-unknown-permission-denied":
+			return "owner liveness cannot be probed (permission denied); verify the owner process out-of-band before recover";
+		default:
+			return "no live owner holds this session; run `gjc harness recover --session <id>` to (re)spawn an owner, then resubmit";
+	}
 }
 
 async function buildOwnerExitEvidence(root: string, state: SessionState): Promise<OwnerExitEvidence> {
@@ -286,6 +310,12 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 	} else {
 		reason = "owner-endpoint-unreachable";
 	}
+	// A just-started owner that emitted `owner_started` (so it reported live) but is now terminal
+	// without ever accepting a prompt died during startup. Surface this as an explicit, actionable
+	// startup blocker rather than letting `submit` fall through to a misleading `owner-not-live` gate.
+	const ownerStarted = events.some(event => event.kind === "owner_started");
+	const startupBlocker = terminal && ownerStarted && !promptAcceptedSeen && !completedSeen;
+	if (startupBlocker) reason = "owner-died-before-first-prompt";
 	return {
 		reason,
 		leaseStatus,
@@ -301,6 +331,8 @@ async function buildOwnerExitEvidence(root: string, state: SessionState): Promis
 		terminal,
 		transient,
 		lastRpcActivityAt,
+		startupBlocker,
+		recoveryGuidance: ownerExitGuidance(reason, startupBlocker),
 	};
 }
 
@@ -399,6 +431,29 @@ async function markVanishedOwnerBlocked(
 	const blocker = `owner-vanished:${observation.gitDelta}`;
 	state.lifecycle = "blocked";
 	state.blockers = state.blockers.includes(blocker) ? state.blockers : [...state.blockers, blocker];
+	state.updatedAt = nowIso();
+	await writeSessionState(root, state);
+	return state;
+}
+
+const OWNER_STARTUP_BLOCKER = "owner-died-before-first-prompt";
+
+/**
+ * Persist an explicit startup blocker when an owner started, reported live, but died before
+ * accepting the first prompt. This makes the failure an actionable lifecycle state instead of a
+ * silent `owner-not-live` gate, so observe/recover surface it and recover can respawn the owner.
+ */
+async function markStartupOwnerBlocked(
+	root: string,
+	state: SessionState,
+	ownerExit: OwnerExitEvidence,
+): Promise<SessionState> {
+	if (!ownerExit.startupBlocker) return state;
+	if (state.lifecycle === "completed" || state.lifecycle === "retired") return state;
+	state.lifecycle = "blocked";
+	state.blockers = state.blockers.includes(OWNER_STARTUP_BLOCKER)
+		? state.blockers
+		: [...state.blockers, OWNER_STARTUP_BLOCKER];
 	state.updatedAt = nowIso();
 	await writeSessionState(root, state);
 	return state;
@@ -834,10 +889,12 @@ export default class Harness extends Command {
 		state = await reconcileCompletedOwnerExited(root, state, observation, completedTerminalEvent);
 		const vanishedOwnerBlock = needsVanishedOwnerBlock(state, observation, completedTerminalEvent);
 		state = await markVanishedOwnerBlocked(root, state, observation, completedTerminalEvent);
-		const ownerExit =
-			!ownerLive && (vanishedOwnerBlock || completedTerminalEvent)
-				? await buildOwnerExitEvidence(root, state)
-				: null;
+		// Build owner-exit evidence whenever the owner is gone so a startup death (owner started,
+		// reported live, then died before the first prompt) is detectable, not just vanish/completion.
+		const ownerExit = !ownerLive ? await buildOwnerExitEvidence(root, state) : null;
+		const startupBlocked = ownerExit?.startupBlocker ?? false;
+		if (ownerExit && startupBlocked) state = await markStartupOwnerBlocked(root, state, ownerExit);
+		const includeOwnerExit = Boolean(ownerExit && (vanishedOwnerBlock || completedTerminalEvent || startupBlocked));
 		writeJson(
 			buildResponse(state, ownerLive, {
 				observation: { ...observation, lifecycle: state.lifecycle },
@@ -848,7 +905,10 @@ export default class Harness extends Command {
 				...(completedTerminalEvent && !ownerLive
 					? { completedOwnerExited: true, terminalResult: completedTerminalEvent }
 					: {}),
-				...(ownerExit ? { ownerExit } : {}),
+				...(startupBlocked
+					? { startupBlocked: true, blockerReason: OWNER_STARTUP_BLOCKER, guidance: ownerExit?.recoveryGuidance }
+					: {}),
+				...(includeOwnerExit && ownerExit ? { ownerExit } : {}),
 			}),
 		);
 	}
@@ -910,9 +970,22 @@ export default class Harness extends Command {
 	async #submit(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
 		const sessionId = requireSessionId(input, flagSession);
 		if (await this.#tryOwnerRoute(root, sessionId, "submit", { ...input, sessionId })) return;
-		const state = await loadState(root, sessionId);
-		// No live owner: submission is blocked (never echoed-as-accepted).
-		writeJson(buildResponse(state, false, { accepted: false, submitted: false, reason: "owner-not-live" }, false));
+		let state = await loadState(root, sessionId);
+		// No live owner: submission is blocked (never echoed-as-accepted). Surface owner exit
+		// evidence + explicit recovery guidance so the caller is not left with a bare gate.
+		const ownerExit = await buildOwnerExitEvidence(root, state);
+		// An owner that started, reported live, then died before accepting the first prompt is a
+		// startup blocker, not a healthy `owner-not-live` gate — persist it and report it as such.
+		if (ownerExit.startupBlocker) state = await markStartupOwnerBlocked(root, state, ownerExit);
+		const reason = ownerExit.startupBlocker ? ownerExit.reason : "owner-not-live";
+		writeJson(
+			buildResponse(
+				state,
+				false,
+				{ accepted: false, submitted: false, reason, ownerExit, guidance: ownerExit.recoveryGuidance },
+				false,
+			),
+		);
 		process.exitCode = 1;
 	}
 
@@ -1030,6 +1103,7 @@ export default class Harness extends Command {
 					decision,
 					observation: { ...observation, lifecycle: state.lifecycle },
 					ownerExit: afterExit,
+					guidance: afterExit.recoveryGuidance,
 					...(restoredOwner
 						? {
 								restoreAttempt: {

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -121,6 +121,45 @@ async function appendSignal(sessionId: string, cursor: number, signal: string): 
 	});
 }
 
+const DEAD_PID = 2_147_483_646;
+
+/**
+ * Seed a session whose owner started (emitted `owner_started`, so it reported live) but whose
+ * process is now dead, with no prompt ever accepted: the issue #485 "owner died before first
+ * prompt" scenario. Writes a dead-pid lease plus the `owner_started` event deterministically.
+ */
+async function seedOwnerDiedBeforeFirstPrompt(sessionId: string): Promise<void> {
+	const state = await readSessionState(root, sessionId);
+	if (!state) throw new Error("missing seeded state");
+	state.lifecycle = "started";
+	state.updatedAt = "2026-06-03T00:00:00.000Z";
+	await writeSessionState(root, state);
+	const lease = {
+		ownerId: "owner-dead",
+		sessionId,
+		pid: DEAD_PID,
+		leaseTokenHash: "0".repeat(64),
+		endpoint: { kind: "unix-socket" as const, path: "/tmp/dead-owner.sock" },
+		eventsPath: sessionPaths(root, sessionId).events,
+		heartbeatAt: "2026-06-03T00:00:01.000Z",
+		expiresAt: new Date(Date.now() + 30_000).toISOString(),
+		leaseEpoch: 1,
+		writer: { ownerId: "owner-dead", leaseEpoch: 1 },
+	};
+	await writeFile(sessionPaths(root, sessionId).lease, `${JSON.stringify(lease, null, 2)}\n`, "utf8");
+	await appendEvent(root, sessionId, {
+		eventId: "evt-owner-started",
+		cursor: 1,
+		createdAt: "2026-06-03T00:00:01.000Z",
+		severity: "info",
+		kind: "owner_started",
+		state: { sessionId, lifecycle: "started", harness: "gajae-code", ownerLive: true, blockers: [] },
+		evidence: { ownerId: "owner-dead", leaseEpoch: 1 },
+		nextAllowedActions: [],
+		writer: { ownerId: "owner-dead", leaseEpoch: 1 },
+	});
+}
+
 describe("gjc harness CLI (foundation)", () => {
 	it("test CLI env cleanup removes overlapping created links and preserves pre-existing links", async () => {
 		const fakeRepo = await mkdtemp(path.join(tmpdir(), "harness-cli-env-repo-"));
@@ -702,5 +741,92 @@ describe("gjc harness CLI (foundation)", () => {
 		expect(res.json.ok).toBe(false);
 		expect(res.json.evidence.pending).toBe(true);
 		expect(res.json.evidence.verb).toBe("validate");
+	});
+
+	it("submit surfaces owner death before first prompt as an actionable startup blocker (#485)", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		await seedOwnerDiedBeforeFirstPrompt(sessionId);
+
+		const res = runHarness(["submit", "--session", sessionId, "--input", JSON.stringify({ prompt: "go" })]);
+
+		expect(res.code).toBe(1);
+		assertContract(res.json);
+		expect(res.json.ok).toBe(false);
+		expect(res.json.evidence.accepted).toBe(false);
+		expect(res.json.evidence.submitted).toBe(false);
+		// Not the misleading bare gate: an explicit, distinct startup-death reason.
+		expect(res.json.evidence.reason).toBe("owner-died-before-first-prompt");
+		expect(res.json.evidence.guidance).toContain("recover");
+		expect(res.json.evidence.ownerExit).toMatchObject({
+			reason: "owner-died-before-first-prompt",
+			leaseStatus: "dead",
+			pid: DEAD_PID,
+			lastEventKind: "owner_started",
+			promptAcceptedSeen: false,
+			completedSeen: false,
+			terminal: true,
+			startupBlocker: true,
+		});
+		// The session is persisted as an actionable blocked state, not left as a healthy "started".
+		expect(res.json.state.lifecycle).toBe("blocked");
+		expect(res.json.state.blockers).toContain("owner-died-before-first-prompt");
+		const persisted = await readSessionState(root, sessionId);
+		expect(persisted?.lifecycle).toBe("blocked");
+		expect(persisted?.blockers).toContain("owner-died-before-first-prompt");
+	});
+
+	it("observe surfaces owner death before first prompt with preserved exit evidence (#485)", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		await seedOwnerDiedBeforeFirstPrompt(sessionId);
+
+		const res = runHarness(["observe", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.ownerLive).toBe(false);
+		expect(res.json.state.lifecycle).toBe("blocked");
+		expect(res.json.state.blockers).toContain("owner-died-before-first-prompt");
+		expect(res.json.evidence.startupBlocked).toBe(true);
+		expect(res.json.evidence.blockerReason).toBe("owner-died-before-first-prompt");
+		expect(res.json.evidence.guidance).toContain("recover");
+		expect(res.json.evidence.ownerExit).toMatchObject({
+			reason: "owner-died-before-first-prompt",
+			leaseStatus: "dead",
+			pid: DEAD_PID,
+			startupBlocker: true,
+		});
+	});
+
+	it("does not classify owner death after prompt acceptance as a startup blocker (boundary, #485)", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		await seedOwnerDiedBeforeFirstPrompt(sessionId);
+		// A prompt was accepted before the owner died -> post-acceptance exit, not a startup blocker.
+		await appendEvent(root, sessionId, {
+			eventId: "evt-prompt-accepted",
+			cursor: 2,
+			createdAt: "2026-06-03T00:00:02.000Z",
+			severity: "info",
+			kind: "prompt_accepted",
+			state: { sessionId, lifecycle: "observing", harness: "gajae-code", ownerLive: true, blockers: [] },
+			evidence: { reason: "protocol-ack-single-flight", agentStartCursor: 2 },
+			nextAllowedActions: [],
+			writer: { ownerId: "owner-dead", leaseEpoch: 1 },
+		});
+
+		const res = runHarness(["submit", "--session", sessionId, "--input", JSON.stringify({ prompt: "go" })]);
+
+		expect(res.code).toBe(1);
+		expect(res.json.evidence.reason).toBe("owner-not-live");
+		expect(res.json.evidence.ownerExit).toMatchObject({
+			reason: "owner-exited-after-prompt-acceptance",
+			startupBlocker: false,
+			promptAcceptedSeen: true,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the control-plane bug in #485: a tmux-resident harness owner could start, report `ownerLive:true`, then die before accepting the first prompt. A subsequent `gjc harness submit` returned a bare `owner-not-live` with no diagnostics, and the event stream's `owner-process-dead` was not surfaced as an actionable startup failure.

## Changes

- **`buildOwnerExitEvidence`**: detects a terminal owner that emitted `owner_started` but never accepted a prompt or completed. Reports the distinct reason `owner-died-before-first-prompt`, adds a `startupBlocker` flag and explicit `recoveryGuidance`, while preserving owner exit evidence (`leaseStatus`, `pid`, `lastEventKind`/`lastEventAt`).
- **`submit`**: no longer falls through to a misleading `owner-not-live`. It surfaces the owner exit evidence + guidance and persists the session as `blocked` with an `owner-died-before-first-prompt` blocker so `recover`/`observe` stay actionable. The pre-existing never-started case still reports `owner-not-live`.
- **`observe`**: surfaces the startup blocker (`startupBlocked` + `blockerReason` + `guidance` + `ownerExit`) instead of a silent read-only view.
- **`recover`**: failure responses now include explicit recovery `guidance`.

## Tests

- New deterministic control-plane regression tests (dead-pid lease + `owner_started` event) covering owner death between live observation and first `submit`, including an `observe` surfacing test and a boundary test that post-acceptance exit is still classified as `owner-exited-after-prompt-acceptance`.
- `bun test test/harness-control-plane/` → 173 pass / 0 fail.
- `bun run check:ts` → clean (lint + typecheck).

## Scope

Minimal, no unrelated harness refactor. Issue stays open until this merges to `dev`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*