### PR TITLE
team: add opt-in same-task Whiplash strategy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `gjc team --whiplash` strategy for same-task low/medium/high reasoning lanes with forced first-round review rejection.
+
 ## [0.2.0] - 2026-05-28
 
 ### Added

--- a/packages/coding-agent/src/commands/team.ts
+++ b/packages/coding-agent/src/commands/team.ts
@@ -77,10 +77,12 @@ export default class Team extends Command {
 	static flags = {
 		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
 		"dry-run": Flags.boolean({ description: "Create team state without starting tmux panes", default: false }),
+		whiplash: Flags.boolean({ description: "Start Team in Whiplash strategy mode", default: false }),
 	};
 
 	static examples = [
 		'gjc team 3:executor "Implement the approved plan"',
+		'gjc team --whiplash "Implement the approved plan"',
 		"gjc team status <team-name> --json",
 		'gjc team api claim-task --input \'{"team_name":"demo","worker_id":"worker-1"}\' --json',
 		"gjc team shutdown <team-name>",
@@ -118,6 +120,12 @@ export default class Team extends Command {
 				`state: ${snapshot.state_dir}`,
 				`tasks: ${snapshot.task_total} (${formatTaskCounts(snapshot.task_counts)})`,
 				`workers: ${snapshot.workers.map(worker => `${worker.id}:${worker.status}`).join(" ")}`,
+				`strategy: ${snapshot.strategy}`,
+				...(snapshot.whiplash
+					? [
+							`whiplash: round=${snapshot.whiplash.round} status=${snapshot.whiplash.status} lanes=${snapshot.whiplash.lanes.map(lane => `${lane.worker_id}:${lane.requested_thinking_effort}/${lane.effort_status}`).join(" ")}`,
+						]
+					: []),
 				...formatIntegrationSummary(snapshot),
 			]);
 			return;
@@ -145,6 +153,7 @@ export default class Team extends Command {
 					"create-task read-task list-tasks update-task claim-task transition-task-status release-task-claim",
 					"read-config read-manifest read-worker-status read-worker-heartbeat update-worker-heartbeat write-worker-inbox write-worker-identity",
 					"append-event read-events await-event write-shutdown-request read-shutdown-ack read-monitor-snapshot write-monitor-snapshot read-task-approval write-task-approval",
+					"read-whiplash-state report-whiplash-effort write-whiplash-review advance-whiplash-round",
 				]);
 				return;
 			}
@@ -163,7 +172,7 @@ export default class Team extends Command {
 		}
 
 		const startArgs = action === "start" ? rest : this.argv;
-		const options = parseTeamLaunchArgs(startArgs);
+		const options = parseTeamLaunchArgs(flags.whiplash ? ["--whiplash", ...startArgs] : startArgs);
 		const snapshot = await startGjcTeam({ ...options, dryRun });
 		await syncTeamHud(snapshot);
 		if (json) {
@@ -176,6 +185,7 @@ export default class Team extends Command {
 			`tmux: ${snapshot.tmux_session}`,
 			`state: ${snapshot.state_dir}`,
 			`workers: ${snapshot.workers.length}`,
+			`strategy: ${snapshot.strategy}`,
 		]);
 	}
 }

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -47,6 +47,40 @@ gjc team 3:executor "analyze feature X and report flaws"
 gjc team "debug flaky integration tests"
 gjc team "ship end-to-end fix with verification"
 ```
+Whiplash strategy example:
+
+```bash
+gjc team --whiplash "fix the approved plan and prove failure paths"
+```
+
+### Whiplash mode
+
+Whiplash is a **Team execution strategy**, not a fifth workflow skill and not a new public role-agent roster. Use `gjc team --whiplash "<task>"` when the user explicitly asks for Whiplash-style same-task reasoning collision.
+
+Protocol:
+
+1. Launch exactly three `executor` workers for the MVP.
+2. Give all three workers the same canonical task, same conditions, and same acceptance criteria; store the same canonical task hash on each Whiplash task.
+3. The only intentional worker difference is runtime reasoning effort:
+   - `worker-1` low lane launches with `--thinking low`.
+   - `worker-2` medium lane launches with `--thinking medium`.
+   - `worker-3` high lane launches with `--thinking high`.
+4. Do not assign different roles, personas, subjects, or complementary subtasks before review.
+5. Workers report effective model/thinking effort with `gjc team api report-whiplash-effort`; unsupported, capped, mismatched, or unknown effort activates degraded mode.
+6. Reviewer/leader waits for all current-round Whiplash tasks to reach terminal status before `write-whiplash-review`.
+7. Round 1 cannot accept. It must force reject with comparative critique and non-empty `proof_required`.
+8. `lead_worker` is a benchmark only; it is never the sole executor or an acceptance bypass.
+9. Retry rounds preserve the same canonical task hash and requested `--thinking` lane mapping; strategy rotation, non-convergence, recurrence, `prevention_note`, and degraded-mode rationale must be explicit.
+
+Useful Team API operations:
+
+```bash
+gjc team api read-whiplash-state --input '{"team_name":"<team>"}' --json
+gjc team api report-whiplash-effort --input '{"team_name":"<team>","worker_id":"worker-1","effective_thinking_effort":"low","effective_model_id":"provider/model","effort_evidence":"session resolved requested effort"}' --json
+gjc team api write-whiplash-review --input '{"team_name":"<team>","decision":"force_reject","comparative_critique":"...","proof_required":["failure path evidence"]}' --json
+gjc team api advance-whiplash-round --input '{"team_name":"<team>","retry_strategy":"structural-change","rationale":"round 1 proof gaps"}' --json
+```
+
 
 ### Team-first launch contract
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -134,6 +134,16 @@ gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evid
 
 Workers do not own ultragoal goal state, do not create worker ultragoal ledgers, and do not checkpoint Ultragoal. Workers must not run `gjc ultragoal checkpoint`; checkpoint authority stays with the leader after worker tasks are terminal. Team launch remains explicit; Ultragoal does not auto-launch Team and performs no hidden goal mutation.
 
+Whiplash Team strategy is allowed when the approved Ultragoal story benefits from same-task heterogeneous-reasoning collision rather than normal role-split parallelism. Launch it explicitly with `gjc team --whiplash "<story task>"`. Whiplash remains Team-owned execution state, not a new Ultragoal mode, not a fifth workflow skill, and not a new public role-agent roster.
+
+When consuming Whiplash evidence:
+
+- verify all three lanes used the same canonical task hash and the runtime launch args `--thinking low`, `--thinking medium`, and `--thinking high`;
+- require `read-whiplash-state` / review evidence showing round 1 forced reject, all-worker terminal barrier, comparative critique, and non-empty `proof_required`;
+- treat unsupported, capped, mismatched, or unknown effective effort as degraded evidence that must be explicitly justified before checkpointing;
+- treat `lead_worker` as benchmark evidence only, never as proof that one worker alone completed the story;
+- cite Team Whiplash review/evidence in the Ultragoal quality gate, while keeping `gjc ultragoal checkpoint` authority with the Ultragoal leader only.
+
 ## Mandatory completion cleanup and review gate
 
 An ultragoal story cannot be checkpointed `complete` until the active agent has run the quality gate:

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -8,6 +8,97 @@ import { applyGjcTmuxProfile } from "./launch-tmux";
 export type GjcTeamPhase = "starting" | "running" | "complete" | "failed" | "cancelled";
 export type GjcTeamTaskStatus = "pending" | "blocked" | "in_progress" | "completed" | "failed";
 export type GjcWorkerStatusState = "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown";
+export type GjcTeamStrategy = "standard" | "whiplash";
+export type GjcWhiplashReasoningTier = "low" | "medium" | "high";
+export type GjcWhiplashRequestedEffort = GjcWhiplashReasoningTier;
+export type GjcWhiplashEffectiveEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+export type GjcWhiplashEffortStatus = "pending" | "honored" | "capped" | "mismatched" | "unsupported" | "unknown";
+export type GjcWhiplashStatus = "collecting" | "retrying" | "accepted" | "non_converged" | "degraded";
+export type GjcWhiplashReviewDecision = "force_reject" | "retry" | "accept" | "non_converged";
+
+export interface GjcWhiplashCanonicalBrief {
+	task: string;
+	shared_conditions: string[];
+	shared_acceptance_criteria: string[];
+	hash: string;
+}
+
+export interface GjcWhiplashEffortMismatch {
+	worker_id: string;
+	requested: GjcWhiplashRequestedEffort;
+	effective?: GjcWhiplashEffectiveEffort;
+	status: GjcWhiplashEffortStatus;
+	reason: string;
+}
+
+export interface GjcWhiplashDegradedMode {
+	active: boolean;
+	missing_tiers: GjcWhiplashReasoningTier[];
+	missing_workers: string[];
+	effort_mismatches: GjcWhiplashEffortMismatch[];
+	recovery_attempted: string;
+	acceptance_impact: string;
+}
+
+export interface GjcWhiplashLane {
+	worker_id: string;
+	reasoning_tier: GjcWhiplashReasoningTier;
+	agent_type: "executor";
+	canonical_hash: string;
+	launch_args: ["--thinking", GjcWhiplashRequestedEffort];
+	requested_thinking_effort: GjcWhiplashRequestedEffort;
+	effective_thinking_effort?: GjcWhiplashEffectiveEffort;
+	effective_model_id?: string;
+	effort_status: GjcWhiplashEffortStatus;
+	effort_evidence?: string;
+	lead_worker_benchmark: boolean;
+}
+
+export interface GjcWhiplashProofRequirement {
+	id: string;
+	claim: string;
+	required_evidence: string;
+	status: "open" | "satisfied" | "waived";
+	satisfied_by?: string;
+	waiver_rationale?: string;
+}
+
+export interface GjcWhiplashReview {
+	round: number;
+	decision: GjcWhiplashReviewDecision;
+	reviewer: string;
+	worker_results: Record<string, { task_id: string; status: GjcTeamTaskStatus; evidence?: string }>;
+	comparative_critique: string;
+	proof_required: GjcWhiplashProofRequirement[];
+	lead_worker_id?: string;
+	lead_worker_benchmark_note: string;
+	retry_strategy?: string;
+	non_convergence_note?: string;
+	prevention_note?: string;
+	degraded_mode?: GjcWhiplashDegradedMode;
+	round_consumed: boolean;
+	created_at: string;
+}
+
+export interface GjcWhiplashRetryStrategyEntry {
+	round: number;
+	strategy: string;
+	rationale: string;
+	created_at: string;
+}
+
+export interface GjcWhiplashState {
+	strategy: "whiplash";
+	status: GjcWhiplashStatus;
+	round: number;
+	canonical: GjcWhiplashCanonicalBrief;
+	lanes: GjcWhiplashLane[];
+	reviews: GjcWhiplashReview[];
+	retry_strategy_history: GjcWhiplashRetryStrategyEntry[];
+	degraded_mode: GjcWhiplashDegradedMode;
+	lead_worker_id?: string;
+	updated_at: string;
+}
 
 export const GJC_TEAM_DEFAULT_WORKERS = 3;
 export const GJC_TEAM_MAX_WORKERS = 20;
@@ -40,6 +131,7 @@ export interface GjcTeamWorker {
 	worktree_created?: boolean;
 	worktree_base_ref?: string;
 	team_state_root?: string;
+	whiplash_lane?: GjcWhiplashLane;
 }
 
 export interface GjcTeamTaskClaim {
@@ -61,6 +153,7 @@ export interface GjcTeamTask {
 	error?: string;
 	blocked_by?: string[];
 	depends_on?: string[];
+	metadata?: Record<string, unknown>;
 	version: number;
 	claim?: GjcTeamTaskClaim;
 	created_at: string;
@@ -78,6 +171,7 @@ export interface GjcTeamConfig {
 	display_name: string;
 	requested_name: string;
 	task: string;
+	strategy: GjcTeamStrategy;
 	agent_type: string;
 	worker_count: number;
 	max_workers: number;
@@ -93,6 +187,7 @@ export interface GjcTeamConfig {
 	leader_cwd: string;
 	team_state_root: string;
 	workers: GjcTeamWorker[];
+	whiplash?: GjcWhiplashState;
 	created_at: string;
 	updated_at: string;
 }
@@ -133,6 +228,8 @@ export interface GjcTeamSnapshot {
 	task_counts: Record<GjcTeamTaskStatus, number>;
 	workers: GjcTeamWorker[];
 	integration_by_worker?: Record<string, GjcTeamWorkerIntegrationState>;
+	strategy: GjcTeamStrategy;
+	whiplash?: GjcWhiplashState;
 	updated_at: string;
 }
 
@@ -145,6 +242,7 @@ export interface GjcTeamStartOptions {
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
 	dryRun?: boolean;
+	strategy?: GjcTeamStrategy;
 }
 
 export interface GjcTeamApiClaimResult {
@@ -343,6 +441,10 @@ export const GJC_TEAM_API_OPERATIONS = [
 	"write-monitor-snapshot",
 	"read-task-approval",
 	"write-task-approval",
+	"read-whiplash-state",
+	"report-whiplash-effort",
+	"write-whiplash-review",
+	"advance-whiplash-round",
 ] as const;
 
 function now(): string {
@@ -367,6 +469,125 @@ function sanitizeName(value: string): string {
 function shortHash(value: string): string {
 	return Bun.hash(value).toString(16).slice(0, 8).padStart(8, "0");
 }
+const WHIPLASH_TIERS: readonly GjcWhiplashReasoningTier[] = ["low", "medium", "high"];
+const WHIPLASH_EFFECT_ORDER: readonly GjcWhiplashEffectiveEffort[] = ["minimal", "low", "medium", "high", "xhigh"];
+
+function emptyWhiplashDegradedMode(): GjcWhiplashDegradedMode {
+	return {
+		active: false,
+		missing_tiers: [],
+		missing_workers: [],
+		effort_mismatches: [],
+		recovery_attempted: "",
+		acceptance_impact: "",
+	};
+}
+
+function createWhiplashCanonicalBrief(task: string): GjcWhiplashCanonicalBrief {
+	const sharedConditions = [
+		"All lanes receive the same task, same conditions, and same acceptance criteria.",
+		"Reasoning tier is the only intentional lane difference; do not split roles or personas.",
+	];
+	const sharedAcceptanceCriteria = [
+		"Worker commands differ by per-lane --thinking launch args.",
+		"Round 1 cannot accept and must produce comparative critique plus proof_required.",
+		"Whiplash completion requires all-worker terminal barrier and accepted review state.",
+	];
+	return {
+		task,
+		shared_conditions: sharedConditions,
+		shared_acceptance_criteria: sharedAcceptanceCriteria,
+		hash: shortHash([task, ...sharedConditions, ...sharedAcceptanceCriteria].join("\n---\n")),
+	};
+}
+
+function createWhiplashLane(worker: GjcTeamWorker, canonical: GjcWhiplashCanonicalBrief): GjcWhiplashLane {
+	const tier = WHIPLASH_TIERS[worker.index - 1];
+	if (!tier) throw new Error(`invalid_whiplash_worker_index:${worker.index}`);
+	return {
+		worker_id: worker.id,
+		reasoning_tier: tier,
+		agent_type: "executor",
+		canonical_hash: canonical.hash,
+		launch_args: ["--thinking", tier],
+		requested_thinking_effort: tier,
+		effort_status: "pending",
+		lead_worker_benchmark: false,
+	};
+}
+
+function attachWhiplashLanes(workers: GjcTeamWorker[], canonical: GjcWhiplashCanonicalBrief): GjcTeamWorker[] {
+	return workers.map(worker => ({ ...worker, whiplash_lane: createWhiplashLane(worker, canonical) }));
+}
+
+function createWhiplashState(task: string, workers: GjcTeamWorker[]): GjcWhiplashState {
+	const canonical = createWhiplashCanonicalBrief(task);
+	return {
+		strategy: "whiplash",
+		status: "collecting",
+		round: 1,
+		canonical,
+		lanes: attachWhiplashLanes(workers, canonical).map(worker => worker.whiplash_lane!),
+		reviews: [],
+		retry_strategy_history: [],
+		degraded_mode: emptyWhiplashDegradedMode(),
+		updated_at: now(),
+	};
+}
+
+function isWhiplashEffectiveEffort(value: string): value is GjcWhiplashEffectiveEffort {
+	return WHIPLASH_EFFECT_ORDER.includes(value as GjcWhiplashEffectiveEffort);
+}
+
+function resolveEffortStatus(
+	requested: GjcWhiplashRequestedEffort,
+	effective: GjcWhiplashEffectiveEffort | undefined,
+	explicit?: GjcWhiplashEffortStatus,
+): GjcWhiplashEffortStatus {
+	if (explicit) return explicit;
+	if (!effective) return "unknown";
+	if (effective === requested) return "honored";
+	return WHIPLASH_EFFECT_ORDER.indexOf(effective) < WHIPLASH_EFFECT_ORDER.indexOf(requested) ? "capped" : "mismatched";
+}
+
+function refreshWhiplashDegradedMode(state: GjcWhiplashState): GjcWhiplashDegradedMode {
+	const mismatches = state.lanes
+		.filter(lane => lane.effort_status !== "honored")
+		.map(lane => ({
+			worker_id: lane.worker_id,
+			requested: lane.requested_thinking_effort,
+			effective: lane.effective_thinking_effort,
+			status: lane.effort_status,
+			reason: `requested ${lane.requested_thinking_effort}, effective ${lane.effective_thinking_effort ?? "unknown"}`,
+		}));
+	if (mismatches.length === 0) return emptyWhiplashDegradedMode();
+	return {
+		active: true,
+		missing_tiers: [],
+		missing_workers: [],
+		effort_mismatches: mismatches,
+		recovery_attempted: "Worker reported effective effort through Team whiplash effort state.",
+		acceptance_impact:
+			"Whiplash acceptance is blocked unless review explicitly justifies degraded reasoning evidence.",
+	};
+}
+
+async function readWhiplashState(dir: string): Promise<GjcWhiplashState | undefined> {
+	return (await readJsonFile<GjcWhiplashState>(whiplashStatePath(dir))) ?? undefined;
+}
+
+async function writeWhiplashState(dir: string, state: GjcWhiplashState): Promise<GjcWhiplashState> {
+	const updated = { ...state, updated_at: now() };
+	await writeJsonFile(whiplashStatePath(dir), updated);
+	return updated;
+}
+
+function ensureWhiplashLaunch(options: GjcTeamStartOptions): void {
+	if ((options.strategy ?? "standard") !== "whiplash") return;
+	if (options.workerCount !== 3) throw new Error("whiplash_requires_exactly_three_workers");
+	if (options.agentType !== "executor") throw new Error("whiplash_requires_executor_agent_type");
+}
+
 function makeTeamName(task: string, env: NodeJS.ProcessEnv): string {
 	const basis = [task, env.GJC_SESSION_ID, env.CODEX_SESSION_ID, env.TMUX_PANE, env.TMUX, now()]
 		.filter(Boolean)
@@ -391,6 +612,13 @@ function workerDir(dir: string, worker: string): string {
 }
 function workerIntegrationDedupePath(dir: string, worker: string): string {
 	return path.join(workerDir(dir, worker), "posttooluse-dedupe.json");
+}
+function whiplashStatePath(dir: string): string {
+	return path.join(dir, "whiplash.json");
+}
+
+function whiplashReviewPath(dir: string, round: number): string {
+	return path.join(dir, "whiplash-reviews", `round-${round}.json`);
 }
 
 export function resolveGjcTeamStateRoot(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
@@ -439,6 +667,7 @@ async function readConfig(dir: string): Promise<GjcTeamConfig> {
 		tmux_target: config.tmux_target ?? config.tmux_session ?? tmuxSessionName,
 		leader_cwd: config.leader_cwd ?? config.leader.cwd,
 		team_state_root: config.team_state_root ?? config.state_root,
+		strategy: config.strategy ?? "standard",
 		worker_cli_plan: config.worker_cli_plan ?? Array.from({ length: config.worker_count }, () => "gjc"),
 	};
 }
@@ -669,6 +898,25 @@ export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.Process
 	if (entrypoint && path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
 	return "gjc";
 }
+function buildWhiplashPromptLines(config: GjcTeamConfig, worker: GjcTeamWorker): string[] {
+	const lane = worker.whiplash_lane;
+	const whiplash = config.whiplash;
+	if (!lane || !whiplash) return [];
+	return [
+		"Whiplash mode: solve the same canonical task as the other lanes; do not split roles or personas.",
+		`Reasoning tier: ${lane.reasoning_tier}. Requested launch effort: ${lane.requested_thinking_effort}.`,
+		`Canonical task hash: ${whiplash.canonical.hash}.`,
+		`Canonical task: ${whiplash.canonical.task}`,
+		`Shared conditions: ${whiplash.canonical.shared_conditions.join(" | ")}`,
+		`Shared acceptance criteria: ${whiplash.canonical.shared_acceptance_criteria.join(" | ")}`,
+		"Report effective model/thinking effort with gjc team api report-whiplash-effort before terminal task transition when possible.",
+	];
+}
+
+function buildWorkerLaunchArgs(worker: GjcTeamWorker): string {
+	return worker.whiplash_lane?.launch_args.map(shellQuote).join(" ") ?? "";
+}
+
 function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): string {
 	const workspace = worker.worktree_path
 		? `Worker worktree: ${worker.worktree_path}.`
@@ -678,6 +926,7 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 		`Team state root: ${config.state_root}.`,
 		workspace,
 		`Task: ${config.task}`,
+		...buildWhiplashPromptLines(config, worker),
 		`Use gjc team api claim-task/transition-task-status with this worker id, record evidence, and do not mutate leader-owned goal state.`,
 	].join("\n");
 	const env = [
@@ -690,17 +939,28 @@ function buildWorkerCommand(config: GjcTeamConfig, worker: GjcTeamWorker): strin
 		`GJC_TEAM_DISPLAY_NAME=${shellQuote(config.display_name)}`,
 		...(worker.worktree_path ? [`GJC_TEAM_WORKTREE_PATH=${shellQuote(worker.worktree_path)}`] : []),
 	];
-	return `${env.join(" ")} ${config.worker_command} ${shellQuote(prompt)}`;
+	const launchArgs = buildWorkerLaunchArgs(worker);
+	return `${env.join(" ")} ${config.worker_command}${launchArgs ? ` ${launchArgs}` : ""} ${shellQuote(prompt)}`;
 }
-function buildInitialTasks(task: string, workers: GjcTeamWorker[]): GjcTeamTask[] {
+function buildInitialTasks(task: string, workers: GjcTeamWorker[], whiplash?: GjcWhiplashState): GjcTeamTask[] {
 	return workers.map(worker => ({
 		id: `task-${worker.index}`,
 		subject: `Execute team brief (${worker.id})`,
-		description: task,
+		description: whiplash?.canonical.task ?? task,
 		title: `Execute team brief (${worker.id})`,
-		objective: task,
+		objective: whiplash?.canonical.task ?? task,
 		status: "pending",
 		owner: worker.id,
+		metadata: worker.whiplash_lane
+			? {
+					strategy: "whiplash",
+					round: whiplash?.round ?? 1,
+					canonical_hash: worker.whiplash_lane.canonical_hash,
+					reasoning_tier: worker.whiplash_lane.reasoning_tier,
+					requested_thinking_effort: worker.whiplash_lane.requested_thinking_effort,
+					launch_args: worker.whiplash_lane.launch_args,
+				}
+			: undefined,
 		version: 1,
 		created_at: now(),
 		updated_at: now(),
@@ -1409,7 +1669,7 @@ async function integrateGjcWorkerCommits(
 }
 
 async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promise<void> {
-	for (const folder of ["tasks", "claims", "mailbox", "dispatch", "approvals", "workers"])
+	for (const folder of ["tasks", "claims", "mailbox", "dispatch", "approvals", "workers", "whiplash-reviews"])
 		await fs.mkdir(path.join(dir, folder), { recursive: true });
 	for (const worker of workers) {
 		await fs.mkdir(workerDir(dir, worker.id), { recursive: true });
@@ -1430,6 +1690,8 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const env = options.env ?? process.env;
 	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > GJC_TEAM_MAX_WORKERS)
 		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
+	ensureWhiplashLaunch(options);
+	const strategy = options.strategy ?? "standard";
 	const workerCliPlan = resolveGjcTeamWorkerCliPlan(options.workerCount, env);
 	const stateRoot = resolveGjcTeamStateRoot(cwd, env);
 	const teamName = sanitizeName(options.teamName ?? makeTeamName(options.task, env));
@@ -1441,7 +1703,9 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const tmuxContext = options.dryRun
 		? { sessionName: "dry-run", windowIndex: "0", leaderPaneId: "%dry-run-leader", target: "dry-run:0" }
 		: readCurrentTmuxLeaderContext(tmuxCommand, env);
-	const initialWorkers = buildWorkers(options.workerCount, options.agentType, stateRoot);
+	const baseWorkers = buildWorkers(options.workerCount, options.agentType, stateRoot);
+	const whiplash = strategy === "whiplash" ? createWhiplashState(options.task, baseWorkers) : undefined;
+	const initialWorkers = whiplash ? attachWhiplashLanes(baseWorkers, whiplash.canonical) : baseWorkers;
 	const workers: GjcTeamWorker[] = [];
 	try {
 		for (const worker of initialWorkers)
@@ -1450,11 +1714,13 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		await rollbackCreatedWorktrees(workers);
 		throw error;
 	}
+	const whiplashState = whiplash ? { ...whiplash, lanes: workers.map(worker => worker.whiplash_lane!) } : undefined;
 	const config: GjcTeamConfig = {
 		team_name: teamName,
 		display_name: displayName,
 		requested_name: options.teamName ?? displayName,
 		task: options.task,
+		strategy,
 		agent_type: options.agentType,
 		worker_count: options.workerCount,
 		max_workers: GJC_TEAM_MAX_WORKERS,
@@ -1470,11 +1736,13 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		leader_cwd: cwd,
 		team_state_root: stateRoot,
 		workers,
+		whiplash: whiplashState,
 		created_at: createdAt,
 		updated_at: createdAt,
 	};
 	await initializeStateDirs(dir, config.workers);
 	await writeJsonFile(path.join(dir, "config.json"), config);
+	if (config.whiplash) await writeWhiplashState(dir, config.whiplash);
 	await writeJsonFile(path.join(dir, "manifest.v2.json"), {
 		version: 2,
 		team_name: config.team_name,
@@ -1485,19 +1753,26 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		tmux_target: config.tmux_target,
 		worker_command: config.worker_command,
 		worker_cli_plan: config.worker_cli_plan,
+		strategy: config.strategy,
 		tmux_command: config.tmux_command,
 		leader: config.leader,
 		workers: config.workers,
 		workspace_mode: config.workspace_mode,
+		whiplash: config.whiplash,
 		created_at: createdAt,
 		updated_at: createdAt,
 	});
 	await writePhase(dir, "starting");
-	for (const task of buildInitialTasks(options.task, config.workers)) await writeTask(dir, task);
+	for (const task of buildInitialTasks(options.task, config.workers, config.whiplash)) await writeTask(dir, task);
 	await appendEvent(dir, {
 		type: "team_started",
 		message: "Started native gjc team runtime",
-		data: { worker_count: options.workerCount, agent_type: options.agentType, workspace_mode: config.workspace_mode },
+		data: {
+			worker_count: options.workerCount,
+			agent_type: options.agentType,
+			workspace_mode: config.workspace_mode,
+			strategy: config.strategy,
+		},
 	});
 	await appendTelemetry(dir, {
 		type: "team_runtime",
@@ -1507,6 +1782,7 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 			worker_command: config.worker_command,
 			worker_cli_plan: workerCliPlan,
 			workspace_mode: config.workspace_mode,
+			strategy: config.strategy,
 		},
 	});
 	let tmuxWorkers: GjcTeamWorker[];
@@ -1526,8 +1802,10 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 		...config,
 		workers: tmuxWorkers.map(worker => ({ ...worker, status: "idle" as const, last_heartbeat: now() })),
 		updated_at: now(),
+		whiplash: config.whiplash,
 	};
 	await writeJsonFile(path.join(dir, "config.json"), runningConfig);
+	if (runningConfig.whiplash) await writeWhiplashState(dir, runningConfig.whiplash);
 	await writePhase(dir, "running");
 	return readGjcTeamSnapshot(teamName, cwd, env);
 }
@@ -1550,6 +1828,7 @@ export async function readGjcTeamSnapshot(
 	};
 	for (const task of tasks) taskCounts[task.status] += 1;
 	const monitor = await readJsonFile<GjcTeamMonitorSnapshot>(monitorSnapshotPath(dir));
+	const whiplash = await readWhiplashState(dir);
 	return {
 		team_name: config.team_name,
 		display_name: config.display_name,
@@ -1562,6 +1841,8 @@ export async function readGjcTeamSnapshot(
 		task_counts: taskCounts,
 		workers: config.workers,
 		integration_by_worker: monitor?.integration_by_worker,
+		strategy: config.strategy,
+		whiplash,
 		updated_at: config.updated_at,
 	};
 }
@@ -1705,10 +1986,18 @@ export async function shutdownGjcTeam(
 	const dir = await findTeamDir(teamName, cwd, env);
 	const config = await readConfig(dir);
 	const tasks = await readTasks(dir);
-	const shutdownPhase: GjcTeamPhase =
-		tasks.length === 0 || tasks.every(task => task.status === "completed")
+	const whiplash = await readWhiplashState(dir);
+	const tasksComplete = tasks.length === 0 || tasks.every(task => task.status === "completed");
+	const tasksFailed = tasks.some(task => task.status === "failed" || task.status === "blocked");
+	const shutdownPhase: GjcTeamPhase = whiplash
+		? whiplash.status === "accepted" && tasksComplete
 			? "complete"
-			: tasks.some(task => task.status === "failed" || task.status === "blocked")
+			: whiplash.status === "non_converged" || tasksFailed
+				? "failed"
+				: "cancelled"
+		: tasksComplete
+			? "complete"
+			: tasksFailed
 				? "failed"
 				: "cancelled";
 	killWorkerPanes(config);
@@ -2129,6 +2418,234 @@ export async function readGjcTaskApproval(
 		path.join(await findTeamDir(teamName, cwd, env), "approvals", `${taskId}.json`),
 	);
 }
+function isGjcWhiplashEffortStatus(value: string): value is GjcWhiplashEffortStatus {
+	return ["pending", "honored", "capped", "mismatched", "unsupported", "unknown"].includes(value);
+}
+
+function parseWhiplashProofRequirements(value: unknown): GjcWhiplashProofRequirement[] {
+	if (!Array.isArray(value)) return [];
+	return value.map((entry, index) => {
+		if (typeof entry === "string")
+			return {
+				id: `proof-${index + 1}`,
+				claim: entry,
+				required_evidence: entry,
+				status: "open" as const,
+			};
+		const obj = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+		return {
+			id: String(obj.id ?? `proof-${index + 1}`),
+			claim: String(obj.claim ?? obj.required_evidence ?? obj.evidence ?? ""),
+			required_evidence: String(obj.required_evidence ?? obj.evidence ?? obj.claim ?? ""),
+			status: ["open", "satisfied", "waived"].includes(String(obj.status))
+				? (String(obj.status) as GjcWhiplashProofRequirement["status"])
+				: "open",
+			satisfied_by: typeof obj.satisfied_by === "string" ? obj.satisfied_by : undefined,
+			waiver_rationale: typeof obj.waiver_rationale === "string" ? obj.waiver_rationale : undefined,
+		};
+	});
+}
+
+function isTerminalTaskStatus(status: GjcTeamTaskStatus): boolean {
+	return status === "completed" || status === "failed" || status === "blocked";
+}
+
+function currentWhiplashRoundTasks(tasks: GjcTeamTask[], round: number): GjcTeamTask[] {
+	return tasks.filter(task => task.metadata?.strategy === "whiplash" && task.metadata.round === round);
+}
+
+export async function readGjcWhiplashState(
+	teamName: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcWhiplashState> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const state = await readWhiplashState(dir);
+	if (!state) throw new Error(`whiplash_state_not_found:${teamName}`);
+	return state;
+}
+
+export async function reportGjcWhiplashEffort(
+	teamName: string,
+	workerId: string,
+	input: Record<string, unknown>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcWhiplashState> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const state = await readGjcWhiplashState(teamName, cwd, env);
+	const lane = state.lanes.find(candidate => candidate.worker_id === workerId);
+	if (!lane) throw new Error(`whiplash_lane_not_found:${workerId}`);
+	const effectiveRaw =
+		typeof input.effective_thinking_effort === "string" ? input.effective_thinking_effort : undefined;
+	const effective = effectiveRaw && isWhiplashEffectiveEffort(effectiveRaw) ? effectiveRaw : undefined;
+	const explicitRaw = typeof input.effort_status === "string" ? input.effort_status : undefined;
+	const explicit = explicitRaw && isGjcWhiplashEffortStatus(explicitRaw) ? explicitRaw : undefined;
+	const updatedLane: GjcWhiplashLane = {
+		...lane,
+		effective_thinking_effort: effective,
+		effective_model_id:
+			typeof input.effective_model_id === "string" ? input.effective_model_id : lane.effective_model_id,
+		effort_status: resolveEffortStatus(lane.requested_thinking_effort, effective, explicit),
+		effort_evidence: typeof input.effort_evidence === "string" ? input.effort_evidence : lane.effort_evidence,
+	};
+	const updated: GjcWhiplashState = {
+		...state,
+		lanes: state.lanes.map(candidate => (candidate.worker_id === workerId ? updatedLane : candidate)),
+	};
+	updated.degraded_mode = refreshWhiplashDegradedMode(updated);
+	updated.status = updated.degraded_mode.active && updated.status === "accepted" ? "degraded" : updated.status;
+	const written = await writeWhiplashState(dir, updated);
+	const config = await readConfig(dir);
+	await writeJsonFile(path.join(dir, "config.json"), {
+		...config,
+		workers: config.workers.map(worker =>
+			worker.id === workerId ? { ...worker, whiplash_lane: updatedLane, last_heartbeat: now() } : worker,
+		),
+		whiplash: written,
+		updated_at: now(),
+	});
+	await appendEvent(dir, {
+		type: "whiplash_effort_reported",
+		worker: workerId,
+		message: `Whiplash effort ${updatedLane.effort_status}`,
+		data: {
+			worker_id: workerId,
+			requested: updatedLane.requested_thinking_effort,
+			effective,
+			status: updatedLane.effort_status,
+		},
+	});
+	return written;
+}
+
+export async function writeGjcWhiplashReview(
+	teamName: string,
+	input: Record<string, unknown>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcWhiplashReview> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const state = await readGjcWhiplashState(teamName, cwd, env);
+	const tasks = await readTasks(dir);
+	const roundTasks = currentWhiplashRoundTasks(tasks, state.round);
+	const openTasks = roundTasks.filter(task => !isTerminalTaskStatus(task.status));
+	if (roundTasks.length !== state.lanes.length || openTasks.length > 0)
+		throw new Error(`whiplash_review_premature:${teamName}:round-${state.round}`);
+	const rawDecision = String(input.decision ?? "");
+	if (!["force_reject", "retry", "accept", "non_converged"].includes(rawDecision))
+		throw new Error(`invalid_whiplash_review_decision:${rawDecision}`);
+	const decision = rawDecision as GjcWhiplashReviewDecision;
+	if (state.round === 1 && decision === "accept") throw new Error("whiplash_round1_accept_forbidden");
+	const comparativeCritique = String(input.comparative_critique ?? input.comparativeCritique ?? "").trim();
+	const proofRequired = parseWhiplashProofRequirements(input.proof_required ?? input.proofRequired);
+	if (!comparativeCritique) throw new Error("whiplash_review_requires_comparative_critique");
+	if (proofRequired.length === 0) throw new Error("whiplash_review_requires_proof_required");
+	const preventionNote = String(input.prevention_note ?? input.preventionNote ?? "").trim();
+	if (input.recurrence && !preventionNote) throw new Error("whiplash_recurrence_requires_prevention_note");
+	const effectiveDegradedMode = refreshWhiplashDegradedMode(state);
+	if (
+		decision === "accept" &&
+		effectiveDegradedMode.active &&
+		!String(input.degraded_acceptance_rationale ?? "").trim()
+	)
+		throw new Error("whiplash_accept_requires_degraded_rationale");
+	const review: GjcWhiplashReview = {
+		round: state.round,
+		decision,
+		reviewer: String(input.reviewer ?? "leader-fixed"),
+		worker_results: Object.fromEntries(
+			roundTasks.map(task => [task.owner ?? task.assignee ?? task.id, { task_id: task.id, status: task.status }]),
+		),
+		comparative_critique: comparativeCritique,
+		proof_required: proofRequired,
+		lead_worker_id: typeof input.lead_worker_id === "string" ? input.lead_worker_id : undefined,
+		lead_worker_benchmark_note: String(
+			input.lead_worker_benchmark_note ?? input.leadWorkerBenchmarkNote ?? "benchmark only",
+		),
+		retry_strategy: typeof input.retry_strategy === "string" ? input.retry_strategy : undefined,
+		non_convergence_note: typeof input.non_convergence_note === "string" ? input.non_convergence_note : undefined,
+		prevention_note: preventionNote,
+		degraded_mode: effectiveDegradedMode.active ? effectiveDegradedMode : undefined,
+		round_consumed: true,
+		created_at: now(),
+	};
+	await writeJsonFile(whiplashReviewPath(dir, state.round), review);
+	const updated: GjcWhiplashState = {
+		...state,
+		status: decision === "accept" ? "accepted" : decision === "non_converged" ? "non_converged" : "retrying",
+		reviews: [...state.reviews.filter(existing => existing.round !== state.round), review],
+		lead_worker_id: review.lead_worker_id ?? state.lead_worker_id,
+		degraded_mode: effectiveDegradedMode,
+	};
+	const written = await writeWhiplashState(dir, updated);
+	const config = await readConfig(dir);
+	await writeJsonFile(path.join(dir, "config.json"), { ...config, whiplash: written, updated_at: now() });
+	await appendEvent(dir, {
+		type: "whiplash_review_written",
+		worker: review.reviewer,
+		message: `Whiplash review ${decision} for round ${review.round}`,
+		data: { round: review.round, decision },
+	});
+	return review;
+}
+
+export async function advanceGjcWhiplashRound(
+	teamName: string,
+	input: Record<string, unknown>,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GjcWhiplashState> {
+	const dir = await findTeamDir(teamName, cwd, env);
+	const state = await readGjcWhiplashState(teamName, cwd, env);
+	if (state.status !== "retrying") throw new Error(`whiplash_round_not_retrying:${state.status}`);
+	const nextRound = state.round + 1;
+	if (nextRound > 5) throw new Error("whiplash_max_rounds_exceeded");
+	const strategy = String(input.retry_strategy ?? input.strategy ?? `round-${nextRound}-retry`);
+	const rationale = String(input.rationale ?? "Retry after comparative Whiplash review.");
+	const tasks = await readTasks(dir);
+	let nextIndex = tasks.length + 1;
+	for (const lane of state.lanes) {
+		await writeTask(dir, {
+			id: `task-${nextIndex++}`,
+			subject: `Whiplash round ${nextRound} (${lane.worker_id})`,
+			description: state.canonical.task,
+			title: `Whiplash round ${nextRound} (${lane.worker_id})`,
+			objective: state.canonical.task,
+			status: "pending",
+			owner: lane.worker_id,
+			metadata: {
+				strategy: "whiplash",
+				round: nextRound,
+				canonical_hash: lane.canonical_hash,
+				reasoning_tier: lane.reasoning_tier,
+				requested_thinking_effort: lane.requested_thinking_effort,
+				launch_args: lane.launch_args,
+				retry_strategy: strategy,
+			},
+			version: 1,
+			created_at: now(),
+			updated_at: now(),
+		});
+	}
+	const written = await writeWhiplashState(dir, {
+		...state,
+		status: "collecting",
+		round: nextRound,
+		retry_strategy_history: [
+			...state.retry_strategy_history,
+			{ round: nextRound, strategy, rationale, created_at: now() },
+		],
+	});
+	const config = await readConfig(dir);
+	await writeJsonFile(path.join(dir, "config.json"), { ...config, whiplash: written, updated_at: now() });
+	await appendEvent(dir, {
+		type: "whiplash_round_advanced",
+		message: `Advanced Whiplash to round ${nextRound}`,
+		data: { round: nextRound, retry_strategy: strategy },
+	});
+	return written;
+}
 export async function writeGjcShutdownRequest(
 	teamName: string,
 	worker: string,
@@ -2267,6 +2784,14 @@ export async function executeGjcTeamApiOperation(
 			return await readConfig(await findTeamDir(teamName, cwd, env));
 		case "read-manifest":
 			return readJsonFile(path.join(await findTeamDir(teamName, cwd, env), "manifest.v2.json"));
+		case "read-whiplash-state":
+			return { whiplash: await readGjcWhiplashState(teamName, cwd, env) };
+		case "report-whiplash-effort":
+			return { whiplash: await reportGjcWhiplashEffort(teamName, worker, input, cwd, env) };
+		case "write-whiplash-review":
+			return { review: await writeGjcWhiplashReview(teamName, input, cwd, env) };
+		case "advance-whiplash-round":
+			return { whiplash: await advanceGjcWhiplashRound(teamName, input, cwd, env) };
 		case "read-worker-status":
 			return readGjcWorkerStatus(teamName, worker, cwd, env);
 		case "read-worker-heartbeat":
@@ -2327,7 +2852,8 @@ export async function executeGjcTeamApiOperation(
 
 export function parseTeamLaunchArgs(argv: string[]): GjcTeamStartOptions {
 	const parsedWorktree = parseWorktreeMode(argv);
-	const positionals = parsedWorktree.remainingArgs.filter(arg => !arg.startsWith("--"));
+	const strategy: GjcTeamStrategy = parsedWorktree.remainingArgs.includes("--whiplash") ? "whiplash" : "standard";
+	const positionals = parsedWorktree.remainingArgs.filter(arg => arg !== "--whiplash" && !arg.startsWith("--"));
 	const dryRun = argv.includes("--dry-run");
 	let workerCount = GJC_TEAM_DEFAULT_WORKERS;
 	let agentType = "executor";
@@ -2343,7 +2869,7 @@ export function parseTeamLaunchArgs(argv: string[]): GjcTeamStartOptions {
 	} else if (countOnly) {
 		workerCount = Number.parseInt(countOnly[1] ?? "", 10);
 		taskStartIndex = 1;
-	} else if (roleOnly && positionals.length > 1) {
+	} else if (strategy !== "whiplash" && roleOnly && positionals.length > 1) {
 		agentType = roleOnly[1] ?? "executor";
 		taskStartIndex = 1;
 	}
@@ -2351,5 +2877,14 @@ export function parseTeamLaunchArgs(argv: string[]): GjcTeamStartOptions {
 	if (!task) throw new Error("missing_team_task");
 	if (!Number.isInteger(workerCount) || workerCount < 1 || workerCount > GJC_TEAM_MAX_WORKERS)
 		throw new Error(`invalid_team_worker_count:${workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
-	return { workerCount, agentType, task, dryRun, worktreeMode: resolveDefaultWorktreeMode(parsedWorktree.mode) };
+	if (strategy === "whiplash" && workerCount !== 3) throw new Error("whiplash_requires_exactly_three_workers");
+	if (strategy === "whiplash" && agentType !== "executor") throw new Error("whiplash_requires_executor_agent_type");
+	return {
+		workerCount,
+		agentType,
+		task,
+		dryRun,
+		worktreeMode: resolveDefaultWorktreeMode(parsedWorktree.mode),
+		strategy,
+	};
 }

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -201,6 +201,31 @@ Project executor override body.
 		}
 	});
 
+	it("documents Whiplash as Team strategy without expanding public surfaces", async () => {
+		const definitions = getDefaultGjcDefinitions();
+		const definitionNames = definitions.map(definition => String(definition.name));
+		expect(definitionNames.sort()).toEqual([...DEFAULT_GJC_DEFINITION_NAMES].sort());
+		expect(definitionNames.some(name => name === "whiplash" || name === "whiplash-loop")).toBe(false);
+		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS).toEqual(["default", "executor", "architect", "planner", "critic"]);
+
+		const team = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", "team", "SKILL.md"),
+		).text();
+		const ultragoal = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", "ultragoal", "SKILL.md"),
+		).text();
+
+		expect(team).toContain("gjc team --whiplash");
+		expect(team).toContain("not a fifth workflow skill");
+		expect(team).toContain("--thinking low");
+		expect(team).toContain("--thinking medium");
+		expect(team).toContain("--thinking high");
+		expect(team).toContain("Round 1 cannot accept");
+		expect(ultragoal).toContain("Whiplash Team strategy");
+		expect(ultragoal).toContain("not a fifth workflow skill");
+		expect(ultragoal).toContain("checkpoint authority");
+	});
+
 	it("keeps bundled deep-interview skill on GJC-native workflow vocabulary", () => {
 		const deepInterview = getDefaultGjcDefinitions().find(definition => definition.name === "deep-interview");
 		expect(deepInterview).toBeDefined();

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -266,6 +266,168 @@ describe("native gjc team runtime", () => {
 		expect(separatedShort.task).toBe("ship it");
 	});
 
+	it("parses whiplash mode as exactly three executor lanes", () => {
+		const parsed = parseTeamLaunchArgs(["--whiplash", "prove", "the", "fix"]);
+		expect(parsed.strategy).toBe("whiplash");
+		expect(parsed.workerCount).toBe(3);
+		expect(parsed.agentType).toBe("executor");
+		expect(parsed.task).toBe("prove the fix");
+		expect(() => parseTeamLaunchArgs(["--whiplash", "2:executor", "prove"])).toThrow(
+			"whiplash_requires_exactly_three_workers",
+		);
+		expect(() => parseTeamLaunchArgs(["--whiplash", "3:critic", "prove"])).toThrow(
+			"whiplash_requires_executor_agent_type",
+		);
+	});
+
+	it("starts whiplash workers with per-lane thinking launch args and shared canonical hash", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 3,
+			agentType: "executor",
+			task: "Same task collision",
+			teamName: "whiplash-team",
+			strategy: "whiplash",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "gjc-worker", GJC_TEAM_TMUX_COMMAND: fakeTmux },
+		});
+
+		expect(snapshot.strategy).toBe("whiplash");
+		expect(snapshot.whiplash?.lanes.map(lane => lane.requested_thinking_effort)).toEqual(["low", "medium", "high"]);
+		const hashes = new Set(snapshot.whiplash?.lanes.map(lane => lane.canonical_hash));
+		expect(hashes.size).toBe(1);
+		const config = await readTeamConfig(snapshot.state_dir);
+		const manifest = await Bun.file(path.join(snapshot.state_dir, "manifest.v2.json")).json();
+		expect(config.strategy).toBe("whiplash");
+		expect(manifest.strategy).toBe("whiplash");
+		expect(config.workers.map(worker => worker.whiplash_lane?.launch_args)).toEqual([
+			["--thinking", "low"],
+			["--thinking", "medium"],
+			["--thinking", "high"],
+		]);
+		const tasks = await executeGjcTeamApiOperation("list-tasks", { team_name: "whiplash-team" }, cleanupRoot, {
+			PATH: process.env.PATH ?? "",
+		});
+		expect(JSON.stringify(tasks)).toContain('"canonical_hash"');
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("gjc-worker '--thinking' 'low'");
+		expect(tmuxLog).toContain("gjc-worker '--thinking' 'medium'");
+		expect(tmuxLog).toContain("gjc-worker '--thinking' 'high'");
+	});
+
+	it("enforces whiplash effort reporting, round-one reject, and retry round creation", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 3,
+			agentType: "executor",
+			task: "Review barrier",
+			teamName: "whiplash-api-team",
+			strategy: "whiplash",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { PATH: "" },
+		});
+
+		await expect(
+			executeGjcTeamApiOperation(
+				"write-whiplash-review",
+				{
+					team_name: "whiplash-api-team",
+					decision: "force_reject",
+					comparative_critique: "not all workers are terminal",
+					proof_required: ["failure path"],
+				},
+				cleanupRoot,
+				{ PATH: "" },
+			),
+		).rejects.toThrow("whiplash_review_premature");
+
+		for (const [worker, effort] of [
+			["worker-1", "low"],
+			["worker-2", "medium"],
+			["worker-3", "high"],
+		] as const) {
+			await executeGjcTeamApiOperation(
+				"report-whiplash-effort",
+				{
+					team_name: "whiplash-api-team",
+					worker_id: worker,
+					effective_thinking_effort: effort,
+					effective_model_id: `provider/${effort}`,
+					effort_evidence: "test report",
+				},
+				cleanupRoot,
+				{ PATH: "" },
+			);
+			const claim = await claimGjcTeamTask("whiplash-api-team", worker, cleanupRoot, { PATH: "" });
+			expect(claim.ok).toBe(true);
+			await transitionGjcTeamTask(
+				"whiplash-api-team",
+				claim.task?.id ?? "",
+				"completed",
+				cleanupRoot,
+				{ PATH: "" },
+				claim.claim_token,
+			);
+		}
+
+		const mismatchedEffort = await executeGjcTeamApiOperation(
+			"report-whiplash-effort",
+			{
+				team_name: "whiplash-api-team",
+				worker_id: "worker-1",
+				effective_thinking_effort: "medium",
+				effective_model_id: "provider/medium",
+				effort_evidence: "provider resolved above requested low effort",
+			},
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		expect(JSON.stringify(mismatchedEffort)).toContain('"effort_status":"mismatched"');
+		expect(JSON.stringify(mismatchedEffort)).toContain('"active":true');
+
+		await expect(
+			executeGjcTeamApiOperation(
+				"write-whiplash-review",
+				{
+					team_name: "whiplash-api-team",
+					decision: "accept",
+					comparative_critique: "round one cannot accept",
+					proof_required: ["failure path"],
+				},
+				cleanupRoot,
+				{ PATH: "" },
+			),
+		).rejects.toThrow("whiplash_round1_accept_forbidden");
+
+		const review = await executeGjcTeamApiOperation(
+			"write-whiplash-review",
+			{
+				team_name: "whiplash-api-team",
+				decision: "force_reject",
+				comparative_critique: "compare low medium high",
+				proof_required: ["failure path"],
+				lead_worker_id: "worker-3",
+				lead_worker_benchmark_note: "worker-3 is a benchmark only",
+			},
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		expect(JSON.stringify(review)).toContain('"decision":"force_reject"');
+		const advanced = await executeGjcTeamApiOperation(
+			"advance-whiplash-round",
+			{ team_name: "whiplash-api-team", retry_strategy: "structural-change", rationale: "proof gap" },
+			cleanupRoot,
+			{ PATH: "" },
+		);
+		expect(JSON.stringify(advanced)).toContain('"round":2');
+		const tasks = await executeGjcTeamApiOperation("list-tasks", { team_name: "whiplash-api-team" }, cleanupRoot, {
+			PATH: "",
+		});
+		expect(JSON.stringify(tasks)).toContain('"round":2');
+	});
+
 	it("creates worker worktrees by default for the tmux launch path", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);


### PR DESCRIPTION
> Whiplash 모드는 “여러 worker를 더 쓰자”가 아니라, 같은 조건에서 추론 예산이 다른 모델/worker가 만들어내는 실패 양상의 차이를 강제로 드러내는 프로토콜입니다. task, context, acceptance criteria는 고정하고 reasoning effort만 바꿔 low/medium/high lane을 직접 비교 가능하게 만들며, 1라운드 강제 hard reject로 첫 번째로 그럴듯한 답이나 자신감 있는 답에 끌리는 자기확증 편향을 깨고, reviewer가 먼저 차이를 비교하고 `proof_required`를 명시한 뒤에만 수렴할 수 있게 합니다.

Whiplash mode is not “use more workers.” It is a protocol for exposing how different reasoning budgets fail differently on the same task under the same conditions. The task, context, and acceptance criteria stay fixed; only reasoning effort changes. That makes low/medium/high lanes directly comparable, so the reviewer can see whether a simple answer is missing edge cases, or a deep answer is overfitting the problem.

Round 1 is deliberately non-accepting. It exists to break self-confirmation bias before review convergence: no lane, including the most confident high-reasoning lane, can be accepted on first pass. The reviewer must hard-reject, compare the lanes, identify what each answer missed, and turn unresolved claims into `proof_required` evidence before any solution can be chosen.

## What

Adds an opt-in Whiplash execution strategy to the native GJC Team runtime:

```sh
gjc team --whiplash "<task>"
```

Whiplash launches exactly three `executor` lanes against the same canonical task:

- `worker-1`: `--thinking low`
- `worker-2`: `--thinking medium`
- `worker-3`: `--thinking high`

All lanes receive the same task, shared conditions, shared acceptance criteria, and canonical task hash. The only intentional difference is requested reasoning effort.

This also adds Whiplash-specific Team API operations:

- `read-whiplash-state`
- `report-whiplash-effort`
- `write-whiplash-review`
- `advance-whiplash-round`

The implementation keeps Whiplash inside Team/Ultragoal. It does not add a fifth workflow skill, does not add a public role-agent roster, and does not change default Team behavior.

## Why

Normal multi-agent execution often splits roles too early. One worker implements, another reviews, another verifies, but the system no longer knows whether different outcomes came from different reasoning behavior or simply from different assignments.

Whiplash intentionally does not split roles or personas. It gives the same task, same context, same conditions, and same acceptance criteria to multiple executor lanes. The only intended variable is reasoning effort:

- low: tends to produce common, simple, non-overengineered answers
- medium: acts as a balanced baseline
- high: tends to spend more search on edge cases, invariants, and hidden failure modes

The point is not that one lane is always better. The point is that different reasoning budgets produce different useful failure modes under identical constraints. Low-effort answers can reveal when the high-effort answer is overbuilt. High-effort answers can reveal bugs or edge cases that the low-effort answer skipped. Medium gives the reviewer a practical comparison point.

This makes Whiplash an anti-rubber-stamp protocol:

- no accepting the first plausible answer
- no anchoring on the most confident worker
- no treating the high-effort lane as automatically correct
- no treating the simple lane as automatically product-correct
- no convergence before proof requirements are named

Whiplash stays opt-in because this protocol is intentionally heavier than normal Team execution. It is useful when ambiguity, hidden bugs, overengineering risk, or reviewer bias are more expensive than running three comparable attempts.

## Testing

Passed:

- `bun run check:ts`
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun packages/coding-agent/src/cli.ts team --help`
- Local dry-run smoke test with `bun packages/coding-agent/src/cli.ts team --whiplash --dry-run --json "Smoke whiplash mode"`

Verified behavior:

- exactly three executor lanes
- shared canonical task hash
- `--thinking low|medium|high` launch args
- premature review rejected
- effort reporting recorded
- round 1 accept rejected
- force-reject review written
- round 2 retry created
- public workflow skills remain exactly `deep-interview`, `ralplan`, `team`, and `ultragoal`

Note: `bun run check` currently fails in the Rust formatting lane on pre-existing vendored `crates/brush-*-vendored` rustfmt diffs unrelated to this TS/Team change. The TypeScript/tooling check lane passed with `bun run check:ts`.

---

- [ ] `bun check` passes — blocked by unrelated vendored Rust formatting diffs noted above
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
