### PR TITLE
fix(ai): preserve catalog transport for opencode-go qwen3.7-max (#489)

### DIFF
--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -292,9 +292,21 @@ function fingerprintStatic<TApi extends Api>(models: readonly Model<TApi>[]): st
 
 function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamicModel: Model<TApi>): Model<TApi> {
 	const supportsImage = existingModel.input.includes("image") || dynamicModel.input.includes("image");
+	// The static catalog is authoritative for transport: `api` (and its
+	// api-specific `baseUrl`). Dynamic discovery enumerates ids via a single
+	// hardcoded api (e.g. fetchOpenAICompatibleModels always tags
+	// `openai-completions`), so spreading it blindly would clobber catalog
+	// entries that route through a different format — e.g. opencode-go
+	// qwen3.7-max is `anthropic-messages` but would be downgraded to
+	// `openai-completions` and 401 with `not supported for format oa-compat`
+	// (issue #489). Keep the existing api, and only take the dynamic baseUrl
+	// when the api matches (same transport, same URL shape).
+	const baseUrl = existingModel.api === dynamicModel.api ? dynamicModel.baseUrl : existingModel.baseUrl;
 	return enrichModelThinking({
 		...existingModel,
 		...dynamicModel,
+		api: existingModel.api,
+		baseUrl,
 		name: preferDiscoveryName(dynamicModel.name, existingModel.name, dynamicModel.id),
 		reasoning: existingModel.reasoning || dynamicModel.reasoning,
 		input: supportsImage ? ["text", "image"] : ["text"],

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -134,7 +134,13 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cache.staticFingerprint === staticFingerprint &&
 		cache.staticFingerprint.length > 0
 	) {
-		return { models: passModelList<TApi>(cache.models), stale: false };
+		const cachedModels = passModelList<TApi>(cache.models);
+		if (!hasStaticTransportDrift(staticModels, cachedModels)) {
+			return { models: cachedModels, stale: false };
+		}
+		const repairedModels = mergeDynamicModels(staticModels, cachedModels);
+		writeModelCache(options.providerId, now(), repairedModels, true, staticFingerprint, dbPath);
+		return { models: repairedModels, stale: false };
 	}
 
 	const [fetchedModelsDevModels, fetchedDynamicModels] = shouldFetchFromNetwork
@@ -225,6 +231,20 @@ function shouldFetchRemoteSources(
 	}
 	if (!hasAuthoritativeCache) {
 		return cacheAgeMs >= NON_AUTHORITATIVE_RETRY_MS;
+	}
+	return false;
+}
+
+function hasStaticTransportDrift<TApi extends Api>(
+	staticModels: readonly Model<TApi>[],
+	cachedModels: readonly Model<TApi>[],
+): boolean {
+	if (staticModels.length === 0 || cachedModels.length === 0) return false;
+	const cachedById = new Map(cachedModels.map(model => [model.id, model]));
+	for (const staticModel of staticModels) {
+		const cachedModel = cachedById.get(staticModel.id);
+		if (!cachedModel) continue;
+		if (cachedModel.api !== staticModel.api) return true;
 	}
 	return false;
 }

--- a/packages/ai/test/issue-489-repro.test.ts
+++ b/packages/ai/test/issue-489-repro.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Repro for #489 — OpenCode Go: `qwen3.7-max` is served over the Anthropic
+ * Messages API (`https://opencode.ai/zen/go`), and the bundled catalog records
+ * `api: "anthropic-messages"` accordingly. But the opencode-go model manager's
+ * dynamic discovery (`fetchOpenAICompatibleModels`) enumerates every id with a
+ * single hardcoded `api: "openai-completions"` at `.../v1`. When merged, the
+ * dynamic row used to clobber the catalog's transport, so the model routed as
+ * OpenAI-compatible and the gateway rejected it with
+ * `401 Model qwen3.7-max is not supported for format oa-compat`.
+ *
+ * The merge must treat the static catalog as authoritative for `api` (and its
+ * api-specific `baseUrl`).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveProviderModels } from "../src/model-manager";
+import { getBundledModels } from "../src/models";
+import type { Api, Model } from "../src/types";
+
+describe("opencode-go qwen3.7-max keeps anthropic-messages transport (issue #489)", () => {
+	let cacheDir: string;
+	let cacheDbPath: string;
+
+	beforeEach(() => {
+		cacheDir = mkdtempSync(join(tmpdir(), "issue-489-"));
+		cacheDbPath = join(cacheDir, "models.db");
+	});
+
+	afterEach(() => {
+		rmSync(cacheDir, { recursive: true, force: true });
+	});
+
+	test("bundled catalog routes qwen3.7-max over anthropic-messages", () => {
+		const bundled = getBundledModels("opencode-go");
+		const qwen = bundled.find(m => m.id === "qwen3.7-max");
+		expect(qwen?.api).toBe("anthropic-messages");
+		expect(qwen?.baseUrl).toBe("https://opencode.ai/zen/go");
+	});
+
+	test("dynamic openai-completions discovery does not downgrade qwen3.7-max", async () => {
+		// Mimic fetchOpenAICompatibleModels: every discovered id is tagged with a
+		// single hardcoded openai-completions transport at the /v1 base.
+		const discovered: Model<Api>[] = [
+			{
+				id: "qwen3.7-max",
+				name: "Qwen3.7 Max",
+				api: "openai-completions",
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1000000,
+				maxTokens: 65536,
+			},
+		];
+
+		const { models } = await resolveProviderModels<Api>(
+			{
+				providerId: "opencode-go",
+				cacheDbPath,
+				fetchDynamicModels: async () => discovered,
+			},
+			"online",
+		);
+
+		const qwen = models.find(m => m.id === "qwen3.7-max");
+		expect(qwen).toBeDefined();
+		expect(qwen?.api).toBe("anthropic-messages");
+		expect(qwen?.baseUrl).toBe("https://opencode.ai/zen/go");
+	});
+
+	test("dynamic discovery still enriches matching-transport models", async () => {
+		// A genuinely openai-completions opencode-go model should still pick up
+		// dynamic metadata (pricing/limits) without transport regressions.
+		const discovered: Model<"openai-completions">[] = [
+			{
+				id: "qwen3.6-plus",
+				name: "Qwen3.6 Plus",
+				api: "openai-completions",
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 9, output: 9, cacheRead: 9, cacheWrite: 9 },
+				contextWindow: 1000000,
+				maxTokens: 65536,
+			},
+		];
+
+		const { models } = await resolveProviderModels<"openai-completions">(
+			{
+				providerId: "opencode-go",
+				cacheDbPath,
+				fetchDynamicModels: async () => discovered,
+			},
+			"online",
+		);
+
+		const qwen = models.find(m => m.id === "qwen3.6-plus");
+		expect(qwen?.api).toBe("openai-completions");
+		expect(qwen?.baseUrl).toBe("https://opencode.ai/zen/go/v1");
+		expect(qwen?.cost.input).toBe(9);
+	});
+});

--- a/packages/ai/test/issue-489-repro.test.ts
+++ b/packages/ai/test/issue-489-repro.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { writeModelCache } from "../src/model-cache";
 import { resolveProviderModels } from "../src/model-manager";
 import { getBundledModels } from "../src/models";
 import type { Api, Model } from "../src/types";
@@ -71,6 +72,52 @@ describe("opencode-go qwen3.7-max keeps anthropic-messages transport (issue #489
 		expect(qwen).toBeDefined();
 		expect(qwen?.api).toBe("anthropic-messages");
 		expect(qwen?.baseUrl).toBe("https://opencode.ai/zen/go");
+	});
+
+	test("fresh authoritative cache with stale transport is repaired before fast-path return", async () => {
+		const staticModels: Model<Api>[] = [
+			{
+				id: "qwen3.7-max",
+				name: "Qwen3.7 Max",
+				api: "anthropic-messages",
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 2.5, output: 7.5, cacheRead: 0.5, cacheWrite: 3.125 },
+				contextWindow: 1000000,
+				maxTokens: 65536,
+			},
+		];
+		const poisonedCache: Model<Api>[] = [
+			{
+				...staticModels[0],
+				api: "openai-completions",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+			},
+		];
+		const now = () => 1_800_000_000_000;
+		const staticFingerprint = Bun.hash(JSON.stringify(staticModels)).toString(36);
+		writeModelCache("opencode-go", now(), poisonedCache, true, staticFingerprint, cacheDbPath);
+
+		const { models, stale } = await resolveProviderModels<Api>(
+			{
+				providerId: "opencode-go",
+				staticModels,
+				cacheDbPath,
+				now,
+				fetchDynamicModels: async () => {
+					throw new Error("fast path should not fetch");
+				},
+			},
+			"online-if-uncached",
+		);
+
+		const qwen = models.find(m => m.id === "qwen3.7-max");
+		expect(stale).toBe(false);
+		expect(qwen?.api).toBe("anthropic-messages");
+		expect(qwen?.baseUrl).toBe("https://opencode.ai/zen/go");
+		expect(qwen?.contextWindow).toBe(1000000);
 	});
 
 	test("dynamic discovery still enriches matching-transport models", async () => {


### PR DESCRIPTION
## Problem

`gjc -p --no-tools --model opencode-go/qwen3.7-max "Say ok only."` fails with:

```
401 Model qwen3.7-max is not supported for format oa-compat
```

OpenCode Go serves `qwen3.7-max` over the **Anthropic Messages** API at `https://opencode.ai/zen/go`, and the bundled catalog (`@gajae-code/ai/src/models.json`) correctly records `api: "anthropic-messages"`. The model-catalog generation path (`OPENCODE_GO_API_RESOLUTION`) is already correct.

## Root cause (runtime, not generation)

When the user is authenticated, the opencode-go model manager runs dynamic discovery via `fetchOpenAICompatibleModels`, which enumerates **every** id with a single hardcoded `api: "openai-completions"` at `.../zen/go/v1`. `mergeDynamicModel` then spread the dynamic row over the catalog entry:

```ts
return enrichModelThinking({
  ...existingModel,   // bundled: anthropic-messages @ /zen/go
  ...dynamicModel,    // discovery: openai-completions @ /zen/go/v1  ← clobbers api + baseUrl
  ...
});
```

So `qwen3.7-max` got downgraded to `openai-completions`, routed as oa-compat, and the gateway rejected it.

## Fix

Treat the static catalog as authoritative for transport. In `mergeDynamicModel`, keep `existingModel.api`, and only take the dynamic `baseUrl` when the api matches (same transport ⇒ same URL shape). Dynamic discovery still enriches pricing/limits/name for same-transport models.

This self-heals stale caches on the next non-fast-path merge, since the static catalog is always the merge base.

## Tests

`packages/ai/test/issue-489-repro.test.ts`:
- bundled catalog routes qwen3.7-max over anthropic-messages
- dynamic openai-completions discovery does **not** downgrade qwen3.7-max (fails on `main`, passes with fix)
- dynamic discovery still enriches matching-transport models (qwen3.6-plus)

Verified the regression test fails without the fix (`api` resolves to `openai-completions`) and passes with it. `bun run check:types` clean for the ai package; biome clean on changed files.

Fixes #489