### PR TITLE
fix(harness): derive review verdict from final assistant text on finalize

### DIFF
--- a/packages/coding-agent/src/harness-control-plane/finalize.ts
+++ b/packages/coding-agent/src/harness-control-plane/finalize.ts
@@ -19,11 +19,12 @@ import {
 	type ReceiptSubject,
 	type ReviewFailureEvidence,
 	type ReviewVerdictEvidence,
+	sha256Hex,
 	type ValidationEvidence,
 	validateReceipt,
 } from "./receipts";
 import { readReceiptIndex, writeReceiptImmutable } from "./storage";
-import { isReviewVerdict, type ReviewVerdict } from "./types";
+import { extractReviewVerdict, isReviewVerdict, type ReviewVerdict } from "./types";
 
 export interface ValidationCommandSpec {
 	name: string;
@@ -56,6 +57,11 @@ export interface FinalizeOptions {
 	reviewOnly?: boolean;
 	/** Operator/loop-supplied terminal review verdict (closed vocabulary). */
 	verdict?: string | null;
+	/**
+	 * Final assistant text from the live RPC owner, used to extract a closed-vocabulary verdict
+	 * for review-only sessions when no explicit {@link verdict} is supplied. Never persisted raw.
+	 */
+	assistantText?: string | null;
 	/** Bounded PR/issue reference for the review target (e.g. "PR-414"). Never resolved from the live repo. */
 	prTarget?: string | null;
 	validationCommands?: ValidationCommandSpec[];
@@ -76,6 +82,14 @@ export interface FinalizeResult {
 
 function receiptId(prefix: string): string {
 	return `${prefix}-${Date.now()}-${randomBytes(4).toString("hex")}`;
+}
+
+/** Bound + whitespace-collapse assistant text into a redaction-safe digest summary (never a raw dump). */
+function boundedAssistantSummary(text: string | null): string | null {
+	if (!text) return null;
+	const collapsed = text.replace(/\s+/g, " ").trim();
+	if (collapsed.length === 0) return null;
+	return collapsed.length > 280 ? `${collapsed.slice(0, 280)}…` : collapsed;
 }
 
 export async function runFinalize(opts: FinalizeOptions): Promise<FinalizeResult> {
@@ -214,9 +228,27 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 		issueArtifact: null,
 	};
 
-	if (!isReviewVerdict(opts.verdict)) {
-		const reason = opts.verdict == null ? "review-verdict-missing" : "review-verdict-invalid";
-		const failure: ReviewFailureEvidence = { reason, prTarget, failedAt: now(), fallback: "operator-or-omx-review" };
+	// Explicit operator/loop verdict always wins. Only when none is supplied do we fall back to
+	// extracting a closed-vocabulary verdict from the live RPC owner's final assistant text.
+	const explicitProvided = opts.verdict != null;
+	const explicitValid = isReviewVerdict(opts.verdict);
+	const assistantText = typeof opts.assistantText === "string" ? opts.assistantText : null;
+	const extracted = explicitProvided ? null : extractReviewVerdict(assistantText);
+	const verdict: ReviewVerdict | null = explicitValid ? (opts.verdict as ReviewVerdict) : extracted;
+	const verdictSource: "input" | "assistant" = explicitValid ? "input" : "assistant";
+
+	if (!verdict) {
+		const reason = explicitProvided ? "review-verdict-invalid" : "review-verdict-missing";
+		const assistantDigest = assistantText ? sha256Hex(assistantText) : null;
+		const assistantSummary = boundedAssistantSummary(assistantText);
+		const failure: ReviewFailureEvidence = {
+			reason,
+			prTarget,
+			failedAt: now(),
+			fallback: "operator-or-omx-review",
+			...(assistantDigest ? { assistantDigest } : {}),
+			...(assistantSummary ? { assistantSummary } : {}),
+		};
 		const receipt = buildReceipt<ReviewFailureEvidence>({
 			receiptId: receiptId("revfail"),
 			sessionId: opts.sessionId,
@@ -238,12 +270,14 @@ async function runReviewFinalize(opts: FinalizeOptions): Promise<FinalizeResult>
 		return { ...baseResult, completed: false, receiptPath: entry.path, verdict: null, blockers };
 	}
 
-	const verdict = opts.verdict as ReviewVerdict;
+	const assistantDigest = verdictSource === "assistant" && assistantText ? sha256Hex(assistantText) : null;
 	const evidence: ReviewVerdictEvidence = {
 		verdict,
 		prTarget,
 		finalizedAt: now(),
 		summaryRef: typeof opts.prTarget === "string" ? `verdict:${verdict}@${opts.prTarget}` : `verdict:${verdict}`,
+		verdictSource,
+		...(assistantDigest ? { assistantDigest } : {}),
 	};
 	const receipt = buildReceipt<ReviewVerdictEvidence>({
 		receiptId: receiptId("verdict"),

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -504,13 +504,21 @@ export class RuntimeOwner {
 		const workspace = state.handle.workspace;
 		const checks = this.#finalizeChecks ?? defaultFinalizeChecks(workspace);
 		const reviewOnly = state.handle.mode === "review";
+		const inputVerdict = reviewOnly ? (typeof input.verdict === "string" ? input.verdict : null) : undefined;
+		// Review-only finalize with no explicit verdict pulls the final assistant text from the live
+		// RPC owner so the verdict can be extracted deterministically instead of demanded from the operator.
+		let assistantText: string | null = null;
+		if (reviewOnly && inputVerdict == null && this.#opts.rpc.getLastAssistantText) {
+			assistantText = await this.#opts.rpc.getLastAssistantText().catch(() => null);
+		}
 		const fin = await runFinalize({
 			root: this.#opts.root,
 			sessionId: this.#opts.sessionId,
 			workspace,
 			branch: state.handle.branch ?? "",
 			reviewOnly,
-			verdict: reviewOnly ? (typeof input.verdict === "string" ? input.verdict : null) : undefined,
+			verdict: inputVerdict,
+			assistantText: reviewOnly ? assistantText : undefined,
 			prTarget: reviewOnly ? state.handle.issueOrPr : undefined,
 			requireTests: input.requireTests !== false,
 			requireCommit: input.requireCommit !== false,

--- a/packages/coding-agent/src/harness-control-plane/receipts.ts
+++ b/packages/coding-agent/src/harness-control-plane/receipts.ts
@@ -156,6 +156,10 @@ export interface ReviewVerdictEvidence {
 	finalizedAt: string;
 	/** Bounded summary code/reference for the verdict; never raw assistant text. */
 	summaryRef: string | null;
+	/** Where the verdict came from: explicit operator input or extracted from final assistant text. */
+	verdictSource?: "input" | "assistant";
+	/** sha256 of the assistant text the verdict was extracted from, when sourced from the agent. */
+	assistantDigest?: string | null;
 }
 
 export interface ReviewFailureEvidence {
@@ -165,6 +169,10 @@ export interface ReviewFailureEvidence {
 	failedAt: string;
 	/** Routing hint for the operator/fallback path. */
 	fallback: string;
+	/** sha256 of the assistant text examined for a verdict, when one was available. */
+	assistantDigest?: string | null;
+	/** Bounded, whitespace-collapsed assistant summary (never an unbounded transcript dump). */
+	assistantSummary?: string | null;
 }
 
 function validateFamily(receipt: ReceiptEnvelope<unknown>): string[] {

--- a/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
+++ b/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
@@ -36,6 +36,8 @@ export interface HarnessRpc {
 	isLive?(): boolean;
 	/** ISO timestamp of the last observed event frame, or null. */
 	lastFrameAt?(): string | null;
+	/** Final assistant text from the live session (for review-verdict extraction); null when unavailable. */
+	getLastAssistantText?(): Promise<string | null>;
 }
 
 export interface AcceptanceResult {
@@ -238,6 +240,12 @@ export class GajaeCodeRpc implements HarnessRpc {
 			steeringQueueDepth: typeof data.queuedMessageCount === "number" ? data.queuedMessageCount : 0,
 			followupQueueDepth: 0,
 		};
+	}
+
+	async getLastAssistantText(): Promise<string | null> {
+		const res = await this.#send({ type: "get_last_assistant_text" });
+		const data = (res.data ?? {}) as Record<string, unknown>;
+		return typeof data.text === "string" ? data.text : null;
 	}
 
 	async sendPrompt(prompt: string): Promise<{ commandId: string; ack: boolean }> {

--- a/packages/coding-agent/src/harness-control-plane/types.ts
+++ b/packages/coding-agent/src/harness-control-plane/types.ts
@@ -29,6 +29,33 @@ export function isReviewVerdict(value: unknown): value is ReviewVerdict {
 	return typeof value === "string" && (REVIEW_VERDICTS as readonly string[]).includes(value);
 }
 
+/**
+ * Alias verdict tokens accepted from free-form assistant text, mapped to their canonical verdict.
+ * `MERGE_READY` is treated as `APPROVE_MERGE_READY`.
+ */
+const VERDICT_ALIASES: Readonly<Record<string, ReviewVerdict>> = {
+	MERGE_READY: "APPROVE_MERGE_READY",
+};
+
+/**
+ * Extract a single closed-vocabulary review verdict from free-form assistant text.
+ *
+ * Scans for canonical verdict tokens (and accepted aliases) as whole words and returns the
+ * LAST occurrence — the agent's final stated decision wins over any earlier mention. Returns
+ * null when no allowed token is present, so the finalizer fails closed on a missing verdict.
+ */
+export function extractReviewVerdict(text: string | null | undefined): ReviewVerdict | null {
+	if (typeof text !== "string" || text.length === 0) return null;
+	const tokens = [...REVIEW_VERDICTS, ...Object.keys(VERDICT_ALIASES)];
+	const pattern = new RegExp(`\\b(${tokens.join("|")})\\b`, "g");
+	let last: ReviewVerdict | null = null;
+	for (const match of text.matchAll(pattern)) {
+		const token = match[1];
+		last = VERDICT_ALIASES[token] ?? (token as ReviewVerdict);
+	}
+	return last;
+}
+
 /** Lifecycle states of an operated session. */
 export type HarnessLifecycle =
 	| "new"

--- a/packages/coding-agent/test/harness-control-plane/finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/finalize.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "../../src/harness-control-plane/finalize";
 import { readReceiptIndex } from "../../src/harness-control-plane/storage";
+import type { ReviewFailureEvidence, ReviewVerdictEvidence } from "../../src/harness-control-plane/receipts";
 
 let root: string;
 const SID = "f";
@@ -173,5 +174,116 @@ describe("runFinalize (review-only verdict gate)", () => {
 		});
 		expect(res.completed).toBe(true);
 		expect(res.blockers).not.toContain("validation-required-but-none-run");
+	});
+});
+
+describe("runFinalize (review-only verdict from assistant text)", () => {
+	const reviewBase = () => ({
+		root,
+		sessionId: SID,
+		workspace: "/ws",
+		branch: "gajae-code-pr-414-review",
+		reviewOnly: true as const,
+		prTarget: "PR-414",
+	});
+
+	async function readEvidence<E>(family: "review-verdict" | "review-failure"): Promise<E> {
+		const idx = await readReceiptIndex(root, SID, family);
+		expect(idx).toHaveLength(1);
+		const env = JSON.parse(await readFile(idx[0].path, "utf8")) as { evidence: E };
+		return env.evidence;
+	}
+
+	it("extracts a verdict from final assistant text when no explicit verdict is supplied", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: null,
+			assistantText: "Reviewed the diff. Found blocking issues.\nVerdict: REQUEST_CHANGES",
+			checks: checks(),
+		});
+		expect(res.completed).toBe(true);
+		expect(res.verdict).toBe("REQUEST_CHANGES");
+		expect(res.blockers).toEqual([]);
+		const evidence = await readEvidence<ReviewVerdictEvidence>("review-verdict");
+		expect(evidence.verdict).toBe("REQUEST_CHANGES");
+		expect(evidence.verdictSource).toBe("assistant");
+		expect(typeof evidence.assistantDigest).toBe("string");
+		expect((evidence.assistantDigest as string).length).toBe(64);
+	});
+
+	it("aliases MERGE_READY to APPROVE_MERGE_READY", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: null,
+			assistantText: "Looks good to me. MERGE_READY",
+			checks: checks(),
+		});
+		expect(res.verdict).toBe("APPROVE_MERGE_READY");
+		expect(res.completed).toBe(true);
+	});
+
+	it("uses the final (last) verdict when the assistant text mentions several", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: null,
+			assistantText: "Initially I leaned APPROVE_MERGE_READY but on reflection: REQUEST_CHANGES",
+			checks: checks(),
+		});
+		expect(res.verdict).toBe("REQUEST_CHANGES");
+	});
+
+	it("fails deterministically with bounded/digest evidence when assistant text lacks a verdict", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: null,
+			assistantText: "I looked at the change but I am not sure what to recommend yet.",
+			checks: checks(),
+		});
+		expect(res.completed).toBe(false);
+		expect(res.verdict).toBeNull();
+		expect(res.blockers).toEqual(["review-verdict-missing"]);
+		const evidence = await readEvidence<ReviewFailureEvidence>("review-failure");
+		expect(evidence.reason).toBe("review-verdict-missing");
+		expect(typeof evidence.assistantDigest).toBe("string");
+		expect((evidence.assistantDigest as string).length).toBe(64);
+		expect(evidence.assistantSummary).toContain("not sure what to recommend");
+	});
+
+	it("bounds an oversized assistant summary in the failure receipt", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: null,
+			assistantText: "x".repeat(5000),
+			checks: checks(),
+		});
+		expect(res.completed).toBe(false);
+		const evidence = await readEvidence<ReviewFailureEvidence>("review-failure");
+		expect((evidence.assistantSummary as string).length).toBeLessThanOrEqual(281);
+	});
+
+	it("explicit input.verdict wins over assistant extraction", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: "APPROVE_MERGE_READY",
+			assistantText: "Verdict: REQUEST_CHANGES",
+			checks: checks(),
+		});
+		expect(res.completed).toBe(true);
+		expect(res.verdict).toBe("APPROVE_MERGE_READY");
+		const evidence = await readEvidence<ReviewVerdictEvidence>("review-verdict");
+		expect(evidence.verdictSource).toBe("input");
+		expect(evidence.assistantDigest ?? null).toBeNull();
+	});
+
+	it("treats a non-null invalid explicit verdict as invalid (no extraction fallback)", async () => {
+		const res = await runFinalize({
+			...reviewBase(),
+			verdict: "LGTM",
+			assistantText: "Verdict: REQUEST_CHANGES",
+			checks: checks(),
+		});
+		expect(res.completed).toBe(false);
+		expect(res.blockers).toEqual(["review-verdict-invalid"]);
+		expect(res.verdict).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/harness-control-plane/owner-review-finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-review-finalize.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
+import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
+import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import type { ReviewFailureEvidence, ReviewVerdictEvidence } from "../../src/harness-control-plane/receipts";
+import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { readReceiptIndex, writeSessionState } from "../../src/harness-control-plane/storage";
+import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
+
+class FakeRpc implements HarnessRpc {
+	cursor = 0;
+	#assistantText: string | null;
+	constructor(assistantText: string | null) {
+		this.#assistantText = assistantText;
+	}
+	async getState(): Promise<RpcStateSnapshot> {
+		return { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 };
+	}
+	eventCursor(): number {
+		return this.cursor;
+	}
+	async sendPrompt(): Promise<{ commandId: string; ack: boolean }> {
+		this.cursor += 1;
+		return { commandId: "c", ack: true };
+	}
+	async waitForAgentStart(after: number): Promise<{ cursor: number } | null> {
+		return this.cursor > after ? { cursor: this.cursor } : null;
+	}
+	async getLastAssistantText(): Promise<string | null> {
+		return this.#assistantText;
+	}
+	async close(): Promise<void> {}
+}
+
+const passingChecks: FinalizeChecks = {
+	async runValidation(spec) {
+		return { exactCommand: spec.command, cwd: ".", exitStatus: 0, pass: true };
+	},
+	async resolveCommit() {
+		return "abc123";
+	},
+	async commitOnBranch() {
+		return true;
+	},
+	async prOrIssue() {
+		return { prUrl: "https://x/pr/1", issueArtifact: null };
+	},
+};
+
+let root: string;
+const SID = "rv";
+let owner: RuntimeOwner | null = null;
+
+function seedReview(workspace: string): SessionState {
+	const now = new Date().toISOString();
+	return {
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		sessionId: SID,
+		lifecycle: "finalizing",
+		harness: "gajae-code",
+		handle: {
+			sessionId: SID,
+			harness: "gajae-code",
+			workspace,
+			mode: "review",
+			issueOrPr: "PR-414",
+		} as SessionHandle,
+		retries: {},
+		blockers: [],
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "h"));
+	owner = null;
+});
+
+afterEach(async () => {
+	await owner?.stop();
+	await rm(root, { recursive: true, force: true });
+});
+
+async function readEvidence<E>(family: "review-verdict" | "review-failure"): Promise<E> {
+	const idx = await readReceiptIndex(root, SID, family);
+	expect(idx).toHaveLength(1);
+	const env = JSON.parse(await readFile(idx[0].path, "utf8")) as { evidence: E };
+	return env.evidence;
+}
+
+describe("owner review-only finalize via live RPC assistant text", () => {
+	it("extracts the verdict from the final assistant text when no verdict input is given", async () => {
+		await writeSessionState(root, seedReview(root));
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc("Detailed review.\nVerdict: REQUEST_CHANGES"),
+			finalizeChecks: passingChecks,
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "finalize", input: {} })) as Record<string, unknown>;
+		const fin = (res.evidence as Record<string, unknown>).finalize as Record<string, unknown>;
+		expect(fin.completed).toBe(true); // REQUEST_CHANGES is a valid terminal verdict
+		expect(fin.verdict).toBe("REQUEST_CHANGES");
+		const evidence = await readEvidence<ReviewVerdictEvidence>("review-verdict");
+		expect(evidence.verdict).toBe("REQUEST_CHANGES");
+		expect(evidence.verdictSource).toBe("assistant");
+	});
+
+	it("completes when the assistant text approves merge readiness", async () => {
+		await writeSessionState(root, seedReview(root));
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc("All checks pass. APPROVE_MERGE_READY"),
+			finalizeChecks: passingChecks,
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "finalize", input: {} })) as Record<string, unknown>;
+		const fin = (res.evidence as Record<string, unknown>).finalize as Record<string, unknown>;
+		expect(fin.completed).toBe(true);
+		expect(fin.verdict).toBe("APPROVE_MERGE_READY");
+		expect((res.state as Record<string, unknown>).lifecycle).toBe("completed");
+	});
+
+	it("fails deterministically with bounded/digest evidence when assistant text lacks a verdict", async () => {
+		await writeSessionState(root, seedReview(root));
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc("I am still thinking about this and have no recommendation."),
+			finalizeChecks: passingChecks,
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, { verb: "finalize", input: {} })) as Record<string, unknown>;
+		const fin = (res.evidence as Record<string, unknown>).finalize as Record<string, unknown>;
+		expect(fin.completed).toBe(false);
+		expect(fin.verdict).toBeNull();
+		expect(fin.blockers).toEqual(["review-verdict-missing"]);
+		const evidence = await readEvidence<ReviewFailureEvidence>("review-failure");
+		expect(typeof evidence.assistantDigest).toBe("string");
+		expect(evidence.assistantSummary).toContain("no recommendation");
+		expect((res.state as Record<string, unknown>).lifecycle).toBe("blocked");
+	});
+
+	it("explicit input.verdict still wins over assistant extraction", async () => {
+		await writeSessionState(root, seedReview(root));
+		owner = new RuntimeOwner({
+			root,
+			sessionId: SID,
+			rpc: new FakeRpc("Verdict: REQUEST_CHANGES"),
+			finalizeChecks: passingChecks,
+		});
+		const info = await owner.start();
+		const res = (await callEndpoint(info.socketPath, {
+			verb: "finalize",
+			input: { verdict: "APPROVE_MERGE_READY" },
+		})) as Record<string, unknown>;
+		const fin = (res.evidence as Record<string, unknown>).finalize as Record<string, unknown>;
+		expect(fin.completed).toBe(true);
+		expect(fin.verdict).toBe("APPROVE_MERGE_READY");
+		const evidence = await readEvidence<ReviewVerdictEvidence>("review-verdict");
+		expect(evidence.verdictSource).toBe("input");
+	});
+});


### PR DESCRIPTION
## Summary
Review-only harness finalize no longer requires the operator to pass a verdict manually. When no explicit `input.verdict` is supplied, finalize now retrieves the final assistant text from the live RPC owner and extracts a closed-vocabulary verdict deterministically.

## Changes
- `rpc-adapter.ts`: add optional `getLastAssistantText()` to `HarnessRpc` and implement it on `GajaeCodeRpc` via the `get_last_assistant_text` RPC (`data.text`).
- `types.ts`: add `extractReviewVerdict()` — scans free-form assistant text for canonical verdict tokens (`APPROVE_MERGE_READY`, `REQUEST_CHANGES`, `OWNER_CONFIRMATION_REQUIRED`), aliasing `MERGE_READY` → `APPROVE_MERGE_READY`, returning the last (final) stated decision or null.
- `finalize.ts`: review-only path falls back to assistant-text extraction when no explicit verdict is given. Explicit verdict still wins; a non-null invalid verdict stays invalid (no fallback). Success records `verdictSource` + assistant digest; failure (`review-verdict-missing`) writes a durable `review-failure` receipt with a sha256 assistant digest and a bounded, whitespace-collapsed summary.
- `receipts.ts`: extend `ReviewVerdictEvidence`/`ReviewFailureEvidence` with the optional `verdictSource`/`assistantDigest`/`assistantSummary` evidence fields.
- `owner.ts`: review finalize fetches `getLastAssistantText()` when no `input.verdict` and forwards `assistantText` to `runFinalize`.

## Tests
- `finalize.test.ts`: extraction success/alias/last-wins, deterministic missing-verdict failure with bounded+digest evidence, oversized-summary bounding, explicit-verdict precedence, invalid-explicit-no-fallback.
- `owner-review-finalize.test.ts` (new): fake RPC exposing last assistant text + review-mode session covering extraction success, merge-ready completion, deterministic failure with evidence, and explicit-verdict precedence.

Closes #493