### PR TITLE
Add bundled Grok Build provider

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -27,6 +27,7 @@ import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityUsageProvider } from "./usage/google-antigravity";
+import { grokCliRankingStrategy, grokCliUsageProvider } from "./usage/grok-cli";
 import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
@@ -370,6 +371,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	claudeUsageProvider,
 	zaiUsageProvider,
 	githubCopilotUsageProvider,
+	grokCliUsageProvider,
 ];
 
 const DEFAULT_USAGE_PROVIDER_MAP = new Map<Provider, UsageProvider>(
@@ -498,6 +500,7 @@ function resolveDefaultUsageProvider(provider: Provider): UsageProvider | undefi
 const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>([
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
+	["grok-cli", grokCliRankingStrategy],
 ]);
 
 function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStrategy | undefined {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -33,6 +33,7 @@ export * from "./usage/claude";
 export * from "./usage/gemini";
 export * from "./usage/github-copilot";
 export * from "./usage/google-antigravity";
+export * from "./usage/grok-cli";
 export * from "./usage/kimi";
 export * from "./usage/minimax-code";
 export * from "./usage/openai-codex";

--- a/packages/ai/src/usage/grok-cli.ts
+++ b/packages/ai/src/usage/grok-cli.ts
@@ -1,0 +1,141 @@
+import type {
+	CredentialRankingStrategy,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+} from "../usage";
+
+interface BillingUsage {
+	monthlyLimit: number;
+	used: number;
+	billingPeriodEnd: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object";
+}
+
+function finiteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseValNumber(value: unknown): number | undefined {
+	return isRecord(value) ? finiteNumber(value.val) : undefined;
+}
+
+export function parseGrokCliBillingUsage(payload: unknown): BillingUsage {
+	if (!isRecord(payload) || !isRecord(payload.config)) {
+		throw new Error("invalid Grok CLI billing payload");
+	}
+	const monthlyLimit = parseValNumber(payload.config.monthlyLimit);
+	const used = parseValNumber(payload.config.used);
+	const billingPeriodEnd = payload.config.billingPeriodEnd;
+	if (
+		monthlyLimit === undefined ||
+		used === undefined ||
+		typeof billingPeriodEnd !== "string" ||
+		!Number.isFinite(new Date(billingPeriodEnd).getTime())
+	) {
+		throw new Error("invalid Grok CLI billing payload");
+	}
+	return { monthlyLimit, used, billingPeriodEnd };
+}
+
+function normalizeGrokBaseUrl(baseUrl?: string): string {
+	return (baseUrl?.trim() || "https://cli-chat-proxy.grok.com/v1").replace(/\/+$/, "");
+}
+
+function resolveAccessToken(params: UsageFetchParams): string | undefined {
+	const token = params.credential.accessToken ?? params.credential.apiKey ?? process.env.GROK_CLI_OAUTH_TOKEN;
+	return token?.trim() || undefined;
+}
+
+function buildMonthlyUsageLimit(usage: BillingUsage, nowMs: number): UsageLimit {
+	const usedFraction = usage.monthlyLimit > 0 ? usage.used / usage.monthlyLimit : 0;
+	const percent = usedFraction * 100;
+	const resetsAt = new Date(usage.billingPeriodEnd).getTime();
+	return {
+		id: "grok-cli:7d",
+		label: "SuperGrok monthly credits",
+		scope: { provider: "grok-cli", shared: true, windowId: "7d" },
+		window: {
+			id: "7d",
+			label: "Monthly credits",
+			resetsAt,
+		},
+		amount: {
+			unit: "percent",
+			used: percent,
+			limit: 100,
+			remaining: Math.max(0, 100 - percent),
+			usedFraction,
+			remainingFraction: Math.max(0, 1 - usedFraction),
+		},
+		status: percent >= 95 ? "exhausted" : percent >= 80 ? "warning" : "ok",
+		notes: [
+			`${usage.used}/${usage.monthlyLimit} credits used`,
+			`resets in ${Math.max(0, Math.round((resetsAt - nowMs) / 3_600_000))}h`,
+		],
+	};
+}
+
+export const grokCliUsageProvider: UsageProvider = {
+	id: "grok-cli",
+
+	supports(params) {
+		return params.provider === "grok-cli";
+	},
+
+	async fetchUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+		const accessToken = resolveAccessToken(params);
+		if (!accessToken) {
+			ctx.logger?.warn("Grok CLI usage: no access token", { provider: params.provider });
+			return null;
+		}
+
+		const response = await ctx.fetch(`${normalizeGrokBaseUrl(params.baseUrl)}/billing`, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"x-xai-token-auth": "xai-grok-cli",
+				accept: "application/json",
+			},
+			signal: params.signal,
+		});
+		if (!response.ok) {
+			ctx.logger?.warn("Grok CLI billing request failed", { status: response.status, provider: params.provider });
+			return null;
+		}
+
+		const payload = (await response.json()) as unknown;
+		let billing: BillingUsage;
+		try {
+			billing = parseGrokCliBillingUsage(payload);
+		} catch (error) {
+			ctx.logger?.warn("Grok CLI billing parse failed", { error: String(error) });
+			return null;
+		}
+
+		const nowMs = Date.now();
+		return {
+			provider: "grok-cli",
+			fetchedAt: nowMs,
+			limits: [buildMonthlyUsageLimit(billing, nowMs)],
+			metadata: {
+				email: params.credential.email,
+				accountId: params.credential.accountId,
+				subscription: true,
+			},
+			raw: payload,
+		};
+	},
+};
+
+export const grokCliRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		const monthly = report.limits.find(limit => limit.id === "grok-cli:7d");
+		return { secondary: monthly };
+	},
+	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 30 * 24 * 60 * 60 * 1000 },
+};

--- a/packages/ai/test/grok-cli-usage.test.ts
+++ b/packages/ai/test/grok-cli-usage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { grokCliUsageProvider, parseGrokCliBillingUsage } from "../src/usage/grok-cli";
+
+describe("Grok CLI usage provider", () => {
+	it("parses billing payload", () => {
+		expect(
+			parseGrokCliBillingUsage({
+				config: {
+					monthlyLimit: { val: 10_000 },
+					used: { val: 500 },
+					billingPeriodEnd: "2026-07-01T00:00:00.000Z",
+				},
+			}),
+		).toEqual({ monthlyLimit: 10_000, used: 500, billingPeriodEnd: "2026-07-01T00:00:00.000Z" });
+	});
+
+	it("maps billing to status-line-compatible 7d usage", async () => {
+		const report = await grokCliUsageProvider.fetchUsage(
+			{
+				provider: "grok-cli",
+				credential: { type: "oauth", accessToken: "token", expiresAt: Date.now() + 60_000 },
+				baseUrl: "https://cli-chat-proxy.grok.com/v1/",
+			},
+			{
+				fetch: async (url, init) => {
+					expect(String(url)).toBe("https://cli-chat-proxy.grok.com/v1/billing");
+					expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer token");
+					return Response.json({
+						config: {
+							monthlyLimit: { val: 10_000 },
+							used: { val: 2_500 },
+							billingPeriodEnd: "2026-07-01T00:00:00.000Z",
+						},
+					});
+				},
+			},
+		);
+		expect(report?.provider).toBe("grok-cli");
+		expect(report?.limits[0]?.scope.windowId).toBe("7d");
+		expect(report?.limits[0]?.amount.used).toBe(25);
+		expect(report?.limits[0]?.amount.usedFraction).toBe(0.25);
+	});
+});

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -96,6 +96,13 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		planner: "openai-codex/gpt-5.5:high",
 		critic: "openai-codex/gpt-5.3-codex-spark:high",
 	}),
+	profile("grok-pro", ["grok-cli"], {
+		default: "grok-cli/grok-composer-2.5-fast",
+		executor: "grok-cli/grok-build",
+		architect: "grok-cli/grok-build",
+		planner: "grok-cli/grok-composer-2.5-fast",
+		critic: "grok-cli/grok-composer-2.5-fast",
+	}),
 	profile("opencode-go-codex-eco", ["opencode-go", "openai-codex"], {
 		default: "opencode-go/deepseek-v4-flash",
 		executor: "opencode-go/qwen3.5-plus",

--- a/packages/coding-agent/src/defaults/gjc-grok-cli.ts
+++ b/packages/coding-agent/src/defaults/gjc-grok-cli.ts
@@ -1,0 +1,36 @@
+import * as path from "node:path";
+
+export function getBundledGrokBuildExtensionPath(): string {
+	return path.join(import.meta.dir, "gjc", "extensions", "grok-build", "index.ts");
+}
+
+export function getBundledGrokBuildExtensionDir(): string {
+	return path.dirname(getBundledGrokBuildExtensionPath());
+}
+
+export function getBundledGrokCliVendorDir(): string {
+	return path.join(import.meta.dir, "gjc", "extensions", "grok-cli-vendor");
+}
+
+export function getBundledGrokCliModelDefaultsPath(): string {
+	return path.join(import.meta.dir, "gjc", "agent.models.grok-cli.yml");
+}
+
+export async function assertBundledGrokCliDefaults(): Promise<void> {
+	const required = [
+		getBundledGrokBuildExtensionPath(),
+		path.join(getBundledGrokCliVendorDir(), "src", "index.ts"),
+		path.join(getBundledGrokCliVendorDir(), "src", "provider", "register.ts"),
+		getBundledGrokCliModelDefaultsPath(),
+	];
+	for (const filePath of required) {
+		if (!(await Bun.file(filePath).exists())) {
+			throw new Error(`Bundled Grok Build default is missing: ${filePath}`);
+		}
+	}
+}
+
+export async function getBundledGrokBuildExtensionPaths(): Promise<string[]> {
+	await assertBundledGrokCliDefaults();
+	return [getBundledGrokBuildExtensionPath()];
+}

--- a/packages/coding-agent/src/defaults/gjc/agent.models.grok-cli.yml
+++ b/packages/coding-agent/src/defaults/gjc/agent.models.grok-cli.yml
@@ -1,0 +1,36 @@
+# Merge into ~/.gjc/agent/models.yml (or use as reference)
+# Remove global x-grok-model-override when using multiple Grok CLI models.
+
+providers:
+  grok-cli:
+    baseUrl: https://cli-chat-proxy.grok.com/v1
+    apiKeyEnv: GROK_CLI_OAUTH_TOKEN
+    api: grok-cli-responses
+    auth: oauth
+    headers:
+      x-xai-token-auth: xai-grok-cli
+      x-grok-client-identifier: gjc-grok-cli
+      x-grok-client-version: 0.2.33
+    models:
+      - id: grok-composer-2.5-fast
+        name: Composer 2.5 Fast
+        reasoning: false
+        input: [text, image]
+        contextWindow: 200000
+        maxTokens: 30000
+        cost:
+          input: 3
+          output: 15
+          cacheRead: 0.5
+          cacheWrite: 0
+      - id: grok-build
+        name: Grok Build
+        reasoning: true
+        input: [text, image]
+        contextWindow: 512000
+        maxTokens: 30000
+        cost:
+          input: 1
+          output: 2
+          cacheRead: 0.2
+          cacheWrite: 0.2

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../grok-cli-vendor/src/index.ts';

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-build/package.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-build/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gjc-grok-build",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "GJC extension: Grok Build OAuth and grok-cli models"
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/package.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gjc-grok-cli-vendor",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Grok CLI chat proxy provider for GJC (SuperGrok OAuth, Composer 2.5 Fast)",
+  "dependencies": {}
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/auth/oauth.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/auth/oauth.ts
@@ -1,0 +1,510 @@
+/**
+ * xAI Grok OAuth 2.0 + PKCE implementation.
+ *
+ * Uses Web Crypto API (crypto.subtle) for PKCE so the extension is
+ * portable across Node versions and potential non-Node runtimes.
+ *
+ * SuperGrok OAuth (auth.x.ai OIDC) — same public client_id as the official Grok CLI app.
+ * issuer. The difference is in the API endpoint: this extension targets
+ * cli-chat-proxy.grok.com instead of api.x.ai.
+ */
+
+import { createServer } from 'node:http';
+import { XaiErrorCode, XaiOAuthError } from '../shared/errors.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_BASE_URL = 'https://cli-chat-proxy.grok.com/v1';
+const ISSUER = 'https://auth.x.ai';
+const DISCOVERY_URL = `${ISSUER}/.well-known/openid-configuration`;
+const CLIENT_ID = process.env.GJC_GROK_CLI_OAUTH_CLIENT_ID || 'b1a00492-073a-47ea-816f-4c329264a828';
+const SCOPE =
+  process.env.GJC_GROK_CLI_OAUTH_SCOPE ||
+  'openid profile email offline_access grok-cli:access api:access';
+const CALLBACK_HOST = process.env.GJC_GROK_CLI_CALLBACK_HOST || '127.0.0.1';
+const CALLBACK_PORT = Number.parseInt(process.env.GJC_GROK_CLI_CALLBACK_PORT || '56122', 10);
+const CALLBACK_PATH = '/callback';
+/** Refresh 120s before actual expiry. */
+const REFRESH_SKEW_MS = 120_000;
+const TOKEN_REQUEST_TIMEOUT_MS = Number.parseInt(
+  process.env.GJC_GROK_CLI_TOKEN_TIMEOUT_MS || '30000',
+  10,
+);
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface XaiDiscovery {
+  authorization_endpoint: string;
+  token_endpoint: string;
+}
+
+export interface XaiOAuthCredentials {
+  [key: string]: unknown;
+  refresh: string;
+  access: string;
+  expires: number;
+  tokenEndpoint?: string;
+  discovery?: XaiDiscovery;
+  idToken?: string;
+  tokenType?: string;
+  baseUrl?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getBaseUrl(): string {
+  return (
+    process.env.GJC_GROK_CLI_BASE_URL ||
+    process.env.GROK_CLI_BASE_URL ||
+    DEFAULT_BASE_URL
+  ).replace(/\/+$/, '');
+}
+
+function base64Url(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// ─── PKCE ─────────────────────────────────────────────────────────────────────
+
+async function generatePKCE(): Promise<{
+  verifier: string;
+  challenge: string;
+}> {
+  const verifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64Url(hash) };
+}
+
+// ─── Endpoint validation ──────────────────────────────────────────────────────
+
+function validateEndpoint(value: string, field: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new XaiOAuthError(
+      `xAI OAuth discovery returned invalid ${field}: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  if (url.protocol !== 'https:') {
+    throw new XaiOAuthError(
+      `xAI OAuth ${field} must use HTTPS: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  const host = url.hostname.toLowerCase();
+  if (
+    host !== 'x.ai' &&
+    host !== 'auth.x.ai' &&
+    host !== 'accounts.x.ai' &&
+    !host.endsWith('.x.ai')
+  ) {
+    throw new XaiOAuthError(
+      `Refusing non-xAI OAuth ${field}: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  return url.toString();
+}
+
+// ─── OIDC Discovery ──────────────────────────────────────────────────────────
+
+async function discover(): Promise<XaiDiscovery> {
+  let response: Response;
+  try {
+    response = await fetch(DISCOVERY_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  if (!response.ok) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery returned ${response.status}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await response.json()) as Record<string, unknown>;
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery returned invalid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  const authorizationEndpoint = validateEndpoint(
+    String(payload.authorization_endpoint ?? ''),
+    'authorization_endpoint',
+  );
+  const tokenEndpoint = validateEndpoint(String(payload.token_endpoint ?? ''), 'token_endpoint');
+  return {
+    authorization_endpoint: authorizationEndpoint,
+    token_endpoint: tokenEndpoint,
+  };
+}
+
+// ─── Loopback callback server ────────────────────────────────────────────────
+
+interface CallbackResult {
+  code?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+function startCallbackServer(): Promise<{
+  server: import('node:http').Server;
+  redirectUri: string;
+  waitForCallback: (timeoutMs: number) => Promise<CallbackResult>;
+}> {
+  let settle: ((value: CallbackResult) => void) | undefined;
+  const callbackPromise = new Promise<CallbackResult>((resolve) => {
+    settle = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    try {
+      const origin = req.headers.origin;
+      if (origin === 'https://accounts.x.ai' || origin === 'https://auth.x.ai') {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        res.setHeader('Access-Control-Allow-Private-Network', 'true');
+        res.setHeader('Vary', 'Origin');
+      }
+      if (req.method === 'OPTIONS') {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+
+      const url = new URL(req.url ?? '/', `http://${CALLBACK_HOST}`);
+      if (url.pathname !== CALLBACK_PATH) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+
+      const result: CallbackResult = {
+        code: url.searchParams.get('code') ?? undefined,
+        state: url.searchParams.get('state') ?? undefined,
+        error: url.searchParams.get('error') ?? undefined,
+        errorDescription: url.searchParams.get('error_description') ?? undefined,
+      };
+
+      // Always 200 on the loopback page so the browser does not show HTTP 400.
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      const html = result.error
+        ? '<html><body><h1>xAI authorization was not completed.</h1><p>Return to the terminal for details. You can close this tab.</p></body></html>'
+        : '<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>';
+      res.end(html);
+      settle?.(result);
+    } catch {
+      res.statusCode = 500;
+      res.end('Internal error');
+    }
+  });
+
+  const listen = (port: number) =>
+    new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, CALLBACK_HOST, () => {
+        server.removeListener('error', reject);
+        const addr = server.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : port);
+      });
+    });
+
+  return (async () => {
+    let actualPort: number;
+    try {
+      actualPort = await listen(CALLBACK_PORT);
+    } catch (firstError) {
+      try {
+        actualPort = await listen(0);
+      } catch (secondError) {
+        const errorDescription = `Could not bind xAI OAuth callback server on ${CALLBACK_HOST}:${CALLBACK_PORT} or an ephemeral port: ${secondError instanceof Error ? secondError.message : String(secondError)} (initial error: ${firstError instanceof Error ? firstError.message : String(firstError)})`;
+        return {
+          server,
+          redirectUri: `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`,
+          waitForCallback: async () => ({
+            error: XaiErrorCode.CALLBACK_BIND_FAILED,
+            errorDescription,
+          }),
+        };
+      }
+    }
+    const redirectUri = `http://${CALLBACK_HOST}:${actualPort}${CALLBACK_PATH}`;
+    return {
+      server,
+      redirectUri,
+      waitForCallback: (timeoutMs: number) =>
+        Promise.race([
+          callbackPromise,
+          new Promise<CallbackResult>((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  error: XaiErrorCode.CALLBACK_TIMEOUT,
+                  errorDescription: 'Timed out waiting for xAI OAuth callback.',
+                }),
+              timeoutMs,
+            ),
+          ),
+        ]),
+    };
+  })();
+}
+
+// ─── Token exchange ───────────────────────────────────────────────────────────
+
+async function fetchTokenResponse(
+  tokenEndpoint: string,
+  body: URLSearchParams,
+  errorCode: string,
+  label: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI ${label} failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      errorCode,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function tokenResponseText(response: Response) {
+  try {
+    return await response.text();
+  } catch (cause) {
+    return `unable to read response body: ${cause instanceof Error ? cause.message : String(cause)}`;
+  }
+}
+
+async function tokenResponseJson(
+  response: Response,
+  errorCode: string,
+  label: string,
+): Promise<Record<string, unknown>> {
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI ${label} returned invalid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      errorCode,
+    );
+  }
+}
+
+async function exchangeCode(
+  tokenEndpoint: string,
+  code: string,
+  redirectUri: string,
+  verifier: string,
+): Promise<XaiOAuthCredentials> {
+  const response = await fetchTokenResponse(
+    tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    }),
+    XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    'token exchange',
+  );
+  if (!response.ok) {
+    throw new XaiOAuthError(
+      `xAI token exchange failed: ${response.status} ${await tokenResponseText(response)}`,
+      XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    );
+  }
+  const payload = await tokenResponseJson(
+    response,
+    XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    'token exchange',
+  );
+  const access = String(payload.access_token ?? '');
+  const refresh = String(payload.refresh_token ?? '');
+  if (!access) {
+    throw new XaiOAuthError(
+      'xAI token exchange did not return access_token.',
+      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+    );
+  }
+  if (!refresh) {
+    throw new XaiOAuthError(
+      'xAI token exchange did not return refresh_token.',
+      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+    );
+  }
+  const expiresIn =
+    typeof payload.expires_in === 'number'
+      ? payload.expires_in
+      : Number(payload.expires_in ?? 3600);
+  return {
+    access,
+    refresh,
+    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
+    tokenEndpoint,
+    discovery: { authorization_endpoint: '', token_endpoint: tokenEndpoint },
+    idToken: String(payload.id_token ?? ''),
+    tokenType: String(payload.token_type ?? 'Bearer'),
+    baseUrl: getBaseUrl(),
+  };
+}
+
+// ─── Login (GJC /login OAuth flow) ──────────────────────────────────────
+
+export async function login(
+  callbacks: import('@gajae-code/ai').OAuthLoginCallbacks,
+): Promise<import('@gajae-code/ai').OAuthCredentials> {
+  const discovery = await discover();
+  const { verifier, challenge } = await generatePKCE();
+  const state = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const nonce = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const callback = await startCallbackServer();
+
+  try {
+    const authUrl = new URL(discovery.authorization_endpoint);
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('client_id', CLIENT_ID);
+    authUrl.searchParams.set('redirect_uri', callback.redirectUri);
+    authUrl.searchParams.set('scope', SCOPE);
+    authUrl.searchParams.set('code_challenge', challenge);
+    authUrl.searchParams.set('code_challenge_method', 'S256');
+    authUrl.searchParams.set('state', state);
+    authUrl.searchParams.set('nonce', nonce);
+    authUrl.searchParams.set('plan', 'generic');
+    authUrl.searchParams.set('referrer', 'gjc-grok-cli');
+
+    callbacks.onAuth({
+      url: authUrl.toString(),
+      instructions: `Authorize xAI in your browser, then return to gjc. Callback: ${callback.redirectUri}`,
+    });
+
+    const result = await callback.waitForCallback(180_000);
+
+    if (result.error) {
+      const code =
+        result.error === XaiErrorCode.CALLBACK_BIND_FAILED ||
+        result.error === XaiErrorCode.CALLBACK_TIMEOUT
+          ? result.error
+          : XaiErrorCode.AUTHORIZATION_FAILED;
+      throw new XaiOAuthError(result.errorDescription ?? result.error, code);
+    }
+    if (result.state !== state) {
+      throw new XaiOAuthError(
+        'xAI OAuth state mismatch — possible CSRF.',
+        XaiErrorCode.STATE_MISMATCH,
+      );
+    }
+    if (!result.code) {
+      throw new XaiOAuthError(
+        'xAI OAuth callback did not include an authorization code.',
+        XaiErrorCode.CODE_MISSING,
+      );
+    }
+
+    const credentials = await exchangeCode(
+      discovery.token_endpoint,
+      result.code,
+      callback.redirectUri,
+      verifier,
+    );
+    credentials.discovery = discovery;
+    return credentials;
+  } finally {
+    callback.server.close();
+  }
+}
+
+// ─── Token refresh ────────────────────────────────────────────────────────────
+
+export async function refresh(
+  credentials: import('@gajae-code/ai').OAuthCredentials,
+): Promise<import('@gajae-code/ai').OAuthCredentials> {
+  const xai = credentials as XaiOAuthCredentials;
+  const tokenEndpoint =
+    xai.tokenEndpoint || xai.discovery?.token_endpoint || (await discover()).token_endpoint;
+  validateEndpoint(tokenEndpoint, 'token_endpoint');
+
+  if (!credentials.refresh) {
+    throw new XaiOAuthError(
+      'Missing refresh_token. Re-login required.',
+      XaiErrorCode.REFRESH_MISSING,
+      true,
+    );
+  }
+
+  const response = await fetchTokenResponse(
+    tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: credentials.refresh,
+    }),
+    XaiErrorCode.REFRESH_FAILED,
+    'token refresh',
+  );
+
+  if (!response.ok) {
+    const isFatal = response.status === 400 || response.status === 401 || response.status === 403;
+    throw new XaiOAuthError(
+      `xAI token refresh failed: ${response.status} ${await tokenResponseText(response)}`,
+      XaiErrorCode.REFRESH_FAILED,
+      isFatal,
+    );
+  }
+
+  const payload = await tokenResponseJson(response, XaiErrorCode.REFRESH_FAILED, 'token refresh');
+  const access = String(payload.access_token ?? '');
+  if (!access) {
+    throw new XaiOAuthError(
+      'xAI token refresh did not return access_token.',
+      XaiErrorCode.REFRESH_FAILED,
+      true,
+    );
+  }
+
+  const refresh_new = String(payload.refresh_token ?? credentials.refresh);
+  const expiresIn =
+    typeof payload.expires_in === 'number'
+      ? payload.expires_in
+      : Number(payload.expires_in ?? 3600);
+
+  return {
+    ...xai,
+    access,
+    refresh: refresh_new,
+    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
+    tokenEndpoint,
+    idToken: String(payload.id_token ?? xai.idToken ?? ''),
+    tokenType: String(payload.token_type ?? xai.tokenType ?? 'Bearer'),
+    baseUrl: getBaseUrl(),
+  };
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/index.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './provider/register.js';

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
@@ -1,0 +1,153 @@
+/**
+ * Model definitions for Grok CLI's API.
+ */
+
+// ─── Cost constants ($/M tokens) ──────────────────────────────────────────────
+
+const COST_BUILD = { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 };
+const COST_COMPOSER_FAST = { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 };
+const COST_43 = { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
+const COST_420 = { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 };
+
+// ─── Model type ───────────────────────────────────────────────────────────────
+
+export interface GrokCliModelConfig {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: ('text' | 'image')[];
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+  /** Models that don't support reasoning.effort get a thinkingLevelMap. */
+  thinkingLevelMap?: Record<string, string | null>;
+}
+
+// ─── Hardcoded fallback catalog ───────────────────────────────────────────────
+//
+// These are the models observed via the Grok CLI's /v1/models endpoint and
+// the actual traffic captured through cli-chat-proxy.grok.com.
+
+const FALLBACK_MODELS: GrokCliModelConfig[] = [
+  {
+    id: 'grok-composer-2.5-fast',
+    name: 'Composer 2.5 Fast (Grok CLI)',
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: COST_COMPOSER_FAST,
+    contextWindow: 200_000,
+    maxTokens: 30_000,
+    thinkingLevelMap: {
+      off: 'none',
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    },
+  },
+  {
+    id: 'grok-build',
+    name: 'Grok Build',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_BUILD,
+    contextWindow: 512_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.3',
+    name: 'Grok 4.3',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_43,
+    contextWindow: 1_000_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.20-0309-reasoning',
+    name: 'Grok 4.20 Reasoning',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.20-0309-non-reasoning',
+    name: 'Grok 4.20 Non-Reasoning',
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+    thinkingLevelMap: {
+      off: 'none',
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    },
+  },
+  {
+    id: 'grok-4.20-multi-agent-0309',
+    name: 'Grok 4.20 Multi-Agent',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+  },
+];
+
+const EFFORT_CAPABLE_PREFIXES = ['grok-3-mini', 'grok-4.20-multi-agent', 'grok-4.3'];
+
+export function supportsReasoningEffort(modelId: string): boolean {
+  const parts = modelId.split('/');
+  const name = (parts.at(-1) ?? modelId).toLowerCase();
+  if (!EFFORT_CAPABLE_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    return false;
+  }
+  const model = resolveModels().find((entry) => entry.id.toLowerCase() === name);
+  if (model) {
+    if (!model.reasoning) return false;
+    if (!model.thinkingLevelMap) return true;
+    return Object.values(model.thinkingLevelMap).some((level) => level !== null && level !== 'none');
+  }
+  // Effort-capable id not listed in GJC_GROK_CLI_MODELS env list — still honor prefix (avoids spurious 400s).
+  return true;
+}
+
+// ─── GJC_GROK_CLI_MODELS env override ─────────────────────────────────────
+
+/**
+ * Resolve the active model list. If `GJC_GROK_CLI_MODELS` is set,
+ * it filters/reorders the fallback list; unknown IDs get sensible defaults.
+ */
+export function resolveModels(): GrokCliModelConfig[] {
+  const env = (process.env.GJC_GROK_CLI_MODELS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (env.length === 0) return FALLBACK_MODELS;
+
+  const byId = new Map(FALLBACK_MODELS.map((m) => [m.id, m]));
+  return env.map(
+    (id) =>
+      byId.get(id) ?? {
+        id,
+        name: id,
+        reasoning: true,
+        input: ['text'] as ('text' | 'image')[],
+        cost: COST_BUILD,
+        contextWindow: 1_000_000,
+        maxTokens: 30_000,
+      },
+  );
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
@@ -1,0 +1,362 @@
+/**
+ * Payload sanitization for xAI's Responses API via cli-chat-proxy.grok.com.
+ *
+ * xAI's endpoint has quirks compared to stock OpenAI:
+ *   - Replayed or encrypted `reasoning` items in input cause 400 errors.
+ *   - `reasoning.effort` is only supported on a subset of models.
+ *   - Empty-string content items cause validation failures.
+ *   - `function_call_output.output` cannot contain image arrays.
+ *   - `image_url` parts must be normalized to `input_image` with data URIs.
+ *   - Local image paths must be resolved to base64 data URIs.
+ *   - xAI rejects `role: "developer"` and `role: "system"` in the input
+ *     array; these must be moved to top-level `instructions`.
+ *   - xAI uses `text.format` instead of OpenAI's `response_format`.
+ *   - xAI uses `prompt_cache_key` for conversation caching.
+ *   - xAI doesn't support `prompt_cache_retention`.
+ *
+ * Additional Grok CLI-specific behavior:
+ *   - Adds x-grok-* headers for client identification
+ *   - Uses prompt_cache_key for session affinity
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { extname, isAbsolute, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { supportsReasoningEffort } from '../models/catalog.js';
+
+// ─── Content text extraction ─────────────────────────────────────────────────
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part;
+      if (!part || typeof part !== 'object') return '';
+      const item = part as Record<string, unknown>;
+      const type = typeof item.type === 'string' ? item.type : '';
+      return ['text', 'input_text', 'output_text'].includes(type) && typeof item.text === 'string'
+        ? item.text
+        : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+// ─── Image helpers ────────────────────────────────────────────────────────────
+
+function stripShellQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function unescapeShellPath(value: string): string {
+  return stripShellQuotes(value).replace(/\\([\\\s'"()&;@])/g, '$1');
+}
+
+function imageMimeTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.png':
+      return 'image/png';
+    default:
+      throw new Error('xAI image understanding supports local .jpg, .jpeg, and .png files only');
+  }
+}
+
+function ensurePathWithinWorkspace(cwd: string, filePath: string) {
+  const realCwd = realpathSync(cwd);
+  const realPath = realpathSync(filePath);
+  if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${sep}`)) {
+    throw new Error('Image path is outside the workspace');
+  }
+  return realPath;
+}
+
+function resolveLocalImagePath(value: string, cwd: string): string | undefined {
+  const cleaned = unescapeShellPath(value);
+  if (!cleaned) return undefined;
+
+  if (cleaned.startsWith('file://')) {
+    try {
+      const filePath = fileURLToPath(cleaned);
+      return existsSync(filePath) ? ensurePathWithinWorkspace(cwd, filePath) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const candidate = isAbsolute(cleaned) ? cleaned : resolve(cwd, cleaned);
+
+  return existsSync(candidate) ? ensurePathWithinWorkspace(cwd, candidate) : undefined;
+}
+
+function normalizeImageInput(value: unknown, cwd: string): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const cleaned = stripShellQuotes(value);
+
+  if (/^https?:\/\//i.test(cleaned) || /^data:image\//i.test(cleaned)) {
+    return cleaned;
+  }
+
+  const localPath = resolveLocalImagePath(cleaned, cwd);
+  if (!localPath) {
+    throw new Error(`Image file does not exist or is not a valid URL: ${cleaned}`);
+  }
+
+  const mimeType = imageMimeTypeForPath(localPath);
+  const data = readFileSync(localPath).toString('base64');
+  return `data:${mimeType};base64,${data}`;
+}
+
+// ─── Content part normalization ───────────────────────────────────────────────
+
+function isInputImagePart(value: unknown): value is Record<string, unknown> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as Record<string, unknown>).type === 'input_image'
+  );
+}
+
+function getImageUrlAndDetail(obj: Record<string, unknown>): {
+  imageUrl: unknown;
+  detail: unknown;
+} {
+  if (typeof obj.image_url === 'object' && obj.image_url) {
+    const imageUrl = obj.image_url as Record<string, unknown>;
+    return { imageUrl: imageUrl.url, detail: imageUrl.detail };
+  }
+
+  return { imageUrl: obj.image_url, detail: obj.detail };
+}
+
+function normalizeImageParts(value: unknown, cwd: string): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalizeImageParts(item, cwd));
+  if (!value || typeof value !== 'object') return value;
+
+  const obj = { ...(value as Record<string, unknown>) };
+
+  if (obj.type === 'image' && typeof obj.data === 'string' && typeof obj.mimeType === 'string') {
+    return {
+      type: 'input_image',
+      image_url: `data:${obj.mimeType};base64,${obj.data}`,
+      detail: typeof obj.detail === 'string' && obj.detail ? obj.detail : 'auto',
+    };
+  }
+
+  if (obj.type === 'image_url') {
+    const { imageUrl, detail } = getImageUrlAndDetail(obj);
+    obj.type = 'input_image';
+    obj.image_url = imageUrl;
+    if (typeof detail === 'string' && detail) obj.detail = detail;
+  }
+
+  if (obj.type === 'input_image') {
+    const { imageUrl, detail } = getImageUrlAndDetail(obj);
+    const normalized = normalizeImageInput(imageUrl, cwd);
+    if (normalized) obj.image_url = normalized;
+    if (typeof detail === 'string' && detail) obj.detail = detail;
+    if (typeof obj.detail !== 'string' || !obj.detail) obj.detail = 'auto';
+  }
+
+  if (Array.isArray(obj.content)) obj.content = normalizeImageParts(obj.content, cwd);
+  if (Array.isArray(obj.output)) obj.output = normalizeImageParts(obj.output, cwd);
+  return obj;
+}
+
+// ─── function_call_output rewrite ─────────────────────────────────────────────
+
+function rewriteFunctionCallOutput(input: Record<string, unknown>[]): Record<string, unknown>[] {
+  const rewritten: Record<string, unknown>[] = [];
+
+  for (const item of input) {
+    if (
+      !item ||
+      typeof item !== 'object' ||
+      item.type !== 'function_call_output' ||
+      !Array.isArray(item.output)
+    ) {
+      rewritten.push(item);
+      continue;
+    }
+
+    const outputParts = item.output as unknown[];
+    const imageParts = outputParts.filter(isInputImagePart);
+    const textParts = outputParts.filter((p) => !isInputImagePart(p));
+
+    const textChunks: string[] = [];
+    for (const part of textParts) {
+      if (typeof part === 'string') {
+        textChunks.push(part);
+      } else if (part && typeof part === 'object') {
+        const p = part as Record<string, unknown>;
+        if (typeof p.text === 'string') textChunks.push(p.text);
+      }
+    }
+    let imageCount = 0;
+    for (const _ of imageParts) imageCount++;
+
+    const outputText = textChunks.join('\n') || '(tool returned no text output)';
+    rewritten.push({ ...item, output: outputText });
+
+    if (imageCount > 0) {
+      const callId = item.call_id ? ` (${String(item.call_id)})` : '';
+      const label = `The previous tool result${callId} included ${imageCount} image${imageCount === 1 ? '' : 's'}. Use the attached image${imageCount === 1 ? '' : 's'} as the visual output from that tool.`;
+      rewritten.push({
+        role: 'user',
+        content: [{ type: 'input_text', text: label }, ...imageParts],
+      });
+    }
+  }
+
+  return rewritten;
+}
+
+
+// ─── xAI 400 guards ───────────────────────────────────────────────────────────
+
+const REPLAYED_INPUT_TYPES = new Set([
+  'reasoning',
+  'reasoning.encrypted_content',
+  'encrypted_content',
+  'item_reference',
+]);
+
+function isReplayedOrUnsupportedInputItem(obj: Record<string, unknown>): boolean {
+  const type = typeof obj.type === 'string' ? obj.type : '';
+  if (REPLAYED_INPUT_TYPES.has(type)) return true;
+  if (type.startsWith('reasoning')) return true;
+  if ('encrypted_content' in obj || 'reasoning_encrypted_content' in obj) return true;
+  return false;
+}
+
+function isEmptyMessageItem(obj: Record<string, unknown>): boolean {
+  if (typeof obj.content === 'string') return obj.content.trim().length === 0;
+  if (!Array.isArray(obj.content)) return false;
+  const parts = obj.content as unknown[];
+  if (parts.length === 0) return true;
+  return parts.every((part) => {
+    if (typeof part === 'string') return part.length === 0;
+    if (!part || typeof part !== 'object') return true;
+    const p = part as Record<string, unknown>;
+    const t = typeof p.type === 'string' ? p.type : '';
+    if (['text', 'input_text', 'output_text'].includes(t)) {
+      return typeof p.text !== 'string' || p.text.trim().length === 0;
+    }
+    return false;
+  });
+}
+
+function stripUnsupportedTopLevelFields(next: Record<string, unknown>): void {
+  delete next.prompt_cache_retention;
+  delete next.parallel_tool_calls;
+  delete next.store;
+  delete next.metadata;
+  delete next.user;
+  delete next.service_tier;
+  delete next.truncation;
+}
+
+// ─── Main sanitization ────────────────────────────────────────────────────────
+
+/**
+ * Sanitize a provider request payload for xAI's Responses API via
+ * cli-chat-proxy.grok.com.
+ *
+ * Returns the modified payload.  Mutates the input in place for efficiency.
+ */
+export function sanitizePayload(
+  params: Record<string, unknown>,
+  modelId: string,
+  sessionId: string | undefined,
+  cwd: string,
+): Record<string, unknown> {
+  const next = params;
+
+  // ── Sanitize input array ──────────────────────────────────────────────
+  if (Array.isArray(next.input)) {
+    let input = (next.input as unknown[])
+      .map((item: unknown) => {
+        if (!item || typeof item !== 'object') return item;
+        const obj = item as Record<string, unknown>;
+
+        if (isReplayedOrUnsupportedInputItem(obj)) return null;
+        if (isEmptyMessageItem(obj)) return null;
+
+        return obj;
+      })
+      .filter(Boolean) as Record<string, unknown>[];
+
+    // Move system/developer messages to top-level instructions.
+    // xAI rejects role: "developer" and role: "system" in the input array.
+    const instructionParts: string[] = [];
+    input = input.filter((item) => {
+      const role = (item as Record<string, unknown>).role;
+      if (role !== 'developer' && role !== 'system') return true;
+      const text = textFromContent((item as Record<string, unknown>).content).trim();
+      if (text) instructionParts.push(text);
+      return false;
+    });
+    if (instructionParts.length > 0) {
+      const existing =
+        typeof next.instructions === 'string' && next.instructions ? next.instructions : '';
+      const merged = [existing, ...instructionParts].filter((part) => part.length > 0).join('\n\n');
+      next.instructions = merged;
+    }
+
+    // Normalize image parts (resolve local paths, fix types)
+    input = normalizeImageParts(input, cwd) as Record<string, unknown>[];
+
+    // Rewrite function_call_output with images
+    input = rewriteFunctionCallOutput(input);
+
+    next.input = input;
+  } else if (typeof next.input === 'string') {
+    // String input is valid and should stay string-shaped.
+  }
+
+  // ── response_format → text.format ────────────────────────────────────
+  if (next.response_format) {
+    if (!next.text) next.text = { format: next.response_format };
+    delete next.response_format;
+  }
+
+  // ── Reasoning effort ──────────────────────────────────────────────────
+  if (supportsReasoningEffort(modelId)) {
+    const reasoning = next.reasoning as Record<string, unknown> | undefined;
+    if (reasoning) {
+      const effort = reasoning.effort === 'minimal' ? 'low' : reasoning.effort;
+      next.reasoning = reasoning.summary !== undefined ? { effort } : { ...reasoning, effort };
+    }
+  } else {
+    delete next.reasoning;
+    delete next.reasoningEffort;
+  }
+
+  // ── Strip/filter unsupported fields ──────────────────────────────────
+  if (Array.isArray(next.include)) {
+    next.include = (next.include as unknown[]).filter(
+      (item) => item !== 'reasoning.encrypted_content',
+    );
+    if ((next.include as unknown[]).length === 0) delete next.include;
+  }
+
+  stripUnsupportedTopLevelFields(next);
+
+  // Add prompt_cache_key for conversation caching (routes to same server).
+  if (sessionId && !next.prompt_cache_key) {
+    next.prompt_cache_key = sessionId;
+  }
+
+  return next;
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/billing.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/billing.ts
@@ -1,0 +1,57 @@
+import { getBaseUrl } from '../auth/oauth.js';
+
+interface BillingUsage {
+  monthlyLimit: number;
+  used: number;
+  billingPeriodEnd: string;
+}
+
+function parseBillingUsage(payload: unknown): BillingUsage {
+  if (!payload || typeof payload !== 'object') throw new Error('invalid billing payload');
+  const config = (payload as Record<string, unknown>).config;
+  if (!config || typeof config !== 'object') throw new Error('invalid billing payload');
+  const monthlyLimit = ((config as Record<string, unknown>).monthlyLimit as Record<string, unknown>)
+    ?.val;
+  const used = ((config as Record<string, unknown>).used as Record<string, unknown>)?.val;
+  const billingPeriodEnd = (config as Record<string, unknown>).billingPeriodEnd;
+  if (
+    typeof monthlyLimit !== 'number' ||
+    !Number.isFinite(monthlyLimit) ||
+    typeof used !== 'number' ||
+    !Number.isFinite(used) ||
+    typeof billingPeriodEnd !== 'string' ||
+    !Number.isFinite(new Date(billingPeriodEnd).getTime())
+  ) {
+    throw new Error('invalid billing payload');
+  }
+  return { monthlyLimit, used, billingPeriodEnd };
+}
+
+export async function fetchBillingUsage(token: string): Promise<BillingUsage> {
+  const response = await fetch(`${getBaseUrl()}/billing`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      'x-xai-token-auth': 'xai-grok-cli',
+      accept: 'application/json',
+    },
+  });
+  if (!response.ok) throw new Error(`billing endpoint returned ${response.status}`);
+  return parseBillingUsage(await response.json());
+}
+
+export function formatQuota(usage: BillingUsage | undefined) {
+  if (!usage) {
+    return [
+      '  Usage:',
+      '    no billing data available — run /login grok-cli or set GROK_CLI_OAUTH_TOKEN',
+    ];
+  }
+
+  const resetDate = new Date(new Date(usage.billingPeriodEnd).getTime() - 8 * 60 * 60 * 1000);
+  return [
+    '  Usage:',
+    `    ${usage.used.toLocaleString()} / ${usage.monthlyLimit.toLocaleString()} credits used (${Math.round((usage.used / usage.monthlyLimit) * 100)}%)`,
+    `    ${(usage.monthlyLimit - usage.used).toLocaleString()} credits remaining`,
+    `    Resets at ${['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][resetDate.getUTCMonth()]} ${resetDate.getUTCDate()} ${resetDate.getUTCHours().toString().padStart(2, '0')}:${resetDate.getUTCMinutes().toString().padStart(2, '0')} PT`,
+  ];
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
@@ -1,0 +1,93 @@
+/**
+ * GJC Grok Build provider — SuperGrok OAuth + cli-chat-proxy models.
+ */
+
+import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from '@gajae-code/ai';
+import type { ExtensionAPI, ProviderConfig } from '@gajae-code/coding-agent';
+import * as oauth from '../auth/oauth.js';
+import { getBaseUrl, type XaiOAuthCredentials } from '../auth/oauth.js';
+import { type GrokCliModelConfig, resolveModels } from '../models/catalog.js';
+import { sanitizePayload } from '../payload/sanitize.js';
+import { registerGrokTools } from '../tools/register.js';
+import { streamGrokCli } from './stream.js';
+import { syncGrokTools } from './toolScope.js';
+import { registerUsageCommand } from './usage.js';
+
+export default function registerGrokCli(api: ExtensionAPI) {
+  const baseUrl = getBaseUrl();
+  const models = resolveModels();
+
+  api.on('model_select', (event) => {
+    syncGrokTools(api, event.model.provider);
+  });
+
+  api.on('before_agent_start', (_event, ctx) => {
+    syncGrokTools(api, ctx.model?.provider);
+  });
+
+  api.registerProvider('grok-cli', {
+    name: 'Grok Build',
+    baseUrl,
+    apiKey: '$GROK_CLI_OAUTH_TOKEN',
+    api: 'grok-cli-responses',
+    models: models.map((m: GrokCliModelConfig) => ({
+      id: m.id,
+      name: m.name,
+      reasoning: m.reasoning,
+      thinkingLevelMap: m.thinkingLevelMap,
+      input: m.input,
+      cost: m.cost,
+      contextWindow: m.contextWindow,
+      maxTokens: m.maxTokens,
+    })),
+    oauth: {
+      name: 'Grok Build',
+
+      async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+        return oauth.login(callbacks);
+      },
+
+      async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+        return oauth.refresh(credentials);
+      },
+
+      getApiKey(credentials: OAuthCredentials): string {
+        return credentials.access;
+      },
+
+      modifyModels(models: Model<Api>[], credentials: OAuthCredentials) {
+        const effectiveBaseUrl = String(
+          (credentials as XaiOAuthCredentials).baseUrl ?? getBaseUrl(),
+        ).replace(/\/+$/, '');
+
+        return models.map((m) =>
+          m.provider === 'grok-cli' ? { ...m, baseUrl: effectiveBaseUrl } : m,
+        );
+      },
+    } satisfies ProviderConfig['oauth'],
+
+    streamSimple: streamGrokCli,
+  });
+
+  registerGrokTools(api);
+
+  api.on('session_start', (_event, ctx) => {
+    if (process.env.GROK_CLI_OAUTH_TOKEN) {
+      ctx.ui.notify(
+        '[Grok Build] Using GROK_CLI_OAUTH_TOKEN env bypass — no auto-refresh, no model discovery',
+        'warning',
+      );
+    }
+
+  });
+
+  api.on('before_provider_request', (event, ctx) => {
+    if (ctx.model?.provider !== 'grok-cli') return;
+
+    const modelId = ctx.model?.id ?? '';
+    const sessionId = ctx.sessionManager?.getSessionId();
+    return sanitizePayload(event.payload as Record<string, unknown>, modelId, sessionId, ctx.cwd);
+  });
+
+  registerUsageCommand(api);
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
@@ -1,0 +1,45 @@
+import {
+  type Api,
+  type AssistantMessageEventStream,
+  type Context,
+  type Model,
+  type SimpleStreamOptions,
+  streamSimple,
+} from '@gajae-code/ai';
+
+const GROK_CLI_VERSION = '0.2.33';
+
+/**
+ * Stream function that adds Grok CLI-specific headers to requests.
+ *
+ * GJC Grok Build extension sends cli-chat-proxy headers (see agent.models.grok-cli.yml):
+ *   - x-grok-conv-id: <session/conversation ID>
+ *   - x-grok-model-override: <model ID>
+ *   - x-xai-token-auth: xai-grok-cli
+ */
+export function streamGrokCli(
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+  const sessionId = options?.sessionId;
+  const headers: Record<string, string> = {
+    ...options?.headers,
+    'x-grok-client-identifier': 'gjc-grok-cli',
+    'x-grok-client-version': GROK_CLI_VERSION,
+    'x-xai-token-auth': 'xai-grok-cli',
+    'x-grok-model-override': model.id,
+  };
+
+  if (sessionId) {
+    headers['x-grok-conv-id'] = sessionId;
+  }
+
+  return streamSimple(model as Model<'grok-cli-responses'>, context, {
+    ...options,
+    headers,
+    onResponse(response) {
+      options?.onResponse?.(response, model);
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/toolScope.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/toolScope.ts
@@ -1,0 +1,47 @@
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import {
+  GROK_SUPPRESSED_TOOL_NAMES,
+  GROK_TOOL_NAMES_FOR_SCOPE,
+  grokToolsToActivate,
+} from '../tools/register.js';
+
+const preservedSuppressedTools = new WeakMap<object, string[]>();
+
+export function syncGrokTools(
+  api: Pick<ExtensionAPI, 'getActiveTools' | 'setActiveTools'>,
+  provider: string | undefined,
+) {
+  const currentTools = api.getActiveTools();
+  const baseTools = currentTools.filter(
+    (toolName) =>
+      !GROK_TOOL_NAMES_FOR_SCOPE.includes(toolName as (typeof GROK_TOOL_NAMES_FOR_SCOPE)[number]),
+  );
+  const suppressedTools = baseTools.filter((toolName) =>
+    GROK_SUPPRESSED_TOOL_NAMES.includes(toolName as (typeof GROK_SUPPRESSED_TOOL_NAMES)[number]),
+  );
+  if (suppressedTools.length > 0) preservedSuppressedTools.set(api, suppressedTools);
+
+  const nextTools =
+    provider === 'grok-cli'
+      ? [
+          ...baseTools.filter((toolName) => !suppressedTools.includes(toolName)),
+          ...grokToolsToActivate(),
+        ]
+      : [
+          ...baseTools,
+          ...(preservedSuppressedTools.get(api) ?? []).filter(
+            (toolName) => !baseTools.includes(toolName),
+          ),
+        ];
+
+  if (provider !== 'grok-cli') preservedSuppressedTools.delete(api);
+
+  if (
+    currentTools.length === nextTools.length &&
+    currentTools.every((toolName, i) => toolName === nextTools[i])
+  ) {
+    return;
+  }
+
+  api.setActiveTools(nextTools);
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
@@ -1,0 +1,53 @@
+import type { Api, Model } from '@gajae-code/ai';
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import { XaiOAuthError } from '../shared/errors.js';
+import { fetchBillingUsage, formatQuota } from './billing.js';
+
+export function registerUsageCommand(api: Pick<ExtensionAPI, 'registerCommand'>) {
+  api.registerCommand('grok-cli-usage', {
+    description: 'Show Grok CLI provider status, quota, and token health',
+    handler: async (_args, ctx) => {
+      const token = process.env.GROK_CLI_OAUTH_TOKEN;
+      if (token) {
+        ctx.ui.notify(
+          '⚠️  Grok CLI: using GROK_CLI_OAUTH_TOKEN env bypass — no auto-refresh available',
+          'warning',
+        );
+      }
+
+      try {
+        const registry = ctx.modelRegistry;
+        const grokModels = registry.getAll().filter((m: Model<Api>) => m.provider === 'grok-cli');
+        if (grokModels.length === 0) {
+          ctx.ui.notify('Grok CLI: no models registered. Run /login grok-cli first.', 'warning');
+          return;
+        }
+
+        const apiKey = token ?? (await registry.getApiKeyForProvider?.('grok-cli'));
+        if (!apiKey) {
+          ctx.ui.notify(formatQuota(undefined).join('\n'), 'info');
+          return;
+        }
+
+        try {
+          ctx.ui.notify('Fetching grok cli usage…', 'info');
+          ctx.ui.notify(formatQuota(await fetchBillingUsage(apiKey)).join('\n'), 'info');
+        } catch (err) {
+          ctx.ui.notify(
+            `Grok CLI billing refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+          ctx.ui.notify(formatQuota(undefined).join('\n'), 'info');
+        }
+      } catch (err) {
+        const msg =
+          err instanceof XaiOAuthError
+            ? `${err.message} (code: ${err.code})`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        ctx.ui.notify(`Grok CLI: ${msg}`, 'warning');
+      }
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/errors.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Typed error for xAI OAuth failures.
+ *
+ * Codes allow the login flow and stream handlers to distinguish
+ * retryable failures (network) from fatal ones (revoked refresh token).
+ */
+export class XaiOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly reloginRequired = false,
+  ) {
+    super(message);
+    this.name = 'XaiOAuthError';
+  }
+}
+
+/** Well-known error codes. */
+export const XaiErrorCode = {
+  /** OIDC discovery failed (network, invalid response). */
+  DISCOVERY_FAILED: 'discovery_failed',
+  /** Discovery endpoint returned a non-xAI origin. */
+  DISCOVERY_INVALID_ORIGIN: 'discovery_invalid_origin',
+  /** Authorization was denied or errored in the browser. */
+  AUTHORIZATION_FAILED: 'authorization_failed',
+  /** CSRF state mismatch between request and callback. */
+  STATE_MISMATCH: 'state_mismatch',
+  /** Callback did not include an authorization code. */
+  CODE_MISSING: 'code_missing',
+  /** Token exchange failed (network, invalid response). */
+  TOKEN_EXCHANGE_FAILED: 'token_exchange_failed',
+  /** Token exchange returned an invalid payload. */
+  TOKEN_EXCHANGE_INVALID: 'token_exchange_invalid',
+  /** Refresh token is missing or empty. */
+  REFRESH_MISSING: 'refresh_missing',
+  /** Token refresh failed (expired, revoked). */
+  REFRESH_FAILED: 'refresh_failed',
+  /** No credentials stored. */
+  AUTH_MISSING: 'auth_missing',
+  /** Loopback callback server could not bind. */
+  CALLBACK_BIND_FAILED: 'callback_bind_failed',
+  /** Loopback callback timed out. */
+  CALLBACK_TIMEOUT: 'callback_timeout',
+} as const;

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/files.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/files.ts
@@ -1,0 +1,632 @@
+import {
+  existsSync,
+  promises as fs,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, resolve, sep } from 'node:path';
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import {
+  booleanDetail,
+  detailRecord,
+  fileError,
+  fileNotFound,
+  MAX_OUTPUT_CHARS,
+  numberDetail,
+  recordFrom,
+  renderResultSummary,
+  stringDetail,
+  stringFrom,
+  type ToolError,
+  text,
+} from './rendering.js';
+
+type ReplacementEdit = { oldText: string; newText: string };
+type FileDetails = { path: string; [key: string]: unknown };
+type WriteArgs = { path: string; content: string };
+type StrReplaceArgs = { path: string; old_str: string; new_str: string };
+type EditArgs = {
+  path: string;
+  edits?: ReplacementEdit[];
+  applyPatch?: { patchContent: string };
+  strReplace?: ReplacementEdit;
+  multiStrReplace?: { edits: ReplacementEdit[] };
+};
+
+type ToolTheme = {
+  bold: (text: string) => string;
+  fg: (name: 'accent' | 'toolTitle', text: string) => string;
+};
+
+function parseEditList(value: unknown): ReplacementEdit[] | undefined {
+  const editList = typeof value === 'string' ? parseJson(value) : value;
+  if (!Array.isArray(editList)) return undefined;
+  if (
+    !editList.every(
+      (edit) =>
+        typeof recordFrom(edit)?.oldText === 'string' &&
+        typeof recordFrom(edit)?.newText === 'string',
+    )
+  ) {
+    return undefined;
+  }
+  return editList.map((edit) => ({
+    oldText: stringFrom(recordFrom(edit)?.oldText) ?? '',
+    newText: stringFrom(recordFrom(edit)?.newText) ?? '',
+  }));
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function editFromText(oldText: unknown, newText: unknown) {
+  if (typeof oldText !== 'string' || typeof newText !== 'string') return undefined;
+  return [{ oldText, newText }];
+}
+
+function editsFromArgs(input: Record<string, unknown>) {
+  return (
+    parseEditList(input.edits) ??
+    parseEditList(recordFrom(input.multiStrReplace)?.edits) ??
+    editFromText(input.oldText, input.newText) ??
+    editFromText(recordFrom(input.strReplace)?.oldText, recordFrom(input.strReplace)?.newText)
+  );
+}
+
+function applyEdits(content: string, edits: ReplacementEdit[]) {
+  return edits.reduce(
+    (result, edit) => {
+      const count = result.content.split(edit.oldText).length - 1;
+      return {
+        content:
+          count === 0
+            ? result.content
+            : result.content.replaceAll(edit.oldText, () => edit.newText),
+        replacements: result.replacements + count,
+      };
+    },
+    { content, replacements: 0 },
+  );
+}
+
+function replacementResult(text: string, filePath: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    details: { path: filePath, replacements: 0 },
+  };
+}
+
+function renderReplacementResult(
+  result: { content: { type: string; text?: string }[]; details: unknown },
+  expanded: boolean,
+  isPartial: boolean,
+  theme: { fg: (name: 'dim' | 'muted', text: string) => string },
+) {
+  const replacements = numberDetail(result, 'replacements');
+  return renderResultSummary(
+    result,
+    expanded,
+    isPartial,
+    replacements === 0
+      ? theme.fg('dim', 'No replacements')
+      : theme.fg('muted', `${replacements} replacement(s)`),
+  );
+}
+
+function renderPathToolCall(toolName: string, filePath: string, theme: ToolTheme) {
+  return text(theme.fg('toolTitle', theme.bold(`${toolName} `)) + theme.fg('accent', filePath));
+}
+
+async function canonicalizeWithinWorkspace(cwd: string, requestedPath: string) {
+  const targetPath = resolve(cwd, requestedPath);
+  const realCwd = await fs.realpath(cwd);
+  const missingParts: string[] = [];
+  let currentPath = targetPath;
+  let realTarget: string | undefined;
+  while (!realTarget) {
+    try {
+      realTarget = join(await fs.realpath(currentPath), ...[...missingParts].reverse());
+    } catch (error) {
+      const parentPath = dirname(currentPath);
+      if (parentPath === currentPath) throw error;
+      missingParts.push(basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+  if (realTarget !== realCwd && !realTarget.startsWith(`${realCwd}${sep}`)) {
+    throw new Error('Path is outside the workspace');
+  }
+  return realTarget;
+}
+
+async function existingPathWithinWorkspace(cwd: string, requestedPath: string) {
+  const safePath = await canonicalizeWithinWorkspace(cwd, requestedPath);
+  return existsSync(safePath) ? safePath : undefined;
+}
+
+async function existingPathOrNotFound<T extends FileDetails>(
+  cwd: string,
+  requestedPath: string,
+  extraDetails: Omit<T, 'path'>,
+) {
+  return (
+    (await existingPathWithinWorkspace(cwd, requestedPath)) ??
+    fileNotFound(resolve(cwd, requestedPath), extraDetails)
+  );
+}
+
+function replacementPathOrNotFound(cwd: string, requestedPath: string) {
+  return existingPathOrNotFound(cwd, requestedPath, { replacements: 0 });
+}
+
+export function registerFileTools(api: ExtensionAPI) {
+  const { Type } = api.typebox;
+  // ── LS tool ──────────────────────────────────────────────────────────
+
+  const LsParams = Type.Object({
+    path: Type.String({
+      description: 'Directory path to list',
+    }),
+  });
+
+  api.registerTool({
+    name: 'LS',
+    label: 'LS',
+    description: 'List the contents of a directory, including hidden files.',
+    parameters: LsParams,
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const targetPath = resolve(ctx.cwd, params.path);
+
+      try {
+        const safePath = await canonicalizeWithinWorkspace(ctx.cwd, params.path);
+        if (signal?.aborted) throw new Error('The operation was aborted');
+
+        let output = (await fs.readdir(safePath)).sort().join('\n');
+        if (output.length > MAX_OUTPUT_CHARS) {
+          output = `${output.slice(0, MAX_OUTPUT_CHARS)}\n\n[LS: output truncated at 50KB]`;
+        }
+
+        return {
+          content: [{ type: 'text', text: output }],
+          details: { path: safePath },
+        };
+      } catch (error: unknown) {
+        const err = error as ToolError;
+        const message = err.message ?? 'Unknown error';
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `LS error: ${message}`,
+            },
+          ],
+          details: { path: targetPath, failed: true, error: message },
+        };
+      }
+    },
+    renderCall(args, theme) {
+      return renderPathToolCall('LS', args.path, theme);
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderResultSummary(
+        result,
+        expanded,
+        isPartial,
+        theme.fg('muted', stringDetail(result, 'path')),
+      );
+    },
+  });
+
+  // ── Read tool ────────────────────────────────────────────────────────
+
+  const ReadParams = Type.Object({
+    path: Type.String({
+      description: 'Path to the file to read',
+    }),
+    offset: Type.Optional(
+      Type.Number({
+        description: 'Line number to start reading from (0-indexed)',
+      }),
+    ),
+    limit: Type.Optional(
+      Type.Number({
+        description: 'Maximum number of lines to read',
+      }),
+    ),
+  });
+
+  api.registerTool({
+    name: 'Read',
+    label: 'Read',
+    description: 'Read the contents of a file. Returns the file content with line numbers.',
+    parameters: ReadParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const filePath = resolve(ctx.cwd, params.path);
+
+      try {
+        const safePath = await existingPathOrNotFound(ctx.cwd, params.path, {
+          exists: false,
+          totalLines: 0,
+        });
+        if (typeof safePath !== 'string') return safePath;
+
+        const content = readFileSync(safePath, 'utf-8');
+        const lines = content.endsWith('\n')
+          ? content.slice(0, -1).split('\n')
+          : content.split('\n');
+
+        const startLine = params.offset ?? 0;
+        const endLine =
+          params.limit !== undefined
+            ? Math.min(startLine + params.limit, lines.length)
+            : Math.min(startLine + 2000, lines.length);
+
+        const selectedLines = lines.slice(startLine, endLine);
+        const numberedLines = selectedLines.map((line, i) => `${startLine + i + 1}\t${line}`);
+
+        let output = numberedLines.join('\n');
+        if (endLine < lines.length) {
+          output += `\n\n[Showing lines ${startLine + 1}-${endLine} of ${lines.length} total lines. Use offset to see more.]`;
+        }
+
+        if (output.length > MAX_OUTPUT_CHARS) {
+          output = `${output.slice(0, MAX_OUTPUT_CHARS)}\n\n[Output truncated at 50KB]`;
+        }
+
+        return {
+          content: [{ type: 'text', text: output }],
+          details: { path: safePath, totalLines: lines.length },
+        };
+      } catch (error: unknown) {
+        const err = error as { code?: string };
+        return fileError(error, 'Read', filePath, {
+          exists: err.code !== 'ENOENT',
+          totalLines: 0,
+        });
+      }
+    },
+    renderCall(args, theme) {
+      const range =
+        args.offset !== undefined || args.limit !== undefined
+          ? theme.fg(
+              'muted',
+              ` (from ${args.offset ?? 0}${args.limit !== undefined ? `, ${args.limit} lines` : ''})`,
+            )
+          : '';
+      return text(
+        theme.fg('toolTitle', theme.bold('Read ')) + theme.fg('accent', args.path) + range,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderResultSummary(
+        result,
+        expanded,
+        isPartial,
+        detailRecord(result).exists === false
+          ? theme.fg('error', 'File not found')
+          : theme.fg('muted', `${numberDetail(result, 'totalLines')} line(s)`),
+      );
+    },
+  });
+
+  // ── Write tool ───────────────────────────────────────────────────────
+
+  const WriteParams = Type.Object({
+    path: Type.String({
+      description: 'Path to the file to write',
+    }),
+    content: Type.String({
+      description: 'Content to write to the file',
+    }),
+  });
+
+  api.registerTool({
+    name: 'Write',
+    label: 'Write',
+    description:
+      'Create or overwrite a file with the given content. Creates parent directories if needed.',
+    parameters: WriteParams,
+
+    prepareArguments(args) {
+      const input = recordFrom(args);
+      if (!input) return args as WriteArgs;
+      return {
+        ...input,
+        content: stringFrom(input.content) ?? stringFrom(input.contents),
+      } as WriteArgs;
+    },
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const filePath = resolve(ctx.cwd, params.path);
+
+      try {
+        const safePath = await canonicalizeWithinWorkspace(ctx.cwd, params.path);
+        mkdirSync(dirname(safePath), { recursive: true });
+        writeFileSync(safePath, params.content, 'utf-8');
+        const bytesWritten = Buffer.byteLength(params.content, 'utf8');
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Successfully wrote ${bytesWritten} bytes to ${params.path}`,
+            },
+          ],
+          details: { path: safePath, bytesWritten },
+        };
+      } catch (error: unknown) {
+        const err = error as ToolError;
+        const message = err.message ?? 'Unknown error';
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Write error: ${message}`,
+            },
+          ],
+          details: { path: filePath, bytesWritten: 0, failed: true, error: message },
+        };
+      }
+    },
+    renderCall(args, theme) {
+      return renderPathToolCall('Write', args.path, theme);
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderResultSummary(
+        result,
+        expanded,
+        isPartial,
+        theme.fg('muted', `${numberDetail(result, 'bytesWritten')} bytes written`),
+      );
+    },
+  });
+
+  // ── StrReplace tool ──────────────────────────────────────────────────
+
+  const StrReplaceParams = Type.Object({
+    path: Type.String({
+      description: 'Path to the file to modify',
+    }),
+    old_str: Type.String({
+      description: 'String to search for (exact match)',
+    }),
+    new_str: Type.String({
+      description: 'String to replace with',
+    }),
+  });
+
+  api.registerTool({
+    name: 'StrReplace',
+    label: 'StrReplace',
+    description:
+      'Replace all occurrences of a string in a file. The old_str must be an exact match.',
+    parameters: StrReplaceParams,
+
+    prepareArguments(args) {
+      const input = recordFrom(args);
+      if (!input) return args as StrReplaceArgs;
+      return {
+        ...input,
+        old_str:
+          stringFrom(input.old_str) ??
+          stringFrom(input.old_string) ??
+          stringFrom(input.oldText) ??
+          stringFrom(recordFrom(input.strReplace)?.oldText),
+        new_str:
+          stringFrom(input.new_str) ??
+          stringFrom(input.new_string) ??
+          stringFrom(input.newText) ??
+          stringFrom(recordFrom(input.strReplace)?.newText),
+      } as StrReplaceArgs;
+    },
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const requestedPath = params.path;
+      const filePath = resolve(ctx.cwd, requestedPath);
+
+      try {
+        const safePath = await replacementPathOrNotFound(ctx.cwd, requestedPath);
+        if (typeof safePath !== 'string') return safePath;
+
+        const content = readFileSync(safePath, 'utf-8');
+        if (params.old_str === '') {
+          return replacementResult('StrReplace error: old_str must not be empty', safePath);
+        }
+
+        const count = content.split(params.old_str).length - 1;
+
+        if (count === 0) {
+          return replacementResult(
+            `String not found in ${params.path}: "${params.old_str}"`,
+            safePath,
+          );
+        }
+
+        const newContent = content.replaceAll(params.old_str, () => params.new_str);
+        writeFileSync(safePath, newContent, 'utf-8');
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Replaced ${count} occurrence(s) in ${params.path}`,
+            },
+          ],
+          details: { path: safePath, replacements: count },
+        };
+      } catch (error: unknown) {
+        return fileError(error, 'StrReplace', filePath, { replacements: 0 });
+      }
+    },
+    renderCall(args, theme) {
+      return renderPathToolCall('StrReplace', args.path, theme);
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderReplacementResult(result, expanded, isPartial, theme);
+    },
+  });
+
+  // ── Edit tool ────────────────────────────────────────────────────────
+
+  const EditItemParams = Type.Object({
+    oldText: Type.String({
+      description: 'String to search for (exact match)',
+    }),
+    newText: Type.String({
+      description: 'String to replace with',
+    }),
+    replaceAll: Type.Optional(
+      Type.Boolean({
+        description:
+          'Accepted for Cursor compatibility. Replacements are always applied to all matches.',
+      }),
+    ),
+  });
+
+  const EditParams = Type.Object({
+    path: Type.String({
+      description: 'Path to the file to modify',
+    }),
+    edits: Type.Optional(
+      Type.Array(EditItemParams, {
+        description: 'Exact text replacements to apply sequentially',
+      }),
+    ),
+    applyPatch: Type.Optional(
+      Type.Object({
+        patchContent: Type.String({
+          description: 'Unsupported unified patch content',
+        }),
+      }),
+    ),
+    strReplace: Type.Optional(EditItemParams),
+    multiStrReplace: Type.Optional(
+      Type.Object({
+        edits: Type.Array(EditItemParams),
+      }),
+    ),
+  });
+
+  api.registerTool({
+    name: 'Edit',
+    label: 'Edit',
+    description:
+      'Modify a file with exact text replacement. applyPatch is not supported by this Grok tool shim.',
+    parameters: EditParams,
+
+    prepareArguments(args) {
+      const input = recordFrom(args);
+      if (!input) return args as EditArgs;
+      return {
+        ...input,
+        edits: editsFromArgs(input),
+      } as EditArgs;
+    },
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const filePath = resolve(ctx.cwd, params.path);
+
+      try {
+        const safePath = await replacementPathOrNotFound(ctx.cwd, params.path);
+        if (typeof safePath !== 'string') return safePath;
+        if (!params.edits?.length) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: params.applyPatch
+                  ? 'Edit error: applyPatch is not supported by this Grok tool shim'
+                  : 'Edit error: provide at least one exact text replacement',
+              },
+            ],
+            details: { path: safePath, replacements: 0 },
+          };
+        }
+        if (params.edits.some((edit) => edit.oldText === '')) {
+          return replacementResult('Edit error: oldText must not be empty', safePath);
+        }
+
+        const result = applyEdits(readFileSync(safePath, 'utf-8'), params.edits);
+
+        if (result.replacements === 0) {
+          return replacementResult(`No replacement strings found in ${params.path}`, safePath);
+        }
+
+        writeFileSync(safePath, result.content, 'utf-8');
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Applied ${result.replacements} replacement(s) in ${params.path}`,
+            },
+          ],
+          details: { path: safePath, replacements: result.replacements },
+        };
+      } catch (error: unknown) {
+        return fileError(error, 'Edit', filePath, { replacements: 0 });
+      }
+    },
+    renderCall(args, theme) {
+      return renderPathToolCall('Edit', args.path, theme);
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderReplacementResult(result, expanded, isPartial, theme);
+    },
+  });
+
+  // ── Delete tool ──────────────────────────────────────────────────────
+
+  const DeleteParams = Type.Object({
+    path: Type.String({
+      description: 'Path to the file to delete',
+    }),
+  });
+
+  api.registerTool({
+    name: 'Delete',
+    label: 'Delete',
+    description: 'Delete a file from the filesystem.',
+    parameters: DeleteParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const filePath = resolve(ctx.cwd, params.path);
+
+      try {
+        const safePath = await existingPathOrNotFound(ctx.cwd, params.path, { deleted: false });
+        if (typeof safePath !== 'string') return safePath;
+
+        unlinkSync(safePath);
+
+        return {
+          content: [{ type: 'text', text: `Successfully deleted ${params.path}` }],
+          details: { path: safePath, deleted: true },
+        };
+      } catch (error: unknown) {
+        return fileError(error, 'Delete', filePath, { deleted: false });
+      }
+    },
+    renderCall(args, theme) {
+      return renderPathToolCall('Delete', args.path, theme);
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      return renderResultSummary(
+        result,
+        expanded,
+        isPartial,
+        booleanDetail(result, 'deleted')
+          ? theme.fg('muted', 'Deleted')
+          : theme.fg('error', 'Not deleted'),
+      );
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/register.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/register.ts
@@ -1,0 +1,32 @@
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import { registerFileTools } from './files.js';
+import { registerSearchTools } from './search.js';
+import { registerShellTool } from './shell.js';
+
+/** Grok/Cursor shims always registered by this extension. */
+export const GROK_SHIM_TOOL_NAMES = [
+  'Grep',
+  'Glob',
+  'LS',
+  'Read',
+  'Write',
+  'StrReplace',
+  'Edit',
+  'Delete',
+  'Shell',
+] as const;
+
+/** All shim names used when reconciling the active tool set. */
+export const GROK_TOOL_NAMES_FOR_SCOPE = GROK_SHIM_TOOL_NAMES;
+
+export const GROK_SUPPRESSED_TOOL_NAMES = ['web_search'] as const;
+
+export function grokToolsToActivate() {
+  return [...GROK_SHIM_TOOL_NAMES];
+}
+
+export function registerGrokTools(api: ExtensionAPI) {
+  registerSearchTools(api);
+  registerFileTools(api);
+  registerShellTool(api);
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/rendering.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/rendering.ts
@@ -1,0 +1,257 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import { promisify } from 'node:util';
+import { Text } from '@gajae-code/tui';
+
+const execFileAsync = promisify(execFile);
+
+export const MAX_OUTPUT_CHARS = 50_000;
+export const MAX_OUTPUT_BYTES = MAX_OUTPUT_CHARS * 4 + 1024;
+export const MAX_LINES = 500;
+
+export function recordFrom(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  return value as Record<string, unknown>;
+}
+
+export function stringFrom(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value;
+}
+
+export function truncateLines(lines: string[]): string {
+  if (lines.length > MAX_LINES) {
+    return (
+      lines.slice(0, MAX_LINES).join('\n') +
+      `\n\n[Showing first ${MAX_LINES} of ${lines.length} results. Refine your pattern to narrow results.]`
+    );
+  }
+  return lines.join('\n');
+}
+
+export function truncateChars(output: string): string {
+  if (output.length > MAX_OUTPUT_CHARS) {
+    return `${output.slice(0, MAX_OUTPUT_CHARS)}\n\n[Output truncated at 50KB]`;
+  }
+  return output;
+}
+
+export function globToRegExp(pattern: string) {
+  let source = '^';
+  for (let i = 0; i < pattern.length; i += 1) {
+    const char = pattern[i];
+    const next = pattern[i + 1];
+    if (char === '*' && next === '*' && pattern[i + 2] === '/') {
+      source += '(?:.*/)?';
+      i += 2;
+    } else if (char === '*' && next === '*') {
+      source += '.*';
+      i += 1;
+    } else if (char === '*') {
+      source += '[^/]*';
+    } else if (char === '?') {
+      source += '[^/]';
+    } else {
+      source += char.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+    }
+  }
+  return new RegExp(`${source}$`);
+}
+
+export function normalizePath(filePath: string) {
+  return filePath.replaceAll('\\', '/');
+}
+
+export async function listFilesRecursive(
+  searchPath: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (signal?.aborted) throw new Error('The operation was aborted');
+  const stats = await fs.stat(searchPath);
+  if (stats.isFile()) return [searchPath];
+  if (!stats.isDirectory()) return [];
+
+  return (
+    await Promise.all(
+      (
+        await fs.readdir(searchPath, { withFileTypes: true })
+      ).map((entry) => {
+        const entryPath = join(searchPath, entry.name);
+        if (entry.isDirectory()) return listFilesRecursive(entryPath, signal);
+        if (entry.isFile()) return [entryPath];
+        return [];
+      }),
+    )
+  ).flat();
+}
+
+let rgAvailable: boolean | undefined;
+export async function hasRipgrep(): Promise<boolean> {
+  if (rgAvailable !== undefined) return rgAvailable;
+  try {
+    await execFileAsync('rg', ['--version']);
+    rgAvailable = true;
+  } catch {
+    rgAvailable = false;
+  }
+  return rgAvailable;
+}
+
+export type ToolError = { code?: number; message?: string };
+export type ToolResult<T> = {
+  content: [{ type: 'text'; text: string }];
+  details: T;
+};
+
+export function text(text: string): Text {
+  return new Text(text, 0, 0);
+}
+
+function firstText(result: { content: { type: string; text?: string }[] }) {
+  const first = result.content[0];
+  if (first?.type !== 'text') return undefined;
+  return first.text;
+}
+
+export function renderResultText(
+  result: { content: { type: string; text?: string }[] },
+  expanded: boolean,
+  summary: string,
+): Text {
+  if (expanded) return text(firstText(result) ?? summary);
+  return text(summary);
+}
+
+export function renderRunning(isPartial: boolean): Text | undefined {
+  if (!isPartial) return undefined;
+  return text('Running...');
+}
+
+export function renderResultSummary(
+  result: { content: { type: string; text?: string }[] },
+  expanded: boolean,
+  isPartial: boolean,
+  summary: string,
+): Text {
+  const running = renderRunning(isPartial);
+  if (running) return running;
+  return renderResultText(result, expanded, summary);
+}
+
+export function detailRecord(result: { details: unknown }): Record<string, unknown> {
+  if (!result.details || typeof result.details !== 'object') return {};
+  return result.details as Record<string, unknown>;
+}
+
+export function numberDetail(result: { details: unknown }, key: string): number {
+  const value = detailRecord(result)[key];
+  if (typeof value !== 'number') return 0;
+  return value;
+}
+
+export function stringDetail(result: { details: unknown }, key: string): string {
+  const value = detailRecord(result)[key];
+  if (typeof value !== 'string') return '';
+  return value;
+}
+
+export function booleanDetail(result: { details: unknown }, key: string): boolean {
+  const value = detailRecord(result)[key];
+  return value === true;
+}
+
+type FileDetails = { path: string; [key: string]: unknown };
+
+export function fileNotFound<T extends FileDetails>(
+  filePath: string,
+  extraDetails: Omit<T, 'path'>,
+): ToolResult<T> {
+  return {
+    content: [{ type: 'text', text: `File not found: ${filePath}` }],
+    details: { path: filePath, ...extraDetails } as T,
+  };
+}
+
+export function fileError<T extends FileDetails>(
+  error: unknown,
+  toolName: string,
+  filePath: string,
+  extraDetails: Omit<T, 'path'>,
+): ToolResult<T> {
+  const err = error as ToolError;
+  const message = err.message ?? 'Unknown error';
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `${toolName} error: ${message}`,
+      },
+    ],
+    details: { path: filePath, ...extraDetails, failed: true, error: message } as unknown as T,
+  };
+}
+
+export function toolError<T>(error: unknown, toolName: string, emptyDetails: T): ToolResult<T> {
+  const err = error as ToolError;
+  if (toolName === 'Grep' && err.code === 1) {
+    return {
+      content: [{ type: 'text', text: 'No matches found' }],
+      details: emptyDetails,
+    };
+  }
+  const message = err.message ?? 'Unknown error';
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `${toolName} error: ${message}`,
+      },
+    ],
+    details: { ...emptyDetails, failed: true, error: message } as T,
+  };
+}
+
+export async function execWithRgFallback(
+  rgArgs: string[],
+  options: {
+    cwd: string;
+    signal?: AbortSignal;
+    pattern: string;
+    searchPath: string;
+    include?: string;
+  },
+): Promise<string> {
+  if (await hasRipgrep()) {
+    const result = await execFileAsync('rg', rgArgs, {
+      cwd: options.cwd,
+      maxBuffer: MAX_OUTPUT_BYTES,
+      signal: options.signal,
+    });
+    return result.stdout;
+  }
+
+  const regex = new RegExp(options.pattern);
+  const matcher = options.include ? globToRegExp(normalizePath(options.include)) : undefined;
+  return (
+    await Promise.all(
+      (
+        await listFilesRecursive(options.searchPath, options.signal)
+      )
+        .filter((file) => {
+          if (!matcher) return true;
+          if (!options.include?.includes('/')) return matcher.test(basename(file));
+          return matcher.test(normalizePath(relative(options.cwd, file)));
+        })
+        .map(async (file) =>
+          (
+            await fs.readFile(file, 'utf8')
+          )
+            .split(/\r?\n/)
+            .flatMap((line, index) => (regex.test(line) ? `${file}:${index + 1}:${line}` : [])),
+        ),
+    )
+  )
+    .flat()
+    .join('\n');
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/search.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/search.ts
@@ -1,0 +1,224 @@
+import { execFile } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { basename, relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import {
+  execWithRgFallback,
+  globToRegExp,
+  hasRipgrep,
+  listFilesRecursive,
+  MAX_OUTPUT_BYTES,
+  normalizePath,
+  numberDetail,
+  recordFrom,
+  renderResultText,
+  renderRunning,
+  stringFrom,
+  text,
+  toolError,
+  truncateChars,
+  truncateLines,
+} from './rendering.js';
+
+const execFileAsync = promisify(execFile);
+
+type GrepArgs = { pattern: string; path?: string; include?: string };
+type GlobArgs = { pattern: string; path?: string };
+
+function modifiedTimeMs(file: string) {
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+export function sortByModifiedNewest(files: string[]) {
+  return files.sort((a, b) => {
+    const delta = modifiedTimeMs(b) - modifiedTimeMs(a);
+    if (delta !== 0) return delta;
+    return a.localeCompare(b);
+  });
+}
+
+export function registerSearchTools(api: ExtensionAPI) {
+  const { Type } = api.typebox;
+  const GrepParams = Type.Object({
+    pattern: Type.String({
+      description: 'Regex pattern to search for in file contents',
+    }),
+    path: Type.Optional(
+      Type.String({
+        description: 'Directory or file to search. Defaults to current working directory.',
+      }),
+    ),
+    include: Type.Optional(
+      Type.String({
+        description: 'Glob pattern to filter which files are searched (e.g. *.ts, **/*.md)',
+      }),
+    ),
+  });
+
+  api.registerTool({
+    name: 'Grep',
+    label: 'Grep',
+    description:
+      'Search for a regex pattern in file contents. Returns matching lines with file path and line number. Use the include parameter to filter by file type.',
+    parameters: GrepParams,
+
+    prepareArguments(args) {
+      const input = recordFrom(args);
+      if (!input) return args as GrepArgs;
+      return {
+        ...input,
+        include: stringFrom(input.include) ?? stringFrom(input.glob_filter),
+      } as GrepArgs;
+    },
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const searchPath = resolve(ctx.cwd, params.path ?? '.');
+
+      try {
+        const rgArgs = ['-n', '-H', '--no-heading', '--color=never'];
+        if (params.include) rgArgs.push('--glob', params.include);
+        rgArgs.push('--', params.pattern, searchPath);
+
+        const stdout = await execWithRgFallback(rgArgs, {
+          cwd: ctx.cwd,
+          signal,
+          pattern: params.pattern,
+          searchPath,
+          include: params.include,
+        });
+
+        const lines = stdout.trim().split('\n').filter(Boolean);
+        if (lines.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No matches found' }],
+            details: { matchCount: 0 },
+          };
+        }
+
+        return {
+          content: [{ type: 'text', text: truncateChars(truncateLines(lines)) }],
+          details: { matchCount: lines.length },
+        };
+      } catch (error: unknown) {
+        return toolError(error, 'Grep', { matchCount: 0 });
+      }
+    },
+    renderCall(args, theme) {
+      const path = args.path ? theme.fg('muted', ` in ${args.path}`) : '';
+      const include = args.include ? theme.fg('dim', ` [${args.include}]`) : '';
+      return text(
+        theme.fg('toolTitle', theme.bold('Grep ')) +
+          theme.fg('accent', `"${args.pattern}"`) +
+          path +
+          include,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      const running = renderRunning(isPartial);
+      if (running) return running;
+      const matchCount = numberDetail(result, 'matchCount');
+      return renderResultText(
+        result,
+        expanded,
+        matchCount === 0
+          ? theme.fg('dim', 'No matches')
+          : theme.fg('muted', `${matchCount} match(es)`),
+      );
+    },
+  });
+
+  const GlobParams = Type.Object({
+    pattern: Type.String({
+      description: 'Glob pattern to match files (e.g. **/*.ts, src/**/*.json)',
+    }),
+    path: Type.Optional(
+      Type.String({
+        description: 'Directory to search within. Defaults to current working directory.',
+      }),
+    ),
+  });
+
+  api.registerTool({
+    name: 'Glob',
+    label: 'Glob',
+    description:
+      'Find files matching a glob pattern. Returns a list of matching file paths sorted by modification time (newest first).',
+    parameters: GlobParams,
+
+    prepareArguments(args) {
+      const input = recordFrom(args);
+      if (!input) return args as GlobArgs;
+      return {
+        ...input,
+        pattern: stringFrom(input.pattern) ?? stringFrom(input.glob_pattern),
+      } as GlobArgs;
+    },
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const searchPath = resolve(ctx.cwd, params.path ?? '.');
+
+      try {
+        let files: string[];
+
+        if (await hasRipgrep()) {
+          const result = await execFileAsync(
+            'rg',
+            ['--files', '--color=never', '--glob', params.pattern, searchPath],
+            { cwd: ctx.cwd, maxBuffer: MAX_OUTPUT_BYTES, signal },
+          );
+          files = result.stdout.trim().split('\n').filter(Boolean);
+        } else {
+          const normalizedPattern = normalizePath(params.pattern);
+          const matcher = globToRegExp(normalizedPattern);
+          const matchesFile = normalizedPattern.includes('/')
+            ? (file: string) => matcher.test(normalizePath(relative(ctx.cwd, file)))
+            : (file: string) => matcher.test(basename(file));
+          files = (await listFilesRecursive(searchPath, signal)).filter(matchesFile);
+        }
+        files = sortByModifiedNewest(files);
+
+        if (files.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No files found' }],
+            details: { fileCount: 0 },
+          };
+        }
+
+        return {
+          content: [{ type: 'text', text: truncateChars(truncateLines(files)) }],
+          details: { fileCount: files.length },
+        };
+      } catch (error: unknown) {
+        const err = error as { code?: unknown; stderr?: string };
+        if (err.code === 1 && !err.stderr) {
+          return {
+            content: [{ type: 'text', text: 'No files found' }],
+            details: { fileCount: 0 },
+          };
+        }
+        return toolError(error, 'Glob', { fileCount: 0 });
+      }
+    },
+    renderCall(args, theme) {
+      const path = args.path ? theme.fg('muted', ` in ${args.path}`) : '';
+      return text(
+        theme.fg('toolTitle', theme.bold('Glob ')) + theme.fg('accent', args.pattern) + path,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      const running = renderRunning(isPartial);
+      if (running) return running;
+      const fileCount = numberDetail(result, 'fileCount');
+      return renderResultText(
+        result,
+        expanded,
+        fileCount === 0 ? theme.fg('dim', 'No files') : theme.fg('muted', `${fileCount} file(s)`),
+      );
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/shell.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/tools/shell.ts
@@ -1,0 +1,159 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import {
+  detailRecord,
+  MAX_OUTPUT_BYTES,
+  MAX_OUTPUT_CHARS,
+  renderResultText,
+  renderRunning,
+  text,
+} from './rendering.js';
+
+const execFileAsync = promisify(execFile);
+
+function shellCommand(command: string): { file: string; args: string[] } | undefined {
+  if (process.platform === 'win32') {
+    if (existsSync('C:\\Windows\\System32\\cmd.exe')) {
+      return { file: 'cmd.exe', args: ['/d', '/s', '/c', command] };
+    }
+    if (existsSync('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')) {
+      return {
+        file: 'powershell.exe',
+        args: ['-NoLogo', '-NoProfile', '-Command', command],
+      };
+    }
+    return undefined;
+  }
+
+  if (
+    process.platform !== 'darwin' &&
+    process.platform !== 'linux' &&
+    process.platform !== 'freebsd'
+  ) {
+    return undefined;
+  }
+
+  if (existsSync('/bin/bash')) return { file: '/bin/bash', args: ['-c', command] };
+  if (existsSync('/usr/bin/bash')) return { file: '/usr/bin/bash', args: ['-c', command] };
+  if (existsSync('/bin/sh')) return { file: '/bin/sh', args: ['-c', command] };
+  if (existsSync('/usr/bin/sh')) return { file: '/usr/bin/sh', args: ['-c', command] };
+  return undefined;
+}
+
+export function registerShellTool(api: ExtensionAPI) {
+  const { Type } = api.typebox;
+  // ── Shell tool ───────────────────────────────────────────────────────
+
+  const ShellParams = Type.Object({
+    command: Type.String({
+      description: 'Shell command to execute',
+    }),
+    working_directory: Type.Optional(
+      Type.String({
+        description: 'Working directory for the command',
+      }),
+    ),
+    timeout: Type.Optional(
+      Type.Number({
+        description: 'Timeout in milliseconds (default: 120000)',
+      }),
+    ),
+  });
+
+  api.registerTool({
+    name: 'Shell',
+    label: 'Shell',
+    description: 'Execute a shell command and return stdout, stderr, and exit code.',
+    parameters: ShellParams,
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const cwd = params.working_directory ? resolve(ctx.cwd, params.working_directory) : ctx.cwd;
+      const timeout = params.timeout ?? 120_000;
+
+      try {
+        const shell = shellCommand(params.command);
+        if (!shell) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Shell error: unsupported platform or shell not found',
+              },
+            ],
+            details: { exitCode: 1, command: params.command },
+          };
+        }
+        const { stdout, stderr } = await execFileAsync(shell.file, shell.args, {
+          cwd,
+          maxBuffer: MAX_OUTPUT_BYTES,
+          timeout,
+          signal,
+        });
+
+        let output = '';
+        if (stdout) output += stdout;
+        if (stderr) output += `\n[stderr]\n${stderr}`;
+
+        if (output.length > MAX_OUTPUT_CHARS) {
+          output = `${output.slice(0, MAX_OUTPUT_CHARS)}\n\n[Output truncated at 50KB]`;
+        }
+
+        return {
+          content: [{ type: 'text', text: output || '(no output)' }],
+          details: { exitCode: 0, command: params.command },
+        };
+      } catch (error: unknown) {
+        const err = error as {
+          code?: unknown;
+          message?: string;
+          signal?: unknown;
+          stdout?: string;
+          stderr?: string;
+        };
+        const exitCode = typeof err.code === 'number' ? err.code : 1;
+
+        let output = '';
+        if (err.stdout) output += err.stdout;
+        if (err.stderr) output += `\n[stderr]\n${err.stderr}`;
+
+        if (output.length > MAX_OUTPUT_CHARS) {
+          output = `${output.slice(0, MAX_OUTPUT_CHARS)}\n\n[Output truncated at 50KB]`;
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Shell error (exit code ${err.code ?? 'unknown'}): ${err.message ?? 'Unknown error'}${output ? `\n${output}` : ''}`,
+            },
+          ],
+          details: {
+            exitCode,
+            command: params.command,
+            ...(typeof err.signal === 'string' ? { signal: err.signal } : {}),
+          },
+        };
+      }
+    },
+    renderCall(args, theme) {
+      const cwd = args.working_directory ? theme.fg('muted', ` in ${args.working_directory}`) : '';
+      return text(
+        theme.fg('toolTitle', theme.bold('Shell ')) + theme.fg('accent', args.command) + cwd,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      const running = renderRunning(isPartial);
+      if (running) return running;
+      const exitCode =
+        typeof detailRecord(result).exitCode === 'number' ? detailRecord(result).exitCode : 1;
+      return renderResultText(
+        result,
+        expanded,
+        exitCode === 0 ? theme.fg('muted', 'Exit 0') : theme.fg('warning', `Exit ${exitCode}`),
+      );
+    },
+  });
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -30,6 +30,7 @@ import { activateModelProfile } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedModel } from "./config/model-resolver";
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
+import { getBundledGrokBuildExtensionPaths } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
@@ -741,7 +742,7 @@ export async function runRootCommand(
 		await runListModelsCommand({
 			modelRegistry,
 			cwd: getProjectDir(),
-			additionalExtensionPaths: [],
+			additionalExtensionPaths: await getBundledGrokBuildExtensionPaths(),
 			settingsExtensions: [],
 			disabledExtensionIds: [],
 			disableExtensionDiscovery: true,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -50,6 +50,7 @@ import { CursorExecHandlers } from "./cursor";
 import "./discovery";
 import { resolveConfigValue } from "./config/resolve-config-value";
 import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
+import { getBundledGrokBuildExtensionPaths } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
 import { TtsrManager } from "./export/ttsr";
@@ -64,6 +65,7 @@ import {
 	type ExtensionUIContext,
 	type LoadExtensionsResult,
 	loadExtensionFromFactory,
+	loadExtensions,
 	type ToolDefinition,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
@@ -1337,13 +1339,23 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}
 
-		// Extension/module discovery is quarantined; retain only the private
-		// runtime needed for explicitly supplied SDK extensions and custom tools.
-		const extensionsResult: LoadExtensionsResult = options.preloadedExtensions ?? {
-			extensions: [],
-			errors: [],
-			runtime: new ExtensionRuntime(),
-		};
+		// Extension/module discovery is quarantined from the public GJC utility surface.
+		// The bundled Grok Build provider is part of the shipped product surface, so
+		// load it explicitly even when filesystem extension discovery is disabled.
+		const bundledGrokExtensionPaths = await getBundledGrokBuildExtensionPaths();
+		const extensionsResult: LoadExtensionsResult =
+			options.preloadedExtensions ??
+			(await loadExtensions(
+				[...bundledGrokExtensionPaths, ...(options.additionalExtensionPaths ?? [])],
+				cwd,
+				eventBus,
+			));
+		const bundledGrokLoadErrors = extensionsResult.errors.filter(error =>
+			bundledGrokExtensionPaths.includes(error.path),
+		);
+		if (bundledGrokLoadErrors.length > 0) {
+			throw new Error(bundledGrokLoadErrors.map(error => error.error).join("\n"));
+		}
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/test/grok-cli-defaults-install.test.ts
+++ b/packages/coding-agent/test/grok-cli-defaults-install.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import {
+	assertBundledGrokCliDefaults,
+	getBundledGrokBuildExtensionPath,
+	getBundledGrokCliModelDefaultsPath,
+	getBundledGrokCliVendorDir,
+} from "../src/defaults/gjc-grok-cli";
+
+describe("bundled Grok CLI defaults", () => {
+	it("fails loud only when the shipped vendor tree is missing", async () => {
+		await expect(assertBundledGrokCliDefaults()).resolves.toBeUndefined();
+		expect(getBundledGrokBuildExtensionPath().endsWith(path.join("grok-build", "index.ts"))).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokCliVendorDir(), "src", "payload", "sanitize.ts")).exists()).toBe(
+			true,
+		);
+		expect((await Bun.file(getBundledGrokCliModelDefaultsPath()).text()).includes("grok-composer-2.5-fast")).toBe(
+			true,
+		);
+	});
+});

--- a/packages/coding-agent/test/grok-cli-sanitize.test.ts
+++ b/packages/coding-agent/test/grok-cli-sanitize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { sanitizePayload } from "../src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize";
+
+describe("Grok CLI payload sanitize", () => {
+	it("strips replayed reasoning and unsupported Composer effort", () => {
+		const payload = sanitizePayload(
+			{
+				input: [
+					{ role: "system", content: "be terse" },
+					{ type: "reasoning", content: "cached" },
+					{ role: "user", content: "hello" },
+				],
+				include: ["reasoning.encrypted_content"],
+				reasoning: { effort: "high" },
+			},
+			"grok-composer-2.5-fast",
+			"session-1",
+			process.cwd(),
+		);
+		expect(payload.input).toEqual([{ role: "user", content: "hello" }]);
+		expect(payload.instructions).toBe("be terse");
+		expect(payload.include).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
+		expect(payload.prompt_cache_key).toBe("session-1");
+	});
+});

--- a/packages/coding-agent/test/grok-cli-vendor-deps.test.ts
+++ b/packages/coding-agent/test/grok-cli-vendor-deps.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { getBundledGrokCliVendorDir } from "../src/defaults/gjc-grok-cli";
+
+describe("bundled Grok CLI vendor dependencies", () => {
+	it("does not require runtime npm install from setup defaults", async () => {
+		const pkg = (await Bun.file(path.join(getBundledGrokCliVendorDir(), "package.json")).json()) as {
+			dependencies?: Record<string, string>;
+		};
+		expect(pkg.dependencies ?? {}).toEqual({});
+	});
+});

--- a/packages/coding-agent/test/grok-main-session-path.test.ts
+++ b/packages/coding-agent/test/grok-main-session-path.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { setAgentDir } from "@gajae-code/utils";
+import { Settings } from "../src/config/settings";
+import { getBundledGrokBuildExtensionPath } from "../src/defaults/gjc-grok-cli";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
+
+describe("bundled Grok Build session path", () => {
+	it("loads Grok Build OAuth and models with extension discovery disabled", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-grok-main-session-"));
+		setAgentDir(agentDir);
+		try {
+			const { session } = await createAgentSession({
+				cwd: agentDir,
+				agentDir,
+				settings: Settings.isolated(),
+				sessionManager: SessionManager.inMemory(agentDir),
+				disableExtensionDiscovery: true,
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["__none__"],
+			});
+			try {
+				const grokModels = session.modelRegistry.getAll().filter(model => model.provider === "grok-cli");
+				expect(grokModels.some(model => model.id === "grok-composer-2.5-fast")).toBe(true);
+				expect(grokModels.some(model => model.id === "grok-build")).toBe(true);
+				expect(getOAuthProviders().find(provider => provider.id === "grok-cli")?.name).toBe("Grok Build");
+				expect(
+					session.extensionRunner?.extensions.some(
+						extension => extension.path === getBundledGrokBuildExtensionPath(),
+					),
+				).toBe(true);
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/grok-post-merge-sequence.test.ts
+++ b/packages/coding-agent/test/grok-post-merge-sequence.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import {
+	getBundledGrokBuildExtensionDir,
+	getBundledGrokBuildExtensionPath,
+	getBundledGrokCliModelDefaultsPath,
+	getBundledGrokCliVendorDir,
+} from "../src/defaults/gjc-grok-cli";
+
+describe("Grok Build post-merge sequence", () => {
+	it("ships the extension, vendor tree, reference models, and grok-pro profile needed by the user flow", async () => {
+		expect(await Bun.file(getBundledGrokBuildExtensionPath()).exists()).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokBuildExtensionDir(), "package.json")).exists()).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokCliVendorDir(), "src", "provider", "register.ts")).exists()).toBe(
+			true,
+		);
+		expect(await Bun.file(getBundledGrokCliModelDefaultsPath()).exists()).toBe(true);
+
+		const profile = BUILTIN_MODEL_PROFILES.find(definition => definition.name === "grok-pro");
+		expect(profile?.requiredProviders).toContain("grok-cli");
+		expect(profile?.modelMapping.default).toBe("grok-cli/grok-composer-2.5-fast");
+		expect(profile?.modelMapping.executor).toBe("grok-cli/grok-build");
+	});
+});

--- a/packages/coding-agent/test/grok-third-party-sequence.test.ts
+++ b/packages/coding-agent/test/grok-third-party-sequence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
+
+describe("Grok Build with explicit third-party extensions", () => {
+	it("loads bundled Grok Build alongside caller-supplied extension paths", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-grok-third-party-"));
+		const extensionPath = path.join(root, "third-party.ts");
+		await Bun.write(
+			extensionPath,
+			`export default function thirdParty(api) { api.registerProvider("third-party-test", { name: "Third Party", baseUrl: "https://example.invalid/v1", apiKey: "$THIRD_PARTY_TEST_KEY", api: "openai-responses", models: [{ id: "model", name: "Model", reasoning: false, input: ["text"], cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }] }); }`,
+		);
+		try {
+			const { session } = await createAgentSession({
+				cwd: root,
+				agentDir: root,
+				settings: Settings.isolated(),
+				sessionManager: SessionManager.inMemory(root),
+				disableExtensionDiscovery: true,
+				additionalExtensionPaths: [extensionPath],
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["__none__"],
+			});
+			try {
+				expect(session.modelRegistry.find("grok-cli", "grok-composer-2.5-fast")).toBeTruthy();
+				expect(session.modelRegistry.find("third-party-test", "model")).toBeTruthy();
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -31,6 +31,7 @@ function builtIn(name: string): ModelProfileDefinition {
 function selectorExists(selector: string): boolean {
 	const parsed = parseModelString(selector);
 	if (!parsed) return false;
+	if (parsed.provider === "grok-cli") return ["grok-composer-2.5-fast", "grok-build"].includes(parsed.id);
 	return getBundledModel(parsed.provider as GeneratedProvider, parsed.id) !== undefined;
 }
 
@@ -40,9 +41,9 @@ function effortOf(selector: string): number {
 }
 
 describe("built-in model profile catalog", () => {
-	test("contains exactly 9 builtins", () => {
-		expect(BUILTIN_MODEL_PROFILES).toHaveLength(9);
-		expect(new Set(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).size).toBe(9);
+	test("contains exactly 10 builtins", () => {
+		expect(BUILTIN_MODEL_PROFILES).toHaveLength(10);
+		expect(new Set(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).size).toBe(10);
 	});
 
 	test("required_providers are correct per family", () => {
@@ -53,6 +54,8 @@ describe("built-in model profile catalog", () => {
 				expect(profile.requiredProviders).toEqual(["opencode-go"]);
 			} else if (profile.name.startsWith("codex-")) {
 				expect(profile.requiredProviders).toEqual(["openai-codex"]);
+			} else if (profile.name === "grok-pro") {
+				expect(profile.requiredProviders).toEqual(["grok-cli"]);
 			} else {
 				throw new Error(`Unexpected built-in profile ${profile.name}`);
 			}
@@ -83,7 +86,9 @@ describe("built-in model profile catalog", () => {
 	});
 
 	test("*-pro profiles raise effort on architect/planner/critic", () => {
-		for (const profile of BUILTIN_MODEL_PROFILES.filter(candidate => candidate.name.endsWith("-pro"))) {
+		for (const profile of BUILTIN_MODEL_PROFILES.filter(
+			candidate => candidate.name.endsWith("-pro") && candidate.name !== "grok-pro",
+		)) {
 			for (const role of reviewRoles) {
 				expect(effortOf(profile.modelMapping[role] ?? "")).toBeGreaterThanOrEqual(
 					effortRank[ThinkingLevel.High] ?? 3,
@@ -118,6 +123,18 @@ describe("built-in model profile catalog", () => {
 		expect(parsed?.thinkingLevel).toBeUndefined();
 		const model = getBundledModel("openai-codex", "gpt-5.5");
 		expect(model?.thinking?.defaultLevel).toBe(ThinkingLevel.XHigh);
+	});
+
+	test("grok-pro maps Composer 2.5 Fast and Grok Build roles", () => {
+		const profile = builtIn("grok-pro");
+		expect(profile.requiredProviders).toEqual(["grok-cli"]);
+		expect(profile.modelMapping).toEqual({
+			default: "grok-cli/grok-composer-2.5-fast",
+			executor: "grok-cli/grok-build",
+			architect: "grok-cli/grok-build",
+			planner: "grok-cli/grok-composer-2.5-fast",
+			critic: "grok-cli/grok-composer-2.5-fast",
+		});
 	});
 
 	test("user same-name profile overrides builtin via mergeModelProfiles", () => {


### PR DESCRIPTION
## Summary
- Bundle Grok Build as an in-tree GJC extension/provider (`grok-cli`) so first-run sessions load it even with extension discovery disabled.
- Add xAI/SuperGrok OAuth login, `grok-composer-2.5-fast`, `grok-build`, and the `grok-pro` profile.
- Add Grok usage reporting and focused smoke tests for `/login` → Grok Build → `/model` Composer 2.5 Fast.

## Verified user flow
`gjc` → `/login` → OAuth → `Grok Build` → browser opens xAI login → `/model` → `grok-cli/grok-composer-2.5-fast`.

## Tests
- `bash scripts/verify-pr-flow.sh` against fresh `Yeachan-Heo/gajae-code` main `498d86bb8b695a6427bc8b464425e4fa5cdd8335`
- `bun test test/grok-main-session-path.test.ts`
- `createAgentSession` smoke: bundled Grok Build loaded, OAuth registered, 6 grok-cli models registered
- `bun test test/grok-post-merge-sequence.test.ts test/grok-third-party-sequence.test.ts`
- `bun test test/model-profiles-catalog.test.ts`
- `bun test test/grok-cli-defaults-install.test.ts`
- `bun test test/grok-cli-vendor-deps.test.ts test/grok-cli-sanitize.test.ts`
- `bun test packages/ai/test/grok-cli-usage.test.ts`

## Security check
- No `.env`, private key, GitHub token, cloud key, JWT, bearer token, or personal credential found in the integration repo current tree or git history.
- The xAI OAuth `client_id` is a public client id, not a secret.