### PR TITLE
fix(ai): set busy_timeout before journal_mode=WAL in auth store init

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3621,10 +3621,14 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	}
 
 	#initializeSchema(): void {
+		// Apply busy_timeout FIRST: `PRAGMA journal_mode=WAL` needs a brief
+		// exclusive lock, and without an active busy_timeout a concurrent writer
+		// makes it fail immediately with SQLITE_BUSY (deterministic on Windows,
+		// where file locks are mandatory).
+		this.#db.run("PRAGMA busy_timeout=5000");
 		this.#db.run(`
 			PRAGMA journal_mode=WAL;
 			PRAGMA synchronous=NORMAL;
-			PRAGMA busy_timeout=5000;
 			CREATE TABLE IF NOT EXISTS auth_schema_version (
 				id INTEGER PRIMARY KEY CHECK (id = 1),
 				version INTEGER NOT NULL

--- a/packages/ai/test/issue-490-repro.test.ts
+++ b/packages/ai/test/issue-490-repro.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Repro for #490 — SQLiteError: database is locked on Windows startup.
+ *
+ * `PRAGMA journal_mode=WAL` needs a brief exclusive lock. On Windows file
+ * locks are mandatory, so if a concurrent process holds the database while
+ * the WAL switch runs and no `busy_timeout` is active yet, SQLite fails
+ * immediately with SQLITE_BUSY ("database is locked").
+ *
+ * SqliteAuthCredentialStore#initializeSchema must therefore set
+ * `PRAGMA busy_timeout` BEFORE switching journal_mode (or running any other
+ * lock-taking PRAGMA/operation). This test pins that ordering and confirms
+ * WAL + synchronous=NORMAL are still applied.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SqliteAuthCredentialStore } from "../src/auth-storage";
+
+describe("issue #490 - SqliteAuthCredentialStore startup lock ordering", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "issue-490-busy-timeout-"));
+	});
+
+	afterEach(async () => {
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("applies busy_timeout before journal_mode=WAL during initialization", () => {
+		const dbPath = path.join(tempDir, "agent.db");
+		const db = new Database(dbPath);
+		const ranSql: string[] = [];
+		const originalRun = db.run.bind(db);
+		db.run = ((sql: string, ...args: unknown[]) => {
+			ranSql.push(String(sql));
+			// biome-ignore lint/suspicious/noExplicitAny: passthrough spy
+			return (originalRun as any)(sql, ...args);
+		}) as typeof db.run;
+
+		const store = new SqliteAuthCredentialStore(db);
+		try {
+			const busyIdx = ranSql.findIndex(sql => /busy_timeout/i.test(sql));
+			const walIdx = ranSql.findIndex(sql => /journal_mode\s*=\s*WAL/i.test(sql));
+
+			expect(busyIdx).toBeGreaterThanOrEqual(0);
+			expect(walIdx).toBeGreaterThanOrEqual(0);
+			expect(busyIdx).toBeLessThan(walIdx);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("still enables WAL after initialization (behavior preserved)", async () => {
+		const dbPath = path.join(tempDir, "agent2.db");
+		const store = await SqliteAuthCredentialStore.open(dbPath);
+		try {
+			const probe = new Database(dbPath, { readonly: true });
+			try {
+				const journalMode = probe.query("PRAGMA journal_mode").get() as { journal_mode?: string };
+				expect(journalMode.journal_mode?.toLowerCase()).toBe("wal");
+			} finally {
+				probe.close();
+			}
+		} finally {
+			store.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
`SqliteAuthCredentialStore#initializeSchema` ran `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`. The WAL switch needs a brief exclusive lock; without an active `busy_timeout`, a concurrent database holder makes it fail immediately with `SQLITE_BUSY` ("database is locked"). This is deterministic on Windows, where file locks are mandatory — the reported startup crash in #490.

## Fix
Apply `PRAGMA busy_timeout=5000` first, before the `journal_mode=WAL` / `synchronous=NORMAL` block and any other lock-taking operation.

## Tests
- Added `packages/ai/test/issue-490-repro.test.ts`:
  - pins ordering (busy_timeout before journal_mode=WAL during init)
  - confirms WAL is still enabled after initialization
- `bun test test/` in `packages/ai`: 1258 pass, 0 fail.

Closes #490