### PR TITLE
feat(subagent): ctrl+s observe-sessions hint in await panel + ctrl+o expand contract tests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a dim `(ctrl+s to observe sessions)` discoverability hint under the `subagent` await panel header while any awaited subagent is still running, pointing to the full session observer overlay; the hint shows in both collapsed and expanded states and disappears once no subagent is running.
+
 ### Fixed
 
 - Preserved provider abort root causes in the final TUI abort label, kept replay rendering idempotent, and added a `PI_STREAM_IDLE_TIMEOUT_MS` remediation hint when stream idle watchdogs fire.

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -73,7 +73,11 @@ function renderSubagentSnapshot(
 		for (const al of snapshot.assignment.split("\n")) lines.push(`    ${theme.fg("toolOutput", replaceTabs(al))}`);
 	}
 
-	if (snapshot.progress) {
+	// Defense in depth: the producer only attaches `progress` when a live
+	// producer exists (subagent.ts #liveProgressFields), but the renderer
+	// also honors an explicit `liveProgressAvailable: false` so stale retained
+	// progress can never resurrect a live panel (AC5).
+	if (snapshot.progress && snapshot.liveProgressAvailable !== false) {
 		// Live streaming panel (full task-panel parity), indented under the header.
 		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, spinnerFrame)) {
 			lines.push(`  ${pl}`);
@@ -142,6 +146,11 @@ export const subagentToolRenderer = {
 				);
 
 				const lines: string[] = [header];
+				// Discoverability: the inline panel is a bounded preview; the session
+				// observer (ctrl+s) streams the full per-subagent message history.
+				if (runningCount > 0) {
+					lines.push(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`);
+				}
 				for (const snapshot of subagents) {
 					lines.push(...renderSubagentSnapshot(snapshot, expanded, theme, options.spinnerFrame));
 				}

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -42,10 +42,10 @@ function snapshot(overrides: Partial<SubagentSnapshot> & Pick<SubagentSnapshot, 
 	};
 }
 
-function render(details: SubagentToolDetails): string {
+function render(details: SubagentToolDetails, expanded = true): string {
 	const component = subagentToolRenderer.renderResult(
 		{ content: [{ type: "text", text: "" }], details },
-		{ expanded: true, isPartial: true, spinnerFrame: 0 },
+		{ expanded, isPartial: true, spinnerFrame: 0 },
 		theme,
 	);
 	return Bun.stripANSI(component.render(160).join("\n"));
@@ -64,6 +64,106 @@ describe("subagentToolRenderer", () => {
 		});
 		expect(out).toContain("read");
 		expect(out).toContain("scanning the repo");
+	});
+
+	it("expands live recent output, tool args, and the full task section when expanded=true and collapses them back (AC1/AC2)", () => {
+		const details: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-Toggle",
+					liveProgressAvailable: true,
+					progress: progress({
+						id: "0-Toggle",
+						currentTool: "bash",
+						currentToolArgs: "bun test --watch",
+						// First line is wider than the 40-col collapsed header preview,
+						// so the second line can only surface via the expand-gated
+						// Task section (renderTaskSection).
+						task: "Refactor the authentication module across services\nMigrate sessions to JWT with rotating refresh tokens",
+						recentOutput: ["compiling workspace", "running unit tests"],
+					}),
+				}),
+			],
+		};
+
+		const expanded = render(details, true);
+		expect(expanded).toContain("bash");
+		expect(expanded).toContain("bun test --watch");
+		expect(expanded).toContain("compiling workspace");
+		expect(expanded).toContain("running unit tests");
+		expect(expanded).toContain("Migrate sessions to JWT with rotating refresh tokens");
+
+		const collapsed = render(details, false);
+		expect(collapsed).toContain("bash");
+		// Truncated task title stays visible in the collapsed header line.
+		expect(collapsed).toContain("Refactor the authentication");
+		// The expand-gated Task section and recent output must not leak.
+		expect(collapsed).not.toContain("Migrate sessions to JWT");
+		expect(collapsed).not.toContain("compiling workspace");
+		expect(collapsed).not.toContain("running unit tests");
+	});
+
+	it("degrades to a static snapshot when liveProgressAvailable=false despite retained progress (AC5 defense in depth)", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Stale",
+					status: "running",
+					liveProgressAvailable: false,
+					progress: progress({ id: "0-Stale", currentTool: "edit", recentOutput: ["stale output line"] }),
+				}),
+			],
+		});
+		expect(out).toContain("0-Stale");
+		expect(out).not.toContain("edit");
+		expect(out).not.toContain("stale output line");
+		expect(out).not.toContain("running, no activity yet");
+	});
+
+	it("shows the ctrl+s observe hint under the header while any subagent is running, in both expand states (AC3)", () => {
+		const details: SubagentToolDetails = {
+			subagents: [
+				snapshot({ id: "0-Run", status: "running", liveProgressAvailable: true }),
+				snapshot({ id: "0-Done", status: "completed", resultText: "done" }),
+			],
+		};
+		for (const expanded of [true, false]) {
+			const out = render(details, expanded);
+			const lines = out.split("\n");
+			expect(lines[1]).toContain("(ctrl+s to observe sessions)");
+		}
+	});
+
+	it("omits the ctrl+s observe hint when no subagent is running (AC4)", () => {
+		const out = render({
+			subagents: [
+				snapshot({ id: "0-Done", status: "completed", resultText: "done" }),
+				snapshot({ id: "0-Fail", status: "failed", errorText: "boom" }),
+			],
+		});
+		expect(out).not.toContain("ctrl+s");
+	});
+
+	it("caps the result preview at one line collapsed and at four lines expanded (AC2)", () => {
+		const details: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-Preview",
+					status: "completed",
+					resultText: "line one\nline two\nline three\nline four\nline five",
+				}),
+			],
+		};
+
+		const collapsed = render(details, false);
+		expect(collapsed).toContain("line one");
+		expect(collapsed).not.toContain("line two");
+
+		const expanded = render(details, true);
+		expect(expanded).toContain("line one");
+		expect(expanded).toContain("line four");
+		// PREVIEW_LINES_EXPANDED=4 is an upper bound, not a minimum.
+		expect(expanded).not.toContain("line five");
 	});
 
 	it("renders the placeholder when a live producer exists but no progress yet", () => {


### PR DESCRIPTION
## Summary

While awaiting subagents, the inline await panel is a bounded preview (8-line `recentOutput` tail, 6 rendered) — the full per-subagent stream lives in the session observer overlay (`ctrl+s`, `app.session.observe`), but nothing in the await panel points there. This PR adds the discoverability hint and locks the `ctrl+o` expand contract that #475 introduced but never asserted.

Spec: distilled from a deep-interview session (`deep-interview-subagent-await-ctrlo-live-view`).

## Changes

- **`(ctrl+s to observe sessions)` hint** — rendered dim, directly under the `Subagent` await panel header whenever `runningCount > 0`, in both collapsed and expanded states; absent once all subagents are terminal. Follows the existing `(ctrl+o to expand)` hint convention from `execution-shared.ts`.
- **AC5 defense-in-depth** — the live panel previously keyed off `snapshot.progress` presence alone; a snapshot carrying stale retained progress with `liveProgressAvailable: false` would resurrect a live panel. The renderer now honors the explicit `false` (the producer `subagent.ts` already enforces this; undefined keeps backward compat for legacy records).
- **ctrl+o expand contract tests** — the existing suite only rendered `expanded: true`. Added discriminating coverage: expand-gated `Task` section (multiline task wider than the 40-col collapsed header preview), `currentToolArgs`, recent-output gating, and the 1/4-line result preview caps asserted as upper bounds.

## Verification

- `bun test packages/coding-agent/test/tools/subagent-render.test.ts packages/coding-agent/test/tools/subagent-live-progress.test.ts` — 21/21 on this branch (dev base)
- `biome check` clean on changed files (`finalize.test.ts` import-sort failure on dev is pre-existing and untouched)
- Black-box red-team suite over the exported renderer: 12/12 (hint placement/absence/truncation at widths 0/1/10/20, 4500-char lines, embedded ANSI, stale-progress resurrection, cache-key toggle round-trip)
- Architect review lanes: architecture/product/code all CLEAR, APPROVE

## Notes

- Queued-only panels show no hint (`runningCount` counts `status === "running"` only). Queued sessions are still observable via ctrl+s — flag if you want `queued` included; it is a one-line change.
- No keybinding changes; no buffer/cap changes; hint text goes through the same `truncateToWidth` pass as every other panel line.
