### PR TITLE
fix(cursor): guard composer empty grep pattern

### DIFF
--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -198,6 +198,12 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 
 	async grep(args: Parameters<NonNullable<ICursorExecHandlers["grep"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
+		if (args.pattern.trim() === "") {
+			const result = buildToolErrorResult(
+				"Cursor grep request rejected: pattern must not be empty. Provide a non-empty search pattern.",
+			);
+			return createToolResultMessage(toolCallId, "search", result, true);
+		}
 		const searchPath = args.glob ? `${args.path || "."}/${args.glob}` : args.path || ".";
 		const toolResultMessage = await executeTool(this.#optionsForCall(), "search", toolCallId, {
 			pattern: args.pattern,

--- a/packages/coding-agent/test/cursor-exec-handlers.test.ts
+++ b/packages/coding-agent/test/cursor-exec-handlers.test.ts
@@ -71,3 +71,54 @@ describe("CursorExecHandlers detached invocation (#484)", () => {
 		}
 	});
 });
+
+describe("CursorExecHandlers grep empty pattern guard (#501)", () => {
+	function makeRecordingHandlers(searchCalls: Array<Record<string, unknown>>): CursorExecHandlers {
+		const searchTool = {
+			name: "search",
+			label: "search",
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				searchCalls.push(args);
+				return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+			},
+		} as unknown as AgentTool;
+		const tools = new Map<string, AgentTool>([["search", searchTool]]);
+		return new CursorExecHandlers({ cwd: process.cwd(), tools } as never);
+	}
+
+	it("empty pattern does not call search and returns an actionable error", async () => {
+		const searchCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeRecordingHandlers(searchCalls);
+		const result = await handlers.grep(create(GrepArgsSchema, { pattern: "", path: "/tmp", toolCallId: "g" }));
+		expect(searchCalls.length).toBe(0);
+		expect(result.role).toBe("toolResult");
+		expect(result.isError).toBe(true);
+		expect(result.toolName).toBe("search");
+		const text = result.content.map(c => (c.type === "text" ? c.text : "")).join("");
+		expect(text).toContain("must not be empty");
+	});
+
+	it("whitespace-only pattern does not call search and returns an actionable error", async () => {
+		const searchCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeRecordingHandlers(searchCalls);
+		const result = await handlers.grep(create(GrepArgsSchema, { pattern: "   ", path: "/tmp", toolCallId: "g" }));
+		expect(searchCalls.length).toBe(0);
+		expect(result.isError).toBe(true);
+	});
+
+	it("non-empty pattern calls search with the same searchPath behavior", async () => {
+		const searchCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeRecordingHandlers(searchCalls);
+		const result = await handlers.grep(create(GrepArgsSchema, { pattern: "foo", path: "/tmp", toolCallId: "g" }));
+		expect(searchCalls.length).toBe(1);
+		expect(searchCalls[0]).toMatchObject({ pattern: "foo", paths: ["/tmp"] });
+		expect(result.isError).toBeFalsy();
+	});
+
+	it("preserves glob/path behavior for non-empty patterns", async () => {
+		const searchCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeRecordingHandlers(searchCalls);
+		await handlers.grep(create(GrepArgsSchema, { pattern: "foo", path: "/tmp", glob: "*.ts", toolCallId: "g" }));
+		expect(searchCalls[0]).toMatchObject({ paths: ["/tmp/*.ts"] });
+	});
+});


### PR DESCRIPTION
## Summary
Cursor/composer-2.5 can emit a Cursor native grep/search request with an empty `pattern`. The Cursor bridge in `packages/coding-agent/src/cursor.ts` forwarded `args.pattern` directly into the local `search` tool, which correctly rejects `pattern.trim() === ""` with `Pattern must not be empty`. This produced a noisy/less-actionable tool failure during normal Cursor-agent work.

## Change
- Guard `grepArgs.pattern.trim() === ""` in the Cursor bridge `grep` handler before calling `executeTool(..., "search", ...)`.
- Return a structured, actionable rejected tool result built with the existing bridge helpers (`buildToolErrorResult` + `createToolResultMessage`, `isError: true`). No new protocol shapes invented.
- Non-empty patterns preserve existing `search`/glob/path behavior.

## Tests
Added focused tests in `packages/coding-agent/test/cursor-exec-handlers.test.ts`:
- empty pattern → does not call `search`, returns actionable error
- whitespace-only pattern → does not call `search`, returns error
- non-empty pattern → calls `search` with same `searchPath` behavior
- glob/path behavior preserved for non-empty patterns

## Verification
- `bun test packages/coding-agent/test/cursor-exec-handlers.test.ts` → 6 pass / 0 fail
- `bun --cwd=packages/coding-agent run check:types` → clean
- `bunx biome check` on changed files → OK

Closes #501