### PR TITLE
fix(auth): ignore project dotenv for provider credentials

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $env, $inheritedEnv, $pickenv, extractHttpStatusFromError } from "@gajae-code/utils";
+import { $credentialEnv, $pickCredentialEnv, extractHttpStatusFromError } from "@gajae-code/utils";
 import { getCustomApi } from "./api-registry";
 import type { Effort } from "./model-thinking";
 import {
@@ -61,7 +61,7 @@ let cachedVertexAdcCredentialsExists: boolean | null = null;
 
 function hasVertexAdcCredentials(): boolean {
 	if (cachedVertexAdcCredentialsExists === null) {
-		const gacPath = $env.GOOGLE_APPLICATION_CREDENTIALS;
+		const gacPath = $credentialEnv("GOOGLE_APPLICATION_CREDENTIALS");
 		if (gacPath) {
 			cachedVertexAdcCredentialsExists = fs.existsSync(gacPath);
 		} else {
@@ -77,7 +77,7 @@ type KeyResolver = string | (() => string | undefined);
 
 const serviceProviderMap: Record<string, KeyResolver> = {
 	"alibaba-coding-plan": "ALIBABA_CODING_PLAN_API_KEY",
-	openai: () => $inheritedEnv("OPENAI_API_KEY") ?? $env.OPENAI_API_KEY,
+	openai: () => $credentialEnv("OPENAI_API_KEY"),
 	google: "GEMINI_API_KEY",
 	groq: "GROQ_API_KEY",
 	cerebras: "CEREBRAS_API_KEY",
@@ -107,21 +107,21 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	parallel: "PARALLEL_API_KEY",
 	kagi: "KAGI_API_KEY",
 	// GitHub Copilot uses GitHub personal access token
-	"github-copilot": () => $pickenv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+	"github-copilot": () => $pickCredentialEnv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
 	// Foundry mode optionally switches Anthropic auth to enterprise gateway credentials.
 	anthropic: () =>
 		isFoundryEnabled()
-			? $pickenv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
-			: $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
+			? $pickCredentialEnv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+			: $pickCredentialEnv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
 	"gitlab-duo": "GITLAB_TOKEN",
 	// Vertex AI supports either GOOGLE_CLOUD_API_KEY or Application Default Credentials.
 	"google-vertex": () => {
-		if ($env.GOOGLE_CLOUD_API_KEY) {
-			return $env.GOOGLE_CLOUD_API_KEY;
+		if ($credentialEnv("GOOGLE_CLOUD_API_KEY")) {
+			return $credentialEnv("GOOGLE_CLOUD_API_KEY");
 		}
 		const hasCredentials = hasVertexAdcCredentials();
-		const hasProject = !!($env.GOOGLE_CLOUD_PROJECT || $env.GCLOUD_PROJECT);
-		const hasLocation = !!$env.GOOGLE_CLOUD_LOCATION;
+		const hasProject = !!($credentialEnv("GOOGLE_CLOUD_PROJECT") || $credentialEnv("GCLOUD_PROJECT"));
+		const hasLocation = !!$credentialEnv("GOOGLE_CLOUD_LOCATION");
 		if (hasCredentials && hasProject && hasLocation) {
 			return "<authenticated>";
 		}
@@ -134,12 +134,13 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	// 5. AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN - IRSA (EKS) web identity
 	"amazon-bedrock": () => {
 		const hasEcsCredentials =
-			!!$env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || !!$env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
-		const hasWebIdentity = !!$env.AWS_WEB_IDENTITY_TOKEN_FILE && !!$env.AWS_ROLE_ARN;
+			!!$credentialEnv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
+			!!$credentialEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI");
+		const hasWebIdentity = !!$credentialEnv("AWS_WEB_IDENTITY_TOKEN_FILE") && !!$credentialEnv("AWS_ROLE_ARN");
 		if (
-			$env.AWS_PROFILE ||
-			($env.AWS_ACCESS_KEY_ID && $env.AWS_SECRET_ACCESS_KEY) ||
-			$env.AWS_BEARER_TOKEN_BEDROCK ||
+			$credentialEnv("AWS_PROFILE") ||
+			($credentialEnv("AWS_ACCESS_KEY_ID") && $credentialEnv("AWS_SECRET_ACCESS_KEY")) ||
+			$credentialEnv("AWS_BEARER_TOKEN_BEDROCK") ||
 			hasEcsCredentials ||
 			hasWebIdentity
 		) {
@@ -148,7 +149,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	},
 	synthetic: "SYNTHETIC_API_KEY",
 	"cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-	huggingface: () => $pickenv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
+	huggingface: () => $pickCredentialEnv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
 	litellm: "LITELLM_API_KEY",
 	moonshot: "MOONSHOT_API_KEY",
 	nvidia: "NVIDIA_API_KEY",
@@ -158,7 +159,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"ollama-cloud": "OLLAMA_CLOUD_API_KEY",
 	"llama.cpp": "LLAMA_CPP_API_KEY",
 	qianfan: "QIANFAN_API_KEY",
-	"qwen-portal": () => $pickenv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),
+	"qwen-portal": () => $pickCredentialEnv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),
 	together: "TOGETHER_API_KEY",
 	zenmux: "ZENMUX_API_KEY",
 	venice: "VENICE_API_KEY",
@@ -169,13 +170,13 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 /**
  * Get API key for provider from known environment variables, e.g. OPENAI_API_KEY.
  *
- * Will not return API keys for providers that require OAuth tokens.
- * Checks Bun.env, then cwd/.env, then ~/.env.
+ * Provider authentication intentionally excludes cwd/.env values. Project dotenv files are
+ * loaded into $env for app/tool execution, but must not silently fund GJC model requests.
  */
 export function getEnvApiKey(provider: string): string | undefined {
 	const resolver = serviceProviderMap[provider];
 	if (typeof resolver === "string") {
-		return $env[resolver];
+		return $credentialEnv(resolver);
 	}
 	return resolver?.();
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -145,6 +145,19 @@ export function $inheritedEnv(name: string): string | undefined {
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function resolveFileEnvValue(file: Record<string, string>, name: string): string | undefined {
+	if (!isSafeEnvName(name)) return undefined;
+	const value = file[name];
+	if (value === undefined || !isSafeEnvValue(value)) return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isProjectEnvValue(name: string, value: string): boolean {
+	const projectValue = resolveFileEnvValue(projectEnv, name);
+	return projectValue !== undefined && projectValue === value;
+}
+
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
 const homeShellEnv = {
 	...parseShellEnvFile(path.join(os.homedir(), ".zshenv")),
@@ -179,6 +192,9 @@ for (const file of [projectEnv, agentEnv, piEnv, homeEnv, homeShellEnv]) {
  * All users should import this env module (import { $env } from "@gajae-code/utils")
  * before using environment variables. This ensures that .env files have been loaded and
  * overrides (project, home) have been applied, so $env always reflects the correct values.
+ *
+ * Provider credential resolution must not use this merged view because it includes the
+ * caller's cwd/.env. Use $credentialEnv/$pickCredentialEnv for model authentication.
  */
 export const $env: Record<string, string> = Bun.env as Record<string, string>;
 
@@ -193,6 +209,34 @@ export function $pickenv(...keys: string[]): string | undefined {
 		if (value) {
 			return value;
 		}
+	}
+	return undefined;
+}
+
+/**
+ * Resolve credential-bearing environment variables without consulting the caller's project .env.
+ *
+ * GJC loads cwd/.env into $env for project-aware tools, but model-provider authentication should
+ * only use values explicitly inherited from the launching shell or GJC/user-owned config files.
+ */
+export function $credentialEnv(name: string): string | undefined {
+	const inherited = $inheritedEnv(name);
+	if (inherited !== undefined && !isProjectEnvValue(name, inherited)) return inherited;
+	return (
+		resolveFileEnvValue(agentEnv, name) ??
+		resolveFileEnvValue(piEnv, name) ??
+		resolveFileEnvValue(homeEnv, name) ??
+		resolveFileEnvValue(homeShellEnv, name)
+	);
+}
+
+/**
+ * Resolve the first credential env value from the given keys, excluding cwd/.env overlays.
+ */
+export function $pickCredentialEnv(...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = $credentialEnv(key);
+		if (value) return value;
 	}
 	return undefined;
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -127,6 +127,62 @@ assertEqual($env.GJC_ENV_TEST_FALLBACK_ONLY, "fallback-after-import", "fallback 
 	});
 });
 
+describe("$credentialEnv", () => {
+	it("does not read provider credentials from the current project's .env overlay", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-credential-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(path.join(dir, ".env"), "ANTHROPIC_API_KEY=project-key\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $credentialEnv, $env } from ${JSON.stringify(envSourceUrl)};
+
+function assertEqual(actual: string | undefined, expected: string | undefined, label: string): void {
+	if (actual !== expected) {
+		throw new Error(\`\${label}: expected \${expected}, got \${actual}\`);
+	}
+}
+
+assertEqual($env.ANTHROPIC_API_KEY, "project-key", "project dotenv remains available through $env");
+assertEqual($credentialEnv("ANTHROPIC_API_KEY"), undefined, "provider credential excludes project dotenv");
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+			},
+			dir,
+		);
+	});
+
+	it("still resolves explicitly inherited provider credentials", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-credential-inherited-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(path.join(dir, ".env"), "ANTHROPIC_API_KEY=project-key\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $credentialEnv } from ${JSON.stringify(envSourceUrl)};
+
+if ($credentialEnv("ANTHROPIC_API_KEY") !== "inherited-key") {
+	throw new Error("inherited provider credential was not resolved");
+}
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+				ANTHROPIC_API_KEY: "inherited-key",
+			},
+			dir,
+		);
+	});
+});
+
 describe("filterProcessEnv", () => {
 	it("drops entries that cannot be passed to process spawn env", () => {
 		expect(


### PR DESCRIPTION
## Summary
- Add a credential-only env resolver that excludes the caller project `cwd/.env` overlay.
- Route model provider API-key fallback through that resolver so app `.env` secrets do not silently fund GJC model calls.
- Keep project `.env` available through `$env` for project-aware tools and add regression coverage for the credential resolver.

## Verification
- `bun test packages/utils/test/env.test.ts`
- `bunx biome check packages/utils/src/env.ts packages/utils/test/env.test.ts packages/ai/src/stream.ts`
- `bun run check:types` in `packages/utils`
- `bun run check:types` in `packages/ai`
