### PR TITLE
fix(auth): ignore project dotenv for provider credentials

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $env, $inheritedEnv, $pickenv, extractHttpStatusFromError } from "@gajae-code/utils";
+import { $credentialEnv, $env, $pickCredentialEnv, extractHttpStatusFromError } from "@gajae-code/utils";
 import { getCustomApi } from "./api-registry";
 import type { Effort } from "./model-thinking";
 import {
@@ -61,7 +61,7 @@ let cachedVertexAdcCredentialsExists: boolean | null = null;
 
 function hasVertexAdcCredentials(): boolean {
 	if (cachedVertexAdcCredentialsExists === null) {
-		const gacPath = $env.GOOGLE_APPLICATION_CREDENTIALS;
+		const gacPath = $credentialEnv("GOOGLE_APPLICATION_CREDENTIALS");
 		if (gacPath) {
 			cachedVertexAdcCredentialsExists = fs.existsSync(gacPath);
 		} else {
@@ -77,7 +77,7 @@ type KeyResolver = string | (() => string | undefined);
 
 const serviceProviderMap: Record<string, KeyResolver> = {
 	"alibaba-coding-plan": "ALIBABA_CODING_PLAN_API_KEY",
-	openai: () => $inheritedEnv("OPENAI_API_KEY") ?? $env.OPENAI_API_KEY,
+	openai: () => $credentialEnv("OPENAI_API_KEY"),
 	google: "GEMINI_API_KEY",
 	groq: "GROQ_API_KEY",
 	cerebras: "CEREBRAS_API_KEY",
@@ -107,18 +107,18 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	parallel: "PARALLEL_API_KEY",
 	kagi: "KAGI_API_KEY",
 	// GitHub Copilot uses GitHub personal access token
-	"github-copilot": () => $pickenv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+	"github-copilot": () => $pickCredentialEnv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
 	// Foundry mode optionally switches Anthropic auth to enterprise gateway credentials.
 	anthropic: () =>
 		isFoundryEnabled()
-			? $pickenv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
-			: $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
+			? $pickCredentialEnv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+			: $pickCredentialEnv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
 	"gitlab-duo": "GITLAB_TOKEN",
 	// Vertex AI supports either GOOGLE_CLOUD_API_KEY or Application Default Credentials.
 	"google-vertex": () => {
-		if ($env.GOOGLE_CLOUD_API_KEY) {
-			return $env.GOOGLE_CLOUD_API_KEY;
-		}
+		const googleCloudApiKey = $credentialEnv("GOOGLE_CLOUD_API_KEY");
+		if (googleCloudApiKey) return googleCloudApiKey;
+
 		const hasCredentials = hasVertexAdcCredentials();
 		const hasProject = !!($env.GOOGLE_CLOUD_PROJECT || $env.GCLOUD_PROJECT);
 		const hasLocation = !!$env.GOOGLE_CLOUD_LOCATION;
@@ -133,13 +133,18 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	// 4. AWS_CONTAINER_CREDENTIALS_* - ECS/Task IAM role credentials
 	// 5. AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN - IRSA (EKS) web identity
 	"amazon-bedrock": () => {
+		const awsProfile = $credentialEnv("AWS_PROFILE");
+		const awsAccessKeyId = $credentialEnv("AWS_ACCESS_KEY_ID");
+		const awsSecretAccessKey = $credentialEnv("AWS_SECRET_ACCESS_KEY");
+		const awsBearerToken = $credentialEnv("AWS_BEARER_TOKEN_BEDROCK");
 		const hasEcsCredentials =
-			!!$env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || !!$env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
-		const hasWebIdentity = !!$env.AWS_WEB_IDENTITY_TOKEN_FILE && !!$env.AWS_ROLE_ARN;
+			!!$credentialEnv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
+			!!$credentialEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI");
+		const hasWebIdentity = !!$credentialEnv("AWS_WEB_IDENTITY_TOKEN_FILE") && !!$credentialEnv("AWS_ROLE_ARN");
 		if (
-			$env.AWS_PROFILE ||
-			($env.AWS_ACCESS_KEY_ID && $env.AWS_SECRET_ACCESS_KEY) ||
-			$env.AWS_BEARER_TOKEN_BEDROCK ||
+			awsProfile ||
+			(awsAccessKeyId && awsSecretAccessKey) ||
+			awsBearerToken ||
 			hasEcsCredentials ||
 			hasWebIdentity
 		) {
@@ -148,7 +153,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	},
 	synthetic: "SYNTHETIC_API_KEY",
 	"cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
-	huggingface: () => $pickenv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
+	huggingface: () => $pickCredentialEnv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
 	litellm: "LITELLM_API_KEY",
 	moonshot: "MOONSHOT_API_KEY",
 	nvidia: "NVIDIA_API_KEY",
@@ -158,7 +163,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"ollama-cloud": "OLLAMA_CLOUD_API_KEY",
 	"llama.cpp": "LLAMA_CPP_API_KEY",
 	qianfan: "QIANFAN_API_KEY",
-	"qwen-portal": () => $pickenv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),
+	"qwen-portal": () => $pickCredentialEnv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),
 	together: "TOGETHER_API_KEY",
 	zenmux: "ZENMUX_API_KEY",
 	venice: "VENICE_API_KEY",
@@ -169,13 +174,13 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 /**
  * Get API key for provider from known environment variables, e.g. OPENAI_API_KEY.
  *
- * Will not return API keys for providers that require OAuth tokens.
- * Checks Bun.env, then cwd/.env, then ~/.env.
+ * Provider authentication intentionally excludes cwd/.env values. Project dotenv files are
+ * loaded into $env for app/tool execution, but must not silently fund GJC model requests.
  */
 export function getEnvApiKey(provider: string): string | undefined {
 	const resolver = serviceProviderMap[provider];
 	if (typeof resolver === "string") {
-		return $env[resolver];
+		return $credentialEnv(resolver);
 	}
 	return resolver?.();
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -135,14 +135,30 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 	return result;
 }
 
-const inheritedEnv = filterProcessEnv(Bun.env);
-
-export function $inheritedEnv(name: string): string | undefined {
+function resolveFileEnvValue(file: Record<string, string>, name: string): string | undefined {
 	if (!isSafeEnvName(name)) return undefined;
-	const value = inheritedEnv[name];
+	const value = file[name];
 	if (value === undefined || !isSafeEnvValue(value)) return undefined;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function filterCredentialInheritedEnv(env: Record<string, string | undefined>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const key in env) {
+		const value = env[key];
+		if (!isSafeEnvName(key) || value === undefined || !isSafeEnvValue(value)) continue;
+
+		// Bun may have already loaded cwd/.env before JS runs. It does not expose the
+		// source of each entry, so an exact match with projectEnv is ambiguous. Use
+		// the safer credential rule: ambiguous project matches are excluded from the
+		// credential-only inherited snapshot, while remaining available through $env.
+		const projectValue = resolveFileEnvValue(projectEnv, key);
+		if (projectValue !== undefined && projectValue === value) continue;
+
+		result[key] = value;
+	}
+	return result;
 }
 
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
@@ -158,11 +174,10 @@ const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
 const projectEnv = parseEnvFile(path.join(process.cwd(), ".env"));
 
-for (const key of Object.keys(Bun.env)) {
-	const value = Bun.env[key];
-	if (!isSafeEnvName(key) || value === undefined || !isSafeEnvValue(value)) {
-		delete Bun.env[key];
-	}
+const inheritedEnv = filterCredentialInheritedEnv(Bun.env);
+
+export function $inheritedEnv(name: string): string | undefined {
+	return resolveFileEnvValue(inheritedEnv, name);
 }
 
 for (const file of [projectEnv, agentEnv, piEnv, homeEnv, homeShellEnv]) {
@@ -179,6 +194,9 @@ for (const file of [projectEnv, agentEnv, piEnv, homeEnv, homeShellEnv]) {
  * All users should import this env module (import { $env } from "@gajae-code/utils")
  * before using environment variables. This ensures that .env files have been loaded and
  * overrides (project, home) have been applied, so $env always reflects the correct values.
+ *
+ * Provider credential resolution must not use this merged view because it includes the
+ * caller's cwd/.env. Use $credentialEnv/$pickCredentialEnv for model authentication.
  */
 export const $env: Record<string, string> = Bun.env as Record<string, string>;
 
@@ -193,6 +211,33 @@ export function $pickenv(...keys: string[]): string | undefined {
 		if (value) {
 			return value;
 		}
+	}
+	return undefined;
+}
+
+/**
+ * Resolve credential-bearing environment variables without consulting the caller's project .env.
+ *
+ * GJC loads cwd/.env into $env for project-aware tools, but model-provider authentication should
+ * only use values explicitly inherited from the launching shell or GJC/user-owned config files.
+ */
+export function $credentialEnv(name: string): string | undefined {
+	return (
+		$inheritedEnv(name) ??
+		resolveFileEnvValue(agentEnv, name) ??
+		resolveFileEnvValue(piEnv, name) ??
+		resolveFileEnvValue(homeEnv, name) ??
+		resolveFileEnvValue(homeShellEnv, name)
+	);
+}
+
+/**
+ * Resolve the first credential env value from the given keys, excluding cwd/.env overlays.
+ */
+export function $pickCredentialEnv(...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = $credentialEnv(key);
+		if (value) return value;
 	}
 	return undefined;
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -127,6 +127,131 @@ assertEqual($env.GJC_ENV_TEST_FALLBACK_ONLY, "fallback-after-import", "fallback 
 	});
 });
 
+describe("$credentialEnv", () => {
+	it("does not read provider credentials from the current project's .env overlay", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-credential-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(path.join(dir, ".env"), "ANTHROPIC_API_KEY=project-key\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $credentialEnv, $env } from ${JSON.stringify(envSourceUrl)};
+
+function assertEqual(actual: string | undefined, expected: string | undefined, label: string): void {
+	if (actual !== expected) {
+		throw new Error(\`\${label}: expected \${expected}, got \${actual}\`);
+	}
+}
+
+assertEqual($env.ANTHROPIC_API_KEY, "project-key", "project dotenv remains available through $env");
+assertEqual($credentialEnv("ANTHROPIC_API_KEY"), undefined, "provider credential excludes project dotenv");
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+			},
+			dir,
+		);
+	});
+
+	it("still resolves explicitly inherited provider credentials", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-credential-inherited-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(path.join(dir, ".env"), "ANTHROPIC_API_KEY=project-key\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $credentialEnv } from ${JSON.stringify(envSourceUrl)};
+
+if ($credentialEnv("ANTHROPIC_API_KEY") !== "inherited-key") {
+	throw new Error("inherited provider credential was not resolved");
+}
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+				ANTHROPIC_API_KEY: "inherited-key",
+			},
+			dir,
+		);
+	});
+
+	it("uses the secure project-dotenv rule when inherited and project values are indistinguishable", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-credential-ambiguous-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(path.join(dir, ".env"), "ANTHROPIC_API_KEY=same-key\n");
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $credentialEnv, $env } from ${JSON.stringify(envSourceUrl)};
+
+if ($env.ANTHROPIC_API_KEY !== "same-key") {
+	throw new Error("project dotenv should remain available through $env");
+}
+if ($credentialEnv("ANTHROPIC_API_KEY") !== undefined) {
+	throw new Error("ambiguous inherited/project dotenv match should not be used as provider credential");
+}
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+				ANTHROPIC_API_KEY: "same-key",
+			},
+			dir,
+		);
+	});
+});
+
+describe("$pickCredentialEnv", () => {
+	it("returns the first available credential key while excluding project dotenv", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-pick-credential-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-agent-"));
+		tempDirs.push(dir, home, agentDir);
+		fs.writeFileSync(
+			path.join(dir, ".env"),
+			[
+				"FIRST_PROVIDER_KEY=project-first",
+				"SECOND_PROVIDER_KEY=project-second",
+				"THIRD_PROVIDER_KEY=project-third",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(agentDir, ".env"),
+			"SECOND_PROVIDER_KEY=agent-second\nTHIRD_PROVIDER_KEY=agent-third\n",
+		);
+
+		const envSourceUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/env.ts")).href;
+		runEnvIsolationScript(
+			`
+import { $env, $pickCredentialEnv } from ${JSON.stringify(envSourceUrl)};
+
+if ($env.FIRST_PROVIDER_KEY !== "project-first") {
+	throw new Error("project dotenv should remain available through $env");
+}
+const value = $pickCredentialEnv("FIRST_PROVIDER_KEY", "SECOND_PROVIDER_KEY", "THIRD_PROVIDER_KEY");
+if (value !== "agent-second") {
+	throw new Error(\`expected first non-project credential env value, got \${value}\`);
+}
+`,
+			{
+				HOME: home,
+				GJC_CODING_AGENT_DIR: agentDir,
+			},
+			dir,
+		);
+	});
+});
+
 describe("filterProcessEnv", () => {
 	it("drops entries that cannot be passed to process spawn env", () => {
 		expect(


### PR DESCRIPTION
## Summary
- Add credential-only env lookup helpers that exclude the caller project `cwd/.env` overlay.
- Route model provider API-key fallback through those helpers so app `.env` secrets do not silently fund GJC model calls.
- Preserve project `.env` availability through `$env` for project-aware tools.
- Add isolation tests for `$credentialEnv` and `$pickCredentialEnv`.

## Repro
1. Put `ANTHROPIC_API_KEY=...` in an app repo `.env` for the app itself.
2. Launch GJC from that app repo while Anthropic OAuth is missing/expired.
3. Provider fallback can resolve the project `.env` key and authenticate model calls with the app secret.

## Verification
- `bun test packages/utils/test/env.test.ts`
- `bunx biome check packages/utils/src/env.ts packages/utils/test/env.test.ts packages/ai/src/stream.ts`
- `bun run check:types` in `packages/utils`
- `bun run check:types` in `packages/ai`

Supersedes closed PR #506, which targeted `main` by mistake.
