### PR TITLE
fix(compaction): gate pruning on the compaction threshold and make it staleness-aware

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Made tool-output pruning staleness-aware: results superseded by a later same-target result (re-read file, re-run search) or invalidated by a later successful edit/write are pruned before merely-old ones, including inside the recency protect window. New optional `PruneConfig.staleOverridableTools` (default `["read"]`) waives protected-tool immunity for superseded results while the most recent result per target stays protected. Target identity uses collision-proof canonical JSON tuple keys.
+- `PruneResult` now returns `prunedEntries` so callers whose entry source materializes copies (e.g. blob-externalized session entries) can write mutations back into their canonical store.
+
 ## [0.4.4] - 2026-06-10
 
 - Version aligned with the 0.4.4 monorepo release; no functional changes in this package.

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -72,6 +72,27 @@ function toolCallPath(call: ToolCall): string | undefined {
 	return typeof path === "string" && path.length > 0 ? path : undefined;
 }
 
+/** `*** Add|Update|Delete File: <path>` headers in an apply_patch envelope. */
+const APPLY_PATCH_FILE_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm;
+
+/**
+ * Paths touched by an edit-class tool call. Most edit tools carry a single
+ * path argument; the OpenAI custom `apply_patch` envelope carries an `input`
+ * string with one or more `*** <Op> File:` headers instead.
+ */
+function editToolPaths(call: ToolCall): string[] {
+	const path = toolCallPath(call);
+	if (path !== undefined) return [path];
+	const input = call.arguments.input;
+	if (call.name !== "apply_patch" || typeof input !== "string") return [];
+	const paths: string[] = [];
+	for (const match of input.matchAll(APPLY_PATCH_FILE_HEADER)) {
+		const headerPath = match[1]?.trim();
+		if (headerPath) paths.push(headerPath);
+	}
+	return paths;
+}
+
 /**
  * Stable identity for "the same logical lookup": same tool re-targeting the
  * same subject. A later result with the same key supersedes earlier ones.
@@ -125,8 +146,9 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 		resultMeta.set(i, { key, call });
 		if (key !== undefined) lastResultIndexByKey.set(key, i);
 		if (EDIT_TOOL_NAMES.has(call.name)) {
-			const path = toolCallPath(call);
-			if (path !== undefined) lastEditIndexByPath.set(path, i);
+			for (const editPath of editToolPaths(call)) {
+				lastEditIndexByPath.set(editPath, i);
+			}
 		}
 	}
 

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -73,31 +73,39 @@ function toolCallPath(call: ToolCall): string | undefined {
 }
 
 /**
- * `*** Add|Update|Delete File: <path>` and `*** Move to: <path>` headers in
- * an apply_patch envelope. Move destinations count as touched paths: a rename
- * onto a file invalidates earlier reads of that destination.
+ * `*** Add|Update|Delete File: <path>` headers open a hunk; `*** Move to:
+ * <path>` attaches a rename destination to the current hunk. Move
+ * destinations count as touched paths: a rename onto a file invalidates
+ * earlier reads of that destination.
  */
-const APPLY_PATCH_FILE_HEADER = /^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$/gm;
+const APPLY_PATCH_HEADER = /^\*\*\* (?:((?:Add|Update|Delete) File)|(Move to)): (.+)$/gm;
 
 /**
- * Paths touched by an edit-class tool call. Most edit tools carry a single
- * path argument; apply_patch envelopes carry an `input` string with
- * `*** <Op> File:` / `*** Move to:` headers instead. The envelope shape can
+ * Paths touched by an edit-class tool call, grouped per hunk so a failed
+ * hunk can be excluded wholesale (its rename destination included). Most
+ * edit tools carry a single path argument; apply_patch envelopes carry an
+ * `input` string with per-file headers instead. The envelope shape can
  * arrive under the custom `apply_patch` tool OR the regular `edit` tool
  * (providers without custom-tool support fall back to the JSON function), so
  * any edit-class call with a string `input` is parsed for headers.
  */
-function editToolPaths(call: ToolCall): string[] {
+function editToolPathGroups(call: ToolCall): string[][] {
 	const path = toolCallPath(call);
-	if (path !== undefined) return [path];
+	if (path !== undefined) return [[path]];
 	const input = call.arguments.input;
 	if (typeof input !== "string") return [];
-	const paths: string[] = [];
-	for (const match of input.matchAll(APPLY_PATCH_FILE_HEADER)) {
-		const headerPath = match[1]?.trim();
-		if (headerPath) paths.push(headerPath);
+	const groups: string[][] = [];
+	for (const match of input.matchAll(APPLY_PATCH_HEADER)) {
+		const headerPath = match[3]?.trim();
+		if (!headerPath) continue;
+		const isMoveTo = match[2] !== undefined;
+		if (isMoveTo && groups.length > 0) {
+			groups[groups.length - 1].push(headerPath);
+		} else {
+			groups.push([headerPath]);
+		}
 	}
-	return paths;
+	return groups;
 }
 
 /**
@@ -188,6 +196,17 @@ function failedEditPaths(message: ToolResultMessage): Set<string> {
 	return failed;
 }
 
+/**
+ * Concrete file path a `read` result actually came from, when the tool
+ * reported one (`details.resolvedPath`). Suffix resolution can map a bare
+ * filename argument onto a different concrete path.
+ */
+function readResolvedPath(message: ToolResultMessage): string | undefined {
+	const details = message.details as { resolvedPath?: unknown } | undefined;
+	const resolved = details?.resolvedPath;
+	return typeof resolved === "string" && resolved.length > 0 ? resolved : undefined;
+}
+
 interface StalenessIndex {
 	/** Entry indices of toolResults superseded by a later same-target result or a later edit. */
 	staleResultIndices: Set<number>;
@@ -211,7 +230,7 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 	}
 
 	const lastResultIndexByKey = new Map<string, number>();
-	const resultMeta = new Map<number, { key?: string; call: ToolCall }>();
+	const resultMeta = new Map<number, { key?: string; call: ToolCall; message: ToolResultMessage }>();
 	const lastEditIndexByPath = new Map<string, number>();
 
 	for (let i = 0; i < entries.length; i++) {
@@ -233,14 +252,18 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 		if (message.isError) continue;
 
 		const key = toolTargetKey(call);
-		resultMeta.set(i, { key, call });
+		resultMeta.set(i, { key, call, message });
 		if (key !== undefined) lastResultIndexByKey.set(key, i);
 		if (EDIT_TOOL_NAMES.has(call.name)) {
 			// Per-file edit results record failures in details.perFileResults;
-			// failed files were not mutated and must not stale reads.
+			// a failed hunk mutated nothing, so exclude its whole path group
+			// (rename destination included) from touched paths.
 			const failed = failedEditPaths(message);
-			for (const editPath of editToolPaths(call)) {
-				if (!failed.has(editPath)) lastEditIndexByPath.set(editPath, i);
+			for (const group of editToolPathGroups(call)) {
+				if (group.some(groupPath => failed.has(groupPath))) continue;
+				for (const editPath of group) {
+					lastEditIndexByPath.set(editPath, i);
+				}
 			}
 		}
 	}
@@ -255,11 +278,20 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 			}
 		}
 		if (meta.call.name === "read") {
-			const path = toolCallPath(meta.call);
-			if (path !== undefined) {
-				// Selector-qualified reads (src/foo.ts:50-100) still read the file.
-				const editIndex = lastEditIndexByPath.get(readBasePath(path));
-				if (editIndex !== undefined && editIndex > index) staleResultIndices.add(index);
+			// Check both the call argument (selectors stripped) and the resolved
+			// path from result details: suffix resolution can map a bare filename
+			// onto a different concrete path, and edits may use either form.
+			const lookupPaths = new Set<string>();
+			const argPath = toolCallPath(meta.call);
+			if (argPath !== undefined) lookupPaths.add(readBasePath(argPath));
+			const resolved = readResolvedPath(meta.message);
+			if (resolved !== undefined) lookupPaths.add(resolved);
+			for (const lookupPath of lookupPaths) {
+				const editIndex = lastEditIndexByPath.get(lookupPath);
+				if (editIndex !== undefined && editIndex > index) {
+					staleResultIndices.add(index);
+					break;
+				}
 			}
 		}
 	}

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -121,7 +121,8 @@ function readBasePath(path: string): string {
  * same subject. A later result with the same key supersedes earlier ones.
  * Keys are canonical JSON tuples so user-controlled text (patterns, paths)
  * can never collide via delimiter ambiguity. Search keys include pagination
- * (`skip`): later pages complement page 1, they do not replace it.
+ * (`skip`) and result-shaping flags (`i`, `gitignore`): a later page or a
+ * differently-shaped search complements earlier output, it does not replace it.
  */
 function toolTargetKey(call: ToolCall): string | undefined {
 	const path = toolCallPath(call);
@@ -131,7 +132,9 @@ function toolTargetKey(call: ToolCall): string | undefined {
 		const paths = call.arguments.paths;
 		const pathList = Array.isArray(paths) ? paths.filter((p): p is string => typeof p === "string") : [];
 		const skip = typeof call.arguments.skip === "number" ? call.arguments.skip : 0;
-		return JSON.stringify([call.name, "pattern", pattern, pathList, skip]);
+		const caseInsensitive = call.arguments.i === true;
+		const gitignore = call.arguments.gitignore !== false;
+		return JSON.stringify([call.name, "pattern", pattern, pathList, skip, caseInsensitive, gitignore]);
 	}
 	return undefined;
 }

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -160,19 +160,31 @@ function resultDetailFiles(message: ToolResultMessage): string[] {
 }
 
 /**
- * Paths that FAILED in a per-file edit result (`details.perFileResults`).
- * Multi-file apply_patch catches per-file failures and still returns a
- * non-error result; failed files were not mutated and must not stale reads.
+ * Paths that FAILED in a per-file edit result (`details.perFileResults`) and
+ * were NOT mutated by any same-path entry. Multi-file apply_patch catches
+ * per-file failures and still returns a non-error result; a purely-failed
+ * path was not mutated and must not stale reads. But apply_patch can emit
+ * multiple entries for the same path (e.g. several hunks): if any same-path
+ * entry succeeded the file still mutated, so it must NOT be suppressed.
+ * Conservative: only an entry explicitly marked `isError === true` counts as
+ * a failure; anything else (including ambiguous/malformed entries) counts as
+ * a success and keeps the path out of the suppression set.
  */
 function failedEditPaths(message: ToolResultMessage): Set<string> {
 	const details = message.details as { perFileResults?: unknown } | undefined;
 	const perFile = details?.perFileResults;
 	if (!Array.isArray(perFile)) return new Set();
 	const failed = new Set<string>();
+	const succeeded = new Set<string>();
 	for (const item of perFile) {
 		const entry = item as { path?: unknown; isError?: unknown };
-		if (entry?.isError === true && typeof entry.path === "string") failed.add(entry.path);
+		if (typeof entry?.path !== "string") continue;
+		if (entry.isError === true) failed.add(entry.path);
+		else succeeded.add(entry.path);
 	}
+	// A path mutated if any same-path entry succeeded, even when another
+	// same-path entry failed; drop those from the suppression set.
+	for (const path of succeeded) failed.delete(path);
 	return failed;
 }
 

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -1,8 +1,14 @@
 /**
  * Tool output pruning utilities for compaction.
+ *
+ * Candidate selection is staleness-aware: tool results that have been
+ * superseded by a later result for the same target (same file read again,
+ * same search re-run) or invalidated by a later successful edit/write to a
+ * covered file are pruned in preference to merely-old results. Protect-window
+ * and minimum-savings hysteresis semantics are unchanged.
  */
 
-import type { ToolResultMessage } from "@gajae-code/ai";
+import type { ToolCall, ToolResultMessage } from "@gajae-code/ai";
 import type { AgentMessage } from "../types";
 import { estimateTokens } from "./compaction";
 import type { SessionEntry, SessionMessageEntry } from "./entries";
@@ -14,17 +20,31 @@ export interface PruneConfig {
 	minimumSavings: number;
 	/** Tool names that should never be pruned. */
 	protectedTools: string[];
+	/**
+	 * Tools in `protectedTools` whose protection is waived once the result is
+	 * superseded (a later result for the same target, or a later successful
+	 * edit/write to the covered file). The most recent result per target is
+	 * never considered superseded. Optional; defaults to none.
+	 */
+	staleOverridableTools?: string[];
 }
 
 export const DEFAULT_PRUNE_CONFIG: PruneConfig = {
 	protectTokens: 40_000,
 	minimumSavings: 20_000,
 	protectedTools: ["skill", "read"],
+	staleOverridableTools: ["read"],
 };
 
 export interface PruneResult {
 	prunedCount: number;
 	tokensSaved: number;
+	/**
+	 * The mutated message entries. Callers whose entry source returns
+	 * materialized copies (not live references) must write these back into
+	 * their canonical store by id.
+	 */
+	prunedEntries: SessionMessageEntry[];
 }
 
 function createPrunedNotice(tokens: number): string {
@@ -43,11 +63,101 @@ function estimatePrunedSavings(tokens: number): number {
 	return Math.max(0, tokens - noticeTokens);
 }
 
+const EDIT_TOOL_NAMES = new Set(["edit", "write", "apply_patch", "ast_edit"]);
+
+/** Extract the file-path argument from a tool call, when the tool has one. */
+function toolCallPath(call: ToolCall): string | undefined {
+	const args = call.arguments;
+	const path = args.path ?? args.file_path ?? args.filePath;
+	return typeof path === "string" && path.length > 0 ? path : undefined;
+}
+
+/**
+ * Stable identity for "the same logical lookup": same tool re-targeting the
+ * same subject. A later result with the same key supersedes earlier ones.
+ * Keys are canonical JSON tuples so user-controlled text (patterns, paths)
+ * can never collide via delimiter ambiguity.
+ */
+function toolTargetKey(call: ToolCall): string | undefined {
+	const path = toolCallPath(call);
+	if (path !== undefined) return JSON.stringify([call.name, "path", path]);
+	const pattern = call.arguments.pattern;
+	if (typeof pattern === "string" && pattern.length > 0) {
+		const paths = call.arguments.paths;
+		const pathList = Array.isArray(paths) ? paths.filter((p): p is string => typeof p === "string") : [];
+		return JSON.stringify([call.name, "pattern", pattern, pathList]);
+	}
+	return undefined;
+}
+
+interface StalenessIndex {
+	/** Entry indices of toolResults superseded by a later same-target result or a later edit. */
+	staleResultIndices: Set<number>;
+}
+
+/**
+ * Build a staleness index over session entries (oldest -> newest):
+ * - a toolResult is stale when a later non-error toolResult shares its target key;
+ * - a `read` result is stale when a later non-error edit/write touches its file.
+ * The most recent result per target is never stale.
+ */
+function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
+	const callsById = new Map<string, ToolCall>();
+	for (const entry of entries) {
+		if (entry.type !== "message") continue;
+		const message = entry.message as AgentMessage;
+		if (message.role !== "assistant") continue;
+		for (const content of message.content) {
+			if (content.type === "toolCall") callsById.set(content.id, content);
+		}
+	}
+
+	const lastResultIndexByKey = new Map<string, number>();
+	const resultMeta = new Map<number, { key?: string; call: ToolCall }>();
+	const lastEditIndexByPath = new Map<string, number>();
+
+	for (let i = 0; i < entries.length; i++) {
+		const message = getToolResultMessage(entries[i]);
+		if (!message || message.isError) continue;
+		const call = callsById.get(message.toolCallId);
+		if (!call) continue;
+		const key = toolTargetKey(call);
+		resultMeta.set(i, { key, call });
+		if (key !== undefined) lastResultIndexByKey.set(key, i);
+		if (EDIT_TOOL_NAMES.has(call.name)) {
+			const path = toolCallPath(call);
+			if (path !== undefined) lastEditIndexByPath.set(path, i);
+		}
+	}
+
+	const staleResultIndices = new Set<number>();
+	for (const [index, meta] of resultMeta) {
+		if (meta.key !== undefined) {
+			const lastIndex = lastResultIndexByKey.get(meta.key);
+			if (lastIndex !== undefined && lastIndex > index) {
+				staleResultIndices.add(index);
+				continue;
+			}
+		}
+		if (meta.call.name === "read") {
+			const path = toolCallPath(meta.call);
+			if (path !== undefined) {
+				const editIndex = lastEditIndexByPath.get(path);
+				if (editIndex !== undefined && editIndex > index) staleResultIndices.add(index);
+			}
+		}
+	}
+
+	return { staleResultIndices };
+}
+
 export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = DEFAULT_PRUNE_CONFIG): PruneResult {
 	let accumulatedTokens = 0;
 	let tokensSaved = 0;
 	let prunedCount = 0;
 
+	const { staleResultIndices } = buildStalenessIndex(entries);
+	const staleOverridable = new Set(config.staleOverridableTools ?? []);
 	const candidates: Array<{ entry: SessionMessageEntry; tokens: number }> = [];
 
 	for (let i = entries.length - 1; i >= 0; i--) {
@@ -56,14 +166,24 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 		if (!message) continue;
 
 		const tokens = estimateTokens(message as AgentMessage);
-		const isProtected = config.protectedTools.includes(message.toolName);
+		const isStale = staleResultIndices.has(i);
+		// Staleness waives protected-tool immunity for overridable tools
+		// (e.g. a superseded `read`); the most recent result per target is
+		// never stale, so the latest read of each file stays protected.
+		const isProtected =
+			config.protectedTools.includes(message.toolName) && !(isStale && staleOverridable.has(message.toolName));
 
 		if (message.prunedAt !== undefined) {
 			accumulatedTokens += tokens;
 			continue;
 		}
 
-		if (accumulatedTokens < config.protectTokens || isProtected) {
+		// Stale results are prunable even inside the recency protect window —
+		// they are superseded, so recency no longer implies relevance. They
+		// still count toward window accounting so non-stale protection is
+		// unchanged.
+		const insideProtectWindow = accumulatedTokens < config.protectTokens;
+		if ((insideProtectWindow && !isStale) || isProtected) {
 			accumulatedTokens += tokens;
 			continue;
 		}
@@ -77,16 +197,18 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 	}
 
 	if (tokensSaved < config.minimumSavings || candidates.length === 0) {
-		return { prunedCount: 0, tokensSaved: 0 };
+		return { prunedCount: 0, tokensSaved: 0, prunedEntries: [] };
 	}
 
 	const prunedAt = Date.now();
+	const prunedEntries: SessionMessageEntry[] = [];
 	for (const candidate of candidates) {
 		const message = candidate.entry.message as ToolResultMessage;
 		message.content = [{ type: "text", text: createPrunedNotice(candidate.tokens) }];
 		message.prunedAt = prunedAt;
+		prunedEntries.push(candidate.entry);
 		prunedCount++;
 	}
 
-	return { prunedCount, tokensSaved };
+	return { prunedCount, tokensSaved, prunedEntries };
 }

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -142,13 +142,38 @@ function toolTargetKey(call: ToolCall): string | undefined {
 /**
  * Files actually mutated according to a tool result's details. Used for
  * AST-edit-shaped results (`ast_edit` direct-apply and the hidden `resolve`
- * apply step), which report `{ applied: true, files: [...] }`. Conservative:
+ * apply step), which report `{ applied: true, files: [...] }` — the resolve
+ * tool nests that payload under `details.sourceResultDetails`. Conservative:
  * returns nothing unless the details explicitly mark the change as applied.
+ * Checked even on `isError` results: a stale-preview apply reports an error
+ * while still having mutated the listed files.
  */
 function resultDetailFiles(message: ToolResultMessage): string[] {
-	const details = message.details as { applied?: unknown; files?: unknown } | undefined;
-	if (details?.applied !== true || !Array.isArray(details.files)) return [];
-	return details.files.filter((file): file is string => typeof file === "string" && file.length > 0);
+	const raw = message.details as { applied?: unknown; files?: unknown; sourceResultDetails?: unknown } | undefined;
+	const candidates = [raw, raw?.sourceResultDetails as { applied?: unknown; files?: unknown } | undefined];
+	for (const details of candidates) {
+		if (details?.applied === true && Array.isArray(details.files)) {
+			return details.files.filter((file): file is string => typeof file === "string" && file.length > 0);
+		}
+	}
+	return [];
+}
+
+/**
+ * Paths that FAILED in a per-file edit result (`details.perFileResults`).
+ * Multi-file apply_patch catches per-file failures and still returns a
+ * non-error result; failed files were not mutated and must not stale reads.
+ */
+function failedEditPaths(message: ToolResultMessage): Set<string> {
+	const details = message.details as { perFileResults?: unknown } | undefined;
+	const perFile = details?.perFileResults;
+	if (!Array.isArray(perFile)) return new Set();
+	const failed = new Set<string>();
+	for (const item of perFile) {
+		const entry = item as { path?: unknown; isError?: unknown };
+		if (entry?.isError === true && typeof entry.path === "string") failed.add(entry.path);
+	}
+	return failed;
 }
 
 interface StalenessIndex {
@@ -179,23 +204,31 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 
 	for (let i = 0; i < entries.length; i++) {
 		const message = getToolResultMessage(entries[i]);
-		if (!message || message.isError) continue;
+		if (!message) continue;
 		const call = callsById.get(message.toolCallId);
 		if (!call) continue;
+
+		// AST edits mutate files when previews are applied via the hidden
+		// `resolve` tool; the call args carry globs, not concrete paths. Both
+		// tools report actually-touched files in result details. Collected
+		// BEFORE the error gate: a stale-preview apply reports an error while
+		// still having mutated the listed files.
+		if (call.name === "resolve" || call.name === "ast_edit") {
+			for (const editPath of resultDetailFiles(message)) {
+				lastEditIndexByPath.set(editPath, i);
+			}
+		}
+		if (message.isError) continue;
+
 		const key = toolTargetKey(call);
 		resultMeta.set(i, { key, call });
 		if (key !== undefined) lastResultIndexByKey.set(key, i);
 		if (EDIT_TOOL_NAMES.has(call.name)) {
+			// Per-file edit results record failures in details.perFileResults;
+			// failed files were not mutated and must not stale reads.
+			const failed = failedEditPaths(message);
 			for (const editPath of editToolPaths(call)) {
-				lastEditIndexByPath.set(editPath, i);
-			}
-		}
-		// AST edits mutate files when previews are applied via the hidden
-		// `resolve` tool; the call args carry globs, not concrete paths. Both
-		// tools report the actually-touched files in result details.
-		if (call.name === "resolve" || call.name === "ast_edit") {
-			for (const editPath of resultDetailFiles(message)) {
-				lastEditIndexByPath.set(editPath, i);
+				if (!failed.has(editPath)) lastEditIndexByPath.set(editPath, i);
 			}
 		}
 	}

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -72,19 +72,26 @@ function toolCallPath(call: ToolCall): string | undefined {
 	return typeof path === "string" && path.length > 0 ? path : undefined;
 }
 
-/** `*** Add|Update|Delete File: <path>` headers in an apply_patch envelope. */
-const APPLY_PATCH_FILE_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm;
+/**
+ * `*** Add|Update|Delete File: <path>` and `*** Move to: <path>` headers in
+ * an apply_patch envelope. Move destinations count as touched paths: a rename
+ * onto a file invalidates earlier reads of that destination.
+ */
+const APPLY_PATCH_FILE_HEADER = /^\*\*\* (?:(?:Add|Update|Delete) File|Move to): (.+)$/gm;
 
 /**
  * Paths touched by an edit-class tool call. Most edit tools carry a single
- * path argument; the OpenAI custom `apply_patch` envelope carries an `input`
- * string with one or more `*** <Op> File:` headers instead.
+ * path argument; apply_patch envelopes carry an `input` string with
+ * `*** <Op> File:` / `*** Move to:` headers instead. The envelope shape can
+ * arrive under the custom `apply_patch` tool OR the regular `edit` tool
+ * (providers without custom-tool support fall back to the JSON function), so
+ * any edit-class call with a string `input` is parsed for headers.
  */
 function editToolPaths(call: ToolCall): string[] {
 	const path = toolCallPath(call);
 	if (path !== undefined) return [path];
 	const input = call.arguments.input;
-	if (call.name !== "apply_patch" || typeof input !== "string") return [];
+	if (typeof input !== "string") return [];
 	const paths: string[] = [];
 	for (const match of input.matchAll(APPLY_PATCH_FILE_HEADER)) {
 		const headerPath = match[1]?.trim();
@@ -94,10 +101,27 @@ function editToolPaths(call: ToolCall): string[] {
 }
 
 /**
+ * Trailing read selectors (`:50`, `:50-200`, `:50+150`, `:5-16,960-973`,
+ * `:raw`, `:conflicts`), possibly stacked (`:2-4:raw`). Stripped to resolve
+ * the underlying file for edit invalidation.
+ */
+const READ_SELECTOR_SUFFIX = /:(?:raw|conflicts|\d+(?:[-+]\d+)?(?:,\d+(?:[-+]\d+)?)*)$/;
+
+/** Base file path of a read target with any line/mode selectors stripped. */
+function readBasePath(path: string): string {
+	let base = path;
+	while (READ_SELECTOR_SUFFIX.test(base)) {
+		base = base.replace(READ_SELECTOR_SUFFIX, "");
+	}
+	return base;
+}
+
+/**
  * Stable identity for "the same logical lookup": same tool re-targeting the
  * same subject. A later result with the same key supersedes earlier ones.
  * Keys are canonical JSON tuples so user-controlled text (patterns, paths)
- * can never collide via delimiter ambiguity.
+ * can never collide via delimiter ambiguity. Search keys include pagination
+ * (`skip`): later pages complement page 1, they do not replace it.
  */
 function toolTargetKey(call: ToolCall): string | undefined {
 	const path = toolCallPath(call);
@@ -106,7 +130,8 @@ function toolTargetKey(call: ToolCall): string | undefined {
 	if (typeof pattern === "string" && pattern.length > 0) {
 		const paths = call.arguments.paths;
 		const pathList = Array.isArray(paths) ? paths.filter((p): p is string => typeof p === "string") : [];
-		return JSON.stringify([call.name, "pattern", pattern, pathList]);
+		const skip = typeof call.arguments.skip === "number" ? call.arguments.skip : 0;
+		return JSON.stringify([call.name, "pattern", pattern, pathList, skip]);
 	}
 	return undefined;
 }
@@ -164,7 +189,8 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 		if (meta.call.name === "read") {
 			const path = toolCallPath(meta.call);
 			if (path !== undefined) {
-				const editIndex = lastEditIndexByPath.get(path);
+				// Selector-qualified reads (src/foo.ts:50-100) still read the file.
+				const editIndex = lastEditIndexByPath.get(readBasePath(path));
 				if (editIndex !== undefined && editIndex > index) staleResultIndices.add(index);
 			}
 		}

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -139,6 +139,18 @@ function toolTargetKey(call: ToolCall): string | undefined {
 	return undefined;
 }
 
+/**
+ * Files actually mutated according to a tool result's details. Used for
+ * AST-edit-shaped results (`ast_edit` direct-apply and the hidden `resolve`
+ * apply step), which report `{ applied: true, files: [...] }`. Conservative:
+ * returns nothing unless the details explicitly mark the change as applied.
+ */
+function resultDetailFiles(message: ToolResultMessage): string[] {
+	const details = message.details as { applied?: unknown; files?: unknown } | undefined;
+	if (details?.applied !== true || !Array.isArray(details.files)) return [];
+	return details.files.filter((file): file is string => typeof file === "string" && file.length > 0);
+}
+
 interface StalenessIndex {
 	/** Entry indices of toolResults superseded by a later same-target result or a later edit. */
 	staleResultIndices: Set<number>;
@@ -175,6 +187,14 @@ function buildStalenessIndex(entries: SessionEntry[]): StalenessIndex {
 		if (key !== undefined) lastResultIndexByKey.set(key, i);
 		if (EDIT_TOOL_NAMES.has(call.name)) {
 			for (const editPath of editToolPaths(call)) {
+				lastEditIndexByPath.set(editPath, i);
+			}
+		}
+		// AST edits mutate files when previews are applied via the hidden
+		// `resolve` tool; the call args carry globs, not concrete paths. Both
+		// tools report the actually-touched files in result details.
+		if (call.name === "resolve" || call.name === "ast_edit") {
+			for (const editPath of resultDetailFiles(message)) {
 				lastEditIndexByPath.set(editPath, i);
 			}
 		}

--- a/packages/agent/test/pruning-redteam.test.ts
+++ b/packages/agent/test/pruning-redteam.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { estimateTokens } from "@gajae-code/agent-core/compaction/compaction";
+import type { SessionEntry, SessionMessageEntry } from "@gajae-code/agent-core/compaction/entries";
+import { type PruneConfig, pruneToolOutputs } from "@gajae-code/agent-core/compaction/pruning";
+import type { ToolResultMessage } from "@gajae-code/ai/types";
+
+const timestamp = "2026-06-11T00:00:00.000Z";
+
+function textForTokens(label: string, repetitions: number): string {
+	return Array.from(
+		{ length: repetitions },
+		(_, index) => `${label}-${index.toString(36)} alpha beta gamma delta`,
+	).join("\n");
+}
+
+function toolEntry(id: string, toolName: string, text: string, prunedAt?: number): SessionMessageEntry {
+	const message: ToolResultMessage = {
+		role: "toolResult",
+		toolCallId: `call-${id}`,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.parse(timestamp),
+	};
+	if (prunedAt !== undefined) message.prunedAt = prunedAt;
+	return {
+		type: "message",
+		id,
+		parentId: null,
+		timestamp,
+		message,
+	};
+}
+
+function customEntry(id: string): SessionEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp,
+		customType: "redteam-marker",
+		data: { id },
+	};
+}
+
+function textOf(entry: SessionMessageEntry): string {
+	const content = (entry.message as ToolResultMessage).content;
+	expect(Array.isArray(content)).toBe(true);
+	const block = Array.isArray(content) ? content[0] : undefined;
+	expect(block?.type).toBe("text");
+	return block?.type === "text" ? block.text : "";
+}
+
+function tokens(entry: SessionMessageEntry): number {
+	return estimateTokens(entry.message);
+}
+
+function savingsFor(entry: SessionMessageEntry): number {
+	const tokenCount = tokens(entry);
+	const noticeTokens = Math.ceil(`[Output truncated - ${tokenCount} tokens]`.length / 4);
+	return Math.max(0, tokenCount - noticeTokens);
+}
+
+function config(overrides: Partial<PruneConfig> = {}): PruneConfig {
+	return {
+		protectTokens: 0,
+		minimumSavings: 0,
+		protectedTools: ["skill", "read"],
+		...overrides,
+	};
+}
+
+describe("pruneToolOutputs red-team boundaries", () => {
+	test("minimumSavings boundary is strict below and inclusive at the threshold", () => {
+		const recent = toolEntry("recent", "bash", "recent guard text");
+		const old = toolEntry("old", "bash", textForTokens("old-boundary", 80));
+		const threshold = savingsFor(old);
+
+		const belowEntries = [
+			toolEntry("old", "bash", textForTokens("old-boundary", 80)),
+			toolEntry("recent", "bash", "recent guard text"),
+		];
+		const below = pruneToolOutputs(
+			belowEntries,
+			config({ protectTokens: tokens(recent), minimumSavings: threshold + 1 }),
+		);
+		expect(below.prunedCount).toBe(0);
+		expect(below.tokensSaved).toBe(0);
+		expect(below.prunedEntries).toEqual([]);
+		expect(textOf(belowEntries[0] as SessionMessageEntry)).not.toStartWith("[Output truncated - ");
+
+		const atEntries = [
+			toolEntry("old", "bash", textForTokens("old-boundary", 80)),
+			toolEntry("recent", "bash", "recent guard text"),
+		];
+		const at = pruneToolOutputs(atEntries, config({ protectTokens: tokens(recent), minimumSavings: threshold }));
+		expect(at.prunedCount).toBe(1);
+		expect(at.tokensSaved).toBe(threshold);
+		expect(at.prunedEntries.map(entry => entry.id)).toEqual(["old"]);
+		expect(textOf(atEntries[0] as SessionMessageEntry)).toBe(`[Output truncated - ${tokens(old)} tokens]`);
+	});
+
+	test("protect window accumulates newest-first and never prunes newest protected toolResults", () => {
+		const old = toolEntry("old", "bash", textForTokens("old", 50));
+		const middle = toolEntry("middle", "bash", textForTokens("middle", 50));
+		const newest = toolEntry("newest", "bash", textForTokens("newest", 50));
+		const entries = [old, middle, newest];
+
+		const result = pruneToolOutputs(entries, config({ protectTokens: tokens(newest) + 1, minimumSavings: 0 }));
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["old"]);
+		expect(textOf(old)).toStartWith("[Output truncated - ");
+		expect(textOf(middle)).not.toStartWith("[Output truncated - ");
+		expect(textOf(newest)).not.toStartWith("[Output truncated - ");
+	});
+
+	test("protected tool names are never pruned even when old and large", () => {
+		const read = toolEntry("read-old", "read", textForTokens("read", 80));
+		const skill = toolEntry("skill-old", "skill", textForTokens("skill", 80));
+		const bash = toolEntry("bash-old", "bash", textForTokens("bash", 80));
+		const newest = toolEntry("newest", "bash", "newest");
+		const result = pruneToolOutputs(
+			[read, skill, bash, newest],
+			config({ protectTokens: tokens(newest), minimumSavings: 0 }),
+		);
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["bash-old"]);
+		expect(textOf(read)).not.toStartWith("[Output truncated - ");
+		expect(textOf(skill)).not.toStartWith("[Output truncated - ");
+		expect(textOf(bash)).toStartWith("[Output truncated - ");
+	});
+
+	test("already-pruned entries are not re-pruned and still count toward the protect window", () => {
+		const old = toolEntry("old", "bash", textForTokens("old", 50));
+		const alreadyPruned = toolEntry("already", "bash", "[Output truncated - 400 tokens]", 12345);
+		const newest = toolEntry("newest", "bash", textForTokens("newest", 50));
+		const entries = [old, alreadyPruned, newest];
+
+		const result = pruneToolOutputs(
+			entries,
+			config({ protectTokens: tokens(newest) + tokens(alreadyPruned), minimumSavings: 0 }),
+		);
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["old"]);
+		expect((alreadyPruned.message as ToolResultMessage).prunedAt).toBe(12345);
+		expect(textOf(alreadyPruned)).toBe("[Output truncated - 400 tokens]");
+	});
+
+	test("prunedEntries contains exactly mutated entries with preserved ids, truncation notice, and numeric prunedAt", () => {
+		const pruneA = toolEntry("prune-a", "bash", textForTokens("a", 40));
+		const pruneB = toolEntry("prune-b", "edit", textForTokens("b", 40));
+		const newest = toolEntry("newest", "bash", "newest");
+		const originalTokens = new Map([
+			["prune-a", tokens(pruneA)],
+			["prune-b", tokens(pruneB)],
+		]);
+
+		const result = pruneToolOutputs(
+			[pruneA, customEntry("interleaved"), pruneB, newest],
+			config({ protectTokens: tokens(newest), minimumSavings: 0 }),
+		);
+
+		expect(result.prunedEntries).toEqual([pruneB, pruneA]);
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["prune-b", "prune-a"]);
+		for (const entry of result.prunedEntries) {
+			expect(textOf(entry)).toBe(`[Output truncated - ${originalTokens.get(entry.id)} tokens]`);
+			expect(typeof (entry.message as ToolResultMessage).prunedAt).toBe("number");
+		}
+		expect(result.prunedEntries.every(entry => textOf(entry).startsWith("[Output truncated - "))).toBe(true);
+	});
+
+	test("adversarial inputs: empty entries, non-messages, empty content, zero thresholds, and duplicate outputs", () => {
+		expect(pruneToolOutputs([], config())).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });
+
+		const empty = toolEntry("empty", "bash", "");
+		const duplicateA = toolEntry("dup-a", "bash", textForTokens("duplicate", 40));
+		const duplicateB = toolEntry("dup-b", "bash", textForTokens("duplicate", 40));
+		const entries: SessionEntry[] = [
+			customEntry("start"),
+			empty,
+			customEntry("middle"),
+			duplicateA,
+			customEntry("middle-2"),
+			duplicateB,
+		];
+		const result = pruneToolOutputs(entries, config({ protectTokens: 0, minimumSavings: 0 }));
+
+		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["dup-b", "dup-a", "empty"]);
+		expect(result.prunedCount).toBe(3);
+		expect(textOf(empty)).toBe("[Output truncated - 0 tokens]");
+		expect(textOf(duplicateA)).toStartWith("[Output truncated - ");
+		expect(textOf(duplicateB)).toStartWith("[Output truncated - ");
+	});
+
+	test("mutating returned prunedEntries does not make the same entries re-prunable on a second call", () => {
+		const old = toolEntry("old", "bash", textForTokens("old", 50));
+		const newest = toolEntry("newest", "bash", "newest");
+		const entries = [old, newest];
+
+		const first = pruneToolOutputs(entries, config({ protectTokens: tokens(newest), minimumSavings: 0 }));
+		expect(first.prunedEntries.map(entry => entry.id)).toEqual(["old"]);
+		(first.prunedEntries[0].message as ToolResultMessage).content = [
+			{ type: "text", text: "external mutation after pruning" },
+		];
+
+		const second = pruneToolOutputs(entries, config({ protectTokens: tokens(newest), minimumSavings: 0 }));
+		expect(second).toEqual({ prunedCount: 0, tokensSaved: 0, prunedEntries: [] });
+		expect((old.message as ToolResultMessage).prunedAt).toBeNumber();
+	});
+});

--- a/packages/agent/test/pruning-staleness-redteam.test.ts
+++ b/packages/agent/test/pruning-staleness-redteam.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolResultMessage } from "@gajae-code/ai";
+import type { SessionEntry, SessionMessageEntry } from "../src/compaction/entries";
+import { type PruneConfig, pruneToolOutputs } from "../src/compaction/pruning";
+
+let idCounter = 0;
+
+function assistantCallEntry(callId: string, toolName: string, args: Record<string, unknown>): SessionEntry {
+	idCounter++;
+	return {
+		type: "message",
+		id: `a-${idCounter}`,
+		parentId: null,
+		timestamp: new Date(idCounter).toISOString(),
+		message: {
+			role: "assistant",
+			content: [{ type: "toolCall", id: callId, name: toolName, arguments: args }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "m",
+			stopReason: "toolUse",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: idCounter,
+		},
+	} as SessionEntry;
+}
+
+function toolResultEntry(callId: string, toolName: string, sizeChars = 8000, isError = false): SessionMessageEntry {
+	idCounter++;
+	return {
+		type: "message",
+		id: `r-${idCounter}`,
+		parentId: null,
+		timestamp: new Date(idCounter).toISOString(),
+		message: {
+			role: "toolResult",
+			toolCallId: callId,
+			toolName,
+			content: [{ type: "text", text: `result-${callId} ${"x ".repeat(Math.floor(sizeChars / 2))}` }],
+			isError,
+			timestamp: idCounter,
+		} as ToolResultMessage,
+	} as SessionMessageEntry;
+}
+
+function pair(
+	entries: SessionEntry[],
+	callId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+	sizeChars = 8000,
+	isError = false,
+): SessionMessageEntry {
+	entries.push(assistantCallEntry(callId, toolName, args));
+	const result = toolResultEntry(callId, toolName, sizeChars, isError);
+	entries.push(result);
+	return result;
+}
+
+const EAGER: PruneConfig = {
+	protectTokens: 0,
+	minimumSavings: 0,
+	protectedTools: ["skill", "read"],
+	staleOverridableTools: ["read"],
+};
+
+function prunedIds(entries: SessionEntry[], config: PruneConfig = EAGER): string[] {
+	return pruneToolOutputs(entries, config)
+		.prunedEntries.map(entry => entry.id)
+		.sort();
+}
+
+describe("pruning staleness red-team", () => {
+	it("orphaned tool results do not crash and fall back to classic pruning/protection", () => {
+		const entries: SessionEntry[] = [
+			toolResultEntry("missing-read-call", "read"),
+			toolResultEntry("missing-bash-call", "bash"),
+		];
+
+		expect(() => pruneToolOutputs(entries, EAGER)).not.toThrow();
+		expect(prunedIds(entries)).toEqual([]);
+	});
+
+	it("different tools targeting the same path do not cross-supersede by path alone", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/shared.ts" });
+		const inspect = pair(entries, "c2", "inspect_image", { path: "src/shared.ts" });
+
+		const ids = prunedIds(entries, { ...EAGER, protectTokens: 1_000_000 });
+		expect(ids).not.toContain(read.id);
+		expect(ids).not.toContain(inspect.id);
+	});
+
+	it("recognizes path, file_path, and filePath variants for read invalidation by edits", () => {
+		const entries: SessionEntry[] = [];
+		const pathRead = pair(entries, "c1", "read", { path: "src/path.ts" });
+		const snakeRead = pair(entries, "c2", "read", { file_path: "src/snake.ts" });
+		const camelRead = pair(entries, "c3", "read", { filePath: "src/camel.ts" });
+		pair(entries, "c4", "edit", { file_path: "src/path.ts" }, 100);
+		pair(entries, "c5", "write", { filePath: "src/snake.ts" }, 100);
+		pair(entries, "c6", "apply_patch", { path: "src/camel.ts" }, 100);
+
+		const ids = prunedIds(entries);
+		expect(ids).toEqual(expect.arrayContaining([pathRead.id, snakeRead.id, camelRead.id]));
+	});
+
+	it("keeps pattern keys order-sensitive for paths arrays", () => {
+		const entries: SessionEntry[] = [];
+		const first = pair(entries, "c1", "search", { pattern: "needle", paths: ["a", "b"] });
+		const reversed = pair(entries, "c2", "search", { pattern: "needle", paths: ["b", "a"] });
+
+		const ids = prunedIds(entries, { ...EAGER, protectTokens: 1_000_000 });
+		expect(ids).not.toContain(first.id);
+		expect(ids).not.toContain(reversed.id);
+	});
+
+	it("does not stale earlier reads when the later edit result is an error", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		pair(entries, "c2", "edit", { path: "src/a.ts" }, 100, true);
+
+		expect(prunedIds(entries)).not.toContain(read.id);
+	});
+
+	it("handles interleaved already-pruned entries without losing staleness decisions", () => {
+		const entries: SessionEntry[] = [];
+		const oldRead = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const alreadyPruned = pair(entries, "c2", "bash", { command: "old" });
+		(alreadyPruned.message as ToolResultMessage).prunedAt = 123;
+		(alreadyPruned.message as ToolResultMessage).content = [
+			{ type: "text", text: "[Output truncated - 100 tokens]" },
+		];
+		const newRead = pair(entries, "c3", "read", { path: "src/a.ts" });
+
+		const ids = prunedIds(entries, { ...EAGER, protectTokens: 1_000_000 });
+		expect(ids).toContain(oldRead.id);
+		expect(ids).not.toContain(alreadyPruned.id);
+		expect(ids).not.toContain(newRead.id);
+	});
+
+	it("processes a 1000+ entry list within a sanity performance bound", () => {
+		const entries: SessionEntry[] = [];
+		for (let i = 0; i < 550; i++) {
+			pair(entries, `c${i}`, "bash", { command: `echo ${i}` }, 200);
+		}
+		const start = performance.now();
+		const result = pruneToolOutputs(entries, { ...EAGER, protectedTools: [], minimumSavings: 0 });
+		const elapsedMs = performance.now() - start;
+
+		expect(entries.length).toBeGreaterThan(1000);
+		expect(result.prunedCount).toBeGreaterThan(0);
+		expect(elapsedMs).toBeLessThan(2000);
+	});
+
+	it("for three reads of the same file, only the latest survives protected", () => {
+		const entries: SessionEntry[] = [];
+		const first = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const second = pair(entries, "c2", "read", { path: "src/a.ts" });
+		const third = pair(entries, "c3", "read", { path: "src/a.ts" });
+
+		const ids = prunedIds(entries);
+		expect(ids).toEqual(expect.arrayContaining([first.id, second.id]));
+		expect(ids).not.toContain(third.id);
+	});
+
+	it("keeps stale protected non-overridable skill output protected inside the protect window", () => {
+		const entries: SessionEntry[] = [];
+		const oldSkill = pair(entries, "c1", "skill", { path: "skills/x.md" });
+		const newSkill = pair(entries, "c2", "skill", { path: "skills/x.md" });
+
+		const ids = prunedIds(entries, { ...EAGER, protectTokens: 1_000_000 });
+		expect(ids).not.toContain(oldSkill.id);
+		expect(ids).not.toContain(newSkill.id);
+	});
+});

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -252,6 +252,63 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(read.id);
 	});
 
+	it("a resolve apply with nested sourceResultDetails invalidates touched files", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		entries.push(assistantCallEntry("c2", "resolve", { action: "apply", reason: "Apply." }));
+		const resolveResult = toolResultEntry("c2", "resolve", 100);
+		(resolveResult.message as ToolResultMessage & { details?: unknown }).details = {
+			label: "AST Edit",
+			sourceResultDetails: { applied: true, files: ["src/a.ts"] },
+		};
+		entries.push(resolveResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(read.id);
+	});
+
+	it("a partially applied (errored) AST resolve still invalidates the applied files", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		entries.push(assistantCallEntry("c2", "resolve", { action: "apply", reason: "Apply." }));
+		const staleApply = toolResultEntry("c2", "resolve", 100, true);
+		(staleApply.message as ToolResultMessage & { details?: unknown }).details = {
+			sourceResultDetails: { applied: true, files: ["src/a.ts"] },
+		};
+		entries.push(staleApply);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(read.id);
+	});
+
+	it("failed files in a multi-file edit result do not stale their reads", () => {
+		const entries: SessionEntry[] = [];
+		const readOk = pair(entries, "c1", "read", { path: "src/ok.ts" });
+		const readFailed = pair(entries, "c2", "read", { path: "src/failed.ts" });
+		const envelope = [
+			"*** Begin Patch",
+			"*** Update File: src/ok.ts",
+			"@@",
+			"-a",
+			"+b",
+			"*** Update File: src/failed.ts",
+			"@@",
+			"-x",
+			"+y",
+			"*** End Patch",
+		].join("\n");
+		entries.push(assistantCallEntry("c3", "apply_patch", { input: envelope }));
+		const patchResult = toolResultEntry("c3", "apply_patch", 100);
+		(patchResult.message as ToolResultMessage & { details?: unknown }).details = {
+			perFileResults: [
+				{ path: "src/ok.ts", isError: false },
+				{ path: "src/failed.ts", isError: true, errorText: "hash mismatch" },
+			],
+		};
+		entries.push(patchResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(readOk.id);
+		expect(ids).not.toContain(readFailed.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -159,6 +159,56 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(readC.id);
 	});
 
+	it("an apply_patch-shaped envelope sent through the edit tool also supersedes reads", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const envelope = ["*** Begin Patch", "*** Update File: src/a.ts", "@@", "-old", "+new", "*** End Patch"].join(
+			"\n",
+		);
+		pair(entries, "c2", "edit", { input: envelope }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(read.id);
+	});
+
+	it("a Move to: rename destination invalidates earlier reads of that destination", () => {
+		const entries: SessionEntry[] = [];
+		const readDest = pair(entries, "c1", "read", { path: "src/dest.ts" });
+		const envelope = [
+			"*** Begin Patch",
+			"*** Update File: src/source.ts",
+			"*** Move to: src/dest.ts",
+			"@@",
+			"-old",
+			"+new",
+			"*** End Patch",
+		].join("\n");
+		pair(entries, "c2", "apply_patch", { input: envelope }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(readDest.id);
+	});
+
+	it("a later edit invalidates selector-qualified reads of the same file", () => {
+		const entries: SessionEntry[] = [];
+		const rangeRead = pair(entries, "c1", "read", { path: "src/a.ts:50-100" });
+		const rawRead = pair(entries, "c2", "read", { path: "src/a.ts:2-4:raw" });
+		const otherFile = pair(entries, "c3", "read", { path: "src/b.ts:50-100" });
+		pair(entries, "c4", "edit", { path: "src/a.ts" }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(rangeRead.id);
+		expect(ids).toContain(rawRead.id);
+		expect(ids).not.toContain(otherFile.id);
+	});
+
+	it("search pagination pages do not supersede each other", () => {
+		const entries: SessionEntry[] = [];
+		const pageOne = pair(entries, "c1", "search", { pattern: "foo", paths: ["src"] });
+		const pageTwo = pair(entries, "c2", "search", { pattern: "foo", paths: ["src"], skip: 20 });
+		const config: PruneConfig = { ...EAGER, protectTokens: 1_000_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).not.toContain(pageOne.id);
+		expect(ids).not.toContain(pageTwo.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolResultMessage } from "@gajae-code/ai";
+import type { SessionEntry, SessionMessageEntry } from "../src/compaction/entries";
+import { DEFAULT_PRUNE_CONFIG, type PruneConfig, pruneToolOutputs } from "../src/compaction/pruning";
+
+/**
+ * Staleness-aware pruning: superseded tool results (same target read/searched
+ * again later, or a covered file edited later) are pruned before merely-old
+ * ones, and superseded `read` results lose their protected-tool immunity while
+ * the most recent read per file stays protected.
+ */
+
+let idCounter = 0;
+
+function assistantCallEntry(callId: string, toolName: string, args: Record<string, unknown>): SessionEntry {
+	idCounter++;
+	return {
+		type: "message",
+		id: `a-${idCounter}`,
+		parentId: null,
+		timestamp: new Date(idCounter).toISOString(),
+		message: {
+			role: "assistant",
+			content: [{ type: "toolCall", id: callId, name: toolName, arguments: args }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "m",
+			stopReason: "toolUse",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: idCounter,
+		},
+	} as SessionEntry;
+}
+
+function toolResultEntry(callId: string, toolName: string, sizeChars = 8000, isError = false): SessionMessageEntry {
+	idCounter++;
+	return {
+		type: "message",
+		id: `r-${idCounter}`,
+		parentId: null,
+		timestamp: new Date(idCounter).toISOString(),
+		message: {
+			role: "toolResult",
+			toolCallId: callId,
+			toolName,
+			content: [{ type: "text", text: `result-${callId} ${"x ".repeat(Math.floor(sizeChars / 2))}` }],
+			isError,
+			timestamp: idCounter,
+		} as ToolResultMessage,
+	} as SessionMessageEntry;
+}
+
+/** A call+result pair appended as two entries. */
+function pair(
+	entries: SessionEntry[],
+	callId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+	sizeChars = 8000,
+	isError = false,
+): SessionMessageEntry {
+	entries.push(assistantCallEntry(callId, toolName, args));
+	const result = toolResultEntry(callId, toolName, sizeChars, isError);
+	entries.push(result);
+	return result;
+}
+
+const EAGER: PruneConfig = {
+	protectTokens: 0,
+	minimumSavings: 0,
+	protectedTools: ["skill", "read"],
+	staleOverridableTools: ["read"],
+};
+
+function prunedIds(entries: SessionEntry[], config: PruneConfig): string[] {
+	const result = pruneToolOutputs(entries, config);
+	return result.prunedEntries.map(entry => entry.id).sort();
+}
+
+describe("staleness supersession ordering", () => {
+	it("a later read of the same file supersedes the earlier read (earlier prunable, latest protected)", () => {
+		const entries: SessionEntry[] = [];
+		const oldRead = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const newRead = pair(entries, "c2", "read", { path: "src/a.ts" });
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(oldRead.id);
+		expect(ids).not.toContain(newRead.id);
+	});
+
+	it("a later identical search supersedes the earlier one; different patterns are independent", () => {
+		const entries: SessionEntry[] = [];
+		const oldSearch = pair(entries, "c1", "search", { pattern: "foo", paths: ["src"] });
+		const otherSearch = pair(entries, "c2", "search", { pattern: "bar", paths: ["src"] });
+		const newSearch = pair(entries, "c3", "search", { pattern: "foo", paths: ["src"] });
+		// Use a config protecting nothing but with a window so only stale items are pruned.
+		const config: PruneConfig = { ...EAGER, protectTokens: 1_000_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).toContain(oldSearch.id);
+		expect(ids).not.toContain(otherSearch.id);
+		expect(ids).not.toContain(newSearch.id);
+	});
+
+	it("delimiter-looking patterns/paths never collide (canonical tuple keys)", () => {
+		const entries: SessionEntry[] = [];
+		// Historic collision shapes under naive `${name}:${pattern}@${paths.join(",")}` keys:
+		const a = pair(entries, "c1", "search", { pattern: "foo@a", paths: ["b"] });
+		const b = pair(entries, "c2", "search", { pattern: "foo", paths: ["a@b"] });
+		const c = pair(entries, "c3", "search", { pattern: "x", paths: ["a,b"] });
+		const d = pair(entries, "c4", "search", { pattern: "x", paths: ["a", "b"] });
+		const config: PruneConfig = { ...EAGER, protectTokens: 1_000_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).not.toContain(a.id);
+		expect(ids).not.toContain(b.id);
+		expect(ids).not.toContain(c.id);
+		expect(ids).not.toContain(d.id);
+	});
+
+	it("a later edit to a file supersedes an earlier read of that file", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		pair(entries, "c2", "edit", { path: "src/a.ts" }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(read.id);
+	});
+
+	it("an edit to a different file does not stale the read", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		pair(entries, "c2", "edit", { path: "src/b.ts" }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).not.toContain(read.id);
+	});
+
+	it("an errored later result does not supersede the earlier success", () => {
+		const entries: SessionEntry[] = [];
+		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });
+		pair(entries, "c2", "read", { path: "src/a.ts" }, 100, true);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).not.toContain(okRead.id);
+	});
+});
+
+describe("protect-window interaction", () => {
+	it("stale results inside the protect window are still prunable; fresh ones are not", () => {
+		const entries: SessionEntry[] = [];
+		const staleRead = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const freshBash = pair(entries, "c2", "bash", { command: "ls" });
+		const newRead = pair(entries, "c3", "read", { path: "src/a.ts" });
+		// Window large enough that everything is "recent".
+		const config: PruneConfig = { ...EAGER, protectTokens: 1_000_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).toContain(staleRead.id);
+		expect(ids).not.toContain(freshBash.id);
+		expect(ids).not.toContain(newRead.id);
+	});
+
+	it("non-stale results keep classic window semantics (old beyond window prunable)", () => {
+		const entries: SessionEntry[] = [];
+		const oldBash = pair(entries, "c1", "bash", { command: "a" }, 60_000);
+		const newBash = pair(entries, "c2", "bash", { command: "b" }, 60_000);
+		// Window covers only the newest result (~15k tokens each).
+		const config: PruneConfig = { ...EAGER, protectTokens: 20_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).toContain(oldBash.id);
+		expect(ids).not.toContain(newBash.id);
+	});
+
+	it("minimumSavings hysteresis still gates staleness pruning", () => {
+		const entries: SessionEntry[] = [];
+		pair(entries, "c1", "read", { path: "src/a.ts" }, 400);
+		pair(entries, "c2", "read", { path: "src/a.ts" }, 400);
+		const config: PruneConfig = { ...EAGER, minimumSavings: 50_000 };
+		const result = pruneToolOutputs(entries, config);
+		expect(result.prunedCount).toBe(0);
+		expect(result.prunedEntries).toEqual([]);
+	});
+});
+
+describe("protected tools", () => {
+	it("the most recent read per file is never pruned even with zero protect window", () => {
+		const entries: SessionEntry[] = [];
+		const reads = ["a", "b", "c"].map(name => pair(entries, `c-${name}`, "read", { path: `src/${name}.ts` }));
+		const ids = prunedIds(entries, EAGER);
+		for (const read of reads) expect(ids).not.toContain(read.id);
+	});
+
+	it("non-overridable protected tools (skill) stay protected even when superseded", () => {
+		const entries: SessionEntry[] = [];
+		const oldSkill = pair(entries, "c1", "skill", { path: "skills/x.md" });
+		pair(entries, "c2", "skill", { path: "skills/x.md" });
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).not.toContain(oldSkill.id);
+	});
+
+	it("default config keeps read in protectedTools and staleOverridableTools", () => {
+		expect(DEFAULT_PRUNE_CONFIG.protectedTools).toContain("read");
+		expect(DEFAULT_PRUNE_CONFIG.staleOverridableTools).toContain("read");
+	});
+
+	it("config without staleOverridableTools behaves like classic protection", () => {
+		const entries: SessionEntry[] = [];
+		const oldRead = pair(entries, "c1", "read", { path: "src/a.ts" });
+		pair(entries, "c2", "read", { path: "src/a.ts" });
+		const config: PruneConfig = { protectTokens: 0, minimumSavings: 0, protectedTools: ["read"] };
+		const ids = prunedIds(entries, config);
+		expect(ids).not.toContain(oldRead.id);
+	});
+});

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -312,14 +312,9 @@ describe("staleness supersession ordering", () => {
 	it("a same-path edit that partly succeeds still invalidates its reads", () => {
 		const entries: SessionEntry[] = [];
 		const read = pair(entries, "c1", "read", { path: "src/multi.ts" });
-		const envelope = [
-			"*** Begin Patch",
-			"*** Update File: src/multi.ts",
-			"@@",
-			"-a",
-			"+b",
-			"*** End Patch",
-		].join("\n");
+		const envelope = ["*** Begin Patch", "*** Update File: src/multi.ts", "@@", "-a", "+b", "*** End Patch"].join(
+			"\n",
+		);
 		entries.push(assistantCallEntry("c2", "apply_patch", { input: envelope }));
 		const patchResult = toolResultEntry("c2", "apply_patch", 100);
 		// apply_patch emits multiple entries for the same path: an earlier
@@ -334,6 +329,52 @@ describe("staleness supersession ordering", () => {
 		entries.push(patchResult);
 		const ids = prunedIds(entries, EAGER);
 		expect(ids).toContain(read.id);
+	});
+
+	it("a failed rename hunk does not stale reads of its Move to destination", () => {
+		const entries: SessionEntry[] = [];
+		const readDest = pair(entries, "c1", "read", { path: "src/dest.ts" });
+		const readOk = pair(entries, "c2", "read", { path: "src/ok.ts" });
+		const envelope = [
+			"*** Begin Patch",
+			"*** Update File: src/ok.ts",
+			"@@",
+			"-a",
+			"+b",
+			"*** Update File: src/source.ts",
+			"*** Move to: src/dest.ts",
+			"@@",
+			"-x",
+			"+y",
+			"*** End Patch",
+		].join("\n");
+		entries.push(assistantCallEntry("c3", "apply_patch", { input: envelope }));
+		const patchResult = toolResultEntry("c3", "apply_patch", 100);
+		(patchResult.message as ToolResultMessage & { details?: unknown }).details = {
+			perFileResults: [
+				{ path: "src/ok.ts", isError: false },
+				{ path: "src/source.ts", isError: true, errorText: "hash mismatch" },
+			],
+		};
+		entries.push(patchResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(readOk.id);
+		expect(ids).not.toContain(readDest.id);
+	});
+
+	it("a suffix-resolved read is invalidated via its resolvedPath details", () => {
+		const entries: SessionEntry[] = [];
+		// Read called with a bare filename; tool resolved it to src/foo.ts.
+		entries.push(assistantCallEntry("c1", "read", { path: "foo.ts" }));
+		const suffixRead = toolResultEntry("c1", "read", 8000);
+		(suffixRead.message as ToolResultMessage & { details?: unknown }).details = {
+			resolvedPath: "src/foo.ts",
+			suffixResolution: { from: "foo.ts", to: "src/foo.ts" },
+		};
+		entries.push(suffixRead);
+		pair(entries, "c2", "edit", { path: "src/foo.ts" }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(suffixRead.id);
 	});
 
 	it("an errored later result does not supersede the earlier success", () => {

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -138,6 +138,27 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(read.id);
 	});
 
+	it("an apply_patch envelope edit supersedes earlier reads of every patched file", () => {
+		const entries: SessionEntry[] = [];
+		const readA = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const readB = pair(entries, "c2", "read", { path: "src/b.ts" });
+		const readC = pair(entries, "c3", "read", { path: "src/c.ts" });
+		const envelope = [
+			"*** Begin Patch",
+			"*** Update File: src/a.ts",
+			"@@",
+			"-old",
+			"+new",
+			"*** Delete File: src/b.ts",
+			"*** End Patch",
+		].join("\n");
+		pair(entries, "c4", "apply_patch", { input: envelope }, 100);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(readA.id);
+		expect(ids).toContain(readB.id);
+		expect(ids).not.toContain(readC.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -221,6 +221,37 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(noGitignore.id);
 	});
 
+	it("an applied ast_edit/resolve result invalidates earlier reads of touched files", () => {
+		const entries: SessionEntry[] = [];
+		const readA = pair(entries, "c1", "read", { path: "src/a.ts" });
+		const readB = pair(entries, "c2", "read", { path: "src/b.ts" });
+		// Applied AST edit (direct or via the hidden resolve tool) reports touched files in details.
+		entries.push(assistantCallEntry("c3", "resolve", { action: "apply", reason: "Apply." }));
+		const resolveResult = toolResultEntry("c3", "resolve", 100);
+		(resolveResult.message as ToolResultMessage & { details?: unknown }).details = {
+			applied: true,
+			files: ["src/a.ts"],
+		};
+		entries.push(resolveResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(readA.id);
+		expect(ids).not.toContain(readB.id);
+	});
+
+	it("a dry-run (not applied) ast_edit preview does not invalidate reads", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/a.ts" });
+		entries.push(assistantCallEntry("c2", "ast_edit", { paths: ["src/**/*.ts"] }));
+		const previewResult = toolResultEntry("c2", "ast_edit", 100);
+		(previewResult.message as ToolResultMessage & { details?: unknown }).details = {
+			applied: false,
+			files: ["src/a.ts"],
+		};
+		entries.push(previewResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).not.toContain(read.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -309,6 +309,33 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(readFailed.id);
 	});
 
+	it("a same-path edit that partly succeeds still invalidates its reads", () => {
+		const entries: SessionEntry[] = [];
+		const read = pair(entries, "c1", "read", { path: "src/multi.ts" });
+		const envelope = [
+			"*** Begin Patch",
+			"*** Update File: src/multi.ts",
+			"@@",
+			"-a",
+			"+b",
+			"*** End Patch",
+		].join("\n");
+		entries.push(assistantCallEntry("c2", "apply_patch", { input: envelope }));
+		const patchResult = toolResultEntry("c2", "apply_patch", 100);
+		// apply_patch emits multiple entries for the same path: an earlier
+		// same-path hunk succeeds while a later same-path hunk fails. The file
+		// still mutated, so reads of it must be invalidated.
+		(patchResult.message as ToolResultMessage & { details?: unknown }).details = {
+			perFileResults: [
+				{ path: "src/multi.ts", isError: false },
+				{ path: "src/multi.ts", isError: true, errorText: "hash mismatch" },
+			],
+		};
+		entries.push(patchResult);
+		const ids = prunedIds(entries, EAGER);
+		expect(ids).toContain(read.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/agent/test/pruning-staleness.test.ts
+++ b/packages/agent/test/pruning-staleness.test.ts
@@ -209,6 +209,18 @@ describe("staleness supersession ordering", () => {
 		expect(ids).not.toContain(pageTwo.id);
 	});
 
+	it("searches with different result-shaping flags do not supersede each other", () => {
+		const entries: SessionEntry[] = [];
+		const caseSensitive = pair(entries, "c1", "search", { pattern: "foo", paths: ["src"] });
+		const caseInsensitive = pair(entries, "c2", "search", { pattern: "foo", paths: ["src"], i: true });
+		const noGitignore = pair(entries, "c3", "search", { pattern: "foo", paths: ["src"], gitignore: false });
+		const config: PruneConfig = { ...EAGER, protectTokens: 1_000_000 };
+		const ids = prunedIds(entries, config);
+		expect(ids).not.toContain(caseSensitive.id);
+		expect(ids).not.toContain(caseInsensitive.id);
+		expect(ids).not.toContain(noGitignore.id);
+	});
+
 	it("an errored later result does not supersede the earlier success", () => {
 		const entries: SessionEntry[] = [];
 		const okRead = pair(entries, "c1", "read", { path: "src/a.ts" });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Tool-output pruning no longer rewrites already-sent provider-facing history mid prompt-cache epoch: `#checkCompaction` now invokes pruning only when un-pruned context already crosses the compaction threshold (a sanctioned maintenance boundary), preserving the prefix-stability invariant. Also fixed a latent no-op where pruning mutated materialized branch copies and never persisted; `SessionManager.applyEntryMessageUpdates` now writes pruned messages back into the canonical store.
+
 - Preserved provider abort root causes in the final TUI abort label, kept replay rendering idempotent, and added a `PI_STREAM_IDLE_TIMEOUT_MS` remediation hint when stream idle watchdogs fire.
 
 ## [0.4.4] - 2026-06-10

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6063,6 +6063,9 @@ export class AgentSession {
 			return undefined;
 		}
 
+		// getBranch() returns materialized copies for blob-externalized entries, so
+		// the pruning mutations must be written back into the canonical store.
+		this.sessionManager.applyEntryMessageUpdates(result.prunedEntries);
 		await this.sessionManager.rewriteEntries();
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
@@ -6507,12 +6510,18 @@ export class AgentSession {
 		// Case 2: Threshold - turn succeeded but context is getting large
 		// Skip if this was an error (non-overflow errors don't have usage data)
 		if (assistantMessage.stopReason === "error") return;
-		const pruneResult = await this.#pruneToolOutputs();
 		let contextTokens = calculateContextTokens(assistantMessage.usage);
+		const maxOutputTokens = this.model?.maxTokens ?? 0;
+		// Cache-epoch invariant: pruning rewrites already-sent toolResult history,
+		// which breaks the provider prompt-cache prefix mid-epoch. Only prune at a
+		// sanctioned maintenance boundary, i.e. when the un-pruned context already
+		// crosses the compaction threshold. Pruning may then avert full compaction.
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) return;
+		const pruneResult = await this.#pruneToolOutputs();
 		if (pruneResult) {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
-		if (shouldCompact(contextTokens, contextWindow, compactionSettings, this.model?.maxTokens ?? 0)) {
+		if (shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) {
 			// Try promotion first — if a larger model is available, switch instead of compacting
 			const promoted = await this.#tryContextPromotion(assistantMessage);
 			if (!promoted) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -3126,6 +3126,26 @@ export class SessionManager {
 	}
 
 	/**
+	 * Write mutated message entries back into the canonical entry store by id.
+	 *
+	 * `getBranch()` materializes resident-blob entries into copies, so in-place
+	 * mutation of returned entries (e.g. pruning tool outputs) does not affect
+	 * the canonical store. This applies such mutations for real.
+	 */
+	applyEntryMessageUpdates(entries: readonly SessionMessageEntry[]): void {
+		for (const updated of entries) {
+			const canonical = this.#byId.get(updated.id);
+			if (canonical?.type !== "message") continue;
+			const residentEntry = prepareEntryForResidentSync(
+				{ ...canonical, message: updated.message },
+				this.#residentBlobStore,
+			) as SessionMessageEntry;
+			canonical.message = residentEntry.message;
+		}
+		this.#needsFullRewriteOnNextPersist = true;
+	}
+
+	/**
 	 * Rewrite the session file after in-place entry updates.
 	 * Use sparingly (e.g., pruning old tool outputs).
 	 */

--- a/packages/coding-agent/test/pruning-cache-epoch.test.ts
+++ b/packages/coding-agent/test/pruning-cache-epoch.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import type { AssistantMessage, ToolResultMessage } from "@gajae-code/ai";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getProjectAgentDir, TempDir } from "@gajae-code/utils";
+
+/**
+ * Cache-epoch invariant regression tests for tool-output pruning.
+ *
+ * Pruning rewrites already-sent toolResult history, which mutates the
+ * provider-facing prompt prefix. Within a cache epoch that is only allowed at
+ * a sanctioned maintenance boundary (the compaction threshold). These tests
+ * lock the invariant: below the compaction threshold pruning must never fire;
+ * at/above the threshold pruning may fire as part of context maintenance.
+ */
+
+function assistantMessage(totalTokens: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: totalTokens - 1000,
+			output: 1000,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	} as AssistantMessage;
+}
+
+function toolResultMessage(index: number, sizeChars: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: `call-${index}`,
+		toolName: "bash",
+		content: [{ type: "text", text: `output-${index} ${"x ".repeat(Math.floor(sizeChars / 2))}` }],
+		isError: false,
+		timestamp: Date.now() + index,
+	} as ToolResultMessage;
+}
+
+describe("pruning cache-epoch invariant", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+
+	async function createSession(): Promise<void> {
+		tempDir = TempDir.createSync("@pi-prune-epoch-");
+		// Extension short-circuits compaction so no LLM calls happen.
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
+		fs.writeFileSync(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async (event) => {',
+				'\t\treturn { compaction: { summary: "compacted", shortSummary: undefined, firstKeptEntryId: event.preparation.firstKeptEntryId, tokensBefore: event.preparation.tokensBefore, details: {} } };',
+				"\t});",
+				"}",
+			].join("\n"),
+		);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const extensionsResult = await loadExtensions([extensionPath], tempDir.path());
+		const extensionRunner = new ExtensionRunner(
+			extensionsResult.extensions,
+			extensionsResult.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.autoContinue": false,
+				"contextPromotion.enabled": false,
+				"todo.reminders": false,
+			}),
+			modelRegistry,
+			extensionRunner,
+		});
+	}
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	function seedPrunableHistory(): void {
+		sessionManager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+		// ~75k tokens of toolResult output: well past the 40k protect window and
+		// 20k minimum-savings hysteresis, so pruning WOULD fire if invoked.
+		for (let i = 0; i < 25; i++) {
+			sessionManager.appendMessage(toolResultMessage(i, 12_000));
+		}
+	}
+
+	function prunedEntryCount(): number {
+		return sessionManager.getBranch().filter(entry => {
+			if (entry.type !== "message") return false;
+			const message = (entry as { message: { role?: string; prunedAt?: number } }).message;
+			return message.role === "toolResult" && message.prunedAt !== undefined;
+		}).length;
+	}
+
+	async function driveTurnEnd(message: AssistantMessage): Promise<void> {
+		sessionManager.appendMessage(message);
+		session.agent.emitExternalEvent({ type: "message_end", message });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [message] });
+		for (let i = 0; i < 20; i++) await Promise.resolve();
+		await session.waitForIdle();
+		await new Promise(resolve => setTimeout(resolve, 100));
+		await session.waitForIdle();
+	}
+
+	it("does not prune already-sent tool outputs while below the compaction threshold", async () => {
+		await createSession();
+		seedPrunableHistory();
+		const branchBefore = JSON.stringify(sessionManager.getBranch());
+		// 50k tokens on a 200k-context model: far below the compaction threshold.
+		await driveTurnEnd(assistantMessage(50_000));
+		expect(prunedEntryCount()).toBe(0);
+		// Already-sent toolResult history must be byte-identical (no mid-epoch rewrite).
+		expect(JSON.stringify(sessionManager.getBranch().slice(0, 26))).toBe(
+			JSON.stringify(JSON.parse(branchBefore).slice(0, 26)),
+		);
+	});
+
+	it("prunes tool outputs at the compaction maintenance boundary", async () => {
+		await createSession();
+		seedPrunableHistory();
+		// 190k tokens on a 200k-context model: over the threshold, so context
+		// maintenance (pruning, then compaction if still over) is sanctioned.
+		await driveTurnEnd(assistantMessage(190_000));
+		expect(prunedEntryCount()).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

Two bugs and one optimization in tool-output pruning:

1. **Cache-epoch violation (fixed).** `pruneToolOutputs` fired after *every* successful turn from `AgentSession#checkCompaction`, rewriting already-sent `toolResult` history mid prompt-cache epoch — an unsanctioned provider-facing prefix mutation under the prefix-stability policy (`packages/orchestration-token-benchmark/src/prefix-stability.ts`). Pruning is now gated on the compaction threshold (`shouldCompact` on un-pruned context), i.e. a sanctioned maintenance boundary; if pruning frees enough tokens it averts full compaction.
2. **Latent no-op (fixed).** `SessionManager.getBranch()` materializes blob-externalized entries into copies, so pruning mutations never reached the canonical store. `PruneResult` now returns `prunedEntries`, and new `SessionManager.applyEntryMessageUpdates` writes them back by id and marks the file for full rewrite.
3. **Staleness-aware candidate selection (new).** Results superseded by a later same-target result (file re-read, identical search re-run — collision-proof canonical JSON tuple keys) or invalidated by a later successful edit/write are pruned before merely-old ones, including inside the recency protect window. New optional `PruneConfig.staleOverridableTools` (default `["read"]`) waives protected-tool immunity for superseded reads; the most recent result per target is never stale. Hysteresis semantics (`protectTokens`, `minimumSavings`) unchanged.

## Review history (internal gates already run)

- Architect three-lane reviews: initial review BLOCKED on collision-prone delimiter target keys; fixed with canonical JSON tuples + collision regression test; re-review APPROVE, no blockers.
- Red-team lanes: 16 adversarial cases (orphaned toolResults from restored sessions, cross-tool non-supersession, path arg variants, errored edits, interleaved pruned entries, 1000-entry perf bound, idempotence after external mutation) — zero implementation bugs.

## Testing

- `bun test packages/agent/test/pruning-staleness.test.ts packages/agent/test/pruning-staleness-redteam.test.ts packages/agent/test/pruning-redteam.test.ts packages/coding-agent/test/pruning-cache-epoch.test.ts` — 31 pass
- Full agent + session compaction suites and `bun run check:ts` clean on the integration branch