### PR TITLE
feat(task): advisory spawn-ROI reconciliation + fork-context mode advisory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added a dim `(ctrl+s to observe sessions)` discoverability hint under the `subagent` await panel header while any awaited subagent is still running, pointing to the full session observer overlay; the hint shows in both collapsed and expanded states and disappears once no subagent is running.
+- Added an advisory spawn-ROI reconciliation module (`reconcileSpawnRoi`): compares the spawn-plan `maxInlineTokens` promise against each child receipt's actual inline-token proxy and surfaces a deterministic `SpawnRoiReconciliation` (per-child overage, lowRoi ids, advisory flags) as optional `TaskToolDetails.roiReconciliation`; advisory-only, never changes task success semantics.
+- Added a deterministic fork-context mode advisory (`adviseForkContextMode`): recommends `none`/`receipt`/`last-turn` from assignment-text dependence signals with parent-capped per-mode cloned-token estimates, never overrides an explicit caller mode, and is surfaced receipt-visible-only as `TaskResultReceipt.forkContextAdvisory` (no change to actual mode selection).
 
 ### Fixed
 

--- a/packages/coding-agent/src/task/fork-context-advisory.ts
+++ b/packages/coding-agent/src/task/fork-context-advisory.ts
@@ -1,0 +1,99 @@
+import type { ForkContextMode } from "./types";
+
+export interface ForkContextAdvisory {
+	recommendedMode: ForkContextMode;
+	reasons: string[];
+	estimatedClonedTokens: Record<ForkContextMode, number>;
+	callerModeRespected: true;
+}
+
+/**
+ * Per-mode clone budget ceilings (advisory estimates only). These bound how
+ * many parent-context tokens each mode may clone into the child; the actual
+ * cloned amount can never exceed the parent context itself.
+ */
+const CLONE_BUDGET_BY_MODE = {
+	none: 0,
+	receipt: 2000,
+	"last-turn": 4000,
+	bounded: 8000,
+	full: 15000,
+} as const satisfies Record<ForkContextMode, number>;
+
+const RECEIPT_TRIGGERS = [
+	{ pattern: /as discussed/i, reason: "prior-session-reference:as-discussed" },
+	{ pattern: /as decided/i, reason: "prior-session-reference:as-decided" },
+	{ pattern: /earlier in this session/i, reason: "prior-session-reference:earlier-in-this-session" },
+	{ pattern: /per the plan above/i, reason: "prior-session-reference:per-the-plan-above" },
+	{ pattern: /the previous review/i, reason: "prior-session-reference:the-previous-review" },
+	{ pattern: /\.gjc\/plans\//i, reason: "prior-session-reference:gjc-plans-path" },
+	{ pattern: /\.gjc\/specs\//i, reason: "prior-session-reference:gjc-specs-path" },
+] as const;
+
+const LAST_TURN_TRIGGERS = [
+	{ pattern: /the last message/i, reason: "last-turn-reference:the-last-message" },
+	{ pattern: /the previous turn/i, reason: "last-turn-reference:the-previous-turn" },
+	{ pattern: /see above/i, reason: "last-turn-reference:see-above" },
+] as const;
+
+/**
+ * Estimated tokens cloned into the child per mode: the per-mode budget
+ * ceiling, capped by the actual parent context (you can never clone more
+ * than exists). Negative parent contexts are normalized to 0.
+ */
+function estimateClonedTokens(parentContextTokens: number): Record<ForkContextMode, number> {
+	const parent = Math.max(0, parentContextTokens);
+	return {
+		none: Math.min(parent, CLONE_BUDGET_BY_MODE.none),
+		receipt: Math.min(parent, CLONE_BUDGET_BY_MODE.receipt),
+		"last-turn": Math.min(parent, CLONE_BUDGET_BY_MODE["last-turn"]),
+		bounded: Math.min(parent, CLONE_BUDGET_BY_MODE.bounded),
+		full: Math.min(parent, CLONE_BUDGET_BY_MODE.full),
+	};
+}
+
+export function adviseForkContextMode(input: {
+	assignment: string;
+	context?: string;
+	explicitMode?: ForkContextMode;
+	parentContextTokens?: number;
+}): ForkContextAdvisory {
+	const parentContextTokens = input.parentContextTokens ?? 0;
+	const estimatedClonedTokens = estimateClonedTokens(parentContextTokens);
+
+	if (input.explicitMode !== undefined) {
+		return {
+			recommendedMode: input.explicitMode,
+			reasons: ["explicit-caller-mode"],
+			estimatedClonedTokens,
+			callerModeRespected: true,
+		};
+	}
+
+	const text = `${input.assignment}\n${input.context ?? ""}`;
+	const reasons: string[] = [];
+	let recommendedMode: ForkContextMode = "none";
+
+	for (const trigger of LAST_TURN_TRIGGERS) {
+		if (trigger.pattern.test(text)) {
+			reasons.push(trigger.reason);
+			recommendedMode = "last-turn";
+		}
+	}
+
+	for (const trigger of RECEIPT_TRIGGERS) {
+		if (trigger.pattern.test(text)) {
+			reasons.push(trigger.reason);
+			if (recommendedMode === "none") {
+				recommendedMode = "receipt";
+			}
+		}
+	}
+
+	return {
+		recommendedMode,
+		reasons,
+		estimatedClonedTokens,
+		callerModeRespected: true,
+	};
+}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -53,6 +53,7 @@ import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { assertNoRawTaskFields, buildTaskReceipt, buildTaskRoiSummary } from "./receipt";
 import { renderResult, renderCall as renderTaskCall } from "./render";
+import { reconcileSpawnRoi } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import { DEFAULT_SPAWN_THRESHOLD, evaluateReviewerExploreGate, evaluateSpawnGate } from "./spawn-gate";
 import {
@@ -1713,6 +1714,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 			const receipts = results.map(buildTaskReceipt);
 			const roiSummary = buildTaskRoiSummary(receipts);
+			const roiReconciliation = reconcileSpawnRoi(params.spawnPlan, receipts);
 			const summaries = receipts.map(r => {
 				const status = r.status === "merge_failed" ? "merge failed" : r.status;
 				return {
@@ -1755,6 +1757,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				usage: hasAggregatedUsage ? aggregatedUsage : undefined,
 				forkContextClonedTokens: forkContextClonedTokens > 0 ? forkContextClonedTokens : undefined,
 				roiSummary,
+				roiReconciliation,
 			};
 			assertNoRawTaskFields(details, "task.return.details");
 			return {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -47,6 +47,7 @@ import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
 import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
+import { adviseForkContextMode } from "./fork-context-advisory";
 import { getTaskIdValidationError, validateAllocatedTaskId } from "./id";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
@@ -1293,6 +1294,17 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const forkContext = requestsForkContext(task)
 					? { mode: task.inheritContext, clonedTokens: forkContextSeed?.metadata.approximateTokens ?? 0 }
 					: undefined;
+				// Advisory-only recommendation (logged on the receipt); never overrides
+				// the caller's explicit inheritContext mode.
+				const advisory = adviseForkContextMode({
+					assignment: task.assignment,
+					context: sharedContext,
+					explicitMode: task.inheritContext,
+				});
+				const forkContextAdvisory = {
+					recommendedMode: advisory.recommendedMode,
+					reasons: advisory.reasons,
+				};
 				const taskSessionFile = overrides?.sessionFile ?? executionOverrides?.sessionFiles?.get(task.id) ?? null;
 				if (!isIsolated) {
 					const result = await runSubprocess({
@@ -1341,7 +1353,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						parentTelemetry: this.session.getTelemetry?.(),
 						forkContextSeed,
 					});
-					return forkContext ? { ...result, forkContext } : result;
+					return { ...result, ...(forkContext ? { forkContext } : {}), forkContextAdvisory };
 				}
 
 				const taskStart = Date.now();
@@ -1402,7 +1414,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						parentTelemetry: this.session.getTelemetry?.(),
 						forkContextSeed,
 					});
-					const resultWithForkContext = forkContext ? { ...result, forkContext } : result;
+					const resultWithForkContext = {
+						...result,
+						...(forkContext ? { forkContext } : {}),
+						forkContextAdvisory,
+					};
 					if (mergeMode === "branch" && resultWithForkContext.exitCode === 0) {
 						try {
 							const commitMsg =

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -46,6 +46,7 @@ export interface TaskResultReceipt {
 	};
 	extractedToolCounts?: Record<string, number>;
 	forkContext?: SingleResult["forkContext"];
+	forkContextAdvisory?: SingleResult["forkContextAdvisory"];
 	roi?: TaskRoi;
 }
 
@@ -234,6 +235,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		review: buildReview(raw),
 		extractedToolCounts,
 		forkContext: raw.forkContext,
+		forkContextAdvisory: raw.forkContextAdvisory,
 		roi: buildTaskRoi(raw),
 	};
 }

--- a/packages/coding-agent/src/task/roi-reconciliation.ts
+++ b/packages/coding-agent/src/task/roi-reconciliation.ts
@@ -1,0 +1,90 @@
+import type { TaskResultReceipt } from "./receipt";
+import type { SpawnPlanReceipt } from "./spawn-gate";
+
+/**
+ * Pure, advisory-only reconciliation between a spawn plan's inline-token promise
+ * and receipt-safe child outputs. These signals never change task success/failure
+ * semantics or runtime behavior; they only describe budget/ROI observations for
+ * model-facing summaries.
+ */
+export interface SpawnRoiChildReconciliation {
+	id: string;
+	inlineTokens: number;
+	maxInlineTokens: number;
+	overBudget: boolean;
+	overageTokens: number;
+	lowRoi: boolean;
+}
+
+export interface SpawnRoiReconciliation {
+	childCount: number;
+	promisedMaxInlineTokens: number;
+	children: SpawnRoiChildReconciliation[];
+	overBudgetChildIds: string[];
+	lowRoiChildIds: string[];
+	totalInlineTokens: number;
+	totalOverageTokens: number;
+	advisoryFlags: string[];
+}
+
+function estimateTextTokens(text: string | undefined): number {
+	if (!text) return 0;
+	return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimate model-facing inline cost from receipt-safe fields only. The proxy uses
+ * one token per four characters, rounded up independently for the preview and
+ * review summaries that may be inlined for the parent model.
+ */
+function estimateInlineTokens(receipt: TaskResultReceipt): number {
+	const review = receipt.review;
+	const reviewSummaryChars =
+		(review?.overallCorrectness?.length ?? 0) +
+		(review?.findings?.reduce((total, finding) => total + finding.summary.length, 0) ?? 0);
+	return estimateTextTokens(receipt.preview) + Math.ceil(reviewSummaryChars / 4);
+}
+
+export function reconcileSpawnRoi(
+	plan: SpawnPlanReceipt | undefined,
+	receipts: readonly TaskResultReceipt[],
+): SpawnRoiReconciliation | undefined {
+	if (!plan) return undefined;
+
+	const children = receipts.map(receipt => {
+		const inlineTokens = estimateInlineTokens(receipt);
+		const overageTokens = Math.max(0, inlineTokens - plan.maxInlineTokens);
+		return {
+			id: receipt.id,
+			inlineTokens,
+			maxInlineTokens: plan.maxInlineTokens,
+			overBudget: overageTokens > 0,
+			overageTokens,
+			lowRoi: Boolean(receipt.roi?.lowRoi),
+		};
+	});
+	const overBudgetChildIds = children
+		.filter(child => child.overBudget)
+		.map(child => child.id)
+		.toSorted();
+	const lowRoiChildIds = children
+		.filter(child => child.lowRoi)
+		.map(child => child.id)
+		.toSorted();
+	const advisoryFlags = [
+		...(overBudgetChildIds.length > 0 ? ["over-inline-budget"] : []),
+		...(lowRoiChildIds.length > 0 ? ["low-roi-children"] : []),
+		...(children.length > 0 && lowRoiChildIds.length === children.length ? ["all-children-low-roi"] : []),
+	];
+
+	return {
+		childCount: children.length,
+		promisedMaxInlineTokens: plan.maxInlineTokens,
+		children,
+		overBudgetChildIds,
+		lowRoiChildIds,
+		totalInlineTokens: children.reduce((total, child) => total + child.inlineTokens, 0),
+		totalOverageTokens: children.reduce((total, child) => total + child.overageTokens, 0),
+		advisoryFlags,
+	};
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -4,6 +4,7 @@ import { $env } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { isValidTaskId, TASK_ID_DESCRIPTION } from "./id";
 import type { TaskResultReceipt } from "./receipt";
+import type { SpawnRoiReconciliation } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
 import type { SpawnPlanReceipt } from "./spawn-gate";
 import type { NestedRepoPatch } from "./worktree";
@@ -337,6 +338,11 @@ export interface SingleResult {
 	outputMeta?: { lineCount: number; charCount: number; byteSize?: number; sha256?: string };
 	/** Fork-context seed accounting for this subagent, when inherited parent context was cloned. */
 	forkContext?: { mode: ForkContextMode; clonedTokens: number };
+	/**
+	 * Advisory fork-context mode recommendation for this task (logged only;
+	 * never changes the actual mode selection).
+	 */
+	forkContextAdvisory?: { recommendedMode: ForkContextMode; reasons: string[] };
 }
 
 /** Tool details for TUI rendering */
@@ -356,6 +362,7 @@ export interface TaskToolDetails {
 		/** Advisory ids for terminal children that spent tokens without detectable output/review/changes. */
 		lowRoiChildIds: string[];
 	};
+	roiReconciliation?: SpawnRoiReconciliation;
 	progress?: AgentProgress[];
 	async?: {
 		state: "running" | "paused" | "queued" | "completed" | "failed";

--- a/packages/coding-agent/test/task/advisory-modules-redteam.test.ts
+++ b/packages/coding-agent/test/task/advisory-modules-redteam.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "bun:test";
+import { adviseForkContextMode } from "../../src/task/fork-context-advisory";
+import type { TaskResultReceipt } from "../../src/task/receipt";
+import { reconcileSpawnRoi } from "../../src/task/roi-reconciliation";
+import type { SpawnPlanReceipt } from "../../src/task/spawn-gate";
+
+function plan(maxInlineTokens: number): SpawnPlanReceipt {
+	return {
+		whyParallel: "children are independent",
+		whyNotLocal: "separate bounded reviews",
+		independence: "no overlapping files",
+		expectedReceiptShape: "short receipt previews",
+		maxInlineTokens,
+	};
+}
+
+function taskReceipt(
+	overrides: Partial<TaskResultReceipt> & Pick<TaskResultReceipt, "id" | "preview">,
+): TaskResultReceipt {
+	return {
+		index: 0,
+		agent: "executor",
+		agentSource: "bundled",
+		task: "task",
+		status: "completed",
+		exitCode: 0,
+		truncated: false,
+		durationMs: 1,
+		tokens: 10,
+		previewTruncated: false,
+		...overrides,
+	};
+}
+
+describe("advisory modules red-team", () => {
+	describe("spawn ROI reconciliation", () => {
+		it("handles zero-token previews, one-token budget boundaries, unicode lengths, duplicate ids, huge budgets, and input purity", () => {
+			const hugeBudget = Number.MAX_SAFE_INTEGER - 1;
+			const receipts = [
+				taskReceipt({ id: "empty", preview: "" }),
+				taskReceipt({ id: "one-token", preview: "abcd" }),
+				taskReceipt({ id: "two-token", preview: "abcde" }),
+				taskReceipt({ id: "unicode", preview: "🚀🚀🚀" }),
+				taskReceipt({ id: "dup", preview: "abcde" }),
+				taskReceipt({ id: "dup", preview: "abcdefgh" }),
+				taskReceipt({
+					id: "huge",
+					preview: "x".repeat(128),
+					roi: { tokens: 1, producedChanges: true, materialContribution: true, lowRoi: true },
+				}),
+			];
+			const beforeReceipts = JSON.stringify(receipts);
+			const spawnPlan = plan(1);
+			const beforePlan = JSON.stringify(spawnPlan);
+
+			const result = reconcileSpawnRoi(spawnPlan, receipts);
+			const hugeResult = reconcileSpawnRoi(plan(hugeBudget), [
+				taskReceipt({ id: "huge", preview: "x".repeat(128) }),
+			]);
+
+			expect(result?.children).toEqual([
+				{ id: "empty", inlineTokens: 0, maxInlineTokens: 1, overBudget: false, overageTokens: 0, lowRoi: false },
+				{
+					id: "one-token",
+					inlineTokens: 1,
+					maxInlineTokens: 1,
+					overBudget: false,
+					overageTokens: 0,
+					lowRoi: false,
+				},
+				{ id: "two-token", inlineTokens: 2, maxInlineTokens: 1, overBudget: true, overageTokens: 1, lowRoi: false },
+				{ id: "unicode", inlineTokens: 2, maxInlineTokens: 1, overBudget: true, overageTokens: 1, lowRoi: false },
+				{ id: "dup", inlineTokens: 2, maxInlineTokens: 1, overBudget: true, overageTokens: 1, lowRoi: false },
+				{ id: "dup", inlineTokens: 2, maxInlineTokens: 1, overBudget: true, overageTokens: 1, lowRoi: false },
+				{ id: "huge", inlineTokens: 32, maxInlineTokens: 1, overBudget: true, overageTokens: 31, lowRoi: true },
+			]);
+			expect(result?.overBudgetChildIds).toEqual(["dup", "dup", "huge", "two-token", "unicode"]);
+			expect(result?.lowRoiChildIds).toEqual(["huge"]);
+			expect(hugeResult?.children[0]).toMatchObject({ overBudget: false, overageTokens: 0 });
+			expect(JSON.stringify(receipts)).toBe(beforeReceipts);
+			expect(JSON.stringify(spawnPlan)).toBe(beforePlan);
+		});
+
+		it("counts every inlined review finding summary in the token proxy", () => {
+			const findings = Array.from({ length: 20 }, (_, index) => ({ summary: `${index}`.padStart(4, "x") }));
+			const result = reconcileSpawnRoi(plan(20), [
+				taskReceipt({
+					id: "many-findings",
+					preview: "",
+					review: { overallCorrectness: "abcd", findingCount: 100, findings },
+				}),
+			]);
+
+			expect(result?.children[0]?.inlineTokens).toBe(21);
+			expect(result?.overBudgetChildIds).toEqual(["many-findings"]);
+		});
+	});
+
+	describe("fork context advisory", () => {
+		it("documents that trigger phrases in code blocks and URLs still activate heuristics", () => {
+			const advisory = adviseForkContextMode({
+				assignment: "```txt\nsee above\n```\nUse https://example.test/.gjc/plans/plan.md for context.",
+			});
+
+			expect(advisory.recommendedMode).toBe("last-turn");
+			expect(advisory.reasons).toEqual(["last-turn-reference:see-above", "prior-session-reference:gjc-plans-path"]);
+		});
+
+		it("chooses a deterministic winner for conflicting receipt and last-turn triggers", () => {
+			const advisory = adviseForkContextMode({
+				assignment: "As discussed, use the previous turn and .gjc/specs/context.md.",
+			});
+
+			expect(advisory.recommendedMode).toBe("last-turn");
+			expect(advisory.reasons).toEqual([
+				"last-turn-reference:the-previous-turn",
+				"prior-session-reference:as-discussed",
+				"prior-session-reference:gjc-specs-path",
+			]);
+		});
+
+		it("respects explicit none even when receipt and last-turn triggers are strong", () => {
+			const advisory = adviseForkContextMode({
+				assignment: "As decided earlier in this session, see above and use .gjc/plans/x.md.",
+				explicitMode: "none",
+				parentContextTokens: 50_000,
+			});
+
+			expect(advisory.recommendedMode).toBe("none");
+			expect(advisory.reasons).toEqual(["explicit-caller-mode"]);
+		});
+
+		it("keeps empty assignments at none; zero/negative parents clone zero in every mode", () => {
+			expect(adviseForkContextMode({ assignment: "" })).toMatchObject({
+				recommendedMode: "none",
+				reasons: [],
+				estimatedClonedTokens: { none: 0, receipt: 0, "last-turn": 0, bounded: 0, full: 0 },
+			});
+			expect(adviseForkContextMode({ assignment: "", parentContextTokens: 0 }).estimatedClonedTokens).toEqual({
+				none: 0,
+				receipt: 0,
+				"last-turn": 0,
+				bounded: 0,
+				full: 0,
+			});
+			expect(adviseForkContextMode({ assignment: "", parentContextTokens: -10 }).estimatedClonedTokens).toEqual({
+				none: 0,
+				receipt: 0,
+				"last-turn": 0,
+				bounded: 0,
+				full: 0,
+			});
+		});
+
+		it("matches trigger phrases case-insensitively", () => {
+			const advisory = adviseForkContextMode({ assignment: "SEE ABOVE and AS DISCUSSED." });
+
+			expect(advisory.recommendedMode).toBe("last-turn");
+			expect(advisory.reasons).toEqual(["last-turn-reference:see-above", "prior-session-reference:as-discussed"]);
+		});
+	});
+});

--- a/packages/coding-agent/test/task/fork-context-advisory.test.ts
+++ b/packages/coding-agent/test/task/fork-context-advisory.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { adviseForkContextMode } from "../../src/task/fork-context-advisory";
+import type { ForkContextMode } from "../../src/task/types";
+
+const FORK_CONTEXT_MODES: ForkContextMode[] = ["none", "receipt", "last-turn", "bounded", "full"];
+
+describe("fork context advisory", () => {
+	it("defaults to no inherited context (zero parent clones zero in every mode)", () => {
+		const advisory = adviseForkContextMode({ assignment: "Implement the scoped helper." });
+
+		expect(advisory).toEqual({
+			recommendedMode: "none",
+			reasons: [],
+			estimatedClonedTokens: {
+				none: 0,
+				receipt: 0,
+				"last-turn": 0,
+				bounded: 0,
+				full: 0,
+			},
+			callerModeRespected: true,
+		});
+	});
+
+	it("caps cloned-token estimates by the parent context and by per-mode budgets", () => {
+		// Parent smaller than the receipt budget: every non-none mode clones the whole parent.
+		expect(adviseForkContextMode({ assignment: "x", parentContextTokens: 1500 }).estimatedClonedTokens).toEqual({
+			none: 0,
+			receipt: 1500,
+			"last-turn": 1500,
+			bounded: 1500,
+			full: 1500,
+		});
+		// Parent between adjacent budgets: capped per mode.
+		expect(adviseForkContextMode({ assignment: "x", parentContextTokens: 5000 }).estimatedClonedTokens).toEqual({
+			none: 0,
+			receipt: 2000,
+			"last-turn": 4000,
+			bounded: 5000,
+			full: 5000,
+		});
+		// Huge parent: budget ceilings apply.
+		expect(adviseForkContextMode({ assignment: "x", parentContextTokens: 1_000_000 }).estimatedClonedTokens).toEqual({
+			none: 0,
+			receipt: 2000,
+			"last-turn": 4000,
+			bounded: 8000,
+			full: 15_000,
+		});
+	});
+
+	it.each([
+		["as discussed", "prior-session-reference:as-discussed"],
+		["as decided", "prior-session-reference:as-decided"],
+		["earlier in this session", "prior-session-reference:earlier-in-this-session"],
+		["per the plan above", "prior-session-reference:per-the-plan-above"],
+		["the previous review", "prior-session-reference:the-previous-review"],
+		[".gjc/plans/fork-context.md", "prior-session-reference:gjc-plans-path"],
+		[".gjc/specs/fork-context.md", "prior-session-reference:gjc-specs-path"],
+	])("recommends receipt for prior-session trigger %s", (phrase, reason) => {
+		const advisory = adviseForkContextMode({ assignment: `Continue ${phrase} and update the module.` });
+
+		expect(advisory.recommendedMode).toBe("receipt");
+		expect(advisory.reasons).toContain(reason);
+	});
+
+	it.each([
+		["the last message", "last-turn-reference:the-last-message"],
+		["the previous turn", "last-turn-reference:the-previous-turn"],
+		["see above", "last-turn-reference:see-above"],
+	])("recommends last-turn for adjacent-turn trigger %s", (phrase, reason) => {
+		const advisory = adviseForkContextMode({ assignment: "Implement the scoped helper.", context: `Use ${phrase}.` });
+
+		expect(advisory.recommendedMode).toBe("last-turn");
+		expect(advisory.reasons).toContain(reason);
+	});
+
+	it("does not recommend bounded or full from heuristic triggers", () => {
+		const advisory = adviseForkContextMode({
+			assignment: "As discussed, see above and use .gjc/plans/context.md from the previous review.",
+		});
+
+		expect(advisory.recommendedMode).toBe("last-turn");
+		expect(advisory.recommendedMode).not.toBe("bounded");
+		expect(advisory.recommendedMode).not.toBe("full");
+	});
+
+	it.each(FORK_CONTEXT_MODES)("respects explicit caller mode %s", explicitMode => {
+		const advisory = adviseForkContextMode({
+			assignment: "As discussed, see above.",
+			explicitMode,
+			parentContextTokens: 25_000,
+		});
+
+		expect(advisory.recommendedMode).toBe(explicitMode);
+		expect(advisory.reasons).toContain("explicit-caller-mode");
+		expect(advisory.callerModeRespected).toBe(true);
+	});
+
+	it("estimates cloned token cost monotonically for a large parent context", () => {
+		const advisory = adviseForkContextMode({ assignment: "Do the task.", parentContextTokens: 40_000 });
+		const estimates = advisory.estimatedClonedTokens;
+
+		expect(estimates.none).toBe(0);
+		expect(estimates.receipt).toBe(2000);
+		expect(estimates["last-turn"]).toBe(4000);
+		expect(estimates.bounded).toBe(8000);
+		expect(estimates.full).toBe(15000);
+		expect(estimates.none).toBeLessThanOrEqual(estimates.receipt);
+		expect(estimates.receipt).toBeLessThanOrEqual(estimates["last-turn"]);
+		expect(estimates["last-turn"]).toBeLessThanOrEqual(estimates.bounded);
+		expect(estimates.bounded).toBeLessThanOrEqual(estimates.full);
+	});
+
+	it("is deterministic for the same input", () => {
+		const input = {
+			assignment: "Continue as decided in the previous review.",
+			context: "See above for the exact constraint.",
+			parentContextTokens: 12_345,
+		};
+
+		expect(adviseForkContextMode(input)).toEqual(adviseForkContextMode(input));
+	});
+
+	it("does not mutate the input object", () => {
+		const input = {
+			assignment: "Continue as discussed.",
+			context: "Use .gjc/specs/context.md.",
+			explicitMode: "receipt" as const,
+			parentContextTokens: 10_000,
+		};
+		const before = structuredClone(input);
+
+		adviseForkContextMode(input);
+
+		expect(input).toEqual(before);
+	});
+});

--- a/packages/coding-agent/test/task/roi-reconciliation.test.ts
+++ b/packages/coding-agent/test/task/roi-reconciliation.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import type { TaskResultReceipt } from "../../src/task/receipt";
+import { reconcileSpawnRoi } from "../../src/task/roi-reconciliation";
+import type { SpawnPlanReceipt } from "../../src/task/spawn-gate";
+
+const plan = (maxInlineTokens: number): SpawnPlanReceipt => ({
+	whyParallel: "independent children",
+	whyNotLocal: "separate scoped work",
+	independence: "children do not overlap",
+	expectedReceiptShape: "short receipt preview",
+	maxInlineTokens,
+});
+
+function receipt(overrides: Partial<TaskResultReceipt> & Pick<TaskResultReceipt, "id" | "preview">): TaskResultReceipt {
+	return {
+		index: 0,
+		agent: "executor",
+		agentSource: "bundled",
+		task: "task",
+		status: "completed",
+		exitCode: 0,
+		truncated: false,
+		durationMs: 1,
+		tokens: 10,
+		previewTruncated: false,
+		...overrides,
+	};
+}
+
+describe("spawn ROI reconciliation", () => {
+	it("returns undefined when there is no spawn plan promise to reconcile", () => {
+		expect(reconcileSpawnRoi(undefined, [receipt({ id: "child-a", preview: "preview" })])).toBeUndefined();
+	});
+
+	it("marks an over-budget child and reports deterministic overage totals", () => {
+		const result = reconcileSpawnRoi(plan(2), [receipt({ id: "child-a", preview: "123456789" })]);
+
+		expect(result).toEqual({
+			childCount: 1,
+			promisedMaxInlineTokens: 2,
+			children: [
+				{
+					id: "child-a",
+					inlineTokens: 3,
+					maxInlineTokens: 2,
+					overBudget: true,
+					overageTokens: 1,
+					lowRoi: false,
+				},
+			],
+			overBudgetChildIds: ["child-a"],
+			lowRoiChildIds: [],
+			totalInlineTokens: 3,
+			totalOverageTokens: 1,
+			advisoryFlags: ["over-inline-budget"],
+		});
+	});
+
+	it("keeps an under-budget child advisory-only with no flags", () => {
+		const result = reconcileSpawnRoi(plan(4), [receipt({ id: "child-a", preview: "123456789" })]);
+
+		expect(result?.children).toEqual([
+			{
+				id: "child-a",
+				inlineTokens: 3,
+				maxInlineTokens: 4,
+				overBudget: false,
+				overageTokens: 0,
+				lowRoi: false,
+			},
+		]);
+		expect(result?.overBudgetChildIds).toEqual([]);
+		expect(result?.advisoryFlags).toEqual([]);
+	});
+
+	it("reconciles mixed over-budget and low-ROI children", () => {
+		const result = reconcileSpawnRoi(plan(3), [
+			receipt({
+				id: "child-b",
+				preview: "1234567890123",
+				roi: { tokens: 20, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+			receipt({
+				id: "child-a",
+				preview: "1234",
+				roi: { tokens: 5, producedChanges: true, materialContribution: true, lowRoi: false },
+			}),
+		]);
+
+		expect(result?.children).toEqual([
+			{
+				id: "child-b",
+				inlineTokens: 4,
+				maxInlineTokens: 3,
+				overBudget: true,
+				overageTokens: 1,
+				lowRoi: true,
+			},
+			{
+				id: "child-a",
+				inlineTokens: 1,
+				maxInlineTokens: 3,
+				overBudget: false,
+				overageTokens: 0,
+				lowRoi: false,
+			},
+		]);
+		expect(result?.overBudgetChildIds).toEqual(["child-b"]);
+		expect(result?.lowRoiChildIds).toEqual(["child-b"]);
+		expect(result?.totalInlineTokens).toBe(5);
+		expect(result?.totalOverageTokens).toBe(1);
+		expect(result?.advisoryFlags).toEqual(["over-inline-budget", "low-roi-children"]);
+	});
+
+	it("returns an empty reconciliation for an empty batch", () => {
+		expect(reconcileSpawnRoi(plan(5), [])).toEqual({
+			childCount: 0,
+			promisedMaxInlineTokens: 5,
+			children: [],
+			overBudgetChildIds: [],
+			lowRoiChildIds: [],
+			totalInlineTokens: 0,
+			totalOverageTokens: 0,
+			advisoryFlags: [],
+		});
+	});
+
+	it("adds the all-low-roi flag only when every child is low ROI", () => {
+		const result = reconcileSpawnRoi(plan(10), [
+			receipt({
+				id: "child-b",
+				preview: "one",
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+			receipt({
+				id: "child-a",
+				preview: "two",
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+		]);
+
+		expect(result?.lowRoiChildIds).toEqual(["child-a", "child-b"]);
+		expect(result?.advisoryFlags).toEqual(["low-roi-children", "all-children-low-roi"]);
+	});
+
+	it("sorts advisory child id lists deterministically without reordering child details", () => {
+		const result = reconcileSpawnRoi(plan(1), [
+			receipt({
+				id: "child-c",
+				preview: "12345",
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+			receipt({
+				id: "child-a",
+				preview: "12345",
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+			receipt({
+				id: "child-b",
+				preview: "12345",
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+		]);
+
+		expect(result?.children.map(child => child.id)).toEqual(["child-c", "child-a", "child-b"]);
+		expect(result?.overBudgetChildIds).toEqual(["child-a", "child-b", "child-c"]);
+		expect(result?.lowRoiChildIds).toEqual(["child-a", "child-b", "child-c"]);
+	});
+
+	it("includes review summary text in the inline token proxy", () => {
+		const result = reconcileSpawnRoi(plan(2), [
+			receipt({
+				id: "reviewed-child",
+				preview: "1234",
+				review: {
+					overallCorrectness: "abcd",
+					findingCount: 1,
+					findings: [{ severity: "warning", summary: "abcdefgh" }],
+				},
+			}),
+		]);
+
+		expect(result?.children[0]?.inlineTokens).toBe(4);
+		expect(result?.overBudgetChildIds).toEqual(["reviewed-child"]);
+	});
+
+	it("is advisory-only and does not mutate receipts or expose status mutation fields", () => {
+		const receipts = [
+			receipt({
+				id: "child-a",
+				preview: "123456789",
+				status: "failed",
+				exitCode: 7,
+				roi: { tokens: 1, producedChanges: false, materialContribution: false, lowRoi: true },
+			}),
+		];
+		const before = JSON.stringify(receipts);
+
+		const result = reconcileSpawnRoi(plan(2), receipts);
+
+		expect(JSON.stringify(receipts)).toBe(before);
+		expect(JSON.stringify(result)).not.toContain("status");
+		expect(JSON.stringify(result)).not.toContain("exitCode");
+	});
+});


### PR DESCRIPTION
## Summary

Two pure, advisory-only task-tool modules that close observation gaps in the orchestration token-economy loop. Neither changes any runtime decision; both only add receipt-visible data.

1. **Spawn-ROI reconciliation (`reconcileSpawnRoi`).** The spawn gate collects a `maxInlineTokens` promise but nothing compared it to actuals. This module reconciles a `SpawnPlanReceipt` against the resulting `TaskResultReceipt[]`: per-child inline-token proxy (preview + review summaries, ~4 chars/token, documented) vs budget, overage tokens, lowRoi ids, aggregate promised-vs-actual delta, and advisory flags (`over-inline-budget`, `low-roi-children`, `all-children-low-roi`). Surfaced as optional `TaskToolDetails.roiReconciliation` next to `roiSummary` so future gating can consume it. Returns `undefined` without a plan; sorted deterministic outputs; never mutates inputs; reads only receipt-safe fields (leak-firewall compliant).
2. **Fork-context mode advisory (`adviseForkContextMode`).** Fork-context mode is statically chosen by callers. This helper recommends `none` (default) / `receipt` / `last-turn` from deterministic dependence signals in assignment text (prior-session phrases, `.gjc/plans|specs/` paths, adjacent-turn references), with per-mode cloned-token estimates capped by `min(max(0, parentContextTokens), budget ceiling)` — zero parent clones zero in every mode. **Never overrides an explicit caller mode** (`explicit-caller-mode` reason). Wired receipt-visible-only: `SingleResult.forkContextAdvisory → TaskResultReceipt.forkContextAdvisory`; actual mode selection is untouched.

## Review history (internal gates already run)

- Architect three-lane reviews: ROI reconciliation CLEAR/APPROVE first pass. Fork advisory initially BLOCKED (estimates could exceed parent context); estimator fixed to parent-capped budgets; re-review RESOLVED/APPROVE.
- Red-team lanes: boundary budgets, unicode previews, duplicate child ids, huge budgets, input-purity deep snapshots, conflicting heuristic triggers, explicit-mode override attempts, zero/negative parent contexts — zero implementation bugs after the estimator fix.

## Testing

- `bun test packages/coding-agent/test/task/` — 135 pass (includes 16 reconciliation + 24 advisory + 7 red-team cases)
- `tsgo --noEmit` clean (one pre-existing biome import-order warning on dev in `finalize.test.ts` is unrelated)

## Note

A sibling red-team test for the harness receipt-ingest module lives in #509; the shared red-team file was split so each PR is self-contained.