### PR TITLE
fix(task): suppress batch ROI reconciliation in per-child async runs

### DIFF
--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -580,6 +580,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								runMode: message ? "message" : "resume",
 								resumeMessage: message,
 								sessionFiles: new Map([[descriptor.task.id, descriptor.sessionFile]]),
+								suppressRoiReconciliation: true,
 							},
 						);
 						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
@@ -677,6 +678,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								frozenForkSeeds,
 								{
 									sessionFiles: new Map([[uniqueId, subtaskSessionFile]]),
+									suppressRoiReconciliation: true,
 								},
 							);
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
@@ -876,6 +878,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			runMode?: "initial" | "resume" | "message";
 			resumeMessage?: string;
 			sessionFiles?: ReadonlyMap<string, string | null>;
+			/**
+			 * Set for per-child async runs: the spawnPlan is carried for gate
+			 * consistency, but batch-level ROI reconciliation must not be computed
+			 * against a single child's receipts.
+			 */
+			suppressRoiReconciliation?: boolean;
 		},
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
@@ -1714,7 +1722,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 			const receipts = results.map(buildTaskReceipt);
 			const roiSummary = buildTaskRoiSummary(receipts);
-			const roiReconciliation = reconcileSpawnRoi(params.spawnPlan, receipts);
+			const roiReconciliation = executionOverrides?.suppressRoiReconciliation
+				? undefined
+				: reconcileSpawnRoi(params.spawnPlan, receipts);
 			const summaries = receipts.map(r => {
 				const status = r.status === "merge_failed" ? "merge failed" : r.status;
 				return {


### PR DESCRIPTION
## Summary

Follow-up to #510, which merged before this fix landed on the branch. Addresses the codex round-2 finding on #510:

The async batch path schedules one `#executeSync` per task with the batch params (including the batch `spawnPlan`), so each child job reconciled the batch plan against only its own single receipt — producing misleading `childCount: 1` advisories instead of batch-level reconciliation. Per-child async invocations (initial run and resume) now pass `executionOverrides.suppressRoiReconciliation`, so `reconcileSpawnRoi` only runs where the full batch receipt set exists (the synchronous path). The spawnPlan itself is still carried for spawn-gate consistency.

## Testing

- `bun test packages/coding-agent/test/task/` — 135 pass
- `tsgo --noEmit` clean