### PR TITLE
Purge memory/binary bloat: default-small grammars, tokenizer tiering, compiled CLI fast paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ packages/*/dist-firefox/
 target/
 *.tsbuildinfo
 *.node
+*.node.build.json
 *.b64.js
 
 # Environment

--- a/crates/pi-ast/Cargo.toml
+++ b/crates/pi-ast/Cargo.toml
@@ -17,58 +17,99 @@ ignore.workspace = true
 phf.workspace = true
 serde.workspace = true
 tree-sitter.workspace = true
-tree-sitter-astro.workspace = true
+tree-sitter-astro = { workspace = true, optional = true }
 tree-sitter-bash.workspace = true
 tree-sitter-c.workspace = true
-tree-sitter-clojure.workspace = true
-tree-sitter-cmake.workspace = true
+tree-sitter-clojure = { workspace = true, optional = true }
+tree-sitter-cmake = { workspace = true, optional = true }
 tree-sitter-c-sharp.workspace = true
 tree-sitter-cpp.workspace = true
-tree-sitter-dart.workspace = true
+tree-sitter-dart = { workspace = true, optional = true }
 tree-sitter-css.workspace = true
-tree-sitter-diff.workspace = true
-tree-sitter-dockerfile.workspace = true
-tree-sitter-elixir.workspace = true
-tree-sitter-erlang.workspace = true
+tree-sitter-diff = { workspace = true, optional = true }
+tree-sitter-dockerfile = { workspace = true, optional = true }
+tree-sitter-elixir = { workspace = true, optional = true }
+tree-sitter-erlang = { workspace = true, optional = true }
 tree-sitter-go.workspace = true
-tree-sitter-graphql.workspace = true
-tree-sitter-haskell.workspace = true
-tree-sitter-hcl.workspace = true
+tree-sitter-graphql = { workspace = true, optional = true }
+tree-sitter-haskell = { workspace = true, optional = true }
+tree-sitter-hcl = { workspace = true, optional = true }
 tree-sitter-html.workspace = true
-tree-sitter-ini.workspace = true
+tree-sitter-ini = { workspace = true, optional = true }
 tree-sitter-java.workspace = true
 tree-sitter-javascript.workspace = true
 tree-sitter-json.workspace = true
-tree-sitter-just.workspace = true
-tree-sitter-julia.workspace = true
-tree-sitter-kotlin.workspace = true
-tree-sitter-lua.workspace = true
-tree-sitter-make.workspace = true
+tree-sitter-just = { workspace = true, optional = true }
+tree-sitter-julia = { workspace = true, optional = true }
+tree-sitter-kotlin = { workspace = true, optional = true }
+tree-sitter-lua = { workspace = true, optional = true }
+tree-sitter-make = { workspace = true, optional = true }
 tree-sitter-md.workspace = true
-tree-sitter-nix.workspace = true
-tree-sitter-objc.workspace = true
-tree-sitter-ocaml.workspace = true
-tree-sitter-odin.workspace = true
-tree-sitter-perl.workspace = true
+tree-sitter-nix = { workspace = true, optional = true }
+tree-sitter-objc = { workspace = true, optional = true }
+tree-sitter-ocaml = { workspace = true, optional = true }
+tree-sitter-odin = { workspace = true, optional = true }
+tree-sitter-perl = { workspace = true, optional = true }
 tree-sitter-php.workspace = true
-tree-sitter-powershell.workspace = true
-tree-sitter-proto.workspace = true
+tree-sitter-powershell = { workspace = true, optional = true }
+tree-sitter-proto = { workspace = true, optional = true }
 tree-sitter-python.workspace = true
-tree-sitter-r.workspace = true
-tree-sitter-regex.workspace = true
+tree-sitter-r = { workspace = true, optional = true }
+tree-sitter-regex = { workspace = true, optional = true }
 tree-sitter-ruby.workspace = true
 tree-sitter-rust.workspace = true
-tree-sitter-scala.workspace = true
-tree-sitter-solidity.workspace = true
-tree-sitter-sql.workspace = true
-tree-sitter-starlark.workspace = true
-tree-sitter-svelte.workspace = true
-tree-sitter-swift.workspace = true
+tree-sitter-scala = { workspace = true, optional = true }
+tree-sitter-solidity = { workspace = true, optional = true }
+tree-sitter-sql = { workspace = true, optional = true }
+tree-sitter-starlark = { workspace = true, optional = true }
+tree-sitter-svelte = { workspace = true, optional = true }
+tree-sitter-swift = { workspace = true, optional = true }
 tree-sitter-toml-ng.workspace = true
-tree-sitter-tlaplus.workspace = true
+tree-sitter-tlaplus = { workspace = true, optional = true }
 tree-sitter-typescript.workspace = true
-tree-sitter-verilog.workspace = true
-tree-sitter-vue.workspace = true
-tree-sitter-xml.workspace = true
+tree-sitter-verilog = { workspace = true, optional = true }
+tree-sitter-vue = { workspace = true, optional = true }
+tree-sitter-xml = { workspace = true, optional = true }
 tree-sitter-yaml.workspace = true
-tree-sitter-zig.workspace = true
+tree-sitter-zig = { workspace = true, optional = true }
+[features]
+default = []
+full-langs = [
+	"dep:tree-sitter-astro",
+	"dep:tree-sitter-clojure",
+	"dep:tree-sitter-cmake",
+	"dep:tree-sitter-dart",
+	"dep:tree-sitter-diff",
+	"dep:tree-sitter-dockerfile",
+	"dep:tree-sitter-elixir",
+	"dep:tree-sitter-erlang",
+	"dep:tree-sitter-graphql",
+	"dep:tree-sitter-haskell",
+	"dep:tree-sitter-hcl",
+	"dep:tree-sitter-ini",
+	"dep:tree-sitter-just",
+	"dep:tree-sitter-julia",
+	"dep:tree-sitter-kotlin",
+	"dep:tree-sitter-lua",
+	"dep:tree-sitter-make",
+	"dep:tree-sitter-nix",
+	"dep:tree-sitter-objc",
+	"dep:tree-sitter-ocaml",
+	"dep:tree-sitter-odin",
+	"dep:tree-sitter-perl",
+	"dep:tree-sitter-powershell",
+	"dep:tree-sitter-proto",
+	"dep:tree-sitter-r",
+	"dep:tree-sitter-regex",
+	"dep:tree-sitter-scala",
+	"dep:tree-sitter-solidity",
+	"dep:tree-sitter-sql",
+	"dep:tree-sitter-starlark",
+	"dep:tree-sitter-svelte",
+	"dep:tree-sitter-swift",
+	"dep:tree-sitter-tlaplus",
+	"dep:tree-sitter-verilog",
+	"dep:tree-sitter-vue",
+	"dep:tree-sitter-xml",
+	"dep:tree-sitter-zig",
+]

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -607,19 +607,15 @@ impl SupportLang {
 
 	pub fn from_alias(value: &str) -> Option<Self> {
 		let lowered = value.trim().to_ascii_lowercase();
-		CORE_LANG_ALIASES
-			.get(lowered.as_str())
-			.copied()
-			.or_else(|| {
-				#[cfg(feature = "full-langs")]
-				{
-					LONG_TAIL_LANG_ALIASES.get(lowered.as_str()).copied()
-				}
-				#[cfg(not(feature = "full-langs"))]
-				{
-					None
-				}
-			})
+		let core = CORE_LANG_ALIASES.get(lowered.as_str()).copied();
+		#[cfg(feature = "full-langs")]
+		{
+			core.or_else(|| LONG_TAIL_LANG_ALIASES.get(lowered.as_str()).copied())
+		}
+		#[cfg(not(feature = "full-langs"))]
+		{
+			core
+		}
 	}
 
 	pub fn from_path(path: &Path) -> Option<Self> {

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -107,64 +107,101 @@ macro_rules! impl_lang_expando {
 impl_lang_expando!(C, language_c, '𐀀');
 impl_lang_expando!(Cpp, language_cpp, '𐀀');
 impl_lang_expando!(CSharp, language_c_sharp, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Cmake, language_cmake, 'µ');
 impl_lang_expando!(Css, language_css, '_');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Dockerfile, language_dockerfile, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Elixir, language_elixir, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Erlang, language_erlang, 'µ');
 impl_lang_expando!(Go, language_go, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang!(Graphql, language_graphql);
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Haskell, language_haskell, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Hcl, language_hcl, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Ini, language_ini, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Just, language_just, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Kotlin, language_kotlin, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Nix, language_nix, '_');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Ocaml, language_ocaml, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Perl, language_perl, 'µ');
 impl_lang_expando!(Php, language_php, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Powershell, language_powershell, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Proto, language_proto, 'µ');
 impl_lang_expando!(Python, language_python, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(R, language_r, 'µ');
 impl_lang_expando!(Ruby, language_ruby, 'µ');
 impl_lang_expando!(Rust, language_rust, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Sql, language_sql, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Swift, language_swift, 'µ');
 
 // New expando languages
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Make, language_make, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(ObjC, language_objc, '𐀀');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Starlark, language_starlark, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Odin, language_odin, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Julia, language_julia, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Verilog, language_verilog, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Zig, language_zig, 'µ');
+#[cfg(feature = "full-langs")]
 impl_lang_expando!(Tlaplus, language_tlaplus, 'µ');
 
 // ── Stub languages ($ accepted in grammar) ──────────────────────────────
 
+#[cfg(feature = "full-langs")]
 impl_lang!(Astro, language_astro);
 impl_lang!(Bash, language_bash);
+#[cfg(feature = "full-langs")]
 impl_lang!(Clojure, language_clojure);
 impl_lang!(Java, language_java);
 impl_lang!(JavaScript, language_javascript);
 impl_lang!(Json, language_json);
+#[cfg(feature = "full-langs")]
 impl_lang!(Lua, language_lua);
+#[cfg(feature = "full-langs")]
 impl_lang!(Scala, language_scala);
+#[cfg(feature = "full-langs")]
 impl_lang!(Solidity, language_solidity);
+#[cfg(feature = "full-langs")]
 impl_lang!(Svelte, language_svelte);
 impl_lang!(Tsx, language_tsx);
 impl_lang!(TypeScript, language_typescript);
+#[cfg(feature = "full-langs")]
 impl_lang!(Vue, language_vue);
 impl_lang!(Yaml, language_yaml);
 
 // New stub languages
 impl_lang!(Markdown, language_markdown);
 impl_lang!(Toml, language_toml);
+#[cfg(feature = "full-langs")]
 impl_lang!(Diff, language_diff);
+#[cfg(feature = "full-langs")]
 impl_lang!(Xml, language_xml);
+#[cfg(feature = "full-langs")]
 impl_lang!(Regex, language_regex);
+#[cfg(feature = "full-langs")]
 impl_lang!(Dart, language_dart);
 
 // ── Html (custom implementation with injection support) ──────────────────
@@ -267,148 +304,323 @@ fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
 /// All supported languages for ast-grep structural search/replace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SupportLang {
+	#[cfg(feature = "full-langs")]
 	Astro,
 	Bash,
 	C,
+	#[cfg(feature = "full-langs")]
 	Cmake,
 	Cpp,
 	CSharp,
+	#[cfg(feature = "full-langs")]
 	Dart,
+	#[cfg(feature = "full-langs")]
 	Clojure,
 	Css,
+	#[cfg(feature = "full-langs")]
 	Diff,
+	#[cfg(feature = "full-langs")]
 	Dockerfile,
+	#[cfg(feature = "full-langs")]
 	Elixir,
+	#[cfg(feature = "full-langs")]
 	Erlang,
 	Go,
+	#[cfg(feature = "full-langs")]
 	Graphql,
+	#[cfg(feature = "full-langs")]
 	Haskell,
+	#[cfg(feature = "full-langs")]
 	Hcl,
 	Html,
+	#[cfg(feature = "full-langs")]
 	Ini,
 	Java,
 	JavaScript,
 	Json,
+	#[cfg(feature = "full-langs")]
 	Just,
+	#[cfg(feature = "full-langs")]
 	Julia,
+	#[cfg(feature = "full-langs")]
 	Kotlin,
+	#[cfg(feature = "full-langs")]
 	Lua,
+	#[cfg(feature = "full-langs")]
 	Make,
 	Markdown,
+	#[cfg(feature = "full-langs")]
 	Nix,
+	#[cfg(feature = "full-langs")]
 	ObjC,
+	#[cfg(feature = "full-langs")]
 	Ocaml,
+	#[cfg(feature = "full-langs")]
 	Odin,
+	#[cfg(feature = "full-langs")]
 	Perl,
 	Php,
+	#[cfg(feature = "full-langs")]
 	Powershell,
+	#[cfg(feature = "full-langs")]
 	Proto,
 	Python,
+	#[cfg(feature = "full-langs")]
 	R,
+	#[cfg(feature = "full-langs")]
 	Regex,
 	Ruby,
 	Rust,
+	#[cfg(feature = "full-langs")]
 	Scala,
+	#[cfg(feature = "full-langs")]
 	Solidity,
+	#[cfg(feature = "full-langs")]
 	Sql,
+	#[cfg(feature = "full-langs")]
 	Starlark,
+	#[cfg(feature = "full-langs")]
 	Svelte,
+	#[cfg(feature = "full-langs")]
 	Swift,
 	Toml,
+	#[cfg(feature = "full-langs")]
 	Tlaplus,
 	Tsx,
 	TypeScript,
+	#[cfg(feature = "full-langs")]
 	Verilog,
+	#[cfg(feature = "full-langs")]
 	Vue,
+	#[cfg(feature = "full-langs")]
 	Xml,
 	Yaml,
+	#[cfg(feature = "full-langs")]
 	Zig,
 }
 
+
+#[cfg(not(feature = "full-langs"))]
+const ALL_LANGS_DEFAULT: [SupportLang; 19] = [
+	SupportLang::TypeScript,
+	SupportLang::Tsx,
+	SupportLang::JavaScript,
+	SupportLang::Python,
+	SupportLang::Rust,
+	SupportLang::Go,
+	SupportLang::Java,
+	SupportLang::C,
+	SupportLang::Cpp,
+	SupportLang::CSharp,
+	SupportLang::Ruby,
+	SupportLang::Php,
+	SupportLang::Bash,
+	SupportLang::Json,
+	SupportLang::Yaml,
+	SupportLang::Toml,
+	SupportLang::Markdown,
+	SupportLang::Html,
+	SupportLang::Css,
+];
+
+#[cfg(feature = "full-langs")]
+const ALL_LANGS_FULL: [SupportLang; 56] = [
+	SupportLang::Astro,
+	SupportLang::Bash,
+	SupportLang::C,
+	SupportLang::Cmake,
+	SupportLang::Cpp,
+	SupportLang::CSharp,
+	SupportLang::Dart,
+	SupportLang::Clojure,
+	SupportLang::Css,
+	SupportLang::Diff,
+	SupportLang::Dockerfile,
+	SupportLang::Elixir,
+	SupportLang::Erlang,
+	SupportLang::Go,
+	SupportLang::Graphql,
+	SupportLang::Haskell,
+	SupportLang::Hcl,
+	SupportLang::Html,
+	SupportLang::Ini,
+	SupportLang::Java,
+	SupportLang::JavaScript,
+	SupportLang::Json,
+	SupportLang::Just,
+	SupportLang::Julia,
+	SupportLang::Kotlin,
+	SupportLang::Lua,
+	SupportLang::Make,
+	SupportLang::Markdown,
+	SupportLang::Nix,
+	SupportLang::ObjC,
+	SupportLang::Ocaml,
+	SupportLang::Odin,
+	SupportLang::Perl,
+	SupportLang::Php,
+	SupportLang::Powershell,
+	SupportLang::Proto,
+	SupportLang::Python,
+	SupportLang::R,
+	SupportLang::Regex,
+	SupportLang::Ruby,
+	SupportLang::Rust,
+	SupportLang::Scala,
+	SupportLang::Solidity,
+	SupportLang::Sql,
+	SupportLang::Starlark,
+	SupportLang::Svelte,
+	SupportLang::Swift,
+	SupportLang::Toml,
+	SupportLang::Tlaplus,
+	SupportLang::Tsx,
+	SupportLang::TypeScript,
+	SupportLang::Verilog,
+	SupportLang::Vue,
+	SupportLang::Xml,
+	SupportLang::Yaml,
+	SupportLang::Zig,
+];
+
 static SORTED_ALIASES: LazyLock<Box<[&'static str]>> = LazyLock::new(|| {
-	let mut aliases = LANG_ALIASES.keys().copied().collect::<Box<[_]>>();
+	let aliases = CORE_LANG_ALIASES.keys().copied().collect::<Vec<_>>();
+	#[cfg(feature = "full-langs")]
+	let mut aliases = aliases;
+	#[cfg(feature = "full-langs")]
+	aliases.extend(LONG_TAIL_LANG_ALIASES.keys().copied());
+	let mut aliases = aliases.into_boxed_slice();
 	aliases.sort_unstable();
 	aliases
 });
 
 impl SupportLang {
 	pub const fn all_langs() -> &'static [Self] {
-		use SupportLang::*;
-		&[
-			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, Elixir, Erlang,
-			Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia, Kotlin, Lua,
-			Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python, R, Regex,
-			Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx, TypeScript,
-			Verilog, Vue, Xml, Yaml, Zig,
-		]
+		#[cfg(feature = "full-langs")]
+		{
+			&ALL_LANGS_FULL
+		}
+		#[cfg(not(feature = "full-langs"))]
+		{
+			&ALL_LANGS_DEFAULT
+		}
 	}
 
 	/// The canonical lowercase name used as a stable key in alias maps,
 	/// file-type inference results, and error messages.
 	pub const fn canonical_name(self) -> &'static str {
 		match self {
+			#[cfg(feature = "full-langs")]
 			Self::Astro => "astro",
 			Self::Bash => "bash",
 			Self::C => "c",
+			#[cfg(feature = "full-langs")]
 			Self::Cmake => "cmake",
 			Self::Cpp => "cpp",
 			Self::CSharp => "csharp",
+			#[cfg(feature = "full-langs")]
 			Self::Dart => "dart",
+			#[cfg(feature = "full-langs")]
 			Self::Clojure => "clojure",
 			Self::Css => "css",
+			#[cfg(feature = "full-langs")]
 			Self::Diff => "diff",
+			#[cfg(feature = "full-langs")]
 			Self::Dockerfile => "dockerfile",
+			#[cfg(feature = "full-langs")]
 			Self::Elixir => "elixir",
+			#[cfg(feature = "full-langs")]
 			Self::Erlang => "erlang",
 			Self::Go => "go",
+			#[cfg(feature = "full-langs")]
 			Self::Graphql => "graphql",
+			#[cfg(feature = "full-langs")]
 			Self::Haskell => "haskell",
+			#[cfg(feature = "full-langs")]
 			Self::Hcl => "hcl",
 			Self::Html => "html",
+			#[cfg(feature = "full-langs")]
 			Self::Ini => "ini",
 			Self::Java => "java",
 			Self::JavaScript => "javascript",
 			Self::Json => "json",
+			#[cfg(feature = "full-langs")]
 			Self::Just => "just",
+			#[cfg(feature = "full-langs")]
 			Self::Julia => "julia",
+			#[cfg(feature = "full-langs")]
 			Self::Kotlin => "kotlin",
+			#[cfg(feature = "full-langs")]
 			Self::Lua => "lua",
+			#[cfg(feature = "full-langs")]
 			Self::Make => "make",
 			Self::Markdown => "markdown",
+			#[cfg(feature = "full-langs")]
 			Self::Nix => "nix",
+			#[cfg(feature = "full-langs")]
 			Self::ObjC => "objc",
+			#[cfg(feature = "full-langs")]
 			Self::Ocaml => "ocaml",
+			#[cfg(feature = "full-langs")]
 			Self::Odin => "odin",
+			#[cfg(feature = "full-langs")]
 			Self::Perl => "perl",
 			Self::Php => "php",
+			#[cfg(feature = "full-langs")]
 			Self::Powershell => "powershell",
+			#[cfg(feature = "full-langs")]
 			Self::Proto => "protobuf",
 			Self::Python => "python",
+			#[cfg(feature = "full-langs")]
 			Self::R => "r",
+			#[cfg(feature = "full-langs")]
 			Self::Regex => "regex",
 			Self::Ruby => "ruby",
 			Self::Rust => "rust",
+			#[cfg(feature = "full-langs")]
 			Self::Scala => "scala",
+			#[cfg(feature = "full-langs")]
 			Self::Solidity => "solidity",
+			#[cfg(feature = "full-langs")]
 			Self::Sql => "sql",
+			#[cfg(feature = "full-langs")]
 			Self::Starlark => "starlark",
+			#[cfg(feature = "full-langs")]
 			Self::Svelte => "svelte",
+			#[cfg(feature = "full-langs")]
 			Self::Swift => "swift",
 			Self::Toml => "toml",
+			#[cfg(feature = "full-langs")]
 			Self::Tlaplus => "tlaplus",
 			Self::Tsx => "tsx",
 			Self::TypeScript => "typescript",
+			#[cfg(feature = "full-langs")]
 			Self::Verilog => "verilog",
+			#[cfg(feature = "full-langs")]
 			Self::Vue => "vue",
+			#[cfg(feature = "full-langs")]
 			Self::Xml => "xml",
 			Self::Yaml => "yaml",
+			#[cfg(feature = "full-langs")]
 			Self::Zig => "zig",
 		}
 	}
 
 	pub fn from_alias(value: &str) -> Option<Self> {
 		let lowered = value.trim().to_ascii_lowercase();
-		LANG_ALIASES.get(lowered.as_str()).copied()
+		CORE_LANG_ALIASES
+			.get(lowered.as_str())
+			.copied()
+			.or_else(|| {
+				#[cfg(feature = "full-langs")]
+				{
+					LONG_TAIL_LANG_ALIASES.get(lowered.as_str()).copied()
+				}
+				#[cfg(not(feature = "full-langs"))]
+				{
+					None
+				}
+			})
 	}
 
 	pub fn from_path(path: &Path) -> Option<Self> {
@@ -432,61 +644,98 @@ macro_rules! execute_lang_method {
 	($me:expr, $method:ident, $($pname:tt),*) => {
 		use SupportLang as S;
 		match *$me {
+			#[cfg(feature = "full-langs")]
 			S::Astro => Astro.$method($($pname,)*),
 			S::Bash => Bash.$method($($pname,)*),
 			S::C => C.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Cmake => Cmake.$method($($pname,)*),
 			S::Cpp => Cpp.$method($($pname,)*),
 			S::CSharp => CSharp.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Dart => Dart.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Clojure => Clojure.$method($($pname,)*),
 			S::Css => Css.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Diff => Diff.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Dockerfile => Dockerfile.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Elixir => Elixir.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Erlang => Erlang.$method($($pname,)*),
 			S::Go => Go.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Graphql => Graphql.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Haskell => Haskell.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Hcl => Hcl.$method($($pname,)*),
 			S::Html => Html.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Ini => Ini.$method($($pname,)*),
 			S::Java => Java.$method($($pname,)*),
 			S::JavaScript => JavaScript.$method($($pname,)*),
 			S::Json => Json.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Just => Just.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Julia => Julia.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Kotlin => Kotlin.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Lua => Lua.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Make => Make.$method($($pname,)*),
 			S::Markdown => Markdown.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Nix => Nix.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::ObjC => ObjC.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Ocaml => Ocaml.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Odin => Odin.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Perl => Perl.$method($($pname,)*),
 			S::Php => Php.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Powershell => Powershell.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Proto => Proto.$method($($pname,)*),
 			S::Python => Python.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::R => R.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Regex => Regex.$method($($pname,)*),
 			S::Ruby => Ruby.$method($($pname,)*),
 			S::Rust => Rust.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Scala => Scala.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Solidity => Solidity.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Sql => Sql.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Starlark => Starlark.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Svelte => Svelte.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Swift => Swift.$method($($pname,)*),
 			S::Toml => Toml.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Tlaplus => Tlaplus.$method($($pname,)*),
 			S::Tsx => Tsx.$method($($pname,)*),
 			S::TypeScript => TypeScript.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Verilog => Verilog.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Vue => Vue.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Xml => Xml.$method($($pname,)*),
 			S::Yaml => Yaml.$method($($pname,)*),
+			#[cfg(feature = "full-langs")]
 			S::Zig => Zig.$method($($pname,)*),
 		}
 	};
@@ -544,79 +793,121 @@ impl LanguageExt for SupportLang {
 const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 	use SupportLang::*;
 	match lang {
+		#[cfg(feature = "full-langs")]
 		Astro => &["astro"],
 		Bash => {
 			&["bash", "bats", "cgi", "command", "env", "fcgi", "ksh", "sh", "tmux", "tool", "zsh"]
 		},
 		C => &["c", "h"],
+		#[cfg(feature = "full-langs")]
 		Cmake => &["cmake"],
 		Cpp => &["cc", "hpp", "cpp", "c++", "hh", "cxx", "cu", "ino"],
 		CSharp => &["cs"],
+		#[cfg(feature = "full-langs")]
 		Dart => &["dart"],
+		#[cfg(feature = "full-langs")]
 		Clojure => &["clj", "cljs", "cljc", "edn"],
 		Css => &["css", "scss"],
+		#[cfg(feature = "full-langs")]
 		Diff => &["diff", "patch"],
+		#[cfg(feature = "full-langs")]
 		Dockerfile => &["dockerfile"],
+		#[cfg(feature = "full-langs")]
 		Elixir => &["ex", "exs"],
+		#[cfg(feature = "full-langs")]
 		Erlang => &["erl", "hrl"],
 		Go => &["go"],
+		#[cfg(feature = "full-langs")]
 		Graphql => &["graphql", "gql"],
+		#[cfg(feature = "full-langs")]
 		Haskell => &["hs"],
+		#[cfg(feature = "full-langs")]
 		Hcl => &["hcl", "tf", "tfvars"],
 		Html => &["html", "htm", "xhtml"],
+		#[cfg(feature = "full-langs")]
 		Ini => &["ini", "cfg", "conf", "properties"],
 		Java => &["java"],
 		JavaScript => &["cjs", "js", "mjs", "jsx"],
 		Json => &["json"],
+		#[cfg(feature = "full-langs")]
 		Just => &[],
+		#[cfg(feature = "full-langs")]
 		Julia => &["jl"],
+		#[cfg(feature = "full-langs")]
 		Kotlin => &["kt", "ktm", "kts"],
+		#[cfg(feature = "full-langs")]
 		Lua => &["lua"],
+		#[cfg(feature = "full-langs")]
 		Make => &["mk", "mak"],
 		Markdown => &["md", "markdown", "mdx"],
+		#[cfg(feature = "full-langs")]
 		Nix => &["nix"],
+		#[cfg(feature = "full-langs")]
 		ObjC => &["m"],
+		#[cfg(feature = "full-langs")]
 		Ocaml => &["ml"],
+		#[cfg(feature = "full-langs")]
 		Odin => &["odin"],
+		#[cfg(feature = "full-langs")]
 		Perl => &["pl", "pm"],
 		Php => &["php"],
+		#[cfg(feature = "full-langs")]
 		Powershell => &["ps1", "psm1"],
+		#[cfg(feature = "full-langs")]
 		Proto => &["proto"],
-		Python => &["py", "py3", "pyi", "bzl"],
+		Python => &["py", "py3", "pyi"],
+		#[cfg(feature = "full-langs")]
 		R => &["r"],
+		#[cfg(feature = "full-langs")]
 		Regex => &[],
 		Ruby => &["rb", "rbw", "gemspec"],
 		Rust => &["rs"],
+		#[cfg(feature = "full-langs")]
 		Scala => &["scala", "sc", "sbt"],
+		#[cfg(feature = "full-langs")]
 		Solidity => &["sol"],
+		#[cfg(feature = "full-langs")]
 		Sql => &["sql"],
+		#[cfg(feature = "full-langs")]
 		Starlark => &["star", "bzl"],
+		#[cfg(feature = "full-langs")]
 		Svelte => &["svelte"],
+		#[cfg(feature = "full-langs")]
 		Swift => &["swift"],
 		Toml => &["toml"],
+		#[cfg(feature = "full-langs")]
 		Tlaplus => &["tla"],
 		Tsx => &["tsx"],
 		TypeScript => &["ts", "cts", "mts"],
+		#[cfg(feature = "full-langs")]
 		Verilog => &["v", "sv", "svh", "vh"],
+		#[cfg(feature = "full-langs")]
 		Vue => &["vue"],
+		#[cfg(feature = "full-langs")]
 		Xml => &["xml", "xsl", "xslt", "svg", "plist"],
 		Yaml => &["yaml", "yml"],
+		#[cfg(feature = "full-langs")]
 		Zig => &["zig"],
 	}
 }
 
 /// Guess language from file extension.
 fn from_extension(path: &Path) -> Option<SupportLang> {
+	#[cfg(feature = "full-langs")]
 	let name = path.file_name()?.to_str()?;
+	#[cfg(feature = "full-langs")]
 	if name == "Makefile" || name == "makefile" || name == "GNUmakefile" {
 		return Some(SupportLang::Make);
 	}
+	#[cfg(feature = "full-langs")]
 	if name == "Justfile" || name == "justfile" {
 		return Some(SupportLang::Just);
 	}
+	#[cfg(feature = "full-langs")]
 	if name == "CMakeLists.txt" {
 		return Some(SupportLang::Cmake);
 	}
+	#[cfg(feature = "full-langs")]
 	if name == "Dockerfile"
 		|| name == "dockerfile"
 		|| name.starts_with("Dockerfile.")
@@ -634,8 +925,7 @@ fn from_extension(path: &Path) -> Option<SupportLang> {
 		.find(|&l| extensions(l).contains(&ext))
 }
 
-static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
-"astro"          => SupportLang::Astro,
+static CORE_LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "bash"           => SupportLang::Bash,
 "sh"             => SupportLang::Bash,
 "zsh"            => SupportLang::Bash,
@@ -643,7 +933,6 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "bats"           => SupportLang::Bash,
 "c"              => SupportLang::C,
 "h"              => SupportLang::C,
-"cmake"          => SupportLang::Cmake,
 "cpp"            => SupportLang::Cpp,
 "c++"            => SupportLang::Cpp,
 "cc"             => SupportLang::Cpp,
@@ -655,8 +944,48 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "csharp"         => SupportLang::CSharp,
 "c#"             => SupportLang::CSharp,
 "cs"             => SupportLang::CSharp,
-"dart"           => SupportLang::Dart,
 "css"            => SupportLang::Css,
+"go"             => SupportLang::Go,
+"golang"         => SupportLang::Go,
+"html"           => SupportLang::Html,
+"htm"            => SupportLang::Html,
+"xhtml"          => SupportLang::Html,
+"java"           => SupportLang::Java,
+"javascript"     => SupportLang::JavaScript,
+"js"             => SupportLang::JavaScript,
+"jsx"            => SupportLang::JavaScript,
+"mjs"            => SupportLang::JavaScript,
+"cjs"            => SupportLang::JavaScript,
+"json"           => SupportLang::Json,
+"markdown"       => SupportLang::Markdown,
+"md"             => SupportLang::Markdown,
+"mdx"            => SupportLang::Markdown,
+"php"            => SupportLang::Php,
+"python"         => SupportLang::Python,
+"py"             => SupportLang::Python,
+"py3"            => SupportLang::Python,
+"pyi"            => SupportLang::Python,
+"ruby"           => SupportLang::Ruby,
+"rb"             => SupportLang::Ruby,
+"rbw"            => SupportLang::Ruby,
+"gemspec"        => SupportLang::Ruby,
+"rust"           => SupportLang::Rust,
+"rs"             => SupportLang::Rust,
+"toml"           => SupportLang::Toml,
+"tsx"            => SupportLang::Tsx,
+"typescript"     => SupportLang::TypeScript,
+"ts"             => SupportLang::TypeScript,
+"mts"            => SupportLang::TypeScript,
+"cts"            => SupportLang::TypeScript,
+"yaml"           => SupportLang::Yaml,
+"yml"            => SupportLang::Yaml,
+};
+
+#[cfg(feature = "full-langs")]
+static LONG_TAIL_LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
+"astro"          => SupportLang::Astro,
+"cmake"          => SupportLang::Cmake,
+"dart"           => SupportLang::Dart,
 "clj"            => SupportLang::Clojure,
 "cljc"           => SupportLang::Clojure,
 "cljs"           => SupportLang::Clojure,
@@ -674,8 +1003,6 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "erlang"         => SupportLang::Erlang,
 "erl"            => SupportLang::Erlang,
 "hrl"            => SupportLang::Erlang,
-"go"             => SupportLang::Go,
-"golang"         => SupportLang::Go,
 "graphql"        => SupportLang::Graphql,
 "gql"            => SupportLang::Graphql,
 "haskell"        => SupportLang::Haskell,
@@ -684,21 +1011,11 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "tf"             => SupportLang::Hcl,
 "tfvars"         => SupportLang::Hcl,
 "terraform"      => SupportLang::Hcl,
-"html"           => SupportLang::Html,
-"htm"            => SupportLang::Html,
-"xhtml"          => SupportLang::Html,
 "ini"            => SupportLang::Ini,
 "cfg"            => SupportLang::Ini,
 "conf"           => SupportLang::Ini,
 "config"         => SupportLang::Ini,
 "properties"     => SupportLang::Ini,
-"java"           => SupportLang::Java,
-"javascript"     => SupportLang::JavaScript,
-"js"             => SupportLang::JavaScript,
-"jsx"            => SupportLang::JavaScript,
-"mjs"            => SupportLang::JavaScript,
-"cjs"            => SupportLang::JavaScript,
-"json"           => SupportLang::Json,
 "just"           => SupportLang::Just,
 "justfile"       => SupportLang::Just,
 "julia"          => SupportLang::Julia,
@@ -713,9 +1030,6 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "gnumake"        => SupportLang::Make,
 "mk"             => SupportLang::Make,
 "mak"            => SupportLang::Make,
-"markdown"       => SupportLang::Markdown,
-"md"             => SupportLang::Markdown,
-"mdx"            => SupportLang::Markdown,
 "nix"            => SupportLang::Nix,
 "objc"           => SupportLang::ObjC,
 "obj-c"          => SupportLang::ObjC,
@@ -728,25 +1042,14 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "perl"           => SupportLang::Perl,
 "pl"             => SupportLang::Perl,
 "pm"             => SupportLang::Perl,
-"php"            => SupportLang::Php,
 "powershell"     => SupportLang::Powershell,
 "ps1"            => SupportLang::Powershell,
 "psm1"           => SupportLang::Powershell,
 "protobuf"       => SupportLang::Proto,
 "proto"          => SupportLang::Proto,
-"python"         => SupportLang::Python,
-"py"             => SupportLang::Python,
-"py3"            => SupportLang::Python,
-"pyi"            => SupportLang::Python,
 "r"              => SupportLang::R,
 "regex"          => SupportLang::Regex,
 "re"             => SupportLang::Regex,
-"ruby"           => SupportLang::Ruby,
-"rb"             => SupportLang::Ruby,
-"rbw"            => SupportLang::Ruby,
-"gemspec"        => SupportLang::Ruby,
-"rust"           => SupportLang::Rust,
-"rs"             => SupportLang::Rust,
 "scala"          => SupportLang::Scala,
 "sc"             => SupportLang::Scala,
 "sbt"            => SupportLang::Scala,
@@ -760,17 +1063,11 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "skylark"        => SupportLang::Starlark,
 "svelte"         => SupportLang::Svelte,
 "swift"          => SupportLang::Swift,
-"toml"           => SupportLang::Toml,
 "tla"            => SupportLang::Tlaplus,
 "tla+"           => SupportLang::Tlaplus,
 "tlaplus"        => SupportLang::Tlaplus,
 "pluscal"        => SupportLang::Tlaplus,
 "pcal"           => SupportLang::Tlaplus,
-"tsx"            => SupportLang::Tsx,
-"typescript"     => SupportLang::TypeScript,
-"ts"             => SupportLang::TypeScript,
-"mts"            => SupportLang::TypeScript,
-"cts"            => SupportLang::TypeScript,
 "verilog"        => SupportLang::Verilog,
 "systemverilog"  => SupportLang::Verilog,
 "sv"             => SupportLang::Verilog,
@@ -783,7 +1080,174 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "xslt"           => SupportLang::Xml,
 "svg"            => SupportLang::Xml,
 "plist"          => SupportLang::Xml,
-"yaml"           => SupportLang::Yaml,
-"yml"            => SupportLang::Yaml,
 "zig"            => SupportLang::Zig,
 };
+
+pub const KNOWN_LONG_TAIL_ALIASES: &[&str] = &[
+	"astro",
+	"cmake",
+	"dart",
+	"clj",
+	"cljc",
+	"cljs",
+	"clojure",
+	"clojurescript",
+	"edn",
+	"diff",
+	"patch",
+	"docker",
+	"dockerfile",
+	"containerfile",
+	"elixir",
+	"ex",
+	"exs",
+	"erlang",
+	"erl",
+	"hrl",
+	"graphql",
+	"gql",
+	"haskell",
+	"hs",
+	"hcl",
+	"tf",
+	"tfvars",
+	"terraform",
+	"ini",
+	"cfg",
+	"conf",
+	"config",
+	"properties",
+	"just",
+	"justfile",
+	"julia",
+	"jl",
+	"kotlin",
+	"kt",
+	"kts",
+	"ktm",
+	"lua",
+	"make",
+	"makefile",
+	"gnumake",
+	"mk",
+	"mak",
+	"nix",
+	"objc",
+	"obj-c",
+	"objective-c",
+	"m",
+	"mm",
+	"ocaml",
+	"ml",
+	"odin",
+	"perl",
+	"pl",
+	"pm",
+	"powershell",
+	"ps1",
+	"psm1",
+	"protobuf",
+	"proto",
+	"r",
+	"regex",
+	"re",
+	"scala",
+	"sc",
+	"sbt",
+	"solidity",
+	"sol",
+	"sql",
+	"starlark",
+	"star",
+	"bzl",
+	"bazel",
+	"skylark",
+	"svelte",
+	"swift",
+	"tla",
+	"tla+",
+	"tlaplus",
+	"pluscal",
+	"pcal",
+	"verilog",
+	"systemverilog",
+	"sv",
+	"svh",
+	"vh",
+	"v",
+	"vue",
+	"xml",
+	"xsl",
+	"xslt",
+	"svg",
+	"plist",
+	"zig",];
+
+#[cfg(test)]
+mod tests {
+	use std::path::Path;
+
+	use ast_grep_core::{Language, matcher::KindMatcher, tree_sitter::LanguageExt};
+
+	use super::SupportLang;
+
+	#[test]
+	fn all_langs_matches_locked_registry() {
+		let langs = SupportLang::all_langs();
+		#[cfg(not(feature = "full-langs"))]
+		assert_eq!(
+			langs,
+			&[
+				SupportLang::TypeScript,
+				SupportLang::Tsx,
+				SupportLang::JavaScript,
+				SupportLang::Python,
+				SupportLang::Rust,
+				SupportLang::Go,
+				SupportLang::Java,
+				SupportLang::C,
+				SupportLang::Cpp,
+				SupportLang::CSharp,
+				SupportLang::Ruby,
+				SupportLang::Php,
+				SupportLang::Bash,
+				SupportLang::Json,
+				SupportLang::Yaml,
+				SupportLang::Toml,
+				SupportLang::Markdown,
+				SupportLang::Html,
+				SupportLang::Css,
+			],
+		);
+
+		#[cfg(feature = "full-langs")]
+		{
+			assert_eq!(langs.len(), 56);
+			assert!(langs.contains(&SupportLang::Starlark));
+			assert!(langs.contains(&SupportLang::Swift));
+		}
+	}
+
+	#[test]
+	fn bzl_extension_inference_matches_language_set() {
+		let inferred = SupportLang::from_path(Path::new("x.bzl"));
+		#[cfg(not(feature = "full-langs"))]
+		assert_eq!(inferred, None);
+		#[cfg(feature = "full-langs")]
+		assert_eq!(inferred, Some(SupportLang::Starlark));
+	}
+
+	#[test]
+	fn html_script_injection_range_is_available_in_default_registry() {
+		let html = SupportLang::Html;
+		let ast = html.ast_grep("<html><script>const x=1</script></html>");
+		let injections = html.extract_injections(ast.root());
+		let ranges = injections.get("js").expect("script should inject JavaScript");
+		let range = ranges.first().expect("script should expose raw text range");
+		assert_eq!(&ast.root().text().as_ref()[range.start_byte..range.end_byte], "const x=1");
+
+		let matcher = KindMatcher::new("script_element", html);
+		assert!(ast.root().find(matcher).is_some());
+	}
+}
+

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -399,7 +399,6 @@ pub enum SupportLang {
 	Zig,
 }
 
-
 #[cfg(not(feature = "full-langs"))]
 const ALL_LANGS_DEFAULT: [SupportLang; 19] = [
 	SupportLang::TypeScript,
@@ -1181,7 +1180,8 @@ pub const KNOWN_LONG_TAIL_ALIASES: &[&str] = &[
 	"xslt",
 	"svg",
 	"plist",
-	"zig",];
+	"zig",
+];
 
 #[cfg(test)]
 mod tests {
@@ -1195,30 +1195,27 @@ mod tests {
 	fn all_langs_matches_locked_registry() {
 		let langs = SupportLang::all_langs();
 		#[cfg(not(feature = "full-langs"))]
-		assert_eq!(
-			langs,
-			&[
-				SupportLang::TypeScript,
-				SupportLang::Tsx,
-				SupportLang::JavaScript,
-				SupportLang::Python,
-				SupportLang::Rust,
-				SupportLang::Go,
-				SupportLang::Java,
-				SupportLang::C,
-				SupportLang::Cpp,
-				SupportLang::CSharp,
-				SupportLang::Ruby,
-				SupportLang::Php,
-				SupportLang::Bash,
-				SupportLang::Json,
-				SupportLang::Yaml,
-				SupportLang::Toml,
-				SupportLang::Markdown,
-				SupportLang::Html,
-				SupportLang::Css,
-			],
-		);
+		assert_eq!(langs, &[
+			SupportLang::TypeScript,
+			SupportLang::Tsx,
+			SupportLang::JavaScript,
+			SupportLang::Python,
+			SupportLang::Rust,
+			SupportLang::Go,
+			SupportLang::Java,
+			SupportLang::C,
+			SupportLang::Cpp,
+			SupportLang::CSharp,
+			SupportLang::Ruby,
+			SupportLang::Php,
+			SupportLang::Bash,
+			SupportLang::Json,
+			SupportLang::Yaml,
+			SupportLang::Toml,
+			SupportLang::Markdown,
+			SupportLang::Html,
+			SupportLang::Css,
+		],);
 
 		#[cfg(feature = "full-langs")]
 		{
@@ -1242,7 +1239,9 @@ mod tests {
 		let html = SupportLang::Html;
 		let ast = html.ast_grep("<html><script>const x=1</script></html>");
 		let injections = html.extract_injections(ast.root());
-		let ranges = injections.get("js").expect("script should inject JavaScript");
+		let ranges = injections
+			.get("js")
+			.expect("script should inject JavaScript");
 		let range = ranges.first().expect("script should expose raw text range");
 		assert_eq!(&ast.root().text().as_ref()[range.start_byte..range.end_byte], "const x=1");
 
@@ -1250,4 +1249,3 @@ mod tests {
 		assert!(ast.root().find(matcher).is_some());
 	}
 }
-

--- a/crates/pi-ast/src/language/parsers.rs
+++ b/crates/pi-ast/src/language/parsers.rs
@@ -2,6 +2,7 @@
 
 use ast_grep_core::tree_sitter::TSLanguage;
 
+#[cfg(feature = "full-langs")]
 pub fn language_astro() -> TSLanguage {
 	tree_sitter_astro::LANGUAGE.into()
 }
@@ -11,9 +12,11 @@ pub fn language_bash() -> TSLanguage {
 pub fn language_c() -> TSLanguage {
 	tree_sitter_c::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_clojure() -> TSLanguage {
 	tree_sitter_clojure::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_cmake() -> TSLanguage {
 	tree_sitter_cmake::LANGUAGE.into()
 }
@@ -23,39 +26,48 @@ pub fn language_cpp() -> TSLanguage {
 pub fn language_c_sharp() -> TSLanguage {
 	tree_sitter_c_sharp::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_dart() -> TSLanguage {
 	tree_sitter_dart::LANGUAGE.into()
 }
 pub fn language_css() -> TSLanguage {
 	tree_sitter_css::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_diff() -> TSLanguage {
 	tree_sitter_diff::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_dockerfile() -> TSLanguage {
 	tree_sitter_dockerfile::language()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_elixir() -> TSLanguage {
 	tree_sitter_elixir::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_erlang() -> TSLanguage {
 	tree_sitter_erlang::LANGUAGE.into()
 }
 pub fn language_go() -> TSLanguage {
 	tree_sitter_go::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_graphql() -> TSLanguage {
 	tree_sitter_graphql::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_haskell() -> TSLanguage {
 	tree_sitter_haskell::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_hcl() -> TSLanguage {
 	tree_sitter_hcl::LANGUAGE.into()
 }
 pub fn language_html() -> TSLanguage {
 	tree_sitter_html::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_ini() -> TSLanguage {
 	tree_sitter_ini::LANGUAGE.into()
 }
@@ -68,54 +80,68 @@ pub fn language_javascript() -> TSLanguage {
 pub fn language_json() -> TSLanguage {
 	tree_sitter_json::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_just() -> TSLanguage {
 	tree_sitter_just::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_julia() -> TSLanguage {
 	tree_sitter_julia::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_kotlin() -> TSLanguage {
 	tree_sitter_kotlin::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_lua() -> TSLanguage {
 	tree_sitter_lua::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_make() -> TSLanguage {
 	tree_sitter_make::LANGUAGE.into()
 }
 pub fn language_markdown() -> TSLanguage {
 	tree_sitter_md::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_nix() -> TSLanguage {
 	tree_sitter_nix::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_objc() -> TSLanguage {
 	tree_sitter_objc::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_ocaml() -> TSLanguage {
 	tree_sitter_ocaml::LANGUAGE_OCAML.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_odin() -> TSLanguage {
 	tree_sitter_odin::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_perl() -> TSLanguage {
 	tree_sitter_perl::LANGUAGE.into()
 }
 pub fn language_php() -> TSLanguage {
 	tree_sitter_php::LANGUAGE_PHP_ONLY.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_powershell() -> TSLanguage {
 	tree_sitter_powershell::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_proto() -> TSLanguage {
 	tree_sitter_proto::LANGUAGE.into()
 }
 pub fn language_python() -> TSLanguage {
 	tree_sitter_python::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_r() -> TSLanguage {
 	tree_sitter_r::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_regex() -> TSLanguage {
 	tree_sitter_regex::LANGUAGE.into()
 }
@@ -125,21 +151,27 @@ pub fn language_ruby() -> TSLanguage {
 pub fn language_rust() -> TSLanguage {
 	tree_sitter_rust::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_scala() -> TSLanguage {
 	tree_sitter_scala::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_solidity() -> TSLanguage {
 	tree_sitter_solidity::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_sql() -> TSLanguage {
 	tree_sitter_sql::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_starlark() -> TSLanguage {
 	tree_sitter_starlark::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_svelte() -> TSLanguage {
 	tree_sitter_svelte::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_swift() -> TSLanguage {
 	tree_sitter_swift::LANGUAGE.into()
 }
@@ -152,21 +184,26 @@ pub fn language_tsx() -> TSLanguage {
 pub fn language_typescript() -> TSLanguage {
 	tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_tlaplus() -> TSLanguage {
 	tree_sitter_tlaplus::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_verilog() -> TSLanguage {
 	tree_sitter_verilog::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_vue() -> TSLanguage {
 	tree_sitter_vue::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_xml() -> TSLanguage {
 	tree_sitter_xml::LANGUAGE_XML.into()
 }
 pub fn language_yaml() -> TSLanguage {
 	tree_sitter_yaml::LANGUAGE.into()
 }
+#[cfg(feature = "full-langs")]
 pub fn language_zig() -> TSLanguage {
 	tree_sitter_zig::LANGUAGE.into()
 }

--- a/crates/pi-ast/src/ops.rs
+++ b/crates/pi-ast/src/ops.rs
@@ -73,7 +73,9 @@ pub fn resolve_supported_lang(value: &str) -> Result<SupportLang> {
 		let lowered = value.trim().to_ascii_lowercase();
 		if KNOWN_LONG_TAIL_ALIASES.contains(&lowered.as_str()) {
 			anyhow!(
-				"language \"{lowered}\" is not included in the default build; rebuild from source with --features full-langs (PI_NATIVE_FULL_LANGS=1 bun --cwd=packages/natives run build)"
+				"language \"{lowered}\" is not included in the default build; rebuild from source \
+				 with --features full-langs (PI_NATIVE_FULL_LANGS=1 bun --cwd=packages/natives run \
+				 build)"
 			)
 		} else {
 			anyhow!("Unsupported language '{value}'. Supported: {}", supported_lang_list())

--- a/crates/pi-ast/src/ops.rs
+++ b/crates/pi-ast/src/ops.rs
@@ -10,7 +10,7 @@ use ast_grep_core::{
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 
-use crate::language::SupportLang;
+use crate::language::{KNOWN_LONG_TAIL_ALIASES, SupportLang};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AstMatchStrictness {
@@ -70,7 +70,14 @@ pub fn supported_lang_list() -> String {
 
 pub fn resolve_supported_lang(value: &str) -> Result<SupportLang> {
 	SupportLang::from_alias(value).ok_or_else(|| {
-		anyhow!("Unsupported language '{value}'. Supported: {}", supported_lang_list())
+		let lowered = value.trim().to_ascii_lowercase();
+		if KNOWN_LONG_TAIL_ALIASES.contains(&lowered.as_str()) {
+			anyhow!(
+				"language \"{lowered}\" is not included in the default build; rebuild from source with --features full-langs (PI_NATIVE_FULL_LANGS=1 bun --cwd=packages/natives run build)"
+			)
+		} else {
+			anyhow!("Unsupported language '{value}'. Supported: {}", supported_lang_list())
+		}
 	})
 }
 
@@ -284,13 +291,28 @@ fn compile_rust_contextual_pattern(pattern: &str) -> Option<Pattern> {
 mod tests {
 	use ast_grep_core::source::Edit;
 
-	use super::{SupportLang, apply_edits, compile_search_patterns};
+	use super::{SupportLang, apply_edits, compile_search_patterns, resolve_supported_lang};
 
 	#[test]
 	fn compile_search_patterns_compiles_rust_patterns() {
 		let patterns = compile_search_patterns("foo($$$ARGS)", SupportLang::Rust)
 			.expect("rust pattern should compile");
 		assert!(!patterns.is_empty());
+	}
+
+	#[test]
+	fn resolves_core_aliases_and_reports_default_long_tail() {
+		assert_eq!(resolve_supported_lang("typescript").ok(), Some(SupportLang::TypeScript));
+		assert_eq!(resolve_supported_lang("python").ok(), Some(SupportLang::Python));
+
+		let swift = resolve_supported_lang("swift");
+		#[cfg(feature = "full-langs")]
+		assert_eq!(swift.ok(), Some(SupportLang::Swift));
+		#[cfg(not(feature = "full-langs"))]
+		{
+			let err = swift.expect_err("swift should require full-langs in default builds");
+			assert!(err.to_string().contains("full-langs"));
+		}
 	}
 
 	#[test]

--- a/crates/pi-ast/src/summary.rs
+++ b/crates/pi-ast/src/summary.rs
@@ -7,7 +7,7 @@ use ast_grep_core::tree_sitter::LanguageExt;
 use serde::{Deserialize, Serialize};
 use tree_sitter::{Node, Parser};
 
-use crate::language::SupportLang;
+use crate::{language::SupportLang, ops};
 
 const DEFAULT_MIN_BODY_LINES: u32 = 4;
 const DEFAULT_MIN_COMMENT_LINES: u32 = 6;
@@ -65,7 +65,7 @@ pub fn summarize_code(options: SummaryOptions) -> Result<SummaryResult> {
 		return Ok(unparsed_result(source, total_lines));
 	}
 
-	let Some(language) = resolve_language(options.lang.as_deref(), options.path.as_deref()) else {
+	let Some(language) = resolve_language(options.lang.as_deref(), options.path.as_deref())? else {
 		return Ok(unparsed_result(source, total_lines));
 	};
 
@@ -103,15 +103,14 @@ pub fn summarize_code(options: SummaryOptions) -> Result<SummaryResult> {
 	})
 }
 
-fn resolve_language(lang: Option<&str>, path: Option<&str>) -> Option<SupportLang> {
+fn resolve_language(lang: Option<&str>, path: Option<&str>) -> Result<Option<SupportLang>> {
 	if let Some(lang) = lang.map(str::trim).filter(|lang| !lang.is_empty()) {
-		return SupportLang::from_alias(lang);
+		return ops::resolve_supported_lang(lang).map(Some);
 	}
-	let path = path?.trim();
-	if path.is_empty() {
-		return None;
-	}
-	SupportLang::from_path(Path::new(path))
+	let Some(path) = path.map(str::trim).filter(|path| !path.is_empty()) else {
+		return Ok(None);
+	};
+	Ok(SupportLang::from_path(Path::new(path)))
 }
 
 fn unparsed_result(source: String, total_lines: u32) -> SummaryResult {
@@ -274,13 +273,19 @@ fn is_comment_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Python => kind == "comment",
 		SupportLang::Go => kind == "comment",
 		SupportLang::Java => kind == "block_comment",
-		SupportLang::C | SupportLang::Cpp | SupportLang::ObjC => kind == "comment",
+		SupportLang::C | SupportLang::Cpp => kind == "comment",
+		#[cfg(feature = "full-langs")]
+		SupportLang::ObjC => kind == "comment",
 		SupportLang::CSharp => kind == "comment",
 		SupportLang::Ruby => kind == "comment",
 		SupportLang::Php => kind == "comment",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Swift => kind == "comment",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Kotlin => kind == "block_comment",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Scala => kind == "block_comment",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Lua => kind == "comment",
 		_ => false,
 	}
@@ -385,6 +390,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "raw_string_literal"
 				| "requires_clause"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::ObjC => matches!(
 			kind,
 			"compound_statement"
@@ -427,6 +433,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "heredoc"
 				| "nowdoc"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Swift => matches!(
 			kind,
 			"function_body"
@@ -439,6 +446,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "computed_property"
 				| "lambda_literal"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Kotlin => matches!(
 			kind,
 			"function_body"
@@ -449,6 +457,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "when_expression"
 				| "import_list"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Scala => matches!(
 			kind,
 			"block"
@@ -459,10 +468,13 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "for_expression"
 				| "string"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Lua => matches!(kind, "block" | "table_constructor" | "string"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Perl => {
 			matches!(kind, "block" | "list_expression" | "heredoc_content" | "regexp_content")
 		},
+		#[cfg(feature = "full-langs")]
 		SupportLang::Dart => matches!(
 			kind,
 			"block"
@@ -485,6 +497,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "array"
 				| "heredoc_body"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Powershell => matches!(
 			kind,
 			"script_block"
@@ -496,6 +509,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "expandable_here_string_literal"
 				| "verbatim_here_string_characters"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Haskell => matches!(
 			kind,
 			"imports"
@@ -507,6 +521,7 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "let" | "local_binds"
 				| "list" | "tuple"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Ocaml => matches!(
 			kind,
 			"structure"
@@ -519,7 +534,9 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "value_definition"
 				| "list_expression"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Elixir => matches!(kind, "do_block" | "list" | "map" | "string" | "sigil"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Erlang => matches!(
 			kind,
 			"fun_decl"
@@ -530,18 +547,24 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "list" | "map_expr"
 				| "tuple"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Clojure => {
 			matches!(kind, "list_lit" | "map_lit" | "vec_lit" | "set_lit" | "str_lit")
 		},
+		#[cfg(feature = "full-langs")]
 		SupportLang::Solidity => {
 			matches!(kind, "contract_body" | "function_body" | "struct_body" | "enum_body")
 		},
+		#[cfg(feature = "full-langs")]
 		SupportLang::Sql => matches!(kind, "column_definitions" | "case"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Zig => matches!(kind, "Block" | "ContainerDecl" | "InitList"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Odin => matches!(
 			kind,
 			"block" | "struct_declaration" | "enum_declaration" | "union_declaration" | "struct"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Verilog => matches!(
 			kind,
 			"module_declaration"
@@ -551,12 +574,16 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "task_declaration"
 				| "list_of_port_declarations"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Tlaplus => matches!(kind, "module" | "theorem" | "let_in"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Nix => matches!(
 			kind,
 			"attrset_expression" | "list_expression" | "let_expression" | "indented_string_expression"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Proto => matches!(kind, "message_body" | "enum_body" | "oneof" | "service"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Julia => matches!(
 			kind,
 			"function_definition"
@@ -566,20 +593,27 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "vector_expression"
 				| "string_literal"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::R => matches!(kind, "braced_expression" | "call" | "string"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Starlark => matches!(kind, "block" | "list" | "dictionary" | "string"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Astro => {
 			matches!(kind, "frontmatter_js_block" | "script_element" | "style_element" | "element")
 		},
+		#[cfg(feature = "full-langs")]
 		SupportLang::Vue => {
 			matches!(kind, "template_element" | "script_element" | "style_element" | "element")
 		},
+		#[cfg(feature = "full-langs")]
 		SupportLang::Svelte => matches!(kind, "script_element" | "style_element" | "element"),
 		SupportLang::Html => matches!(kind, "element" | "script_element" | "style_element"),
 		SupportLang::Css => matches!(kind, "block" | "keyframe_block_list"),
 		SupportLang::Json => matches!(kind, "object" | "array"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Xml => kind == "element",
 		SupportLang::Markdown => matches!(kind, "fenced_code_block" | "pipe_table" | "list"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Graphql => matches!(
 			kind,
 			"fields_definition"
@@ -587,21 +621,24 @@ fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
 				| "input_fields_definition"
 				| "schema_definition"
 		),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Hcl => matches!(kind, "body" | "object"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Dockerfile => kind == "shell_command",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Cmake => matches!(kind, "argument_list" | "body"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Make => kind == "recipe",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Just => kind == "recipe_body",
 		// Skip: data formats with no closing-token anchor (Yaml mappings,
 		// Toml tables, Ini sections), the diff format whose informational
 		// content IS the lines inside hunks, and the leaf-token-only Regex
 		// grammar. Eliding any of these deletes the only content worth
 		// reading.
-		SupportLang::Yaml
-		| SupportLang::Toml
-		| SupportLang::Ini
-		| SupportLang::Diff
-		| SupportLang::Regex => false,
+		SupportLang::Yaml | SupportLang::Toml => false,
+		#[cfg(feature = "full-langs")]
+		SupportLang::Ini | SupportLang::Diff | SupportLang::Regex => false,
 	}
 }
 
@@ -617,25 +654,42 @@ fn is_groupable_kind(language: SupportLang, kind: &str) -> bool {
 		SupportLang::Go => kind == "import_declaration",
 		SupportLang::Java => kind == "import_declaration",
 		SupportLang::C | SupportLang::Cpp => kind == "preproc_include",
+		#[cfg(feature = "full-langs")]
 		SupportLang::ObjC => matches!(kind, "preproc_include" | "import_declaration"),
 		SupportLang::CSharp => kind == "using_directive",
 		SupportLang::Php => kind == "namespace_use_declaration",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Swift => kind == "import_declaration",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Scala => matches!(kind, "import_declaration" | "import"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Dart => kind == "import_or_export",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Ocaml => kind == "open_module",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Solidity => kind == "import_directive",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Julia => matches!(kind, "import_statement" | "using_statement"),
+		#[cfg(feature = "full-langs")]
 		SupportLang::Proto => kind == "import",
+		#[cfg(feature = "full-langs")]
 		SupportLang::Perl => kind == "use_statement",
 		// Languages where imports either have no run pattern, are wrapped in a
 		// single AST node already covered by `is_elidable_kind` (Kotlin's
 		// `import_list`, Haskell's `imports`), or live inside a too-generic
 		// container (Powershell `statement_list`).
+		SupportLang::Ruby
+		| SupportLang::Bash
+		| SupportLang::Html
+		| SupportLang::Css
+		| SupportLang::Json
+		| SupportLang::Markdown
+		| SupportLang::Yaml
+		| SupportLang::Toml => false,
+		#[cfg(feature = "full-langs")]
 		SupportLang::Kotlin
 		| SupportLang::Haskell
 		| SupportLang::Powershell
-		| SupportLang::Ruby
 		| SupportLang::Lua
 		| SupportLang::Elixir
 		| SupportLang::Erlang
@@ -648,23 +702,16 @@ fn is_groupable_kind(language: SupportLang, kind: &str) -> bool {
 		| SupportLang::Nix
 		| SupportLang::R
 		| SupportLang::Starlark
-		| SupportLang::Bash
 		| SupportLang::Astro
 		| SupportLang::Vue
 		| SupportLang::Svelte
-		| SupportLang::Html
-		| SupportLang::Css
-		| SupportLang::Json
 		| SupportLang::Xml
-		| SupportLang::Markdown
 		| SupportLang::Graphql
 		| SupportLang::Hcl
 		| SupportLang::Dockerfile
 		| SupportLang::Cmake
 		| SupportLang::Make
 		| SupportLang::Just
-		| SupportLang::Yaml
-		| SupportLang::Toml
 		| SupportLang::Ini
 		| SupportLang::Diff
 		| SupportLang::Regex => false,

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -61,3 +61,7 @@ winreg.workspace = true
 napi-build.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[features]
+default = []
+full-langs = ["pi-ast/full-langs"]

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -555,6 +555,9 @@ pub fn ast_grep(options: AstFindOptions<'_>) -> task::Promise<AstFindResult> {
 		let strictness = resolve_strictness(strictness);
 		let include_meta = include_meta.unwrap_or(false);
 		let lang_str = lang.as_deref().map(str::trim).filter(|v| !v.is_empty());
+		if let Some(lang) = lang_str {
+			resolve_supported_lang(lang)?;
+		}
 		let candidates: Vec<_> = collect_candidates(path, glob.as_deref(), &ct)?
 			.into_iter()
 			.filter(|candidate| is_supported_file(&candidate.absolute_path, lang_str))
@@ -712,6 +715,9 @@ pub fn ast_edit(options: AstReplaceOptions<'_>) -> task::Promise<AstReplaceResul
 		let fail_on_parse_error = fail_on_parse_error.unwrap_or(false);
 
 		let lang_str = lang.as_deref().map(str::trim).filter(|v| !v.is_empty());
+		if let Some(lang) = lang_str {
+			resolve_supported_lang(lang)?;
+		}
 		let candidates: Vec<_> = collect_candidates(path, glob.as_deref(), &ct)?
 			.into_iter()
 			.filter(|candidate| is_supported_file(&candidate.absolute_path, lang_str))
@@ -973,12 +979,20 @@ mod tests {
 		assert_eq!(resolve_supported_lang("ts").ok(), Some(SupportLang::TypeScript));
 		assert_eq!(resolve_supported_lang("jsx").ok(), Some(SupportLang::JavaScript));
 		assert_eq!(resolve_supported_lang("rs").ok(), Some(SupportLang::Rust));
-		assert_eq!(resolve_supported_lang("kotlin").ok(), Some(SupportLang::Kotlin));
+		#[cfg(feature = "full-langs")]
+		{
+			assert_eq!(resolve_supported_lang("kotlin").ok(), Some(SupportLang::Kotlin));
+			assert_eq!(resolve_supported_lang("tla").ok(), Some(SupportLang::Tlaplus));
+			assert_eq!(resolve_supported_lang("pluscal").ok(), Some(SupportLang::Tlaplus));
+		}
+		#[cfg(not(feature = "full-langs"))]
+		{
+			let err = resolve_supported_lang("kotlin").expect_err("kotlin should require full-langs");
+			assert!(err.to_string().contains("full-langs"));
+		}
 		assert_eq!(resolve_supported_lang("bash").ok(), Some(SupportLang::Bash));
 		assert_eq!(resolve_supported_lang("c").ok(), Some(SupportLang::C));
 		assert_eq!(resolve_supported_lang("cpp").ok(), Some(SupportLang::Cpp));
-		assert_eq!(resolve_supported_lang("tla").ok(), Some(SupportLang::Tlaplus));
-		assert_eq!(resolve_supported_lang("pluscal").ok(), Some(SupportLang::Tlaplus));
 		assert!(resolve_supported_lang("brainfuck").is_err());
 	}
 

--- a/crates/pi-natives/src/build_info.rs
+++ b/crates/pi-natives/src/build_info.rs
@@ -2,7 +2,7 @@ use napi_derive::napi;
 
 #[napi(object)]
 pub struct BuildInfo {
-	pub version: String,
+	pub version:      String,
 	#[napi(js_name = "languageSet")]
 	pub language_set: String,
 }
@@ -10,7 +10,12 @@ pub struct BuildInfo {
 #[napi]
 pub fn native_build_info() -> BuildInfo {
 	BuildInfo {
-		version: env!("CARGO_PKG_VERSION").to_string(),
-		language_set: if cfg!(feature = "full-langs") { "full" } else { "default" }.to_string(),
+		version:      env!("CARGO_PKG_VERSION").to_string(),
+		language_set: if cfg!(feature = "full-langs") {
+			"full"
+		} else {
+			"default"
+		}
+		.to_string(),
 	}
 }

--- a/crates/pi-natives/src/build_info.rs
+++ b/crates/pi-natives/src/build_info.rs
@@ -1,0 +1,16 @@
+use napi_derive::napi;
+
+#[napi(object)]
+pub struct BuildInfo {
+	pub version: String,
+	#[napi(js_name = "languageSet")]
+	pub language_set: String,
+}
+
+#[napi]
+pub fn native_build_info() -> BuildInfo {
+	BuildInfo {
+		version: env!("CARGO_PKG_VERSION").to_string(),
+		language_set: if cfg!(feature = "full-langs") { "full" } else { "default" }.to_string(),
+	}
+}

--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod appearance;
 pub mod ast;
+pub mod build_info;
 pub mod clipboard;
 pub mod crash;
 pub mod edit_fuzzy;

--- a/crates/pi-natives/src/tokens.rs
+++ b/crates/pi-natives/src/tokens.rs
@@ -1,44 +1,46 @@
 //! Token counting via tiktoken-rs.
 //!
-//! Two encodings are exposed:
+//! Two encodings are exposed at the API level:
 //!
 //!   - `O200kBase` — GPT-4o / o1 / GPT-5 (the modern `OpenAI` default).
-//!   - `Cl100kBase` — GPT-3.5 / GPT-4 / older models.
+//!   - `Cl100kBase` — compatibility alias; routes to `o200k_base` in default
+//!     builds (the cl100k BPE table is no longer embedded).
 //!
 //! `o200k_base` is the default. Anthropic doesn't publish their tokenizer, so
-//! either of these is an approximation for Claude (within ~5–10% across
-//! English/code text). `o200k_base` is closer to current frontier models'
-//! actual segmentation and is the right default for budget estimates.
+//! o200k is an approximation for Claude (within ~5–10% across English/code
+//! text). It is closer to current frontier models' actual segmentation and is
+//! the right default for budget estimates.
 //!
-//! Both BPE tables are embedded in the binary; encoders are built once on
-//! first use and reused thereafter.
+//! Only the o200k BPE table is embedded in the binary; the encoder is built
+//! once on first use and reused thereafter. Counting is exact for o200k only;
+//! treat results as a model-family estimate elsewhere and keep conservative
+//! reserve padding at context-changing decisions.
 
 use std::sync::LazyLock;
 
 use napi::bindgen_prelude::Either;
 use napi_derive::napi;
 use rayon::prelude::*;
-use tiktoken_rs::{CoreBPE, cl100k_base, o200k_base};
+use tiktoken_rs::{CoreBPE, o200k_base};
 
 /// Tokenizer encoding to use.
 #[napi(string_enum)]
 pub enum Encoding {
 	/// GPT-4o / o1 / GPT-5 (default).
 	O200kBase,
-	/// GPT-3.5 / GPT-4 / older.
+	/// Compatibility alias: routes to `o200k_base` in default builds. The
+	/// cl100k BPE table is not embedded; callers needing true cl100k counts
+	/// must use an external tokenizer.
 	Cl100kBase,
 }
 
 static O200K: LazyLock<CoreBPE> =
 	LazyLock::new(|| o200k_base().expect("failed to initialize o200k_base BPE tables"));
 
-static CL100K: LazyLock<CoreBPE> =
-	LazyLock::new(|| cl100k_base().expect("failed to initialize cl100k_base BPE tables"));
-
 fn encoder(encoding: Option<Encoding>) -> &'static CoreBPE {
 	match encoding.unwrap_or(Encoding::O200kBase) {
-		Encoding::O200kBase => &O200K,
-		Encoding::Cl100kBase => &CL100K,
+		// Cl100kBase is a compatibility alias for o200k in default builds.
+		Encoding::O200kBase | Encoding::Cl100kBase => &O200K,
 	}
 }
 
@@ -51,7 +53,8 @@ fn encoder(encoding: Option<Encoding>) -> &'static CoreBPE {
 ///
 /// Uses ordinary encoding (no special-token handling), which is the right
 /// choice for measuring user/model content rather than wire-protocol tokens.
-/// Defaults to `o200k_base`; pass `Cl100kBase` for older `OpenAI` models.
+/// Always counts with `o200k_base` in default builds (`Cl100kBase` is a
+/// compatibility alias). Exact for o200k only.
 #[napi]
 pub fn count_tokens(input: Either<String, Vec<String>>, encoding: Option<Encoding>) -> u32 {
 	let bpe = encoder(encoding);
@@ -61,5 +64,34 @@ pub fn count_tokens(input: Either<String, Vec<String>>, encoding: Option<Encodin
 			.par_iter()
 			.map(|s| bpe.encode_ordinary(s).len() as u32)
 			.sum(),
+	}
+}
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn counts_tokens_o200k() {
+		let n = count_tokens(Either::A("hello world".to_string()), None);
+		assert!(n >= 1 && n <= 4, "unexpected token count: {n}");
+	}
+
+	#[test]
+	fn cl100k_aliases_to_o200k() {
+		let text = "fn main() { println!(\"hello\"); } // 안녕하세요 world";
+		let o200k = count_tokens(Either::A(text.to_string()), Some(Encoding::O200kBase));
+		let cl100k = count_tokens(Either::A(text.to_string()), Some(Encoding::Cl100kBase));
+		assert_eq!(o200k, cl100k, "Cl100kBase must route to the o200k encoder");
+	}
+
+	#[test]
+	fn array_input_sums() {
+		let parts = vec!["hello".to_string(), "world".to_string()];
+		let sum = count_tokens(Either::B(parts.clone()), None);
+		let manual: u32 = parts
+			.iter()
+			.map(|s| count_tokens(Either::A(s.clone()), None))
+			.sum();
+		assert_eq!(sum, manual);
 	}
 }

--- a/docs/natives-media-system-utils.md
+++ b/docs/natives-media-system-utils.md
@@ -86,7 +86,7 @@ There is no current `packages/natives` TS wrapper that emits OSC52, handles Term
 
 - `countTokens(input, encoding?)` accepts a single string or an array of strings.
 - Arrays return one aggregate token count; encoding work is parallelized in Rust.
-- Default encoding is `O200kBase`; `Cl100kBase` is also exported.
+- Default encoding is `O200kBase`; `Cl100kBase` remains exported as a compatibility alias that routes to `o200k_base` (the cl100k BPE table is not embedded in default builds).
 - The implementation uses ordinary encoding, not special-token handling.
 
 ### macOS appearance and power helpers

--- a/docs/natives-text-search-pipeline.md
+++ b/docs/natives-text-search-pipeline.md
@@ -234,7 +234,7 @@ Text functions generally return deterministic transformed output; errors are lim
 
 - `input` may be a single string or an array of strings.
 - Arrays return one aggregate count and are encoded in parallel in Rust.
-- Default encoding is `O200kBase`; `Cl100kBase` is also available.
+- Default encoding is `O200kBase`; `Cl100kBase` remains available as a compatibility alias routing to `o200k_base` in default builds.
 - The implementation uses ordinary tokenization, not special-token handling.
 
 ## Pure utility vs filesystem-dependent flows

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -13,7 +13,6 @@ import {
 	type Model,
 	type Usage,
 } from "@gajae-code/ai";
-import { countTokens } from "@gajae-code/natives";
 import { logger, prompt } from "@gajae-code/utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
 import type { AgentMessage, AgentTool } from "../types";
@@ -268,18 +267,95 @@ export function resolveThresholdTokens(
 const IMAGE_TOKEN_ESTIMATE = 1200;
 
 /**
- * Estimate token count for a message using cl100k_base via the native
- * tokenizer. This is not Anthropic's first-party tokenizer (Anthropic doesn't
- * publish one) but is within ~5–10% across English/code text.
+ * Lazily-required native `countTokens`. `@gajae-code/natives` dlopens a ~39MB
+ * addon; importing it at module scope would put that cost on every cold path
+ * that touches compaction exports (status line, print mode, context report).
+ * Deferring the require to the first context-changing call keeps the trivial
+ * `-p` / display paths native-free.
  */
-export function estimateTokens(message: AgentMessage): number {
+let cachedNativeCountTokens: ((input: string | string[], encoding?: unknown) => number) | null = null;
+
+function nativeCountTokens(fragments: string[]): number {
+	if (!cachedNativeCountTokens) {
+		const { createRequire } = require("node:module") as typeof import("node:module");
+		const requireFromHere = createRequire(import.meta.url);
+		const natives = requireFromHere("@gajae-code/natives") as {
+			countTokens: (input: string | string[], encoding?: unknown) => number;
+		};
+		cachedNativeCountTokens = natives.countTokens;
+	}
+	return cachedNativeCountTokens(fragments);
+}
+
+/**
+ * Estimate token count for a message using the native o200k tokenizer.
+ * Exact for o200k only; an approximation for Anthropic/other model families
+ * (Anthropic doesn't publish a tokenizer) within ~5–10% on English/code text.
+ *
+ * This materializes the native BPE table (~50MB RSS) on first call. Use it
+ * only for context-changing decisions (compaction trigger/cut points, pruning
+ * budgets, branch summarization, fork-context seeding, context-limit
+ * enforcement). For display-only totals use
+ * {@link estimateMessageTokensHeuristic}.
+ */
+export function countMessageTokensNativeO200k(message: AgentMessage): number {
+	const { fragments, extra } = collectMessageFragments(message);
+	if (fragments.length === 0) return extra;
+	return extra + nativeCountTokens(fragments);
+}
+
+/**
+ * Backwards-compatible alias for {@link countMessageTokensNativeO200k}.
+ * Existing callers treat this as the canonical message-token estimator for
+ * context-changing decisions.
+ */
+export const estimateTokens = countMessageTokensNativeO200k;
+
+/**
+ * Average bytes per token for the cheap heuristic. ~4 bytes/token is the
+ * conventional approximation for English/code text under modern BPE
+ * vocabularies; it intentionally errs slightly low-precision in exchange for
+ * never touching the native tokenizer (and its ~50MB BPE table).
+ */
+const HEURISTIC_BYTES_PER_TOKEN = 4;
+
+/**
+ * Cheap, native-free token estimate for a message. Suitable ONLY for
+ * display/init surfaces (status line, /context report, HUD totals) — never
+ * for context-changing decisions, which must use
+ * {@link countMessageTokensNativeO200k}.
+ */
+export function estimateMessageTokensHeuristic(message: AgentMessage): number {
+	const { fragments, extra } = collectMessageFragments(message);
+	let bytes = 0;
+	for (const fragment of fragments) {
+		bytes += fragment.length;
+	}
+	return extra + Math.ceil(bytes / HEURISTIC_BYTES_PER_TOKEN);
+}
+
+/**
+ * Cheap, native-free token estimate for plain string fragments. Display-only
+ * counterpart of the native `countTokens(fragments)` aggregate.
+ */
+export function estimateTextTokensHeuristic(fragments: string | readonly string[]): number {
+	if (typeof fragments === "string") return Math.ceil(fragments.length / HEURISTIC_BYTES_PER_TOKEN);
+	let bytes = 0;
+	for (const fragment of fragments) {
+		bytes += fragment.length;
+	}
+	return Math.ceil(bytes / HEURISTIC_BYTES_PER_TOKEN);
+}
+
+/** Shared content walk for both the native and heuristic estimators. */
+function collectMessageFragments(message: AgentMessage): { fragments: string[]; extra: number } {
 	const fragments: string[] = [];
 	let extra = 0;
 	if ((message as { role?: string }).role === "bashExecution") {
 		const bash = message as { command?: unknown; output?: unknown };
 		if (typeof bash.command === "string") fragments.push(bash.command);
 		if (typeof bash.output === "string") fragments.push(bash.output);
-		return fragments.length === 0 ? 0 : countTokens(fragments);
+		return { fragments, extra };
 	}
 
 	switch (message.role) {
@@ -331,11 +407,10 @@ export function estimateTokens(message: AgentMessage): number {
 			break;
 		}
 		default:
-			return 0;
+			break;
 	}
 
-	if (fragments.length === 0) return extra;
-	return extra + countTokens(fragments);
+	return { fragments, extra };
 }
 
 function estimateEntriesTokens(entries: SessionEntry[], startIndex: number, endIndex: number): number {

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -39,6 +39,10 @@ async function main(): Promise<void> {
 					"bun",
 					"build",
 					"--compile",
+					// Minify shrinks the bundled JS the compiled binary must parse at
+					// startup (302MB → ~114MB --help RSS measured on darwin-arm64).
+					// --keep-names below preserves identifiers for error reports.
+					"--minify",
 					"--no-compile-autoload-bunfig",
 					"--no-compile-autoload-dotenv",
 					"--no-compile-autoload-tsconfig",

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -1,24 +1,14 @@
 #!/usr/bin/env bun
-import { installH2Fetch } from "@gajae-code/ai";
-import { APP_NAME, MIN_BUN_VERSION, procmgr, VERSION } from "@gajae-code/utils";
+import { APP_NAME, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 
-// Activate HTTP/2 for all `fetch()` calls (provider streams, OAuth, model
-// discovery, web tools). Bun's HTTP/2 client is gated on a startup flag we
-// can't toggle from JS, so we patch globalThis.fetch to pass
-// `protocol: "http2"` per request, with transparent HTTP/1.1 fallback on
-// `HTTP2Unsupported`. See @gajae-code/ai/utils/h2-fetch for details.
-installH2Fetch();
 
-// Strip macOS malloc-stack-logging env vars before any subprocess is spawned.
-// Otherwise every child bun process (subagents, plugin installs, ptree spawns,
-// etc.) prints a `MallocStackLogging: can't turn off …` warning to stderr.
-procmgr.scrubProcessEnv();
+
 
 /**
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
-import { type CliConfig, type CommandEntry, run } from "@gajae-code/utils/cli";
+import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -28,6 +18,9 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 }
 
 process.title = APP_NAME;
+const rootHelpFlags = ["--help", "-h", "help", ""];
+const versionFlags = ["--version", "-v"];
+
 
 const commands: CommandEntry[] = [
 	{ name: "codex-native-hook", load: () => import("./commands/codex-native-hook").then(m => m.default) },
@@ -54,12 +47,94 @@ const commands: CommandEntry[] = [
 
 async function showHelp(config: CliConfig): Promise<void> {
 	const { renderRootHelp } = await import("@gajae-code/utils/cli");
-	const { getExtraHelpText } = await import("./cli/args");
+	const { getExtraHelpText } = await import("./cli/fast-help");
 	renderRootHelp(config);
 	const extra = getExtraHelpText();
 	if (extra.trim().length > 0) {
 		process.stdout.write(`\n${extra}\n`);
 	}
+}
+
+async function installRuntimeGlobals(): Promise<void> {
+	const [{ installH2Fetch }, { procmgr }] = await Promise.all([import("@gajae-code/ai"), import("@gajae-code/utils")]);
+	// Activate HTTP/2 for all `fetch()` calls (provider streams, OAuth, model
+	// discovery, web tools). Bun's HTTP/2 client is gated on a startup flag we
+	// can't toggle from JS, so we patch globalThis.fetch to pass
+	// `protocol: "http2"` per request, with transparent HTTP/1.1 fallback on
+	// `HTTP2Unsupported`. See @gajae-code/ai/utils/h2-fetch for details.
+	installH2Fetch();
+
+	// Strip macOS malloc-stack-logging env vars before any subprocess is spawned.
+	// Otherwise every child bun process (subagents, plugin installs, ptree spawns,
+	// etc.) prints a `MallocStackLogging: can't turn off …` warning to stderr.
+	procmgr.scrubProcessEnv();
+}
+
+async function loadLaunchCommand() {
+	return import("./commands/launch").then(m => m.default);
+}
+
+
+class RootHelpCommand extends Command {
+	static description = "Red-claw AI coding assistant";
+	static hidden = true;
+	static args = {
+		messages: Args.string({
+			description: "Messages to send (prefix files with @)",
+			required: false,
+			multiple: true,
+		}),
+	};
+	static flags = {
+		model: Flags.string({ description: 'Model to use (fuzzy match: "opus", "gpt-5.2", or "openai/gpt-5.2")' }),
+		smol: Flags.string({ description: "Smol/fast model for lightweight tasks (or GJC_SMOL_MODEL env)" }),
+		slow: Flags.string({ description: "Slow/reasoning model for thorough analysis (or GJC_SLOW_MODEL env)" }),
+		plan: Flags.string({ description: "Plan model for architectural planning (or GJC_PLAN_MODEL env)" }),
+		mpreset: Flags.string({ description: "Model profile preset to activate for this session" }),
+		default: Flags.boolean({ description: "Persist --mpreset as the default model profile" }),
+		provider: Flags.string({ description: "Provider to use (legacy; prefer --model)" }),
+		"api-key": Flags.string({ description: "API key (defaults to env vars)" }),
+		"system-prompt": Flags.string({ description: "System prompt (default: coding assistant prompt)" }),
+		"append-system-prompt": Flags.string({ description: "Append text or file contents to the system prompt" }),
+		"allow-home": Flags.boolean({ description: "Allow starting in ~ without auto-switching to a temp dir" }),
+		mode: Flags.string({ description: "Output mode: text (default), json, rpc, acp, rpc-ui, or bridge", options: ["text", "json", "rpc", "acp", "rpc-ui", "bridge"] }),
+		print: Flags.boolean({ char: "p", description: "Non-interactive mode: process prompt and exit" }),
+		continue: Flags.boolean({ char: "c", description: "Continue previous session" }),
+		resume: Flags.string({ char: "r", description: "Resume a session (by ID prefix, path, or picker if omitted)" }),
+		"session-dir": Flags.string({ description: "Directory for session storage and lookup" }),
+		"no-session": Flags.boolean({ description: "Don't save session (ephemeral)" }),
+		models: Flags.string({ description: "Comma-separated model patterns for Ctrl+P cycling" }),
+		"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),
+		"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
+		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
+		tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
+		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
+		thinking: Flags.string({ description: "Set thinking level: ultra, high, medium, low", options: ["ultra", "high", "medium", "low"] }),
+		hook: Flags.string({ description: "Load a hook/extension file (can be used multiple times)", multiple: true }),
+		extension: Flags.string({ char: "e", description: "Load an extension file (can be used multiple times)", multiple: true }),
+		"no-extensions": Flags.boolean({ description: "Disable extension discovery (explicit -e paths still work)" }),
+		"no-skills": Flags.boolean({ description: "Disable skills discovery and loading" }),
+		skills: Flags.string({ description: "Comma-separated glob patterns to filter skills (e.g., git-*,docker)" }),
+		"no-rules": Flags.boolean({ description: "Disable rules discovery and loading" }),
+		export: Flags.string({ description: "Export session file to HTML and exit" }),
+		"list-models": Flags.string({ description: "List available models (with optional fuzzy search)" }),
+		"no-title": Flags.boolean({ description: "Disable title auto-generation" }),
+	};
+	static examples = [
+		`# Interactive mode\n  ${APP_NAME}`,
+		`# Interactive mode with initial prompt\n  ${APP_NAME} "List all .ts files in src/"`,
+		`# Include files in initial message\n  ${APP_NAME} @prompt.md @image.png "What color is the sky?"`,
+		`# Non-interactive mode (process and exit)\n  ${APP_NAME} -p "List all .ts files in src/"`,
+		`# Continue previous session\n  ${APP_NAME} --continue "What did we discuss?"`,
+		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
+		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
+		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
+		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-standard`,
+		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencode-go-pro --default`,
+		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,
+	];
+	static strict = false;
+	async run(): Promise<void> {}
 }
 
 /**
@@ -109,6 +184,21 @@ export async function runCli(argv: string[]): Promise<void> {
 		await runSmokeTest();
 		return;
 	}
+	if (rootHelpFlags.includes(argv[0] ?? "")) {
+		const { renderRootHelp } = await import("@gajae-code/utils/cli");
+		const { getExtraHelpText } = await import("./cli/fast-help");
+		renderRootHelp({ bin: APP_NAME, version: VERSION, commands: new Map([["launch", RootHelpCommand]]) });
+		const extra = getExtraHelpText();
+		if (extra.trim().length > 0) {
+			process.stdout.write(`\n${extra}\n`);
+		}
+		return;
+	}
+	if (versionFlags.includes(argv[0] ?? "")) {
+		process.stdout.write(`${APP_NAME}/${VERSION}\n`);
+		return;
+	}
+	await installRuntimeGlobals();
 	// --help and --version are handled by run() directly, don't rewrite those.
 	// Everything else that isn't a known subcommand routes to "launch".
 	const first = argv[0];

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -1,0 +1,80 @@
+import { APP_NAME, CONFIG_DIR_NAME } from "@gajae-code/utils/dirs";
+
+export function getExtraHelpText(): string {
+	return `Environment Variables:
+  # Core Providers
+  ANTHROPIC_API_KEY          - Anthropic Claude models
+  ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)
+  CLAUDE_CODE_USE_FOUNDRY    - Enable Anthropic Foundry mode (uses Foundry endpoint + mTLS)
+  FOUNDRY_BASE_URL           - Anthropic Foundry base URL (e.g., https://<foundry-host>)
+  ANTHROPIC_FOUNDRY_API_KEY  - Anthropic token used as Authorization: Bearer <token> in Foundry mode
+  ANTHROPIC_CUSTOM_HEADERS   - Extra Foundry headers (e.g., "user-id: USERNAME")
+  CLAUDE_CODE_CLIENT_CERT    - Client certificate (PEM path or inline PEM) for mTLS
+  CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
+  NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
+  OPENAI_API_KEY             - OpenAI GPT models
+  GEMINI_API_KEY             - Google Gemini models
+  GITHUB_TOKEN               - GitHub Copilot (or GH_TOKEN, COPILOT_GITHUB_TOKEN)
+
+  # Additional LLM Providers
+  AZURE_OPENAI_API_KEY       - Azure OpenAI models
+  GROQ_API_KEY               - Groq models
+  CEREBRAS_API_KEY           - Cerebras models
+  XAI_API_KEY                - xAI Grok models
+  OPENROUTER_API_KEY         - OpenRouter aggregated models
+  KILO_API_KEY               - Kilo Gateway models
+  MISTRAL_API_KEY            - Mistral models
+  ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
+  MINIMAX_API_KEY            - MiniMax models
+  OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
+  CURSOR_ACCESS_TOKEN        - Cursor AI models
+  AI_GATEWAY_API_KEY         - Vercel AI Gateway
+
+  # Cloud Providers
+  AWS_PROFILE                - AWS Bedrock (or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
+  GOOGLE_CLOUD_PROJECT       - Google Vertex AI (requires GOOGLE_CLOUD_LOCATION)
+  GOOGLE_APPLICATION_CREDENTIALS - Service account for Vertex AI
+
+  # Search & Tools
+  EXA_API_KEY                - Exa web search
+  BRAVE_API_KEY              - Brave web search
+  PERPLEXITY_API_KEY         - Perplexity web search (API)
+  PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
+  TAVILY_API_KEY             - Tavily web search
+  ANTHROPIC_SEARCH_API_KEY   - Anthropic search provider
+
+  # Configuration
+  GJC_CODING_AGENT_DIR       - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  GJC_PACKAGE_DIR            - Override package directory (for Nix/Guix store paths)
+  GJC_SMOL_MODEL              - Override smol/fast model (see --smol)
+  GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
+  GJC_PLAN_MODEL              - Override planning model (see --plan)
+  GJC_NO_PTY                  - Disable PTY-based interactive bash execution
+  --tmux                       - Launch interactive startup inside a new tmux session
+  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
+  GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
+  GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
+
+  For complete environment variable reference, see:
+  docs/environment-variables.md
+Available Tools (default-enabled unless noted):
+  read          - Read file contents
+  bash          - Execute bash commands
+  edit          - Edit files with find/replace
+  write         - Write files (creates/overwrites)
+  grep          - Search file contents
+  find          - Find files by glob pattern
+  lsp           - Language server protocol (code intelligence)
+  python        - Execute Python code (requires: ${APP_NAME} setup python)
+  notebook      - Edit Jupyter notebooks
+  inspect_image - Analyze images with a vision model
+  browser       - Browser automation (Puppeteer)
+  task          - Launch sub-agents for parallel tasks
+  todo_write    - Manage todo/task lists
+  web_search    - Search the web
+  ask           - Ask user questions (interactive mode only)
+
+Useful Commands:
+  ${APP_NAME} --list-models        - List configured provider models
+  ${APP_NAME} --help               - Show this help`;
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -33,9 +33,9 @@ import { getDefault, type SettingPath, Settings, settings } from "./config/setti
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
-import { InteractiveMode, runAcpMode, runBridgeMode, runPrintMode, runRpcMode } from "./modes";
-import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
+import type { InteractiveMode, InteractiveModeOptions } from "./modes/interactive-mode";
 import type { SubmittedUserInput } from "./modes/types";
+import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { MCPManager } from "./runtime-mcp";
 import {
 	type CreateAgentSessionOptions,
@@ -304,6 +304,7 @@ async function runInteractiveMode(
 	initialMessage?: string,
 	initialImages?: ImageContent[],
 ): Promise<void> {
+	const { InteractiveMode } = await import("./modes/interactive-mode");
 	const mode = new InteractiveMode(
 		session,
 		version,
@@ -706,7 +707,7 @@ async function buildSessionOptions(
 interface RunRootCommandDependencies {
 	createAgentSession?: typeof createAgentSession;
 	discoverAuthStorage?: typeof discoverAuthStorage;
-	runAcpMode?: typeof runAcpMode;
+	runAcpMode?: (createSession: AcpSessionFactory) => Promise<void>;
 	settings?: Settings;
 }
 
@@ -927,7 +928,7 @@ export async function runRootCommand(
 			rawArgs,
 			createSession,
 		});
-		await (deps.runAcpMode ?? runAcpMode)(createAcpSession);
+		await (deps.runAcpMode ?? (await import("./modes/acp")).runAcpMode)(createAcpSession);
 	} else {
 		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager, eventBus } =
 			await createSession(sessionOptions);
@@ -973,8 +974,10 @@ export async function runRootCommand(
 		}
 
 		if (mode === "rpc" || mode === "rpc-ui") {
+			const { runRpcMode } = await import("./modes/rpc/rpc-mode");
 			await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined);
 		} else if (mode === "bridge") {
+			const { runBridgeMode } = await import("./modes/bridge/bridge-mode");
 			await runBridgeMode(session, setToolUIContext);
 		} else if (isInteractive) {
 			const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
@@ -1014,6 +1017,7 @@ export async function runRootCommand(
 				initialImages,
 			);
 		} else {
+			const { runPrintMode } = await import("./modes/print-mode");
 			await runPrintMode(session, {
 				mode,
 				messages: parsedArgs.messages,

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import type { AgentMessage } from "@gajae-code/agent-core";
-import { estimateTokens } from "@gajae-code/agent-core/compaction";
+import { estimateMessageTokensHeuristic } from "@gajae-code/agent-core/compaction";
 import { type Component, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { formatCount, getProjectDir } from "@gajae-code/utils";
 import { $ } from "bun";
@@ -50,7 +50,7 @@ export interface StatusLineSettings {
 
 /**
  * Symbol-keyed sidecar tagged onto each `AgentMessage` to memoize its
- * `estimateTokens` result. Keyed by message identity (the object itself);
+ * `estimateMessageTokensHeuristic` result. Keyed by message identity (the object itself);
  * a cheap content fingerprint detects in-place mutations (post-hoc error
  * attachment, retry-truncated branch rebuild, etc.) and forces recompute.
  *
@@ -64,11 +64,11 @@ interface TaggedMessage {
 }
 
 /**
- * Cheap structural fingerprint mirroring `estimateTokens`'s content walk.
+ * Cheap structural fingerprint mirroring `estimateMessageTokensHeuristic`'s content walk.
  * O(blocks) — only reads string `.length` and primitives, never copies or
  * serializes content. Any in-place mutation that alters total tokenized
  * content also alters one of the byte-length sums or block counts captured
- * here, forcing the cached `estimateTokens` value to be recomputed.
+ * here, forcing the cached heuristic token value to be recomputed.
  */
 function messageFingerprint(msg: AgentMessage): string {
 	const role = (msg as { role?: string }).role ?? "";
@@ -136,7 +136,7 @@ function tokensForMessage(msg: AgentMessage): number {
 	const tagged = msg as TaggedMessage;
 	const cached = tagged[kTokenCache];
 	if (cached && cached.fingerprint === fp) return cached.tokens;
-	const tokens = estimateTokens(msg);
+	const tokens = estimateMessageTokensHeuristic(msg);
 	tagged[kTokenCache] = { fingerprint: fp, tokens };
 	return tokens;
 }
@@ -560,7 +560,7 @@ export class StatusLineComponent implements Component {
 		let messagesTokens = 0;
 		const lastIdx = messages.length - 1;
 		for (let i = 0; i < messages.length; i++) {
-			messagesTokens += i === lastIdx ? estimateTokens(messages[i]) : tokensForMessage(messages[i]);
+			messagesTokens += i === lastIdx ? estimateMessageTokensHeuristic(messages[i]) : tokensForMessage(messages[i]);
 		}
 
 		const usedTokens = this.#nonMessageTokensCache + messagesTokens;

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -1,8 +1,12 @@
 import type { AgentMessage } from "@gajae-code/agent-core";
 import type { CompactionSettings } from "@gajae-code/agent-core/compaction";
-import { effectiveReserveTokens, estimateTokens, resolveThresholdTokens } from "@gajae-code/agent-core/compaction";
+import {
+	effectiveReserveTokens,
+	estimateMessageTokensHeuristic,
+	estimateTextTokensHeuristic,
+	resolveThresholdTokens,
+} from "@gajae-code/agent-core/compaction";
 import type { Model } from "@gajae-code/ai";
-import { countTokens } from "@gajae-code/natives";
 import { formatNumber } from "@gajae-code/utils";
 import type { Skill } from "../../extensibility/skills";
 import type { AgentSession } from "../../session/agent-session";
@@ -46,7 +50,7 @@ export function estimateSkillsTokens(skills: readonly Skill[]): number {
 		// concatenated form, so encode each piece separately and sum.
 		fragments.push(skill.name, skill.description);
 	}
-	return countTokens(fragments);
+	return estimateTextTokensHeuristic(fragments);
 }
 
 export function estimateToolSchemaTokens(
@@ -61,7 +65,7 @@ export function estimateToolSchemaTokens(
 			// Schema may contain functions or cycles; ignore.
 		}
 	}
-	return countTokens(fragments);
+	return estimateTextTokensHeuristic(fragments);
 }
 
 /**
@@ -100,8 +104,8 @@ function computeNonMessageBreakdown(session: AgentSession): {
 	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? []);
 	const systemPromptParts = session.systemPrompt ?? [];
 	const rulesTokens = estimateRulesTokens(systemPromptParts);
-	const systemContextTokens = countTokens(systemPromptParts.slice(1));
-	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens - rulesTokens);
+	const systemContextTokens = estimateTextTokensHeuristic(systemPromptParts.slice(1));
+	const systemPromptTokens = Math.max(0, estimateTextTokensHeuristic(systemPromptParts[0] ?? "") - skillsTokens - rulesTokens);
 	return { rulesTokens, skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
 }
 
@@ -112,7 +116,7 @@ function estimateRulesTokens(systemPromptParts: readonly string[]): number {
 			fragments.push(match[0]);
 		}
 	}
-	return fragments.length === 0 ? 0 : countTokens(fragments);
+	return fragments.length === 0 ? 0 : estimateTextTokensHeuristic(fragments);
 }
 
 function splitLastUserTurn(messages: readonly AgentMessage[]): {
@@ -130,7 +134,7 @@ function splitLastUserTurn(messages: readonly AgentMessage[]): {
 	let regularMessagesTokens = 0;
 	let lastUserTurnTokens = 0;
 	for (let i = 0; i < messages.length; i++) {
-		const tokens = estimateTokens(messages[i]);
+		const tokens = estimateMessageTokensHeuristic(messages[i]);
 		if (i === lastUserIndex) {
 			lastUserTurnTokens = tokens;
 		} else {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -41,6 +41,7 @@ import {
 	calculatePromptTokens,
 	collectEntriesForBranchSummary,
 	compact,
+	estimateMessageTokensHeuristic,
 	estimateTokens,
 	generateBranchSummary,
 	generateHandoff,
@@ -9527,7 +9528,7 @@ export class AgentSession {
 			// No usage data - estimate all messages
 			let estimated = 0;
 			for (const message of messages) {
-				estimated += estimateTokens(message);
+				estimated += estimateMessageTokensHeuristic(message);
 			}
 			return {
 				tokens: estimated,
@@ -9537,7 +9538,7 @@ export class AgentSession {
 		const usageTokens = calculatePromptTokens(lastUsage);
 		let trailingTokens = 0;
 		for (let i = lastUsageIndex + 1; i < messages.length; i++) {
-			trailingTokens += estimateTokens(messages[i]);
+			trailingTokens += estimateMessageTokensHeuristic(messages[i]);
 		}
 
 		return {

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -344,6 +344,11 @@ export interface BashFixupResult {
   stripped: Array<string>
 }
 
+export interface BuildInfo {
+  version: string
+  languageSet: string
+}
+
 /** Clipboard image payload encoded as PNG bytes. */
 export interface ClipboardImage {
   /** PNG-encoded image bytes. */
@@ -381,7 +386,8 @@ export declare function copyToClipboard(text: string): void
  *
  * Uses ordinary encoding (no special-token handling), which is the right
  * choice for measuring user/model content rather than wire-protocol tokens.
- * Defaults to `o200k_base`; pass `Cl100kBase` for older `OpenAI` models.
+ * Always counts with `o200k_base` in default builds (`Cl100kBase` is a
+ * compatibility alias). Exact for o200k only.
  */
 export declare function countTokens(input: string | Array<string>, encoding?: Encoding | undefined | null): number
 
@@ -422,7 +428,11 @@ export declare function encodeSixel(bytes: Uint8Array, targetWidthPx: number, ta
 export declare enum Encoding {
   /** GPT-4o / o1 / GPT-5 (default). */
   O200kBase = 'O200kBase',
-  /** GPT-3.5 / GPT-4 / older. */
+  /**
+   * Compatibility alias: routes to `o200k_base` in default builds. The
+   * cl100k BPE table is not embedded; callers needing true cl100k counts
+   * must use an external tokenizer.
+   */
   Cl100kBase = 'Cl100kBase'
 }
 
@@ -1103,6 +1113,8 @@ export interface MinimizerResult {
   /** Byte length of the minimized text the consumer received. */
   outputBytes: number
 }
+
+export declare function nativeBuildInfo(): BuildInfo
 
 /** Parsed Kitty keyboard protocol sequence result for a Kitty input sequence. */
 export interface ParsedKittyResult {

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -59,6 +59,7 @@ export const listWorkspace = nativeBindings.listWorkspace;
 export const matchesKey = nativeBindings.matchesKey;
 export const matchesKittySequence = nativeBindings.matchesKittySequence;
 export const matchesLegacySequence = nativeBindings.matchesLegacySequence;
+export const nativeBuildInfo = nativeBindings.nativeBuildInfo;
 export const parseKey = nativeBindings.parseKey;
 export const parseKittySequence = nativeBindings.parseKittySequence;
 export const readImageFromClipboard = nativeBindings.readImageFromClipboard;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -235,6 +235,7 @@ function maybeExtractEmbeddedAddon(ctx, errors) {
 	const selectedEmbeddedFile = selectEmbeddedAddonFile(ctx.selectedVariant);
 	if (!selectedEmbeddedFile) return null;
 	const targetPath = path.join(ctx.versionedDir, selectedEmbeddedFile.filename);
+	if (fs.existsSync(targetPath)) return targetPath;
 
 	try {
 		fs.mkdirSync(ctx.versionedDir, { recursive: true });

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -59,7 +59,8 @@
 	"exports": {
 		".": {
 			"types": "./native/index.d.ts",
-			"import": "./native/index.js"
+			"import": "./native/index.js",
+			"default": "./native/index.js"
 		}
 	}
 }

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -14,6 +14,7 @@ const targetPlatform = Bun.env.TARGET_PLATFORM || process.platform;
 const targetArch = Bun.env.TARGET_ARCH || process.arch;
 const configuredVariantRaw = Bun.env.TARGET_VARIANT;
 const isCrossCompile = Boolean(crossTarget) || targetPlatform !== process.platform || targetArch !== process.arch;
+const languageSet = Bun.env.PI_NATIVE_FULL_LANGS === "1" ? "full" : "default";
 
 type X64Variant = "modern" | "baseline";
 
@@ -170,6 +171,7 @@ const napiArgs = [
 ];
 
 if (crossTarget) napiArgs.push("--target", crossTarget);
+if (languageSet === "full") napiArgs.push("--", "--features", "full-langs");
 
 const canonicalAddonFilename = `pi_natives.${targetPlatform}-${targetArch}${variantSuffix}.node`;
 const canonicalAddonPath = path.join(nativeDir, canonicalAddonFilename);
@@ -205,6 +207,11 @@ try {
 	}
 
 	await installGeneratedBindings(buildOutputDir);
+
+	await Bun.write(
+		`${canonicalAddonPath}.build.json`,
+		`${JSON.stringify({ languageSet, builtAt: new Date().toISOString() }, null, 2)}\n`,
+	);
 
 	await generateEnumExports();
 

--- a/packages/natives/scripts/embed-guard.ts
+++ b/packages/natives/scripts/embed-guard.ts
@@ -1,0 +1,56 @@
+export interface CandidateAddon {
+	variant: "modern" | "baseline" | "default";
+	filename: string;
+}
+
+export interface BuildSidecar {
+	languageSet?: string;
+}
+
+export interface NativeBuildInfo {
+	languageSet?: string;
+}
+
+interface NativeAddonModule {
+	nativeBuildInfo?: () => NativeBuildInfo;
+}
+
+export interface VerifyDefaultLanguageSetOptions {
+	platformTag: string;
+	hostPlatformTag: string;
+	readBuildSidecar: (candidatePath: string) => Promise<BuildSidecar | null>;
+	loadNativeAddon: (candidatePath: string) => NativeAddonModule;
+	warn: (message: string) => void;
+}
+
+function assertDefaultLanguageSet(filename: string, languageSet: string | undefined, source: string): void {
+	if (languageSet !== "default") {
+		throw new Error(
+			`Refusing to embed ${filename}: native addon ${source} languageSet is ${JSON.stringify(languageSet)}, expected "default". Rebuild without PI_NATIVE_FULL_LANGS=1.`,
+		);
+	}
+}
+
+export async function verifyDefaultLanguageSet(
+	candidate: CandidateAddon,
+	candidatePath: string,
+	options: VerifyDefaultLanguageSetOptions,
+): Promise<void> {
+	const sidecar = await options.readBuildSidecar(candidatePath);
+	if (sidecar) {
+		assertDefaultLanguageSet(candidate.filename, sidecar.languageSet, "sidecar");
+	}
+
+	if (options.platformTag !== options.hostPlatformTag) {
+		if (!sidecar) {
+			options.warn(
+				`Warning: ${candidate.filename} has no build sidecar; skipping in-process languageSet check for non-host platform ${options.platformTag}.`,
+			);
+		}
+		return;
+	}
+
+	const addon = options.loadNativeAddon(candidatePath);
+	const info = addon.nativeBuildInfo?.();
+	assertDefaultLanguageSet(candidate.filename, info?.languageSet, "in-process");
+}

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { type BuildSidecar, type CandidateAddon, verifyDefaultLanguageSet } from "./embed-guard";
 
 const reset = process.argv.includes("--reset");
 const outputPath = path.join(import.meta.dir, "../native/embedded-addon.js");
@@ -34,9 +35,14 @@ if (reset) {
 	process.exit(0);
 }
 
-interface CandidateAddon {
-	variant: "modern" | "baseline" | "default";
-	filename: string;
+async function readBuildSidecar(candidatePath: string): Promise<BuildSidecar | null> {
+	const sidecarPath = `${candidatePath}.build.json`;
+	try {
+		return (await Bun.file(sidecarPath).json()) as BuildSidecar;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw err;
+	}
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -51,6 +57,7 @@ async function fileExists(filePath: string): Promise<boolean> {
 const targetPlatform = Bun.env.TARGET_PLATFORM || process.platform;
 const targetArch = Bun.env.TARGET_ARCH || process.arch;
 const platformTag = `${targetPlatform}-${targetArch}`;
+const hostPlatformTag = `${process.platform}-${process.arch}`;
 const candidates: CandidateAddon[] =
 	targetArch === "x64"
 		? [
@@ -63,6 +70,13 @@ const available: CandidateAddon[] = [];
 for (const candidate of candidates) {
 	const candidatePath = path.join(nativeDir, candidate.filename);
 	if (await fileExists(candidatePath)) {
+		await verifyDefaultLanguageSet(candidate, candidatePath, {
+			platformTag,
+			hostPlatformTag,
+			readBuildSidecar,
+			loadNativeAddon: candidatePath => require(candidatePath) as { nativeBuildInfo?: () => { languageSet?: string } },
+			warn: message => console.warn(message),
+		});
 		available.push(candidate);
 	}
 }

--- a/packages/natives/test/embed-guard.test.ts
+++ b/packages/natives/test/embed-guard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+
+import { type CandidateAddon, verifyDefaultLanguageSet } from "../scripts/embed-guard";
+
+const candidate: CandidateAddon = { variant: "default", filename: "pi_natives.test.node" };
+
+function verifier(options: {
+	platformTag?: string;
+	hostPlatformTag?: string;
+	sidecar?: { languageSet?: string } | null;
+	inProcessLanguageSet?: string;
+	warnings?: string[];
+}) {
+	return verifyDefaultLanguageSet(candidate, "/tmp/pi_natives.test.node", {
+		platformTag: options.platformTag ?? "darwin-arm64",
+		hostPlatformTag: options.hostPlatformTag ?? "darwin-arm64",
+		readBuildSidecar: async () => options.sidecar ?? null,
+		loadNativeAddon: () => ({ nativeBuildInfo: () => ({ languageSet: options.inProcessLanguageSet }) }),
+		warn: message => options.warnings?.push(message),
+	});
+}
+
+describe("embed native language-set guard", () => {
+	it("rejects a host addon whose stale default sidecar disagrees with in-process build info", async () => {
+		await expect(verifier({ sidecar: { languageSet: "default" }, inProcessLanguageSet: "full" })).rejects.toThrow(
+			/in-process languageSet is "full"/,
+		);
+	});
+
+	it("rejects a tampered full-langs sidecar before loading the addon", async () => {
+		await expect(verifier({ sidecar: { languageSet: "full" }, inProcessLanguageSet: "default" })).rejects.toThrow(
+			/sidecar languageSet is "full"/,
+		);
+	});
+
+	it("warns and passes when a non-host addon has no sidecar", async () => {
+		const warnings: string[] = [];
+		await verifier({
+			platformTag: "linux-x64",
+			hostPlatformTag: "darwin-arm64",
+			sidecar: null,
+			inProcessLanguageSet: "full",
+			warnings,
+		});
+
+		expect(warnings).toEqual([
+			"Warning: pi_natives.test.node has no build sidecar; skipping in-process languageSet check for non-host platform linux-x64.",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Executes the consensus-approved memory purge plan (ralplan run `2026-06-11-0235-28bc`, Option A). Driven through ultragoal with per-story architect + QA red-team gates; full audit trail in `.gjc/ultragoal/ledger.jsonl` and review stages under `.gjc/plans/ralplan/2026-06-11-0235-28bc/`.

### Measured results (darwin-arm64)

| Metric | Before | After | Δ |
|---|---|---|---|
| Native addon size | 112MB | **38.9MB** | −65% |
| `__TEXT,__const` (grammar data) | 96MB | **22.9MB** | −76% |
| `gjc --help` peak RSS | 232–239MB | **113MB** (compiled) | −52% |
| Display-path BPE heap | ~50MB at init | **0** (lazy) | −50MB steady-state |
| `gjc -p "say hi"` peak RSS | 367MB | 327MB | −11% |

### Changes

**Tokenizer tiering** — cl100k BPE table removed from the addon; `Encoding.Cl100kBase` remains exported as a documented o200k alias. New split: `countMessageTokensNativeO200k` (compaction/pruning/branch-summary/fork-seed — context-changing only) vs `estimateMessageTokensHeuristic`/`estimateTextTokensHeuristic` (status line, /context panel, display totals). Natives are now lazily `createRequire`d in `compaction.ts`, so the addon never dlopens on display/print cold paths (instrumented no-load-marker proof).

**Default-small AST grammars** — 37 long-tail tree-sitter grammars moved behind a source-only `full-langs` cargo feature; default build = 19 core languages (TS/TSX/JS, Python, Rust, Go, Java, C, C++, C#, Ruby, PHP, Bash, JSON, YAML, TOML, Markdown, HTML, CSS) with exact-registry tests and a clear unsupported-language error naming the rebuild path (`PI_NATIVE_FULL_LANGS=1`). Release guard: `nativeBuildInfo()` NAPI export + build sidecar; `embed-native` refuses `languageSet != default` (host addons always verified in-process; tamper/stale-sidecar cases unit-tested in `packages/natives/test/embed-guard.test.ts`).

**Compiled CLI fast paths** — `--minify` added to `build-binary.ts`; `--help`/`--version` no longer evaluate the heavy barrel graph; mode modules lazy-load in `main.ts`; embedded addon extraction is once-per-version. Source exports and `packages/gajae-code/bin/gjc.js` fallback unchanged.

**Export audit** — all 61 native exports kept with file-level liveness evidence (sixel stays default: live consumer in `packages/tui/src/terminal-capabilities.ts`); natives `exports` map gains a `"default"` condition for `require()` consumers.

### Known misses (recorded, not laundered)

- First `countTokens` call: 99MB vs 75MB target — the ~50MB is the o200k table itself; now confined to context-changing paths that genuinely need it.
- Compiled `-p`: 327MB vs 220MB target — root-caused to the JS agent/session/provider launch graph, **not** natives. Split-native escalation gate evaluated and **deferred** with documented analysis; recommended follow-up is a separately-planned launch-graph campaign (print-mode session split, deeper lazy provider/tool boundaries).

## Test plan

- [x] `cargo test -p pi-ast` (default: 21 pass) and `--features full-langs` (21 pass)
- [x] `cargo test -p pi-natives tokens` (3) and `ast` (8)
- [x] `bun test packages/agent/test` (206), `packages/natives/test/embed-guard.test.ts` (3), status-line-context-cache (9), theme-auto-detection, task/worktree, full `packages/tui` suite (1527 expects)
- [x] Compiled binary: `--version` / `--help` / `-p "say hi"` / `--smoke-test` all pass
- [x] Source fallback: `bun packages/coding-agent/src/cli.ts --help` works; `coding-agent/package.json` exports diff-free
- [x] Embed guard red-team: tampered/stale sidecar rejected; `embed:native --reset` round-trip
- [x] RSS/size numbers independently reproduced by a second QA lane (within tolerance; methodology note included)