### PR TITLE
fix(cli): no-arg gjc launched help instead of interactive mode

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -18,7 +18,7 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 }
 
 process.title = APP_NAME;
-const rootHelpFlags = ["--help", "-h", "help", ""];
+const rootHelpFlags = ["--help", "-h", "help"];
 const versionFlags = ["--version", "-v"];
 
 


### PR DESCRIPTION
## Problem
Running `gjc` with no arguments printed the root help instead of starting interactive mode.

## Cause
The compiled-CLI help fast path added in #512 defined:
```ts
const rootHelpFlags = ["--help", "-h", "help", ""];
```
and checked `rootHelpFlags.includes(argv[0] ?? "")`. With no args, `argv[0]` is `undefined`, coalesces to `""`, matches the empty-string entry, and the help renders before the launch-command routing is ever reached.

## Fix
Drop the empty string from `rootHelpFlags`. No-arg invocations now fall through to the existing default routing (`["launch", ...argv]`), restoring interactive mode. `--help`/`-h`/`help` and `--version`/`-v` fast paths are unchanged.

## Verified
- `bun packages/coding-agent/src/cli.ts --help` → still prints fast help
- `bun packages/coding-agent/src/cli.ts -v` → `gjc/0.4.4`
- `bun packages/coding-agent/src/cli.ts` (no args) → launches interactive mode (no help output)