### PR TITLE
fix(cursor): render and execute cursor-native tool calls

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -680,7 +680,11 @@ export class Agent {
 		if (!source) return undefined;
 
 		const guarded: CursorExecHandlers = {};
-		const read = source.read;
+		// Bind each handler to `source`: they are methods of a CursorExecHandlers
+		// instance that reference private fields via `this`. Extracting them bare
+		// (`const read = source.read`) and calling `read(args)` would invoke them with
+		// `this === undefined`, throwing "undefined is not an object (this.#optionsForCall)".
+		const read = source.read?.bind(source);
 		if (read) {
 			guarded.read = async args => {
 				this.#assertActiveRun(runId);
@@ -689,7 +693,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const ls = source.ls;
+		const ls = source.ls?.bind(source);
 		if (ls) {
 			guarded.ls = async args => {
 				this.#assertActiveRun(runId);
@@ -698,7 +702,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const grep = source.grep;
+		const grep = source.grep?.bind(source);
 		if (grep) {
 			guarded.grep = async args => {
 				this.#assertActiveRun(runId);
@@ -707,7 +711,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const write = source.write;
+		const write = source.write?.bind(source);
 		if (write) {
 			guarded.write = async args => {
 				this.#assertActiveRun(runId);
@@ -716,7 +720,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const deleteHandler = source.delete;
+		const deleteHandler = source.delete?.bind(source);
 		if (deleteHandler) {
 			guarded.delete = async args => {
 				this.#assertActiveRun(runId);
@@ -725,7 +729,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const shell = source.shell;
+		const shell = source.shell?.bind(source);
 		if (shell) {
 			guarded.shell = async args => {
 				this.#assertActiveRun(runId);
@@ -734,7 +738,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const shellStream = source.shellStream;
+		const shellStream = source.shellStream?.bind(source);
 		if (shellStream) {
 			guarded.shellStream = async (args, callbacks) => {
 				this.#assertActiveRun(runId);
@@ -743,7 +747,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const diagnostics = source.diagnostics;
+		const diagnostics = source.diagnostics?.bind(source);
 		if (diagnostics) {
 			guarded.diagnostics = async args => {
 				this.#assertActiveRun(runId);
@@ -752,7 +756,7 @@ export class Agent {
 				return result;
 			};
 		}
-		const mcp = source.mcp;
+		const mcp = source.mcp?.bind(source);
 		if (mcp) {
 			guarded.mcp = async call => {
 				this.#assertActiveRun(runId);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -569,7 +569,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 	return stream;
 };
 
-type ToolCallState = ToolCall & { index: number; partialJson?: string; kind: "mcp" | "todo_write" };
+type ToolCallState = ToolCall & { index: number; partialJson?: string; kind: "mcp" | "todo_write" | "native" };
 
 interface BlockState {
 	currentTextBlock: (TextContent & { index: number }) | null;
@@ -1844,6 +1844,60 @@ function buildTodoWriteArgs(toolCall: CursorUpdateTodosToolCall): {
 	};
 }
 
+// Map a cursor ToolCall oneof field name (e.g. "shellToolCall") to a display tool
+// name. Mirrors cli-jaw's cursorToolKindLabel (src/agent/events/cursor.ts) so the
+// two surfaces label cursor-native tools identically.
+const CURSOR_NATIVE_KIND_ALIASES: Record<string, string> = {
+	shell: "bash",
+	read: "read",
+	write: "write",
+	delete: "delete",
+	edit: "edit",
+	grep: "grep",
+	glob: "glob",
+	ls: "ls",
+	semSearch: "codebase_search",
+	webSearch: "web_search",
+	fetch: "fetch",
+	task: "task",
+	createPlan: "create_plan",
+	askQuestion: "ask_question",
+	readLints: "read_lints",
+	applyAgentDiff: "apply_diff",
+};
+
+function cursorNativeToolName(kindKey: string): string {
+	const base = kindKey.replace(/ToolCall$/i, "");
+	if (!base) return "tool";
+	return CURSOR_NATIVE_KIND_ALIASES[base] ?? base;
+}
+
+// Cursor's model sometimes calls its own native IDE tools (shell/glob/grep/…)
+// instead of the advertised MCP tools. Those arrive as ToolCall oneof variants we
+// do not otherwise handle (everything except mcpToolCall / updateTodosToolCall), so
+// without this they are silently dropped and never render. Build a generic toolCall
+// block from whichever *ToolCall field is set so the call (and its result) is shown.
+function buildNativeToolCallBlock(
+	toolCall: Record<string, unknown>,
+	callId: string,
+	index: number,
+): ToolCallState | null {
+	for (const [key, payload] of Object.entries(toolCall)) {
+		if (!/ToolCall$/.test(key) || !payload || typeof payload !== "object") continue;
+		if (key === "mcpToolCall" || key === "updateTodosToolCall") continue;
+		const args = (payload as { args?: unknown }).args;
+		return {
+			type: "toolCall",
+			id: callId,
+			name: cursorNativeToolName(key),
+			arguments: args && typeof args === "object" ? (args as Record<string, unknown>) : { raw: payload },
+			index,
+			kind: "native",
+		};
+	}
+	return null;
+}
+
 function buildMcpResultFromToolResult(_mcpCall: CursorMcpCall, toolResult: ToolResultMessage) {
 	if (toolResult.isError) {
 		return buildMcpErrorResult(toolResultToText(toolResult) || "MCP tool failed");
@@ -1986,6 +2040,21 @@ function processInteractionUpdate(
 				};
 				output.content.push(block);
 				state.setToolCall(block);
+				stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+				return;
+			}
+
+			// Fallback: cursor-native tool variants (shell/glob/grep/…) we don't model
+			// explicitly. Render them so the call and its result are visible instead of
+			// vanishing.
+			const nativeBlock = buildNativeToolCallBlock(
+				toolCall,
+				update.message.value.callId || crypto.randomUUID(),
+				output.content.length,
+			);
+			if (nativeBlock) {
+				output.content.push(nativeBlock);
+				state.setToolCall(nativeBlock);
 				stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
 			}
 		}

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -198,7 +198,16 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 
 	async grep(args: Parameters<NonNullable<ICursorExecHandlers["grep"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
-		if (args.pattern.trim() === "") {
+		// Cursor's native Glob tool arrives as a grep exec with a glob but no content
+		// pattern. The search tool requires a non-empty pattern, so an empty pattern
+		// means "list files matching this glob" — route that to find instead of
+		// throwing "Pattern must not be empty".
+		const pattern = typeof args.pattern === "string" ? args.pattern : "";
+		if (pattern.trim().length === 0) {
+			if (args.glob) {
+				const globPath = `${args.path || "."}/${args.glob}`;
+				return executeTool(this.#optionsForCall(), "find", toolCallId, { paths: [globPath] });
+			}
 			const result = buildToolErrorResult(
 				"Cursor grep request rejected: pattern must not be empty. Provide a non-empty search pattern.",
 			);
@@ -206,7 +215,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		}
 		const searchPath = args.glob ? `${args.path || "."}/${args.glob}` : args.path || ".";
 		const toolResultMessage = await executeTool(this.#optionsForCall(), "search", toolCallId, {
-			pattern: args.pattern,
+			pattern,
 			paths: [searchPath],
 			i: args.caseInsensitive || undefined,
 		});

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -20,6 +20,13 @@ const TITLE_MAX_TOKENS = 30;
 const REASONING_SAFE_MAX_TOKENS = 1024;
 const SET_TITLE_TOOL_NAME = "set_title";
 
+// Some models (notably cursor/composer-*) ignore the forced set_title tool call
+// and instead emit a long free-text narrative. Without the tool call we fall back
+// to the plain text, so cap its length: a real 3-6 word title never exceeds these.
+// Beyond the cap we treat the response as a non-title hallucination and reject it.
+const MAX_TITLE_CHARS = 80;
+const MAX_TITLE_WORDS = 12;
+
 const setTitleTool: Tool = {
 	name: SET_TITLE_TOOL_NAME,
 	description: "Set the generated session title.",
@@ -169,7 +176,14 @@ function extractGeneratedTitle(contentBlocks: AssistantMessage["content"]): stri
 			textTitle += content.text;
 		}
 	}
-	return textTitle.trim();
+	// Plain-text fallback (no set_title tool call): only accept it if it actually
+	// looks like a title. A model that ignored the tool and rambled produces a long
+	// blob — reject it so the caller falls back rather than persisting the narrative.
+	const trimmed = textTitle.trim();
+	if (trimmed.length > MAX_TITLE_CHARS || trimmed.split(/\s+/).length > MAX_TITLE_WORDS) {
+		return "";
+	}
+	return trimmed;
 }
 
 /**

--- a/packages/coding-agent/test/cursor-exec-handlers.test.ts
+++ b/packages/coding-agent/test/cursor-exec-handlers.test.ts
@@ -73,7 +73,10 @@ describe("CursorExecHandlers detached invocation (#484)", () => {
 });
 
 describe("CursorExecHandlers grep empty pattern guard (#501)", () => {
-	function makeRecordingHandlers(searchCalls: Array<Record<string, unknown>>): CursorExecHandlers {
+	function makeRecordingHandlers(
+		searchCalls: Array<Record<string, unknown>>,
+		findCalls: Array<Record<string, unknown>> = [],
+	): CursorExecHandlers {
 		const searchTool = {
 			name: "search",
 			label: "search",
@@ -82,7 +85,18 @@ describe("CursorExecHandlers grep empty pattern guard (#501)", () => {
 				return { content: [{ type: "text" as const, text: "ok" }], details: {} };
 			},
 		} as unknown as AgentTool;
-		const tools = new Map<string, AgentTool>([["search", searchTool]]);
+		const findTool = {
+			name: "find",
+			label: "find",
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				findCalls.push(args);
+				return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+			},
+		} as unknown as AgentTool;
+		const tools = new Map<string, AgentTool>([
+			["search", searchTool],
+			["find", findTool],
+		]);
 		return new CursorExecHandlers({ cwd: process.cwd(), tools } as never);
 	}
 
@@ -104,6 +118,20 @@ describe("CursorExecHandlers grep empty pattern guard (#501)", () => {
 		const result = await handlers.grep(create(GrepArgsSchema, { pattern: "   ", path: "/tmp", toolCallId: "g" }));
 		expect(searchCalls.length).toBe(0);
 		expect(result.isError).toBe(true);
+	});
+
+	it("empty pattern with a glob is treated as native Glob and routes to find", async () => {
+		const searchCalls: Array<Record<string, unknown>> = [];
+		const findCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeRecordingHandlers(searchCalls, findCalls);
+		const result = await handlers.grep(
+			create(GrepArgsSchema, { pattern: "", path: "/tmp", glob: "**/*.ts", toolCallId: "g" }),
+		);
+		expect(searchCalls.length).toBe(0);
+		expect(findCalls).toEqual([{ paths: ["/tmp/**/*.ts"] }]);
+		expect(result.role).toBe("toolResult");
+		expect(result.isError).toBeFalsy();
+		expect(result.toolName).toBe("find");
 	});
 
 	it("non-empty pattern calls search with the same searchPath behavior", async () => {


### PR DESCRIPTION
## What

Fixes four independent bugs that broke cursor-native tools (shell / grep / read / glob …) when using cursor-provider models such as `cursor/composer-2.5-fast`. With these, the model's native tool calls never render and never execute.

- **`packages/agent/src/agent.ts` (`#cursorExecHandlersForRun`)** — `CursorExecHandlers` methods were extracted bare (`const read = source.read;`) and later called unbound, so `this` was `undefined` and the method's `this.#optionsForCall()` threw `undefined is not an object (evaluating 'this.#optionsForCall')`. Now each handler is bound to `source` (`source.read?.bind(source)`). This is the bug that actually crashed tool execution.
- **`packages/ai/src/providers/cursor.ts` (`processInteractionUpdate`)** — `toolCallStarted` only handled the `mcpToolCall` / `updateTodosToolCall` oneof variants of `agent.v1.ToolCall` and silently dropped the cursor-native variants (`shellToolCall`/`globToolCall`/`grepToolCall`/…), so native tool calls never produced a `toolCall` block and never rendered. Adds a `buildNativeToolCallBlock` fallback.
- **`packages/coding-agent/src/cursor.ts` (grep handler)** — the native Glob tool arrives as a grep exec with an empty content pattern; that empty pattern was forwarded to the search tool, which rejects it (`Pattern must not be empty`). Empty-pattern calls now route to `find`.
- **`packages/coding-agent/src/utils/title-generator.ts` (`extractGeneratedTitle`)** — when the model ignored the forced `set_title` tool call and returned long free text, the entire narrative was accepted as the session title. The plain-text fallback is now capped (80 chars / 12 words) so a hallucinated response falls back instead of being persisted.

## Why

With the cursor provider + a composer model, every tool invocation failed: the TUI showed no tool rows at all, and the underlying exec crashed with the unbound-`this` error above. Root cause was confirmed by isolated repro (a bare-extracted private-method call reproduces the exact error string) and by an end-to-end run after the fix (Bash/Read/Grep/Find/WebSearch/MCP tools all execute and render).

## Testing

- `bun run check:types` passes for `packages/ai`, `packages/agent`, `packages/coding-agent`.
- `biome check` clean on the changed files.
- Isolated repro of the unbound-`this` crash (before: throws `…this.#optionsForCall`; after: returns normally).
- Manual e2e: cursor/composer model running ~10 tool calls now executes and renders real output (shell, read, grep, find, web search, MCP tools).

---

- [x] `bun check` passes (typecheck + biome on touched packages)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)