### PR TITLE
feat(xai): add grok-composer-2.5-fast model entry

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -70520,6 +70520,33 @@
 				"maxLevel": "high"
 			}
 		},
+		"grok-composer-2.5-fast": {
+			"id": "grok-composer-2.5-fast",
+			"name": "Grok Composer 2.5 Fast",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"compat": {
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"grok-vision-beta": {
 			"id": "grok-vision-beta",
 			"name": "Grok Vision Beta",


### PR DESCRIPTION
## Summary

Adds xAI's hidden composer coding model `grok-composer-2.5-fast` to the bundled `xai` catalog (`packages/ai/src/models.json`).

- **API surface**: `openai-completions` on `https://api.x.ai/v1` — responds on `/v1/chat/completions`, multi-turn + system prompt verified by live probe. Text-only input.
- **Reasoning**: the model returns `reasoning_content` (parsed via the default `reasoningContentField`), but the backend **rejects** the `reasoningEffort` parameter with HTTP 400 (`Model grok-composer-2.5-fast does not support parameter reasoningEffort`). The entry therefore pins `"compat": { "supportsReasoningEffort": false }` **per-model**, so any selected thinking level is dropped at the transport instead of forwarded. No other xai model entry is touched.
- **Pricing/limits**: hidden model — absent from `/v1/models` and `/v1/language-models`, so there is no public pricing metadata; cost is recorded as 0 (same convention as the bundled cursor `composer-1`/`composer-1.5` entries), contextWindow 200000 / maxTokens 64000 mirroring those entries.

## Verification

- `models.json` parses; entry resolves through `getBundledModels("xai")`.
- `resolveOpenAICompat` on this model returns `supportsReasoningEffort: false` while `grok-4.3` / `grok-code-fast-1` keep their detected defaults (verified side by side).
- `tsgo -p tsconfig.json --noEmit` clean on `packages/ai` (run on a checkout of the same package state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)