### PR TITLE
fix(cursor): convert wire shell timeouts from ms to bash seconds

### DIFF
--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -160,6 +160,20 @@ function formatMcpToolErrorMessage(toolName: string, availableTools: string[]): 
 	return `MCP tool "${toolName}" not found. Available tools: ${list}`;
 }
 
+/**
+ * Cursor's wire protocol carries shell timeouts in milliseconds — the
+ * model-facing parameter is `block_until_ms`, and `ShellArgs.hard_timeout` is
+ * likewise documented in ms — while the bash tool's `timeout` is seconds.
+ * Passing the raw value through made a requested 30 s wait (30000 ms) arrive
+ * as 30000 s and clamp to the 3600 s ceiling, i.e. an accidental 1-hour
+ * timeout on a blocking command. Convert, rounding sub-second values up to 1 s
+ * so a tiny requested wait does not collapse to "no timeout".
+ */
+function shellTimeoutSeconds(timeout: number | undefined): number | undefined {
+	if (!timeout || timeout <= 0) return undefined;
+	return Math.max(1, Math.ceil(timeout / 1000));
+}
+
 export class CursorExecHandlers implements ICursorExecHandlers {
 	constructor(private options: CursorExecBridgeOptions) {
 		// Bind every native handler so methods stay instance-safe when invoked
@@ -240,7 +254,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 
 	async shell(args: Parameters<NonNullable<ICursorExecHandlers["shell"]>>[0]) {
 		const toolCallId = decodeToolCallId(args.toolCallId);
-		const timeoutSeconds = args.timeout && args.timeout > 0 ? args.timeout : undefined;
+		const timeoutSeconds = shellTimeoutSeconds(args.timeout);
 		const toolResultMessage = await executeTool(this.#optionsForCall(), "bash", toolCallId, {
 			command: args.command,
 			cwd: args.workingDirectory || undefined,
@@ -262,7 +276,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			return createToolResultMessage(toolCallId, toolName, result, true);
 		}
 
-		const timeoutSeconds = args.timeout && args.timeout > 0 ? args.timeout : undefined;
+		const timeoutSeconds = shellTimeoutSeconds(args.timeout);
 		const toolArgs: Record<string, unknown> = {
 			command: args.command,
 			cwd: args.workingDirectory || undefined,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -51,7 +51,7 @@ async function saveBashOriginalArtifact(session: ToolSession, originalText: stri
 const bashSchemaBase = z.object({
 	command: z.string().describe("command to execute"),
 	env: z.record(z.string().regex(BASH_ENV_NAME_PATTERN), z.string()).optional().describe("extra env vars"),
-	timeout: z.number().default(300).describe("timeout in seconds").optional(),
+	timeout: z.number().default(300).describe("timeout in seconds, NOT milliseconds (30 = 30s)").optional(),
 	cwd: z.string().describe("working directory").optional(),
 	pty: z.boolean().describe("run in pty mode").optional(),
 });

--- a/packages/coding-agent/test/cursor-exec-handlers.test.ts
+++ b/packages/coding-agent/test/cursor-exec-handlers.test.ts
@@ -150,3 +150,39 @@ describe("CursorExecHandlers grep empty pattern guard (#501)", () => {
 		expect(searchCalls[0]).toMatchObject({ paths: ["/tmp/*.ts"] });
 	});
 });
+
+describe("CursorExecHandlers shell timeout unit conversion", () => {
+	function makeShellRecordingHandlers(bashCalls: Array<Record<string, unknown>>): CursorExecHandlers {
+		const bashTool = {
+			name: "bash",
+			label: "bash",
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				bashCalls.push(args);
+				return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+			},
+		} as unknown as AgentTool;
+		const tools = new Map<string, AgentTool>([["bash", bashTool]]);
+		return new CursorExecHandlers({ cwd: process.cwd(), tools } as never);
+	}
+
+	it("converts wire milliseconds to bash seconds (block_until_ms: 30000 → 30s, not 30000s)", async () => {
+		const bashCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeShellRecordingHandlers(bashCalls);
+		await handlers.shell(create(ShellArgsSchema, { command: "echo hi", timeout: 30000, toolCallId: "s" }));
+		expect(bashCalls[0]).toMatchObject({ command: "echo hi", timeout: 30 });
+	});
+
+	it("omits the timeout when unset or zero", async () => {
+		const bashCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeShellRecordingHandlers(bashCalls);
+		await handlers.shell(create(ShellArgsSchema, { command: "echo hi", toolCallId: "s" }));
+		expect(bashCalls[0]?.["timeout"]).toBeUndefined();
+	});
+
+	it("rounds sub-second timeouts up to 1s instead of dropping them", async () => {
+		const bashCalls: Array<Record<string, unknown>> = [];
+		const handlers = makeShellRecordingHandlers(bashCalls);
+		await handlers.shell(create(ShellArgsSchema, { command: "echo hi", timeout: 500, toolCallId: "s" }));
+		expect(bashCalls[0]).toMatchObject({ timeout: 1 });
+	});
+});


### PR DESCRIPTION
## Problem

Cursor's wire protocol carries shell timeouts in **milliseconds** — the model-facing parameter is `block_until_ms`, and `ShellArgs.hard_timeout` in the generated proto is likewise documented "kill the command after this many **ms**". The exec bridge (`CursorExecHandlers.shell` / `shellStream`) forwarded the raw value straight into the bash tool's `timeout` field, which is **seconds**.

Result: a model requesting a 30 s wait (`block_until_ms: 30000`) ran with a 30000 **s** timeout, clamped to the 3600 s ceiling. Observed live in a composer session (session JSONL):

```
Timeout clamped to 3600s (requested 30000s; allowed range 1-3600s).
details: {"timeoutSeconds": 3600, "requestedTimeoutSeconds": 30000}
```

Every shell call in that session carried the same ms-as-s value — any blocking command becomes an accidental 1-hour hang.

## Fix

- `shell` / `shellStream` convert ms → s via a shared helper; sub-second values round up to 1 s so a tiny requested wait doesn't collapse to "no timeout requested".
- The bash schema description now spells out the unit (`"timeout in seconds, NOT milliseconds (30 = 30s)"`), so harness-trained models that default to ms-named parameters (cursor/grok composer family) stop writing millisecond values into second fields on the OpenAI-compat path too.

## Verification

- `bun test test/cursor-exec-handlers.test.ts` — 10 pass (7 existing + 3 new: `30000 → 30`, unset/0 → omitted, `500 → 1`).
- `tsgo -p tsconfig.json --noEmit` clean on `packages/coding-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)