### PR TITLE
feat: /effort slash command — set reasoning effort directly

### DIFF
--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,8 +1,8 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
-import type { Component, OverlayHandle } from "@gajae-code/tui";
-import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
+import type { Component, OverlayHandle, SelectItem } from "@gajae-code/tui";
+import { Container, Input, Loader, SelectList, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import { activateModelProfile } from "../../config/model-profile-activation";
 import { settings } from "../../config/settings";
@@ -20,6 +20,7 @@ import {
 	getAvailableThemes,
 	getCurrentThemeName,
 	getDetectedThemeSettingsPath,
+	getSelectListTheme,
 	getSymbolTheme,
 	previewTheme,
 	restoreThemePreview,
@@ -28,6 +29,7 @@ import {
 	setTheme,
 	theme,
 } from "../../modes/theme/theme";
+import { DynamicBorder } from "../../modes/components/dynamic-border";
 import type { InteractiveModeContext } from "../../modes/types";
 import { type SessionInfo, SessionManager } from "../../session/session-manager";
 import { FileSessionStorage } from "../../session/session-storage";
@@ -244,6 +246,42 @@ export class SelectorController {
 		this.ctx.statusLine.invalidate();
 		this.ctx.updateEditorTopBorder();
 		this.ctx.ui.requestRender();
+	}
+
+	/** 083.4: dropdown for /effort — pick a reasoning effort (thinking level). */
+	showEffortSelector(): void {
+		const levels: SelectItem[] = [
+			{ value: "off", label: "off", description: "No reasoning" },
+			{ value: "min", label: "minimal", description: "Very brief reasoning (~1k tokens)" },
+			{ value: "low", label: "low", description: "Light reasoning (~2k tokens)" },
+			{ value: "medium", label: "medium", description: "Moderate reasoning (~8k tokens)" },
+			{ value: "high", label: "high", description: "Deep reasoning (~16k tokens)" },
+			{ value: "xhigh", label: "xhigh", description: "Maximum reasoning (~32k tokens)" },
+			{ value: "max", label: "max", description: "Unrestricted reasoning" },
+		];
+		this.showSelector(done => {
+			const container = new Container();
+			container.addChild(new DynamicBorder());
+			container.addChild(new Text(theme.fg("accent", " Reasoning effort"), 1, 0));
+			const list = new SelectList(levels, 8, getSelectListTheme());
+			const current = this.ctx.session.thinkingLevel;
+			const currentIndex = levels.findIndex(item => item.value === current);
+			if (currentIndex >= 0) list.setSelectedIndex(currentIndex);
+			list.onSelect = item => {
+				done();
+				this.ctx.session.setThinkingLevel(item.value as ThinkingLevel);
+				this.ctx.statusLine.invalidate();
+				this.ctx.showStatus(`Reasoning effort set to ${this.ctx.session.thinkingLevel ?? "off"}.`);
+				this.ctx.ui.requestRender();
+			};
+			list.onCancel = () => {
+				done();
+				this.ctx.ui.requestRender();
+			};
+			container.addChild(list);
+			container.addChild(new DynamicBorder());
+			return { component: container, focus: list };
+		});
 	}
 
 	showThemeSelector(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2438,6 +2438,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		void this.#selectorController.showAgentsDashboard();
 	}
 
+	showEffortSelector(): void {
+		this.#selectorController.showEffortSelector();
+	}
+
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
 		this.#selectorController.showModelSelector(options);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -239,6 +239,7 @@ export interface InteractiveModeContext {
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
+	showEffortSelector(): void;
 	showProviderOnboarding(): void;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -21,6 +21,17 @@ import {
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
+
+/**
+ * 083.4: parse a /effort argument, accepting Codex ReasoningEffort vocabulary
+ * (none/minimal) as aliases for jwc thinking levels (off/min).
+ */
+function parseEffortArg(raw: string): ThinkingLevel | undefined {
+	const normalized = raw === "none" ? "off" : raw === "minimal" ? "min" : raw;
+	const level = parseThinkingLevel(normalized);
+	// "inherit" is a model-selector concept, not a session effort.
+	return level === "inherit" ? undefined : level;
+}
 import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
@@ -324,6 +335,67 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showModelSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "effort",
+		description: "Set reasoning effort for the current session",
+		acpDescription: "Set reasoning effort",
+		acpInputHint: "[off|minimal|low|medium|high|xhigh|max]",
+		subcommands: [
+			{ name: "off", description: "No reasoning" },
+			{ name: "minimal", description: "Very brief reasoning (~1k tokens)" },
+			{ name: "low", description: "Light reasoning (~2k tokens)" },
+			{ name: "medium", description: "Moderate reasoning (~8k tokens)" },
+			{ name: "high", description: "Deep reasoning (~16k tokens)" },
+			{ name: "xhigh", description: "Maximum reasoning (~32k tokens)" },
+			{ name: "max", description: "Unrestricted reasoning" },
+			{ name: "status", description: "Show current reasoning effort" },
+		],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const raw = command.args.trim().toLowerCase();
+			if (!raw || raw === "status") {
+				await runtime.output(
+					`Reasoning effort: ${runtime.session.thinkingLevel ?? "off"}. Options: off, minimal, low, medium, high, xhigh, max.`,
+				);
+				return commandConsumed();
+			}
+			const level = parseEffortArg(raw);
+			if (!level) {
+				await runtime.output(
+					`Unknown effort "${command.args.trim()}". Options: off, minimal, low, medium, high, xhigh, max.`,
+				);
+				return commandConsumed();
+			}
+			runtime.session.setThinkingLevel(level);
+			await runtime.output(`Reasoning effort set to ${runtime.session.thinkingLevel ?? "off"}.`);
+			return commandConsumed();
+		},
+		handleTui: (command, runtime) => {
+			const raw = command.args.trim().toLowerCase();
+			if (!raw) {
+				runtime.ctx.showEffortSelector();
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (raw === "status") {
+				runtime.ctx.showStatus(
+					`Reasoning effort: ${runtime.ctx.session.thinkingLevel ?? "off"} (off|minimal|low|medium|high|xhigh|max)`,
+				);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			const level = parseEffortArg(raw);
+			if (!level) {
+				runtime.ctx.showError(`Unknown effort "${command.args.trim()}" (off|minimal|low|medium|high|xhigh|max)`);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.session.setThinkingLevel(level);
+			refreshStatusLine(runtime.ctx);
+			runtime.ctx.showStatus(`Reasoning effort set to ${runtime.ctx.session.thinkingLevel ?? "off"}.`);
 			runtime.ctx.editor.setText("");
 		},
 	},


### PR DESCRIPTION
## What

Adds a `/effort` builtin slash command exposing the existing thinking-level engine with the industry-standard vocabulary (Codex `ReasoningEffort`). Until now the level was only reachable via shift+tab cycling or the `/model` selector colon syntax (`/model sonnet:high`).

- `/effort` — opens a dropdown selector (current level preselected, enter applies, esc cancels), same `showSelector` swap pattern as the theme/model pickers
- `/effort <level>` — sets directly: `off|minimal|low|medium|high|xhigh|max` (aliases `none`→off, `minimal`→min)
- `/effort status` — prints the current level

## Why

Reasoning effort is a per-task dial; a direct command beats cycling through seven levels with shift+tab or re-running model selection. `effort` matches the vocabulary users know from Codex (`ReasoningEffort`: none/minimal/low/medium/high/xhigh).

## Implementation

- `slash-commands/builtin-registry.ts`: `/effort` entry (generic/ACP `handle` stays text-based; `handleTui` opens the dropdown and refreshes the status line) + `parseEffortArg()` alias normalization, rejects the selector-only `inherit`
- `modes/controllers/selector-controller.ts`: `showEffortSelector()` (Container + SelectList + DynamicBorder)
- `modes/types.ts` / `modes/interactive-mode.ts`: ctx exposure

Model-specific clamping is handled by the existing `clampThinkingLevelForModel` layer — no engine changes.

## Testing

- `cli-command-surface`, `slash-command-format`, `acp-builtins` suites pass on this branch (58 tests)
- `tsc --noEmit` clean on `packages/coding-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)