### PR TITLE
feat(tui): tighten tool block spacing — vertical padding 0, Spacer-only separation

### DIFF
--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -197,9 +197,11 @@ export class ToolExecutionComponent extends Container {
 
 		this.addChild(new Spacer(1));
 
-		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins
-		this.#contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
-		this.#contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins.
+		// Vertical padding is 0: block separation comes solely from the leading Spacer
+		// (1 blank line above each block), matching reference TUIs (083.2).
+		this.#contentBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
+		this.#contentText = new Text("", 1, 0, (text: string) => theme.bg("toolPendingBg", text));
 
 		// Use Box for custom tools or built-in tools that have renderers
 		const hasRenderer = toolName in toolRenderers;
@@ -514,7 +516,7 @@ export class ToolExecutionComponent extends Container {
 					const fileBgFn = fileResult.isError
 						? (text: string) => theme.bg("toolErrorBg", text)
 						: (text: string) => theme.bg("toolSuccessBg", text);
-					const fileBox = new Box(1, 1, fileBgFn);
+					const fileBox = new Box(1, 0, fileBgFn);
 					try {
 						const resultComponent = renderer.renderResult(
 							{ content: [], details: fileResult, isError: fileResult.isError },
@@ -540,7 +542,7 @@ export class ToolExecutionComponent extends Container {
 					const pendingSpacer = new Spacer(1);
 					this.#multiFileBoxes.push(pendingSpacer);
 					this.addChild(pendingSpacer);
-					const pendingBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+					const pendingBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
 					const pendingText = renderStatusLine(
 						{
 							icon: "pending",

--- a/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { ToolExecutionComponent } from "@gajae-code/coding-agent/modes/components/tool-execution";
+import * as themeModule from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function renderTool(command: string): string[] {
+	const component = new ToolExecutionComponent("bash", { command }, {}, undefined, uiStub);
+	component.updateResult({ content: [{ type: "text", text: `output of ${command}` }], isError: false }, false);
+	return component.render(80).map(line => Bun.stripANSI(line));
+}
+
+function countEdgeBlanks(lines: string[]): { leading: number; trailing: number } {
+	let leading = 0;
+	for (let i = 0; i < lines.length && lines[i].trim() === ""; i++) leading++;
+	let trailing = 0;
+	for (let i = lines.length - 1; i >= 0 && lines[i].trim() === ""; i--) trailing++;
+	return { leading, trailing };
+}
+
+// 083.2: block separation is exactly the leading Spacer (1 blank line above each
+// block); the content box itself has no vertical padding. Two consecutive tools
+// must be separated by exactly 1 blank line.
+describe("ToolExecutionComponent spacing", () => {
+	it("renders exactly one blank line above and none below a tool block", () => {
+		const lines = renderTool("ls -la");
+		const { leading, trailing } = countEdgeBlanks(lines);
+		expect(leading).toBe(1);
+		expect(trailing).toBe(0);
+	});
+
+	it("separates consecutive tool blocks by exactly one blank line", () => {
+		const a = renderTool("ls -la");
+		const b = renderTool("git status");
+		const { trailing } = countEdgeBlanks(a);
+		const { leading } = countEdgeBlanks(b);
+		expect(trailing + leading).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

Tool blocks currently sit ~3 blank lines apart: each block adds a leading `Spacer(1)` **and** `Box`/`Text` vertical padding `(1,1)`. Reference TUIs (Codex `Insets::tlbr(top=1)` excluding the first cell, gemini-cli `marginBottom={0}`) converge on **1 blank line above each block, no internal vertical padding**.

This drops the vertical padding to 0 (`contentBox`/`contentText`, and the multi-file `fileBox`/`pendingBox` which mirror separate tool calls), so block separation is exactly the leading Spacer: **1 blank line**.

## Testing

- New regression test: 1 blank line above a tool block, 0 below, exactly 1 between consecutive tools
- modes + tools test suites: no new failures (the 18 failing tools tests on `dev` are pre-existing network/credential-dependent tests, identical without this change)

## Stack

Part 1/3 of a TUI output-density stack: this → tool auto-collapse → reasoning interleave fix. Each part stands alone; later PRs include this diff until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)