### PR TITLE
feat(tui): auto-collapse completed tools with per-tool and transcript reopen

### DIFF
--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -27,6 +27,8 @@ interface AppKeybindings {
 	"app.model.select": true;
 	"app.model.selectTemporary": true;
 	"app.tools.expand": true;
+	"app.tools.focus": true;
+	"app.tools.transcript": true;
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
@@ -105,6 +107,14 @@ export const KEYBINDINGS = {
 	"app.tools.expand": {
 		defaultKeys: "ctrl+o",
 		description: "Expand tools",
+	},
+	"app.tools.focus": {
+		defaultKeys: "ctrl+up",
+		description: "Focus tool blocks (↑↓ move, enter toggle, esc exit)",
+	},
+	"app.tools.transcript": {
+		defaultKeys: "alt+t",
+		description: "Open full tool transcript overlay",
 	},
 	"app.editor.external": {
 		defaultKeys: "ctrl+g",

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -197,9 +197,11 @@ export class ToolExecutionComponent extends Container {
 
 		this.addChild(new Spacer(1));
 
-		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins
-		this.#contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
-		this.#contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins.
+		// Vertical padding is 0: block separation comes solely from the leading Spacer
+		// (1 blank line above each block), matching reference TUIs (083.2).
+		this.#contentBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
+		this.#contentText = new Text("", 1, 0, (text: string) => theme.bg("toolPendingBg", text));
 
 		// Use Box for custom tools or built-in tools that have renderers
 		const hasRenderer = toolName in toolRenderers;
@@ -514,7 +516,7 @@ export class ToolExecutionComponent extends Container {
 					const fileBgFn = fileResult.isError
 						? (text: string) => theme.bg("toolErrorBg", text)
 						: (text: string) => theme.bg("toolSuccessBg", text);
-					const fileBox = new Box(1, 1, fileBgFn);
+					const fileBox = new Box(1, 0, fileBgFn);
 					try {
 						const resultComponent = renderer.renderResult(
 							{ content: [], details: fileResult, isError: fileResult.isError },
@@ -540,7 +542,7 @@ export class ToolExecutionComponent extends Container {
 					const pendingSpacer = new Spacer(1);
 					this.#multiFileBoxes.push(pendingSpacer);
 					this.addChild(pendingSpacer);
-					const pendingBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+					const pendingBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
 					const pendingText = renderStatusLine(
 						{
 							icon: "pending",

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -124,6 +124,7 @@ export interface ToolExecutionHandle {
 	): void;
 	setArgsComplete(toolCallId?: string): void;
 	setExpanded(expanded: boolean): void;
+	setMinimized?(minimized: boolean): void;
 }
 
 /**
@@ -164,6 +165,10 @@ export class ToolExecutionComponent extends Container {
 	#spinnerInterval?: NodeJS.Timeout;
 	// Track if args are still being streamed (for edit/write spinner)
 	#argsComplete = false;
+	// One-line summary mode (083.1) — set when a newer tool starts
+	#minimized = false;
+	// Focus marker for the tool-focus mode (083.1 pattern B)
+	#focused = false;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -395,6 +400,70 @@ export class ToolExecutionComponent extends Container {
 	setExpanded(expanded: boolean): void {
 		this.#expanded = expanded;
 		this.#updateDisplay();
+	}
+
+	/**
+	 * Collapse this tool to a one-line summary (083.1). Set when a newer tool
+	 * starts so only the active/latest tool shows its preview. Expansion
+	 * (individual or global ctrl+o) overrides minimization at render time, so
+	 * a minimized tool can always be re-opened.
+	 */
+	setMinimized(minimized: boolean): void {
+		this.#minimized = minimized;
+	}
+
+	get minimized(): boolean {
+		return this.#minimized;
+	}
+
+	/** Focus marker for tool-focus mode (083.1 pattern B). Render-only — no layout change. */
+	setFocused(focused: boolean): void {
+		this.#focused = focused;
+	}
+
+	/** Individual expand state (read by tool-focus mode for toggling). */
+	get expanded(): boolean {
+		return this.#expanded;
+	}
+
+	/**
+	 * Replace the leading separator blank line with an accent focus marker.
+	 * Same line count, so toggling focus never reflows the chat.
+	 */
+	#applyFocusMarker(lines: string[]): string[] {
+		if (!this.#focused || lines.length === 0 || lines[0] !== "") return lines;
+		return [theme.fg("accent", " ❯"), ...lines.slice(1)];
+	}
+
+	override render(width: number): string[] {
+		if (this.#minimized && !this.#expanded) {
+			// Children still render (cheap — they cache); we need their height for
+			// the hidden-line hint and the spacer/content split.
+			const full = super.render(width);
+			const hiddenLines = Math.max(0, full.length - 2);
+			const icon = this.#isPartial ? "pending" : this.#result?.isError ? "error" : "success";
+			let description: string | undefined;
+			if (this.#result?.isError) {
+				description = this.#getTextOutput().split("\n")[0]?.trim() || undefined;
+			} else {
+				const argsObject =
+					this.#args && typeof this.#args === "object" ? (this.#args as Record<string, unknown>) : null;
+				description = argsObject ? formatArgsInline(argsObject, 60) || undefined : undefined;
+			}
+			const line = renderStatusLine(
+				{
+					icon,
+					spinnerFrame: this.#spinnerFrame,
+					title: this.#toolLabel,
+					description,
+					meta: hiddenLines > 0 ? [`… +${hiddenLines} lines`] : undefined,
+				},
+				theme,
+			);
+			// Keep the leading blank line (block separation, 083.2) + pad like Box paddingX=1.
+			return this.#applyFocusMarker(["", ` ${truncateToWidth(line, Math.max(1, width - 1))}`]);
+		}
+		return this.#applyFocusMarker(super.render(width));
 	}
 
 	setShowImages(show: boolean): void {

--- a/packages/coding-agent/src/modes/components/tool-transcript-overlay.ts
+++ b/packages/coding-agent/src/modes/components/tool-transcript-overlay.ts
@@ -1,0 +1,78 @@
+import { Container, matchesKey } from "@gajae-code/tui";
+import { theme } from "../theme/theme";
+import { ToolExecutionComponent } from "./tool-execution";
+
+/**
+ * 083.1 pattern A — full tool transcript overlay (Codex pager analogue).
+ * Renders every tool block fully expanded in a scrollable viewport, regardless
+ * of minimize/preview state in the chat. Tools live in the chat container for
+ * the whole session, so no pendingTools lifecycle change is needed.
+ */
+export class ToolTranscriptOverlayComponent extends Container {
+	#tools: ToolExecutionComponent[];
+	#close: () => void;
+	#requestRender: () => void;
+	#scroll = 0;
+	#cache?: { width: number; lines: string[] };
+
+	constructor(tools: ToolExecutionComponent[], callbacks: { close: () => void; requestRender: () => void }) {
+		super();
+		this.#tools = tools;
+		this.#close = callbacks.close;
+		this.#requestRender = callbacks.requestRender;
+	}
+
+	getFocus(): ToolTranscriptOverlayComponent {
+		return this;
+	}
+
+	#viewportRows(): number {
+		return Math.max(8, (process.stdout.rows ?? 30) - 8);
+	}
+
+	#transcriptLines(width: number): string[] {
+		if (this.#cache?.width === width) return this.#cache.lines;
+		const lines: string[] = [];
+		for (const tool of this.#tools) {
+			const wasExpanded = tool.expanded;
+			if (!wasExpanded) tool.setExpanded(true);
+			lines.push(...tool.render(width));
+			if (!wasExpanded) tool.setExpanded(false);
+		}
+		// Drop the leading separator blank so the pager starts at content.
+		while (lines.length > 0 && lines[0] === "") lines.shift();
+		this.#cache = { width, lines };
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		const rows = this.#viewportRows();
+		const total = this.#cache?.lines.length ?? 0;
+		const maxScroll = Math.max(0, total - rows);
+		if (matchesKey(data, "escape") || data === "q") {
+			this.#close();
+			return;
+		}
+		if (matchesKey(data, "up")) this.#scroll = Math.max(0, this.#scroll - 1);
+		else if (matchesKey(data, "down")) this.#scroll = Math.min(maxScroll, this.#scroll + 1);
+		else if (matchesKey(data, "pageUp")) this.#scroll = Math.max(0, this.#scroll - rows);
+		else if (matchesKey(data, "pageDown")) this.#scroll = Math.min(maxScroll, this.#scroll + rows);
+		else if (data === "g") this.#scroll = 0;
+		else if (data === "G") this.#scroll = maxScroll;
+		else return;
+		this.#requestRender();
+	}
+
+	override render(width: number): string[] {
+		const lines = this.#transcriptLines(width);
+		const rows = this.#viewportRows();
+		const maxScroll = Math.max(0, lines.length - rows);
+		this.#scroll = Math.min(this.#scroll, maxScroll);
+		const out: string[] = [];
+		const position = lines.length === 0 ? "empty" : `${this.#scroll + 1}–${Math.min(this.#scroll + rows, lines.length)}/${lines.length}`;
+		out.push(theme.fg("accent", ` Tool transcript (${this.#tools.length} tools, ${position})`));
+		out.push(...lines.slice(this.#scroll, this.#scroll + rows));
+		out.push(theme.fg("dim", " ↑↓ scroll · pgup/pgdn page · g/G top/bottom · esc close"));
+		return out;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -262,6 +262,10 @@ export class EventController {
 		} else if (event.message.role === "assistant") {
 			this.#lastThinkingCount = 0;
 			this.#resetReadGroup();
+			// 083.1: a new assistant message means the previous tool batch is done —
+			// collapse its last tool too (new tools in this message start a new chain).
+			this.ctx.lastToolComponent?.setMinimized?.(true);
+			this.ctx.lastToolComponent = undefined;
 			this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock, () =>
 				this.ctx.ui.requestRender(),
 			);
@@ -370,6 +374,9 @@ export class EventController {
 						content.id,
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
+					// 083.1: a new tool starting collapses the previous one to a one-line summary
+					this.ctx.lastToolComponent?.setMinimized?.(true);
+					this.ctx.lastToolComponent = component;
 					this.ctx.chatContainer.addChild(component);
 					this.ctx.pendingTools.set(content.id, component);
 				} else {
@@ -485,6 +492,9 @@ export class EventController {
 				event.toolCallId,
 			);
 			component.setExpanded(this.ctx.toolOutputExpanded);
+			// 083.1: a new tool starting collapses the previous one to a one-line summary
+			this.ctx.lastToolComponent?.setMinimized?.(true);
+			this.ctx.lastToolComponent = component;
 			this.ctx.chatContainer.addChild(component);
 			this.ctx.pendingTools.set(event.toolCallId, component);
 			this.ctx.ui.requestRender();
@@ -613,6 +623,9 @@ export class EventController {
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
 		this.#lastAssistantComponent = undefined;
+		// 083.1: turn is over — no tool is active anymore, collapse the last one.
+		this.ctx.lastToolComponent?.setMinimized?.(true);
+		this.ctx.lastToolComponent = undefined;
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.sendCompletionNotification();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -10,6 +10,8 @@ import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
+import { ToolExecutionComponent } from "../components/tool-execution";
+import { ToolTranscriptOverlayComponent } from "../components/tool-transcript-overlay";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
@@ -217,6 +219,12 @@ export class InputController {
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.jobs.open")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showJobsOverlay());
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.tools.focus")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.enterOrMoveToolFocus());
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.tools.transcript")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.showToolTranscript());
 		}
 
 		this.ctx.editor.onChange = (text: string) => {
@@ -865,6 +873,117 @@ export class InputController {
 		} catch (error) {
 			this.ctx.showError(error instanceof Error ? error.message : String(error));
 		}
+	}
+
+	// =========================================================================
+	// Tool focus mode (083.1 pattern B): ctrl+up enters / moves up, ↑↓ navigate,
+	// enter toggles the focused tool's expansion, esc or typing exits.
+	// =========================================================================
+
+	#toolFocus:
+		| {
+				tools: ToolExecutionComponent[];
+				index: number;
+				prevOnChange: ((text: string) => void) | undefined;
+				prevInterruptPriority: (() => boolean) | undefined;
+		  }
+		| undefined;
+
+	enterOrMoveToolFocus(): void {
+		if (this.#toolFocus) {
+			this.#moveToolFocus(-1);
+			return;
+		}
+		const tools = this.ctx.chatContainer.children.filter(
+			(child): child is ToolExecutionComponent => child instanceof ToolExecutionComponent,
+		);
+		if (tools.length === 0) {
+			this.ctx.showStatus("No tool blocks to focus");
+			return;
+		}
+		const editor = this.ctx.editor;
+		const prevOnChange = editor.onChange;
+		this.#toolFocus = {
+			tools,
+			index: tools.length - 1,
+			prevOnChange,
+			prevInterruptPriority: editor.onInterruptPriority,
+		};
+		// Esc exits focus mode before any other interrupt handling (btw-panel pattern).
+		editor.onInterruptPriority = () => {
+			this.#exitToolFocus();
+			return true;
+		};
+		// Typing drops focus so the prompt stays fluent.
+		editor.onChange = (text: string) => {
+			this.#exitToolFocus();
+			prevOnChange?.(text);
+		};
+		editor.setCustomKeyHandler("up", () => this.#moveToolFocus(-1));
+		editor.setCustomKeyHandler("down", () => this.#moveToolFocus(1));
+		editor.setCustomKeyHandler("enter", () => this.#toggleFocusedTool());
+		tools[this.#toolFocus.index].setFocused(true);
+		this.ctx.showStatus("tool focus: ↑↓ move · enter open/close · esc exit");
+		this.ctx.ui.requestRender();
+	}
+
+	#exitToolFocus(): void {
+		const focus = this.#toolFocus;
+		if (!focus) return;
+		this.#toolFocus = undefined;
+		focus.tools[focus.index]?.setFocused(false);
+		const editor = this.ctx.editor;
+		editor.removeCustomKeyHandler("up");
+		editor.removeCustomKeyHandler("down");
+		editor.removeCustomKeyHandler("enter");
+		editor.onChange = focus.prevOnChange;
+		editor.onInterruptPriority = focus.prevInterruptPriority;
+		this.ctx.ui.requestRender();
+	}
+
+	#moveToolFocus(delta: number): void {
+		const focus = this.#toolFocus;
+		if (!focus) return;
+		const next = focus.index + delta;
+		if (next < 0 || next >= focus.tools.length) return;
+		focus.tools[focus.index].setFocused(false);
+		focus.index = next;
+		focus.tools[next].setFocused(true);
+		this.ctx.ui.requestRender();
+	}
+
+	#toggleFocusedTool(): void {
+		const focus = this.#toolFocus;
+		if (!focus) return;
+		const tool = focus.tools[focus.index];
+		tool.setExpanded(!tool.expanded);
+		this.ctx.ui.requestRender();
+	}
+
+	/** 083.1 pattern A: full tool transcript in a scrollable overlay (alt+t). */
+	showToolTranscript(): void {
+		this.#exitToolFocus();
+		const tools = this.ctx.chatContainer.children.filter(
+			(child): child is ToolExecutionComponent => child instanceof ToolExecutionComponent,
+		);
+		if (tools.length === 0) {
+			this.ctx.showStatus("No tool blocks to show");
+			return;
+		}
+		const close = () => {
+			this.ctx.editorContainer.clear();
+			this.ctx.editorContainer.addChild(this.ctx.editor);
+			this.ctx.ui.setFocus(this.ctx.editor);
+			this.ctx.ui.requestRender();
+		};
+		const overlay = new ToolTranscriptOverlayComponent(tools, {
+			close,
+			requestRender: () => this.ctx.ui.requestRender(),
+		});
+		this.ctx.editorContainer.clear();
+		this.ctx.editorContainer.addChild(overlay);
+		this.ctx.ui.setFocus(overlay.getFocus());
+		this.ctx.ui.requestRender();
 	}
 
 	toggleToolOutputExpansion(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -267,6 +267,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	pendingImages: ImageContent[] = [];
 	compactionQueuedMessages: CompactionQueuedMessage[] = [];
 	pendingTools = new Map<string, ToolExecutionHandle>();
+	lastToolComponent: ToolExecutionHandle | undefined = undefined;
 	pendingBashComponents: BashExecutionComponent[] = [];
 	bashComponent: BashExecutionComponent | undefined = undefined;
 	pendingPythonComponents: EvalExecutionComponent[] = [];
@@ -904,6 +905,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	rebuildChatFromMessages(): void {
 		this.chatContainer.clear();
+		this.lastToolComponent = undefined;
 		const context = this.session.buildDisplaySessionContext();
 		this.renderSessionContext(context);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -97,6 +97,8 @@ export interface InteractiveModeContext {
 	pendingImages: ImageContent[];
 	compactionQueuedMessages: CompactionQueuedMessage[];
 	pendingTools: Map<string, ToolExecutionHandle>;
+	/** Latest tool block in the chat — minimized when the next tool starts (083.1). */
+	lastToolComponent: ToolExecutionHandle | undefined;
 	pendingBashComponents: BashExecutionComponent[];
 	bashComponent: BashExecutionComponent | undefined;
 	pendingPythonComponents: EvalExecutionComponent[];

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -45,6 +45,8 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.plan.toggle")}\` | Toggle plan mode |`,
 		`| \`${appKey(bindings, "app.history.search")}\` | Search prompt history |`,
 		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
+		`| \`${appKey(bindings, "app.tools.focus")}\` | Focus tool blocks (↑↓ move, enter toggle, esc exit) |`,
+		`| \`${appKey(bindings, "app.tools.transcript")}\` | Open full tool transcript overlay |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
 		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
 		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image from clipboard |`,

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -308,6 +308,10 @@ export class UiHelpers {
 			}
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
+				// 083.1: a new assistant message closes the previous tool batch —
+				// in replay every batch is history, so its last tool collapses too.
+				this.ctx.lastToolComponent?.setMinimized?.(true);
+				this.ctx.lastToolComponent = undefined;
 				this.ctx.addMessageToChat(message);
 				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
 				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
@@ -386,6 +390,10 @@ export class UiHelpers {
 						content.id,
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
+					// 083.1: during replay, every tool minimizes its predecessor so only
+					// the final tool block keeps its preview.
+					this.ctx.lastToolComponent?.setMinimized?.(true);
+					this.ctx.lastToolComponent = component;
 					this.ctx.chatContainer.addChild(component);
 
 					if (hasErrorStop && errorMessage) {

--- a/packages/coding-agent/test/modes/components/tool-execution-minimize.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-minimize.test.ts
@@ -1,0 +1,83 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { ToolExecutionComponent } from "@gajae-code/coding-agent/modes/components/tool-execution";
+import { ToolTranscriptOverlayComponent } from "@gajae-code/coding-agent/modes/components/tool-transcript-overlay";
+import * as themeModule from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function makeTool(command: string, output: string, isError = false): ToolExecutionComponent {
+	const component = new ToolExecutionComponent("bash", { command }, {}, undefined, uiStub);
+	component.updateResult({ content: [{ type: "text", text: output }], isError }, false);
+	return component;
+}
+
+function strip(lines: string[]): string[] {
+	return lines.map(line => Bun.stripANSI(line));
+}
+
+// 083.1: completed tools collapse to a one-line summary when a newer tool
+// starts; expansion (individual or global ctrl+o) overrides minimization.
+describe("ToolExecutionComponent minimize", () => {
+	it("renders a one-line summary with hidden-line hint when minimized", () => {
+		const tool = makeTool("ls -la", "a\nb\nc\nd");
+		const fullHeight = tool.render(80).length;
+		tool.setMinimized(true);
+		const lines = strip(tool.render(80));
+		expect(lines.length).toBe(2);
+		expect(lines[0]).toBe("");
+		expect(lines[1]).toContain("bash");
+		expect(lines[1]).toContain("ls -la");
+		expect(lines[1]).toContain(`+${fullHeight - 2} lines`);
+	});
+
+	it("expansion overrides minimization and is reversible", () => {
+		const tool = makeTool("git status", "clean");
+		const fullLines = strip(tool.render(80));
+		tool.setMinimized(true);
+		expect(tool.render(80).length).toBe(2);
+		tool.setExpanded(true);
+		expect(strip(tool.render(80)).length).toBeGreaterThanOrEqual(fullLines.length);
+		tool.setExpanded(false);
+		expect(tool.render(80).length).toBe(2);
+	});
+
+	it("focus marker replaces the separator line without changing height", () => {
+		const tool = makeTool("ls", "out");
+		tool.setMinimized(true);
+		const before = strip(tool.render(80));
+		tool.setFocused(true);
+		const after = strip(tool.render(80));
+		expect(after.length).toBe(before.length);
+		expect(after[0]).toContain("❯");
+		tool.setFocused(false);
+		expect(strip(tool.render(80))[0]).toBe("");
+	});
+
+	it("transcript overlay shows full output of minimized tools without mutating chat state", () => {
+		const tool = makeTool("ls", "line1\nline2\nline3");
+		tool.setMinimized(true);
+		const overlay = new ToolTranscriptOverlayComponent([tool], { close() {}, requestRender() {} });
+		const rendered = strip(overlay.render(100)).join("\n");
+		expect(rendered).toContain("line3");
+		expect(rendered).toContain("Tool transcript (1 tools");
+		expect(tool.expanded).toBe(false);
+		expect(tool.render(100).length).toBe(2);
+	});
+
+	it("keeps the error icon and first error line when minimized", () => {
+		const tool = makeTool("false", "command failed: exit 1\ndetails follow", true);
+		tool.setMinimized(true);
+		const lines = strip(tool.render(80));
+		expect(lines.length).toBe(2);
+		expect(lines[1]).toContain("command failed: exit 1");
+		expect(lines[1]).not.toContain("details follow");
+	});
+});

--- a/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { ToolExecutionComponent } from "@gajae-code/coding-agent/modes/components/tool-execution";
+import * as themeModule from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+const uiStub = { requestRender() {} } as unknown as TUI;
+
+function renderTool(command: string): string[] {
+	const component = new ToolExecutionComponent("bash", { command }, {}, undefined, uiStub);
+	component.updateResult({ content: [{ type: "text", text: `output of ${command}` }], isError: false }, false);
+	return component.render(80).map(line => Bun.stripANSI(line));
+}
+
+function countEdgeBlanks(lines: string[]): { leading: number; trailing: number } {
+	let leading = 0;
+	for (let i = 0; i < lines.length && lines[i].trim() === ""; i++) leading++;
+	let trailing = 0;
+	for (let i = lines.length - 1; i >= 0 && lines[i].trim() === ""; i--) trailing++;
+	return { leading, trailing };
+}
+
+// 083.2: block separation is exactly the leading Spacer (1 blank line above each
+// block); the content box itself has no vertical padding. Two consecutive tools
+// must be separated by exactly 1 blank line.
+describe("ToolExecutionComponent spacing", () => {
+	it("renders exactly one blank line above and none below a tool block", () => {
+		const lines = renderTool("ls -la");
+		const { leading, trailing } = countEdgeBlanks(lines);
+		expect(leading).toBe(1);
+		expect(trailing).toBe(0);
+	});
+
+	it("separates consecutive tool blocks by exactly one blank line", () => {
+		const a = renderTool("ls -la");
+		const b = renderTool("git status");
+		const { trailing } = countEdgeBlanks(a);
+		const { leading } = countEdgeBlanks(b);
+		expect(trailing + leading).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

Long sessions read like `--verbose`: every tool keeps its multi-line preview forever. This makes completed tools collapse to a **one-line summary** (icon + label + inline args + `… +N lines` hint; errors keep ✘ and the first error line) so only the active tool shows its preview — with three reopen surfaces:

- **ctrl+o** (existing global expand) overrides collapse at render time
- **ctrl+up** tool-focus mode: accent `❯` marker replaces the separator blank line (zero reflow), ↑↓ move between tool blocks, **enter toggles just that tool**, esc or typing exits
- **alt+t** full tool transcript overlay: every tool fully expanded in a scrollable pager (↑↓/pgup/pgdn/g/G, esc), without mutating chat state

Collapse triggers: the next tool starting, a new assistant message beginning (the batch is done — folds right as the final text starts streaming), and agent end as a safety net for aborted turns. Replay applies the same rule; read groups are excluded (already one line per file).

## Design notes

- Modeled on Codex's `display_lines`/`transcript_lines` split + pager overlay; alt+t instead of Codex's ctrl+t (taken by the thinking toggle here)
- Focus-mode keys ride the custom-editor dispatch ahead of cursor/history handling; esc preempts via `onInterruptPriority`
- No `pendingTools` lifecycle change: tool components persist in the chat container

## Testing

Unit tests for the one-line summary + hidden-line hint, expand override, error marker, focus marker (height-stable), and overlay no-mutation guarantee. modes suite green; the 18 failing tools tests on `dev` are pre-existing and unrelated.

## Stack

Part 2/3 — **depends on #521** (spacing); includes its diff until it merges. Part 3 (reasoning interleave) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)