### PR TITLE
fix(goal): keep goal tool registered by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added a deterministic fork-context mode advisory (`adviseForkContextMode`): recommends `none`/`receipt`/`last-turn` from assignment-text dependence signals with parent-capped per-mode cloned-token estimates, never overrides an explicit caller mode, and is surfaced receipt-visible-only as `TaskResultReceipt.forkContextAdvisory` (no change to actual mode selection).
 
 ### Fixed
+- Kept the unified `goal` tool registered and active by default whenever `goal.enabled` is true, including explicit tool subsets and `gjc ultragoal create-goals` arming flows.
 
 - Tool-output pruning no longer rewrites already-sent provider-facing history mid prompt-cache epoch: `#checkCompaction` now invokes pruning only when un-pruned context already crosses the compaction threshold (a sanctioned maintenance boundary), preserving the prefix-stability invariant. Also fixed a latent no-op where pruning mutated materialized branch copies and never persisted; `SessionManager.applyEntryMessageUpdates` now writes pruned messages back into the canonical store.
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -1,14 +1,11 @@
 #!/usr/bin/env bun
-import { APP_NAME, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
-
-
-
 
 /**
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
+import { APP_NAME, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -20,7 +17,6 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 process.title = APP_NAME;
 const rootHelpFlags = ["--help", "-h", "help"];
 const versionFlags = ["--version", "-v"];
-
 
 const commands: CommandEntry[] = [
 	{ name: "codex-native-hook", load: () => import("./commands/codex-native-hook").then(m => m.default) },
@@ -74,7 +70,6 @@ async function loadLaunchCommand() {
 	return import("./commands/launch").then(m => m.default);
 }
 
-
 class RootHelpCommand extends Command {
 	static description = "Red-claw AI coding assistant";
 	static hidden = true;
@@ -97,7 +92,10 @@ class RootHelpCommand extends Command {
 		"system-prompt": Flags.string({ description: "System prompt (default: coding assistant prompt)" }),
 		"append-system-prompt": Flags.string({ description: "Append text or file contents to the system prompt" }),
 		"allow-home": Flags.boolean({ description: "Allow starting in ~ without auto-switching to a temp dir" }),
-		mode: Flags.string({ description: "Output mode: text (default), json, rpc, acp, rpc-ui, or bridge", options: ["text", "json", "rpc", "acp", "rpc-ui", "bridge"] }),
+		mode: Flags.string({
+			description: "Output mode: text (default), json, rpc, acp, rpc-ui, or bridge",
+			options: ["text", "json", "rpc", "acp", "rpc-ui", "bridge"],
+		}),
 		print: Flags.boolean({ char: "p", description: "Non-interactive mode: process prompt and exit" }),
 		continue: Flags.boolean({ char: "c", description: "Continue previous session" }),
 		resume: Flags.string({ char: "r", description: "Resume a session (by ID prefix, path, or picker if omitted)" }),
@@ -109,9 +107,16 @@ class RootHelpCommand extends Command {
 		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
 		tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
 		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
-		thinking: Flags.string({ description: "Set thinking level: ultra, high, medium, low", options: ["ultra", "high", "medium", "low"] }),
+		thinking: Flags.string({
+			description: "Set thinking level: ultra, high, medium, low",
+			options: ["ultra", "high", "medium", "low"],
+		}),
 		hook: Flags.string({ description: "Load a hook/extension file (can be used multiple times)", multiple: true }),
-		extension: Flags.string({ char: "e", description: "Load an extension file (can be used multiple times)", multiple: true }),
+		extension: Flags.string({
+			char: "e",
+			description: "Load an extension file (can be used multiple times)",
+			multiple: true,
+		}),
 		"no-extensions": Flags.boolean({ description: "Disable extension discovery (explicit -e paths still work)" }),
 		"no-skills": Flags.boolean({ description: "Disable skills discovery and loading" }),
 		skills: Flags.string({ description: "Comma-separated glob patterns to filter skills (e.g., git-*,docker)" }),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -33,9 +33,9 @@ import { getDefault, type SettingPath, Settings, settings } from "./config/setti
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
-import type { InteractiveMode, InteractiveModeOptions } from "./modes/interactive-mode";
-import type { SubmittedUserInput } from "./modes/types";
+import type { InteractiveMode } from "./modes/interactive-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
+import type { SubmittedUserInput } from "./modes/types";
 import type { MCPManager } from "./runtime-mcp";
 import {
 	type CreateAgentSessionOptions,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1057,7 +1057,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				return;
 			}
 			if (event.state?.enabled === true && !this.#goalModePreviousTools) {
-				this.#goalModePreviousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+				this.#goalModePreviousTools = this.session.getActiveToolNames();
 			}
 			this.goalModeEnabled = event.state?.enabled === true;
 			this.goalModePaused = event.state?.enabled !== true && event.state?.goal?.status === "paused";
@@ -1146,10 +1146,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			const restored = await this.session.goalRuntime.onThreadResumed();
 			this.goalModeEnabled = restored?.enabled === true;
 			this.goalModePaused = restored?.enabled !== true && restored?.goal.status === "paused";
-			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
-			// Re-add it now so the agent can call resume, complete, or drop on this goal.
+			// Keep `goal` armed on resumed threads; it is part of the default active tool set.
 			if (restored?.goal) {
-				const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+				const previousTools = this.session.getActiveToolNames();
 				this.#goalModePreviousTools = previousTools;
 				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
 			}
@@ -1318,7 +1317,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit plan mode first.");
 			return;
 		}
-		const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+		const previousTools = this.session.getActiveToolNames();
 		const goalTools = [...new Set([...previousTools, "goal"])];
 		this.#goalModePreviousTools = previousTools;
 		this.goalModePaused = false;

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -105,7 +105,10 @@ function computeNonMessageBreakdown(session: AgentSession): {
 	const systemPromptParts = session.systemPrompt ?? [];
 	const rulesTokens = estimateRulesTokens(systemPromptParts);
 	const systemContextTokens = estimateTextTokensHeuristic(systemPromptParts.slice(1));
-	const systemPromptTokens = Math.max(0, estimateTextTokensHeuristic(systemPromptParts[0] ?? "") - skillsTokens - rulesTokens);
+	const systemPromptTokens = Math.max(
+		0,
+		estimateTextTokensHeuristic(systemPromptParts[0] ?? "") - skillsTokens - rulesTokens,
+	);
 	return { rulesTokens, skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
 }
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1622,9 +1622,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		};
 
 		const toolNamesFromRegistry = Array.from(toolRegistry.keys());
-		const requestedToolNames =
-			(options.toolNames ? [...new Set(options.toolNames.map(name => name.toLowerCase()))] : undefined) ??
-			toolNamesFromRegistry;
+		const requestedToolNames = options.toolNames
+			? [
+					...new Set([
+						...options.toolNames.map(name => name.toLowerCase()),
+						...(settings.get("goal.enabled") ? ["goal"] : []),
+					]),
+				]
+			: toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const requestedToolNameSet = new Set(normalizedRequested);
 		// Effective discovery mode only covers built-in tools; MCP tool discovery
@@ -1635,7 +1640,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const defaultInactiveToolNames = new Set(
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
-		const requestedActiveToolNames = normalizedRequested.filter(name => name !== "goal");
+		const requestedActiveToolNames = normalizedRequested;
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4389,7 +4389,7 @@ export class AgentSession {
 			return false;
 		}
 
-		const previousTools = this.getActiveToolNames().filter(name => name !== "goal");
+		const previousTools = this.getActiveToolNames();
 		const goalTools = [...new Set([...previousTools, "goal"])];
 		await this.#goalRuntime.createGoal({ objective: pendingGoal.objective });
 		await this.setActiveToolsByName(goalTools);
@@ -8348,6 +8348,7 @@ export class AgentSession {
 				onChunk,
 				signal: abortController.signal,
 				sessionKey: this.sessionId,
+				cwd,
 				timeout: clampTimeout("bash") * 1000,
 				env: buildGjcRuntimeSessionEnv({
 					sessionFile: this.sessionManager.getSessionFile(),

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -403,7 +403,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		toolNames && toolNames.length > 0 ? [...new Set(toolNames.map(name => name.toLowerCase()))] : undefined;
 	const goalEnabled = session.settings.get("goal.enabled");
 	const goalStateToolNames = [...GOAL_MODE_TOOL_NAMES];
-	if (goalEnabled && session.getGoalRuntime !== undefined && requestedTools && !requestedTools.includes("goal")) {
+	if (goalEnabled && requestedTools && !requestedTools.includes("goal")) {
 		requestedTools = [...requestedTools, "goal"];
 	}
 	if (goalEnabled && requestedTools) {
@@ -482,7 +482,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		allToolsByRequestName.set(name.toLowerCase(), [name, factory]);
 	}
 	const isToolAllowed = (name: string) => {
-		if (name === "goal") return goalEnabled && session.getGoalRuntime !== undefined;
+		if (name === "goal") return goalEnabled;
 		if (goalStateToolNames.includes(name as (typeof GOAL_MODE_TOOL_NAMES)[number])) return goalEnabled;
 		if (name === "lsp") return enableLsp && session.settings.get("lsp.enabled");
 		if (name === "bash") return true;

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -207,6 +207,17 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(await toolNamesFor(harness)).toContain("goal");
 	});
 
+	it("arms the active goal tool after gjc ultragoal create-goals succeeds", async () => {
+		const cliPath = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+		const result = await harness.session.executeBash(
+			`bun ${JSON.stringify(cliPath)} ultragoal create-goals --brief "Complete ultragoal regression"`,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(harness.session.getGoalModeState()?.goal.objective).toContain(".gjc/ultragoal/goals.json");
+		expect(harness.session.getActiveToolNames()).toContain("goal");
+	});
+
 	it("treats budget as objective text instead of a goal budget command", async () => {
 		await harness.mode.handleGoalModeCommand("budget 123");
 
@@ -233,7 +244,7 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.session.getActiveToolNames()).toContain("goal");
 	});
 
-	it("removes the goal tool from the active set when goal({op:complete}) flows through getUserInput", async () => {
+	it("keeps the goal tool in the active set when goal({op:complete}) flows through getUserInput", async () => {
 		await harness.mode.handleGoalModeCommand("objective A");
 		expect(harness.session.getActiveToolNames()).toContain("goal");
 
@@ -252,7 +263,7 @@ describe("InteractiveMode goal mode integration", () => {
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
 		await nextTurn;
 
-		expect(harness.session.getActiveToolNames()).not.toContain("goal");
+		expect(harness.session.getActiveToolNames()).toContain("goal");
 	});
 
 	it("supports create A → drop → create B → get in one session", async () => {

--- a/packages/coding-agent/test/harness-control-plane/finalize.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/finalize.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "../../src/harness-control-plane/finalize";
-import { readReceiptIndex } from "../../src/harness-control-plane/storage";
 import type { ReviewFailureEvidence, ReviewVerdictEvidence } from "../../src/harness-control-plane/receipts";
+import { readReceiptIndex } from "../../src/harness-control-plane/storage";
 
 let root: string;
 const SID = "f";

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -32,6 +32,28 @@ const toolActivationExtension: ExtensionFactory = pi => {
 	});
 };
 
+async function createMinimalSession(tempDirs: string[], settings: Settings, toolNames?: string[]) {
+	const tempDir = path.join(os.tmpdir(), `pi-sdk-goal-tool-${Snowflake.next()}`);
+	tempDirs.push(tempDir);
+	fs.mkdirSync(tempDir, { recursive: true });
+	return createAgentSession({
+		cwd: tempDir,
+		agentDir: tempDir,
+		sessionManager: SessionManager.inMemory(),
+		settings,
+		model: getBundledModel("openai", "gpt-4o-mini"),
+		disableExtensionDiscovery: true,
+		extensions: [],
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		toolNames,
+	});
+}
+
 describe("createAgentSession defaultInactive tool activation", () => {
 	const tempDirs: string[] = [];
 	const authStorages: AuthStorage[] = [];
@@ -44,6 +66,40 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			authStorage.close();
 		}
 		vi.restoreAllMocks();
+	});
+
+	it("registers and activates the goal tool by default", async () => {
+		const { session } = await createMinimalSession(tempDirs, Settings.isolated());
+
+		try {
+			expect(session.getAllToolNames()).toContain("goal");
+			expect(session.getActiveToolNames()).toContain("goal");
+			expect(session.systemPrompt.join("\n")).toContain("goal");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("keeps the goal tool active with explicit toolNames lists", async () => {
+		const { session } = await createMinimalSession(tempDirs, Settings.isolated(), ["read", "bash"]);
+
+		try {
+			expect(session.getAllToolNames()).toContain("goal");
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "bash", "goal"]));
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("excludes the goal tool only when goal mode is disabled", async () => {
+		const { session } = await createMinimalSession(tempDirs, Settings.isolated({ "goal.enabled": false }));
+
+		try {
+			expect(session.getAllToolNames()).not.toContain("goal");
+			expect(session.getActiveToolNames()).not.toContain("goal");
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	it("excludes defaultInactive extension tools from the initial active set unless explicitly requested", async () => {

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -81,6 +81,7 @@ describe("createTools", () => {
 		expect(names).toContain("todo_write");
 		expect(names).toContain("web_search");
 		expect(names).toContain("resolve");
+		expect(names).toContain("goal");
 		expect(names).not.toContain("fetch");
 		expect(names).not.toContain("vim");
 	});
@@ -147,7 +148,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "lsp", "write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write", "resolve"]);
+		expect(names).toEqual(["read", "write", "goal", "resolve"]);
 	});
 
 	it("excludes lsp tool when disabled", async () => {
@@ -163,7 +164,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write", "resolve"]);
+		expect(names).toEqual(["read", "write", "goal", "resolve"]);
 	});
 
 	it("ignores vim as an unknown requested tool even when vim edit mode is active", async () => {
@@ -175,7 +176,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "vim"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "resolve"]);
+		expect(names).toEqual(["read", "goal", "resolve"]);
 	});
 
 	it("lowercases requested tool subset", async () => {
@@ -183,7 +184,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["Read", "Write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write", "resolve"]);
+		expect(names).toEqual(["read", "write", "goal", "resolve"]);
 	});
 
 	it("includes hidden tools when explicitly requested", async () => {
@@ -191,7 +192,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["report_finding"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["report_finding", "resolve"]);
+		expect(names).toEqual(["report_finding", "goal", "resolve"]);
 	});
 
 	it("includes yield tool when required", async () => {
@@ -258,6 +259,20 @@ describe("createTools", () => {
 		expect(defaultTools.map(t => t.name)).not.toContain("exit_plan_mode");
 
 		const requestedTools = await createTools(session, ["read"]);
+		expect(requestedTools.map(t => t.name)).toEqual(["read", "goal", "resolve"]);
+	});
+
+	it("excludes the unified goal tool only when goal mode is disabled", async () => {
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({
+				"goal.enabled": false,
+			}),
+		});
+
+		const defaultTools = await createTools(session);
+		expect(defaultTools.map(t => t.name)).not.toContain("goal");
+
+		const requestedTools = await createTools(session, ["read", "goal"]);
 		expect(requestedTools.map(t => t.name)).toEqual(["read", "resolve"]);
 	});
 	it("auto-includes the unified goal tool when goal mode is enabled", async () => {

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -74,7 +74,8 @@ for (const candidate of candidates) {
 			platformTag,
 			hostPlatformTag,
 			readBuildSidecar,
-			loadNativeAddon: candidatePath => require(candidatePath) as { nativeBuildInfo?: () => { languageSet?: string } },
+			loadNativeAddon: candidatePath =>
+				require(candidatePath) as { nativeBuildInfo?: () => { languageSet?: string } },
 			warn: message => console.warn(message),
 		});
 		available.push(candidate);


### PR DESCRIPTION
## Summary
- keep the unified goal tool registered and active by default whenever goal.enabled is true
- preserve goal in active tool restoration for goal mode and pending ultragoal requests
- run session-owned bash commands in the session cwd so gjc ultragoal arming targets the active repo/session
- add regression coverage for createTools, createAgentSession, goal completion, and gjc ultragoal create-goals arming

## Verification
- bun test packages/coding-agent/test/tools/index.test.ts packages/coding-agent/test/sdk-tool-activation.test.ts packages/coding-agent/test/goals/goal-mode-integration.test.ts packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
- bun run check (passes with existing warnings: packages/ai/test/issue-490-repro.test.ts unused suppression, packages/coding-agent/src/cli.ts unused loadLaunchCommand)
