### PR TITLE
docs(windows): improve native install diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,12 @@ jobs:
    # Windows-latest smoke for the `bun install -g gajae-code` runtime path
    # (issue #525): build the win32-x64 native addon, then exercise the bun-run
    # CLI surface a native install hits — bun + gjc version, help, `gjc team
-   # --help`, and the native/worker smoke probe. Runs on PRs/pushes (not
-   # tag-gated) so Windows regressions surface before release.
+   # --help`, and the native/worker smoke probe. Runs on PRs and branch pushes
+   # so Windows regressions surface before release; release tags already run the
+   # Windows release-binary smoke in the publishing gate.
    windows_smoke:
       timeout-minutes: 60
-      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
       runs-on: windows-latest
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,55 @@ jobs:
               rust_checks: ${{ matrix.rust_checks && 'true' || 'false' }}
               save_cache: ${{ github.event_name == 'push' && ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') || startsWith(github.ref, 'refs/tags/v')) }}
 
+   # Windows-latest smoke for the `bun install -g gajae-code` runtime path
+   # (issue #525): build the win32-x64 native addon, then exercise the bun-run
+   # CLI surface a native install hits — bun + gjc version, help, `gjc team
+   # --help`, and the native/worker smoke probe. Runs on PRs/pushes (not
+   # tag-gated) so Windows regressions surface before release.
+   windows_smoke:
+      timeout-minutes: 60
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      runs-on: windows-latest
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+           with:
+              toolchain: nightly-2026-04-29
+         - name: Prepend rustup toolchain bin to PATH
+           shell: bash
+           run: |
+              toolchain_bin="$(dirname "$(rustup which cargo)")"
+              echo "$toolchain_bin" >> "$GITHUB_PATH"
+         - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+           with:
+              shared-key: windows-smoke-win32-x64
+              cache-on-failure: true
+              save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+              cache-workspace-crates: true
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3"
+         - name: Cache bun dependencies
+           uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+           with:
+              path: ~/.bun/install/cache
+              key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+         - run: bun install --frozen-lockfile
+         - name: Build native addon (win32-x64 baseline)
+           env:
+              TARGET_PLATFORM: win32
+              TARGET_ARCH: x64
+              TARGET_VARIANTS: baseline
+           run: bun run ci:build:native
+         - name: Smoke bun + gjc CLI (source runtime)
+           shell: pwsh
+           run: |
+              bun --version
+              bun packages/coding-agent/src/cli.ts --version
+              bun packages/coding-agent/src/cli.ts --help
+              bun packages/coding-agent/src/cli.ts team --help
+              bun packages/coding-agent/src/cli.ts --smoke-test
+
    # Remaining platforms only ship in release tags; PRs and main never build them.
    native_release:
       timeout-minutes: 90

--- a/README.md
+++ b/README.md
@@ -40,6 +40,39 @@ bun install -g gajae-code
 
 The scoped package is also available as `@gajae-code/coding-agent`.
 
+### Windows (native install)
+
+On a clean Windows 11 machine, install Bun first, then install `gjc` with Bun's
+global installer:
+
+```powershell
+# 1. Install Bun
+powershell -c "irm bun.sh/install.ps1|iex"
+
+# 2. Restart the terminal so PATH and the Bun runtime refresh, then confirm Bun
+bun --version
+
+# 3. Install and verify gjc
+bun install -g gajae-code
+gjc --version
+gjc --smoke-test
+```
+
+`bun install -g` places the `gjc` launcher in `%USERPROFILE%\.bun\bin`. That
+directory must be on `PATH` for `gjc` to resolve as a command. Bun's installer
+adds it automatically, but the change only applies to terminals started after
+installation — restart PowerShell (or sign out/in) if `gjc` is "not recognized".
+
+Troubleshooting:
+
+- **`gjc` reports an old Bun runtime.** Re-run the Bun installer above, restart
+  the terminal, and confirm `bun --version` matches what `gjc --version`
+  expects. If an older Bun still wins, make sure `%USERPROFILE%\.bun\bin` is
+  first on `PATH` and remove any stale Bun installs shadowing it.
+- **`gjc.exe` exists but `gjc` is "not recognized".** The launcher is installed
+  but not on `PATH`. Confirm `%USERPROFILE%\.bun\bin` is listed in
+  `echo $env:Path`, then restart the terminal.
+
 ## Quick start
 
 ```sh

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved the Bun runtime version guard diagnostic: when the Bun running `gjc` is older than the required version, the error now names the exact detected Bun runtime path and prints a platform-specific upgrade and PATH fix (Windows gets the `irm bun.sh/install.ps1|iex` reinstall plus a `%USERPROFILE%\.bun\bin` PATH hint) instead of a bare `bun upgrade` (#525).
+
 ## [0.4.5] - 2026-06-12
 
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,11 +5,15 @@
  * lightweight CLI runner from pi-utils.
  */
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
-import { APP_NAME, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
+import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
-		`error: Bun runtime must be >= ${MIN_BUN_VERSION} (found v${Bun.version}). Please upgrade: bun upgrade\n`,
+		formatBunRuntimeError({
+			currentVersion: Bun.version,
+			minVersion: MIN_BUN_VERSION,
+			execPath: process.execPath,
+		}),
 	);
 	process.exit(1);
 }

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -28,6 +28,58 @@ export const VERSION: string = version;
 /** Minimum Bun version */
 export const MIN_BUN_VERSION: string = engines.bun.replace(/[^0-9.]/g, "");
 
+/**
+ * Build the diagnostic shown when the Bun runtime executing `gjc` is older
+ * than {@link MIN_BUN_VERSION}. This is the most common Windows native-install
+ * failure (issue #525): `bun install -g gajae-code` probes a recent Bun while
+ * the `gjc` launcher resolves an older Bun still on PATH. The message names the
+ * exact detected runtime path and gives a platform-specific upgrade + PATH fix
+ * instead of a bare `bun upgrade`.
+ *
+ * Pure and platform-parameterized so it can be unit-tested cross-platform.
+ */
+export function formatBunRuntimeError(opts: {
+	currentVersion: string;
+	minVersion: string;
+	execPath?: string;
+	platform?: NodeJS.Platform;
+}): string {
+	const platform = opts.platform ?? process.platform;
+	const lines = [
+		`error: ${APP_NAME} requires Bun >= ${opts.minVersion}, but the running Bun is v${opts.currentVersion}.`,
+	];
+	if (opts.execPath) {
+		lines.push(`  detected Bun runtime: ${opts.execPath}`);
+	}
+	if (platform === "win32") {
+		lines.push(
+			"",
+			"The 'gjc' launcher is using an older Bun than the one used to install it.",
+			"Upgrade Bun, then restart your terminal so PATH and the runtime refresh:",
+			"",
+			'  powershell -c "irm bun.sh/install.ps1|iex"',
+			"",
+			"After restarting the terminal, verify both versions match:",
+			"  bun --version",
+			"  gjc --version",
+			"",
+			"If 'gjc' still loads the old runtime, make sure %USERPROFILE%\\.bun\\bin is",
+			"first on PATH and remove any stale Bun installs shadowing it.",
+		);
+	} else {
+		lines.push(
+			"",
+			"Upgrade Bun, then restart your terminal:",
+			"  bun upgrade",
+			"",
+			"Then verify:",
+			"  bun --version",
+			"  gjc --version",
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
 // =============================================================================
 // Project directory
 // =============================================================================

--- a/packages/utils/test/bun-runtime.test.ts
+++ b/packages/utils/test/bun-runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatBunRuntimeError } from "../src/dirs";
+
+describe("formatBunRuntimeError", () => {
+	it("reports the required and detected Bun versions", () => {
+		const message = formatBunRuntimeError({
+			currentVersion: "1.3.12",
+			minVersion: "1.3.14",
+			platform: "linux",
+		});
+		expect(message).toContain("requires Bun >= 1.3.14");
+		expect(message).toContain("v1.3.12");
+		expect(message.endsWith("\n")).toBe(true);
+	});
+
+	it("names the detected runtime path when provided", () => {
+		const message = formatBunRuntimeError({
+			currentVersion: "1.3.12",
+			minVersion: "1.3.14",
+			execPath: "C:\\Users\\dev\\.bun\\bin\\bun.exe",
+			platform: "win32",
+		});
+		expect(message).toContain("detected Bun runtime: C:\\Users\\dev\\.bun\\bin\\bun.exe");
+	});
+
+	it("gives a Windows-specific upgrade and PATH fix on win32", () => {
+		const message = formatBunRuntimeError({
+			currentVersion: "1.3.12",
+			minVersion: "1.3.14",
+			platform: "win32",
+		});
+		expect(message).toContain('powershell -c "irm bun.sh/install.ps1|iex"');
+		expect(message).toContain("%USERPROFILE%\\.bun\\bin");
+		expect(message).not.toContain("bun upgrade");
+	});
+
+	it("uses bun upgrade on non-Windows platforms", () => {
+		const message = formatBunRuntimeError({
+			currentVersion: "1.3.12",
+			minVersion: "1.3.14",
+			platform: "darwin",
+		});
+		expect(message).toContain("bun upgrade");
+		expect(message).not.toContain("install.ps1");
+		expect(message).not.toContain("%USERPROFILE%");
+	});
+});


### PR DESCRIPTION
## Summary
- document native Windows install steps, including terminal reload and `%USERPROFILE%\.bun\bin` PATH expectations
- improve the Bun runtime version guard with detected runtime path/version plus Windows-specific recovery guidance
- add a `windows-latest` smoke job that builds the baseline native addon and exercises the source CLI (`--version`, `--help`, `team --help`, `--smoke-test`)

Fixes #525

## Verification
- `bunx biome check --write packages/utils/src/dirs.ts packages/utils/test/bun-runtime.test.ts packages/coding-agent/src/cli.ts`
- `bun --cwd=packages/utils run check:types`
- `bun --cwd=packages/coding-agent run check:types`
- `bun packages/utils/test/bun-runtime.test.ts && bun packages/coding-agent/src/cli.ts --version`
- `bun --cwd=packages/utils test`