### PR TITLE
feat(ai): inject anchor/edit discipline prompt for composer models

### DIFF
--- a/packages/ai/src/providers/composer-discipline.ts
+++ b/packages/ai/src/providers/composer-discipline.ts
@@ -1,0 +1,38 @@
+/**
+ * Anchor/edit discipline for composer-harness models (xai grok-composer-*,
+ * cursor composer-*).
+ *
+ * Composer models are trained on a proprietary coding-agent harness
+ * (Cursor / Grok Build) and carry habits that break this agent's hashline
+ * edit workflow when driven through a generic provider. Observed in live
+ * sessions with grok-composer-2.5-fast:
+ *
+ *  - they print files with shell commands (`sed -n`, `cat`, `grep -n`) or
+ *    python heredocs whose output carries NO line anchors, then FABRICATE the
+ *    2-char anchor hash the edit tool requires (e.g. guessed "617hp" where
+ *    the file had "617ca" → "Edit rejected: N anchors do not match");
+ *  - they mutate files out-of-band via python heredocs (pathlib write_text /
+ *    str.replace), which invalidates every previously seen anchor and defeats
+ *    the read-cache snapshot that powers stale-anchor recovery;
+ *  - they arithmetically renumber anchors after their own edits instead of
+ *    copying them from the latest tool output;
+ *  - they leak reasoning prose into heredoc bodies, producing shell/python
+ *    syntax errors.
+ *
+ * This prompt is the per-request countermeasure, pinned ahead of the host
+ * system prompt on both the openai-completions path and the cursor RPC path.
+ */
+
+/** Matches composer-harness model ids on any provider (xai grok-composer-*, cursor composer-*). */
+export function isComposerHarnessModel(modelId: string): boolean {
+	return modelId.toLowerCase().includes("composer");
+}
+
+export const COMPOSER_EDIT_DISCIPLINE_PROMPT = `File-editing discipline for this harness (this OVERRIDES contrary habits from your training):
+
+- Read file contents ONLY with the provided read/search tools. NEVER print files through shell commands (sed, cat, awk, head, grep) or scripts — that output carries no line anchors, and the edit tool accepts ONLY anchors.
+- Modify files ONLY with the provided edit/write tools. NEVER mutate files through shell redirection, sed -i, or inline python scripts — out-of-band writes invalidate every known anchor and break edit recovery.
+- A line anchor (e.g. "42sr") is a line number plus a 2-char content hash. You CANNOT compute the hash yourself: copy anchors verbatim from the MOST RECENT read/search/edit output of that exact file. NEVER guess, renumber, or arithmetically shift an anchor.
+- After ANY edit to a file (including your own), anchors you saw earlier are stale. Re-read the edited region, or copy the fresh anchors printed in the edit result, before issuing the next edit.
+- If an edit is rejected with "anchors do not match", the rejection message prints the current lines WITH fresh anchors. Retry using exactly those printed anchors.
+- A shell command string must contain only the command itself. NEVER interleave reasoning or commentary into command strings or heredocs.`;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -30,6 +30,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseStreamingJson } from "../utils/json-parse";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 import { toolWireSchema } from "../utils/schema/wire";
+import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
 import type { McpToolDefinition } from "./cursor/gen/agent_pb";
 import {
 	AgentClientMessageSchema,
@@ -2284,12 +2285,18 @@ function findLastUserMessageIndex(messages: Message[]): number {
  * When no system prompts are provided, returns a single default greeting so we never emit
  * an empty `rootPromptMessagesJson` head.
  */
-export function buildCursorSystemPromptJsons(systemPrompt: readonly string[] | undefined): string[] {
+export function buildCursorSystemPromptJsons(systemPrompt: readonly string[] | undefined, modelId?: string): string[] {
 	const systemPrompts = normalizeSystemPrompts(systemPrompt);
 	if (systemPrompts.length === 0) {
 		return [JSON.stringify({ role: "system", content: "You are a helpful assistant." })];
 	}
-	return systemPrompts.map(content => JSON.stringify({ role: "system", content }));
+	const jsons = systemPrompts.map(content => JSON.stringify({ role: "system", content }));
+	// Composer-harness models need anchor/edit discipline pinned ahead of the
+	// host prompt (see composer-discipline.ts for the observed failure modes).
+	if (modelId !== undefined && isComposerHarnessModel(modelId)) {
+		jsons.unshift(JSON.stringify({ role: "system", content: COMPOSER_EDIT_DISCIPLINE_PROMPT }));
+	}
+	return jsons;
 }
 
 function buildRootPromptMessagesJson(
@@ -2501,7 +2508,7 @@ function buildGrpcRequest(
 } {
 	const blobStore = state.blobStore;
 
-	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt).map(json =>
+	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt, model.id).map(json =>
 		storeCursorBlob(blobStore, new TextEncoder().encode(json)),
 	);
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -61,6 +61,7 @@ import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
 import { type HealedToolCall, modelMayLeakKimiToolCalls, ToolCallHealer } from "../utils/tool-call-healing";
 import { isForcedToolChoice, mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
+import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
 import {
 	buildCopilotDynamicHeaders,
 	hasCopilotVisionInput,
@@ -1430,6 +1431,11 @@ export function convertMessages(
 	};
 
 	const systemPrompts = normalizeSystemPrompts(context.systemPrompt);
+	// Composer-harness models need anchor/edit discipline pinned ahead of the
+	// host prompt (see composer-discipline.ts for the observed failure modes).
+	if (systemPrompts.length > 0 && isComposerHarnessModel(model.id)) {
+		systemPrompts.unshift(COMPOSER_EDIT_DISCIPLINE_PROMPT);
+	}
 	if (systemPrompts.length > 0) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
 		const role = useDeveloperRole ? "developer" : "system";

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Composer-harness models (xai grok-composer-*, cursor composer-*) get the
+ * anchor/edit discipline prompt pinned ahead of the host system prompt, on
+ * both the openai-completions path and the cursor RPC path. Non-composer
+ * models must stay byte-identical to previous behavior.
+ */
+import { describe, expect, it } from "bun:test";
+import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "@gajae-code/ai/providers/composer-discipline";
+import { buildCursorSystemPromptJsons } from "@gajae-code/ai/providers/cursor";
+import { convertMessages } from "@gajae-code/ai/providers/openai-completions";
+import type { Context, Model, OpenAICompat } from "@gajae-code/ai/types";
+
+const compat: Required<OpenAICompat> = {
+	supportsStore: true,
+	supportsDeveloperRole: false,
+	supportsMultipleSystemMessages: true,
+	supportsReasoningEffort: false,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: true,
+	supportsToolChoice: true,
+	disableReasoningOnForcedToolChoice: false,
+	disableReasoningOnToolChoice: false,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresMistralToolIds: false,
+	thinkingFormat: "openai",
+	reasoningContentField: "reasoning_content",
+	requiresReasoningContentForToolCalls: false,
+	allowsSyntheticReasoningContentForToolCalls: true,
+	requiresAssistantContentForToolCalls: false,
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	extraBody: {},
+	supportsStrictMode: true,
+	toolStrictMode: "none",
+};
+
+function createXaiModel(id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "xai",
+		baseUrl: "https://api.x.ai/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	} as unknown as Model<"openai-completions">;
+}
+
+function createContext(systemPrompt?: string[]): Context {
+	return {
+		systemPrompt,
+		messages: [{ role: "user", content: "hi", timestamp: 1 }],
+	} as unknown as Context;
+}
+
+describe("isComposerHarnessModel", () => {
+	it("matches composer ids on any provider, rejects others", () => {
+		expect(isComposerHarnessModel("grok-composer-2.5-fast")).toBe(true);
+		expect(isComposerHarnessModel("composer-1")).toBe(true);
+		expect(isComposerHarnessModel("Grok-Composer-Next")).toBe(true);
+		expect(isComposerHarnessModel("grok-4.3")).toBe(false);
+		expect(isComposerHarnessModel("gpt-5")).toBe(false);
+	});
+});
+
+describe("openai-completions composer discipline injection", () => {
+	it("prepends the discipline prompt for composer models", () => {
+		const params = convertMessages(
+			createXaiModel("grok-composer-2.5-fast"),
+			createContext(["Host system prompt."]),
+			compat,
+		);
+		expect(params[0]).toEqual({ role: "system", content: COMPOSER_EDIT_DISCIPLINE_PROMPT });
+		expect(params[1]).toEqual({ role: "system", content: "Host system prompt." });
+	});
+
+	it("does not inject for non-composer models", () => {
+		const params = convertMessages(createXaiModel("grok-4.3"), createContext(["Host system prompt."]), compat);
+		expect(params[0]).toEqual({ role: "system", content: "Host system prompt." });
+		expect(JSON.stringify(params)).not.toContain("File-editing discipline");
+	});
+
+	it("does not inject when there is no host system prompt", () => {
+		const params = convertMessages(createXaiModel("grok-composer-2.5-fast"), createContext(undefined), compat);
+		expect(JSON.stringify(params)).not.toContain("File-editing discipline");
+	});
+
+	it("joins the discipline prompt first when multiple system messages are unsupported", () => {
+		const singleMessageCompat = { ...compat, supportsMultipleSystemMessages: false };
+		const params = convertMessages(
+			createXaiModel("grok-composer-2.5-fast"),
+			createContext(["Host system prompt."]),
+			singleMessageCompat,
+		);
+		expect(params[0].role).toBe("system");
+		expect(params[0].content).toBe(`${COMPOSER_EDIT_DISCIPLINE_PROMPT}\n\nHost system prompt.`);
+	});
+});
+
+describe("cursor composer discipline injection", () => {
+	it("pins the discipline block ahead of the host prompt for composer model ids", () => {
+		const jsons = buildCursorSystemPromptJsons(["Host system prompt."], "composer-1");
+		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
+		expect(contents[0]).toBe(COMPOSER_EDIT_DISCIPLINE_PROMPT);
+		expect(contents[1]).toBe("Host system prompt.");
+	});
+
+	it("keeps non-composer cursor models unchanged", () => {
+		const jsons = buildCursorSystemPromptJsons(["Host system prompt."], "gpt-5");
+		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
+		expect(contents).toEqual(["Host system prompt."]);
+	});
+
+	it("keeps the legacy single-argument call shape unchanged", () => {
+		const jsons = buildCursorSystemPromptJsons(["Host system prompt."]);
+		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
+		expect(contents).toEqual(["Host system prompt."]);
+	});
+
+	it("does not inject discipline without a host system prompt", () => {
+		const jsons = buildCursorSystemPromptJsons(undefined, "composer-1");
+		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
+		expect(contents).toEqual(["You are a helpful assistant."]);
+	});
+});


### PR DESCRIPTION
## Problem

Follow-up to #518 (grok-composer-2.5-fast support). Composer-harness models (xai `grok-composer-*`, cursor `composer-*`) are trained on a proprietary harness (Cursor / Grok Build) and routinely break the hashline edit workflow when driven through a generic provider. Observed in live sessions with `xai/grok-composer-2.5-fast` (session transcript evidence):

- They print files via `sed -n` / `cat` / python heredocs — output that carries **no line anchors** — then **fabricate** the 2-char anchor hash the edit tool requires (e.g. sent `617hp` where the file had `617ca`). Since `computeLineHash` is content-keyed, a guessed/arithmetically-shifted hash can never match → `Edit rejected: N anchors do not match`.
- They mutate files **out-of-band** via python heredocs (`pathlib.write_text`), invalidating every previously seen anchor and defeating the read-cache snapshot behind stale-anchor recovery.
- They renumber anchors arithmetically after their own edits instead of copying them from the latest tool output, and ignore the fresh anchors printed in the rejection message — so the failure loops (observed 4 consecutive rejections, up to 13 stale anchors in one call).

## Fix

New `packages/ai/src/providers/composer-discipline.ts`: `isComposerHarnessModel(modelId)` (id contains "composer") + a discipline system block targeting exactly those failure modes (read only via anchored read/search tools, edit only via edit/write tools, copy anchors verbatim from the most recent output, use the rejection message's fresh anchors, no prose inside command strings).

Injected per-request, pinned ahead of the host system prompt, on both delivery paths:

- **openai-completions** (`convertMessages`): unshifted into the system prompts — covers xai `grok-composer-*`. Stays first in the joined string when `supportsMultipleSystemMessages` is false.
- **cursor RPC** (`buildCursorSystemPromptJsons`): optional `modelId` param (legacy call shape unchanged); the block is its own blob so the per-entry blob cache keeps hitting.

Non-composer models stay byte-identical to previous behavior; nothing is injected when there is no host system prompt.

## Tests

- New `packages/ai/test/composer-discipline.test.ts` — 9 tests: id matching, openai path (inject / non-composer / no host prompt / single-system-message join order), cursor path (inject / non-composer / legacy single-arg shape / no host prompt).
- `bun test packages/ai/test`: 1266 pass / 1 fail — the failure (`provider-fetch-override.test.ts`) is environment-dependent and fails identically on a clean tree.
- `biome check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)