### PR TITLE
fix: ignore shell function env assignments

### DIFF
--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -70,9 +70,24 @@ export function parseShellEnvFile(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	try {
 		const content = fs.readFileSync(filePath, "utf-8");
+		let functionBlockDepth = 0;
 		for (const line of content.split("\n")) {
 			const trimmed = line.trim();
 			if (!trimmed || trimmed.startsWith("#")) continue;
+
+			if (functionBlockDepth > 0) {
+				functionBlockDepth += (line.match(/{/g) ?? []).length;
+				functionBlockDepth -= (line.match(/}/g) ?? []).length;
+				functionBlockDepth = Math.max(0, functionBlockDepth);
+				continue;
+			}
+
+			if (/^(?:function\s+)?[A-Za-z_][A-Za-z0-9_-]*\s*(?:\(\))?\s*\{/.test(trimmed)) {
+				functionBlockDepth += (line.match(/{/g) ?? []).length;
+				functionBlockDepth -= (line.match(/}/g) ?? []).length;
+				functionBlockDepth = Math.max(0, functionBlockDepth);
+				continue;
+			}
 
 			const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
 			if (!match) continue;

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -93,6 +93,29 @@ describe("parseShellEnvFile", () => {
 			OPENAI_API_KEY: "shell-key",
 		});
 	});
+
+	it("ignores assignments inside shell function bodies", () => {
+		const filePath = writeTempEnv(
+			[
+				"export TOP_LEVEL_TOKEN=keep-me",
+				"configure_session() {",
+				"  export FUNCTION_TOKEN=ignore-me",
+				"  INNER_SETTING=ignore-me",
+				"  nested() {",
+				"    export NESTED_SECRET=ignore-me",
+				"  }",
+				"}",
+				"AFTER_FUNCTION=also-keep",
+				"inline_function() { export INLINE_SECRET=ignore-me; }",
+			].join("\n"),
+			".zshrc",
+		);
+
+		expect(parseShellEnvFile(filePath)).toEqual({
+			TOP_LEVEL_TOKEN: "keep-me",
+			AFTER_FUNCTION: "also-keep",
+		});
+	});
 });
 
 describe("$inheritedEnv", () => {


### PR DESCRIPTION
## Summary
- Ignore assignments inside shell function bodies when parsing shell startup files such as `.zshrc`
- Preserve top-level shell env assignments before and after function blocks
- Add regression coverage with generic fixture values only; no local env files or user-specific environment values are included

## Why
`parseShellEnvFile` intentionally reads simple top-level shell assignments without executing shell code. Before this change, assignments inside helper functions were treated as global env, so values that should apply only when a function is invoked could leak into CLI startup and provider auth/network calls.

## Validation
- `bun test packages/utils/test/env.test.ts`
- `bun run check` from `packages/utils`
