### PR TITLE
feat(ai): add claude-fable-5 to Anthropic model catalog

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -2849,6 +2849,31 @@
 			"contextWindow": 200000,
 			"maxTokens": 4096
 		},
+		"claude-fable-5": {
+			"id": "claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-haiku-4-5": {
 			"id": "claude-haiku-4-5",
 			"name": "Anthropic Haiku 4.5 (latest)",


### PR DESCRIPTION
## Problem
`claude-fable-5` (Claude Fable 5, GA 2026-06-09) is missing from the bundled Anthropic catalog in `packages/ai/src/models.json`. As a result it never appears in `/model` or `--list-models`, and cannot be selected even after `gjc update` — because the Anthropic provider has no dynamic model listing, so the static catalog is the only source.

The forced-tool-choice compat path (`packages/ai/src/providers/anthropic.ts`, `claude-(fable|mythos)` regex) and `packages/ai/test/anthropic-alignment.test.ts` already reference `claude-fable-5`, but the catalog row was never added.

## Fix
Add the `claude-fable-5` entry to the `anthropic` provider block, mirroring the structure of `claude-opus-4-8` with values from Anthropic’s published specs:
- 1M context window, 128K max output
- $10 / $50 per MTok in/out, $1 cache read, $12.50 (5-min) cache write
- text + image input, adaptive thinking (minimal–xhigh)

## Verification
- `node` parse: valid JSON; entry present under `anthropic.claude-fable-5` with top/cost/thinking keys identical to `claude-opus-4-8`.
- E2E: with this catalog, `gjc --list-models fable` lists `anthropic/claude-fable-5` (1M / 128K / images yes). Baseline (without it): `No models matching "fable"`.

## Scope note
This adds only the first-party `anthropic` entry (the path backed by existing compat code + tests). Fable 5 is also GA on GitHub Copilot, Bedrock, Vertex, and Foundry; mirroring it into those provider blocks is left as a follow-up since their exact id formats differ.