### PR TITLE
fix(coordinator): persist active turns before tmux delivery

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -742,6 +742,7 @@ async function startTmuxSession(
 	config: CoordinatorMcpConfig,
 	input: SessionStartInput,
 	namespaceDir: string,
+	runner: CommandRunner = runCommand,
 ): Promise<Record<string, unknown>> {
 	if (!config.sessionCommand) throw new Error("coordinator_session_command_required");
 	const sessionName = `gjc-coordinator-${randomUUID().slice(0, 8)}`;
@@ -752,7 +753,7 @@ async function startTmuxSession(
 		`${GJC_COORDINATOR_SESSION_ID_ENV}=${shellQuote(sessionName)}`,
 		config.sessionCommand,
 	].join(" ");
-	const started = await runCommand([
+	const started = await runner([
 		"tmux",
 		"new-session",
 		"-d",
@@ -767,9 +768,6 @@ async function startTmuxSession(
 	]);
 	if (started.exitCode !== 0) throw new Error(`coordinator_tmux_start_failed:${started.stderr || started.stdout}`);
 	const [tmuxTarget, paneId] = started.stdout.trim().split(/\s+/, 2);
-	const initialPromptTmuxKeysSent = input.prompt
-		? await sendTmuxPromptKeys(tmuxTarget || sessionName, input.prompt)
-		: false;
 	return {
 		sessionId: sessionName,
 		tmuxSession: sessionName,
@@ -779,7 +777,6 @@ async function startTmuxSession(
 		createdAt: new Date().toISOString(),
 		sessionCommand: config.sessionCommand,
 		runtimeStateFile,
-		initialPromptTmuxKeysSent,
 	};
 }
 
@@ -964,13 +961,45 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	}
 
 	async function activateTurn(session: Record<string, unknown>, turn: TurnRecord): Promise<TurnRecord> {
-		const tmuxKeysSent = await sendTmuxPrompt(session, turn.prompt.text, commandRunner);
 		const timestamp = new Date().toISOString();
 		const target = typeof session.tmux_target === "string" ? session.tmux_target : session.tmuxTarget;
 		const live = hasTmuxIdentity(session) ? await hasTmuxSession(session, commandRunner) : null;
-		const activeTurn: TurnRecord = {
+		const pendingTurn: TurnRecord = {
 			...turn,
 			status: "active",
+			delivery: {
+				delivered: false,
+				queued: true,
+				target: typeof target === "string" ? target : null,
+				tmux_keys_sent: false,
+				prompt_acknowledged: false,
+				state: "queued",
+				attempts: [
+					{
+						delivered: false,
+						tmux_keys_sent: false,
+						channel: "tmux_keys",
+						created_at: timestamp,
+						reason: "awaiting_tmux_delivery",
+					},
+				],
+			},
+			liveness: { checked_at: timestamp, live, reason: live === false ? "tmux_session_missing" : null },
+			started_at: turn.started_at ?? timestamp,
+			updated_at: timestamp,
+		};
+		await writeTurnRecord(namespaceDir, pendingTurn);
+		await writeActiveTurn(namespaceDir, pendingTurn);
+		await writeSessionState(namespaceDir, pendingTurn.session_id, "running", {
+			currentTurnId: pendingTurn.turn_id,
+			live,
+			reason: null,
+		});
+
+		const tmuxKeysSent = await sendTmuxPrompt(session, turn.prompt.text, commandRunner);
+		const deliveredAt = new Date().toISOString();
+		const activeTurn: TurnRecord = {
+			...pendingTurn,
 			delivery: {
 				delivered: false,
 				queued: !tmuxKeysSent,
@@ -983,22 +1012,26 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						delivered: false,
 						tmux_keys_sent: tmuxKeysSent,
 						channel: "tmux_keys",
-						created_at: timestamp,
+						created_at: deliveredAt,
 						reason: tmuxKeysSent ? "awaiting_runtime_ack" : "tmux_delivery_unavailable",
 					},
 				],
 			},
-			liveness: { checked_at: timestamp, live, reason: live === false ? "tmux_session_missing" : null },
-			started_at: turn.started_at ?? timestamp,
-			updated_at: timestamp,
+			updated_at: deliveredAt,
 		};
-		await writeActiveTurn(namespaceDir, activeTurn);
-		await writeSessionState(namespaceDir, activeTurn.session_id, tmuxKeysSent ? "running" : "stale", {
-			currentTurnId: activeTurn.turn_id,
-			live,
-			reason: tmuxKeysSent ? null : "tmux_delivery_unavailable",
-		});
 		await writeTurnRecord(namespaceDir, activeTurn);
+		await writeActiveTurn(namespaceDir, activeTurn);
+		const sessionState = await readSessionState(namespaceDir, activeTurn.session_id);
+		const runtimeStateAlreadySettled =
+			sessionState?.current_turn_id === activeTurn.turn_id &&
+			(sessionState.state === "completed" || sessionState.state === "errored");
+		if (!runtimeStateAlreadySettled) {
+			await writeSessionState(namespaceDir, activeTurn.session_id, tmuxKeysSent ? "running" : "stale", {
+				currentTurnId: activeTurn.turn_id,
+				live,
+				reason: tmuxKeysSent ? null : "tmux_delivery_unavailable",
+			});
+		}
 		return activeTurn;
 	}
 
@@ -1149,18 +1182,16 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				};
 				const started = services.startSession
 					? await services.startSession(input)
-					: await startTmuxSession(config, input, namespaceDir);
+					: await startTmuxSession(config, input, namespaceDir, commandRunner);
 				const startedRecord = asRecord(started);
 				if (!startedRecord) throw new Error("coordinator_session_command_required");
 				const session = normalizeSession(startedRecord);
 				await writeJsonFile(sessionFile(session.session_id), session);
 				const live = hasTmuxIdentity(session) ? await hasTmuxSession(session, commandRunner) : null;
-				let sessionState = await writeSessionState(
-					namespaceDir,
-					String(session.session_id),
-					input.prompt ? "running" : "ready_for_input",
-					{ live, reason: null },
-				);
+				let sessionState = await writeSessionState(namespaceDir, String(session.session_id), "ready_for_input", {
+					live,
+					reason: null,
+				});
 				if (typeof args.prompt === "string" && args.prompt.length > 0) {
 					const turn = await activateTurn(
 						session,

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -201,6 +201,49 @@ describe("Coordinator MCP server protocol", () => {
 			{ cwd: root, prompt: "hello", namespace: { profile: "local", repo: "repo" }, worktree: true },
 		]);
 	});
+	it("delivers start-session prompts exactly once after the active turn is durable", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "hermes-start-session-prompt");
+		const commands: string[][] = [];
+		let activeTurnExistedAtSend = false;
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_SESSION_COMMAND: "gjc --worktree",
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				commandRunner: async command => {
+					commands.push(command);
+					if (command[1] === "new-session")
+						return { exitCode: 0, stdout: "gjc-coordinator-test:0.0 %99\n", stderr: "" };
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "send-keys") {
+						const activeTurnsDir = path.join(stateRoot, "local", "repo", "active-turns");
+						const activeTurns = await fs.readdir(activeTurnsDir).catch(() => []);
+						activeTurnExistedAtSend = activeTurns.length === 1;
+						return { exitCode: 0, stdout: "", stderr: "" };
+					}
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		const response = await server.callTool("gjc_coordinator_start_session", {
+			cwd: root,
+			prompt: "hello",
+			allow_mutation: true,
+		});
+
+		expect(response.ok).toBe(true);
+		expect(activeTurnExistedAtSend).toBe(true);
+		expect(commands.filter(command => command[1] === "send-keys")).toEqual([
+			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "hello", "C-m", "C-m"],
+		]);
+	});
 
 	it("persists audited follow-up, question answers, and bounded reports", async () => {
 		const root = await tempRoot();
@@ -637,6 +680,89 @@ describe("Coordinator MCP server protocol", () => {
 		});
 		expect((read.session_state as { state: string; last_turn_id: string }).state).toBe("completed");
 		expect((read.session_state as { state: string; last_turn_id: string }).last_turn_id).toBe(turnId);
+	});
+	it("preserves runtime completion when callback wins the turn activation race", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "hermes-runtime-race");
+		let runtimeStatePath = "";
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				startSession: async input => ({
+					sessionId: "gjc-demo",
+					tmuxSession: "gjc-demo",
+					tmuxTarget: "gjc-demo:0.0",
+					cwd: input.cwd,
+					createdAt: "2026-06-07T00:00:00.000Z",
+				}),
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "send-keys") {
+						const activeTurn = JSON.parse(
+							await Bun.file(path.join(stateRoot, "local", "repo", "active-turns", "gjc-demo.json")).text(),
+						) as {
+							turn_id: string;
+						};
+						runtimeStatePath = path.join(stateRoot, "local", "repo", "session-states", "gjc-demo.json");
+						await fs.mkdir(path.dirname(runtimeStatePath), { recursive: true });
+						await Bun.write(
+							runtimeStatePath,
+							JSON.stringify({
+								schema_version: 1,
+								session_id: "gjc-demo",
+								state: "completed",
+								ready_for_input: true,
+								current_turn_id: activeTurn.turn_id,
+								last_turn_id: activeTurn.turn_id,
+								updated_at: "2026-06-07T00:00:01.000Z",
+								source: "agent_session_event",
+								live: null,
+								reason: "agent_end",
+								final_response: {
+									text: "Runtime final answer",
+									format: "markdown",
+									source: "agent_end",
+									artifact_path: null,
+									truncated: false,
+								},
+							}),
+						);
+						return { exitCode: 0, stdout: "", stderr: "" };
+					}
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+		await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+
+		const turn = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "gjc-demo",
+			prompt: "work",
+			allow_mutation: true,
+		});
+		const turnId = turn.turn_id as string;
+		const persistedState = JSON.parse(await Bun.file(runtimeStatePath).text()) as {
+			state: string;
+			current_turn_id: string;
+		};
+		expect(persistedState).toMatchObject({ state: "completed", current_turn_id: turnId });
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "gjc-demo",
+			turn_id: turnId,
+		});
+
+		expect((read.turn as { status: string }).status).toBe("completed");
+		expect((read.turn as { final_response: { source: string; text: string } }).final_response).toMatchObject({
+			source: "agent_end",
+			text: "Runtime final answer",
+		});
 	});
 	it("flags completed turns that lack reportable final responses", async () => {
 		const root = await tempRoot();


### PR DESCRIPTION
## Summary
- Persist coordinator active turns and `current_turn_id` before tmux prompt delivery.
- Route start-session prompts through the same activation path so they are delivered exactly once after durable state exists.
- Preserve runtime completion/errored session state when a fast callback wins the activation race.

## Problem
The coordinator bridge could send tmux keys before the active turn and session `current_turn_id` were durably recorded. If the GJC runtime completed very quickly, its completion callback could arrive before the coordinator knew which active turn should receive it. That left Hermes/Meeseeks-style callers polling a turn that never got the terminal completion.

## Root cause
`activateTurn()` performed tmux delivery first, then persisted active-turn/session state. The start-session prompt path also sent the initial prompt during tmux session startup, outside the durable turn activation flow.

## What changed
- `activateTurn()` now writes a queued active turn and session `current_turn_id` before sending tmux keys.
- After tmux delivery, the turn delivery metadata is updated without overwriting a runtime state that has already settled to `completed` or `errored`.
- `startTmuxSession()` no longer sends an initial prompt directly; start-session prompts go through `activateTurn()`.
- `startTmuxSession()` accepts the injected command runner so the start-session delivery ordering is regression-testable.
- Added regression coverage for:
  - start-session prompt delivery after active-turn durability
  - preserving runtime completion when the callback wins the activation race

## Overlap assessment
Net-new bug fix / follow-up hardening. I searched existing PRs and issues for coordinator MCP completion-race and visible-session reuse terms and found no open duplicate PR/issue for this exact completion race.

## Validation
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts` — 17 pass, 0 fail.
- `bun run check:ts` — passed across workspace checks.

Notes for the clean worktree verification:
- A fresh worktree needed `bun install --frozen-lockfile`.
- The native binary artifact was copied locally from the existing workspace only to run local verification; it is ignored and not included in this PR.

## Target-base diff classification
Bug fix with real implementation delta.

## Risks
- This changes coordinator prompt activation ordering. The regression tests cover fast completion and start-session prompt delivery, but CI should still run the broader workspace checks on the PR branch.

## Changed files
- `packages/coding-agent/src/coordinator-mcp/server.ts`
- `packages/coding-agent/test/coordinator-mcp-server.test.ts`
