### PR TITLE
fix(team): tighten Windows/psmux tmux provider boundary (#531)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Improved the Bun runtime version guard diagnostic: when the Bun running `gjc` is older than the required version, the error now names the exact detected Bun runtime path and prints a platform-specific upgrade and PATH fix (Windows gets the `irm bun.sh/install.ps1|iex` reinstall plus a `%USERPROFILE%\.bun\bin` PATH hint) instead of a bare `bun upgrade` (#525).
 
 - Aligned the `codex-standard` and `codex-pro` model profiles on the `openai-codex/gpt-5.5` baseline so they no longer default to stale mixed model generations (`gpt-5.4`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.3-codex-spark`); the profiles now differentiate purely by per-role reasoning effort (#532).
+### Fixed
+
+- Tightened the Windows/psmux tmux provider boundary: `gjc team` now honors `GJC_TMUX_COMMAND` (not just `GJC_TEAM_TMUX_COMMAND`) so the team leader resolves the same multiplexer as `gjc session`/`gjc --tmux`; and when a multiplexer lists a session that lacks GJC's `@gjc-profile` ownership tag, `gjc session status` now returns `gjc_tmux_session_untagged` with a `detail` hint and `gjc team` reports the same cause, instead of a bare `gjc_tmux_session_not_found` / `unmanaged_tmux_session`. Documented that alternative multiplexers such as psmux on Windows are not fully supported because they do not round-trip tmux user options (#531).
 
 ## [0.4.5] - 2026-06-12
 

--- a/packages/coding-agent/src/commands/session.ts
+++ b/packages/coding-agent/src/commands/session.ts
@@ -18,7 +18,9 @@ function writeText(lines: string[]): void {
 function writeJsonFailure(error: unknown): void {
 	const message = error instanceof Error ? error.message : String(error);
 	const [reason = "session_error"] = message.split(":");
-	writeJson({ ok: false, reason });
+	const hintIndex = message.indexOf(" — ");
+	const detail = hintIndex >= 0 ? message.slice(hintIndex + " — ".length).trim() : "";
+	writeJson(detail ? { ok: false, reason, detail } : { ok: false, reason });
 }
 
 interface SessionJsonDto {

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -306,8 +306,9 @@ Worker protocol:
 
 Useful runtime env vars:
 
-- `GJC_TEAM_TMUX_COMMAND`
-  - tmux binary/command override (default `tmux`)
+- `GJC_TMUX_COMMAND` / `GJC_TEAM_TMUX_COMMAND`
+  - tmux binary/command override (default `tmux`). `GJC_TMUX_COMMAND` applies to every GJC tmux flow; `GJC_TEAM_TMUX_COMMAND` is honored as an alias by the team path. Both resolve through the same resolver, so the team leader and `gjc session ...` always target the same multiplexer.
+  - Multiplexer support boundary: GJC-managed sessions and the team leader are detected via tmux user options (`@gjc-profile`, written with `set-option` and read back with `show-options` / `list-sessions -F`). A provider must round-trip those user options to be supported. Real tmux works. Alternative multiplexers such as psmux on Windows do not reliably persist tmux user options yet, so `gjc session status` reports `gjc_tmux_session_untagged` (the session exists in the multiplexer but is not GJC-tagged) and team startup rejects the leader as `unmanaged_tmux_session`. The Windows-native psmux path is therefore not fully supported; use real tmux for GJC-managed session and team flows.
 - `GJC_TEAM_WORKER_COMMAND`
   - worker command override (default resolves to active GJC entrypoint or `gjc`)
 - `GJC_TEAM_STATE_ROOT`

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -17,7 +17,12 @@ import {
 	writeReport,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
-import { GJC_TMUX_PROFILE_OPTION, GJC_TMUX_PROFILE_VALUE } from "./tmux-common";
+import {
+	buildGjcTmuxUntaggedSessionHint,
+	GJC_TMUX_PROFILE_OPTION,
+	GJC_TMUX_PROFILE_VALUE,
+	resolveGjcTmuxCommand,
+} from "./tmux-common";
 
 export type GjcTeamPhase = "starting" | "running" | "awaiting_integration" | "complete" | "failed" | "cancelled";
 export type GjcTeamTaskStatus = "pending" | "blocked" | "in_progress" | "completed" | "failed";
@@ -1622,9 +1627,6 @@ async function ensureWorkerWorktree(
 	};
 }
 
-export function resolveGjcTmuxCommand(env: NodeJS.ProcessEnv = process.env): string {
-	return env.GJC_TEAM_TMUX_COMMAND?.trim() || "tmux";
-}
 function buildTeamTmuxLeaderRequirementMessage(detail?: string): string {
 	const suffix = detail?.trim() ? `:${detail.trim()}` : "";
 	return `gjc_team_requires_tmux_leader: run \`gjc --tmux\` first, then run \`gjc team ...\` inside that tmux-backed leader session, or use \`gjc team --dry-run\` for state-only smoke tests${suffix}`;
@@ -1653,7 +1655,11 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%"))
 		throw new Error(buildTeamTmuxLeaderRequirementMessage(`invalid_tmux_context:${result.stdout.toString().trim()}`));
 	if (readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE)
-		throw new Error(buildTeamTmuxLeaderRequirementMessage(`unmanaged_tmux_session:${sessionName}`));
+		throw new Error(
+			buildTeamTmuxLeaderRequirementMessage(
+				`unmanaged_tmux_session:${sessionName} — ${buildGjcTmuxUntaggedSessionHint(tmuxCommand)}`,
+			),
+		);
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
 export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/coding-agent/src/gjc-runtime/tmux-common.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-common.ts
@@ -32,6 +32,21 @@ export function resolveGjcTmuxCommand(env: NodeJS.ProcessEnv = process.env): str
 	return env[GJC_TMUX_COMMAND_ENV]?.trim() || env.GJC_TEAM_TMUX_COMMAND?.trim() || "tmux";
 }
 
+export const GJC_TMUX_UNTAGGED_REASON = "gjc_tmux_session_untagged";
+
+export function buildGjcTmuxUntaggedSessionHint(tmuxCommand: string): string {
+	return (
+		`the active multiplexer "${tmuxCommand}" lists this session but did not return GJC's ${GJC_TMUX_PROFILE_OPTION} ownership tag; ` +
+		"GJC-managed sessions and `gjc team` require a tmux provider that round-trips tmux user options. " +
+		"Alternative multiplexers such as psmux on Windows do not persist user options yet, so the Windows-native psmux path is not fully supported; " +
+		"use real tmux for GJC-managed session and team flows."
+	);
+}
+
+export function buildGjcTmuxUntaggedSessionError(sessionName: string, tmuxCommand: string): string {
+	return `${GJC_TMUX_UNTAGGED_REASON}:${sessionName} — ${buildGjcTmuxUntaggedSessionHint(tmuxCommand)}`;
+}
+
 export function sanitizeTmuxToken(value: string): string {
 	return (
 		value

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -1,6 +1,7 @@
 import {
 	buildGjcTmuxProfileCommands,
 	buildGjcTmuxSessionName,
+	buildGjcTmuxUntaggedSessionError,
 	GJC_TMUX_BRANCH_OPTION,
 	GJC_TMUX_BRANCH_SLUG_OPTION,
 	GJC_TMUX_PROFILE_OPTION,
@@ -73,17 +74,10 @@ function parseSessionLine(line: string): GjcTmuxSessionStatus | null {
 	};
 }
 
-function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
+function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): string[] {
 	let output = "";
 	try {
-		output = runTmux(
-			[
-				"list-sessions",
-				"-F",
-				`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
-			],
-			env,
-		);
+		output = runTmux(["list-sessions", "-F", format], env);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.includes("no server running") || message.includes("failed to connect to server")) return [];
@@ -93,6 +87,17 @@ function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
 		.split("\n")
 		.map(line => line.trim())
 		.filter(Boolean);
+}
+
+function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
+	return runListSessions(
+		`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
+		env,
+	);
+}
+
+function listRawTmuxSessionNames(env: NodeJS.ProcessEnv = process.env): string[] {
+	return runListSessions("#{session_name}", env).map(line => line.split("\t")[0] ?? line);
 }
 
 export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus[] {
@@ -114,8 +119,11 @@ export function findGjcTmuxSessionByBranch(
 
 export function statusGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {
 	const session = listGjcTmuxSessions(env).find(candidate => candidate.name === sessionName);
-	if (!session) throw new Error(`gjc_tmux_session_not_found:${sessionName}`);
-	return session;
+	if (session) return session;
+	if (listRawTmuxSessionNames(env).includes(sessionName)) {
+		throw new Error(buildGjcTmuxUntaggedSessionError(sessionName, resolveGjcTmuxCommand(env)));
+	}
+	throw new Error(`gjc_tmux_session_not_found:${sessionName}`);
 }
 
 export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -453,6 +453,25 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).not.toContain("kill-session");
 	});
 
+	it("resolves the team tmux leader from GJC_TMUX_COMMAND, not only GJC_TEAM_TMUX_COMMAND", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Resolve tmux command from the general override",
+			teamName: "tmux-command-override-team",
+			cwd: cleanupRoot,
+			env: { PATH: process.env.PATH ?? "", GJC_TEAM_WORKER_COMMAND: "true", GJC_TMUX_COMMAND: fakeTmux },
+		});
+
+		const config = await Bun.file(path.join(snapshot.state_dir, "config.json")).json();
+		expect(config.tmux_command).toBe(fakeTmux);
+		expect(config.tmux_target).toBe("test-session:0");
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
+	});
+
 	it("starts multiple runtime workers before tmux state mutation", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -92,4 +92,29 @@ describe("GJC tmux session management", () => {
 		expect(() => removeGjcTmuxSession("gajae_code_work")).toThrow("gjc_tmux_session_not_managed:gajae_code_work");
 		expect(calls.some(call => call.includes("kill-session"))).toBe(false);
 	});
+
+	it("diagnoses sessions the multiplexer lists but did not tag with the GJC profile", () => {
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				// The bare `#{session_name}` probe sees the session (psmux ls shows it)...
+				if (format === "#{session_name}") return spawnResult(0, "psmux_session\n");
+				// ...but the full format does not round-trip @gjc-profile, so the profile column is empty.
+				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		expect(() => statusGjcTmuxSession("psmux_session", { GJC_TMUX_COMMAND: "psmux" })).toThrow(
+			"gjc_tmux_session_untagged:psmux_session",
+		);
+		expect(() => statusGjcTmuxSession("psmux_session", { GJC_TMUX_COMMAND: "psmux" })).toThrow(/not fully supported/);
+	});
+
+	it("still reports plain not-found when the multiplexer does not list the session", () => {
+		spyOn(Bun, "spawnSync").mockReturnValue(spawnResult(0, ""));
+
+		expect(() => statusGjcTmuxSession("ghost")).toThrow("gjc_tmux_session_not_found:ghost");
+	});
 });

--- a/packages/coding-agent/test/session-command.test.ts
+++ b/packages/coding-agent/test/session-command.test.ts
@@ -109,4 +109,24 @@ describe("gjc session command", () => {
 			},
 		});
 	});
+
+	it("surfaces an untagged-session diagnostic with a detail hint in JSON failures", async () => {
+		mockSpawnSync((cmd: string[]) => {
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "winsess\n");
+				return spawnResult(0, "winsess\t1\t0\t1770000000\t\troot\t0\t\t\t\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const output = await runSessionCommand(["status", "winsess", "--json"]);
+		const payload = JSON.parse(output);
+
+		expect(payload.ok).toBe(false);
+		expect(payload.reason).toBe("gjc_tmux_session_untagged");
+		expect(typeof payload.detail).toBe("string");
+		expect(payload.detail).toContain("not fully supported");
+		expect(payload.detail).not.toContain(" — ");
+	});
 });


### PR DESCRIPTION
Closes #531.

## Problem

On Windows with `GJC_TMUX_COMMAND=psmux` / `GJC_TEAM_TMUX_COMMAND=psmux`, psmux is tmux-compatible for core verbs but does **not** reliably round-trip tmux *user options* (`@gjc-profile`, `@gjc-branch`, …) across separate invocations. GJC marks and detects its own sessions purely via those user options, so:

- `gjc session create --json` could appear to succeed, but a later `gjc session status <name> --json` returned `gjc_tmux_session_not_found` even though `psmux ls` still listed the session.
- `gjc team` rejected the leader as `unmanaged_tmux_session` because `show-options … @gjc-profile` did not return the tag.

The result was confusing *partial* compatibility that looks close to working, then fails late. There was also a real override bug: the team path resolved the tmux command from `GJC_TEAM_TMUX_COMMAND` only and **ignored** `GJC_TMUX_COMMAND`, so the leader could target a different multiplexer than `gjc session` / `gjc --tmux`.

Full psmux support is not feasible here (the gap is psmux's user-option semantics, and there is no Windows/psmux available to verify against), so this PR makes the boundary **explicit** and fixes the genuine override bug.

## Changes

- **Unified tmux command resolution.** Removed the team-local `resolveGjcTmuxCommand` that ignored `GJC_TMUX_COMMAND`; team now imports the shared resolver (`tmux-common`), guaranteeing the leader and `gjc session` resolve the *same* multiplexer.
- **Clear session diagnostic.** `statusGjcTmuxSession` now probes the raw multiplexer session list (`list-sessions -F '#{session_name}'`). If the session exists but lacks the `@gjc-profile` tag, it throws `gjc_tmux_session_untagged:<name>` with an actionable hint instead of a bare `gjc_tmux_session_not_found`.
- **JSON detail.** `gjc session … --json` failures now include a `detail` field carrying the human-readable hint.
- **Team leader diagnostic.** The `unmanaged_tmux_session` error now explains the user-option round-trip requirement and names psmux/Windows as not fully supported.
- **Docs + changelog.** Documented the multiplexer support boundary in the Team skill's Environment Knobs and added an Unreleased CHANGELOG entry.

## Verification

All mockable (no Windows/psmux required):

- `bun test packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/session-command.test.ts` → 10 pass
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` → 45 pass
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/slash-commands/session.test.ts` → 24 pass
- `bun scripts/check-visible-definitions.ts` → pass
- `bun scripts/rebrand-inventory.ts --strict` → pass
- `bun scripts/verify-g002-gates.ts` → pass
- `bun run check:ts` → pass

New tests added: untagged-session diagnostic (`tmux-sessions`), `--json` `detail` surfacing (`session-command`), and team `GJC_TMUX_COMMAND` resolution (`team-runtime`).
