### PR TITLE
Restore top-level MCP tool discovery

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -78,7 +78,7 @@ import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-e
 import { resolveMemoryBackend } from "./memory-backend";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
-import { MCPManager } from "./runtime-mcp";
+import { discoverAndLoadMCPTools, MCPManager } from "./runtime-mcp";
 import {
 	collectEnvSecrets,
 	deobfuscateSessionContext,
@@ -275,7 +275,7 @@ export interface CreateAgentSessionOptions {
 	/** File-based slash commands. Default: discovered from commands/ directories */
 	slashCommands?: FileSlashCommand[];
 
-	/** @deprecated MCP runtime discovery is quarantined and ignored. */
+	/** Enable runtime MCP discovery for top-level sessions. Default: true. */
 	enableMCP?: boolean;
 	/** Existing MCP manager to reuse (skips discovery, propagates to toolSession). */
 	mcpManager?: MCPManager;
@@ -1266,15 +1266,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Create built-in tools (already wrapped with meta notice formatting)
 		const builtinTools = await logger.time("createAllTools", createTools, toolSession, options.toolNames);
 
-		// MCP runtime discovery is quarantined for the GJC surface. Keep an
-		// explicitly supplied manager only for legacy in-process callers that own
-		// lifecycle themselves; never discover project/user MCP configs here.
-		const mcpManager: MCPManager | undefined = options.mcpManager;
+		// Load runtime MCP tools for top-level sessions unless explicitly disabled.
+		// ACP clients and subagents pass enableMCP: false because they either own
+		// their MCP lifecycle or intentionally avoid inheriting host integrations.
+		let mcpManager: MCPManager | undefined = options.mcpManager;
 		const customTools: CustomTool[] = [];
-		// Only top-level sessions own the global MCPManager. Subagents already
-		// receive the parent's manager via `options.mcpManager`, and reassigning
-		// the singleton to the same value is a no-op \u2014 keep the gate explicit
-		// to mirror the AsyncJobManager ownership rule.
+		if (!mcpManager && options.enableMCP !== false && !options.parentTaskPrefix) {
+			const mcpLoadResult = await logger.time("discoverAndLoadMCPTools", () =>
+				discoverAndLoadMCPTools(cwd, {
+					authStorage,
+					enableProjectConfig: settings.get("mcp.enableProjectConfig"),
+					filterBrowser: options.toolNames?.includes("browser") ?? false,
+				}),
+			);
+			mcpManager = mcpLoadResult.manager;
+			customTools.push(...mcpLoadResult.tools.map(loaded => loaded.tool));
+			for (const error of mcpLoadResult.errors) {
+				logger.warn("MCP tool load failed", error);
+			}
+		}
 		if (mcpManager && !options.parentTaskPrefix) MCPManager.setInstance(mcpManager);
 
 		// Add image tools when the active model or configured image providers can generate images.
@@ -1632,8 +1642,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			: toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const requestedToolNameSet = new Set(normalizedRequested);
-		// Effective discovery mode only covers built-in tools; MCP tool discovery
-		// is quarantined from the GJC public surface.
 		const toolsDiscoveryModeSetting = settings.get("tools.discoveryMode");
 		const effectiveDiscoveryMode: "off" | "all" = toolsDiscoveryModeSetting === "all" ? "all" : "off";
 		const mcpDiscoveryEnabled = false;

--- a/packages/coding-agent/test/mcp-quarantine-surface.test.ts
+++ b/packages/coding-agent/test/mcp-quarantine-surface.test.ts
@@ -11,7 +11,7 @@ async function source(...parts: string[]): Promise<string> {
 	return await Bun.file(srcPath(...parts)).text();
 }
 
-describe("GJC MCP quarantine surface", () => {
+describe("GJC MCP public surface", () => {
 	it("does not register MCP as a public internal URL protocol", async () => {
 		const router = await source("internal-urls", "router.ts");
 		const barrel = await source("internal-urls", "index.ts");
@@ -20,29 +20,23 @@ describe("GJC MCP quarantine surface", () => {
 		expect(barrel).not.toContain("mcp-protocol");
 	});
 
-	it("does not discover or proxy MCP tools into agent or subagent sessions", async () => {
+	it("discovers MCP tools for top-level agent sessions while keeping subagents isolated", async () => {
 		const sdk = await source("sdk.ts");
 		const taskExecutor = await source("task", "executor.ts");
 		const taskIndex = await source("task", "index.ts");
 
-		expect(sdk).not.toContain("discoverAndLoadMCPTools");
-		expect(sdk).not.toContain("discoverMCPServers");
+		expect(sdk).toContain("discoverAndLoadMCPTools");
+		expect(sdk).toContain("options.enableMCP !== false");
 		expect(taskExecutor).not.toContain("createMCPProxyTools");
 		expect(taskExecutor).not.toContain("runtime-mcp/client");
 		expect(taskIndex).not.toContain("MCPManager.instance()");
 	});
 
-	it("hides MCP configuration and read-tool resource hints from the public UI", async () => {
-		const settingsSchema = await source("config", "settings-schema.ts");
+	it("keeps MCP resource URLs out of the public read prompt unless the manager is active", async () => {
 		const readPrompt = await source("prompts", "tools", "read.md");
 		const systemPrompt = await source("prompts", "system", "system-prompt.md");
-		const interactiveMode = await source("modes", "interactive-mode.ts");
 
-		expect(settingsSchema).not.toContain("MCP Project Config");
-		expect(settingsSchema).not.toContain("MCP Tool Discovery");
-		expect(settingsSchema).not.toContain('"mcp-only"');
 		expect(readPrompt).not.toContain("mcp://");
 		expect(systemPrompt).not.toContain("mcp://");
-		expect(interactiveMode).not.toContain("MCPCommandController");
 	});
 });

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -76,7 +76,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		}
 	});
 
-	it("does not load project MCP config unless MCP is explicitly enabled", async () => {
+	it("does not load project MCP config unless project MCP config is enabled", async () => {
 		fs.writeFileSync(
 			path.join(tempDir, ".mcp.json"),
 			JSON.stringify({
@@ -104,9 +104,9 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			toolNames: ["read"],
 		});
 
-		expect(mcpManager).toBeUndefined();
-		expect(session.getAllToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
-		expect(session.getActiveToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+		expect(mcpManager).toBeDefined();
+		expect(session.getAllToolNames()).not.toContain("mcp__local_local");
+		expect(session.getActiveToolNames()).not.toContain("mcp__local_local");
 	});
 
 	it("does not advertise MCP discovery when search_tool_bm25 is not active", async () => {


### PR DESCRIPTION
## Summary
- re-enable runtime MCP tool loading for top-level GJC sessions unless `enableMCP: false` is passed
- keep ACP and subagent sessions isolated from host MCP discovery
- update MCP surface tests to reflect restored top-level behavior while keeping project MCP config gated by `mcp.enableProjectConfig`

## Verification
- `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/test/mcp-quarantine-surface.test.ts packages/coding-agent/test/sdk-mcp-discovery.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/mcp-quarantine-surface.test.ts packages/coding-agent/test/sdk-mcp-discovery.test.ts`
