### PR TITLE
fix(compaction): run pre-prompt context maintenance

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compaction cut-point selection when the newest retained context ends in an uncuttable tool result, so automatic compaction can keep the latest assistant/tool-result pair instead of falling back to a no-op cut.
+
 ## [0.4.5] - 2026-06-12
 
 ### Changed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -542,11 +542,16 @@ export function findCutPoint(
 		// Check if we've exceeded the budget
 		if (accumulatedTokens >= keepRecentTokens) {
 			// Find the closest valid cut point at or after this entry
+			let foundCutPoint = false;
 			for (let c = 0; c < cutPoints.length; c++) {
 				if (cutPoints[c] >= i) {
 					cutIndex = cutPoints[c];
+					foundCutPoint = true;
 					break;
 				}
+			}
+			if (!foundCutPoint) {
+				cutIndex = cutPoints[cutPoints.length - 1];
 			}
 			break;
 		}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - Tightened the Windows/psmux tmux provider boundary: `gjc team` now honors `GJC_TMUX_COMMAND` (not just `GJC_TEAM_TMUX_COMMAND`) so the team leader resolves the same multiplexer as `gjc session`/`gjc --tmux`; and when a multiplexer lists a session that lacks GJC's `@gjc-profile` ownership tag, `gjc session status` now returns `gjc_tmux_session_untagged` with a `detail` hint and `gjc team` reports the same cause, instead of a bare `gjc_tmux_session_not_found` / `unmanaged_tmux_session`. Documented that alternative multiplexers such as psmux on Windows are not fully supported because they do not round-trip tmux user options (#531).
 - Hardened RPC stdio lifecycle behavior: `gjc --mode rpc` now reports malformed JSONL frames as parse-error responses without killing the session, flushes durable session state before exiting on EOF/shutdown, and has red-team coverage for attached persistence, reload, malformed-frame recovery, and concurrent child-session isolation.
+### Fixed
+
+- Ran estimated context maintenance before sending a new prompt, including tool-output pruning and threshold compaction, so large tool results appended after the last assistant turn cannot push the next model request over the context window.
 
 ## [0.4.5] - 2026-06-12
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6551,7 +6551,10 @@ export class AgentSession {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
 		if (shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) {
-			await this.#runAutoCompaction("threshold", false, false, { continueAfterMaintenance: false });
+			await this.#runAutoCompaction("threshold", false, false, {
+				continueAfterMaintenance: false,
+				deferHandoffMaintenance: false,
+			});
 		}
 	}
 
@@ -7283,18 +7286,24 @@ export class AgentSession {
 		reason: "overflow" | "threshold" | "idle",
 		willRetry: boolean,
 		deferred = false,
-		options?: { continueAfterMaintenance?: boolean },
+		options?: { continueAfterMaintenance?: boolean; deferHandoffMaintenance?: boolean },
 	): Promise<void> {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.strategy === "off") return;
 		if (reason !== "idle" && !compactionSettings.enabled) return;
 		const generation = this.#promptGeneration;
-		if (!deferred && reason !== "overflow" && reason !== "idle" && compactionSettings.strategy === "handoff") {
+		if (
+			options?.deferHandoffMaintenance !== false &&
+			!deferred &&
+			reason !== "overflow" &&
+			reason !== "idle" &&
+			compactionSettings.strategy === "handoff"
+		) {
 			this.#schedulePostPromptTask(
 				async signal => {
 					await Promise.resolve();
 					if (signal.aborted) return;
-					await this.#runAutoCompaction(reason, willRetry, true);
+					await this.#runAutoCompaction(reason, willRetry, true, options);
 				},
 				{ generation },
 			);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4749,6 +4749,9 @@ export class AgentSession {
 			if (lastAssistant && !options?.skipCompactionCheck) {
 				await this.#checkCompaction(lastAssistant, false);
 			}
+			if (!options?.skipCompactionCheck) {
+				await this.#checkEstimatedContextBeforePrompt();
+			}
 
 			// Build messages array (session context, eager todo prelude, then active prompt message)
 			const messages: AgentMessage[] = [];
@@ -6530,6 +6533,28 @@ export class AgentSession {
 			}
 		}
 	}
+
+	async #checkEstimatedContextBeforePrompt(): Promise<void> {
+		const model = this.model;
+		if (!model) return;
+		const contextWindow = model.contextWindow ?? 0;
+		if (contextWindow <= 0) return;
+		const compactionSettings = this.settings.getGroup("compaction");
+		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
+
+		let contextTokens = this.#estimateContextTokens().tokens;
+		const maxOutputTokens = model.maxTokens ?? 0;
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) return;
+
+		const pruneResult = await this.#pruneToolOutputs();
+		if (pruneResult) {
+			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
+		}
+		if (shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) {
+			await this.#runAutoCompaction("threshold", false, false, { continueAfterMaintenance: false });
+		}
+	}
+
 	#assistantEndedWithSuccessfulYield(assistantMessage: AssistantMessage): boolean {
 		const toolCallId = this.#lastSuccessfulYieldToolCallId;
 		if (!toolCallId) return false;
@@ -7258,6 +7283,7 @@ export class AgentSession {
 		reason: "overflow" | "threshold" | "idle",
 		willRetry: boolean,
 		deferred = false,
+		options?: { continueAfterMaintenance?: boolean },
 	): Promise<void> {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.strategy === "off") return;
@@ -7277,6 +7303,7 @@ export class AgentSession {
 
 		let action: "context-full" | "handoff" =
 			compactionSettings.strategy === "handoff" && reason !== "overflow" ? "handoff" : "context-full";
+		const continueAfterMaintenance = options?.continueAfterMaintenance !== false;
 		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 		// Abort any older auto-compaction before installing this run's controller.
 		this.#autoCompactionAbortController?.abort();
@@ -7316,7 +7343,12 @@ export class AgentSession {
 						aborted: false,
 						willRetry: false,
 					});
-					if (!autoCompactionSignal.aborted && reason !== "idle" && compactionSettings.autoContinue !== false) {
+					if (
+						continueAfterMaintenance &&
+						!autoCompactionSignal.aborted &&
+						reason !== "idle" &&
+						compactionSettings.autoContinue !== false
+					) {
 						this.#scheduleAutoContinuePrompt(generation);
 					}
 					return;
@@ -7378,7 +7410,7 @@ export class AgentSession {
 							stopReason: tail?.stopReason,
 						});
 					}
-				} else if (reason !== "idle" && this.agent.hasQueuedMessages()) {
+				} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({
 						delayMs: 100,
 						generation,
@@ -7386,7 +7418,7 @@ export class AgentSession {
 						onSkip: skipReason => this.#logCompactionContinuationSkipped("queued_continue", skipReason),
 						onError: error => this.#logCompactionContinuationError("queued_continue", error),
 					});
-				} else if (reason !== "idle" && compactionSettings.autoContinue !== false) {
+				} else if (continueAfterMaintenance && reason !== "idle" && compactionSettings.autoContinue !== false) {
 					this.#scheduleAutoContinuePrompt(generation);
 				}
 				return;
@@ -7607,7 +7639,7 @@ export class AgentSession {
 						onError: error => this.#logCompactionContinuationError("overflow_retry", error),
 					});
 				}
-			} else if (reason !== "idle" && this.agent.hasQueuedMessages()) {
+			} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
 				this.#scheduleAgentContinue({
@@ -7617,7 +7649,7 @@ export class AgentSession {
 					onSkip: reason => this.#logCompactionContinuationSkipped("queued_continue", reason),
 					onError: error => this.#logCompactionContinuationError("queued_continue", error),
 				});
-			} else if (reason !== "idle" && compactionSettings.autoContinue !== false) {
+			} else if (continueAfterMaintenance && reason !== "idle" && compactionSettings.autoContinue !== false) {
 				this.#scheduleAutoContinuePrompt(generation);
 			}
 		} catch (error) {

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -269,6 +269,52 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(sessionManager.getBranch().some(entry => entry.type === "compaction")).toBe(true);
 	});
 
+	it("runs pre-prompt handoff maintenance before sending the oversized prompt", async () => {
+		vi.useRealTimers();
+		session.settings.set("compaction.strategy", "handoff");
+		session.settings.set("compaction.thresholdTokens", 1000);
+
+		const handoffSpy = vi.spyOn(session, "handoff").mockImplementation(async () => {
+			expect(streamCallCount).toBe(0);
+			return { document: "handoff document" };
+		});
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "Ready for tool output" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 800,
+				output: 50,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 850,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		const largeToolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tool-large-read",
+			toolName: "read",
+			content: [{ type: "text", text: "x".repeat(10_000) }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		sessionManager.appendMessage(assistantMsg);
+		sessionManager.appendMessage(largeToolResult);
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		await session.prompt("next prompt after large read");
+
+		expect(handoffSpy).toHaveBeenCalledTimes(1);
+		expect(streamCallCount).toBe(1);
+		expect(getRuntimeSignals()).toContain("compaction:start:threshold");
+	});
+
 	it("forwards todo reminder lifecycle signals to extensions", async () => {
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
+import type { AssistantMessage, ToolResultMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
@@ -34,6 +36,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 	let sessionManager: SessionManager;
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
+	let streamCallCount: number;
 
 	beforeEach(async () => {
 		tempDir = TempDir.createSync("@pi-auto-compaction-queue-");
@@ -94,6 +97,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		if (!model) {
 			throw new Error("Expected built-in anthropic model to exist");
 		}
+		streamCallCount = 0;
 
 		const agent = new Agent({
 			initialState: {
@@ -101,6 +105,32 @@ describe("AgentSession auto-compaction queue resume", () => {
 				systemPrompt: ["Test"],
 				tools: [],
 				messages: [],
+			},
+			streamFn: () => {
+				streamCallCount++;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message: AssistantMessage = {
+						role: "assistant",
+						content: [{ type: "text", text: "ok" }],
+						api: "anthropic-messages",
+						provider: "anthropic",
+						model: "claude-sonnet-4-5",
+						stopReason: "stop",
+						usage: {
+							input: 100,
+							output: 10,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 110,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
 			},
 		});
 
@@ -195,6 +225,48 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runtimeSignals = getRuntimeSignals();
 		expect(runtimeSignals).toContain("compaction:start:threshold");
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
+	});
+
+	it("compacts before a new prompt when tool results push context over threshold", async () => {
+		vi.useRealTimers();
+		session.settings.set("compaction.thresholdTokens", 1000);
+		session.settings.set("compaction.keepRecentTokens", 1);
+
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "Ready for tool output" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 800,
+				output: 50,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 850,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		const largeToolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tool-large-read",
+			toolName: "read",
+			content: [{ type: "text", text: "x".repeat(10_000) }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		sessionManager.appendMessage(assistantMsg);
+		sessionManager.appendMessage(largeToolResult);
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		await session.prompt("next prompt after large read");
+
+		expect(streamCallCount).toBe(1);
+		expect(getRuntimeSignals()).toContain("compaction:start:threshold");
+		expect(sessionManager.getBranch().some(entry => entry.type === "compaction")).toBe(true);
 	});
 
 	it("forwards todo reminder lifecycle signals to extensions", async () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -15,7 +15,7 @@ import {
 import * as ai from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { encodeTextSignatureV1 } from "@gajae-code/ai/providers/openai-responses-shared";
-import type { AssistantMessage, Model, ProviderPayload, Usage } from "@gajae-code/ai/types";
+import type { AssistantMessage, Model, ProviderPayload, ToolResultMessage, Usage } from "@gajae-code/ai/types";
 import { hookFetch } from "@gajae-code/utils";
 import {
 	buildSessionContext,
@@ -66,6 +66,17 @@ function createAssistantMessage(text: string, usage?: Usage): AssistantMessage {
 		api: "anthropic-messages",
 		provider: "anthropic",
 		model: "claude-sonnet-4-5",
+	};
+}
+
+function createToolResultMessage(text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: `tool-${entryCounter}`,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
 	};
 }
 
@@ -809,6 +820,22 @@ describe("findCutPoint", () => {
 			expect(result.isSplitTurn).toBe(true);
 			expect(result.turnStartIndex).toBe(2); // Turn 2 starts at index 2
 		}
+	});
+
+	it("keeps the latest assistant/tool-result pair when the newest entry is an uncuttable tool result", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Turn 1")),
+			createMessageEntry(createAssistantMessage("A1")),
+			createMessageEntry(createUserMessage("Turn 2")),
+			createMessageEntry(createAssistantMessage("A2")),
+			createMessageEntry(createToolResultMessage("x".repeat(10_000))),
+		];
+
+		const result = findCutPoint(entries, 0, entries.length, 1);
+
+		expect(result.firstKeptEntryIndex).toBe(3);
+		expect(result.isSplitTurn).toBe(true);
+		expect(result.turnStartIndex).toBe(2);
 	});
 });
 


### PR DESCRIPTION
## Summary
- run estimated context maintenance before sending a new user prompt, so large tool results appended after the last assistant turn can trigger pruning/threshold compaction before the next model request
- prevent pre-prompt maintenance from scheduling an auto-continue turn that would race the explicit user prompt
- fix compaction cut-point selection when the newest retained context ends in an uncuttable tool result

## Why
The recurring `context_length_exceeded` case happened because context maintenance was mostly driven from the last assistant usage at turn end. Large `toolResult` entries could be appended after that point and push the next prompt over the model window before compaction ran. A separate cut-point fallback also made some newest-tool-result cases compact poorly or no-op.

## Verification
- `bunx biome check packages/agent/src/compaction/compaction.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts packages/coding-agent/test/compaction.test.ts packages/agent/CHANGELOG.md packages/coding-agent/CHANGELOG.md`
- `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts packages/coding-agent/test/compaction.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/agent run check:types`
- LSP diagnostics clean on changed TypeScript files

Note: Biome reported 4 checked files because the changelog Markdown files are ignored by the current Biome config.