### PR TITLE
fix(team): self-heal missing @gjc-profile tag for gjc-launched leaders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Ran estimated context maintenance before sending a new prompt, including tool-output pruning and threshold compaction, so large tool results appended after the last assistant turn cannot push the next model request over the context window.
+- `gjc team` now self-heals a missing `@gjc-profile` ownership tag when the current leader pane was genuinely launched by `gjc --tmux` (detected via `GJC_TMUX_LAUNCHED=1`): the session is re-tagged with `set-option` and startup proceeds, instead of hard-failing with `unmanaged_tmux_session` after a mid-startup attach failure or registry race stripped the tag. Sessions without the GJC launch marker are still rejected unchanged, so foreign tmux sessions cannot be hijacked.
 
 ## [0.4.5] - 2026-06-12
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -5,7 +5,7 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 
-import { applyGjcTmuxProfile } from "./launch-tmux";
+import { applyGjcTmuxProfile, GJC_TMUX_LAUNCHED_ENV } from "./launch-tmux";
 import {
 	AlreadyExistsError,
 	appendJsonl as appendJsonlAudited,
@@ -1643,6 +1643,17 @@ function readGjcTmuxProfileValue(tmuxCommand: string, sessionName: string): stri
 	return result.stdout.toString().trim();
 }
 
+function retagGjcLaunchedTmuxSession(tmuxCommand: string, sessionName: string): boolean {
+	const result = Bun.spawnSync(
+		[tmuxCommand, "set-option", "-t", `=${sessionName}`, GJC_TMUX_PROFILE_OPTION, GJC_TMUX_PROFILE_VALUE],
+		{
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+	return result.exitCode === 0;
+}
+
 function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEnv): GjcTmuxLeaderContext {
 	const paneTarget = env.TMUX_PANE?.trim();
 	const args = paneTarget
@@ -1654,12 +1665,21 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	const [sessionName = "", windowIndex = ""] = sessionAndWindow.split(":");
 	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%"))
 		throw new Error(buildTeamTmuxLeaderRequirementMessage(`invalid_tmux_context:${result.stdout.toString().trim()}`));
-	if (readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE)
-		throw new Error(
-			buildTeamTmuxLeaderRequirementMessage(
-				`unmanaged_tmux_session:${sessionName} — ${buildGjcTmuxUntaggedSessionHint(tmuxCommand)}`,
-			),
-		);
+	if (readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE) {
+		// Self-heal: a pane launched through `gjc --tmux` exports
+		// GJC_TMUX_LAUNCHED=1, but the session can lose (or never receive) the
+		// @gjc-profile user-option tag when startup attach fails mid-way or the
+		// registry write races. That stranded-but-genuinely-GJC leader pane
+		// previously hard-failed as unmanaged_tmux_session; re-tag it instead.
+		const launchedByGjc = env[GJC_TMUX_LAUNCHED_ENV] === "1";
+		const retagged = launchedByGjc && retagGjcLaunchedTmuxSession(tmuxCommand, sessionName);
+		if (!retagged || readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE)
+			throw new Error(
+				buildTeamTmuxLeaderRequirementMessage(
+					`unmanaged_tmux_session:${sessionName} — ${buildGjcTmuxUntaggedSessionHint(tmuxCommand)}`,
+				),
+			);
+	}
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
 export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -63,8 +63,17 @@ case "$1" in
 }
     ;;
   show-options)
+    profile_file=${JSON.stringify(path.join(root, "tmux-profile-tag"))}
     if [ "${options.gjcProfile === false ? "0" : "1"}" = "1" ]; then echo "1"; exit 0; fi
+    if [ -f "$profile_file" ]; then echo "1"; exit 0; fi
     exit 1
+    ;;
+  set-option)
+    profile_file=${JSON.stringify(path.join(root, "tmux-profile-tag"))}
+    for arg in "$@"; do
+      if [ "$arg" = "@gjc-profile" ]; then echo "1" > "$profile_file"; fi
+    done
+    exit 0
     ;;
   split-window)
     ${options.failSplit ? "echo split failed >&2; exit 1" : ""}
@@ -624,6 +633,56 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).toContain("show-options -qv -t =test-session @gjc-profile");
 		expect(tmuxLog).not.toContain("split-window");
 		expect(tmuxLog).not.toContain("set-option -t test-session:0");
+	});
+
+	it("self-heals a missing @gjc-profile tag when the leader pane was launched by gjc --tmux", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false });
+
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Recover managed leader",
+			teamName: "self-heal-team",
+			cwd: cleanupRoot,
+			dryRun: false,
+			env: {
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+				GJC_TMUX_LAUNCHED: "1",
+			},
+		});
+
+		expect(snapshot.team_name).toBe("self-heal-team");
+		expect(snapshot.tmux_target).toBe("test-session:0");
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("set-option -t =test-session @gjc-profile 1");
+		expect(tmuxLog).toContain("split-window");
+	});
+
+	it("keeps rejecting untagged sessions when GJC_TMUX_LAUNCHED is not set even with TMUX present", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false });
+
+		await expect(
+			startGjcTeam({
+				workerCount: 1,
+				agentType: "executor",
+				task: "Do not hijack foreign tmux",
+				teamName: "foreign-team",
+				cwd: cleanupRoot,
+				env: {
+					PATH: process.env.PATH ?? "",
+					GJC_TEAM_WORKER_COMMAND: "true",
+					GJC_TEAM_TMUX_COMMAND: fakeTmux,
+					TMUX: "/tmp/tmux-501/default,1,0",
+				},
+			}),
+		).rejects.toThrow(/unmanaged_tmux_session:test-session/);
+
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).not.toContain("set-option");
 	});
 
 	it("cleans partial worker worktrees without killing the leader session when pane startup fails", async () => {


### PR DESCRIPTION
## Problem

A leader pane launched through `gjc --tmux` exports `GJC_TMUX_LAUNCHED=1`, but the tmux session can lose (or never receive) the `@gjc-profile` user-option tag — observed in the wild when the startup attach fails mid-way (`gjc --tmux failed after creating tmux session: attach failed.`) or the registry write races. After that, every `gjc team ...` launch from that genuine GJC leader hard-fails:

```text
gjc_team_requires_tmux_leader: run `gjc --tmux` first, ...
unmanaged_tmux_session:gajae_code_main_mqattu3e_ddkgaxq0
```

while `gjc session list` shows the same session as attached with `panes: 0` (the untagged session is filtered out of the managed view). Reproduced on macOS with real tmux 3.6a on gjc v0.4.5 and on current `dev`.

## Fix

`readCurrentTmuxLeaderContext` now self-heals: when the profile tag is missing **and** the environment carries the GJC launch marker (`GJC_TMUX_LAUNCHED=1`), it re-tags the current session via `set-option <session> @gjc-profile 1`, re-verifies the tag round-trips, and proceeds. If the marker is absent, or the re-tag does not round-trip (e.g. psmux-style providers that drop user options), the launch is rejected exactly as before — foreign tmux sessions cannot be hijacked.

## Tests

- new: `self-heals a missing @gjc-profile tag when the leader pane was launched by gjc --tmux` (fails on `dev` with the exact production error, passes with the fix)
- new: `keeps rejecting untagged sessions when GJC_TMUX_LAUNCHED is not set even with TMUX present`
- existing `rejects unmanaged tmux sessions before state, worktree, split, or profile mutation` unchanged and still green (asserts no `set-option` is attempted without the marker)
- fake tmux test bin extended to round-trip `set-option`/`show-options` for `@gjc-profile`

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/gjc-runtime/team-convergence.test.ts` → 68 pass / 0 fail
- `bun run check:ts` → clean (biome + tsgo across workspaces)
- changelog entry added under `[Unreleased]` → Fixed