### PR TITLE
fix(coding-agent): gate harness RPC submit readiness

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Hardened RPC stdio lifecycle behavior: `gjc --mode rpc` now reports malformed JSONL frames as parse-error responses without killing the session, flushes durable session state before exiting on EOF/shutdown, and has red-team coverage for attached persistence, reload, malformed-frame recovery, and concurrent child-session isolation.
 ### Fixed
 
+- Hardened the harness RPC submit/router contract so `submit` is no longer advertised or accepted during finalizing/non-idle lifecycle windows, non-idle RPC state reports `submitted:false` with a retryable gate, and degraded owner endpoints fall back to `owner-not-live` without false acceptance (#544).
+
 - Ran estimated context maintenance before sending a new prompt, including tool-output pruning and threshold compaction, so large tool results appended after the last assistant turn cannot push the next model request over the context window.
 - `gjc team` now self-heals a missing `@gjc-profile` ownership tag when the current leader pane was genuinely launched by `gjc --tmux` (detected via `GJC_TMUX_LAUNCHED=1`): the session is re-tagged with `set-option` and startup proceeds, instead of hard-failing with `unmanaged_tmux_session` after a mid-startup attach failure or registry race stripped the tag. Sessions without the GJC launch marker are still rejected unchanged, so foreign tmux sessions cannot be hijacked.
 

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -20,7 +20,7 @@ import { preserveDirtyWorktree } from "../harness-control-plane/preserve";
 import { buildReceipt, requiresVanishBeforeAction, type VanishEvidence } from "../harness-control-plane/receipts";
 import { GajaeCodeRpc } from "../harness-control-plane/rpc-adapter";
 import { classifyLeaseStatus, readLease } from "../harness-control-plane/session-lease";
-import { buildResponse, buildStateView } from "../harness-control-plane/state-machine";
+import { buildResponse, buildStateView, submitUnavailableReason } from "../harness-control-plane/state-machine";
 import {
 	canonicalWorkspacePath,
 	generateSessionId,
@@ -978,8 +978,21 @@ export default class Harness extends Command {
 
 	async #submit(root: string, input: Record<string, unknown>, flagSession: string | undefined): Promise<void> {
 		const sessionId = requireSessionId(input, flagSession);
-		if (await this.#tryOwnerRoute(root, sessionId, "submit", { ...input, sessionId })) return;
 		let state = await loadState(root, sessionId);
+		const noOwnerGate = submitUnavailableReason(state.lifecycle, false);
+		if (!noOwnerGate || noOwnerGate === "owner-not-live") {
+			if (await this.#tryOwnerRoute(root, sessionId, "submit", { ...input, sessionId })) return;
+			state = await loadState(root, sessionId);
+		}
+		const blockedByOwnerLiveness = state.blockers.some(
+			blocker => isOwnerLivenessBlocker(blocker) || blocker === OWNER_STARTUP_BLOCKER,
+		);
+		const lifecycleGate = submitUnavailableReason(state.lifecycle, false);
+		if (lifecycleGate && lifecycleGate !== "owner-not-live" && !blockedByOwnerLiveness) {
+			writeJson(buildResponse(state, false, { accepted: false, submitted: false, reason: lifecycleGate }, false));
+			process.exitCode = 1;
+			return;
+		}
 		// No live owner: submission is blocked (never echoed-as-accepted). Surface owner exit
 		// evidence + explicit recovery guidance so the caller is not left with a bare gate.
 		const ownerExit = await buildOwnerExitEvidence(root, state);

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -28,8 +28,7 @@ import {
 	type VanishEvidence,
 	validateReceipt,
 } from "./receipts";
-import type { HarnessRpc } from "./rpc-adapter";
-import { singleFlightAccept } from "./rpc-adapter";
+import { type HarnessRpc, type RpcStateSnapshot, singleFlightAccept } from "./rpc-adapter";
 import {
 	acquireLease,
 	canWriteEvents,
@@ -39,7 +38,7 @@ import {
 	releaseLease,
 	type SessionLease,
 } from "./session-lease";
-import { buildStateView, nextAllowedActions } from "./state-machine";
+import { buildStateView, nextAllowedActions, submitUnavailableReason } from "./state-machine";
 import {
 	appendEvent,
 	controlSocketPath,
@@ -200,11 +199,6 @@ export class RuntimeOwner {
 	}
 
 	async #emitMapped(mapped: NonNullable<ReturnType<typeof observeRpcOutboundFrame>>): Promise<void> {
-		await this.#emit(
-			mapped.severity,
-			mapped.kind,
-			mapped.signal ? { ...mapped.evidence, signal: mapped.signal } : mapped.evidence,
-		);
 		if (mapped.kind === "rpc_agent_completed") {
 			const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
 			if (
@@ -218,6 +212,11 @@ export class RuntimeOwner {
 				await writeSessionState(this.#opts.root, state);
 			}
 		}
+		await this.#emit(
+			mapped.severity,
+			mapped.kind,
+			mapped.signal ? { ...mapped.evidence, signal: mapped.signal } : mapped.evidence,
+		);
 	}
 
 	#aggregateSignals(events: EventEnvelope[]): string[] {
@@ -231,6 +230,20 @@ export class RuntimeOwner {
 			if (e.kind === "prompt_accepted") add("prompt-accepted");
 		}
 		return out;
+	}
+
+	#eventSubmitGateReason(kind: string, evidence: Record<string, unknown>): string | null {
+		const reason = typeof evidence.reason === "string" ? evidence.reason : null;
+		const signal = typeof evidence.signal === "string" ? evidence.signal : null;
+		const rpcActive =
+			kind === "prompt_accepted" ||
+			reason === "pre-state-not-idle" ||
+			kind.startsWith("rpc_") ||
+			signal === "prompt-accepted" ||
+			signal === "streaming" ||
+			signal === "tool-call" ||
+			signal === "test-running";
+		return rpcActive ? "rpc-not-idle" : null;
 	}
 
 	async #emit(severity: Severity, kind: string, evidence: Record<string, unknown>): Promise<void> {
@@ -247,6 +260,7 @@ export class RuntimeOwner {
 					ownerLive: true,
 					blockers: [],
 				};
+		const submitGateReason = this.#eventSubmitGateReason(kind, evidence);
 		const envelope: EventEnvelope = {
 			eventId: randomUUID(),
 			cursor: ++this.#cursor,
@@ -255,19 +269,33 @@ export class RuntimeOwner {
 			kind,
 			state: view,
 			evidence,
-			nextAllowedActions: nextAllowedActions(view.lifecycle, true),
+			nextAllowedActions: nextAllowedActions(view.lifecycle, true, { submitUnavailableReason: submitGateReason }),
 			writer: { ownerId: this.ownerId, leaseEpoch: this.#leaseEpoch },
 		};
 		await appendEvent(this.#opts.root, this.#opts.sessionId, envelope);
 	}
 
-	#response(state: SessionState, evidence: Record<string, unknown>, ok = true): PrimitiveResponse {
+	#response(
+		state: SessionState,
+		evidence: Record<string, unknown>,
+		ok = true,
+		submitGateReason: string | null = null,
+	): PrimitiveResponse {
 		return {
 			ok,
 			state: buildStateView(state, true),
 			evidence,
-			nextAllowedActions: nextAllowedActions(state.lifecycle, true),
+			nextAllowedActions: nextAllowedActions(state.lifecycle, true, { submitUnavailableReason: submitGateReason }),
 		};
+	}
+
+	#submitGateReason(state: SessionState, rpcState: RpcStateSnapshot | null): string | null {
+		const rpcReason = rpcState
+			? rpcState.isStreaming || rpcState.steeringQueueDepth > 0 || rpcState.followupQueueDepth > 0
+				? "rpc-not-idle"
+				: null
+			: "rpc-not-live";
+		return submitUnavailableReason(state.lifecycle, true, rpcReason);
 	}
 
 	async #handle(req: EndpointRequest): Promise<unknown> {
@@ -297,8 +325,10 @@ export class RuntimeOwner {
 		const state = await this.#loadState();
 		const workspace = state.handle.workspace;
 		let streaming = false;
+		let rpcState: RpcStateSnapshot | null = null;
 		try {
-			streaming = (await this.#opts.rpc.getState()).isStreaming;
+			rpcState = await this.#opts.rpc.getState();
+			streaming = rpcState.isStreaming;
 		} catch {
 			streaming = false;
 		}
@@ -328,12 +358,7 @@ export class RuntimeOwner {
 				gitDelta = "unknown";
 			}
 		}
-		const rpcLive = this.#opts.rpc.isLive
-			? this.#opts.rpc.isLive()
-			: await this.#opts.rpc
-					.getState()
-					.then(() => true)
-					.catch(() => false);
+		const rpcLive = this.#opts.rpc.isLive ? this.#opts.rpc.isLive() : rpcState !== null;
 		const rpcLastFrameAt = this.#opts.rpc.lastFrameAt ? this.#opts.rpc.lastFrameAt() : null;
 		// Sticky semantic signals come from the persisted owner event log -> survive polling gaps.
 		const recent = (await readEvents(this.#opts.root, this.#opts.sessionId, 0)).slice(-200);
@@ -343,6 +368,7 @@ export class RuntimeOwner {
 			(t): t is string => typeof t === "string",
 		);
 		const lastActivityAt = stamps.length > 0 ? (stamps.sort().at(-1) ?? state.updatedAt) : state.updatedAt;
+		const submitGateReason = this.#submitGateReason(state, rpcState);
 		return {
 			lifecycle: state.lifecycle,
 			ownerLive: true,
@@ -354,6 +380,8 @@ export class RuntimeOwner {
 			risk: deleted ? "deleted-worktree" : "normal",
 			rpcLive,
 			rpcLastFrameAt,
+			readyForSubmit: submitGateReason === null,
+			submitUnavailableReason: submitGateReason,
 		};
 	}
 
@@ -543,10 +571,21 @@ export class RuntimeOwner {
 		const prompt = typeof input.prompt === "string" ? input.prompt : "";
 		const state = await this.#loadState();
 		if (!prompt) {
-			return this.#response(state, { accepted: false, reason: "empty-prompt" }, false);
+			return this.#response(
+				state,
+				{ accepted: false, submitted: false, reason: "empty-prompt" },
+				false,
+				"empty-prompt",
+			);
 		}
-		if (state.lifecycle === "blocked") {
-			return this.#response(state, { accepted: false, reason: "lifecycle-blocked" }, false);
+		const lifecycleGate = submitUnavailableReason(state.lifecycle, true);
+		if (lifecycleGate) {
+			return this.#response(
+				state,
+				{ accepted: false, submitted: false, reason: lifecycleGate },
+				false,
+				lifecycleGate,
+			);
 		}
 		const result = await singleFlightAccept(this.#opts.rpc, prompt, this.#opts.acceptanceTimeoutMs);
 		if (result.accepted) {
@@ -560,11 +599,12 @@ export class RuntimeOwner {
 		} else {
 			await this.#emit("warn", "prompt_not_accepted", { reason: result.reason });
 		}
+		const submitGateReason = result.accepted ? null : result.reason === "pre-state-not-idle" ? "rpc-not-idle" : null;
 		return this.#response(
 			state,
 			{
 				accepted: result.accepted,
-				submitted: true,
+				submitted: result.commandId !== null,
 				reason: result.reason,
 				commandId: result.commandId,
 				preSubmitCursor: result.preSubmitCursor,
@@ -572,12 +612,16 @@ export class RuntimeOwner {
 				acceptanceEvidence: result.preSubmitState,
 			},
 			result.accepted,
+			submitGateReason,
 		);
 	}
 
 	async #observe(): Promise<PrimitiveResponse> {
 		const state = await this.#loadState();
-		return this.#response(state, { observation: await this.#observeGit(), ownerRouted: true });
+		const observation = await this.#observeGit();
+		const submitGateReason =
+			typeof observation.submitUnavailableReason === "string" ? observation.submitUnavailableReason : null;
+		return this.#response(state, { observation, ownerRouted: true }, true, submitGateReason);
 	}
 
 	async #retire(): Promise<PrimitiveResponse> {

--- a/packages/coding-agent/src/harness-control-plane/state-machine.ts
+++ b/packages/coding-agent/src/harness-control-plane/state-machine.ts
@@ -8,6 +8,7 @@
 import type { HarnessLifecycle, NextAllowedAction, PrimitiveResponse, SessionState, SessionStateView } from "./types";
 
 const TERMINAL_LIFECYCLES: ReadonlySet<HarnessLifecycle> = new Set(["completed", "retired"]);
+const SUBMIT_READY_LIFECYCLES: ReadonlySet<HarnessLifecycle> = new Set(["started", "observing"]);
 
 const TRANSITIONS: Record<HarnessLifecycle, readonly HarnessLifecycle[]> = {
 	new: ["started", "blocked", "retired"],
@@ -37,11 +38,32 @@ export function assertTransition(from: HarnessLifecycle, to: HarnessLifecycle): 
 	}
 }
 
+export interface NextAllowedActionsOptions {
+	/** Additional live-owner/RPC readiness gate for submit, e.g. rpc-not-idle. */
+	submitUnavailableReason?: string | null;
+}
+
+export function submitUnavailableReason(
+	lifecycle: HarnessLifecycle,
+	ownerLive: boolean,
+	gateReason: string | null = null,
+): string | null {
+	if (isTerminal(lifecycle)) return `lifecycle-terminal:${lifecycle}`;
+	if (lifecycle === "blocked") return "lifecycle-blocked";
+	if (!SUBMIT_READY_LIFECYCLES.has(lifecycle)) return `lifecycle-not-idle:${lifecycle}`;
+	if (!ownerLive) return "owner-not-live";
+	return gateReason;
+}
+
 /**
  * Derive the permitted next actions for a session given its lifecycle and whether
  * a live owner currently holds the lease.
  */
-export function nextAllowedActions(lifecycle: HarnessLifecycle, ownerLive: boolean): NextAllowedAction[] {
+export function nextAllowedActions(
+	lifecycle: HarnessLifecycle,
+	ownerLive: boolean,
+	options: NextAllowedActionsOptions = {},
+): NextAllowedAction[] {
 	const terminal = isTerminal(lifecycle);
 	const actions: NextAllowedAction[] = [];
 	const add = (verb: NextAllowedAction["verb"], available: boolean, reason?: string): void => {
@@ -57,11 +79,10 @@ export function nextAllowedActions(lifecycle: HarnessLifecycle, ownerLive: boole
 	// `start` creates a new session; never re-applicable to an existing record.
 	add("start", false, "session-already-exists");
 
-	// `submit` is owner-routed: it requires a live owner and a non-blocked, non-terminal lifecycle.
-	if (terminal) add("submit", false, `lifecycle-terminal:${lifecycle}`);
-	else if (lifecycle === "blocked") add("submit", false, "lifecycle-blocked");
-	else if (!ownerLive) add("submit", false, "owner-not-live");
-	else add("submit", true);
+	// `submit` is owner-routed: it requires a live owner, a submit-ready lifecycle,
+	// and (for owner-observed responses) an idle/routable RPC backend.
+	const submitReason = submitUnavailableReason(lifecycle, ownerLive, options.submitUnavailableReason ?? null);
+	add("submit", submitReason === null, submitReason ?? undefined);
 
 	// `recover` handles a dead/failed owner, so it is available without a live owner.
 	add("recover", !terminal, terminal ? `lifecycle-terminal:${lifecycle}` : undefined);

--- a/packages/coding-agent/src/harness-control-plane/types.ts
+++ b/packages/coding-agent/src/harness-control-plane/types.ts
@@ -210,6 +210,10 @@ export interface Observation {
 	rpcLive?: boolean;
 	/** ISO timestamp of the most recent RPC frame the owner observed, if any. */
 	rpcLastFrameAt?: string | null;
+	/** True only when owner/rpc/lifecycle gates indicate a prompt can be submitted now. */
+	readyForSubmit?: boolean;
+	/** Present when readyForSubmit is false; mirrors submit's nextAllowedActions reason. */
+	submitUnavailableReason?: string | null;
 }
 
 /** Input to the deterministic recovery classifier. */

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -175,4 +175,41 @@ describe("gjc harness CLI -> live owner routing", () => {
 		expect((res.json?.state as Record<string, unknown>).ownerLive).toBe(false);
 		expect((res.json?.evidence as Record<string, unknown>).ownerRouted).toBeUndefined();
 	}, 10_000);
+
+	it("does not accept or advertise submit when the owner endpoint degrades", async () => {
+		await owner?.stop();
+		owner = null;
+		const socketPath = controlSocketPath(root, SID);
+		hungServer = net.createServer(socket => {
+			socket.end("not-json\n");
+		});
+		await new Promise<void>((resolve, reject) => {
+			hungServer?.once("error", reject);
+			hungServer?.listen(socketPath, () => {
+				hungServer?.removeListener("error", reject);
+				resolve();
+			});
+		});
+		await acquireLease(root, SID, {
+			ownerId: "bad-frame-owner",
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: socketPath },
+			eventsPath: sessionPaths(root, SID).events,
+			ttlMs: 30_000,
+		});
+
+		const res = await runHarness(["submit", "--session", SID, "--input", JSON.stringify({ prompt: "do it" })]);
+
+		expect(res.code).toBe(1);
+		expect(res.json?.ok).toBe(false);
+		expect((res.json?.state as Record<string, unknown>).ownerLive).toBe(false);
+		expect((res.json?.evidence as Record<string, unknown>).accepted).toBe(false);
+		expect((res.json?.evidence as Record<string, unknown>).submitted).toBe(false);
+		expect((res.json?.evidence as Record<string, unknown>).reason).toBe("owner-not-live");
+		expect(res.json?.nextAllowedActions).toContainEqual({
+			verb: "submit",
+			available: false,
+			reason: "owner-not-live",
+		});
+	}, 10_000);
 });

--- a/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner-frames.test.ts
@@ -131,6 +131,12 @@ describe("owner frame -> observability", () => {
 		expect(obs.observedSignals).toContain("test-running");
 		expect(obs.observedSignals).toContain("completed");
 		expect(obs.rpcLive).toBe(true);
+		const completed = events.find(e => e.kind === "rpc_agent_completed");
+		expect(completed?.nextAllowedActions).toContainEqual({
+			verb: "submit",
+			available: false,
+			reason: "lifecycle-not-idle:finalizing",
+		});
 		expect(obs.lifecycle).toBe("finalizing");
 	});
 

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -164,6 +164,48 @@ describe("RuntimeOwner (in-process integration)", () => {
 		expect(warn?.severity).toBe("warn");
 	});
 
+	it("blocks submit during finalizing and does not call RPC", async () => {
+		const rpc = new FakeRpc();
+		await writeSessionState(root, { ...seedState(root), lifecycle: "finalizing" });
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 100 });
+		const info = await owner.start();
+
+		const res = (await callEndpoint(info.socketPath, { verb: "submit", input: { prompt: "too soon" } })) as Record<
+			string,
+			unknown
+		>;
+
+		expect(res.ok).toBe(false);
+		expect((res.evidence as Record<string, unknown>).accepted).toBe(false);
+		expect((res.evidence as Record<string, unknown>).submitted).toBe(false);
+		expect((res.evidence as Record<string, unknown>).reason).toBe("lifecycle-not-idle:finalizing");
+		expect(res.nextAllowedActions).toContainEqual({
+			verb: "submit",
+			available: false,
+			reason: "lifecycle-not-idle:finalizing",
+		});
+		expect(rpc.cursor).toBe(0);
+	});
+
+	it("reports rpc-not-idle as not submitted and stops advertising submit", async () => {
+		const rpc = new FakeRpc();
+		rpc.state = { isStreaming: true, steeringQueueDepth: 0, followupQueueDepth: 0 };
+		owner = new RuntimeOwner({ root, sessionId: SID, rpc, acceptanceTimeoutMs: 100 });
+		const info = await owner.start();
+
+		const res = (await callEndpoint(info.socketPath, { verb: "submit", input: { prompt: "too soon" } })) as Record<
+			string,
+			unknown
+		>;
+
+		expect(res.ok).toBe(false);
+		expect((res.evidence as Record<string, unknown>).accepted).toBe(false);
+		expect((res.evidence as Record<string, unknown>).submitted).toBe(false);
+		expect((res.evidence as Record<string, unknown>).reason).toBe("pre-state-not-idle");
+		expect(res.nextAllowedActions).toContainEqual({ verb: "submit", available: false, reason: "rpc-not-idle" });
+		expect(rpc.cursor).toBe(0);
+	});
+
 	it("live owner reconcile preserves vanished blockers until recovery evidence", async () => {
 		const rpc = new FakeRpc();
 		await writeSessionState(root, {

--- a/packages/coding-agent/test/harness-control-plane/state-machine.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/state-machine.test.ts
@@ -37,15 +37,34 @@ describe("harness state machine", () => {
 		expect(submit.reason).toBe("owner-not-live");
 	});
 
-	it("submit is available with a live owner (non-terminal)", () => {
-		const submit = findAction(nextAllowedActions("submitted", true), "submit");
-		expect(submit.available).toBe(true);
+	it("submit is available only when a live owner is in a submit-ready lifecycle", () => {
+		for (const lifecycle of ["started", "observing"] as const) {
+			const submit = findAction(nextAllowedActions(lifecycle, true), "submit");
+			expect(submit.available).toBe(true);
+		}
 	});
 
 	it("submit is blocked while lifecycle is blocked even with a live owner", () => {
 		const submit = findAction(nextAllowedActions("blocked", true), "submit");
 		expect(submit.available).toBe(false);
 		expect(submit.reason).toBe("lifecycle-blocked");
+	});
+
+	it("submit is blocked during non-idle lifecycle windows even with a live owner", () => {
+		for (const lifecycle of ["submitted", "recovering", "validating", "finalizing"] as const) {
+			const submit = findAction(nextAllowedActions(lifecycle, true), "submit");
+			expect(submit.available).toBe(false);
+			expect(submit.reason).toBe(`lifecycle-not-idle:${lifecycle}`);
+		}
+	});
+
+	it("submit is blocked while the owner RPC is not idle", () => {
+		const submit = findAction(
+			nextAllowedActions("observing", true, { submitUnavailableReason: "rpc-not-idle" }),
+			"submit",
+		);
+		expect(submit.available).toBe(false);
+		expect(submit.reason).toBe("rpc-not-idle");
 	});
 
 	it("terminal lifecycles block submit/recover/validate/finalize", () => {


### PR DESCRIPTION
## Summary
- gate harness submit availability to started/observing lifecycles only, so finalizing/non-idle windows no longer advertise or accept submit
- surface owner/RPC readiness in owner-routed observe responses and return submitted:false for lifecycle/RPC readiness rejects
- preserve manual/no-owner semantics while making degraded owner endpoints fall back to owner-not-live without false submit acceptance

Fixes #544

## Verification
- bun test packages/coding-agent/test/harness-control-plane
- bun run check:tools