### PR TITLE
Optimize TUI width overflow checks

### DIFF
--- a/packages/tui/bench/text-layout.ts
+++ b/packages/tui/bench/text-layout.ts
@@ -1,4 +1,4 @@
-import { visibleWidth, wrapTextWithAnsi, truncateToWidth, sliceWithWidth, extractSegments, Ellipsis } from "../src/utils";
+import { visibleWidth, visibleWidthExceeds, wrapTextWithAnsi, truncateToWidth, sliceWithWidth, extractSegments, Ellipsis } from "../src/utils";
 import { matchesKey } from "../src/keys";
 
 const ITERATIONS = 2000;
@@ -7,6 +7,7 @@ const samples = {
 	plain: "hello world this is a plain ASCII string with some words",
 	ansi: "\x1b[31mred text\x1b[0m and \x1b[4munderlined content\x1b[24m with emoji 😅😅",
 	links: "prefix \x1b]8;;https://example.com\x07link\x1b]8;;\x07 suffix",
+	paddedAnsi: `${" ".repeat(96)}\x1b[0m`,
 	wide: "日本語のテキストとemoji 🚀✨ mixed with ascii",
 	wrapped: "This is a long line that should wrap multiple times when rendered with ANSI \x1b[32mcolors\x1b[0m and tabs\tbetween words.",
 };
@@ -32,6 +33,10 @@ bench("visibleWidth/plain", () => {
 
 bench("visibleWidth/ansi", () => {
 	visibleWidth(samples.ansi);
+});
+
+bench("visibleWidthExceeds/paddedAnsi", () => {
+	visibleWidthExceeds(samples.paddedAnsi, 100);
 });
 
 bench("truncateToWidth/ansi", () => {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -17,6 +17,7 @@ import {
 	sliceWithWidth,
 	truncateToWidth,
 	visibleWidth,
+	visibleWidthExceeds,
 } from "./utils";
 
 const SEGMENT_RESET = "\x1b[0m";
@@ -984,8 +985,9 @@ export class TUI extends Container {
 				if (idx >= 0 && idx < result.length) {
 					// Defensive: truncate overlay line to declared width before compositing
 					// (components should already respect width, but this ensures it)
-					const truncatedOverlayLine =
-						visibleWidth(overlayLines[i]) > w ? sliceByColumn(overlayLines[i], 0, w, true) : overlayLines[i];
+					const truncatedOverlayLine = visibleWidthExceeds(overlayLines[i], w)
+						? sliceByColumn(overlayLines[i], 0, w, true)
+						: overlayLines[i];
 					result[idx] = this.#compositeLineAt(result[idx], truncatedOverlayLine, col, w, termWidth);
 					modifiedLines.add(idx);
 				}
@@ -997,8 +999,7 @@ export class TUI extends Container {
 		// guarantee this, but we verify here to prevent crashes from any edge cases
 		// Only check lines that were actually modified (optimization)
 		for (const idx of modifiedLines) {
-			const lineWidth = visibleWidth(result[idx]);
-			if (lineWidth > termWidth) {
+			if (visibleWidthExceeds(result[idx], termWidth)) {
 				result[idx] = sliceByColumn(result[idx], 0, termWidth, true);
 			}
 		}
@@ -1049,8 +1050,7 @@ export class TUI extends Container {
 		// - Complex ANSI/OSC sequences (hyperlinks, colors)
 		// - Wide characters at segment boundaries
 		// - Edge cases in segment extraction
-		const resultWidth = visibleWidth(result);
-		if (resultWidth <= totalWidth) {
+		if (!visibleWidthExceeds(result, totalWidth)) {
 			return result;
 		}
 		// Truncate with strict=true to ensure we don't exceed totalWidth
@@ -1107,7 +1107,7 @@ export class TUI extends Container {
 	#truncateLinesToWidth(lines: string[], width: number): string[] {
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			if (TERMINAL.isImageLine(line) || visibleWidth(line) <= width) continue;
+			if (TERMINAL.isImageLine(line) || !visibleWidthExceeds(line, width)) continue;
 			const truncated = truncateToWidth(line, width, Ellipsis.Omit);
 			lines[i] = truncated + (truncated.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
 		}
@@ -1199,7 +1199,7 @@ export class TUI extends Container {
 				if (lineIndex >= newLines.length) continue;
 				const line = newLines[lineIndex];
 				const isImage = TERMINAL.isImageLine(line);
-				if (!isImage && visibleWidth(line) > width) {
+				if (!isImage && visibleWidthExceeds(line, width)) {
 					let truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
 					truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
 					buffer += truncatedLine;
@@ -1413,7 +1413,7 @@ export class TUI extends Container {
 			const line = newLines[i];
 			let truncatedLine = line;
 			const isImage = TERMINAL.isImageLine(line);
-			if (!isImage && visibleWidth(line) > width) {
+			if (!isImage && visibleWidthExceeds(line, width)) {
 				if (debugRedraw) {
 					const debugData = [
 						`[TUI Truncate] ${new Date().toISOString()}`,

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -142,6 +142,113 @@ export function visibleWidth(str: string): number {
 	return recordTextHelper("text.visibleWidth", () => visibleWidthRaw(str));
 }
 
+function skipAnsiSequence(str: string, escIndex: number): number | undefined {
+	const next = str.charCodeAt(escIndex + 1);
+	if (Number.isNaN(next)) return escIndex + 1;
+
+	// CSI: ESC [ ... final-byte
+	if (next === 0x5b) {
+		for (let i = escIndex + 2; i < str.length; i++) {
+			const code = str.charCodeAt(i);
+			if (code >= 0x40 && code <= 0x7e) return i + 1;
+		}
+		return undefined;
+	}
+
+	// OSC / DCS / APC / PM strings terminate with BEL or ST (ESC \\).
+	if (next === 0x5d || next === 0x50 || next === 0x5e || next === 0x5f) {
+		for (let i = escIndex + 2; i < str.length; i++) {
+			const code = str.charCodeAt(i);
+			if (code === 0x07) return i + 1;
+			if (code === 0x1b && str.charCodeAt(i + 1) === 0x5c) return i + 2;
+		}
+		return undefined;
+	}
+
+	// Other ESC forms are fixed-width control sequences for our purposes.
+	return Math.min(str.length, escIndex + 2);
+}
+
+interface VisibleWidthExceedsCacheEntry {
+	limit: number;
+	tabWidth: number;
+	result: boolean;
+}
+
+const VISIBLE_WIDTH_EXCEEDS_CACHE_LIMIT = 4096;
+const VISIBLE_WIDTH_EXCEEDS_MAX_CACHEABLE_LENGTH = 2048;
+const visibleWidthExceedsCache = new Map<string, VisibleWidthExceedsCacheEntry>();
+
+function rememberVisibleWidthExceeds(str: string, entry: VisibleWidthExceedsCacheEntry): void {
+	if (str.length > VISIBLE_WIDTH_EXCEEDS_MAX_CACHEABLE_LENGTH) return;
+	if (visibleWidthExceedsCache.size >= VISIBLE_WIDTH_EXCEEDS_CACHE_LIMIT) {
+		const firstKey = visibleWidthExceedsCache.keys().next().value;
+		if (firstKey === undefined) {
+			visibleWidthExceedsCache.clear();
+		} else {
+			visibleWidthExceedsCache.delete(firstKey);
+		}
+	}
+	visibleWidthExceedsCache.set(str, entry);
+}
+
+function computeVisibleWidthExceedsRaw(str: string, limit: number, tabWidth: number): boolean {
+	let width = 0;
+
+	for (let i = 0; i < str.length; ) {
+		const code = str.charCodeAt(i);
+		if (code === 0x1b) {
+			const next = skipAnsiSequence(str, i);
+			if (next === undefined) return visibleWidthRaw(str) > limit;
+			i = next;
+			continue;
+		}
+		if (code === 0x09) {
+			width += tabWidth;
+		} else if (code >= 0x20 && code <= 0x7e) {
+			width += 1;
+		} else if (code < 0x20) {
+			i += 1;
+			continue;
+		} else {
+			return visibleWidthRaw(str) > limit;
+		}
+
+		if (width > limit) return true;
+		i += 1;
+	}
+
+	return false;
+}
+
+function visibleWidthExceedsRaw(str: string, maxWidth: number): boolean {
+	if (Number.isNaN(maxWidth)) return false;
+	if (maxWidth === Number.POSITIVE_INFINITY) return false;
+	if (maxWidth === Number.NEGATIVE_INFINITY) return true;
+	if (!str) return 0 > maxWidth;
+	const limit = Math.floor(maxWidth);
+	const tabWidth = getDefaultTabWidth();
+	const cached = visibleWidthExceedsCache.get(str);
+	if (cached && cached.limit === limit && cached.tabWidth === tabWidth) {
+		return cached.result;
+	}
+
+	const result = computeVisibleWidthExceedsRaw(str, limit, tabWidth);
+	rememberVisibleWidthExceeds(str, { limit, tabWidth, result });
+	return result;
+}
+
+/**
+ * Cheap overflow predicate for renderer guard paths.
+ *
+ * ASCII/ANSI terminal lines are answered without allocating or crossing the
+ * native boundary; complex Unicode falls back to exact visible-width logic.
+ */
+export function visibleWidthExceeds(str: string, maxWidth: number): boolean {
+	if (!renderMetrics.enabled) return visibleWidthExceedsRaw(str, maxWidth);
+	return recordTextHelper("text.visibleWidthExceeds", () => visibleWidthExceedsRaw(str, maxWidth));
+}
+
 const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;
 const THAI_LAO_AM_GLOBAL_REGEX = /[\u0e33\u0eb3]/g;
 

--- a/packages/tui/test/text-utils.test.ts
+++ b/packages/tui/test/text-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { extractSegments, sliceWithWidth, truncateToWidth, visibleWidth } from "@gajae-code/tui/utils";
+import {
+	extractSegments,
+	sliceWithWidth,
+	truncateToWidth,
+	visibleWidth,
+	visibleWidthExceeds,
+} from "@gajae-code/tui/utils";
 
 describe("text utils", () => {
 	it("computes visible width for ANSI and tabs", () => {
@@ -32,5 +38,22 @@ describe("text utils", () => {
 		expect(result.before).toContain("hel");
 		expect(result.after.startsWith("\x1b[31m")).toBe(true);
 		expect(result.afterWidth).toBeGreaterThan(0);
+	});
+
+	it("checks ASCII/ANSI overflow without counting escape bytes", () => {
+		expect(visibleWidthExceeds("abc\x1b[0m", 3)).toBe(false);
+		expect(visibleWidthExceeds("abc\x1b[0m", 2)).toBe(true);
+		expect(visibleWidthExceeds("hi\t", 5)).toBe(false);
+		expect(visibleWidthExceeds("hi\t", 4)).toBe(true);
+		expect(visibleWidthExceeds("", -1)).toBe(true);
+		expect(visibleWidthExceeds("x", Number.NaN)).toBe(false);
+	});
+
+	it("checks OSC hyperlinks and wide text overflow exactly", () => {
+		const link = "\x1b]8;;https://example.com\x07link\x1b]8;;\x07";
+		expect(visibleWidthExceeds(link, 4)).toBe(false);
+		expect(visibleWidthExceeds(link, 3)).toBe(true);
+		expect(visibleWidthExceeds("ㅁ", 2)).toBe(false);
+		expect(visibleWidthExceeds("ㅁ", 1)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
- add a cached visibleWidthExceeds predicate for ASCII/ANSI renderer overflow guards
- use the predicate in TUI truncation/compositing hot paths to avoid full visible-width calculations on already-fitting terminal lines
- cover ANSI, OSC hyperlink, tab, wide-character, and edge-case overflow behavior; add a benchmark case for padded ANSI lines

## Verification
- bun --cwd=packages/tui run check
- bun test --timeout 30000 test/text-utils.test.ts test/render-regressions.test.ts test/perf-gates.test.ts
- bun --cwd=packages/tui run test:perf
- bun bench/text-layout.ts