### PR TITLE
Add harness receipt JSONL spool exporter

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added first-class `minimax-standard`, `minimax-cn-standard`, `kimi-standard`, and `glm-standard` model profiles plus a grouped `/model` Presets browser so profile presets stay scannable as the catalog grows (#532).
+- Added a harness receipt JSONL spool exporter for gajae receipt-runtime interop: configured `gjc harness --receipt-spool-dir <dir>` / `GJC_RECEIPT_SPOOL_DIR` now appends persisted native `ReceiptEnvelope` records as `{cursor,envelope}` lines to `spool.jsonl`, with restart-safe 12-digit cursors and installed-package smoke coverage (#545).
 
 ### Changed
 

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -11,12 +11,14 @@
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { resolveGjcTmuxCommand, sanitizeTmuxToken } from "../gjc-runtime/tmux-common";
 import { classifyRecovery } from "../harness-control-plane/classifier";
 import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
 import { type ResolvedOwner, RuntimeOwner, resolveOwner } from "../harness-control-plane/owner";
 import { preserveDirtyWorktree } from "../harness-control-plane/preserve";
+import { RECEIPT_SPOOL_DIR_ENV } from "../harness-control-plane/receipt-spool";
 import { buildReceipt, requiresVanishBeforeAction, type VanishEvidence } from "../harness-control-plane/receipts";
 import { GajaeCodeRpc } from "../harness-control-plane/rpc-adapter";
 import { classifyLeaseStatus, readLease } from "../harness-control-plane/session-lease";
@@ -513,6 +515,9 @@ export default class Harness extends Command {
 		cursor: Flags.string({ description: "Event cursor for events --follow (exclusive)", default: "0" }),
 		follow: Flags.boolean({ description: "Tail the owner-written event log", default: false }),
 		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: true }),
+		"receipt-spool-dir": Flags.string({
+			description: "Append persisted ReceiptEnvelope records to spool.jsonl under this directory",
+		}),
 	};
 
 	static examples = [
@@ -527,6 +532,11 @@ export default class Harness extends Command {
 		const verb = String(args.verb);
 		let root = resolveHarnessRoot();
 		try {
+			const receiptSpoolDir = flags["receipt-spool-dir"];
+			if (receiptSpoolDir !== undefined) {
+				if (!receiptSpoolDir.trim()) throw new Error("receipt_spool_dir_empty");
+				process.env[RECEIPT_SPOOL_DIR_ENV] = path.resolve(receiptSpoolDir.trim());
+			}
 			const input = parseInput(flags.input);
 			const promptFile = flags["prompt-file"];
 			if (promptFile !== undefined) {
@@ -676,6 +686,9 @@ export default class Harness extends Command {
 		}
 		const sessionName = deterministicHarnessTmuxSessionName(sessionId);
 		const envAssignments = [`GJC_HARNESS_STATE_ROOT=${shellQuote(root)}`];
+		if (process.env[RECEIPT_SPOOL_DIR_ENV]) {
+			envAssignments.push(`${RECEIPT_SPOOL_DIR_ENV}=${shellQuote(process.env[RECEIPT_SPOOL_DIR_ENV])}`);
+		}
 		if (process.env.GJC_HARNESS_RPC_COMMAND) {
 			envAssignments.push(`GJC_HARNESS_RPC_COMMAND=${shellQuote(process.env.GJC_HARNESS_RPC_COMMAND)}`);
 		}
@@ -715,6 +728,9 @@ export default class Harness extends Command {
 			env: {
 				...process.env,
 				GJC_HARNESS_STATE_ROOT: root,
+				...(process.env[RECEIPT_SPOOL_DIR_ENV]
+					? { [RECEIPT_SPOOL_DIR_ENV]: process.env[RECEIPT_SPOOL_DIR_ENV] }
+					: {}),
 				...(process.env.GJC_HARNESS_TEST_NODE_MODULES
 					? { GJC_HARNESS_TEST_NODE_MODULES: process.env.GJC_HARNESS_TEST_NODE_MODULES }
 					: {}),
@@ -878,7 +894,9 @@ export default class Harness extends Command {
 	): Promise<boolean> {
 		const owner = await resolveOwner(root, sessionId);
 		if (!owner.live || !owner.socketPath) return false;
+		const priorSpoolDir = input[RECEIPT_SPOOL_DIR_ENV];
 		try {
+			if (process.env[RECEIPT_SPOOL_DIR_ENV]) input[RECEIPT_SPOOL_DIR_ENV] = process.env[RECEIPT_SPOOL_DIR_ENV];
 			const res = (await callEndpoint(owner.socketPath, { verb, input })) as { ok?: boolean };
 			writeJson(res);
 			if (res?.ok === false) process.exitCode = 1;
@@ -886,6 +904,9 @@ export default class Harness extends Command {
 		} catch (error) {
 			if (error instanceof EndpointUnreachableError) return false;
 			throw error;
+		} finally {
+			if (priorSpoolDir === undefined) delete input[RECEIPT_SPOOL_DIR_ENV];
+			else input[RECEIPT_SPOOL_DIR_ENV] = priorSpoolDir;
 		}
 	}
 

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -20,6 +20,7 @@ import { ControlServer, type EndpointRequest } from "./control-endpoint";
 import { defaultFinalizeChecks, type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "./finalize";
 import { type OperateResult, operate } from "./operate";
 import { preserveDirtyWorktree } from "./preserve";
+import { RECEIPT_SPOOL_DIR_ENV, withReceiptSpoolDir } from "./receipt-spool";
 import {
 	buildReceipt,
 	type ReceiptSubject,
@@ -298,6 +299,12 @@ export class RuntimeOwner {
 		return submitUnavailableReason(state.lifecycle, true, rpcReason);
 	}
 
+	async #withReceiptSpoolFromInput<T>(input: Record<string, unknown>, fn: () => Promise<T>): Promise<T> {
+		const requested = input[RECEIPT_SPOOL_DIR_ENV];
+		if (typeof requested === "string" && requested.trim()) return withReceiptSpoolDir(requested, fn);
+		return fn();
+	}
+
 	async #handle(req: EndpointRequest): Promise<unknown> {
 		switch (req.verb) {
 			case "ping":
@@ -309,13 +316,13 @@ export class RuntimeOwner {
 			case "retire":
 				return this.#retire();
 			case "finalize":
-				return this.#finalize(req.input);
+				return this.#withReceiptSpoolFromInput(req.input, () => this.#finalize(req.input));
 			case "recover":
-				return this.#recover();
+				return this.#withReceiptSpoolFromInput(req.input, () => this.#recover());
 			case "validate":
-				return this.#validate();
+				return this.#withReceiptSpoolFromInput(req.input, () => this.#validate());
 			case "operate":
-				return this.#operate(req.input);
+				return this.#withReceiptSpoolFromInput(req.input, () => this.#operate(req.input));
 			default:
 				return { ok: false, error: `owner_unsupported_verb:${req.verb}` };
 		}

--- a/packages/coding-agent/src/harness-control-plane/receipt-spool.ts
+++ b/packages/coding-agent/src/harness-control-plane/receipt-spool.ts
@@ -1,0 +1,128 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { withFileLock } from "../config/file-lock";
+import type { ReceiptEnvelope } from "./receipts";
+
+export const RECEIPT_SPOOL_DIR_ENV = "GJC_RECEIPT_SPOOL_DIR";
+export const RECEIPT_SPOOL_FILENAME = "spool.jsonl";
+export const RECEIPT_SPOOL_CURSOR_WIDTH = 12;
+
+export interface ReceiptSpoolRecord {
+	cursor: string;
+	envelope: ReceiptEnvelope<unknown>;
+}
+
+export interface ReceiptSpoolAppendResult {
+	cursor: string;
+	path: string;
+}
+
+const receiptSpoolDirStorage = new AsyncLocalStorage<string | undefined>();
+const spoolQueues = new Map<string, Promise<void>>();
+const noop = (): void => undefined;
+export async function withReceiptSpoolDir<T>(spoolDir: string, fn: () => Promise<T>): Promise<T> {
+	const trimmed = spoolDir.trim();
+	if (!trimmed) throw new Error("receipt_spool_dir_empty");
+	const resolved = path.resolve(trimmed);
+	return receiptSpoolDirStorage.run(resolved, fn);
+}
+
+export function resolveReceiptSpoolDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const active = receiptSpoolDirStorage.getStore();
+	if (active !== undefined) return active;
+	const raw = env[RECEIPT_SPOOL_DIR_ENV]?.trim();
+	return raw ? path.resolve(raw) : undefined;
+}
+
+export function receiptSpoolPath(spoolDir: string): string {
+	return path.join(path.resolve(spoolDir), RECEIPT_SPOOL_FILENAME);
+}
+
+function parseCursor(value: unknown): bigint | undefined {
+	if (typeof value !== "string" || !/^\d+$/.test(value)) return undefined;
+	try {
+		return BigInt(value);
+	} catch {
+		return undefined;
+	}
+}
+
+export function formatReceiptSpoolCursor(cursor: bigint): string {
+	const raw = cursor.toString();
+	return raw.length >= RECEIPT_SPOOL_CURSOR_WIDTH ? raw : raw.padStart(RECEIPT_SPOOL_CURSOR_WIDTH, "0");
+}
+
+export async function readHighestReceiptSpoolCursor(spoolDir: string): Promise<bigint> {
+	const spoolFile = receiptSpoolPath(spoolDir);
+	let raw: string;
+	try {
+		raw = await fs.readFile(spoolFile, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0n;
+		throw error;
+	}
+
+	let highest = 0n;
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed) as { cursor?: unknown };
+			const cursor = parseCursor(parsed.cursor);
+			if (cursor !== undefined && cursor > highest) highest = cursor;
+		} catch {
+			// A crash may leave a torn tail; consumers skip malformed lines and so do we.
+		}
+	}
+	return highest;
+}
+
+async function enqueueSpoolAppend<T>(spoolFile: string, task: () => Promise<T>): Promise<T> {
+	const previous = spoolQueues.get(spoolFile) ?? Promise.resolve();
+	const running = previous.catch(noop).then(task);
+	const normalized = running.then(noop, noop);
+	spoolQueues.set(spoolFile, normalized);
+	normalized
+		.finally(() => {
+			if (spoolQueues.get(spoolFile) === normalized) spoolQueues.delete(spoolFile);
+		})
+		.catch(noop);
+	return running;
+}
+
+export async function appendReceiptToSpool(
+	spoolDir: string,
+	envelope: ReceiptEnvelope<unknown>,
+): Promise<ReceiptSpoolAppendResult> {
+	const resolvedDir = path.resolve(spoolDir);
+	const spoolFile = receiptSpoolPath(resolvedDir);
+	return enqueueSpoolAppend(spoolFile, async () => {
+		await fs.mkdir(resolvedDir, { recursive: true, mode: 0o700 });
+		return withFileLock(
+			spoolFile,
+			async () => {
+				const cursor = formatReceiptSpoolCursor((await readHighestReceiptSpoolCursor(resolvedDir)) + 1n);
+				const record: ReceiptSpoolRecord = { cursor, envelope };
+				const handle = await fs.open(spoolFile, "a", 0o600);
+				try {
+					await handle.writeFile(`${JSON.stringify(record)}\n`, "utf8");
+					await handle.sync();
+				} finally {
+					await handle.close();
+				}
+				return { cursor, path: spoolFile };
+			},
+			{ staleMs: 30_000, retries: 100, retryDelayMs: 25 },
+		);
+	});
+}
+
+export async function appendReceiptToConfiguredSpool(
+	envelope: ReceiptEnvelope<unknown>,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<ReceiptSpoolAppendResult | undefined> {
+	const spoolDir = resolveReceiptSpoolDir(env);
+	if (!spoolDir) return undefined;
+	return appendReceiptToSpool(spoolDir, envelope);
+}

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -18,6 +18,8 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { appendReceiptToConfiguredSpool } from "./receipt-spool";
+import type { ReceiptEnvelope } from "./receipts";
 import type { EventEnvelope, ReceiptFamily, SessionState } from "./types";
 
 interface HarnessRootRegistryEntry {
@@ -227,6 +229,26 @@ async function readJson<T>(file: string): Promise<T | null> {
 		throw error;
 	}
 }
+function isReceiptEnvelope(value: unknown): value is ReceiptEnvelope<unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const envelope = value as Record<string, unknown>;
+	return (
+		typeof envelope.receiptId === "string" &&
+		typeof envelope.schemaVersion === "number" &&
+		typeof envelope.sessionId === "string" &&
+		typeof envelope.family === "string" &&
+		typeof envelope.valid === "boolean" &&
+		typeof envelope.createdAt === "string" &&
+		typeof envelope.source === "string" &&
+		envelope.subject !== null &&
+		typeof envelope.subject === "object" &&
+		envelope.evidence !== null &&
+		typeof envelope.evidence === "object" &&
+		envelope.artifactHashes !== null &&
+		typeof envelope.artifactHashes === "object" &&
+		typeof envelope.sha256 === "string"
+	);
+}
 
 export async function readSessionState(root: string, sessionId: string): Promise<SessionState | null> {
 	return readJson<SessionState>(sessionPaths(root, sessionId).state);
@@ -372,6 +394,7 @@ export async function writeReceiptImmutable(
 		path: file,
 	};
 	await fs.appendFile(paths.receiptsIndex, `${JSON.stringify(entry)}\n`, "utf8");
+	if (isReceiptEnvelope(value)) await appendReceiptToConfiguredSpool(value);
 	return entry;
 }
 

--- a/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import type { FinalizeChecks } from "../../src/harness-control-plane/finalize";
 import { RuntimeOwner } from "../../src/harness-control-plane/owner";
+import { RECEIPT_SPOOL_FILENAME, type ReceiptSpoolRecord } from "../../src/harness-control-plane/receipt-spool";
+import { type CompletionEvidence, validateReceipt } from "../../src/harness-control-plane/receipts";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
 import { acquireLease } from "../../src/harness-control-plane/session-lease";
 import { controlSocketPath, sessionPaths, writeSessionState } from "../../src/harness-control-plane/storage";
@@ -141,6 +143,27 @@ describe("gjc harness CLI -> live owner routing", () => {
 		const state = res.json?.state as Record<string, unknown>;
 		expect((evidence.finalize as Record<string, unknown>).completed).toBe(true);
 		expect(state.lifecycle).toBe("completed");
+	}, 30_000);
+
+	it("passes --receipt-spool-dir through live owner routing", async () => {
+		const spoolDir = await mkdtemp(path.join(tmpdir(), "harness-owner-spool-"));
+		try {
+			const res = await runHarness(["finalize", "--session", SID, "--receipt-spool-dir", spoolDir, "--input", "{}"]);
+			expect(res.code).toBe(0);
+			expect(res.json?.ok).toBe(true);
+
+			const raw = await Bun.file(path.join(spoolDir, RECEIPT_SPOOL_FILENAME)).text();
+			const records = raw
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line) as ReceiptSpoolRecord);
+			expect(records.map(record => record.cursor)).toEqual(["000000000001", "000000000002"]);
+			expect(records.map(record => record.envelope.family)).toEqual(["validation", "completion"]);
+			expect(records.every(record => validateReceipt(record.envelope).valid)).toBe(true);
+			expect((records.at(-1)?.envelope.evidence as CompletionEvidence).finalLifecycle).toBe("completed");
+		} finally {
+			await rm(spoolDir, { recursive: true, force: true });
+		}
 	}, 30_000);
 
 	it("falls back to bounded observe when a live owner endpoint accepts but never responds", async () => {

--- a/packages/coding-agent/test/harness-control-plane/receipt-spool.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/receipt-spool.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { type FinalizeChecks, runFinalize, type ValidationCommandSpec } from "../../src/harness-control-plane/finalize";
+import {
+	appendReceiptToSpool,
+	RECEIPT_SPOOL_DIR_ENV,
+	RECEIPT_SPOOL_FILENAME,
+	type ReceiptSpoolRecord,
+	readHighestReceiptSpoolCursor,
+	withReceiptSpoolDir,
+} from "../../src/harness-control-plane/receipt-spool";
+import { type CompletionEvidence, validateReceipt } from "../../src/harness-control-plane/receipts";
+import { readReceiptIndex } from "../../src/harness-control-plane/storage";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+
+let root: string;
+let spoolDir: string;
+const SID = "spool-session";
+
+function checks(): FinalizeChecks {
+	return {
+		async runValidation(spec: ValidationCommandSpec) {
+			return { exactCommand: spec.command, cwd: "/ws", exitStatus: 0, pass: true };
+		},
+		async resolveCommit() {
+			return "abc123";
+		},
+		async commitOnBranch() {
+			return true;
+		},
+		async prOrIssue() {
+			return { prUrl: "https://example.test/pull/545", issueArtifact: null };
+		},
+	};
+}
+
+async function readSpoolRecords(): Promise<ReceiptSpoolRecord[]> {
+	const raw = await readFile(path.join(spoolDir, RECEIPT_SPOOL_FILENAME), "utf8");
+	const records: ReceiptSpoolRecord[] = [];
+	for (const line of raw.trim().split("\n")) {
+		if (!line) continue;
+		try {
+			records.push(JSON.parse(line) as ReceiptSpoolRecord);
+		} catch {
+			// Crash-torn or pre-existing malformed lines are skipped by the consumer contract.
+		}
+	}
+	return records;
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), "harness-spool-root-"));
+	spoolDir = await mkdtemp(path.join(tmpdir(), "harness-receipt-spool-"));
+});
+
+afterEach(async () => {
+	delete process.env[RECEIPT_SPOOL_DIR_ENV];
+	await rm(root, { recursive: true, force: true });
+	await rm(spoolDir, { recursive: true, force: true });
+});
+
+describe("harness receipt JSONL spool exporter", () => {
+	it("is disabled when no spool directory is configured", async () => {
+		delete process.env[RECEIPT_SPOOL_DIR_ENV];
+
+		const res = await runFinalize({
+			root,
+			sessionId: SID,
+			workspace: "/ws",
+			branch: "feat/545",
+			requireTests: true,
+			requireCommit: true,
+			requirePr: true,
+			validationCommands: [{ name: "test", command: "bun test" }],
+			checks: checks(),
+		});
+
+		expect(res.completed).toBe(true);
+		expect(await Bun.file(path.join(spoolDir, RECEIPT_SPOOL_FILENAME)).exists()).toBe(false);
+	});
+
+	it("exports persisted receipts as append-only {cursor,envelope} JSONL", async () => {
+		process.env[RECEIPT_SPOOL_DIR_ENV] = spoolDir;
+
+		const res = await runFinalize({
+			root,
+			sessionId: SID,
+			workspace: "/ws",
+			branch: "feat/545",
+			requireTests: true,
+			requireCommit: true,
+			requirePr: true,
+			validationCommands: [{ name: "test", command: "bun test" }],
+			checks: checks(),
+		});
+
+		expect(res.completed).toBe(true);
+		const records = await readSpoolRecords();
+		expect(records.map(record => record.cursor)).toEqual(["000000000001", "000000000002"]);
+		expect(records.map(record => record.envelope.family)).toEqual(["validation", "completion"]);
+		expect(records.every(record => validateReceipt(record.envelope).valid)).toBe(true);
+		expect(Object.keys(records[1])).toEqual(["cursor", "envelope"]);
+
+		const completions = await readReceiptIndex(root, SID, "completion");
+		expect(completions).toHaveLength(1);
+		const persistedCompletion = JSON.parse(
+			await readFile(completions[0].path, "utf8"),
+		) as (typeof records)[1]["envelope"];
+		expect(records[1].envelope).toEqual(persistedCompletion);
+		expect((records[1].envelope.evidence as CompletionEvidence).finalLifecycle).toBe("completed");
+	});
+
+	it("resumes the next cursor from the highest valid existing spool cursor", async () => {
+		process.env[RECEIPT_SPOOL_DIR_ENV] = spoolDir;
+		await writeFile(
+			path.join(spoolDir, RECEIPT_SPOOL_FILENAME),
+			'{"cursor":"000000000041","envelope":{"ignored":true}}\nnot-json\n{"cursor":"000000000009"}\n',
+			"utf8",
+		);
+
+		expect(await readHighestReceiptSpoolCursor(spoolDir)).toBe(41n);
+		const res = await runFinalize({
+			root,
+			sessionId: SID,
+			workspace: "/ws",
+			branch: "feat/545",
+			requireTests: true,
+			requireCommit: true,
+			requirePr: true,
+			validationCommands: [{ name: "resume", command: "true" }],
+			checks: checks(),
+		});
+
+		expect(res.completed).toBe(true);
+		const records = await readSpoolRecords();
+		expect(records.at(-2)?.cursor).toBe("000000000042");
+		expect(records.at(-1)?.cursor).toBe("000000000043");
+		expect(records.at(-1)?.envelope.family).toBe("completion");
+	});
+
+	it("serializes concurrent appends with unique monotonic cursors", async () => {
+		process.env[RECEIPT_SPOOL_DIR_ENV] = spoolDir;
+
+		const runs = await Promise.all(
+			Array.from({ length: 8 }, (_, index) =>
+				runFinalize({
+					root,
+					sessionId: `spool-concurrent-${index}`,
+					workspace: "/ws",
+					branch: "feat/545",
+					requireTests: true,
+					requireCommit: true,
+					requirePr: true,
+					validationCommands: [{ name: `test-${index}`, command: "true" }],
+					checks: checks(),
+				}),
+			),
+		);
+
+		expect(runs.every(result => result.completed)).toBe(true);
+		const records = await readSpoolRecords();
+		expect(records.map(record => record.cursor)).toEqual(
+			Array.from({ length: 16 }, (_, index) => String(index + 1).padStart(12, "0")),
+		);
+		expect(new Set(records.map(record => record.cursor)).size).toBe(16);
+		expect(records.every(record => validateReceipt(record.envelope).valid)).toBe(true);
+	});
+
+	it("keeps per-request spool directories isolated without mutating process env", async () => {
+		const first = await mkdtemp(path.join(tmpdir(), "harness-receipt-spool-a-"));
+		const second = await mkdtemp(path.join(tmpdir(), "harness-receipt-spool-b-"));
+		try {
+			process.env[RECEIPT_SPOOL_DIR_ENV] = first;
+			await withReceiptSpoolDir(second, async () => {
+				expect(process.env[RECEIPT_SPOOL_DIR_ENV]).toBe(first);
+				const res = await runFinalize({
+					root,
+					sessionId: "spool-scoped",
+					workspace: "/ws",
+					branch: "feat/545",
+					requireTests: true,
+					requireCommit: true,
+					requirePr: true,
+					validationCommands: [{ name: "scoped", command: "true" }],
+					checks: checks(),
+				});
+				expect(res.completed).toBe(true);
+			});
+
+			expect(await Bun.file(path.join(first, RECEIPT_SPOOL_FILENAME)).exists()).toBe(false);
+			const raw = await readFile(path.join(second, RECEIPT_SPOOL_FILENAME), "utf8");
+			const records = raw
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line) as ReceiptSpoolRecord);
+			expect(records.map(record => record.cursor)).toEqual(["000000000001", "000000000002"]);
+		} finally {
+			await rm(first, { recursive: true, force: true });
+			await rm(second, { recursive: true, force: true });
+		}
+	});
+
+	it("exports directly appended native receipt envelopes", async () => {
+		process.env[RECEIPT_SPOOL_DIR_ENV] = spoolDir;
+		const res = await runFinalize({
+			root,
+			sessionId: "spool-direct-source",
+			workspace: "/ws",
+			branch: "feat/545",
+			requireTests: true,
+			requireCommit: true,
+			requirePr: true,
+			validationCommands: [{ name: "direct-source", command: "true" }],
+			checks: checks(),
+		});
+		expect(res.completed).toBe(true);
+
+		const records = await readSpoolRecords();
+		const completion = records.at(-1)?.envelope;
+		expect(completion?.family).toBe("completion");
+		const direct = await appendReceiptToSpool(spoolDir, completion!);
+		expect(direct.cursor).toBe("000000000003");
+
+		const reread = await readSpoolRecords();
+		expect(reread.at(-1)?.envelope).toEqual(completion);
+		expect(Object.keys(reread.at(-1) ?? {})).toEqual(["cursor", "envelope"]);
+	});
+
+	it("smokes the installed package import path with a configured receipt spool", async () => {
+		const script = `
+import { runFinalize } from "@gajae-code/coding-agent/harness-control-plane/finalize";
+process.env.GJC_RECEIPT_SPOOL_DIR = ${JSON.stringify(spoolDir)};
+const checks = {
+	async runValidation(spec) {
+		return { exactCommand: spec.command, cwd: "/ws", exitStatus: 0, pass: true };
+	},
+	async resolveCommit() {
+		return "abc123";
+	},
+	async commitOnBranch() {
+		return true;
+	},
+	async prOrIssue() {
+		return { prUrl: "https://example.test/pull/545", issueArtifact: null };
+	},
+};
+const result = await runFinalize({
+	root: ${JSON.stringify(root)},
+	sessionId: "spool-installed",
+	workspace: "/ws",
+	branch: "feat/545",
+	requireTests: true,
+	requireCommit: true,
+	requirePr: true,
+	validationCommands: [{ name: "smoke", command: "true" }],
+	checks,
+});
+if (!result.completed) {
+	console.error(JSON.stringify(result));
+	process.exit(1);
+}
+`;
+		const proc = Bun.spawnSync(["bun", "-e", script], {
+			cwd: repoRoot,
+			env: { ...process.env },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		expect(proc.stderr.toString()).toBe("");
+		expect(proc.exitCode ?? 0).toBe(0);
+		const records = await readSpoolRecords();
+		expect(records.map(record => record.cursor)).toEqual(["000000000001", "000000000002"]);
+		expect(records[1].envelope.family).toBe("completion");
+		expect((records[1].envelope.evidence as CompletionEvidence).finalLifecycle).toBe("completed");
+	});
+});


### PR DESCRIPTION
## Summary
- add a harness receipt JSONL spool exporter for control-plane receipt capture
- wire spool directory handling through harness owner/storage paths
- add regression coverage for receipt spool behavior and CLI owner routing

Fixes #545

## Verification
- `bun test packages/coding-agent/test/harness-control-plane/receipt-spool.test.ts packages/coding-agent/test/harness-control-plane/cli-owner-routing.test.ts` — 13 pass
- `bun --cwd=packages/coding-agent run check` — biome passed; package check reached workspace tsgo/check phase before operator delivery prompt interrupted the harness turn