### PR TITLE
fix(tui): preserve reasoning↔tool interleaving via assistant segment split

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -261,6 +261,7 @@ export class EventController {
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
 			this.#lastThinkingCount = 0;
+			this.#segmentStartIndex = 0;
 			this.#resetReadGroup();
 			this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock, () =>
 				this.ctx.ui.requestRender(),
@@ -308,10 +309,46 @@ export class EventController {
 		}
 	}
 
+	/**
+	 * First content-block index of the current assistant segment. Thinking/
+	 * text arriving after a toolCall starts a new segment component appended
+	 * below the tool rows, preserving the reasoning→tool→reasoning timeline.
+	 */
+	#segmentStartIndex = 0;
+
+	/** Render the current segment's slice of the streaming assistant message. */
+	#segmentSlice(message: AssistantMessage): AssistantMessage {
+		if (this.#segmentStartIndex === 0) return message;
+		return { ...message, content: message.content.slice(this.#segmentStartIndex) };
+	}
+
 	async #handleMessageUpdate(event: Extract<AgentSessionEvent, { type: "message_update" }>): Promise<void> {
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
 			this.ctx.streamingMessage = event.message;
-			this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage);
+			// Visible thinking/text after the latest toolCall → cut a new
+			// segment so it renders below the tool rows instead of merging into
+			// the original block above them.
+			const content = event.message.content;
+			let lastToolIndex = -1;
+			for (let i = content.length - 1; i >= 0; i--) {
+				if (content[i].type === "toolCall") {
+					lastToolIndex = i;
+					break;
+				}
+			}
+			if (lastToolIndex >= this.#segmentStartIndex) {
+				const hasPostToolContent = content
+					.slice(lastToolIndex + 1)
+					.some(c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+				if (hasPostToolContent) {
+					this.#segmentStartIndex = lastToolIndex + 1;
+					this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock, () =>
+						this.ctx.ui.requestRender(),
+					);
+					this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
+				}
+			}
+			this.ctx.streamingComponent.updateContent(this.#segmentSlice(this.ctx.streamingMessage));
 
 			const thinkingCount = this.ctx.streamingMessage.content.filter(
 				content => content.type === "thinking" && content.thinking.trim(),
@@ -431,9 +468,9 @@ export class EventController {
 				// display only — does NOT mutate the persisted message's stopReason
 				// (the marker on errorMessage drives replay-side suppression).
 				const msgWithoutAbort = { ...this.ctx.streamingMessage, stopReason: "stop" as const };
-				this.ctx.streamingComponent.updateContent(msgWithoutAbort);
+				this.ctx.streamingComponent.updateContent(this.#segmentSlice(msgWithoutAbort));
 			} else {
-				this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage);
+				this.ctx.streamingComponent.updateContent(this.#segmentSlice(this.ctx.streamingMessage));
 			}
 
 			if (this.ctx.streamingMessage.stopReason !== "aborted" && this.ctx.streamingMessage.stopReason !== "error") {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -308,12 +308,30 @@ export class UiHelpers {
 			}
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
-				this.ctx.addMessageToChat(message);
-				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
-				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
-				if (assistantComponent) {
-					assistantComponent.setUsageInfo(message.usage);
-				}
+				// Render the message in segments split at toolCall boundaries so
+				// reasoning that followed a tool call appears below that tool's row,
+				// matching arrival order: [segment, tools, segment, …].
+				const contentBlocks = message.content;
+				let assistantComponent: AssistantMessageComponent | undefined;
+				let segmentStart = 0;
+				const flushSegment = (end: number): void => {
+					const slice = contentBlocks.slice(segmentStart, end);
+					segmentStart = end;
+					const visible = slice.some(
+						c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+					);
+					if (!visible) return;
+					// Only the final segment keeps the error/abort footer.
+					const segmentMessage =
+						end < contentBlocks.length
+							? { ...message, content: slice, stopReason: "stop" as const, errorMessage: undefined }
+							: { ...message, content: slice };
+					this.ctx.addMessageToChat(segmentMessage);
+					const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
+					if (lastChild instanceof AssistantMessageComponent) {
+						assistantComponent = lastChild;
+					}
+				};
 				readGroup = null;
 				const isAbortedSilently = message.stopReason === "aborted" && isSilentAbort(message.errorMessage);
 				const hasErrorStop =
@@ -327,11 +345,14 @@ export class UiHelpers {
 						: message.errorMessage || "Error"
 					: null;
 
-				// Render tool call components
-				for (const content of message.content) {
+				// Render tool call components, flushing the preceding assistant
+				// segment before each so block order matches arrival order.
+				for (let blockIndex = 0; blockIndex < contentBlocks.length; blockIndex++) {
+					const content = contentBlocks[blockIndex];
 					if (content.type !== "toolCall") {
 						continue;
 					}
+					flushSegment(blockIndex);
 
 					if (
 						content.name === "read" &&
@@ -398,6 +419,8 @@ export class UiHelpers {
 						this.ctx.pendingTools.set(content.id, component);
 					}
 				}
+				flushSegment(contentBlocks.length);
+				assistantComponent?.setUsageInfo(message.usage);
 			} else if (message.role === "toolResult") {
 				const pendingReadComponent = this.ctx.pendingTools.get(message.toolCallId);
 				const isReadGroupResult =

--- a/packages/coding-agent/test/event-controller-segment-interleave.test.ts
+++ b/packages/coding-agent/test/event-controller-segment-interleave.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression tests for assistant segment splitting (reasoning↔tool interleaving).
+ *
+ * A streaming assistant message shaped [thinking, toolCall, thinking] used to
+ * render as [thinking+thinking] above [tool row]: the streaming component is
+ * created once at message_start and `updateContent` re-renders the whole
+ * message in place, while tool components append below. The fix cuts a new
+ * assistant segment component below the tool rows whenever visible thinking/
+ * text arrives after the latest toolCall, and `updateContent` (including the
+ * final message_end render) only receives the active segment's slice.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+import { TempDir } from "@gajae-code/utils";
+
+function makeAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+const toolCall = { type: "toolCall", id: "tc-1", name: "bash", arguments: { cmd: "ls" } } as const;
+
+function createFixture() {
+	const addChild = vi.fn();
+	const initialComponent = new AssistantMessageComponent(undefined, false, () => {});
+	const ctx = {
+		isInitialized: true,
+		init: vi.fn(async () => {}),
+		ui: { requestRender: vi.fn() },
+		statusLine: { invalidate: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		chatContainer: { addChild },
+		streamingComponent: initialComponent,
+		streamingMessage: undefined as AssistantMessage | undefined,
+		hideThinkingBlock: false,
+		// Prepopulated so the tool-component creation path (out of scope here)
+		// stays inert and addChild calls reflect segment cuts only.
+		pendingTools: new Map([
+			["tc-1", { updateArgs: vi.fn(), setArgsComplete: vi.fn() }],
+			["tc-2", { updateArgs: vi.fn(), setArgsComplete: vi.fn() }],
+		]),
+		session: { isTtsrAbortPending: false, retryAttempt: 0, getToolByName: () => undefined },
+	} as unknown as InteractiveModeContext;
+
+	const controller = new EventController(ctx);
+	return { controller, ctx, addChild, initialComponent };
+}
+
+async function update(controller: EventController, message: AssistantMessage): Promise<void> {
+	await controller.handleEvent({ type: "message_update", message } as AgentSessionEvent);
+}
+
+describe("EventController assistant segment split (reasoning↔tool interleaving)", () => {
+	let tempDir: TempDir;
+
+	beforeAll(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-segment-interleave-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		initTheme();
+	});
+
+	afterAll(() => {
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("keeps a tool-free message in the original component (no segment cut)", async () => {
+		const { controller, ctx, addChild, initialComponent } = createFixture();
+		const spy = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+
+		await update(controller, makeAssistantMessage([{ type: "thinking", thinking: "pondering" }]));
+
+		expect(addChild).not.toHaveBeenCalled();
+		expect(ctx.streamingComponent).toBe(initialComponent);
+		const rendered = spy.mock.calls.at(-1)?.[0] as AssistantMessage;
+		expect(rendered.content).toHaveLength(1);
+		spy.mockRestore();
+	});
+
+	it("cuts a new segment when visible thinking arrives after a toolCall", async () => {
+		const { controller, ctx, addChild, initialComponent } = createFixture();
+		const spy = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+
+		await update(
+			controller,
+			makeAssistantMessage([
+				{ type: "thinking", thinking: "before" },
+				toolCall,
+				{ type: "thinking", thinking: "after" },
+			]),
+		);
+
+		// A fresh component was appended below the tool rows and became the
+		// streaming target; it renders only the post-tool slice.
+		expect(addChild).toHaveBeenCalledTimes(1);
+		expect(ctx.streamingComponent).not.toBe(initialComponent);
+		expect(addChild.mock.calls[0][0]).toBe(ctx.streamingComponent);
+		const rendered = spy.mock.calls.at(-1)?.[0] as AssistantMessage;
+		expect(rendered.content).toEqual([{ type: "thinking", thinking: "after" }]);
+		spy.mockRestore();
+	});
+
+	it("does not cut a segment while post-tool content is still invisible (whitespace)", async () => {
+		const { controller, ctx, addChild, initialComponent } = createFixture();
+
+		await update(
+			controller,
+			makeAssistantMessage([{ type: "thinking", thinking: "before" }, toolCall, { type: "text", text: "  " }]),
+		);
+
+		expect(addChild).not.toHaveBeenCalled();
+		expect(ctx.streamingComponent).toBe(initialComponent);
+	});
+
+	it("keeps streaming into the active segment without cutting again", async () => {
+		const { controller, ctx, addChild } = createFixture();
+		const spy = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+
+		await update(
+			controller,
+			makeAssistantMessage([
+				{ type: "thinking", thinking: "before" },
+				toolCall,
+				{ type: "thinking", thinking: "after" },
+			]),
+		);
+		const segmentComponent = ctx.streamingComponent;
+		await update(
+			controller,
+			makeAssistantMessage([
+				{ type: "thinking", thinking: "before" },
+				toolCall,
+				{ type: "thinking", thinking: "after, extended" },
+			]),
+		);
+
+		expect(addChild).toHaveBeenCalledTimes(1); // no second cut
+		expect(ctx.streamingComponent).toBe(segmentComponent);
+		const rendered = spy.mock.calls.at(-1)?.[0] as AssistantMessage;
+		expect(rendered.content).toEqual([{ type: "thinking", thinking: "after, extended" }]);
+		spy.mockRestore();
+	});
+
+	it("cuts again for a second toolCall followed by visible text", async () => {
+		const { controller, addChild } = createFixture();
+		const spy = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+		const secondTool = { ...toolCall, id: "tc-2" };
+
+		await update(
+			controller,
+			makeAssistantMessage([{ type: "thinking", thinking: "a" }, toolCall, { type: "thinking", thinking: "b" }]),
+		);
+		await update(
+			controller,
+			makeAssistantMessage([
+				{ type: "thinking", thinking: "a" },
+				toolCall,
+				{ type: "thinking", thinking: "b" },
+				secondTool,
+				{ type: "text", text: "done" },
+			]),
+		);
+
+		expect(addChild).toHaveBeenCalledTimes(2);
+		const rendered = spy.mock.calls.at(-1)?.[0] as AssistantMessage;
+		expect(rendered.content).toEqual([{ type: "text", text: "done" }]);
+		spy.mockRestore();
+	});
+
+	it("final render on message_end stays scoped to the active segment", async () => {
+		const { controller, ctx } = createFixture();
+		const message = makeAssistantMessage([
+			{ type: "thinking", thinking: "before" },
+			toolCall,
+			{ type: "text", text: "final answer" },
+		]);
+
+		await update(controller, message);
+		const spy = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+		ctx.streamingMessage = message;
+		await controller.handleEvent({ type: "message_end", message } as AgentSessionEvent);
+
+		const rendered = spy.mock.calls.at(0)?.[0] as AssistantMessage;
+		expect(rendered.content).toEqual([{ type: "text", text: "final answer" }]);
+		spy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary

Standalone revival of #523, addressing both review blockers.

A streaming assistant message shaped `[think, tool, think]` used to render as `[think+think]` above `[tool]`: the streaming component is created once at `message_start` and `updateContent` re-renders the whole message in place, while tool components append below — destroying the timeline and reading as a giant reasoning wall above a list of tool rows.

**Live path** (`event-controller.ts`): when visible thinking/text appears after the latest toolCall, cut a new assistant segment component below the tool rows and point the streaming component at it; `updateContent` (including the final `message_end` render) only receives the active segment's slice.

**Replay path** (`ui-helpers.ts`): assistant content is flushed segment-by-segment at toolCall boundaries — `[segment, tools, segment, …]`. The error/abort footer stays on the final segment only; usage attaches to the last segment; read-result images still attach to the segment directly above their read row.

## Review blockers from #523 — resolved

1. **Stale branch / duplicate #521 stack** → this is a fresh branch cut from current `dev` (`2b4d407b`); the spacing commit is not carried (already merged as `31a5ec44`).
2. **Coupling to #522's minimize machinery** → fully decoupled: no `setMinimized` / `lastToolComponent` references. This is now a pure ordering bugfix.

## Testing

- New regression suite `event-controller-segment-interleave.test.ts` (6 cases): no-cut for tool-free messages, segment cut on post-tool thinking, whitespace-only post-tool content stays merged, continued streaming into the active segment, second cut for a second toolCall, and message_end final render staying segment-scoped.
- `bun run check:ts` exit 0 (biome + tsgo + schema/UI gates).
- Full `bun test packages/coding-agent`: 5481 pass / 6 fail — the 6 failures (rpc-stdio-redteam, launch-worktree, ast-grep tlaplus ×2, image-gen antigravity ×2) reproduce identically on clean `dev` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)