### PR TITLE
feat: /effort slash command — set reasoning effort directly

### DIFF
--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,8 +1,9 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
+import { THINKING_EFFORTS } from "@gajae-code/ai/model-thinking";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
-import type { Component, OverlayHandle } from "@gajae-code/tui";
-import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
+import type { Component, OverlayHandle, SelectItem } from "@gajae-code/tui";
+import { Container, Input, Loader, SelectList, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import { activateModelProfile } from "../../config/model-profile-activation";
 import { settings } from "../../config/settings";
@@ -16,10 +17,12 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
+import { DynamicBorder } from "../../modes/components/dynamic-border";
 import {
 	getAvailableThemes,
 	getCurrentThemeName,
 	getDetectedThemeSettingsPath,
+	getSelectListTheme,
 	getSymbolTheme,
 	previewTheme,
 	restoreThemePreview,
@@ -37,6 +40,7 @@ import {
 	MODEL_ONBOARDING_SETUP_COMMAND,
 } from "../../setup/model-onboarding-guidance";
 import { addApiCompatibleProvider, formatProviderSetupResult } from "../../setup/provider-onboarding";
+import { getThinkingLevelMetadata } from "../../thinking";
 import { isSearchProviderPreference, setPreferredImageProvider, setPreferredSearchProvider } from "../../tools";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
@@ -244,6 +248,41 @@ export class SelectorController {
 		this.ctx.statusLine.invalidate();
 		this.ctx.updateEditorTopBorder();
 		this.ctx.ui.requestRender();
+	}
+
+	/**
+	 * Dropdown for bare /effort — pick a reasoning effort (thinking level).
+	 * Items derive from the canonical thinking vocabulary so the selector can
+	 * never drift from the levels the session actually accepts.
+	 */
+	showEffortSelector(): void {
+		const levels: SelectItem[] = [ThinkingLevel.Off, ...THINKING_EFFORTS].map(value => {
+			const metadata = getThinkingLevelMetadata(value);
+			return { value, label: metadata.label, description: metadata.description };
+		});
+		this.showSelector(done => {
+			const container = new Container();
+			container.addChild(new DynamicBorder());
+			container.addChild(new Text(theme.fg("accent", " Reasoning effort"), 1, 0));
+			const list = new SelectList(levels, levels.length + 1, getSelectListTheme());
+			const current = this.ctx.session.thinkingLevel;
+			const currentIndex = levels.findIndex(item => item.value === current);
+			if (currentIndex >= 0) list.setSelectedIndex(currentIndex);
+			list.onSelect = item => {
+				done();
+				this.ctx.session.setThinkingLevel(item.value as ThinkingLevel);
+				this.ctx.statusLine.invalidate();
+				this.ctx.showStatus(`Reasoning effort set to ${this.ctx.session.thinkingLevel ?? "off"}.`);
+				this.ctx.ui.requestRender();
+			};
+			list.onCancel = () => {
+				done();
+				this.ctx.ui.requestRender();
+			};
+			container.addChild(list);
+			container.addChild(new DynamicBorder());
+			return { component: container, focus: list };
+		});
 	}
 
 	showThemeSelector(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2441,6 +2441,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController.showModelSelector(options);
 	}
 
+	showEffortSelector(): void {
+		this.#selectorController.showEffortSelector();
+	}
+
 	showProviderOnboarding(): void {
 		this.#selectorController.showProviderOnboarding();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -239,6 +239,7 @@ export interface InteractiveModeContext {
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
+	showEffortSelector(): void;
 	showProviderOnboarding(): void;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { ThinkingLevel } from "@gajae-code/agent-core";
+import type { ResolvedThinkingLevel, ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
+import { THINKING_EFFORTS } from "@gajae-code/ai/model-thinking";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { setProjectDir } from "@gajae-code/utils";
 import {
@@ -20,7 +21,7 @@ import {
 	formatProviderSetupResult,
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
-import { parseThinkingLevel } from "../thinking";
+import { getThinkingLevelMetadata, parseThinkingLevel } from "../thinking";
 import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
@@ -201,6 +202,22 @@ function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.ui.requestRender();
 }
 
+/**
+ * Parse a /effort argument into a session thinking level. Accepts canonical
+ * levels plus the Codex-style aliases none→off and min→minimal. "inherit" is
+ * a model-selector concept, not a session effort, so it is rejected.
+ */
+function parseEffortArg(raw: string): ThinkingLevel | undefined {
+	const normalized = raw === "none" ? "off" : raw === "min" ? "minimal" : raw;
+	const level = parseThinkingLevel(normalized);
+	return level === "inherit" ? undefined : level;
+}
+
+/** Selectable /effort levels, derived from the canonical thinking vocabulary. */
+const EFFORT_LEVEL_VALUES: ReadonlyArray<ResolvedThinkingLevel> = ["off", ...THINKING_EFFORTS];
+
+const EFFORT_OPTIONS_HINT = EFFORT_LEVEL_VALUES.join("|");
+
 const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime): SlashCommandResult => {
 	runtime.ctx.editor.setText("");
 	void runtime.ctx.shutdown();
@@ -324,6 +341,64 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showModelSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "effort",
+		description: "Set reasoning effort for the current session",
+		acpDescription: "Set reasoning effort",
+		acpInputHint: `[${EFFORT_OPTIONS_HINT}]`,
+		subcommands: [
+			...EFFORT_LEVEL_VALUES.map(value => ({
+				name: value,
+				description: getThinkingLevelMetadata(value).description,
+			})),
+			{ name: "status", description: "Show current reasoning effort" },
+		],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const raw = command.args.trim().toLowerCase();
+			if (!raw || raw === "status") {
+				await runtime.output(
+					`Reasoning effort: ${runtime.session.thinkingLevel ?? "off"}. Options: ${EFFORT_LEVEL_VALUES.join(", ")}.`,
+				);
+				return commandConsumed();
+			}
+			const level = parseEffortArg(raw);
+			if (!level) {
+				await runtime.output(
+					`Unknown effort "${command.args.trim()}". Options: ${EFFORT_LEVEL_VALUES.join(", ")}.`,
+				);
+				return commandConsumed();
+			}
+			runtime.session.setThinkingLevel(level);
+			await runtime.output(`Reasoning effort set to ${runtime.session.thinkingLevel ?? "off"}.`);
+			return commandConsumed();
+		},
+		handleTui: (command, runtime) => {
+			const raw = command.args.trim().toLowerCase();
+			if (!raw) {
+				runtime.ctx.showEffortSelector();
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (raw === "status") {
+				runtime.ctx.showStatus(
+					`Reasoning effort: ${runtime.ctx.session.thinkingLevel ?? "off"} (${EFFORT_OPTIONS_HINT})`,
+				);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			const level = parseEffortArg(raw);
+			if (!level) {
+				runtime.ctx.showError(`Unknown effort "${command.args.trim()}" (${EFFORT_OPTIONS_HINT})`);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.session.setThinkingLevel(level);
+			refreshStatusLine(runtime.ctx);
+			runtime.ctx.showStatus(`Reasoning effort set to ${runtime.ctx.session.thinkingLevel ?? "off"}.`);
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -52,6 +52,7 @@ interface FakeAcpBuiltinSession {
 	getContextUsage(): { tokens?: number; contextWindow: number } | undefined;
 	getAvailableModels(): Array<{ provider: string; id: string; contextWindow?: number }>;
 	setModel(model: unknown): Promise<void>;
+	thinkingLevel: unknown;
 	setThinkingLevel(thinkingLevel: unknown): void;
 }
 
@@ -117,7 +118,10 @@ function createRuntime() {
 		getContextUsage: () => undefined,
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
 		async setModel(_model: unknown) {},
-		setThinkingLevel(_thinkingLevel: unknown) {},
+		thinkingLevel: undefined,
+		setThinkingLevel(thinkingLevel: unknown) {
+			this.thinkingLevel = thinkingLevel;
+		},
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
 	};
 	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
@@ -195,6 +199,50 @@ function createRuntime() {
 }
 
 describe("ACP builtin slash commands", () => {
+	it("effort: sets a canonical reasoning level", async () => {
+		const { output, runtime } = createRuntime();
+		const setThinkingLevelSpy = spyOn(runtime.session, "setThinkingLevel");
+
+		const result = await executeAcpBuiltinSlashCommand("/effort minimal", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(setThinkingLevelSpy).toHaveBeenCalledWith("minimal");
+		expect(output).toEqual(["Reasoning effort set to minimal."]);
+	});
+
+	it("effort: normalizes the min and none aliases to canonical levels", async () => {
+		const { runtime } = createRuntime();
+		const setThinkingLevelSpy = spyOn(runtime.session, "setThinkingLevel");
+
+		await executeAcpBuiltinSlashCommand("/effort min", runtime);
+		expect(setThinkingLevelSpy).toHaveBeenLastCalledWith("minimal");
+
+		await executeAcpBuiltinSlashCommand("/effort none", runtime);
+		expect(setThinkingLevelSpy).toHaveBeenLastCalledWith("off");
+	});
+
+	it("effort: rejects inherit and unknown values without touching the session", async () => {
+		const { output, runtime } = createRuntime();
+		const setThinkingLevelSpy = spyOn(runtime.session, "setThinkingLevel");
+
+		await executeAcpBuiltinSlashCommand("/effort inherit", runtime);
+		await executeAcpBuiltinSlashCommand("/effort turbo", runtime);
+
+		expect(setThinkingLevelSpy).not.toHaveBeenCalled();
+		expect(output[0]).toContain('Unknown effort "inherit"');
+		expect(output[1]).toContain('Unknown effort "turbo"');
+	});
+
+	it("effort: bare and status report the current level", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.thinkingLevel = "high";
+
+		const result = await executeAcpBuiltinSlashCommand("/effort status", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toStartWith("Reasoning effort: high.");
+	});
+
 	it("consumes fast status without returning prompt text", async () => {
 		const { output, runtime } = createRuntime();
 


### PR DESCRIPTION
## Summary

Fresh take on #520 (closed by the sweep policy while in request-changes), addressing all three review blockers.

Today the only paths to reasoning effort are shift+tab cycling or the `/model <sel>:level` suffix. This adds `/effort`:

- `/effort <level>` sets the session thinking level via the existing `parseThinkingLevel` / `setThinkingLevel` APIs (model clamping stays in `clampThinkingLevelForModel`, untouched).
- `/effort status` (and the bare ACP/text form) reports the current level.
- **Bare `/effort` in the TUI opens a dropdown selector** — `SelectList` with the current level preselected, enter applies, esc cancels, using the same `showSelector` swap pattern as the theme/model pickers (`showEffortSelector()` on the selector controller).

## Review blockers from #520 — resolved

1. **`/effort minimal` was broken** (normalized to `min`, not a valid `ThinkingLevel`) → aliases now normalize INTO the canonical vocabulary: `none→off`, `min→minimal`. `/effort minimal` resolves directly.
2. **Selector used `value: "min"`** (preselection mismatch, silent effort clear) → selector items, autocomplete subcommands, and the options hint all **derive from the canonical vocabulary** (`THINKING_EFFORTS` + `getThinkingLevelMetadata`), so the surface cannot drift from what the session accepts — this removes the root cause rather than patching the literal.
3. **Biome failure (helper declared mid-imports)** → helpers live after the import block; `bun run check:ts` exits 0.

`inherit` is rejected (model-selector concept, not a session effort).

## Testing

- 4 new ACP-path tests in `acp-builtins.test.ts`: canonical set, `min`/`none` alias normalization, `inherit`/unknown rejection without touching the session, and status reporting (52 pass).
- `cli-command-surface`, `slash-command-format`, `provider-slash-command`, `slash-commands/*`: all pass.
- `bun run check:ts` exit 0 (biome + tsgo + schema/UI gates).

I understand builtin command vocabulary is a maintainer-owned surface — the owner's earlier "I approve" on #520 read as that product decision, so this re-submission keeps the exact same vocabulary and only fixes the blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)