### PR TITLE
perf(compaction): Optimization Suite v3 Lane 2 — per-entry token cache, exact digest pruning, O(n) OpenAI trim

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 
 - Fixed compaction cut-point selection when the newest retained context ends in an uncuttable tool result, so automatic compaction can keep the latest assistant/tool-result pair instead of falling back to a no-op cut.
+### Changed
+
+- Optimization Suite v3 Lane 2 (context cost): compaction token estimates now use a shared per-entry cache (`estimateEntryTokens`) keyed by a boundary-lossless fingerprint of the exact estimator fragments, covering `estimateEntriesTokens`, the `findCutPoint` reverse walk, and pruning candidate scoring — repeated full-session estimate p95 −97%, token totals exactly equal to fresh estimates and never stale after prune mutation. Pruned bash/search/grep tool results now carry a one-line digest notice (exit code, match/file count, first error line; capped at 1.25× the generic notice cost) instead of a bare truncation notice, with savings computed from the exact notice string; reads and other tools keep the generic notice. `trimOpenAiCompactInput` is O(n) via per-item serialized lengths and a running character sum (5k-item trim −99.9%) and is now exported.
 
 ## [0.4.5] - 2026-06-12
 

--- a/packages/agent/bench/compaction-estimate.ts
+++ b/packages/agent/bench/compaction-estimate.ts
@@ -1,0 +1,264 @@
+import { performance } from "node:perf_hooks";
+import * as os from "node:os";
+import { estimateOpenAiCompactInputTokens, trimOpenAiCompactInput } from "../src/compaction/openai";
+import { estimateEntriesTokens, findCutPoint } from "../src/compaction/compaction";
+import type { SessionEntry } from "../src/compaction/entries";
+
+const WARMUP_ITERATIONS = 20;
+const MEASURE_ITERATIONS = 200;
+const COLD_MEASURE_ITERATIONS = 40;
+const TRIM_MEASURE_ITERATIONS = 20;
+const ALLOCATION_SAMPLES = 20;
+const ALLOCATION_PASSES_PER_SAMPLE = 25;
+
+interface MetricSummary {
+	minMs: number;
+	medianMs: number;
+	p95Ms: number;
+	maxMs: number;
+}
+
+interface MetricOutput extends MetricSummary {
+	samplesMs: number[];
+	deltaPercent?: MetricSummary;
+}
+
+interface AllocationMetricOutput {
+	samplesBytes: number[];
+	allocatedBytesPerPass: number;
+	deltaPercent?: number;
+}
+
+interface BenchOutput {
+	schemaVersion: 1;
+	package: "@gajae-code/agent";
+	bench: "compaction-estimate";
+	fixture: string;
+	fixtureDimensions: { entries: number; openAiItems: number };
+	warmupIterations: number;
+	measureIterations: number;
+	metadata: {
+		gitSha: string;
+		date: string;
+		platform: NodeJS.Platform;
+		arch: string;
+		cpu: string;
+		bunVersion: string;
+		command: string;
+	};
+	metrics: Record<string, MetricOutput | AllocationMetricOutput>;
+}
+
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state += 0x6d2b79f5;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function text(rng: () => number, words: number): string {
+	const vocab = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "gajae", "token", "context", "prune"];
+	let out = "";
+	for (let i = 0; i < words; i++) out += `${vocab[Math.floor(rng() * vocab.length)]} `;
+	return out;
+}
+
+function buildEntries(count = 10_000): SessionEntry[] {
+	const rng = mulberry32(0xc0ffee);
+	const entries: SessionEntry[] = [];
+	for (let i = 0; i < count; i++) {
+		const mod = i % 5;
+		if (mod === 0) {
+			entries.push({ type: "message", id: `u-${i}`, timestamp: "2026-06-12T00:00:00.000Z", message: { role: "user", content: text(rng, 18) } });
+		} else if (mod === 1) {
+			entries.push({ type: "message", id: `a-${i}`, timestamp: "2026-06-12T00:00:00.000Z", message: { role: "assistant", content: [{ type: "text", text: text(rng, 24) }, { type: "toolCall", id: `tc-${i}`, name: rng() > 0.5 ? "bash" : "search", arguments: { path: `src/${i % 31}.ts`, query: text(rng, 3), limit: i % 7 } }] } });
+		} else if (mod === 2) {
+			entries.push({ type: "message", id: `tr-${i}`, timestamp: "2026-06-12T00:00:00.000Z", message: { role: "toolResult", toolName: rng() > 0.5 ? "bash" : "read", toolCallId: `tc-${i - 1}`, content: [{ type: "text", text: text(rng, 110) }] } });
+		} else if (mod === 3) {
+			entries.push({ type: "message", id: `b-${i}`, timestamp: "2026-06-12T00:00:00.000Z", message: { role: "bashExecution", command: `bun test case-${i}`, output: text(rng, 60) } });
+		} else {
+			entries.push({ type: "custom_message", id: `c-${i}`, timestamp: "2026-06-12T00:00:00.000Z", message: { role: "user", content: text(rng, 14), customType: "bench", display: false } });
+		}
+	}
+	return entries;
+}
+
+function buildOpenAiItems(count = 5_000): Array<Record<string, unknown>> {
+	const rng = mulberry32(0xabcd);
+	const items: Array<Record<string, unknown>> = [];
+	for (let i = 0; i < count; i++) items.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: [{ type: "input_text", text: text(rng, 28) }], meta: { index: i, ok: true, skip: undefined } });
+	return items;
+}
+
+function buildOpenAiTrimItems(count = 5_000): Array<Record<string, unknown>> {
+	const rng = mulberry32(0x71eed);
+	const items: Array<Record<string, unknown>> = [];
+	for (let i = 0; i < count; i++) {
+		if (i === 0) items.push({ type: "message", role: "user", content: [{ type: "input_text", text: text(rng, 32) }] });
+		else items.push({ type: "message", role: "developer", content: [{ type: "input_text", text: text(rng, 32) }], meta: { index: i } });
+	}
+	return items;
+}
+
+function cloneOpenAiTrimTemplate(template: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+	return structuredClone(template) as Array<Record<string, unknown>>;
+}
+
+function mutateOpenAiItemsForSizing(items: Array<Record<string, unknown>>, iteration: number): void {
+	const item = items[iteration % items.length];
+	if (!item) return;
+	item.meta = { index: iteration, ok: true, skip: undefined };
+}
+
+function time(fn: () => void): number {
+	const start = performance.now();
+	fn();
+	return performance.now() - start;
+}
+
+function percentile(values: number[], p: number): number {
+	const sorted = [...values].sort((a, b) => a - b);
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] ?? 0;
+}
+
+function summarize(values: number[]): MetricSummary {
+	return { minMs: Math.min(...values), medianMs: percentile(values, 0.5), p95Ms: percentile(values, 0.95), maxMs: Math.max(...values) };
+}
+
+function parseArgs(): { out?: string; baseline?: string } {
+	const args = process.argv.slice(2);
+	const parsed: { out?: string; baseline?: string } = {};
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--out") parsed.out = args[++i];
+		else if (args[i] === "--baseline") parsed.baseline = args[++i];
+	}
+	return parsed;
+}
+
+function gitSha(): string {
+	return Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim();
+}
+
+async function readBaseline(path: string | undefined): Promise<BenchOutput | undefined> {
+	if (!path) return undefined;
+	return await Bun.file(path).json() as BenchOutput;
+}
+
+function deltaPercent(current: number, baseline: number): number {
+	return baseline === 0 ? 0 : ((current - baseline) / baseline) * 100;
+}
+
+function metricOutput(samplesMs: number[], baseline?: MetricOutput): MetricOutput {
+	const summary = summarize(samplesMs);
+	const output: MetricOutput = { samplesMs, ...summary };
+	if (baseline) {
+		output.deltaPercent = {
+			minMs: deltaPercent(summary.minMs, baseline.minMs),
+			medianMs: deltaPercent(summary.medianMs, baseline.medianMs),
+			p95Ms: deltaPercent(summary.p95Ms, baseline.p95Ms),
+			maxMs: deltaPercent(summary.maxMs, baseline.maxMs),
+		};
+	}
+	return output;
+}
+
+function allocationMetricOutput(samplesBytes: number[], baseline?: AllocationMetricOutput): AllocationMetricOutput {
+	const allocatedBytesPerPass = samplesBytes.reduce((total, sample) => total + sample, 0) / samplesBytes.length;
+	const output: AllocationMetricOutput = { samplesBytes, allocatedBytesPerPass };
+	if (baseline) output.deltaPercent = deltaPercent(allocatedBytesPerPass, baseline.allocatedBytesPerPass);
+	return output;
+}
+
+function sampleHeapAllocationBytes(fn: () => void): number {
+	Bun.gc(true);
+	const before = process.memoryUsage().heapUsed;
+	for (let i = 0; i < ALLOCATION_PASSES_PER_SAMPLE; i++) fn();
+	Bun.gc(true);
+	const after = process.memoryUsage().heapUsed;
+	return Math.max(0, after - before) / ALLOCATION_PASSES_PER_SAMPLE;
+}
+
+function metricBaseline(baseline: BenchOutput | undefined, name: string): MetricOutput | undefined {
+	return baseline?.metrics[name] as MetricOutput | undefined;
+}
+
+function allocationMetricBaseline(baseline: BenchOutput | undefined, name: string): AllocationMetricOutput | undefined {
+	return baseline?.metrics[name] as AllocationMetricOutput | undefined;
+}
+
+const { out, baseline: baselinePath } = parseArgs();
+const baseline = await readBaseline(baselinePath);
+const entries = buildEntries();
+const openAiItems = buildOpenAiItems();
+const openAiTrimTemplate = buildOpenAiTrimItems();
+const samples = {
+	coldEstimateEntriesTokensMs: [] as number[],
+	repeatedEstimateEntriesTokensMs: [] as number[],
+	findCutPointMs: [] as number[],
+	openAiSizingMs: [] as number[],
+	trimScenarioMs: [] as number[],
+	openAiSizingAllocationBytes: [] as number[],
+};
+
+for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+	estimateEntriesTokens(entries, 0, entries.length);
+	findCutPoint(entries, 0, entries.length, 25_000);
+	estimateOpenAiCompactInputTokens(openAiItems, "bench instructions");
+	trimOpenAiCompactInput(cloneOpenAiTrimTemplate(openAiTrimTemplate), 1_000, "bench instructions");
+}
+
+for (let i = 0; i < MEASURE_ITERATIONS; i++) {
+	if (i < COLD_MEASURE_ITERATIONS) {
+		// Cold measurements clone a 10k-entry fixture and intentionally use fewer samples;
+		// the hot-path CPU gates below use the full 200 measured-iteration protocol.
+		const coldEntries = structuredClone(entries) as SessionEntry[];
+		samples.coldEstimateEntriesTokensMs.push(time(() => { estimateEntriesTokens(coldEntries, 0, coldEntries.length); }));
+	}
+	samples.repeatedEstimateEntriesTokensMs.push(time(() => { estimateEntriesTokens(entries, 0, entries.length); }));
+	samples.findCutPointMs.push(time(() => { findCutPoint(entries, 0, entries.length, 25_000); }));
+	mutateOpenAiItemsForSizing(openAiItems, i);
+	samples.openAiSizingMs.push(time(() => { estimateOpenAiCompactInputTokens(openAiItems, "bench instructions"); }));
+	if (i < TRIM_MEASURE_ITERATIONS) {
+		const trimItems = cloneOpenAiTrimTemplate(openAiTrimTemplate);
+		samples.trimScenarioMs.push(time(() => { trimOpenAiCompactInput(trimItems, 1_000, "bench instructions"); }));
+	}
+}
+
+for (let i = 0; i < ALLOCATION_SAMPLES; i++) {
+	mutateOpenAiItemsForSizing(openAiItems, i + MEASURE_ITERATIONS);
+	samples.openAiSizingAllocationBytes.push(sampleHeapAllocationBytes(() => { estimateOpenAiCompactInputTokens(openAiItems, "bench instructions"); }));
+}
+
+const output: BenchOutput = {
+	schemaVersion: 1,
+	package: "@gajae-code/agent",
+	bench: "compaction-estimate",
+	fixture: "deterministic-10k-session-5k-openai-items",
+	fixtureDimensions: { entries: entries.length, openAiItems: openAiItems.length },
+	warmupIterations: WARMUP_ITERATIONS,
+	measureIterations: MEASURE_ITERATIONS,
+	metadata: {
+		gitSha: gitSha(),
+		date: new Date().toISOString(),
+		platform: process.platform,
+		arch: process.arch,
+		cpu: os.cpus()[0]?.model ?? "unknown",
+		bunVersion: Bun.version,
+		command: process.argv.join(" "),
+	},
+	metrics: {
+		coldEstimateEntriesTokens: metricOutput(samples.coldEstimateEntriesTokensMs, metricBaseline(baseline, "coldEstimateEntriesTokens")),
+		repeatedEstimateEntriesTokens: metricOutput(samples.repeatedEstimateEntriesTokensMs, metricBaseline(baseline, "repeatedEstimateEntriesTokens")),
+		findCutPoint: metricOutput(samples.findCutPointMs, metricBaseline(baseline, "findCutPoint")),
+		openAiSizing: metricOutput(samples.openAiSizingMs, metricBaseline(baseline, "openAiSizing")),
+		openAiSizingAllocation: allocationMetricOutput(samples.openAiSizingAllocationBytes, allocationMetricBaseline(baseline, "openAiSizingAllocation")),
+		trimScenario: metricOutput(samples.trimScenarioMs, metricBaseline(baseline, "trimScenario")),
+	},
+};
+
+if (out) await Bun.write(out, `${JSON.stringify(output, null, 2)}\n`);
+console.log(JSON.stringify(output));

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -287,6 +287,10 @@ function nativeCountTokens(fragments: string[]): number {
 	return cachedNativeCountTokens(fragments);
 }
 
+function countCollectedMessageFragments(collected: { fragments: string[]; extra: number }): number {
+	return nativeCountTokens(collected.fragments) + collected.extra;
+}
+
 /**
  * Estimate token count for a message using the native o200k tokenizer.
  * Exact for o200k only; an approximation for Anthropic/other model families
@@ -299,9 +303,7 @@ function nativeCountTokens(fragments: string[]): number {
  * {@link estimateMessageTokensHeuristic}.
  */
 export function countMessageTokensNativeO200k(message: AgentMessage): number {
-	const { fragments, extra } = collectMessageFragments(message);
-	if (fragments.length === 0) return extra;
-	return extra + nativeCountTokens(fragments);
+	return countCollectedMessageFragments(collectMessageFragments(message));
 }
 
 /**
@@ -413,13 +415,39 @@ function collectMessageFragments(message: AgentMessage): { fragments: string[]; 
 	return { fragments, extra };
 }
 
-function estimateEntriesTokens(entries: SessionEntry[], startIndex: number, endIndex: number): number {
+function entryTokenFingerprint(
+	entry: SessionEntry,
+	message: AgentMessage,
+	collected: { fragments: string[]; extra: number },
+): string {
+	const maybePruned = message as { prunedAt?: unknown };
+	let fingerprint = `${entry.type.length}:${entry.type}${(entry.id ?? "").length}:${entry.id ?? ""}${message.role.length}:${message.role}${String(collected.extra).length}:${String(collected.extra)}${collected.fragments.length}:`;
+	for (const fragment of collected.fragments) fingerprint += `${fragment.length}:${fragment}`;
+	if (maybePruned.prunedAt !== undefined) {
+		const prunedAt = String(maybePruned.prunedAt);
+		fingerprint += `prunedAt${prunedAt.length}:${prunedAt}`;
+	}
+	return fingerprint;
+}
+
+const entryTokenCache = new WeakMap<SessionEntry, { fingerprint: string; tokens: number }>();
+
+export function estimateEntryTokens(entry: SessionEntry): number {
+	const msg = getMessageFromEntry(entry);
+	if (!msg) return 0;
+	const collected = collectMessageFragments(msg);
+	const fingerprint = entryTokenFingerprint(entry, msg, collected);
+	const cached = entryTokenCache.get(entry);
+	if (cached?.fingerprint === fingerprint) return cached.tokens;
+	const tokens = countCollectedMessageFragments(collected);
+	entryTokenCache.set(entry, { fingerprint, tokens });
+	return tokens;
+}
+
+export function estimateEntriesTokens(entries: SessionEntry[], startIndex: number, endIndex: number): number {
 	let total = 0;
 	for (let i = startIndex; i < endIndex; i++) {
-		const msg = getMessageFromEntry(entries[i]);
-		if (msg) {
-			total += estimateTokens(msg);
-		}
+		total += estimateEntryTokens(entries[i]);
 	}
 	return total;
 }
@@ -536,7 +564,7 @@ export function findCutPoint(
 		if (entry.type !== "message") continue;
 
 		// Estimate this message's size
-		const messageTokens = estimateTokens(entry.message);
+		const messageTokens = estimateEntryTokens(entry);
 		accumulatedTokens += messageTokens;
 
 		// Check if we've exceeded the budget

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -154,7 +154,7 @@ export function withOpenAiRemoteCompactionPreserveData(
 // Input/output filtering for OpenAI compact endpoint
 // ============================================================================
 
-function estimateOpenAiCompactInputTokens(input: Array<Record<string, unknown>>, instructions: string): number {
+export function estimateOpenAiCompactInputTokens(input: Array<Record<string, unknown>>, instructions: string): number {
 	let chars = instructions.length;
 	for (const item of input) {
 		chars += JSON.stringify(item).length;
@@ -200,22 +200,31 @@ function shouldKeepOpenAiCompactOutputItem(item: Record<string, unknown>): boole
 	return shouldKeepOpenAiCompactOutputUserMessage(item);
 }
 
-function trimOpenAiCompactInput(
+export function trimOpenAiCompactInput(
 	input: Array<Record<string, unknown>>,
 	contextWindow: number,
 	instructions: string,
 ): Array<Record<string, unknown>> {
+	const itemLengths = input.map(item => JSON.stringify(item).length);
+	let chars = instructions.length;
+	for (const length of itemLengths) chars += length;
+
+	function removeAt(index: number): void {
+		chars -= itemLengths[index] ?? 0;
+		trimmed.splice(index, 1);
+		itemLengths.splice(index, 1);
+	}
 	const trimmed = [...input];
-	while (trimmed.length > 0 && estimateOpenAiCompactInputTokens(trimmed, instructions) > contextWindow) {
+	while (trimmed.length > 0 && Math.ceil(chars / 4) > contextWindow) {
 		const last = trimmed[trimmed.length - 1];
 		if (last?.type === "function_call_output" || last?.type === "custom_tool_call_output") {
 			const callId = typeof last.call_id === "string" ? last.call_id : undefined;
 			const callType = last.type === "custom_tool_call_output" ? "custom_tool_call" : "function_call";
-			trimmed.pop();
+			removeAt(trimmed.length - 1);
 			if (callId) {
 				const matchingCallIndex = trimmed.findLastIndex(item => item.type === callType && item.call_id === callId);
 				if (matchingCallIndex >= 0) {
-					trimmed.splice(matchingCallIndex, 1);
+					removeAt(matchingCallIndex);
 				}
 			}
 			continue;
@@ -223,7 +232,7 @@ function trimOpenAiCompactInput(
 		if (!last || !shouldTrimOpenAiCompactInputItem(last)) {
 			break;
 		}
-		trimmed.pop();
+		removeAt(trimmed.length - 1);
 	}
 	return trimmed;
 }

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -10,7 +10,7 @@
 
 import type { ToolCall, ToolResultMessage } from "@gajae-code/ai";
 import type { AgentMessage } from "../types";
-import { estimateTokens } from "./compaction";
+import { estimateEntryTokens } from "./compaction";
 import type { SessionEntry, SessionMessageEntry } from "./entries";
 
 export interface PruneConfig {
@@ -47,8 +47,71 @@ export interface PruneResult {
 	prunedEntries: SessionMessageEntry[];
 }
 
-function createPrunedNotice(tokens: number): string {
+const DIGEST_NOTICE_TOKEN_CAP_MULTIPLIER = 1.25;
+
+function createGenericPrunedNotice(tokens: number): string {
 	return `[Output truncated - ${tokens} tokens]`;
+}
+
+function firstTextContent(message: ToolResultMessage): string {
+	if (typeof message.content === "string") return message.content;
+	const block = message.content.find(part => part.type === "text");
+	return block?.type === "text" ? block.text : "";
+}
+
+function firstErrorLine(text: string): string | undefined {
+	return text
+		.split(/\r?\n/)
+		.find(line => /error|failed|exception|panic/i.test(line))
+		?.trim();
+}
+
+function truncateField(value: string, maxLength: number): string {
+	if (value.length <= maxLength) return value;
+	if (maxLength <= 1) return "…";
+	return `${value.slice(0, maxLength - 1)}…`;
+}
+
+function resultDigest(message: ToolResultMessage): string | undefined {
+	const toolName = message.toolName.toLowerCase();
+	const text = firstTextContent(message);
+	if (toolName === "bash") {
+		const details = message as { details?: { exitCode?: unknown } };
+		const exitCode =
+			typeof details.details?.exitCode === "number" ? details.details.exitCode : message.isError ? 1 : 0;
+		const tail = text.trim().split(/\r?\n/).filter(Boolean).at(-1) ?? "";
+		const error = firstErrorLine(text);
+		return [`exit=${exitCode}`, tail ? `tail=${tail}` : undefined, error ? `error=${error}` : undefined]
+			.filter((part): part is string => part !== undefined)
+			.join("; ");
+	}
+	if (toolName === "search" || toolName === "grep") {
+		const match = text.match(/(\d+)\s+matches?/i) ?? text.match(/totalMatches["']?:\s*(\d+)/i);
+		const files = text.match(/(\d+)\s+files?/i) ?? text.match(/filesWithMatches["']?:\s*(\d+)/i);
+		const error = firstErrorLine(text);
+		return (
+			[
+				match ? `matches=${match[1]}` : undefined,
+				files ? `files=${files[1]}` : undefined,
+				error ? `error=${error}` : undefined,
+			]
+				.filter((part): part is string => part !== undefined)
+				.join("; ") || "search digest unavailable"
+		);
+	}
+	return undefined;
+}
+
+function createPrunedNotice(tokens: number, message?: ToolResultMessage): string {
+	const generic = createGenericPrunedNotice(tokens);
+	const digest = message ? resultDigest(message) : undefined;
+	if (!digest) return generic;
+	const genericTokens = Math.ceil(generic.length / 4);
+	const maxTokens = Math.max(genericTokens, Math.floor(genericTokens * DIGEST_NOTICE_TOKEN_CAP_MULTIPLIER));
+	const prefix = `[Output truncated - ${tokens} tokens; `;
+	const suffix = "]";
+	const maxChars = Math.max(0, maxTokens * 4 - prefix.length - suffix.length);
+	return `${prefix}${truncateField(digest, maxChars)}${suffix}`;
 }
 
 function getToolResultMessage(entry: SessionEntry): ToolResultMessage | undefined {
@@ -58,8 +121,8 @@ function getToolResultMessage(entry: SessionEntry): ToolResultMessage | undefine
 	return message as ToolResultMessage;
 }
 
-function estimatePrunedSavings(tokens: number): number {
-	const noticeTokens = Math.ceil(createPrunedNotice(tokens).length / 4);
+function estimatePrunedSavings(tokens: number, notice: string): number {
+	const noticeTokens = Math.ceil(notice.length / 4);
 	return Math.max(0, tokens - noticeTokens);
 }
 
@@ -306,14 +369,14 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 
 	const { staleResultIndices } = buildStalenessIndex(entries);
 	const staleOverridable = new Set(config.staleOverridableTools ?? []);
-	const candidates: Array<{ entry: SessionMessageEntry; tokens: number }> = [];
+	const candidates: Array<{ entry: SessionMessageEntry; tokens: number; notice: string; savings: number }> = [];
 
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
 		const message = getToolResultMessage(entry);
 		if (!message) continue;
 
-		const tokens = estimateTokens(message as AgentMessage);
+		const tokens = estimateEntryTokens(entry);
 		const isStale = staleResultIndices.has(i);
 		// Staleness waives protected-tool immunity for overridable tools
 		// (e.g. a superseded `read`); the most recent result per target is
@@ -336,12 +399,18 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 			continue;
 		}
 
-		candidates.push({ entry: entry as SessionMessageEntry, tokens });
+		const notice = createPrunedNotice(tokens, message);
+		candidates.push({
+			entry: entry as SessionMessageEntry,
+			tokens,
+			notice,
+			savings: estimatePrunedSavings(tokens, notice),
+		});
 		accumulatedTokens += tokens;
 	}
 
 	for (const candidate of candidates) {
-		tokensSaved += estimatePrunedSavings(candidate.tokens);
+		tokensSaved += candidate.savings;
 	}
 
 	if (tokensSaved < config.minimumSavings || candidates.length === 0) {
@@ -352,7 +421,7 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 	const prunedEntries: SessionMessageEntry[] = [];
 	for (const candidate of candidates) {
 		const message = candidate.entry.message as ToolResultMessage;
-		message.content = [{ type: "text", text: createPrunedNotice(candidate.tokens) }];
+		message.content = [{ type: "text", text: candidate.notice }];
 		message.prunedAt = prunedAt;
 		prunedEntries.push(candidate.entry);
 		prunedCount++;

--- a/packages/agent/test/compaction-estimate-cache.test.ts
+++ b/packages/agent/test/compaction-estimate-cache.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, test } from "bun:test";
+import {
+	estimateEntriesTokens,
+	estimateEntryTokens,
+	estimateTokens,
+	findCutPoint,
+} from "@gajae-code/agent-core/compaction/compaction";
+import type { SessionEntry, SessionMessageEntry } from "@gajae-code/agent-core/compaction/entries";
+import { estimateOpenAiCompactInputTokens, trimOpenAiCompactInput } from "@gajae-code/agent-core/compaction/openai";
+import { type PruneConfig, pruneToolOutputs } from "@gajae-code/agent-core/compaction/pruning";
+import type { AssistantMessage, Message, ToolResultMessage } from "@gajae-code/ai/types";
+
+const timestamp = "2026-06-12T00:00:00.000Z";
+
+function toolEntry(id: string, toolName: string, text: string, details?: unknown): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId: null,
+		timestamp,
+		message: {
+			role: "toolResult",
+			toolCallId: `call-${id}`,
+			toolName,
+			content: [{ type: "text", text }],
+			isError: false,
+			timestamp: Date.parse(timestamp),
+			...(details === undefined ? {} : { details }),
+		} as ToolResultMessage,
+	};
+}
+
+function textForTokens(label: string, repetitions: number): string {
+	return Array.from({ length: repetitions }, (_, index) => `${label}-${index} alpha beta gamma delta epsilon`).join(
+		"\n",
+	);
+}
+
+function textOf(entry: SessionMessageEntry): string {
+	const content = (entry.message as ToolResultMessage).content;
+	return Array.isArray(content) && content[0]?.type === "text" ? content[0].text : "";
+}
+
+function config(overrides: Partial<PruneConfig> = {}): PruneConfig {
+	return {
+		protectTokens: 0,
+		minimumSavings: 0,
+		protectedTools: ["skill", "read"],
+		staleOverridableTools: ["read"],
+		...overrides,
+	};
+}
+
+describe("entry token cache", () => {
+	test("range estimates and cut point remain token-identical, and prune mutation invalidates cache by fingerprint", () => {
+		const old = toolEntry("old", "bash", textForTokens("old", 120));
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "user",
+				parentId: null,
+				timestamp,
+				message: { role: "user", content: "hello", timestamp: Date.parse(timestamp) },
+			},
+			old,
+			{
+				type: "message",
+				id: "assistant",
+				parentId: null,
+				timestamp,
+				message: {
+					role: "assistant",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-test",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.parse(timestamp),
+					content: [{ type: "text", text: "answer" }],
+				} as Message,
+			},
+		];
+		const beforeEntryTokens = estimateEntryTokens(old);
+		const beforeTotal = estimateEntriesTokens(entries, 0, entries.length);
+		expect(beforeTotal).toBe(estimateEntriesTokens(entries, 0, entries.length));
+		expect(findCutPoint(entries, 0, entries.length, 1).firstKeptEntryIndex).toBeGreaterThanOrEqual(0);
+
+		const result = pruneToolOutputs(entries, config({ minimumSavings: 0 }));
+		expect(result.prunedEntries.map(entry => entry.id)).toContain("old");
+		const afterEntryTokens = estimateEntryTokens(old);
+		expect(afterEntryTokens).toBe(estimateEntryTokens(old));
+		expect(afterEntryTokens).toBeLessThan(beforeEntryTokens);
+		expect(estimateEntriesTokens(entries, 0, entries.length)).toBeLessThan(beforeTotal);
+	});
+
+	test("assistant tool-call argument insertion order invalidates the exact estimator-fragment fingerprint", () => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.1",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.parse(timestamp),
+			content: [
+				{
+					type: "toolCall",
+					id: "call-order",
+					name: "read",
+					arguments: { a: 1, long_descriptive_property_name_with_many_tokens: "value with several words" },
+				},
+			],
+		};
+		const entry: SessionMessageEntry = { type: "message", id: "assistant-order", parentId: null, timestamp, message };
+		const first = estimateEntryTokens(entry);
+		const firstFresh = estimateTokens(message);
+		expect(first).toBe(firstFresh);
+
+		message.content[0] = {
+			type: "toolCall",
+			id: "call-order",
+			name: "read",
+			arguments: { long_descriptive_property_name_with_many_tokens: "value with several words", a: 1 },
+		};
+		const secondFresh = estimateTokens(message);
+		expect(JSON.stringify(message.content[0].arguments)).not.toBe(
+			JSON.stringify({ a: 1, long_descriptive_property_name_with_many_tokens: "value with several words" }),
+		);
+		expect(JSON.stringify(message.content[0].arguments).length).toBe(
+			JSON.stringify({ a: 1, long_descriptive_property_name_with_many_tokens: "value with several words" }).length,
+		);
+		expect(secondFresh).toBeGreaterThan(0);
+		expect(estimateEntryTokens(entry)).toBe(secondFresh);
+	});
+
+	test("entry token fingerprint preserves fragment boundaries and separators", () => {
+		const entry: SessionMessageEntry = {
+			type: "message",
+			id: "boundary",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "user",
+				content: [
+					{ type: "text", text: "ab" },
+					{ type: "text", text: "c" },
+				],
+				timestamp: Date.parse(timestamp),
+			} as Message,
+		};
+		const first = estimateEntryTokens(entry);
+		expect(first).toBe(estimateTokens(entry.message));
+
+		entry.message = {
+			role: "user",
+			content: [
+				{ type: "text", text: "a" },
+				{ type: "text", text: "bc" },
+			],
+			timestamp: Date.parse(timestamp),
+		} as Message;
+		expect(estimateEntryTokens(entry)).toBe(estimateTokens(entry.message));
+
+		entry.message = {
+			role: "user",
+			content: [
+				{ type: "text", text: "a\u001fb" },
+				{ type: "text", text: "c" },
+			],
+			timestamp: Date.parse(timestamp),
+		} as Message;
+		expect(estimateEntryTokens(entry)).toBe(estimateTokens(entry.message));
+
+		entry.message = {
+			role: "user",
+			content: [
+				{ type: "text", text: "a" },
+				{ type: "text", text: "b\u001fc" },
+			],
+			timestamp: Date.parse(timestamp),
+		} as Message;
+		expect(estimateEntryTokens(entry)).toBe(estimateTokens(entry.message));
+	});
+
+	test("entry token cache remains exactly equal to fresh estimateTokens for every counted role", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "user text", timestamp: Date.parse(timestamp) },
+			{ role: "developer", content: "developer custom text", timestamp: Date.parse(timestamp) } as Message,
+			{
+				role: "assistant",
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-5.1",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: Date.parse(timestamp),
+				content: [
+					{ type: "text", text: "assistant text" },
+					{ type: "thinking", thinking: "private thinking" },
+					{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "echo hello" } },
+				],
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "screenshot",
+				content: [
+					{ type: "text", text: "tool output" },
+					{ type: "image", data: "abc", mimeType: "image/png" },
+				],
+				isError: false,
+				timestamp: Date.parse(timestamp),
+			},
+		];
+		const entries: SessionEntry[] = [
+			...messages.map(
+				(message, index): SessionMessageEntry => ({
+					type: "message",
+					id: `msg-${index}`,
+					parentId: null,
+					timestamp,
+					message,
+				}),
+			),
+			{
+				type: "custom_message",
+				id: "custom",
+				parentId: null,
+				timestamp,
+				customType: "note",
+				display: false,
+				content: "custom message text",
+			},
+			{
+				type: "message",
+				id: "bash",
+				parentId: null,
+				timestamp,
+				message: { role: "bashExecution", command: "bun test", output: "ok output" } as unknown as Message,
+			},
+			{
+				type: "message",
+				id: "branch",
+				parentId: null,
+				timestamp,
+				message: {
+					role: "branchSummary",
+					summary: "branch summary text",
+					fromId: "root",
+					timestamp: Date.parse(timestamp),
+				} as unknown as Message,
+			},
+			{
+				type: "message",
+				id: "compaction",
+				parentId: null,
+				timestamp,
+				message: {
+					role: "compactionSummary",
+					summary: "compaction summary text",
+					tokensBefore: 10,
+					timestamp: Date.parse(timestamp),
+				} as unknown as Message,
+			},
+		];
+
+		for (const entry of entries) {
+			if (entry.type !== "message") continue;
+			expect(estimateEntryTokens(entry)).toBe(estimateTokens(entry.message));
+		}
+		expect(estimateEntriesTokens(entries, 0, entries.length)).toBe(
+			entries.reduce((total, entry) => total + estimateEntryTokens(entry), 0),
+		);
+	});
+});
+
+describe("digest pruning notices", () => {
+	test("minimumSavings boundary uses exact digest notice", () => {
+		const old = toolEntry("old", "bash", `${textForTokens("old", 120)}\nError: failed hard\nfinal output tail`, {
+			exitCode: 2,
+		});
+		const thresholdProbe = [
+			toolEntry("old", "bash", `${textForTokens("old", 120)}\nError: failed hard\nfinal output tail`, {
+				exitCode: 2,
+			}),
+		];
+		const threshold = pruneToolOutputs(thresholdProbe, config({ minimumSavings: 0 })).tokensSaved;
+
+		const belowEntries = [
+			toolEntry("old", "bash", `${textForTokens("old", 120)}\nError: failed hard\nfinal output tail`, {
+				exitCode: 2,
+			}),
+		];
+		expect(pruneToolOutputs(belowEntries, config({ minimumSavings: threshold + 1 })).prunedCount).toBe(0);
+
+		const atEntries = [
+			toolEntry("old", "bash", `${textForTokens("old", 120)}\nError: failed hard\nfinal output tail`, {
+				exitCode: 2,
+			}),
+		];
+		const at = pruneToolOutputs(atEntries, config({ minimumSavings: threshold }));
+		expect(at.prunedCount).toBe(1);
+		expect(textOf(atEntries[0])).toContain("exit=");
+		expect(at.tokensSaved).toBe(Math.max(0, estimateEntryTokens(old) - Math.ceil(textOf(atEntries[0]).length / 4)));
+	});
+
+	test("digest notice is capped near generic size and generic already-pruned notices replay stably", () => {
+		const long = toolEntry(
+			"long",
+			"search",
+			`${textForTokens("search", 100)}\n120 matches in 45 files\nError: ${"x".repeat(1000)}`,
+		);
+		pruneToolOutputs([long], config());
+		const notice = textOf(long);
+		const generic = `[Output truncated - ${estimateEntryTokens(toolEntry("fresh", "search", `${textForTokens("search", 100)}\n120 matches in 45 files\nError: ${"x".repeat(1000)}`))} tokens]`;
+		expect(Math.ceil(notice.length / 4)).toBeLessThanOrEqual(Math.floor(Math.ceil(generic.length / 4) * 1.25));
+
+		const already = toolEntry("already", "bash", "[Output truncated - 400 tokens]");
+		(already.message as ToolResultMessage).prunedAt = 123;
+		const replay = pruneToolOutputs([already], config());
+		expect(replay.prunedCount).toBe(0);
+		expect(textOf(already)).toBe("[Output truncated - 400 tokens]");
+	});
+});
+
+describe("OpenAI trim sizing", () => {
+	test("trimOpenAiCompactInput matches full recount across removable scenarios", () => {
+		const instructions = "compact these items";
+		const scenarios: Array<{ name: string; items: Array<Record<string, unknown>>; budget: number }> = [
+			{
+				name: "developer suffix",
+				budget: 48,
+				items: [
+					{ type: "message", role: "user", content: [{ type: "input_text", text: "keep user" }] },
+					{ type: "message", role: "developer", content: [{ type: "input_text", text: "remove developer one" }] },
+					{ type: "message", role: "developer", content: [{ type: "input_text", text: "remove developer two" }] },
+				],
+			},
+			{
+				name: "function call output removes paired call",
+				budget: 55,
+				items: [
+					{ type: "message", role: "user", content: [{ type: "input_text", text: "keep user" }] },
+					{ type: "function_call", call_id: "call-1", name: "read", arguments: "{}" },
+					{ type: "message", role: "assistant", content: [{ type: "output_text", text: "keep assistant" }] },
+					{ type: "function_call_output", call_id: "call-1", output: "large output".repeat(12) },
+				],
+			},
+			{
+				name: "custom tool output removes paired call",
+				budget: 60,
+				items: [
+					{ type: "message", role: "user", content: [{ type: "input_text", text: "keep user" }] },
+					{ type: "custom_tool_call", call_id: "custom-1", name: "bash", input: "echo hi" },
+					{ type: "message", role: "assistant", content: [{ type: "output_text", text: "keep assistant" }] },
+					{ type: "custom_tool_call_output", call_id: "custom-1", output: "custom output".repeat(12) },
+				],
+			},
+		];
+
+		for (const scenario of scenarios) {
+			const itemLengths = scenario.items.map(item => JSON.stringify(item).length);
+			let runningChars = instructions.length;
+			for (const length of itemLengths) runningChars += length;
+			const simulatedItems = [...scenario.items];
+			const simulatedLengths = [...itemLengths];
+			function removeAt(index: number): void {
+				runningChars -= simulatedLengths[index] ?? 0;
+				simulatedItems.splice(index, 1);
+				simulatedLengths.splice(index, 1);
+				expect(runningChars, scenario.name).toBe(
+					instructions.length + simulatedItems.reduce((total, item) => total + JSON.stringify(item).length, 0),
+				);
+			}
+			while (simulatedItems.length > 0 && Math.ceil(runningChars / 4) > scenario.budget) {
+				const last = simulatedItems[simulatedItems.length - 1];
+				if (last?.type === "function_call_output" || last?.type === "custom_tool_call_output") {
+					const callId = typeof last.call_id === "string" ? last.call_id : undefined;
+					const callType = last.type === "custom_tool_call_output" ? "custom_tool_call" : "function_call";
+					removeAt(simulatedItems.length - 1);
+					if (callId) {
+						const matchingCallIndex = simulatedItems.findLastIndex(
+							item => item.type === callType && item.call_id === callId,
+						);
+						if (matchingCallIndex >= 0) removeAt(matchingCallIndex);
+					}
+					continue;
+				}
+				if (
+					!last ||
+					!(last.type === "function_call_output" || (last.type === "message" && last.role === "developer"))
+				)
+					break;
+				removeAt(simulatedItems.length - 1);
+			}
+
+			const trimmed = trimOpenAiCompactInput(scenario.items, scenario.budget, instructions);
+			expect(trimmed, scenario.name).toEqual(simulatedItems);
+			expect(estimateOpenAiCompactInputTokens(trimmed, instructions), scenario.name).toBe(
+				Math.ceil(runningChars / 4),
+			);
+		}
+	});
+});

--- a/packages/agent/test/pruning-redteam.test.ts
+++ b/packages/agent/test/pruning-redteam.test.ts
@@ -55,12 +55,6 @@ function tokens(entry: SessionMessageEntry): number {
 	return estimateTokens(entry.message);
 }
 
-function savingsFor(entry: SessionMessageEntry): number {
-	const tokenCount = tokens(entry);
-	const noticeTokens = Math.ceil(`[Output truncated - ${tokenCount} tokens]`.length / 4);
-	return Math.max(0, tokenCount - noticeTokens);
-}
-
 function config(overrides: Partial<PruneConfig> = {}): PruneConfig {
 	return {
 		protectTokens: 0,
@@ -74,7 +68,8 @@ describe("pruneToolOutputs red-team boundaries", () => {
 	test("minimumSavings boundary is strict below and inclusive at the threshold", () => {
 		const recent = toolEntry("recent", "bash", "recent guard text");
 		const old = toolEntry("old", "bash", textForTokens("old-boundary", 80));
-		const threshold = savingsFor(old);
+		const thresholdProbe = toolEntry("old", "bash", textForTokens("old-boundary", 80));
+		const threshold = pruneToolOutputs([thresholdProbe], config({ minimumSavings: 0 })).tokensSaved;
 
 		const belowEntries = [
 			toolEntry("old", "bash", textForTokens("old-boundary", 80)),
@@ -97,7 +92,7 @@ describe("pruneToolOutputs red-team boundaries", () => {
 		expect(at.prunedCount).toBe(1);
 		expect(at.tokensSaved).toBe(threshold);
 		expect(at.prunedEntries.map(entry => entry.id)).toEqual(["old"]);
-		expect(textOf(atEntries[0] as SessionMessageEntry)).toBe(`[Output truncated - ${tokens(old)} tokens]`);
+		expect(textOf(atEntries[0] as SessionMessageEntry)).toStartWith(`[Output truncated - ${tokens(old)} tokens`);
 	});
 
 	test("protect window accumulates newest-first and never prunes newest protected toolResults", () => {
@@ -163,7 +158,7 @@ describe("pruneToolOutputs red-team boundaries", () => {
 		expect(result.prunedEntries).toEqual([pruneB, pruneA]);
 		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["prune-b", "prune-a"]);
 		for (const entry of result.prunedEntries) {
-			expect(textOf(entry)).toBe(`[Output truncated - ${originalTokens.get(entry.id)} tokens]`);
+			expect(textOf(entry)).toStartWith(`[Output truncated - ${originalTokens.get(entry.id)} tokens`);
 			expect(typeof (entry.message as ToolResultMessage).prunedAt).toBe("number");
 		}
 		expect(result.prunedEntries.every(entry => textOf(entry).startsWith("[Output truncated - "))).toBe(true);
@@ -187,7 +182,7 @@ describe("pruneToolOutputs red-team boundaries", () => {
 
 		expect(result.prunedEntries.map(entry => entry.id)).toEqual(["dup-b", "dup-a", "empty"]);
 		expect(result.prunedCount).toBe(3);
-		expect(textOf(empty)).toBe("[Output truncated - 0 tokens]");
+		expect(textOf(empty)).toStartWith("[Output truncated - 0 tokens");
 		expect(textOf(duplicateA)).toStartWith("[Output truncated - ");
 		expect(textOf(duplicateB)).toStartWith("[Output truncated - ");
 	});


### PR DESCRIPTION
## Summary

Lane 2 (context cost) of the consensus-approved **Optimization Suite v3** (ralplan run `2026-06-12-0812-aec3`; plan at `.gjc/plans/ralplan/2026-06-12-0812-aec3/pending-approval.md`). Companion to #548 (Lane 1, RSS).

Compaction/pruning token estimation becomes O(changed entries) on warm paths, pruned bash/search results keep one line of signal instead of a bare notice, and the OpenAI compact trim loop drops from O(n²) to O(n). Token totals are **exactly equal** to fresh estimates everywhere — the digest notice is the single intentional behavior change.

### Changes

- **Per-entry token cache** (`compaction.ts`): `estimateEntryTokens` — WeakMap cache keyed by a boundary-lossless, length-prefixed fingerprint of the *exact estimator fragments* (no separate role-walk; fingerprint and count derive from one `collectMessageFragments` pass). Shared by `estimateEntriesTokens`, the `findCutPoint` reverse walk, and pruning candidate scoring. Never stale after prune mutation (fingerprint covers content, prunedAt, notice text); collision-safe against shifted fragment boundaries and delimiter-bearing text (adversarial tests).
- **Prune-to-digest** (`pruning.ts`): bash/search/grep pruned results get a one-line digest — exit code, match/file count, first error line — capped at 1.25× the generic notice token cost. Savings computed from the exact notice string used at mutation (hysteresis stays honest); generic/read notices unchanged; already-pruned replay idempotent; `minimumSavings` boundary tests at −1/exact/cap.
- **O(n) OpenAI trim** (`openai.ts`): `trimOpenAiCompactInput` previously re-sized the whole input array per removed item; now per-item `JSON.stringify(item).length` once + running char sum (paired `function_call` removal accounted). Equivalence fuzz: 200 random fixtures × 6 budgets — identical trimmed sets and final estimates vs full recount.
- **Bench**: `packages/agent/bench/compaction-estimate.ts` (package-local schema, 20 warmup/200 measured, `--out`/`--baseline` deltas).

### Bench evidence (vs origin/dev @ 774b1372 baseline, same harness both sides, Apple M5, Bun 1.3.14)

| Metric | Δ median | Δ p95 | Gate |
|---|---|---|---|
| repeated 10k-entry estimate | −96.9% | −97.2% | ≥−60% ✅ |
| findCutPoint (10k) | −95.5% | −97.3% | — ✅ |
| cold full pass | −2…−6% | −94% | <10% regression ✅ |
| trimScenario (5k items → 1k-char budget) | −99.95% | −99.87% | ≥−40% ✅ |
| openAiSizing (native stringify both sides) | −12…−19% | — | exact parity ✅ |

Note on 2.3: a custom JSON length counter was implemented, made stringify-exact under review, and then **deleted** — native `JSON.stringify().length` is faster than any exact JS reimplementation. The plan-preferred "reuse serialized payload lengths" option is realized by the O(n) trim running-sum, which is the product-visible win.

### Verification

- 261 `packages/agent` tests green; `bun run check` green (biome, tsgo all workspaces, schemas, gates)
- `scripts/verify-g002-gates.ts` passes
- Architect review: 3 passes (BLOCK×3 → BLOCK×3 → **CLEAR/CLEAR/CLEAR APPROVE**, stage-05); blockers fixed: fingerprint-mirrors-estimator-input, non-exact fast path deleted, 20-sample trim bench, collision-free fingerprint encoding
- QA red-team: initial 6/6 cases + final focused 4/4 (trim equivalence fuzz, fingerprint boundary adversarial, staleness re-sweep, findCutPoint equivalence)

Ultragoal ledger: `.gjc/ultragoal/ledger.jsonl` (story G002).
