### PR TITLE
Warn on subagent model substitutions

### DIFF
--- a/packages/agent/src/compaction/entries.ts
+++ b/packages/agent/src/compaction/entries.ts
@@ -24,6 +24,12 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	model: string;
 	/** Role: "default", "smol", "slow", etc. Undefined treated as "default" */
 	role?: string;
+	/** Requested model before a runtime substitution/fallback, in "provider/modelId" format. */
+	previousModel?: string;
+	/** Machine-readable reason for runtime model substitution/fallback. */
+	reason?: string;
+	/** Effective thinking level when the change was recorded. */
+	thinkingLevel?: string | null;
 }
 
 export interface ServiceTierChangeEntry extends SessionEntryBase {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -776,30 +776,33 @@ export async function resolveModelOverrideWithAuthFallback(
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
 	authFallbackUsed: boolean;
+	requestedModel?: Model<Api>;
+	fallbackReason?: "auth_unavailable";
 }> {
 	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings);
+	const unchanged = { ...primary, requestedModel: primary.model, authFallbackUsed: false };
 	if (!primary.model || !parentActiveModelPattern) {
-		return { ...primary, authFallbackUsed: false };
+		return unchanged;
 	}
 
 	const primaryKey = await modelRegistry.getApiKey(primary.model, sessionId);
 	if (primaryKey === kNoAuth || isAuthenticated(primaryKey)) {
-		return { ...primary, authFallbackUsed: false };
+		return unchanged;
 	}
 
 	const fallback = resolveModelOverride([parentActiveModelPattern], modelRegistry, settings);
 	if (!fallback.model) {
-		return { ...primary, authFallbackUsed: false };
+		return unchanged;
 	}
 	if (modelsAreEqual(fallback.model, primary.model)) {
-		return { ...primary, authFallbackUsed: false };
+		return unchanged;
 	}
 	const fallbackKey = await modelRegistry.getApiKey(fallback.model, sessionId);
 	if (!isAuthenticated(fallbackKey)) {
-		return { ...primary, authFallbackUsed: false };
+		return unchanged;
 	}
 
-	return { ...fallback, authFallbackUsed: true };
+	return { ...fallback, requestedModel: primary.model, authFallbackUsed: true, fallbackReason: "auth_unavailable" };
 }
 
 /**

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -234,6 +234,8 @@ export interface CreateAgentSessionOptions {
 	modelPattern?: string;
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ThinkingLevel;
+	/** Runtime substitution metadata for the initial model_change session event. */
+	modelSubstitution?: { requestedModel: Model; reason: string };
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: ScopedModelSelection[];
 
@@ -1912,7 +1914,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		} else {
 			// Save initial model, thinking level, and service tier for new sessions so they can be restored on resume.
 			if (model) {
-				sessionManager.appendModelChange(`${model.provider}/${model.id}`);
+				const substitution = options.modelSubstitution;
+				sessionManager.appendModelChange(
+					`${model.provider}/${model.id}`,
+					undefined,
+					substitution
+						? {
+								previousModel: `${substitution.requestedModel.provider}/${substitution.requestedModel.id}`,
+								reason: substitution.reason,
+								thinkingLevel: thinkingLevel ?? null,
+							}
+						: undefined,
+				);
 			}
 			sessionManager.appendThinkingLevelChange(thinkingLevel);
 			if (initialServiceTier) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -107,6 +107,12 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	model: string;
 	/** Role: "default" or an agent role. Undefined treated as "default" */
 	role?: string;
+	/** Requested model before a runtime substitution/fallback, in "provider/modelId" format. */
+	previousModel?: string;
+	/** Machine-readable reason for runtime model substitution/fallback. */
+	reason?: string;
+	/** Effective thinking level when the change was recorded. */
+	thinkingLevel?: string | null;
 }
 
 export interface ServiceTierChangeEntry extends SessionEntryBase {
@@ -3244,7 +3250,11 @@ export class SessionManager {
 	 * @param model Model in "provider/modelId" format
 	 * @param role Optional role (default: "default")
 	 */
-	appendModelChange(model: string, role?: string): string {
+	appendModelChange(
+		model: string,
+		role?: string,
+		metadata?: { previousModel?: string; reason?: string; thinkingLevel?: string | null },
+	): string {
 		const entry: ModelChangeEntry = {
 			type: "model_change",
 			id: generateId(this.#byId),
@@ -3252,6 +3262,9 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			model,
 			role,
+			previousModel: metadata?.previousModel,
+			reason: metadata?.reason,
+			thinkingLevel: metadata?.thinkingLevel,
 		};
 		this.#appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -13,7 +13,7 @@ import { type JsonSchemaValidationIssue, validateJsonSchemaValue } from "@gajae-
 import { logger, prompt, untilAborted } from "@gajae-code/utils";
 import { AsyncJobManager } from "../async";
 import { ModelRegistry } from "../config/model-registry";
-import { resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
+import { formatModelString, resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
 import type { PromptTemplate } from "../config/prompt-templates";
 import { Settings } from "../config/settings";
 import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
@@ -46,6 +46,7 @@ import {
 	type AgentProgress,
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
+	type ModelSubstitutionWarning,
 	type ReviewFinding,
 	type SingleResult,
 	TASK_SUBAGENT_EVENT_CHANNEL,
@@ -627,6 +628,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let yieldCalled = false;
 	let pauseRequested = false;
 	let paused = false;
+	let modelSubstitutionWarning: ModelSubstitutionWarning | undefined;
+	let resolvedModelString: string | undefined;
+	let lastAssistantModelString: string | undefined;
+	let effectiveThinkingLevelForWarning: ThinkingLevel | undefined;
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
 	const accumulatedUsage = {
@@ -760,6 +765,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			return (message as { usage?: unknown }).usage;
 		}
 		return undefined;
+	};
+
+	const getMessageModelString = (message: unknown): string | undefined => {
+		if (!message || typeof message !== "object") return undefined;
+		const record = message as { provider?: unknown; model?: unknown };
+		return typeof record.provider === "string" && typeof record.model === "string"
+			? `${record.provider}/${record.model}`
+			: undefined;
 	};
 
 	const updateRecentOutputLines = () => {
@@ -964,6 +977,29 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 							}
 						}
 					}
+					const assistantModel = getMessageModelString(event.message);
+					if (assistantModel) {
+						lastAssistantModelString = assistantModel;
+						if (resolvedModelString && assistantModel !== resolvedModelString && !modelSubstitutionWarning) {
+							modelSubstitutionWarning = {
+								requested: resolvedModelString,
+								effective: assistantModel,
+								reason: "assistant_model_mismatch",
+							};
+							progress.modelSubstitutionWarning = modelSubstitutionWarning;
+							activeSession?.sessionManager.appendModelChange(assistantModel, undefined, {
+								previousModel: resolvedModelString,
+								reason: modelSubstitutionWarning.reason,
+								thinkingLevel: effectiveThinkingLevelForWarning ?? null,
+							});
+							logger.warn("Subagent assistant response reported a substituted effective model", {
+								requested: resolvedModelString,
+								effective: assistantModel,
+								agent: agent.name,
+								id,
+							});
+						}
+					}
 				}
 				// Extract and accumulate usage (prefer message.usage, fallback to event.usage)
 				const messageUsage = getMessageUsage(event.message) || (event as AgentEvent & { usage?: unknown }).usage;
@@ -1090,6 +1126,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				thinkingLevel: resolvedThinkingLevel,
 				explicitThinkingLevel,
 				authFallbackUsed,
+				requestedModel,
+				fallbackReason,
 			} = await awaitAbortable(
 				resolveModelOverrideWithAuthFallback(
 					modelPatterns,
@@ -1099,9 +1137,18 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					options.parentSessionId,
 				),
 			);
-			if (authFallbackUsed && model) {
+			if (model) {
+				resolvedModelString = formatModelString(model);
+			}
+			if (authFallbackUsed && model && requestedModel) {
+				modelSubstitutionWarning = {
+					requested: formatModelString(requestedModel),
+					effective: formatModelString(model),
+					reason: fallbackReason ?? "auth_unavailable",
+				};
+				progress.modelSubstitutionWarning = modelSubstitutionWarning;
 				logger.warn("Subagent model has no working credentials; falling back to parent session model", {
-					requested: modelPatterns,
+					requested: modelSubstitutionWarning.requested,
 					parentModel: options.parentActiveModelPattern,
 					resolvedProvider: model.provider,
 					resolvedModel: model.id,
@@ -1113,6 +1160,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const effectiveThinkingLevel = explicitThinkingLevel
 				? resolvedThinkingLevel
 				: (thinkingLevel ?? resolvedThinkingLevel);
+			effectiveThinkingLevelForWarning = effectiveThinkingLevel;
 
 			const sessionManager = sessionFile
 				? await awaitAbortable(SessionManager.open(sessionFile))
@@ -1174,6 +1222,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					settings: subagentSettings,
 					model,
 					thinkingLevel: effectiveThinkingLevel,
+					modelSubstitution:
+						modelSubstitutionWarning?.reason === "auth_unavailable" && requestedModel
+							? { requestedModel, reason: modelSubstitutionWarning.reason }
+							: undefined,
 					toolNames,
 					outputSchema,
 					requireYieldTool: true,
@@ -1466,6 +1518,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					error = undefined;
 				}
 			}
+			if (lastAssistantModelString && resolvedModelString && lastAssistantModelString !== resolvedModelString) {
+				modelSubstitutionWarning ??= {
+					requested: resolvedModelString,
+					effective: lastAssistantModelString,
+					reason: "assistant_model_mismatch",
+				};
+				progress.modelSubstitutionWarning = modelSubstitutionWarning;
+			}
 		} catch (err) {
 			exitCode = 1;
 			if (!abortSignal.aborted) {
@@ -1642,6 +1702,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		contextTokens: progress.contextTokens,
 		contextWindow: progress.contextWindow,
 		modelOverride,
+		modelSubstitutionWarning,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -29,6 +29,7 @@ export interface TaskResultReceipt {
 	contextTokens?: number;
 	contextWindow?: number;
 	modelOverride?: string | string[];
+	modelSubstitutionWarning?: SingleResult["modelSubstitutionWarning"];
 	usage?: SingleResult["usage"];
 	cost?: number;
 	branchName?: string;
@@ -78,6 +79,9 @@ function truncateText(value: string | undefined, maxChars: number): string | und
 
 function buildSafeSynopsis(raw: SingleResult, outputRef: TaskResultReceipt["outputRef"]): string {
 	const status = getStatus(raw);
+	if (raw.modelSubstitutionWarning) {
+		return `Task ${status}; requested model substituted from ${raw.modelSubstitutionWarning.requested} to ${raw.modelSubstitutionWarning.effective}.`;
+	}
 	if (raw.retryFailure) {
 		return `Task ${status}; retry stopped after attempt ${raw.retryFailure.attempt}.`;
 	}
@@ -220,6 +224,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		contextTokens: raw.contextTokens,
 		contextWindow: raw.contextWindow,
 		modelOverride: raw.modelOverride,
+		modelSubstitutionWarning: raw.modelSubstitutionWarning,
 		usage: raw.usage,
 		cost: raw.usage?.cost.total,
 		branchName: raw.branchName,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -119,6 +119,10 @@ function normalizeReportFindings(value: unknown): ReportFindingDetails[] {
 	return findings;
 }
 
+function formatModelSubstitutionWarning(warning: { requested: string; effective: string }): string {
+	return `Requested model substituted: ${warning.requested} -> ${warning.effective}`;
+}
+
 function formatJsonScalar(value: unknown, _theme: Theme): string {
 	if (value === null) return "null";
 	if (typeof value === "string") {
@@ -566,6 +570,14 @@ function renderAgentProgress(
 	lines.push(statusLine);
 
 	lines.push(...renderTaskSection(progress.assignment ?? progress.task, continuePrefix, expanded, theme));
+	if (progress.modelSubstitutionWarning) {
+		lines.push(
+			`${continuePrefix}${theme.fg(
+				"warning",
+				truncateToWidth(replaceTabs(formatModelSubstitutionWarning(progress.modelSubstitutionWarning)), 90),
+			)}`,
+		);
+	}
 
 	// Current tool (if running) or most recent completed tool
 	if (progress.status === "running") {
@@ -862,8 +874,16 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 				}
 			}
 		}
-	} else {
+	} else if (!result.modelSubstitutionWarning) {
 		lines.push(...renderOutputSection(result.preview, continuePrefix, expanded, theme, 3, 12));
+	}
+	if (result.modelSubstitutionWarning) {
+		lines.push(
+			`${continuePrefix}${theme.fg(
+				"warning",
+				truncateToWidth(replaceTabs(formatModelSubstitutionWarning(result.modelSubstitutionWarning)), 90),
+			)}`,
+		);
 	}
 	if (result.roi?.lowRoi) {
 		lines.push(`${continuePrefix}${theme.fg("warning", "low ROI: produced no material contribution")}`);

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -215,6 +215,12 @@ export interface AgentDefinition {
 	filePath?: string;
 }
 
+export interface ModelSubstitutionWarning {
+	requested: string;
+	effective: string;
+	reason: "auth_unavailable" | "assistant_model_mismatch";
+}
+
 /** Progress tracking for a single agent */
 export interface AgentProgress {
 	index: number;
@@ -247,6 +253,7 @@ export interface AgentProgress {
 	cost: number;
 	durationMs: number;
 	modelOverride?: string | string[];
+	modelSubstitutionWarning?: ModelSubstitutionWarning;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -306,6 +313,7 @@ export interface SingleResult {
 	/** Model's context window in tokens, when known. */
 	contextWindow?: number;
 	modelOverride?: string | string[];
+	modelSubstitutionWarning?: ModelSubstitutionWarning;
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;

--- a/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
@@ -90,6 +90,9 @@ describe("issue #985: subagent dispatch auth fallback", () => {
 		expect(result.authFallbackUsed).toBe(true);
 		expect(result.model?.provider).toBe("deepseek");
 		expect(result.model?.id).toBe("deepseek-v4-pro");
+		expect(result.requestedModel?.provider).toBe("opencode-zen");
+		expect(result.requestedModel?.id).toBe("qwen3.6-plus-free");
+		expect(result.fallbackReason).toBe("auth_unavailable");
 	});
 
 	test("does not fall back when resolved subagent model has working auth", async () => {
@@ -107,6 +110,9 @@ describe("issue #985: subagent dispatch auth fallback", () => {
 		expect(result.authFallbackUsed).toBe(false);
 		expect(result.model?.provider).toBe("opencode-zen");
 		expect(result.model?.id).toBe("qwen3.6-plus-free");
+		expect(result.requestedModel?.provider).toBe("opencode-zen");
+		expect(result.requestedModel?.id).toBe("qwen3.6-plus-free");
+		expect(result.fallbackReason).toBeUndefined();
 	});
 
 	test("returns primary unchanged when parent active model also has no auth", async () => {

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getBundledModel } from "@gajae-code/ai";
+import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { createAgentSession, type ExtensionFactory } from "@gajae-code/coding-agent/sdk";
@@ -146,6 +146,62 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		} finally {
 			getApiKeySpy.mockRestore();
 			authStorage.close();
+		}
+	});
+
+	test("persists model substitution metadata on new session model_change", async () => {
+		const effectiveModel: Model = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			thinking: { minLevel: Effort.Minimal, maxLevel: Effort.XHigh, mode: "effort" },
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 8192,
+		};
+		const requestedModel: Model = {
+			...effectiveModel,
+			id: "gpt-5.3-codex",
+			name: "GPT-5.3 Codex",
+			contextWindow: 272000,
+		};
+		const sessionManager = SessionManager.inMemory(tempDir);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			model: effectiveModel,
+			thinkingLevel: Effort.High,
+			modelSubstitution: { requestedModel, reason: "auth_unavailable" },
+			sessionManager,
+			disableExtensionDiscovery: true,
+			skills: [],
+			rules: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			workspaceTree: { rootPath: tempDir, rendered: "", truncated: false, totalLines: 0, agentsMdFiles: [] },
+			toolNames: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const modelChanges = sessionManager.getEntries().filter(entry => entry.type === "model_change");
+			expect(modelChanges).toHaveLength(1);
+			expect(modelChanges[0]).toMatchObject({
+				type: "model_change",
+				model: "openai-codex/gpt-5.5",
+				previousModel: "openai-codex/gpt-5.3-codex",
+				reason: "auth_unavailable",
+				thinkingLevel: Effort.High,
+			});
+		} finally {
+			await session.dispose();
 		}
 	});
 });

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -411,6 +411,151 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.thinkingLevel).toBe(cases[0].expectedThinkingLevel);
 		expect(createAgentSessionSpy.mock.calls[1]?.[0]?.thinkingLevel).toBe(cases[1].expectedThinkingLevel);
 	});
+	it("surfaces auth fallback model substitution and annotates session model_change", async () => {
+		vi.clearAllMocks();
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-auth-fallback",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const sessionModelChanges: Array<{
+			model: string;
+			role?: string;
+			metadata?: { previousModel?: string; reason?: string; thinkingLevel?: string | null };
+		}> = [];
+		(
+			session as unknown as {
+				sessionManager: {
+					appendSessionInit: () => void;
+					appendModelChange: (
+						model: string,
+						role?: string,
+						metadata?: { previousModel?: string; reason?: string; thinkingLevel?: string | null },
+					) => string;
+				};
+			}
+		).sessionManager = {
+			appendSessionInit: () => {},
+			appendModelChange: (model, role, metadata) => {
+				sessionModelChanges.push({ model, role, metadata });
+				return "model-change-id";
+			},
+		};
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+		const modelRegistry = {
+			refresh: async () => {},
+			getAvailable: () => [
+				{ provider: "openai-codex", id: "gpt-5.3-codex", name: "GPT-5.3 Codex", contextWindow: 272000 },
+				{ provider: "openai-codex", id: "gpt-5.5", name: "GPT-5.5", contextWindow: 400000 },
+			],
+			getApiKey: async (model: { id: string }) => (model.id === "gpt-5.5" ? "sk-test" : undefined),
+		} as unknown as import("../../src/config/model-registry").ModelRegistry;
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-auth-fallback-warning",
+			modelOverride: "openai-codex/gpt-5.3-codex:high",
+			parentActiveModelPattern: "openai-codex/gpt-5.5",
+			modelRegistry,
+		});
+
+		expect(result.modelSubstitutionWarning).toEqual({
+			requested: "openai-codex/gpt-5.3-codex",
+			effective: "openai-codex/gpt-5.5",
+			reason: "auth_unavailable",
+		});
+		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.model?.id).toBe("gpt-5.5");
+		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.modelSubstitution).toMatchObject({
+			reason: "auth_unavailable",
+			requestedModel: { provider: "openai-codex", id: "gpt-5.3-codex" },
+		});
+		expect(sessionModelChanges).toEqual([]);
+	});
+
+	it("surfaces server-side assistant model substitution evidence", async () => {
+		vi.clearAllMocks();
+		const sessionModelChanges: Array<{
+			model: string;
+			role?: string;
+			metadata?: { previousModel?: string; reason?: string; thinkingLevel?: string | null };
+		}> = [];
+		const session = createMockSession(({ emit, state }) => {
+			const assistant: AssistantMessage = {
+				...createAssistantStopMessage("done"),
+				provider: "openai-codex",
+				model: "gpt-5.5",
+			};
+			state.messages.push(assistant);
+			emit({ type: "message_end", message: assistant });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-server-substitution",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		(
+			session as unknown as {
+				sessionManager: {
+					appendSessionInit: () => void;
+					appendModelChange: (
+						model: string,
+						role?: string,
+						metadata?: { previousModel?: string; reason?: string; thinkingLevel?: string | null },
+					) => string;
+				};
+			}
+		).sessionManager = {
+			appendSessionInit: () => {},
+			appendModelChange: (model, role, metadata) => {
+				sessionModelChanges.push({ model, role, metadata });
+				return "model-change-id";
+			},
+		};
+		mockCreateAgentSession(session);
+		const modelRegistry = {
+			refresh: async () => {},
+			getAvailable: () => [
+				{ provider: "openai-codex", id: "gpt-5.3-codex", name: "GPT-5.3 Codex", contextWindow: 272000 },
+			],
+			getApiKey: async () => "sk-test",
+		} as unknown as import("../../src/config/model-registry").ModelRegistry;
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-server-substitution-warning",
+			modelOverride: "openai-codex/gpt-5.3-codex:high",
+			modelRegistry,
+		});
+
+		expect(result.modelSubstitutionWarning).toEqual({
+			requested: "openai-codex/gpt-5.3-codex",
+			effective: "openai-codex/gpt-5.5",
+			reason: "assistant_model_mismatch",
+		});
+		expect(sessionModelChanges).toEqual([
+			{
+				model: "openai-codex/gpt-5.5",
+				role: undefined,
+				metadata: {
+					previousModel: "openai-codex/gpt-5.3-codex",
+					reason: "assistant_model_mismatch",
+					thinkingLevel: Effort.High,
+				},
+			},
+		]);
+	});
 	it("fails after 3 reminders when yield is never called for a structured task", async () => {
 		const prompts: string[] = [];
 		const session = createMockSession(({ text, promptIndex, emit, state }) => {

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -110,6 +110,29 @@ describe("task result receipts", () => {
 		expect(receipt.outputUnavailable).toBe(true);
 	});
 
+	it("surfaces model substitution warnings without raw output", () => {
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				modelOverride: "openai-codex/gpt-5.3-codex:high",
+				modelSubstitutionWarning: {
+					requested: "openai-codex/gpt-5.3-codex",
+					effective: "openai-codex/gpt-5.5",
+					reason: "auth_unavailable",
+				},
+			}),
+		);
+
+		expect(receipt.modelSubstitutionWarning).toEqual({
+			requested: "openai-codex/gpt-5.3-codex",
+			effective: "openai-codex/gpt-5.5",
+			reason: "auth_unavailable",
+		});
+		expect(receipt.preview).toBe(
+			"Task completed; requested model substituted from openai-codex/gpt-5.3-codex to openai-codex/gpt-5.5.",
+		);
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
 	it("detects raw leak keys and allows sanitized receipt details without sentinel", () => {
 		const leaky = {
 			results: [

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -90,6 +90,21 @@ describe("task renderer: nested live rendering", () => {
 		return Bun.stripANSI(component.render(160).join("\n"));
 	}
 
+	async function renderResult(result: TaskResultReceipt): Promise<string> {
+		const theme = (await getThemeByName("red-claw"))!;
+		const details: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [result],
+			totalDurationMs: result.durationMs,
+		};
+		const component = taskToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "Task complete" }], details },
+			{ expanded: false, isPartial: false, spinnerFrame: 0 },
+			theme,
+		);
+		return Bun.stripANSI(component.render(160).join("\n"));
+	}
+
 	it("renders completed nested task results stored in extractedToolData.task while parent is in-progress", async () => {
 		const parent = makeRunningProgress({
 			id: "1-Parent",
@@ -144,6 +159,36 @@ describe("task renderer: nested live rendering", () => {
 		expect(text).toContain("Delta child running");
 		expect(text).toContain("2.0 Parent>GammaSub");
 		expect(text).toContain("2.1 Parent>DeltaSub");
+	});
+
+	it("renders requested model substitution in live progress", async () => {
+		const text = await render(
+			makeRunningProgress({
+				id: "2-ModelSub",
+				modelSubstitutionWarning: {
+					requested: "openai-codex/gpt-5.3-codex",
+					effective: "openai-codex/gpt-5.5",
+					reason: "auth_unavailable",
+				},
+			}),
+		);
+
+		expect(text).toContain("Requested model substituted: openai-codex/gpt-5.3-codex -> openai-codex/gpt-5.5");
+		expect(text).not.toContain("Model override substituted");
+	});
+
+	it("renders requested model substitution in final results", async () => {
+		const text = await renderResult({
+			...makeCompletedSubResult("4-ModelSub", "Model substituted child"),
+			modelSubstitutionWarning: {
+				requested: "openai-codex/gpt-5.3-codex",
+				effective: "openai-codex/gpt-5.5",
+				reason: "assistant_model_mismatch",
+			},
+		});
+
+		expect(text).toContain("Requested model substituted: openai-codex/gpt-5.3-codex -> openai-codex/gpt-5.5");
+		expect(text).not.toContain("Model override substituted");
 	});
 
 	it("combines completed and in-flight nested snapshots in one tree", async () => {


### PR DESCRIPTION
Fixes #543.

## Summary
- record requested/effective model substitution metadata on session model changes
- surface subagent model substitution warnings in progress, receipts, and rendered results
- preserve auth fallback requested-model evidence from resolver through executor results

## Verification
- bun test packages/coding-agent/test/sdk-model-selection.test.ts packages/coding-agent/test/task/executor-subagent-reminders.test.ts packages/coding-agent/test/task/receipt.test.ts packages/coding-agent/test/task/render-nested-live.test.ts packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
- bun run check:ts