### PR TITLE
feat(model-profiles): preset-first /model UX with rebuilt builtin catalog

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -18046,6 +18046,40 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "kimi-code",
+			"baseUrl": "https://api.kimi.com/coding/v1",
+			"headers": {
+				"User-Agent": "KimiCLI/1.0",
+				"X-Msh-Platform": "kimi_cli"
+			},
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"litellm": {
@@ -35151,6 +35185,37 @@
 		"minimax-m3": {
 			"id": "minimax-m3",
 			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "minimax-code",
+			"baseUrl": "https://api.minimax.io/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax-v3": {
+			"id": "minimax-v3",
+			"name": "MiniMax-V3",
 			"api": "openai-completions",
 			"provider": "minimax-code",
 			"baseUrl": "https://api.minimax.io/v1",

--- a/packages/ai/test/preset-catalog-models.test.ts
+++ b/packages/ai/test/preset-catalog-models.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { getBundledModel } from "../src/models";
+
+describe("preset catalog model entries", () => {
+	test("bundles kimi-code/kimi-k2.7-code", () => {
+		const model = getBundledModel("kimi-code", "kimi-k2.7-code");
+
+		expect(model.id).toBe("kimi-k2.7-code");
+		expect(model.provider).toBe("kimi-code");
+		expect(model.name).toBe("Kimi K2.7 Code");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toContain("text");
+		expect(model.thinking).toEqual({ mode: "effort", minLevel: "minimal", maxLevel: "high" });
+	});
+
+	test("bundles minimax-code/minimax-v3", () => {
+		const model = getBundledModel("minimax-code", "minimax-v3");
+
+		expect(model.id).toBe("minimax-v3");
+		expect(model.provider).toBe("minimax-code");
+		expect(model.name).toBe("MiniMax-V3");
+		expect(model.reasoning).toBe(true);
+		expect(model.contextWindow).toBe(512_000);
+		expect(model.maxTokens).toBe(128_000);
+		expect(model.thinking).toEqual({ mode: "effort", minLevel: "minimal", maxLevel: "high" });
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,10 +3,17 @@
 ## [Unreleased]
 
 ### Added
-
-- Added first-class `minimax-standard`, `minimax-cn-standard`, `kimi-standard`, and `glm-standard` model profiles plus a grouped `/model` Presets browser so profile presets stay scannable as the catalog grows (#532).
+- Made `/model` open to a preset-first landing view: provider-grouped presets with live auth checkmarks, highlight-to-expand tiers, a full clamped role→model preview before applying, and a session/default apply scope choice; typing still jumps straight to model search, "Browse all models" opens the classic tabbed selector, and temporary-only quick-switch bypasses the landing entirely.
+- Rebuilt the builtin model profile catalog as 27 profiles: `codex-{eco,medium,pro}` on `gpt-5.5` effort spreads, a single `opencodego` preset, `claude-opus`/`claude-fable`, `{glm,kimi-coding-plan,mimo,grok,cursor,minimax}-{eco,medium,pro}` trios with thinking levels clamped to provider support, and `fable-codex`/`opus-codex`/`codex-opencodego` combos. Legacy profile names (including the `*-standard` family) were removed clean-break and now fail with the available-profile listing.
+- Added a post-`/login` smart preset recommendation: when login succeeds and no profile is active, prompts "Apply <preset> now?" (session-only on confirm); when a profile is active, prints a one-line hint instead. The active profile is tracked in-memory on the session with rollback-safe activation.
+- Bundled `kimi-code/kimi-k2.7-code` and `minimax-code/minimax-v3` model entries; MiniMax presets use the canonical `minimax-code` provider id throughout.
+- Added first-class `minimax-standard`, `minimax-cn-standard`, `kimi-standard`, and `glm-standard` model profiles plus a grouped `/model` Presets browser so profile presets stay scannable as the catalog grows (#532). (Superseded in the same release by the preset-first landing view and the rebuilt 27-profile catalog above.)
 - Added a harness receipt JSONL spool exporter for gajae receipt-runtime interop: configured `gjc harness --receipt-spool-dir <dir>` / `GJC_RECEIPT_SPOOL_DIR` now appends persisted native `ReceiptEnvelope` records as `{cursor,envelope}` lines to `spool.jsonl`, with restart-safe 12-digit cursors and installed-package smoke coverage (#545).
 - Optimization Suite v3 Lane 1 (RSS): large resident text in persisted sessions is now backed by an ephemeral session-scoped disk cache (`EphemeralBlobStore`) instead of being pinned in JS heap for the whole session lifetime; canonical JSONL persistence, reload, and export semantics are byte-identical (resident refs never persist). Missing resident text cache blobs now surface a typed `ResidentBlobMissingError` instead of silently leaking `blob:sha256:` refs into provider payloads, UI, or exports. `getEntries()`/`buildSessionContext()` are served from revision-keyed WeakRef caches below the public ownership boundary (callers still receive caller-owned copies). Fixture retained heap −82%, RSS −55%, warm `getEntries()` p95 −80% on 10k-entry sessions; one-shot `exportFromFile()` now closes its session manager.
+
+### Removed
+
+- Removed the hardcoded OpenAI Codex role-preset action from the model selector; builtin model profiles are now the only preset concept.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -134,8 +134,8 @@ class RootHelpCommand extends Command {
 		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
-		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-standard`,
-		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencode-go-pro --default`,
+		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-medium`,
+		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencodego --default`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,
 	];
 	static strict = false;

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -142,8 +142,8 @@ export default class Index extends Command {
 		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
-		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-standard`,
-		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencode-go-pro --default`,
+		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-medium`,
+		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencodego --default`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,
 	];
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -1,6 +1,7 @@
 import type { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Api, Model } from "@gajae-code/ai";
 import type { AgentSession } from "../session/agent-session";
+import { formatClampedModelSelector } from "../thinking";
 import {
 	aggregateModelProfileRequiredProviders,
 	formatAvailableProfileNames,
@@ -9,9 +10,15 @@ import {
 import { type GjcModelAssignmentTargetId, isAuthenticated, type ModelRegistry } from "./model-registry";
 import { resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
+type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel" | "sessionId"> & {
+	setModelTemporary?: AgentSession["setModelTemporary"];
+	setActiveModelProfile?: (name: string | undefined) => void;
+	getActiveModelProfile?: () => string | undefined;
+};
+
 
 export interface PrepareModelProfileActivationOptions {
-	session: Pick<AgentSession, "model" | "thinkingLevel" | "sessionId">;
+	session: ModelProfileActivationSession;
 	modelRegistry: Pick<
 		ModelRegistry,
 		| "getModelProfile"
@@ -29,7 +36,7 @@ export interface PrepareModelProfileActivationOptions {
 
 export interface PreparedModelProfileActivation {
 	profileName: string;
-	session: Pick<AgentSession, "model" | "thinkingLevel" | "sessionId" | "setModelTemporary">;
+	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
 	settings: Pick<Settings, "get" | "override" | "set" | "flush">;
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
@@ -37,6 +44,7 @@ export interface PreparedModelProfileActivation {
 	defaultModel: Model<Api> | undefined;
 	defaultThinkingLevel: ThinkingLevel | undefined;
 	agentModelOverrides: Record<string, string>;
+	previousActiveModelProfile: string | undefined;
 }
 
 export function formatModelProfileCredentialError(profileName: string, providers: readonly string[]): string {
@@ -89,7 +97,7 @@ export async function prepareModelProfileActivation(
 		if (!resolved.model) {
 			throw new Error(`Model profile "${options.profileName}" ${role} selector did not resolve: ${selector}`);
 		}
-		agentModelOverrides[role] = selector;
+		agentModelOverrides[role] = formatClampedModelSelector(selector, resolved.model);
 	}
 
 	return {
@@ -102,6 +110,7 @@ export async function prepareModelProfileActivation(
 		defaultModel: resolvedDefault?.model,
 		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
 		agentModelOverrides,
+		previousActiveModelProfile: options.session.getActiveModelProfile?.(),
 	};
 }
 
@@ -113,6 +122,7 @@ export async function applyPreparedModelProfileActivation(
 	const previousThinkingLevel = prepared.previousThinkingLevel;
 	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
 	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
+	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	let modelChanged = false;
 	let overridesChanged = false;
 	let defaultChanged = false;
@@ -134,6 +144,7 @@ export async function applyPreparedModelProfileActivation(
 			defaultChanged = true;
 			await prepared.settings.flush();
 		}
+		prepared.session.setActiveModelProfile?.(prepared.profileName);
 	} catch (error) {
 		if (defaultChanged) {
 			prepared.settings.set("modelProfile.default", previousPersistedDefault);
@@ -141,6 +152,7 @@ export async function applyPreparedModelProfileActivation(
 		if (overridesChanged) {
 			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
 		}
+		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 		if (modelChanged && previousModel) {
 			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
 		}

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -54,98 +54,285 @@ const profile = (
 });
 
 export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
-	profile("opencode-go-eco", ["opencode-go"], {
-		default: "opencode-go/deepseek-v4-flash",
-		executor: "opencode-go/qwen3.5-plus",
-		architect: "opencode-go/glm-5",
-		planner: "opencode-go/minimax-m2.5",
-		critic: "opencode-go/kimi-k2.5",
-	}),
-	profile("opencode-go-standard", ["opencode-go"], {
-		default: "opencode-go/kimi-k2.6",
-		executor: "opencode-go/qwen3.6-plus",
-		architect: "opencode-go/glm-5.1",
-		planner: "opencode-go/minimax-m2.7",
-		critic: "opencode-go/deepseek-v4-pro",
-	}),
-	profile("opencode-go-pro", ["opencode-go"], {
-		default: "opencode-go/qwen3.7-max",
-		executor: "opencode-go/kimi-k2.6",
-		architect: "opencode-go/deepseek-v4-pro:high",
-		planner: "opencode-go/glm-5.1:high",
-		critic: "opencode-go/minimax-m2.7:high",
-	}),
 	profile("codex-eco", ["openai-codex"], {
-		default: "openai-codex/gpt-5.4-mini",
-		executor: "openai-codex/gpt-5.4-nano",
-		architect: "openai-codex/gpt-5.4-mini",
-		planner: "openai-codex/gpt-5.4-mini",
-		critic: "openai-codex/gpt-5.4-mini",
+		default: "openai-codex/gpt-5.5:low",
+		executor: "openai-codex/gpt-5.5:minimal",
+		planner: "openai-codex/gpt-5.5:low",
+		critic: "openai-codex/gpt-5.5:medium",
+		architect: "openai-codex/gpt-5.5:high",
 	}),
-	profile("codex-standard", ["openai-codex"], {
+	profile("codex-medium", ["openai-codex"], {
 		default: "openai-codex/gpt-5.5:medium",
 		executor: "openai-codex/gpt-5.5:low",
-		architect: "openai-codex/gpt-5.5:xhigh",
 		planner: "openai-codex/gpt-5.5:medium",
 		critic: "openai-codex/gpt-5.5:high",
+		architect: "openai-codex/gpt-5.5:xhigh",
 	}),
 	profile("codex-pro", ["openai-codex"], {
 		default: "openai-codex/gpt-5.5:xhigh",
-		executor: "openai-codex/gpt-5.5:high",
-		architect: "openai-codex/gpt-5.5:xhigh",
+		executor: "openai-codex/gpt-5.5:medium",
 		planner: "openai-codex/gpt-5.5:high",
-		critic: "openai-codex/gpt-5.5:high",
+		critic: "openai-codex/gpt-5.5:xhigh",
+		architect: "openai-codex/gpt-5.5:xhigh",
 	}),
-	profile("minimax-standard", ["minimax-code"], {
-		default: "minimax-code/minimax-m3:medium",
-		executor: "minimax-code/minimax-m3:low",
-		architect: "minimax-code/minimax-m3:high",
-		planner: "minimax-code/minimax-m3:medium",
-		critic: "minimax-code/minimax-m3:high",
+	profile("opencodego", ["opencode-go"], {
+		default: "opencode-go/kimi-k2.6",
+		executor: "opencode-go/deepseek-v4-flash",
+		planner: "opencode-go/qwen3.7-max",
+		critic: "opencode-go/mimo-v2.5-pro",
+		architect: "opencode-go/deepseek-v4-pro",
 	}),
-	profile("minimax-cn-standard", ["minimax-code-cn"], {
-		default: "minimax-code-cn/minimax-m3:medium",
-		executor: "minimax-code-cn/minimax-m3:low",
-		architect: "minimax-code-cn/minimax-m3:high",
-		planner: "minimax-code-cn/minimax-m3:medium",
-		critic: "minimax-code-cn/minimax-m3:high",
+	profile("claude-opus", ["anthropic"], {
+		default: "anthropic/claude-opus-4-8:xhigh",
+		executor: "anthropic/claude-sonnet-4-6",
+		planner: "anthropic/claude-opus-4-8:low",
+		critic: "anthropic/claude-opus-4-8:high",
+		architect: "anthropic/claude-opus-4-8:xhigh",
 	}),
-	profile("kimi-standard", ["kimi-code"], {
-		default: "kimi-code/kimi-k2.5:medium",
-		executor: "kimi-code/kimi-k2.5:low",
-		architect: "kimi-code/kimi-k2.5:high",
-		planner: "kimi-code/kimi-k2.5:medium",
-		critic: "kimi-code/kimi-k2.5:high",
+	profile("claude-fable", ["anthropic"], {
+		default: "anthropic/claude-fable-5:xhigh",
+		executor: "anthropic/claude-sonnet-4-6",
+		planner: "anthropic/claude-opus-4-8:low",
+		critic: "anthropic/claude-opus-4-8:high",
+		architect: "anthropic/claude-fable-5:xhigh",
 	}),
-	profile("glm-standard", ["zai"], {
+	profile("glm-eco", ["zai"], {
+		default: "zai/glm-5.1:low",
+		executor: "zai/glm-5.1:minimal",
+		planner: "zai/glm-5.1:low",
+		critic: "zai/glm-5.1:medium",
+		architect: "zai/glm-5.1:high",
+	}),
+	profile("glm-medium", ["zai"], {
 		default: "zai/glm-5.1:medium",
 		executor: "zai/glm-5.1:low",
-		architect: "zai/glm-5.1:high",
 		planner: "zai/glm-5.1:medium",
 		critic: "zai/glm-5.1:high",
+		architect: "zai/glm-5.1:xhigh",
 	}),
-	profile("opencode-go-codex-eco", ["opencode-go", "openai-codex"], {
-		default: "opencode-go/deepseek-v4-flash",
-		executor: "opencode-go/qwen3.5-plus",
-		architect: "openai-codex/gpt-5.4-mini",
-		planner: "openai-codex/gpt-5.4-mini",
-		critic: "openai-codex/gpt-5.4-mini",
+	profile("glm-pro", ["zai"], {
+		default: "zai/glm-5.1:xhigh",
+		executor: "zai/glm-5.1:medium",
+		planner: "zai/glm-5.1:high",
+		critic: "zai/glm-5.1:xhigh",
+		architect: "zai/glm-5.1:xhigh",
 	}),
-	profile("opencode-go-codex-standard", ["opencode-go", "openai-codex"], {
-		default: "opencode-go/kimi-k2.6",
-		executor: "opencode-go/qwen3.6-plus",
-		architect: "openai-codex/gpt-5.4",
-		planner: "openai-codex/gpt-5.4",
-		critic: "openai-codex/gpt-5.4",
+	profile("kimi-coding-plan-eco", ["kimi-code"], {
+		default: "kimi-code/kimi-k2.7-code:low",
+		executor: "kimi-code/kimi-k2.7-code:minimal",
+		planner: "kimi-code/kimi-k2.7-code:low",
+		critic: "kimi-code/kimi-k2.7-code:medium",
+		architect: "kimi-code/kimi-k2.7-code:high",
 	}),
-	profile("opencode-go-codex-pro", ["opencode-go", "openai-codex"], {
-		default: "opencode-go/qwen3.7-max",
-		executor: "opencode-go/kimi-k2.6",
-		architect: "openai-codex/gpt-5.1-codex-max:high",
-		planner: "openai-codex/gpt-5.5:high",
-		critic: "openai-codex/gpt-5.3-codex-spark:high",
+	profile("kimi-coding-plan-medium", ["kimi-code"], {
+		default: "kimi-code/kimi-k2.7-code:medium",
+		executor: "kimi-code/kimi-k2.7-code:low",
+		planner: "kimi-code/kimi-k2.7-code:medium",
+		critic: "kimi-code/kimi-k2.7-code:high",
+		architect: "kimi-code/kimi-k2.7-code:xhigh",
+	}),
+	profile("kimi-coding-plan-pro", ["kimi-code"], {
+		default: "kimi-code/kimi-k2.7-code:xhigh",
+		executor: "kimi-code/kimi-k2.7-code:medium",
+		planner: "kimi-code/kimi-k2.7-code:high",
+		critic: "kimi-code/kimi-k2.7-code:xhigh",
+		architect: "kimi-code/kimi-k2.7-code:xhigh",
+	}),
+	profile("mimo-eco", ["xiaomi"], {
+		default: "xiaomi/mimo-v2.5-pro:low",
+		executor: "xiaomi/mimo-v2.5-pro:minimal",
+		planner: "xiaomi/mimo-v2.5-pro:low",
+		critic: "xiaomi/mimo-v2.5-pro:medium",
+		architect: "xiaomi/mimo-v2.5-pro:high",
+	}),
+	profile("mimo-medium", ["xiaomi"], {
+		default: "xiaomi/mimo-v2.5-pro:medium",
+		executor: "xiaomi/mimo-v2.5-pro:low",
+		planner: "xiaomi/mimo-v2.5-pro:medium",
+		critic: "xiaomi/mimo-v2.5-pro:high",
+		architect: "xiaomi/mimo-v2.5-pro:xhigh",
+	}),
+	profile("mimo-pro", ["xiaomi"], {
+		default: "xiaomi/mimo-v2.5-pro:xhigh",
+		executor: "xiaomi/mimo-v2.5-pro:medium",
+		planner: "xiaomi/mimo-v2.5-pro:high",
+		critic: "xiaomi/mimo-v2.5-pro:xhigh",
+		architect: "xiaomi/mimo-v2.5-pro:xhigh",
+	}),
+	profile("grok-eco", ["xai"], {
+		default: "xai/grok-4.3:low",
+		executor: "xai/grok-4.3:minimal",
+		planner: "xai/grok-4.3:low",
+		critic: "xai/grok-4.3:medium",
+		architect: "xai/grok-4.3:high",
+	}),
+	profile("grok-medium", ["xai"], {
+		default: "xai/grok-4.3:medium",
+		executor: "xai/grok-4.3:low",
+		planner: "xai/grok-4.3:medium",
+		critic: "xai/grok-4.3:high",
+		architect: "xai/grok-4.3:xhigh",
+	}),
+	profile("grok-pro", ["xai"], {
+		default: "xai/grok-4.3:xhigh",
+		executor: "xai/grok-4.3:medium",
+		planner: "xai/grok-4.3:high",
+		critic: "xai/grok-4.3:xhigh",
+		architect: "xai/grok-4.3:xhigh",
+	}),
+	profile("cursor-eco", ["cursor"], {
+		default: "cursor/composer-1.5:low",
+		executor: "cursor/composer-1.5:minimal",
+		planner: "cursor/composer-1.5:low",
+		critic: "cursor/composer-1.5:medium",
+		architect: "cursor/composer-1.5:high",
+	}),
+	profile("cursor-medium", ["cursor"], {
+		default: "cursor/composer-1.5:medium",
+		executor: "cursor/composer-1.5:low",
+		planner: "cursor/composer-1.5:medium",
+		critic: "cursor/composer-1.5:high",
+		architect: "cursor/composer-1.5:xhigh",
+	}),
+	profile("cursor-pro", ["cursor"], {
+		default: "cursor/composer-1.5:xhigh",
+		executor: "cursor/composer-1.5:medium",
+		planner: "cursor/composer-1.5:high",
+		critic: "cursor/composer-1.5:xhigh",
+		architect: "cursor/composer-1.5:xhigh",
+	}),
+	profile("minimax-eco", ["minimax-code"], {
+		default: "minimax-code/minimax-v3:low",
+		executor: "minimax-code/minimax-v3:minimal",
+		planner: "minimax-code/minimax-v3:low",
+		critic: "minimax-code/minimax-v3:medium",
+		architect: "minimax-code/minimax-v3:high",
+	}),
+	profile("minimax-medium", ["minimax-code"], {
+		default: "minimax-code/minimax-v3:medium",
+		executor: "minimax-code/minimax-v3:low",
+		planner: "minimax-code/minimax-v3:medium",
+		critic: "minimax-code/minimax-v3:high",
+		architect: "minimax-code/minimax-v3:xhigh",
+	}),
+	profile("minimax-pro", ["minimax-code"], {
+		default: "minimax-code/minimax-v3:xhigh",
+		executor: "minimax-code/minimax-v3:medium",
+		planner: "minimax-code/minimax-v3:high",
+		critic: "minimax-code/minimax-v3:xhigh",
+		architect: "minimax-code/minimax-v3:xhigh",
+	}),
+	profile("fable-codex", ["anthropic", "openai-codex"], {
+		default: "anthropic/claude-fable-5:xhigh",
+		executor: "openai-codex/gpt-5.5:low",
+		planner: "openai-codex/gpt-5.5:medium",
+		critic: "openai-codex/gpt-5.5:high",
+		architect: "openai-codex/gpt-5.5:xhigh",
+	}),
+	profile("opus-codex", ["anthropic", "openai-codex"], {
+		default: "anthropic/claude-opus-4-8:xhigh",
+		executor: "openai-codex/gpt-5.5:low",
+		planner: "openai-codex/gpt-5.5:medium",
+		critic: "openai-codex/gpt-5.5:high",
+		architect: "openai-codex/gpt-5.5:xhigh",
+	}),
+	profile("codex-opencodego", ["openai-codex", "opencode-go"], {
+		default: "openai-codex/gpt-5.5:medium",
+		executor: "opencode-go/deepseek-v4-pro",
+		planner: "opencode-go/kimi-k2.6",
+		critic: "opencode-go/mimo-v2.5-pro",
+		architect: "openai-codex/gpt-5.5:xhigh",
 	}),
 ];
+
+export interface ModelProfilePresentation {
+	displayName: string;
+	providerGroup: string;
+}
+
+const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
+	"codex-eco": { displayName: "Codex Eco", providerGroup: "CODEX" },
+	"codex-medium": { displayName: "Codex Medium", providerGroup: "CODEX" },
+	"codex-pro": { displayName: "Codex Pro", providerGroup: "CODEX" },
+	opencodego: { displayName: "OpenCodeGo", providerGroup: "OPENCODEGO" },
+	"claude-opus": { displayName: "Claude Opus", providerGroup: "CLAUDE" },
+	"claude-fable": { displayName: "Claude Fable", providerGroup: "CLAUDE" },
+	"glm-eco": { displayName: "GLM Eco", providerGroup: "GLM" },
+	"glm-medium": { displayName: "GLM Medium", providerGroup: "GLM" },
+	"glm-pro": { displayName: "GLM Pro", providerGroup: "GLM" },
+	"kimi-coding-plan-eco": { displayName: "Kimi Coding Plan Eco", providerGroup: "KIMI CODING PLAN" },
+	"kimi-coding-plan-medium": { displayName: "Kimi Coding Plan Medium", providerGroup: "KIMI CODING PLAN" },
+	"kimi-coding-plan-pro": { displayName: "Kimi Coding Plan Pro", providerGroup: "KIMI CODING PLAN" },
+	"mimo-eco": { displayName: "Mimo Eco", providerGroup: "MIMO" },
+	"mimo-medium": { displayName: "Mimo Medium", providerGroup: "MIMO" },
+	"mimo-pro": { displayName: "Mimo Pro", providerGroup: "MIMO" },
+	"grok-eco": { displayName: "Grok Eco", providerGroup: "GROK" },
+	"grok-medium": { displayName: "Grok Medium", providerGroup: "GROK" },
+	"grok-pro": { displayName: "Grok Pro", providerGroup: "GROK" },
+	"cursor-eco": { displayName: "Cursor Eco", providerGroup: "CURSOR" },
+	"cursor-medium": { displayName: "Cursor Medium", providerGroup: "CURSOR" },
+	"cursor-pro": { displayName: "Cursor Pro", providerGroup: "CURSOR" },
+	"minimax-eco": { displayName: "MiniMax Eco", providerGroup: "MINIMAX" },
+	"minimax-medium": { displayName: "MiniMax Medium", providerGroup: "MINIMAX" },
+	"minimax-pro": { displayName: "MiniMax Pro", providerGroup: "MINIMAX" },
+	"fable-codex": { displayName: "Fable + Codex", providerGroup: "COMBOS" },
+	"opus-codex": { displayName: "Opus + Codex", providerGroup: "COMBOS" },
+	"codex-opencodego": { displayName: "Codex + OpenCodeGo", providerGroup: "COMBOS" },
+};
+
+const PROFILE_GROUP_ORDER = [
+	"CODEX",
+	"OPENCODEGO",
+	"CLAUDE",
+	"GLM",
+	"KIMI CODING PLAN",
+	"MIMO",
+	"GROK",
+	"CURSOR",
+	"MINIMAX",
+	"COMBOS",
+];
+
+const PROFILE_RECOMMENDATIONS: Record<string, string> = {
+	"openai-codex": "codex-medium",
+	anthropic: "claude-opus",
+	"opencode-go": "opencodego",
+	zai: "glm-medium",
+	"kimi-code": "kimi-coding-plan-medium",
+	xiaomi: "mimo-medium",
+	xai: "grok-medium",
+	cursor: "cursor-medium",
+	"minimax-code": "minimax-medium",
+};
+
+export function getModelProfilePresentation(name: string): ModelProfilePresentation {
+	return PROFILE_PRESENTATION[name] ?? { displayName: name, providerGroup: "COMBOS" };
+}
+
+export function groupModelProfilesForPresetLanding(
+	profiles: ReadonlyMap<string, ModelProfileDefinition>,
+): Map<string, ModelProfileDefinition[]> {
+	const groups = new Map<string, ModelProfileDefinition[]>();
+	for (const group of PROFILE_GROUP_ORDER) groups.set(group, []);
+	for (const profile of profiles.values()) {
+		const group = getModelProfilePresentation(profile.name).providerGroup;
+		if (!groups.has(group)) groups.set(group, []);
+		groups.get(group)?.push(profile);
+	}
+	for (const [group, entries] of groups) {
+		if (entries.length === 0) groups.delete(group);
+		else entries.sort((a, b) => a.name.localeCompare(b.name));
+	}
+	return groups;
+}
+
+export function recommendModelProfileForProvider(
+	providerId: string,
+	profiles: ReadonlyMap<string, ModelProfileDefinition>,
+): ModelProfileDefinition | undefined {
+	const recommended = PROFILE_RECOMMENDATIONS[providerId];
+	return recommended ? profiles.get(recommended) : undefined;
+}
 
 export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
 	const profiles = new Map<string, ModelProfileDefinition>();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1,5 +1,5 @@
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { clampThinkingLevelForModel, getSupportedEfforts, type Model, modelsAreEqual } from "@gajae-code/ai";
+import { getSupportedEfforts, type Model, modelsAreEqual } from "@gajae-code/ai";
 import {
 	Container,
 	fuzzyFilter,
@@ -12,9 +12,14 @@ import {
 	Text,
 	type TUI,
 } from "@gajae-code/tui";
-import type { ModelProfileDefinition } from "../../config/model-profiles";
+import {
+	getModelProfilePresentation,
+	groupModelProfilesForPresetLanding,
+	type ModelProfileDefinition,
+} from "../../config/model-profiles";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
 import { GJC_MODEL_ASSIGNMENT_TARGET_IDS, GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
+import { isAuthenticated } from "../../config/model-registry";
 import {
 	formatModelSelectorValue,
 	resolveModelRoleValue,
@@ -23,7 +28,7 @@ import {
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
-import { getThinkingLevelMetadata, parseThinkingLevel } from "../../thinking";
+import { formatClampedModelSelector, getThinkingLevelMetadata, parseThinkingLevel } from "../../thinking";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -75,52 +80,12 @@ interface CanonicalModelItem {
 	explicitThinkingLevel?: boolean;
 }
 
-interface ProfileItem {
-	kind: "profile";
-	name: string;
-	profile: ModelProfileDefinition;
-}
-
-interface ProfileSurfaceItem {
-	kind: "profile-surface";
-	count: number;
-	groupCount: number;
-}
-
-interface ProfileGroup {
-	id: string;
-	label: string;
-	description: string;
-	profiles: ProfileItem[];
-}
-
-interface ProfileGroupDefinition {
-	id: string;
-	label: string;
-	description: string;
-	matches: (profile: ProfileItem) => boolean;
-}
-
-interface ProfileActionItem {
-	kind: "profile-action";
-	profile: ProfileItem;
-}
-
-type ProfileMenuState = { kind: "groups" } | { kind: "profiles"; group: ProfileGroup };
-type ActionMenuItem = ModelItem | CanonicalModelItem | ProfileActionItem;
 
 type ScopedModelItem = ScopedModelSelection;
 
 interface RoleAssignment {
 	model: Model;
 	thinkingLevel: ThinkingLevel;
-}
-
-export interface ModelAssignmentPreset {
-	id: "openai-codex";
-	label: string;
-	description: string;
-	assignments: Partial<Record<GjcModelAssignmentTargetId, ThinkingLevel>>;
 }
 
 export type ModelSelectorSelection =
@@ -130,13 +95,6 @@ export type ModelSelectorSelection =
 			role: GjcModelAssignmentTargetId | null;
 			thinkingLevel?: ThinkingLevel;
 			selector?: string;
-	  }
-	| {
-			kind: "preset";
-			model: Model;
-			selector: string;
-			preset: ModelAssignmentPreset;
-			assignments: Record<GjcModelAssignmentTargetId, ThinkingLevel>;
 	  }
 	| {
 			kind: "profile";
@@ -165,52 +123,6 @@ const STATIC_PROVIDER_TABS: ProviderTabState[] = [
 	{ id: ALL_TAB, label: ALL_TAB },
 	{ id: CANONICAL_TAB, label: CANONICAL_TAB },
 ];
-const OPENAI_CODE_PROFILE_PRESET: ModelAssignmentPreset = {
-	id: "openai-codex",
-	label: "Apply OpenAI Codex role preset",
-	description: "Default medium, Executor low, Architect xhigh, Planner medium, Critic high",
-	assignments: {
-		default: ThinkingLevel.Medium,
-		executor: ThinkingLevel.Low,
-		architect: ThinkingLevel.XHigh,
-		planner: ThinkingLevel.Medium,
-		critic: ThinkingLevel.High,
-	},
-};
-
-const PROFILE_GROUP_DEFINITIONS: readonly ProfileGroupDefinition[] = [
-	{
-		id: "codex",
-		label: "Codex",
-		description: "OpenAI Codex profiles",
-		matches: profile => profile.name.startsWith("codex-"),
-	},
-	{
-		id: "opencode-go",
-		label: "OpenCode Go",
-		description: "OpenCode Go profiles",
-		matches: profile => profile.name.startsWith("opencode-go-") && !profile.name.includes("-codex-"),
-	},
-	{
-		id: "opencode-go-codex",
-		label: "OpenCode Go + Codex",
-		description: "OpenCode Go defaults with Codex review roles",
-		matches: profile => profile.name.startsWith("opencode-go-codex-"),
-	},
-	{
-		id: "coding-plans",
-		label: "Coding Plans",
-		description: "MiniMax, Kimi, and GLM/zAI profiles",
-		matches: profile =>
-			profile.name.startsWith("minimax-") || profile.name.startsWith("kimi-") || profile.name.startsWith("glm-"),
-	},
-];
-
-const CUSTOM_PROFILE_GROUP_DEFINITION: Omit<ProfileGroupDefinition, "matches"> = {
-	id: "custom",
-	label: "Custom",
-	description: "User-defined profiles",
-};
 
 function formatProviderTabLabel(providerId: string): string {
 	return providerId.replace(/[-_]+/g, " ").toUpperCase();
@@ -219,11 +131,42 @@ function formatProviderTabLabel(providerId: string): string {
 function createProviderTab(providerId: string): ProviderTabState {
 	return { id: providerId, label: formatProviderTabLabel(providerId), providerId };
 }
+
+type ModelSelectorViewMode = "presets" | "models";
+
+interface PresetGroupRow {
+	kind: "group";
+	groupId: string;
+	profiles: ModelProfileDefinition[];
+}
+
+interface PresetProfileRow {
+	kind: "profile";
+	groupId: string;
+	profile: ModelProfileDefinition;
+}
+
+interface PresetBrowseRow {
+	kind: "browse";
+}
+
+type PresetLandingRow = PresetGroupRow | PresetProfileRow | PresetBrowseRow;
+
+const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = ["default", "executor", "planner", "critic", "architect"];
+const PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default"];
+
+function isPrintableCharacter(keyData: string): boolean {
+	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
+}
+
+function profileRequiredProviders(profile: ModelProfileDefinition): string[] {
+	return [...new Set(profile.requiredProviders)].sort((a, b) => a.localeCompare(b));
+}
 /**
  * Component that renders a canonical model selector with provider tabs.
  * - Tab/Arrow Left/Right: Switch between provider tabs
  * - Arrow Up/Down: Navigate model list
- * - Enter: Open grouped profile picker or assignment actions for default plus GJC role-agent models
+ * - Enter: Open assignment actions for default plus GJC role-agent models
  * - Escape: Close selector
  */
 export class ModelSelectorComponent extends Container {
@@ -235,7 +178,6 @@ export class ModelSelectorComponent extends Container {
 	#filteredModels: ModelItem[] = [];
 	#canonicalModels: CanonicalModelItem[] = [];
 	#filteredCanonicalModels: CanonicalModelItem[] = [];
-	#profileItems: ProfileItem[] = [];
 	#selectedIndex: number = 0;
 	#roles = {} as Record<string, RoleAssignment | undefined>;
 	#settings = null as unknown as Settings;
@@ -246,13 +188,22 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
-	#pendingActionItem?: ActionMenuItem;
+	#pendingActionItem?: ModelItem | CanonicalModelItem;
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
 	#selectedThinkingIndex: number = 0;
-	#profileMenuState?: ProfileMenuState;
-	#selectedProfileGroupIndex: number = 0;
-	#selectedProfileIndex: number = 0;
+
+	// Preset landing state
+	#viewMode: ModelSelectorViewMode = "presets";
+	#presetCursor: number = 0;
+	#expandedPresetProviderId?: string;
+	#previewProfileName?: string;
+	#presetScopeMenuOpen: boolean = false;
+	#presetScopeIndex: number = 0;
+	#providerAuthById = new Map<string, boolean>();
+	#providerAuthPending: boolean = false;
+	#presetLoginHint?: string;
+	#authSessionId?: string;
 
 	// Tab state
 	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
@@ -266,7 +217,7 @@ export class ModelSelectorComponent extends Container {
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
+		options?: { temporaryOnly?: boolean; initialSearchInput?: string; sessionId?: string },
 	) {
 		super();
 
@@ -277,7 +228,9 @@ export class ModelSelectorComponent extends Container {
 		this.#onSelectCallback = onSelect;
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
+		this.#authSessionId = options?.sessionId;
 		const initialSearchInput = options?.initialSearchInput;
+		this.#viewMode = this.#temporaryOnly || !!initialSearchInput || scopedModels.length > 0 ? "models" : "presets";
 
 		// Load current role assignments from settings
 		this.#loadRoleModels();
@@ -305,12 +258,7 @@ export class ModelSelectorComponent extends Container {
 		}
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
-			if (!selectedItem) return;
-			if (selectedItem.kind === "profile-surface") {
-				this.#openProfileMenu();
-			} else {
-				this.#beginActionMenuOrSelect(selectedItem);
-			}
+			if (selectedItem) this.#beginActionMenuOrSelect(selectedItem);
 		};
 		this.addChild(this.#searchInput);
 
@@ -328,14 +276,23 @@ export class ModelSelectorComponent extends Container {
 		// Load models and do initial render
 		this.#loadModels().then(() => {
 			this.#buildProviderTabs();
-			this.#updateTabBar();
-			// Always apply the current search query — the user may have typed
-			// while models were loading asynchronously.
-			const currentQuery = this.#searchInput.getValue();
-			if (currentQuery) {
-				this.#filterModels(currentQuery);
+			if (this.#viewMode === "presets" && (this.#modelRegistry.getModelProfiles?.().size ?? 0) === 0) {
+				this.#viewMode = "models";
+			}
+			if (this.#viewMode === "presets") {
+				this.#updatePresetExpansion();
+				void this.#refreshProviderAuth();
+				this.#renderPresetLanding();
 			} else {
-				this.#updateList();
+				this.#updateTabBar();
+				// Always apply the current search query — the user may have typed
+				// while models were loading asynchronously.
+				const currentQuery = this.#searchInput.getValue();
+				if (currentQuery) {
+					this.#filterModels(currentQuery);
+				} else {
+					this.#updateList();
+				}
 			}
 			// Request re-render after models are loaded
 			this.#tui.requestRender();
@@ -546,22 +503,11 @@ export class ModelSelectorComponent extends Container {
 
 		this.#sortModels(models);
 		this.#sortCanonicalModels(canonicalModels);
-		const profiles = this.#modelRegistry.getModelProfiles?.() ?? new Map();
-		const profileItems = this.#temporaryOnly
-			? []
-			: [...profiles.values()]
-					.sort((a, b) => a.name.localeCompare(b.name))
-					.map(profile => ({ kind: "profile" as const, name: profile.name, profile }));
-
 		this.#allModels = models;
 		this.#filteredModels = models;
 		this.#canonicalModels = canonicalModels;
 		this.#filteredCanonicalModels = canonicalModels;
-		this.#profileItems = profileItems;
-		this.#selectedIndex = Math.min(
-			this.#selectedIndex,
-			Math.max(0, models.length + this.#getVisibleProfileSurface().length - 1),
-		);
+		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, models.length - 1));
 	}
 
 	#buildProviderTabs(): void {
@@ -686,14 +632,8 @@ export class ModelSelectorComponent extends Container {
 			this.#filteredModels = baseModels;
 			this.#filteredCanonicalModels = baseCanonicalModels;
 		}
-		this.#profileMenuState = undefined;
-		if (this.#pendingActionItem?.kind === "profile-action") {
-			this.#pendingActionItem = undefined;
-		}
 
-		const profileSurfaceCount = this.#getVisibleProfileSurface().length;
-		const visibleCount =
-			profileSurfaceCount + (isCanonicalTab ? this.#filteredCanonicalModels.length : this.#filteredModels.length);
+		const visibleCount = isCanonicalTab ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
 		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, visibleCount - 1));
 		this.#updateList();
 	}
@@ -713,6 +653,151 @@ export class ModelSelectorComponent extends Container {
 		}
 		const ageMinutes = Math.round(ageMs / 60_000);
 		return `${ageMinutes}m ago`;
+	}
+
+	#getPresetGroups(): Map<string, ModelProfileDefinition[]> {
+		return groupModelProfilesForPresetLanding(this.#modelRegistry.getModelProfiles?.() ?? new Map());
+	}
+
+	#getPresetRows(): PresetLandingRow[] {
+		const rows: PresetLandingRow[] = [];
+		for (const [groupId, profiles] of this.#getPresetGroups()) {
+			rows.push({ kind: "group", groupId, profiles });
+			if (this.#expandedPresetProviderId === groupId) {
+				for (const profile of profiles) rows.push({ kind: "profile", groupId, profile });
+			}
+		}
+		rows.push({ kind: "browse" });
+		return rows;
+	}
+
+	#getSelectedPresetRow(): PresetLandingRow | undefined {
+		return this.#getPresetRows()[this.#presetCursor];
+	}
+
+	#getProfileByName(name: string | undefined): ModelProfileDefinition | undefined {
+		if (!name) return undefined;
+		return this.#modelRegistry.getModelProfile?.(name) ?? this.#modelRegistry.getModelProfiles?.().get(name);
+	}
+
+	#isProviderAuthenticated(providerId: string): boolean | undefined {
+		return this.#providerAuthById.get(providerId);
+	}
+
+	#getMissingProviders(profileOrProfiles: ModelProfileDefinition | ModelProfileDefinition[]): string[] {
+		const profiles = Array.isArray(profileOrProfiles) ? profileOrProfiles : [profileOrProfiles];
+		const providers = new Set<string>();
+		for (const profile of profiles) for (const provider of profileRequiredProviders(profile)) providers.add(provider);
+		return [...providers].filter(provider => this.#isProviderAuthenticated(provider) !== true).sort((a, b) => a.localeCompare(b));
+	}
+
+	#isPresetAuthenticated(profileOrProfiles: ModelProfileDefinition | ModelProfileDefinition[]): boolean {
+		return this.#getMissingProviders(profileOrProfiles).length === 0;
+	}
+
+	async #refreshProviderAuth(): Promise<void> {
+		const providers = new Set<string>();
+		for (const profiles of this.#getPresetGroups().values()) {
+			for (const profile of profiles) for (const provider of profileRequiredProviders(profile)) providers.add(provider);
+		}
+		this.#providerAuthPending = providers.size > 0;
+		this.#renderPresetLanding();
+		const entries = await Promise.all(
+			[...providers].map(async provider => {
+				const apiKey = await this.#modelRegistry.getApiKeyForProvider(provider, this.#authSessionId);
+				return [provider, isAuthenticated(apiKey)] as const;
+			}),
+		);
+		this.#providerAuthById = new Map(entries);
+		this.#providerAuthPending = false;
+		this.#renderPresetLanding();
+		this.#tui.requestRender();
+	}
+
+	#updatePresetExpansion(): void {
+		const selected = this.#getSelectedPresetRow();
+		if (selected?.kind === "group") this.#expandedPresetProviderId = selected.groupId;
+		if (selected?.kind === "profile") this.#expandedPresetProviderId = selected.groupId;
+		const rows = this.#getPresetRows();
+		this.#presetCursor = Math.min(this.#presetCursor, Math.max(0, rows.length - 1));
+	}
+
+	#switchToModelMode(seed?: string): void {
+		this.#viewMode = "models";
+		this.#expandedPresetProviderId = undefined;
+		this.#previewProfileName = undefined;
+		this.#presetScopeMenuOpen = false;
+		this.#presetScopeIndex = 0;
+		this.#presetLoginHint = undefined;
+		this.#activeTabIndex = 0;
+		this.#selectedIndex = 0;
+		this.#searchInput.setValue(seed ?? this.#searchInput.getValue());
+		this.#updateTabBar();
+		this.#filterModels(this.#searchInput.getValue());
+	}
+
+	#renderPresetLanding(): void {
+		this.#headerContainer.clear();
+		this.#tabBar = null;
+		this.#listContainer.clear();
+		this.#headerContainer.addChild(new Text(theme.fg("accent", "Model presets"), 0, 0));
+		const rows = this.#getPresetRows();
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i];
+			const selected = i === this.#presetCursor;
+			const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			if (row.kind === "browse") {
+				const label = "Browse all models";
+				this.#listContainer.addChild(new Text(`${prefix}${selected ? theme.fg("accent", label) : label}`, 0, 0));
+				continue;
+			}
+			if (row.kind === "group") {
+				const authenticated = this.#isPresetAuthenticated(row.profiles);
+				const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+				const label = `${mark} ${row.groupId}`;
+				const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
+				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+				continue;
+			}
+			const presentation = getModelProfilePresentation(row.profile.name);
+			const authenticated = this.#isPresetAuthenticated(row.profile);
+			const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+			const label = `  ${mark} ${presentation.displayName}`;
+			const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
+			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+		}
+		if (this.#presetLoginHint) {
+			this.#listContainer.addChild(new Spacer(1));
+			this.#listContainer.addChild(new Text(theme.fg("warning", `  ${this.#presetLoginHint}`), 0, 0));
+		}
+		const previewProfile = this.#getProfileByName(this.#previewProfileName);
+		if (previewProfile) this.#renderPresetPreview(previewProfile);
+	}
+
+	#renderPresetPreview(profile: ModelProfileDefinition): void {
+		this.#listContainer.addChild(new Spacer(1));
+		this.#listContainer.addChild(new Text(theme.fg("muted", `  Preset preview: ${getModelProfilePresentation(profile.name).displayName}`), 0, 0));
+		for (const role of PROFILE_ROLE_PREVIEW_ORDER) {
+			const selector = profile.modelMapping[role];
+			if (!selector) continue;
+			const resolved = resolveModelRoleValue(selector, this.#modelRegistry.getAll(), {
+				settings: this.#settings,
+				matchPreferences: { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() },
+				modelRegistry: this.#modelRegistry,
+			});
+			const label = GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase();
+			this.#listContainer.addChild(new Text(`  ${label}: ${formatClampedModelSelector(selector, resolved.model)}`, 0, 0));
+		}
+		this.#listContainer.addChild(new Spacer(1));
+		if (this.#presetScopeMenuOpen) {
+			for (let i = 0; i < PRESET_SCOPE_LABELS.length; i++) {
+				const label = PRESET_SCOPE_LABELS[i] ?? "";
+				const prefix = i === this.#presetScopeIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+				this.#listContainer.addChild(new Text(`${prefix}${i === this.#presetScopeIndex ? theme.fg("accent", label) : label}`, 0, 0));
+			}
+		} else {
+			this.#listContainer.addChild(new Text(theme.fg("muted", "  Press Enter to apply this preset"), 0, 0));
+		}
 	}
 
 	#formatDiscoveryErrorHint(error: string | undefined): string | undefined {
@@ -761,65 +846,10 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
-	#buildProfileGroups(): ProfileGroup[] {
-		const groups: ProfileGroup[] = [];
-		const groupedProfiles = new Set<ProfileItem>();
-		for (const definition of PROFILE_GROUP_DEFINITIONS) {
-			const profiles = this.#profileItems.filter(profile => definition.matches(profile));
-			if (profiles.length === 0) continue;
-			groups.push({
-				id: definition.id,
-				label: definition.label,
-				description: definition.description,
-				profiles,
-			});
-			for (const profile of profiles) groupedProfiles.add(profile);
-		}
-		const customProfiles = this.#profileItems.filter(profile => !groupedProfiles.has(profile));
-		if (customProfiles.length > 0) {
-			groups.push({
-				id: CUSTOM_PROFILE_GROUP_DEFINITION.id,
-				label: CUSTOM_PROFILE_GROUP_DEFINITION.label,
-				description: CUSTOM_PROFILE_GROUP_DEFINITION.description,
-				profiles: customProfiles,
-			});
-		}
-		return groups;
-	}
-
-	#getVisibleProfileSurface(): ProfileSurfaceItem[] {
-		if (
-			this.#temporaryOnly ||
-			this.#isCanonicalTab() ||
-			this.#getActiveTabId() !== ALL_TAB ||
-			this.#profileItems.length === 0
-		) {
-			return [];
-		}
-		return [
-			{ kind: "profile-surface", count: this.#profileItems.length, groupCount: this.#buildProfileGroups().length },
-		];
-	}
-
 	#updateList(): void {
 		this.#listContainer.clear();
-
-		if (this.#pendingActionItem?.kind === "profile-action") {
-			this.#listContainer.addChild(new Text(theme.fg("muted", "Presets"), 0, 0));
-			this.#listContainer.addChild(new Text(`  ${this.#pendingActionItem.profile.name}`, 0, 0));
-			this.#renderProfileActionMenu(this.#pendingActionItem.profile);
-			return;
-		}
-
-		if (this.#profileMenuState) {
-			this.#renderProfileMenu(this.#profileMenuState);
-			return;
-		}
-
 		const isCanonicalTab = this.#isCanonicalTab();
-		const visibleProfileSurface = this.#getVisibleProfileSurface();
-		const profileSurfaceCount = visibleProfileSurface.length;
-		const modelSelectedIndex = Math.max(0, this.#selectedIndex - profileSurfaceCount);
+		const modelSelectedIndex = this.#selectedIndex;
 		const visibleItems = isCanonicalTab ? this.#filteredCanonicalModels : this.#filteredModels;
 
 		const maxVisible = 10;
@@ -831,25 +861,16 @@ export class ModelSelectorComponent extends Container {
 
 		const showProvider = this.#getActiveTabId() === ALL_TAB;
 
-		if (visibleProfileSurface.length > 0) {
-			const surface = visibleProfileSurface[0];
-			const isSelected = this.#selectedIndex === 0;
-			const prefix = isSelected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-			const label = isSelected ? theme.fg("accent", "Browse presets") : "Browse presets";
-			const details = theme.fg("dim", ` (${surface.count} profiles in ${surface.groupCount} groups)`);
-			this.#listContainer.addChild(new Text(theme.fg("muted", "Presets"), 0, 0));
-			this.#listContainer.addChild(new Text(`${prefix}${label}${details}`, 0, 0));
-			this.#listContainer.addChild(new Spacer(1));
-		}
-
+		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = visibleItems[i];
 			if (!item) continue;
 			const canonicalItem = isCanonicalTab ? (item as CanonicalModelItem) : undefined;
 			const providerItem = isCanonicalTab ? undefined : (item as ModelItem);
 
-			const isSelected = i + profileSurfaceCount === this.#selectedIndex;
+			const isSelected = i === this.#selectedIndex;
 
+			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
 			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
@@ -892,17 +913,19 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(new Text(line, 0, 0));
 		}
 
+		// Add scroll indicator if needed
 		if (startIndex > 0 || endIndex < visibleItems.length) {
-			const scrollInfo = theme.fg("muted", `  (${modelSelectedIndex + 1}/${visibleItems.length})`);
+			const scrollInfo = theme.fg("muted", `  (${this.#selectedIndex + 1}/${visibleItems.length})`);
 			this.#listContainer.addChild(new Text(scrollInfo, 0, 0));
 		}
 
+		// Show error message or "no results" if empty
 		if (this.#errorMessage) {
 			const errorLines = String(this.#errorMessage).split("\n");
 			for (const line of errorLines) {
 				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
-		} else if (visibleItems.length === 0 && profileSurfaceCount === 0) {
+		} else if (visibleItems.length === 0) {
 			const statusMessage = this.#getProviderEmptyStateMessage();
 			this.#listContainer.addChild(
 				new Text(
@@ -911,8 +934,6 @@ export class ModelSelectorComponent extends Container {
 					0,
 				),
 			);
-		} else if (this.#selectedIndex < profileSurfaceCount) {
-			this.#listContainer.addChild(new Text(theme.fg("muted", "  Enter to open grouped presets"), 0, 0));
 		} else {
 			const selected = visibleItems[modelSelectedIndex];
 			if (!selected) {
@@ -941,9 +962,7 @@ export class ModelSelectorComponent extends Container {
 		for (let i = 0; i < actionCount; i++) {
 			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
-			const label = role
-				? `Set as ${GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()} (${GJC_MODEL_ASSIGNMENT_TARGETS[role].name})`
-				: `${OPENAI_CODE_PROFILE_PRESET.label} (${OPENAI_CODE_PROFILE_PRESET.description})`;
+			const label = `Set as ${GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()} (${GJC_MODEL_ASSIGNMENT_TARGETS[role].name})`;
 			this.#listContainer.addChild(
 				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
 			);
@@ -968,147 +987,16 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
-	#renderProfileActionMenu(profile: ProfileItem): void {
-		this.#listContainer.addChild(new Spacer(1));
-		this.#listContainer.addChild(new Text(theme.fg("muted", `  Action for profile: ${profile.name}`), 0, 0));
-		this.#listContainer.addChild(new Spacer(1));
-		const labels = ["Apply for this session", "Set as default"];
-		for (let i = 0; i < labels.length; i++) {
-			const label = labels[i] ?? "";
-			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-			this.#listContainer.addChild(
-				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
-			);
-		}
-	}
-
-	#renderProfileMenu(state: ProfileMenuState): void {
-		this.#listContainer.addChild(new Text(theme.fg("muted", "Presets"), 0, 0));
-		if (state.kind === "groups") {
-			const groups = this.#buildProfileGroups();
-			for (let i = 0; i < groups.length; i++) {
-				const group = groups[i];
-				if (!group) continue;
-				const prefix = i === this.#selectedProfileGroupIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-				const label = i === this.#selectedProfileGroupIndex ? theme.fg("accent", group.label) : group.label;
-				const details = theme.fg("dim", ` (${group.profiles.length}) — ${group.description}`);
-				this.#listContainer.addChild(new Text(`${prefix}${label}${details}`, 0, 0));
-			}
-			this.#listContainer.addChild(new Spacer(1));
-			this.#listContainer.addChild(
-				new Text(theme.fg("muted", "  Enter to open a group; Esc to return to models"), 0, 0),
-			);
-			return;
-		}
-
-		this.#listContainer.addChild(
-			new Text(theme.fg("dim", `  ${state.group.label} — ${state.group.description}`), 0, 0),
-		);
-		this.#listContainer.addChild(new Spacer(1));
-		for (let i = 0; i < state.group.profiles.length; i++) {
-			const profile = state.group.profiles[i];
-			if (!profile) continue;
-			const prefix = i === this.#selectedProfileIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-			const label = i === this.#selectedProfileIndex ? theme.fg("accent", profile.name) : profile.name;
-			this.#listContainer.addChild(new Text(`${prefix}${label}`, 0, 0));
-		}
-		this.#listContainer.addChild(new Spacer(1));
-		this.#listContainer.addChild(
-			new Text(theme.fg("muted", "  Enter for actions; Esc to return to preset groups"), 0, 0),
-		);
-	}
-
-	#openProfileMenu(): void {
-		const groups = this.#buildProfileGroups();
-		if (groups.length === 0) return;
-		this.#profileMenuState = { kind: "groups" };
-		this.#selectedProfileGroupIndex = Math.min(this.#selectedProfileGroupIndex, groups.length - 1);
-		this.#selectedProfileIndex = 0;
-		this.#updateList();
-	}
-
-	#handleProfileMenuInput(keyData: string): void {
-		const state = this.#profileMenuState;
-		if (!state) return;
-		if (state.kind === "groups") {
-			const groups = this.#buildProfileGroups();
-			if (groups.length === 0) {
-				this.#profileMenuState = undefined;
-				this.#updateList();
-				return;
-			}
-			if (matchesKey(keyData, "up")) {
-				this.#selectedProfileGroupIndex =
-					this.#selectedProfileGroupIndex === 0 ? groups.length - 1 : this.#selectedProfileGroupIndex - 1;
-				this.#updateList();
-				return;
-			}
-			if (matchesKey(keyData, "down")) {
-				this.#selectedProfileGroupIndex = (this.#selectedProfileGroupIndex + 1) % groups.length;
-				this.#updateList();
-				return;
-			}
-			if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-				const group = groups[this.#selectedProfileGroupIndex];
-				if (!group) return;
-				this.#profileMenuState = { kind: "profiles", group };
-				this.#selectedProfileIndex = 0;
-				this.#updateList();
-				return;
-			}
-			if (getKeybindings().matches(keyData, "tui.select.cancel")) {
-				this.#profileMenuState = undefined;
-				this.#updateList();
-			}
-			return;
-		}
-
-		const profiles = state.group.profiles;
-		if (profiles.length === 0) {
-			this.#profileMenuState = { kind: "groups" };
-			this.#selectedProfileIndex = 0;
-			this.#updateList();
-			return;
-		}
-		if (matchesKey(keyData, "up")) {
-			this.#selectedProfileIndex =
-				this.#selectedProfileIndex === 0 ? profiles.length - 1 : this.#selectedProfileIndex - 1;
-			this.#updateList();
-			return;
-		}
-		if (matchesKey(keyData, "down")) {
-			this.#selectedProfileIndex = (this.#selectedProfileIndex + 1) % profiles.length;
-			this.#updateList();
-			return;
-		}
-		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const profile = profiles[this.#selectedProfileIndex];
-			if (!profile) return;
-			this.#profileMenuState = undefined;
-			this.#pendingActionItem = { kind: "profile-action", profile };
-			this.#selectedActionIndex = 0;
-			this.#updateList();
-			return;
-		}
-		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
-			this.#profileMenuState = { kind: "groups" };
-			this.#selectedProfileIndex = 0;
-			this.#updateList();
-		}
-	}
 
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
-	#getActionCount(model: Model): number {
-		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length + (supportsOpenAICodexPreset(model) ? 1 : 0);
+	#getActionCount(_model: Model): number {
+		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
 	}
 
-	#getSelectedItem(): ModelItem | CanonicalModelItem | ProfileSurfaceItem | undefined {
-		const visibleProfileSurface = this.#getVisibleProfileSurface();
-		if (this.#selectedIndex < visibleProfileSurface.length) return visibleProfileSurface[this.#selectedIndex];
-		const modelIndex = this.#selectedIndex - visibleProfileSurface.length;
-		return this.#isCanonicalTab() ? this.#filteredCanonicalModels[modelIndex] : this.#filteredModels[modelIndex];
+	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
+		return this.#isCanonicalTab() ? this.#filteredCanonicalModels[this.#selectedIndex] : this.#filteredModels[this.#selectedIndex];
 	}
 
 	handleInput(keyData: string): void {
@@ -1120,8 +1008,9 @@ export class ModelSelectorComponent extends Container {
 			this.#handleActionMenuInput(keyData);
 			return;
 		}
-		if (this.#profileMenuState) {
-			this.#handleProfileMenuInput(keyData);
+
+		if (this.#viewMode === "presets") {
+			this.#handlePresetLandingInput(keyData);
 			return;
 		}
 
@@ -1132,9 +1021,7 @@ export class ModelSelectorComponent extends Container {
 
 		// Up arrow - navigate list (wrap to bottom when at top)
 		if (matchesKey(keyData, "up")) {
-			const itemCount =
-				this.#getVisibleProfileSurface().length +
-				(this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length);
+			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === 0 ? itemCount - 1 : this.#selectedIndex - 1;
 			this.#updateList();
@@ -1143,24 +1030,18 @@ export class ModelSelectorComponent extends Container {
 
 		// Down arrow - navigate list (wrap to top when at bottom)
 		if (matchesKey(keyData, "down")) {
-			const itemCount =
-				this.#getVisibleProfileSurface().length +
-				(this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length);
+			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === itemCount - 1 ? 0 : this.#selectedIndex + 1;
 			this.#updateList();
 			return;
 		}
 
-		// Enter opens the grouped preset picker or persistent assignment menu.
-		// Temporary-only mode keeps the existing non-persistent quick-switch behavior.
+		// Enter opens the persistent assignment menu. Temporary-only mode keeps the
+		// existing non-persistent quick-switch behavior.
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selectedItem = this.#getSelectedItem();
-			if (selectedItem?.kind === "profile-surface") {
-				this.#openProfileMenu();
-			} else if (selectedItem) {
-				this.#beginActionMenuOrSelect(selectedItem);
-			}
+			if (selectedItem) this.#beginActionMenuOrSelect(selectedItem);
 			return;
 		}
 
@@ -1173,6 +1054,94 @@ export class ModelSelectorComponent extends Container {
 		// Pass everything else to search input
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());
+	}
+
+	#handlePresetLandingInput(keyData: string): void {
+		if (isPrintableCharacter(keyData)) {
+			this.#switchToModelMode(keyData);
+			return;
+		}
+		if (matchesKey(keyData, "up")) {
+			const rows = this.#getPresetRows();
+			if (rows.length === 0) return;
+			if (this.#presetScopeMenuOpen) {
+				this.#presetScopeIndex = this.#presetScopeIndex === 0 ? PRESET_SCOPE_LABELS.length - 1 : this.#presetScopeIndex - 1;
+			} else {
+				this.#presetCursor = this.#presetCursor === 0 ? rows.length - 1 : this.#presetCursor - 1;
+				this.#previewProfileName = undefined;
+				this.#presetLoginHint = undefined;
+				this.#updatePresetExpansion();
+			}
+			this.#renderPresetLanding();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			const rows = this.#getPresetRows();
+			if (rows.length === 0) return;
+			if (this.#presetScopeMenuOpen) {
+				this.#presetScopeIndex = (this.#presetScopeIndex + 1) % PRESET_SCOPE_LABELS.length;
+			} else {
+				this.#presetCursor = (this.#presetCursor + 1) % rows.length;
+				this.#previewProfileName = undefined;
+				this.#presetLoginHint = undefined;
+				this.#updatePresetExpansion();
+			}
+			this.#renderPresetLanding();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			this.#handlePresetEnter();
+			return;
+		}
+		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+			if (this.#presetScopeMenuOpen) {
+				this.#presetScopeMenuOpen = false;
+				this.#renderPresetLanding();
+				return;
+			}
+			if (this.#previewProfileName) {
+				this.#previewProfileName = undefined;
+				this.#renderPresetLanding();
+				return;
+			}
+			if (this.#expandedPresetProviderId) {
+				this.#expandedPresetProviderId = undefined;
+				this.#presetCursor = Math.min(this.#presetCursor, Math.max(0, this.#getPresetRows().length - 1));
+				this.#renderPresetLanding();
+				return;
+			}
+			this.#onCancelCallback();
+		}
+	}
+
+	#handlePresetEnter(): void {
+		if (this.#presetScopeMenuOpen && this.#previewProfileName) {
+			this.#onSelectCallback({ kind: "profile", profileName: this.#previewProfileName, setDefault: this.#presetScopeIndex === 1 });
+			return;
+		}
+		if (this.#previewProfileName) {
+			this.#presetScopeMenuOpen = true;
+			this.#presetScopeIndex = 0;
+			this.#renderPresetLanding();
+			return;
+		}
+		const row = this.#getSelectedPresetRow();
+		if (!row) return;
+		if (row.kind === "browse") {
+			this.#switchToModelMode();
+			return;
+		}
+		const missing = row.kind === "group" ? this.#getMissingProviders(row.profiles) : this.#getMissingProviders(row.profile);
+		if (missing.length > 0) {
+			this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
+			this.#renderPresetLanding();
+			return;
+		}
+		if (row.kind === "profile") {
+			this.#previewProfileName = row.profile.name;
+			this.#presetLoginHint = undefined;
+			this.#renderPresetLanding();
+		}
 	}
 
 	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
@@ -1188,7 +1157,7 @@ export class ModelSelectorComponent extends Container {
 	#handleActionMenuInput(keyData: string): void {
 		const item = this.#pendingActionItem;
 		if (!item) return;
-		const actionCount = item.kind === "profile-action" ? 2 : this.#getActionCount(item.model);
+		const actionCount = this.#getActionCount(item.model);
 		if (matchesKey(keyData, "up")) {
 			this.#selectedActionIndex = this.#selectedActionIndex === 0 ? actionCount - 1 : this.#selectedActionIndex - 1;
 			this.#updateList();
@@ -1201,20 +1170,8 @@ export class ModelSelectorComponent extends Container {
 		}
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			this.#pendingActionItem = undefined;
-			if (item.kind === "profile-action") {
-				this.#onSelectCallback({
-					kind: "profile",
-					profileName: item.profile.name,
-					setDefault: this.#selectedActionIndex === 1,
-				});
-			} else {
-				const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
-				if (role) {
-					this.#handleSelect(item, role);
-				} else {
-					this.#handlePresetSelect(item, OPENAI_CODE_PROFILE_PRESET);
-				}
-			}
+			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
+			if (role) this.#handleSelect(item, role);
 			return;
 		}
 		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
@@ -1252,18 +1209,6 @@ export class ModelSelectorComponent extends Container {
 			}
 			this.#updateList();
 		}
-	}
-	#handlePresetSelect(item: ModelItem | CanonicalModelItem, preset: ModelAssignmentPreset): void {
-		const selectorValue = item.selector;
-		const assignments = resolvePresetAssignments(item.model, preset);
-		for (const [role, thinkingLevel] of Object.entries(assignments) as [
-			GjcModelAssignmentTargetId,
-			ThinkingLevel,
-		][]) {
-			this.#roles[role] = { model: item.model, thinkingLevel };
-		}
-		this.#onSelectCallback({ kind: "preset", model: item.model, selector: selectorValue, preset, assignments });
-		this.#updateList();
 	}
 
 	#handleSelect(
@@ -1324,30 +1269,6 @@ function requiresExplicitThinkingChoice(model: Model): boolean {
 	return model.reasoning === true && (model.provider === "openai" || model.provider === "openai-codex");
 }
 
-function supportsOpenAICodexPreset(model: Model): boolean {
-	return model.provider === "openai-codex" && model.reasoning === true;
-}
-
-function resolvePresetAssignments(
-	model: Model,
-	preset: ModelAssignmentPreset,
-): Record<GjcModelAssignmentTargetId, ThinkingLevel> {
-	const resolved = {} as Record<GjcModelAssignmentTargetId, ThinkingLevel>;
-	for (const [role, requestedLevel] of Object.entries(preset.assignments) as [
-		GjcModelAssignmentTargetId,
-		ThinkingLevel,
-	][]) {
-		const clampedLevel =
-			requestedLevel === ThinkingLevel.Off || requestedLevel === ThinkingLevel.Inherit
-				? requestedLevel
-				: clampThinkingLevelForModel(model, requestedLevel);
-		if (!clampedLevel) {
-			throw new Error(`Model ${model.provider}/${model.id} does not support ${requestedLevel} reasoning`);
-		}
-		resolved[role] = clampedLevel;
-	}
-	return resolved;
-}
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {
 	const levels: ThinkingLevel[] = [ThinkingLevel.Off];

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -5,6 +5,7 @@ import type { Component, OverlayHandle } from "@gajae-code/tui";
 import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import { activateModelProfile } from "../../config/model-profile-activation";
+import { recommendModelProfileForProvider } from "../../config/model-profiles";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
@@ -537,12 +538,6 @@ export class SelectorController {
 				this.ctx.session.scopedModels,
 				async selection => {
 					try {
-						if (selection.kind === "preset") {
-							await this.#applyModelAssignmentPreset(selection);
-							done();
-							this.ctx.ui.requestRender();
-							return;
-						}
 						if (selection.kind === "profile") {
 							await activateModelProfile(
 								{
@@ -609,44 +604,12 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				options,
+				{ ...options, sessionId: this.ctx.session.sessionId },
 			);
 			return { component: selector, focus: selector };
 		});
 	}
 
-	async #applyModelAssignmentPreset(selection: Extract<ModelSelectorSelection, { kind: "preset" }>): Promise<void> {
-		const { assignments, model, preset, selector } = selection;
-		const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
-		if (!apiKey) {
-			throw new Error(`No API key for ${model.provider}/${model.id}`);
-		}
-
-		const defaultThinkingLevel = assignments.default;
-		await this.ctx.session.setModel(model, "default", {
-			selector,
-			thinkingLevel: defaultThinkingLevel,
-		});
-		if (defaultThinkingLevel && defaultThinkingLevel !== ThinkingLevel.Inherit) {
-			this.ctx.session.setThinkingLevel(defaultThinkingLevel);
-		}
-
-		const overrides = this.ctx.settings.get("task.agentModelOverrides");
-		const nextOverrides = { ...overrides };
-		for (const [targetRole, presetThinkingLevel] of Object.entries(assignments) as [
-			keyof Extract<ModelSelectorSelection, { kind: "preset" }>["assignments"],
-			ThinkingLevel,
-		][]) {
-			if (!targetRole || targetRole === "default") continue;
-			nextOverrides[targetRole] =
-				presetThinkingLevel === ThinkingLevel.Inherit ? selector : `${selector}:${presetThinkingLevel}`;
-		}
-		this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
-		this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
-		this.ctx.statusLine.invalidate();
-		this.ctx.updateEditorBorderColor();
-		this.ctx.showStatus(`${preset.label}: ${selector}`);
-	}
 
 	async showPluginSelector(mode: "install" | "uninstall" = "install"): Promise<void> {
 		const mgr = new MarketplaceManager({
@@ -1034,6 +997,31 @@ export class SelectorController {
 		await this.showSessionSelector();
 	}
 
+	async #handlePostLoginModelProfileRecommendation(providerId: string): Promise<void> {
+		const recommendedProfile = recommendModelProfileForProvider(providerId, this.ctx.session.modelRegistry.getModelProfiles());
+		if (!recommendedProfile) {
+			return;
+		}
+
+		const activeProfile = this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default");
+		if (activeProfile) {
+			this.ctx.showStatus(`Preset ${recommendedProfile.name} is available in /model.`);
+			return;
+		}
+
+		const confirmed = await this.ctx.showHookConfirm(`Apply ${recommendedProfile.name} now?`, "");
+		if (!confirmed) {
+			return;
+		}
+
+		await activateModelProfile({
+			session: this.ctx.session,
+			modelRegistry: this.ctx.session.modelRegistry,
+			settings: this.ctx.settings,
+			profileName: recommendedProfile.name,
+		});
+	}
+
 	async #handleOAuthLogin(providerId: string): Promise<void> {
 		this.ctx.showStatus(`Logging in to ${providerId}…`);
 		const manualInput = this.ctx.oauthManualInput;
@@ -1090,6 +1078,7 @@ export class SelectorController {
 				new Text(theme.fg("success", `${theme.status.success} Successfully logged in to ${providerId}`), 1, 0),
 			);
 			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`), 1, 0));
+			await this.#handlePostLoginModelProfileRecommendation(providerId);
 			this.ctx.ui.requestRender();
 		} catch (error: unknown) {
 			this.ctx.showError(`Login failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -1120,7 +1109,7 @@ export class SelectorController {
 	async showOAuthSelector(mode: "login" | "logout", providerId?: string): Promise<void> {
 		if (providerId) {
 			const oauthProvider = getOAuthProviders().find(provider => provider.id === providerId);
-			if (!oauthProvider) {
+			if (!oauthProvider && !this.ctx.session.modelRegistry.getModelProfiles().has(providerId)) {
 				this.ctx.showError(`Unknown OAuth provider: ${providerId}`);
 				return;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -865,6 +865,7 @@ export class AgentSession {
 
 	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
+	#activeModelProfile: string | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -5732,6 +5733,14 @@ export class AgentSession {
 		// configured defaultLevel; otherwise preserve the current level.
 		this.setThinkingLevel(model.thinking?.defaultLevel ?? this.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
+	}
+
+	setActiveModelProfile(name: string | undefined): void {
+		this.#activeModelProfile = name;
+	}
+
+	getActiveModelProfile(): string | undefined {
+		return this.#activeModelProfile;
 	}
 
 	/**

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -91,3 +91,28 @@ export function resolveThinkingLevelForModel(
 	}
 	return clampThinkingLevelForModel(model, level);
 }
+
+export function clampExplicitThinkingLevelForModel(
+	model: Model | undefined,
+	level: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
+	if (level === undefined || level === ThinkingLevel.Inherit || level === ThinkingLevel.Off) {
+		return level;
+	}
+	return clampThinkingLevelForModel(model, level);
+}
+
+export function formatClampedModelSelector(selector: string, model: Model | undefined): string {
+	const slashIdx = selector.indexOf("/");
+	if (slashIdx <= 0) return selector;
+	const id = selector.slice(slashIdx + 1);
+	const colonIdx = id.lastIndexOf(":");
+	if (colonIdx === -1) return selector;
+	const suffix = id.slice(colonIdx + 1);
+	const thinkingLevel = parseThinkingLevel(suffix);
+	if (!thinkingLevel) return selector;
+	const clamped = clampExplicitThinkingLevelForModel(model, thinkingLevel);
+	return clamped && clamped !== ThinkingLevel.Inherit
+		? `${selector.slice(0, slashIdx + 1)}${id.slice(0, colonIdx)}:${clamped}`
+		: selector.slice(0, slashIdx + 1) + id.slice(0, colonIdx);
+}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -38,8 +38,8 @@ function fakeSession(initial = model("initial-provider", "initial")) {
 }
 describe("CLI model profile args", () => {
 	test("parses --mpreset with separate value", () => {
-		const parsed = parseArgs(["--mpreset", "codex-standard"]);
-		expect(parsed.mpreset).toBe("codex-standard");
+		const parsed = parseArgs(["--mpreset", "codex-medium"]);
+		expect(parsed.mpreset).toBe("codex-medium");
 		expect(parsed.default).toBeUndefined();
 	});
 
@@ -49,8 +49,8 @@ describe("CLI model profile args", () => {
 	});
 
 	test("parses --default with --mpreset", () => {
-		const parsed = parseArgs(["--mpreset", "opencode-go-standard", "--default"]);
-		expect(parsed.mpreset).toBe("opencode-go-standard");
+		const parsed = parseArgs(["--mpreset", "opencodego", "--default"]);
+		expect(parsed.mpreset).toBe("opencodego");
 		expect(parsed.default).toBe(true);
 	});
 
@@ -96,13 +96,13 @@ test("deferred explicit CLI --model is reapplied after --mpreset activation", as
 		settings,
 		modelRegistry: fakeRegistry([
 			{
-				name: "codex-standard",
+				name: "codex-medium",
 				requiredProviders: ["profile-provider"],
 				modelMapping: { default: "profile-provider/default:high" },
 				source: "user",
 			},
 		]) as never,
-		parsedArgs: { mpreset: "codex-standard", model: "cli-provider/explicit" },
+		parsedArgs: { mpreset: "codex-medium", model: "cli-provider/explicit" },
 		startupModel: undefined,
 		startupThinkingLevel: undefined,
 	});

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -1,0 +1,192 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+
+const model = (provider: string, id: string): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking: { minLevel: ThinkingLevel.Low, maxLevel: ThinkingLevel.XHigh },
+	}) as Model;
+
+const codexModel = model("openai-codex", "gpt-5.5");
+const minimaxModel = model("minimax-code", "minimax-v3");
+
+const profile = (name: string, provider: string, selector: string): ModelProfileDefinition => ({
+	name,
+	requiredProviders: [provider],
+	modelMapping: { default: selector },
+	source: "builtin",
+});
+
+const codexProfile = profile("codex-medium", "openai-codex", "openai-codex/gpt-5.5:medium");
+const minimaxProfile = profile("minimax-medium", "minimax-code", "minimax-code/minimax-v3:medium");
+const plainMinimaxProfile = profile("minimax", "minimax-code", "minimax-code/minimax-v3:medium");
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+function createControllerContext(options: {
+	confirm?: boolean;
+	activeProfile?: string;
+	defaultProfile?: string;
+	profiles?: ModelProfileDefinition[];
+} = {}) {
+	const settings = Settings.isolated({
+		"task.agentModelOverrides": { executor: "openai-codex/original-executor" },
+		"modelProfile.default": options.defaultProfile,
+	});
+	const setCalls: Array<{ path: string; value: unknown }> = [];
+	const originalSet = settings.set.bind(settings);
+	settings.set = ((path: never, value: never) => {
+		setCalls.push({ path: path as string, value });
+		return originalSet(path, value);
+	}) as typeof settings.set;
+	settings.flush = vi.fn(async () => {}) as typeof settings.flush;
+
+	const profiles = new Map((options.profiles ?? [codexProfile, minimaxProfile]).map(entry => [entry.name, entry]));
+	let activeProfile = options.activeProfile;
+	const session = {
+		model: undefined as Model | undefined,
+		thinkingLevel: undefined as ThinkingLevel | undefined,
+		sessionId: "session-1",
+		scopedModels: [],
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile: vi.fn((name: string | undefined) => {
+			activeProfile = name;
+		}),
+		getActiveModelProfile: vi.fn(() => activeProfile),
+		modelRegistry: {
+			refresh: vi.fn(async () => {}),
+			authStorage: {
+				login: vi.fn(async () => {}),
+			},
+			getModelProfiles: () => new Map(profiles),
+			getModelProfile: (name: string) => profiles.get(name),
+			getAvailableModelProfileNames: () => [...profiles.keys()],
+			getApiKeyForProvider: vi.fn(async () => "key"),
+			getAll: () => [codexModel, minimaxModel],
+			resolveCanonicalModel: () => undefined,
+			getCanonicalVariants: () => [],
+			getCanonicalId: () => undefined,
+		},
+	};
+	const ctx = {
+		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+		editor: {},
+		settings,
+		session,
+		chatContainer: { addChild: vi.fn() },
+		oauthManualInput: { waitForInput: vi.fn(), clear: vi.fn() },
+		openInBrowser: vi.fn(),
+		showHookConfirm: vi.fn(async () => options.confirm ?? false),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+	};
+	return { ctx, settings, session, setCalls };
+}
+
+async function login(ctx: ReturnType<typeof createControllerContext>["ctx"], providerId: string): Promise<void> {
+	installTestTheme();
+	const controller = new SelectorController(ctx as never);
+	await controller.showOAuthSelector("login", providerId);
+}
+
+describe("login preset recommendation", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+
+	test("login on openai-codex with no active profile prompts and confirm activates session-only profile", async () => {
+		const { ctx, settings, session, setCalls } = createControllerContext({ confirm: true });
+
+		await login(ctx, "openai-codex");
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(ctx.showHookConfirm).toHaveBeenCalledWith("Apply codex-medium now?", "");
+		expect(session.setModelTemporaryCalls).toEqual([{ model: codexModel, thinkingLevel: ThinkingLevel.Medium }]);
+		expect(session.setActiveModelProfile).toHaveBeenCalledWith("codex-medium");
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(setCalls).not.toContainEqual({ path: "modelProfile.default", value: "codex-medium" });
+	});
+
+	test("declining the post-login recommendation performs no mutation", async () => {
+		const { ctx, session, settings } = createControllerContext({ confirm: false });
+
+		await login(ctx, "openai-codex");
+
+		expect(ctx.showHookConfirm).toHaveBeenCalledWith("Apply codex-medium now?", "");
+		expect(session.setModelTemporaryCalls).toEqual([]);
+		expect(session.setActiveModelProfile).not.toHaveBeenCalled();
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "openai-codex/original-executor" });
+	});
+
+	test("login with session active profile shows hint instead of prompting", async () => {
+		const { ctx, session } = createControllerContext({ activeProfile: "codex-eco" });
+
+		await login(ctx, "openai-codex");
+
+		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
+		expect(ctx.showStatus).toHaveBeenCalledWith("Preset codex-medium is available in /model.");
+		expect(session.setModelTemporaryCalls).toEqual([]);
+	});
+
+	test("login with default profile setting shows hint instead of prompting", async () => {
+		const { ctx, session } = createControllerContext({ defaultProfile: "codex-eco" });
+
+		await login(ctx, "openai-codex");
+
+		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
+		expect(ctx.showStatus).toHaveBeenCalledWith("Preset codex-medium is available in /model.");
+		expect(session.setModelTemporaryCalls).toEqual([]);
+	});
+
+	test("minimax-code login recommends minimax-medium", async () => {
+		const { ctx, session } = createControllerContext({ confirm: true });
+
+		await login(ctx, "minimax-code");
+
+		expect(ctx.showHookConfirm).toHaveBeenCalledWith("Apply minimax-medium now?", "");
+		expect(session.setModelTemporaryCalls).toEqual([{ model: minimaxModel, thinkingLevel: ThinkingLevel.Medium }]);
+		expect(session.setActiveModelProfile).toHaveBeenCalledWith("minimax-medium");
+	});
+
+	test("provider with no recommendation mapping does nothing", async () => {
+		const { ctx, session } = createControllerContext();
+
+		await login(ctx, "ollama");
+
+		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
+		expect(ctx.showStatus).toHaveBeenCalledWith("Logging in to ollama…");
+		expect(session.setModelTemporaryCalls).toEqual([]);
+	});
+
+	test("plain minimax has no recommendation mapping", async () => {
+		const { ctx, session } = createControllerContext({ activeProfile: "codex-eco", profiles: [codexProfile, minimaxProfile, plainMinimaxProfile] });
+
+		await login(ctx, "minimax");
+
+		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
+		expect(ctx.showStatus).toHaveBeenCalledWith("Logging in to minimax…");
+		expect(ctx.showStatus).not.toHaveBeenCalledWith("Preset minimax-medium is available in /model.");
+		expect(session.setModelTemporaryCalls).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -1,0 +1,227 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { Effort, type Model } from "@gajae-code/ai";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent, type ModelSelectorSelection } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+function normalizeRenderedText(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\s+/g, " ").trim();
+}
+
+const model = (provider: string, id: string, minLevel = Effort.Low): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking: { minLevel, maxLevel: Effort.XHigh, mode: "effort" },
+	}) as Model;
+
+const codexModel = model("openai-codex", "gpt-5.5", Effort.Low);
+const anthropicModel = model("anthropic", "claude-opus-4-8");
+const minimaxModel = model("minimax-code", "minimax-v3");
+const noSuffixModel = model("provider-a", "default");
+
+const codexEco: ModelProfileDefinition = {
+	name: "codex-eco",
+	requiredProviders: ["openai-codex"],
+	modelMapping: {
+		default: "openai-codex/gpt-5.5:low",
+		executor: "openai-codex/gpt-5.5:minimal",
+		planner: "openai-codex/gpt-5.5:low",
+	},
+	source: "builtin",
+};
+const combo: ModelProfileDefinition = {
+	name: "opus-codex",
+	requiredProviders: ["anthropic", "openai-codex"],
+	modelMapping: { default: "anthropic/claude-opus-4-8:xhigh", executor: "openai-codex/gpt-5.5:low" },
+	source: "builtin",
+};
+const minimax: ModelProfileDefinition = {
+	name: "minimax-medium",
+	requiredProviders: ["minimax-code"],
+	modelMapping: { default: "minimax-code/minimax-v3:medium" },
+	source: "builtin",
+};
+const noSuffixProfile: ModelProfileDefinition = {
+	name: "profile-no-suffix",
+	requiredProviders: ["provider-a"],
+	modelMapping: { default: "provider-a/default" },
+	source: "user",
+};
+
+let testTheme = await getThemeByName("red-claw");
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+function createRegistry(authenticatedProviders: readonly string[], profiles: ModelProfileDefinition[] = [codexEco, combo, minimax, noSuffixProfile]) {
+	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
+	return {
+		refresh: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [codexModel, anthropicModel, minimaxModel, noSuffixModel],
+		getAll: () => [codexModel, anthropicModel, minimaxModel, noSuffixModel],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(profileMap),
+		getModelProfile: (name: string) => profileMap.get(name),
+		getAvailableModelProfileNames: () => [...profileMap.keys()],
+		getApiKeyForProvider: async (provider: string) => authenticatedProviders.includes(provider) ? "key" : undefined,
+		getApiKey: async () => "key",
+	};
+}
+
+function createSelector(options: {
+	authenticatedProviders?: readonly string[];
+	temporaryOnly?: boolean;
+	initialSearchInput?: string;
+	scopedModels?: Array<{ model: Model }>;
+	onCancel?: () => void;
+	onSelect?: (selection: ModelSelectorSelection) => void | Promise<void>;
+	profiles?: ModelProfileDefinition[];
+} = {}) {
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		undefined,
+		Settings.isolated(),
+		createRegistry(options.authenticatedProviders ?? ["openai-codex", "anthropic", "minimax-code", "provider-a"], options.profiles) as never,
+		options.scopedModels ?? [],
+		options.onSelect ?? (() => {}),
+		options.onCancel ?? (() => {}),
+		{ temporaryOnly: options.temporaryOnly, initialSearchInput: options.initialSearchInput },
+	);
+}
+
+async function rendered(selector: ModelSelectorComponent): Promise<string> {
+	await Bun.sleep(10);
+	installTestTheme();
+	return normalizeRenderedText(selector.render(260).join("\n"));
+}
+
+describe("preset landing adversarial QA", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+
+	test("Escape closes exactly one preset layer in order", async () => {
+		const cancel = vi.fn();
+		const selector = createSelector({ onCancel: cancel });
+		await rendered(selector);
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n"); // preview first expanded profile
+		selector.handleInput("\n"); // scope menu
+		expect(normalizeRenderedText(selector.render(260).join("\n"))).toContain("Apply for this session");
+
+		selector.handleInput("\x1b");
+		let text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).not.toContain("Apply for this session");
+		expect(text).toContain("Preset preview: Codex Eco");
+
+		selector.handleInput("\x1b");
+		text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).not.toContain("Preset preview:");
+		expect(text).toContain("Codex Eco");
+
+		selector.handleInput("\x1b");
+		text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).not.toContain("codex-eco");
+		expect(text).toContain("CODEX");
+
+		selector.handleInput("\x1b");
+		expect(cancel).toHaveBeenCalledTimes(1);
+	});
+
+	test("printable input exits preview/scope menu into seeded model search", async () => {
+		const selector = createSelector();
+		await rendered(selector);
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		selector.handleInput("g");
+		const text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).toContain("Models");
+		expect(text).toContain("gpt-5.5");
+		expect(text).not.toContain("Preset preview:");
+		expect(text).not.toContain("Apply for this session");
+	});
+
+	test("up/down wraps at landing boundaries and Browse all preserves model role menu", async () => {
+		const selector = createSelector();
+		await rendered(selector);
+		selector.handleInput("\x1b[A");
+		let text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).toContain("Browse all models");
+		selector.handleInput("\x1b[B");
+		text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).toContain("CODEX");
+		selector.handleInput("\x1b[A");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).toContain("Action for:");
+		expect(text).toContain("Set as DEFAULT");
+		expect(text).toContain("Set as EXECUTOR");
+	});
+
+	test("temporaryOnly, initialSearchInput, and scoped models bypass preset landing", async () => {
+		expect(await rendered(createSelector({ temporaryOnly: true }))).not.toContain("Model presets");
+		const initial = await rendered(createSelector({ initialSearchInput: "claude" }));
+		expect(initial).not.toContain("Model presets");
+		expect(initial).toContain("Models");
+		const scoped = await rendered(createSelector({ scopedModels: [{ model: codexModel }] }));
+		expect(scoped).not.toContain("Model presets");
+		expect(scoped).toContain("Showing models from --models scope");
+	});
+
+	test("partial combo auth blocks selection and MiniMax hint uses canonical provider id only", async () => {
+		const selections: ModelSelectorSelection[] = [];
+		const comboSelector = createSelector({ authenticatedProviders: ["openai-codex"], onSelect: selection => { selections.push(selection); } });
+		await rendered(comboSelector);
+		comboSelector.handleInput("\n"); // expand CODEX so COMBOS is visible
+		comboSelector.handleInput("\x1b[B"); // codex-eco profile
+		comboSelector.handleInput("\x1b[B"); // MINIMAX group
+		comboSelector.handleInput("\x1b[B"); // COMBOS group
+		comboSelector.handleInput("\n");
+		let text = normalizeRenderedText(comboSelector.render(260).join("\n"));
+		expect(text).toContain("✗ COMBOS");
+		expect(text).toContain("anthropic");
+		expect(selections).toEqual([]);
+
+		const miniSelector = createSelector({ authenticatedProviders: ["openai-codex", "anthropic", "provider-a"] });
+		await rendered(miniSelector);
+		for (let i = 0; i < 2; i++) miniSelector.handleInput("\x1b[B");
+		miniSelector.handleInput("\n");
+		text = normalizeRenderedText(miniSelector.render(260).join("\n"));
+		expect(text).toContain("/login minimax-code");
+		expect(text).not.toContain("minimax/");
+		expect(text).not.toContain("/login minimax ");
+	});
+
+	test("preview clamps codex eco executor to low and omits suffix for suffixless selector", async () => {
+		const selector = createSelector();
+		await rendered(selector);
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		let text = normalizeRenderedText(selector.render(260).join("\n"));
+		expect(text).toContain("EXECUTOR: openai-codex/gpt-5.5");
+		expect(text).not.toContain("EXECUTOR: openai-codex/gpt-5.5:minimal");
+
+		const suffixless = createSelector({ profiles: [noSuffixProfile] });
+		await rendered(suffixless);
+		suffixless.handleInput("\x1b[B");
+		suffixless.handleInput("\n");
+		text = normalizeRenderedText(suffixless.render(260).join("\n"));
+		expect(text).toContain("DEFAULT: provider-a/default");
+		expect(text).not.toContain("DEFAULT: provider-a/default:");
+	});
+});

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -10,8 +10,8 @@ import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
 import { Settings } from "../src/config/settings";
 
-const model = (provider: string, id: string): Model =>
-	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000, thinking, reasoning: thinking !== undefined }) as Model;
 
 function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelProfileDefinition[] }) {
 	const profiles = new Map<string, ModelProfileDefinition>();
@@ -42,7 +42,7 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 			model("openai-codex", "gpt-5.4"),
 			model("openai-codex", "gpt-5.1-codex-max"),
 			model("openai-codex", "gpt-5.2-codex"),
-			model("openai-codex", "gpt-5.5"),
+			model("openai-codex", "gpt-5.5", { mode: "effort", minLevel: ThinkingLevel.Low, maxLevel: ThinkingLevel.XHigh }),
 			model("openai-codex", "gpt-5.3-codex-spark"),
 			model("minimax-code", "minimax-m3"),
 			model("minimax-code-cn", "minimax-m3"),
@@ -56,6 +56,7 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 }
 
 function fakeSession(initial = model("provider-a", "initial")) {
+	let activeModelProfile: string | undefined;
 	return {
 		model: initial as Model | undefined,
 		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
@@ -65,6 +66,12 @@ function fakeSession(initial = model("provider-a", "initial")) {
 			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
 			this.model = next;
 			this.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+		getActiveModelProfile() {
+			return activeModelProfile;
 		},
 	};
 }
@@ -87,32 +94,21 @@ describe("model profile activation", () => {
 		});
 	});
 
-	test("builtin profiles preserve explicit role thinking suffixes in overrides", async () => {
+	test("builtin codex-eco executor selector clamps from catalog minimal to prepared low", async () => {
 		const registry = fakeRegistry({ profiles: [...BUILTIN_MODEL_PROFILES] });
+		const catalog = BUILTIN_MODEL_PROFILES.find(profile => profile.name === "codex-eco");
+		expect(catalog?.modelMapping.executor).toBe("openai-codex/gpt-5.5:minimal");
 
-		const codexStandard = await prepareModelProfileActivation({
+		const prepared = await prepareModelProfileActivation({
 			session: fakeSession(),
 			modelRegistry: registry,
 			settings: Settings.isolated(),
-			profileName: "codex-standard",
+			profileName: "codex-eco",
 		});
-		expect(codexStandard.agentModelOverrides).toEqual({
-			executor: "openai-codex/gpt-5.5:low",
-			architect: "openai-codex/gpt-5.5:xhigh",
-			planner: "openai-codex/gpt-5.5:medium",
-			critic: "openai-codex/gpt-5.5:high",
-		});
-
-		const codexPro = await prepareModelProfileActivation({
-			session: fakeSession(),
-			modelRegistry: registry,
-			settings: Settings.isolated(),
-			profileName: "codex-pro",
-		});
-		expect(codexPro.agentModelOverrides.executor).toBe("openai-codex/gpt-5.5:high");
-		expect(codexPro.agentModelOverrides.architect).toBe("openai-codex/gpt-5.5:xhigh");
-		expect(codexPro.agentModelOverrides.planner).toBe("openai-codex/gpt-5.5:high");
-		expect(codexPro.agentModelOverrides.critic).toBe("openai-codex/gpt-5.5:high");
+		expect(prepared.agentModelOverrides.executor).toBe("openai-codex/gpt-5.5:low");
+		expect(prepared.agentModelOverrides.architect).toBe("openai-codex/gpt-5.5:high");
+		expect(prepared.agentModelOverrides.planner).toBe("openai-codex/gpt-5.5:low");
+		expect(prepared.agentModelOverrides.critic).toBe("openai-codex/gpt-5.5:medium");
 	});
 
 	test("session-only changes active model and applies runtime overrides without persisted sets", async () => {
@@ -136,6 +132,7 @@ describe("model profile activation", () => {
 		});
 		expect(setCalls).toEqual([]);
 		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(session.getActiveModelProfile()).toBe("profile-a");
 	});
 
 	test("--default persists only modelProfile.default and flushes", async () => {
@@ -160,6 +157,7 @@ describe("model profile activation", () => {
 		expect(setCalls).toEqual(["modelProfile.default"]);
 		expect(settings.get("modelProfile.default")).toBe("profile-a");
 		expect(flushCount).toBe(1);
+		expect(session.getActiveModelProfile()).toBe("profile-a");
 	});
 
 	test("missing credentials hard-block before mutation", async () => {
@@ -223,6 +221,7 @@ describe("model profile activation", () => {
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
 		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 
 	test("precedence composes configured, default, mpreset, and explicit overrides", async () => {

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -1,79 +1,75 @@
 import { describe, expect, test } from "bun:test";
-import { ThinkingLevel } from "@gajae-code/agent-core";
-import { type GeneratedProvider, getBundledModel } from "@gajae-code/ai/models";
+import modelsJson from "../../ai/src/models.json";
 import {
 	BUILTIN_MODEL_PROFILES,
-	type ModelProfileDefinition,
+	formatAvailableProfileNames,
+	getModelProfilePresentation,
+	groupModelProfilesForPresetLanding,
 	mergeModelProfiles,
+	recommendModelProfileForProvider,
 	resolveProfileBindings,
+	type ModelProfileDefinition,
 } from "@gajae-code/coding-agent/config/model-profiles";
 import { parseModelString } from "@gajae-code/coding-agent/config/model-resolver";
 import { ProfileModelSelectorSchema } from "@gajae-code/coding-agent/config/models-config-schema";
 
-type Role = "default" | "executor" | "architect" | "planner" | "critic";
+type Role = "default" | "executor" | "planner" | "critic" | "architect";
 
-const roles: Role[] = ["default", "executor", "architect", "planner", "critic"];
-const reviewRoles: Role[] = ["architect", "planner", "critic"];
-const effortRank: Partial<Record<ThinkingLevel, number>> = {
-	[ThinkingLevel.Minimal]: 0,
-	[ThinkingLevel.Low]: 1,
-	[ThinkingLevel.Medium]: 2,
-	[ThinkingLevel.High]: 3,
-	[ThinkingLevel.XHigh]: 4,
-};
+const roles: Role[] = ["default", "executor", "planner", "critic", "architect"];
 
-function builtIn(name: string): ModelProfileDefinition {
-	const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === name);
-	expect(profile).toBeDefined();
-	return profile as ModelProfileDefinition;
-}
+const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mapping: Record<Role, string> }> = [
+	{ name: "codex-eco", requiredProviders: ["openai-codex"], mapping: { default: "openai-codex/gpt-5.5:low", executor: "openai-codex/gpt-5.5:minimal", planner: "openai-codex/gpt-5.5:low", critic: "openai-codex/gpt-5.5:medium", architect: "openai-codex/gpt-5.5:high" } },
+	{ name: "codex-medium", requiredProviders: ["openai-codex"], mapping: { default: "openai-codex/gpt-5.5:medium", executor: "openai-codex/gpt-5.5:low", planner: "openai-codex/gpt-5.5:medium", critic: "openai-codex/gpt-5.5:high", architect: "openai-codex/gpt-5.5:xhigh" } },
+	{ name: "codex-pro", requiredProviders: ["openai-codex"], mapping: { default: "openai-codex/gpt-5.5:xhigh", executor: "openai-codex/gpt-5.5:medium", planner: "openai-codex/gpt-5.5:high", critic: "openai-codex/gpt-5.5:xhigh", architect: "openai-codex/gpt-5.5:xhigh" } },
+	{ name: "opencodego", requiredProviders: ["opencode-go"], mapping: { default: "opencode-go/kimi-k2.6", executor: "opencode-go/deepseek-v4-flash", planner: "opencode-go/qwen3.7-max", critic: "opencode-go/mimo-v2.5-pro", architect: "opencode-go/deepseek-v4-pro" } },
+	{ name: "claude-opus", requiredProviders: ["anthropic"], mapping: { default: "anthropic/claude-opus-4-8:xhigh", executor: "anthropic/claude-sonnet-4-6", planner: "anthropic/claude-opus-4-8:low", critic: "anthropic/claude-opus-4-8:high", architect: "anthropic/claude-opus-4-8:xhigh" } },
+	{ name: "claude-fable", requiredProviders: ["anthropic"], mapping: { default: "anthropic/claude-fable-5:xhigh", executor: "anthropic/claude-sonnet-4-6", planner: "anthropic/claude-opus-4-8:low", critic: "anthropic/claude-opus-4-8:high", architect: "anthropic/claude-fable-5:xhigh" } },
+	{ name: "glm-eco", requiredProviders: ["zai"], mapping: { default: "zai/glm-5.1:low", executor: "zai/glm-5.1:minimal", planner: "zai/glm-5.1:low", critic: "zai/glm-5.1:medium", architect: "zai/glm-5.1:high" } },
+	{ name: "glm-medium", requiredProviders: ["zai"], mapping: { default: "zai/glm-5.1:medium", executor: "zai/glm-5.1:low", planner: "zai/glm-5.1:medium", critic: "zai/glm-5.1:high", architect: "zai/glm-5.1:xhigh" } },
+	{ name: "glm-pro", requiredProviders: ["zai"], mapping: { default: "zai/glm-5.1:xhigh", executor: "zai/glm-5.1:medium", planner: "zai/glm-5.1:high", critic: "zai/glm-5.1:xhigh", architect: "zai/glm-5.1:xhigh" } },
+	{ name: "kimi-coding-plan-eco", requiredProviders: ["kimi-code"], mapping: { default: "kimi-code/kimi-k2.7-code:low", executor: "kimi-code/kimi-k2.7-code:minimal", planner: "kimi-code/kimi-k2.7-code:low", critic: "kimi-code/kimi-k2.7-code:medium", architect: "kimi-code/kimi-k2.7-code:high" } },
+	{ name: "kimi-coding-plan-medium", requiredProviders: ["kimi-code"], mapping: { default: "kimi-code/kimi-k2.7-code:medium", executor: "kimi-code/kimi-k2.7-code:low", planner: "kimi-code/kimi-k2.7-code:medium", critic: "kimi-code/kimi-k2.7-code:high", architect: "kimi-code/kimi-k2.7-code:xhigh" } },
+	{ name: "kimi-coding-plan-pro", requiredProviders: ["kimi-code"], mapping: { default: "kimi-code/kimi-k2.7-code:xhigh", executor: "kimi-code/kimi-k2.7-code:medium", planner: "kimi-code/kimi-k2.7-code:high", critic: "kimi-code/kimi-k2.7-code:xhigh", architect: "kimi-code/kimi-k2.7-code:xhigh" } },
+	{ name: "mimo-eco", requiredProviders: ["xiaomi"], mapping: { default: "xiaomi/mimo-v2.5-pro:low", executor: "xiaomi/mimo-v2.5-pro:minimal", planner: "xiaomi/mimo-v2.5-pro:low", critic: "xiaomi/mimo-v2.5-pro:medium", architect: "xiaomi/mimo-v2.5-pro:high" } },
+	{ name: "mimo-medium", requiredProviders: ["xiaomi"], mapping: { default: "xiaomi/mimo-v2.5-pro:medium", executor: "xiaomi/mimo-v2.5-pro:low", planner: "xiaomi/mimo-v2.5-pro:medium", critic: "xiaomi/mimo-v2.5-pro:high", architect: "xiaomi/mimo-v2.5-pro:xhigh" } },
+	{ name: "mimo-pro", requiredProviders: ["xiaomi"], mapping: { default: "xiaomi/mimo-v2.5-pro:xhigh", executor: "xiaomi/mimo-v2.5-pro:medium", planner: "xiaomi/mimo-v2.5-pro:high", critic: "xiaomi/mimo-v2.5-pro:xhigh", architect: "xiaomi/mimo-v2.5-pro:xhigh" } },
+	{ name: "grok-eco", requiredProviders: ["xai"], mapping: { default: "xai/grok-4.3:low", executor: "xai/grok-4.3:minimal", planner: "xai/grok-4.3:low", critic: "xai/grok-4.3:medium", architect: "xai/grok-4.3:high" } },
+	{ name: "grok-medium", requiredProviders: ["xai"], mapping: { default: "xai/grok-4.3:medium", executor: "xai/grok-4.3:low", planner: "xai/grok-4.3:medium", critic: "xai/grok-4.3:high", architect: "xai/grok-4.3:xhigh" } },
+	{ name: "grok-pro", requiredProviders: ["xai"], mapping: { default: "xai/grok-4.3:xhigh", executor: "xai/grok-4.3:medium", planner: "xai/grok-4.3:high", critic: "xai/grok-4.3:xhigh", architect: "xai/grok-4.3:xhigh" } },
+	{ name: "cursor-eco", requiredProviders: ["cursor"], mapping: { default: "cursor/composer-1.5:low", executor: "cursor/composer-1.5:minimal", planner: "cursor/composer-1.5:low", critic: "cursor/composer-1.5:medium", architect: "cursor/composer-1.5:high" } },
+	{ name: "cursor-medium", requiredProviders: ["cursor"], mapping: { default: "cursor/composer-1.5:medium", executor: "cursor/composer-1.5:low", planner: "cursor/composer-1.5:medium", critic: "cursor/composer-1.5:high", architect: "cursor/composer-1.5:xhigh" } },
+	{ name: "cursor-pro", requiredProviders: ["cursor"], mapping: { default: "cursor/composer-1.5:xhigh", executor: "cursor/composer-1.5:medium", planner: "cursor/composer-1.5:high", critic: "cursor/composer-1.5:xhigh", architect: "cursor/composer-1.5:xhigh" } },
+	{ name: "minimax-eco", requiredProviders: ["minimax-code"], mapping: { default: "minimax-code/minimax-v3:low", executor: "minimax-code/minimax-v3:minimal", planner: "minimax-code/minimax-v3:low", critic: "minimax-code/minimax-v3:medium", architect: "minimax-code/minimax-v3:high" } },
+	{ name: "minimax-medium", requiredProviders: ["minimax-code"], mapping: { default: "minimax-code/minimax-v3:medium", executor: "minimax-code/minimax-v3:low", planner: "minimax-code/minimax-v3:medium", critic: "minimax-code/minimax-v3:high", architect: "minimax-code/minimax-v3:xhigh" } },
+	{ name: "minimax-pro", requiredProviders: ["minimax-code"], mapping: { default: "minimax-code/minimax-v3:xhigh", executor: "minimax-code/minimax-v3:medium", planner: "minimax-code/minimax-v3:high", critic: "minimax-code/minimax-v3:xhigh", architect: "minimax-code/minimax-v3:xhigh" } },
+	{ name: "fable-codex", requiredProviders: ["anthropic", "openai-codex"], mapping: { default: "anthropic/claude-fable-5:xhigh", executor: "openai-codex/gpt-5.5:low", planner: "openai-codex/gpt-5.5:medium", critic: "openai-codex/gpt-5.5:high", architect: "openai-codex/gpt-5.5:xhigh" } },
+	{ name: "opus-codex", requiredProviders: ["anthropic", "openai-codex"], mapping: { default: "anthropic/claude-opus-4-8:xhigh", executor: "openai-codex/gpt-5.5:low", planner: "openai-codex/gpt-5.5:medium", critic: "openai-codex/gpt-5.5:high", architect: "openai-codex/gpt-5.5:xhigh" } },
+	{ name: "codex-opencodego", requiredProviders: ["openai-codex", "opencode-go"], mapping: { default: "openai-codex/gpt-5.5:medium", executor: "opencode-go/deepseek-v4-pro", planner: "opencode-go/kimi-k2.6", critic: "opencode-go/mimo-v2.5-pro", architect: "openai-codex/gpt-5.5:xhigh" } },
+];
+
+const oldNames = ["opencode-go-eco", "opencode-go-standard", "opencode-go-pro", "codex-standard", "opencode-go-codex-eco", "opencode-go-codex-standard", "opencode-go-codex-pro"];
 
 function selectorExists(selector: string): boolean {
 	const parsed = parseModelString(selector);
 	if (!parsed) return false;
-	return getBundledModel(parsed.provider as GeneratedProvider, parsed.id) !== undefined;
-}
-
-function effortOf(selector: string): number {
-	const parsed = parseModelString(selector);
-	return parsed?.thinkingLevel ? (effortRank[parsed.thinkingLevel] ?? 0) : 0;
+	return (modelsJson as Record<string, Record<string, unknown>>)[parsed.provider]?.[parsed.id] !== undefined;
 }
 
 describe("built-in model profile catalog", () => {
-	test("contains exactly 13 builtins", () => {
-		expect(BUILTIN_MODEL_PROFILES).toHaveLength(13);
-		expect(new Set(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).size).toBe(13);
-	});
-
-	test("required_providers are correct per family", () => {
-		for (const profile of BUILTIN_MODEL_PROFILES) {
-			if (profile.name.startsWith("opencode-go-codex-")) {
-				expect(profile.requiredProviders).toEqual(["opencode-go", "openai-codex"]);
-			} else if (profile.name.startsWith("opencode-go-")) {
-				expect(profile.requiredProviders).toEqual(["opencode-go"]);
-			} else if (profile.name.startsWith("codex-")) {
-				expect(profile.requiredProviders).toEqual(["openai-codex"]);
-			} else if (profile.name === "minimax-standard") {
-				expect(profile.requiredProviders).toEqual(["minimax-code"]);
-			} else if (profile.name === "minimax-cn-standard") {
-				expect(profile.requiredProviders).toEqual(["minimax-code-cn"]);
-			} else if (profile.name === "kimi-standard") {
-				expect(profile.requiredProviders).toEqual(["kimi-code"]);
-			} else if (profile.name === "glm-standard") {
-				expect(profile.requiredProviders).toEqual(["zai"]);
-			} else {
-				throw new Error(`Unexpected built-in profile ${profile.name}`);
-			}
+	test("contains exact 26-profile matrix cell-for-cell", () => {
+		expect(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).toEqual(expectedProfiles.map(profile => profile.name));
+		for (const expected of expectedProfiles) {
+			const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === expected.name);
+			expect(profile?.requiredProviders).toEqual(expected.requiredProviders);
+			expect(profile?.modelMapping).toEqual(expected.mapping);
 		}
 	});
 
-	test("models.json package export is a plain relative path", async () => {
-		const manifest = (await Bun.file(new URL("../../ai/package.json", import.meta.url)).json()) as {
-			exports?: Record<string, { import?: string }>;
-		};
-		const exportTarget = manifest.exports?.["./models.json"]?.import;
-		expect(exportTarget).toBe("./src/models.json");
-		expect(exportTarget).not.toMatch(/^file:(?:file:)+/u);
+	test("old builtin names are absent and available names list current names", () => {
+		const profiles = mergeModelProfiles();
+		for (const oldName of oldNames) expect(profiles.has(oldName)).toBe(false);
+		expect(formatAvailableProfileNames(profiles)).toContain("codex-medium");
+		expect(formatAvailableProfileNames(profiles)).not.toContain("codex-standard");
 	});
 
 	test("every selector parses with schema validation and exists in models.json", () => {
@@ -88,144 +84,39 @@ describe("built-in model profile catalog", () => {
 			}
 		}
 		expect(missing).toEqual([]);
+		expect((modelsJson as Record<string, Record<string, unknown>>)["kimi-code"]?.["kimi-k2.7-code"]).toBeDefined();
+		expect((modelsJson as Record<string, Record<string, unknown>>)["minimax-code"]?.["minimax-v3"]).toBeDefined();
 	});
 
-	test("*-pro profiles raise effort on architect/planner/critic", () => {
-		for (const profile of BUILTIN_MODEL_PROFILES.filter(candidate => candidate.name.endsWith("-pro"))) {
-			for (const role of reviewRoles) {
-				expect(effortOf(profile.modelMapping[role] ?? "")).toBeGreaterThanOrEqual(
-					effortRank[ThinkingLevel.High] ?? 3,
-				);
-			}
-		}
+	test("plain minimax provider does not appear in catalog or recommendations", () => {
+		expect(JSON.stringify(BUILTIN_MODEL_PROFILES)).not.toContain("minimax/");
+		expect(recommendModelProfileForProvider("minimax", mergeModelProfiles())).toBeUndefined();
+		expect(recommendModelProfileForProvider("minimax-code", mergeModelProfiles())?.name).toBe("minimax-medium");
 	});
 
-	test("codex-standard mapping exactly equals OpenAI Code profile preset efforts", () => {
-		const profile = builtIn("codex-standard");
-		const expected: Record<Role, ThinkingLevel> = {
-			default: ThinkingLevel.Medium,
-			executor: ThinkingLevel.Low,
-			architect: ThinkingLevel.XHigh,
-			planner: ThinkingLevel.Medium,
-			critic: ThinkingLevel.High,
-		};
-		for (const role of roles) {
-			const parsed = parseModelString(profile.modelMapping[role] ?? "");
-			expect(parsed?.provider).toBe("openai-codex");
-			expect(parsed?.id).toBe("gpt-5.5");
-			expect(parsed?.thinkingLevel).toBe(expected[role]);
-		}
-	});
-
-	test("codex-pro mapping uses the GPT-5.5 baseline with raised effort", () => {
-		const profile = builtIn("codex-pro");
-		const expected: Record<Role, ThinkingLevel> = {
-			default: ThinkingLevel.XHigh,
-			executor: ThinkingLevel.High,
-			architect: ThinkingLevel.XHigh,
-			planner: ThinkingLevel.High,
-			critic: ThinkingLevel.High,
-		};
-		for (const role of roles) {
-			const parsed = parseModelString(profile.modelMapping[role] ?? "");
-			expect(parsed?.provider).toBe("openai-codex");
-			expect(parsed?.id).toBe("gpt-5.5");
-			expect(parsed?.thinkingLevel).toBe(expected[role]);
-		}
-	});
-
-	test("codex profiles share the GPT-5.5 baseline and differ only by effort", () => {
-		const standard = builtIn("codex-standard");
-		const pro = builtIn("codex-pro");
-		for (const role of roles) {
-			expect(parseModelString(standard.modelMapping[role] ?? "")?.id).toBe("gpt-5.5");
-			expect(parseModelString(pro.modelMapping[role] ?? "")?.id).toBe("gpt-5.5");
-			expect(effortOf(pro.modelMapping[role] ?? "")).toBeGreaterThanOrEqual(
-				effortOf(standard.modelMapping[role] ?? ""),
-			);
-		}
-		const strictlyHigher = roles.some(
-			role => effortOf(pro.modelMapping[role] ?? "") > effortOf(standard.modelMapping[role] ?? ""),
-		);
-		expect(strictlyHigher).toBe(true);
-	});
-
-	test("MiniMax, Kimi, and GLM presets map to first-class coding plan providers", () => {
-		const expected: Record<string, { provider: string; id: string; efforts: Record<Role, ThinkingLevel> }> = {
-			"minimax-standard": {
-				provider: "minimax-code",
-				id: "minimax-m3",
-				efforts: {
-					default: ThinkingLevel.Medium,
-					executor: ThinkingLevel.Low,
-					architect: ThinkingLevel.High,
-					planner: ThinkingLevel.Medium,
-					critic: ThinkingLevel.High,
-				},
-			},
-			"minimax-cn-standard": {
-				provider: "minimax-code-cn",
-				id: "minimax-m3",
-				efforts: {
-					default: ThinkingLevel.Medium,
-					executor: ThinkingLevel.Low,
-					architect: ThinkingLevel.High,
-					planner: ThinkingLevel.Medium,
-					critic: ThinkingLevel.High,
-				},
-			},
-			"kimi-standard": {
-				provider: "kimi-code",
-				id: "kimi-k2.5",
-				efforts: {
-					default: ThinkingLevel.Medium,
-					executor: ThinkingLevel.Low,
-					architect: ThinkingLevel.High,
-					planner: ThinkingLevel.Medium,
-					critic: ThinkingLevel.High,
-				},
-			},
-			"glm-standard": {
-				provider: "zai",
-				id: "glm-5.1",
-				efforts: {
-					default: ThinkingLevel.Medium,
-					executor: ThinkingLevel.Low,
-					architect: ThinkingLevel.High,
-					planner: ThinkingLevel.Medium,
-					critic: ThinkingLevel.High,
-				},
-			},
-		};
-
-		for (const [profileName, expectation] of Object.entries(expected)) {
-			const profile = builtIn(profileName);
-			for (const role of roles) {
-				const parsed = parseModelString(profile.modelMapping[role] ?? "");
-				expect(parsed?.provider).toBe(expectation.provider);
-				expect(parsed?.id).toBe(expectation.id);
-				expect(parsed?.thinkingLevel).toBe(expectation.efforts[role]);
-			}
-		}
+	test("presentation groups and provider recommendations are pure catalog helpers", () => {
+		const profiles = mergeModelProfiles();
+		expect(getModelProfilePresentation("kimi-coding-plan-medium")).toEqual({ displayName: "Kimi Coding Plan Medium", providerGroup: "KIMI CODING PLAN" });
+		expect([...groupModelProfilesForPresetLanding(profiles).keys()]).toEqual(["CODEX", "OPENCODEGO", "CLAUDE", "GLM", "KIMI CODING PLAN", "MIMO", "GROK", "CURSOR", "MINIMAX", "COMBOS"]);
+		expect(recommendModelProfileForProvider("openai-codex", profiles)?.name).toBe("codex-medium");
+		expect(recommendModelProfileForProvider("anthropic", profiles)?.name).toBe("claude-opus");
+		expect(recommendModelProfileForProvider("opencode-go", profiles)?.name).toBe("opencodego");
+		expect(recommendModelProfileForProvider("zai", profiles)?.name).toBe("glm-medium");
+		expect(recommendModelProfileForProvider("kimi-code", profiles)?.name).toBe("kimi-coding-plan-medium");
+		expect(recommendModelProfileForProvider("xiaomi", profiles)?.name).toBe("mimo-medium");
+		expect(recommendModelProfileForProvider("xai", profiles)?.name).toBe("grok-medium");
+		expect(recommendModelProfileForProvider("cursor", profiles)?.name).toBe("cursor-medium");
 	});
 
 	test("user same-name profile overrides builtin via mergeModelProfiles", () => {
 		const merged = mergeModelProfiles({
-			"codex-standard": {
+			"codex-medium": {
 				required_providers: ["custom"],
 				model_mapping: { default: "custom/model" },
 			},
 		});
-		const profile = merged.get("codex-standard");
-		expect(profile).toEqual({
-			name: "codex-standard",
-			requiredProviders: ["custom"],
-			modelMapping: { default: "custom/model" },
-			source: "user",
-		});
-		expect(resolveProfileBindings(profile as ModelProfileDefinition)).toEqual({
-			defaultSelector: "custom/model",
-			agentModelOverrides: {},
-		});
+		const profile = merged.get("codex-medium");
+		expect(profile).toEqual({ name: "codex-medium", requiredProviders: ["custom"], modelMapping: { default: "custom/model" }, source: "user" });
+		expect(resolveProfileBindings(profile as ModelProfileDefinition)).toEqual({ defaultSelector: "custom/model", agentModelOverrides: {} });
 	});
 });

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -142,30 +142,27 @@ describe("model selector profile red-team", () => {
 		installTestTheme();
 	});
 
-	test("empty profile catalog omits Presets section and does not crash", async () => {
+	test("empty profile catalog omits Profiles section and does not crash", async () => {
 		const selector = createSelector(() => {}, { profiles: [] });
 		const rendered = await renderSelector(selector);
 
-		expect(rendered).not.toContain("Presets");
+		expect(rendered).not.toContain("Profiles");
 		expect(rendered).toContain("provider-a/default");
 	});
 
-	test("temporary-only mode hides Presets even when profiles exist", async () => {
+	test("temporary-only mode hides Profiles even when profiles exist", async () => {
 		const selector = createSelector(() => {}, { temporaryOnly: true });
 		const rendered = await renderSelector(selector);
 
-		expect(rendered).not.toContain("Presets");
+		expect(rendered).not.toContain("Profiles");
 		expect(rendered).not.toContain("profile-a");
 	});
 
-	test("user-overridden profile name appears once inside grouped presets", async () => {
+	test("user-overridden profile name appears once", async () => {
 		const builtinProfile: ModelProfileDefinition = { ...userProfile, source: "builtin" };
 		const overriddenProfile: ModelProfileDefinition = { ...userProfile, source: "user" };
 		const selector = createSelector(() => {}, { profiles: [builtinProfile, overriddenProfile] });
-		await renderSelector(selector);
-		selector.handleInput("\n");
-		selector.handleInput("\n");
-		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
+		const rendered = await renderSelector(selector);
 
 		expect(rendered.match(/profile-a/g) ?? []).toHaveLength(1);
 	});
@@ -176,7 +173,7 @@ describe("model selector profile red-team", () => {
 			selections.push(selection);
 		});
 		await renderSelector(applySelector);
-		applySelector.handleInput("\n");
+		applySelector.handleInput("\x1b[B");
 		applySelector.handleInput("\n");
 		applySelector.handleInput("\n");
 		applySelector.handleInput("\n");
@@ -185,7 +182,7 @@ describe("model selector profile red-team", () => {
 			selections.push(selection);
 		});
 		await renderSelector(defaultSelector);
-		defaultSelector.handleInput("\n");
+		defaultSelector.handleInput("\x1b[B");
 		defaultSelector.handleInput("\n");
 		defaultSelector.handleInput("\n");
 		defaultSelector.handleInput("\x1b[B");
@@ -229,30 +226,29 @@ describe("model selector profile red-team", () => {
 		expect(setCalls).toEqual([]);
 	});
 
-	test("profile names with unusual characters render without breaking the grouped preset list", async () => {
+	test("profile names with unusual characters render without breaking the list", async () => {
 		const weirdProfile: ModelProfileDefinition = {
 			...userProfile,
 			name: "Team/Profile: β 🚀 [default] {x}|$",
 		};
 		const selector = createSelector(() => {}, { profiles: [weirdProfile] });
+		const rendered = await renderSelector(selector);
+
+		expect(rendered).toContain("Model presets");
+		expect(rendered).toContain("Team/Profile: β 🚀 [default] {x}|$");
+		expect(rendered).toContain("Browse all models");
+	});
+
+	test("Browse all models switches to flat model rows", async () => {
+		const selector = createSelector(() => {});
 		await renderSelector(selector);
-		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
 
-		expect(rendered).toContain("Presets");
-		expect(rendered).toContain("Team/Profile: β 🚀 [default] {x}|$");
-		expect(rendered).not.toContain("provider-a/default");
-	});
-
-	test("grouped presets render above flat model rows", async () => {
-		const selector = createSelector(() => {});
-		const rendered = await renderSelector(selector);
-
-		expect(rendered.indexOf("Presets")).toBeGreaterThanOrEqual(0);
-		expect(rendered.indexOf("Browse presets")).toBeGreaterThan(rendered.indexOf("Presets"));
-		expect(rendered.indexOf("provider-a/default")).toBeGreaterThan(rendered.indexOf("Browse presets"));
-		expect(rendered.indexOf("provider-b/zzz-flat-model")).toBeGreaterThan(rendered.indexOf("Browse presets"));
-		expect(rendered).not.toContain("profile-a");
+		expect(rendered).toContain("Models");
+		expect(rendered).toContain("provider-a/default");
+		expect(rendered).toContain("provider-b/zzz-flat-model");
 	});
 });

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
-import { BUILTIN_MODEL_PROFILES, type ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import {
 	ModelSelectorComponent,
@@ -36,12 +36,9 @@ const profile: ModelProfileDefinition = {
 	modelMapping: { default: "provider-a/default:high", executor: "provider-a/alternate" },
 	source: "user",
 };
-const codingPlanProfiles = BUILTIN_MODEL_PROFILES.filter(profile =>
-	["minimax-standard", "minimax-cn-standard", "kimi-standard", "glm-standard"].includes(profile.name),
-);
 
-function createRegistry(options: { missingCredentials?: boolean; profiles?: ModelProfileDefinition[] } = {}) {
-	const profiles = new Map((options.profiles ?? [profile]).map(profile => [profile.name, profile]));
+function createRegistry(options: { missingCredentials?: boolean } = {}) {
+	const profiles = new Map([[profile.name, profile]]);
 	return {
 		refresh: vi.fn(async () => {}),
 		getError: () => undefined,
@@ -60,14 +57,14 @@ function createRegistry(options: { missingCredentials?: boolean; profiles?: Mode
 
 function createSelector(
 	onSelect: (selection: ModelSelectorSelection) => void,
-	options: { temporaryOnly?: boolean; profiles?: ModelProfileDefinition[] } = {},
+	options: { temporaryOnly?: boolean } = {},
 ) {
 	const ui = { requestRender: vi.fn() } as unknown as TUI;
 	return new ModelSelectorComponent(
 		ui,
 		undefined,
 		Settings.isolated(),
-		createRegistry({ profiles: options.profiles }) as never,
+		createRegistry() as never,
 		[],
 		onSelect,
 		() => {},
@@ -131,78 +128,27 @@ describe("model selector profiles", () => {
 		installTestTheme();
 	});
 
-	test("renders grouped Presets above model rows", async () => {
+	test("renders preset landing above model rows", async () => {
 		installTestTheme();
 		const selector = createSelector(() => {});
 		await Bun.sleep(10);
 		installTestTheme();
 
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered.indexOf("Presets")).toBeGreaterThanOrEqual(0);
-		expect(rendered).toContain("Browse presets");
-		expect(rendered).toContain("Enter to open grouped presets");
-		expect(rendered.indexOf("provider-a/default")).toBeGreaterThan(rendered.indexOf("Browse presets"));
-		expect(rendered).not.toContain("profile-a");
-	});
-
-	test("opens profile actions through grouped preset picker", async () => {
-		installTestTheme();
-		let selected: ModelSelectorSelection | undefined;
-		const selector = createSelector(selection => {
-			selected = selection;
-		});
-		await Bun.sleep(10);
-		installTestTheme();
-
-		selector.handleInput("\n");
-		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("Custom (1) — User-defined profiles");
-		selector.handleInput("\n");
-		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Model presets");
+		expect(rendered).toContain("COMBOS");
 		expect(rendered).toContain("profile-a");
-		selector.handleInput("\n");
-		rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("Action for profile: profile-a");
-		selector.handleInput("\n");
-
-		expect(selected).toEqual({ kind: "profile", profileName: "profile-a", setDefault: false });
+		expect(rendered).toContain("Browse all models");
 	});
 
-	test("groups first-class coding plan presets under Coding Plans", async () => {
-		installTestTheme();
-		const selector = createSelector(() => {}, { profiles: codingPlanProfiles });
-		await Bun.sleep(10);
-		installTestTheme();
-
-		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("Browse presets");
-		expect(rendered).not.toContain("minimax-standard");
-		expect(rendered).not.toContain("minimax-cn-standard");
-		expect(rendered).not.toContain("kimi-standard");
-		expect(rendered).not.toContain("glm-standard");
-
-		selector.handleInput("\n");
-		rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("Coding Plans (4) — MiniMax, Kimi, and GLM/zAI profiles");
-
-		selector.handleInput("\n");
-		rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("minimax-standard");
-		expect(rendered).toContain("minimax-cn-standard");
-		expect(rendered).toContain("kimi-standard");
-		expect(rendered).toContain("glm-standard");
-		expect(rendered).not.toContain("provider-a/default");
-	});
-
-	test("temporary-only mode hides Presets", async () => {
+	test("temporary-only mode hides Profiles", async () => {
 		installTestTheme();
 		const selector = createSelector(() => {}, { temporaryOnly: true });
 		await Bun.sleep(10);
 		installTestTheme();
 
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).not.toContain("Presets");
-		expect(rendered).not.toContain("Browse presets");
+		expect(rendered).not.toContain("Profiles");
 		expect(rendered).not.toContain("profile-a");
 	});
 

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -25,22 +25,14 @@ interface SelectionCapture {
 	selector?: string;
 }
 
-interface PresetCapture {
-	kind: "preset";
-	model: Model;
-	selector: string;
-	assignments: Record<GjcModelAssignmentTargetId, ThinkingLevel>;
-}
 
-type TestModelSelectorSelection =
-	| {
-			kind: "assignment";
-			model: Model;
-			role: GjcModelAssignmentTargetId | null;
-			thinkingLevel?: ThinkingLevel;
-			selector?: string;
-	  }
-	| PresetCapture;
+type TestModelSelectorSelection = {
+	kind: "assignment";
+	model: Model;
+	role: GjcModelAssignmentTargetId | null;
+	thinkingLevel?: ThinkingLevel;
+	selector?: string;
+};
 
 interface CreateSelectorOptions {
 	modelRegistry?: ModelRegistry;
@@ -472,9 +464,9 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}:high`);
 	});
 
-	test("shows OpenAI Codex role preset action with requested reasoning map", async () => {
+	test("shows only role assignment actions for OpenAI Codex reasoning models", async () => {
 		installTestTheme();
-		const model = createOpenAIModel("openai-codex", "gpt-codex-preset-test");
+		const model = createOpenAIModel("openai-codex", "gpt-codex-actions-test");
 		model.thinking = {
 			minLevel: Effort.Low,
 			maxLevel: Effort.XHigh,
@@ -483,75 +475,20 @@ describe("ModelSelector canonical model selection", () => {
 		};
 		const settings = Settings.isolated({});
 
-		let selected: PresetCapture | undefined;
-		const selector = createSelector(
-			model,
-			settings,
-			selection => {
-				if (selection.kind === "preset") selected = selection;
-			},
-			{ thinkingLevel: null },
-		);
+		const selector = createSelector(model, settings, undefined, { thinkingLevel: null });
 		await Bun.sleep(0);
 		installTestTheme();
 
 		selector.handleInput("\n");
 		const actionRendered = normalizeRenderedText(selector.render(260).join("\n"));
-		expect(actionRendered).toContain("Apply OpenAI Codex role preset");
-		expect(actionRendered).toContain("Default medium, Executor low, Architect xhigh, Planner medium, Critic high");
 
-		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
-		selector.handleInput("\n");
-
-		const selectedAfterPreset = selected;
-		if (!selectedAfterPreset) throw new Error("Expected OpenAI Codex preset selection");
-		expect(selectedAfterPreset.kind).toBe("preset");
-		expect(selectedAfterPreset.selector).toBe(`${model.provider}/${model.id}`);
-		expect(selectedAfterPreset.assignments).toEqual({
-			default: ThinkingLevel.Medium,
-			executor: ThinkingLevel.Low,
-			architect: ThinkingLevel.XHigh,
-			planner: ThinkingLevel.Medium,
-			critic: ThinkingLevel.High,
-		});
-	});
-
-	test("clamps OpenAI Codex role preset to selected model supported reasoning", async () => {
-		installTestTheme();
-		const model = createOpenAIModel("openai-codex", "gpt-codex-clamped-preset-test");
-		model.thinking = {
-			minLevel: Effort.Medium,
-			maxLevel: Effort.High,
-			defaultLevel: Effort.Medium,
-			mode: "effort",
-		};
-		const settings = Settings.isolated({});
-
-		let selected: PresetCapture | undefined;
-		const selector = createSelector(
-			model,
-			settings,
-			selection => {
-				if (selection.kind === "preset") selected = selection;
-			},
-			{ thinkingLevel: null },
-		);
-		await Bun.sleep(0);
-		installTestTheme();
-
-		selector.handleInput("\n");
-		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
-		selector.handleInput("\n");
-
-		const selectedAfterPreset = selected;
-		if (!selectedAfterPreset) throw new Error("Expected OpenAI Codex preset selection");
-		expect(selectedAfterPreset.assignments).toEqual({
-			default: ThinkingLevel.Medium,
-			executor: ThinkingLevel.Medium,
-			architect: ThinkingLevel.High,
-			planner: ThinkingLevel.Medium,
-			critic: ThinkingLevel.High,
-		});
+		expect(actionRendered).toContain("Set as DEFAULT (Default)");
+		expect(actionRendered).toContain("Set as EXECUTOR (Executor)");
+		expect(actionRendered).toContain("Set as ARCHITECT (Architect)");
+		expect(actionRendered).toContain("Set as PLANNER (Planner)");
+		expect(actionRendered).toContain("Set as CRITIC (Critic)");
+		expect(actionRendered).not.toContain("Apply OpenAI Codex role preset");
+		expect(actionRendered).not.toContain("Default medium, Executor low, Architect xhigh, Planner medium, Critic high");
 	});
 
 	test("prompts for reasoning when scoped OpenAI thinking came from defaults", async () => {


### PR DESCRIPTION
## Summary

Reworks the `/model` preset experience end-to-end: presets become the primary landing surface, the builtin profile catalog is rebuilt from scratch, the redundant hardcoded codex preset is removed, and `/login` success now recommends the matching preset.

Pipeline: deep-interview spec (`.gjc/specs/deep-interview-model-preset-ux.md`, final ambiguity 4.1%) -> ralplan consensus (3 passes, Critic OKAY; plan `.gjc/plans/ralplan/2026-06-12-1311-53d7/`) -> ultragoal execution (6 stories, all gated by architect CLEAR x3 APPROVE + executor red-team QA).

### Preset-first `/model` landing view
- Provider-grouped presets with live auth checkmarks (session-scoped credential lookup, same semantics as activation)
- Highlight-to-expand tiers; full clamped role->model preview **before** applying; session/default apply scope choice
- Escapes preserved: typing jumps straight to model search, "Browse all models" opens the classic tabbed selector (role-assignment menus intact), temporary-only quick-switch bypasses the landing
- Unauthenticated providers are dimmed and offer exact `/login <provider>` (MiniMax: `/login minimax-code`); selection is never emitted without auth
- One-layer-per-press Escape cascade: scope -> preview -> group -> close

### Rebuilt builtin catalog (27 profiles)
- `codex-{eco,medium,pro}` on `gpt-5.5` per-role effort spreads
- Single `opencodego` preset; `claude-opus` / `claude-fable`
- `{glm,kimi-coding-plan,mimo,grok,cursor,minimax}-{eco,medium,pro}` trios with thinking levels clamped to provider support
- Combos: `fable-codex`, `opus-codex`, `codex-opencodego`
- Clean break: legacy names (incl. the `*-standard` family from #553) error with the available-profile listing; `--mpreset` flag and profile schema unchanged

### Shared thinking clamp
- `clampExplicitThinkingLevelForModel` / `formatClampedModelSelector` used by both preview rendering and activation
- `codex-eco` executor stays `openai-codex/gpt-5.5:minimal` in the catalog and clamps to effective `low` everywhere it is shown or applied

### Hardcoded preset removal
- `OPENAI_CODE_PROFILE_PRESET`, the `preset` selection kind, and the controller apply path are deleted end-to-end; builtin profiles are the only preset concept

### Post-`/login` smart recommendation
- No active profile: prompts `Apply <preset> now?` (session-only on confirm, zero mutation on decline)
- Active profile: one-line hint `Preset <preset> is available in /model.`
- Active profile tracked in-memory on `AgentSession` with rollback-safe activation; RPC login untouched

### Model registry
- Bundled `kimi-code/kimi-k2.7-code` and `minimax-code/minimax-v3` seed entries (models.json seed mechanism, per repo precedent #533/#518)

## Conflicts with #553
This branch was rebased onto dev over #553 (grouped Presets browser + `*-standard` profiles). This PR supersedes both: the grouped browser is replaced by the preset-first landing state machine, and the `*-standard` profiles are replaced by the eco/medium/pro catalog. Changelog notes the supersession.

## Testing
- 70 focused tests across 10 files, 0 fail (post-rebase): catalog matrix cell-for-cell, activation clamping, clean-break errors, landing state machine, adversarial red-team suite (Escape layering, partial combo auth, MiniMax canonical id leakage, clamp display, bypass integrity), login recommendation (7 tests)
- `tsc --noEmit` clean on `packages/coding-agent`
- New suites: `packages/ai/test/preset-catalog-models.test.ts`, `packages/coding-agent/test/login-preset-recommendation.test.ts`, `packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts`

## Follow-ups (advisory, from architect review)
- Harden QA assertions to check all five preview role lines exactly
- Negative assertion that MiniMax offers never render `/provider login minimax-code`
- Direct fixture proving preset auth lookup passes `sessionId` + `isAuthenticated` semantics