### PR TITLE
docs(hotspots): close out cpu-hotspot-map with Optimization Suite v1-v3 resolutions

### DIFF
--- a/docs/cpu-hotspot-map.json
+++ b/docs/cpu-hotspot-map.json
@@ -3,7 +3,21 @@
   "generatedBy": "ultragoal G001+G002",
   "spec": ".gjc/specs/deep-interview-cpu-hotspots-rust-optimization.md",
   "method": "static structural ranking (algorithmic complexity x trigger frequency); CPU self-time to be measured by the agreed profiling corpus during optimization. Already-native pi-natives surfaces excluded.",
-  "alreadyNativeExcluded": ["grep", "fd/glob", "text(ANSI width/wrap/truncate/slice)", "highlight", "html->md", "countTokens", "ast", "summary", "ps/pty/shell", "sixel", "clipboard", "Bun.hash.xxHash32/64", "JSON.parse/stringify"],
+  "alreadyNativeExcluded": [
+    "grep",
+    "fd/glob",
+    "text(ANSI width/wrap/truncate/slice)",
+    "highlight",
+    "html->md",
+    "countTokens",
+    "ast",
+    "summary",
+    "ps/pty/shell",
+    "sixel",
+    "clipboard",
+    "Bun.hash.xxHash32/64",
+    "JSON.parse/stringify"
+  ],
   "hotspots": [
     {
       "id": "H01",
@@ -17,7 +31,9 @@
       "trigger": "every fuzzy edit and apply_patch when exact match fails",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API: whole fuzzy block (window scan + similarity) in pi-natives",
-      "evidence": "fuzzyScoreAt sums similarity() per pattern line per window; findMatch scans all windows"
+      "evidence": "fuzzyScoreAt sums similarity() per pattern line per window; findMatch scans all windows",
+      "status": "resolved",
+      "resolution": "v1: native fuzzy match in pi-natives"
     },
     {
       "id": "H02",
@@ -31,7 +47,9 @@
       "trigger": "called per line-pair by H01 and by direct similarity checks",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API: banded/thresholded/early-exit Levenshtein, or integrate into the H01 fuzzy matcher; reuse row buffers to avoid per-call allocation",
-      "evidence": "levenshteinDistance uses two-row DP (replace.ts:312-330); similarity = 1 - dist/maxLen"
+      "evidence": "levenshteinDistance uses two-row DP (replace.ts:312-330); similarity = 1 - dist/maxLen",
+      "status": "resolved",
+      "resolution": "v1: native levenshtein/similarity"
     },
     {
       "id": "H03",
@@ -45,7 +63,9 @@
       "trigger": "every edit preview, edit apply, and hashline recovery",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API line-diff (e.g. similar/imara-diff) replacing npm 'diff'",
-      "evidence": "import * as Diff from 'diff'; diffLines used in generateDiffString"
+      "evidence": "import * as Diff from 'diff'; diffLines used in generateDiffString",
+      "status": "resolved",
+      "resolution": "v2: native diffLines (jsdiff-byte-identical) with JS fallback"
     },
     {
       "id": "H04",
@@ -59,7 +79,9 @@
       "trigger": "TUI diff rendering, per changed line of every shown diff",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API word/char diff; reuse H03 backend",
-      "evidence": "Diff.diffWords(oldContent, newContent) per intra-line render"
+      "evidence": "Diff.diffWords(oldContent, newContent) per intra-line render",
+      "status": "resolved-partial",
+      "resolution": "v3 #558: TS fast paths for identical/prefix-suffix token-aligned spans (-60..-67%); whitespace-only and boundary-spanning edits intentionally fall back to Diff.diffWords for byte parity; native word-diff rejected without fresh FFI gate"
     },
     {
       "id": "H05",
@@ -73,7 +95,9 @@
       "trigger": "diffMentalModelContent on agent turns (model list changes)",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API LCS (Hunt-Szymanski or banded) returning line ops",
-      "evidence": "Array.from(n+1) of Array(m+1) plus double loop building table"
+      "evidence": "Array.from(n+1) of Array(m+1) plus double loop building table",
+      "status": "partial",
+      "resolution": "v3 #558: legacy dense DP retained — Hunt-Szymanski produced byte-different rendered diffs (red-team repro) and was reverted per byte-parity principle; MAX_LCS_LINES cap bounds the cost"
     },
     {
       "id": "H06",
@@ -87,7 +111,9 @@
       "trigger": "every read, search, and edit display that emits LINE+HASH anchors",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API: whole-text hash+format in one pass (hash already native, loop/alloc is the cost)",
-      "evidence": "computeLineHash uses native xxHash32 but allocates per line; formatHashLines loops all lines"
+      "evidence": "computeLineHash uses native xxHash32 but allocates per line; formatHashLines loops all lines",
+      "status": "resolved",
+      "resolution": "v1: native whole-text hash+format"
     },
     {
       "id": "H07",
@@ -101,7 +127,9 @@
       "trigger": "every compaction pass and budget check over full session",
       "nativeCandidate": false,
       "recommendedAction": "TS optimize: cache per-entry token counts; batch fragments into one countTokens call; avoid re-stringify",
-      "evidence": "fragments.push(JSON.stringify(block.arguments)); estimateEntriesTokens loops all entries"
+      "evidence": "fragments.push(JSON.stringify(block.arguments)); estimateEntriesTokens loops all entries",
+      "status": "resolved",
+      "resolution": "v3 #557: estimateEntryTokens WeakMap cache, boundary-lossless fingerprint from exact estimator fragments; covers estimateEntriesTokens, findCutPoint, pruning scoring (repeated p95 -97%)"
     },
     {
       "id": "H08",
@@ -115,7 +143,9 @@
       "trigger": "OpenAI request building / token approximation",
       "nativeCandidate": false,
       "recommendedAction": "TS optimize: measure char length without full JSON.stringify, or reuse already-serialized payload",
-      "evidence": "for (item of input) chars += JSON.stringify(item).length"
+      "evidence": "for (item of input) chars += JSON.stringify(item).length",
+      "status": "resolved",
+      "resolution": "v3 #557: O(n) trim via per-item serialized lengths + running sum (-99.9% on 5k-item trim); custom JSON length counter implemented, made exact, then deleted — native JSON.stringify is faster than exact JS reimplementation"
     },
     {
       "id": "H09",
@@ -129,7 +159,9 @@
       "trigger": "context assembly per turn",
       "nativeCandidate": false,
       "recommendedAction": "TS optimize: structuredClone or structural sharing instead of JSON round-trip",
-      "evidence": "return JSON.parse(JSON.stringify(value)) as T"
+      "evidence": "return JSON.parse(JSON.stringify(value)) as T",
+      "status": "resolved",
+      "resolution": "v3 #558: typed JSON-semantic recursive clone, exact stringify byte parity incl. toJSON holder-key protocol (-36% median); exported as cloneJson"
     },
     {
       "id": "H10",
@@ -143,7 +175,9 @@
       "trigger": "provider-replay change detection",
       "nativeCandidate": false,
       "recommendedAction": "TS optimize: incremental/structural hash compare instead of stringify-and-compare",
-      "evidence": "JSON.stringify(prev.map(normalize)) !== JSON.stringify(next.map(normalize))"
+      "evidence": "JSON.stringify(prev.map(normalize)) !== JSON.stringify(next.map(normalize))",
+      "status": "resolved",
+      "resolution": "v3 #558: WeakMap-cached normalized source + xxHash64 prefilter with first-difference short-circuit; hash is accelerator, source compare is authority (unchanged-session -95.8%)"
     },
     {
       "id": "H11",
@@ -157,7 +191,9 @@
       "trigger": "every outbound message when secrets are configured",
       "nativeCandidate": true,
       "recommendedAction": "Rust N-API multi-pattern (Aho-Corasick) single-pass replace, or TS trie",
-      "evidence": "for secret of plainMappings: result = replaceAll(result, secret, placeholder)"
+      "evidence": "for secret of plainMappings: result = replaceAll(result, secret, placeholder)",
+      "status": "resolved",
+      "resolution": "v3 #558: lazy combined longest-first regex single pass (-69.8% median/-76.8% p95) with conservative sequential fallback on cross-mapping secret overlap; byte-identical"
     }
   ],
   "memoryHotspots": [
@@ -172,7 +208,9 @@
       "growthDriver": "per-message; grows for entire session lifetime",
       "detail": "Every SessionEntry (including large tool outputs and full file reads) is retained verbatim in memory. MAX_PERSIST_CHARS (500000) truncation applies ONLY to on-disk persistence, not the in-memory #fileEntries/#byId structures.",
       "recommendedAction": "Cap in-memory entry content (mirror MAX_PERSIST_CHARS in RAM, or store large bodies in blob store / lazy-load from disk); keep only metadata + small inline content resident.",
-      "evidence": "MAX_PERSIST_CHARS used only in persist path; #appendEntry pushes full entry to #fileEntries and #byId"
+      "evidence": "MAX_PERSIST_CHARS used only in persist path; #appendEntry pushes full entry to #fileEntries and #byId",
+      "status": "resolved",
+      "resolution": "v3 #548: large resident TEXT externalized to ephemeral session-scoped disk cache (EphemeralBlobStore, 8MB LRU buffer with disk-presence validation); canonical JSONL truncation contract unchanged"
     },
     {
       "id": "M02",
@@ -185,7 +223,9 @@
       "growthDriver": "per call x history length (called every turn, getTree, branching, context build)",
       "detail": "getEntries() returns this.#fileEntries.filter(...) — a fresh O(history) array allocation on every call; many hot callers.",
       "recommendedAction": "Cache the filtered view and invalidate on append; or store non-session entries separately to avoid filtering.",
-      "evidence": "return this.#fileEntries.filter(e => e.type !== 'session') called at agent-session.ts:5897,7252,9045 and getTree"
+      "evidence": "return this.#fileEntries.filter(e => e.type !== 'session') called at agent-session.ts:5897,7252,9045 and getTree",
+      "status": "resolved",
+      "resolution": "v3 #548: revision-keyed WeakRef materialized-entries cache below ownership boundary; getEntries returns caller-owned clones (warm p95 -80% on 10k entries)"
     },
     {
       "id": "M03",
@@ -198,7 +238,9 @@
       "growthDriver": "per-turn x full message history",
       "detail": "Each turn rebuilds the entire session context and replaces the provider message array; combined with messagesChanged double JSON.stringify (H10), multiple full-history copies exist transiently per turn.",
       "recommendedAction": "Incremental context updates (append delta) instead of full rebuild+replace; structural hash compare instead of stringify.",
-      "evidence": "getEntries(); buildDisplaySessionContext(); agent.replaceMessages(sessionContext.messages) per turn"
+      "evidence": "getEntries(); buildDisplaySessionContext(); agent.replaceMessages(sessionContext.messages) per turn",
+      "status": "resolved",
+      "resolution": "v3 #548: buildSessionContext served from WeakRef cache keyed by entry/leaf/replayMetadata revisions, caller-owned deep-cloned messages (-94% median)"
     },
     {
       "id": "M04",
@@ -211,7 +253,9 @@
       "growthDriver": "per-message; deep-clone copies retained",
       "detail": "#entries grows unbounded with the conversation; cloneJson (JSON round-trip) creates full deep copies of message payloads.",
       "recommendedAction": "Structural sharing / structuredClone; avoid retaining clones; rely on compaction to bound retained tokens.",
-      "evidence": "#entries: Message[] = []; cloneJson = JSON.parse(JSON.stringify(value))"
+      "evidence": "#entries: Message[] = []; cloneJson = JSON.parse(JSON.stringify(value))",
+      "status": "resolved",
+      "resolution": "v2 fingerprint caching + v3 #558 JSON-semantic clone replacing JSON round-trips"
     },
     {
       "id": "M05",
@@ -224,7 +268,50 @@
       "growthDriver": "per snapshot (switch/reload/undo) x history length",
       "detail": "captureState shallow-copies the whole entry array per snapshot; entries are by reference so content is shared, but the arrays accumulate if snapshots are held.",
       "recommendedAction": "Bound retained snapshots; ensure snapshots are released after rollback window.",
-      "evidence": "fileEntries: [...this.#fileEntries] in captureState"
+      "evidence": "fileEntries: [...this.#fileEntries] in captureState",
+      "status": "resolved",
+      "resolution": "v3 #548: capture/restore paths bump all revision domains; snapshots stay reference-shallow, caches invalidated on restore"
+    }
+  ],
+  "resolutionLog": [
+    {
+      "suite": "optimization-suite-v1 (#356)",
+      "resolved": [
+        "H01",
+        "H02",
+        "H06"
+      ],
+      "note": "native H06 + H02, byte-identical >=2x; H01 native fuzzy extraction (d9cccda4)"
+    },
+    {
+      "suite": "optimization-suite-v2 (#530)",
+      "resolved": [
+        "H03"
+      ],
+      "partial": [
+        "M04"
+      ],
+      "note": "native diffLines for H03; EventStream deque, lazy model registry, append-only fingerprint caching around M04 clones; all five remaining Rust candidates measured and rejected per FFI gates"
+    },
+    {
+      "suite": "optimization-suite-v3 (plan 2026-06-12-0812-aec3; PRs #548 #557 #558)",
+      "resolved": [
+        "H04",
+        "H07",
+        "H08",
+        "H09",
+        "H10",
+        "H11",
+        "M01",
+        "M02",
+        "M03",
+        "M04",
+        "M05"
+      ],
+      "partial": [
+        "H05"
+      ],
+      "note": "Lane 1 (#548): ephemeral disk resident cache for large text, typed ResidentBlobMissingError, revision-keyed WeakRef materialization/context caches (fixture retained heap -82.6%, warm getEntries p95 -80%). Lane 2 (#557): per-entry token cache across estimateEntriesTokens/findCutPoint/pruning, exact digest pruning savings, O(n) OpenAI trim (repeated estimate p95 -97%). Lane 3 (#558): JSON-semantic cloneJson (H09/M04), xxHash64-accelerated session equality with source-string authority (H10), single-pass combined-regex obfuscator (H11, -70%), byte-identical word-diff fast paths (H04 partial-by-fast-path; full native word-diff rejected). H05 capped + loop-tuned only: Hunt-Szymanski implemented then REVERTED for render-byte divergence; byte parity is the gate."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the loop on `docs/cpu-hotspot-map.json` now that all three optimization suites have landed. Every hotspot entry (H01–H11, M01–M05) gains a `status` + `resolution` field with the delivering PR and measured outcome, plus a top-level `resolutionLog` tracing the suites:

| Suite | Resolved |
|---|---|
| v1 (#356) | H01, H02, H06 — native rewrites |
| v2 (#530) | H03 — native diffLines; FFI gates rejected the remaining Rust candidates |
| v3 (#548, #557, #558) | H07–H11, M01–M05 — TS-level fixes with byte-parity gates |

Two entries are intentionally partial, each with explicit rationale recorded in the map:
- **H04** (word diff): byte-parity-guarded TS fast paths (−60…−67% on fast-path classes); boundary-spanning edits fall back to `Diff.diffWords` because the oracle showed non-identity; native word-diff stays rejected without a fresh FFI gate.
- **H05** (mental-model LCS): Hunt-Szymanski was implemented and **reverted** — red-team produced a concrete rendered-byte divergence; legacy dense DP retained per the plan's byte-exact-behavior principle (architect ruled the deviation acceptable-with-note).

Docs-only change; no source or behavior. JSON validated.

Refs: ralplan run `2026-06-12-0812-aec3`, ultragoal ledger `.gjc/ultragoal/ledger.jsonl` (G001–G004).