### PR TITLE
ci: optimize PR runtime without regressing validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,36 +163,49 @@ jobs:
       runs-on: windows-latest
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3"
+         - name: Check job relevance
+           id: relevance
+           env:
+              GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+           shell: bash
+           run: bun scripts/ci-job-relevance.ts
          - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+           if: steps.relevance.outputs.relevant == 'true'
            with:
               toolchain: nightly-2026-04-29
          - name: Prepend rustup toolchain bin to PATH
+           if: steps.relevance.outputs.relevant == 'true'
            shell: bash
            run: |
               toolchain_bin="$(dirname "$(rustup which cargo)")"
               echo "$toolchain_bin" >> "$GITHUB_PATH"
          - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+           if: steps.relevance.outputs.relevant == 'true'
            with:
               shared-key: windows-smoke-win32-x64
               cache-on-failure: true
               save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
               cache-workspace-crates: true
-         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
-           with:
-              bun-version: "1.3"
          - name: Cache bun dependencies
+           if: steps.relevance.outputs.relevant == 'true'
            uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
            with:
               path: ~/.bun/install/cache
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-         - run: bun install --frozen-lockfile
+         - if: steps.relevance.outputs.relevant == 'true'
+           run: bun install --frozen-lockfile
          - name: Build native addon (win32-x64 baseline)
+           if: steps.relevance.outputs.relevant == 'true'
            env:
               TARGET_PLATFORM: win32
               TARGET_ARCH: x64
               TARGET_VARIANTS: baseline
            run: bun run ci:build:native
          - name: Smoke bun + gjc CLI (source runtime)
+           if: steps.relevance.outputs.relevant == 'true'
            shell: pwsh
            run: |
               bun --version
@@ -245,21 +258,7 @@ jobs:
               path: ~/.bun/install/cache
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
          - name: Install system deps
-           run: |
-              if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-                 sudo apt-get update
-                 sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
-                 sudo ln -sf $(which fdfind) /usr/local/bin/fd
-                 sudo ln -sf /usr/bin/convert /usr/local/bin/magick
-              else
-                 echo "sudo unavailable on this runner; skipping apt-based system dependency install."
-                 echo "The self-hosted runner image is expected to provide optional smoke-test helpers when needed."
-                 for tool in fd rg convert tmux gh; do
-                    if ! command -v "$tool" >/dev/null 2>&1; then
-                       echo "warning: optional helper not on PATH: $tool"
-                    fi
-                 done
-              fi
+           run: bash scripts/ci-install-system-deps.sh
          - run: bun install --frozen-lockfile
          - name: Resolve native source run
            id: source
@@ -296,16 +295,25 @@ jobs:
       runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-           with:
-              node-version: "24"
          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
            with:
               bun-version: "1.3"
+         - name: Check job relevance
+           id: relevance
+           env:
+              GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+           shell: bash
+           run: bun scripts/ci-job-relevance.ts
+         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+           if: steps.relevance.outputs.relevant == 'true'
+           with:
+              node-version: "24"
          - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+           if: steps.relevance.outputs.relevant == 'true'
            with:
               toolchain: nightly-2026-04-29
          - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+           if: steps.relevance.outputs.relevant == 'true'
            with:
               shared-key: install-methods-linux-x64
               cache-on-failure: true
@@ -313,28 +321,18 @@ jobs:
                  startsWith(github.ref, 'refs/tags/v')) }}
               cache-workspace-crates: true
          - name: Cache bun dependencies
+           if: steps.relevance.outputs.relevant == 'true'
            uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
            with:
               path: ~/.bun/install/cache
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
          - name: Install system deps
-           run: |
-              if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-                 sudo apt-get update
-                 sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
-                 sudo ln -sf $(which fdfind) /usr/local/bin/fd
-                 sudo ln -sf /usr/bin/convert /usr/local/bin/magick
-              else
-                 echo "sudo unavailable on this runner; skipping apt-based system dependency install."
-                 echo "The self-hosted runner image is expected to provide optional smoke-test helpers when needed."
-                 for tool in fd rg convert tmux gh; do
-                    if ! command -v "$tool" >/dev/null 2>&1; then
-                       echo "warning: optional helper not on PATH: $tool"
-                    fi
-                 done
-              fi
-         - run: bun install --frozen-lockfile
+           if: steps.relevance.outputs.relevant == 'true'
+           run: bash scripts/ci-install-system-deps.sh
+         - if: steps.relevance.outputs.relevant == 'true'
+           run: bun install --frozen-lockfile
          - name: Install method smoke tests
+           if: steps.relevance.outputs.relevant == 'true'
            run: bun run ci:test:install-methods
 
    release_binary:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -48,21 +48,7 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - name: Install system deps
-        run: |
-          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-             sudo apt-get update
-             sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
-             sudo ln -sf $(which fdfind) /usr/local/bin/fd
-             sudo ln -sf /usr/bin/convert /usr/local/bin/magick
-          else
-             echo "sudo unavailable on this runner; skipping apt-based system dependency install."
-             echo "The self-hosted runner image is expected to provide optional smoke-test helpers when needed."
-             for tool in fd rg convert tmux gh; do
-                if ! command -v "$tool" >/dev/null 2>&1; then
-                   echo "warning: optional helper not on PATH: $tool"
-                fi
-             done
-          fi
+        run: bash scripts/ci-install-system-deps.sh
       - run: bun install --frozen-lockfile
       - name: Run affected path checks and tests
         run: bun scripts/ci-dev-affected.ts

--- a/scripts/ci-install-system-deps.sh
+++ b/scripts/ci-install-system-deps.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Install (or verify) the system dependencies needed by CI smoke/test jobs.
+#
+# Shared by ci.yml (`test`, `install_methods`) and dev-ci.yml (`affected`).
+# When every required tool and library is already present the script exits
+# without touching apt, so warm self-hosted runners skip the install entirely.
+# When anything is missing it performs exactly the historical install
+# behavior, including the sudo-unavailable warning fallback.
+#
+# `-eo pipefail` mirrors the default shell GitHub Actions uses for `run:`
+# steps, so the extracted script keeps the inline blocks' failure semantics.
+set -eo pipefail
+
+# Tools expected on PATH (imagemagick is satisfied by `convert` or `magick`).
+required_path_tools=(fd rg tmux gh)
+# Development libraries verified via dpkg.
+required_dpkg_libs=(libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev)
+
+missing=0
+
+for tool in "${required_path_tools[@]}"; do
+   if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "system-deps: missing tool on PATH: $tool"
+      missing=1
+   fi
+done
+
+if ! command -v convert >/dev/null 2>&1 && ! command -v magick >/dev/null 2>&1; then
+   echo "system-deps: missing imagemagick (convert/magick) on PATH"
+   missing=1
+fi
+
+for lib in "${required_dpkg_libs[@]}"; do
+   if ! dpkg -s "$lib" >/dev/null 2>&1; then
+      echo "system-deps: missing dpkg package: $lib"
+      missing=1
+   fi
+done
+
+if [ "$missing" -eq 0 ]; then
+   echo "system-deps: all required tools and libraries already present; skipping apt."
+   exit 0
+fi
+
+echo "system-deps: missing dependencies detected; installing."
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+   sudo apt-get update
+   sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick tmux gh
+   sudo ln -sf $(which fdfind) /usr/local/bin/fd
+   sudo ln -sf /usr/bin/convert /usr/local/bin/magick
+else
+   echo "sudo unavailable on this runner; skipping apt-based system dependency install."
+   echo "The self-hosted runner image is expected to provide optional smoke-test helpers when needed."
+   for tool in fd rg convert tmux gh; do
+      if ! command -v "$tool" >/dev/null 2>&1; then
+         echo "warning: optional helper not on PATH: $tool"
+      fi
+   done
+fi

--- a/scripts/ci-job-relevance.ts
+++ b/scripts/ci-job-relevance.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+/**
+ * Conservative changed-path relevance gate for expensive CI jobs.
+ *
+ * Emits `relevant=true|false` to $GITHUB_OUTPUT. `relevant=false` is only
+ * produced when the run is a pull_request with a known base SHA and EVERY
+ * changed path is provably irrelevant (markdown, docs/, .gjc/). Any other
+ * event, missing data, or error fails open to `relevant=true` so validation
+ * is never weakened by ambiguity.
+ */
+
+import { $ } from "bun";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..");
+
+interface Decision {
+	relevant: boolean;
+	reason: string;
+}
+
+function isProvablyIrrelevant(changedPath: string): boolean {
+	return changedPath.endsWith(".md") || changedPath.startsWith("docs/") || changedPath.startsWith(".gjc/");
+}
+
+async function changedFiles(baseSha: string): Promise<string[]> {
+	await $`git fetch --no-tags --depth=1 origin ${baseSha}`.cwd(repoRoot).quiet().nothrow();
+	const result = await $`git diff --name-only ${baseSha} HEAD`.cwd(repoRoot).quiet();
+	return result.stdout.toString().split("\n").filter(Boolean);
+}
+
+async function decide(): Promise<Decision> {
+	const eventName = process.env.GITHUB_EVENT_NAME ?? "";
+	if (eventName !== "pull_request") {
+		return { relevant: true, reason: `event '${eventName || "unknown"}' is not pull_request; running everything` };
+	}
+
+	const baseSha = process.env.GITHUB_BASE_SHA;
+	if (!baseSha) {
+		return { relevant: true, reason: "GITHUB_BASE_SHA missing; running everything" };
+	}
+
+	const files = await changedFiles(baseSha);
+	if (files.length === 0) {
+		return { relevant: true, reason: "empty diff against base; running everything" };
+	}
+
+	const relevantFiles = files.filter(file => !isProvablyIrrelevant(file));
+	if (relevantFiles.length > 0) {
+		return { relevant: true, reason: `relevant path changed: ${relevantFiles[0]}` };
+	}
+
+	return {
+		relevant: false,
+		reason: `all ${files.length} changed path(s) are provably irrelevant (*.md, docs/, .gjc/)`,
+	};
+}
+
+let decision: Decision;
+try {
+	decision = await decide();
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	decision = { relevant: true, reason: `relevance check failed (${message}); running everything` };
+}
+
+console.log(`ci-job-relevance: relevant=${decision.relevant} (${decision.reason})`);
+
+if (process.env.GITHUB_OUTPUT) {
+	await fs.appendFile(process.env.GITHUB_OUTPUT, `relevant=${decision.relevant}\n`);
+}


### PR DESCRIPTION
## Summary

Optimize CI runtime without weakening validation. Two independent, fail-open changes:

### Path-gate expensive PR jobs (`scripts/ci-job-relevance.ts` + `ci.yml`)
- New conservative bun gate that skips the heavy steps of `windows_smoke` and `install_methods` **only** on PRs whose entire diff is provably irrelevant (`**/*.md`, `docs/**`, `.gjc/**`).
- Fails **open** on any ambiguity — non-`pull_request` events, missing base SHA, empty diff, any relevant path, or any git/script error all yield `relevant=true`.
- Gating is at **step level**, so both jobs stay always-present and green; branch protection is unaffected. No other job's triggers or release-tag behavior changed.

### Deduplicate + short-circuit system-deps install (`scripts/ci-install-system-deps.sh` + `ci.yml` + `dev-ci.yml`)
- Triplicated "Install system deps" block (ci.yml `test`, ci.yml `install_methods`, dev-ci.yml `affected`) extracted into one shared script.
- Skips apt entirely when every tool (`fd`, `rg`, `convert`/`magick`, `tmux`, `gh`) and dev lib (`dpkg -s`) is already present.
- Any missing or unverifiable dependency (e.g. `dpkg` absent) falls through to the **byte-identical** historical install/warning behavior — validation is never weakened.

## Validation

- `bun scripts/check-workflow-yaml.ts` passes; no inline apt blocks remain.
- **Relevance gate** exercised across 14 real-git scenarios: docs-only/.gjc-only → `relevant=false`; crates/packages/scripts, mixed diffs, deny-list bypass (`docs-internal/`, `.gjcfoo`), missing base SHA, push/tag/workflow_dispatch, and error injection → `relevant=true`.
- **Install script** exercised across 9 PATH-manipulation scenarios with sentinel files proving: no apt invoked when all deps present; exact historical `sudo apt-get`/`ln -sf` sequence when missing+sudo; identical warning fallback when missing+no-sudo; `convert` OR `magick` both satisfy imagemagick; partial presence and absent `dpkg` never short-circuit.
- Architect review (architecture/product/code lanes) CLEAR → APPROVE on both changes.

## Notes

- All gating is fail-open toward running validation; required job statuses remain always-present.
- No checks removed, no matrices narrowed, no release-tag behavior changed.
