### PR TITLE
feat(models): bundle xai grok-composer-2.5-max alias

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added a generic tool-choice capability model: `toolChoiceSupport` compat enum (`none`/`auto`/`required`/`named`) available on every forced-choice-capable API, derived from the legacy `supportsToolChoice`/`supportsForcedToolChoice` booleans when absent, with a shared `resolveToolChoice` helper that clamps requested tool choices (`named` → `required` → omit) and returns structured degradation metadata.
 - Added a transparent one-shot fallback for forced `tool_choice` 400s ("tool_choice forces tool use is not compatible with this model" and equivalents): transports retry once without the forced field at a pre-content streaming boundary, record the discovery in an in-memory per-process incapability registry, and emit an internal non-rendered `toolChoiceIncapability` event. Applies to Anthropic, OpenAI Completions/Responses, Azure Responses, OpenAI code Responses, Bedrock (including event-stream `validationException`), Ollama, Google, and Gemini CLI transports.
-- Added bundled catalog entries for `kimi-code/kimi-k2.7-code`, `minimax-code/minimax-v3`, and `xai/grok-composer-2.5-fast`.
+- Added bundled catalog entries for `kimi-code/kimi-k2.7-code`, `minimax-code/minimax-v3`, `xai/grok-composer-2.5-fast`, and `xai/grok-composer-2.5-max` (wired to `grok-composer-2.5-fast` with max-effort thinking metadata).
 - Added composer-harness anchor/edit discipline injection for Cursor Composer and Grok Composer models so provider-specific coding harness priors do not override GJC hashline/edit contracts.
 
 ### Removed

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -70612,6 +70612,40 @@
 				"maxLevel": "high"
 			}
 		},
+		"grok-composer-2.5-max": {
+			"id": "grok-composer-2.5-max",
+			"name": "Grok Composer 2.5 Max",
+			"wireModelId": "grok-composer-2.5-fast",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"compat": {
+				"supportsReasoningEffort": false,
+				"thinkingFormat": "openrouter",
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "max",
+				"maxLevel": "max",
+				"defaultLevel": "max",
+				"levels": [
+					"max"
+				]
+			}
+		},
 		"grok-vision-beta": {
 			"id": "grok-vision-beta",
 			"name": "Grok Vision Beta",

--- a/packages/ai/test/grok-composer-catalog.test.ts
+++ b/packages/ai/test/grok-composer-catalog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { isComposerHarnessModel } from "../src/providers/composer-discipline";
+
+describe("grok composer bundled catalog", () => {
+	it("bundles fast and max composer variants for xAI", () => {
+		const fast = getBundledModel("xai", "grok-composer-2.5-fast");
+		const max = getBundledModel("xai", "grok-composer-2.5-max");
+
+		expect(fast?.provider).toBe("xai");
+		expect(max?.provider).toBe("xai");
+		expect(max?.wireModelId).toBe("grok-composer-2.5-fast");
+		expect(max?.thinking).toEqual({
+			mode: "effort",
+			minLevel: "max",
+			maxLevel: "max",
+			defaultLevel: "max",
+			levels: ["max"],
+		});
+	});
+
+	it("treats both composer variants as harness models", () => {
+		expect(isComposerHarnessModel("grok-composer-2.5-fast")).toBe(true);
+		expect(isComposerHarnessModel("grok-composer-2.5-max")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Add bundled `xai/grok-composer-2.5-max` to the static catalog
- Wire the Max alias to `grok-composer-2.5-fast` via `wireModelId`
- Pin max-effort thinking metadata and OpenRouter-style reasoning fields so users can select Composer Max without custom `models.yml` overrides

## Why
`grok-composer-2.5-fast` is already bundled, but users who want the Max alias currently need local `~/.gjc/agent/models.yml` overrides (or helper scripts) to keep `xai/grok-composer-2.5-max` available after updates.

This PR moves that alias into the official bundled catalog so `gjc update` alone is enough to keep both Composer variants available.

## Security / privacy
- No environment variable values
- No user config files
- No API keys or OAuth tokens
- Only public model metadata (`apiKeyEnv` names, public base URL, model ids)

## Validation
- `bun test packages/ai/test/grok-composer-catalog.test.ts`

## Follow-up (optional)
After this lands, users can set their preferred default in `~/.gjc/agent/config.yml`, for example:

```yaml
modelRoles:
  default: xai/grok-composer-2.5-max
  composer: xai/grok-composer-2.5-max
  composer-fast: xai/grok-composer-2.5-fast
  composer-max: xai/grok-composer-2.5-max
```

That user-local config is intentionally not bundled here.

Made with [Cursor](https://cursor.com)