### PR TITLE
fix(tui): add keyboard protocol opt-out for Android Termius Hangul IME

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -470,6 +470,7 @@ These are read as runtime signals; they are usually set by the terminal/OS rathe
 | `GJC_DEBUG_REDRAW`         | If `1`, enables redraw debug logging                                                  |
 | `GJC_TUI_DEBUG`            | If `1`, enables deep TUI debug dump path                                              |
 | `GJC_FORCE_IMAGE_PROTOCOL` | Forces terminal image protocol detection (`kitty`, `iterm2`/`iterm`, `sixel`, `none`) |
+| `GJC_TUI_KEYBOARD_PROTOCOL` | Enhanced keyboard input (Kitty keyboard protocol + xterm modifyOtherKeys). Enabled by default; set `0` / `false` to leave the keyboard in its default mode. Use this when a terminal (e.g. Android Termius) breaks IME/Hangul composition while these enhanced modes are active. |
 
 ---
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Tightened markdown/editor rendering and terminal repaint behavior for the compact tool-block spacing and render-golden stability work.
 
+### Fixed
+
+- Fixed Korean/Hangul input composition breaking in Android Termius, where typing `안녕하세요` produced duplicated jamo/syllable residue (`ㅇ아안ㄴ녀녕…`). GJC's startup keyboard reprogramming (Kitty keyboard protocol query `CSI ? u` / push `CSI > 7 u`, and the xterm modifyOtherKeys fallback `CSI > 4 ; 2 m`) disrupts the Android IME's syllable composition. Added a `GJC_TUI_KEYBOARD_PROTOCOL` opt-out (enabled by default): set `GJC_TUI_KEYBOARD_PROTOCOL=0` to leave the keyboard in its default mode so IME composition works, matching terminals/TUIs that never enable these enhanced input modes.
+
 ## [0.4.5] - 2026-06-12
 
 - Version aligned with the 0.4.5 monorepo release; no functional changes in this package.

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,12 +1,28 @@
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import * as fs from "node:fs";
-import { $env } from "@gajae-code/utils";
+import { $env, $flag } from "@gajae-code/utils";
 import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
 
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
+
+/**
+ * Whether GJC may reprogram the keyboard with enhanced input protocols
+ * (the Kitty keyboard protocol and the xterm modifyOtherKeys fallback).
+ *
+ * Enabled by default. Set `GJC_TUI_KEYBOARD_PROTOCOL=0` to leave the keyboard in
+ * its default mode. Some terminals — notably Android Termius — break IME
+ * composition (e.g. Korean/Hangul syllable composition) while these enhanced
+ * modes are active, committing every intermediate composing jamo/syllable
+ * instead of only the final character. Disabling the protocol restores normal
+ * IME behavior, matching how other TUIs that leave the keyboard untouched render
+ * Korean correctly.
+ */
+export function keyboardEnhancementEnabled(): boolean {
+	return $flag("GJC_TUI_KEYBOARD_PROTOCOL", true);
+}
 
 /**
  * Minimal terminal interface for TUI
@@ -513,6 +529,14 @@ export class ProcessTerminal implements Terminal {
 	#queryAndEnableKittyProtocol(): void {
 		this.#setupStdinBuffer();
 		process.stdin.on("data", this.#stdinDataHandler!);
+		// Leave the keyboard in its default mode when enhanced input protocols are
+		// disabled. Android Termius (and similar terminals) break IME/Hangul
+		// composition when the Kitty keyboard protocol or modifyOtherKeys is active,
+		// committing every intermediate composing jamo/syllable. Skipping the query
+		// and the modifyOtherKeys fallback restores normal IME composition.
+		if (!keyboardEnhancementEnabled()) {
+			return;
+		}
 		this.#safeWrite("\x1b[?u");
 		this.#modifyOtherKeysTimeout = setTimeout(() => {
 			this.#modifyOtherKeysTimeout = undefined;

--- a/packages/tui/test/keyboard-protocol-optout.test.ts
+++ b/packages/tui/test/keyboard-protocol-optout.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { keyboardEnhancementEnabled, ProcessTerminal } from "@gajae-code/tui/terminal";
+
+const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+const originalKeyboardProtocolEnv = Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+
+// Kitty keyboard protocol query and the xterm modifyOtherKeys level-2 fallback.
+const KITTY_QUERY = "\x1b[?u";
+const MODIFY_OTHER_KEYS = "\x1b[>4;2m";
+
+function restoreProperty(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	delete (target as Record<string, unknown>)[key];
+}
+
+function restoreEnv(key: string, original: string | undefined): void {
+	if (original === undefined) {
+		delete Bun.env[key];
+		return;
+	}
+	Bun.env[key] = original;
+}
+
+describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)", () => {
+	beforeEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdin, "setRawMode", { value: vi.fn(), configurable: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
+		restoreEnv("GJC_TUI_KEYBOARD_PROTOCOL", originalKeyboardProtocolEnv);
+	});
+
+	function setupTerminal() {
+		const writes: string[] = [];
+		const received: string[] = [];
+		vi.spyOn(process, "kill").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			data => received.push(data),
+			() => {},
+		);
+
+		return { terminal, writes, received };
+	}
+
+	it("enables the keyboard protocol by default (query + modifyOtherKeys fallback)", () => {
+		vi.useFakeTimers();
+		delete Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+		expect(keyboardEnhancementEnabled()).toBe(true);
+
+		const { terminal, writes } = setupTerminal();
+
+		expect(writes).toContain(KITTY_QUERY);
+
+		// No Kitty response arrives → modifyOtherKeys fallback fires after 150ms.
+		vi.advanceTimersByTime(150);
+		expect(writes).toContain(MODIFY_OTHER_KEYS);
+
+		terminal.stop();
+	});
+
+	it("skips the query and modifyOtherKeys fallback when disabled", () => {
+		vi.useFakeTimers();
+		Bun.env.GJC_TUI_KEYBOARD_PROTOCOL = "0";
+		expect(keyboardEnhancementEnabled()).toBe(false);
+
+		const { terminal, writes } = setupTerminal();
+
+		expect(writes).not.toContain(KITTY_QUERY);
+
+		vi.advanceTimersByTime(150);
+		expect(writes).not.toContain(MODIFY_OTHER_KEYS);
+
+		terminal.stop();
+	});
+
+	it("still delivers keyboard input to the handler when disabled", () => {
+		Bun.env.GJC_TUI_KEYBOARD_PROTOCOL = "0";
+
+		const { terminal, received } = setupTerminal();
+
+		// Typed Hangul must still reach the input handler in default keyboard mode.
+		process.stdin.emit("data", Buffer.from("안", "utf8"));
+
+		expect(received).toContain("안");
+
+		terminal.stop();
+	});
+});


### PR DESCRIPTION
## Summary
- Add a `GJC_TUI_KEYBOARD_PROTOCOL` opt-out for terminals where enhanced keyboard input breaks IME composition.
- Document the env var and add changelog notes.
- Add regression coverage for enabled/default keyboard protocol behavior and disabled opt-out behavior.

## Root cause
Android Termius breaks Hangul IME composition when GJC enables enhanced keyboard input modes at startup:
- Kitty keyboard protocol query/push (`CSI ? u`, `CSI > 7 u`)
- xterm `modifyOtherKeys` fallback (`CSI > 4 ; 2 m`)

In the reported Android Termius session, typing `안녕하세요` rendered as duplicated composition residue like `ㅇ아안ㄴ녀녕ㅎ하핫하세셍세요`. Disabling the enhanced keyboard protocol leaves the terminal keyboard in its default mode, matching other TUIs where Hangul composition works normally.

## Fix
- Keep enhanced keyboard input enabled by default.
- Add `GJC_TUI_KEYBOARD_PROTOCOL=0` / `false` opt-out to skip Kitty keyboard protocol and `modifyOtherKeys` activation.
- Preserve stdin handling when the opt-out is active.

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/keyboard-protocol-optout.test.ts`
  - 3 pass / 0 fail
- `bun test packages/tui/test/terminal-appearance.test.ts packages/tui/test/terminal-detach.test.ts packages/tui/test/stdin-buffer.test.ts packages/tui/test/ime-jamo-cursor.test.ts packages/tui/test/keys.test.ts`
  - 89 pass / 0 fail
- `bun --cwd=packages/tui test`
  - 465 pass / 0 fail
- `bun run check:ts`
  - biome clean; package tsgo checks exited 0
- Manual Android Termius smoke on WorkPC Byobu session `1`, window `gjc-ko-termius-smoke`, with `GJC_TUI_KEYBOARD_PROTOCOL=0`:
  - typing `안녕하세요` worked correctly per reporter.

## Notes
- This is intentionally an opt-out rather than changing default keyboard behavior for all terminals.
- PR target is `dev`.
