### PR TITLE
feat: add bundled Grok Build auth

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -27,6 +27,7 @@ import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityUsageProvider } from "./usage/google-antigravity";
+import { grokCliRankingStrategy, grokCliUsageProvider } from "./usage/grok-cli";
 import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
@@ -370,6 +371,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	claudeUsageProvider,
 	zaiUsageProvider,
 	githubCopilotUsageProvider,
+	grokCliUsageProvider,
 ];
 
 const DEFAULT_USAGE_PROVIDER_MAP = new Map<Provider, UsageProvider>(
@@ -498,6 +500,7 @@ function resolveDefaultUsageProvider(provider: Provider): UsageProvider | undefi
 const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>([
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
+	["grok-build", grokCliRankingStrategy],
 ]);
 
 function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStrategy | undefined {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -33,6 +33,7 @@ export * from "./usage/claude";
 export * from "./usage/gemini";
 export * from "./usage/github-copilot";
 export * from "./usage/google-antigravity";
+export * from "./usage/grok-cli";
 export * from "./usage/kimi";
 export * from "./usage/minimax-code";
 export * from "./usage/openai-codex";

--- a/packages/ai/src/usage/grok-cli.ts
+++ b/packages/ai/src/usage/grok-cli.ts
@@ -1,0 +1,141 @@
+import type {
+	CredentialRankingStrategy,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+} from "../usage";
+
+interface BillingUsage {
+	monthlyLimit: number;
+	used: number;
+	billingPeriodEnd: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object";
+}
+
+function finiteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseValNumber(value: unknown): number | undefined {
+	return isRecord(value) ? finiteNumber(value.val) : undefined;
+}
+
+export function parseGrokCliBillingUsage(payload: unknown): BillingUsage {
+	if (!isRecord(payload) || !isRecord(payload.config)) {
+		throw new Error("invalid Grok CLI billing payload");
+	}
+	const monthlyLimit = parseValNumber(payload.config.monthlyLimit);
+	const used = parseValNumber(payload.config.used);
+	const billingPeriodEnd = payload.config.billingPeriodEnd;
+	if (
+		monthlyLimit === undefined ||
+		used === undefined ||
+		typeof billingPeriodEnd !== "string" ||
+		!Number.isFinite(new Date(billingPeriodEnd).getTime())
+	) {
+		throw new Error("invalid Grok CLI billing payload");
+	}
+	return { monthlyLimit, used, billingPeriodEnd };
+}
+
+function normalizeGrokBaseUrl(baseUrl?: string): string {
+	return (baseUrl?.trim() || "https://cli-chat-proxy.grok.com/v1").replace(/\/+$/, "");
+}
+
+function resolveAccessToken(params: UsageFetchParams): string | undefined {
+	const token = params.credential.accessToken ?? params.credential.apiKey ?? process.env.GROK_CLI_OAUTH_TOKEN;
+	return token?.trim() || undefined;
+}
+
+function buildMonthlyUsageLimit(usage: BillingUsage, nowMs: number): UsageLimit {
+	const usedFraction = usage.monthlyLimit > 0 ? usage.used / usage.monthlyLimit : 0;
+	const percent = usedFraction * 100;
+	const resetsAt = new Date(usage.billingPeriodEnd).getTime();
+	return {
+		id: "grok-build:7d",
+		label: "SuperGrok monthly credits",
+		scope: { provider: "grok-build", shared: true, windowId: "7d" },
+		window: {
+			id: "7d",
+			label: "Monthly credits",
+			resetsAt,
+		},
+		amount: {
+			unit: "percent",
+			used: percent,
+			limit: 100,
+			remaining: Math.max(0, 100 - percent),
+			usedFraction,
+			remainingFraction: Math.max(0, 1 - usedFraction),
+		},
+		status: percent >= 95 ? "exhausted" : percent >= 80 ? "warning" : "ok",
+		notes: [
+			`${usage.used}/${usage.monthlyLimit} credits used`,
+			`resets in ${Math.max(0, Math.round((resetsAt - nowMs) / 3_600_000))}h`,
+		],
+	};
+}
+
+export const grokCliUsageProvider: UsageProvider = {
+	id: "grok-build",
+
+	supports(params) {
+		return params.provider === "grok-build";
+	},
+
+	async fetchUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+		const accessToken = resolveAccessToken(params);
+		if (!accessToken) {
+			ctx.logger?.warn("Grok Build usage: no access token", { provider: params.provider });
+			return null;
+		}
+
+		const response = await ctx.fetch(`${normalizeGrokBaseUrl(params.baseUrl)}/billing`, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"x-xai-token-auth": "xai-grok-cli",
+				accept: "application/json",
+			},
+			signal: params.signal,
+		});
+		if (!response.ok) {
+			ctx.logger?.warn("Grok Build billing request failed", { status: response.status, provider: params.provider });
+			return null;
+		}
+
+		const payload = (await response.json()) as unknown;
+		let billing: BillingUsage;
+		try {
+			billing = parseGrokCliBillingUsage(payload);
+		} catch (error) {
+			ctx.logger?.warn("Grok Build billing parse failed", { error: String(error) });
+			return null;
+		}
+
+		const nowMs = Date.now();
+		return {
+			provider: "grok-build",
+			fetchedAt: nowMs,
+			limits: [buildMonthlyUsageLimit(billing, nowMs)],
+			metadata: {
+				email: params.credential.email,
+				accountId: params.credential.accountId,
+				subscription: true,
+			},
+			raw: payload,
+		};
+	},
+};
+
+export const grokCliRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		const monthly = report.limits.find(limit => limit.id === "grok-build:7d");
+		return { secondary: monthly };
+	},
+	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 30 * 24 * 60 * 60 * 1000 },
+};

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -30,6 +30,15 @@ interface XaiTokenPayload {
 	token_type?: unknown;
 }
 
+export interface XaiOAuthFlowOptions {
+	extraAuthorizeParams?: Readonly<Record<string, string>>;
+}
+
+export interface XaiOAuthRefreshOptions {
+	signal?: AbortSignal;
+	extraTokenParams?: Readonly<Record<string, string>>;
+}
+
 interface XaiJwtPayload {
 	sub?: unknown;
 	email?: unknown;
@@ -39,6 +48,25 @@ interface XaiJwtPayload {
 function requestSignal(signal: AbortSignal | undefined): AbortSignal {
 	const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
 	return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+function addNonOverridingParams(target: URLSearchParams | Record<string, string>, params: Readonly<Record<string, string>>): void {
+	for (const [key, value] of Object.entries(params)) {
+		if (key.length === 0 || value.length === 0) continue;
+		if (target instanceof URLSearchParams) {
+			if (!target.has(key)) target.set(key, value);
+		} else if (!(key in target)) {
+			target[key] = value;
+		}
+	}
+}
+
+function isAbortSignal(value: AbortSignal | XaiOAuthRefreshOptions | undefined): value is AbortSignal {
+	return value instanceof AbortSignal;
+}
+
+function resolveRefreshOptions(options: AbortSignal | XaiOAuthRefreshOptions | undefined): XaiOAuthRefreshOptions {
+	return isAbortSignal(options) ? { signal: options } : (options ?? {});
 }
 
 function validateXaiEndpoint(rawUrl: string): string {
@@ -136,8 +164,9 @@ function credentialsFromTokenPayload(payload: XaiTokenPayload, refreshFallback =
 export class XaiOAuthFlow extends OAuthCallbackFlow {
 	#verifier = "";
 	#discovery: XaiDiscovery | undefined;
+	#extraAuthorizeParams: Readonly<Record<string, string>>;
 
-	constructor(ctrl: OAuthController) {
+	constructor(ctrl: OAuthController, options: XaiOAuthFlowOptions = {}) {
 		super(ctrl, {
 			preferredPort: XAI_OAUTH_CALLBACK_PORT,
 			callbackPath: XAI_OAUTH_CALLBACK_PATH,
@@ -145,6 +174,7 @@ export class XaiOAuthFlow extends OAuthCallbackFlow {
 			callbackBindHostname: "127.0.0.1",
 			redirectUri: `http://127.0.0.1:${XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`,
 		} satisfies OAuthCallbackFlowOptions);
+		this.#extraAuthorizeParams = options.extraAuthorizeParams ?? {};
 	}
 
 	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
@@ -161,6 +191,7 @@ export class XaiOAuthFlow extends OAuthCallbackFlow {
 			state,
 			nonce: crypto.randomUUID(),
 		});
+		addNonOverridingParams(params, this.#extraAuthorizeParams);
 		return {
 			url: `${this.#discovery.authorizationEndpoint}?${params.toString()}`,
 			instructions:
@@ -188,23 +219,25 @@ export class XaiOAuthFlow extends OAuthCallbackFlow {
 	}
 }
 
-export async function loginXai(ctrl: OAuthController): Promise<OAuthCredentials> {
-	return new XaiOAuthFlow(ctrl).login();
+export async function loginXai(ctrl: OAuthController, options?: XaiOAuthFlowOptions): Promise<OAuthCredentials> {
+	return new XaiOAuthFlow(ctrl, options).login();
 }
 
-export async function refreshXaiToken(refreshToken: string, signal?: AbortSignal): Promise<OAuthCredentials> {
+export async function refreshXaiToken(
+	refreshToken: string,
+	options?: AbortSignal | XaiOAuthRefreshOptions,
+): Promise<OAuthCredentials> {
 	if (!refreshToken) {
 		throw new Error("xAI credentials are expired and do not include a refresh token");
 	}
+	const { signal, extraTokenParams = {} } = resolveRefreshOptions(options);
 	const discovery = await discoverXaiOAuthEndpoints(signal);
-	const tokenPayload = await postXaiToken(
-		discovery.tokenEndpoint,
-		{
-			grant_type: "refresh_token",
-			client_id: XAI_OAUTH_CLIENT_ID,
-			refresh_token: refreshToken,
-		},
-		signal,
-	);
+	const body = {
+		grant_type: "refresh_token",
+		client_id: XAI_OAUTH_CLIENT_ID,
+		refresh_token: refreshToken,
+	};
+	addNonOverridingParams(body, extraTokenParams);
+	const tokenPayload = await postXaiToken(discovery.tokenEndpoint, body, signal);
 	return credentialsFromTokenPayload(tokenPayload, refreshToken);
 }

--- a/packages/ai/test/grok-cli-usage.test.ts
+++ b/packages/ai/test/grok-cli-usage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { grokCliUsageProvider, parseGrokCliBillingUsage } from "../src/usage/grok-cli";
+
+describe("Grok CLI usage provider", () => {
+	it("parses billing payload", () => {
+		expect(
+			parseGrokCliBillingUsage({
+				config: {
+					monthlyLimit: { val: 10_000 },
+					used: { val: 500 },
+					billingPeriodEnd: "2026-07-01T00:00:00.000Z",
+				},
+			}),
+		).toEqual({ monthlyLimit: 10_000, used: 500, billingPeriodEnd: "2026-07-01T00:00:00.000Z" });
+	});
+
+	it("maps billing to status-line-compatible 7d usage", async () => {
+		const report = await grokCliUsageProvider.fetchUsage(
+			{
+				provider: "grok-build",
+				credential: { type: "oauth", accessToken: "token", expiresAt: Date.now() + 60_000 },
+				baseUrl: "https://cli-chat-proxy.grok.com/v1/",
+			},
+			{
+				fetch: (async (url, init) => {
+					expect(String(url)).toBe("https://cli-chat-proxy.grok.com/v1/billing");
+					expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer token");
+					return Response.json({
+						config: {
+							monthlyLimit: { val: 10_000 },
+							used: { val: 2_500 },
+							billingPeriodEnd: "2026-07-01T00:00:00.000Z",
+						},
+					});
+				}) as typeof fetch,
+			},
+		);
+		expect(report?.provider).toBe("grok-build");
+		expect(report?.limits[0]?.scope.windowId).toBe("7d");
+		expect(report?.limits[0]?.amount.used).toBe(25);
+		expect(report?.limits[0]?.amount.usedFraction).toBe(0.25);
+	});
+});

--- a/packages/ai/test/oauth-xai.test.ts
+++ b/packages/ai/test/oauth-xai.test.ts
@@ -8,6 +8,7 @@ import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
 import type { OAuthCredentials } from "../src/utils/oauth/types";
 import {
 	discoverXaiOAuthEndpoints,
+	refreshXaiToken,
 	XAI_OAUTH_CLIENT_ID,
 	XAI_OAUTH_DISCOVERY_URL,
 	XAI_OAUTH_SCOPE,
@@ -142,6 +143,28 @@ describe("xAI OAuth login provider", () => {
 		expect(authUrl.searchParams.get("nonce")?.length).toBeGreaterThan(20);
 	});
 
+	it("adds provider-specific authorization metadata when requested", async () => {
+		const fetchMock = vi.fn(async () => discoveryResponse());
+		global.fetch = fetchMock as unknown as typeof fetch;
+		const flow = new XaiOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{
+				extraAuthorizeParams: {
+					client_id: "must-not-override",
+					plan: "generic",
+					referrer: "gjc-grok-cli",
+				},
+			},
+		);
+
+		const { url } = await flow.generateAuthUrl("state-123", "http://127.0.0.1:56121/callback");
+		const authUrl = new URL(url);
+
+		expect(authUrl.searchParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+		expect(authUrl.searchParams.get("plan")).toBe("generic");
+		expect(authUrl.searchParams.get("referrer")).toBe("gjc-grok-cli");
+	});
+
 	it("exchanges an authorization code for refreshable OAuth credentials", async () => {
 		let tokenBody = "";
 		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -245,6 +268,43 @@ describe("xAI OAuth login provider", () => {
 			refresh: "refresh-rotated",
 			accountId: "account-rotated",
 			email: "rotated@example.com",
+		});
+	});
+
+	it("adds provider-specific refresh metadata when requested", async () => {
+		let tokenBody = "";
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === XAI_OAUTH_DISCOVERY_URL) return discoveryResponse();
+			if (url === TOKEN_ENDPOINT) {
+				tokenBody = String(init?.body ?? "");
+				return tokenResponse("access-build", "refresh-build", "account-build", "build@example.com");
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const refreshed = await refreshXaiToken("refresh-old", {
+			extraTokenParams: {
+				client_id: "must-not-override",
+				plan: "generic",
+				referrer: "gjc-grok-cli",
+				scope: XAI_OAUTH_SCOPE,
+			},
+		});
+		const tokenParams = new URLSearchParams(tokenBody);
+
+		expect(tokenParams.get("grant_type")).toBe("refresh_token");
+		expect(tokenParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+		expect(tokenParams.get("refresh_token")).toBe("refresh-old");
+		expect(tokenParams.get("plan")).toBe("generic");
+		expect(tokenParams.get("referrer")).toBe("gjc-grok-cli");
+		expect(tokenParams.get("scope")).toBe(XAI_OAUTH_SCOPE);
+		expect(refreshed).toMatchObject({
+			access: "access-build",
+			refresh: "refresh-build",
+			accountId: "account-build",
+			email: "build@example.com",
 		});
 	});
 });

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -70,6 +70,7 @@ const CALLBACK_PORTS: Record<string, number> = {
 	"google-antigravity": 51121,
 	"gitlab-duo": 8080,
 	xai: 56121,
+	"grok-build": 56121,
 };
 
 function getTokenFilePath(): string {

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -173,6 +173,13 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "xai/grok-4.3:xhigh",
 		architect: "xai/grok-4.3:xhigh",
 	}),
+	profile("grok-build-pro", ["grok-build"], {
+		default: "grok-build/grok-composer-2.5-fast",
+		executor: "grok-build/grok-build",
+		planner: "grok-build/grok-composer-2.5-fast",
+		critic: "grok-build/grok-composer-2.5-fast",
+		architect: "grok-build/grok-build",
+	}),
 	profile("cursor-eco", ["cursor"], {
 		default: "cursor/composer-1.5:low",
 		executor: "cursor/composer-1.5:minimal",
@@ -254,6 +261,7 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	"grok-eco": { displayName: "Grok Eco", providerGroup: "GROK" },
 	"grok-medium": { displayName: "Grok Medium", providerGroup: "GROK" },
 	"grok-pro": { displayName: "Grok Pro", providerGroup: "GROK" },
+	"grok-build-pro": { displayName: "Grok Build Pro", providerGroup: "GROK" },
 	"cursor-eco": { displayName: "Cursor Eco", providerGroup: "CURSOR" },
 	"cursor-medium": { displayName: "Cursor Medium", providerGroup: "CURSOR" },
 	"cursor-pro": { displayName: "Cursor Pro", providerGroup: "CURSOR" },
@@ -285,6 +293,7 @@ const PROFILE_RECOMMENDATIONS: Record<string, string> = {
 	"kimi-code": "kimi-coding-plan-medium",
 	xiaomi: "mimo-medium",
 	xai: "grok-medium",
+	"grok-build": "grok-build-pro",
 	cursor: "cursor-medium",
 	"minimax-code": "minimax-medium",
 };

--- a/packages/coding-agent/src/defaults/gjc-grok-cli.ts
+++ b/packages/coding-agent/src/defaults/gjc-grok-cli.ts
@@ -1,0 +1,36 @@
+import * as path from "node:path";
+
+export function getBundledGrokBuildExtensionPath(): string {
+	return path.join(import.meta.dir, "gjc", "extensions", "grok-build", "index.ts");
+}
+
+export function getBundledGrokBuildExtensionDir(): string {
+	return path.dirname(getBundledGrokBuildExtensionPath());
+}
+
+export function getBundledGrokCliVendorDir(): string {
+	return path.join(import.meta.dir, "gjc", "extensions", "grok-cli-vendor");
+}
+
+export function getBundledGrokCliModelDefaultsPath(): string {
+	return path.join(import.meta.dir, "gjc", "agent.models.grok-cli.yml");
+}
+
+export async function assertBundledGrokCliDefaults(): Promise<void> {
+	const required = [
+		getBundledGrokBuildExtensionPath(),
+		path.join(getBundledGrokCliVendorDir(), "src", "index.ts"),
+		path.join(getBundledGrokCliVendorDir(), "src", "provider", "register.ts"),
+		getBundledGrokCliModelDefaultsPath(),
+	];
+	for (const filePath of required) {
+		if (!(await Bun.file(filePath).exists())) {
+			throw new Error(`Bundled Grok Build default is missing: ${filePath}`);
+		}
+	}
+}
+
+export async function getBundledGrokBuildExtensionPaths(): Promise<string[]> {
+	await assertBundledGrokCliDefaults();
+	return [getBundledGrokBuildExtensionPath()];
+}

--- a/packages/coding-agent/src/defaults/gjc/agent.models.grok-cli.yml
+++ b/packages/coding-agent/src/defaults/gjc/agent.models.grok-cli.yml
@@ -1,0 +1,36 @@
+# Merge into ~/.gjc/agent/models.yml (or use as reference)
+# Remove global x-grok-model-override when using multiple Grok Build models.
+
+providers:
+  grok-build:
+    baseUrl: https://cli-chat-proxy.grok.com/v1
+    apiKeyEnv: GROK_CLI_OAUTH_TOKEN
+    api: grok-cli-responses
+    auth: oauth
+    headers:
+      x-xai-token-auth: xai-grok-cli
+      x-grok-client-identifier: gjc-grok-cli
+      x-grok-client-version: 0.2.33
+    models:
+      - id: grok-composer-2.5-fast
+        name: Composer 2.5 Fast
+        reasoning: false
+        input: [text, image]
+        contextWindow: 200000
+        maxTokens: 30000
+        cost:
+          input: 3
+          output: 15
+          cacheRead: 0.5
+          cacheWrite: 0
+      - id: grok-build
+        name: Grok Build
+        reasoning: true
+        input: [text, image]
+        contextWindow: 512000
+        maxTokens: 30000
+        cost:
+          input: 1
+          output: 2
+          cacheRead: 0.2
+          cacheWrite: 0.2

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../grok-cli-vendor/src/index.js';

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-build/package.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-build/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gjc-grok-build",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "GJC extension: Grok Build OAuth and grok-cli models"
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/package.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gjc-grok-cli-vendor",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Grok CLI chat proxy provider for GJC (SuperGrok OAuth, Composer 2.5 Fast)",
+  "dependencies": {}
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/auth/oauth.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/auth/oauth.ts
@@ -1,0 +1,485 @@
+/**
+ * xAI Grok OAuth 2.0 + PKCE implementation.
+ *
+ * Uses Web Crypto API (crypto.subtle) for PKCE so the extension is
+ * portable across Node versions and potential non-Node runtimes.
+ *
+ * SuperGrok OAuth (auth.x.ai OIDC) — same public client_id as the official Grok CLI app.
+ * issuer. The difference is in the API endpoint: this extension targets
+ * cli-chat-proxy.grok.com instead of api.x.ai.
+ */
+
+import { createServer } from 'node:http';
+import type { OAuthCredentials, OAuthLoginCallbacks } from '@gajae-code/ai/utils/oauth/types';
+import { XaiErrorCode, XaiOAuthError } from '../shared/errors.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_BASE_URL = 'https://cli-chat-proxy.grok.com/v1';
+const ISSUER = 'https://auth.x.ai';
+const DISCOVERY_URL = `${ISSUER}/.well-known/openid-configuration`;
+const CLIENT_ID = process.env.GJC_GROK_CLI_OAUTH_CLIENT_ID || 'b1a00492-073a-47ea-816f-4c329264a828';
+const SCOPE =
+  process.env.GJC_GROK_CLI_OAUTH_SCOPE ||
+  'openid profile email offline_access grok-cli:access api:access';
+const CALLBACK_HOST = process.env.GJC_GROK_CLI_CALLBACK_HOST || '127.0.0.1';
+const CALLBACK_PORT = Number.parseInt(process.env.GJC_GROK_CLI_CALLBACK_PORT || '56122', 10);
+const CALLBACK_PATH = '/callback';
+/** Refresh 120s before actual expiry. */
+const REFRESH_SKEW_MS = 120_000;
+const TOKEN_REQUEST_TIMEOUT_MS = Number.parseInt(
+  process.env.GJC_GROK_CLI_TOKEN_TIMEOUT_MS || '30000',
+  10,
+);
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface XaiDiscovery {
+  authorization_endpoint: string;
+  token_endpoint: string;
+}
+
+export interface XaiOAuthCredentials extends OAuthCredentials {}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getBaseUrl(): string {
+  return (
+    process.env.GJC_GROK_CLI_BASE_URL ||
+    process.env.GROK_CLI_BASE_URL ||
+    DEFAULT_BASE_URL
+  ).replace(/\/+$/, '');
+}
+
+function base64Url(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// ─── PKCE ─────────────────────────────────────────────────────────────────────
+
+async function generatePKCE(): Promise<{
+  verifier: string;
+  challenge: string;
+}> {
+  const verifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64Url(hash) };
+}
+
+// ─── Endpoint validation ──────────────────────────────────────────────────────
+
+function validateEndpoint(value: string, field: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new XaiOAuthError(
+      `xAI OAuth discovery returned invalid ${field}: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  if (url.protocol !== 'https:') {
+    throw new XaiOAuthError(
+      `xAI OAuth ${field} must use HTTPS: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  const host = url.hostname.toLowerCase();
+  if (
+    host !== 'x.ai' &&
+    host !== 'auth.x.ai' &&
+    host !== 'accounts.x.ai' &&
+    !host.endsWith('.x.ai')
+  ) {
+    throw new XaiOAuthError(
+      `Refusing non-xAI OAuth ${field}: ${value}`,
+      XaiErrorCode.DISCOVERY_INVALID_ORIGIN,
+    );
+  }
+  return url.toString();
+}
+
+// ─── OIDC Discovery ──────────────────────────────────────────────────────────
+
+async function discover(): Promise<XaiDiscovery> {
+  let response: Response;
+  try {
+    response = await fetch(DISCOVERY_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  if (!response.ok) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery returned ${response.status}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await response.json()) as Record<string, unknown>;
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery returned invalid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      XaiErrorCode.DISCOVERY_FAILED,
+    );
+  }
+  const authorizationEndpoint = validateEndpoint(
+    String(payload.authorization_endpoint ?? ''),
+    'authorization_endpoint',
+  );
+  const tokenEndpoint = validateEndpoint(String(payload.token_endpoint ?? ''), 'token_endpoint');
+  return {
+    authorization_endpoint: authorizationEndpoint,
+    token_endpoint: tokenEndpoint,
+  };
+}
+
+// ─── Loopback callback server ────────────────────────────────────────────────
+
+interface CallbackResult {
+  code?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+function startCallbackServer(): Promise<{
+  server: import('node:http').Server;
+  redirectUri: string;
+  waitForCallback: (timeoutMs: number) => Promise<CallbackResult>;
+}> {
+  let settle: ((value: CallbackResult) => void) | undefined;
+  const callbackPromise = new Promise<CallbackResult>((resolve) => {
+    settle = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    try {
+      const origin = req.headers.origin;
+      if (origin === 'https://accounts.x.ai' || origin === 'https://auth.x.ai') {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        res.setHeader('Access-Control-Allow-Private-Network', 'true');
+        res.setHeader('Vary', 'Origin');
+      }
+      if (req.method === 'OPTIONS') {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+
+      const url = new URL(req.url ?? '/', `http://${CALLBACK_HOST}`);
+      if (url.pathname !== CALLBACK_PATH) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+
+      const result: CallbackResult = {
+        code: url.searchParams.get('code') ?? undefined,
+        state: url.searchParams.get('state') ?? undefined,
+        error: url.searchParams.get('error') ?? undefined,
+        errorDescription: url.searchParams.get('error_description') ?? undefined,
+      };
+
+      // Always 200 on the loopback page so the browser does not show HTTP 400.
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      const html = result.error
+        ? '<html><body><h1>xAI authorization was not completed.</h1><p>Return to the terminal for details. You can close this tab.</p></body></html>'
+        : '<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>';
+      res.end(html);
+      settle?.(result);
+    } catch {
+      res.statusCode = 500;
+      res.end('Internal error');
+    }
+  });
+
+  const listen = (port: number) =>
+    new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, CALLBACK_HOST, () => {
+        server.removeListener('error', reject);
+        const addr = server.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : port);
+      });
+    });
+
+  return (async () => {
+    let actualPort: number;
+    try {
+      actualPort = await listen(CALLBACK_PORT);
+    } catch (firstError) {
+      try {
+        actualPort = await listen(0);
+      } catch (secondError) {
+        const errorDescription = `Could not bind xAI OAuth callback server on ${CALLBACK_HOST}:${CALLBACK_PORT} or an ephemeral port: ${secondError instanceof Error ? secondError.message : String(secondError)} (initial error: ${firstError instanceof Error ? firstError.message : String(firstError)})`;
+        return {
+          server,
+          redirectUri: `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`,
+          waitForCallback: async () => ({
+            error: XaiErrorCode.CALLBACK_BIND_FAILED,
+            errorDescription,
+          }),
+        };
+      }
+    }
+    const redirectUri = `http://${CALLBACK_HOST}:${actualPort}${CALLBACK_PATH}`;
+    return {
+      server,
+      redirectUri,
+      waitForCallback: (timeoutMs: number) =>
+        Promise.race([
+          callbackPromise,
+          new Promise<CallbackResult>((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  error: XaiErrorCode.CALLBACK_TIMEOUT,
+                  errorDescription: 'Timed out waiting for xAI OAuth callback.',
+                }),
+              timeoutMs,
+            ),
+          ),
+        ]),
+    };
+  })();
+}
+
+// ─── Token exchange ───────────────────────────────────────────────────────────
+
+async function fetchTokenResponse(
+  tokenEndpoint: string,
+  body: URLSearchParams,
+  errorCode: string,
+  label: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI ${label} failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      errorCode,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function tokenResponseText(response: Response) {
+  try {
+    return await response.text();
+  } catch (cause) {
+    return `unable to read response body: ${cause instanceof Error ? cause.message : String(cause)}`;
+  }
+}
+
+async function tokenResponseJson(
+  response: Response,
+  errorCode: string,
+  label: string,
+): Promise<Record<string, unknown>> {
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch (cause) {
+    throw new XaiOAuthError(
+      `xAI ${label} returned invalid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      errorCode,
+    );
+  }
+}
+
+async function exchangeCode(
+  tokenEndpoint: string,
+  code: string,
+  redirectUri: string,
+  verifier: string,
+): Promise<XaiOAuthCredentials> {
+  const response = await fetchTokenResponse(
+    tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    }),
+    XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    'token exchange',
+  );
+  if (!response.ok) {
+    throw new XaiOAuthError(
+      `xAI token exchange failed: ${response.status} ${await tokenResponseText(response)}`,
+      XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    );
+  }
+  const payload = await tokenResponseJson(
+    response,
+    XaiErrorCode.TOKEN_EXCHANGE_FAILED,
+    'token exchange',
+  );
+  const access = String(payload.access_token ?? '');
+  const refresh = String(payload.refresh_token ?? '');
+  if (!access) {
+    throw new XaiOAuthError(
+      'xAI token exchange did not return access_token.',
+      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+    );
+  }
+  if (!refresh) {
+    throw new XaiOAuthError(
+      'xAI token exchange did not return refresh_token.',
+      XaiErrorCode.TOKEN_EXCHANGE_INVALID,
+    );
+  }
+  const expiresIn =
+    typeof payload.expires_in === 'number'
+      ? payload.expires_in
+      : Number(payload.expires_in ?? 3600);
+  return {
+    access,
+    refresh,
+    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
+  };
+}
+
+// ─── Login (GJC /login OAuth flow) ──────────────────────────────────────
+
+export async function login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+  const discovery = await discover();
+  const { verifier, challenge } = await generatePKCE();
+  const state = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const nonce = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  const callback = await startCallbackServer();
+
+  try {
+    const authUrl = new URL(discovery.authorization_endpoint);
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('client_id', CLIENT_ID);
+    authUrl.searchParams.set('redirect_uri', callback.redirectUri);
+    authUrl.searchParams.set('scope', SCOPE);
+    authUrl.searchParams.set('code_challenge', challenge);
+    authUrl.searchParams.set('code_challenge_method', 'S256');
+    authUrl.searchParams.set('state', state);
+    authUrl.searchParams.set('nonce', nonce);
+    authUrl.searchParams.set('plan', 'generic');
+    authUrl.searchParams.set('referrer', 'gjc-grok-cli');
+
+    callbacks.onAuth({
+      url: authUrl.toString(),
+      instructions: `Authorize xAI in your browser, then return to gjc. Callback: ${callback.redirectUri}`,
+    });
+
+    const result = await callback.waitForCallback(180_000);
+
+    if (result.error) {
+      const code =
+        result.error === XaiErrorCode.CALLBACK_BIND_FAILED ||
+        result.error === XaiErrorCode.CALLBACK_TIMEOUT
+          ? result.error
+          : XaiErrorCode.AUTHORIZATION_FAILED;
+      throw new XaiOAuthError(result.errorDescription ?? result.error, code);
+    }
+    if (result.state !== state) {
+      throw new XaiOAuthError(
+        'xAI OAuth state mismatch — possible CSRF.',
+        XaiErrorCode.STATE_MISMATCH,
+      );
+    }
+    if (!result.code) {
+      throw new XaiOAuthError(
+        'xAI OAuth callback did not include an authorization code.',
+        XaiErrorCode.CODE_MISSING,
+      );
+    }
+
+    const credentials = await exchangeCode(
+      discovery.token_endpoint,
+      result.code,
+      callback.redirectUri,
+      verifier,
+    );
+    return credentials;
+  } finally {
+    callback.server.close();
+  }
+}
+
+// ─── Token refresh ────────────────────────────────────────────────────────────
+
+export async function refresh(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+  const tokenEndpoint = (await discover()).token_endpoint;
+  validateEndpoint(tokenEndpoint, 'token_endpoint');
+
+  if (!credentials.refresh) {
+    throw new XaiOAuthError(
+      'Missing refresh_token. Re-login required.',
+      XaiErrorCode.REFRESH_MISSING,
+      true,
+    );
+  }
+
+  const response = await fetchTokenResponse(
+    tokenEndpoint,
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: credentials.refresh,
+    }),
+    XaiErrorCode.REFRESH_FAILED,
+    'token refresh',
+  );
+
+  if (!response.ok) {
+    const isFatal = response.status === 400 || response.status === 401 || response.status === 403;
+    throw new XaiOAuthError(
+      `xAI token refresh failed: ${response.status} ${await tokenResponseText(response)}`,
+      XaiErrorCode.REFRESH_FAILED,
+      isFatal,
+    );
+  }
+
+  const payload = await tokenResponseJson(response, XaiErrorCode.REFRESH_FAILED, 'token refresh');
+  const access = String(payload.access_token ?? '');
+  if (!access) {
+    throw new XaiOAuthError(
+      'xAI token refresh did not return access_token.',
+      XaiErrorCode.REFRESH_FAILED,
+      true,
+    );
+  }
+
+  const refresh_new = String(payload.refresh_token ?? credentials.refresh);
+  const expiresIn =
+    typeof payload.expires_in === 'number'
+      ? payload.expires_in
+      : Number(payload.expires_in ?? 3600);
+
+  return {
+    ...credentials,
+    access,
+    refresh: refresh_new,
+    expires: Date.now() + expiresIn * 1000 - REFRESH_SKEW_MS,
+  };
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/index.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './provider/register.js';

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
@@ -1,0 +1,153 @@
+/**
+ * Model definitions for Grok CLI's API.
+ */
+
+// ─── Cost constants ($/M tokens) ──────────────────────────────────────────────
+
+const COST_BUILD = { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 };
+const COST_COMPOSER_FAST = { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 };
+const COST_43 = { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
+const COST_420 = { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 };
+
+// ─── Model type ───────────────────────────────────────────────────────────────
+
+export interface GrokCliModelConfig {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: ('text' | 'image')[];
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+  /** Models that don't support reasoning.effort get a thinkingLevelMap. */
+  thinkingLevelMap?: Record<string, string | null>;
+}
+
+// ─── Hardcoded fallback catalog ───────────────────────────────────────────────
+//
+// These are the models observed via the Grok CLI's /v1/models endpoint and
+// the actual traffic captured through cli-chat-proxy.grok.com.
+
+const FALLBACK_MODELS: GrokCliModelConfig[] = [
+  {
+    id: 'grok-composer-2.5-fast',
+    name: 'Composer 2.5 Fast (Grok CLI)',
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: COST_COMPOSER_FAST,
+    contextWindow: 200_000,
+    maxTokens: 30_000,
+    thinkingLevelMap: {
+      off: 'none',
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    },
+  },
+  {
+    id: 'grok-build',
+    name: 'Grok Build',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_BUILD,
+    contextWindow: 512_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.3',
+    name: 'Grok 4.3',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_43,
+    contextWindow: 1_000_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.20-0309-reasoning',
+    name: 'Grok 4.20 Reasoning',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.20-0309-non-reasoning',
+    name: 'Grok 4.20 Non-Reasoning',
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+    thinkingLevelMap: {
+      off: 'none',
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    },
+  },
+  {
+    id: 'grok-4.20-multi-agent-0309',
+    name: 'Grok 4.20 Multi-Agent',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_420,
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+  },
+];
+
+const EFFORT_CAPABLE_PREFIXES = ['grok-3-mini', 'grok-4.20-multi-agent', 'grok-4.3'];
+
+export function supportsReasoningEffort(modelId: string): boolean {
+  const parts = modelId.split('/');
+  const name = (parts.at(-1) ?? modelId).toLowerCase();
+  if (!EFFORT_CAPABLE_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    return false;
+  }
+  const model = resolveModels().find((entry) => entry.id.toLowerCase() === name);
+  if (model) {
+    if (!model.reasoning) return false;
+    if (!model.thinkingLevelMap) return true;
+    return Object.values(model.thinkingLevelMap).some((level) => level !== null && level !== 'none');
+  }
+  // Effort-capable id not listed in GJC_GROK_CLI_MODELS env list — still honor prefix (avoids spurious 400s).
+  return true;
+}
+
+// ─── GJC_GROK_CLI_MODELS env override ─────────────────────────────────────
+
+/**
+ * Resolve the active model list. If `GJC_GROK_CLI_MODELS` is set,
+ * it filters/reorders the fallback list; unknown IDs get sensible defaults.
+ */
+export function resolveModels(): GrokCliModelConfig[] {
+  const env = (process.env.GJC_GROK_CLI_MODELS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (env.length === 0) return FALLBACK_MODELS;
+
+  const byId = new Map(FALLBACK_MODELS.map((m) => [m.id, m]));
+  return env.map(
+    (id) =>
+      byId.get(id) ?? {
+        id,
+        name: id,
+        reasoning: true,
+        input: ['text'] as ('text' | 'image')[],
+        cost: COST_BUILD,
+        contextWindow: 1_000_000,
+        maxTokens: 30_000,
+      },
+  );
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
@@ -1,0 +1,362 @@
+/**
+ * Payload sanitization for xAI's Responses API via cli-chat-proxy.grok.com.
+ *
+ * xAI's endpoint has quirks compared to stock OpenAI:
+ *   - Replayed or encrypted `reasoning` items in input cause 400 errors.
+ *   - `reasoning.effort` is only supported on a subset of models.
+ *   - Empty-string content items cause validation failures.
+ *   - `function_call_output.output` cannot contain image arrays.
+ *   - `image_url` parts must be normalized to `input_image` with data URIs.
+ *   - Local image paths must be resolved to base64 data URIs.
+ *   - xAI rejects `role: "developer"` and `role: "system"` in the input
+ *     array; these must be moved to top-level `instructions`.
+ *   - xAI uses `text.format` instead of OpenAI's `response_format`.
+ *   - xAI uses `prompt_cache_key` for conversation caching.
+ *   - xAI doesn't support `prompt_cache_retention`.
+ *
+ * Additional Grok CLI-specific behavior:
+ *   - Adds x-grok-* headers for client identification
+ *   - Uses prompt_cache_key for session affinity
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { extname, isAbsolute, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { supportsReasoningEffort } from '../models/catalog.js';
+
+// ─── Content text extraction ─────────────────────────────────────────────────
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part;
+      if (!part || typeof part !== 'object') return '';
+      const item = part as Record<string, unknown>;
+      const type = typeof item.type === 'string' ? item.type : '';
+      return ['text', 'input_text', 'output_text'].includes(type) && typeof item.text === 'string'
+        ? item.text
+        : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+// ─── Image helpers ────────────────────────────────────────────────────────────
+
+function stripShellQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function unescapeShellPath(value: string): string {
+  return stripShellQuotes(value).replace(/\\([\\\s'"()&;@])/g, '$1');
+}
+
+function imageMimeTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.png':
+      return 'image/png';
+    default:
+      throw new Error('xAI image understanding supports local .jpg, .jpeg, and .png files only');
+  }
+}
+
+function ensurePathWithinWorkspace(cwd: string, filePath: string) {
+  const realCwd = realpathSync(cwd);
+  const realPath = realpathSync(filePath);
+  if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${sep}`)) {
+    throw new Error('Image path is outside the workspace');
+  }
+  return realPath;
+}
+
+function resolveLocalImagePath(value: string, cwd: string): string | undefined {
+  const cleaned = unescapeShellPath(value);
+  if (!cleaned) return undefined;
+
+  if (cleaned.startsWith('file://')) {
+    try {
+      const filePath = fileURLToPath(cleaned);
+      return existsSync(filePath) ? ensurePathWithinWorkspace(cwd, filePath) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const candidate = isAbsolute(cleaned) ? cleaned : resolve(cwd, cleaned);
+
+  return existsSync(candidate) ? ensurePathWithinWorkspace(cwd, candidate) : undefined;
+}
+
+function normalizeImageInput(value: unknown, cwd: string): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const cleaned = stripShellQuotes(value);
+
+  if (/^https?:\/\//i.test(cleaned) || /^data:image\//i.test(cleaned)) {
+    return cleaned;
+  }
+
+  const localPath = resolveLocalImagePath(cleaned, cwd);
+  if (!localPath) {
+    throw new Error(`Image file does not exist or is not a valid URL: ${cleaned}`);
+  }
+
+  const mimeType = imageMimeTypeForPath(localPath);
+  const data = readFileSync(localPath).toString('base64');
+  return `data:${mimeType};base64,${data}`;
+}
+
+// ─── Content part normalization ───────────────────────────────────────────────
+
+function isInputImagePart(value: unknown): value is Record<string, unknown> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as Record<string, unknown>).type === 'input_image'
+  );
+}
+
+function getImageUrlAndDetail(obj: Record<string, unknown>): {
+  imageUrl: unknown;
+  detail: unknown;
+} {
+  if (typeof obj.image_url === 'object' && obj.image_url) {
+    const imageUrl = obj.image_url as Record<string, unknown>;
+    return { imageUrl: imageUrl.url, detail: imageUrl.detail };
+  }
+
+  return { imageUrl: obj.image_url, detail: obj.detail };
+}
+
+function normalizeImageParts(value: unknown, cwd: string): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalizeImageParts(item, cwd));
+  if (!value || typeof value !== 'object') return value;
+
+  const obj = { ...(value as Record<string, unknown>) };
+
+  if (obj.type === 'image' && typeof obj.data === 'string' && typeof obj.mimeType === 'string') {
+    return {
+      type: 'input_image',
+      image_url: `data:${obj.mimeType};base64,${obj.data}`,
+      detail: typeof obj.detail === 'string' && obj.detail ? obj.detail : 'auto',
+    };
+  }
+
+  if (obj.type === 'image_url') {
+    const { imageUrl, detail } = getImageUrlAndDetail(obj);
+    obj.type = 'input_image';
+    obj.image_url = imageUrl;
+    if (typeof detail === 'string' && detail) obj.detail = detail;
+  }
+
+  if (obj.type === 'input_image') {
+    const { imageUrl, detail } = getImageUrlAndDetail(obj);
+    const normalized = normalizeImageInput(imageUrl, cwd);
+    if (normalized) obj.image_url = normalized;
+    if (typeof detail === 'string' && detail) obj.detail = detail;
+    if (typeof obj.detail !== 'string' || !obj.detail) obj.detail = 'auto';
+  }
+
+  if (Array.isArray(obj.content)) obj.content = normalizeImageParts(obj.content, cwd);
+  if (Array.isArray(obj.output)) obj.output = normalizeImageParts(obj.output, cwd);
+  return obj;
+}
+
+// ─── function_call_output rewrite ─────────────────────────────────────────────
+
+function rewriteFunctionCallOutput(input: Record<string, unknown>[]): Record<string, unknown>[] {
+  const rewritten: Record<string, unknown>[] = [];
+
+  for (const item of input) {
+    if (
+      !item ||
+      typeof item !== 'object' ||
+      item.type !== 'function_call_output' ||
+      !Array.isArray(item.output)
+    ) {
+      rewritten.push(item);
+      continue;
+    }
+
+    const outputParts = item.output as unknown[];
+    const imageParts = outputParts.filter(isInputImagePart);
+    const textParts = outputParts.filter((p) => !isInputImagePart(p));
+
+    const textChunks: string[] = [];
+    for (const part of textParts) {
+      if (typeof part === 'string') {
+        textChunks.push(part);
+      } else if (part && typeof part === 'object') {
+        const p = part as Record<string, unknown>;
+        if (typeof p.text === 'string') textChunks.push(p.text);
+      }
+    }
+    let imageCount = 0;
+    for (const _ of imageParts) imageCount++;
+
+    const outputText = textChunks.join('\n') || '(tool returned no text output)';
+    rewritten.push({ ...item, output: outputText });
+
+    if (imageCount > 0) {
+      const callId = item.call_id ? ` (${String(item.call_id)})` : '';
+      const label = `The previous tool result${callId} included ${imageCount} image${imageCount === 1 ? '' : 's'}. Use the attached image${imageCount === 1 ? '' : 's'} as the visual output from that tool.`;
+      rewritten.push({
+        role: 'user',
+        content: [{ type: 'input_text', text: label }, ...imageParts],
+      });
+    }
+  }
+
+  return rewritten;
+}
+
+
+// ─── xAI 400 guards ───────────────────────────────────────────────────────────
+
+const REPLAYED_INPUT_TYPES = new Set([
+  'reasoning',
+  'reasoning.encrypted_content',
+  'encrypted_content',
+  'item_reference',
+]);
+
+function isReplayedOrUnsupportedInputItem(obj: Record<string, unknown>): boolean {
+  const type = typeof obj.type === 'string' ? obj.type : '';
+  if (REPLAYED_INPUT_TYPES.has(type)) return true;
+  if (type.startsWith('reasoning')) return true;
+  if ('encrypted_content' in obj || 'reasoning_encrypted_content' in obj) return true;
+  return false;
+}
+
+function isEmptyMessageItem(obj: Record<string, unknown>): boolean {
+  if (typeof obj.content === 'string') return obj.content.trim().length === 0;
+  if (!Array.isArray(obj.content)) return false;
+  const parts = obj.content as unknown[];
+  if (parts.length === 0) return true;
+  return parts.every((part) => {
+    if (typeof part === 'string') return part.length === 0;
+    if (!part || typeof part !== 'object') return true;
+    const p = part as Record<string, unknown>;
+    const t = typeof p.type === 'string' ? p.type : '';
+    if (['text', 'input_text', 'output_text'].includes(t)) {
+      return typeof p.text !== 'string' || p.text.trim().length === 0;
+    }
+    return false;
+  });
+}
+
+function stripUnsupportedTopLevelFields(next: Record<string, unknown>): void {
+  delete next.prompt_cache_retention;
+  delete next.parallel_tool_calls;
+  delete next.store;
+  delete next.metadata;
+  delete next.user;
+  delete next.service_tier;
+  delete next.truncation;
+}
+
+// ─── Main sanitization ────────────────────────────────────────────────────────
+
+/**
+ * Sanitize a provider request payload for xAI's Responses API via
+ * cli-chat-proxy.grok.com.
+ *
+ * Returns the modified payload.  Mutates the input in place for efficiency.
+ */
+export function sanitizePayload(
+  params: Record<string, unknown>,
+  modelId: string,
+  sessionId: string | undefined,
+  cwd: string,
+): Record<string, unknown> {
+  const next = params;
+
+  // ── Sanitize input array ──────────────────────────────────────────────
+  if (Array.isArray(next.input)) {
+    let input = (next.input as unknown[])
+      .map((item: unknown) => {
+        if (!item || typeof item !== 'object') return item;
+        const obj = item as Record<string, unknown>;
+
+        if (isReplayedOrUnsupportedInputItem(obj)) return null;
+        if (isEmptyMessageItem(obj)) return null;
+
+        return obj;
+      })
+      .filter(Boolean) as Record<string, unknown>[];
+
+    // Move system/developer messages to top-level instructions.
+    // xAI rejects role: "developer" and role: "system" in the input array.
+    const instructionParts: string[] = [];
+    input = input.filter((item) => {
+      const role = (item as Record<string, unknown>).role;
+      if (role !== 'developer' && role !== 'system') return true;
+      const text = textFromContent((item as Record<string, unknown>).content).trim();
+      if (text) instructionParts.push(text);
+      return false;
+    });
+    if (instructionParts.length > 0) {
+      const existing =
+        typeof next.instructions === 'string' && next.instructions ? next.instructions : '';
+      const merged = [existing, ...instructionParts].filter((part) => part.length > 0).join('\n\n');
+      next.instructions = merged;
+    }
+
+    // Normalize image parts (resolve local paths, fix types)
+    input = normalizeImageParts(input, cwd) as Record<string, unknown>[];
+
+    // Rewrite function_call_output with images
+    input = rewriteFunctionCallOutput(input);
+
+    next.input = input;
+  } else if (typeof next.input === 'string') {
+    // String input is valid and should stay string-shaped.
+  }
+
+  // ── response_format → text.format ────────────────────────────────────
+  if (next.response_format) {
+    if (!next.text) next.text = { format: next.response_format };
+    delete next.response_format;
+  }
+
+  // ── Reasoning effort ──────────────────────────────────────────────────
+  if (supportsReasoningEffort(modelId)) {
+    const reasoning = next.reasoning as Record<string, unknown> | undefined;
+    if (reasoning) {
+      const effort = reasoning.effort === 'minimal' ? 'low' : reasoning.effort;
+      next.reasoning = reasoning.summary !== undefined ? { effort } : { ...reasoning, effort };
+    }
+  } else {
+    delete next.reasoning;
+    delete next.reasoningEffort;
+  }
+
+  // ── Strip/filter unsupported fields ──────────────────────────────────
+  if (Array.isArray(next.include)) {
+    next.include = (next.include as unknown[]).filter(
+      (item) => item !== 'reasoning.encrypted_content',
+    );
+    if ((next.include as unknown[]).length === 0) delete next.include;
+  }
+
+  stripUnsupportedTopLevelFields(next);
+
+  // Add prompt_cache_key for conversation caching (routes to same server).
+  if (sessionId && !next.prompt_cache_key) {
+    next.prompt_cache_key = sessionId;
+  }
+
+  return next;
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/billing.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/billing.ts
@@ -1,0 +1,57 @@
+import { getBaseUrl } from '../auth/oauth.js';
+
+interface BillingUsage {
+  monthlyLimit: number;
+  used: number;
+  billingPeriodEnd: string;
+}
+
+function parseBillingUsage(payload: unknown): BillingUsage {
+  if (!payload || typeof payload !== 'object') throw new Error('invalid billing payload');
+  const config = (payload as Record<string, unknown>).config;
+  if (!config || typeof config !== 'object') throw new Error('invalid billing payload');
+  const monthlyLimit = ((config as Record<string, unknown>).monthlyLimit as Record<string, unknown>)
+    ?.val;
+  const used = ((config as Record<string, unknown>).used as Record<string, unknown>)?.val;
+  const billingPeriodEnd = (config as Record<string, unknown>).billingPeriodEnd;
+  if (
+    typeof monthlyLimit !== 'number' ||
+    !Number.isFinite(monthlyLimit) ||
+    typeof used !== 'number' ||
+    !Number.isFinite(used) ||
+    typeof billingPeriodEnd !== 'string' ||
+    !Number.isFinite(new Date(billingPeriodEnd).getTime())
+  ) {
+    throw new Error('invalid billing payload');
+  }
+  return { monthlyLimit, used, billingPeriodEnd };
+}
+
+export async function fetchBillingUsage(token: string): Promise<BillingUsage> {
+  const response = await fetch(`${getBaseUrl()}/billing`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      'x-xai-token-auth': 'xai-grok-cli',
+      accept: 'application/json',
+    },
+  });
+  if (!response.ok) throw new Error(`billing endpoint returned ${response.status}`);
+  return parseBillingUsage(await response.json());
+}
+
+export function formatQuota(usage: BillingUsage | undefined) {
+  if (!usage) {
+    return [
+      '  Usage:',
+      '    no billing data available — run /login grok-build or set GROK_CLI_OAUTH_TOKEN',
+    ];
+  }
+
+  const resetDate = new Date(new Date(usage.billingPeriodEnd).getTime() - 8 * 60 * 60 * 1000);
+  return [
+    '  Usage:',
+    `    ${usage.used.toLocaleString()} / ${usage.monthlyLimit.toLocaleString()} credits used (${Math.round((usage.used / usage.monthlyLimit) * 100)}%)`,
+    `    ${(usage.monthlyLimit - usage.used).toLocaleString()} credits remaining`,
+    `    Resets at ${['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][resetDate.getUTCMonth()]} ${resetDate.getUTCDate()} ${resetDate.getUTCHours().toString().padStart(2, '0')}:${resetDate.getUTCMinutes().toString().padStart(2, '0')} PT`,
+  ];
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
@@ -1,0 +1,92 @@
+/**
+ * GJC Grok Build provider — SuperGrok OAuth + cli-chat-proxy models.
+ */
+
+import { Effort } from '@gajae-code/ai/model-thinking';
+import type { Api, Model } from '@gajae-code/ai';
+import type { OAuthCredentials, OAuthLoginCallbacks } from '@gajae-code/ai/utils/oauth/types';
+import { XAI_OAUTH_SCOPE, loginXai, refreshXaiToken } from '@gajae-code/ai/utils/oauth/xai';
+import type { ExtensionAPI, ProviderConfig } from '@gajae-code/coding-agent';
+import { getBaseUrl } from '../auth/oauth.js';
+import { type GrokCliModelConfig, resolveModels } from '../models/catalog.js';
+import { sanitizePayload } from '../payload/sanitize.js';
+import { streamGrokCli } from './stream.js';
+import { registerUsageCommand } from './usage.js';
+
+const GROK_BUILD_XAI_AUTHORIZE_PARAMS = {
+  plan: 'generic',
+  referrer: 'gjc-grok-cli',
+} satisfies Readonly<Record<string, string>>;
+
+const GROK_BUILD_XAI_REFRESH_PARAMS = {
+  scope: XAI_OAUTH_SCOPE,
+  ...GROK_BUILD_XAI_AUTHORIZE_PARAMS,
+} satisfies Readonly<Record<string, string>>;
+
+export default function registerGrokCli(api: ExtensionAPI) {
+  const baseUrl = getBaseUrl();
+  const models = resolveModels();
+
+
+  api.registerProvider('grok-build', {
+    baseUrl,
+    apiKey: process.env.GROK_CLI_OAUTH_TOKEN ? 'GROK_CLI_OAUTH_TOKEN' : undefined,
+    api: 'grok-cli-responses',
+    models: models.map((m: GrokCliModelConfig) => ({
+      id: m.id,
+      name: m.name,
+      reasoning: m.reasoning,
+      thinking: m.reasoning ? { minLevel: Effort.Low, maxLevel: Effort.XHigh, mode: 'effort' } : undefined,
+      input: m.input,
+      cost: m.cost,
+      contextWindow: m.contextWindow,
+      maxTokens: m.maxTokens,
+    })),
+    oauth: {
+      name: 'Grok Build',
+
+      async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+        return loginXai(callbacks, { extraAuthorizeParams: GROK_BUILD_XAI_AUTHORIZE_PARAMS });
+      },
+
+      async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+        return refreshXaiToken(credentials.refresh, { extraTokenParams: GROK_BUILD_XAI_REFRESH_PARAMS });
+      },
+
+      getApiKey(credentials: OAuthCredentials): string {
+        return credentials.access;
+      },
+
+      modifyModels(models: Model<Api>[], _credentials: OAuthCredentials) {
+        const effectiveBaseUrl = getBaseUrl().replace(/\/+$/, '');
+
+        return models.map((m) =>
+          m.provider === 'grok-build' ? { ...m, baseUrl: effectiveBaseUrl } : m,
+        );
+      },
+    } satisfies ProviderConfig['oauth'],
+
+    streamSimple: streamGrokCli,
+  });
+
+
+  api.on('session_start', (_event, ctx) => {
+    if (process.env.GROK_CLI_OAUTH_TOKEN) {
+      ctx.ui.notify(
+        '[Grok Build] Using GROK_CLI_OAUTH_TOKEN env bypass — no auto-refresh, no model discovery. Login with /login grok-build for persisted refreshable auth.',
+        'warning',
+      );
+    }
+
+  });
+
+  api.on('before_provider_request', (event, ctx) => {
+    if (ctx.model?.provider !== 'grok-build') return;
+
+    const modelId = ctx.model?.id ?? '';
+    const sessionId = ctx.sessionManager?.getSessionId();
+    return sanitizePayload(event.payload as Record<string, unknown>, modelId, sessionId, ctx.cwd);
+  });
+
+  registerUsageCommand(api);
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
@@ -1,0 +1,50 @@
+import {
+  type Api,
+  type AssistantMessageEventStream,
+  type Context,
+  type Model,
+  type SimpleStreamOptions,
+} from '@gajae-code/ai';
+import { streamOpenAIResponses } from '@gajae-code/ai/providers/openai-responses';
+
+const GROK_CLI_VERSION = '0.2.33';
+
+/**
+ * Stream function that adds Grok CLI-specific headers to requests.
+ *
+ * GJC Grok Build extension sends cli-chat-proxy headers (see agent.models.grok-cli.yml):
+ *   - x-grok-conv-id: <session/conversation ID>
+ *   - x-grok-model-override: <model ID>
+ *   - x-xai-token-auth: xai-grok-cli
+ */
+export function streamGrokCli(
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+  const sessionId = options?.sessionId;
+  const headers: Record<string, string> = {
+    ...options?.headers,
+    'x-grok-client-identifier': 'gjc-grok-cli',
+    'x-grok-client-version': GROK_CLI_VERSION,
+    'x-xai-token-auth': 'xai-grok-cli',
+    'x-grok-model-override': model.id,
+  };
+
+  if (sessionId) {
+    headers['x-grok-conv-id'] = sessionId;
+  }
+
+  const responsesModel = {
+    ...model,
+    api: 'openai-responses',
+  } as Model<'openai-responses'>;
+
+  return streamOpenAIResponses(responsesModel, context, {
+    ...options,
+    headers,
+    onResponse(response) {
+      options?.onResponse?.(response, model);
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
@@ -1,0 +1,53 @@
+import type { Api, Model } from '@gajae-code/ai';
+import type { ExtensionAPI } from '@gajae-code/coding-agent';
+import { XaiOAuthError } from '../shared/errors.js';
+import { fetchBillingUsage, formatQuota } from './billing.js';
+
+export function registerUsageCommand(api: Pick<ExtensionAPI, 'registerCommand'>) {
+  api.registerCommand('grok-build-usage', {
+    description: 'Show Grok Build provider status, quota, and token health',
+    handler: async (_args, ctx) => {
+      const token = process.env.GROK_CLI_OAUTH_TOKEN;
+      if (token) {
+        ctx.ui.notify(
+          '⚠️  Grok Build: using GROK_CLI_OAUTH_TOKEN env bypass — no auto-refresh available',
+          'warning',
+        );
+      }
+
+      try {
+        const registry = ctx.modelRegistry;
+        const grokModels = registry.getAll().filter((m: Model<Api>) => m.provider === 'grok-build');
+        if (grokModels.length === 0) {
+          ctx.ui.notify('Grok Build: no models registered. Run /login grok-build first.', 'warning');
+          return;
+        }
+
+        const apiKey = token ?? (await registry.getApiKeyForProvider?.('grok-build'));
+        if (!apiKey) {
+          ctx.ui.notify(formatQuota(undefined).join('\n'), 'info');
+          return;
+        }
+
+        try {
+          ctx.ui.notify('Fetching grok build usage…', 'info');
+          ctx.ui.notify(formatQuota(await fetchBillingUsage(apiKey)).join('\n'), 'info');
+        } catch (err) {
+          ctx.ui.notify(
+            `Grok Build billing refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+          ctx.ui.notify(formatQuota(undefined).join('\n'), 'info');
+        }
+      } catch (err) {
+        const msg =
+          err instanceof XaiOAuthError
+            ? `${err.message} (code: ${err.code})`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        ctx.ui.notify(`Grok Build: ${msg}`, 'warning');
+      }
+    },
+  });
+}

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/errors.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Typed error for xAI OAuth failures.
+ *
+ * Codes allow the login flow and stream handlers to distinguish
+ * retryable failures (network) from fatal ones (revoked refresh token).
+ */
+export class XaiOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly reloginRequired = false,
+  ) {
+    super(message);
+    this.name = 'XaiOAuthError';
+  }
+}
+
+/** Well-known error codes. */
+export const XaiErrorCode = {
+  /** OIDC discovery failed (network, invalid response). */
+  DISCOVERY_FAILED: 'discovery_failed',
+  /** Discovery endpoint returned a non-xAI origin. */
+  DISCOVERY_INVALID_ORIGIN: 'discovery_invalid_origin',
+  /** Authorization was denied or errored in the browser. */
+  AUTHORIZATION_FAILED: 'authorization_failed',
+  /** CSRF state mismatch between request and callback. */
+  STATE_MISMATCH: 'state_mismatch',
+  /** Callback did not include an authorization code. */
+  CODE_MISSING: 'code_missing',
+  /** Token exchange failed (network, invalid response). */
+  TOKEN_EXCHANGE_FAILED: 'token_exchange_failed',
+  /** Token exchange returned an invalid payload. */
+  TOKEN_EXCHANGE_INVALID: 'token_exchange_invalid',
+  /** Refresh token is missing or empty. */
+  REFRESH_MISSING: 'refresh_missing',
+  /** Token refresh failed (expired, revoked). */
+  REFRESH_FAILED: 'refresh_failed',
+  /** No credentials stored. */
+  AUTH_MISSING: 'auth_missing',
+  /** Loopback callback server could not bind. */
+  CALLBACK_BIND_FAILED: 'callback_bind_failed',
+  /** Loopback callback timed out. */
+  CALLBACK_TIMEOUT: 'callback_timeout',
+} as const;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -30,6 +30,7 @@ import { activateModelProfile } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedModel } from "./config/model-resolver";
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
+import { getBundledGrokBuildExtensionPaths } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
@@ -742,7 +743,7 @@ export async function runRootCommand(
 		await runListModelsCommand({
 			modelRegistry,
 			cwd: getProjectDir(),
-			additionalExtensionPaths: [],
+			additionalExtensionPaths: await getBundledGrokBuildExtensionPaths(),
 			settingsExtensions: [],
 			disabledExtensionIds: [],
 			disableExtensionDiscovery: true,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -70,6 +70,7 @@ const CALLBACK_SERVER_PROVIDERS = new Set<string>([
 	"google-gemini-cli",
 	"google-antigravity",
 	"xai",
+	"grok-build",
 ]);
 
 const MANUAL_LOGIN_TIP = "Tip: You can complete pairing with /login <redirect URL>.";

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -50,6 +50,7 @@ import { CursorExecHandlers } from "./cursor";
 import "./discovery";
 import { resolveConfigValue } from "./config/resolve-config-value";
 import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
+import { getBundledGrokBuildExtensionPaths } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
 import { TtsrManager } from "./export/ttsr";
@@ -64,6 +65,7 @@ import {
 	type ExtensionUIContext,
 	type LoadExtensionsResult,
 	loadExtensionFromFactory,
+	loadExtensions,
 	type ToolDefinition,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
@@ -1340,13 +1342,23 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}
 
-		// Extension/module discovery is quarantined; retain only the private
-		// runtime needed for explicitly supplied SDK extensions and custom tools.
-		const extensionsResult: LoadExtensionsResult = options.preloadedExtensions ?? {
-			extensions: [],
-			errors: [],
-			runtime: new ExtensionRuntime(),
-		};
+		// Extension/module discovery is quarantined from the public GJC utility surface.
+		// The bundled Grok Build provider is part of the shipped product surface, so
+		// load it explicitly even when filesystem extension discovery is disabled.
+		const bundledGrokExtensionPaths = await getBundledGrokBuildExtensionPaths();
+		const extensionsResult: LoadExtensionsResult =
+			options.preloadedExtensions ??
+			(await loadExtensions(
+				[...bundledGrokExtensionPaths, ...(options.additionalExtensionPaths ?? [])],
+				cwd,
+				eventBus,
+			));
+		const bundledGrokLoadErrors = extensionsResult.errors.filter(error =>
+			bundledGrokExtensionPaths.includes(error.path),
+		);
+		if (bundledGrokLoadErrors.length > 0) {
+			throw new Error(bundledGrokLoadErrors.map(error => error.error).join("\n"));
+		}
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/test/grok-build-stream.test.ts
+++ b/packages/coding-agent/test/grok-build-stream.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import * as openaiResponses from "@gajae-code/ai/providers/openai-responses";
+import type { Api, Context, Model, SimpleStreamOptions } from "@gajae-code/ai";
+import { streamGrokCli } from "../src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream";
+
+describe("Grok Build stream wrapper", () => {
+	it("forwards requests through OpenAI responses with Grok Build headers", () => {
+		const captured: { model?: Model<Api>; options?: unknown } = {};
+		const spy = spyOn(openaiResponses, "streamOpenAIResponses").mockImplementation((model, _context, options) => {
+			captured.model = model as Model<Api>;
+			captured.options = options as unknown;
+			return new AssistantMessageEventStream();
+		});
+		try {
+			const model = {
+				provider: "grok-build",
+				id: "grok-composer-2.5-fast",
+				api: "grok-cli-responses",
+			} as Model<Api>;
+			const context = { messages: [], systemPrompt: [] } as unknown as Context;
+
+			const stream = streamGrokCli(model, context, {
+				sessionId: "session-123",
+				headers: { "x-test": "ok" },
+			} as SimpleStreamOptions);
+
+			expect(stream).toBeInstanceOf(AssistantMessageEventStream);
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(captured.model?.provider).toBe("grok-build");
+			expect(captured.model?.id).toBe("grok-composer-2.5-fast");
+			expect(captured.model?.api).toBe("openai-responses");
+			expect((captured.options as { headers?: Record<string, string> } | undefined)?.headers).toMatchObject({
+				"x-test": "ok",
+				"x-grok-client-identifier": "gjc-grok-cli",
+				"x-grok-client-version": "0.2.33",
+				"x-grok-conv-id": "session-123",
+				"x-grok-model-override": "grok-composer-2.5-fast",
+				"x-xai-token-auth": "xai-grok-cli",
+			});
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/grok-cli-defaults-install.test.ts
+++ b/packages/coding-agent/test/grok-cli-defaults-install.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import {
+	assertBundledGrokCliDefaults,
+	getBundledGrokBuildExtensionPath,
+	getBundledGrokCliModelDefaultsPath,
+	getBundledGrokCliVendorDir,
+} from "../src/defaults/gjc-grok-cli";
+
+describe("bundled Grok CLI defaults", () => {
+	it("fails loud only when the shipped vendor tree is missing", async () => {
+		await expect(assertBundledGrokCliDefaults()).resolves.toBeUndefined();
+		expect(getBundledGrokBuildExtensionPath().endsWith(path.join("grok-build", "index.ts"))).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokCliVendorDir(), "src", "payload", "sanitize.ts")).exists()).toBe(
+			true,
+		);
+		expect((await Bun.file(getBundledGrokCliModelDefaultsPath()).text()).includes("grok-composer-2.5-fast")).toBe(
+			true,
+		);
+	});
+});

--- a/packages/coding-agent/test/grok-cli-sanitize.test.ts
+++ b/packages/coding-agent/test/grok-cli-sanitize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { sanitizePayload } from "../src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize";
+
+describe("Grok CLI payload sanitize", () => {
+	it("strips replayed reasoning and unsupported Composer effort", () => {
+		const payload = sanitizePayload(
+			{
+				input: [
+					{ role: "system", content: "be terse" },
+					{ type: "reasoning", content: "cached" },
+					{ role: "user", content: "hello" },
+				],
+				include: ["reasoning.encrypted_content"],
+				reasoning: { effort: "high" },
+			},
+			"grok-composer-2.5-fast",
+			"session-1",
+			process.cwd(),
+		);
+		expect(payload.input).toEqual([{ role: "user", content: "hello" }]);
+		expect(payload.instructions).toBe("be terse");
+		expect(payload.include).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
+		expect(payload.prompt_cache_key).toBe("session-1");
+	});
+});

--- a/packages/coding-agent/test/grok-cli-vendor-deps.test.ts
+++ b/packages/coding-agent/test/grok-cli-vendor-deps.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { getBundledGrokCliVendorDir } from "../src/defaults/gjc-grok-cli";
+
+describe("bundled Grok CLI vendor dependencies", () => {
+	it("does not require runtime npm install from setup defaults", async () => {
+		const pkg = (await Bun.file(path.join(getBundledGrokCliVendorDir(), "package.json")).json()) as {
+			dependencies?: Record<string, string>;
+		};
+		expect(pkg.dependencies ?? {}).toEqual({});
+	});
+});

--- a/packages/coding-agent/test/grok-main-session-path.test.ts
+++ b/packages/coding-agent/test/grok-main-session-path.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { setAgentDir } from "@gajae-code/utils";
+import { Settings } from "../src/config/settings";
+import { getBundledGrokBuildExtensionPath } from "../src/defaults/gjc-grok-cli";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
+
+describe("bundled Grok Build session path", () => {
+	it("loads Grok Build OAuth and models with extension discovery disabled", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-grok-main-session-"));
+		setAgentDir(agentDir);
+		try {
+			const { session } = await createAgentSession({
+				cwd: agentDir,
+				agentDir,
+				settings: Settings.isolated(),
+				sessionManager: SessionManager.inMemory(agentDir),
+				disableExtensionDiscovery: true,
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["__none__"],
+			});
+			try {
+				const grokModels = session.modelRegistry.getAll().filter(model => model.provider === "grok-build");
+				expect(grokModels.some(model => model.id === "grok-composer-2.5-fast")).toBe(true);
+				expect(grokModels.some(model => model.id === "grok-build")).toBe(true);
+				expect(getOAuthProviders().find(provider => provider.id === "grok-build")?.name).toBe("Grok Build");
+				expect(
+					(session.extensionRunner as unknown as { extensions?: Array<{ path: string }> } | undefined)?.extensions?.some(
+						extension => extension.path === getBundledGrokBuildExtensionPath(),
+					),
+				).toBe(true);
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/grok-post-merge-sequence.test.ts
+++ b/packages/coding-agent/test/grok-post-merge-sequence.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import {
+	getBundledGrokBuildExtensionDir,
+	getBundledGrokBuildExtensionPath,
+	getBundledGrokCliModelDefaultsPath,
+	getBundledGrokCliVendorDir,
+} from "../src/defaults/gjc-grok-cli";
+
+describe("Grok Build post-merge sequence", () => {
+	it("ships the extension, vendor tree, reference models, and grok-build-pro profile needed by the user flow", async () => {
+		expect(await Bun.file(getBundledGrokBuildExtensionPath()).exists()).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokBuildExtensionDir(), "package.json")).exists()).toBe(true);
+		expect(await Bun.file(path.join(getBundledGrokCliVendorDir(), "src", "provider", "register.ts")).exists()).toBe(
+			true,
+		);
+		expect(await Bun.file(getBundledGrokCliModelDefaultsPath()).exists()).toBe(true);
+
+		const profile = BUILTIN_MODEL_PROFILES.find(definition => definition.name === "grok-build-pro");
+		expect(profile?.requiredProviders).toContain("grok-build");
+		expect(profile?.modelMapping.default).toBe("grok-build/grok-composer-2.5-fast");
+		expect(profile?.modelMapping.executor).toBe("grok-build/grok-build");
+	});
+});

--- a/packages/coding-agent/test/grok-third-party-sequence.test.ts
+++ b/packages/coding-agent/test/grok-third-party-sequence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
+
+describe("Grok Build with explicit third-party extensions", () => {
+	it("loads bundled Grok Build alongside caller-supplied extension paths", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-grok-third-party-"));
+		const extensionPath = path.join(root, "third-party.ts");
+		await Bun.write(
+			extensionPath,
+			`export default function thirdParty(api) { api.registerProvider("third-party-test", { name: "Third Party", baseUrl: "https://example.invalid/v1", apiKey: "$THIRD_PARTY_TEST_KEY", api: "openai-responses", models: [{ id: "model", name: "Model", reasoning: false, input: ["text"], cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }] }); }`,
+		);
+		try {
+			const { session } = await createAgentSession({
+				cwd: root,
+				agentDir: root,
+				settings: Settings.isolated(),
+				sessionManager: SessionManager.inMemory(root),
+				disableExtensionDiscovery: true,
+				additionalExtensionPaths: [extensionPath],
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["__none__"],
+			});
+			try {
+				expect(session.modelRegistry.find("grok-build", "grok-composer-2.5-fast")).toBeTruthy();
+				expect(session.modelRegistry.find("third-party-test", "model")).toBeTruthy();
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -206,6 +206,17 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		},
 	},
 	{
+		name: "grok-build-pro",
+		requiredProviders: ["grok-build"],
+		mapping: {
+			default: "grok-build/grok-composer-2.5-fast",
+			executor: "grok-build/grok-build",
+			planner: "grok-build/grok-composer-2.5-fast",
+			critic: "grok-build/grok-composer-2.5-fast",
+			architect: "grok-build/grok-build",
+		},
+	},
+	{
 		name: "cursor-eco",
 		requiredProviders: ["cursor"],
 		mapping: {
@@ -314,11 +325,12 @@ const oldNames = [
 function selectorExists(selector: string): boolean {
 	const parsed = parseModelString(selector);
 	if (!parsed) return false;
+	if (parsed.provider === "grok-build") return ["grok-composer-2.5-fast", "grok-build"].includes(parsed.id);
 	return (modelsJson as Record<string, Record<string, unknown>>)[parsed.provider]?.[parsed.id] !== undefined;
 }
 
 describe("built-in model profile catalog", () => {
-	test("contains exact 25-profile matrix cell-for-cell", () => {
+	test("contains exact 26-profile matrix cell-for-cell", () => {
 		expect(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).toEqual(
 			expectedProfiles.map(profile => profile.name),
 		);
@@ -383,7 +395,21 @@ describe("built-in model profile catalog", () => {
 		expect(recommendModelProfileForProvider("kimi-code", profiles)?.name).toBe("kimi-coding-plan-medium");
 		expect(recommendModelProfileForProvider("xiaomi", profiles)?.name).toBe("mimo-medium");
 		expect(recommendModelProfileForProvider("xai", profiles)?.name).toBe("grok-medium");
+		expect(recommendModelProfileForProvider("grok-build", profiles)?.name).toBe("grok-build-pro");
 		expect(recommendModelProfileForProvider("cursor", profiles)?.name).toBe("cursor-medium");
+	});
+
+	test("grok-build-pro maps Composer 2.5 Fast and Grok Build roles", () => {
+		const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === "grok-build-pro");
+		expect(profile).toBeDefined();
+		expect(profile?.requiredProviders).toEqual(["grok-build"]);
+		expect(profile?.modelMapping).toEqual({
+			default: "grok-build/grok-composer-2.5-fast",
+			executor: "grok-build/grok-build",
+			architect: "grok-build/grok-build",
+			planner: "grok-build/grok-composer-2.5-fast",
+			critic: "grok-build/grok-composer-2.5-fast",
+		});
 	});
 
 	test("user same-name profile overrides builtin via mergeModelProfiles", () => {


### PR DESCRIPTION
## Summary
- bundle the Grok Build provider and vendor extension into GJC defaults
- add grok-build OAuth, model loading, grok-build-pro preset, usage reporting, and focused coverage
- preserve xAI authorize/refresh metadata (`plan=generic`, `referrer=gjc-grok-cli`, refresh `scope`) so refreshed tokens keep cli-chat-proxy auth context
- avoid treating the optional `GROK_CLI_OAUTH_TOKEN` env bypass as a literal config key when it is unset, so OAuth refresh is used normally

## Verification
- bun test packages/ai/test/oauth-xai.test.ts packages/coding-agent/test/grok-main-session-path.test.ts packages/coding-agent/test/grok-post-merge-sequence.test.ts packages/coding-agent/test/grok-third-party-sequence.test.ts packages/coding-agent/test/grok-cli-defaults-install.test.ts packages/coding-agent/test/grok-cli-vendor-deps.test.ts packages/coding-agent/test/grok-cli-sanitize.test.ts packages/coding-agent/test/grok-build-stream.test.ts packages/ai/test/grok-cli-usage.test.ts packages/coding-agent/test/model-profiles-catalog.test.ts (`25 pass`, `0 fail`)
- bun --cwd=packages/ai run check:types && bun --cwd=packages/coding-agent run check:types
- git diff --check && git diff --cached --check
- user-assisted E2E: fresh `/login grok-build` -> chat sentinel -> forced token refresh -> post-refresh chat sentinel -> usage, PASS (`PARAM_REFRESH_E2E_RESULT PASS`)
- dev-branch natural expiry E2E: mark OAuth credential expired -> request triggers one refresh with scope/plan/referrer -> Grok chat sentinel -> usage, PASS (`NATURAL_RESULT PASS`)