### PR TITLE
fix(harness): classify live manual owners correctly

### DIFF
--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -16,7 +16,7 @@ import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { resolveGjcTmuxCommand, sanitizeTmuxToken } from "../gjc-runtime/tmux-common";
 import { classifyRecovery } from "../harness-control-plane/classifier";
 import { callEndpoint, EndpointUnreachableError } from "../harness-control-plane/control-endpoint";
-import { type ResolvedOwner, RuntimeOwner, resolveOwner } from "../harness-control-plane/owner";
+import { type ResolvedOwner, RuntimeOwner, resolveOwner, resolveOwnerLive } from "../harness-control-plane/owner";
 import { preserveDirtyWorktree } from "../harness-control-plane/preserve";
 import { RECEIPT_SPOOL_DIR_ENV } from "../harness-control-plane/receipt-spool";
 import { buildReceipt, requiresVanishBeforeAction, type VanishEvidence } from "../harness-control-plane/receipts";
@@ -948,10 +948,14 @@ export default class Harness extends Command {
 		let observation = input.observation as Partial<Observation> | undefined;
 		let stateView: SessionState | null = null;
 		const sessionId = flagSession ?? (typeof input.sessionId === "string" ? input.sessionId : undefined);
+		// Session-backed classify derives owner liveness from the same lease/socket probe observe
+		// uses for routing, so a live (e.g. manual) owner is never misread as vanished/restart-clean.
+		let ownerLive = false;
 		if (sessionId) {
 			stateView = await loadState(root, sessionId);
+			ownerLive = await resolveOwnerLive(root, sessionId);
 			if (!observation) {
-				const built = await buildObservation(root, stateView, ownerLiveFor(stateView));
+				const built = await buildObservation(root, stateView, ownerLive);
 				observation = built.observation;
 				stateView = await markVanishedOwnerBlocked(
 					root,
@@ -975,7 +979,7 @@ export default class Harness extends Command {
 		const decision = classifyRecovery({ observation: full, retryBudget: budget });
 		if (stateView) {
 			writeJson(
-				buildResponse(stateView, ownerLiveFor(stateView), {
+				buildResponse(stateView, ownerLive, {
 					decision,
 					observation: { ...full, lifecycle: stateView.lifecycle },
 				}),

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -670,3 +670,14 @@ export async function resolveOwner(root: string, sessionId: string): Promise<Res
 	const live = status === "live" || status === "expiredAlive" || status === "epermAlive";
 	return { live, socketPath: lease.endpoint?.path ?? null, lease };
 }
+
+/**
+ * Owner liveness for verbs that do not route to the owner (e.g. `classify`): a routable owner
+ * has a live lease and a socket endpoint. This is the same lease/socket probe `observe` uses to
+ * decide routing, so non-routing verbs derive `ownerLive` consistently instead of assuming the
+ * owner is gone (which would misclassify a live owner as vanished/restart-clean).
+ */
+export async function resolveOwnerLive(root: string, sessionId: string): Promise<boolean> {
+	const owner = await resolveOwner(root, sessionId);
+	return owner.live && owner.socketPath !== null;
+}

--- a/packages/coding-agent/test/harness-control-plane/cli.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli.test.ts
@@ -3,8 +3,10 @@ import { realpathSync } from "node:fs";
 import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { acquireLease } from "../../src/harness-control-plane/session-lease";
 import {
 	appendEvent,
+	controlSocketPath,
 	readSessionState,
 	sessionPaths,
 	writeSessionState,
@@ -721,6 +723,30 @@ describe("gjc harness CLI (foundation)", () => {
 		assertContract(res.json);
 		expect(res.json.evidence.decision.classification).toBe("restart-preserve-delta");
 		expect(res.json.evidence.decision.requiredReceiptFamily).toBe("vanish");
+	});
+
+	it("classify --session treats a live manual owner as active, not vanished (#575)", async () => {
+		await initCleanGitWorkspace();
+		const started = runHarness(["start", "--input", JSON.stringify({ harness: "gajae-code", workspace })]);
+		const sessionId = started.json.evidence.handle.sessionId as string;
+		const state = await readSessionState(root, sessionId);
+		if (!state) throw new Error("expected session state");
+		await acquireLease(root, sessionId, {
+			ownerId: "manual-owner",
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: controlSocketPath(root, sessionId) },
+			eventsPath: sessionPaths(root, sessionId).events,
+			ttlMs: 30_000,
+		});
+
+		const res = runHarness(["classify", "--session", sessionId]);
+
+		expect(res.code).toBe(0);
+		assertContract(res.json);
+		expect(res.json.state.ownerLive).toBe(true);
+		expect(res.json.evidence.observation.ownerLive).toBe(true);
+		expect(res.json.evidence.decision.classification).toBe("continue");
+		expect(res.json.evidence.decision.reason).toBe("owner-live-active");
 	});
 
 	it("retire is blocked on an unknown/dirty delta (data-loss safety)", () => {

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -3,12 +3,15 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { callEndpoint } from "../../src/harness-control-plane/control-endpoint";
-import { RuntimeOwner, resolveOwner } from "../../src/harness-control-plane/owner";
+import { RuntimeOwner, resolveOwner, resolveOwnerLive } from "../../src/harness-control-plane/owner";
 import type { HarnessRpc, RpcStateSnapshot } from "../../src/harness-control-plane/rpc-adapter";
+import { acquireLease } from "../../src/harness-control-plane/session-lease";
 import {
+	controlSocketPath,
 	readEvents,
 	readReceiptIndex,
 	readSessionState,
+	sessionPaths,
 	writeSessionState,
 } from "../../src/harness-control-plane/storage";
 import { SESSION_SCHEMA_VERSION, type SessionHandle, type SessionState } from "../../src/harness-control-plane/types";
@@ -292,5 +295,32 @@ describe("RuntimeOwner (in-process integration)", () => {
 			after = await resolveOwner(root, SID);
 		}
 		expect(after.live).toBe(false);
+	});
+});
+
+describe("resolveOwnerLive (lease/socket liveness probe)", () => {
+	it("returns false when no lease exists (owner never started)", async () => {
+		expect(await resolveOwnerLive(root, SID)).toBe(false);
+	});
+
+	it("returns true for a live lease with a socket endpoint (live manual owner)", async () => {
+		await acquireLease(root, SID, {
+			ownerId: "manual-owner",
+			pid: process.pid,
+			endpoint: { kind: "unix-socket", path: controlSocketPath(root, SID) },
+			eventsPath: sessionPaths(root, SID).events,
+			ttlMs: 30_000,
+		});
+		expect(await resolveOwnerLive(root, SID)).toBe(true);
+	});
+
+	it("returns false for a live lease without a routable endpoint", async () => {
+		await acquireLease(root, SID, {
+			ownerId: "endpointless-owner",
+			pid: process.pid,
+			eventsPath: sessionPaths(root, SID).events,
+			ttlMs: 30_000,
+		});
+		expect(await resolveOwnerLive(root, SID)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- derive `classify --session` owner liveness from the session lease/socket probe instead of the hardcoded non-routed fallback
- add `resolveOwnerLive` coverage for no lease, live socket lease, and endpointless lease
- add CLI regression coverage so a live manual owner classifies as `continue` instead of vanished/restart-clean

Fixes #575.

## Verification
- `bun test packages/coding-agent/test/harness-control-plane/owner.test.ts packages/coding-agent/test/harness-control-plane/cli.test.ts` (`38 pass`, `0 fail`)
- `bun test packages/coding-agent/test/harness-control-plane/rpc-acceptance.test.ts packages/coding-agent/test/harness-control-plane/receipts.test.ts` (`21 pass`, `0 fail`)
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`
- `git diff origin/dev...HEAD --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
