### PR TITLE
fix(team): window-qualify tmux exact option targets for tmux 3.6a (#580)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -18,6 +18,7 @@ import {
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
 import {
+	buildGjcTmuxExactOptionTarget,
 	buildGjcTmuxUntaggedSessionHint,
 	GJC_TMUX_PROFILE_OPTION,
 	GJC_TMUX_PROFILE_VALUE,
@@ -1633,7 +1634,7 @@ function buildTeamTmuxLeaderRequirementMessage(detail?: string): string {
 }
 function readGjcTmuxProfileValue(tmuxCommand: string, sessionName: string): string {
 	const result = Bun.spawnSync(
-		[tmuxCommand, "show-options", "-qv", "-t", `=${sessionName}`, GJC_TMUX_PROFILE_OPTION],
+		[tmuxCommand, "show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), GJC_TMUX_PROFILE_OPTION],
 		{
 			stdout: "pipe",
 			stderr: "pipe",
@@ -1645,7 +1646,14 @@ function readGjcTmuxProfileValue(tmuxCommand: string, sessionName: string): stri
 
 function retagGjcLaunchedTmuxSession(tmuxCommand: string, sessionName: string): boolean {
 	const result = Bun.spawnSync(
-		[tmuxCommand, "set-option", "-t", `=${sessionName}`, GJC_TMUX_PROFILE_OPTION, GJC_TMUX_PROFILE_VALUE],
+		[
+			tmuxCommand,
+			"set-option",
+			"-t",
+			buildGjcTmuxExactOptionTarget(sessionName),
+			GJC_TMUX_PROFILE_OPTION,
+			GJC_TMUX_PROFILE_VALUE,
+		],
 		{
 			stdout: "pipe",
 			stderr: "pipe",

--- a/packages/coding-agent/src/gjc-runtime/tmux-common.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-common.ts
@@ -32,6 +32,20 @@ export function resolveGjcTmuxCommand(env: NodeJS.ProcessEnv = process.env): str
 	return env[GJC_TMUX_COMMAND_ENV]?.trim() || env.GJC_TEAM_TMUX_COMMAND?.trim() || "tmux";
 }
 
+/**
+ * Build the exact-session target for tmux *option* commands
+ * (`show-options` / `set-option`) and `display-message -t`.
+ *
+ * Session-scoped commands such as `kill-session` / `attach-session` resolve a
+ * bare exact target (`=NAME`), but tmux 3.6a refuses to resolve a bare `=NAME`
+ * for option/display commands. Appending the empty window separator (`=NAME:`)
+ * keeps the exact-session match while giving tmux the window-qualified target
+ * those commands require. See gajae-code#580.
+ */
+export function buildGjcTmuxExactOptionTarget(sessionName: string): string {
+	return `=${sessionName}:`;
+}
+
 export const GJC_TMUX_UNTAGGED_REASON = "gjc_tmux_session_untagged";
 
 export function buildGjcTmuxUntaggedSessionHint(tmuxCommand: string): string {

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -1,4 +1,5 @@
 import {
+	buildGjcTmuxExactOptionTarget,
 	buildGjcTmuxProfileCommands,
 	buildGjcTmuxSessionName,
 	buildGjcTmuxUntaggedSessionError,
@@ -148,7 +149,10 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 }
 
 function readProfileForExactTarget(sessionName: string, env: NodeJS.ProcessEnv): string {
-	return runTmux(["show-options", "-qv", "-t", `=${sessionName}`, GJC_TMUX_PROFILE_OPTION], env).trim();
+	return runTmux(
+		["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), GJC_TMUX_PROFILE_OPTION],
+		env,
+	).trim();
 }
 
 export function removeGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -630,7 +630,10 @@ describe("native gjc team runtime", () => {
 		).toBe(false);
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
-		expect(tmuxLog).toContain("show-options -qv -t =test-session @gjc-profile");
+		// Option commands must use the window-qualified exact target (`=NAME:`);
+		// tmux 3.6a refuses to resolve the bare `=NAME` form for show-options (#580).
+		expect(tmuxLog).toContain("show-options -qv -t =test-session: @gjc-profile");
+		expect(tmuxLog).not.toContain("show-options -qv -t =test-session @gjc-profile");
 		expect(tmuxLog).not.toContain("split-window");
 		expect(tmuxLog).not.toContain("set-option -t test-session:0");
 	});
@@ -657,7 +660,10 @@ describe("native gjc team runtime", () => {
 		expect(snapshot.team_name).toBe("self-heal-team");
 		expect(snapshot.tmux_target).toBe("test-session:0");
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
-		expect(tmuxLog).toContain("set-option -t =test-session @gjc-profile 1");
+		// Re-tagging the stranded leader must target the window-qualified exact
+		// session (`=NAME:`) so tmux 3.6a resolves the set-option target (#580).
+		expect(tmuxLog).toContain("set-option -t =test-session: @gjc-profile 1");
+		expect(tmuxLog).not.toContain("set-option -t =test-session @gjc-profile 1");
 		expect(tmuxLog).toContain("split-window");
 	});
 

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { buildGjcTmuxExactOptionTarget } from "@gajae-code/coding-agent/gjc-runtime/tmux-common";
 import {
 	listGjcTmuxSessions,
 	removeGjcTmuxSession,
@@ -116,5 +117,31 @@ describe("GJC tmux session management", () => {
 		spyOn(Bun, "spawnSync").mockReturnValue(spawnResult(0, ""));
 
 		expect(() => statusGjcTmuxSession("ghost")).toThrow("gjc_tmux_session_not_found:ghost");
+	});
+
+	it("builds a window-qualified exact target for tmux option commands", () => {
+		// tmux 3.6a only resolves the exact session for option commands when the
+		// target is window-qualified (`=NAME:`); a bare `=NAME` does not (#580).
+		expect(buildGjcTmuxExactOptionTarget("gajae_code_work")).toBe("=gajae_code_work:");
+	});
+
+	it("queries the profile option with a window-qualified exact target", () => {
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+			}
+			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
+			return spawnResult(0, "");
+		});
+
+		removeGjcTmuxSession("gajae_code_work");
+
+		const showOptions = calls.find(call => call.includes("show-options"));
+		expect(showOptions).toEqual(["tmux", "show-options", "-qv", "-t", "=gajae_code_work:", "@gjc-profile"]);
+		// Session-scoped commands keep the bare exact target, which tmux resolves.
+		expect(calls.at(-1)).toEqual(["tmux", "kill-session", "-t", "=gajae_code_work"]);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #580. `gjc team` (real, non-`--dry-run`) always failed with `unmanaged_tmux_session` on **tmux 3.6a**, even from a valid `gjc --tmux` leader session tagged with `@gjc-profile=1`.

**Root cause:** tmux 3.6a does not resolve the bare `=NAME` exact-session target for the option/display command family (`show-options` / `set-option`), although it still resolves `=NAME` for `has-session` / `kill-session` / `attach-session`. The `@gjc-profile` ownership tag is *written* with a plain target (works) but *read* / *retagged* via `=NAME` (returns empty / "no such session"), so the leader gate concluded the session was unmanaged. The same asymmetry broke `removeGjcTmuxSession` teardown (`gjc_tmux_session_not_managed`).

The reporter's minimal tmux-only repro confirms the behavior and that `=NAME:` (window-qualified) resolves everywhere while preserving exact-session semantics.

## Change

- Add `buildGjcTmuxExactOptionTarget(sessionName)` in `tmux-common.ts`, returning the window-qualified exact target `=NAME:`.
- Route the three exact-target option call sites through it:
  - `readGjcTmuxProfileValue` (`team-runtime.ts`) — leader gate
  - `retagGjcLaunchedTmuxSession` (`team-runtime.ts`) — self-heal retag
  - `readProfileForExactTarget` (`tmux-sessions.ts`) — `removeGjcTmuxSession`
- Session-scoped `kill-session` / `attach-session` `=NAME` targets are intentionally left unchanged (they resolve fine on 3.6a).

## Tests

Command-construction / mock tests only — no host tmux 3.6a required:
- `tmux-sessions.test.ts`: helper returns `=NAME:`; `removeGjcTmuxSession` issues `show-options` with the window-qualified target while `kill-session` keeps bare `=NAME`.
- `team-runtime.test.ts`: leader-gate and self-heal fake-tmux logs assert the option-command targets are window-qualified (`=NAME:`) and *not* the bare `=NAME` form.

```
bun test test/gjc-runtime/tmux-sessions.test.ts test/gjc-runtime/team-runtime.test.ts test/gjc-runtime/launch-tmux.test.ts
# 69 pass, 0 fail
bun run check:ts   # biome + node20 baseline + schemas + tsgo across workspaces: pass
```

## Residual risk

Low. The change is confined to three option-command targets behind a single helper; behavior is unchanged on tmux versions that already resolved `=NAME` (the trailing-colon form is equivalent exact-session targeting). Not exercised against a live tmux 3.6a host in CI — coverage is command-construction assertions, matching the repro's documented tmux behavior.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
