### PR TITLE
fix(model-selector): keep preset group available when any combo is usable

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -705,6 +705,15 @@ export class ModelSelectorComponent extends Container {
 		return this.#getMissingProviders(profileOrProfiles).length === 0;
 	}
 
+	/**
+	 * A preset group is a list of alternative presets, not an all-or-nothing
+	 * bundle. Treat the group as usable when at least one member preset has all
+	 * of its required providers authenticated.
+	 */
+	#isPresetGroupUsable(profiles: ModelProfileDefinition[]): boolean {
+		return profiles.some(profile => this.#isPresetAuthenticated(profile));
+	}
+
 	async #refreshProviderAuth(): Promise<void> {
 		const providers = new Set<string>();
 		for (const profiles of this.#getPresetGroups().values()) {
@@ -763,7 +772,7 @@ export class ModelSelectorComponent extends Container {
 				continue;
 			}
 			if (row.kind === "group") {
-				const authenticated = this.#isPresetAuthenticated(row.profiles);
+				const authenticated = this.#isPresetGroupUsable(row.profiles);
 				const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
 				const label = `${mark} ${row.groupId}`;
 				const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
@@ -1158,18 +1167,26 @@ export class ModelSelectorComponent extends Container {
 			this.#switchToModelMode();
 			return;
 		}
-		const missing =
-			row.kind === "group" ? this.#getMissingProviders(row.profiles) : this.#getMissingProviders(row.profile);
+		if (row.kind === "group") {
+			// A group is a list of alternative presets; only surface a login hint
+			// when none of its members are usable. A partially-usable group stays
+			// navigable so the user can drill in and pick a usable member.
+			if (!this.#isPresetGroupUsable(row.profiles)) {
+				const missing = this.#getMissingProviders(row.profiles);
+				this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
+				this.#renderPresetLanding();
+			}
+			return;
+		}
+		const missing = this.#getMissingProviders(row.profile);
 		if (missing.length > 0) {
 			this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
 			this.#renderPresetLanding();
 			return;
 		}
-		if (row.kind === "profile") {
-			this.#previewProfileName = row.profile.name;
-			this.#presetLoginHint = undefined;
-			this.#renderPresetLanding();
-		}
+		this.#previewProfileName = row.profile.name;
+		this.#presetLoginHint = undefined;
+		this.#renderPresetLanding();
 	}
 
 	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -48,6 +48,12 @@ const combo: ModelProfileDefinition = {
 	modelMapping: { default: "anthropic/claude-opus-4-8:xhigh", executor: "openai-codex/gpt-5.5:low" },
 	source: "builtin",
 };
+const comboOpencode: ModelProfileDefinition = {
+	name: "codex-opencodego",
+	requiredProviders: ["openai-codex", "opencode-go"],
+	modelMapping: { default: "opencode-go/kimi-k2.6", executor: "openai-codex/gpt-5.5:low" },
+	source: "builtin",
+};
 const minimax: ModelProfileDefinition = {
 	name: "minimax-medium",
 	requiredProviders: ["minimax-code"],
@@ -224,6 +230,20 @@ describe("preset landing adversarial QA", () => {
 		expect(text).toContain("/login minimax-code");
 		expect(text).not.toContain("minimax/");
 		expect(text).not.toContain("/login minimax ");
+	});
+
+	test("COMBOS group stays available when at least one combo is usable", async () => {
+		// Regression: a group is a list of alternative presets, not an all-or-nothing
+		// bundle. With codex + opencode-go authenticated, codex-opencodego is fully
+		// usable, so the COMBOS group must render as available (✓) even though the
+		// sibling opus-codex preset is missing its anthropic credential.
+		const selector = createSelector({
+			authenticatedProviders: ["openai-codex", "opencode-go"],
+			profiles: [codexEco, combo, comboOpencode],
+		});
+		const text = await rendered(selector);
+		expect(text).toContain("✓ COMBOS");
+		expect(text).not.toContain("✗ COMBOS");
 	});
 
 	test("preview clamps codex eco executor to low and omits suffix for suffixless selector", async () => {


### PR DESCRIPTION
## Problem

In the model preset landing (`/model` → presets), a provider **group** is marked unavailable (`✗`, dimmed) and its selection is blocked whenever **any** member preset is missing credentials.

The group-level auth check unions the required providers across *all* member presets:

```ts
// model-selector.ts (group row)
const authenticated = this.#isPresetAuthenticated(row.profiles); // union of ALL members
```

The only group with heterogeneous member requirements is **COMBOS**, which contains:

- `Opus + Codex` → needs `anthropic` + `openai-codex`
- `Codex + OpenCodeGo` → needs `openai-codex` + `opencode-go`

So if you are logged into `openai-codex` + `opencode-go` (making **`Codex + OpenCodeGo` fully usable**), the entire COMBOS group still renders `✗` and dimmed, just because the sibling `Opus + Codex` is missing `anthropic`. A group is a list of *alternatives*, not an all-or-nothing bundle, so this misrepresents availability.

## Fix

Add `#isPresetGroupUsable()` — a group is available when **at least one** member preset has all its required providers authenticated. Use it for:

- the group header `✓/✗` mark + dim styling, and
- the Enter handler, which now only surfaces a `/login` hint when **none** of the group's members are usable (a partially-usable group stays navigable so the user can drill in and pick a usable member).

Per-preset rows are unchanged — they still require all of their own providers.

## Tests

- New regression test (`model-preset-landing-redteam-qa.test.ts`): a mixed COMBOS group with `codex + opencode-go` authenticated renders `✓ COMBOS`, not `✗`. Verified it fails on the pre-fix code and passes after.
- Existing preset/profile suites pass: `model-preset-landing-redteam-qa`, `model-selector-profiles(-redteam)`, `model-profile-activation(-redteam)`, `cli-args-mpreset`, `login-preset-recommendation` (43 tests).
- `biome check` and `tsgo --noEmit` clean on the changed files.
