### PR TITLE
fix(usage): align account columns across windows in /usage

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1538,7 +1538,7 @@ function resolveColumnWidth(count: number, available: number, trailing: number):
 	return ideal;
 }
 
-function renderUsageReports(
+export function renderUsageReports(
 	reports: UsageReport[],
 	uiTheme: typeof theme,
 	nowMs: number,
@@ -1592,17 +1592,35 @@ function renderUsageReports(
 
 		lines.push(uiTheme.bold(uiTheme.fg("accent", providerName)));
 
+		// Stable account column order shared across every window group, so each
+		// account keeps the same column in the 5h / 7d / ... rows. Rank accounts
+		// by total usage across their windows (a per-account value identical for
+		// every group), tie-broken by label for determinism.
+		const rankedAccounts = providerReports
+			.map(report => {
+				const [firstLimit] = report.limits;
+				return {
+					report,
+					total: report.limits.reduce((sum, limit) => sum + (resolveFraction(limit) ?? 0), 0),
+					label: firstLimit ? formatAccountLabel(firstLimit, report, 0) : formatUnlimitedReportLabel(report, 0),
+				};
+			})
+			.sort((a, b) => (a.total !== b.total ? b.total - a.total : a.label.localeCompare(b.label)));
+		const accountRank = new Map<UsageReport, number>();
+		rankedAccounts.forEach((entry, rank) => {
+			accountRank.set(entry.report, rank);
+		});
+
 		const renderableGroups = Array.from(limitGroups.values()).map(group => {
 			const entries = group.limits.map((limit, index) => ({
 				limit,
 				report: group.reports[index],
-				fraction: resolveFraction(limit),
 				index,
 			}));
 			entries.sort((a, b) => {
-				const aFraction = a.fraction ?? -1;
-				const bFraction = b.fraction ?? -1;
-				if (aFraction !== bFraction) return bFraction - aFraction;
+				const aRank = accountRank.get(a.report) ?? Number.MAX_SAFE_INTEGER;
+				const bRank = accountRank.get(b.report) ?? Number.MAX_SAFE_INTEGER;
+				if (aRank !== bRank) return aRank - bRank;
 				return a.index - b.index;
 			});
 			const sortedLimits = entries.map(entry => entry.limit);

--- a/packages/coding-agent/test/usage-report-columns.test.ts
+++ b/packages/coding-agent/test/usage-report-columns.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import type { UsageLimit, UsageReport } from "@gajae-code/ai";
+import { renderUsageReports } from "@gajae-code/coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const NOW = 1_700_000_000_000;
+
+function limit(windowId: string, label: string, windowLabel: string, resetMs: number, fraction: number): UsageLimit {
+	return {
+		label,
+		status: "ok",
+		amount: { usedFraction: fraction, unit: "percent" },
+		scope: { provider: "anthropic", windowId },
+		window: { id: windowId, label: windowLabel, resetsAt: NOW + resetMs },
+	} as UsageLimit;
+}
+
+function report(email: string, fiveHour: number, sevenDay: number): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt: NOW,
+		metadata: { email },
+		limits: [
+			limit("5h", "Claude 5 Hour", "5 Hour", 2 * 3_600_000, fiveHour),
+			limit("7d", "Claude 7 Day", "7 Day", 5 * 86_400_000, sevenDay),
+		],
+	} as UsageReport;
+}
+
+describe("usage report column ordering", () => {
+	beforeAll(async () => {
+		const loaded = await getThemeByName("red-claw");
+		if (loaded) setThemeInstance(loaded);
+	});
+
+	test("accounts keep the same column across every window", () => {
+		// alice has the higher TOTAL usage (0.2 + 0.6) but the lower 5h usage; bob
+		// has the higher 5h usage. A per-window sort would put bob first in the 5h
+		// row and alice first in the 7d row, so the columns would not line up.
+		const reports = [report("alice@example.com", 0.2, 0.6), report("bob@example.com", 0.5, 0.1)];
+		const lines = stripAnsi(renderUsageReports(reports, theme, NOW, 100)).split("\n");
+
+		const headerAfter = (titleNeedle: string): string => {
+			const titleIdx = lines.findIndex(line => line.includes(titleNeedle));
+			expect(titleIdx).toBeGreaterThanOrEqual(0);
+			return lines[titleIdx + 1] ?? "";
+		};
+
+		for (const header of [headerAfter("Claude 5 Hour"), headerAfter("Claude 7 Day")]) {
+			const aliceCol = header.indexOf("alice@example.com");
+			const bobCol = header.indexOf("bob@example.com");
+			expect(aliceCol).toBeGreaterThanOrEqual(0);
+			expect(bobCol).toBeGreaterThanOrEqual(0);
+			// Same account order in every window row → columns line up vertically.
+			expect(aliceCol).toBeLessThan(bobCol);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

In the interactive `/usage` panel, each rate-limit **window** (e.g. `5h`, `7d`) sorts its accounts **independently by that window's usage fraction** (`command-controller.ts` `renderUsageReports`). With multiple accounts this places the same account in **different columns** across windows, so the columns don't line up vertically.

Example (alice: 5h 20% / 7d 60%, bob: 5h 80% / 7d 10%):

```
✓ Claude 5 Hour
  bob@example.com    (45m) alice@example.com   (2h)
  ███████████████████░░░░░ ████▓░░░░░░░░░░░░░░░░░░░ 50% free
✓ Claude 7 Day
  alice@example.com   (5d) bob@example.com     (6d)
  ████████████░░░░░░░░░░░░ ██▒░░░░░░░░░░░░░░░░░░░░░ 70% free
```

`bob`'s 5h bar sits directly above `alice`'s 7d bar — the windows don't align by account.

## Fix

Compute a **stable account order once per provider**, ranked by each account's **total usage across its windows** (a per-account value identical for every window), tie-broken by label. Apply that order to every window group instead of re-sorting per window.

```
✓ Claude 5 Hour
  alice@example.com   (2h) bob@example.com    (45m)
✓ Claude 7 Day
  alice@example.com   (5d) bob@example.com     (6d)
```

Ranking by total usage preserves the original "heaviest account first" intent while keeping columns consistent across windows. Single-account output is unchanged.

## Tests

- Exports `renderUsageReports` and adds `usage-report-columns.test.ts`: a two-account provider whose per-window order would diverge now keeps the same column order in both the 5h and 7d rows. Verified it fails on the pre-fix per-window sort and passes after.
- `copy-command` / `handoff-command` tests (same module) still pass.
- `biome check` and `tsgo --noEmit` clean on the changed files.
