### PR TITLE
feat(tui): use lobster emoji instead of GJC in status line

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -66,7 +66,7 @@ function classifyProjectDir(pwd: string): { scratch: boolean; relative: string |
 const gajaeSegment: StatusLineSegment = {
 	id: "gajae",
 	render(_ctx) {
-		return { content: theme.fg("accent", "GJC"), visible: true };
+		return { content: theme.fg("accent", "🦞"), visible: true };
 	},
 };
 


### PR DESCRIPTION
## Summary
- Replace the literal `GJC` text in the status line `gajae` segment with the lobster emoji 🦞.

The legacy `pi` segment alias delegates to `gajaeSegment.render`, so it picks up the change automatically.

## Changes
- `packages/coding-agent/src/modes/components/status-line/segments.ts`: `gajaeSegment.render` now returns `theme.fg("accent", "🦞")`.

## Test plan
- Visual: status line renders 🦞 in place of `GJC` in presets that include the `gajae`/`pi` segment.