### PR TITLE
feat(deep-interview): conflict-aware bidirectional ambiguity scoring + history-efficient recording

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -132,6 +132,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
     "initial_idea": "<prompt-safe initial-context summary or user input>",
     "initial_context_summary": "<summary if oversized, else null>",
     "rounds": [],
+    "established_facts": [],
     "current_ambiguity": 1.0,
     "threshold": <resolvedThreshold>,
     "threshold_source": "<resolvedThresholdSource>",
@@ -281,6 +282,8 @@ Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} 
 
 Options should include contextually relevant choices plus free-text, translated/localized according to `language.instruction` when present.
 
+When calling `ask`, SHOULD include optional structured metadata so the runtime can record the round without manual state writes: `deepInterview.round_id?`, `deepInterview.round`, `deepInterview.component`, `deepInterview.dimension`, and `deepInterview.ambiguity`. Keep this metadata aligned with the visible Round/Component/Targeting/Ambiguity line; if metadata cannot be supplied, the legacy formatted question text remains the fallback.
+
 ### Step 2b′: Auto-Answer Opted-Out Questions
 
 After the `ask` tool resolves and before ambiguity scoring, if the user opts out of answering the current question or explicitly asks the agent to decide, load `auto-answer-uncertain.md` as an internal `kind: "skill-fragment"` prompt for a fork-context architect. Pass the opted-out question, prompt-safe transcript summary, locked topology, current scores/gaps, and any auto-research candidates used for the round. The architect must return exactly one decisive answer with rationale, confidence, and explicit uncertainty. Validate the response shape before using it; if valid, record it as the tentative answer for scoring, append the round number to `auto_answered_rounds`, and mark the transcript answer as architect-assisted.
@@ -292,6 +295,28 @@ Auto-answer has a clarity cap: unless the architect confidence is `high` and unc
 After receiving the user's answer, score clarity across all dimensions.
 
 If the round used an auto-answer, include the architect answer, rationale, confidence, and uncertainty in the scoring prompt. Apply the Step 2b′ clarity cap mechanically before calculating ambiguity, and treat any low-confidence or insufficient-context auto-answer as an unresolved gap rather than user-confirmed truth.
+
+Before scoring, compare the new answer against `state.established_facts`. Treat established facts as durable confirmed decisions with source-round evidence; do not score an answer in isolation from facts that the interview has already stabilized.
+
+Ambiguity is BIDIRECTIONAL and NON-MONOTONIC. A later answer can increase ambiguity when it invalidates, weakens, or expands prior understanding; convergence is not assumed to be a one-way decrease.
+
+Ambiguity-raising triggers:
+- **A direct contradiction**: the answer contradicts an established fact.
+- **B internal inconsistency**: two requirements that cannot co-hold are now present.
+- **C low-quality/evasive**: the answer avoids, hand-waves, or fails to resolve the targeted gap.
+- **D scope expansion**: the answer adds a component, entity, constraint, deliverable, or integration not already covered or explicitly deferred.
+
+Use **mechanism A** for every ambiguity rise: a trigger LOWERS the affected component/dimension clarity score, and the existing weighted formula raises ambiguity. There is **no separate penalty term**; ambiguity remains bounded by the same greenfield/brownfield formula.
+
+The rise is SILENT: no modal, no forced-resolution step, and no dedicated conflict UI. Surface it through the normal per-round report and by targeting the next question at the affected component/dimension.
+
+Structured scorer output is required. Include `triggers`, `trigger_status`, `affected_component`, `affected_dimension`, `prior_dimension_score`, `new_dimension_score`, `prior_ambiguity`, `new_ambiguity`, `evidence`, `contradicted_established_fact` when relevant, and `disputed_unresolved_rationale` when applicable.
+
+Established-facts maintenance: promote stable confirmed decisions into `state.established_facts` with source/evidence; when a new answer contradicts an established fact, mark the fact disputed and preserve the contradicted fact instead of deleting it.
+
+TRANSITION VALIDATION: if a trigger is present, the affected dimension must not improve and overall ambiguity must rise vs the prior scored round, unless the trigger is explicitly marked disputed or unresolved with rationale.
+
+Convergence Pacing deferral: do not add a min-round floor, score-drop cap, confidence dampening, or other explicit pacing brake. Bidirectional scoring is the pacing mechanism.
 
 **Scoring prompt** (use opus model, temperature 0.1 for consistency):
 
@@ -305,6 +330,9 @@ Transcript or prompt-safe transcript summary:
 
 Locked topology:
 {state.topology.components and state.topology.deferrals}
+
+Established facts:
+{state.established_facts}
 
 Score each active component on each dimension, then provide the overall dimension scores as the minimum or coverage-weighted weakest score across active components. Deferred components are excluded from ambiguity math but must remain listed in topology and the final spec.
 
@@ -324,6 +352,7 @@ Also identify:
 - weakest_dimension: the single lowest-confidence dimension for that component this round
 - weakest_dimension_rationale: one sentence explaining why this component/dimension pair is the highest-leverage target for the next question
 - component_scores: object keyed by component id, with per-dimension scores and gaps
+- structured_scorer_output: object containing triggers, trigger_status, affected_component, affected_dimension, prior_dimension_score, new_dimension_score, prior_ambiguity, new_ambiguity, evidence, contradicted_established_fact when relevant, and disputed_unresolved_rationale when applicable
 
 5. Ontology Extraction: Identify all key entities (nouns) discussed in the transcript.
 
@@ -373,7 +402,7 @@ Round {n} complete.
 | Constraints | {s} | {w} | {s*w} | {gap or "Clear"} |
 | Success Criteria | {s} | {w} | {s*w} | {gap or "Clear"} |
 | Context (brownfield) | {s} | {w} | {s*w} | {gap or "Clear"} |
-| **Ambiguity** | | | **{score}%** | |
+| **Ambiguity** | | | **{prior_score}% -> {score}% {up|down|flat}** | {if up: trigger name such as "A direct contradiction"} |
 
 **Topology:** Targeted {target_component_name} | Active: {active_component_count} | Deferred: {deferred_component_count} | Next rotation after: {last_targeted_component_id}
 
@@ -389,7 +418,7 @@ Apply `language.instruction` when present before showing this progress report so
 
 ### Step 2e: Update State
 
-Update interview state with the new round, global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures` via `gjc state write`; never patch `.gjc/state` directly unless an explicit force override is active.
+Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round `gjc state write` is required for the answer shell; only scoring enrichment/state maintenance remains. When metadata is absent, use the legacy `gjc state write` path to persist the new round and never patch `.gjc/state` directly unless an explicit force override is active.
 
 ### Step 2f: Check Soft Limits
 
@@ -463,6 +492,12 @@ Spec structure:
 |-----------|--------|-------------|--------------------------|
 | {component.name} | {active|deferred} | {component.description} | {covered acceptance criteria or deferral reason} |
 
+## Established Facts
+{List stable confirmed decisions promoted into `state.established_facts`, including source round, evidence, and disputed status when any fact was contradicted.}
+
+## Trigger Metadata
+{Summarize per-round trigger metadata: trigger label/status, affected component/dimension, prior -> new ambiguity direction, evidence, contradicted established fact when relevant, and disputed/unresolved rationale when applicable.}
+
 ## Goal
 {crystal-clear goal statement derived from interview, covering every active topology component}
 
@@ -480,6 +515,9 @@ Spec structure:
 - [ ] {testable criterion 2}
 - [ ] {testable criterion 3}
 - ...
+
+## Deferrals
+{List user-confirmed topology deferrals and scoring/pacing deferrals, including Convergence Pacing when applicable: no min-round floor, score-drop cap, or dampening; bidirectional scoring is the pacing mechanism.}
 
 ## Assumptions Exposed & Resolved
 | Assumption | Challenge | Resolution |

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -1,0 +1,460 @@
+import { createHash } from "node:crypto";
+import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
+import { readExistingStateForMutation, writeWorkflowEnvelopeAtomic } from "./state-writer";
+
+/**
+ * Runtime-owned deep-interview round recorder (conflict-aware scoring support).
+ *
+ * Ownership boundary (per the approved consensus plan): this module owns durable
+ * round-record semantics — stable identity, append-or-merge, lifecycle, compact
+ * reads, replay detection, and the pure scored-transition validator. Callers such
+ * as the `ask` tool only resolve an answer and invoke these helpers; they never
+ * compute state paths, merge records, or write `.gjc` files directly. All writes
+ * go through the sanctioned state-writer (`writeWorkflowEnvelopeAtomic`).
+ */
+
+// =============================================================================
+// Domain types
+// =============================================================================
+
+export type DeepInterviewRoundLifecycle = "answered" | "pending_scoring" | "scored";
+
+export type DeepInterviewTriggerKind = "A" | "B" | "C" | "D";
+
+/** `active` triggers must satisfy the bidirectional invariant; disputed/unresolved are exempt with rationale. */
+export type DeepInterviewTriggerStatus = "active" | "disputed" | "unresolved";
+
+export interface DeepInterviewEstablishedFact {
+	id: string;
+	statement: string;
+	round: number;
+	component?: string;
+	dimension?: string;
+	evidence?: string;
+	disputed: boolean;
+}
+
+export interface DeepInterviewTriggerMetadata {
+	kind: DeepInterviewTriggerKind;
+	name: string;
+	status: DeepInterviewTriggerStatus;
+	component: string;
+	dimension: string;
+	priorDimensionScore?: number;
+	newDimensionScore?: number;
+	priorAmbiguity?: number;
+	newAmbiguity?: number;
+	evidence?: string;
+	contradictedFactId?: string;
+	/** Required when status is `disputed` or `unresolved` to exempt the invariant. */
+	rationale?: string;
+}
+
+export interface DeepInterviewRoundRecord {
+	round_key: string;
+	round_id?: string;
+	round: number;
+	question_id?: string;
+	question_text?: string;
+	question_hash: string;
+	answer_hash: string;
+	selected_options?: string[];
+	custom_input?: string;
+	component?: string;
+	dimension?: string;
+	ambiguity_at_ask?: number;
+	lifecycle: DeepInterviewRoundLifecycle;
+	answered_at: string;
+	scored_at?: string;
+	scores?: Record<string, number>;
+	ambiguity?: number;
+	triggers?: DeepInterviewTriggerMetadata[];
+}
+
+export interface DeepInterviewAnswerInput {
+	interviewId?: string;
+	round: number;
+	round_id?: string;
+	questionId?: string;
+	questionText: string;
+	component?: string;
+	dimension?: string;
+	ambiguity?: number;
+	selectedOptions?: string[];
+	customInput?: string;
+}
+
+export interface DeepInterviewScoringInput {
+	interviewId?: string;
+	round: number;
+	round_id?: string;
+	questionId?: string;
+	scores: Record<string, number>;
+	ambiguity: number;
+	triggers?: DeepInterviewTriggerMetadata[];
+}
+
+export type AppendOrMergeAction = "created" | "noop" | "replaced";
+
+export interface AppendOrMergeResult {
+	rounds: DeepInterviewRoundRecord[];
+	action: AppendOrMergeAction;
+	record: DeepInterviewRoundRecord;
+}
+
+export interface DeepInterviewCompactState {
+	threshold?: number;
+	threshold_source?: string;
+	current_ambiguity?: number;
+	topology_summary?: { active: number; deferred: number; components: string[] };
+	established_facts: DeepInterviewEstablishedFact[];
+	unresolved_triggers: DeepInterviewTriggerMetadata[];
+	recent_scored_rounds: DeepInterviewRoundRecord[];
+	pending_shells: DeepInterviewRoundRecord[];
+}
+
+export interface TransitionValidationResult {
+	ok: boolean;
+	violations: string[];
+}
+
+// =============================================================================
+// Pure helpers: identity + hashing
+// =============================================================================
+
+export function hashContent(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 32);
+}
+
+export function questionHash(questionText: string): string {
+	return hashContent(questionText);
+}
+
+export function answerHash(selectedOptions: string[] | undefined, customInput: string | undefined): string {
+	return hashContent(JSON.stringify({ selected: selectedOptions ?? [], custom: customInput ?? null }));
+}
+
+/**
+ * Durable round identity. Prefer `interview_id + round_id`; fall back to
+ * `interview_id + round + question.id` when no caller-supplied `round_id` exists.
+ */
+export function deriveRoundKey(
+	interviewId: string | undefined,
+	input: { round_id?: string; round: number; questionId?: string },
+): string {
+	const interview = interviewId && interviewId.trim() !== "" ? interviewId : "nointerview";
+	if (input.round_id && input.round_id.trim() !== "") {
+		return `${interview}::rid:${input.round_id}`;
+	}
+	return `${interview}::r:${input.round}::q:${input.questionId ?? "noqid"}`;
+}
+
+// =============================================================================
+// Pure helpers: records
+// =============================================================================
+
+export function buildAnswerShell(
+	input: DeepInterviewAnswerInput,
+	now: string = new Date().toISOString(),
+): DeepInterviewRoundRecord {
+	return {
+		round_key: deriveRoundKey(input.interviewId, input),
+		round_id: input.round_id,
+		round: input.round,
+		question_id: input.questionId,
+		question_text: input.questionText,
+		question_hash: questionHash(input.questionText),
+		answer_hash: answerHash(input.selectedOptions, input.customInput),
+		selected_options: input.selectedOptions,
+		custom_input: input.customInput,
+		component: input.component,
+		dimension: input.dimension,
+		ambiguity_at_ask: input.ambiguity,
+		lifecycle: "answered",
+		answered_at: now,
+	};
+}
+
+/**
+ * Append-or-merge by `round_key`. Exactly one record per key:
+ * - no existing record -> append (`created`);
+ * - identical question_hash + answer_hash -> deterministic no-op (`noop`);
+ * - same key, different hashes -> deterministic replacement of the prior shell
+ *   (`replaced`); the prior answer for that key is superseded and lifecycle resets.
+ */
+export function appendOrMergeRound(
+	rounds: readonly DeepInterviewRoundRecord[],
+	shell: DeepInterviewRoundRecord,
+): AppendOrMergeResult {
+	const next = [...rounds];
+	const index = next.findIndex(r => r.round_key === shell.round_key);
+	if (index < 0) {
+		next.push(shell);
+		return { rounds: next, action: "created", record: shell };
+	}
+	const existing = next[index];
+	if (existing.question_hash === shell.question_hash && existing.answer_hash === shell.answer_hash) {
+		return { rounds: next, action: "noop", record: existing };
+	}
+	next[index] = shell;
+	return { rounds: next, action: "replaced", record: shell };
+}
+
+/**
+ * Merge scoring output into the existing record for the derived key, transitioning
+ * it to `scored`. Never appends a second record for the same key; if no shell exists
+ * yet (scoring without a prior ask), a scored record is created so data is not lost.
+ */
+export function enrichRoundWithScoring(
+	rounds: readonly DeepInterviewRoundRecord[],
+	input: DeepInterviewScoringInput,
+	now: string = new Date().toISOString(),
+): { rounds: DeepInterviewRoundRecord[]; record: DeepInterviewRoundRecord } {
+	const roundKey = deriveRoundKey(input.interviewId, input);
+	const next = [...rounds];
+	const index = next.findIndex(r => r.round_key === roundKey);
+	if (index < 0) {
+		const created: DeepInterviewRoundRecord = {
+			round_key: roundKey,
+			round_id: input.round_id,
+			round: input.round,
+			question_id: input.questionId,
+			question_hash: "",
+			answer_hash: "",
+			lifecycle: "scored",
+			answered_at: now,
+			scored_at: now,
+			scores: input.scores,
+			ambiguity: input.ambiguity,
+			triggers: input.triggers,
+		};
+		next.push(created);
+		return { rounds: next, record: created };
+	}
+	const merged: DeepInterviewRoundRecord = {
+		...next[index],
+		lifecycle: "scored",
+		scored_at: now,
+		scores: input.scores,
+		ambiguity: input.ambiguity,
+		triggers: input.triggers,
+	};
+	next[index] = merged;
+	return { rounds: next, record: merged };
+}
+
+// =============================================================================
+// Pure helper: scored-transition validator
+// =============================================================================
+
+/**
+ * Bidirectional invariant: if `next` carries an `active` trigger, the affected
+ * dimension must not improve and overall ambiguity must rise vs the prior scored
+ * round. `disputed`/`unresolved` triggers are exempt but must carry a rationale.
+ */
+export function validateDeepInterviewScoredTransition(
+	prior: DeepInterviewRoundRecord | undefined,
+	next: DeepInterviewRoundRecord,
+): TransitionValidationResult {
+	const violations: string[] = [];
+	const triggers = next.triggers ?? [];
+	for (const trigger of triggers) {
+		if (trigger.status === "disputed" || trigger.status === "unresolved") {
+			if (!trigger.rationale || trigger.rationale.trim() === "") {
+				violations.push(`trigger ${trigger.kind} is ${trigger.status} but has no rationale`);
+			}
+			continue;
+		}
+		// status === "active": enforce the invariant only when a prior scored round exists.
+		if (!prior) continue;
+		// Ambiguity must be present on both sides and must rise; missing metrics cannot prove a rise.
+		if (typeof prior.ambiguity !== "number" || typeof next.ambiguity !== "number") {
+			violations.push(`active trigger ${trigger.kind} is missing ambiguity metrics to prove a rise`);
+		} else if (!(next.ambiguity > prior.ambiguity)) {
+			violations.push(
+				`active trigger ${trigger.kind} did not raise ambiguity (${prior.ambiguity} -> ${next.ambiguity})`,
+			);
+		}
+		// Affected dimension must not improve. Prefer record scores, fall back to the trigger's
+		// own prior/new dimension scores; absent metrics cannot prove non-improvement.
+		const priorDim = prior.scores?.[trigger.dimension] ?? trigger.priorDimensionScore;
+		const nextDim = next.scores?.[trigger.dimension] ?? trigger.newDimensionScore;
+		if (typeof priorDim !== "number" || typeof nextDim !== "number") {
+			violations.push(
+				`active trigger ${trigger.kind} is missing dimension "${trigger.dimension}" scores to prove non-improvement`,
+			);
+		} else if (nextDim > priorDim) {
+			violations.push(
+				`active trigger ${trigger.kind} on dimension "${trigger.dimension}" improved clarity ${priorDim} -> ${nextDim}`,
+			);
+		}
+	}
+	return { ok: violations.length === 0, violations };
+}
+
+// =============================================================================
+// Pure helper: state-shape migration + compact projection
+// =============================================================================
+
+interface DeepInterviewStateEnvelope {
+	threshold?: number;
+	threshold_source?: string;
+	state?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Default new fields for legacy state written before conflict-aware scoring.
+ * Returns a shallow-cloned envelope safe to mutate; never deletes existing fields.
+ */
+export function ensureDeepInterviewStateShape(value: unknown): DeepInterviewStateEnvelope {
+	const envelope: DeepInterviewStateEnvelope =
+		value && typeof value === "object" && !Array.isArray(value) ? { ...(value as DeepInterviewStateEnvelope) } : {};
+	const inner =
+		envelope.state && typeof envelope.state === "object" ? { ...(envelope.state as Record<string, unknown>) } : {};
+	if (!Array.isArray(inner.rounds)) inner.rounds = [];
+	if (!Array.isArray(inner.established_facts)) inner.established_facts = [];
+	envelope.state = inner;
+	return envelope;
+}
+
+function readRounds(envelope: DeepInterviewStateEnvelope): DeepInterviewRoundRecord[] {
+	const inner = (envelope.state ?? {}) as Record<string, unknown>;
+	return Array.isArray(inner.rounds) ? (inner.rounds as DeepInterviewRoundRecord[]) : [];
+}
+
+export function projectCompactState(value: unknown, options: { lastN?: number } = {}): DeepInterviewCompactState {
+	const lastN = options.lastN ?? 3;
+	const envelope = ensureDeepInterviewStateShape(value);
+	const inner = (envelope.state ?? {}) as Record<string, unknown>;
+	const rounds = readRounds(envelope);
+	const scored = rounds.filter(r => r.lifecycle === "scored");
+	const pending = rounds.filter(r => r.lifecycle !== "scored");
+	const latestScored = scored.length > 0 ? scored[scored.length - 1] : undefined;
+	const established = Array.isArray(inner.established_facts)
+		? (inner.established_facts as DeepInterviewEstablishedFact[])
+		: [];
+	const unresolved: DeepInterviewTriggerMetadata[] = [];
+	for (const round of scored) {
+		for (const trigger of round.triggers ?? []) {
+			if (trigger.status === "unresolved" || trigger.status === "disputed") unresolved.push(trigger);
+		}
+	}
+	const topology = inner.topology as { components?: Array<{ status?: string; name?: string }> } | undefined;
+	let topologySummary: DeepInterviewCompactState["topology_summary"];
+	if (topology && Array.isArray(topology.components)) {
+		const active = topology.components.filter(c => c.status !== "deferred");
+		topologySummary = {
+			active: active.length,
+			deferred: topology.components.length - active.length,
+			components: topology.components.map(c => c.name ?? "").filter(Boolean),
+		};
+	}
+	return {
+		threshold: typeof envelope.threshold === "number" ? envelope.threshold : (inner.threshold as number | undefined),
+		threshold_source:
+			typeof envelope.threshold_source === "string"
+				? envelope.threshold_source
+				: (inner.threshold_source as string | undefined),
+		current_ambiguity:
+			typeof latestScored?.ambiguity === "number"
+				? latestScored.ambiguity
+				: (inner.current_ambiguity as number | undefined),
+		topology_summary: topologySummary,
+		established_facts: established,
+		unresolved_triggers: unresolved,
+		recent_scored_rounds: scored.slice(-lastN),
+		pending_shells: pending,
+	};
+}
+
+// =============================================================================
+// Persistence wrappers (state-writer backed; runtime-owned)
+// =============================================================================
+
+async function readEnvelope(statePath: string): Promise<DeepInterviewStateEnvelope> {
+	const read = await readExistingStateForMutation(statePath);
+	if (read.kind === "valid") return ensureDeepInterviewStateShape(read.value);
+	if (read.kind === "corrupt") {
+		// Fail closed: never silently overwrite a corrupt/tampered state file. Callers
+		// (e.g. the ask tool) catch this and warn without mutating, preserving the file
+		// for recovery. Only a genuinely absent file is defaulted below.
+		throw new Error(
+			`deep-interview state at ${statePath} is corrupt or tampered (${read.error}); refusing to overwrite`,
+		);
+	}
+	// Absent: start from a defaulted shape.
+	return ensureDeepInterviewStateShape(undefined);
+}
+
+function interviewIdOf(envelope: DeepInterviewStateEnvelope): string | undefined {
+	const inner = (envelope.state ?? {}) as Record<string, unknown>;
+	return typeof inner.interview_id === "string" ? inner.interview_id : undefined;
+}
+
+async function persistEnvelope(
+	cwd: string,
+	statePath: string,
+	envelope: DeepInterviewStateEnvelope,
+	sessionId: string | undefined,
+	command: string,
+): Promise<void> {
+	const now = new Date().toISOString();
+	const payload: Record<string, unknown> = { ...envelope, updated_at: now };
+	// Guarantee RequiredOnWriteEnvelopeSchema fields for the fresh/absent fallback;
+	// existing real state already carries these and is preserved by the spread above.
+	payload.skill ??= "deep-interview";
+	payload.version ??= WORKFLOW_STATE_VERSION;
+	payload.active ??= true;
+	payload.current_phase ??= "interviewing";
+	await writeWorkflowEnvelopeAtomic(statePath, payload, {
+		cwd,
+		receipt: { cwd, skill: "deep-interview", owner: "gjc-runtime", command, sessionId, nowIso: now },
+		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
+	});
+}
+
+/** Record an `answered` shell for one round (append-or-merge by durable key). */
+export async function appendOrMergeDeepInterviewRound(
+	cwd: string,
+	statePath: string,
+	input: DeepInterviewAnswerInput,
+	options: { sessionId?: string } = {},
+): Promise<{ action: AppendOrMergeAction; record: DeepInterviewRoundRecord }> {
+	const envelope = await readEnvelope(statePath);
+	const interviewId = input.interviewId ?? interviewIdOf(envelope);
+	const shell = buildAnswerShell({ ...input, interviewId });
+	const rounds = readRounds(envelope);
+	const result = appendOrMergeRound(rounds, shell);
+	if (result.action === "noop") return { action: result.action, record: result.record };
+	(envelope.state as Record<string, unknown>).rounds = result.rounds;
+	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview record-answer");
+	return { action: result.action, record: result.record };
+}
+
+/** Merge scoring output into the same round record, transitioning to `scored`. */
+export async function enrichDeepInterviewRoundScoring(
+	cwd: string,
+	statePath: string,
+	input: DeepInterviewScoringInput,
+	options: { sessionId?: string } = {},
+): Promise<{ record: DeepInterviewRoundRecord }> {
+	const envelope = await readEnvelope(statePath);
+	const interviewId = input.interviewId ?? interviewIdOf(envelope);
+	const rounds = readRounds(envelope);
+	const { rounds: nextRounds, record } = enrichRoundWithScoring(rounds, { ...input, interviewId });
+	(envelope.state as Record<string, unknown>).rounds = nextRounds;
+	(envelope.state as Record<string, unknown>).current_ambiguity = input.ambiguity;
+	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview score-round");
+	return { record };
+}
+
+/** Compact projection so callers read a slice instead of the full transcript. */
+export async function readDeepInterviewStateCompact(
+	statePath: string,
+	options: { lastN?: number } = {},
+): Promise<DeepInterviewCompactState> {
+	const read = await readExistingStateForMutation(statePath);
+	const value = read.kind === "valid" ? read.value : undefined;
+	return projectCompactState(value, options);
+}

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -9,6 +9,8 @@ import { runNativeRalplanCommand } from "./ralplan-runtime";
 import { runNativeStateCommand } from "./state-runtime";
 import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
 
+export * from "./deep-interview-recorder";
+
 /**
  * Native implementation of `gjc deep-interview`.
  *
@@ -92,7 +94,7 @@ function stateDirFor(cwd: string, sessionId: string | undefined): string {
 		: path.join(cwd, ".gjc", "state");
 }
 
-function deepInterviewStatePath(cwd: string, sessionId: string | undefined): string {
+export function deepInterviewStatePath(cwd: string, sessionId: string | undefined): string {
 	return path.join(stateDirFor(cwd, sessionId), "deep-interview-state.json");
 }
 
@@ -476,6 +478,7 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		state: {
 			initial_idea: resolved.idea,
 			rounds: [],
+			established_facts: [],
 			current_ambiguity: 1.0,
 			threshold: resolved.threshold,
 			threshold_source: resolved.thresholdSource,

--- a/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
@@ -17,12 +17,26 @@ import type { OpenGateInput } from "./workflow-gate-broker";
 /** "Other (type your own)" sentinel, mirroring the interactive ask tool. */
 export const GATE_OTHER_OPTION = "Other (type your own)";
 
+/** Optional structured deep-interview round metadata supplied by the agent. */
+export interface AskGateDeepInterviewState {
+	round_id?: string;
+	round: number;
+	component: string;
+	dimension: string;
+	ambiguity: number;
+}
+
 export interface AskGateQuestion {
 	id: string;
 	question: string;
 	options: Array<{ label: string }>;
 	multi?: boolean;
 	recommended?: number;
+	/**
+	 * Structured round metadata. When present it is the authoritative source for gate
+	 * `stage_state`; when absent, the question text is regex-parsed as a fallback.
+	 */
+	deepInterview?: AskGateDeepInterviewState;
 }
 
 export interface AskGateResult {
@@ -130,6 +144,19 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 	};
 }
 
+/** Build `stage_state` round metadata from the structured param (authoritative when present). */
+function structuredDeepInterviewState(meta: AskGateDeepInterviewState): Record<string, unknown> {
+	const state: Record<string, unknown> = {
+		deep_interview_metadata: true,
+		round: meta.round,
+		component: meta.component,
+		dimension: meta.dimension,
+		ambiguity: meta.ambiguity,
+	};
+	if (meta.round_id !== undefined) state.round_id = meta.round_id;
+	return state;
+}
+
 /** Build the `workflow_gate` open-input for one deep-interview question. */
 export function questionToGate(question: AskGateQuestion): OpenGateInput {
 	const labels = question.options.map(o => o.label);
@@ -151,7 +178,9 @@ export function questionToGate(question: AskGateQuestion): OpenGateInput {
 				multi: question.multi ?? false,
 				options: labels,
 				other_option: GATE_OTHER_OPTION,
-				...deepInterviewQuestionState(question.question),
+				...(question.deepInterview
+					? structuredDeepInterviewState(question.deepInterview)
+					: deepInterviewQuestionState(question.question)),
 			},
 		},
 	};

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -34,6 +34,8 @@ import {
 	renderDeepInterviewAskQuestion,
 } from "../deep-interview/render-middleware";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { appendOrMergeDeepInterviewRound } from "../gjc-runtime/deep-interview-recorder";
+import { deepInterviewStatePath } from "../gjc-runtime/deep-interview-runtime";
 import { gateAnswerToResult, questionToGate } from "../modes/shared/agent-wire/deep-interview-gate";
 import { getMarkdownTheme, type Theme, theme } from "../modes/theme/theme";
 import askDescription from "../prompts/tools/ask.md" with { type: "text" };
@@ -50,15 +52,25 @@ const OptionItem = z.object({
 	label: z.string().describe("display label"),
 });
 
+/** Optional structured deep-interview round metadata; when present the round is recorded automatically. */
+const DeepInterviewMeta = z.object({
+	round_id: z.string().describe("stable optional round identity").optional(),
+	round: z.number().int().nonnegative().describe("round number"),
+	component: z.string().min(1).describe("targeted topology component"),
+	dimension: z.string().min(1).describe("targeted clarity dimension"),
+	ambiguity: z.number().min(0).max(1).describe("ambiguity at ask time (0..1)"),
+});
+
 const QuestionItem = z.object({
 	id: z.string().describe("question id"),
 	question: z.string().describe("question text"),
 	options: z.array(OptionItem).describe("available options"),
 	multi: z.boolean().describe("allow multiple selections").optional(),
 	recommended: z.number().describe("recommended option index").optional(),
+	deepInterview: DeepInterviewMeta.describe("optional deep-interview round metadata").optional(),
 });
 
-const askSchema = z.object({
+export const askSchema = z.object({
 	questions: z.array(QuestionItem).min(1).describe("questions to ask"),
 });
 
@@ -456,6 +468,45 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		TERMINAL.sendNotification("Waiting for input");
 	}
 
+	/**
+	 * Record a resolved deep-interview round when the question carries structured
+	 * metadata. The runtime owns durable record/merge semantics; this tool is only the
+	 * caller. Best-effort: a state-write hiccup must not break the user's answer flow.
+	 */
+	async #recordDeepInterviewRound(
+		q: AskParams["questions"][number],
+		selectedOptions: string[],
+		customInput: string | undefined,
+	): Promise<void> {
+		const meta = q.deepInterview;
+		if (!meta) return;
+		try {
+			const cwd = this.session.cwd;
+			const sessionId = this.session.getSessionId?.() ?? undefined;
+			const statePath = deepInterviewStatePath(cwd, sessionId);
+			await appendOrMergeDeepInterviewRound(
+				cwd,
+				statePath,
+				{
+					round: meta.round,
+					round_id: meta.round_id,
+					questionId: q.id,
+					questionText: q.question,
+					component: meta.component,
+					dimension: meta.dimension,
+					ambiguity: meta.ambiguity,
+					selectedOptions,
+					customInput,
+				},
+				{ sessionId },
+			);
+		} catch (error) {
+			console.warn(
+				`ask: deep-interview round recording failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
 	async execute(
 		_toolCallId: string,
 		params: AskParams,
@@ -515,6 +566,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 					options: q.options,
 					multi: q.multi,
 					recommended: q.recommended,
+					deepInterview: q.deepInterview,
 				};
 				const answer = await gateEmitter.emitGate(questionToGate(gateQuestion));
 				const decoded = gateAnswerToResult(gateQuestion, answer);
@@ -582,6 +634,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				context?.abort();
 				throw new ToolAbortError("Ask tool was cancelled by the user");
 			}
+			await this.#recordDeepInterviewRound(q, selectedOptions, customInput);
 			const details: AskToolDetails = {
 				question: q.question,
 				options: optionLabels,
@@ -643,6 +696,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				selectedOptions,
 				customInput,
 			};
+
+			await this.#recordDeepInterviewRound(q, selectedOptions, customInput);
 
 			if (navAction === "back") {
 				questionIndex = Math.max(0, questionIndex - 1);

--- a/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
+++ b/packages/coding-agent/test/deep-interview-gate-redteam.test.ts
@@ -10,6 +10,7 @@ import {
 	WorkflowGateBroker,
 } from "@gajae-code/coding-agent/modes/shared/agent-wire/workflow-gate-broker";
 import { schemaHash } from "@gajae-code/coding-agent/modes/shared/agent-wire/workflow-gate-schema";
+import { askSchema } from "@gajae-code/coding-agent/tools/ask";
 
 const singleQ: AskGateQuestion = {
 	id: "single-auth",
@@ -203,5 +204,58 @@ describe("deep-interview question gates red-team", () => {
 		const rejected = await broker.resolve({ gate_id: gate.gate_id, answer: { selected: ["Password"] } });
 		expect(rejected.status).toBe("rejected");
 		expect(rejected.error?.schema_hash).toBe(gate.schema_hash);
+	});
+});
+
+describe("deep-interview structured metadata red-team", () => {
+	it("does not alter selection or free-text decoding when metadata is present", async () => {
+		const withMeta: AskGateQuestion = {
+			...singleQ,
+			deepInterview: { round: 1, component: "conflict-detection", dimension: "goal", ambiguity: 0.6 },
+		};
+		const selection = await resolveQuestion(withMeta, { selected: ["JWT"] });
+		expect(selection.resolution.status).toBe("accepted");
+		expect(gateAnswerToResult(withMeta, { selected: ["JWT"] }).selectedOptions).toEqual(["JWT"]);
+
+		const free = await resolveQuestion(withMeta, { selected: [], other: true, custom: "Passkeys" });
+		expect(free.resolution.status).toBe("accepted");
+		expect(gateAnswerToResult(withMeta, { selected: [], other: true, custom: "Passkeys" }).customInput).toBe(
+			"Passkeys",
+		);
+	});
+
+	it("rejects invalid deepInterview metadata at the ask schema boundary", () => {
+		const base = { id: "q1", question: "Q?", options: [{ label: "A" }] };
+		// ambiguity out of range
+		expect(
+			askSchema.safeParse({
+				questions: [{ ...base, deepInterview: { round: 1, component: "c", dimension: "goal", ambiguity: 1.5 } }],
+			}).success,
+		).toBe(false);
+		// missing required round
+		expect(
+			askSchema.safeParse({
+				questions: [{ ...base, deepInterview: { component: "c", dimension: "goal", ambiguity: 0.5 } }],
+			}).success,
+		).toBe(false);
+		// empty component
+		expect(
+			askSchema.safeParse({
+				questions: [{ ...base, deepInterview: { round: 1, component: "", dimension: "goal", ambiguity: 0.5 } }],
+			}).success,
+		).toBe(false);
+		// valid metadata accepted
+		expect(
+			askSchema.safeParse({
+				questions: [
+					{
+						...base,
+						deepInterview: { round_id: "r1", round: 1, component: "c", dimension: "goal", ambiguity: 0.5 },
+					},
+				],
+			}).success,
+		).toBe(true);
+		// absent metadata still valid (backward compatible)
+		expect(askSchema.safeParse({ questions: [base] }).success).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const skillPath = join(dirname(fileURLToPath(import.meta.url)), "../src/defaults/gjc/skills/deep-interview/SKILL.md");
+
+const skill = readFileSync(skillPath, "utf8");
+
+describe("deep-interview skill conflict-aware scoring contract", () => {
+	it("documents the ambiguity-raising triggers and established facts", () => {
+		expect(skill).toContain("A direct contradiction");
+		expect(skill).toContain("B internal inconsistency");
+		expect(skill).toContain("C low-quality/evasive");
+		expect(skill).toContain("D scope expansion");
+		expect(skill).toContain("established_facts");
+	});
+
+	it("documents bidirectional scoring mechanism A without a penalty term", () => {
+		expect(skill).toMatch(/BIDIRECTIONAL/i);
+		expect(skill).toMatch(/NON-MONOTONIC/i);
+		expect(skill).toMatch(/mechanism A/i);
+		expect(skill).toMatch(/no separate penalty term/i);
+	});
+
+	it("requires structured scorer output for conflict transitions", () => {
+		expect(skill).toMatch(/Structured scorer output is required/i);
+		expect(skill).toContain("affected_dimension");
+		expect(skill).toContain("prior_ambiguity");
+		expect(skill).toContain("new_ambiguity");
+		expect(skill).toContain("contradicted_established_fact");
+	});
+
+	it("reports ambiguity direction and validates trigger transitions", () => {
+		expect(skill).toContain("{prior_score}% -> {score}% {up|down|flat}");
+		expect(skill).toMatch(/TRANSITION VALIDATION/i);
+		expect(skill).toMatch(
+			/trigger is present, the affected dimension must not improve and overall ambiguity must rise/i,
+		);
+	});
+
+	it("documents convergence pacing as deferred", () => {
+		expect(skill).toMatch(/Convergence Pacing deferral/i);
+		expect(skill).toMatch(/min-round floor, score-drop cap, (confidence )?dampening/i);
+		expect(skill).toMatch(/Bidirectional scoring is the pacing mechanism/i);
+	});
+});

--- a/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
+++ b/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
@@ -115,3 +115,52 @@ describe("end-to-end via the broker", () => {
 		expect(other.status).toBe("accepted");
 	});
 });
+
+describe("questionToGate structured deep-interview metadata", () => {
+	it("uses structured metadata for stage_state when present", () => {
+		const gate = questionToGate({
+			id: "q-struct",
+			question: "Round 1 | Component: Conflict Detection | Targeting: Goal | Ambiguity: 66%\n\nWhich triggers?",
+			options: [{ label: "A only" }, { label: "All four" }],
+			deepInterview: {
+				round_id: "r-1",
+				round: 1,
+				component: "conflict-detection",
+				dimension: "goal",
+				ambiguity: 0.66,
+			},
+		});
+		const state = gate.context?.stage_state as Record<string, unknown>;
+		expect(state.deep_interview_metadata).toBe(true);
+		expect(state.round).toBe(1);
+		expect(state.component).toBe("conflict-detection");
+		expect(state.dimension).toBe("goal");
+		expect(state.ambiguity).toBe(0.66);
+		expect(state.round_id).toBe("r-1");
+	});
+
+	it("structured metadata wins over conflicting question text", () => {
+		const gate = questionToGate({
+			id: "q-conflict",
+			question: "Round 99 | Topology confirmation | Ambiguity: 80%",
+			options: [{ label: "x" }],
+			deepInterview: { round: 2, component: "bidirectional-ambiguity", dimension: "constraints", ambiguity: 0.4 },
+		});
+		const state = gate.context?.stage_state as Record<string, unknown>;
+		expect(state.round).toBe(2);
+		expect(state.deep_interview_metadata).toBe(true);
+		// The regex would have parsed round 99 / topology_gate from the text; metadata overrides it.
+		expect(state.topology_gate).toBeUndefined();
+	});
+
+	it("falls back to regex parsing when metadata is absent (unchanged behavior)", () => {
+		const gate = questionToGate({
+			id: "q-regex",
+			question: "Round 3 | Targeting: Constraints | Ambiguity: 40%",
+			options: [{ label: "x" }],
+		});
+		const state = gate.context?.stage_state as Record<string, unknown>;
+		expect(state.round).toBe(3);
+		expect(state.deep_interview_metadata).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	answerHash,
+	appendOrMergeDeepInterviewRound,
+	buildAnswerShell,
+	type DeepInterviewRoundRecord,
+	type DeepInterviewTriggerMetadata,
+	deriveRoundKey,
+	enrichDeepInterviewRoundScoring,
+	readDeepInterviewStateCompact,
+	validateDeepInterviewScoredTransition,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+import { askSchema } from "@gajae-code/coding-agent/tools/ask";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-deep-interview-recorder-redteam-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function statePathFor(cwd: string): string {
+	return path.join(cwd, ".gjc", "state", "deep-interview-state.json");
+}
+
+async function readPersistedRounds(statePath: string): Promise<DeepInterviewRoundRecord[]> {
+	const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+	return persisted.state.rounds;
+}
+
+function answerInput(over: Partial<Parameters<typeof appendOrMergeDeepInterviewRound>[2]> = {}) {
+	return {
+		interviewId: "iv-redteam",
+		round: 1,
+		questionId: "q1",
+		questionText: "Which entity owns the workflow?",
+		component: "conflict-detection",
+		dimension: "goal",
+		ambiguity: 0.5,
+		selectedOptions: ["A"],
+		...over,
+	};
+}
+
+function trigger(over: Partial<DeepInterviewTriggerMetadata> = {}): DeepInterviewTriggerMetadata {
+	return {
+		kind: "A",
+		name: "direct contradiction",
+		status: "active",
+		component: "conflict-detection",
+		dimension: "goal",
+		...over,
+	};
+}
+
+function scoredRound(over: Partial<DeepInterviewRoundRecord> = {}): DeepInterviewRoundRecord {
+	return {
+		...buildAnswerShell(
+			{
+				interviewId: "iv-redteam",
+				round: 1,
+				questionId: "q1",
+				questionText: "Which entity owns the workflow?",
+				selectedOptions: ["A"],
+				component: "conflict-detection",
+				dimension: "goal",
+				ambiguity: 0.5,
+			},
+			"2026-01-01T00:00:00.000Z",
+		),
+		lifecycle: "scored",
+		scores: { goal: 0.5 },
+		ambiguity: 0.5,
+		...over,
+	};
+}
+
+describe("deep-interview recorder redteam: corrupt state is fail-closed (not overwritten)", () => {
+	it.each([
+		["malformed JSON", "{ not json"],
+		["valid JSON non-object", "42"],
+	])("rejects recording against %s and preserves the corrupt file for recovery", async (_name, corruptContent) => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(statePath, corruptContent, "utf-8");
+
+		// Fail closed: recording must not silently overwrite corrupt/tampered state.
+		await expect(appendOrMergeDeepInterviewRound(cwd, statePath, answerInput())).rejects.toThrow(
+			/corrupt or tampered/,
+		);
+
+		// The corrupt file is preserved unchanged for recovery.
+		expect(await fs.readFile(statePath, "utf-8")).toBe(corruptContent);
+	});
+});
+
+describe("deep-interview recorder redteam: persistence merge invariants", () => {
+	it("replace-then-enrich keeps exactly one record and enriches the replacement answer", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput({ selectedOptions: ["A"] }));
+
+		const replaced = await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput({ selectedOptions: ["B"] }));
+		expect(replaced.action).toBe("replaced");
+		let rounds = await readPersistedRounds(statePath);
+		expect(rounds).toHaveLength(1);
+		expect(rounds[0].answer_hash).toBe(answerHash(["B"], undefined));
+
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			interviewId: "iv-redteam",
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.35 },
+			ambiguity: 0.7,
+		});
+
+		rounds = await readPersistedRounds(statePath);
+		expect(rounds).toHaveLength(1);
+		expect(rounds[0].lifecycle).toBe("scored");
+		expect(rounds[0].answer_hash).toBe(answerHash(["B"], undefined));
+	});
+
+	it("idempotent replay across persistence returns noop and does not append", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		const first = await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput());
+		const second = await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput());
+
+		expect(first.action).toBe("created");
+		expect(second.action).toBe("noop");
+		expect(await readPersistedRounds(statePath)).toHaveLength(1);
+	});
+});
+
+describe("deep-interview recorder redteam: validator bypass attempts", () => {
+	it("does not falsely pass when active ambiguity is present but not raised, even if affected score is absent", () => {
+		const prior = scoredRound({ scores: { goal: 0.5 }, ambiguity: 0.5 });
+		const next = scoredRound({
+			round: 2,
+			question_id: "q2",
+			scores: { audience: 0.1 },
+			ambiguity: 0.5,
+			triggers: [trigger({ dimension: "goal" })],
+		});
+
+		const result = validateDeepInterviewScoredTransition(prior, next);
+		expect(result.ok).toBe(false);
+		expect(result.violations.join(" ")).toContain("did not raise ambiguity");
+	});
+
+	it("fails active triggers when transition metrics are missing", () => {
+		const prior = scoredRound({ scores: { goal: 0.5 }, ambiguity: 0.5 });
+		const next = scoredRound({
+			round: 2,
+			question_id: "q2",
+			scores: { audience: 0.1 },
+			ambiguity: undefined,
+			triggers: [trigger({ dimension: "goal" })],
+		});
+
+		const result = validateDeepInterviewScoredTransition(prior, next);
+		expect(result.ok).toBe(false);
+		expect(result.violations.join(" ")).toMatch(/missing ambiguity metrics|missing dimension/);
+	});
+
+	it("fails disputed triggers with empty-string rationale", () => {
+		const result = validateDeepInterviewScoredTransition(
+			scoredRound(),
+			scoredRound({
+				round: 2,
+				question_id: "q2",
+				scores: { goal: 0.9 },
+				ambiguity: 0.1,
+				triggers: [trigger({ status: "disputed", rationale: "   " })],
+			}),
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.violations.join(" ")).toContain("has no rationale");
+	});
+});
+
+describe("deep-interview recorder redteam: round_key collision safety", () => {
+	it("keeps different question ids in the same round distinct", () => {
+		expect(deriveRoundKey("iv-redteam", { round: 4, questionId: "q-left" })).not.toBe(
+			deriveRoundKey("iv-redteam", { round: 4, questionId: "q-right" }),
+		);
+	});
+
+	it("round_id deliberately forces the same key even if round and question id differ", () => {
+		expect(deriveRoundKey("iv-redteam", { round_id: "stable", round: 4, questionId: "q-left" })).toBe(
+			deriveRoundKey("iv-redteam", { round_id: "stable", round: 99, questionId: "q-right" }),
+		);
+	});
+});
+
+describe("deep-interview recorder redteam: ask schema boundaries", () => {
+	function askWithDeepInterview(deepInterview?: unknown) {
+		return {
+			questions: [
+				{
+					id: "q1",
+					question: "Q?",
+					options: [{ label: "A" }],
+					...(deepInterview === undefined ? {} : { deepInterview }),
+				},
+			],
+		};
+	}
+
+	it.each([
+		["ambiguity below zero", { round: 1, component: "c", dimension: "goal", ambiguity: -0.001 }],
+		["ambiguity above one", { round: 1, component: "c", dimension: "goal", ambiguity: 1.001 }],
+		["non-integer round", { round: 1.5, component: "c", dimension: "goal", ambiguity: 0.5 }],
+		["negative round", { round: -1, component: "c", dimension: "goal", ambiguity: 0.5 }],
+		["empty dimension", { round: 1, component: "c", dimension: "", ambiguity: 0.5 }],
+	])("rejects %s", (_name, deepInterview) => {
+		expect(askSchema.safeParse(askWithDeepInterview(deepInterview)).success).toBe(false);
+	});
+
+	it("accepts well-formed metadata and absent metadata", () => {
+		expect(
+			askSchema.safeParse(
+				askWithDeepInterview({
+					round_id: "rid-1",
+					round: 0,
+					component: "conflict-detection",
+					dimension: "goal",
+					ambiguity: 1,
+				}),
+			).success,
+		).toBe(true);
+		expect(askSchema.safeParse(askWithDeepInterview()).success).toBe(true);
+	});
+});
+
+describe("deep-interview recorder redteam: compact read transcript minimization", () => {
+	it("returns only lastN scored rounds and separates all pending shells", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+
+		for (let round = 1; round <= 6; round++) {
+			await appendOrMergeDeepInterviewRound(
+				cwd,
+				statePath,
+				answerInput({ round, questionId: `q${round}`, questionText: `Scored question ${round}?` }),
+			);
+			await enrichDeepInterviewRoundScoring(cwd, statePath, {
+				interviewId: "iv-redteam",
+				round,
+				questionId: `q${round}`,
+				scores: { goal: 1 - round / 10 },
+				ambiguity: round / 10,
+			});
+		}
+		for (let round = 7; round <= 9; round++) {
+			await appendOrMergeDeepInterviewRound(
+				cwd,
+				statePath,
+				answerInput({ round, questionId: `q${round}`, questionText: `Pending question ${round}?` }),
+			);
+		}
+
+		const compact = await readDeepInterviewStateCompact(statePath, { lastN: 2 });
+		expect(compact.recent_scored_rounds.map(r => r.round)).toEqual([5, 6]);
+		expect(compact.pending_shells.map(r => r.round)).toEqual([7, 8, 9]);
+		expect(compact.recent_scored_rounds.some(r => r.round < 5)).toBe(false);
+		expect(compact.current_ambiguity).toBe(0.6);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	answerHash,
+	appendOrMergeDeepInterviewRound,
+	appendOrMergeRound,
+	buildAnswerShell,
+	type DeepInterviewRoundRecord,
+	type DeepInterviewTriggerMetadata,
+	deriveRoundKey,
+	enrichDeepInterviewRoundScoring,
+	enrichRoundWithScoring,
+	ensureDeepInterviewStateShape,
+	projectCompactState,
+	questionHash,
+	readDeepInterviewStateCompact,
+	validateDeepInterviewScoredTransition,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-deep-interview-recorder-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function shell(over: Partial<Parameters<typeof buildAnswerShell>[0]> = {}): DeepInterviewRoundRecord {
+	return buildAnswerShell(
+		{
+			interviewId: "iv1",
+			round: 1,
+			questionId: "q1",
+			questionText: "What is the core entity?",
+			component: "conflict-detection",
+			dimension: "goal",
+			ambiguity: 0.6,
+			selectedOptions: ["A"],
+			...over,
+		},
+		"2026-01-01T00:00:00.000Z",
+	);
+}
+
+function trigger(over: Partial<DeepInterviewTriggerMetadata> = {}): DeepInterviewTriggerMetadata {
+	return {
+		kind: "A",
+		name: "direct contradiction",
+		status: "active",
+		component: "conflict-detection",
+		dimension: "goal",
+		...over,
+	};
+}
+
+describe("deep-interview recorder: identity & hashing", () => {
+	it("prefers interview_id + round_id, falls back to interview_id + round + question.id", () => {
+		expect(deriveRoundKey("iv1", { round_id: "r-abc", round: 2, questionId: "q9" })).toBe("iv1::rid:r-abc");
+		expect(deriveRoundKey("iv1", { round: 2, questionId: "q9" })).toBe("iv1::r:2::q:q9");
+		expect(deriveRoundKey("iv1", { round: 2 })).toBe("iv1::r:2::q:noqid");
+		expect(deriveRoundKey(undefined, { round: 1, questionId: "q1" })).toBe("nointerview::r:1::q:q1");
+	});
+
+	it("hashes are stable and content-sensitive for replay detection", () => {
+		expect(questionHash("same")).toBe(questionHash("same"));
+		expect(questionHash("a")).not.toBe(questionHash("b"));
+		expect(answerHash(["A"], undefined)).toBe(answerHash(["A"], undefined));
+		expect(answerHash(["A"], undefined)).not.toBe(answerHash(["B"], undefined));
+		expect(answerHash([], "free text")).not.toBe(answerHash([], "other text"));
+	});
+
+	it("answer shells record hashes, component/dimension, and answered lifecycle", () => {
+		const s = shell();
+		expect(s.lifecycle).toBe("answered");
+		expect(s.question_hash).toBe(questionHash("What is the core entity?"));
+		expect(s.answer_hash).toBe(answerHash(["A"], undefined));
+		expect(s.component).toBe("conflict-detection");
+		expect(s.round_key).toBe("iv1::r:1::q:q1");
+	});
+});
+
+describe("deep-interview recorder: append-or-merge", () => {
+	it("creates one record per key", () => {
+		const r = appendOrMergeRound([], shell());
+		expect(r.action).toBe("created");
+		expect(r.rounds).toHaveLength(1);
+	});
+
+	it("is a deterministic no-op on identical replay", () => {
+		const first = appendOrMergeRound([], shell());
+		const replay = appendOrMergeRound(first.rounds, shell());
+		expect(replay.action).toBe("noop");
+		expect(replay.rounds).toHaveLength(1);
+	});
+
+	it("replaces the prior shell when the same key has different hashes", () => {
+		const first = appendOrMergeRound([], shell());
+		const changed = appendOrMergeRound(first.rounds, shell({ selectedOptions: ["B"] }));
+		expect(changed.action).toBe("replaced");
+		expect(changed.rounds).toHaveLength(1);
+		expect(changed.rounds[0].answer_hash).toBe(answerHash(["B"], undefined));
+	});
+});
+
+describe("deep-interview recorder: scoring enrichment", () => {
+	it("updates the same record to scored and never appends a second", () => {
+		const created = appendOrMergeRound([], shell()).rounds;
+		const { rounds, record } = enrichRoundWithScoring(created, {
+			interviewId: "iv1",
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.5 },
+			ambiguity: 0.5,
+		});
+		expect(rounds).toHaveLength(1);
+		expect(record.lifecycle).toBe("scored");
+		expect(record.scores).toEqual({ goal: 0.5 });
+		expect(record.question_hash).toBe(questionHash("What is the core entity?")); // shell fields preserved
+	});
+
+	it("creates a scored record if scoring arrives with no shell", () => {
+		const { rounds, record } = enrichRoundWithScoring([], {
+			interviewId: "iv1",
+			round: 3,
+			questionId: "q3",
+			scores: { goal: 0.4 },
+			ambiguity: 0.4,
+		});
+		expect(rounds).toHaveLength(1);
+		expect(record.lifecycle).toBe("scored");
+	});
+});
+
+describe("deep-interview recorder: transition validator", () => {
+	const prior: DeepInterviewRoundRecord = {
+		...shell(),
+		lifecycle: "scored",
+		scores: { goal: 0.5 },
+		ambiguity: 0.5,
+	};
+
+	it("passes when an active trigger lowers the dimension and raises ambiguity", () => {
+		const next: DeepInterviewRoundRecord = {
+			...shell({ round: 2, questionId: "q2" }),
+			lifecycle: "scored",
+			scores: { goal: 0.3 },
+			ambiguity: 0.62,
+			triggers: [trigger()],
+		};
+		expect(validateDeepInterviewScoredTransition(prior, next).ok).toBe(true);
+	});
+
+	it("fails when an active trigger improves the affected dimension", () => {
+		const next: DeepInterviewRoundRecord = {
+			...shell({ round: 2, questionId: "q2" }),
+			lifecycle: "scored",
+			scores: { goal: 0.8 },
+			ambiguity: 0.62,
+			triggers: [trigger()],
+		};
+		const result = validateDeepInterviewScoredTransition(prior, next);
+		expect(result.ok).toBe(false);
+		expect(result.violations.join(" ")).toContain("improved clarity");
+	});
+
+	it("fails when an active trigger does not raise ambiguity", () => {
+		const next: DeepInterviewRoundRecord = {
+			...shell({ round: 2, questionId: "q2" }),
+			lifecycle: "scored",
+			scores: { goal: 0.3 },
+			ambiguity: 0.4,
+			triggers: [trigger()],
+		};
+		const result = validateDeepInterviewScoredTransition(prior, next);
+		expect(result.ok).toBe(false);
+		expect(result.violations.join(" ")).toContain("did not raise ambiguity");
+	});
+
+	it("exempts disputed/unresolved triggers only with a rationale", () => {
+		const disputedNoRationale: DeepInterviewRoundRecord = {
+			...shell({ round: 2 }),
+			lifecycle: "scored",
+			scores: { goal: 0.9 },
+			ambiguity: 0.4,
+			triggers: [trigger({ status: "disputed" })],
+		};
+		expect(validateDeepInterviewScoredTransition(prior, disputedNoRationale).ok).toBe(false);
+
+		const disputedWithRationale: DeepInterviewRoundRecord = {
+			...disputedNoRationale,
+			triggers: [trigger({ status: "disputed", rationale: "user retracted the contradiction" })],
+		};
+		expect(validateDeepInterviewScoredTransition(prior, disputedWithRationale).ok).toBe(true);
+	});
+});
+
+describe("deep-interview recorder: contradiction fixture (round N vs N-2)", () => {
+	it("a contradiction of an N-2 established fact yields ambiguity_N > ambiguity_{N-1} and passes the validator", () => {
+		// N-2 established a fact (goal clear); N-1 is a non-contradictory baseline; N contradicts.
+		const established = [
+			{ id: "f1", statement: "Core entity is Task", round: 1, dimension: "goal", disputed: false },
+		];
+		const roundN1: DeepInterviewRoundRecord = {
+			...shell({ round: 2, questionId: "q2" }),
+			lifecycle: "scored",
+			scores: { goal: 0.8 },
+			ambiguity: 0.3,
+		};
+		const roundN: DeepInterviewRoundRecord = {
+			...shell({ round: 3, questionId: "q3" }),
+			lifecycle: "scored",
+			scores: { goal: 0.4 },
+			ambiguity: 0.55,
+			triggers: [
+				trigger({
+					contradictedFactId: "f1",
+					priorDimensionScore: 0.8,
+					newDimensionScore: 0.4,
+					priorAmbiguity: 0.3,
+					newAmbiguity: 0.55,
+					evidence: "Round 3 says the core entity is Project, contradicting f1",
+				}),
+			],
+		};
+		expect(roundN.ambiguity).toBeGreaterThan(roundN1.ambiguity as number);
+		expect(validateDeepInterviewScoredTransition(roundN1, roundN).ok).toBe(true);
+		expect(established[0].id).toBe("f1");
+
+		// Fail variant: same contradiction but the scorer failed to raise ambiguity.
+		const broken: DeepInterviewRoundRecord = { ...roundN, ambiguity: 0.25 };
+		expect(validateDeepInterviewScoredTransition(roundN1, broken).ok).toBe(false);
+	});
+});
+
+describe("deep-interview recorder: state-shape migration & compact projection", () => {
+	it("defaults rounds and established_facts for legacy/empty state without deleting fields", () => {
+		const migrated = ensureDeepInterviewStateShape({ state: { initial_idea: "x" }, skill: "deep-interview" });
+		expect(migrated.state?.rounds).toEqual([]);
+		expect(migrated.state?.established_facts).toEqual([]);
+		expect((migrated.state as Record<string, unknown>).initial_idea).toBe("x");
+		expect(migrated.skill).toBe("deep-interview");
+	});
+
+	it("compact projection separates pending shells from scored rounds and surfaces latest ambiguity", () => {
+		const rounds: DeepInterviewRoundRecord[] = [
+			{ ...shell({ round: 1, questionId: "q1" }), lifecycle: "scored", scores: { goal: 0.7 }, ambiguity: 0.4 },
+			{ ...shell({ round: 2, questionId: "q2" }), lifecycle: "scored", scores: { goal: 0.6 }, ambiguity: 0.35 },
+			{ ...shell({ round: 3, questionId: "q3" }), lifecycle: "answered" },
+		];
+		const compact = projectCompactState({ state: { rounds, established_facts: [] }, threshold: 0.05 }, { lastN: 1 });
+		expect(compact.current_ambiguity).toBe(0.35);
+		expect(compact.recent_scored_rounds).toHaveLength(1);
+		expect(compact.pending_shells).toHaveLength(1);
+		expect(compact.pending_shells[0].round).toBe(3);
+		expect(compact.threshold).toBe(0.05);
+	});
+});
+
+describe("deep-interview recorder: persistence (state-writer backed)", () => {
+	function statePathFor(cwd: string): string {
+		return path.join(cwd, ".gjc", "state", "deep-interview-state.json");
+	}
+
+	it("persists exactly one durable record per key and no-ops identical replay", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		const input = {
+			round: 1,
+			questionId: "q1",
+			questionText: "Q1?",
+			component: "c",
+			dimension: "goal",
+			selectedOptions: ["A"],
+		};
+		const created = await appendOrMergeDeepInterviewRound(cwd, statePath, input);
+		expect(created.action).toBe("created");
+
+		const replay = await appendOrMergeDeepInterviewRound(cwd, statePath, input);
+		expect(replay.action).toBe("noop");
+
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(persisted.state.rounds).toHaveLength(1);
+		expect(persisted.skill).toBe("deep-interview");
+	});
+
+	it("enriches the same record to scored without appending a second", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			questionText: "Q1?",
+		});
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.5 },
+			ambiguity: 0.5,
+		});
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(persisted.state.rounds).toHaveLength(1);
+		expect(persisted.state.rounds[0].lifecycle).toBe("scored");
+		expect(persisted.state.current_ambiguity).toBe(0.5);
+	});
+
+	it("reads a compact slice and migrates legacy on-disk state safely", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		// Legacy envelope lacking rounds/established_facts.
+		await fs.writeFile(
+			statePath,
+			`${JSON.stringify({ skill: "deep-interview", state: { initial_idea: "legacy" } })}\n`,
+			"utf-8",
+		);
+		const compact = await readDeepInterviewStateCompact(statePath);
+		expect(compact.established_facts).toEqual([]);
+		expect(compact.recent_scored_rounds).toEqual([]);
+		expect(compact.pending_shells).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -238,6 +238,7 @@ describe("native gjc deep-interview runtime", () => {
 		expect(state.threshold).toBeCloseTo(0.05);
 		expect(state.threshold_source).toBe("default");
 		expect(state.state.initial_idea).toBe("my vague idea");
+		expect(state.state.established_facts).toEqual([]);
 	});
 
 	it("honors gjc.deepInterview.ambiguityThreshold in project .gjc/settings.json", async () => {


### PR DESCRIPTION
## Summary
Makes deep-interview ambiguity **bidirectional** instead of monotonically converging, and removes the agent's per-round state bookkeeping.

Pipeline: deep-interview spec (`.gjc/specs/deep-interview-conflict-aware-scoring.md`) → ralplan consensus (run `2026-06-13-1407-40f6`) → approved plan → this implementation.

## What changed
- **Conflict detection + bidirectional scoring (mechanism A):** a trigger lowers the affected dimension's clarity so the existing weighted formula raises ambiguity — no separate penalty term, silent surfacing via the per-round report + next-question targeting. Four triggers: A direct contradiction, B internal inconsistency, C low-quality/evasive, D scope expansion; each answer is compared against `state.established_facts`.
- **History-efficient recording:** optional `ask.deepInterview` param (`{round_id?, round, component, dimension, ambiguity}`) records the round automatically into `deep-interview-state.json`, eliminating manual per-round `gjc state write` and full-transcript dumps. Backward-compatible: `questionToGate` keeps its regex fallback when metadata is absent.
- **Runtime-owned recorder** (`deep-interview-recorder.ts`): durable `round_key`, append-or-merge (one record per key, idempotent replay, deterministic replacement), `answered`→`scored` lifecycle with `pending_scoring`, compact-read projection, and a pure scored-transition validator. Fails closed on corrupt state. `ask.ts` is only the caller; `questionToGate` stays pure.
- **SKILL.md** Step 2c/2d/2e updated for the methodology; Convergence Pacing documented as deferred.

## Tests / verification
- New: recorder unit tests, adversarial red-team (corrupt-state fail-closed, replay idempotency, validator bypass attempts, schema-boundary fuzz, compact-read minimization), skill-doc contract test.
- Updated: gate structured-metadata + schema-boundary, runtime seed.
- `bun run check:ts` (biome + tsgo across all workspaces + schemas + node20 baseline) green; deep-interview + ask suites pass (129 focused tests).

## Review trail
Planner→Architect→Critic consensus (APPROVE) + post-implementation architect quality gate (CLEAR/CLEAR/CLEAR, APPROVE) after resolving 2 correctness blockers (fail-closed on corrupt state; validator rejects active triggers with missing metrics).
