### PR TITLE
feat(gc): add global `gjc gc` garbage-collection command

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -32,6 +32,7 @@ const commands: CommandEntry[] = [
 	{ name: "coordinator", load: () => import("./commands/coordinator").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
 	{ name: "ultragoal", load: () => import("./commands/ultragoal").then(m => m.default) },
+	{ name: "gc", load: () => import("./commands/gc").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "mcp-serve", load: () => import("./commands/mcp-serve").then(m => m.default) },

--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -1,0 +1,22 @@
+import { Command, Flags } from "@gajae-code/utils/cli";
+import { runGjcGcCommand } from "../gjc-runtime/gc-runtime";
+
+export default class Gc extends Command {
+	static description = "Garbage-collect stale GJC session/PID records (dry-run by default)";
+	static strict = false;
+	static flags = {
+		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
+		prune: Flags.boolean({ description: "Remove stale records (default: report only)", default: false }),
+		force: Flags.boolean({ description: "Alias for --prune (eligible records only)", default: false }),
+		"dry-run": Flags.boolean({ description: "Force report-only mode", default: false }),
+	};
+
+	static examples = ["gjc gc", "gjc gc --json", "gjc gc --prune", "gjc gc --prune --json"];
+
+	async run(): Promise<void> {
+		const result = await runGjcGcCommand(this.argv, process.cwd(), process.env);
+		if (result.stdout) process.stdout.write(result.stdout);
+		if (result.stderr) process.stderr.write(result.stderr);
+		process.exitCode = result.status;
+	}
+}

--- a/packages/coding-agent/src/config/file-lock-gc.ts
+++ b/packages/coding-agent/src/config/file-lock-gc.ts
@@ -1,0 +1,181 @@
+/**
+ * GC adapter for config file-locks (`<file>.lock` dirs holding `{pid, timestamp}`).
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getAgentDir, getConfigRootDir, isEnoent } from "@gajae-code/utils";
+import type {
+	GcCollectResult,
+	GcContext,
+	GcError,
+	GcPruneOutcome,
+	GcRecord,
+	GcStoreAdapter,
+} from "../gjc-runtime/gc-runtime";
+import { gcPidStatusLabel } from "../gjc-runtime/gc-runtime";
+import { resolveReceiptSpoolDir } from "../harness-control-plane/receipt-spool";
+import { readFileLockInfoForGc, removeFileLockDirForGc } from "./file-lock";
+
+const MAX_WALK_DEPTH = 6;
+const MAX_WALK_ENTRIES = 20_000;
+
+// High-cardinality, lock-free subtrees we never descend into. `.lock` dirs are
+// created next to config files, never inside these.
+const PRUNED_DIR_NAMES = new Set(["sessions", "node_modules", ".git", "blobs", "artifacts", "receipts", "events"]);
+
+interface WalkState {
+	entries: number;
+	truncated: boolean;
+}
+
+// Global, env-aware GJC lock roots. Per the approved scope this covers the
+// user config root, the agent dir (honors GJC_CODING_AGENT_DIR), and the
+// configured receipt-spool dir — NOT the invocation cwd's project `.gjc`.
+function knownFileLockRoots(ctx: GcContext): string[] {
+	const roots = [getConfigRootDir(), getAgentDir()];
+	const spoolDir = resolveReceiptSpoolDir(ctx.env);
+	if (spoolDir) roots.push(spoolDir);
+	return Array.from(new Set(roots.map(root => path.resolve(root))));
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function keptMalformedRecord(lockDir: string): GcRecord {
+	return {
+		store: "file_locks",
+		id: lockDir,
+		path: lockDir,
+		pid_status: "none",
+		status: "malformed",
+		stale: false,
+		removable: false,
+		action: "none",
+		reason: "missing_or_malformed_file_lock_info",
+	};
+}
+
+async function collectLockRecord(lockDir: string, ctx: GcContext): Promise<GcRecord> {
+	const info = await readFileLockInfoForGc(lockDir);
+	if (!info) return keptMalformedRecord(lockDir);
+
+	const probeResult = ctx.probe(info.pid);
+	const pidStatus = gcPidStatusLabel(probeResult);
+	const removable = probeResult.status === "dead";
+
+	return {
+		store: "file_locks",
+		id: lockDir,
+		path: lockDir,
+		pid: info.pid,
+		pid_status: pidStatus,
+		status: pidStatus,
+		stale: removable,
+		removable,
+		action: "none",
+		reason: removable ? "file_lock_owner_pid_dead" : `file_lock_owner_pid_${pidStatus}`,
+		detail: `timestamp=${info.timestamp}`,
+	};
+}
+
+async function walkForLockDirs(
+	dir: string,
+	depth: number,
+	state: WalkState,
+	lockDirs: Set<string>,
+	errors: GcError[],
+): Promise<void> {
+	if (state.entries >= MAX_WALK_ENTRIES) {
+		state.truncated = true;
+		return;
+	}
+
+	let stat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		stat = await fs.lstat(dir);
+	} catch (error) {
+		if (isEnoent(error)) return;
+		errors.push({ store: "file_locks", scope: dir, message: errorMessage(error) });
+		return;
+	}
+
+	state.entries++;
+	if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+
+	if (path.basename(dir).endsWith(".lock")) {
+		lockDirs.add(dir);
+		return;
+	}
+
+	if (depth >= MAX_WALK_DEPTH) return;
+
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dir);
+	} catch (error) {
+		if (isEnoent(error)) return;
+		errors.push({ store: "file_locks", scope: dir, message: errorMessage(error) });
+		return;
+	}
+
+	for (const entry of entries) {
+		if (state.entries >= MAX_WALK_ENTRIES) {
+			state.truncated = true;
+			return;
+		}
+		if (PRUNED_DIR_NAMES.has(entry)) continue;
+		await walkForLockDirs(path.join(dir, entry), depth + 1, state, lockDirs, errors);
+	}
+}
+
+export const fileLocksGcAdapter: GcStoreAdapter = {
+	store: "file_locks",
+	async collect(ctx: GcContext): Promise<GcCollectResult> {
+		const records: GcRecord[] = [];
+		const errors: GcError[] = [];
+		const lockDirs = new Set<string>();
+		const state: WalkState = { entries: 0, truncated: false };
+
+		for (const root of knownFileLockRoots(ctx)) {
+			await walkForLockDirs(root, 0, state, lockDirs, errors);
+			if (state.truncated) break;
+		}
+
+		if (state.truncated) {
+			errors.push({
+				store: "file_locks",
+				scope: "discovery",
+				message: `file lock discovery capped at ${MAX_WALK_ENTRIES} entries`,
+			});
+		}
+
+		for (const lockDir of lockDirs) {
+			try {
+				records.push(await collectLockRecord(lockDir, ctx));
+			} catch (error) {
+				errors.push({ store: "file_locks", scope: lockDir, message: errorMessage(error) });
+			}
+		}
+
+		return { records, errors };
+	},
+	async prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome> {
+		const lockDir = record.path ?? record.id;
+		const info = await readFileLockInfoForGc(lockDir);
+		if (!info) return { removed: false, skipped: "lock_no_longer_dead_or_missing" };
+
+		const probeResult = ctx.probe(info.pid);
+		if (probeResult.status !== "dead") {
+			return { removed: false, skipped: "lock_no_longer_dead_or_missing" };
+		}
+
+		try {
+			await removeFileLockDirForGc(lockDir);
+			return { removed: true };
+		} catch (error) {
+			return { removed: false, error: errorMessage(error) };
+		}
+	},
+};

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -36,6 +36,20 @@ async function readLockInfo(lockPath: string): Promise<LockInfo | null> {
 	}
 }
 
+/** @internal */
+export async function readFileLockInfoForGc(lockDir: string): Promise<{ pid: number; timestamp: number } | null> {
+	const info = await readLockInfo(lockDir);
+	if (!info) return null;
+	if (!Number.isFinite(info.pid) || info.pid <= 0) return null;
+	if (!Number.isFinite(info.timestamp)) return null;
+	return info;
+}
+
+/** @internal */
+export async function removeFileLockDirForGc(lockDir: string): Promise<void> {
+	await fs.rm(lockDir, { recursive: true, force: true });
+}
+
 function isProcessAlive(pid: number): boolean {
 	try {
 		process.kill(pid, 0);

--- a/packages/coding-agent/src/gjc-runtime/gc-render.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-render.ts
@@ -1,0 +1,70 @@
+/**
+ * Text rendering for `gjc gc` reports. JSON output is produced directly in
+ * `gc-runtime.ts`; this module owns the human-readable grouped report.
+ */
+
+import type { GcRecord, GcReport, GcStore } from "./gc-runtime";
+import { GC_STORES } from "./gc-runtime";
+
+const STORE_HEADINGS: Record<GcStore, string> = {
+	harness_leases: "Harness owner leases",
+	team_workers: "Team workers",
+	file_locks: "Config file-locks",
+	tmux_sessions: "Tmux sessions",
+	registry_entries: "Harness-root registry entries",
+};
+
+function actionLabel(record: GcRecord): string {
+	switch (record.action) {
+		case "would_remove":
+			return "would remove";
+		case "removed":
+			return "removed";
+		case "remove_failed":
+			return `remove failed${record.error ? `: ${record.error}` : ""}`;
+		case "skipped":
+			return `skipped: ${record.reason}`;
+		default:
+			return "keep";
+	}
+}
+
+function renderRecord(record: GcRecord): string {
+	const target = record.path ?? record.id;
+	const pid = record.pid !== undefined ? ` pid=${record.pid}` : "";
+	const pidStatus = record.pid_status ? ` (${record.pid_status})` : "";
+	const note = record.detail ? ` — ${record.detail}` : "";
+	return `  [${actionLabel(record)}] ${target}${pid}${pidStatus} :: ${record.status} — ${record.reason}${note}`;
+}
+
+export function buildGcReportText(report: GcReport): string {
+	const lines: string[] = [];
+	lines.push(report.dry_run ? "gjc gc — dry run (no changes made; pass --prune to remove)" : "gjc gc — prune");
+	lines.push("");
+
+	for (const store of GC_STORES) {
+		const records = report.stores[store];
+		lines.push(`${STORE_HEADINGS[store]} (${records.length})`);
+		if (records.length === 0) {
+			lines.push("  (none)");
+		} else {
+			for (const record of records) lines.push(renderRecord(record));
+		}
+		lines.push("");
+	}
+
+	if (report.errors.length > 0) {
+		lines.push(`Errors (${report.errors.length})`);
+		for (const err of report.errors) lines.push(`  [${err.store}/${err.scope}] ${err.message}`);
+		lines.push("");
+	}
+
+	const c = report.counts;
+	lines.push(
+		`Summary: discovered=${c.discovered} stale=${c.stale} alive=${c.alive} eperm=${c.eperm} unknown=${c.unknown} ` +
+			`terminal_lifecycle=${c.terminal_lifecycle} unclassified=${c.unclassified} ` +
+			`${report.dry_run ? `would_remove=${c.would_remove}` : `removed=${c.removed} failed=${c.failed}`} errors=${c.errors}`,
+	);
+	lines.push("");
+	return `${lines.join("\n")}`;
+}

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -1,0 +1,403 @@
+/**
+ * `gjc gc` runtime — a global, liveness-only, dry-run-by-default garbage
+ * collector for stale GJC session/PID records.
+ *
+ * Design (see .gjc/plans/ralplan/2026-06-13-1347-954f/pending-approval.md):
+ * - This module is an ORCHESTRATOR only. It owns the shared PID probe, the
+ *   report/exit-code policy, and text/JSON rendering. It must NOT parse private
+ *   store layouts directly; every store is reached through an injectable
+ *   `GcStoreAdapter` that lives next to its store owner.
+ * - Liveness-only and fail-closed: only `ESRCH` (no such process) is `dead`
+ *   (removable). `process.kill(pid, 0)` success, `EPERM`, and any unknown probe
+ *   error all mean KEEP — a live process is never signalled or killed.
+ * - Dry-run by default: nothing is deleted unless `--prune`/`--force`.
+ */
+
+import { buildGcReportText } from "./gc-render";
+
+export type GcStore = "harness_leases" | "team_workers" | "file_locks" | "tmux_sessions" | "registry_entries";
+
+export const GC_STORES: readonly GcStore[] = [
+	"harness_leases",
+	"team_workers",
+	"file_locks",
+	"tmux_sessions",
+	"registry_entries",
+] as const;
+
+/** Why a probed pid is kept instead of treated as dead. */
+export type GcPidKeepReason = "alive" | "eperm" | "unknown";
+
+export interface GcPidProbeResult {
+	/** `dead` only on ESRCH; `keep` for alive/eperm/unknown (fail-closed). */
+	status: "dead" | "keep";
+	reason?: GcPidKeepReason;
+	error?: string;
+}
+
+/** Single shared liveness contract threaded through every classifier + prune path. */
+export type GcPidProbe = (pid: number) => GcPidProbeResult;
+
+export type GcPidStatus = "dead" | "alive" | "eperm" | "unknown" | "none";
+
+export type GcAction = "none" | "would_remove" | "removed" | "remove_failed" | "skipped";
+
+export interface GcRecord {
+	store: GcStore;
+	/** Stable identifier: session id, lock dir path, worker id, tmux name, registry session id. */
+	id: string;
+	path?: string;
+	root?: string;
+	pid?: number;
+	pid_status?: GcPidStatus;
+	/** Store-specific classification label (e.g. "dead", "live", "unclassified", "terminal_lifecycle"). */
+	status: string;
+	stale: boolean;
+	removable: boolean;
+	action: GcAction;
+	reason: string;
+	detail?: string;
+	error?: string;
+	removed?: boolean;
+}
+
+export interface GcError {
+	store: GcStore;
+	scope: string;
+	message: string;
+}
+
+export interface GcCollectResult {
+	records: GcRecord[];
+	errors: GcError[];
+}
+
+export interface GcPruneOutcome {
+	removed: boolean;
+	error?: string;
+	/** Set when a removable record was skipped at prune time (e.g. TOCTOU became live). */
+	skipped?: string;
+}
+
+export interface GcContext {
+	probe: GcPidProbe;
+	force: boolean;
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+}
+
+/**
+ * A store-owned GC adapter. `collect` discovers + classifies (using the shared
+ * probe) without mutating anything. `prune` removes a single record, and MUST
+ * re-validate / re-probe immediately before any destructive action.
+ */
+export interface GcStoreAdapter {
+	store: GcStore;
+	collect(ctx: GcContext): Promise<GcCollectResult>;
+	prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome>;
+}
+
+export interface GcCounts {
+	discovered: number;
+	stale: number;
+	alive: number;
+	eperm: number;
+	unknown: number;
+	terminal_lifecycle: number;
+	unclassified: number;
+	would_remove: number;
+	removed: number;
+	failed: number;
+	errors: number;
+	by_store: Record<
+		GcStore,
+		{ discovered: number; stale: number; would_remove: number; removed: number; failed: number }
+	>;
+}
+
+export interface GcReport {
+	dry_run: boolean;
+	stores: Record<GcStore, GcRecord[]>;
+	counts: GcCounts;
+	errors: GcError[];
+}
+
+export interface GcRunResult {
+	stdout: string;
+	stderr: string;
+	status: number;
+}
+
+/**
+ * The shared, fail-closed PID probe. ESRCH => dead/removable; success => alive;
+ * EPERM => kept (owned by another user); any other error => kept as unknown.
+ */
+export const gcPidProbe: GcPidProbe = (pid: number): GcPidProbeResult => {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return { status: "keep", reason: "unknown", error: `invalid_pid:${pid}` };
+	}
+	try {
+		process.kill(pid, 0);
+		return { status: "keep", reason: "alive" };
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return { status: "dead" };
+		if (code === "EPERM") return { status: "keep", reason: "eperm" };
+		return { status: "keep", reason: "unknown", error: code ?? String(error) };
+	}
+};
+
+/** Map a `GcPidProbe` onto the harness lease probe shape (`"alive"|"dead"|"eperm"`). */
+export function gcProbeToLeasePidStatus(probe: GcPidProbe): (pid: number) => "alive" | "dead" | "eperm" {
+	return (pid: number) => {
+		const result = probe(pid);
+		if (result.status === "dead") return "dead";
+		// EPERM stays eperm; unknown maps to alive so classifyLeaseStatus keeps it.
+		return result.reason === "eperm" ? "eperm" : "alive";
+	};
+}
+
+/** Translate a probe result into a record-friendly pid status label. */
+export function gcPidStatusLabel(result: GcPidProbeResult): Exclude<GcPidStatus, "none"> {
+	if (result.status === "dead") return "dead";
+	return result.reason ?? "alive";
+}
+
+function emptyByStore(): GcCounts["by_store"] {
+	const by = {} as GcCounts["by_store"];
+	for (const store of GC_STORES) {
+		by[store] = { discovered: 0, stale: 0, would_remove: 0, removed: 0, failed: 0 };
+	}
+	return by;
+}
+
+function emptyStores(): Record<GcStore, GcRecord[]> {
+	const stores = {} as Record<GcStore, GcRecord[]>;
+	for (const store of GC_STORES) stores[store] = [];
+	return stores;
+}
+
+function computeCounts(stores: Record<GcStore, GcRecord[]>, errors: GcError[]): GcCounts {
+	const counts: GcCounts = {
+		discovered: 0,
+		stale: 0,
+		alive: 0,
+		eperm: 0,
+		unknown: 0,
+		terminal_lifecycle: 0,
+		unclassified: 0,
+		would_remove: 0,
+		removed: 0,
+		failed: 0,
+		errors: errors.length,
+		by_store: emptyByStore(),
+	};
+	for (const store of GC_STORES) {
+		for (const record of stores[store]) {
+			counts.discovered++;
+			counts.by_store[store].discovered++;
+			if (record.stale) {
+				counts.stale++;
+				counts.by_store[store].stale++;
+			}
+			if (record.pid_status === "alive") counts.alive++;
+			else if (record.pid_status === "eperm") counts.eperm++;
+			else if (record.pid_status === "unknown") counts.unknown++;
+			if (record.status === "terminal_lifecycle") counts.terminal_lifecycle++;
+			if (record.status === "unclassified") counts.unclassified++;
+			if (record.action === "would_remove") {
+				counts.would_remove++;
+				counts.by_store[store].would_remove++;
+			}
+			if (record.action === "removed") {
+				counts.removed++;
+				counts.by_store[store].removed++;
+			}
+			if (record.action === "remove_failed") {
+				counts.failed++;
+				counts.by_store[store].failed++;
+			}
+		}
+	}
+	return counts;
+}
+
+interface ParsedGcArgs {
+	json: boolean;
+	prune: boolean;
+	help: boolean;
+}
+
+class GcUsageError extends Error {}
+
+function parseGcArgs(argv: string[]): ParsedGcArgs {
+	let json = false;
+	let prune = false;
+	let dryRun = false;
+	let help = false;
+	for (const arg of argv) {
+		switch (arg) {
+			case "--json":
+			case "-j":
+				json = true;
+				break;
+			case "--prune":
+			case "--force":
+				prune = true;
+				break;
+			case "--dry-run":
+				dryRun = true;
+				break;
+			case "--help":
+			case "-h":
+				help = true;
+				break;
+			default:
+				throw new GcUsageError(`unknown_flag:${arg}`);
+		}
+	}
+	// Explicit --dry-run always wins over --prune/--force.
+	if (dryRun) prune = false;
+	return { json, prune, help };
+}
+
+/**
+ * Collect every store's records (catching hard discovery errors per adapter),
+ * then optionally prune removable records with per-record revalidation.
+ */
+export async function collectGcReport(adapters: GcStoreAdapter[], ctx: GcContext, prune: boolean): Promise<GcReport> {
+	const stores = emptyStores();
+	const errors: GcError[] = [];
+
+	for (const adapter of adapters) {
+		try {
+			const result = await adapter.collect(ctx);
+			stores[adapter.store].push(...result.records);
+			errors.push(...result.errors);
+		} catch (error) {
+			errors.push({
+				store: adapter.store,
+				scope: "collect",
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	// Mark dry-run intent on every removable record before pruning.
+	for (const store of GC_STORES) {
+		for (const record of stores[store]) {
+			if (record.removable) record.action = "would_remove";
+		}
+	}
+
+	if (prune) {
+		const adapterByStore = new Map(adapters.map(a => [a.store, a] as const));
+		for (const store of GC_STORES) {
+			const adapter = adapterByStore.get(store);
+			if (!adapter) continue;
+			for (const record of stores[store]) {
+				if (!record.removable) continue;
+				try {
+					const outcome = await adapter.prune(record, ctx);
+					if (outcome.removed) {
+						record.action = "removed";
+						record.removed = true;
+					} else if (outcome.skipped) {
+						record.action = "skipped";
+						record.reason = outcome.skipped;
+						record.removed = false;
+					} else {
+						record.action = "remove_failed";
+						record.removed = false;
+						record.error = outcome.error ?? "remove_failed";
+					}
+				} catch (error) {
+					record.action = "remove_failed";
+					record.removed = false;
+					record.error = error instanceof Error ? error.message : String(error);
+				}
+			}
+		}
+	}
+
+	return { dry_run: !prune, stores, counts: computeCounts(stores, errors), errors };
+}
+
+/**
+ * Exit-code policy:
+ * - usage/parse error => 2
+ * - hard discovery errors => 1 (both modes)
+ * - prune mode with a failed intended removal => 1
+ * - otherwise => 0
+ */
+export function computeExitCode(report: GcReport): number {
+	if (report.errors.length > 0) return 1;
+	if (!report.dry_run && report.counts.failed > 0) return 1;
+	return 0;
+}
+
+export async function runGjcGcCommand(
+	argv: string[],
+	cwd: string = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+	adapters?: GcStoreAdapter[],
+): Promise<GcRunResult> {
+	let parsed: ParsedGcArgs;
+	try {
+		parsed = parseGcArgs(argv);
+	} catch (error) {
+		const message = error instanceof GcUsageError ? error.message : String(error);
+		return { stdout: "", stderr: `gjc gc: ${message}\n`, status: 2 };
+	}
+
+	if (parsed.help) {
+		return { stdout: gcHelpText(), stderr: "", status: 0 };
+	}
+
+	const resolvedAdapters = adapters ?? (await defaultGcAdapters());
+	const ctx: GcContext = { probe: gcPidProbe, force: parsed.prune, env, cwd };
+	const report = await collectGcReport(resolvedAdapters, ctx, parsed.prune);
+	const status = computeExitCode(report);
+	const stdout = parsed.json ? `${JSON.stringify(report, null, 2)}\n` : buildGcReportText(report);
+	return { stdout, stderr: "", status };
+}
+
+export function gcHelpText(): string {
+	return [
+		"gjc gc - garbage-collect stale GJC session/PID records",
+		"",
+		"USAGE",
+		"  $ gjc gc [--prune|--force] [--json]",
+		"",
+		"FLAGS",
+		"  --prune, --force  Actually remove stale records (default: dry-run report only)",
+		"  --dry-run         Force report-only mode (overrides --prune/--force)",
+		"  -j, --json        Emit machine-readable JSON",
+		"",
+		"Liveness-only: a record is removed only when its owning process is dead",
+		"(ESRCH). Live / permission-denied / unknown processes are always kept.",
+		"",
+	].join("\n");
+}
+
+/** Lazily assemble the real store adapters (kept lazy to avoid import cycles). */
+export async function defaultGcAdapters(): Promise<GcStoreAdapter[]> {
+	const [
+		{ harnessLeasesGcAdapter, registryEntriesGcAdapter },
+		{ fileLocksGcAdapter },
+		{ teamWorkersGcAdapter },
+		{ tmuxSessionsGcAdapter },
+	] = await Promise.all([
+		import("../harness-control-plane/gc-adapter"),
+		import("../config/file-lock-gc"),
+		import("./team-gc"),
+		import("./tmux-gc"),
+	]);
+	return [
+		harnessLeasesGcAdapter,
+		teamWorkersGcAdapter,
+		fileLocksGcAdapter,
+		tmuxSessionsGcAdapter,
+		registryEntriesGcAdapter,
+	];
+}

--- a/packages/coding-agent/src/gjc-runtime/team-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-gc.ts
@@ -1,0 +1,49 @@
+/**
+ * GC adapter for team workers (`.gjc/state/team/<name>/workers/<id>/` heartbeat
+ * + lifecycle). Liveness-only: numeric PID status dominates lifecycle/heartbeat
+ * signals.
+ */
+
+import * as path from "node:path";
+import { listHarnessRootRegistriesForGc } from "../harness-control-plane/storage";
+import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapter } from "./gc-runtime";
+import { listTeamWorkerGcRecords, pruneTeamWorkerGcRecord } from "./team-runtime";
+
+function uniqueTeamRootsFromHarnessRoots(roots: string[]): string[] {
+	return [...new Set(roots.map(root => path.join(path.dirname(root), "team")))].sort();
+}
+
+export const teamWorkersGcAdapter: GcStoreAdapter = {
+	store: "team_workers",
+	async collect(ctx: GcContext): Promise<GcCollectResult> {
+		const records: GcRecord[] = [];
+		const errors: GcCollectResult["errors"] = [];
+		const registries = await listHarnessRootRegistriesForGc(ctx.env);
+		for (const registry of registries) {
+			if (registry.error) errors.push({ store: "team_workers", scope: registry.file, message: registry.error });
+		}
+
+		const teamRoots = uniqueTeamRootsFromHarnessRoots(
+			registries.flatMap(registry => registry.roots.map(entry => entry.root)),
+		);
+		for (const teamRoot of teamRoots) {
+			try {
+				records.push(...(await listTeamWorkerGcRecords(teamRoot, ctx.probe)));
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (code === "ENOENT") continue;
+				errors.push({ store: "team_workers", scope: teamRoot, message: (error as Error).message });
+			}
+		}
+
+		return { records, errors };
+	},
+	async prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome> {
+		try {
+			const removed = await pruneTeamWorkerGcRecord(record, ctx.probe);
+			return removed ? { removed: true } : { removed: false, skipped: "worker_no_longer_dead" };
+		} catch (error) {
+			return { removed: false, error: (error as Error).message };
+		}
+	},
+};

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
+import type { GcPidProbe, GcRecord } from "./gc-runtime";
 
 import { applyGjcTmuxProfile, GJC_TMUX_LAUNCHED_ENV } from "./launch-tmux";
 import {
@@ -677,6 +678,174 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 		if (isEnoent(error)) return null;
 		throw error;
 	}
+}
+function isPositivePid(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function collectTeamGcWorkerPids(
+	heartbeat: WorkerHeartbeatFile | null,
+	lifecycle: GjcTeamWorkerLifecycle | null,
+): number[] {
+	const pids: number[] = [];
+	if (isPositivePid(heartbeat?.pid)) pids.push(heartbeat.pid);
+	if (isPositivePid(lifecycle?.pid) && !pids.includes(lifecycle.pid)) pids.push(lifecycle.pid);
+	return pids;
+}
+
+interface TeamGcPidClassification {
+	removable: boolean;
+	pidStatus: "dead" | "alive" | "eperm" | "unknown" | "none";
+	pid?: number;
+}
+
+/**
+ * Liveness-only, fail-closed: a worker is removable ONLY when it has at least
+ * one authoritative pid and EVERY candidate pid probes dead (ESRCH). Any alive,
+ * EPERM, or unknown candidate (heartbeat OR lifecycle) keeps the worker, so a
+ * dead heartbeat pid can never override a live lifecycle pid.
+ */
+function classifyTeamGcWorkerPids(pids: number[], probe: GcPidProbe): TeamGcPidClassification {
+	if (pids.length === 0) return { removable: false, pidStatus: "none" };
+	const statuses = pids.map(pid => ({ pid, status: gcProbeStatus(probe, pid) }));
+	const kept = statuses.find(entry => entry.status !== "dead");
+	if (kept) return { removable: false, pidStatus: kept.status, pid: kept.pid };
+	return { removable: true, pidStatus: "dead", pid: statuses[0]?.pid };
+}
+
+function gcProbeStatus(probe: GcPidProbe, pid: number): "dead" | "alive" | "eperm" | "unknown" {
+	const result = probe(pid);
+	if (result.status === "dead") return "dead";
+	return result.reason ?? "unknown";
+}
+
+function teamGcRecordDetail(heartbeat: WorkerHeartbeatFile | null, lifecycle: GjcTeamWorkerLifecycle | null): string {
+	return [
+		`heartbeat=${heartbeat ? "present" : "missing"}`,
+		...(heartbeat ? [`heartbeat_alive=${heartbeat.alive}`, `last_turn_at=${heartbeat.last_turn_at}`] : []),
+		`lifecycle=${lifecycle?.lifecycle_state ?? "missing"}`,
+		...(lifecycle?.pane_id ? [`pane_id=${lifecycle.pane_id}`] : []),
+		...(lifecycle?.stop_reason ? [`stop_reason=${lifecycle.stop_reason}`] : []),
+	].join(" ");
+}
+
+/** @internal */
+export async function listTeamWorkerGcRecords(teamRoot: string, probe: GcPidProbe): Promise<GcRecord[]> {
+	const teamEntries = await fs.readdir(teamRoot, { withFileTypes: true });
+	const records: GcRecord[] = [];
+	for (const teamEntry of teamEntries) {
+		if (!teamEntry.isDirectory()) continue;
+		const teamName = teamEntry.name;
+		const teamDirPath = path.join(teamRoot, teamName);
+		let workerEntries: import("node:fs").Dirent[];
+		try {
+			workerEntries = await fs.readdir(path.join(teamDirPath, "workers"), { withFileTypes: true });
+		} catch (error) {
+			if (isEnoent(error)) continue;
+			throw error;
+		}
+
+		for (const workerEntry of workerEntries) {
+			if (!workerEntry.isDirectory()) continue;
+			const workerId = workerEntry.name;
+			const dir = path.join(teamDirPath, "workers", workerId);
+			let heartbeat: WorkerHeartbeatFile | null = null;
+			let lifecycle: GjcTeamWorkerLifecycle | null = null;
+			try {
+				heartbeat = await readJsonFile<WorkerHeartbeatFile>(path.join(dir, "heartbeat.json"));
+				lifecycle = await readJsonFile<GjcTeamWorkerLifecycle>(path.join(dir, "lifecycle.json"));
+			} catch (error) {
+				records.push({
+					store: "team_workers",
+					id: `${teamName}/${workerId}`,
+					root: teamRoot,
+					path: dir,
+					pid_status: "none",
+					status: "malformed",
+					stale: false,
+					removable: false,
+					action: "none",
+					reason: "worker_state_malformed_kept",
+					error: error instanceof Error ? error.message : String(error),
+				});
+				continue;
+			}
+			const pids = collectTeamGcWorkerPids(heartbeat, lifecycle);
+			const { removable, pidStatus, pid } = classifyTeamGcWorkerPids(pids, probe);
+			const terminalLifecycle = lifecycle?.lifecycle_state === "failed" || lifecycle?.lifecycle_state === "stopped";
+			const status = removable
+				? "dead"
+				: pidStatus === "none" && terminalLifecycle
+					? "terminal_lifecycle"
+					: pidStatus === "none"
+						? "no_pid"
+						: pidStatus;
+			records.push({
+				store: "team_workers",
+				id: `${teamName}/${workerId}`,
+				root: teamRoot,
+				path: dir,
+				pid,
+				pid_status: pidStatus,
+				status,
+				stale: removable,
+				removable,
+				action: "none",
+				reason: removable
+					? "worker_all_pids_dead"
+					: pidStatus === "none" && terminalLifecycle
+						? "terminal_lifecycle_without_pid_kept"
+						: pidStatus === "none"
+							? "worker_pid_missing_kept"
+							: `worker_pid_${pidStatus}_kept`,
+				detail: teamGcRecordDetail(heartbeat, lifecycle),
+			});
+		}
+	}
+	return records;
+}
+
+/** @internal */
+export async function pruneTeamWorkerGcRecord(record: GcRecord, probe: GcPidProbe): Promise<boolean> {
+	if (!record.path || !record.id.includes("/")) return false;
+	const [teamName, workerId] = record.id.split("/", 2);
+	if (!teamName || !workerId) return false;
+	const teamDirPath = path.dirname(path.dirname(record.path));
+	const heartbeat = await readJsonFile<WorkerHeartbeatFile>(path.join(record.path, "heartbeat.json"));
+	const lifecycle = await readJsonFile<GjcTeamWorkerLifecycle>(path.join(record.path, "lifecycle.json"));
+	const pids = collectTeamGcWorkerPids(heartbeat, lifecycle);
+	if (!classifyTeamGcWorkerPids(pids, probe).removable) return false;
+
+	const claimDir = path.join(teamDirPath, "claims");
+	try {
+		for (const entry of await fs.readdir(claimDir, { withFileTypes: true })) {
+			if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+			const claimPath = path.join(claimDir, entry.name);
+			const claim = readClaimRecord(await readJsonFile<unknown>(claimPath));
+			if (claim?.owner !== workerId) continue;
+			await removeFileAudited(claimPath, stateWriterOptions(claimPath, "prune", "gc-team-worker"));
+		}
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+
+	for (const task of await readTasks(teamDirPath)) {
+		if (task.claim?.owner !== workerId && task.assignee !== workerId) continue;
+		if (task.status === "completed" || task.status === "failed") continue;
+		await writeTask(teamDirPath, {
+			...task,
+			status: "pending",
+			assignee: undefined,
+			claim: undefined,
+			version: task.version + 1,
+			updated_at: now(),
+		});
+	}
+
+	// Remove the stale worker record dir itself so a removable record always
+	// results in an observable removal, even when it owns no claims/tasks.
+	await fs.rm(record.path, { recursive: true, force: true });
+	return true;
 }
 function stateCategoryForJsonPath(filePath: string): "state" | "ledger" {
 	return filePath.endsWith(".jsonl") || filePath.includes(`${path.sep}telemetry${path.sep}`) ? "ledger" : "state";

--- a/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
@@ -1,0 +1,176 @@
+/**
+ * GC adapter for gjc-tagged tmux sessions. Stale iff `@gjc-project` path is gone
+ * OR `@gjc-branch` has no live git worktree. Removal is a spec-authorized
+ * destructive `kill-session`, gated by exact-target re-read + revalidation.
+ */
+
+import * as fs from "node:fs";
+
+import { worktree } from "../utils/git";
+import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapter } from "./gc-runtime";
+import { GJC_TMUX_PROFILE_VALUE } from "./tmux-common";
+import {
+	type GjcTmuxSessionStatus,
+	listTmuxSessionsForGc,
+	readTmuxSessionTagsForGc,
+	removeGjcTmuxSession,
+} from "./tmux-sessions";
+
+const STORE = "tmux_sessions" as const;
+const TOCTOU_SKIP = "tmux_revalidation_failed_or_became_live";
+
+function pathExists(path: string): boolean {
+	try {
+		return fs.existsSync(path);
+	} catch {
+		return false;
+	}
+}
+
+function detail(project?: string, branch?: string): string | undefined {
+	const parts = [];
+	if (project) parts.push(`project=${project}`);
+	if (branch) parts.push(`branch=${branch}`);
+	return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function unclassifiedRecord(id: string, reason: string, project?: string, branch?: string): GcRecord {
+	return {
+		store: STORE,
+		id,
+		path: project,
+		root: project,
+		pid_status: "none",
+		status: "unclassified",
+		stale: false,
+		removable: false,
+		action: "none",
+		reason,
+		detail: detail(project, branch),
+	};
+}
+
+function branchMatches(candidate: string | undefined, branch: string): boolean {
+	if (!candidate) return false;
+	const branchNames = new Set([
+		branch,
+		branch.startsWith("refs/heads/") ? branch.slice("refs/heads/".length) : `refs/heads/${branch}`,
+	]);
+	return branchNames.has(candidate);
+}
+
+async function hasLiveWorktreeForBranch(project: string, branch: string): Promise<boolean> {
+	const entries = await worktree.list(project);
+	return entries.some(entry => branchMatches(entry.branch, branch));
+}
+
+async function classifyTaggedSession(session: GjcTmuxSessionStatus): Promise<GcRecord> {
+	const { name, project, branch } = session;
+	if (!project || !branch) return unclassifiedRecord(name, "missing_project_or_branch_tag", project, branch);
+	if (!pathExists(project)) {
+		return {
+			store: STORE,
+			id: name,
+			path: project,
+			root: project,
+			pid_status: "none",
+			status: "stale",
+			stale: true,
+			removable: true,
+			action: "none",
+			reason: "project_missing",
+			detail: detail(project, branch),
+		};
+	}
+	if (!(await hasLiveWorktreeForBranch(project, branch))) {
+		return {
+			store: STORE,
+			id: name,
+			path: project,
+			root: project,
+			pid_status: "none",
+			status: "stale",
+			stale: true,
+			removable: true,
+			action: "none",
+			reason: "branch_no_worktree",
+			detail: detail(project, branch),
+		};
+	}
+	return {
+		store: STORE,
+		id: name,
+		path: project,
+		root: project,
+		pid_status: "none",
+		status: "live",
+		stale: false,
+		removable: false,
+		action: "none",
+		reason: "project_and_branch_worktree_present",
+		detail: detail(project, branch),
+	};
+}
+
+async function revalidateRemovable(name: string, env: NodeJS.ProcessEnv): Promise<boolean> {
+	const tags = readTmuxSessionTagsForGc(name, env);
+	if (tags.profile !== GJC_TMUX_PROFILE_VALUE || !tags.project || !tags.branch) return false;
+	if (!pathExists(tags.project)) return true;
+	return !(await hasLiveWorktreeForBranch(tags.project, tags.branch));
+}
+
+export const tmuxSessionsGcAdapter: GcStoreAdapter = {
+	store: STORE,
+	async collect(ctx: GcContext): Promise<GcCollectResult> {
+		const records: GcRecord[] = [];
+		const errors: GcCollectResult["errors"] = [];
+		let sessions: ReturnType<typeof listTmuxSessionsForGc>;
+		try {
+			sessions = listTmuxSessionsForGc(ctx.env);
+		} catch (error) {
+			return {
+				records,
+				errors: [
+					{
+						store: STORE,
+						scope: "list_sessions",
+						message: error instanceof Error ? error.message : String(error),
+					},
+				],
+			};
+		}
+
+		for (const session of sessions.tagged) {
+			try {
+				records.push(await classifyTaggedSession(session));
+			} catch (error) {
+				errors.push({
+					store: STORE,
+					scope: session.name,
+					message: error instanceof Error ? error.message : String(error),
+				});
+				records.push(unclassifiedRecord(session.name, "worktree_list_failed", session.project, session.branch));
+			}
+		}
+
+		for (const name of sessions.untagged) {
+			records.push(unclassifiedRecord(name, "untagged_tmux_session"));
+		}
+
+		return { records, errors };
+	},
+	async prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome> {
+		if (record.store !== STORE || record.status !== "stale" || !record.removable) {
+			return { removed: false, skipped: "not_removable_tmux_session" };
+		}
+		try {
+			if (!(await revalidateRemovable(record.id, ctx.env))) {
+				return { removed: false, skipped: TOCTOU_SKIP };
+			}
+			removeGjcTmuxSession(record.id, ctx.env);
+			return { removed: true };
+		} catch (error) {
+			return { removed: false, error: error instanceof Error ? error.message : String(error) };
+		}
+	},
+};

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -24,6 +24,17 @@ export interface GjcTmuxSessionStatus {
 	project?: string;
 }
 
+export interface GjcTmuxSessionTagsForGc {
+	profile?: string;
+	project?: string;
+	branch?: string;
+}
+
+export interface GjcTmuxSessionsForGc {
+	tagged: GjcTmuxSessionStatus[];
+	untagged: string[];
+}
+
 function runTmux(args: string[], env: NodeJS.ProcessEnv = process.env): string {
 	const tmuxCommand = resolveGjcTmuxCommand(env);
 	const result = Bun.spawnSync([tmuxCommand, ...args], { stdout: "pipe", stderr: "pipe", env });
@@ -108,6 +119,16 @@ export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTm
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** @internal */
+export function listTmuxSessionsForGc(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionsForGc {
+	const tagged = listGjcTmuxSessions(env);
+	const taggedNames = new Set(tagged.map(session => session.name));
+	const untagged = listRawTmuxSessionNames(env)
+		.filter(name => !taggedNames.has(name))
+		.sort((a, b) => a.localeCompare(b));
+	return { tagged, untagged };
+}
+
 export function findGjcTmuxSessionByBranch(
 	branch: string,
 	env: NodeJS.ProcessEnv = process.env,
@@ -153,6 +174,29 @@ function readProfileForExactTarget(sessionName: string, env: NodeJS.ProcessEnv):
 		["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), GJC_TMUX_PROFILE_OPTION],
 		env,
 	).trim();
+}
+
+function readExactOptionForGc(sessionName: string, option: string, env: NodeJS.ProcessEnv): string | undefined {
+	try {
+		return (
+			runTmux(["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), option], env).trim() ||
+			undefined
+		);
+	} catch {
+		return undefined;
+	}
+}
+
+/** @internal */
+export function readTmuxSessionTagsForGc(
+	sessionName: string,
+	env: NodeJS.ProcessEnv = process.env,
+): GjcTmuxSessionTagsForGc {
+	return {
+		profile: readExactOptionForGc(sessionName, GJC_TMUX_PROFILE_OPTION, env),
+		project: readExactOptionForGc(sessionName, GJC_TMUX_PROJECT_OPTION, env),
+		branch: readExactOptionForGc(sessionName, GJC_TMUX_BRANCH_OPTION, env),
+	};
 }
 
 export function removeGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {

--- a/packages/coding-agent/src/harness-control-plane/gc-adapter.ts
+++ b/packages/coding-agent/src/harness-control-plane/gc-adapter.ts
@@ -1,0 +1,184 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	type GcCollectResult,
+	type GcContext,
+	type GcError,
+	type GcPruneOutcome,
+	type GcRecord,
+	type GcStoreAdapter,
+	gcPidStatusLabel,
+	gcProbeToLeasePidStatus,
+} from "../gjc-runtime/gc-runtime";
+import { classifyLeaseStatus, readLease, reapDeadOwnerArtifacts } from "./session-lease";
+import {
+	type HarnessRootRegistryForGc,
+	type HarnessRootRegistryListingForGc,
+	listHarnessRootRegistriesForGc,
+	removeHarnessRootRegistryFileForGc,
+	rewriteHarnessRootRegistryForGc,
+	sessionPaths,
+} from "./storage";
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+async function exists(file: string): Promise<boolean> {
+	try {
+		await fs.access(file);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function registryErrors(registries: HarnessRootRegistryListingForGc[]): GcError[] {
+	return registries
+		.filter(registry => registry.error)
+		.map(registry => ({
+			store: "registry_entries",
+			scope: registry.file,
+			message: registry.error ?? "registry_error",
+		}));
+}
+
+async function collectRegistries(ctx: GcContext): Promise<HarnessRootRegistryListingForGc[]> {
+	return listHarnessRootRegistriesForGc(ctx.env);
+}
+
+export const harnessLeasesGcAdapter: GcStoreAdapter = {
+	store: "harness_leases",
+	async collect(ctx: GcContext): Promise<GcCollectResult> {
+		const records: GcRecord[] = [];
+		const errors: GcError[] = [];
+		const registries = await collectRegistries(ctx);
+		errors.push(...registryErrors(registries).map(error => ({ ...error, store: "harness_leases" as const })));
+
+		const roots = new Set<string>();
+		for (const registry of registries) {
+			if (registry.error) continue;
+			for (const entry of registry.roots) roots.add(path.resolve(entry.root));
+		}
+
+		for (const root of roots) {
+			const sessionsDir = path.join(root, "sessions");
+			let sessionEntries: string[];
+			try {
+				sessionEntries = await fs.readdir(sessionsDir);
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (code === "ENOENT") continue;
+				errors.push({ store: "harness_leases", scope: sessionsDir, message: errorMessage(error) });
+				continue;
+			}
+
+			for (const sessionId of sessionEntries) {
+				const sessionDir = sessionPaths(root, sessionId).dir;
+				try {
+					const stat = await fs.stat(sessionDir);
+					if (!stat.isDirectory()) continue;
+					const lease = await readLease(root, sessionId);
+					if (!lease) continue;
+					const status = classifyLeaseStatus(lease, { probe: gcProbeToLeasePidStatus(ctx.probe) });
+					const pidProbe = ctx.probe(lease.pid);
+					const pidStatus = gcPidStatusLabel(pidProbe);
+					const removable = status === "dead" && pidProbe.status === "dead";
+					records.push({
+						store: "harness_leases",
+						id: sessionId,
+						root,
+						path: sessionPaths(root, sessionId).lease,
+						pid: lease.pid,
+						pid_status: pidStatus,
+						status,
+						stale: status === "dead",
+						removable,
+						action: "none",
+						reason: removable
+							? `lease owner pid ${lease.pid} is dead`
+							: `lease owner pid ${lease.pid} is ${pidStatus}; keeping`,
+					});
+				} catch (error) {
+					errors.push({ store: "harness_leases", scope: sessionDir, message: errorMessage(error) });
+				}
+			}
+		}
+
+		return { records, errors };
+	},
+	async prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome> {
+		if (!record.root) return { removed: false, skipped: "missing_root" };
+		const lease = await readLease(record.root, record.id);
+		if (!lease) return { removed: false, skipped: "lease_not_dead_or_missing" };
+		const status = classifyLeaseStatus(lease, { probe: gcProbeToLeasePidStatus(ctx.probe) });
+		if (status !== "dead") return { removed: false, skipped: "lease_not_dead_or_missing" };
+		const removed = await reapDeadOwnerArtifacts(record.root, record.id, lease.ownerId, lease.leaseEpoch, {
+			probe: gcProbeToLeasePidStatus(ctx.probe),
+		});
+		return removed ? { removed: true } : { removed: false, skipped: "reaper_guard_rejected" };
+	},
+};
+
+async function splitRegistryRoots(registry: HarnessRootRegistryForGc): Promise<{
+	liveRoots: HarnessRootRegistryForGc["roots"];
+	danglingRoots: HarnessRootRegistryForGc["roots"];
+}> {
+	const liveRoots: HarnessRootRegistryForGc["roots"] = [];
+	const danglingRoots: HarnessRootRegistryForGc["roots"] = [];
+	for (const entry of registry.roots) {
+		const sessionDir = sessionPaths(entry.root, registry.sessionId).dir;
+		if (await exists(sessionDir)) liveRoots.push(entry);
+		else danglingRoots.push(entry);
+	}
+	return { liveRoots, danglingRoots };
+}
+
+export const registryEntriesGcAdapter: GcStoreAdapter = {
+	store: "registry_entries",
+	async collect(ctx: GcContext): Promise<GcCollectResult> {
+		const records: GcRecord[] = [];
+		const errors: GcError[] = [];
+		const registries = await collectRegistries(ctx);
+		errors.push(...registryErrors(registries));
+
+		for (const registry of registries) {
+			if (registry.error) continue;
+			try {
+				const { liveRoots, danglingRoots } = await splitRegistryRoots(registry);
+				if (danglingRoots.length === 0) continue;
+				records.push({
+					store: "registry_entries",
+					id: registry.sessionId,
+					path: registry.file,
+					pid_status: "none",
+					status: "dangling",
+					stale: true,
+					removable: true,
+					action: "none",
+					reason: `dangling roots: ${danglingRoots.map(entry => entry.root).join(", ")}`,
+					detail: `${danglingRoots.length} dangling, ${liveRoots.length} live`,
+				});
+			} catch (error) {
+				errors.push({ store: "registry_entries", scope: registry.file, message: errorMessage(error) });
+			}
+		}
+
+		return { records, errors };
+	},
+	async prune(record: GcRecord, ctx: GcContext): Promise<GcPruneOutcome> {
+		if (!record.path) return { removed: false, skipped: "missing_registry_path" };
+		const registries = await collectRegistries(ctx);
+		const registry = registries.find(entry => entry.file === record.path);
+		if (!registry || registry.error) return { removed: false, skipped: "registry_not_readable" };
+		const { liveRoots, danglingRoots } = await splitRegistryRoots(registry);
+		if (danglingRoots.length === 0) return { removed: false, skipped: "no_dangling_roots" };
+		if (liveRoots.length === 0) {
+			await removeHarnessRootRegistryFileForGc(record.path);
+		} else {
+			await rewriteHarnessRootRegistryForGc(record.path, { sessionId: registry.sessionId, roots: liveRoots });
+		}
+		return { removed: true };
+	},
+};

--- a/packages/coding-agent/src/harness-control-plane/storage.ts
+++ b/packages/coding-agent/src/harness-control-plane/storage.ts
@@ -32,6 +32,18 @@ interface HarnessRootRegistry {
 	roots: HarnessRootRegistryEntry[];
 }
 
+export interface HarnessRootRegistryForGc {
+	sessionId: string;
+	roots: HarnessRootRegistryEntry[];
+}
+
+export interface HarnessRootRegistryListingForGc {
+	sessionId: string;
+	file: string;
+	roots: HarnessRootRegistryEntry[];
+	error?: string;
+}
+
 interface ResolveHarnessSessionRootOptions {
 	expectedWorkspace?: string;
 }
@@ -100,6 +112,64 @@ async function writeHarnessRootRegistry(
 	await ensurePrivateDir(dir);
 	const file = harnessRootRegistryPath(registry.sessionId, env);
 	await writeJsonAtomicPrivate(file, registry);
+}
+
+function parseHarnessRootRegistryForGc(value: unknown, fallbackSessionId: string): HarnessRootRegistryForGc | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const registry = value as Record<string, unknown>;
+	if (typeof registry.sessionId !== "string" || !Array.isArray(registry.roots)) return null;
+	const roots: HarnessRootRegistryEntry[] = [];
+	for (const entry of registry.roots) {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+		const rootEntry = entry as Record<string, unknown>;
+		if (typeof rootEntry.root !== "string" || typeof rootEntry.updatedAt !== "string") return null;
+		roots.push({ root: rootEntry.root, updatedAt: rootEntry.updatedAt });
+	}
+	return { sessionId: registry.sessionId || fallbackSessionId, roots };
+}
+
+/** @internal */
+export async function listHarnessRootRegistriesForGc(
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<HarnessRootRegistryListingForGc[]> {
+	const dir = harnessRootRegistryDir(env);
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dir);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return [];
+		return [{ sessionId: "", file: dir, roots: [], error: (error as Error).message }];
+	}
+
+	const registries: HarnessRootRegistryListingForGc[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".json")) continue;
+		const file = path.join(dir, entry);
+		const fallbackSessionId = entry.slice(0, -".json".length);
+		try {
+			const raw = await fs.readFile(file, "utf8");
+			const parsed = parseHarnessRootRegistryForGc(JSON.parse(raw), fallbackSessionId);
+			if (!parsed) {
+				registries.push({ sessionId: fallbackSessionId, file, roots: [], error: "malformed_registry" });
+				continue;
+			}
+			registries.push({ sessionId: parsed.sessionId, file, roots: parsed.roots });
+		} catch (error) {
+			registries.push({ sessionId: fallbackSessionId, file, roots: [], error: (error as Error).message });
+		}
+	}
+	return registries;
+}
+
+/** @internal */
+export async function rewriteHarnessRootRegistryForGc(file: string, registry: HarnessRootRegistryForGc): Promise<void> {
+	await writeJsonAtomicPrivate(file, registry);
+}
+
+/** @internal */
+export async function removeHarnessRootRegistryFileForGc(file: string): Promise<void> {
+	await fs.rm(file, { force: true });
 }
 const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const MAX_UNIX_SOCKET_PATH_BYTES = 100;

--- a/packages/coding-agent/test/gc-e2e.test.ts
+++ b/packages/coding-agent/test/gc-e2e.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runGjcGcCommand } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTemp(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gc-e2e-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Spawn and reap a process so its pid is guaranteed dead (ESRCH on probe). */
+async function reapedPid(): Promise<number> {
+	const proc = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
+	await proc.exited;
+	return proc.pid;
+}
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function seedDeadLease(base: string, registryDir: string, deadPid: number): Promise<string> {
+	const root = path.join(base, "root");
+	await writeJson(path.join(registryDir, "h-e2e.json"), {
+		sessionId: "h-e2e",
+		roots: [{ root, updatedAt: new Date().toISOString() }],
+	});
+	const leaseFile = path.join(root, "sessions", "h-e2e", "lease.json");
+	const now = new Date();
+	await writeJson(leaseFile, {
+		ownerId: "owner-e2e",
+		sessionId: "h-e2e",
+		pid: deadPid,
+		leaseTokenHash: "deadbeef",
+		endpoint: null,
+		eventsPath: "events.jsonl",
+		heartbeatAt: now.toISOString(),
+		expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+		leaseEpoch: 1,
+		writer: { ownerId: "owner-e2e", leaseEpoch: 1 },
+	});
+	return leaseFile;
+}
+
+describe("gjc gc end-to-end (default adapters)", () => {
+	test("dry-run reports a dead lease as would_remove and deletes nothing", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		const deadPid = await reapedPid();
+		const leaseFile = await seedDeadLease(base, registryDir, deadPid);
+		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
+
+		const result = await runGjcGcCommand(["--json"], base, env);
+		const report = JSON.parse(result.stdout);
+		expect(report.dry_run).toBe(true);
+		const rec = report.stores.harness_leases.find((r: { id: string }) => r.id === "h-e2e");
+		expect(rec?.action).toBe("would_remove");
+		expect(rec?.removable).toBe(true);
+		// nothing removed in dry-run
+		expect(await fs.exists(leaseFile)).toBe(true);
+		expect(result.status).toBe(0);
+	});
+
+	test("--prune removes the dead lease and exits 0", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		const deadPid = await reapedPid();
+		const leaseFile = await seedDeadLease(base, registryDir, deadPid);
+		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir };
+
+		const result = await runGjcGcCommand(["--prune", "--json"], base, env);
+		const report = JSON.parse(result.stdout);
+		expect(report.dry_run).toBe(false);
+		const rec = report.stores.harness_leases.find((r: { id: string }) => r.id === "h-e2e");
+		expect(rec?.action).toBe("removed");
+		expect(await fs.exists(leaseFile)).toBe(false);
+		expect(result.status).toBe(0);
+	});
+
+	test("text dry-run output names the harness store and dry-run mode", async () => {
+		const base = await makeTemp();
+		const env = { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: path.join(base, "reg-empty") };
+		const result = await runGjcGcCommand([], base, env);
+		expect(result.stdout).toContain("dry run");
+		expect(result.stdout).toContain("Harness owner leases");
+		expect(result.status).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/gc-redteam.test.ts
+++ b/packages/coding-agent/test/gc-redteam.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileLocksGcAdapter } from "@gajae-code/coding-agent/config/file-lock-gc";
+import {
+	collectGcReport,
+	computeExitCode,
+	type GcContext,
+	type GcPidProbe,
+	type GcRecord,
+	type GcStoreAdapter,
+	gcPidProbe,
+	runGjcGcCommand,
+} from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { teamWorkersGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/team-gc";
+import { harnessLeasesGcAdapter } from "@gajae-code/coding-agent/harness-control-plane/gc-adapter";
+
+const tempDirs: string[] = [];
+const originalKill = process.kill.bind(process);
+
+const EPERM_PID = 91_001;
+const UNKNOWN_PID = 91_002;
+const ALIVE_PID = 91_003;
+const DEAD_PID = 91_004;
+
+afterEach(async () => {
+	process.kill = originalKill;
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTemp(prefix = "gc-redteam-"): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function ctxFor(base: string, registryDir: string, probe: GcPidProbe): GcContext {
+	return {
+		probe,
+		force: false,
+		env: {
+			...process.env,
+			GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir,
+			GJC_RECEIPT_SPOOL_DIR: path.join(base, "spool"),
+		},
+		cwd: base,
+	};
+}
+
+function adversarialProbe(pid: number) {
+	if (pid === DEAD_PID) return { status: "dead" } as const;
+	if (pid === EPERM_PID) return { status: "keep", reason: "eperm" } as const;
+	if (pid === UNKNOWN_PID) return { status: "keep", reason: "unknown", error: "EINVAL" } as const;
+	return { status: "keep", reason: "alive" } as const;
+}
+
+function lease(sessionId: string, pid: number) {
+	const now = new Date();
+	return {
+		ownerId: `owner-${sessionId}`,
+		sessionId,
+		pid,
+		leaseTokenHash: "deadbeef",
+		endpoint: null,
+		eventsPath: "events.jsonl",
+		heartbeatAt: now.toISOString(),
+		expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+		leaseEpoch: 1,
+		writer: { ownerId: `owner-${sessionId}`, leaseEpoch: 1 },
+	};
+}
+
+async function seedHarnessLease(base: string, registryDir: string, sessionId: string, pid: number): Promise<string> {
+	const root = path.join(base, "harness-root");
+	await writeJson(path.join(registryDir, `${sessionId}.json`), {
+		sessionId,
+		roots: [{ root, updatedAt: new Date().toISOString() }],
+	});
+	const leaseFile = path.join(root, "sessions", sessionId, "lease.json");
+	await writeJson(leaseFile, lease(sessionId, pid));
+	return leaseFile;
+}
+
+async function seedFileLock(base: string, id: string, pid: number): Promise<string> {
+	const lockDir = path.join(base, "spool", `${id}.lock`);
+	await writeJson(path.join(lockDir, "info"), { pid, timestamp: 1 });
+	return lockDir;
+}
+
+async function seedTeamWorker(
+	base: string,
+	registryDir: string,
+	workerId: string,
+	pid: number,
+	lifecycleState: "running" | "failed" | "stopped" = "running",
+): Promise<string> {
+	const harnessRoot = path.join(base, "state", "harness");
+	const teamRoot = path.join(base, "state", "team");
+	await writeJson(path.join(registryDir, `team-${workerId}.json`), {
+		sessionId: `team-${workerId}`,
+		roots: [{ root: harnessRoot, updatedAt: new Date().toISOString() }],
+	});
+	const workerDir = path.join(teamRoot, "red", "workers", workerId);
+	await writeJson(path.join(workerDir, "heartbeat.json"), {
+		pid,
+		last_turn_at: new Date().toISOString(),
+		turn_count: 0,
+	});
+	await writeJson(path.join(workerDir, "lifecycle.json"), {
+		pid,
+		lifecycle_state: lifecycleState,
+		stop_reason: lifecycleState === "running" ? null : "adversarial terminal state",
+	});
+	return workerDir;
+}
+
+async function collectSingle(adapter: GcStoreAdapter, ctx: GcContext): Promise<GcRecord> {
+	const result = await adapter.collect(ctx);
+	expect(result.errors).toEqual([]);
+	expect(result.records).toHaveLength(1);
+	return result.records[0]!;
+}
+
+function fakeAdapter(
+	store: GcStoreAdapter["store"],
+	records: GcRecord[],
+	prune: (record: GcRecord) => Promise<{ removed: boolean; error?: string; skipped?: string }>,
+): GcStoreAdapter {
+	return {
+		store,
+		async collect() {
+			return { records: records.map(r => ({ ...r })), errors: [] };
+		},
+		prune,
+	};
+}
+
+function record(store: GcStoreAdapter["store"], id: string): GcRecord {
+	return {
+		store,
+		id,
+		status: "dead",
+		stale: true,
+		removable: true,
+		action: "none",
+		reason: "adversarial_removable",
+	};
+}
+
+async function reapedPid(): Promise<number> {
+	const proc = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
+	await proc.exited;
+	return proc.pid;
+}
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	const err = new Error(code) as NodeJS.ErrnoException;
+	err.code = code;
+	return err;
+}
+
+function stubKill(impl: (pid: number, sig?: string | number) => void): void {
+	process.kill = ((pid: number, sig?: string | number) => {
+		impl(pid, sig);
+		return true;
+	}) as typeof process.kill;
+}
+
+describe("gc red-team invariants", () => {
+	test("EPERM-probed records are never removable across real harness/file-lock/team adapters and prune never prunes them", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		const harnessLease = await seedHarnessLease(base, registryDir, "h-eperm", EPERM_PID);
+		const lockDir = await seedFileLock(base, "eperm", EPERM_PID);
+		const workerDir = await seedTeamWorker(base, registryDir, "w-eperm", EPERM_PID);
+		const ctx = ctxFor(base, registryDir, adversarialProbe);
+
+		const harnessRec = await collectSingle(harnessLeasesGcAdapter, ctx);
+		const fileLockRec = await collectSingle(fileLocksGcAdapter, ctx);
+		const teamRec = await collectSingle(teamWorkersGcAdapter, ctx);
+
+		for (const rec of [harnessRec, fileLockRec, teamRec]) {
+			expect(rec.pid_status).toBe("eperm");
+			expect(rec.removable).toBe(false);
+			expect(rec.action).toBe("none");
+		}
+
+		const report = await collectGcReport(
+			[harnessLeasesGcAdapter, fileLocksGcAdapter, teamWorkersGcAdapter],
+			ctx,
+			true,
+		);
+		expect(report.counts.removed).toBe(0);
+		expect(report.counts.failed).toBe(0);
+		expect(report.counts.would_remove).toBe(0);
+		expect(report.stores.harness_leases[0]?.action).toBe("none");
+		expect(report.stores.file_locks[0]?.action).toBe("none");
+		expect(report.stores.team_workers[0]?.action).toBe("none");
+		expect(await fs.exists(harnessLease)).toBe(true);
+		expect(await fs.exists(lockDir)).toBe(true);
+		expect(await fs.exists(workerDir)).toBe(true);
+	});
+
+	test("unknown probe errors fail closed as kept, never removable, and prune mode does not remove", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		const leaseFile = await seedHarnessLease(base, registryDir, "h-unknown", UNKNOWN_PID);
+		const lockDir = await seedFileLock(base, "unknown", UNKNOWN_PID);
+		const workerDir = await seedTeamWorker(base, registryDir, "w-unknown", UNKNOWN_PID);
+		const ctx = ctxFor(base, registryDir, adversarialProbe);
+
+		const report = await collectGcReport(
+			[harnessLeasesGcAdapter, fileLocksGcAdapter, teamWorkersGcAdapter],
+			ctx,
+			true,
+		);
+		const records = [report.stores.harness_leases[0]!, report.stores.file_locks[0]!, report.stores.team_workers[0]!];
+		for (const rec of records) {
+			expect(rec.removable).toBe(false);
+			expect(rec.action).toBe("none");
+			expect(["alive", "unknown"]).toContain(rec.pid_status ?? "none");
+		}
+		expect(report.counts.removed).toBe(0);
+		expect(report.counts.failed).toBe(0);
+		expect(await fs.exists(leaseFile)).toBe(true);
+		expect(await fs.exists(lockDir)).toBe(true);
+		expect(await fs.exists(workerDir)).toBe(true);
+	});
+
+	test("dry-run JSON with a real reaped dead lease deletes nothing on disk and exits zero", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		const leaseFile = await seedHarnessLease(base, registryDir, "h-dry-run", await reapedPid());
+		const result = await runGjcGcCommand(["--json"], base, {
+			...process.env,
+			GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir,
+		});
+		const report = JSON.parse(result.stdout);
+
+		expect(result.status).toBe(0);
+		expect(report.dry_run).toBe(true);
+		expect(report.stores.harness_leases[0]?.action).toBe("would_remove");
+		expect(await fs.exists(leaseFile)).toBe(true);
+	});
+
+	test("--prune partial failure keeps failure visible while successful removable records are removed", async () => {
+		const adapter = fakeAdapter(
+			"harness_leases",
+			[record("harness_leases", "throws"), record("harness_leases", "ok")],
+			async r => {
+				if (r.id === "throws") throw new Error("adversarial prune explosion");
+				return { removed: true };
+			},
+		);
+		const report = await collectGcReport([adapter], ctxFor("/tmp", "/tmp/reg", adversarialProbe), true);
+		const byId = Object.fromEntries(report.stores.harness_leases.map(r => [r.id, r]));
+
+		expect(byId.throws?.action).toBe("remove_failed");
+		expect(byId.throws?.removed).toBe(false);
+		expect(byId.ok?.action).toBe("removed");
+		expect(byId.ok?.removed).toBe(true);
+		expect(report.counts.removed).toBe(1);
+		expect(report.counts.failed).toBe(1);
+		expect(computeExitCode(report)).toBe(1);
+	});
+
+	test("team workers in failed/stopped lifecycle remain non-removable when their pid is alive", async () => {
+		const base = await makeTemp();
+		const registryDir = path.join(base, "reg");
+		await seedTeamWorker(base, registryDir, "w-failed-live", ALIVE_PID, "failed");
+		await seedTeamWorker(base, registryDir, "w-stopped-live", ALIVE_PID, "stopped");
+		const result = await teamWorkersGcAdapter.collect(ctxFor(base, registryDir, adversarialProbe));
+		expect(result.errors).toEqual([]);
+		const byId = Object.fromEntries(result.records.map(r => [r.id, r]));
+
+		expect(byId["red/w-failed-live"]?.pid_status).toBe("alive");
+		expect(byId["red/w-failed-live"]?.removable).toBe(false);
+		expect(byId["red/w-failed-live"]?.status).toBe("alive");
+		expect(byId["red/w-stopped-live"]?.pid_status).toBe("alive");
+		expect(byId["red/w-stopped-live"]?.removable).toBe(false);
+		expect(byId["red/w-stopped-live"]?.status).toBe("alive");
+	});
+
+	test("TOCTOU prune skip is reported as skipped, not removed or failed, and exits zero", async () => {
+		const adapter = fakeAdapter("file_locks", [record("file_locks", "became-live")], async () => ({
+			removed: false,
+			skipped: "became_live_before_delete",
+		}));
+		const report = await collectGcReport([adapter], ctxFor("/tmp", "/tmp/reg", adversarialProbe), true);
+		const rec = report.stores.file_locks[0]!;
+
+		expect(rec.action).toBe("skipped");
+		expect(rec.removed).toBe(false);
+		expect(report.counts.removed).toBe(0);
+		expect(report.counts.failed).toBe(0);
+		expect(computeExitCode(report)).toBe(0);
+	});
+
+	test("unknown gc flag exits with parse status 2", async () => {
+		const result = await runGjcGcCommand(["--bogus"], "/tmp", process.env, []);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("unknown_flag:--bogus");
+	});
+
+	test("real gcPidProbe maps process.kill ESRCH/EPERM/EINVAL fail-closed and restores process.kill", () => {
+		stubKill(() => {
+			throw errnoError("ESRCH");
+		});
+		expect(gcPidProbe(12345)).toEqual({ status: "dead" });
+
+		stubKill(() => {
+			throw errnoError("EPERM");
+		});
+		expect(gcPidProbe(12345)).toEqual({ status: "keep", reason: "eperm" });
+
+		stubKill(() => {
+			throw errnoError("EINVAL");
+		});
+		expect(gcPidProbe(12345)).toEqual({ status: "keep", reason: "unknown", error: "EINVAL" });
+
+		process.kill = originalKill;
+		expect(process.kill).toBe(originalKill);
+	});
+});

--- a/packages/coding-agent/test/gc-runtime.test.ts
+++ b/packages/coding-agent/test/gc-runtime.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	collectGcReport,
+	computeExitCode,
+	type GcContext,
+	type GcPidProbe,
+	type GcRecord,
+	type GcStoreAdapter,
+	gcPidProbe,
+	gcProbeToLeasePidStatus,
+	runGjcGcCommand,
+} from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+
+const originalKill = process.kill.bind(process);
+
+afterEach(() => {
+	process.kill = originalKill;
+});
+
+function stubKill(impl: (pid: number) => void): void {
+	process.kill = ((pid: number, _sig?: string | number) => {
+		impl(pid);
+		return true;
+	}) as typeof process.kill;
+}
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	const err = new Error(code) as NodeJS.ErrnoException;
+	err.code = code;
+	return err;
+}
+
+const keepProbe: GcPidProbe = () => ({ status: "keep", reason: "alive" });
+
+function fakeAdapter(
+	store: GcStoreAdapter["store"],
+	records: GcRecord[],
+	prune?: (record: GcRecord) => Promise<{ removed: boolean; error?: string; skipped?: string }>,
+): GcStoreAdapter {
+	return {
+		store,
+		async collect() {
+			return { records: records.map(r => ({ ...r })), errors: [] };
+		},
+		async prune(record) {
+			return prune ? prune(record) : { removed: true };
+		},
+	};
+}
+
+function ctx(probe: GcPidProbe = keepProbe): GcContext {
+	return { probe, force: false, env: {}, cwd: "/tmp" };
+}
+
+function record(store: GcStoreAdapter["store"], over: Partial<GcRecord> = {}): GcRecord {
+	return {
+		store,
+		id: over.id ?? "r1",
+		status: over.status ?? "dead",
+		stale: over.stale ?? true,
+		removable: over.removable ?? true,
+		action: "none",
+		reason: over.reason ?? "test",
+		...over,
+	};
+}
+
+describe("gcPidProbe (liveness-only, fail-closed)", () => {
+	test("alive process => keep/alive", () => {
+		stubKill(() => {});
+		expect(gcPidProbe(1234)).toEqual({ status: "keep", reason: "alive" });
+	});
+
+	test("ESRCH => dead (the only removable status)", () => {
+		stubKill(() => {
+			throw errnoError("ESRCH");
+		});
+		expect(gcPidProbe(1234)).toEqual({ status: "dead" });
+	});
+
+	test("EPERM => keep/eperm (owned by another user)", () => {
+		stubKill(() => {
+			throw errnoError("EPERM");
+		});
+		expect(gcPidProbe(1234)).toEqual({ status: "keep", reason: "eperm" });
+	});
+
+	test("unknown error => keep/unknown (never dead)", () => {
+		stubKill(() => {
+			throw errnoError("EINVAL");
+		});
+		const result = gcPidProbe(1234);
+		expect(result.status).toBe("keep");
+		expect(result.reason).toBe("unknown");
+	});
+
+	test("invalid pid => keep/unknown, never probes", () => {
+		stubKill(() => {
+			throw new Error("should not be called");
+		});
+		for (const pid of [0, -1, Number.NaN, 1.5]) {
+			expect(gcPidProbe(pid).status).toBe("keep");
+		}
+	});
+});
+
+describe("gcProbeToLeasePidStatus", () => {
+	test("maps dead/eperm/alive/unknown onto lease pid status", () => {
+		expect(gcProbeToLeasePidStatus(() => ({ status: "dead" }))(1)).toBe("dead");
+		expect(gcProbeToLeasePidStatus(() => ({ status: "keep", reason: "eperm" }))(1)).toBe("eperm");
+		expect(gcProbeToLeasePidStatus(() => ({ status: "keep", reason: "alive" }))(1)).toBe("alive");
+		// unknown maps to alive so classifyLeaseStatus never treats it as dead
+		expect(gcProbeToLeasePidStatus(() => ({ status: "keep", reason: "unknown" }))(1)).toBe("alive");
+	});
+});
+
+describe("computeExitCode", () => {
+	test("dry-run with no errors => 0", () => {
+		expect(computeExitCode({ dry_run: true, stores: {} as never, counts: { failed: 0 } as never, errors: [] })).toBe(
+			0,
+		);
+	});
+
+	test("hard discovery errors => 1 (both modes)", () => {
+		const errors = [{ store: "file_locks" as const, scope: "discovery", message: "boom" }];
+		expect(computeExitCode({ dry_run: true, stores: {} as never, counts: { failed: 0 } as never, errors })).toBe(1);
+		expect(computeExitCode({ dry_run: false, stores: {} as never, counts: { failed: 0 } as never, errors })).toBe(1);
+	});
+
+	test("prune with a failed intended removal => 1; dry-run ignores failed count", () => {
+		expect(computeExitCode({ dry_run: false, stores: {} as never, counts: { failed: 2 } as never, errors: [] })).toBe(
+			1,
+		);
+		expect(computeExitCode({ dry_run: true, stores: {} as never, counts: { failed: 2 } as never, errors: [] })).toBe(
+			0,
+		);
+	});
+});
+
+describe("collectGcReport", () => {
+	test("dry-run marks removable records would_remove and never prunes", async () => {
+		let pruned = false;
+		const adapter = fakeAdapter("harness_leases", [record("harness_leases", { removable: true })], async () => {
+			pruned = true;
+			return { removed: true };
+		});
+		const report = await collectGcReport([adapter], ctx(), false);
+		expect(report.dry_run).toBe(true);
+		expect(report.stores.harness_leases[0]?.action).toBe("would_remove");
+		expect(report.counts.would_remove).toBe(1);
+		expect(pruned).toBe(false);
+	});
+
+	test("non-removable records are kept (action none) and never pruned", async () => {
+		const adapter = fakeAdapter("team_workers", [
+			record("team_workers", { removable: false, status: "alive", stale: false }),
+		]);
+		const report = await collectGcReport([adapter], ctx(), true);
+		expect(report.stores.team_workers[0]?.action).toBe("none");
+		expect(report.counts.removed).toBe(0);
+	});
+
+	test("prune: removed / skipped / failed map to actions and counts", async () => {
+		const adapter = fakeAdapter(
+			"file_locks",
+			[
+				record("file_locks", { id: "ok", removable: true }),
+				record("file_locks", { id: "skip", removable: true }),
+				record("file_locks", { id: "fail", removable: true }),
+			],
+			async r => {
+				if (r.id === "ok") return { removed: true };
+				if (r.id === "skip") return { removed: false, skipped: "became_live" };
+				return { removed: false, error: "EACCES" };
+			},
+		);
+		const report = await collectGcReport([adapter], ctx(), true);
+		const byId = Object.fromEntries(report.stores.file_locks.map(r => [r.id, r]));
+		expect(byId.ok?.action).toBe("removed");
+		expect(byId.skip?.action).toBe("skipped");
+		expect(byId.fail?.action).toBe("remove_failed");
+		expect(report.counts.removed).toBe(1);
+		expect(report.counts.failed).toBe(1);
+		expect(computeExitCode(report)).toBe(1);
+	});
+
+	test("adapter.collect throwing becomes a hard error (scope=collect)", async () => {
+		const broken: GcStoreAdapter = {
+			store: "tmux_sessions",
+			async collect() {
+				throw new Error("kaboom");
+			},
+			async prune() {
+				return { removed: false };
+			},
+		};
+		const report = await collectGcReport([broken], ctx(), false);
+		expect(report.errors).toHaveLength(1);
+		expect(report.errors[0]?.scope).toBe("collect");
+		expect(computeExitCode(report)).toBe(1);
+	});
+});
+
+describe("runGjcGcCommand", () => {
+	const adapters = [fakeAdapter("harness_leases", [])];
+
+	test("unknown flag => status 2 with stderr", async () => {
+		const result = await runGjcGcCommand(["--nope"], "/tmp", {}, adapters);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("unknown_flag");
+	});
+
+	test("--json emits a report with all five store arrays", async () => {
+		const result = await runGjcGcCommand(["--json"], "/tmp", {}, adapters);
+		expect(result.status).toBe(0);
+		const parsed = JSON.parse(result.stdout);
+		expect(parsed.dry_run).toBe(true);
+		expect(Object.keys(parsed.stores).sort()).toEqual([
+			"file_locks",
+			"harness_leases",
+			"registry_entries",
+			"team_workers",
+			"tmux_sessions",
+		]);
+	});
+
+	test("default text mode reports dry run", async () => {
+		const result = await runGjcGcCommand([], "/tmp", {}, adapters);
+		expect(result.stdout).toContain("dry run");
+	});
+
+	test("--dry-run overrides --prune", async () => {
+		let pruned = false;
+		const a = fakeAdapter("harness_leases", [record("harness_leases", { removable: true })], async () => {
+			pruned = true;
+			return { removed: true };
+		});
+		const result = await runGjcGcCommand(["--prune", "--dry-run", "--json"], "/tmp", {}, [a]);
+		expect(pruned).toBe(false);
+		expect(JSON.parse(result.stdout).dry_run).toBe(true);
+	});
+
+	test("--prune actually prunes removable records", async () => {
+		let pruned = 0;
+		const a = fakeAdapter("harness_leases", [record("harness_leases", { removable: true })], async () => {
+			pruned++;
+			return { removed: true };
+		});
+		const result = await runGjcGcCommand(["--prune", "--json"], "/tmp", {}, [a]);
+		expect(pruned).toBe(1);
+		const parsed = JSON.parse(result.stdout);
+		expect(parsed.dry_run).toBe(false);
+		expect(parsed.counts.removed).toBe(1);
+		expect(result.status).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/gc-stores.test.ts
+++ b/packages/coding-agent/test/gc-stores.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileLocksGcAdapter } from "@gajae-code/coding-agent/config/file-lock-gc";
+import type { GcContext, GcPidProbe } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { teamWorkersGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/team-gc";
+import {
+	harnessLeasesGcAdapter,
+	registryEntriesGcAdapter,
+} from "@gajae-code/coding-agent/harness-control-plane/gc-adapter";
+
+const DEAD_PID = 4242;
+const ALIVE_PID = 4243;
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTemp(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gc-stores-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Dead only for DEAD_PID; everything else is a live (kept) process. */
+const splitProbe: GcPidProbe = pid => (pid === DEAD_PID ? { status: "dead" } : { status: "keep", reason: "alive" });
+
+function ctxFor(base: string, registryDir: string, probe: GcPidProbe = splitProbe): GcContext {
+	return { probe, force: false, env: { ...process.env, GJC_HARNESS_ROOT_REGISTRY_DIR: registryDir }, cwd: base };
+}
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function lease(sessionId: string, pid: number) {
+	const now = new Date();
+	return {
+		ownerId: `owner-${sessionId}`,
+		sessionId,
+		pid,
+		leaseTokenHash: "deadbeef",
+		endpoint: null,
+		eventsPath: "events.jsonl",
+		heartbeatAt: now.toISOString(),
+		expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+		leaseEpoch: 1,
+		writer: { ownerId: `owner-${sessionId}`, leaseEpoch: 1 },
+	};
+}
+
+describe("harnessLeasesGcAdapter", () => {
+	test("dead-pid lease is removable; prune reaps the lease file", async () => {
+		const base = await makeTemp();
+		const root = path.join(base, "root");
+		const registryDir = path.join(base, "reg");
+		await writeJson(path.join(registryDir, "h-dead.json"), {
+			sessionId: "h-dead",
+			roots: [{ root, updatedAt: new Date().toISOString() }],
+		});
+		const leaseFile = path.join(root, "sessions", "h-dead", "lease.json");
+		await writeJson(leaseFile, lease("h-dead", DEAD_PID));
+
+		const ctx = ctxFor(base, registryDir);
+		const { records } = await harnessLeasesGcAdapter.collect(ctx);
+		const rec = records.find(r => r.id === "h-dead");
+		expect(rec).toBeDefined();
+		expect(rec?.removable).toBe(true);
+		expect(rec?.status).toBe("dead");
+		expect(rec?.pid_status).toBe("dead");
+
+		const outcome = await harnessLeasesGcAdapter.prune(rec!, ctx);
+		expect(outcome.removed).toBe(true);
+		expect(await fs.exists(leaseFile)).toBe(false);
+	});
+
+	test("live-pid lease is kept (never removable)", async () => {
+		const base = await makeTemp();
+		const root = path.join(base, "root");
+		const registryDir = path.join(base, "reg");
+		await writeJson(path.join(registryDir, "h-live.json"), {
+			sessionId: "h-live",
+			roots: [{ root, updatedAt: new Date().toISOString() }],
+		});
+		await writeJson(path.join(root, "sessions", "h-live", "lease.json"), lease("h-live", ALIVE_PID));
+
+		const { records } = await harnessLeasesGcAdapter.collect(ctxFor(base, registryDir));
+		const rec = records.find(r => r.id === "h-live");
+		expect(rec?.removable).toBe(false);
+	});
+});
+
+describe("registryEntriesGcAdapter", () => {
+	test("registry pointing at a missing session dir is a removable dangling entry", async () => {
+		const base = await makeTemp();
+		const root = path.join(base, "root");
+		const registryDir = path.join(base, "reg");
+		await fs.mkdir(path.join(root, "sessions"), { recursive: true });
+		await writeJson(path.join(registryDir, "h-gone.json"), {
+			sessionId: "h-gone",
+			roots: [{ root, updatedAt: new Date().toISOString() }],
+		});
+
+		const { records } = await registryEntriesGcAdapter.collect(ctxFor(base, registryDir));
+		const rec = records.find(r => r.id === "h-gone");
+		expect(rec).toBeDefined();
+		expect(rec?.removable).toBe(true);
+		expect(rec?.status).toBe("dangling");
+	});
+
+	test("registry whose session dir still exists is not dangling", async () => {
+		const base = await makeTemp();
+		const root = path.join(base, "root");
+		const registryDir = path.join(base, "reg");
+		await fs.mkdir(path.join(root, "sessions", "h-here"), { recursive: true });
+		await writeJson(path.join(registryDir, "h-here.json"), {
+			sessionId: "h-here",
+			roots: [{ root, updatedAt: new Date().toISOString() }],
+		});
+
+		const { records } = await registryEntriesGcAdapter.collect(ctxFor(base, registryDir));
+		expect(records.find(r => r.id === "h-here")).toBeUndefined();
+	});
+});
+
+describe("fileLocksGcAdapter", () => {
+	test("dead-pid lock removable; live + malformed locks kept; old timestamp alone never removable", async () => {
+		const base = await makeTemp();
+		const spoolDir = path.join(base, "spool");
+		const deadLock = path.join(spoolDir, "dead.lock");
+		const aliveLock = path.join(spoolDir, "alive.lock");
+		const oldLiveLock = path.join(spoolDir, "old.lock");
+		const malformedLock = path.join(spoolDir, "bad.lock");
+		await writeJson(path.join(deadLock, "info"), { pid: DEAD_PID, timestamp: Date.now() });
+		await writeJson(path.join(aliveLock, "info"), { pid: ALIVE_PID, timestamp: Date.now() });
+		await writeJson(path.join(oldLiveLock, "info"), { pid: ALIVE_PID, timestamp: 1 });
+		await fs.mkdir(malformedLock, { recursive: true });
+		await fs.writeFile(path.join(malformedLock, "info"), "not json", "utf8");
+
+		const ctx: GcContext = {
+			probe: splitProbe,
+			force: false,
+			env: { ...process.env, GJC_RECEIPT_SPOOL_DIR: spoolDir },
+			cwd: base,
+		};
+		const { records } = await fileLocksGcAdapter.collect(ctx);
+		const byPath = new Map(records.map(r => [path.resolve(r.path ?? r.id), r]));
+		expect(byPath.get(path.resolve(deadLock))?.removable).toBe(true);
+		expect(byPath.get(path.resolve(aliveLock))?.removable).toBe(false);
+		expect(byPath.get(path.resolve(oldLiveLock))?.removable).toBe(false);
+		expect(byPath.get(path.resolve(malformedLock))?.removable).toBe(false);
+
+		// prune removes only the dead lock dir after re-probe.
+		const outcome = await fileLocksGcAdapter.prune(byPath.get(path.resolve(deadLock))!, ctx);
+		expect(outcome.removed).toBe(true);
+		expect(await fs.exists(deadLock)).toBe(false);
+		expect(await fs.exists(aliveLock)).toBe(true);
+	});
+});
+
+describe("teamWorkersGcAdapter (PID dominance)", () => {
+	test("dead-pid worker removable; live-pid worker with failed lifecycle is KEPT", async () => {
+		const base = await makeTemp();
+		const harnessRoot = path.join(base, "state", "harness");
+		const teamRoot = path.join(base, "state", "team");
+		const registryDir = path.join(base, "reg");
+		await writeJson(path.join(registryDir, "h-x.json"), {
+			sessionId: "h-x",
+			roots: [{ root: harnessRoot, updatedAt: new Date().toISOString() }],
+		});
+		const deadWorker = path.join(teamRoot, "alpha", "workers", "w-dead");
+		const liveFailedWorker = path.join(teamRoot, "alpha", "workers", "w-live-failed");
+		await writeJson(path.join(deadWorker, "heartbeat.json"), {
+			pid: DEAD_PID,
+			last_turn_at: new Date().toISOString(),
+			turn_count: 0,
+		});
+		await writeJson(path.join(deadWorker, "lifecycle.json"), {
+			pid: DEAD_PID,
+			lifecycle_state: "running",
+			stop_reason: null,
+		});
+		await writeJson(path.join(liveFailedWorker, "heartbeat.json"), {
+			pid: ALIVE_PID,
+			last_turn_at: new Date().toISOString(),
+			turn_count: 0,
+		});
+		await writeJson(path.join(liveFailedWorker, "lifecycle.json"), {
+			pid: ALIVE_PID,
+			lifecycle_state: "failed",
+			stop_reason: "crashed",
+		});
+
+		const { records } = await teamWorkersGcAdapter.collect(ctxFor(base, registryDir));
+		const dead = records.find(r => r.id === "alpha/w-dead");
+		const liveFailed = records.find(r => r.id === "alpha/w-live-failed");
+		expect(dead?.removable).toBe(true);
+		expect(dead?.status).toBe("dead");
+		// PID liveness dominates the failed lifecycle => kept.
+		expect(liveFailed?.removable).toBe(false);
+	});
+
+	test("dead heartbeat pid but LIVE lifecycle pid is KEPT (all-PID dominance)", async () => {
+		const base = await makeTemp();
+		const harnessRoot = path.join(base, "state", "harness");
+		const teamRoot = path.join(base, "state", "team");
+		const registryDir = path.join(base, "reg");
+		await writeJson(path.join(registryDir, "h-mixed.json"), {
+			sessionId: "h-mixed",
+			roots: [{ root: harnessRoot, updatedAt: new Date().toISOString() }],
+		});
+		const mixedWorker = path.join(teamRoot, "alpha", "workers", "w-mixed");
+		// heartbeat pid is dead, but the lifecycle pid is a live process => keep.
+		await writeJson(path.join(mixedWorker, "heartbeat.json"), {
+			pid: DEAD_PID,
+			last_turn_at: new Date().toISOString(),
+			turn_count: 0,
+		});
+		await writeJson(path.join(mixedWorker, "lifecycle.json"), {
+			pid: ALIVE_PID,
+			lifecycle_state: "running",
+			stop_reason: null,
+		});
+
+		const { records } = await teamWorkersGcAdapter.collect(ctxFor(base, registryDir));
+		const mixed = records.find(r => r.id === "alpha/w-mixed");
+		expect(mixed?.removable).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new top-level **`gjc gc`** command: a global, **liveness-only**, **dry-run-by-default** garbage collector for stale GJC session/PID records.

A record is stale strictly by liveness — its owning OS process is dead (`ESRCH`). `gjc gc` only removes records/files; it **never signals or kills a live process**. Discovery is global, and deletion requires an explicit `--prune`/`--force`.

## Stores covered

| Store | Stale rule | Removal |
|-------|-----------|---------|
| Harness owner leases | lease `pid` dead (ESRCH) | reuse `reapDeadOwnerArtifacts` with the GC probe |
| Harness-root registry | session dir gone (dangling) | atomic rewrite / file removal |
| Team workers | **all** heartbeat+lifecycle pids dead (any alive/EPERM/unknown keeps) | re-validate, then remove worker record dir |
| Config file-locks | `.lock` dir whose pid is dead | bounded, env-aware GJC-format discovery |
| Tmux sessions | `@gjc-project` gone or `@gjc-branch` has no live worktree | exact-target re-read + TOCTOU revalidation before `kill-session`; untagged kept |

## Behavior / contract

- **Dry-run by default** (report only). `--prune` (alias `--force`) deletes; `--dry-run` overrides; `--json` for machine output.
- **Fail-closed probe**: `ESRCH` => dead/removable; success / `EPERM` / unknown error => keep.
- **Exit codes**: dry-run `0` (unless a hard discovery error); `--prune` non-zero only on a failed *intended* removal; unknown flag `2`.
- Global discovery via the harness-root registry (`$TMPDIR/gjch<uid>/harness-roots/*.json`), global `~/.gjc` config-lock roots (incl. `GJC_RECEIPT_SPOOL_DIR`), and the per-user tmux server.

## Architecture

`gjc-runtime/gc-runtime.ts` is an orchestrator (shared probe, report model, exit codes, render selection); each store is reached through an `@internal` `*ForGc` adapter that owns its on-disk layout. New `commands/gc.ts` registered in `cli.ts`.

## Tests

36 tests: unit (probe / exit-code reducer / orchestration with fakes), per-store integration with temp roots + injected probes, real-default-adapter e2e (`gjc gc` / `--json` / `--prune`), and an adversarial **red-team** suite (EPERM/unknown kept, dry-run deletes nothing, partial-prune-failure exit 1, team PID dominance, TOCTOU skip).

Verification: `tsc` 0 errors, biome clean, 36/36 gc tests pass.

> Built via the gjc deep-interview -> ralplan consensus -> ultragoal pipeline; consensus plan and spec recorded under `.gjc/` (gitignored).
