### PR TITLE
feat(rpc): session registry (issue 10) + persistent UDS server (issue 09)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc --mode rpc` registers each live session in a cross-process registry (`<agent-dir>/rpc-sessions/<id>.json`) on start and removes it on shutdown, so other processes can enumerate running RPC sessions. The Python `gjc_rpc` client exposes `list_sessions()` / `RpcClient.list_sessions()` returning typed `SessionHandle`s and reaps records whose owning process is gone (issue 10; foundation for reattach/issue 09).
+
 ### Fixed
 
 - RPC control-plane hardening (from dogfooding `gjc --mode rpc`): `dispatchRpcCommand` now wraps the command switch so failures return a correlated response carrying the request `id` and the real command name, instead of dropping the id and mislabeling handler exceptions as `parse`; `set_thinking_level`/`set_steering_mode`/`set_follow_up_mode`/`set_interrupt_mode` validate their inputs and reject out-of-contract values instead of silently corrupting session state; `negotiate_unattended` rejects unknown scopes/action classes with `invalid_unattended_declaration` and merges the mandatory `prompt` scope plus its `command.prompt` action floor into the accepted grant (so prompt/`workflow_gate_response` are never locked out); and read-only/control RPC commands no longer consume the unattended `max_tool_calls` budget while wall-time enforcement is preserved. `docs/rpc.md`'s first `workflow_gate` example now matches the canonical `RpcWorkflowGate` shape.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `gjc --mode rpc` registers each live session in a cross-process registry (`<agent-dir>/rpc-sessions/<id>.json`) on start and removes it on shutdown, so other processes can enumerate running RPC sessions. The Python `gjc_rpc` client exposes `list_sessions()` / `RpcClient.list_sessions()` returning typed `SessionHandle`s and reaps records whose owning process is gone (issue 10; foundation for reattach/issue 09).
+- `gjc --mode rpc --listen <socket-path>` runs a persistent Unix-domain-socket RPC server: the `AgentSession` outlives client disconnects (no stdin-EOF teardown) and a client can disconnect and reconnect to the same live session over the socket. The session is registered with `transport: "socket"` and the socket path as its `endpoint`, so it is discoverable/attachable via the registry. The stdio path is unchanged (frame output routes through a swappable sink shared by both transports) (issue 09).
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -30,6 +30,7 @@ export interface Args {
 	mode?: Mode;
 	noSession?: boolean;
 	sessionDir?: string;
+	rpcListen?: string;
 	providerSessionId?: string;
 	fork?: string;
 	models?: string[];
@@ -145,6 +146,8 @@ export function parseArgs(args: string[]): Args {
 			result.noSession = true;
 		} else if (arg === "--session-dir" && i + 1 < args.length) {
 			result.sessionDir = args[++i];
+		} else if (arg === "--listen" && i + 1 < args.length) {
+			result.rpcListen = args[++i];
 		} else if (arg === "--models" && i + 1 < args.length) {
 			result.models = args[++i].split(",").map(s => s.trim());
 		} else if (arg === "--no-tools") {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -975,7 +975,9 @@ export async function runRootCommand(
 
 		if (mode === "rpc" || mode === "rpc-ui") {
 			const { runRpcMode } = await import("./modes/rpc/rpc-mode");
-			await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined);
+			await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined, {
+				listen: parsedArgs.rpcListen,
+			});
 		} else if (mode === "bridge") {
 			const { runBridgeMode } = await import("./modes/bridge/bridge-mode");
 			await runBridgeMode(session, setToolUIContext);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -23,6 +23,7 @@ import { initializeExtensions } from "../runtime-init";
 import { dispatchRpcCommand } from "../shared/agent-wire/command-dispatch";
 import { AgentWireFrameSequencer, toAgentWireEventFrame } from "../shared/agent-wire/event-envelope";
 import { rpcError as error } from "../shared/agent-wire/responses";
+import { registerRpcSession, unregisterRpcSession } from "../shared/agent-wire/session-registry";
 import { defaultAuditPath, UnattendedAuditLog } from "../shared/agent-wire/unattended-audit";
 import { UnattendedSessionControlPlane } from "../shared/agent-wire/unattended-session";
 import { FileGateStore } from "../shared/agent-wire/workflow-gate-broker";
@@ -246,6 +247,7 @@ export async function runRpcMode(
 		if (inFlightCommands.size > 0) {
 			await Promise.race([Promise.allSettled([...inFlightCommands]), Bun.sleep(5000)]);
 		}
+		await unregisterRpcSession(session.sessionId).catch(() => {});
 		hostToolBridge.rejectAllPending(`${reason} before host tool execution completed`);
 		hostUriBridge.clear(`${reason} before host URI request completed`);
 		try {
@@ -560,6 +562,17 @@ export async function runRpcMode(
 		if (!shutdownState.requested) return;
 		await shutdown(0, "RPC shutdown requested");
 	}
+
+	// Register this RPC session so other processes can discover it (issue 10).
+	// Best-effort: a registry write failure must not break the protocol channel.
+	await registerRpcSession({
+		sessionId: session.sessionId,
+		pid: process.pid,
+		transport: "stdio",
+		cwd: session.sessionManager.getCwd(),
+		model: session.model?.id,
+		startedAt: new Date().toISOString(),
+	}).catch(() => {});
 
 	// Listen for JSONL input using Bun's stdin. Parse frame-by-frame so a malformed
 	// command reports a parse error without poisoning the whole long-lived RPC session.

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -10,6 +10,8 @@
  * - Events: AgentSessionEvent objects streamed as they occur
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
+
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { $pickenv, readLines, Snowflake } from "@gajae-code/utils";
 import type {
@@ -159,6 +161,7 @@ export function requestRpcEditor(
 export async function runRpcMode(
 	session: AgentSession,
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
+	options?: { listen?: string },
 ): Promise<never> {
 	// Signal to RPC clients that the server is ready to accept commands
 	// Suppress terminal notifications: they write \x07 (BEL) or OSC sequences directly to
@@ -167,10 +170,18 @@ export async function runRpcMode(
 	// may write there.
 	process.env.PI_NOTIFICATIONS = "off";
 
-	process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
-	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		process.stdout.write(`${JSON.stringify(obj)}\n`);
+	// Frames go to a swappable sink: stdout for stdio, the active client socket for a
+	// persistent --listen (UDS) server. Defaults to stdout, so the stdio path is unchanged.
+	let frameSink = (line: string): void => {
+		process.stdout.write(line);
 	};
+	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
+		frameSink(`${JSON.stringify(obj)}\n`);
+	};
+	// stdio announces readiness immediately; the UDS server announces it per client connection.
+	if (!options?.listen) {
+		output({ type: "ready" });
+	}
 	const emitRpcTitles = shouldEmitRpcTitles();
 	const decodeError = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
@@ -563,8 +574,109 @@ export async function runRpcMode(
 		await shutdown(0, "RPC shutdown requested");
 	}
 
-	// Register this RPC session so other processes can discover it (issue 10).
-	// Best-effort: a registry write failure must not break the protocol channel.
+	// Parse + route a single inbound JSONL frame. Shared by the stdio reader and the
+	// persistent UDS server so both transports use the same command surface.
+	const inputDecoder = new TextDecoder("utf-8", { fatal: false });
+	async function handleInboundLine(text: string): Promise<void> {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(text);
+		} catch (err) {
+			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
+			return;
+		}
+		try {
+			if ((parsed as RpcExtensionUIResponse).type === "extension_ui_response") {
+				const response = parsed as RpcExtensionUIResponse;
+				pendingExtensionRequests.get(response.id)?.resolve(response);
+				return;
+			}
+			if (isRpcHostToolResult(parsed)) {
+				hostToolBridge.handleResult(parsed);
+				return;
+			}
+			if (isRpcHostToolUpdate(parsed)) {
+				hostToolBridge.handleUpdate(parsed);
+				return;
+			}
+			if (isRpcHostUriResult(parsed)) {
+				hostUriBridge.handleResult(parsed);
+				return;
+			}
+			// Ordered commands run through a serial chain to preserve causal order; the
+			// reader never blocks, so cancellation commands stay responsive even while a
+			// long command is in flight (issue 13).
+			dispatchCommand(parsed as RpcCommand);
+			await checkShutdownRequested();
+		} catch (err) {
+			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
+		}
+	}
+
+	// Persistent UDS server (issue 09): keep the AgentSession alive across client
+	// reconnects instead of exiting on stdin EOF. Frames route to the active client
+	// socket; while no client is connected they are dropped (clients resync via
+	// get_state/get_messages on reconnect).
+	if (options?.listen) {
+		const socketPath = options.listen;
+		await fs.mkdir(path.dirname(socketPath), { recursive: true }).catch(() => {});
+		await fs.rm(socketPath, { force: true }).catch(() => {});
+		await registerRpcSession({
+			sessionId: session.sessionId,
+			pid: process.pid,
+			transport: "socket",
+			cwd: session.sessionManager.getCwd(),
+			model: session.model?.id,
+			startedAt: new Date().toISOString(),
+			endpoint: socketPath,
+		}).catch(() => {});
+
+		const noopSink = (_line: string): void => {};
+		let currentSocket: object | undefined;
+		let buf = "";
+		Bun.listen({
+			unix: socketPath,
+			socket: {
+				open(socket) {
+					currentSocket = socket;
+					buf = "";
+					frameSink = (line: string) => {
+						socket.write(line);
+					};
+					output({ type: "ready" });
+				},
+				data(socket, data) {
+					if (socket !== currentSocket) return;
+					buf += inputDecoder.decode(data);
+					while (true) {
+						const nl = buf.indexOf("\n");
+						if (nl < 0) break;
+						const text = buf.slice(0, nl).trim();
+						buf = buf.slice(nl + 1);
+						if (text) void handleInboundLine(text);
+					}
+				},
+				close(socket) {
+					if (socket === currentSocket) {
+						currentSocket = undefined;
+						frameSink = noopSink;
+					}
+				},
+				error() {},
+			},
+		});
+
+		const onSignal = (): void => {
+			void shutdown(0, "RPC socket server signal");
+		};
+		process.on("SIGINT", onSignal);
+		process.on("SIGTERM", onSignal);
+		// Block until an explicit shutdown (signal/extension) calls process.exit.
+		await new Promise<never>(() => {});
+		throw new Error("RPC socket server returned unexpectedly");
+	}
+
+	// Register this stdio RPC session so other processes can discover it (issue 10).
 	await registerRpcSession({
 		sessionId: session.sessionId,
 		pid: process.pid,
@@ -576,55 +688,10 @@ export async function runRpcMode(
 
 	// Listen for JSONL input using Bun's stdin. Parse frame-by-frame so a malformed
 	// command reports a parse error without poisoning the whole long-lived RPC session.
-	const inputDecoder = new TextDecoder("utf-8", { fatal: false });
 	for await (const line of readLines(Bun.stdin.stream())) {
 		const text = inputDecoder.decode(line).trim();
 		if (!text) continue;
-
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(text);
-		} catch (err) {
-			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
-			continue;
-		}
-
-		try {
-			// Handle extension UI responses
-			if ((parsed as RpcExtensionUIResponse).type === "extension_ui_response") {
-				const response = parsed as RpcExtensionUIResponse;
-				const pending = pendingExtensionRequests.get(response.id);
-				if (pending) {
-					pending.resolve(response);
-				}
-				continue;
-			}
-
-			if (isRpcHostToolResult(parsed)) {
-				hostToolBridge.handleResult(parsed);
-				continue;
-			}
-
-			if (isRpcHostToolUpdate(parsed)) {
-				hostToolBridge.handleUpdate(parsed);
-				continue;
-			}
-
-			if (isRpcHostUriResult(parsed)) {
-				hostUriBridge.handleResult(parsed);
-				continue;
-			}
-
-			// Handle regular commands. Ordered commands run through a serial chain to
-			// preserve causal order; the read loop never blocks, so cancellation commands
-			// stay responsive even while a long command is in flight (issue 13).
-			dispatchCommand(parsed as RpcCommand);
-
-			// Check for deferred shutdown request (idle between commands)
-			await checkShutdownRequested();
-		} catch (err) {
-			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
-		}
+		await handleInboundLine(text);
 	}
 
 	// stdin closed — RPC client is gone, flush durable state and exit cleanly

--- a/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
@@ -34,10 +34,17 @@ function recordPath(sessionId: string, agentDir?: string): string {
 	return path.join(rpcSessionsDir(agentDir), `${sessionId}.json`);
 }
 
-/** Write (or replace) the registry record for a session. */
+/**
+ * Write (or replace) the registry record for a session. The record is written to
+ * a same-directory temp file and atomically renamed into place so a concurrent
+ * reader never observes (and reaps) a partially-written record.
+ */
 export async function registerRpcSession(record: RpcSessionRecord, agentDir?: string): Promise<string> {
 	const file = recordPath(record.sessionId, agentDir);
-	await Bun.write(file, JSON.stringify(record));
+	// `.tmp` suffix keeps the staging file out of the `*.json` listing/reaping path.
+	const staging = `${file}.${process.pid}.tmp`;
+	await Bun.write(staging, JSON.stringify(record));
+	await fs.rename(staging, file);
 	return file;
 }
 

--- a/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
@@ -1,0 +1,102 @@
+/**
+ * Cross-process registry of running gjc RPC sessions (issue 10).
+ *
+ * Each live RPC server writes a record under `<agent-dir>/rpc-sessions/<id>.json`
+ * on start and removes it on shutdown, so a separate process can discover which
+ * sessions are alive (and, once persistence lands in issue 09, how to reach
+ * them). Listing reaps records whose owning process is no longer alive, so a
+ * crashed server never leaves a permanent phantom entry.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getAgentDir } from "@gajae-code/utils";
+
+export type RpcSessionTransport = "stdio" | "bridge";
+
+export interface RpcSessionRecord {
+	sessionId: string;
+	pid: number;
+	transport: RpcSessionTransport;
+	cwd: string;
+	model?: string;
+	/** ISO-8601 start timestamp. */
+	startedAt: string;
+	/** Reachable endpoint for persistent transports (issue 09); absent for stdio. */
+	endpoint?: string;
+}
+
+/** Registry directory: `<agent-dir>/rpc-sessions` (honors GJC_CODING_AGENT_DIR via getAgentDir). */
+function rpcSessionsDir(agentDir?: string): string {
+	return path.join(agentDir ?? getAgentDir(), "rpc-sessions");
+}
+
+function recordPath(sessionId: string, agentDir?: string): string {
+	return path.join(rpcSessionsDir(agentDir), `${sessionId}.json`);
+}
+
+/** Write (or replace) the registry record for a session. */
+export async function registerRpcSession(record: RpcSessionRecord, agentDir?: string): Promise<string> {
+	const file = recordPath(record.sessionId, agentDir);
+	await Bun.write(file, JSON.stringify(record));
+	return file;
+}
+
+/** Remove a session's registry record. Best-effort: a missing file is not an error. */
+export async function unregisterRpcSession(sessionId: string, agentDir?: string): Promise<void> {
+	await fs.rm(recordPath(sessionId, agentDir), { force: true });
+}
+
+function isProcessAlive(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		// Signal 0 performs error checking without delivering a signal.
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		// ESRCH => no such process (dead). EPERM => alive but owned by another user.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function parseRecord(raw: string): RpcSessionRecord | undefined {
+	let obj: Partial<RpcSessionRecord>;
+	try {
+		obj = JSON.parse(raw) as Partial<RpcSessionRecord>;
+	} catch {
+		return undefined;
+	}
+	if (typeof obj.sessionId !== "string" || typeof obj.pid !== "number") return undefined;
+	return obj as RpcSessionRecord;
+}
+
+/**
+ * List live RPC sessions, reaping records whose process is gone or whose file is
+ * unparseable. Returns records sorted by `startedAt` ascending.
+ */
+export async function listRpcSessions(agentDir?: string): Promise<RpcSessionRecord[]> {
+	const dir = rpcSessionsDir(agentDir);
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dir);
+	} catch {
+		return [];
+	}
+	const live: RpcSessionRecord[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".json")) continue;
+		const file = path.join(dir, entry);
+		let raw: string;
+		try {
+			raw = await fs.readFile(file, "utf8");
+		} catch {
+			continue;
+		}
+		const record = parseRecord(raw);
+		if (!record || !isProcessAlive(record.pid)) {
+			await fs.rm(file, { force: true });
+			continue;
+		}
+		live.push(record);
+	}
+	return live.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+}

--- a/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/session-registry.ts
@@ -11,7 +11,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir } from "@gajae-code/utils";
 
-export type RpcSessionTransport = "stdio" | "bridge";
+export type RpcSessionTransport = "stdio" | "bridge" | "socket";
 
 export interface RpcSessionRecord {
 	sessionId: string;

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+	listRpcSessions,
+	type RpcSessionRecord,
+	registerRpcSession,
+	unregisterRpcSession,
+} from "@gajae-code/coding-agent/modes/shared/agent-wire/session-registry";
+
+let agentDir: string;
+
+beforeEach(async () => {
+	agentDir = await mkdtemp(path.join(tmpdir(), "rpc-reg-"));
+});
+
+afterEach(async () => {
+	await rm(agentDir, { recursive: true, force: true });
+});
+
+function rec(over: Partial<RpcSessionRecord> = {}): RpcSessionRecord {
+	return {
+		sessionId: "s1",
+		pid: process.pid,
+		transport: "stdio",
+		cwd: "/tmp",
+		model: "test-model",
+		startedAt: new Date().toISOString(),
+		...over,
+	};
+}
+
+describe("rpc session registry (issue 10)", () => {
+	test("register then list returns the live record; unregister removes it", async () => {
+		await registerRpcSession(rec({ sessionId: "live" }), agentDir);
+		expect((await listRpcSessions(agentDir)).map(s => s.sessionId)).toEqual(["live"]);
+		await unregisterRpcSession("live", agentDir);
+		expect(await listRpcSessions(agentDir)).toEqual([]);
+	});
+
+	test("listing reaps records whose process is dead and keeps live ones", async () => {
+		await registerRpcSession(
+			rec({ sessionId: "alive", pid: process.pid, startedAt: "2026-01-01T00:00:00.000Z" }),
+			agentDir,
+		);
+		await registerRpcSession(
+			rec({ sessionId: "dead", pid: 2 ** 30, startedAt: "2026-01-02T00:00:00.000Z" }),
+			agentDir,
+		);
+		expect((await listRpcSessions(agentDir)).map(s => s.sessionId)).toEqual(["alive"]);
+		expect(await readdir(path.join(agentDir, "rpc-sessions"))).toEqual(["alive.json"]);
+	});
+
+	test("listing reaps unparseable records", async () => {
+		await registerRpcSession(rec({ sessionId: "ok" }), agentDir);
+		const dir = path.join(agentDir, "rpc-sessions");
+		await writeFile(path.join(dir, "junk.json"), "{not valid json");
+		expect((await listRpcSessions(agentDir)).map(s => s.sessionId)).toEqual(["ok"]);
+		expect((await readdir(dir)).sort()).toEqual(["ok.json"]);
+	});
+
+	test("missing registry directory lists empty", async () => {
+		expect(await listRpcSessions(path.join(agentDir, "does-not-exist"))).toEqual([]);
+	});
+
+	test("records sort by startedAt ascending", async () => {
+		await registerRpcSession(rec({ sessionId: "second", startedAt: "2026-02-01T00:00:00.000Z" }), agentDir);
+		await registerRpcSession(rec({ sessionId: "first", startedAt: "2026-01-01T00:00:00.000Z" }), agentDir);
+		expect((await listRpcSessions(agentDir)).map(s => s.sessionId)).toEqual(["first", "second"]);
+	});
+});

--- a/packages/coding-agent/test/rpc-socket-server.test.ts
+++ b/packages/coding-agent/test/rpc-socket-server.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const fixtureModelsYaml = `providers:
+  rpc-test:
+    auth: none
+    api: openai-responses
+    baseUrl: http://127.0.0.1:9/v1
+    models:
+      - id: rpc-test-model
+        contextWindow: 100000
+        maxTokens: 4096
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+`;
+
+interface Frame {
+	type?: string;
+	id?: string;
+	command?: string;
+	success?: boolean;
+	data?: { sessionId?: string; output?: string } & Record<string, unknown>;
+}
+
+let workspace: string;
+let agentDir: string;
+let cliEnv: HarnessCliEnv;
+
+beforeEach(async () => {
+	workspace = await mkdtemp(path.join(tmpdir(), "rpc-sock-ws-"));
+	agentDir = path.join(workspace, ".gjc", "agent");
+	cliEnv = createHarnessCliEnv(repoRoot);
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(path.join(agentDir, "models.yml"), fixtureModelsYaml);
+	cliEnv.env.GJC_CODING_AGENT_DIR = agentDir;
+	cliEnv.env.PI_CODING_AGENT_DIR = agentDir;
+});
+
+afterEach(async () => {
+	try {
+		cliEnv.cleanup();
+	} catch {
+		// best-effort
+	}
+	await rm(workspace, { recursive: true, force: true });
+});
+
+interface SocketConn {
+	send(obj: object): void;
+	nextResponse(id: string, timeoutMs?: number): Promise<Frame>;
+	nextFrame(timeoutMs?: number): Promise<Frame>;
+	close(): void;
+}
+
+async function connect(socketPath: string): Promise<SocketConn> {
+	const queue: Frame[] = [];
+	const waiters: Array<(frame: Frame) => void> = [];
+	const decoder = new TextDecoder("utf-8", { fatal: false });
+	let buf = "";
+	const socket = await Bun.connect({
+		unix: socketPath,
+		socket: {
+			data(_sock, bytes) {
+				buf += decoder.decode(bytes);
+				while (true) {
+					const nl = buf.indexOf("\n");
+					if (nl < 0) break;
+					const line = buf.slice(0, nl).trim();
+					buf = buf.slice(nl + 1);
+					if (!line) continue;
+					const frame = JSON.parse(line) as Frame;
+					const waiter = waiters.shift();
+					if (waiter) waiter(frame);
+					else queue.push(frame);
+				}
+			},
+		},
+	});
+	const nextFrame = (timeoutMs = 12_000): Promise<Frame> => {
+		const queued = queue.shift();
+		if (queued) return Promise.resolve(queued);
+		return new Promise<Frame>((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error("timed out waiting for socket frame")), timeoutMs);
+			waiters.push(frame => {
+				clearTimeout(timer);
+				resolve(frame);
+			});
+		});
+	};
+	return {
+		send(obj: object) {
+			socket.write(`${JSON.stringify(obj)}\n`);
+		},
+		nextFrame,
+		async nextResponse(id: string, timeoutMs = 15_000): Promise<Frame> {
+			const start = Date.now();
+			while (Date.now() - start < timeoutMs) {
+				const frame = await nextFrame(timeoutMs);
+				if (frame.type === "response" && frame.id === id) return frame;
+			}
+			throw new Error(`no response for ${id}`);
+		},
+		close() {
+			socket.end();
+		},
+	};
+}
+
+async function waitForSocket(socketPath: string, timeoutMs = 15_000): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		try {
+			await stat(socketPath);
+			return;
+		} catch {
+			await Bun.sleep(100);
+		}
+	}
+	throw new Error(`socket ${socketPath} was not created`);
+}
+
+describe("gjc --mode rpc --listen (UDS persistent server, issue 09)", () => {
+	it("keeps the AgentSession alive across client reconnects", async () => {
+		const socketPath = path.join(workspace, "rpc.sock");
+		const proc = Bun.spawn(
+			[
+				"bun",
+				cliEntry,
+				"--mode",
+				"rpc",
+				"--provider",
+				"rpc-test",
+				"--model",
+				"rpc-test-model",
+				"--session-dir",
+				path.join(workspace, "sessions"),
+				"--listen",
+				socketPath,
+			],
+			{
+				cwd: workspace,
+				env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		try {
+			await waitForSocket(socketPath);
+
+			const first = await connect(socketPath);
+			expect(await first.nextFrame()).toEqual({ type: "ready" });
+			first.send({ id: "s1", type: "get_state" });
+			const state1 = await first.nextResponse("s1");
+			expect(state1.success).toBe(true);
+			const sessionId = state1.data?.sessionId;
+			expect(sessionId).toBeTruthy();
+			first.close();
+
+			// The server must remain alive after the client disconnects.
+			await Bun.sleep(400);
+			expect(proc.killed).toBe(false);
+
+			const second = await connect(socketPath);
+			expect(await second.nextFrame()).toEqual({ type: "ready" });
+			second.send({ id: "s2", type: "get_state" });
+			const state2 = await second.nextResponse("s2");
+			// Same session survived the reconnect.
+			expect(state2.data?.sessionId).toBe(sessionId);
+
+			// Still functional after reconnect.
+			second.send({ id: "b1", type: "bash", command: "echo persisted-across-reconnect" });
+			const bash = await second.nextResponse("b1");
+			expect(bash.success).toBe(true);
+			expect(bash.data?.output).toContain("persisted-across-reconnect");
+			second.close();
+		} finally {
+			proc.kill();
+		}
+	}, 45_000);
+
+	it("registers a discoverable socket record while listening", async () => {
+		const socketPath = path.join(workspace, "rpc2.sock");
+		const proc = Bun.spawn(
+			[
+				"bun",
+				cliEntry,
+				"--mode",
+				"rpc",
+				"--provider",
+				"rpc-test",
+				"--model",
+				"rpc-test-model",
+				"--session-dir",
+				path.join(workspace, "sessions2"),
+				"--listen",
+				socketPath,
+			],
+			{
+				cwd: workspace,
+				env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		try {
+			await waitForSocket(socketPath);
+			const { listRpcSessions } = await import("@gajae-code/coding-agent/modes/shared/agent-wire/session-registry");
+			const sessions = await listRpcSessions(agentDir);
+			const socketRecord = sessions.find(s => s.transport === "socket");
+			expect(socketRecord).toBeDefined();
+			expect(socketRecord?.endpoint).toBe(socketPath);
+		} finally {
+			proc.kill();
+		}
+	}, 45_000);
+});

--- a/python/gjc-rpc/src/gjc_rpc/__init__.py
+++ b/python/gjc-rpc/src/gjc_rpc/__init__.py
@@ -17,6 +17,7 @@ from .client import (
     UiRequestListener,
     WorkflowGateListener,
 )
+from .registry import SessionHandle, list_sessions
 from .host_tools import HostTool, HostToolContext, HostToolResultPayload, HostToolResultValue, host_tool
 from .host_uris import (
     HostUri,
@@ -107,6 +108,8 @@ from .protocol import (
 )
 
 __all__ = [
+    "SessionHandle",
+    "list_sessions",
     "ContextUsage",
     "HandoffResult",
     "LoginProvider",

--- a/python/gjc-rpc/src/gjc_rpc/client.py
+++ b/python/gjc-rpc/src/gjc_rpc/client.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar, cast
 
 from .host_tools import HostTool, HostToolContext
 from .host_uris import HostUri, HostUriContext, normalize_read_result
+from .registry import SessionHandle, list_sessions as _list_sessions
 from .protocol import (
     AgentStartEvent,
     AgentEndEvent,
@@ -870,6 +871,11 @@ class RpcClient:
     def login(self, provider_id: str) -> str:
         payload = self._request("login", providerId=provider_id)
         return str(payload.get("providerId", provider_id))
+
+    @staticmethod
+    def list_sessions(sessions_dir: str | Path | None = None) -> tuple[SessionHandle, ...]:
+        """Discover live gjc RPC sessions from the cross-process registry (issue 10)."""
+        return _list_sessions(sessions_dir)
 
     def set_custom_tools(self, tools: Sequence[HostTool[Any, Any]]) -> tuple[str, ...]:
         self._custom_tools = tuple(tools)

--- a/python/gjc-rpc/src/gjc_rpc/registry.py
+++ b/python/gjc-rpc/src/gjc_rpc/registry.py
@@ -1,0 +1,105 @@
+"""Discovery of running gjc RPC sessions (issue 10).
+
+Each live `gjc --mode rpc` server writes a record under
+``<agent-dir>/rpc-sessions/<sessionId>.json``. ``list_sessions`` reads that
+directory and reaps records whose owning process is gone, so a crashed server
+never leaves a permanent phantom entry.
+
+Directory resolution mirrors the TS side: ``GJC_CODING_AGENT_DIR`` if set, else
+``~/.gjc/agent``, plus ``/rpc-sessions``. Custom XDG layouts can pass
+``sessions_dir`` explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True, frozen=True)
+class SessionHandle:
+    session_id: str
+    pid: int
+    transport: str
+    cwd: str
+    started_at: str
+    model: str | None = None
+    endpoint: str | None = None
+
+
+def _resolve_sessions_dir(sessions_dir: str | Path | None) -> Path:
+    if sessions_dir is not None:
+        return Path(sessions_dir)
+    agent_dir = os.environ.get("GJC_CODING_AGENT_DIR")
+    base = Path(agent_dir) if agent_dir else Path.home() / ".gjc" / "agent"
+    return base / "rpc-sessions"
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # alive but owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def _parse_handle(payload: object) -> SessionHandle | None:
+    if not isinstance(payload, dict):
+        return None
+    session_id = payload.get("sessionId")
+    pid = payload.get("pid")
+    if not isinstance(session_id, str) or not isinstance(pid, int) or isinstance(pid, bool):
+        return None
+    model = payload.get("model")
+    endpoint = payload.get("endpoint")
+    return SessionHandle(
+        session_id=session_id,
+        pid=pid,
+        transport=str(payload.get("transport", "stdio")),
+        cwd=str(payload.get("cwd", "")),
+        started_at=str(payload.get("startedAt", "")),
+        model=model if isinstance(model, str) else None,
+        endpoint=endpoint if isinstance(endpoint, str) else None,
+    )
+
+
+def _reap(entry: Path) -> None:
+    try:
+        entry.unlink()
+    except OSError:
+        pass
+
+
+def list_sessions(sessions_dir: str | Path | None = None) -> tuple[SessionHandle, ...]:
+    """List live gjc RPC sessions, reaping records whose process is gone (issue 10)."""
+    directory = _resolve_sessions_dir(sessions_dir)
+    try:
+        entries = sorted(directory.glob("*.json"))
+    except OSError:
+        return ()
+    handles: list[SessionHandle] = []
+    for entry in entries:
+        try:
+            raw = entry.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            _reap(entry)
+            continue
+        handle = _parse_handle(payload)
+        if handle is None or not _process_alive(handle.pid):
+            _reap(entry)
+            continue
+        handles.append(handle)
+    handles.sort(key=lambda handle: handle.started_at)
+    return tuple(handles)

--- a/python/gjc-rpc/tests/test_real_binary.py
+++ b/python/gjc-rpc/tests/test_real_binary.py
@@ -98,6 +98,13 @@ class RealBinaryRpcTest(unittest.TestCase):
                     action_allowlist=[],
                 )
 
+    def test_live_session_appears_in_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, self._client(tmp) as client:
+            state = client.get_state()
+            registry_dir = os.path.join(tmp, ".agent", "rpc-sessions")
+            handles = RpcClient.list_sessions(sessions_dir=registry_dir)
+            self.assertIn(state.session_id, [h.session_id for h in handles])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/gjc-rpc/tests/test_registry.py
+++ b/python/gjc-rpc/tests/test_registry.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from gjc_rpc import SessionHandle, list_sessions
+
+
+def _write(directory: Path, name: str, payload: dict[str, object]) -> None:
+    (directory / f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _record(session_id: str, pid: int, started_at: str, **extra: object) -> dict[str, object]:
+    return {
+        "sessionId": session_id,
+        "pid": pid,
+        "transport": "stdio",
+        "cwd": "/tmp",
+        "startedAt": started_at,
+        **extra,
+    }
+
+
+class RegistryTests(unittest.TestCase):
+    def test_lists_live_and_reaps_dead(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            _write(directory, "alive", _record("alive", os.getpid(), "2026-01-01T00:00:00Z", model="m"))
+            _write(directory, "dead", _record("dead", 2**30, "2026-01-02T00:00:00Z"))
+            sessions = list_sessions(sessions_dir=directory)
+            self.assertEqual([s.session_id for s in sessions], ["alive"])
+            self.assertIsInstance(sessions[0], SessionHandle)
+            self.assertEqual(sessions[0].model, "m")
+            self.assertFalse((directory / "dead.json").exists())
+
+    def test_reaps_unparseable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "junk.json").write_text("{not valid json", encoding="utf-8")
+            _write(directory, "ok", _record("ok", os.getpid(), "2026-01-01T00:00:00Z"))
+            sessions = list_sessions(sessions_dir=directory)
+            self.assertEqual([s.session_id for s in sessions], ["ok"])
+            self.assertFalse((directory / "junk.json").exists())
+
+    def test_sorts_by_started_at(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            _write(directory, "b", _record("second", os.getpid(), "2026-02-01T00:00:00Z"))
+            _write(directory, "a", _record("first", os.getpid(), "2026-01-01T00:00:00Z"))
+            sessions = list_sessions(sessions_dir=directory)
+            self.assertEqual([s.session_id for s in sessions], ["first", "second"])
+
+    def test_missing_dir_is_empty(self) -> None:
+        self.assertEqual(list_sessions(sessions_dir="/no/such/registry/dir"), ())
+
+    def test_env_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            previous = os.environ.get("GJC_CODING_AGENT_DIR")
+            os.environ["GJC_CODING_AGENT_DIR"] = tmp
+            try:
+                registry = Path(tmp) / "rpc-sessions"
+                registry.mkdir(parents=True)
+                _write(registry, "x", _record("x", os.getpid(), "2026-01-01T00:00:00Z"))
+                self.assertEqual([s.session_id for s in list_sessions()], ["x"])
+            finally:
+                if previous is None:
+                    os.environ.pop("GJC_CODING_AGENT_DIR", None)
+                else:
+                    os.environ["GJC_CODING_AGENT_DIR"] = previous
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First story (G001) of the RPC persistence + registry follow-up (issues 09/10 deferred from #586). Adds a **cross-process registry of running gjc RPC sessions** so a separate process can answer "what sessions are alive?" — the foundation for reattach (issue 09).

> Stacked on `feat/rpc-control-plane-weaknesses` (#586). Retarget to `dev` once #586 merges.

## What's added

- **TS** `modes/shared/agent-wire/session-registry.ts`: `register`/`unregister`/`list` with stale-PID **and** bad-file reaping, writing `<agent-dir>/rpc-sessions/<sessionId>.json` (`{sessionId, pid, transport, cwd, model, startedAt, endpoint?}`). `rpc-mode` registers on start (before the input loop) and unregisters in `shutdown()` — both best-effort so a registry failure never pollutes the protocol channel.
- **Python** `gjc_rpc`: typed `SessionHandle` + `list_sessions()` / `RpcClient.list_sessions()` that read the registry and reap records whose owning process is gone (`os.kill(pid, 0)`).

## Verification

- `bun run check:ts` — green.
- `rpc-session-registry.test.ts` (5): register/list/unregister, dead-PID reap, bad-file reap, sort, missing-dir.
- Python `test_registry.py` (5): parse/reap/sort/env-resolution.
- Real-binary lane (`test_real_binary.py`, `GJC_RPC_REAL_BINARY=1`): a live session is discoverable end-to-end via `list_sessions`.
- Existing stdio lifecycle suites unaffected (registration is side-effect-free on the wire).

## Scope / next

- **G002 (issue 09 — persistent/detached session)** is **not** in this PR. The registry's `endpoint` field is reserved for it; stdio records carry no endpoint (not yet reattachable). Persistence needs a transport decision (UDS socket server vs. reuse the bridge HTTP transport) — a dedicated follow-up.
- `attach()` and a `gjc rpc sessions` CLI are deferred with persistence.
