### PR TITLE
feat(web-search): native model-provider search as primary with configurable fallback

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -35,6 +35,7 @@ import { $pickenv, isRecord, logger } from "@gajae-code/utils";
 import { parseModelString, resolveProviderModelReference } from "../config/model-resolver";
 import { isValidThemeColor, type ThemeColor } from "../modes/theme/theme";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
+import type { ActiveSearchModelContext, WebSearchMode } from "../web/search/types";
 import { type ConfigError, ConfigFile } from "./config-file";
 import {
 	buildCanonicalModelIndex,
@@ -964,6 +965,7 @@ export class ModelRegistry {
 	#models: Model<Api>[] = [];
 	#canonicalIndex: CanonicalModelIndex = { records: [], byId: new Map(), bySelector: new Map() };
 	#customProviderApiKeys: Map<string, string> = new Map();
+	#providerWebSearchModes: Map<string, WebSearchMode> = new Map();
 	#keylessProviders: Set<string> = new Set();
 	#discoverableProviders: DiscoveryProviderConfig[] = [];
 	#customModelOverlays: CustomModelOverlay[] = [];
@@ -1073,6 +1075,7 @@ export class ModelRegistry {
 		}
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
+		this.#providerWebSearchModes.clear();
 		this.#keylessProviders.clear();
 		this.#discoverableProviders = [];
 		// Drop config-sourced apiKeys from AuthStorage before reload; entries
@@ -1390,6 +1393,7 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 
 		for (const [providerName, providerConfig] of providerEntries) {
+			if (providerConfig.webSearch) this.#providerWebSearchModes.set(providerName, providerConfig.webSearch);
 			const providerApiKeyConfig = providerConfig.apiKey ?? resolveApiKeyEnvConfig(providerConfig.apiKeyEnv);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
 			if (
@@ -2439,6 +2443,22 @@ export class ModelRegistry {
 			this.#models.find(m => m.provider === provider && m.baseUrl)?.baseUrl ??
 			resolveProviderBaseUrlFromEnv(provider)
 		);
+	}
+
+	getProviderWebSearchMode(provider: string): WebSearchMode | undefined {
+		return this.#providerWebSearchModes.get(provider);
+	}
+
+	getActiveSearchModelContext(model: Model<Api>): ActiveSearchModelContext {
+		return {
+			provider: model.provider,
+			modelId: model.id,
+			wireModelId: model.wireModelId,
+			api: model.api,
+			baseUrl: model.baseUrl,
+			headers: model.headers,
+			webSearch: this.getProviderWebSearchMode(model.provider),
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -218,6 +218,7 @@ const ProviderConfigSchema = z
 			.optional(),
 		headers: z.record(z.string(), z.string()).optional(),
 		compat: OpenAICompatSchema.optional(),
+		webSearch: z.enum(["on", "off", "auto"]).optional(),
 		authHeader: z.boolean().optional(),
 		auth: ProviderAuthSchema.optional(),
 		discovery: ProviderDiscoverySchema.optional(),

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2,6 +2,7 @@ import type { Effort } from "@gajae-code/ai/model-thinking";
 import { TASK_SIMPLE_MODES } from "../task/simple-mode";
 import { getThinkingLevelMetadata } from "../thinking-metadata";
 import { EDIT_MODES } from "../utils/edit-mode";
+import { CONFIGURABLE_SEARCH_PROVIDER_IDS } from "../web/search/types";
 
 const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
 
@@ -164,6 +165,7 @@ interface EnumDef<T extends readonly string[]> {
 interface ArrayDef<T> {
 	type: "array";
 	default: T[];
+	items?: { enum: readonly string[] };
 	ui?: UiBase;
 }
 
@@ -2066,6 +2068,17 @@ export const SETTINGS_SCHEMA = {
 		type: "boolean",
 		default: true,
 		ui: { tab: "tools", label: "Web Search", description: "Enable the web_search tool for web searching" },
+	},
+
+	"web_search.fallback": {
+		type: "array",
+		default: EMPTY_STRING_ARRAY,
+		items: { enum: CONFIGURABLE_SEARCH_PROVIDER_IDS },
+		ui: {
+			tab: "tools",
+			label: "Web Search Fallback",
+			description: "Ordered fallback web search providers after the active model native provider",
+		},
 	},
 
 	"browser.enabled": {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -38,7 +38,13 @@ import {
 	MODEL_ONBOARDING_SETUP_COMMAND,
 } from "../../setup/model-onboarding-guidance";
 import { addApiCompatibleProvider, formatProviderSetupResult } from "../../setup/provider-onboarding";
-import { isSearchProviderPreference, setPreferredImageProvider, setPreferredSearchProvider } from "../../tools";
+import {
+	isConfigurableSearchProviderId,
+	isSearchProviderPreference,
+	setPreferredImageProvider,
+	setPreferredSearchProvider,
+	setSearchFallbackProviders,
+} from "../../tools";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
@@ -504,6 +510,13 @@ export class SelectorController {
 			case "providers.webSearch":
 				if (typeof value === "string" && isSearchProviderPreference(value)) {
 					setPreferredSearchProvider(value);
+				}
+				break;
+			case "web_search.fallback":
+				if (Array.isArray(value)) {
+					setSearchFallbackProviders(
+						value.filter(item => typeof item === "string" && isConfigurableSearchProviderId(item)),
+					);
 				}
 				break;
 			case "providers.image":

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -114,6 +114,7 @@ import {
 	FindTool,
 	getSearchTools,
 	HIDDEN_TOOLS,
+	isConfigurableSearchProviderId,
 	isSearchProviderPreference,
 	type LspStartupServerInfo,
 	loadSshTool,
@@ -123,6 +124,7 @@ import {
 	SearchTool,
 	setPreferredImageProvider,
 	setPreferredSearchProvider,
+	setSearchFallbackProviders,
 	type Tool,
 	type ToolSession,
 	WebSearchTool,
@@ -863,6 +865,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const webSearchProvider = settings.get("providers.webSearch");
 	if (typeof webSearchProvider === "string" && isSearchProviderPreference(webSearchProvider)) {
 		setPreferredSearchProvider(webSearchProvider);
+	}
+	const webSearchFallback = settings.get("web_search.fallback");
+	if (Array.isArray(webSearchFallback)) {
+		setSearchFallbackProviders(
+			webSearchFallback.filter(value => typeof value === "string" && isConfigurableSearchProviderId(value)),
+		);
 	}
 
 	const imageProvider = settings.get("providers.image");

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -8,7 +8,6 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import type { AuthStorage } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
-import { parseModelString } from "../../config/model-resolver";
 import type { CustomTool, CustomToolContext, RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme } from "../../modes/theme/theme";
 import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { type: "text" };
@@ -19,7 +18,7 @@ import { formatAge } from "../../tools/render-utils";
 import { throwIfAborted } from "../../tools/tool-errors";
 import { getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
-import type { SearchProviderId, SearchResponse } from "./types";
+import type { ActiveSearchModelContext, SearchProviderId, SearchResponse } from "./types";
 import { SearchProviderError } from "./types";
 
 /** Web search tool parameters schema */
@@ -116,21 +115,11 @@ function formatForLLM(response: SearchResponse): string {
 	return parts.join("\n");
 }
 
-/** Best-effort active model provider: prefer the resolved Model, fall back to parsing the model string. */
-function resolveActiveModelProvider(
-	modelProvider: string | undefined,
-	modelString: string | undefined,
-): string | undefined {
-	if (modelProvider) return modelProvider;
-	if (modelString) return parseModelString(modelString)?.provider;
-	return undefined;
-}
-
 interface ExecuteSearchOptions {
 	authStorage: AuthStorage;
 	sessionId?: string;
 	signal?: AbortSignal;
-	activeModelProvider?: string;
+	activeModelContext?: ActiveSearchModelContext;
 }
 
 /** Execute web search */
@@ -139,11 +128,17 @@ async function executeSearch(
 	params: SearchQueryParams,
 	options: ExecuteSearchOptions,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const { authStorage, sessionId, signal, activeModelProvider } = options;
+	const { authStorage, sessionId, signal, activeModelContext } = options;
 	// Pass `params.provider` straight through: when omitted (the normal model-facing
 	// path) it is `undefined`, so `resolveProviderChain` applies the settings-configured
 	// preferred provider. Coalescing to "auto" here would silently bypass that preference.
-	const providers = await resolveProviderChain(authStorage, params.provider, activeModelProvider);
+	const providers = await resolveProviderChain({
+		authStorage,
+		sessionId,
+		signal,
+		preferredProvider: params.provider,
+		activeModelContext,
+	});
 
 	const failures: Array<{ provider: SearchProvider; error: unknown }> = [];
 	let lastProvider = providers[0];
@@ -161,6 +156,7 @@ async function executeSearch(
 				signal,
 				authStorage,
 				sessionId,
+				activeModelContext,
 			});
 
 			const text = formatForLLM(response);
@@ -210,14 +206,19 @@ async function executeSearch(
  */
 export async function runSearchQuery(
 	params: SearchQueryParams,
-	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal; activeModelProvider?: string } = {},
+	options: {
+		authStorage?: AuthStorage;
+		sessionId?: string;
+		signal?: AbortSignal;
+		activeModelContext?: ActiveSearchModelContext;
+	} = {},
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
 	const authStorage = options.authStorage ?? (await discoverAuthStorage());
 	return executeSearch("cli-web-search", params, {
 		authStorage,
 		sessionId: options.sessionId,
 		signal: options.signal,
-		activeModelProvider: options.activeModelProvider,
+		activeModelContext: options.activeModelContext,
 	});
 }
 
@@ -251,11 +252,10 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 	): Promise<AgentToolResult<SearchRenderDetails>> {
 		const authStorage = this.#session.authStorage ?? (await discoverAuthStorage());
 		const sessionId = this.#session.getSessionId?.() ?? undefined;
-		const activeModelProvider = resolveActiveModelProvider(
-			this.#session.model?.provider,
-			this.#session.getActiveModelString?.(),
-		);
-		return executeSearch(_toolCallId, params, { authStorage, sessionId, signal, activeModelProvider });
+		const activeModelContext = this.#session.model
+			? this.#session.modelRegistry?.getActiveSearchModelContext(this.#session.model)
+			: undefined;
+		return executeSearch(_toolCallId, params, { authStorage, sessionId, signal, activeModelContext });
 	}
 }
 
@@ -279,7 +279,7 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 			authStorage,
 			sessionId,
 			signal,
-			activeModelProvider: ctx.model?.provider,
+			activeModelContext: ctx.model ? ctx.modelRegistry?.getActiveSearchModelContext(ctx.model) : undefined,
 		});
 	},
 
@@ -296,6 +296,6 @@ export function getSearchTools(): CustomTool<any, any>[] {
 	return [webSearchCustomTool];
 }
 
-export { getSearchProvider, setPreferredSearchProvider } from "./provider";
+export { getSearchProvider, setPreferredSearchProvider, setSearchFallbackProviders } from "./provider";
 export type { SearchProviderId as SearchProvider, SearchResponse } from "./types";
-export { isSearchProviderPreference } from "./types";
+export { isConfigurableSearchProviderId, isSearchProviderPreference } from "./types";

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -10,7 +10,8 @@
 
 import type { AuthStorage } from "@gajae-code/ai";
 import type { SearchProvider } from "./providers/base";
-import type { SearchProviderId } from "./types";
+import type { ActiveSearchModelContext, SearchProviderId } from "./types";
+import { isConfigurableSearchProviderId } from "./types";
 
 export type { SearchParams } from "./providers/base";
 export { SearchProvider } from "./providers/base";
@@ -23,36 +24,16 @@ interface ProviderMeta {
 
 /** Lazy factories. Each `load()` dynamic-imports its provider module on first call. */
 const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
-	exa: {
-		id: "exa",
-		label: "Exa",
-		load: async () => new (await import("./providers/exa")).ExaProvider(),
-	},
-	brave: {
-		id: "brave",
-		label: "Brave",
-		load: async () => new (await import("./providers/brave")).BraveProvider(),
-	},
-	jina: {
-		id: "jina",
-		label: "Jina",
-		load: async () => new (await import("./providers/jina")).JinaProvider(),
-	},
+	exa: { id: "exa", label: "Exa", load: async () => new (await import("./providers/exa")).ExaProvider() },
+	brave: { id: "brave", label: "Brave", load: async () => new (await import("./providers/brave")).BraveProvider() },
+	jina: { id: "jina", label: "Jina", load: async () => new (await import("./providers/jina")).JinaProvider() },
 	perplexity: {
 		id: "perplexity",
 		label: "Perplexity",
 		load: async () => new (await import("./providers/perplexity")).PerplexityProvider(),
 	},
-	kimi: {
-		id: "kimi",
-		label: "Kimi",
-		load: async () => new (await import("./providers/kimi")).KimiProvider(),
-	},
-	zai: {
-		id: "zai",
-		label: "Z.AI",
-		load: async () => new (await import("./providers/zai")).ZaiProvider(),
-	},
+	kimi: { id: "kimi", label: "Kimi", load: async () => new (await import("./providers/kimi")).KimiProvider() },
+	zai: { id: "zai", label: "Z.AI", load: async () => new (await import("./providers/zai")).ZaiProvider() },
 	anthropic: {
 		id: "anthropic",
 		label: "Anthropic",
@@ -63,11 +44,7 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: "Gemini",
 		load: async () => new (await import("./providers/gemini")).GeminiProvider(),
 	},
-	codex: {
-		id: "codex",
-		label: "OpenAI",
-		load: async () => new (await import("./providers/codex")).CodexProvider(),
-	},
+	codex: { id: "codex", label: "OpenAI", load: async () => new (await import("./providers/codex")).CodexProvider() },
 	tavily: {
 		id: "tavily",
 		label: "Tavily",
@@ -78,11 +55,7 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: "Parallel",
 		load: async () => new (await import("./providers/parallel")).ParallelProvider(),
 	},
-	kagi: {
-		id: "kagi",
-		label: "Kagi",
-		load: async () => new (await import("./providers/kagi")).KagiProvider(),
-	},
+	kagi: { id: "kagi", label: "Kagi", load: async () => new (await import("./providers/kagi")).KagiProvider() },
 	synthetic: {
 		id: "synthetic",
 		label: "Synthetic",
@@ -98,26 +71,24 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: "DuckDuckGo",
 		load: async () => new (await import("./providers/duckduckgo")).DuckDuckGoProvider(),
 	},
+	"openai-compatible": {
+		id: "openai-compatible",
+		label: "OpenAI-compatible",
+		load: async () => new (await import("./providers/openai-compatible")).OpenAICompatibleSearchProvider(),
+	},
 };
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();
 
-/** Cheap, sync metadata accessor — never triggers a provider load. */
 export function getSearchProviderLabel(id: SearchProviderId): string {
 	return PROVIDER_META[id]?.label ?? id;
 }
 
-/**
- * Resolve and cache a provider instance. First call for a given id loads the
- * underlying module; subsequent calls return the cached singleton.
- */
 export async function getSearchProvider(id: SearchProviderId): Promise<SearchProvider> {
 	const cached = instanceCache.get(id);
 	if (cached) return cached;
 	const meta = PROVIDER_META[id];
-	if (!meta) {
-		throw new Error(`Unknown search provider: ${id}`);
-	}
+	if (!meta) throw new Error(`Unknown search provider: ${id}`);
 	const provider = await meta.load();
 	instanceCache.set(id, provider);
 	return provider;
@@ -141,13 +112,6 @@ export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
 	"searxng",
 ];
 
-/**
- * Map an active model's provider string to its own native web-search provider.
- * Keys are real model provider ids (see packages/ai/src/types.ts KnownProvider);
- * a few aliases (gemini/kimi) and API strings (openai-responses) are tolerated
- * defensively. Providers absent from this map (custom/unknown) fall through to
- * DuckDuckGo.
- */
 const MODEL_PROVIDER_TO_SEARCH: Record<string, SearchProviderId> = {
 	openai: "codex",
 	"openai-codex": "codex",
@@ -165,54 +129,173 @@ const MODEL_PROVIDER_TO_SEARCH: Record<string, SearchProviderId> = {
 	synthetic: "synthetic",
 };
 
-/** Preferred provider set via settings (default: auto) */
 let preferredProvId: SearchProviderId | "auto" = "auto";
+let fallbackProvIds: SearchProviderId[] = [];
 
-/** Set the preferred web search provider from settings */
 export function setPreferredSearchProvider(provider: SearchProviderId | "auto"): void {
 	preferredProvId = provider;
 }
 
-/**
- * Resolve the ordered provider chain for a search request.
- *
- * Resolution is active-model-gated, never credential-scanning:
- *   1. An explicitly preferred provider (settings) that is available is primary.
- *   2. Otherwise the active model's own native search is primary, but only when
- *      that provider's own credentials are present (its `isAvailable()`).
- *   3. DuckDuckGo (keyless) is always appended as the terminal fallback, so a
- *      missing primary — or a primary runtime failure — still returns results
- *      with zero configuration. Keyed standalone providers are never
- *      auto-selected; they are reachable only via explicit selection (step 1).
- */
-export async function resolveProviderChain(
+export function setSearchFallbackProviders(ids: readonly string[]): void {
+	fallbackProvIds = ids.filter(isConfigurableSearchProviderId);
+}
+
+export interface ResolveProviderChainOptions {
+	authStorage: AuthStorage;
+	sessionId?: string;
+	signal?: AbortSignal;
+	preferredProvider?: SearchProviderId | "auto";
+	activeModelContext?: ActiveSearchModelContext;
+	fallbackProviders?: readonly SearchProviderId[];
+}
+
+async function appendAvailable(
+	chain: SearchProviderId[],
+	id: SearchProviderId,
 	authStorage: AuthStorage,
-	preferredProvider: SearchProviderId | "auto" = preferredProvId,
-	activeModelProvider?: string,
-): Promise<SearchProvider[]> {
+): Promise<void> {
+	if (chain.includes(id)) return;
+	const provider = await getSearchProvider(id);
+	if (await provider.isAvailable(authStorage)) chain.push(id);
+}
+
+function appendDeduped(chain: SearchProviderId[], id: SearchProviderId): void {
+	if (!chain.includes(id)) chain.push(id);
+}
+
+function isAnthropicWire(api: string): boolean {
+	return api === "anthropic-messages";
+}
+
+function isGoogleWire(api: string): boolean {
+	return api === "google-generative-ai" || api === "google-vertex" || api === "google-gemini-cli";
+}
+
+function isOpenAICompatWire(api: string): boolean {
+	return api === "openai-responses" || api === "openai-completions" || api === "azure-openai-responses";
+}
+
+export function looksHostedModelId(modelId: string | undefined): boolean {
+	if (!modelId) return false;
+	const id = modelId.toLowerCase();
+	return /^(gpt-|o\d|o-|chatgpt-|text-|davinci|babbage|curie)/.test(id);
+}
+
+function looksOpenAIFamilyModelId(ctx: ActiveSearchModelContext): boolean {
+	return looksHostedModelId(ctx.wireModelId) || looksHostedModelId(ctx.modelId);
+}
+
+export function isLocalBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	let url: URL;
+	try {
+		url = new URL(baseUrl);
+	} catch {
+		return true;
+	}
+	const host = url.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "");
+	if (
+		host === "localhost" ||
+		host.endsWith(".localhost") ||
+		host === "host.docker.internal" ||
+		host.endsWith(".local")
+	)
+		return true;
+	const v4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+	if (v4) {
+		const [a, b] = v4.slice(1, 3).map(Number);
+		if (
+			a === 127 ||
+			a === 0 ||
+			a === 10 ||
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 192 && b === 168) ||
+			(a === 169 && b === 254)
+		)
+			return true;
+	}
+	if (host === "::1" || host === "::") return true;
+	if (host.startsWith("fc") || host.startsWith("fd")) return true;
+	if (host.startsWith("fe8") || host.startsWith("fe9") || host.startsWith("fea") || host.startsWith("feb"))
+		return true;
+	return false;
+}
+
+export function inferNativeProviderFromModel(ctx: ActiveSearchModelContext | undefined): SearchProviderId | undefined {
+	if (!ctx || ctx.webSearch === "off") return undefined;
+	const modelId = (ctx.wireModelId ?? ctx.modelId).toLowerCase();
+	if (modelId.startsWith("claude-") && isAnthropicWire(ctx.api)) return "anthropic";
+	if (modelId.startsWith("gemini-") && isGoogleWire(ctx.api)) return "gemini";
+	if (looksOpenAIFamilyModelId(ctx) && isOpenAICompatWire(ctx.api)) {
+		if (ctx.webSearch === "on" || !isLocalBaseUrl(ctx.baseUrl)) return "codex";
+	}
+	return undefined;
+}
+
+export async function canUseGenericCredentials(
+	authStorage: AuthStorage,
+	ctx: ActiveSearchModelContext | undefined,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<boolean> {
+	if (!ctx) return false;
+	const key = await authStorage.getApiKey(ctx.provider, sessionId, {
+		baseUrl: ctx.baseUrl,
+		modelId: ctx.modelId,
+		signal,
+	});
+	return Boolean(key);
+}
+
+export async function shouldTryGenericOpenAICompat(
+	authStorage: AuthStorage,
+	ctx: ActiveSearchModelContext | undefined,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<boolean> {
+	if (!ctx || ctx.webSearch === "off" || !isOpenAICompatWire(ctx.api)) return false;
+	const autoAllowed =
+		ctx.webSearch === "on" ||
+		((ctx.api === "openai-responses" || looksOpenAIFamilyModelId(ctx)) && !isLocalBaseUrl(ctx.baseUrl));
+	return autoAllowed && (await canUseGenericCredentials(authStorage, ctx, sessionId, signal));
+}
+
+export async function resolveProviderChain(options: ResolveProviderChainOptions): Promise<SearchProvider[]> {
+	const {
+		authStorage,
+		sessionId,
+		signal,
+		preferredProvider = preferredProvId,
+		activeModelContext,
+		fallbackProviders = fallbackProvIds,
+	} = options;
 	const chain: SearchProviderId[] = [];
 
-	if (preferredProvider !== "auto") {
-		const provider = await getSearchProvider(preferredProvider);
-		if (await provider.isAvailable(authStorage)) {
-			chain.push(preferredProvider);
-		}
-	} else if (activeModelProvider) {
-		const nativeId = MODEL_PROVIDER_TO_SEARCH[activeModelProvider.toLowerCase()];
-		if (nativeId) {
-			const provider = await getSearchProvider(nativeId);
-			if (await provider.isAvailable(authStorage)) {
-				chain.push(nativeId);
-			}
-		}
+	// A forced primary is honored only when it is a user-configurable provider.
+	// The internal `openai-compatible` adapter (and any non-configurable value) is
+	// never selectable as a forced primary; such inputs fall through to auto
+	// native resolution instead of being injected into the chain.
+	if (preferredProvider !== "auto" && isConfigurableSearchProviderId(preferredProvider)) {
+		await appendAvailable(chain, preferredProvider, authStorage);
+	} else if (activeModelContext) {
+		const directId = MODEL_PROVIDER_TO_SEARCH[activeModelContext.provider.toLowerCase()];
+		if (activeModelContext.webSearch !== "off" && directId) await appendAvailable(chain, directId, authStorage);
+		const inferred = inferNativeProviderFromModel(activeModelContext);
+		if (inferred) await appendAvailable(chain, inferred, authStorage);
+		if (await shouldTryGenericOpenAICompat(authStorage, activeModelContext, sessionId, signal))
+			appendDeduped(chain, "openai-compatible");
 	}
 
-	// DuckDuckGo is the permissionless terminal fallback (deduped).
-	if (!chain.includes("duckduckgo")) chain.push("duckduckgo");
+	// Configured fallbacks are user-facing only: the internal `openai-compatible`
+	// adapter (and any non-configurable id) can never enter the chain through the
+	// fallback list, regardless of how `fallbackProviders` was supplied.
+	for (const id of fallbackProviders) {
+		if (!isConfigurableSearchProviderId(id)) continue;
+		await appendAvailable(chain, id, authStorage);
+	}
+	appendDeduped(chain, "duckduckgo");
 
 	const providers: SearchProvider[] = [];
-	for (const id of chain) {
-		providers.push(await getSearchProvider(id));
-	}
+	for (const id of chain) providers.push(await getSearchProvider(id));
 	return providers;
 }

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -1,5 +1,5 @@
 import type { AuthStorage } from "@gajae-code/ai";
-import type { SearchProviderId, SearchResponse } from "../types";
+import type { ActiveSearchModelContext, SearchProviderId, SearchResponse } from "../types";
 
 /**
  * Shared web search parameters passed to providers.
@@ -50,6 +50,7 @@ export interface SearchParams {
 	 * caller's agent session when available; otherwise omit.
 	 */
 	sessionId?: string;
+	activeModelContext?: ActiveSearchModelContext;
 }
 
 /** Base class for web search providers. */

--- a/packages/coding-agent/src/web/search/providers/openai-compatible.ts
+++ b/packages/coding-agent/src/web/search/providers/openai-compatible.ts
@@ -1,0 +1,151 @@
+import type { SearchCitation, SearchResponse, SearchSource } from "../types";
+import { SearchProviderError } from "../types";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+function endpoint(baseUrl: string, api: string): string {
+	const base = baseUrl.replace(/\/+$/, "");
+	return api === "openai-completions" ? `${base}/chat/completions` : `${base}/responses`;
+}
+
+function textFromResponse(json: any): string | undefined {
+	if (typeof json.output_text === "string") return json.output_text;
+	const chunks: string[] = [];
+	for (const item of json.output ?? []) {
+		for (const content of item.content ?? []) {
+			if (typeof content.text === "string") chunks.push(content.text);
+		}
+	}
+	const chat = json.choices?.[0]?.message?.content;
+	if (typeof chat === "string") chunks.push(chat);
+	return chunks.join("\n") || undefined;
+}
+
+function pushCitation(out: SearchCitation[], rawUrl: unknown, rawTitle: unknown, rawText: unknown): void {
+	if (typeof rawUrl !== "string" || !rawUrl) return;
+	out.push({
+		url: rawUrl,
+		title: typeof rawTitle === "string" && rawTitle ? rawTitle : rawUrl,
+		citedText: typeof rawText === "string" ? rawText : undefined,
+	});
+}
+
+// Only recognized grounding annotations count as citations. An OpenAI-compatible
+// endpoint that ignores the web_search request returns a normal answer with no
+// `url_citation` annotations; treating arbitrary URL/`type:"source"` metadata as a
+// citation would mask that non-search answer as a real search result. Restrict
+// extraction to the documented annotation shapes (Responses
+// `output[].content[].annotations[]` and Chat `choices[].message.annotations[]`),
+// accepting only `type: "url_citation"` entries.
+function collectCitationAnnotations(annotations: unknown, out: SearchCitation[]): void {
+	if (!Array.isArray(annotations)) return;
+	for (const annotation of annotations) {
+		if (!annotation || typeof annotation !== "object") continue;
+		const ann = annotation as Record<string, any>;
+		if (ann.type !== "url_citation") continue;
+		const cite =
+			ann.url_citation && typeof ann.url_citation === "object" ? (ann.url_citation as Record<string, any>) : ann;
+		pushCitation(out, cite.url ?? cite.uri, cite.title, cite.text ?? cite.quote ?? ann.text);
+	}
+}
+
+function parseCitations(json: any): SearchCitation[] {
+	const citations: SearchCitation[] = [];
+	for (const item of json?.output ?? []) {
+		for (const content of item?.content ?? []) {
+			collectCitationAnnotations(content?.annotations, citations);
+		}
+	}
+	for (const choice of json?.choices ?? []) {
+		collectCitationAnnotations(choice?.message?.annotations, citations);
+	}
+	const seen = new Set<string>();
+	return citations.filter(c => {
+		if (seen.has(c.url)) return false;
+		seen.add(c.url);
+		return true;
+	});
+}
+
+function toSources(citations: SearchCitation[], limit: number): SearchSource[] {
+	return citations.slice(0, limit).map(c => ({ title: c.title || c.url, url: c.url, snippet: c.citedText }));
+}
+
+export class OpenAICompatibleSearchProvider extends SearchProvider {
+	readonly id = "openai-compatible" as const;
+	readonly label = "OpenAI-compatible";
+
+	isAvailable(): boolean {
+		return true;
+	}
+
+	async search(params: SearchParams): Promise<SearchResponse> {
+		const ctx = params.activeModelContext;
+		if (!ctx)
+			throw new SearchProviderError(this.id, "OpenAI-compatible web search requires active model context", 400);
+		if (ctx.api !== "openai-responses" && ctx.api !== "openai-completions") {
+			throw new SearchProviderError(this.id, `OpenAI-compatible web search does not support ${ctx.api}`, 400);
+		}
+		const apiKey = await params.authStorage.getApiKey(ctx.provider, params.sessionId, {
+			baseUrl: ctx.baseUrl,
+			modelId: ctx.modelId,
+			signal: params.signal,
+		});
+		if (!apiKey) throw new SearchProviderError(this.id, `No credentials for ${ctx.provider}`, 401);
+		const model = ctx.wireModelId ?? ctx.modelId;
+		const headers = { ...(ctx.headers ?? {}), Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+		const body =
+			ctx.api === "openai-completions"
+				? {
+						model,
+						messages: [
+							{ role: "system", content: params.systemPrompt },
+							{ role: "user", content: params.query },
+						],
+						web_search_options: {},
+						temperature: params.temperature,
+						max_tokens: params.maxOutputTokens,
+					}
+				: {
+						model,
+						input: [
+							{ role: "system", content: params.systemPrompt },
+							{ role: "user", content: params.query },
+						],
+						tools: [{ type: "web_search" }],
+						temperature: params.temperature,
+						max_output_tokens: params.maxOutputTokens,
+					};
+		const response = await fetch(endpoint(ctx.baseUrl ?? "", ctx.api), {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal: withHardTimeout(params.signal),
+		});
+		const text = await response.text();
+		if (!response.ok) {
+			const classified = classifyProviderHttpError(this.id, response.status, text);
+			if (classified) throw classified;
+			throw new SearchProviderError(
+				this.id,
+				`OpenAI-compatible web search error (${response.status}): ${text}`,
+				response.status,
+			);
+		}
+		const json = text ? JSON.parse(text) : {};
+		const citations = parseCitations(json);
+		if (citations.length === 0) {
+			throw new SearchProviderError(this.id, "OpenAI-compatible web search returned no citations", 424);
+		}
+		return {
+			provider: this.id,
+			answer: textFromResponse(json),
+			sources: toSources(citations, params.limit ?? params.numSearchResults ?? 10),
+			citations,
+			model,
+			requestId: json.id,
+			authMode: "api-key",
+		};
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -20,30 +20,55 @@ export type SearchProviderId =
 	| "parallel"
 	| "kagi"
 	| "synthetic"
-	| "searxng";
+	| "searxng"
+	| "openai-compatible";
 
-export function isSearchProviderId(value: string): value is SearchProviderId {
-	return [
-		"duckduckgo",
-		"exa",
-		"brave",
-		"jina",
-		"kimi",
-		"zai",
-		"anthropic",
-		"perplexity",
-		"gemini",
-		"codex",
-		"tavily",
-		"parallel",
-		"kagi",
-		"synthetic",
-		"searxng",
-	].includes(value);
+export type WebSearchMode = "on" | "off" | "auto";
+
+export interface ActiveSearchModelContext {
+	provider: string;
+	modelId: string;
+	wireModelId?: string;
+	api: string;
+	baseUrl?: string;
+	headers?: Record<string, string>;
+	webSearch?: WebSearchMode;
 }
 
-export function isSearchProviderPreference(value: string): value is SearchProviderId | "auto" {
-	return value === "auto" || isSearchProviderId(value);
+export const CONFIGURABLE_SEARCH_PROVIDER_IDS = [
+	"duckduckgo",
+	"exa",
+	"brave",
+	"jina",
+	"kimi",
+	"zai",
+	"anthropic",
+	"perplexity",
+	"gemini",
+	"codex",
+	"tavily",
+	"parallel",
+	"kagi",
+	"synthetic",
+	"searxng",
+] as const satisfies readonly SearchProviderId[];
+
+const SEARCH_PROVIDER_IDS = [...CONFIGURABLE_SEARCH_PROVIDER_IDS, "openai-compatible"] as const;
+
+export function isSearchProviderId(value: string): value is SearchProviderId {
+	return (SEARCH_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+export function isConfigurableSearchProviderId(
+	value: string,
+): value is (typeof CONFIGURABLE_SEARCH_PROVIDER_IDS)[number] {
+	return (CONFIGURABLE_SEARCH_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+export function isSearchProviderPreference(
+	value: string,
+): value is (typeof CONFIGURABLE_SEARCH_PROVIDER_IDS)[number] | "auto" {
+	return value === "auto" || isConfigurableSearchProviderId(value);
 }
 
 /** Source returned by search (all providers) */

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -48,11 +48,31 @@ function fakeAuth(opts: { oauth?: string[]; auth?: string[] } = {}): AuthStorage
 	return {
 		hasOAuth: (provider: string) => oauth.has(provider),
 		hasAuth: (provider: string) => auth.has(provider),
+		getApiKey: (provider: string) => (auth.has(provider) ? `${provider}-key` : undefined),
 	} as unknown as AuthStorage;
 }
 
-async function chainIds(...args: Parameters<typeof resolveProviderChain>): Promise<string[]> {
-	const providers = await resolveProviderChain(...args);
+async function chainIds(
+	authStorage: AuthStorage,
+	preferredProvider: any = "auto",
+	activeModelProvider?: string,
+): Promise<string[]> {
+	const activeModelContext = activeModelProvider
+		? {
+				provider: activeModelProvider,
+				modelId: "test",
+				api:
+					activeModelProvider.includes("google") || activeModelProvider === "gemini"
+						? "google-generative-ai"
+						: activeModelProvider === "anthropic"
+							? "anthropic-messages"
+							: activeModelProvider.includes("kimi")
+								? "anthropic-messages"
+								: "openai-responses",
+				baseUrl: "https://api.example.com",
+			}
+		: undefined;
+	const providers = await resolveProviderChain({ authStorage, preferredProvider, activeModelContext });
 	return providers.map(p => p.id);
 }
 
@@ -214,6 +234,7 @@ describe("resolveProviderChain — active-model-gated resolution", () => {
 		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai")).toEqual(["codex", "duckduckgo"]);
 		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai-codex")).toEqual([
 			"codex",
+			"openai-compatible",
 			"duckduckgo",
 		]);
 		expect(await chainIds(fakeAuth({ oauth: ["google-gemini-cli"] }), "auto", "google-gemini-cli")).toEqual([

--- a/packages/coding-agent/test/web/search/config-schema.test.ts
+++ b/packages/coding-agent/test/web/search/config-schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { ModelsConfigSchema } from "../../../src/config/models-config-schema";
+import { SETTINGS_SCHEMA } from "../../../src/config/settings-schema";
+import { isConfigurableSearchProviderId, isSearchProviderPreference } from "../../../src/web/search/types";
+
+describe("web search config schema", () => {
+	it("accepts provider webSearch mode enum and rejects invalid modes", () => {
+		expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch: "on" } } }).success).toBe(true);
+		expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch: "off" } } }).success).toBe(true);
+		expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch: "auto" } } }).success).toBe(true);
+		expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch: "maybe" } } }).success).toBe(false);
+	});
+
+	it("fallback item metadata rejects the internal openai-compatible provider", () => {
+		const fallback = SETTINGS_SCHEMA["web_search.fallback"];
+		expect(fallback.type).toBe("array");
+		expect(fallback.items?.enum).toContain("exa");
+		expect(fallback.items?.enum).not.toContain("openai-compatible");
+		expect(isConfigurableSearchProviderId("openai-compatible")).toBe(false);
+		expect(isSearchProviderPreference("openai-compatible")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
+++ b/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import { ToolAbortError } from "../../../src/tools/tool-errors";
+import { runSearchQuery } from "../../../src/web/search";
+import * as provider from "../../../src/web/search/provider";
+import type { SearchParams } from "../../../src/web/search/providers/base";
+import { SearchProviderError, type SearchProviderId, type SearchResponse } from "../../../src/web/search/types";
+
+function fakeProvider(
+	id: SearchProviderId,
+	search: (params: SearchParams) => Promise<SearchResponse>,
+): provider.SearchProvider {
+	return { id, label: id, isAvailable: () => true, search };
+}
+
+const authStorage = {} as AuthStorage;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("executeSearch fallback", () => {
+	it("falls through after a no-citation generic failure and preserves ordering", async () => {
+		const calls: string[] = [];
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("openai-compatible", async () => {
+				calls.push("generic");
+				throw new SearchProviderError("openai-compatible", "no citations", 424);
+			}),
+			fakeProvider("exa", async () => {
+				calls.push("exa");
+				return { provider: "exa", sources: [{ title: "Exa", url: "https://exa.example" }] };
+			}),
+		]);
+		const result = await runSearchQuery({ query: "anything" }, { authStorage });
+		expect(calls).toEqual(["generic", "exa"]);
+		expect(result.content[0]?.text).toContain("https://exa.example");
+	});
+
+	it("rethrows caller abort instead of falling through", async () => {
+		const second = vi.fn();
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("openai-compatible", async () => {
+				throw new DOMException("aborted", "AbortError");
+			}),
+			fakeProvider("exa", second),
+		]);
+		const ac = new AbortController();
+		ac.abort();
+		await expect(runSearchQuery({ query: "anything" }, { authStorage, signal: ac.signal })).rejects.toBeInstanceOf(
+			ToolAbortError,
+		);
+		expect(second).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
+++ b/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import { type ActiveSearchModelContext, SearchProviderError } from "../../../src/web/search/types";
+
+function auth(keys: Record<string, string> = {}): AuthStorage {
+	return {
+		getApiKey: (provider: string) => keys[provider],
+	} as unknown as AuthStorage;
+}
+
+const baseCtx: ActiveSearchModelContext = {
+	provider: "custom",
+	modelId: "gpt-5-mini",
+	api: "openai-responses",
+	baseUrl: "https://llm.example/v1",
+	headers: { "X-Test": "yes" },
+};
+
+function params(ctx: ActiveSearchModelContext = baseCtx, store = auth({ custom: "sk-custom" })) {
+	return { query: "news", systemPrompt: "search", authStorage: store, activeModelContext: ctx };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("OpenAI-compatible web search provider", () => {
+	it("sends Responses requests with the web_search tool", async () => {
+		let body: any;
+		using _hook = hookFetch(async (_input, init) => {
+			body = JSON.parse(String(init?.body));
+			return Response.json({
+				id: "r1",
+				output_text: "answer",
+				output: [{ content: [{ annotations: [{ type: "url_citation", url: "https://a.example", title: "A" }] }] }],
+			});
+		});
+		await new OpenAICompatibleSearchProvider().search(params());
+		expect(body.tools).toEqual([{ type: "web_search" }]);
+		expect(body.model).toBe("gpt-5-mini");
+	});
+
+	it("sends Chat Completions requests with web_search_options", async () => {
+		let body: any;
+		using _hook = hookFetch(async (_input, init) => {
+			body = JSON.parse(String(init?.body));
+			return Response.json({
+				choices: [
+					{
+						message: {
+							content: "answer",
+							annotations: [{ type: "url_citation", url: "https://b.example", title: "B" }],
+						},
+					},
+				],
+			});
+		});
+		await new OpenAICompatibleSearchProvider().search(params({ ...baseCtx, api: "openai-completions" }));
+		expect(body.web_search_options).toEqual({});
+		expect(body.messages[1].content).toBe("news");
+	});
+
+	it("parses citations into sources", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				output_text: "answer",
+				output: [
+					{
+						content: [
+							{
+								text: "answer",
+								annotations: [{ type: "url_citation", url: "https://c.example", title: "C", text: "quote" }],
+							},
+						],
+					},
+				],
+			}),
+		);
+		const result = await new OpenAICompatibleSearchProvider().search(params());
+		expect(result.provider).toBe("openai-compatible");
+		expect(result.sources).toEqual([{ title: "C", url: "https://c.example", snippet: "quote" }]);
+	});
+
+	it("throws 424 when the response has no citations", async () => {
+		using _hook = hookFetch(async () => Response.json({ output_text: "plain answer" }));
+		await expect(new OpenAICompatibleSearchProvider().search(params())).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 424,
+		});
+	});
+
+	it("does not accept non-url_citation source metadata as a citation (no masking)", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				output_text: "answer with stray metadata",
+				// A response that ignored web_search but carries unrelated URL-bearing
+				// objects (type "source", bare url fields) MUST NOT be treated as a search result.
+				output: [
+					{
+						content: [
+							{ text: "answer", annotations: [{ type: "source", url: "https://nope.example", title: "Nope" }] },
+						],
+					},
+				],
+				sources: [{ url: "https://also-nope.example" }],
+				metadata: { citation: { url: "https://still-nope.example" } },
+			}),
+		);
+		await expect(new OpenAICompatibleSearchProvider().search(params())).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 424,
+		});
+	});
+
+	it("does not fetch without an exact active-provider key", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		await expect(new OpenAICompatibleSearchProvider().search(params(baseCtx, auth()))).rejects.toBeInstanceOf(
+			SearchProviderError,
+		);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps concurrent request context isolated", async () => {
+		const seen: string[] = [];
+		using _hook = hookFetch(async (input, init) => {
+			seen.push(`${input}:${(init?.headers as Record<string, string>).Authorization}`);
+			return Response.json({
+				output_text: "answer",
+				output: [{ content: [{ annotations: [{ type: "url_citation", url: "https://d.example", title: "D" }] }] }],
+			});
+		});
+		const provider = new OpenAICompatibleSearchProvider();
+		await Promise.all([
+			provider.search(params({ ...baseCtx, provider: "a", baseUrl: "https://a.example/v1" }, auth({ a: "sk-a" }))),
+			provider.search(params({ ...baseCtx, provider: "b", baseUrl: "https://b.example/v1" }, auth({ b: "sk-b" }))),
+		]);
+		expect(seen).toContain("https://a.example/v1/responses:Bearer sk-a");
+		expect(seen).toContain("https://b.example/v1/responses:Bearer sk-b");
+	});
+
+	it("passes a composed abort signal to fetch", async () => {
+		const ac = new AbortController();
+		let captured: AbortSignal | undefined | null;
+		using _hook = hookFetch(async (_input, init) => {
+			captured = init?.signal;
+			return Response.json({
+				output_text: "answer",
+				output: [{ content: [{ annotations: [{ type: "url_citation", url: "https://e.example", title: "E" }] }] }],
+			});
+		});
+		await new OpenAICompatibleSearchProvider().search({
+			...params(baseCtx, auth({ custom: "sk" })),
+			signal: ac.signal,
+		});
+		expect(captured).toBeInstanceOf(AbortSignal);
+		expect(captured).not.toBe(ac.signal);
+	});
+});

--- a/packages/coding-agent/test/web/search/provider-resolution.test.ts
+++ b/packages/coding-agent/test/web/search/provider-resolution.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import {
+	resolveProviderChain,
+	setPreferredSearchProvider,
+	setSearchFallbackProviders,
+} from "../../../src/web/search/provider";
+import type { ActiveSearchModelContext } from "../../../src/web/search/types";
+
+function auth(providers: string[] = []): AuthStorage {
+	const set = new Set(providers);
+	return {
+		hasAuth: (provider: string) => set.has(provider),
+		hasOAuth: (provider: string) => set.has(provider),
+		getOAuthAccess: (provider: string) => (set.has(provider) ? `${provider}-oauth` : undefined),
+		getApiKey: (provider: string) => (set.has(provider) ? `${provider}-key` : undefined),
+	} as unknown as AuthStorage;
+}
+
+async function ids(ctx?: ActiveSearchModelContext, opts: { preferred?: any; fallback?: any[]; auth?: string[] } = {}) {
+	const providers = await resolveProviderChain({
+		authStorage: auth(opts.auth),
+		preferredProvider: opts.preferred ?? "auto",
+		activeModelContext: ctx,
+		fallbackProviders: opts.fallback ?? [],
+	});
+	return providers.map(p => p.id);
+}
+
+beforeEach(() => {
+	setPreferredSearchProvider("auto");
+	setSearchFallbackProviders([]);
+});
+
+describe("native web-search provider resolution", () => {
+	it("infers Anthropic native search for proxy Claude context with Anthropic credentials", async () => {
+		await expect(
+			ids(
+				{
+					provider: "proxy",
+					modelId: "claude-sonnet-4",
+					api: "anthropic-messages",
+					baseUrl: "https://proxy.example",
+				},
+				{ auth: ["anthropic"] },
+			),
+		).resolves.toEqual(["anthropic", "duckduckgo"]);
+	});
+
+	it("keeps local OpenAI-compatible auto contexts away from codex and generic even with Codex OAuth", async () => {
+		await expect(
+			ids(
+				{ provider: "local", modelId: "gpt-oss", api: "openai-responses", baseUrl: "http://localhost:11434" },
+				{ auth: ["openai-codex", "codex"] },
+			),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("honors forced provider first and dedupes configured fallback plus DuckDuckGo", async () => {
+		await expect(
+			ids(
+				{ provider: "proxy", modelId: "claude-3", api: "anthropic-messages", baseUrl: "https://proxy.example" },
+				{ preferred: "anthropic", fallback: ["anthropic", "duckduckgo"], auth: ["anthropic"] },
+			),
+		).resolves.toEqual(["anthropic", "duckduckgo"]);
+	});
+
+	it("applies fallback order with credential gating and terminal DuckDuckGo", async () => {
+		await expect(ids(undefined, { fallback: ["anthropic", "duckduckgo"], auth: ["anthropic"] })).resolves.toEqual([
+			"anthropic",
+			"duckduckgo",
+		]);
+		await expect(ids(undefined, { fallback: ["anthropic", "duckduckgo"], auth: [] })).resolves.toEqual([
+			"duckduckgo",
+		]);
+	});
+
+	it("falls back to DuckDuckGo when nothing is known or credentialed", async () => {
+		await expect(
+			ids({ provider: "unknown", modelId: "mystery", api: "openai-completions", baseUrl: "https://models.example" }),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("webSearch on enables generic for local OpenAI-compatible only with exact active-provider credentials", async () => {
+		const ctx = {
+			provider: "local",
+			modelId: "gpt-local",
+			api: "openai-responses",
+			baseUrl: "http://127.0.0.1:8080",
+			webSearch: "on" as const,
+		};
+		await expect(ids(ctx, { auth: ["local"] })).resolves.toEqual(["openai-compatible", "duckduckgo"]);
+		await expect(ids(ctx, { auth: [] })).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("webSearch off disables inferred native and generic while global forced primary still works", async () => {
+		const ctx = {
+			provider: "proxy",
+			modelId: "claude-3",
+			api: "anthropic-messages",
+			baseUrl: "https://proxy.example",
+			webSearch: "off" as const,
+		};
+		await expect(ids(ctx, { auth: ["anthropic"] })).resolves.toEqual(["duckduckgo"]);
+		await expect(ids(ctx, { preferred: "anthropic", auth: ["anthropic"] })).resolves.toEqual([
+			"anthropic",
+			"duckduckgo",
+		]);
+	});
+
+	it("maps only corroborated hosted model families when native credentials exist", async () => {
+		await expect(
+			ids(
+				{
+					provider: "proxy",
+					modelId: "gemini-2.5-pro",
+					api: "google-generative-ai",
+					baseUrl: "https://proxy.example",
+				},
+				{ auth: ["google-gemini-cli"] },
+			),
+		).resolves.toEqual(["gemini", "duckduckgo"]);
+		await expect(
+			ids(
+				{ provider: "proxy", modelId: "gpt-5", api: "openai-responses", baseUrl: "https://models.example" },
+				{ auth: ["openai-codex", "proxy"] },
+			),
+		).resolves.toEqual(["codex", "openai-compatible", "duckduckgo"]);
+		await expect(
+			ids(
+				{ provider: "proxy", modelId: "gpt-5", api: "anthropic-messages", baseUrl: "https://models.example" },
+				{ auth: ["openai-codex", "proxy"] },
+			),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+});

--- a/packages/coding-agent/test/web/search/web-search-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-redteam.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import { ModelsConfigSchema } from "../../../src/config/models-config-schema";
+import { SETTINGS_SCHEMA } from "../../../src/config/settings-schema";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import {
+	inferNativeProviderFromModel,
+	isLocalBaseUrl,
+	resolveProviderChain,
+	setPreferredSearchProvider,
+	setSearchFallbackProviders,
+} from "../../../src/web/search/provider";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import {
+	type ActiveSearchModelContext,
+	CONFIGURABLE_SEARCH_PROVIDER_IDS,
+	isConfigurableSearchProviderId,
+	isSearchProviderPreference,
+} from "../../../src/web/search/types";
+
+function auth(providers: string[] = [], keys: Record<string, string> = {}): AuthStorage {
+	const set = new Set(providers);
+	return {
+		hasAuth: (provider: string) => set.has(provider) || Boolean(keys[provider]),
+		hasOAuth: (provider: string) => set.has(provider) || Boolean(keys[provider]),
+		getOAuthAccess: (provider: string) => (set.has(provider) || keys[provider] ? `${provider}-oauth` : undefined),
+		getApiKey: (provider: string) => keys[provider] ?? (set.has(provider) ? `${provider}-key` : undefined),
+	} as unknown as AuthStorage;
+}
+
+async function chainIds(
+	ctx?: ActiveSearchModelContext,
+	opts: { preferred?: any; fallback?: any[]; auth?: string[]; keys?: Record<string, string> } = {},
+): Promise<string[]> {
+	const chain = await resolveProviderChain({
+		authStorage: auth(opts.auth, opts.keys),
+		preferredProvider: opts.preferred ?? "auto",
+		activeModelContext: ctx,
+		fallbackProviders: opts.fallback ?? [],
+	});
+	return chain.map(provider => provider.id);
+}
+
+const hostedOpenAI: ActiveSearchModelContext = {
+	provider: "custom-openai",
+	modelId: "gpt-4o",
+	api: "openai-responses",
+	baseUrl: "https://api.openai-compatible.example/v1",
+};
+
+const providerParams = (ctx: ActiveSearchModelContext, store = auth([], { [ctx.provider]: "sk-test" })) => ({
+	query: "latest research",
+	systemPrompt: "Use web search.",
+	authStorage: store,
+	activeModelContext: ctx,
+});
+
+beforeEach(() => {
+	setPreferredSearchProvider("auto");
+	setSearchFallbackProviders([]);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("red-team local endpoint classification", () => {
+	it("fails closed for malformed baseUrls", () => {
+		for (const baseUrl of ["not a url", "http://[::1", "http://%zz", "//localhost:11434"]) {
+			expect(isLocalBaseUrl(baseUrl), baseUrl).toBe(true);
+		}
+	});
+
+	it("treats loopback, private, link-local, ULA, and localhost-ish endpoints as local", () => {
+		const localUrls = [
+			"HTTP://LOCALHOST:11434/v1",
+			"http://localhost.:11434/v1",
+			"http://api.localhost/v1",
+			"http://model.local/v1",
+			"http://host.docker.internal:8080/v1",
+			"http://user:pass@127.255.1.2:8080/v1",
+			"http://0.0.0.0:8080/v1",
+			"http://10.255.255.255/v1",
+			"http://169.254.10.20/v1",
+			"http://172.16.0.1/v1",
+			"http://172.31.255.255/v1",
+			"http://192.168.255.255/v1",
+			"http://[::1]:8080/v1",
+			"http://[::]:8080/v1",
+			"http://[fe80::1]:8080/v1",
+			"http://[fd00::1]:8080/v1",
+			"http://[fc00::1]:8080/v1",
+		];
+		for (const baseUrl of localUrls) expect(isLocalBaseUrl(baseUrl), baseUrl).toBe(true);
+	});
+
+	it("does not mark public boundary neighbors or credentialed-host syntax as local", () => {
+		const hostedUrls = [
+			"https://api.openai.com/v1",
+			"https://LOCALHOST.example/v1",
+			"https://user@api.example:443/v1",
+			"https://172.15.255.255/v1",
+			"https://172.32.0.1/v1",
+			"https://169.255.0.1/v1",
+			"https://[2001:4860:4860::8888]/v1",
+		];
+		for (const baseUrl of hostedUrls) expect(isLocalBaseUrl(baseUrl), baseUrl).toBe(false);
+	});
+});
+
+describe("red-team native-provider inference", () => {
+	it("does not select codex for local gpt-oss OpenAI Responses even with Codex OAuth available", async () => {
+		const ctx = {
+			provider: "local",
+			modelId: "gpt-oss-120b",
+			api: "openai-responses",
+			baseUrl: "http://127.0.0.1:11434/v1",
+		};
+		expect(inferNativeProviderFromModel(ctx)).toBeUndefined();
+		await expect(chainIds(ctx, { auth: ["codex", "openai-codex"] })).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("selects codex for hosted OpenAI-family models only when Codex credentials exist", async () => {
+		await expect(chainIds(hostedOpenAI, { auth: [] })).resolves.toEqual(["duckduckgo"]);
+		await expect(chainIds(hostedOpenAI, { auth: ["openai-codex"] })).resolves.toEqual(["codex", "duckduckgo"]);
+	});
+
+	it("keeps ambiguous OpenAI-family ids non-codex on local baseUrls", async () => {
+		await expect(
+			chainIds(
+				{ provider: "local", modelId: "gpt-oss-120b", api: "openai-completions", baseUrl: "http://0.0.0.0:9999" },
+				{ auth: ["openai-codex", "local"] },
+			),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("maps Claude over a localhost proxy to Anthropic dedicated search credentials", async () => {
+		await expect(
+			chainIds(
+				{
+					provider: "proxy",
+					modelId: "claude-3-5-sonnet",
+					api: "anthropic-messages",
+					baseUrl: "http://localhost:8080",
+				},
+				{ auth: ["anthropic"] },
+			),
+		).resolves.toEqual(["anthropic", "duckduckgo"]);
+	});
+
+	it("webSearch off suppresses native inference and generic OpenAI-compatible probing", async () => {
+		await expect(
+			chainIds({ ...hostedOpenAI, webSearch: "off" }, { auth: ["openai-codex", "custom-openai"] }),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+});
+
+describe("red-team provider chain resolution", () => {
+	it("forced providers.webSearch wins and then appends deduped fallback plus DuckDuckGo", async () => {
+		await expect(
+			chainIds(hostedOpenAI, {
+				preferred: "anthropic",
+				fallback: ["anthropic", "tavily", "duckduckgo"],
+				auth: ["anthropic", "tavily", "openai-codex", "custom-openai"],
+			}),
+		).resolves.toEqual(["anthropic", "tavily", "duckduckgo"]);
+	});
+
+	it("does not inject openai-compatible in a generic no-credential context", async () => {
+		await expect(
+			chainIds({ ...hostedOpenAI, provider: "no-key" }, { auth: ["openai-codex"] }),
+		).resolves.not.toContain("openai-compatible");
+	});
+
+	it("skips unavailable keyed fallback providers while keeping available providers and terminal DuckDuckGo", async () => {
+		await expect(
+			chainIds(undefined, { fallback: ["exa", "anthropic", "duckduckgo"], auth: ["anthropic"] }),
+		).resolves.toEqual(["anthropic", "duckduckgo"]);
+	});
+
+	it("does not allow openai-compatible through runtime provider preference or fallback configuration", async () => {
+		expect(isConfigurableSearchProviderId("openai-compatible")).toBe(false);
+		expect(isSearchProviderPreference("openai-compatible")).toBe(false);
+		setPreferredSearchProvider("openai-compatible" as any);
+		setSearchFallbackProviders(["openai-compatible", "anthropic"]);
+		// openai-compatible is filtered out of the configured fallback; the valid
+		// anthropic fallback remains. The internal provider must never appear.
+		const viaModulePreference = await chainIds(undefined, { auth: ["anthropic"] });
+		expect(viaModulePreference).not.toContain("openai-compatible");
+		// Passing the internal id directly as a forced preferredProvider must also be
+		// rejected (falls through to auto/fallback), never injected into the chain.
+		const direct = await resolveProviderChain({
+			authStorage: auth(["anthropic"]),
+			preferredProvider: "openai-compatible" as any,
+		});
+		expect(direct.map(p => p.id)).not.toContain("openai-compatible");
+		// restore module state for other tests
+		setPreferredSearchProvider("auto");
+		setSearchFallbackProviders([]);
+	});
+
+	it("never appends openai-compatible via a directly-passed fallbackProviders list", async () => {
+		// Defense in depth: even if the internal id is forced into the option directly,
+		// the resolver must filter it out of the fallback loop.
+		const ids = await chainIds(undefined, { fallback: ["openai-compatible", "anthropic"], auth: ["anthropic"] });
+		expect(ids).not.toContain("openai-compatible");
+		expect(ids).toEqual(["anthropic", "duckduckgo"]);
+	});
+});
+
+describe("red-team OpenAI-compatible provider behavior", () => {
+	it("throws 424 on no-citation responses so executeSearch can fall through", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({ id: "r-no-cite", output_text: "Plain answer without grounding." }),
+		);
+		await expect(new OpenAICompatibleSearchProvider().search(providerParams(hostedOpenAI))).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 424,
+		});
+	});
+
+	it("throws HTTP errors from the provider", async () => {
+		using _hook = hookFetch(async () => new Response("bad gateway", { status: 502 }));
+		await expect(new OpenAICompatibleSearchProvider().search(providerParams(hostedOpenAI))).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 502,
+		});
+	});
+
+	it("throws 401 and performs no fetch when exact active-provider credentials are missing", async () => {
+		let calls = 0;
+		using _hook = hookFetch(async () => {
+			calls++;
+			return Response.json({});
+		});
+		await expect(
+			new OpenAICompatibleSearchProvider().search(providerParams(hostedOpenAI, auth())),
+		).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 401,
+		});
+		expect(calls).toBe(0);
+	});
+
+	it("does not treat bare prose URLs as citations", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				id: "r-bare-url",
+				output_text: "I found https://example.com in prose, but there is no structured source annotation.",
+			}),
+		);
+		await expect(new OpenAICompatibleSearchProvider().search(providerParams(hostedOpenAI))).rejects.toMatchObject({
+			status: 424,
+		});
+	});
+
+	it("keeps concurrent baseUrls, headers, models, and auth isolated", async () => {
+		const seen: Array<{ url: string; authorization: string; tenant: string; model: string }> = [];
+		using _hook = hookFetch(async (input, init) => {
+			const headers = init?.headers as Record<string, string>;
+			const body = JSON.parse(String(init?.body));
+			seen.push({
+				url: String(input),
+				authorization: headers.Authorization,
+				tenant: headers["X-Tenant"],
+				model: body.model,
+			});
+			return Response.json({
+				id: `resp-${body.model}`,
+				output_text: "grounded",
+				output: [
+					{
+						content: [
+							{
+								annotations: [
+									{ type: "url_citation", url: `https://${body.model}.example`, title: body.model },
+								],
+							},
+						],
+					},
+				],
+			});
+		});
+		const provider = new OpenAICompatibleSearchProvider();
+		await Promise.all([
+			provider.search(
+				providerParams(
+					{
+						...hostedOpenAI,
+						provider: "tenant-a",
+						modelId: "gpt-4o-a",
+						baseUrl: "https://a.example/v1",
+						headers: { "X-Tenant": "a" },
+					},
+					auth([], { "tenant-a": "sk-a" }),
+				),
+			),
+			provider.search(
+				providerParams(
+					{
+						...hostedOpenAI,
+						provider: "tenant-b",
+						modelId: "gpt-4o-b",
+						baseUrl: "https://b.example/v1",
+						headers: { "X-Tenant": "b" },
+					},
+					auth([], { "tenant-b": "sk-b" }),
+				),
+			),
+		]);
+		expect(seen).toEqual(
+			expect.arrayContaining([
+				{ url: "https://a.example/v1/responses", authorization: "Bearer sk-a", tenant: "a", model: "gpt-4o-a" },
+				{ url: "https://b.example/v1/responses", authorization: "Bearer sk-b", tenant: "b", model: "gpt-4o-b" },
+			]),
+		);
+	});
+
+	it("passes abort signals through to fetch without mutating request context", async () => {
+		const ac = new AbortController();
+		let captured: AbortSignal | undefined | null;
+		using _hook = hookFetch(async (_input, init) => {
+			captured = init?.signal;
+			return Response.json({
+				id: "abort-signal-capture",
+				output_text: "grounded",
+				output: [
+					{
+						content: [
+							{ annotations: [{ type: "url_citation", url: "https://signal.example", title: "Signal" }] },
+						],
+					},
+				],
+			});
+		});
+		await new OpenAICompatibleSearchProvider().search({ ...providerParams(hostedOpenAI), signal: ac.signal });
+		expect(captured).toBeInstanceOf(AbortSignal);
+		expect(captured).not.toBe(ac.signal);
+	});
+});
+
+describe("red-team schema and runtime validation guards", () => {
+	it("web_search.fallback enum metadata rejects openai-compatible and unknown ids", () => {
+		const fallback = SETTINGS_SCHEMA["web_search.fallback"];
+		expect(fallback.type).toBe("array");
+		expect(fallback.items?.enum).toEqual(CONFIGURABLE_SEARCH_PROVIDER_IDS);
+		expect(fallback.items?.enum).not.toContain("openai-compatible");
+		expect(fallback.items?.enum).not.toContain("totally-unknown");
+		expect(isConfigurableSearchProviderId("openai-compatible")).toBe(false);
+		expect(isConfigurableSearchProviderId("totally-unknown")).toBe(false);
+	});
+
+	it("providers.webSearch enum rejects invalid values including openai-compatible", () => {
+		const providerSetting = SETTINGS_SCHEMA["providers.webSearch"];
+		expect(providerSetting.type).toBe("enum");
+		expect(providerSetting.values).not.toContain("openai-compatible");
+		expect(providerSetting.values).not.toContain("totally-unknown");
+		expect(isSearchProviderPreference("openai-compatible")).toBe(false);
+		expect(isSearchProviderPreference("totally-unknown")).toBe(false);
+	});
+
+	it("models config provider webSearch accepts only on/off/auto", () => {
+		for (const webSearch of ["on", "off", "auto"]) {
+			expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch } } }).success, webSearch).toBe(true);
+		}
+		expect(ModelsConfigSchema.safeParse({ providers: { custom: { webSearch: "invalid" } } }).success).toBe(false);
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1492,6 +1492,31 @@
 					"type": "boolean",
 					"description": "Enable the web_search tool for web searching",
 					"default": true
+				},
+				"fallback": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"enum": [
+							"duckduckgo",
+							"exa",
+							"brave",
+							"jina",
+							"kimi",
+							"zai",
+							"anthropic",
+							"perplexity",
+							"gemini",
+							"codex",
+							"tavily",
+							"parallel",
+							"kagi",
+							"synthetic",
+							"searxng"
+						]
+					},
+					"description": "Ordered fallback web search providers after the active model native provider",
+					"default": []
 				}
 			},
 			"additionalProperties": false

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -215,6 +215,14 @@
 						},
 						"additionalProperties": false
 					},
+					"webSearch": {
+						"type": "string",
+						"enum": [
+							"on",
+							"off",
+							"auto"
+						]
+					},
 					"authHeader": {
 						"type": "boolean"
 					},

--- a/scripts/generate-json-schemas.test.ts
+++ b/scripts/generate-json-schemas.test.ts
@@ -10,4 +10,15 @@ describe("generated JSON Schemas", () => {
 			expect(existing).toBe(stableJson(output.schema));
 		}
 	});
+
+	it("emits web search fallback item enum and provider webSearch enum", () => {
+		const configSchema = JSON_SCHEMA_OUTPUTS.find(output => output.path === "schemas/config.schema.json")?.schema as any;
+		const fallbackItems = configSchema.properties.web_search.properties.fallback.items;
+		expect(fallbackItems.enum).toContain("exa");
+		expect(fallbackItems.enum).not.toContain("openai-compatible");
+
+		const modelsSchema = JSON_SCHEMA_OUTPUTS.find(output => output.path === "schemas/models.schema.json")?.schema as any;
+		const providerSchema = modelsSchema.properties.providers.additionalProperties;
+		expect(providerSchema.properties.webSearch.enum).toEqual(["on", "off", "auto"]);
+	});
 });

--- a/scripts/generate-json-schemas.ts
+++ b/scripts/generate-json-schemas.ts
@@ -115,13 +115,14 @@ function settingTypeToJsonSchema(definition: SettingDefinition): JsonSchemaObjec
 		case "enum":
 			return { type: "string", enum: definition.values };
 		case "array":
-			return { type: "array", items: arrayItemsSchema(definition.default) };
+			return { type: "array", items: arrayItemsSchema(definition.default, definition.items) };
 		case "record":
 			return { type: "object", additionalProperties: true };
 	}
 }
 
-function arrayItemsSchema(defaultValue: unknown): JsonSchema {
+function arrayItemsSchema(defaultValue: unknown, items?: { enum?: readonly string[] }): JsonSchema {
+	if (items?.enum) return { type: "string", enum: items.enum };
 	if (!Array.isArray(defaultValue) || defaultValue.length === 0) return true;
 	if (defaultValue.every(value => typeof value === "string")) return { type: "string" };
 	if (defaultValue.every(value => typeof value === "number")) return { type: "number" };


### PR DESCRIPTION
## Summary

Makes the model provider's **native web search** the PRIMARY `web_search` backend — even under proxy / custom / api-compatible / local providers — with a new **configurable, credential-gated fallback chain**. DuckDuckGo remains the zero-config terminal fallback so search never hard-fails.

Previously `resolveProviderChain` only selected a native provider when the active provider string was a direct `MODEL_PROVIDER_TO_SEARCH` key; under proxy/custom/local providers it silently dropped to DuckDuckGo (the de-facto primary). This is a provider-**selection** change — native adapters already run on their own dedicated credentials/endpoints.

Produced via deep-interview → ralplan consensus (Planner→Architect→Critic, 2 passes) → ultragoal execution with a full quality gate. Plan/spec live under `.gjc/` (local audit trail).

## What changed

- **Layered resolver precedence** (`resolveProviderChain`, options-object form): forced `providers.webSearch` → direct `MODEL_PROVIDER_TO_SEARCH` → conservative local-aware OpenAI-family inference → internal generic `openai-compatible` adapter → `web_search.fallback` ordered list → DuckDuckGo terminal.
- **New internal-only `openai-compatible` adapter**: dispatches to the active provider's own `baseUrl`/creds — Responses `tools:[{type:"web_search"}]`, Chat `web_search_options`. Citation-gated success (only `url_citation` annotations count; otherwise throws `424` and falls through, so a no-search answer is never masked as search). Stateless singleton, exact `getApiKey(baseUrl+modelId)` credential gating with no-key/no-fetch, cloned headers, abort-preserving. Excluded from `providers.webSearch`, `web_search.fallback`, CLI lists, UI, and generated config enums.
- **Conservative, local-aware inference**: `claude-*`→anthropic / `gemini-*`→gemini (own dedicated creds, work through a local proxy); `gpt-*`/`o*`→codex **only** with wire-API corroboration AND (non-local hosted baseUrl OR per-provider `webSearch:"on"`). A local GPT-like id can never hit Codex/ChatGPT OAuth in `auto` mode. Complete local-baseUrl detection (localhost incl. trailing-dot, `*.localhost`, `host.docker.internal`, `*.local`, `127/8`, `0.0.0.0`, RFC1918, `169.254/16`, IPv6 `::1`/`::`/`fc00::/7`/`fe80::/10`; fail-closed on unparseable).
- **New settings**: per-provider `webSearch: "on"|"off"|"auto"` (models config) and `web_search.fallback` ordered, enum-constrained provider-id array. Schema generator extended to emit `items.enum` for empty-default arrays; `schemas/config.schema.json` + `schemas/models.schema.json` regenerated.
- **Plumbing**: `ActiveSearchModelContext` built via a `ModelRegistry` helper (no `packages/ai` `Model` coupling), threaded through `WebSearchTool`, the custom web_search tool, `runSearchQuery`, `executeSearch`, and `SearchParams`. Startup + live settings wiring in `sdk.ts` and `selector-controller.ts`.

## ADR (summary)

- **Decision:** layered, credential-gated `resolveProviderChain` fed by a per-request `ActiveSearchModelContext`, plus an internal-only generic OpenAI-compatible adapter and a configurable `web_search.fallback`; DuckDuckGo stays terminal.
- **Drivers:** preserve the spec's locked precedence; make active wire metadata + `webSearch` policy available at resolution without global state; prevent stray OAuth / wasted local probes.
- **Alternatives rejected:** resolver→ModelRegistry lookup by provider id (couples resolver to registry; provider id insufficient); process-global active state (unsafe for concurrency); exposing the generic adapter as a user-configurable provider; adding `Model.webSearch` in `packages/ai`; Responses legacy `web_search_preview` as default.
- **Consequences:** signature churn across search execution; new internal provider + configurable-id split; schema-generator extension; conservative inference may skip some capable endpoints (escape hatch: `webSearch:"on"`).
- **Follow-ups:** provider-onboarding CLI flag for `webSearch`; broader Chat-Completions search support; optional UI for a global "force generic" choice.

## Tests & gates

- `bun test packages/coding-agent/test/web/search/` → **61 pass, 0 fail** (AC A–H resolution matrix incl. negative chain-membership, generic adapter citation-gating/no-mask, no-key/no-fetch, concurrency isolation, abort preservation, schema validation, plus an adversarial red-team suite).
- `bun run check:ts` → green across all workspaces (`@gajae-code/coding-agent` `tsgo --noEmit` exit 0); biome clean.
- `bun run check:schemas` → clean (regenerated schemas in sync).

## Live testing (real network)

| Path | Result |
|------|--------|
| **Native primary** — active OpenAI model context → real web search | provider `codex` selected (native, not DuckDuckGo); returned cited answer ("latest Node.js LTS" → nodejs.org sources) |
| **Zero-config fallback** — no provider config | provider `duckduckgo`; 10 real sources |

The native-primary outcome is proven end-to-end: the active OpenAI model's native web search was selected as primary instead of DuckDuckGo. (The generic `openai-compatible` adapter — step 4 — is covered by black-box `hookFetch` tests; live it is superseded here by the higher-precedence direct native map, which is the correct behavior.)

## Quality gate

Architect (architecture/product/code) **CLEAR / APPROVE** after a recorded BLOCK→RESOLVED loop (3 blockers: over-broad citation parser that could mask non-search answers; trailing-dot localhost misclassification; internal provider injectable via forced/direct fallback — all fixed + guard-tested). Executor red-team lane **passed**.

Do not merge automatically — opening for review.
