### PR TITLE
fix(ask): enable @ file-link autocomplete in inline "Other" input

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -3,6 +3,7 @@
  * Displays a list of string options with keyboard navigation.
  */
 import {
+	type AutocompleteProvider,
 	Container,
 	Editor,
 	Markdown,
@@ -73,6 +74,12 @@ export interface HookSelectorOptions {
 		optionLabel: string;
 		onSubmit: (text: string) => void;
 	};
+	/**
+	 * Autocomplete provider for the inline custom-input editor. When present,
+	 * the "Other (type your own)" editor gains the same `@` file-link and `/`
+	 * completion behavior as the main prompt editor.
+	 */
+	autocompleteProvider?: AutocompleteProvider;
 }
 
 class OutlinedList extends Container {
@@ -320,6 +327,7 @@ export class HookSelectorComponent extends Container {
 	#helpTextComponent: Text;
 	#baseHelpText: string;
 	#tui: TUI | undefined;
+	#autocompleteProvider: AutocompleteProvider | undefined;
 	constructor(
 		title: string,
 		options: string[],
@@ -342,6 +350,7 @@ export class HookSelectorComponent extends Container {
 		this.#outline = opts?.outline === true;
 		this.#customInput = opts?.customInput;
 		this.#tui = opts?.tui;
+		this.#autocompleteProvider = opts?.autocompleteProvider;
 
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
@@ -491,6 +500,13 @@ export class HookSelectorComponent extends Container {
 
 	/** Keys while the inline custom-input editor is open below the option list. */
 	#handleInputModeKey(keyData: string, editor: Editor): void {
+		// While the autocomplete dropdown is open, every key belongs to the
+		// editor (navigate/apply/cancel the suggestion) instead of submitting
+		// or backing out of input mode.
+		if (editor.isAutocompleteOpen()) {
+			editor.handleInput(keyData);
+			return;
+		}
 		// Escape backs out to option selection instead of cancelling the dialog,
 		// so a stray Esc never throws away the question context.
 		if (matchesKey(keyData, "escape") || matchesAppInterrupt(keyData)) {
@@ -521,6 +537,9 @@ export class HookSelectorComponent extends Container {
 		editor.setBorderVisible(false);
 		editor.setPromptGutter("> ");
 		editor.disableSubmit = true;
+		if (this.#autocompleteProvider) {
+			editor.setAutocompleteProvider(this.#autocompleteProvider);
+		}
 		this.#inlineEditor = editor;
 		this.#inputArea.addChild(new Spacer(1));
 		this.#inputArea.addChild(editor);

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -645,6 +645,9 @@ export class ExtensionUiController {
 				timeout: dialogOptions?.timeout,
 				onTimeout: dialogOptions?.onTimeout,
 				tui: this.ctx.ui,
+				// Share the main prompt editor's autocomplete provider so the
+				// inline "Other (type your own)" editor supports `@` file links.
+				autocompleteProvider: dialogOptions?.customInput ? this.ctx.editor.getAutocompleteProvider() : undefined,
 				outline: dialogOptions?.outline,
 				wrapFocused: dialogOptions?.wrapFocused,
 				scrollTitleRows,

--- a/packages/coding-agent/test/hook-selector-inline-input.test.ts
+++ b/packages/coding-agent/test/hook-selector-inline-input.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components/hook-selector";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { AutocompleteItem, AutocompleteProvider } from "@gajae-code/tui/autocomplete";
 
 beforeAll(async () => {
 	const themeInstance = await getThemeByName("red-claw");
@@ -20,7 +21,7 @@ interface Callbacks {
 	submitted: string[];
 }
 
-function createSelector(opts?: { scrollTitleRows?: number }): {
+function createSelector(opts?: { scrollTitleRows?: number; autocompleteProvider?: AutocompleteProvider }): {
 	component: HookSelectorComponent;
 	calls: Callbacks;
 } {
@@ -36,6 +37,7 @@ function createSelector(opts?: { scrollTitleRows?: number }): {
 				onSubmit: text => calls.submitted.push(text),
 			},
 			scrollTitleRows: opts?.scrollTitleRows,
+			autocompleteProvider: opts?.autocompleteProvider,
 		},
 	);
 	return { component, calls };
@@ -48,6 +50,33 @@ function renderText(component: HookSelectorComponent, width = 80): string {
 function moveToOther(component: HookSelectorComponent): void {
 	component.handleInput("\x1b[B"); // down
 	component.handleInput("\x1b[B"); // down
+}
+
+// Minimal provider that completes an "@" file-link prefix, mirroring the real
+// CombinedAutocompleteProvider's `@` behavior closely enough to exercise wiring.
+class AtFileProvider implements AutocompleteProvider {
+	async getSuggestions(
+		lines: string[],
+		_cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		const prefix = (lines[0] || "").slice(0, cursorCol);
+		if (!prefix.startsWith("@")) return null;
+		return { prefix, items: [{ value: "@src/app.ts", label: "src/app.ts" }] };
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number } {
+		const line = lines[cursorLine] || "";
+		const start = cursorCol - prefix.length;
+		const newLine = line.slice(0, start) + item.value + line.slice(cursorCol);
+		return { lines: [newLine], cursorLine, cursorCol: start + item.value.length };
+	}
 }
 
 describe("HookSelectorComponent inline custom input", () => {
@@ -151,5 +180,35 @@ describe("HookSelectorComponent inline custom input", () => {
 		const after = renderText(component);
 		expect(after).not.toContain("Deep Interview question body");
 		expect(after).toContain("esc back to options");
+	});
+
+	it("opens @ file autocomplete in the inline input and applies it with enter", async () => {
+		const { component, calls } = createSelector({ autocompleteProvider: new AtFileProvider() });
+		moveToOther(component);
+		component.handleInput("\r");
+
+		component.handleInput("@");
+		await Bun.sleep(0); // let async getSuggestions resolve and open the dropdown
+
+		// Enter belongs to the open dropdown: it applies the completion, not submit.
+		component.handleInput("\r");
+		expect(calls.submitted).toEqual([]);
+		expect(renderText(component)).toContain("@src/app.ts");
+
+		// With the dropdown closed, enter now submits the completed file link.
+		component.handleInput("\r");
+		expect(calls.submitted).toEqual(["@src/app.ts"]);
+	});
+
+	it("without an autocomplete provider, @ stays literal and enter submits it", async () => {
+		const { component, calls } = createSelector();
+		moveToOther(component);
+		component.handleInput("\r");
+
+		component.handleInput("@");
+		await Bun.sleep(0);
+		component.handleInput("\r");
+
+		expect(calls.submitted).toEqual(["@"]);
 	});
 });

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -464,6 +464,15 @@ export class Editor implements Component, Focusable {
 		this.#autocompleteProvider = provider;
 	}
 
+	getAutocompleteProvider(): AutocompleteProvider | undefined {
+		return this.#autocompleteProvider;
+	}
+
+	/** Whether the autocomplete dropdown is currently open. */
+	isAutocompleteOpen(): boolean {
+		return this.#autocompleteState !== null && this.#autocompleteList !== undefined;
+	}
+
 	/**
 	 * Set custom content for the top border (e.g., status line).
 	 * Pass undefined to use the default plain border.


### PR DESCRIPTION
## Problem
In the ask tool, the **Other (type your own)** free-text answer did not support `@` file-link autocomplete.

Two root causes:
1. The inline free-text editor (`HookSelectorComponent#enterInputMode`) was created **without an autocomplete provider**, so `@` file completion / `/` completion never triggered the way it does in the main prompt editor.
2. The selector intercepted **Enter before the editor**, so even with an open autocomplete dropdown, Enter could not apply the highlighted item.

## Fix
- `Editor`: expose `getAutocompleteProvider()` and `isAutocompleteOpen()`.
- `HookSelectorComponent`: accept an `autocompleteProvider` option, attach it to the inline editor, and defer all keys to the editor while its dropdown is open (so Enter applies the suggestion).
- `ExtensionUiController`: share the main prompt editor's provider with the inline custom-input editor (only when `customInput` is present).

## Tests
Added to `packages/coding-agent/test/hook-selector-inline-input.test.ts`:
- `@` autocomplete opens → Enter applies → next Enter submits `@src/app.ts`
- without a provider, `@` stays literal and Enter submits it (preserves prior behavior)

## Verification
- `bun run check:types` (tui, coding-agent) pass
- biome lint clean
- Tests pass: hook-selector inline-input (10), hook-selector-overflow, ask, tui editor/autocomplete