### PR TITLE
fix(deep-interview): sync HUD with persisted round metadata via shared canonical state

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -1,6 +1,19 @@
-import { createHash } from "node:crypto";
+import { syncSkillActiveState } from "../skill-state/active-state";
+import { deriveDeepInterviewHud } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
+import {
+	answerHash,
+	type DeepInterviewEstablishedFact,
+	type DeepInterviewRoundRecord,
+	type DeepInterviewStateEnvelope,
+	type DeepInterviewTriggerMetadata,
+	deriveRoundKey,
+	normalizeDeepInterviewEnvelope,
+	questionHash,
+} from "./deep-interview-state";
 import { readExistingStateForMutation, writeWorkflowEnvelopeAtomic } from "./state-writer";
+
+export * from "./deep-interview-state";
 
 /**
  * Runtime-owned deep-interview round recorder (conflict-aware scoring support).
@@ -16,60 +29,6 @@ import { readExistingStateForMutation, writeWorkflowEnvelopeAtomic } from "./sta
 // =============================================================================
 // Domain types
 // =============================================================================
-
-export type DeepInterviewRoundLifecycle = "answered" | "pending_scoring" | "scored";
-
-export type DeepInterviewTriggerKind = "A" | "B" | "C" | "D";
-
-/** `active` triggers must satisfy the bidirectional invariant; disputed/unresolved are exempt with rationale. */
-export type DeepInterviewTriggerStatus = "active" | "disputed" | "unresolved";
-
-export interface DeepInterviewEstablishedFact {
-	id: string;
-	statement: string;
-	round: number;
-	component?: string;
-	dimension?: string;
-	evidence?: string;
-	disputed: boolean;
-}
-
-export interface DeepInterviewTriggerMetadata {
-	kind: DeepInterviewTriggerKind;
-	name: string;
-	status: DeepInterviewTriggerStatus;
-	component: string;
-	dimension: string;
-	priorDimensionScore?: number;
-	newDimensionScore?: number;
-	priorAmbiguity?: number;
-	newAmbiguity?: number;
-	evidence?: string;
-	contradictedFactId?: string;
-	/** Required when status is `disputed` or `unresolved` to exempt the invariant. */
-	rationale?: string;
-}
-
-export interface DeepInterviewRoundRecord {
-	round_key: string;
-	round_id?: string;
-	round: number;
-	question_id?: string;
-	question_text?: string;
-	question_hash: string;
-	answer_hash: string;
-	selected_options?: string[];
-	custom_input?: string;
-	component?: string;
-	dimension?: string;
-	ambiguity_at_ask?: number;
-	lifecycle: DeepInterviewRoundLifecycle;
-	answered_at: string;
-	scored_at?: string;
-	scores?: Record<string, number>;
-	ambiguity?: number;
-	triggers?: DeepInterviewTriggerMetadata[];
-}
 
 export interface DeepInterviewAnswerInput {
 	interviewId?: string;
@@ -116,37 +75,6 @@ export interface DeepInterviewCompactState {
 export interface TransitionValidationResult {
 	ok: boolean;
 	violations: string[];
-}
-
-// =============================================================================
-// Pure helpers: identity + hashing
-// =============================================================================
-
-export function hashContent(value: string): string {
-	return createHash("sha256").update(value).digest("hex").slice(0, 32);
-}
-
-export function questionHash(questionText: string): string {
-	return hashContent(questionText);
-}
-
-export function answerHash(selectedOptions: string[] | undefined, customInput: string | undefined): string {
-	return hashContent(JSON.stringify({ selected: selectedOptions ?? [], custom: customInput ?? null }));
-}
-
-/**
- * Durable round identity. Prefer `interview_id + round_id`; fall back to
- * `interview_id + round + question.id` when no caller-supplied `round_id` exists.
- */
-export function deriveRoundKey(
-	interviewId: string | undefined,
-	input: { round_id?: string; round: number; questionId?: string },
-): string {
-	const interview = interviewId && interviewId.trim() !== "" ? interviewId : "nointerview";
-	if (input.round_id && input.round_id.trim() !== "") {
-		return `${interview}::rid:${input.round_id}`;
-	}
-	return `${interview}::r:${input.round}::q:${input.questionId ?? "noqid"}`;
 }
 
 // =============================================================================
@@ -296,26 +224,9 @@ export function validateDeepInterviewScoredTransition(
 // Pure helper: state-shape migration + compact projection
 // =============================================================================
 
-interface DeepInterviewStateEnvelope {
-	threshold?: number;
-	threshold_source?: string;
-	state?: Record<string, unknown>;
-	[key: string]: unknown;
-}
-
-/**
- * Default new fields for legacy state written before conflict-aware scoring.
- * Returns a shallow-cloned envelope safe to mutate; never deletes existing fields.
- */
+/** Back-compat wrapper: normalize a deep-interview envelope to its canonical nested shape. */
 export function ensureDeepInterviewStateShape(value: unknown): DeepInterviewStateEnvelope {
-	const envelope: DeepInterviewStateEnvelope =
-		value && typeof value === "object" && !Array.isArray(value) ? { ...(value as DeepInterviewStateEnvelope) } : {};
-	const inner =
-		envelope.state && typeof envelope.state === "object" ? { ...(envelope.state as Record<string, unknown>) } : {};
-	if (!Array.isArray(inner.rounds)) inner.rounds = [];
-	if (!Array.isArray(inner.established_facts)) inner.established_facts = [];
-	envelope.state = inner;
-	return envelope;
+	return normalizeDeepInterviewEnvelope(value);
 }
 
 function readRounds(envelope: DeepInterviewStateEnvelope): DeepInterviewRoundRecord[] {
@@ -400,7 +311,7 @@ async function persistEnvelope(
 	command: string,
 ): Promise<void> {
 	const now = new Date().toISOString();
-	const payload: Record<string, unknown> = { ...envelope, updated_at: now };
+	const payload: Record<string, unknown> = { ...normalizeDeepInterviewEnvelope(envelope), updated_at: now };
 	// Guarantee RequiredOnWriteEnvelopeSchema fields for the fresh/absent fallback;
 	// existing real state already carries these and is preserved by the spread above.
 	payload.skill ??= "deep-interview";
@@ -412,6 +323,47 @@ async function persistEnvelope(
 		receipt: { cwd, skill: "deep-interview", owner: "gjc-runtime", command, sessionId, nowIso: now },
 		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
 	});
+}
+
+/**
+ * Best-effort active-state/HUD cache refresh for the deep-interview rail, derived
+ * from the complete normalized mode-state envelope. HUD is a cache; a failure here
+ * must never change durable record semantics.
+ */
+async function syncRecorderHud(
+	cwd: string,
+	envelope: DeepInterviewStateEnvelope,
+	sessionId: string | undefined,
+): Promise<void> {
+	try {
+		const phase = typeof envelope.current_phase === "string" ? envelope.current_phase : "interviewing";
+		await syncSkillActiveState({
+			cwd,
+			skill: "deep-interview",
+			active: phase !== "complete",
+			phase,
+			sessionId,
+			source: "gjc-runtime-deep-interview-recorder",
+			hud: deriveDeepInterviewHud(envelope as Record<string, unknown>, { phase }),
+		});
+	} catch {
+		// HUD sync is best-effort cache maintenance and must not change record semantics.
+	}
+}
+
+/**
+ * Repair the cached HUD after a no-op append. A no-op writes no mode-state, so the
+ * HUD is derived from a fresh read of the current persisted state (never from the
+ * pre-noop in-memory envelope) to avoid overwriting newer active-state with stale values.
+ */
+async function repairRecorderHudFromPersisted(
+	cwd: string,
+	statePath: string,
+	sessionId: string | undefined,
+): Promise<void> {
+	const read = await readExistingStateForMutation(statePath);
+	if (read.kind !== "valid") return;
+	await syncRecorderHud(cwd, normalizeDeepInterviewEnvelope(read.value), sessionId);
 }
 
 /** Record an `answered` shell for one round (append-or-merge by durable key). */
@@ -426,9 +378,13 @@ export async function appendOrMergeDeepInterviewRound(
 	const shell = buildAnswerShell({ ...input, interviewId });
 	const rounds = readRounds(envelope);
 	const result = appendOrMergeRound(rounds, shell);
-	if (result.action === "noop") return { action: result.action, record: result.record };
+	if (result.action === "noop") {
+		await repairRecorderHudFromPersisted(cwd, statePath, options.sessionId);
+		return { action: result.action, record: result.record };
+	}
 	(envelope.state as Record<string, unknown>).rounds = result.rounds;
 	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview record-answer");
+	await syncRecorderHud(cwd, envelope, options.sessionId);
 	return { action: result.action, record: result.record };
 }
 
@@ -446,6 +402,7 @@ export async function enrichDeepInterviewRoundScoring(
 	(envelope.state as Record<string, unknown>).rounds = nextRounds;
 	(envelope.state as Record<string, unknown>).current_ambiguity = input.ambiguity;
 	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview score-round");
+	await syncRecorderHud(cwd, envelope, options.sessionId);
 	return { record };
 }
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -3,8 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { syncSkillActiveState } from "../skill-state/active-state";
-import { buildDeepInterviewHudSummary } from "../skill-state/workflow-hud";
+import { deriveDeepInterviewHud } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
+import { normalizeDeepInterviewEnvelope } from "./deep-interview-state";
 import { runNativeRalplanCommand } from "./ralplan-runtime";
 import { runNativeStateCommand } from "./state-runtime";
 import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
@@ -415,7 +416,7 @@ export async function persistDeepInterviewSpec(
 		{ cwd, audit: { category: "ledger", verb: "append", owner: "gjc-runtime", skill: "deep-interview" } },
 	);
 
-	const payload: Record<string, unknown> = {
+	const payload = normalizeDeepInterviewEnvelope({
 		...existing,
 		active: true,
 		current_phase: "handoff",
@@ -427,7 +428,7 @@ export async function persistDeepInterviewSpec(
 		spec_stage: resolved.stage,
 		spec_persisted_at: createdAt,
 		updated_at: createdAt,
-	};
+	}) as Record<string, unknown>;
 	if (resolved.sessionId) payload.session_id = resolved.sessionId;
 	await writeWorkflowEnvelopeAtomic(statePath, payload, {
 		cwd,
@@ -450,6 +451,7 @@ export async function persistDeepInterviewSpec(
 	await syncDeepInterviewHud({
 		cwd,
 		sessionId: resolved.sessionId,
+		payload,
 		phase: "handoff",
 		specStatus: "persisted",
 	});
@@ -502,34 +504,29 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		},
 		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "deep-interview" },
 	});
+	await syncDeepInterviewHud({ cwd, sessionId: resolved.sessionId, payload, phase: "interviewing" });
 	return statePath;
 }
 
 async function syncDeepInterviewHud(options: {
 	cwd: string;
 	sessionId?: string;
-	phase: string;
-	ambiguity?: number;
-	threshold?: number;
-	roundCount?: number;
+	payload: Record<string, unknown>;
+	phase?: string;
 	specStatus?: string;
 }): Promise<void> {
 	try {
+		const phase =
+			options.phase ??
+			(typeof options.payload.current_phase === "string" ? options.payload.current_phase : "interviewing");
 		await syncSkillActiveState({
 			cwd: options.cwd,
 			skill: "deep-interview",
-			active: options.phase !== "complete",
-			phase: options.phase,
+			active: phase !== "complete",
+			phase,
 			sessionId: options.sessionId,
 			source: "gjc-deep-interview-native",
-			hud: buildDeepInterviewHudSummary({
-				phase: options.phase,
-				ambiguity: options.ambiguity,
-				threshold: options.threshold,
-				roundCount: options.roundCount,
-				specStatus: options.specStatus,
-				updatedAt: new Date().toISOString(),
-			}),
+			hud: deriveDeepInterviewHud(options.payload, { phase, specStatus: options.specStatus }),
 		});
 	} catch {
 		// HUD sync is best-effort and must not change command semantics.
@@ -614,14 +611,6 @@ export async function runNativeDeepInterviewCommand(
 			);
 		}
 		const statePath = await seedDeepInterviewState(cwd, resolved);
-		await syncDeepInterviewHud({
-			cwd,
-			sessionId: resolved.sessionId,
-			phase: "interviewing",
-			ambiguity: 1,
-			threshold: resolved.threshold,
-			roundCount: 0,
-		});
 
 		const summary = {
 			skill: "deep-interview",

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -288,6 +288,10 @@ export function mergeDeepInterviewEnvelope(
 	incoming: unknown,
 	options: { replace?: boolean } = {},
 ): DeepInterviewStateEnvelope {
+	const incomingEnvelope = isPlainObject(incoming) ? incoming : {};
+	const incomingNestedState = isPlainObject(incomingEnvelope.state) ? incomingEnvelope.state : {};
+	const incomingHasEstablishedFacts =
+		Object.hasOwn(incomingNestedState, "established_facts") || Object.hasOwn(incomingEnvelope, "established_facts");
 	const normalizedIncoming = normalizeDeepInterviewEnvelope(incoming);
 	if (options.replace) return normalizedIncoming;
 
@@ -307,6 +311,7 @@ export function mergeDeepInterviewEnvelope(
 	const mergedState: Record<string, unknown> = { ...existingState };
 	for (const [key, value] of Object.entries(incomingState)) {
 		if (key === "rounds") continue;
+		if (key === "established_facts" && !incomingHasEstablishedFacts) continue;
 		if (value === null) delete mergedState[key];
 		else mergedState[key] = value;
 	}

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -1,0 +1,319 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Pure, dependency-free foundation for deep-interview state shape.
+ *
+ * Ownership boundary (per the approved consensus plan): this leaf module owns the
+ * canonical persisted shape (interview data nested under `state`), durable round
+ * identity/hashing, lossless legacy normalization, and the deep-interview-specific
+ * envelope/round merge used by every writer (`deep-interview-recorder`,
+ * `state-runtime` write/reconcile, seed, and handoff). It MUST NOT import the
+ * active-state, state-writer, CLI runtime, or filesystem so it stays cycle-free and
+ * trivially testable.
+ */
+
+// =============================================================================
+// Domain types
+// =============================================================================
+
+export type DeepInterviewRoundLifecycle = "answered" | "pending_scoring" | "scored";
+
+export type DeepInterviewTriggerKind = "A" | "B" | "C" | "D";
+
+/** `active` triggers must satisfy the bidirectional invariant; disputed/unresolved are exempt with rationale. */
+export type DeepInterviewTriggerStatus = "active" | "disputed" | "unresolved";
+
+export interface DeepInterviewEstablishedFact {
+	id: string;
+	statement: string;
+	round: number;
+	component?: string;
+	dimension?: string;
+	evidence?: string;
+	disputed: boolean;
+}
+
+export interface DeepInterviewTriggerMetadata {
+	kind: DeepInterviewTriggerKind;
+	name: string;
+	status: DeepInterviewTriggerStatus;
+	component: string;
+	dimension: string;
+	priorDimensionScore?: number;
+	newDimensionScore?: number;
+	priorAmbiguity?: number;
+	newAmbiguity?: number;
+	evidence?: string;
+	contradictedFactId?: string;
+	/** Required when status is `disputed` or `unresolved` to exempt the invariant. */
+	rationale?: string;
+}
+
+export interface DeepInterviewRoundRecord {
+	round_key: string;
+	round_id?: string;
+	round: number;
+	question_id?: string;
+	question_text?: string;
+	question_hash: string;
+	answer_hash: string;
+	selected_options?: string[];
+	custom_input?: string;
+	component?: string;
+	dimension?: string;
+	ambiguity_at_ask?: number;
+	lifecycle: DeepInterviewRoundLifecycle;
+	answered_at: string;
+	scored_at?: string;
+	scores?: Record<string, number>;
+	ambiguity?: number;
+	triggers?: DeepInterviewTriggerMetadata[];
+}
+
+export interface DeepInterviewStateEnvelope {
+	threshold?: number;
+	threshold_source?: string;
+	state?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+// =============================================================================
+// Pure helpers: identity + hashing
+// =============================================================================
+
+export function hashContent(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 32);
+}
+
+export function questionHash(questionText: string): string {
+	return hashContent(questionText);
+}
+
+export function answerHash(selectedOptions: string[] | undefined, customInput: string | undefined): string {
+	return hashContent(JSON.stringify({ selected: selectedOptions ?? [], custom: customInput ?? null }));
+}
+
+/**
+ * Durable round identity. Prefer `interview_id + round_id`; fall back to
+ * `interview_id + round + question.id` when no caller-supplied `round_id` exists.
+ */
+export function deriveRoundKey(
+	interviewId: string | undefined,
+	input: { round_id?: string; round: number; questionId?: string },
+): string {
+	const interview = interviewId && interviewId.trim() !== "" ? interviewId : "nointerview";
+	if (input.round_id && input.round_id.trim() !== "") {
+		return `${interview}::rid:${input.round_id}`;
+	}
+	return `${interview}::r:${input.round}::q:${input.questionId ?? "noqid"}`;
+}
+
+// =============================================================================
+// Pure helpers: canonical shape normalization
+// =============================================================================
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Interview transcript/scoring fields that are canonical under `state`. When a
+ * legacy flattened envelope carries them at the top level they are hoisted into
+ * `state` and removed from the top level so exactly one canonical copy survives.
+ */
+const TRANSCRIPT_STATE_FIELDS = [
+	"rounds",
+	"established_facts",
+	"current_ambiguity",
+	"topology",
+	"ontology_snapshots",
+	"auto_researched_rounds",
+	"auto_answered_rounds",
+	"architect_failures",
+] as const;
+
+/**
+ * Interview context fields that belong under `state` but are also legitimately
+ * mirrored at the envelope level by the seed/spec writers (e.g. `threshold`,
+ * `language`). They are hoisted into `state` when missing there but never stripped
+ * from the top level, preserving existing dual-write behavior.
+ */
+const HOISTED_STATE_FIELDS = [
+	"initial_idea",
+	"initial_context_summary",
+	"codebase_context",
+	"challenge_modes_used",
+	"interview_id",
+	"type",
+	"language",
+	"threshold",
+	"threshold_source",
+] as const;
+
+/**
+ * Canonicalize a deep-interview envelope: interview data nested under `state`,
+ * legacy flattened fields hoisted in losslessly, transcript duplicates removed
+ * from the top level, and `rounds`/`established_facts` guaranteed to be arrays.
+ *
+ * Idempotent: a canonical envelope is returned unchanged in shape. Never deletes
+ * unknown envelope or nested fields, and never mutates the input.
+ */
+export function normalizeDeepInterviewEnvelope(value: unknown): DeepInterviewStateEnvelope {
+	const envelope: DeepInterviewStateEnvelope = isPlainObject(value) ? { ...value } : {};
+	const inner: Record<string, unknown> = isPlainObject(envelope.state) ? { ...envelope.state } : {};
+
+	for (const field of TRANSCRIPT_STATE_FIELDS) {
+		if (inner[field] === undefined && envelope[field] !== undefined) inner[field] = envelope[field];
+		if (field in envelope) delete envelope[field];
+	}
+	for (const field of HOISTED_STATE_FIELDS) {
+		if (inner[field] === undefined && envelope[field] !== undefined) inner[field] = envelope[field];
+	}
+
+	if (!Array.isArray(inner.rounds)) inner.rounds = [];
+	if (!Array.isArray(inner.established_facts)) inner.established_facts = [];
+	envelope.state = inner;
+	return envelope;
+}
+
+// =============================================================================
+// Pure helpers: lossless round + envelope merge
+// =============================================================================
+
+function nonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim() !== "";
+}
+
+/** Durable merge key for a round, or `undefined` when the record is not addressable. */
+function durableRoundKey(record: Record<string, unknown>): string | undefined {
+	if (nonEmptyString(record.round_key)) return record.round_key;
+	const hasId = nonEmptyString(record.round_id) || nonEmptyString(record.question_id);
+	if (!hasId) return undefined;
+	return deriveRoundKey(undefined, {
+		round_id: nonEmptyString(record.round_id) ? record.round_id : undefined,
+		round: typeof record.round === "number" ? record.round : 0,
+		questionId: nonEmptyString(record.question_id) ? record.question_id : undefined,
+	});
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (typeof a !== typeof b) return false;
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return a.length === b.length && a.every((item, index) => deepEqual(item, b[index]));
+	}
+	if (isPlainObject(a) && isPlainObject(b)) {
+		const aKeys = Object.keys(a);
+		const bKeys = Object.keys(b);
+		if (aKeys.length !== bKeys.length) return false;
+		return aKeys.every(key => deepEqual(a[key], b[key]));
+	}
+	return false;
+}
+
+/** Merge a later round record into an earlier one for the same durable key. */
+function mergeRoundPair(existing: Record<string, unknown>, incoming: Record<string, unknown>): Record<string, unknown> {
+	const merged: Record<string, unknown> = { ...existing };
+	for (const [key, value] of Object.entries(incoming)) {
+		if (value === undefined) continue;
+		merged[key] = value;
+	}
+	// Never downgrade a scored lifecycle back to answered.
+	if (existing.lifecycle === "scored" && incoming.lifecycle !== "scored") merged.lifecycle = "scored";
+	// Preserve shell identity fields when the incoming (scoring) record blanked them.
+	for (const field of ["question_hash", "answer_hash", "question_text"]) {
+		if (!nonEmptyString(incoming[field]) && nonEmptyString(existing[field])) merged[field] = existing[field];
+	}
+	return merged;
+}
+
+/**
+ * Lossless, idempotent merge of two round arrays.
+ *
+ * - Records sharing a durable key (`round_key`, or synthesized from
+ *   `round_id`/`question_id`) merge into one, preferring scored over answered.
+ * - Records without any durable identity are preserved verbatim; an exact
+ *   duplicate is skipped so repeated writes stay idempotent, but distinct records
+ *   are never collapsed.
+ *
+ * Deliberate refinement of the approved plan: rather than mutating opaque legacy
+ * records with synthetic `legacy:<index>` keys, they are preserved verbatim with
+ * exact-duplicate dedupe. This satisfies the plan's intent (lossless, idempotent,
+ * never collapse distinct rounds) without rewriting user-supplied round objects,
+ * and keeps free-form extension preservation intact. Recorder-produced records
+ * always carry a `round_key`, so the synthetic path is unnecessary in practice.
+ */
+export function mergeDeepInterviewRounds(
+	existing: readonly Record<string, unknown>[],
+	incoming: readonly Record<string, unknown>[],
+): Record<string, unknown>[] {
+	const result: Record<string, unknown>[] = [];
+	const indexByKey = new Map<string, number>();
+
+	const add = (record: Record<string, unknown>): void => {
+		const key = durableRoundKey(record);
+		if (key !== undefined) {
+			const existingIndex = indexByKey.get(key);
+			if (existingIndex === undefined) {
+				const stored = nonEmptyString(record.round_key) ? { ...record } : { ...record, round_key: key };
+				indexByKey.set(key, result.length);
+				result.push(stored);
+			} else {
+				result[existingIndex] = mergeRoundPair(result[existingIndex], record);
+			}
+			return;
+		}
+		// Opaque/legacy record without durable identity: preserve verbatim, dedupe exact copies only.
+		if (result.some(item => deepEqual(item, record))) return;
+		result.push({ ...record });
+	};
+
+	for (const record of existing) if (isPlainObject(record)) add(record);
+	for (const record of incoming) if (isPlainObject(record)) add(record);
+	return result;
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+	return Array.isArray(value) ? value.filter(isPlainObject) : [];
+}
+
+/**
+ * Deep-interview-specific envelope merge. Unlike the generic shallow null-delete
+ * merge, this keeps interview data nested under `state`, never deletes `state`,
+ * and merges `rounds` losslessly by durable key so a partial write (e.g. a
+ * scoring update) cannot drop recorder-written transcript history.
+ */
+export function mergeDeepInterviewEnvelope(
+	existing: unknown,
+	incoming: unknown,
+	options: { replace?: boolean } = {},
+): DeepInterviewStateEnvelope {
+	const normalizedIncoming = normalizeDeepInterviewEnvelope(incoming);
+	if (options.replace) return normalizedIncoming;
+
+	const normalizedExisting = normalizeDeepInterviewEnvelope(existing);
+	const merged: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(normalizedExisting)) {
+		if (key !== "state") merged[key] = value;
+	}
+	for (const [key, value] of Object.entries(normalizedIncoming)) {
+		if (key === "state") continue;
+		if (value === null) delete merged[key];
+		else merged[key] = value;
+	}
+
+	const existingState = isPlainObject(normalizedExisting.state) ? normalizedExisting.state : {};
+	const incomingState = isPlainObject(normalizedIncoming.state) ? normalizedIncoming.state : {};
+	const mergedState: Record<string, unknown> = { ...existingState };
+	for (const [key, value] of Object.entries(incomingState)) {
+		if (key === "rounds") continue;
+		if (value === null) delete mergedState[key];
+		else mergedState[key] = value;
+	}
+	mergedState.rounds = mergeDeepInterviewRounds(
+		asRecordArray(existingState.rounds),
+		asRecordArray(incomingState.rounds),
+	);
+	merged.state = mergedState;
+	return merged as DeepInterviewStateEnvelope;
+}

--- a/packages/coding-agent/src/gjc-runtime/state-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-renderer.ts
@@ -118,8 +118,13 @@ export interface StateStatusSummary {
 
 function compactStateFields(state: Record<string, unknown>): Array<[string, string]> {
 	const fields: Array<[string, string]> = [];
+	const nested = isRecord(state.state) ? state.state : undefined;
 	for (const key of COMPACT_ELIDE_KEYS) {
-		const value = state[key];
+		const value = Array.isArray(state[key])
+			? state[key]
+			: nested && Array.isArray(nested[key])
+				? nested[key]
+				: undefined;
 		if (Array.isArray(value)) fields.push([key, `${value.length} entries (elided)`]);
 	}
 	return fields;
@@ -133,9 +138,13 @@ export function compactProjectStateJson(
 	const state = stateObject(stateJson);
 	const compact = projectStateFields(skill, stateJson, manifest, STATE_FIELD_ALLOWLIST);
 	const elisions: Record<string, unknown> = {};
+	const nested = isRecord(state.state) ? state.state : undefined;
 	for (const key of COMPACT_ELIDE_KEYS) {
-		const value = state[key];
-		if (Array.isArray(value)) elisions[key] = { type: "array", count: value.length, pointer: `/${key}` };
+		if (Array.isArray(state[key])) {
+			elisions[key] = { type: "array", count: (state[key] as unknown[]).length, pointer: `/${key}` };
+		} else if (nested && Array.isArray(nested[key])) {
+			elisions[key] = { type: "array", count: (nested[key] as unknown[]).length, pointer: `/state/${key}` };
+		}
 	}
 	if (Object.keys(elisions).length) compact.elided = elisions;
 	return compact;

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -11,10 +11,10 @@ import {
 } from "../skill-state/active-state";
 import { initialPhaseForSkill } from "../skill-state/initial-phase";
 import {
-	buildDeepInterviewHudSummary,
 	buildRalplanHudSummary,
 	buildTeamHudSummary,
 	buildUltragoalHudSummary,
+	deriveDeepInterviewHud,
 } from "../skill-state/workflow-hud";
 import {
 	type AuditEntry,
@@ -26,6 +26,7 @@ import {
 	type WorkflowStateReceipt,
 } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
+import { mergeDeepInterviewEnvelope, normalizeDeepInterviewEnvelope } from "./deep-interview-state";
 import { renderStateGraph, type StateGraphFormat } from "./state-graph";
 import { migrateAndPersistLegacyState, migrateWorkflowState } from "./state-migrations";
 import {
@@ -833,31 +834,9 @@ function buildHudForMode(
 ): WorkflowHudSummary | undefined {
 	const updatedAt = new Date().toISOString();
 	const phase = typeof payload.current_phase === "string" ? payload.current_phase : undefined;
-	const stateField = isPlainObject(payload.state) ? (payload.state as Record<string, unknown>) : {};
 	switch (mode) {
-		case "deep-interview": {
-			const pick = <T>(key: string, guard: (value: unknown) => value is T): T | undefined => {
-				const v = (stateField as Record<string, unknown>)[key] ?? (payload as Record<string, unknown>)[key];
-				return guard(v) ? v : undefined;
-			};
-			const isNumber = (v: unknown): v is number => typeof v === "number";
-			const isString = (v: unknown): v is string => typeof v === "string";
-			const isArray = (v: unknown): v is unknown[] => Array.isArray(v);
-			const ambiguity = pick("current_ambiguity", isNumber);
-			const threshold = pick("threshold", isNumber);
-			const rounds = pick("rounds", isArray);
-			const targetComponent = pick("last_targeted_component_id", isString);
-			const weakestDimension = pick("weakest_dimension", isString);
-			return buildDeepInterviewHudSummary({
-				phase,
-				ambiguity,
-				threshold,
-				roundCount: rounds?.length,
-				targetComponent,
-				weakestDimension,
-				updatedAt,
-			});
-		}
+		case "deep-interview":
+			return deriveDeepInterviewHud(payload, { updatedAt });
 		case "ralplan": {
 			const stage =
 				typeof payload.current_phase === "string"
@@ -1009,7 +988,10 @@ export async function reconcileWorkflowSkillState(options: {
 	receipt.from_phase = fromPhase;
 	receipt.to_phase = trimmedPhase;
 
-	const merged = mergeWithNullDelete(existingPayload, payload);
+	const merged =
+		mode === "deep-interview"
+			? (mergeDeepInterviewEnvelope(existingPayload, payload) as Record<string, unknown>)
+			: mergeWithNullDelete(existingPayload, payload);
 	merged.skill = mode;
 	merged.current_phase = trimmedPhase;
 	merged.active = active;
@@ -1173,7 +1155,11 @@ async function handleWrite(
 					? (innerState.current_phase as string).trim()
 					: undefined;
 	let merged: Record<string, unknown>;
-	if (hasFlag(args, "--replace")) {
+	if (mode === "deep-interview") {
+		// Deep-interview keeps interview data nested under `state` and merges rounds
+		// losslessly by durable key; never flatten or delete `state` (that drops recorder history).
+		merged = mergeDeepInterviewEnvelope(existingPayload, payload, { replace: hasFlag(args, "--replace") });
+	} else if (hasFlag(args, "--replace")) {
 		merged = { ...payload };
 	} else {
 		merged = mergeWithNullDelete(existingPayload, payload);
@@ -1423,8 +1409,20 @@ async function handleHandoff(
 	});
 
 	const calleeInitial = initialPhaseForSkill(callee);
-	const normalizedCaller = migrateWorkflowState(existingCaller, caller).state;
-	const normalizedCallee = migrateWorkflowState(existingCallee, callee).state;
+	const normalizedCaller =
+		caller === "deep-interview"
+			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCaller, caller).state) as Record<
+					string,
+					unknown
+				>)
+			: migrateWorkflowState(existingCaller, caller).state;
+	const normalizedCallee =
+		callee === "deep-interview"
+			? (normalizeDeepInterviewEnvelope(migrateWorkflowState(existingCallee, callee).state) as Record<
+					string,
+					unknown
+				>)
+			: migrateWorkflowState(existingCallee, callee).state;
 	const mergedCalleeState: Record<string, unknown> = {
 		...normalizedCallee,
 		skill: callee,

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -100,6 +100,95 @@ export function buildDeepInterviewHudSummary(state: DeepInterviewHudState): Work
 	};
 }
 
+export interface DeepInterviewHudDeriveOptions {
+	phase?: string;
+	specStatus?: string;
+	updatedAt?: string;
+}
+
+function diIsPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function latestScoredAmbiguity(rounds: unknown): number | undefined {
+	if (!Array.isArray(rounds)) return undefined;
+	for (let index = rounds.length - 1; index >= 0; index--) {
+		const round = rounds[index];
+		if (diIsPlainObject(round) && round.lifecycle === "scored" && typeof round.ambiguity === "number") {
+			return round.ambiguity;
+		}
+	}
+	return undefined;
+}
+
+function weakestDimensionFromTopology(
+	topology: Record<string, unknown>,
+	targetComponent: string | undefined,
+): string | undefined {
+	if (!Array.isArray(topology.components)) return undefined;
+	const components = topology.components.filter(diIsPlainObject);
+	const dimensionOf = (component: Record<string, unknown>): string | undefined =>
+		typeof component.weakest_dimension === "string" && component.weakest_dimension.trim()
+			? component.weakest_dimension
+			: undefined;
+	if (targetComponent) {
+		const targeted = components.find(component => component.id === targetComponent && dimensionOf(component));
+		if (targeted) return dimensionOf(targeted);
+	}
+	const active = components.find(component => component.status !== "deferred" && dimensionOf(component));
+	if (active) return dimensionOf(active);
+	const any = components.find(component => dimensionOf(component));
+	return any ? dimensionOf(any) : undefined;
+}
+
+/**
+ * Single source of deep-interview HUD derivation. Reads a complete (normalized)
+ * mode-state envelope so recorder, `gjc state write`, reconcile, seed, and handoff
+ * all produce identical chips. Topology-aware `target`/`weakest` come from
+ * `state.topology`; `legacy_missing` topology omits those chips (no synthetic values).
+ */
+export function deriveDeepInterviewHud(
+	payload: Record<string, unknown>,
+	options: DeepInterviewHudDeriveOptions = {},
+): WorkflowHudSummary {
+	const stateField = diIsPlainObject(payload.state) ? payload.state : {};
+	const isNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+	const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+	const pick = <T>(key: string, guard: (value: unknown) => value is T): T | undefined => {
+		const value = stateField[key] ?? payload[key];
+		return guard(value) ? value : undefined;
+	};
+
+	const phase = options.phase ?? (typeof payload.current_phase === "string" ? payload.current_phase : undefined);
+	const rounds = pick("rounds", isArray);
+	const ambiguity = pick("current_ambiguity", isNumber) ?? latestScoredAmbiguity(rounds);
+	const threshold = pick("threshold", isNumber);
+	const rawTopology = diIsPlainObject(stateField.topology)
+		? stateField.topology
+		: diIsPlainObject(payload.topology)
+			? payload.topology
+			: undefined;
+	// `legacy_missing` topology was never confirmed: omit target/weakest even if stale fields linger.
+	const topology = rawTopology && rawTopology.status !== "legacy_missing" ? rawTopology : undefined;
+	const targetComponent =
+		topology && typeof topology.last_targeted_component_id === "string"
+			? topology.last_targeted_component_id
+			: undefined;
+	const weakestDimension = topology ? weakestDimensionFromTopology(topology, targetComponent) : undefined;
+	const specStatus = options.specStatus ?? (typeof payload.spec_status === "string" ? payload.spec_status : undefined);
+
+	return buildDeepInterviewHudSummary({
+		phase,
+		ambiguity,
+		threshold,
+		roundCount: rounds?.length,
+		targetComponent,
+		weakestDimension,
+		specStatus,
+		updatedAt: options.updatedAt ?? new Date().toISOString(),
+	});
+}
+
 export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSummary {
 	const verdict = state.verdict?.toUpperCase();
 	const verdictSeverity =

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-hud-sync.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-hud-sync.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	appendOrMergeDeepInterviewRound,
+	enrichDeepInterviewRoundScoring,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+import {
+	deepInterviewStatePath,
+	runNativeDeepInterviewCommand,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { reconcileWorkflowSkillState, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-di-hud-sync-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+beforeAll(() => {
+	delete process.env.GJC_SESSION_ID;
+});
+
+afterEach(async () => {
+	for (const dir of tempRoots.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
+async function deepInterviewChips(cwd: string): Promise<Record<string, string | undefined>> {
+	const raw = JSON.parse(await fs.readFile(path.join(cwd, ".gjc", "state", "skill-active-state.json"), "utf-8")) as {
+		active_skills?: Array<{ skill: string; hud?: { chips?: Array<{ label: string; value?: string }> } }>;
+	};
+	const entry = (raw.active_skills ?? []).find(skill => skill.skill === "deep-interview");
+	return Object.fromEntries((entry?.hud?.chips ?? []).map(chip => [chip.label, chip.value]));
+}
+
+describe("deep-interview recorder -> HUD sync", () => {
+	it("refreshes active-state HUD round count after recording an answered round", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			questionText: "What is the core entity?",
+			component: "api",
+			dimension: "goal",
+			ambiguity: 0.8,
+			selectedOptions: ["A"],
+		});
+		const chips = await deepInterviewChips(cwd);
+		expect(chips.round).toBe("1");
+		expect(chips.phase).toBe("interviewing");
+	});
+
+	it("refreshes HUD ambiguity after scoring enrichment", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, { round: 1, questionId: "q1", questionText: "Q?" });
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.5 },
+			ambiguity: 0.45,
+		});
+		const chips = await deepInterviewChips(cwd);
+		expect(chips.round).toBe("1");
+		expect(chips.ambiguity).toContain("45%");
+	});
+});
+
+describe("deep-interview gjc state write preserves recorder rounds", () => {
+	it("does not drop recorder-written rounds on a partial scoring write", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, { round: 1, questionId: "q1", questionText: "Q1?" });
+		await appendOrMergeDeepInterviewRound(cwd, statePath, { round: 2, questionId: "q2", questionText: "Q2?" });
+
+		const write = await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"deep-interview",
+				"--input",
+				JSON.stringify({ state: { current_ambiguity: 0.3, topology: { last_targeted_component_id: "api" } } }),
+			],
+			cwd,
+		);
+		expect(write.status).toBe(0);
+
+		const onDisk = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(onDisk.state.rounds).toHaveLength(2);
+		expect(onDisk.state.current_ambiguity).toBe(0.3);
+		expect(Object.hasOwn(onDisk, "rounds")).toBe(false);
+	});
+});
+
+describe("deep-interview reconcile and write produce identical HUD", () => {
+	it("derives the same HUD chips for the same normalized payload", async () => {
+		const payloadState = {
+			rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.4 }],
+			current_ambiguity: 0.4,
+			threshold: 0.05,
+			topology: {
+				last_targeted_component_id: "api",
+				components: [{ id: "api", status: "active", weakest_dimension: "goal" }],
+			},
+		};
+
+		const writeCwd = await tempDir();
+		await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"deep-interview",
+				"--input",
+				JSON.stringify({ current_phase: "interviewing", state: payloadState }),
+			],
+			writeCwd,
+		);
+		const writeChips = await deepInterviewChips(writeCwd);
+
+		const reconcileCwd = await tempDir();
+		await reconcileWorkflowSkillState({
+			cwd: reconcileCwd,
+			mode: "deep-interview",
+			sessionId: undefined,
+			active: true,
+			phase: "interviewing",
+			payload: { current_phase: "interviewing", state: payloadState },
+		});
+		const reconcileChips = await deepInterviewChips(reconcileCwd);
+
+		expect(writeChips).toEqual(reconcileChips);
+		expect(writeChips.round).toBe("1");
+		expect(writeChips.target).toBe("api");
+		expect(writeChips.weakest).toBe("goal");
+	});
+});
+
+describe("deep-interview spec persistence canonicalizes state", () => {
+	it("writes canonical nested state for a missing prior state", async () => {
+		const cwd = await tempDir();
+		const result = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "canon-missing", "--spec", "# Spec", "--json"],
+			cwd,
+		);
+		expect(result.status).toBe(0);
+		const onDisk = JSON.parse(await fs.readFile(deepInterviewStatePath(cwd, undefined), "utf-8"));
+		expect(onDisk.current_phase).toBe("handoff");
+		expect(onDisk.spec_slug).toBe("canon-missing");
+		expect(Array.isArray(onDisk.state?.rounds)).toBe(true);
+		expect(Array.isArray(onDisk.state?.established_facts)).toBe(true);
+	});
+
+	it("hoists flattened legacy transcript into nested state during spec persistence", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(
+			statePath,
+			`${JSON.stringify({
+				skill: "deep-interview",
+				current_phase: "interviewing",
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.4 }],
+				current_ambiguity: 0.4,
+			})}\n`,
+		);
+		const result = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "canon-flat", "--spec", "# Spec", "--json"],
+			cwd,
+		);
+		expect(result.status).toBe(0);
+		const onDisk = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(onDisk.state.rounds).toHaveLength(1);
+		expect(onDisk.state.current_ambiguity).toBe(0.4);
+		expect(Object.hasOwn(onDisk, "rounds")).toBe(false);
+	});
+});
+
+describe("deep-interview handoff canonicalizes caller state", () => {
+	it("rewrites a flattened deep-interview caller into canonical nested state on handoff", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(
+			statePath,
+			`${JSON.stringify({
+				skill: "deep-interview",
+				version: 1,
+				active: true,
+				current_phase: "interviewing",
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.4 }],
+				current_ambiguity: 0.4,
+			})}\n`,
+		);
+		const result = await runNativeStateCommand(
+			["handoff", "--mode", "deep-interview", "--to", "ralplan", "--json"],
+			cwd,
+		);
+		expect(result.status).toBe(0);
+		const onDisk = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(onDisk.active).toBe(false);
+		expect(onDisk.handoff_to).toBe("ralplan");
+		expect(onDisk.state.rounds).toHaveLength(1);
+		expect(Object.hasOwn(onDisk, "rounds")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-state-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-state-redteam.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	appendOrMergeDeepInterviewRound,
+	enrichDeepInterviewRoundScoring,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+import { deepInterviewStatePath } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import {
+	mergeDeepInterviewEnvelope,
+	mergeDeepInterviewRounds,
+	normalizeDeepInterviewEnvelope,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
+import { reconcileWorkflowSkillState, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { deriveDeepInterviewHud } from "@gajae-code/coding-agent/skill-state/workflow-hud";
+
+const tempRoots: string[] = [];
+
+beforeAll(() => {
+	delete process.env.GJC_SESSION_ID;
+});
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-di-redteam-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+function inner(envelope: { state?: Record<string, unknown> }): Record<string, unknown> {
+	return (envelope.state ?? {}) as Record<string, unknown>;
+}
+
+function clone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+}
+
+async function activeChips(cwd: string): Promise<Record<string, string | undefined>> {
+	const raw = JSON.parse(await fs.readFile(path.join(cwd, ".gjc", "state", "skill-active-state.json"), "utf-8")) as {
+		active_skills?: Array<{ skill: string; hud?: { chips?: Array<{ label: string; value?: string }> } }>;
+	};
+	const entry = (raw.active_skills ?? []).find(skill => skill.skill === "deep-interview");
+	return Object.fromEntries((entry?.hud?.chips ?? []).map(chip => [chip.label, chip.value]));
+}
+
+function hudChips(payload: Record<string, unknown>): Record<string, string | undefined> {
+	return Object.fromEntries((deriveDeepInterviewHud(payload).chips ?? []).map(chip => [chip.label, chip.value]));
+}
+
+describe("deep-interview redteam: idempotency and lossless shape normalization", () => {
+	it("keeps normalize and merge stable after repeated passes without growing or reordering rounds", () => {
+		const initial = {
+			skill: "deep-interview",
+			current_phase: "interviewing",
+			rounds: [
+				{ round_key: "iv::r:1::q:q1", round: 1, lifecycle: "answered", question_hash: "qh1", answer_hash: "ah1" },
+				{ round: 1, note: "opaque-a" },
+				{ round: 1, note: "opaque-b" },
+			],
+			state: {
+				rounds: [
+					{ round_key: "iv::r:2::q:q2", round: 2, lifecycle: "scored", ambiguity: 0.44 },
+					{ round: 3, question_id: "q3", lifecycle: "answered" },
+				],
+				established_facts: [{ id: "f1", statement: "fact", round: 1, disputed: false }],
+			},
+		};
+
+		const normalizedPasses = [initial];
+		for (let index = 0; index < 4; index++) {
+			normalizedPasses.push(normalizeDeepInterviewEnvelope(normalizedPasses.at(-1)) as typeof initial);
+		}
+		expect(normalizedPasses[4]).toEqual(normalizedPasses[3]);
+		expect(inner(normalizedPasses[4]).rounds).toEqual(inner(normalizedPasses[1]).rounds);
+		expect(Object.hasOwn(normalizedPasses[4], "rounds")).toBe(false);
+
+		let merged = normalizeDeepInterviewEnvelope(initial);
+		const incoming = {
+			state: {
+				rounds: [
+					{ round_key: "iv::r:2::q:q2", round: 2, lifecycle: "scored", ambiguity: 0.44 },
+					{ round: 4, question_id: "q4", lifecycle: "answered" },
+				],
+				current_ambiguity: 0.31,
+			},
+		};
+		const orders: unknown[][] = [];
+		for (let index = 0; index < 4; index++) {
+			merged = mergeDeepInterviewEnvelope(merged, incoming);
+			orders.push(clone(inner(merged).rounds as unknown[]));
+		}
+		expect(orders[1]).toEqual(orders[0]);
+		expect(orders[2]).toEqual(orders[0]);
+		expect(orders[3]).toEqual(orders[0]);
+		expect(orders[0]).toHaveLength(3);
+		expect((orders[0][0] as Record<string, unknown>).round_key).toBe("iv::r:2::q:q2");
+		expect((orders[0][1] as Record<string, unknown>).round_key).toBe("nointerview::r:3::q:q3");
+		expect((orders[0][2] as Record<string, unknown>).round_key).toBe("nointerview::r:4::q:q4");
+	});
+
+	it("merges mixed top-level and nested rounds without loss, duplicate top-level keys, or legacy collapse", () => {
+		const mixed = {
+			skill: "deep-interview",
+			rounds: [
+				{ round_key: "legacy-key", round: 1, lifecycle: "answered", question_hash: "qh", answer_hash: "ah" },
+				{ round: 7, note: "same number first" },
+			],
+			topology: { last_targeted_component_id: "legacy" },
+			state: {
+				rounds: [
+					{ round_key: "nested-key", round: 2, lifecycle: "scored", ambiguity: 0.2 },
+					{ round: 7, note: "same number second" },
+				],
+				topology: { last_targeted_component_id: "nested" },
+			},
+		};
+		const normalized = normalizeDeepInterviewEnvelope(mixed);
+		const merged = mergeDeepInterviewEnvelope(mixed, { state: { rounds: mixed.rounds } });
+
+		expect(Object.hasOwn(normalized, "rounds")).toBe(false);
+		expect(Object.hasOwn(normalized, "topology")).toBe(false);
+		expect(inner(normalized).rounds).toHaveLength(2);
+		expect(inner(merged).rounds).toHaveLength(4);
+		expect(inner(merged).topology).toEqual({ last_targeted_component_id: "nested" });
+		expect((inner(merged).rounds as Array<Record<string, unknown>>).map(round => round.note).filter(Boolean)).toEqual(
+			["same number second", "same number first"],
+		);
+	});
+
+	it("preserves legacy rounds that collide on round number when no durable identity exists", () => {
+		const rounds = mergeDeepInterviewRounds(
+			[{ round: 3, transcript: "first answer", lifecycle: "answered" }],
+			[
+				{ round: 3, transcript: "second answer", lifecycle: "answered" },
+				{ round: 3, transcript: "first answer", lifecycle: "answered" },
+			],
+		);
+		expect(rounds).toHaveLength(2);
+		expect(rounds.map(round => round.transcript)).toEqual(["first answer", "second answer"]);
+	});
+
+	it("merges answered to scored by durable key into one record while preserving shell hashes", () => {
+		const rounds = mergeDeepInterviewRounds(
+			[
+				{
+					round_key: "iv::r:1::q:q1",
+					round: 1,
+					question_id: "q1",
+					question_hash: "question-shell-hash",
+					answer_hash: "answer-shell-hash",
+					lifecycle: "answered",
+				},
+			],
+			[
+				{
+					round_key: "iv::r:1::q:q1",
+					round: 1,
+					question_id: "q1",
+					question_hash: "",
+					answer_hash: "",
+					lifecycle: "scored",
+					ambiguity: 0.27,
+					scores: { goal: 0.7 },
+				},
+			],
+		);
+		expect(rounds).toHaveLength(1);
+		expect(rounds[0]).toMatchObject({
+			lifecycle: "scored",
+			ambiguity: 0.27,
+			question_hash: "question-shell-hash",
+			answer_hash: "answer-shell-hash",
+		});
+	});
+});
+
+describe("deep-interview redteam: writer and recorder integration", () => {
+	it("preserves all recorder rounds across multiple sequential partial state writes", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, { round: 1, questionId: "q1", questionText: "Q1?" });
+		await appendOrMergeDeepInterviewRound(cwd, statePath, { round: 2, questionId: "q2", questionText: "Q2?" });
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.4 },
+			ambiguity: 0.61,
+		});
+
+		const writes = [
+			{ state: { current_ambiguity: 0.51, topology: { last_targeted_component_id: "api" } } },
+			{
+				state: {
+					current_ambiguity: 0.41,
+					topology: {
+						last_targeted_component_id: "cli",
+						components: [{ id: "cli", status: "active", weakest_dimension: "goal" }],
+					},
+				},
+			},
+			{ state: { current_ambiguity: 0.31, topology: { status: "legacy_missing" } } },
+		];
+
+		for (const payload of writes) {
+			const result = await runNativeStateCommand(
+				["write", "--mode", "deep-interview", "--input", JSON.stringify(payload)],
+				cwd,
+			);
+			expect(result.status).toBe(0);
+			const onDisk = await readJson(statePath);
+			expect(Object.hasOwn(onDisk, "rounds")).toBe(false);
+			expect((inner(onDisk).rounds as unknown[]).map(round => (round as Record<string, unknown>).round)).toEqual([
+				1, 2,
+			]);
+		}
+
+		const final = await readJson(statePath);
+		expect(inner(final).current_ambiguity).toBe(0.31);
+		expect(inner(final).topology).toEqual({ status: "legacy_missing" });
+		expect(inner(final).rounds).toHaveLength(2);
+	});
+
+	it("fails closed on corrupt or tampered on-disk state for state write and recorder mutation", async () => {
+		const cwd = await tempDir();
+		const statePath = deepInterviewStatePath(cwd, undefined);
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		const corruptBytes = "{ definitely-not-json";
+		await fs.writeFile(statePath, corruptBytes, "utf-8");
+
+		const write = await runNativeStateCommand(
+			["write", "--mode", "deep-interview", "--input", JSON.stringify({ state: { current_ambiguity: 0.2 } })],
+			cwd,
+		);
+		expect(write.status).not.toBe(0);
+		expect(await fs.readFile(statePath, "utf-8")).toBe(corruptBytes);
+
+		await expect(
+			appendOrMergeDeepInterviewRound(cwd, statePath, {
+				round: 1,
+				questionId: "q1",
+				questionText: "Should not migrate",
+			}),
+		).rejects.toThrow(/corrupt|tampered|refusing to overwrite/);
+		expect(await fs.readFile(statePath, "utf-8")).toBe(corruptBytes);
+	});
+});
+
+describe("deep-interview redteam: HUD derivation edge cases", () => {
+	it("handles empty state without synthetic target or weakest chips", () => {
+		const chips = hudChips({ state: {} });
+		expect(chips.round).toBeUndefined();
+		expect(chips.target).toBeUndefined();
+		expect(chips.weakest).toBeUndefined();
+	});
+
+	it("omits target and weakest when topology is missing", () => {
+		const chips = hudChips({
+			current_phase: "interviewing",
+			state: { rounds: [{ round_key: "k1" }], current_ambiguity: 0.5 },
+		});
+		expect(chips.round).toBe("1");
+		expect(chips.ambiguity).toBe("50%");
+		expect(chips.target).toBeUndefined();
+		expect(chips.weakest).toBeUndefined();
+	});
+
+	it("does not invent an active target for deferred-only topology but can show the known weakest dimension", () => {
+		const chips = hudChips({
+			state: {
+				rounds: [],
+				topology: {
+					components: [
+						{ id: "api", status: "deferred", weakest_dimension: "goal" },
+						{ id: "cli", status: "deferred", weakest_dimension: "constraints" },
+					],
+				},
+			},
+		});
+		expect(chips.target).toBeUndefined();
+		expect(chips.weakest).toBe("goal");
+	});
+
+	it("falls back to first active weakest dimension when targeted component has no weakest dimension", () => {
+		const chips = hudChips({
+			state: {
+				topology: {
+					last_targeted_component_id: "api",
+					components: [
+						{ id: "api", status: "active" },
+						{ id: "cli", status: "active", weakest_dimension: "interface" },
+						{ id: "docs", status: "deferred", weakest_dimension: "goal" },
+					],
+				},
+			},
+		});
+		expect(chips.target).toBe("api");
+		expect(chips.weakest).toBe("interface");
+	});
+
+	it("falls back to ambiguity from latest scored round when current ambiguity is absent", () => {
+		const chips = hudChips({
+			state: {
+				rounds: [
+					{ round_key: "k1", lifecycle: "scored", ambiguity: 0.25 },
+					{ round_key: "k2", lifecycle: "answered" },
+					{ round_key: "k3", lifecycle: "scored", ambiguity: 0.73 },
+				],
+			},
+		});
+		expect(chips.ambiguity).toBe("73%");
+	});
+});
+
+describe("deep-interview redteam: reconcile and state write HUD parity", () => {
+	const payloads = [
+		{
+			current_phase: "interviewing",
+			state: {
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.64 }],
+				threshold: 0.05,
+				topology: {
+					last_targeted_component_id: "api",
+					components: [{ id: "api", status: "active", weakest_dimension: "goal" }],
+				},
+			},
+		},
+		{
+			current_phase: "interviewing",
+			state: {
+				rounds: [
+					{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.4 },
+					{ round_key: "k2", round: 2, lifecycle: "answered" },
+				],
+				topology: { status: "legacy_missing" },
+			},
+		},
+		{
+			current_phase: "interviewing",
+			state: {
+				rounds: [],
+				current_ambiguity: 0.12,
+				topology: { components: [{ id: "only", status: "deferred", weakest_dimension: "risk" }] },
+			},
+		},
+	];
+
+	it("produces identical active-state HUD chips through reconcile and gjc state write", async () => {
+		for (const payload of payloads) {
+			const writeCwd = await tempDir();
+			const write = await runNativeStateCommand(
+				["write", "--mode", "deep-interview", "--input", JSON.stringify(payload)],
+				writeCwd,
+			);
+			expect(write.status).toBe(0);
+			const writeHud = await activeChips(writeCwd);
+
+			const reconcileCwd = await tempDir();
+			await reconcileWorkflowSkillState({
+				cwd: reconcileCwd,
+				mode: "deep-interview",
+				sessionId: undefined,
+				active: payload.current_phase !== "complete",
+				phase: payload.current_phase,
+				payload,
+			});
+			const reconcileHud = await activeChips(reconcileCwd);
+			expect(reconcileHud).toEqual(writeHud);
+		}
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
@@ -110,6 +110,39 @@ describe("deep-interview-state: mergeDeepInterviewEnvelope", () => {
 		expect("rounds" in merged).toBe(false);
 	});
 
+	it("preserves established facts when incoming partial state omits them", () => {
+		const facts = [{ id: "f1", statement: "confirmed fact", round: 1, disputed: false }];
+		const existing = {
+			skill: "deep-interview",
+			state: {
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.5 }],
+				established_facts: facts,
+				topology: { status: "confirmed" },
+			},
+		};
+
+		const nestedPartial = mergeDeepInterviewEnvelope(existing, { state: { current_ambiguity: 0.3 } });
+		expect(inner(nestedPartial).established_facts).toEqual(facts);
+		expect(inner(nestedPartial).current_ambiguity).toBe(0.3);
+		expect(inner(nestedPartial).rounds).toHaveLength(1);
+
+		const topLevelPartial = mergeDeepInterviewEnvelope(existing, { current_phase: "handoff" });
+		expect(inner(topLevelPartial).established_facts).toEqual(facts);
+		expect(topLevelPartial.current_phase).toBe("handoff");
+	});
+
+	it("allows explicit established facts replacement", () => {
+		const existing = {
+			state: {
+				rounds: [],
+				established_facts: [{ id: "f1", statement: "old fact", round: 1, disputed: false }],
+			},
+		};
+
+		const merged = mergeDeepInterviewEnvelope(existing, { state: { established_facts: [] } });
+		expect(inner(merged).established_facts).toEqual([]);
+	});
+
 	it("replace returns the normalized incoming envelope", () => {
 		const merged = mergeDeepInterviewEnvelope(
 			{ state: { rounds: [{ round_key: "k1" }] } },

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-state.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+import {
+	deriveRoundKey,
+	mergeDeepInterviewEnvelope,
+	mergeDeepInterviewRounds,
+	normalizeDeepInterviewEnvelope,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
+import { deriveDeepInterviewHud } from "@gajae-code/coding-agent/skill-state/workflow-hud";
+
+function inner(envelope: { state?: Record<string, unknown> }): Record<string, unknown> {
+	return (envelope.state ?? {}) as Record<string, unknown>;
+}
+
+describe("deep-interview-state: normalizeDeepInterviewEnvelope", () => {
+	it("hoists flattened legacy transcript fields into nested state and strips the top-level copy", () => {
+		const normalized = normalizeDeepInterviewEnvelope({
+			skill: "deep-interview",
+			current_phase: "interviewing",
+			rounds: [{ round_key: "k1", round: 1, lifecycle: "answered" }],
+			current_ambiguity: 0.5,
+			topology: { last_targeted_component_id: "api" },
+			threshold: 0.05,
+		});
+		expect(inner(normalized).rounds).toEqual([{ round_key: "k1", round: 1, lifecycle: "answered" }]);
+		expect(inner(normalized).current_ambiguity).toBe(0.5);
+		expect((inner(normalized).topology as Record<string, unknown>).last_targeted_component_id).toBe("api");
+		expect("rounds" in normalized).toBe(false);
+		expect("current_ambiguity" in normalized).toBe(false);
+		expect("topology" in normalized).toBe(false);
+		// `threshold` is legitimately dual: kept at the top level and mirrored into state.
+		expect(normalized.threshold).toBe(0.05);
+		expect(inner(normalized).threshold).toBe(0.05);
+	});
+
+	it("is idempotent on an already-canonical envelope", () => {
+		const once = normalizeDeepInterviewEnvelope({
+			skill: "deep-interview",
+			state: { rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.4 }], established_facts: [] },
+		});
+		const twice = normalizeDeepInterviewEnvelope(once);
+		expect(twice).toEqual(once);
+	});
+
+	it("defaults rounds/established_facts and preserves unknown fields", () => {
+		const normalized = normalizeDeepInterviewEnvelope({
+			state: { initial_idea: "x" },
+			custom_unknown: { keep: true },
+		});
+		expect(inner(normalized).rounds).toEqual([]);
+		expect(inner(normalized).established_facts).toEqual([]);
+		expect(inner(normalized).initial_idea).toBe("x");
+		expect(normalized.custom_unknown).toEqual({ keep: true });
+	});
+});
+
+describe("deep-interview-state: mergeDeepInterviewRounds", () => {
+	it("merges scoring into the same durable key without appending", () => {
+		const answered = { round_key: "iv::r:1::q:q1", round: 1, lifecycle: "answered", question_hash: "h" };
+		const scored = { round_key: "iv::r:1::q:q1", round: 1, lifecycle: "scored", ambiguity: 0.4 };
+		const merged = mergeDeepInterviewRounds([answered], [scored]);
+		expect(merged).toHaveLength(1);
+		expect(merged[0].lifecycle).toBe("scored");
+		expect(merged[0].ambiguity).toBe(0.4);
+		expect(merged[0].question_hash).toBe("h");
+	});
+
+	it("preserves distinct opaque legacy rounds verbatim and dedupes exact copies", () => {
+		const a = { n: 1, transcript: "full" };
+		const b = { n: 2, transcript: "full" };
+		const merged = mergeDeepInterviewRounds([a], [a, b]);
+		expect(merged).toEqual([a, b]);
+	});
+
+	it("never collapses distinct legacy rounds that share a round number", () => {
+		const merged = mergeDeepInterviewRounds(
+			[],
+			[
+				{ round: 1, note: "first" },
+				{ round: 1, note: "second" },
+			],
+		);
+		expect(merged).toHaveLength(2);
+	});
+
+	it("synthesizes a stable durable key from question_id when round_key is absent", () => {
+		const answered = { round: 2, question_id: "q2", lifecycle: "answered" };
+		const scored = { round: 2, question_id: "q2", lifecycle: "scored", ambiguity: 0.3 };
+		const merged = mergeDeepInterviewRounds([answered], [scored]);
+		expect(merged).toHaveLength(1);
+		expect(merged[0].round_key).toBe(deriveRoundKey(undefined, { round: 2, questionId: "q2" }));
+	});
+});
+
+describe("deep-interview-state: mergeDeepInterviewEnvelope", () => {
+	it("preserves existing rounds when an incoming partial state omits them", () => {
+		const existing = {
+			skill: "deep-interview",
+			state: {
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.5 }],
+				established_facts: [],
+				interview_id: "iv",
+			},
+		};
+		const merged = mergeDeepInterviewEnvelope(existing, {
+			state: { current_ambiguity: 0.4, topology: { last_targeted_component_id: "api" } },
+		});
+		expect(inner(merged).rounds).toHaveLength(1);
+		expect(inner(merged).current_ambiguity).toBe(0.4);
+		expect(inner(merged).interview_id).toBe("iv");
+		expect("rounds" in merged).toBe(false);
+	});
+
+	it("replace returns the normalized incoming envelope", () => {
+		const merged = mergeDeepInterviewEnvelope(
+			{ state: { rounds: [{ round_key: "k1" }] } },
+			{ active: false },
+			{ replace: true },
+		);
+		expect(inner(merged).rounds).toEqual([]);
+		expect(merged.active).toBe(false);
+	});
+});
+
+describe("deep-interview-state: deriveDeepInterviewHud", () => {
+	function chipMap(payload: Record<string, unknown>, options?: Parameters<typeof deriveDeepInterviewHud>[1]) {
+		const hud = deriveDeepInterviewHud(payload, options);
+		return Object.fromEntries((hud.chips ?? []).map(chip => [chip.label, chip.value]));
+	}
+
+	it("derives round/ambiguity/threshold and topology-aware target+weakest", () => {
+		const chips = chipMap({
+			current_phase: "interviewing",
+			state: {
+				rounds: [{ round_key: "k1" }, { round_key: "k2" }],
+				current_ambiguity: 0.42,
+				threshold: 0.05,
+				topology: {
+					last_targeted_component_id: "api",
+					components: [
+						{ id: "api", status: "active", weakest_dimension: "constraints" },
+						{ id: "ui", status: "active", weakest_dimension: "goal" },
+					],
+				},
+			},
+		});
+		expect(chips.round).toBe("2");
+		expect(chips.ambiguity).toBe("42%/5%");
+		expect(chips.target).toBe("api");
+		expect(chips.weakest).toBe("constraints");
+	});
+
+	it("omits target and weakest chips for legacy_missing topology", () => {
+		const chips = chipMap({
+			current_phase: "interviewing",
+			state: { rounds: [], current_ambiguity: 1, topology: { status: "legacy_missing" } },
+		});
+		expect(Object.keys(chips)).not.toContain("target");
+		expect(Object.keys(chips)).not.toContain("weakest");
+	});
+
+	it("falls back to the latest scored round ambiguity when current_ambiguity is absent", () => {
+		const chips = chipMap({
+			state: {
+				rounds: [
+					{ round_key: "k1", lifecycle: "scored", ambiguity: 0.6 },
+					{ round_key: "k2", lifecycle: "answered" },
+				],
+			},
+		});
+		expect(chips.ambiguity).toBe("60%");
+	});
+});
+
+describe("deep-interview-state: deriveDeepInterviewHud legacy_missing topology", () => {
+	it("omits target/weakest even when legacy_missing topology carries stale fields", () => {
+		const hud = deriveDeepInterviewHud({
+			current_phase: "interviewing",
+			state: {
+				rounds: [{ round_key: "k1" }],
+				current_ambiguity: 0.7,
+				topology: {
+					status: "legacy_missing",
+					last_targeted_component_id: "stale-api",
+					components: [{ id: "stale-api", status: "active", weakest_dimension: "goal" }],
+				},
+			},
+		});
+		const labels = (hud.chips ?? []).map(chip => chip.label);
+		expect(labels).not.toContain("target");
+		expect(labels).not.toContain("weakest");
+		expect(labels).toContain("round");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-runtime.test.ts
@@ -77,7 +77,7 @@ describe("native gjc state runtime", () => {
 
 		expect(result.status).toBe(0);
 		const parsed = envelopeState(result.stdout);
-		expect(parsed.interview_id).toBe("abc");
+		expect((parsed.state as Record<string, unknown>).interview_id).toBe("abc");
 	});
 
 	it("prefers CLI --mode over --input payload mode", async () => {
@@ -137,9 +137,9 @@ describe("native gjc state runtime", () => {
 		const merged = JSON.parse(
 			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
 		);
-		expect(merged.current_ambiguity).toBe(0.5);
-		expect(merged.threshold_source).toBe("user");
-		expect(merged.interview_id).toBe("abc");
+		expect(merged.state.current_ambiguity).toBe(0.5);
+		expect(merged.state.threshold_source).toBe("user");
+		expect(merged.state.interview_id).toBe("abc");
 	});
 
 	it("deletes a key when the payload value is null", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts
@@ -52,7 +52,7 @@ describe("GJC state token thrift", () => {
 		expect(compactJson.status).toBe(0);
 		const parsedCompact = JSON.parse(compactJson.stdout ?? "{}");
 		expect(parsedCompact.rounds).toBeUndefined();
-		expect(parsedCompact.elided.rounds).toEqual({ type: "array", count: 2, pointer: "/rounds" });
+		expect(parsedCompact.elided.rounds).toEqual({ type: "array", count: 2, pointer: "/state/rounds" });
 
 		const json = await runNativeStateCommand(
 			["read", "--mode", "deep-interview", "--session-id", "", "--json"],
@@ -62,7 +62,7 @@ describe("GJC state token thrift", () => {
 		const parsed = JSON.parse(json.stdout ?? "{}");
 		const raw = await readWorkflowStateJson(root, "deep-interview");
 		expect(parsed.state).toEqual(raw);
-		expect(parsed.state.rounds).toEqual(payload.rounds);
+		expect(parsed.state.state.rounds).toEqual(payload.rounds);
 	});
 
 	it("projects requested fields in requested order", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -231,9 +231,9 @@ describe("gjc state write hardening", () => {
 		const onDisk = JSON.parse(
 			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),
 		);
-		expect(onDisk.rounds).toEqual(extension.rounds);
-		expect(onDisk.topology).toEqual(extension.topology);
-		expect(onDisk.ontology_snapshots).toEqual(extension.ontology_snapshots);
+		expect(onDisk.state.rounds).toEqual(extension.rounds);
+		expect(onDisk.state.topology).toEqual(extension.topology);
+		expect(onDisk.state.ontology_snapshots).toEqual(extension.ontology_snapshots);
 		expect(onDisk.architect_findings).toEqual(extension.architect_findings);
 		expect(onDisk.new_requirements).toEqual(extension.new_requirements);
 		expect(onDisk.ci_gates).toEqual(extension.ci_gates);


### PR DESCRIPTION
## Problem

After #587 the runtime recorder records interview rounds directly (via the `ask` tool) and **bypasses `gjc state write`**, so the cached HUD in `skill-active-state.json` never refreshed. The HUD bar renders only that cached snapshot (no live recompute), so `round`/`ambiguity` chips froze at seed values while `deep-interview-state.json` advanced. Compounding mismatches:

- **M1 (root):** recorder never synced active-state/HUD after recording rounds.
- **M2:** two competing envelope shapes — nested `state.*` (recorder/seed) vs flattened top-level (`gjc state write`).
- **M3/M4:** `buildHudForMode` read `last_targeted_component_id`/`weakest_dimension` from the wrong path (they live under `topology` / `topology.components[]`), so `target`/`weakest` chips never populated.
- **M5:** `handleWrite` flatten + `delete merged.state` clobbered recorder round history on partial writes.
- **M6:** `enrichDeepInterviewRoundScoring` was unwired; scored transitions only flowed through the destructive write path.
- **M7:** handoff dropped round/ambiguity/threshold HUD context.

## Fix (ralplan run `2026-06-14-0118-52a7`, options A1 + B1)

- **New pure module `gjc-runtime/deep-interview-state.ts`** — `normalizeDeepInterviewEnvelope`, `mergeDeepInterviewEnvelope`, `mergeDeepInterviewRounds` (canonical nested state; lossless, idempotent round merge by durable key; never collapses distinct rounds) plus the moved identity/hashing helpers and domain types. Imports only `node:crypto` (cycle-free leaf).
- **Single shared `deriveDeepInterviewHud`** in `skill-state/workflow-hud.ts` — topology-aware `target`/`weakest`; `legacy_missing` topology omits those chips; no scalar HUD assembly remains anywhere.
- **Recorder** syncs active-state HUD after `append`/`enrich`; the no-op path re-reads persisted state before repairing the HUD (never derives from pre-no-op memory).
- **state-runtime** `handleWrite`/`reconcile` route deep-interview through the canonical merge **before** the generic flatten/delete (generic `mergeWithNullDelete` untouched for other skills); `buildHudForMode` delegates to `deriveDeepInterviewHud`.
- **deep-interview-runtime** seed / `syncDeepInterviewHud` / `persistDeepInterviewSpec`, and `gjc state handoff`, all produce canonical nested state and derive the HUD from the full payload.
- **state-renderer** compact projection reads nested `state` and points elisions at `/state/<key>`.

## Verification

- `bun run check:ts` clean (all workspaces tsc + biome); `bun run lint:ts` clean.
- 149 targeted deep-interview/state tests pass, including new coverage: recorder→HUD sync, partial-write round preservation, `reconcile` vs `gjc state write` HUD parity, normalize/merge idempotency, legacy round-collision safety, fail-closed on corrupt state, `legacy_missing` chip omission, and spec-persist/handoff canonicalization. A 12-case adversarial red-team suite (`deep-interview-state-redteam.test.ts`) found 0 defects.
- Consensus + review trail: architect re-review **CLEAR/CLEAR/CLEAR + APPROVE**; critic **OKAY**.

## Scope / non-goals

Bug fix only. No new public skill/CLI entrypoints, no scoring-math/threshold/topology-enumeration/spec-generation changes, no live HUD recompute in the renderer, and other skills' state-merge behavior is unchanged.
