### PR TITLE
fix(model-selector): mark active preset and badge preset/session default

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -829,8 +829,7 @@ export class ModelSelectorComponent extends Container {
 			const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
 			const label = `  ${mark} ${presentation.displayName}`;
 			const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
-			const profileMarker =
-				row.profile.name === this.#activeModelProfileName ? theme.fg("accent", " ● in use") : "";
+			const profileMarker = row.profile.name === this.#activeModelProfileName ? theme.fg("accent", " ● in use") : "";
 			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}${profileMarker}`, 0, 0));
 		}
 		if (this.#presetLoginHint) {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -188,6 +188,8 @@ export class ModelSelectorComponent extends Container {
 	#filteredCanonicalModels: CanonicalModelItem[] = [];
 	#selectedIndex: number = 0;
 	#roles = {} as Record<string, RoleAssignment | undefined>;
+	#currentModel: Model | undefined;
+	#activeDefaultThinkingLevel?: ThinkingLevel;
 	#settings = null as unknown as Settings;
 	#modelRegistry = null as unknown as ModelRegistry;
 	#onSelectCallback = (() => {}) as RoleSelectCallback;
@@ -206,6 +208,7 @@ export class ModelSelectorComponent extends Container {
 	#presetCursor: number = 0;
 	#expandedPresetProviderId?: string;
 	#previewProfileName?: string;
+	#activeModelProfileName?: string;
 	#presetScopeMenuOpen: boolean = false;
 	#presetScopeIndex: number = 0;
 	#providerAuthById = new Map<string, boolean>();
@@ -219,13 +222,19 @@ export class ModelSelectorComponent extends Container {
 
 	constructor(
 		tui: TUI,
-		_currentModel: Model | undefined,
+		currentModel: Model | undefined,
 		settings: Settings,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string; sessionId?: string },
+		options?: {
+			temporaryOnly?: boolean;
+			initialSearchInput?: string;
+			sessionId?: string;
+			activeModelProfileName?: string;
+			activeDefaultThinkingLevel?: ThinkingLevel;
+		},
 	) {
 		super();
 
@@ -237,6 +246,9 @@ export class ModelSelectorComponent extends Container {
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		this.#authSessionId = options?.sessionId;
+		this.#currentModel = currentModel;
+		this.#activeModelProfileName = options?.activeModelProfileName;
+		this.#activeDefaultThinkingLevel = options?.activeDefaultThinkingLevel;
 		const initialSearchInput = options?.initialSearchInput;
 		this.#viewMode = this.#temporaryOnly || initialSearchInput || scopedModels.length > 0 ? "models" : "presets";
 
@@ -315,6 +327,34 @@ export class ModelSelectorComponent extends Container {
 			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 			const roleValue =
 				target.settingsPath === "modelRoles" ? this.#settings.getModelRole(role) : agentModelOverrides[role];
+			if (role === "default" && this.#currentModel) {
+				// The active session model is the live default (e.g. applied by a preset via
+				// setModelTemporary) and takes precedence over the persisted modelRoles.default.
+				// Prefer the session thinking level supplied by the controller; otherwise, when the
+				// persisted default resolves to this same model, preserve its explicit thinking so
+				// an existing `DEFAULT (low)` does not regress to `DEFAULT (inherit)`.
+				let defaultThinking = this.#activeDefaultThinkingLevel;
+				if (defaultThinking === undefined && roleValue) {
+					const resolvedDefault = resolveModelRoleValue(roleValue, allModels, {
+						settings: this.#settings,
+						matchPreferences,
+						modelRegistry: this.#modelRegistry,
+					});
+					if (
+						resolvedDefault.model &&
+						modelsAreEqual(resolvedDefault.model, this.#currentModel) &&
+						resolvedDefault.explicitThinkingLevel &&
+						resolvedDefault.thinkingLevel !== undefined
+					) {
+						defaultThinking = resolvedDefault.thinkingLevel;
+					}
+				}
+				this.#roles.default = {
+					model: this.#currentModel,
+					thinkingLevel: defaultThinking ?? ThinkingLevel.Inherit,
+				};
+				continue;
+			}
 			if (!roleValue) continue;
 
 			const resolved = resolveModelRoleValue(roleValue, allModels, {
@@ -776,7 +816,12 @@ export class ModelSelectorComponent extends Container {
 				const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
 				const label = `${mark} ${row.groupId}`;
 				const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
-				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+				const groupCollapsed = this.#expandedPresetProviderId !== row.groupId;
+				const groupHasActive =
+					this.#activeModelProfileName !== undefined &&
+					row.profiles.some(profile => profile.name === this.#activeModelProfileName);
+				const groupMarker = groupCollapsed && groupHasActive ? theme.fg("accent", " ● in use") : "";
+				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}${groupMarker}`, 0, 0));
 				continue;
 			}
 			const presentation = getModelProfilePresentation(row.profile.name);
@@ -784,7 +829,9 @@ export class ModelSelectorComponent extends Container {
 			const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
 			const label = `  ${mark} ${presentation.displayName}`;
 			const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
-			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+			const profileMarker =
+				row.profile.name === this.#activeModelProfileName ? theme.fg("accent", " ● in use") : "";
+			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}${profileMarker}`, 0, 0));
 		}
 		if (this.#presetLoginHint) {
 			this.#listContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -604,7 +604,13 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				{ ...options, sessionId: this.ctx.session.sessionId },
+				{
+					...options,
+					sessionId: this.ctx.session.sessionId,
+					activeModelProfileName:
+						this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+					activeDefaultThinkingLevel: this.ctx.session.thinkingLevel,
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -55,9 +55,54 @@ function createRegistry(options: { missingCredentials?: boolean } = {}) {
 	};
 }
 
+const codexProfile: ModelProfileDefinition = {
+	name: "codex-eco",
+	requiredProviders: ["provider-a"],
+	modelMapping: { default: "provider-a/default" },
+	source: "user",
+};
+const comboProfile: ModelProfileDefinition = {
+	name: "opus-codex",
+	requiredProviders: ["provider-a"],
+	modelMapping: { default: "provider-a/default" },
+	source: "user",
+};
+
+function createMultiGroupSelector(activeModelProfileName: string) {
+	const profiles = new Map([
+		[codexProfile.name, codexProfile],
+		[comboProfile.name, comboProfile],
+	]);
+	const registry = {
+		refresh: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => [defaultModel, alternateModel],
+		getAll: () => [defaultModel, alternateModel],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		getApiKeyForProvider: async () => "key",
+		getApiKey: async () => "key",
+	};
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		undefined,
+		Settings.isolated(),
+		registry as never,
+		[],
+		() => {},
+		() => {},
+		{ activeModelProfileName },
+	);
+}
+
 function createSelector(
 	onSelect: (selection: ModelSelectorSelection) => void,
-	options: { temporaryOnly?: boolean } = {},
+	options: { temporaryOnly?: boolean; activeModelProfileName?: string } = {},
 ) {
 	const ui = { requestRender: vi.fn() } as unknown as TUI;
 	return new ModelSelectorComponent(
@@ -68,7 +113,7 @@ function createSelector(
 		[],
 		onSelect,
 		() => {},
-		options,
+		{ temporaryOnly: options.temporaryOnly, activeModelProfileName: options.activeModelProfileName },
 	);
 }
 
@@ -189,5 +234,41 @@ describe("model selector profiles", () => {
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original-executor" });
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
+	});
+
+	test("AC-1/AC-3: active profile row shows marker in expanded group, group row does not", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {}, { activeModelProfileName: "profile-a" });
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("profile-a ● in use");
+		expect(rendered).not.toContain("COMBOS ● in use");
+		expect(rendered).not.toContain("Browse all models ● in use");
+	});
+
+	test("AC-2: collapsed group with active profile shows marker; hidden profile row does not", async () => {
+		installTestTheme();
+		const selector = createMultiGroupSelector("opus-codex");
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("COMBOS ● in use");
+		expect(rendered).not.toContain("Opus + Codex");
+	});
+
+	test("AC-4: no marker when active profile is unset or unknown", async () => {
+		installTestTheme();
+		const none = createSelector(() => {});
+		await Bun.sleep(10);
+		installTestTheme();
+		expect(normalizeRenderedText(none.render(220).join("\n"))).not.toContain("● in use");
+
+		const missing = createSelector(() => {}, { activeModelProfileName: "missing-profile" });
+		await Bun.sleep(10);
+		installTestTheme();
+		expect(normalizeRenderedText(missing.render(220).join("\n"))).not.toContain("● in use");
 	});
 });

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -126,6 +126,45 @@ function installTestTheme(): void {
 	setThemeInstance(testTheme);
 }
 
+function createDefaultBadgeSelector(args: {
+	currentModel: Model | undefined;
+	scoped: Array<{ model: Model; thinkingLevel?: ThinkingLevel; explicitThinkingLevel?: boolean }>;
+	settings: Settings;
+	activeDefaultThinkingLevel?: ThinkingLevel;
+}): ModelSelectorComponent {
+	const allModels = args.scoped.map(s => s.model);
+	const modelRegistry = {
+		getAll: () => allModels,
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		args.currentModel,
+		args.settings,
+		modelRegistry,
+		args.scoped.map(s => ({
+			model: s.model,
+			thinkingLevel: s.thinkingLevel ?? ThinkingLevel.Off,
+			explicitThinkingLevel: s.explicitThinkingLevel,
+		})),
+		() => {},
+		() => {},
+		{ activeDefaultThinkingLevel: args.activeDefaultThinkingLevel },
+	);
+}
+
+function strippedLines(selector: ModelSelectorComponent): string[] {
+	return selector.render(220).map(line =>
+		line
+			.replace(/\x1b\[[0-9;]*m/g, "")
+			.replace(/\s+/g, " ")
+			.trim(),
+	);
+}
+
 describe("ModelSelector canonical model selection", () => {
 	beforeAll(async () => {
 		testTheme = await getThemeByName("red-claw");
@@ -597,5 +636,95 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Inherit);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("AC-5/AC-6: session model wins over modelRoles.default for DEFAULT badge and preserves session thinking", async () => {
+		installTestTheme();
+		const sessionModel = createOpenAIModel("openai", "session-model");
+		const settingsDefaultModel = createOpenAIModel("openai", "settings-default");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${settingsDefaultModel.provider}/${settingsDefaultModel.id}:high` },
+		});
+		const selector = createDefaultBadgeSelector({
+			currentModel: sessionModel,
+			scoped: [{ model: sessionModel }, { model: settingsDefaultModel }],
+			settings,
+			activeDefaultThinkingLevel: ThinkingLevel.Low,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const lines = strippedLines(selector);
+		const sessionLine = lines.find(line => line.includes("session-model"));
+		const settingsLine = lines.find(line => line.includes("settings-default"));
+		expect(sessionLine).toBeDefined();
+		expect(sessionLine).toContain("DEFAULT (low)");
+		expect(settingsLine).toBeDefined();
+		expect(settingsLine).not.toContain("DEFAULT");
+		expect(lines.filter(line => line.includes("DEFAULT"))).toHaveLength(1);
+	});
+
+	test("AC-5 fallback: with no session model, modelRoles.default keeps DEFAULT and explicit thinking", async () => {
+		installTestTheme();
+		const settingsDefaultModel = createOpenAIModel("openai", "settings-default");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${settingsDefaultModel.provider}/${settingsDefaultModel.id}:high` },
+		});
+		const selector = createDefaultBadgeSelector({
+			currentModel: undefined,
+			scoped: [{ model: settingsDefaultModel }],
+			settings,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const settingsLine = strippedLines(selector).find(line => line.includes("settings-default"));
+		expect(settingsLine).toBeDefined();
+		expect(settingsLine).toContain("DEFAULT (high)");
+	});
+
+	test("thinking is not regressed to inherit when session model matches modelRoles.default", async () => {
+		installTestTheme();
+		const sessionModel = createOpenAIModel("openai", "session-model");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${sessionModel.provider}/${sessionModel.id}:low` },
+		});
+		const selector = createDefaultBadgeSelector({
+			currentModel: sessionModel,
+			scoped: [{ model: sessionModel }],
+			settings,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const sessionLine = strippedLines(selector).find(line => line.includes("session-model"));
+		expect(sessionLine).toBeDefined();
+		expect(sessionLine).toContain("DEFAULT (low)");
+		expect(sessionLine).not.toContain("DEFAULT (inherit)");
+	});
+
+	test("AC-7: executor override badge stays on override model even when session model differs", async () => {
+		installTestTheme();
+		const sessionModel = createOpenAIModel("openai", "session-model");
+		const executorModel = createOpenAIModel("openai", "executor-model");
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: `${executorModel.provider}/${executorModel.id}:high` },
+		});
+		const selector = createDefaultBadgeSelector({
+			currentModel: sessionModel,
+			scoped: [{ model: sessionModel }, { model: executorModel }],
+			settings,
+			activeDefaultThinkingLevel: ThinkingLevel.Low,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const lines = strippedLines(selector);
+		const sessionLine = lines.find(line => line.includes("session-model"));
+		const executorLine = lines.find(line => line.includes("executor-model"));
+		expect(sessionLine).toContain("DEFAULT (low)");
+		expect(executorLine).toBeDefined();
+		expect(executorLine).toContain("EXECUTOR (high)");
+		expect(executorLine).not.toContain("DEFAULT");
 	});
 });


### PR DESCRIPTION
## Summary

Make the `/model` selector show what is currently active:

- **Active-preset indicator** — the preset landing now renders an accent `● in use` marker on the active profile row, and on the active group row when that group is collapsed. Source of truth reuses the existing pattern `session.getActiveModelProfile() ?? settings.get("modelProfile.default")`.
- **DEFAULT-badge fix** — the "Browse all models" list now badges the session current model as `DEFAULT`. Previously a preset-applied default (applied via `session.setModelTemporary`, which never writes `modelRoles.default`) got **no** `DEFAULT` badge because the selector ignored the `currentModel` ctor argument and only read `modelRoles.default`.

## Bug fixed

When a preset (e.g. `opus-codex`) was active, its default model showed no `DEFAULT` badge in the model list. Root cause: `#loadRoleModels` resolved the `default` role only from `modelRoles.default`, but preset activation persists only `modelProfile.default` (the profile *name*) and applies the model via `setModelTemporary`. The session current model was passed to the component as `_currentModel` but left unused.

## Changes

- `model-selector.ts`
  - store the ctor `currentModel` as `#currentModel`; add options `activeModelProfileName?` and `activeDefaultThinkingLevel?`
  - `#loadRoleModels`: for the `default` role, prefer `#currentModel` with thinking precedence `activeDefaultThinkingLevel` > same-model settings explicit thinking > `Inherit` (so an existing `DEFAULT (low)` does not regress to `(inherit)`); fall back to `modelRoles.default` when no session model
  - `#renderPresetLanding`: accent `● in use` marker on the active profile row and on the collapsed active group row (gated by `#expandedPresetProviderId`); no marker on no-match
- `selector-controller.ts`: pass `activeModelProfileName = session.getActiveModelProfile?.() ?? settings.get("modelProfile.default")` and `activeDefaultThinkingLevel = session.thinkingLevel` into the component options

## Non-goals / constraints honored

- No changes to `model-profile-activation.ts`, `model-registry.ts`, or settings persistence
- Non-default role badges (`EXECUTOR`/`ARCHITECT`/`PLANNER`/`CRITIC`, via `task.agentModelOverrides`) unchanged
- English UI strings only

## Tests

Added/extended `test/model-selector-profiles.test.ts` and `test/model-selector-role-badge-thinking.test.ts` covering AC-1..AC-8:
- active profile marker (expanded), collapsed group marker, no duplicate marker when expanded, no marker on unset/unknown
- session-model precedence for `DEFAULT`, session-thinking preservation (no inherit regression), fallback to `modelRoles.default`, executor override unchanged
- adversarial: marker must not bleed onto the "Browse all models" row; exactly one `DEFAULT` badge across rows

## Verification (package-local)

- `bun --cwd=packages/coding-agent test model-selector-profiles.test.ts model-selector-role-badge-thinking.test.ts` → 25 pass / 0 fail / 111 expect
- `bun --cwd=packages/coding-agent run check:types` → clean
- `bun --cwd=packages/coding-agent run lint` → clean
