### PR TITLE
fix(ai): treat model limits as usage exhaustion

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - Stripped `OpenAI-Beta` in the `openai-proxy` request transform profile so OpenAI-compatible proxies do not receive SDK beta headers.
+- Classified model/message limit exhaustion as persistent usage-limit errors so hosts fail fast or switch credentials instead of leaving sessions in an unbounded retry/working state.
 
 ## [0.4.5] - 2026-06-12
 

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -45,7 +45,16 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "RATE_LIMIT_EXCEEDED";
 	}
 
-	if (lower.includes("exhausted") || lower.includes("quota") || lower.includes("usage limit")) {
+	if (
+		lower.includes("exhausted") ||
+		lower.includes("quota") ||
+		lower.includes("usage limit") ||
+		lower.includes("model limit") ||
+		lower.includes("model_limit") ||
+		lower.includes("message limit") ||
+		lower.includes("message_limit") ||
+		lower.includes("limit for this model")
+	) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -77,7 +86,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|resource.?exhausted/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|quota.?exceeded|resource has been exhausted[^\n]*(?:quota|limit)/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@gajae-code/ai/rate-limit-utils";
+import { calculateRateLimitBackoffMs, isUsageLimitError, parseRateLimitReason } from "@gajae-code/ai/rate-limit-utils";
 
 describe("parseRateLimitReason", () => {
 	it("classifies Google Quota exceeded as QUOTA_EXHAUSTED", () => {
@@ -45,6 +45,11 @@ describe("parseRateLimitReason", () => {
 			parseRateLimitReason("Codex error event: The usage limit has been reached (code=usage_limit_reached)"),
 		).toBe("QUOTA_EXHAUSTED");
 	});
+
+	it("classifies model/message-limit exhaustion as QUOTA_EXHAUSTED", () => {
+		expect(parseRateLimitReason("429 model_limit_reached: limit for this model reached")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("You have reached the message limit for this model")).toBe("QUOTA_EXHAUSTED");
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {
@@ -54,5 +59,24 @@ describe("calculateRateLimitBackoffMs", () => {
 			expect(ms).toBeGreaterThanOrEqual(45_000);
 			expect(ms).toBeLessThanOrEqual(75_000);
 		}
+	});
+});
+
+describe("isUsageLimitError", () => {
+	it("detects model/message-limit exhaustion as persistent usage limits", () => {
+		expect(isUsageLimitError("429 model_limit_reached: limit for this model reached")).toBe(true);
+		expect(isUsageLimitError("You have reached the message limit for this model")).toBe(true);
+	});
+
+	it("detects explicit resource-exhausted quota messages but not capacity wording", () => {
+		expect(
+			isUsageLimitError("Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota)."),
+		).toBe(true);
+		expect(isUsageLimitError("resource exhausted")).toBe(false);
+	});
+
+	it("does not classify generic rate limits as usage exhaustion", () => {
+		expect(isUsageLimitError("429 rate limit exceeded, please retry in 5s")).toBe(false);
+		expect(isUsageLimitError("Requests per minute limit reached")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -124,6 +124,71 @@ describe("AgentSession retry delay cap", () => {
 		expect(session.isRetrying).toBe(false);
 	});
 
+	it("fails fast on model-limit 429 instead of entering unbounded retry", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const modelLimitError =
+			'429 {"type":"error","error":{"type":"rate_limit_error","message":"model_limit_reached: limit for this model reached"}} retry-after-ms=11180000';
+
+		const mock = createMockModel({
+			responses: [{ throw: modelLimitError }, { content: ["unexpected retry"] }],
+		});
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 100,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger model limit with long retry-after");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${model.provider}/${model.id}`]);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: false, attempt: 1 });
+		expect(retryEndEvents[0].finalError).toContain("exceeds retry.maxDelayMs");
+		expect(waitSpy).not.toHaveBeenCalled();
+
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("error");
+		expect(session.isStreaming).toBe(false);
+		expect(session.isRetrying).toBe(false);
+	});
+
 	it("still retries normally when the delay is under retry.maxDelayMs", async () => {
 		// Sanity check: a small retry-after MUST still go through the retry
 		// loop so we don't regress the existing transient-error recovery.


### PR DESCRIPTION
## Summary
- classify model/message limit exhaustion as persistent usage-limit errors
- prevent long model-limit retry windows from leaving GJC stuck in Working/busy state
- add rate-limit utility coverage and AgentSession fail-fast regression coverage

## Verification
- bun test packages/ai/test/rate-limit-utils.test.ts
- bun test packages/coding-agent/test/agent-session-retry-cap.test.ts
- bunx biome check packages/ai/CHANGELOG.md packages/ai/src/rate-limit-utils.ts packages/ai/test/rate-limit-utils.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts