### PR TITLE
fix: repair Grok vendor Biome config

### DIFF
--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -50,7 +50,10 @@ function requestSignal(signal: AbortSignal | undefined): AbortSignal {
 	return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
-function addNonOverridingParams(target: URLSearchParams | Record<string, string>, params: Readonly<Record<string, string>>): void {
+function addNonOverridingParams(
+	target: URLSearchParams | Record<string, string>,
+	params: Readonly<Record<string, string>>,
+): void {
 	for (const [key, value] of Object.entries(params)) {
 		if (key.length === 0 || value.length === 0) continue;
 		if (target instanceof URLSearchParams) {

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -7,9 +7,9 @@ import { formatNumber } from "@gajae-code/utils";
 import type { ModelRegistry } from "../config/model-registry";
 import {
 	discoverAndLoadExtensions,
+	type ExtensionFactory,
 	loadExtensionFromFactory,
 	loadExtensions,
-	type ExtensionFactory,
 } from "../extensibility/extensions";
 import { EventBus } from "../utils/event-bus";
 

--- a/packages/coding-agent/src/defaults/gjc-grok-cli.ts
+++ b/packages/coding-agent/src/defaults/gjc-grok-cli.ts
@@ -1,6 +1,6 @@
 import type { ExtensionFactory } from "../extensibility/extensions/types";
-import grokBuildExtensionFactory from "./gjc/extensions/grok-build/index";
 import grokCliModelDefaults from "./gjc/agent.models.grok-cli.yml" with { type: "text" };
+import grokBuildExtensionFactory from "./gjc/extensions/grok-build/index";
 
 export const BUNDLED_GROK_BUILD_EXTENSION_ID = "bundled:grok-build";
 

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-build/index.ts
@@ -1,1 +1,1 @@
-export { default } from '../grok-cli-vendor/src/index.js';
+export { default } from "../grok-cli-vendor/src/index.js";

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "root": false,
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
@@ -118,7 +118,9 @@ export function supportsReasoningEffort(modelId: string): boolean {
   if (model) {
     if (!model.reasoning) return false;
     if (!model.thinkingLevelMap) return true;
-    return Object.values(model.thinkingLevelMap).some((level) => level !== null && level !== 'none');
+    return Object.values(model.thinkingLevelMap).some(
+      (level) => level !== null && level !== 'none',
+    );
   }
   // Effort-capable id not listed in GJC_GROK_CLI_MODELS env list — still honor prefix (avoids spurious 400s).
   return true;

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/payload/sanitize.ts
@@ -222,7 +222,6 @@ function rewriteFunctionCallOutput(input: Record<string, unknown>[]): Record<str
   return rewritten;
 }
 
-
 // ─── xAI 400 guards ───────────────────────────────────────────────────────────
 
 const REPLAYED_INPUT_TYPES = new Set([

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/register.ts
@@ -2,14 +2,14 @@
  * GJC Grok Build provider — SuperGrok OAuth + cli-chat-proxy models.
  */
 
-import { Effort } from '@gajae-code/ai/model-thinking';
 import type { Api, Model } from '@gajae-code/ai';
+import { Effort } from '@gajae-code/ai/model-thinking';
 import type { OAuthCredentials, OAuthLoginCallbacks } from '@gajae-code/ai/utils/oauth/types';
-import { XAI_OAUTH_SCOPE, loginXai, refreshXaiToken } from '@gajae-code/ai/utils/oauth/xai';
+import { loginXai, refreshXaiToken, XAI_OAUTH_SCOPE } from '@gajae-code/ai/utils/oauth/xai';
 import type { ExtensionAPI, ProviderConfig } from '@gajae-code/coding-agent';
-import { getBaseUrl, isGrokBuildBaseUrlOverrideIgnored } from '../shared/base-url.js';
 import { type GrokCliModelConfig, resolveModels } from '../models/catalog.js';
 import { sanitizePayload } from '../payload/sanitize.js';
+import { getBaseUrl, isGrokBuildBaseUrlOverrideIgnored } from '../shared/base-url.js';
 import { streamGrokCli } from './stream.js';
 import { registerUsageCommand } from './usage.js';
 
@@ -27,7 +27,6 @@ export default function registerGrokCli(api: ExtensionAPI) {
   const baseUrl = getBaseUrl();
   const models = resolveModels();
 
-
   api.registerProvider('grok-build', {
     baseUrl,
     apiKey: process.env.GROK_CLI_OAUTH_TOKEN ? 'GROK_CLI_OAUTH_TOKEN' : undefined,
@@ -36,7 +35,9 @@ export default function registerGrokCli(api: ExtensionAPI) {
       id: m.id,
       name: m.name,
       reasoning: m.reasoning,
-      thinking: m.reasoning ? { minLevel: Effort.Low, maxLevel: Effort.XHigh, mode: 'effort' } : undefined,
+      thinking: m.reasoning
+        ? { minLevel: Effort.Low, maxLevel: Effort.XHigh, mode: 'effort' }
+        : undefined,
       input: m.input,
       cost: m.cost,
       contextWindow: m.contextWindow,
@@ -50,7 +51,9 @@ export default function registerGrokCli(api: ExtensionAPI) {
       },
 
       async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-        return refreshXaiToken(credentials.refresh, { extraTokenParams: GROK_BUILD_XAI_REFRESH_PARAMS });
+        return refreshXaiToken(credentials.refresh, {
+          extraTokenParams: GROK_BUILD_XAI_REFRESH_PARAMS,
+        });
       },
 
       getApiKey(credentials: OAuthCredentials): string {
@@ -69,7 +72,6 @@ export default function registerGrokCli(api: ExtensionAPI) {
     streamSimple: streamGrokCli,
   });
 
-
   api.on('session_start', (_event, ctx) => {
     if (process.env.GROK_CLI_OAUTH_TOKEN) {
       ctx.ui.notify(
@@ -83,7 +85,6 @@ export default function registerGrokCli(api: ExtensionAPI) {
         'warning',
       );
     }
-
   });
 
   api.on('before_provider_request', (event, ctx) => {

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream.ts
@@ -1,9 +1,9 @@
-import {
-  type Api,
-  type AssistantMessageEventStream,
-  type Context,
-  type Model,
-  type SimpleStreamOptions,
+import type {
+  Api,
+  AssistantMessageEventStream,
+  Context,
+  Model,
+  SimpleStreamOptions,
 } from '@gajae-code/ai';
 import { streamOpenAIResponses } from '@gajae-code/ai/providers/openai-responses';
 

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/provider/usage.ts
@@ -19,7 +19,10 @@ export function registerUsageCommand(api: Pick<ExtensionAPI, 'registerCommand'>)
         const registry = ctx.modelRegistry;
         const grokModels = registry.getAll().filter((m: Model<Api>) => m.provider === 'grok-build');
         if (grokModels.length === 0) {
-          ctx.ui.notify('Grok Build: no models registered. Run /login grok-build first.', 'warning');
+          ctx.ui.notify(
+            'Grok Build: no models registered. Run /login grok-build first.',
+            'warning',
+          );
           return;
         }
 

--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/base-url.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/shared/base-url.ts
@@ -30,5 +30,7 @@ export function isGrokBuildBaseUrlOverrideIgnored(): boolean {
   const configured = process.env.GJC_GROK_CLI_BASE_URL || process.env.GROK_CLI_BASE_URL;
   if (!configured) return false;
   const normalized = normalizeBaseUrl(configured);
-  return !isAllowedCredentialHost(normalized) && process.env.GJC_GROK_CLI_ALLOW_UNSAFE_BASE_URL !== '1';
+  return (
+    !isAllowedCredentialHost(normalized) && process.env.GJC_GROK_CLI_ALLOW_UNSAFE_BASE_URL !== '1'
+  );
 }

--- a/packages/coding-agent/test/grok-build-stream.test.ts
+++ b/packages/coding-agent/test/grok-build-stream.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
-import * as openaiResponses from "@gajae-code/ai/providers/openai-responses";
 import type { Api, Context, Model, SimpleStreamOptions } from "@gajae-code/ai";
+import * as openaiResponses from "@gajae-code/ai/providers/openai-responses";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { streamGrokCli } from "../src/defaults/gjc/extensions/grok-cli-vendor/src/provider/stream";
 
 describe("Grok Build stream wrapper", () => {

--- a/packages/coding-agent/test/grok-third-party-sequence.test.ts
+++ b/packages/coding-agent/test/grok-third-party-sequence.test.ts
@@ -3,9 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../src/config/settings";
+import type { ExtensionAPI } from "../src/extensibility/extensions";
 import { createAgentSession } from "../src/sdk";
 import { SessionManager } from "../src/session/session-manager";
-import type { ExtensionAPI } from "../src/extensibility/extensions";
 
 function registerTestProvider(api: ExtensionAPI, providerName: string): void {
 	api.registerProvider(providerName, {


### PR DESCRIPTION
## Summary
- mark the bundled Grok CLI vendor Biome config as non-root so root Biome no longer fails on a nested root configuration after PR #596
- apply the Biome 2.4.16 formatter/import fixes surfaced once the nested-config blocker was removed

## Post-merge failure being fixed
Dev CI failed on merge commit `3a8ddad4cd35b9f0343999775260c898c87d2007` in run:
https://github.com/Yeachan-Heo/gajae-code/actions/runs/27490639688

Failure:
- `Affected path validation` failed in `Run affected path checks and tests`
- root tooling check hit `packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/biome.json`
- Biome reported a nested root configuration while repo root already has a root config

## Validation
- Reproduced the original nested-root config failure with Biome 2.4.16:
  - `/tmp/node_modules/.bin/biome check . --no-errors-on-unmatched`
- After the fix:
  - `/tmp/node_modules/.bin/biome check . --no-errors-on-unmatched` → pass, 2178 files checked
  - `PATH=/tmp/node_modules/.bin:$PATH bun run check:ts` → pass after `bun install --frozen-lockfile`

## Notes
- `bun install` regenerated `docs-index.generated.ts`; that unrelated generated diff was reverted before commit.
- No runtime behavior changes intended beyond making the vendored Biome config non-root and formatting PR #596 files to satisfy the root tooling gate.
