### PR TITLE
feat(subagent): show effective model and flag auth fallback in subagent panel

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -80,6 +80,12 @@ export interface SubagentRecord {
 	/** False for ephemeral sessions (no persistent artifacts dir). */
 	resumable: boolean;
 	queued?: { ownerId?: string; seq: number; message?: string; createdAt: number };
+	/** Resolved model the subagent was asked to use, e.g. "openai-codex/gpt-5.5". */
+	requestedModel?: string;
+	/** Model actually used after auth fallback (#985); equals requestedModel when no fallback. */
+	effectiveModel?: string;
+	/** True when the requested model lacked credentials and the subagent fell back to the parent model. */
+	modelFellBack?: boolean;
 }
 
 /** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
@@ -501,6 +507,18 @@ export class AsyncJobManager {
 	/** Register or replace the canonical record for a subagent. */
 	registerSubagentRecord(record: SubagentRecord): void {
 		this.#subagentRecords.set(record.subagentId, record);
+	}
+
+	/** Patch model metadata onto an existing subagent record (best-effort; no-op if unknown). */
+	updateSubagentModel(
+		subagentId: string,
+		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean },
+	): void {
+		const record = this.#subagentRecords.get(subagentId);
+		if (!record) return;
+		record.requestedModel = model.requestedModel;
+		record.effectiveModel = model.effectiveModel;
+		record.modelFellBack = model.modelFellBack;
 	}
 
 	getSubagentRecord(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1154,6 +1154,15 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					resolvedModel: model.id,
 				});
 			}
+			// Record which model the subagent actually runs on (and any auth fallback,
+			// see #985) so the subagent panel can surface it to the user.
+			if (model) {
+				AsyncJobManager.instance()?.updateSubagentModel?.(options.subagentId ?? id, {
+					requestedModel: modelSubstitutionWarning?.requested ?? resolvedModelString,
+					effectiveModel: resolvedModelString,
+					modelFellBack: authFallbackUsed === true,
+				});
+			}
 			if (model?.contextWindow && model.contextWindow > 0) {
 				progress.contextWindow = model.contextWindow;
 			}

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -66,6 +66,15 @@ function renderSubagentSnapshot(
 	if (snapshot.agent && snapshot.agent !== "unknown") {
 		lines.push(`  ${theme.fg("dim", `Agent: ${snapshot.agent} (${snapshot.agentSource})`)}`);
 	}
+	if (snapshot.effectiveModel) {
+		if (snapshot.modelFellBack && snapshot.requestedModel) {
+			lines.push(
+				`  ${theme.fg("warning", `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`)}`,
+			);
+		} else {
+			lines.push(`  ${theme.fg("dim", `Model: ${snapshot.effectiveModel}`)}`);
+		}
+	}
 	if (snapshot.description) lines.push(`  ${theme.fg("dim", `Description: ${snapshot.description}`)}`);
 	if (snapshot.outputRef) lines.push(`  ${theme.fg("dim", `Output: ${snapshot.outputRef}`)}`);
 	if (snapshot.assignment) {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -67,6 +67,12 @@ export interface SubagentSnapshot {
 	progress?: AgentProgress;
 	/** True when a live in-session progress producer exists for this subagent. */
 	liveProgressAvailable?: boolean;
+	/** Model the subagent actually runs on (after any auth fallback). */
+	effectiveModel?: string;
+	/** Model originally requested via role/preset mapping; differs from effective on fallback. */
+	requestedModel?: string;
+	/** True when the requested model lacked credentials and fell back to the parent model. */
+	modelFellBack?: boolean;
 }
 
 export interface SubagentToolDetails {
@@ -508,6 +514,13 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			lines.push(`### ${snapshot.id} — ${snapshot.status}`);
 			if (snapshot.jobId !== snapshot.id) lines.push(`Job: ${snapshot.jobId}`);
 			if (snapshot.agent) lines.push(`Agent: ${snapshot.agent} (${snapshot.agentSource})`);
+			if (snapshot.effectiveModel) {
+				lines.push(
+					snapshot.modelFellBack && snapshot.requestedModel
+						? `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`
+						: `Model: ${snapshot.effectiveModel}`,
+				);
+			}
 			if (snapshot.description) lines.push(`Description: ${snapshot.description}`);
 			if (snapshot.outputRef) lines.push(`Output: ${snapshot.outputRef}`);
 			if (snapshot.assignment) lines.push("Assignment:", "```", snapshot.assignment, "```");
@@ -584,7 +597,17 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			durationMs: 0,
 			...(verifiedOutputIds.has(record.subagentId) ? { outputRef: `agent://${record.subagentId}` } : {}),
 			...liveFields,
+			...this.#modelFields(record),
 		};
+	}
+
+	#modelFields(record?: SubagentRecord): Partial<SubagentSnapshot> {
+		if (!record) return {};
+		const fields: Partial<SubagentSnapshot> = {};
+		if (record.effectiveModel) fields.effectiveModel = record.effectiveModel;
+		if (record.requestedModel) fields.requestedModel = record.requestedModel;
+		if (record.modelFellBack) fields.modelFellBack = true;
+		return fields;
 	}
 
 	#snapshot(
@@ -622,6 +645,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				: {}),
 			...(outputRef ? { outputRef } : {}),
 			...(runningTimeoutGuidance ? { guidance: runningTimeoutGuidance } : {}),
+			...this.#modelFields(record),
 		};
 	}
 

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -247,4 +247,28 @@ describe("subagentToolRenderer", () => {
 		const out = render({ subagents: [] });
 		expect(out).toContain("No subagents");
 	});
+
+	it("renders the effective model for a subagent", () => {
+		const out = render({
+			subagents: [snapshot({ id: "0-Codex", effectiveModel: "openai-codex/gpt-5.5" })],
+		});
+		expect(out).toContain("Model: openai-codex/gpt-5.5");
+		expect(out).not.toContain("fell back");
+	});
+
+	it("flags an auth fallback with the requested vs effective model", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-Fallback",
+					effectiveModel: "anthropic/claude-opus-4-8",
+					requestedModel: "openai-codex/gpt-5.5",
+					modelFellBack: true,
+				}),
+			],
+		});
+		expect(out).toContain("Model: anthropic/claude-opus-4-8");
+		expect(out).toContain("requested openai-codex/gpt-5.5");
+		expect(out).toContain("fell back");
+	});
 });


### PR DESCRIPTION
## Summary

Make the subagent panel show **which model each subagent actually runs on**, so role/preset model mappings (e.g. `opus-codex`'s `executor = openai-codex/gpt-5.5`) are visible — and surface when a subagent silently fell back to the parent model because the requested provider had no credentials.

## Motivation

With a combo preset like `opus-codex`, the main agent runs on Opus while worker roles (executor/planner/etc.) are mapped to Codex. There was no way to see, from the UI, which model a subagent was using. Worse, when the requested model has no working credentials the executor falls back to the parent session model (#985) with only a warning log — so a subagent could silently run on Opus instead of Codex with no visible signal.

## Changes

- `SubagentRecord` (`async/job-manager.ts`): add `requestedModel` / `effectiveModel` / `modelFellBack`, plus `AsyncJobManager.updateSubagentModel()` to patch them.
- `task/executor.ts`: after model resolution (`resolveModelOverrideWithAuthFallback`), record the effective model and whether an auth fallback occurred (#985).
- `SubagentSnapshot` (`tools/subagent.ts`): carry the model fields from the record into snapshots (both the job-backed and record-only builders, via a shared `#modelFields` helper).
- Renderers: the TUI panel (`tools/subagent-render.ts`) and the markdown receipt (`tools/subagent.ts`) now print `Model: <effective>`, and on fallback a warning `Model: <effective> (requested <requested>, fell back — no credentials)`.

## Behavior

- Normal: `Model: openai-codex/gpt-5.5`
- Auth fallback: `Model: anthropic/claude-opus-4-8 (requested openai-codex/gpt-5.5, fell back — no credentials)`

This directly answers "is Codex actually being used?": if the fallback warning shows, the Codex provider isn't authenticated and the worker is running on the parent (Opus) model.

## Non-goals

- No change to model resolution or the fallback behavior itself — display only.
- status-line `subagents` segment (count) unchanged.

## Tests

`test/tools/subagent-render.test.ts`: added cases for the effective-model line and the requested-vs-effective fallback warning.

## Verification (package-local)

- `bun --cwd=packages/coding-agent test tools/subagent-render.test.ts tools/subagent.test.ts issue-985-subagent-auth-fallback.test.ts` → 35 pass / 0 fail / 134 expect
- `bun --cwd=packages/coding-agent run check:types` → clean
- `bun --cwd=packages/coding-agent run lint` → clean
