### PR TITLE
feat(observability): surface ledger activity in ralplan/ultragoal HUD chips

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ledger-event-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/ledger-event-renderer.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure parse + summarize for ledger-backed skill observability.
+ *
+ * Workflow progress for ultragoal/ralplan cannot be observed via subagent tool
+ * events (those skills persist through `bash`-backed `gjc` CLI calls whose tool
+ * `details` carry no structured payload). The durable source of truth is the
+ * append-only ledgers:
+ *   - ultragoal: `.gjc/ultragoal/ledger.jsonl`
+ *   - ralplan:   `.gjc/plans/ralplan/<run-id>/index.jsonl`
+ *
+ * This module is I/O-free: callers read the files and pass lines or already-parsed
+ * rows. It feeds the compact HUD chip builders in `skill-state/workflow-hud.ts`
+ * via the runtime sync paths. Display-string helpers stay theme-free.
+ */
+
+/* ------------------------------- ultragoal ------------------------------- */
+
+/** Minimal projection of an ultragoal ledger row used for the HUD chip. */
+export interface UltragoalLedgerEventLite {
+	/** Normalized from the row's `event` field, or `type` for reconcile rows. */
+	event: string;
+	goalId?: string;
+	status?: string;
+	timestamp?: string;
+}
+
+/**
+ * Coerce an already-parsed ledger row into the lite shape. Accepts both the
+ * `event`-keyed vocabulary (plan_created, goal_started, goal_checkpointed,
+ * steering_accepted/rejected, review_blockers_recorded) and the `type`-keyed
+ * reconcile-failure row (`type: "reconcile_failed"`). Returns undefined when no
+ * event/type discriminator is present.
+ */
+export function coerceUltragoalLedgerEvent(row: Record<string, unknown>): UltragoalLedgerEventLite | undefined {
+	const event = typeof row.event === "string" ? row.event : typeof row.type === "string" ? row.type : undefined;
+	if (!event) return undefined;
+	const lite: UltragoalLedgerEventLite = { event };
+	if (typeof row.goalId === "string") lite.goalId = row.goalId;
+	if (typeof row.status === "string") lite.status = row.status;
+	if (typeof row.timestamp === "string") lite.timestamp = row.timestamp;
+	return lite;
+}
+
+/** Parse a single ultragoal ledger JSONL line; undefined for blank/malformed lines. */
+export function parseUltragoalLedgerLine(line: string): UltragoalLedgerEventLite | undefined {
+	const trimmed = line.trim();
+	if (!trimmed) return undefined;
+	let row: unknown;
+	try {
+		row = JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+	if (!row || typeof row !== "object" || Array.isArray(row)) return undefined;
+	return coerceUltragoalLedgerEvent(row as Record<string, unknown>);
+}
+
+/** The most recent event, or undefined when the ledger is empty. */
+export function latestUltragoalLedgerEvent(
+	events: readonly UltragoalLedgerEventLite[],
+): UltragoalLedgerEventLite | undefined {
+	return events.length > 0 ? events[events.length - 1] : undefined;
+}
+
+/**
+ * Best-effort latest event from raw ledger text: parses line-by-line and skips
+ * blank/malformed rows so a torn or hand-edited ledger never throws on the HUD
+ * path. Strict receipt consumers should keep using the validating reader.
+ */
+export function latestUltragoalLedgerEventFromText(text: string): UltragoalLedgerEventLite | undefined {
+	const events: UltragoalLedgerEventLite[] = [];
+	for (const line of text.split(/\r?\n/)) {
+		const event = parseUltragoalLedgerLine(line);
+		if (event) events.push(event);
+	}
+	return latestUltragoalLedgerEvent(events);
+}
+
+/* -------------------------------- ralplan -------------------------------- */
+
+/** Minimal projection of a ralplan `index.jsonl` row. */
+export interface RalplanIndexRow {
+	stage: string;
+	stageN?: number;
+}
+
+/** Stages that open a new consensus iteration when they appear in append order. */
+const RALPLAN_ITERATION_OPENERS = new Set(["planner", "revision"]);
+
+const RALPLAN_STAGE_CODES: Record<string, string> = {
+	planner: "P",
+	revision: "R",
+	architect: "A",
+	critic: "C",
+	adr: "D",
+	final: "F",
+};
+
+const DEFAULT_STAGE_PRESENCE_CAP = 6;
+
+/** Parse a single ralplan index JSONL line; undefined for blank/malformed lines. */
+export function parseRalplanIndexLine(line: string): RalplanIndexRow | undefined {
+	const trimmed = line.trim();
+	if (!trimmed) return undefined;
+	let row: unknown;
+	try {
+		row = JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+	if (!row || typeof row !== "object" || Array.isArray(row)) return undefined;
+	const record = row as Record<string, unknown>;
+	if (typeof record.stage !== "string") return undefined;
+	const out: RalplanIndexRow = { stage: record.stage };
+	if (typeof record.stage_n === "number") out.stageN = record.stage_n;
+	return out;
+}
+
+export interface RalplanIndexSummary {
+	/** Number of consensus iterations (planner/revision boundaries), >= 0. */
+	iteration: number;
+	/** Stage names present in the current (latest) iteration, in append order. */
+	currentStages: string[];
+}
+
+/**
+ * Derive iteration count and current-iteration stage presence from index rows.
+ *
+ * `stage_n` is NOT used as the iteration key: it is stored verbatim per row and a
+ * single planner/architect/critic pass can span multiple stage_n values. Instead,
+ * a `planner` or `revision` row opens a new iteration and subsequent rows attach
+ * to it. No verdict is derived here (index rows carry none).
+ */
+export function summarizeRalplanIndex(rows: readonly RalplanIndexRow[]): RalplanIndexSummary {
+	let iteration = 0;
+	let currentStages: string[] = [];
+	for (const row of rows) {
+		if (RALPLAN_ITERATION_OPENERS.has(row.stage)) {
+			iteration += 1;
+			currentStages = [row.stage];
+		} else {
+			if (iteration === 0) iteration = 1;
+			currentStages.push(row.stage);
+		}
+	}
+	return { iteration, currentStages };
+}
+
+/**
+ * Compact, theme-free presence string for the ralplan `stages` chip, e.g.
+ * `P·A·C`. Collapses past `cap` with a "… N more" suffix. Returns undefined when
+ * there are no stages.
+ */
+export function formatRalplanStagePresence(
+	stages: readonly string[],
+	cap = DEFAULT_STAGE_PRESENCE_CAP,
+): string | undefined {
+	if (stages.length === 0) return undefined;
+	const codes = stages.map(stage => RALPLAN_STAGE_CODES[stage] ?? stage.charAt(0).toUpperCase());
+	if (codes.length <= cap) return codes.join("·");
+	const shown = codes.slice(0, cap).join("·");
+	const remaining = codes.length - cap;
+	return `${shown} … ${remaining} more ${remaining === 1 ? "stage" : "stages"}`;
+}

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -5,6 +5,12 @@ import { syncSkillActiveState } from "../skill-state/active-state";
 import { buildRalplanHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
+import {
+	formatRalplanStagePresence,
+	parseRalplanIndexLine,
+	type RalplanIndexRow,
+	summarizeRalplanIndex,
+} from "./ledger-event-renderer";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { migrateWorkflowState } from "./state-migrations";
 import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
@@ -437,12 +443,32 @@ async function persistArtifact(resolved: ResolvedArtifactArgs, cwd: string): Pro
 	};
 }
 
+/**
+ * Read and parse the run's `index.jsonl` rows. Best-effort: returns [] when the
+ * file is absent or unreadable so HUD sync never fails on a missing index.
+ */
+async function readRalplanIndexRows(cwd: string, runId: string): Promise<RalplanIndexRow[]> {
+	try {
+		const indexPath = path.join(cwd, ".gjc", "plans", "ralplan", runId, "index.jsonl");
+		const text = await fs.readFile(indexPath, "utf8");
+		const rows: RalplanIndexRow[] = [];
+		for (const line of text.split(/\r?\n/)) {
+			const row = parseRalplanIndexLine(line);
+			if (row) rows.push(row);
+		}
+		return rows;
+	} catch {
+		return [];
+	}
+}
+
 async function syncRalplanHud(options: {
 	cwd: string;
 	sessionId?: string;
 	stage: string;
 	pendingApproval: boolean;
 	iteration?: number;
+	runId?: string;
 	latestSummary?: string;
 }): Promise<void> {
 	try {
@@ -453,17 +479,40 @@ async function syncRalplanHud(options: {
 			phase: options.stage,
 			sessionId: options.sessionId,
 			source: "gjc-ralplan-native",
-			hud: buildRalplanHudSummary({
-				stage: options.stage,
-				iteration: options.iteration,
-				pendingApproval: options.pendingApproval,
-				latestSummary: options.latestSummary,
-				updatedAt: new Date().toISOString(),
-			}),
+			hud: await buildRalplanHud(options),
 		});
 	} catch {
 		// HUD sync is best-effort and must not change command semantics.
 	}
+}
+
+async function buildRalplanHud(options: {
+	cwd: string;
+	stage: string;
+	pendingApproval: boolean;
+	iteration?: number;
+	latestSummary?: string;
+	runId?: string;
+}) {
+	let iterationFromIndex: number | undefined;
+	let stages: string | undefined;
+	if (options.runId) {
+		const rows = await readRalplanIndexRows(options.cwd, options.runId);
+		if (rows.length > 0) {
+			const summary = summarizeRalplanIndex(rows);
+			iterationFromIndex = summary.iteration;
+			stages = formatRalplanStagePresence(summary.currentStages);
+		}
+	}
+	return buildRalplanHudSummary({
+		stage: options.stage,
+		iteration: options.iteration,
+		iterationFromIndex,
+		stages,
+		pendingApproval: options.pendingApproval,
+		latestSummary: options.latestSummary,
+		updatedAt: new Date().toISOString(),
+	});
 }
 
 async function handleArtifactWrite(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
@@ -477,6 +526,7 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 		cwd,
 		sessionId: resolved.sessionId,
 		stage: persisted.stage,
+		runId: persisted.runId,
 		pendingApproval: persisted.stage === "final",
 		iteration: persisted.stageN,
 		latestSummary: `persisted ${persisted.stage} stage ${persisted.stageN}`,
@@ -617,6 +667,7 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 		cwd,
 		sessionId: resolved.sessionId,
 		stage: "planner",
+		runId,
 		pendingApproval: false,
 		iteration: 1,
 		latestSummary: `${mode} run · ${resolved.interactive ? "interactive" : "automated"}`,

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -888,6 +888,24 @@ function buildHudForMode(
 				counts[status] = (counts[status] ?? 0) + 1;
 			}
 			const currentGoalRaw = goals.find(g => g.status === "active") ?? goals.find(g => g.status === "pending");
+			const rawLedger = payload.latestLedgerEvent;
+			const latestLedgerEvent =
+				rawLedger && typeof rawLedger === "object" && !Array.isArray(rawLedger)
+					? {
+							event:
+								typeof (rawLedger as Record<string, unknown>).event === "string"
+									? ((rawLedger as Record<string, unknown>).event as string)
+									: undefined,
+							goalId:
+								typeof (rawLedger as Record<string, unknown>).goalId === "string"
+									? ((rawLedger as Record<string, unknown>).goalId as string)
+									: undefined,
+							timestamp:
+								typeof (rawLedger as Record<string, unknown>).timestamp === "string"
+									? ((rawLedger as Record<string, unknown>).timestamp as string)
+									: undefined,
+						}
+					: undefined;
 			const status = typeof payload.status === "string" ? (payload.status as string) : (phase ?? "pending");
 			return buildUltragoalHudSummary({
 				status,
@@ -900,6 +918,7 @@ function buildHudForMode(
 					: undefined,
 				counts,
 				goals: goals.map(g => ({ id: g.id as string, title: g.title as string, status: g.status as string })),
+				latestLedgerEvent,
 				updatedAt,
 			});
 		}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -4,6 +4,7 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import { latestUltragoalLedgerEventFromText } from "./ledger-event-renderer";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
 import { reconcileWorkflowSkillState } from "./state-runtime";
 import { appendJsonl, writeArtifact, writeJsonAtomic } from "./state-writer";
@@ -2127,6 +2128,17 @@ async function reconcileUltragoalState(cwd: string): Promise<void> {
 			goals_path: summary.paths.goalsPath,
 		};
 		if (summary.gjcObjective) payload.gjc_objective = summary.gjcObjective;
+		const ledgerText = await Bun.file(summary.paths.ledgerPath)
+			.text()
+			.catch(() => "");
+		const latestLedger = latestUltragoalLedgerEventFromText(ledgerText);
+		if (latestLedger) {
+			payload.latestLedgerEvent = {
+				event: latestLedger.event,
+				...(latestLedger.goalId ? { goalId: latestLedger.goalId } : {}),
+				...(latestLedger.timestamp ? { timestamp: latestLedger.timestamp } : {}),
+			};
+		}
 		await reconcileWorkflowSkillState({ cwd, mode: "ultragoal", sessionId, active, phase: status, payload });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -21,6 +21,8 @@ interface RalplanHudState extends WorkflowGateHudState {
 	stage?: string;
 	waiting?: string;
 	iteration?: number;
+	iterationFromIndex?: number;
+	stages?: string;
 	verdict?: string;
 	latestSummary?: string;
 	pendingApproval?: boolean;
@@ -118,7 +120,14 @@ export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSumma
 			...gateChips(state, 6),
 			chip("stage", state.stage, 10),
 			chip("waiting", state.waiting, 20),
-			chip("iter", state.iteration === undefined ? undefined : String(state.iteration), 30),
+			chip(
+				"iter",
+				(state.iterationFromIndex ?? state.iteration) === undefined
+					? undefined
+					: String(state.iterationFromIndex ?? state.iteration),
+				30,
+			),
+			chip("stages", state.stages, 35),
 			chip("verdict", verdict, 40, verdictSeverity),
 		]),
 		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
@@ -136,17 +145,15 @@ export function buildUltragoalHudSummary(state: UltragoalHudState): WorkflowHudS
 			chip("goals", `${complete}/${total}`, 10),
 			chip("current", state.currentGoal ? `${state.currentGoal.id}:${state.currentGoal.title}` : state.status, 20),
 			chip("status", state.status, 30, state.status === "complete" ? "success" : undefined),
+			chip(
+				"ledger",
+				state.latestLedgerEvent?.event
+					? [state.latestLedgerEvent.event, state.latestLedgerEvent.goalId].filter(Boolean).join(":")
+					: undefined,
+				35,
+			),
 			...gateChips(state, 40),
 		]),
-		details: state.latestLedgerEvent
-			? compactChips([
-					chip(
-						"ledger",
-						[state.latestLedgerEvent.event, state.latestLedgerEvent.goalId].filter(Boolean).join(":"),
-						100,
-					),
-				])
-			: undefined,
 		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
 	};
 }

--- a/packages/coding-agent/test/gjc-runtime/ledger-event-renderer.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ledger-event-renderer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import {
+	coerceUltragoalLedgerEvent,
+	formatRalplanStagePresence,
+	latestUltragoalLedgerEvent,
+	latestUltragoalLedgerEventFromText,
+	parseRalplanIndexLine,
+	parseUltragoalLedgerLine,
+	type RalplanIndexRow,
+	summarizeRalplanIndex,
+} from "../../src/gjc-runtime/ledger-event-renderer";
+
+describe("ledger-event-renderer: ultragoal", () => {
+	it("parses the event-keyed vocabulary", () => {
+		expect(parseUltragoalLedgerLine('{"event":"goal_checkpointed","goalId":"G003","status":"complete"}')).toEqual({
+			event: "goal_checkpointed",
+			goalId: "G003",
+			status: "complete",
+		});
+	});
+
+	it("parses the type-keyed reconcile_failed row", () => {
+		expect(parseUltragoalLedgerLine('{"type":"reconcile_failed","error":"boom"}')).toEqual({
+			event: "reconcile_failed",
+		});
+	});
+
+	it("skips blank and malformed lines", () => {
+		expect(parseUltragoalLedgerLine("")).toBeUndefined();
+		expect(parseUltragoalLedgerLine("   ")).toBeUndefined();
+		expect(parseUltragoalLedgerLine("{not json")).toBeUndefined();
+		expect(parseUltragoalLedgerLine("[1,2,3]")).toBeUndefined();
+		expect(parseUltragoalLedgerLine('{"goalId":"G001"}')).toBeUndefined();
+	});
+
+	it("coerces already-parsed rows", () => {
+		expect(coerceUltragoalLedgerEvent({ event: "goal_started", goalId: "G001" })).toEqual({
+			event: "goal_started",
+			goalId: "G001",
+		});
+		expect(coerceUltragoalLedgerEvent({ nothing: true })).toBeUndefined();
+	});
+
+	it("returns the latest event, or undefined for an empty ledger", () => {
+		expect(latestUltragoalLedgerEvent([])).toBeUndefined();
+		const events = [
+			{ event: "plan_created" },
+			{ event: "goal_started", goalId: "G001" },
+			{ event: "goal_checkpointed", goalId: "G001", status: "complete" },
+		];
+		expect(latestUltragoalLedgerEvent(events)).toEqual({
+			event: "goal_checkpointed",
+			goalId: "G001",
+			status: "complete",
+		});
+	});
+
+	it("reads the latest event from raw text, skipping malformed/blank lines", () => {
+		const text = [
+			'{"event":"plan_created"}',
+			"{not json",
+			"",
+			'{"event":"goal_started","goalId":"G001"}',
+			'{"type":"reconcile_failed","error":"boom"}',
+		].join("\n");
+		expect(latestUltragoalLedgerEventFromText(text)).toEqual({ event: "reconcile_failed" });
+		expect(latestUltragoalLedgerEventFromText("")).toBeUndefined();
+		expect(latestUltragoalLedgerEventFromText("{bad\n  \n")).toBeUndefined();
+	});
+});
+
+describe("ledger-event-renderer: ralplan", () => {
+	it("parses index rows and skips malformed lines", () => {
+		expect(parseRalplanIndexLine('{"stage":"planner","stage_n":1,"path":"p","sha256":"h"}')).toEqual({
+			stage: "planner",
+			stageN: 1,
+		});
+		expect(parseRalplanIndexLine("")).toBeUndefined();
+		expect(parseRalplanIndexLine("{bad")).toBeUndefined();
+		expect(parseRalplanIndexLine('{"stage_n":1}')).toBeUndefined();
+	});
+
+	it("treats planner=1 + architect=2 in the same run as ONE iteration", () => {
+		const rows: RalplanIndexRow[] = [
+			{ stage: "planner", stageN: 1 },
+			{ stage: "architect", stageN: 2 },
+		];
+		expect(summarizeRalplanIndex(rows)).toEqual({ iteration: 1, currentStages: ["planner", "architect"] });
+	});
+
+	it("opens a new iteration on revision and tracks the current iteration's stages", () => {
+		const rows: RalplanIndexRow[] = [
+			{ stage: "planner", stageN: 1 },
+			{ stage: "architect", stageN: 1 },
+			{ stage: "critic", stageN: 1 },
+			{ stage: "revision", stageN: 2 },
+			{ stage: "architect", stageN: 2 },
+		];
+		expect(summarizeRalplanIndex(rows)).toEqual({ iteration: 2, currentStages: ["revision", "architect"] });
+	});
+
+	it("counts rows before any opener as one iteration", () => {
+		expect(summarizeRalplanIndex([{ stage: "architect" }])).toEqual({
+			iteration: 1,
+			currentStages: ["architect"],
+		});
+		expect(summarizeRalplanIndex([])).toEqual({ iteration: 0, currentStages: [] });
+	});
+
+	it("formats a compact stage-presence string and collapses past the cap", () => {
+		expect(formatRalplanStagePresence([])).toBeUndefined();
+		expect(formatRalplanStagePresence(["planner", "architect", "critic"])).toBe("P·A·C");
+		const collapsed = formatRalplanStagePresence(["planner", "architect", "critic", "revision"], 2);
+		expect(collapsed).toBe("P·A … 2 more stages");
+	});
+});

--- a/packages/coding-agent/test/workflow-hud-summary.test.ts
+++ b/packages/coding-agent/test/workflow-hud-summary.test.ts
@@ -39,7 +39,19 @@ describe("workflow HUD summary builders", () => {
 		expect(hud.chips?.[0]).toEqual({ label: "pending", value: "approval", priority: 5, severity: "warning" });
 	});
 
-	it("keeps ultragoal latest ledger event in details only", () => {
+	it("renders ralplan iteration-from-index and stage presence chips", () => {
+		const hud = buildRalplanHudSummary({
+			stage: "architect",
+			iteration: 2,
+			iterationFromIndex: 1,
+			stages: "P·A·C",
+			pendingApproval: false,
+		});
+		expect(hud.chips?.find(chip => chip.label === "iter")?.value).toBe("1");
+		expect(hud.chips?.find(chip => chip.label === "stages")?.value).toBe("P·A·C");
+	});
+
+	it("renders ultragoal latest ledger event as a main chip", () => {
 		const hud = buildUltragoalHudSummary({
 			status: "blocked",
 			currentGoal: { id: "G001", title: "Build HUD", status: "blocked" },
@@ -50,9 +62,18 @@ describe("workflow HUD summary builders", () => {
 			],
 			latestLedgerEvent: { event: "goal_checkpointed", goalId: "G001" },
 		});
-		expect(hud.chips?.some(chip => chip.label === "ledger")).toBe(false);
-		expect(hud.details?.[0]?.label).toBe("ledger");
+		expect(hud.chips?.find(chip => chip.label === "ledger")?.value).toBe("goal_checkpointed:G001");
+		expect(hud.details).toBeUndefined();
 		expect(hud.chips?.[0]?.severity).toBe("blocked");
+	});
+
+	it("omits the ultragoal ledger chip when no event is present", () => {
+		const hud = buildUltragoalHudSummary({
+			status: "active",
+			counts: { complete: 0 },
+			goals: [{ id: "G001", title: "Build HUD", status: "active" }],
+		});
+		expect(hud.chips?.some(chip => chip.label === "ledger")).toBe(false);
 	});
 
 	it("prioritizes team blockers before progress and latest activity", () => {


### PR DESCRIPTION
## Summary

Surfaces ultragoal and ralplan **ledger activity in the live compact HUD chip line**, sourced from the durable JSONL ledgers (`.gjc/ultragoal/ledger.jsonl`, `.gjc/plans/ralplan/<run-id>/index.jsonl`).

Motivation: subagent observability works by parsing tool-event `details`, but ralplan/ultragoal persist via `bash`-backed `gjc` CLI calls whose tool `details` carry no structured payload — so the tool-event path is structurally blind to them. The ledgers are the durable source of truth.

Planned & consensus-reviewed via ralplan (run `obs-ledger-2026-06-14`): Architect CLEAR/APPROVE, Critic OKAY/APPROVE.

## Changes

- **New** `src/gjc-runtime/ledger-event-renderer.ts` — pure, I/O-free parse/summarize for both ledgers (real event vocabularies incl. `type:reconcile_failed`); best-effort raw-text reader skips malformed/blank lines; local stage-presence collapse (no `tools/render-utils` dependency).
- **ultragoal** — `reconcileUltragoalState` reads the ledger best-effort and threads the latest event through `buildHudForMode` into `buildUltragoalHudSummary`, rendered as a MAIN `ledger` chip. Totals stay authoritative from goals state.
- **ralplan** — `syncRalplanHud` reads `index.jsonl` and derives a corrected `iter` count (planner/revision boundaries, **not** `stage_n`) plus a compact `stages` presence chip (`P·A·C`). No verdict is derived from the index (rows carry none).
- HUD info goes in MAIN `chips` (rendered by `skill-hud/render.ts`), not `details` (which the renderer ignores).

## Non-goals (v1)

Live FSWatcher/`monitor` push, expanded `details` panel, ralplan per-role verdict history, and `team` ledger wiring are deferred (the abstraction admits them).

## Verification

- `bun test` — ledger-event-renderer + workflow-hud-summary + ralplan/ultragoal/state runtime suites: **155 pass / 0 fail** (covers malformed/blank skip, empty ledger, iteration boundaries, `goalIds`-vs-`goalId`, collapse).
- `bun run check:ts` clean; `bun run lint:ts` clean.
- E2E (live HUD): ralplan `iter:1 stages:P·A·C` and (after a revision) `iter:2 stages:R·A`; ultragoal `ledger:plan_created`.
