### PR TITLE
feat(history): scope input prompt history to the current project

### DIFF
--- a/packages/coding-agent/src/modes/components/history-search.ts
+++ b/packages/coding-agent/src/modes/components/history-search.ts
@@ -10,6 +10,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@gajae-code/tui";
+import { getProjectDir } from "@gajae-code/utils";
 import { theme } from "../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
 import type { HistoryEntry, HistoryStorage } from "../../session/history-storage";
@@ -72,6 +73,7 @@ class HistoryResultsList implements Component {
 
 export class HistorySearchComponent extends Container {
 	#historyStorage: HistoryStorage;
+	#cwd: string;
 	#searchInput: Input;
 	#results: HistoryEntry[] = [];
 	#selectedIndex = 0;
@@ -83,6 +85,7 @@ export class HistorySearchComponent extends Container {
 	constructor(historyStorage: HistoryStorage, onSelect: (prompt: string) => void, onCancel: () => void) {
 		super();
 		this.#historyStorage = historyStorage;
+		this.#cwd = getProjectDir();
 		this.#onSelect = onSelect;
 		this.#onCancel = onCancel;
 
@@ -150,8 +153,8 @@ export class HistorySearchComponent extends Container {
 	#updateResults(): void {
 		const query = this.#searchInput.getValue().trim();
 		this.#results = query
-			? this.#historyStorage.search(query, this.#resultLimit)
-			: this.#historyStorage.getRecent(this.#resultLimit);
+			? this.#historyStorage.search(query, this.#resultLimit, this.#cwd)
+			: this.#historyStorage.getRecent(this.#resultLimit, this.#cwd);
 		this.#selectedIndex = 0;
 		this.#resultsList.setResults(this.#results, this.#selectedIndex);
 	}

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -67,10 +67,14 @@ export class HistoryStorage {
 	// Prepared statements
 	#insertRowStmt: Statement;
 	#recentStmt: Statement;
+	#recentByCwdStmt: Statement;
 	#searchStmt: Statement;
+	#searchByCwdStmt: Statement;
 	#lastPromptStmt: Statement;
 	// Cache substring-fallback prepared statements keyed by token count.
 	#substringStmts = new Map<number, Statement>();
+	// Cache cwd-filtered substring-fallback statements keyed by token count.
+	#substringCwdStmts = new Map<number, Statement>();
 
 	// In-memory cache of last prompt to avoid sync DB reads on add
 	#lastPromptCache: string | null = null;
@@ -94,6 +98,7 @@ CREATE TABLE IF NOT EXISTS history (
 	cwd TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_history_cwd_created_at ON history(cwd, created_at DESC);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(prompt, content='history', content_rowid='id');
 
@@ -117,8 +122,14 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 		this.#recentStmt = this.#db.prepare(
 			"SELECT id, prompt, created_at, cwd FROM history ORDER BY created_at DESC, id DESC LIMIT ?",
 		);
+		this.#recentByCwdStmt = this.#db.prepare(
+			"SELECT id, prompt, created_at, cwd FROM history WHERE cwd = ? ORDER BY created_at DESC, id DESC LIMIT ?",
+		);
 		this.#searchStmt = this.#db.prepare(
 			"SELECT h.id, h.prompt, h.created_at, h.cwd FROM history_fts f JOIN history h ON h.id = f.rowid WHERE history_fts MATCH ? ORDER BY h.created_at DESC, h.id DESC LIMIT ?",
+		);
+		this.#searchByCwdStmt = this.#db.prepare(
+			"SELECT h.id, h.prompt, h.created_at, h.cwd FROM history_fts f JOIN history h ON h.id = f.rowid WHERE history_fts MATCH ? AND h.cwd = ? ORDER BY h.created_at DESC, h.id DESC LIMIT ?",
 		);
 		this.#lastPromptStmt = this.#db.prepare("SELECT prompt FROM history ORDER BY id DESC LIMIT 1");
 
@@ -158,12 +169,14 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 		});
 	}
 
-	getRecent(limit: number): HistoryEntry[] {
+	getRecent(limit: number, cwd?: string): HistoryEntry[] {
 		const safeLimit = this.#normalizeLimit(limit);
 		if (safeLimit === 0) return [];
 
 		try {
-			const rows = this.#recentStmt.all(safeLimit) as HistoryRow[];
+			const rows = (
+				cwd === undefined ? this.#recentStmt.all(safeLimit) : this.#recentByCwdStmt.all(cwd, safeLimit)
+			) as HistoryRow[];
 			return rows.map(row => this.#toEntry(row));
 		} catch (error) {
 			logger.error("HistoryStorage getRecent failed", { error: String(error) });
@@ -171,7 +184,7 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 		}
 	}
 
-	search(query: string, limit: number): HistoryEntry[] {
+	search(query: string, limit: number, cwd?: string): HistoryEntry[] {
 		const safeLimit = this.#normalizeLimit(limit);
 		if (safeLimit === 0) return [];
 
@@ -184,7 +197,11 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 		const ftsQuery = tokens.map(tok => `"${tok.replace(/"/g, '""')}"*`).join(" ");
 		let ftsRows: HistoryRow[] = [];
 		try {
-			ftsRows = this.#searchStmt.all(ftsQuery, safeLimit) as HistoryRow[];
+			ftsRows = (
+				cwd === undefined
+					? this.#searchStmt.all(ftsQuery, safeLimit)
+					: this.#searchByCwdStmt.all(ftsQuery, cwd, safeLimit)
+			) as HistoryRow[];
 		} catch (error) {
 			// Malformed FTS expression - fall through to substring path.
 			logger.debug("HistoryStorage FTS query failed, using substring only", { error: String(error) });
@@ -199,7 +216,7 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 		//    by safeLimit, ordered by recency - no full-table load into JS.
 		let subRows: HistoryRow[] = [];
 		try {
-			subRows = this.#searchSubstring(tokens, safeLimit);
+			subRows = this.#searchSubstring(tokens, safeLimit, cwd);
 		} catch (error) {
 			logger.error("HistoryStorage substring search failed", { error: String(error) });
 		}
@@ -250,6 +267,7 @@ CREATE TABLE history (
 	cwd TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_history_cwd_created_at ON history(cwd, created_at DESC);
 INSERT INTO history (id, prompt, created_at, cwd)
 SELECT id, prompt, created_at, cwd
 FROM history_legacy;
@@ -282,21 +300,24 @@ END;
 			.filter(tok => tok.length > 0);
 	}
 
-	#searchSubstring(tokens: string[], limit: number): HistoryRow[] {
-		const stmt = this.#getSubstringStmt(tokens.length);
+	#searchSubstring(tokens: string[], limit: number, cwd?: string): HistoryRow[] {
+		const stmt = this.#getSubstringStmt(tokens.length, cwd !== undefined);
 		const params: unknown[] = tokens.map(tok => `%${escapeLikePattern(tok)}%`);
+		if (cwd !== undefined) params.push(cwd);
 		params.push(limit);
 		return stmt.all(...(params as [string, ...unknown[]])) as HistoryRow[];
 	}
 
-	#getSubstringStmt(tokenCount: number): Statement {
-		let stmt = this.#substringStmts.get(tokenCount);
+	#getSubstringStmt(tokenCount: number, withCwd: boolean): Statement {
+		const cache = withCwd ? this.#substringCwdStmts : this.#substringStmts;
+		let stmt = cache.get(tokenCount);
 		if (stmt) return stmt;
 		const whereClause = Array(tokenCount).fill("prompt LIKE ? ESCAPE '\\' COLLATE NOCASE").join(" AND ");
+		const cwdClause = withCwd ? " AND cwd = ?" : "";
 		stmt = this.#db.prepare(
-			`SELECT id, prompt, created_at, cwd FROM history WHERE ${whereClause} ORDER BY created_at DESC, id DESC LIMIT ?`,
+			`SELECT id, prompt, created_at, cwd FROM history WHERE ${whereClause}${cwdClause} ORDER BY created_at DESC, id DESC LIMIT ?`,
 		);
-		this.#substringStmts.set(tokenCount, stmt);
+		cache.set(tokenCount, stmt);
 		return stmt;
 	}
 

--- a/packages/coding-agent/test/history-storage-search.test.ts
+++ b/packages/coding-agent/test/history-storage-search.test.ts
@@ -135,3 +135,38 @@ describe("HistoryStorage.search", () => {
 		expect(results.map(r => r.prompt)).toEqual(["go commit changes"]);
 	});
 });
+
+describe("HistoryStorage cwd filtering", () => {
+	async function seedWithCwd(storage: HistoryStorage, rows: Array<[string, string]>): Promise<void> {
+		const writes = rows.map(([prompt, cwd]) => storage.add(prompt, cwd));
+		vi.advanceTimersByTime(100);
+		await Promise.all(writes);
+	}
+
+	it("getRecent scoped to a cwd returns only that project's prompts", async () => {
+		const storage = await freshStorage();
+		await seedWithCwd(storage, [
+			["alpha task", "/proj/a"],
+			["beta task", "/proj/b"],
+			["gamma task", "/proj/a"],
+		]);
+
+		expect(storage.getRecent(10, "/proj/a").map(r => r.prompt)).toEqual(["gamma task", "alpha task"]);
+		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["gamma task", "beta task", "alpha task"]);
+	});
+
+	it("search scoped to a cwd excludes other projects via FTS and substring paths", async () => {
+		const storage = await freshStorage();
+		await seedWithCwd(storage, [
+			["run git commit now", "/proj/a"],
+			["git commit later please", "/proj/b"],
+		]);
+
+		// FTS prefix path
+		expect(storage.search("commit", 10, "/proj/a").map(r => r.prompt)).toEqual(["run git commit now"]);
+		// substring fallback path (infix `mit` of `commit`)
+		expect(storage.search("mit", 10, "/proj/a").map(r => r.prompt)).toEqual(["run git commit now"]);
+		// unscoped search still spans every project
+		expect(storage.search("commit", 10).length).toBe(2);
+	});
+});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -368,7 +368,7 @@ interface HistoryEntry {
 
 interface HistoryStorage {
 	add(prompt: string, cwd?: string): Promise<void>;
-	getRecent(limit: number): HistoryEntry[];
+	getRecent(limit: number, cwd?: string): HistoryEntry[];
 }
 
 type HistoryCursorAnchor = "start" | "end";
@@ -545,7 +545,7 @@ export class Editor implements Component, Focusable {
 
 	setHistoryStorage(storage: HistoryStorage): void {
 		this.#historyStorage = storage;
-		const recent = storage.getRecent(100);
+		const recent = storage.getRecent(100, getProjectDir());
 		this.#history = recent.map(entry => entry.prompt);
 		this.#historyIndex = -1;
 	}


### PR DESCRIPTION
## Summary

Input prompt history (up/down arrow navigation and Ctrl+R search) was read from a single **global** history database, so prompts typed in one project showed up when navigating history in every other project. The `cwd` column was already stored per entry but never used to filter reads.

This scopes history reads to the current project (`getProjectDir()`), strictly.

## Problem

- `HistoryStorage.getRecent` / `search` ran `SELECT ... FROM history ORDER BY created_at DESC` with **no `WHERE cwd = ?`** filter.
- The editor loaded up-arrow history via `getRecent(100)` and the Ctrl+R component via `search(query, limit)` — both global.

## Change

- `HistoryStorage.getRecent(limit, cwd?)` and `search(query, limit, cwd?)` now filter by `cwd` when provided (covers both the FTS path and the substring fallback). Passing no `cwd` preserves the old global behavior, so existing callers/tests are unaffected.
- Added a composite `(cwd, created_at)` index for the filtered queries (in both the create and migration paths).
- `editor.ts` up-arrow load and the Ctrl+R `HistorySearchComponent` now pass `getProjectDir()` — the same value `add()` already stores as `cwd`, so existing history rows filter correctly with no schema migration.

## Testing

- Added unit tests for cwd-filtered `getRecent` and `search` (FTS + substring paths).
- `bun test packages/coding-agent/test/history-storage-search.test.ts` → 12 pass.
- `bun run check:ts` (lint + typecheck, all packages) → pass.
- End-to-end harness through the real `HistoryStorage` + `getProjectDir`/`setProjectDir` + a shared DB across 3 sessions / 2 projects: up-arrow and Ctrl+R show only the current project's prompts; unscoped reads still see all projects (no regression).