### PR TITLE
fix(ci): repair 0.5.1 main test failures

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -92,7 +92,15 @@ function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): 
 		output = runTmux(["list-sessions", "-F", format], env);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		if (message.includes("no server running") || message.includes("failed to connect to server")) return [];
+		// No tmux server, an unreachable server, or no tmux binary installed all mean
+		// there are no tmux sessions to enumerate. Read-only callers such as `gjc gc`
+		// must not hard-fail on hosts without tmux.
+		if (
+			message.includes("no server running") ||
+			message.includes("failed to connect to server") ||
+			message.includes("Executable not found")
+		)
+			return [];
 		throw error;
 	}
 	return output

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -26,6 +26,7 @@ describe("GJC public CLI command surface", () => {
 			"coordinator",
 			"team",
 			"ultragoal",
+			"gc",
 			"ralplan",
 			"config",
 			"mcp-serve",
@@ -150,7 +151,7 @@ describe("GJC public CLI command surface", () => {
 
 			expect(result.exitCode, stderr).toBe(0);
 			const payload = JSON.parse(stdout) as { written?: number; targetRoot?: string };
-			expect(payload.written).toBe(7);
+			expect(payload.written).toBe(8);
 			expect(payload.targetRoot).toContain(path.join(home, ".gjc", "agent"));
 		} finally {
 			await fs.rm(home, { recursive: true, force: true });

--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -158,7 +158,7 @@ describe("model profile red-team schema and catalog cases", () => {
 		const merged = mergeModelProfiles(undefined);
 
 		expect(merged.size).toBe(BUILTIN_MODEL_PROFILES.length);
-		expect(merged.size).toBe(25);
+		expect(merged.size).toBe(26);
 		expect([...merged.values()]).toEqual([...BUILTIN_MODEL_PROFILES]);
 	});
 

--- a/packages/coding-agent/test/workflow-state-command.test.ts
+++ b/packages/coding-agent/test/workflow-state-command.test.ts
@@ -65,8 +65,8 @@ describe("gjc state workflow command", () => {
 				expect(modeState).toMatchObject({
 					skill,
 					current_phase: initialPhases[skill],
-					blocked_reason: "execution approval missing",
 				});
+				expect(modeState.blocked_reason ?? modeState.state?.blocked_reason).toBe("execution approval missing");
 				expect(modeState.receipt.command).toBe(`gjc state ${skill} write`);
 
 				const activeState = await Bun.file(


### PR DESCRIPTION
## Summary
- backport dev CI repair commit `32b90f67` onto the 0.5.1 main release line
- include `gc` in the public CLI surface expectation and align setup file count
- align workflow-state and builtin model-profile expectations
- harden tmux session GC parsing for the release CI test surface

## Verification
- `bun test packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/gc-redteam.test.ts packages/coding-agent/test/workflow-state-command.test.ts packages/coding-agent/test/model-profiles-redteam.test.ts packages/coding-agent/test/gc-e2e.test.ts`

Do not merge automatically; this targets `main`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*