### PR TITLE
fix(utils): tolerate trailing commas in frontmatter scalars

### DIFF
--- a/packages/coding-agent/test/discovery/helpers.test.ts
+++ b/packages/coding-agent/test/discovery/helpers.test.ts
@@ -99,6 +99,23 @@ Body content`;
 		expect(result.body).toBe("Body content");
 	});
 
+	test("parses Cursor-style scalar values with trailing commas", () => {
+		const content = `---
+alwaysApply: true
+name: "tanstack-query-and-data-fetching",
+description: "Next.js + Clerk + Supabase + GPT API + Vercel 환경에서 tanstack-query 사용 규칙",
+---
+Body content`;
+
+		const result = parseFrontmatter(content, { source: "tests:frontmatter", level: "fatal" });
+		expect(result.frontmatter).toEqual({
+			alwaysApply: true,
+			name: "tanstack-query-and-data-fetching",
+			description: "Next.js + Clerk + Supabase + GPT API + Vercel 환경에서 tanstack-query 사용 규칙",
+		});
+		expect(result.body).toBe("Body content");
+	});
+
 	test("handles missing frontmatter", () => {
 		const content = "Just body content";
 		const result = parse(content);

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tolerate trailing commas on simple frontmatter scalar lines, avoiding noisy rule-discovery warnings for Cursor-style `.mdc` metadata while preserving strict fallback behavior for genuinely malformed YAML.
+
 ## [0.5.1] - 2026-06-14
 
 - Version aligned with the 0.5.1 monorepo release; no functional changes in this package.
@@ -25,4 +29,3 @@
 ## [0.4.4] - 2026-06-10
 
 - Version aligned with the 0.4.4 monorepo release; no functional changes in this package.
-

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -6,6 +6,32 @@ function stripHtmlComments(content: string): string {
 	return content.replace(/<!--[\s\S]*?-->/g, "");
 }
 
+function stripLooseScalarTrailingCommas(metadata: string): string {
+	return metadata
+		.split("\n")
+		.map(line => {
+			const match = line.match(/^(\s*[\w-]+\s*:\s+.+),(\s*)$/);
+			if (!match) return line;
+			return `${match[1]}${match[2]}`;
+		})
+		.join("\n");
+}
+
+function parseYamlMetadata(metadata: string): Record<string, unknown> | null {
+	const normalized = metadata.replaceAll("\t", "  ");
+	try {
+		return YAML.parse(normalized) as Record<string, unknown> | null;
+	} catch (strictError) {
+		const loose = stripLooseScalarTrailingCommas(normalized);
+		if (loose === normalized) throw strictError;
+		try {
+			return YAML.parse(loose) as Record<string, unknown> | null;
+		} catch {
+			throw strictError;
+		}
+	}
+}
+
 /** Convert kebab-case to camelCase (e.g. "thinking-level" -> "thinkingLevel") */
 function kebabToCamel(key: string): string {
 	if (!key.includes("-")) return key;
@@ -101,7 +127,7 @@ export function parseFrontmatter(
 
 	try {
 		// Replace tabs with spaces for YAML compatibility, use failsafe mode for robustness
-		const loaded = YAML.parse(metadata.replaceAll("\t", "  ")) as Record<string, unknown> | null;
+		const loaded = parseYamlMetadata(metadata);
 		return { frontmatter: normalizeKeys({ ...frontmatter, ...loaded }), body };
 	} catch (error) {
 		const err = new FrontmatterError(


### PR DESCRIPTION
## Summary
- tolerate trailing commas on simple frontmatter scalar lines such as `description: "...",`
- avoid noisy rule-discovery warnings for Cursor-style `.mdc` metadata while preserving the existing fallback path for genuinely malformed YAML
- add a regression test that parses the observed Cursor-style metadata under `level: "fatal"`

## Root cause
`parseFrontmatter()` first uses strict `YAML.parse()`. Cursor/LLM-authored `.mdc` files sometimes contain JSON-ish scalar lines with a trailing comma. Those are invalid YAML, so GJC logged `Failed to parse YAML frontmatter` during rule discovery and degraded into the simple fallback parser. In the dogfooded failure this surfaced for `.cursor/rules/tanstack-query-and-data-fetching.mdc`.

## Verification
- `bun test packages/coding-agent/test/discovery/helpers.test.ts`
- `bun --cwd=packages/utils run check`
- `bun --cwd=packages/coding-agent test test/discovery/agents-monorepo-skills.test.ts test/discovery/builtin-rules-md.test.ts test/discovery/helpers.test.ts`
