### PR TITLE
fix(deep-interview): validate scored transitions before persisting (#606)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -389,19 +389,31 @@ export async function appendOrMergeDeepInterviewRound(
 }
 
 /**
- * The most recent scored round preceding the round currently being scored
- * (matched by durable key). Used as the `prior` baseline for the scored-transition
- * invariant so a re-score of the same key compares against an earlier round, not itself.
+ * The chronological scored predecessor of the round currently being scored: the
+ * scored round with the greatest `round` strictly less than `currentRound`, with
+ * the same durable key excluded. Selecting by `round` (not array position) ensures
+ * an out-of-order re-score of an earlier round compares against its true prior, never
+ * a later ("future") scored round that happens to sit later in the array.
+ *
+ * Fail-safe: if `currentRound` is not a finite number, or a candidate's `round` is
+ * not finite, that comparison is treated as non-matching, so no prior is selected
+ * rather than risking a spurious comparison against an unrelated round.
  */
 function latestPriorScoredRound(
 	rounds: readonly DeepInterviewRoundRecord[],
 	currentKey: string,
+	currentRound: number,
 ): DeepInterviewRoundRecord | undefined {
-	for (let i = rounds.length - 1; i >= 0; i--) {
-		const candidate = rounds[i];
-		if (candidate.lifecycle === "scored" && candidate.round_key !== currentKey) return candidate;
+	if (!Number.isFinite(currentRound)) return undefined;
+	let prior: DeepInterviewRoundRecord | undefined;
+	for (const candidate of rounds) {
+		if (candidate.lifecycle !== "scored") continue;
+		if (candidate.round_key === currentKey) continue;
+		if (!Number.isFinite(candidate.round)) continue;
+		if (!(candidate.round < currentRound)) continue;
+		if (prior === undefined || candidate.round > prior.round) prior = candidate;
 	}
-	return undefined;
+	return prior;
 }
 
 /** Merge scoring output into the same round record, transitioning to `scored`. */
@@ -420,7 +432,7 @@ export async function enrichDeepInterviewRoundScoring(
 	// overall ambiguity, or a disputed/unresolved trigger lacking a rationale) must
 	// never be persisted — storing it lets the interview falsely converge. Validate
 	// against the most recent prior scored round before writing any durable state.
-	const prior = latestPriorScoredRound(rounds, record.round_key);
+	const prior = latestPriorScoredRound(rounds, record.round_key, record.round);
 	const validation = validateDeepInterviewScoredTransition(prior, record);
 	if (!validation.ok) {
 		throw new Error(

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -388,6 +388,22 @@ export async function appendOrMergeDeepInterviewRound(
 	return { action: result.action, record: result.record };
 }
 
+/**
+ * The most recent scored round preceding the round currently being scored
+ * (matched by durable key). Used as the `prior` baseline for the scored-transition
+ * invariant so a re-score of the same key compares against an earlier round, not itself.
+ */
+function latestPriorScoredRound(
+	rounds: readonly DeepInterviewRoundRecord[],
+	currentKey: string,
+): DeepInterviewRoundRecord | undefined {
+	for (let i = rounds.length - 1; i >= 0; i--) {
+		const candidate = rounds[i];
+		if (candidate.lifecycle === "scored" && candidate.round_key !== currentKey) return candidate;
+	}
+	return undefined;
+}
+
 /** Merge scoring output into the same round record, transitioning to `scored`. */
 export async function enrichDeepInterviewRoundScoring(
 	cwd: string,
@@ -399,6 +415,18 @@ export async function enrichDeepInterviewRoundScoring(
 	const interviewId = input.interviewId ?? interviewIdOf(envelope);
 	const rounds = readRounds(envelope);
 	const { rounds: nextRounds, record } = enrichRoundWithScoring(rounds, { ...input, interviewId });
+	// Fail closed: a scored transition that violates the bidirectional invariant
+	// (an active trigger that improves the affected dimension or fails to raise
+	// overall ambiguity, or a disputed/unresolved trigger lacking a rationale) must
+	// never be persisted — storing it lets the interview falsely converge. Validate
+	// against the most recent prior scored round before writing any durable state.
+	const prior = latestPriorScoredRound(rounds, record.round_key);
+	const validation = validateDeepInterviewScoredTransition(prior, record);
+	if (!validation.ok) {
+		throw new Error(
+			`deep-interview scored transition for round ${record.round} is invalid and was refused: ${validation.violations.join("; ")}`,
+		);
+	}
 	(envelope.state as Record<string, unknown>).rounds = nextRounds;
 	(envelope.state as Record<string, unknown>).current_ambiguity = input.ambiguity;
 	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview score-round");

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder-redteam.test.ts
@@ -188,6 +188,58 @@ describe("deep-interview recorder redteam: validator bypass attempts", () => {
 	});
 });
 
+describe("deep-interview recorder redteam: out-of-order re-score never compares against a future round", () => {
+	it("re-scoring an earlier round compares against its chronological predecessor, not a later scored round", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+
+		// Round 1: chronological predecessor — low ambiguity, high goal clarity.
+		await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput({ round: 1, questionId: "q1" }));
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			interviewId: "iv-redteam",
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.6 },
+			ambiguity: 0.4,
+		});
+
+		// Round 2: answered shell, deferred for an out-of-order re-score below.
+		await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput({ round: 2, questionId: "q2" }));
+
+		// Round 3: a LATER scored round with high ambiguity / low goal clarity. If the
+		// validator compared against the latest round in array order, this "future" round
+		// would be picked as the baseline for round 2.
+		await appendOrMergeDeepInterviewRound(cwd, statePath, answerInput({ round: 3, questionId: "q3" }));
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			interviewId: "iv-redteam",
+			round: 3,
+			questionId: "q3",
+			scores: { goal: 0.2 },
+			ambiguity: 0.9,
+		});
+
+		// Re-score round 2 with an active goal trigger. This transition is VALID against
+		// round 1 (ambiguity rises 0.4 -> 0.5, goal does not improve 0.6 -> 0.5) but would
+		// be INVALID against the future round 3 (ambiguity 0.9 -> 0.5 does not rise; goal
+		// 0.2 -> 0.5 improves). It must succeed, proving the chronological prior is used.
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			interviewId: "iv-redteam",
+			round: 2,
+			questionId: "q2",
+			scores: { goal: 0.5 },
+			ambiguity: 0.5,
+			triggers: [trigger({ dimension: "goal" })],
+		});
+
+		const rounds = await readPersistedRounds(statePath);
+		const round2 = rounds.find(r => r.round === 2);
+		expect(round2?.lifecycle).toBe("scored");
+		expect(round2?.ambiguity).toBe(0.5);
+		// Round 3 stays untouched as the later scored round.
+		expect(rounds.find(r => r.round === 3)?.lifecycle).toBe("scored");
+	});
+});
+
 describe("deep-interview recorder redteam: round_key collision safety", () => {
 	it("keeps different question ids in the same round distinct", () => {
 		expect(deriveRoundKey("iv-redteam", { round: 4, questionId: "q-left" })).not.toBe(

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts
@@ -308,6 +308,83 @@ describe("deep-interview recorder: persistence (state-writer backed)", () => {
 		expect(persisted.state.current_ambiguity).toBe(0.5);
 	});
 
+	it("refuses to persist an invalid scored transition and does not falsely converge", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		// Round 1 establishes a clear baseline (goal 0.5, ambiguity 0.5).
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			questionText: "Q1?",
+			dimension: "goal",
+		});
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.5 },
+			ambiguity: 0.5,
+		});
+		// Round 2 claims an active goal contradiction yet improves clarity and drops
+		// ambiguity — an impossible scored transition that would falsely converge.
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 2,
+			questionId: "q2",
+			questionText: "Q2?",
+			dimension: "goal",
+		});
+		await expect(
+			enrichDeepInterviewRoundScoring(cwd, statePath, {
+				round: 2,
+				questionId: "q2",
+				scores: { goal: 0.8 },
+				ambiguity: 0.4,
+				triggers: [trigger()],
+			}),
+		).rejects.toThrow(/invalid and was refused/);
+
+		// Durable state is untouched: round 2 stays an unscored shell and the latest
+		// persisted ambiguity is the prior round's, not the refused 0.4.
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(persisted.state.rounds).toHaveLength(2);
+		const round2 = persisted.state.rounds.find((r: DeepInterviewRoundRecord) => r.round === 2);
+		expect(round2.lifecycle).toBe("answered");
+		expect(persisted.state.current_ambiguity).toBe(0.5);
+	});
+
+	it("persists a valid scored transition that lowers the dimension and raises ambiguity", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			questionText: "Q1?",
+			dimension: "goal",
+		});
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 1,
+			questionId: "q1",
+			scores: { goal: 0.5 },
+			ambiguity: 0.5,
+		});
+		await appendOrMergeDeepInterviewRound(cwd, statePath, {
+			round: 2,
+			questionId: "q2",
+			questionText: "Q2?",
+			dimension: "goal",
+		});
+		await enrichDeepInterviewRoundScoring(cwd, statePath, {
+			round: 2,
+			questionId: "q2",
+			scores: { goal: 0.3 },
+			ambiguity: 0.62,
+			triggers: [trigger()],
+		});
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		const round2 = persisted.state.rounds.find((r: DeepInterviewRoundRecord) => r.round === 2);
+		expect(round2.lifecycle).toBe("scored");
+		expect(persisted.state.current_ambiguity).toBe(0.62);
+	});
+
 	it("reads a compact slice and migrates legacy on-disk state safely", async () => {
 		const cwd = await tempDir();
 		const statePath = statePathFor(cwd);


### PR DESCRIPTION
## Summary

Fixes the leader-confirmed **HIGH** deep-interview finding in #606: `validateDeepInterviewScoredTransition` was defined but never called anywhere in `src`, so `enrichDeepInterviewRoundScoring` persisted `current_ambiguity` and the scored round **without validating the scored transition**. Invalid scored transitions could be stored, letting the interview **falsely converge**.

## Change (narrow slice — #606 only)

- Wire `validateDeepInterviewScoredTransition` into the durable write path inside `enrichDeepInterviewRoundScoring`.
- Compare the newly scored record against the **most recent prior scored round** (new `latestPriorScoredRound` helper, matched by durable key so a re-score compares against an earlier round, not itself).
- **Fail closed**: on any invariant violation (an `active` trigger that improves the affected dimension or fails to raise overall ambiguity, or a `disputed`/`unresolved` trigger lacking a rationale) the write is refused — no `rounds`/`current_ambiguity` mutation. Mirrors the existing corrupt-state fail-closed policy.
- Added persistence-level regression tests: one asserting an invalid scored transition is refused **and** durable state is untouched (no false convergence), one asserting a valid lower-dimension/raise-ambiguity transition persists.

No behavior change for the common no-trigger scoring path (validator returns ok when there are no triggers).

## Scope

Only the deep-interview validator-wiring sub-item of #606. Does **not** bundle the other #606 RPC/runtime findings, #607, or #591.

Files:
- `packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts`
- `packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts`

## Verification

- `deep-interview-recorder.test.ts` — 20 pass / 0 fail (incl. 2 new persistence tests)
- `deep-interview-recorder-redteam.test.ts` — 16 pass / 0 fail
- adjacent: `+ deep-interview-hud-sync` `+ deep-interview-state-redteam` — 55 pass / 0 fail combined
- remaining deep-interview suites (runtime, state, gate-redteam, mutation-guard, skill-contract, workflow-gates, render-middleware) — 70 pass / 0 fail
- `git diff --check` clean

Refs #606

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
