### PR TITLE
chore(dev): canonical source-linked gjc (dev:link / dev:doctor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ bun install
 bun run dev:link
 ```
 
-`dev:link` symlinks `gjc` → `packages/coding-agent/src/cli.ts` into `~/.local/bin` (override with `GJC_DEV_LINK_DIR`), removes stale/compiled `gjc` shims that would shadow it, and runs `--smoke-test` to confirm `@gajae-code/natives` loads. Use `bun run install:dev` for the full bootstrap (install + link + `setup defaults`).
+`dev:link` symlinks `gjc` → `packages/coding-agent/src/cli.ts` into `~/.local/bin` (override with `GJC_DEV_LINK_DIR`), replaces that managed target, warns and fails if another `gjc` still shadows it earlier on `PATH`, and runs `--smoke-test` to confirm `@gajae-code/natives` loads. Use `bun run install:dev` for the full bootstrap (install + link + `setup defaults`).
 
 Check at any time whether your `gjc` has drifted (wrong source, or a compiled binary that can't load skills):
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,26 @@ bun install
 bun run install:defaults
 ```
 
-Run the CLI from source:
+### Canonical: build and link the dev `gjc`
+
+To make the global `gjc` command run **this checkout's TypeScript source** (hot to every edit, with skills/natives working), link it onto your `PATH`:
+
+```sh
+bun install
+bun run dev:link
+```
+
+`dev:link` symlinks `gjc` → `packages/coding-agent/src/cli.ts` into `~/.local/bin` (override with `GJC_DEV_LINK_DIR`), removes stale/compiled `gjc` shims that would shadow it, and runs `--smoke-test` to confirm `@gajae-code/natives` loads. Use `bun run install:dev` for the full bootstrap (install + link + `setup defaults`).
+
+Check at any time whether your `gjc` has drifted (wrong source, or a compiled binary that can't load skills):
+
+```sh
+bun run dev:doctor
+```
+
+> Do **not** use the compiled binary for day-to-day development. `bun --cwd=packages/coding-agent run build` produces a standalone `dist/gjc`, but a `bun build --compile` binary cannot dynamically load `@gajae-code/natives`, so skills fail with `Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc'`. Running from source via `dev:link` avoids this. Build the binary only when validating a release.
+
+Run the CLI from source directly without linking:
 
 ```sh
 bun packages/coding-agent/src/cli.ts --help

--- a/package.json
+++ b/package.json
@@ -78,9 +78,11 @@
   },
   "overrides": {},
   "scripts": {
-    "install:dev": "bun install && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun packages/coding-agent/src/cli.ts setup defaults",
+    "install:dev": "bun install && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun packages/coding-agent/src/cli.ts setup defaults",
     "install:defaults": "bun packages/coding-agent/src/cli.ts setup defaults",
     "dev": "bun --cwd=packages/coding-agent src/cli.ts",
+    "dev:link": "bun scripts/dev-link.ts",
+    "dev:doctor": "bun scripts/dev-link.ts --check",
     "stats": "bun --cwd=packages/coding-agent src/cli.ts stats",
     "build": "bun run --workspaces --if-present build",
     "build:native": "bun --cwd=packages/natives run build",

--- a/scripts/dev-link.test.ts
+++ b/scripts/dev-link.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const tempRoots: string[] = [];
+
+async function makeExecutable(file: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await Bun.write(file, content);
+	await fs.chmod(file, 0o755);
+}
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { force: true, recursive: true })));
+});
+
+describe("dev:link", () => {
+	test("fails when a shadow gjc earlier on PATH would make smoke-test validate the wrong command", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-shadow-"));
+		tempRoots.push(root);
+		const shadowDir = path.join(root, "shadow-bin");
+		const targetDir = path.join(root, "managed-bin");
+		await makeExecutable(
+			path.join(shadowDir, "gjc"),
+			`#!/usr/bin/env sh\nif [ "$1" = "--smoke-test" ]; then echo "smoke-test: ok"; exit 0; fi\necho shadow\nexit 0\n`,
+		);
+
+		const result = Bun.spawnSync([process.execPath, "scripts/dev-link.ts"], {
+			env: {
+				...process.env,
+				GJC_DEV_LINK_DIR: targetDir,
+				PATH: `${shadowDir}:${targetDir}`,
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stdout.toString()).toContain(`Linked ${path.join(targetDir, "gjc")}`);
+		expect(result.stderr.toString()).toContain("still resolves to a different command earlier on PATH");
+		expect(result.stderr.toString()).toContain(path.join(shadowDir, "gjc"));
+	});
+});

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -94,6 +94,19 @@ function smokeTest(gjcPath: string): { ok: boolean; output: string } {
 	return { ok: res.exitCode === 0 && output.includes("smoke-test: ok"), output };
 }
 
+function assertResolvedGjcIsSource(winner: GjcHit | undefined): void {
+	if (!winner || winner.real === cliSourceReal) return;
+
+	console.error("");
+	console.error("✗ Linked, but `gjc` still resolves to a different command earlier on PATH.");
+	console.error(`  Resolved: ${winner.file}`);
+	console.error(`       -> ${describe(winner.real)}`);
+	console.error(`  Expected source: ${cliSourceReal}`);
+	console.error(`  The managed link was created at: ${path.join(targetDir, "gjc")}`);
+	console.error("  Move the managed link directory earlier on PATH or remove the shadowing command.");
+	process.exit(1);
+}
+
 function assertSourceExists(): void {
 	if (!fs.existsSync(cliSource)) {
 		console.error(`✗ Cannot find CLI source at ${cliSource}`);
@@ -178,7 +191,10 @@ function link(): never {
 	}
 
 	const winner = findGjcOnPath()[0];
-	const smoke = smokeTest(winner?.file ?? target);
+	assertResolvedGjcIsSource(winner);
+
+	const smokePath = winner?.file ?? target;
+	const smoke = smokeTest(smokePath);
 	if (!smoke.ok) {
 		console.error("");
 		console.error("✗ Linked, but `gjc --smoke-test` failed (natives/worker did not load):");

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env bun
+
+/**
+ * Canonical dev linker for the `gjc` CLI.
+ *
+ * Makes the global `gjc` command run THIS checkout's TypeScript source
+ * (`packages/coding-agent/src/cli.ts`) instead of a compiled binary or a
+ * published npm install. Running from source is the only mode that can
+ * dynamically load `@gajae-code/natives` for skills — a `bun build --compile`
+ * standalone binary cannot, which surfaces as:
+ *
+ *   Failed to load skill: Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc'
+ *
+ * Usage:
+ *   bun scripts/dev-link.ts            # link `gjc` -> src/cli.ts on PATH
+ *   bun scripts/dev-link.ts --check    # doctor: fail if `gjc` has drifted
+ *
+ * Env:
+ *   GJC_DEV_LINK_DIR   override the target bin dir (default ~/.local/bin)
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const cliSource = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const cliSourceReal = realpath(cliSource) ?? cliSource;
+
+const HOME = os.homedir();
+const PATH_SEP = process.platform === "win32" ? ";" : ":";
+const targetDir = process.env.GJC_DEV_LINK_DIR ?? path.join(HOME, ".local", "bin");
+
+function realpath(p: string): string | null {
+	try {
+		return fs.realpathSync(p);
+	} catch {
+		return null;
+	}
+}
+
+/** Does the symlink/file exist (without following the link)? */
+function lexists(p: string): boolean {
+	try {
+		fs.lstatSync(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function pathDirs(): string[] {
+	return (process.env.PATH ?? "").split(PATH_SEP).filter(Boolean);
+}
+
+function isOnPath(dir: string): boolean {
+	const want = realpath(dir) ?? dir;
+	return pathDirs().some(d => (realpath(d) ?? d) === want);
+}
+
+interface GjcHit {
+	dir: string;
+	file: string;
+	real: string | null;
+}
+
+/** All `gjc` entries on PATH, in resolution order (first wins). */
+function findGjcOnPath(): GjcHit[] {
+	const hits: GjcHit[] = [];
+	const seen = new Set<string>();
+	for (const dir of pathDirs()) {
+		const file = path.join(dir, "gjc");
+		if (seen.has(file) || !lexists(file)) continue;
+		seen.add(file);
+		hits.push({ dir, file, real: realpath(file) });
+	}
+	return hits;
+}
+
+function describe(real: string | null): string {
+	if (!real) return "broken symlink / unresolved";
+	if (real === cliSourceReal) return "workspace source (cli.ts) — OK";
+	if (/[/\\]dist[/\\]/.test(real)) return `compiled binary: ${real}`;
+	if (real.includes("$bunfs")) return `compiled binary (bunfs): ${real}`;
+	if (real.includes(`${path.sep}node_modules${path.sep}gajae-code${path.sep}`)) {
+		return `published wrapper: ${real}`;
+	}
+	return real;
+}
+
+function smokeTest(gjcPath: string): { ok: boolean; output: string } {
+	const res = Bun.spawnSync([gjcPath, "--smoke-test"], { stdout: "pipe", stderr: "pipe" });
+	const output = `${res.stdout.toString()}${res.stderr.toString()}`.trim();
+	return { ok: res.exitCode === 0 && output.includes("smoke-test: ok"), output };
+}
+
+function assertSourceExists(): void {
+	if (!fs.existsSync(cliSource)) {
+		console.error(`✗ Cannot find CLI source at ${cliSource}`);
+		console.error("  Run this from the gajae-code checkout.");
+		process.exit(1);
+	}
+}
+
+/** Doctor: verify the `gjc` the shell resolves is this checkout's source. */
+function check(): never {
+	assertSourceExists();
+	const hits = findGjcOnPath();
+	if (hits.length === 0) {
+		console.error("✗ `gjc` is not on PATH.");
+		console.error("  Fix: bun run dev:link");
+		process.exit(1);
+	}
+
+	const winner = hits[0];
+	const onSource = winner.real === cliSourceReal;
+	console.log(`gjc resolves to: ${winner.file}`);
+	console.log(`            -> ${describe(winner.real)}`);
+
+	if (!onSource) {
+		console.error("");
+		console.error("✗ `gjc` is NOT this checkout's source — it has drifted.");
+		console.error(`  Expected: ${cliSourceReal}`);
+		console.error("  Fix: bun run dev:link");
+		process.exit(1);
+	}
+
+	const smoke = smokeTest(winner.file);
+	if (!smoke.ok) {
+		console.error("");
+		console.error("✗ `gjc --smoke-test` failed (natives/worker did not load):");
+		console.error(smoke.output.replace(/^/gm, "  "));
+		console.error("  Fix: bun run dev:link  (and rebuild natives if needed: bun run build:native)");
+		process.exit(1);
+	}
+
+	console.log("✓ gjc runs this checkout's source and natives load (smoke-test: ok).");
+	process.exit(0);
+}
+
+/** Link: point `gjc` at this checkout's source on PATH. */
+function link(): never {
+	assertSourceExists();
+
+	if (process.platform === "win32") {
+		console.error("dev:link targets Unix-like systems (symlink into ~/.local/bin).");
+		console.error("On Windows, install the dev CLI with Bun instead:");
+		console.error("  bun --cwd=packages/coding-agent link");
+		process.exit(1);
+	}
+
+	fs.mkdirSync(targetDir, { recursive: true });
+	const target = path.join(targetDir, "gjc");
+
+	if (lexists(target)) {
+		fs.rmSync(target, { force: true });
+	}
+	fs.symlinkSync(cliSource, target);
+	console.log(`✓ Linked ${target} -> ${cliSource}`);
+
+	if (!isOnPath(targetDir)) {
+		console.warn(`! ${targetDir} is not on your PATH — add it so \`gjc\` resolves:`);
+		console.warn(`    export PATH="${targetDir}:$PATH"`);
+	}
+
+	// Warn about any drifted `gjc` that shadows the link (earlier on PATH).
+	for (const hit of findGjcOnPath()) {
+		if (hit.file === target) break; // our link wins from here on
+		if (hit.real === cliSourceReal) continue; // another correct source link — harmless
+		console.warn("");
+		console.warn(`! A different \`gjc\` shadows the dev link (earlier on PATH): ${hit.file}`);
+		console.warn(`    -> ${describe(hit.real)}`);
+		if (hit.dir === path.join(HOME, ".bun", "bin")) {
+			console.warn("    Remove the published global install: bun remove -g gajae-code");
+		} else {
+			console.warn(`    Remove it: rm "${hit.file}"`);
+		}
+	}
+
+	const winner = findGjcOnPath()[0];
+	const smoke = smokeTest(winner?.file ?? target);
+	if (!smoke.ok) {
+		console.error("");
+		console.error("✗ Linked, but `gjc --smoke-test` failed (natives/worker did not load):");
+		console.error(smoke.output.replace(/^/gm, "  "));
+		console.error("  Try rebuilding natives: bun run build:native");
+		process.exit(1);
+	}
+	console.log("✓ smoke-test: ok — `gjc` runs this checkout's source with natives loaded.");
+	process.exit(0);
+}
+
+if (process.argv.includes("--check")) {
+	check();
+} else {
+	link();
+}


### PR DESCRIPTION
## Why

The global `gjc` command can silently diverge from `bun run dev`. Two failure modes hit during dogfooding:

1. A **published** `gajae-code` install in `~/.bun/bin` shadows the workspace and drags in stale published `@gajae-code/*` deps → version skew.
2. A **compiled** `dist/gjc` symlinked into `~/.local/bin` (which is earlier on PATH than `~/.bun/bin`) wins, and a `bun build --compile` standalone binary **cannot dynamically load `@gajae-code/natives`**, so skills crash:

   ```
   Failed to load skill: Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc'
   ```

There was no single sanctioned way to make `gjc` run this checkout's TypeScript source, nor any way to detect drift.

## What

- **`scripts/dev-link.ts`**
  - `bun run dev:link` — symlinks `gjc` → `packages/coding-agent/src/cli.ts` into a PATH dir (default `~/.local/bin`, override `GJC_DEV_LINK_DIR`), removes the stale `gjc` at the target, warns about any shadowing entry earlier on PATH (with remediation, e.g. `bun remove -g gajae-code`), and runs `--smoke-test` to confirm natives load.
  - `bun run dev:doctor` (`--check`) — fails (exit 1) if the `gjc` your shell resolves is not this checkout's source, or if `--smoke-test` fails.
- **`package.json`** — adds `dev:link` / `dev:doctor`; `install:dev` now runs `dev:link`.
- **README** — documents this as the canonical build-and-link method for the dev `gjc`, including why the compiled binary must not be used for day-to-day dev.

## Verification

- `bun run dev:doctor` → exit 0, reports source + `smoke-test: ok`.
- `bun run dev:link` → idempotent re-link, `smoke-test: ok`.
- Compiled-binary shadow simulated earlier on PATH → `dev:doctor` exits 1 with clear drift message; `dev:link` warns about the shadow.
- `dev-link.ts` typechecks clean under `tsconfig.tools.json`.

## Notes

Targets `dev`. `dev:doctor` is intentionally not wired into CI `check` (it asserts a developer's local PATH state). Unix-focused; on Windows `dev:link` points users to `bun --cwd=packages/coding-agent link`.