### PR TITLE
fix(rpc): preserve unknown-command id, fail-closed token-cost metrics, guard --listen socket (#606)

### DIFF
--- a/packages/coding-agent/src/modes/bridge/bridge-mode.ts
+++ b/packages/coding-agent/src/modes/bridge/bridge-mode.ts
@@ -29,7 +29,7 @@ import {
 import { UiRequestBroker } from "../shared/agent-wire/ui-request-broker";
 import type { BridgeUiResult } from "../shared/agent-wire/ui-result";
 import { defaultAuditPath, UnattendedAuditLog } from "../shared/agent-wire/unattended-audit";
-import { UnattendedSessionControlPlane } from "../shared/agent-wire/unattended-session";
+import { modelSupportsTokenCostMetrics, UnattendedSessionControlPlane } from "../shared/agent-wire/unattended-session";
 import { FileGateStore } from "../shared/agent-wire/workflow-gate-broker";
 import { assertSafeBridgeBind, isBridgeTokenAuthorized } from "./auth";
 import { type BridgePermissionRequestPayload, createBridgeClientBridge } from "./bridge-client-bridge";
@@ -599,6 +599,7 @@ export async function runBridgeMode(
 		emitFrame: gate => eventStream.publish(toBridgeWorkflowGateFrame(gate, sequencer)),
 		store: gateStore,
 		audit: recordAudit,
+		providerSupportsTokenCostMetrics: modelSupportsTokenCostMetrics(session.model),
 		getUsageSnapshot: () => {
 			const stats = session.getSessionStats();
 			return { tokens: stats.tokens.total, costUsd: stats.cost };

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -27,7 +27,7 @@ import { AgentWireFrameSequencer, toAgentWireEventFrame } from "../shared/agent-
 import { rpcError as error } from "../shared/agent-wire/responses";
 import { registerRpcSession, unregisterRpcSession } from "../shared/agent-wire/session-registry";
 import { defaultAuditPath, UnattendedAuditLog } from "../shared/agent-wire/unattended-audit";
-import { UnattendedSessionControlPlane } from "../shared/agent-wire/unattended-session";
+import { modelSupportsTokenCostMetrics, UnattendedSessionControlPlane } from "../shared/agent-wire/unattended-session";
 import { FileGateStore } from "../shared/agent-wire/workflow-gate-broker";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
@@ -89,6 +89,26 @@ function auditOutcomeFor(event: string): "accepted" | "rejected" | "denied" | "e
 	if (event.includes("rejected") || event.includes("conflict")) return "rejected";
 	if (event.includes("accepted") || event.includes("negotiated") || event.includes("emitted")) return "accepted";
 	return "info";
+}
+
+/**
+ * Probe whether a unix-domain socket path has a live server accepting
+ * connections. Returns `true` only when a connection succeeds (a previous owner
+ * is still alive), so `--listen` startup can refuse to unlink a live endpoint
+ * instead of stealing it (#606). A missing path or a stale socket with no
+ * listener (ENOENT / ECONNREFUSED) returns `false`.
+ */
+export async function isUnixSocketAlive(socketPath: string): Promise<boolean> {
+	try {
+		const socket = await Bun.connect({
+			unix: socketPath,
+			socket: { data() {}, open() {}, error() {}, close() {} },
+		});
+		socket.end();
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export function requestRpcEditor(
@@ -230,6 +250,7 @@ export async function runRpcMode(
 		emitFrame: gate => output(gate),
 		store: gateStore,
 		audit: recordAudit,
+		providerSupportsTokenCostMetrics: modelSupportsTokenCostMetrics(session.model),
 		getUsageSnapshot: () => {
 			const stats = session.getSessionStats();
 			return { tokens: stats.tokens.total, costUsd: stats.cost };
@@ -620,6 +641,15 @@ export async function runRpcMode(
 	if (options?.listen) {
 		const socketPath = options.listen;
 		await fs.mkdir(path.dirname(socketPath), { recursive: true }).catch(() => {});
+		// Refuse to clobber a live previous owner: probe the path first and only
+		// unlink a stale endpoint. A second `--listen` on the same path must not
+		// remove the socket another running server is still serving (#606).
+		if (await isUnixSocketAlive(socketPath)) {
+			throw new Error(
+				`RPC --listen refused: a live server is already listening on ${socketPath}. ` +
+					"Stop it first or choose a different --listen path.",
+			);
+		}
 		await fs.rm(socketPath, { force: true }).catch(() => {});
 		await registerRpcSession({
 			sessionId: session.sessionId,

--- a/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
@@ -447,7 +447,7 @@ export async function dispatchRpcCommand(
 
 			default: {
 				const unknownCommand = command as { type: string };
-				return rpcError(undefined, unknownCommand.type, `Unknown command: ${unknownCommand.type}`);
+				return rpcError(id, unknownCommand.type, `Unknown command: ${unknownCommand.type}`);
 			}
 		}
 	} catch (err) {

--- a/packages/coding-agent/src/modes/shared/agent-wire/unattended-session.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/unattended-session.ts
@@ -14,6 +14,7 @@
  * Also implements the dispatch-facing {@link RpcUnattendedControlPlane} so the
  * RPC server can route `negotiate_unattended` + `workflow_gate_response` here.
  */
+import type { Model } from "@gajae-code/ai";
 import type {
 	RpcCommand,
 	RpcUnattendedAccepted,
@@ -37,6 +38,20 @@ import { type GateStore, MemoryGateStore, type OpenGateInput, WorkflowGateBroker
  * and scope-checked but must NOT charge the tool-call budget (issue 04).
  */
 const CHARGED_COMMAND_TYPES = new Set<RpcCommand["type"]>(["bash", "prompt", "steer", "follow_up", "abort_and_prompt"]);
+
+/**
+ * Derive an explicit `providerSupportsTokenCostMetrics` capability from the
+ * active model so unattended negotiation fails closed when token/cost usage
+ * cannot be accounted for (#606). Callers that omit a model — or whose model is
+ * configured to suppress streaming usage (`compat.supportsUsageInStreaming:
+ * false`) — get `false`, which the controller refuses with
+ * `unsupported_budget_metric`.
+ */
+export function modelSupportsTokenCostMetrics(model: Model | undefined): boolean {
+	if (!model) return false;
+	const compat = model.compat as { supportsUsageInStreaming?: boolean } | undefined;
+	return compat?.supportsUsageInStreaming !== false;
+}
 
 /** Minimal surface a skill runtime / ask tool uses to emit a gate and await its answer. */
 export interface WorkflowGateEmitter {
@@ -92,7 +107,7 @@ export class UnattendedSessionControlPlane implements RpcUnattendedControlPlane,
 					this.#rejectAllPending(new Error(`unattended run aborted: ${reason}`));
 				},
 			},
-			providerSupportsTokenCostMetrics: this.opts.providerSupportsTokenCostMetrics ?? true,
+			providerSupportsTokenCostMetrics: this.opts.providerSupportsTokenCostMetrics,
 		});
 		this.#controller = controller;
 		this.#broker = new WorkflowGateBroker(this.opts.runId, this.opts.store ?? new MemoryGateStore(), {

--- a/packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts
@@ -48,7 +48,12 @@ describe("live bridge unattended workflow gate wiring", () => {
 	});
 
 	it("negotiates unattended during handshake and resolves gates through bridge ui-response compatibility route", async () => {
-		const cp = new UnattendedSessionControlPlane({ runId: "run-b", sessionId: "sess-b", emitFrame: () => undefined });
+		const cp = new UnattendedSessionControlPlane({
+			runId: "run-b",
+			sessionId: "sess-b",
+			emitFrame: () => undefined,
+			providerSupportsTokenCostMetrics: true,
+		});
 		const handle = createBridgeFetchHandler({
 			sessionId: "sess-b",
 			token: "secret",

--- a/packages/coding-agent/test/rpc-dispatch-validation.test.ts
+++ b/packages/coding-agent/test/rpc-dispatch-validation.test.ts
@@ -69,4 +69,14 @@ describe("dispatchRpcCommand validation + error correlation", () => {
 		expect(res.command).toBe("set_session_name");
 		expect(res.command).not.toBe("parse");
 	});
+
+	test("an unknown command preserves the caller's request id (issue 01 default sub-case)", async () => {
+		const res = await dispatchRpcCommand(
+			{ id: "u1", type: "totally_unknown_command" } as unknown as RpcCommand,
+			ctx(),
+		);
+		expect(res.success).toBe(false);
+		expect(res.id).toBe("u1");
+		expect(res.command).toBe("totally_unknown_command");
+	});
 });

--- a/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
+++ b/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { isUnixSocketAlive } from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
+
+let dir: string;
+
+beforeEach(async () => {
+	dir = await mkdtemp(path.join(tmpdir(), "rpc-listen-guard-"));
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("isUnixSocketAlive (--listen live-owner probe, #606)", () => {
+	it("returns false for a socket path that does not exist", async () => {
+		expect(await isUnixSocketAlive(path.join(dir, "missing.sock"))).toBe(false);
+	});
+
+	it("returns false for a non-socket file at the path", async () => {
+		const filePath = path.join(dir, "not-a-socket");
+		await Bun.write(filePath, "stale");
+		expect(await isUnixSocketAlive(filePath)).toBe(false);
+	});
+
+	it("returns true while a live server is listening, false after it stops", async () => {
+		const socketPath = path.join(dir, "live.sock");
+		const server = Bun.listen({
+			unix: socketPath,
+			socket: { data() {}, open() {}, error() {}, close() {} },
+		});
+
+		expect(await isUnixSocketAlive(socketPath)).toBe(true);
+
+		server.stop(true);
+		expect(await isUnixSocketAlive(socketPath)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/rpc-live-unattended-regression.test.ts
+++ b/packages/coding-agent/test/rpc-live-unattended-regression.test.ts
@@ -80,6 +80,7 @@ describe("live RPC unattended dispatch wiring", () => {
 			runId: "run-live",
 			sessionId: "sess-live",
 			emitFrame: () => undefined,
+			providerSupportsTokenCostMetrics: true,
 		});
 		cp.negotiate(declaration);
 		const res = await dispatchRpcCommand(
@@ -98,6 +99,7 @@ describe("live RPC unattended dispatch wiring", () => {
 			runId: "run-live",
 			sessionId: "sess-live",
 			emitFrame: () => undefined,
+			providerSupportsTokenCostMetrics: true,
 		});
 		cp.negotiate(declaration);
 		expect((await dispatchRpcCommand({ id: "1", type: "bash", command: "pwd" }, context(session, cp))).success).toBe(
@@ -120,6 +122,7 @@ describe("live RPC unattended dispatch wiring", () => {
 			runId: "run-live",
 			sessionId: "sess-live",
 			emitFrame: gate => emitted.push(gate),
+			providerSupportsTokenCostMetrics: true,
 		});
 		cp.negotiate(declaration);
 		const answerPromise = cp.emitGate(approvalGate({ summary: "ship?" }));

--- a/packages/coding-agent/test/unattended-session-redteam.test.ts
+++ b/packages/coding-agent/test/unattended-session-redteam.test.ts
@@ -23,6 +23,7 @@ function makePlane(opts: { providerSupportsTokenCostMetrics?: boolean } = {}) {
 	const plane = new UnattendedSessionControlPlane({
 		runId: "redteam-run",
 		emitFrame: gate => emitted.push(gate),
+		providerSupportsTokenCostMetrics: true,
 		...opts,
 	});
 	return { plane, emitted };

--- a/packages/coding-agent/test/unattended-session.test.ts
+++ b/packages/coding-agent/test/unattended-session.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "bun:test";
 import type { RpcUnattendedDeclaration, RpcWorkflowGate } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
 import { approvalGate } from "@gajae-code/coding-agent/modes/shared/agent-wire/approval-gate";
 import { questionToGate } from "@gajae-code/coding-agent/modes/shared/agent-wire/deep-interview-gate";
-import { UnattendedSessionControlPlane } from "@gajae-code/coding-agent/modes/shared/agent-wire/unattended-session";
+import {
+	modelSupportsTokenCostMetrics,
+	UnattendedSessionControlPlane,
+} from "@gajae-code/coding-agent/modes/shared/agent-wire/unattended-session";
 
 const DECL: RpcUnattendedDeclaration = {
 	actor: "hermes",
@@ -13,7 +16,11 @@ const DECL: RpcUnattendedDeclaration = {
 
 function makePlane() {
 	const emitted: RpcWorkflowGate[] = [];
-	const plane = new UnattendedSessionControlPlane({ runId: "run-1", emitFrame: g => emitted.push(g) });
+	const plane = new UnattendedSessionControlPlane({
+		runId: "run-1",
+		emitFrame: g => emitted.push(g),
+		providerSupportsTokenCostMetrics: true,
+	});
 	return { plane, emitted };
 }
 
@@ -30,6 +37,17 @@ describe("UnattendedSessionControlPlane", () => {
 			runId: "r",
 			emitFrame: g => emitted.push(g),
 			providerSupportsTokenCostMetrics: false,
+		});
+		expect(() => plane.negotiate(DECL)).toThrow();
+		expect(plane.isUnattended()).toBe(false);
+	});
+
+	it("negotiates fail-closed when the token/cost capability is omitted (#606: no implicit true default)", () => {
+		const emitted: RpcWorkflowGate[] = [];
+		const plane = new UnattendedSessionControlPlane({
+			runId: "r-omitted",
+			emitFrame: g => emitted.push(g),
+			// providerSupportsTokenCostMetrics intentionally omitted (undefined).
 		});
 		expect(() => plane.negotiate(DECL)).toThrow();
 		expect(plane.isUnattended()).toBe(false);
@@ -58,6 +76,7 @@ describe("UnattendedSessionControlPlane", () => {
 		const emitted: RpcWorkflowGate[] = [];
 		plane = new UnattendedSessionControlPlane({
 			runId: "run-sync",
+			providerSupportsTokenCostMetrics: true,
 			emitFrame: gate => {
 				emitted.push(gate);
 				void plane.resolveGate({ gate_id: gate.gate_id, answer: { decision: "approve" } });
@@ -102,7 +121,11 @@ describe("UnattendedSessionControlPlane", () => {
 
 	it("rejects a pending emitGate when the unattended run aborts (no forever-hang)", async () => {
 		const emitted: RpcWorkflowGate[] = [];
-		const plane = new UnattendedSessionControlPlane({ runId: "run-abort", emitFrame: g => emitted.push(g) });
+		const plane = new UnattendedSessionControlPlane({
+			runId: "run-abort",
+			emitFrame: g => emitted.push(g),
+			providerSupportsTokenCostMetrics: true,
+		});
 		plane.negotiate({
 			...DECL,
 			budget: { max_tokens: 1000, max_tool_calls: 1, max_wall_time_ms: 10_000, max_cost_usd: 5 },
@@ -123,7 +146,11 @@ describe("UnattendedSessionControlPlane", () => {
 	});
 	it("does not charge max_tool_calls for read-only/control commands; bash still charges (issue 04)", () => {
 		const emitted: RpcWorkflowGate[] = [];
-		const plane = new UnattendedSessionControlPlane({ runId: "budget-run", emitFrame: g => emitted.push(g) });
+		const plane = new UnattendedSessionControlPlane({
+			runId: "budget-run",
+			emitFrame: g => emitted.push(g),
+			providerSupportsTokenCostMetrics: true,
+		});
 		plane.negotiate({
 			actor: "hermes",
 			budget: { max_tokens: 1000, max_tool_calls: 10, max_wall_time_ms: 60_000, max_cost_usd: 5 },
@@ -148,5 +175,23 @@ describe("UnattendedSessionControlPlane", () => {
 		// A bash command performs real tool work and still charges one unit.
 		plane.preflightCommand({ type: "bash", command: "pwd" });
 		expect(controller?.usageSnapshot().toolCalls).toBe(1);
+	});
+});
+
+describe("modelSupportsTokenCostMetrics", () => {
+	it("fails closed for an undefined model", () => {
+		expect(modelSupportsTokenCostMetrics(undefined)).toBe(false);
+	});
+
+	it("supports a model with no compat overrides", () => {
+		expect(modelSupportsTokenCostMetrics({} as never)).toBe(true);
+	});
+
+	it("supports a model whose compat enables streaming usage", () => {
+		expect(modelSupportsTokenCostMetrics({ compat: { supportsUsageInStreaming: true } } as never)).toBe(true);
+	});
+
+	it("fails closed for a model that suppresses streaming usage", () => {
+		expect(modelSupportsTokenCostMetrics({ compat: { supportsUsageInStreaming: false } } as never)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

First narrow slice for #606 — three concrete RPC/control-plane defects from the post-0.5.0 dogfood/review pass. Scoped to clearly testable fixes; the Python attach/detach client surface and deep-interview Phase-0 contract work remain deferred follow-up slices (see issue comment).

### 1. Preserve caller request id for unknown-command `rpcError` (MEDIUM)
`command-dispatch.ts` default case returned `rpcError(undefined, …)`, dropping the caller's `id` so unknown commands could not be correlated. Now forwards the captured `id` (new sub-case of issue #01, which only fixed the handler-exception path).

### 2. Fail-closed token/cost metric capability (HIGH)
`unattended-session.ts` used `providerSupportsTokenCostMetrics ?? true`, so constructors that omitted the capability defaulted to **true**, defeating the controller's fail-closed `unsupported_budget_metric` policy. Now:
- the session control plane forwards the explicit capability (omitted/`undefined`/`false` fails closed at the controller),
- a model-derived `modelSupportsTokenCostMetrics(session.model)` capability is plumbed from the RPC and bridge construction sites (fails closed when no model is selected or `compat.supportsUsageInStreaming === false`).

### 3. Guard `--listen` UDS startup against a live previous owner (HIGH)
`rpc-mode.ts` unconditionally `fs.rm`'d the socket path before `Bun.listen`, so a second `--listen` on the same path could unlink a **live** first server's endpoint. Startup now probes with `isUnixSocketAlive()` and refuses to bind when a live owner is still listening; only stale endpoints are unlinked.

## Tests
- `rpc-dispatch-validation.test.ts`: unknown command preserves the request id.
- `unattended-session.test.ts`: fail-closed when capability omitted; `modelSupportsTokenCostMetrics` unit coverage.
- `rpc-listen-socket-guard.test.ts`: `isUnixSocketAlive` returns true for a live server, false for missing/stale/non-socket paths.
- Updated existing unattended/bridge/RPC regression tests to pass the now-required explicit capability.

## Verification
- `bun run check:types` (coding-agent): clean
- `biome check` on changed files: clean
- Targeted suites green: agent-wire, harness-control-plane, unattended-*, rpc-*, bridge-* (incl. the real-server stdio lane).

## Deferred (follow-up slices, not in this PR)
- `python/gjc-rpc` attach/detach client surface (#09/#10 client-side).
- deep-interview Phase-0 threshold/validator contract alignment (#587).
- Other dogfood findings in #606 (read/control fast-lane expansion, file-lock-gc TOCTOU, real-binary CI lane, etc.).

Closes part of #606. **Do not merge** without review.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
