### PR TITLE
fix(goal): stop AgentBusyError loop when busy session triggers goal continuation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed interactive goal-mode auto-continuation looping `Error: Agent is already processing…` (`AgentBusyError`) while the session is busy. A wedged/orphaned subagent turn — or an in-progress compaction — can leave the session non-idle while the interactive loop is back at `getUserInput()`; the 800 ms continuation timer then fired `prompt()`, threw `AgentBusyError`, surfaced it via `showError`, and re-armed — spamming the error roughly every 800 ms. The continuation now skips and re-arms while `isStreaming`/`isCompacting`, firing only once the session returns to idle.
+
 ## [0.5.1] - 2026-06-14
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -709,6 +709,16 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (this.#pendingSubmittedInput) return;
 			if (this.editor.getText().trim().length > 0) return;
 			if ((this.pendingImages?.length ?? 0) > 0) return;
+			// Never fire an autonomous continuation prompt() while the session is
+			// busy. A wedged/orphaned subagent turn can leave isStreaming stuck true;
+			// firing prompt() here throws AgentBusyError, which submitInteractiveInput
+			// surfaces as a red "Error: Agent is already processing…" and then loops
+			// back to getUserInput(), re-arming this timer — an infinite error spam.
+			// Re-arm and only fire once the session returns to idle.
+			if (this.session.isStreaming || this.session.isCompacting) {
+				this.#scheduleGoalContinuation();
+				return;
+			}
 			const latestState = this.session.getGoalModeState();
 			if (!latestState?.enabled || latestState.goal.status !== "active") return;
 			this.#goalContinuationTurnInFlight = true;

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -360,4 +360,78 @@ describe("InteractiveMode goal mode integration", () => {
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
 		await nextTurn;
 	});
+	it("does not loop AgentBusyError when a busy/orphaned session triggers goal continuation", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		expect(harness.mode.goalModeEnabled).toBe(true);
+		expect(harness.session.goalRuntime.buildContinuationPrompt()).toBeTruthy();
+
+		// Simulate a wedged/orphaned turn: the interactive loop is back at
+		// getUserInput() but the session still reports busy (isStreaming stuck true).
+		harness.session.agent.state.isStreaming = true;
+
+		const startPending = vi.spyOn(harness.mode, "startPendingSubmission");
+
+		vi.useFakeTimers();
+		try {
+			// getUserInput() arms the 800ms goal-continuation timer.
+			void harness.mode.getUserInput();
+
+			// While the session is busy, the continuation must never fire prompt()
+			// (which throws AgentBusyError and spams "Error: Agent is already
+			// processing…"). Advancing past several 800ms windows must not produce a
+			// single continuation submission.
+			for (let i = 0; i < 5; i++) {
+				vi.advanceTimersByTime(800);
+			}
+			const busyCalls = startPending.mock.calls.filter(call => call[0]?.customType === "goal-continuation");
+			expect(busyCalls.length).toBe(0);
+
+			// Once the session returns to idle, the re-armed continuation fires.
+			harness.session.agent.state.isStreaming = false;
+			vi.advanceTimersByTime(800);
+			const idleCalls = startPending.mock.calls.filter(call => call[0]?.customType === "goal-continuation");
+			expect(idleCalls.length).toBeGreaterThan(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+	it("does not loop AgentBusyError while compaction is in progress", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		expect(harness.mode.goalModeEnabled).toBe(true);
+		expect(harness.session.goalRuntime.buildContinuationPrompt()).toBeTruthy();
+
+		// Compaction keeps the session busy without necessarily setting isStreaming.
+		// The continuation timer can fire mid-compaction; prompt() would then throw
+		// AgentBusyError and loop the same way the orphan-subagent wedge does.
+		let compacting = true;
+		Object.defineProperty(harness.session, "isCompacting", {
+			configurable: true,
+			get: () => compacting,
+		});
+
+		const startPending = vi.spyOn(harness.mode, "startPendingSubmission");
+
+		vi.useFakeTimers();
+		try {
+			void harness.mode.getUserInput();
+
+			for (let i = 0; i < 5; i++) {
+				vi.advanceTimersByTime(800);
+			}
+			const compactingCalls = startPending.mock.calls.filter(
+				call => call[0]?.customType === "goal-continuation",
+			);
+			expect(compactingCalls.length).toBe(0);
+
+			// Compaction finished: the re-armed continuation fires.
+			compacting = false;
+			vi.advanceTimersByTime(800);
+			const afterCompactionCalls = startPending.mock.calls.filter(
+				call => call[0]?.customType === "goal-continuation",
+			);
+			expect(afterCompactionCalls.length).toBeGreaterThan(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });


### PR DESCRIPTION
## Problem

A wedged/orphaned sub-agent (and, per report, sometimes an in-progress compaction) makes the looping red error:

```
Error: Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion.
```

This is `AgentBusyError`, thrown by `session.prompt()` when the session is already streaming and no `streamingBehavior` is given.

## Root cause

Interactive goal-mode auto-continuation:

- The main loop is `while (true) { input = await getUserInput(); await submitInteractiveInput(...) }`. `submitInteractiveInput` calls `session.prompt(...)` and on failure renders `Error: <message>` in red via `showError` (`main.ts`, `ui-helpers.ts`).
- `getUserInput()` arms `#scheduleGoalContinuation()`, an 800 ms timer that autonomously submits a continuation prompt.
- The timer guards checked goal state / pending input / editor text — but **never `session.isStreaming` / `session.isCompacting`**.

When a turn is left non-idle (orphaned sub-agent leaving `isStreaming` stuck true, or an active compaction), the timer fires `prompt()` → `AgentBusyError` → `showError` → back to `getUserInput()` → re-arm → repeat. That's the periodic red-text loop.

The non-interactive continuation path (`AgentSession.#checkGoalCompletion` → `#scheduleAgentContinue`) was already safe (uses `continue()` and swallows errors).

## Fix

`packages/coding-agent/src/modes/interactive-mode.ts` — guard the continuation timer; while busy it re-arms instead of firing `prompt()`, so it self-heals once the session returns to idle and never spams `AgentBusyError`:

```ts
if (this.session.isStreaming || this.session.isCompacting) {
    this.#scheduleGoalContinuation();
    return;
}
```

## Tests

Added two regression tests in `test/goals/goal-mode-integration.test.ts`:
- orphan/wedge path (`isStreaming` stuck true)
- compaction path (`isCompacting` true)

Each asserts zero continuation submissions while busy, then resumption once idle. Verified both fail without their respective guard branch and pass with the fix. Lint clean; `goal-mode-integration` suite: 15/15 pass.