### PR TITLE
fix(model-registry): canonical MiniMax-M3 display casing for referenced custom models (#614)

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -910,7 +910,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 	const output = resolvedModel.output ?? reference?.output;
 	return enrichModelThinking({
 		id: resolvedModel.id,
-		name: resolvedModel.name ?? (options.useDefaults ? resolvedModel.id : undefined),
+		name: resolvedModel.name ?? reference?.name ?? (options.useDefaults ? resolvedModel.id : undefined),
 		api: resolvedModel.api,
 		provider: resolvedModel.provider,
 		baseUrl: resolvedModel.baseUrl,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1309,6 +1309,10 @@ describe("ModelRegistry", () => {
 			const glm = registry.find("glm-proxy", "glm-4.6");
 
 			expect(minimax?.api).toBe("openai-completions");
+			// #614: preset-onboarded models inherit the bundled canonical display
+			// name (MiniMax-M3) while preserving the lowercase machine id.
+			expect(minimax?.id).toBe("minimax-m3");
+			expect(minimax?.name).toBe("MiniMax-M3");
 			expect(minimax?.baseUrl).toBe("https://api.minimax.io/v1");
 			expect(getOpenAICompat(minimax)?.supportsStore).toBe(false);
 			expect(getOpenAICompat(minimax)?.reasoningContentField).toBe("reasoning_content");
@@ -1316,6 +1320,26 @@ describe("ModelRegistry", () => {
 			expect(glm?.baseUrl).toBe("https://api.z.ai/api/paas/v4");
 			expect(getOpenAICompat(glm)?.thinkingFormat).toBe("zai");
 			expect(getOpenAICompat(glm)?.supportsReasoningEffort).toBe(false);
+		});
+
+		test("#614: custom provider referencing a bundled model id inherits canonical display name", () => {
+			// A user-defined provider whose name does not match a bundled provider but
+			// references a bundled model id (e.g. the documented `minimax-custom` proxy
+			// with `id: minimax-m3` and no explicit name). It must surface the canonical
+			// `MiniMax-M3` display casing while keeping the lowercase machine id.
+			writeRawModelsJson({
+				"minimax-custom": {
+					baseUrl: "https://api.minimax.io/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-completions",
+					models: [{ id: "minimax-m3" }],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("minimax-custom", "minimax-m3");
+			expect(model?.id).toBe("minimax-m3");
+			expect(model?.name).toBe("MiniMax-M3");
 		});
 
 		test("same-id replacement uses configured compat without bundled compat leak", () => {


### PR DESCRIPTION
## Summary

Closes #614.

`minimax-m3` should surface as the canonical `MiniMax-M3` in user-visible model-name surfaces, while machine-facing slugs stay lowercase.

Bundled MiniMax providers already ship `name: "MiniMax-M3"`, and preset onboarding (`minimax-code` / `minimax-code-cn`) inherits it through the bundled-provider merge. The remaining gap was **custom providers that reference a bundled model id without an explicit name** — e.g. a `minimax-custom` proxy with `models: [{ id: "minimax-m3" }]`. These fell through `finalizeCustomModel`'s name fallback straight to the raw lowercase id, so the display name read `minimax-m3`.

## Change

`finalizeCustomModel` now falls back to the resolved bundled reference's `name` before the raw id:

```ts
name: resolvedModel.name ?? reference?.name ?? (options.useDefaults ? resolvedModel.id : undefined)
```

This mirrors how `cost`, `contextWindow`, `input`, etc. already inherit from the bundled reference. The effect is scoped to custom models whose id matches a bundled model and that lack an explicit name — machine slugs (`id`) are untouched.

## Tests

- `packages/coding-agent/test/model-registry.test.ts` (117 pass): adds a `#614` case for a custom provider referencing a bundled model id (expects `id: minimax-m3`, `name: MiniMax-M3`) and tightens the preset-onboarding assertion to verify the same.
- `provider-onboarding.test.ts`, `provider-slash-command.test.ts`, `model-profile-activation.test.ts` (29 pass): regression check on shared onboarding/model paths.
- Biome check clean on both changed files; LSP diagnostics clean.

Note: one unrelated test (`OPENAI_API_KEY supplies env auth for bundled OpenAI models only`) fails only when a real `OPENAI_API_KEY` leaks from the shell env; it passes with the var unset and is not touched by this change.

Do not merge.