### PR TITLE
fix(rpc,file-lock): safe fast-lane allowlist + GC owner-token TOCTOU guard (#606)

### DIFF
--- a/packages/coding-agent/src/config/file-lock-gc.ts
+++ b/packages/coding-agent/src/config/file-lock-gc.ts
@@ -171,8 +171,19 @@ export const fileLocksGcAdapter: GcStoreAdapter = {
 			return { removed: false, skipped: "lock_no_longer_dead_or_missing" };
 		}
 
+		// Fail-closed owner-token guard (#606): we observed `info` (pid+timestamp)
+		// dead, but a fresh owner can reclaim a stale lock dir at this same path
+		// between the probe above and the unlink below. Pass the exact owner token
+		// so removal re-verifies the on-disk identity under the unlink and refuses
+		// to delete a recreated LIVE lock (TOCTOU).
 		try {
-			await removeFileLockDirForGc(lockDir);
+			const removal = await removeFileLockDirForGc(lockDir, info);
+			if (removal === "owner_changed") {
+				return { removed: false, skipped: "file_lock_owner_changed_before_delete" };
+			}
+			if (removal === "missing") {
+				return { removed: false, skipped: "lock_no_longer_dead_or_missing" };
+			}
 			return { removed: true };
 		} catch (error) {
 			return { removed: false, error: errorMessage(error) };

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -45,9 +45,42 @@ export async function readFileLockInfoForGc(lockDir: string): Promise<{ pid: num
 	return info;
 }
 
-/** @internal */
-export async function removeFileLockDirForGc(lockDir: string): Promise<void> {
+/** Owner identity stamped into a `<file>.lock/info` record. */
+export interface FileLockOwnerToken {
+	pid: number;
+	timestamp: number;
+}
+
+/** Outcome of a guarded GC removal attempt (`removeFileLockDirForGc`). */
+export type FileLockGcRemoval = "removed" | "owner_changed" | "missing";
+
+/**
+ * @internal
+ * Fail-closed removal of a dead lock dir for GC. Re-reads the on-disk owner
+ * token as close to the unlink as possible and only deletes the dir when it
+ * STILL holds the exact `{pid, timestamp}` identity the caller observed dead.
+ *
+ * Closes the prune-time TOCTOU window (#606): between GC's dead re-read/probe
+ * and the unlink, a live process can reclaim a stale lock at the same path
+ * (`acquireLock` rms the stale dir, then re-`mkdir`s and rewrites `info` with a
+ * fresh pid+timestamp). Deleting by path alone would reap that LIVE lock. Any
+ * mismatch (`owner_changed`) or absent/unreadable info (`missing` — e.g. a
+ * fresh acquirer between `mkdir` and `writeLockInfo`) refuses the delete and
+ * leaves the dir intact. POSIX has no atomic compare-and-delete for a
+ * directory, so the residual read->unlink window cannot be fully eliminated,
+ * but the reclaim-after-stale scenario the issue describes is now guarded.
+ */
+export async function removeFileLockDirForGc(
+	lockDir: string,
+	expected: FileLockOwnerToken,
+): Promise<FileLockGcRemoval> {
+	const current = await readLockInfo(lockDir);
+	if (!current) return "missing";
+	if (current.pid !== expected.pid || current.timestamp !== expected.timestamp) {
+		return "owner_changed";
+	}
 	await fs.rm(lockDir, { recursive: true, force: true });
+	return "removed";
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -82,6 +82,88 @@ export function shouldEmitRpcTitlesForTest(): boolean {
 
 const shouldEmitRpcTitles = shouldEmitRpcTitlesForTest;
 
+/**
+ * Cancellation commands bypass the ordered serial chain because they must
+ * interrupt in-flight work — they cannot wait behind the very command they are
+ * meant to abort.
+ */
+export const RPC_CANCELLATION_COMMANDS: ReadonlySet<RpcCommand["type"]> = new Set<RpcCommand["type"]>([
+	"abort",
+	"abort_bash",
+	"abort_retry",
+]);
+
+/**
+ * Safe read/control commands that also bypass the ordered serial chain so they
+ * never head-of-line-block behind a long-running ordered command like
+ * `bash`/`compact`/`handoff`/`login` (#606, issue 13 — the partial fix only
+ * fast-laned cancellation).
+ *
+ * Every command listed here has a dispatch handler that is **fully synchronous**:
+ * on the single-threaded event loop it runs to completion between the await
+ * points of any in-flight ordered command, so it can neither observe torn state
+ * nor mutate state mid-operation. Each is additionally either a pure live-state
+ * read or a control-flag setter that only affects *future* turns — never the
+ * in-flight command it jumps ahead of. Mutually they preserve arrival order
+ * (synchronous handlers run in the read loop's order), and every mutating
+ * command still returns its own response, so a client that needs read-your-writes
+ * awaits that response rather than a racing read.
+ *
+ * Deliberately excluded (kept ordered): every async/long command (`prompt`,
+ * `steer`, `follow_up`, `abort_and_prompt`, `bash`, `compact`, `handoff`,
+ * `login`, `new_session`, `switch_session`, `branch`, `export_html`,
+ * `set_session_name`, `set_host_tools`, `set_host_uri_schemes`) and causally
+ * significant async mutations (`set_model`, `cycle_model`, `set_todos`,
+ * `negotiate_unattended`, `workflow_gate_response`). New commands default to the
+ * ordered chain (fail-safe).
+ */
+export const RPC_SAFE_READ_CONTROL_COMMANDS: ReadonlySet<RpcCommand["type"]> = new Set<RpcCommand["type"]>([
+	// Pure synchronous reads — return a live snapshot at processing time.
+	"get_state",
+	"get_session_stats",
+	"get_available_models",
+	"get_branch_messages",
+	"get_last_assistant_text",
+	"get_messages",
+	"get_login_providers",
+	// Synchronous control-flag setters — affect only subsequent turns.
+	"set_thinking_level",
+	"cycle_thinking_level",
+	"set_steering_mode",
+	"set_follow_up_mode",
+	"set_interrupt_mode",
+	"set_auto_compaction",
+	"set_auto_retry",
+]);
+
+/** True when a command may bypass the ordered serial chain and run immediately. */
+export function isFastLaneRpcCommand(type: RpcCommand["type"]): boolean {
+	return RPC_CANCELLATION_COMMANDS.has(type) || RPC_SAFE_READ_CONTROL_COMMANDS.has(type);
+}
+
+/**
+ * Schedules inbound RPC commands: fast-lane commands run immediately while
+ * everything else runs through a serial chain so causal order is preserved. The
+ * read loop never blocks, which is what lets a fast-lane command reach a
+ * long-running ordered command instead of being head-of-line-blocked behind it.
+ */
+export function createRpcCommandScheduler(
+	run: (command: RpcCommand) => Promise<void>,
+	track: (task: Promise<void>) => void,
+): { dispatch: (command: RpcCommand) => void } {
+	let orderedChain: Promise<void> = Promise.resolve();
+	return {
+		dispatch(command: RpcCommand): void {
+			if (isFastLaneRpcCommand(command.type)) {
+				track(run(command));
+				return;
+			}
+			orderedChain = orderedChain.then(() => run(command));
+			track(orderedChain);
+		},
+	};
+}
+
 function auditOutcomeFor(event: string): "accepted" | "rejected" | "denied" | "exceeded" | "aborted" | "info" {
 	if (event.includes("denied")) return "denied";
 	if (event.includes("exceeded")) return "exceeded";
@@ -558,14 +640,13 @@ export async function runRpcMode(
 			unattendedControlPlane,
 		});
 
-	// Cancellation commands must interrupt in-flight work, so they bypass the ordered
-	// queue and run immediately. Everything else runs through a serial chain so causal
-	// order is preserved (e.g. `get_state` after `bash` still observes the bash result)
-	// while the read loop itself never blocks — that is what lets a cancellation command
-	// reach a long-running `bash`/`compact`/`handoff`/`login` instead of being
-	// head-of-line-blocked behind it (issue 13).
-	const CANCELLATION_COMMANDS = new Set<RpcCommand["type"]>(["abort", "abort_bash", "abort_retry"]);
-	let orderedChain: Promise<void> = Promise.resolve();
+	// Fast-lane commands (cancellation + safe read/control, see
+	// isFastLaneRpcCommand) bypass the ordered serial chain and run immediately;
+	// everything else runs through a serial chain so causal order is preserved
+	// (e.g. an ordered `set_model` after `bash` still applies after the bash
+	// result) while the read loop itself never blocks — that is what lets a
+	// fast-lane command reach a long-running `bash`/`compact`/`handoff`/`login`
+	// instead of being head-of-line-blocked behind it (issue 13).
 	const runCommand = async (command: RpcCommand): Promise<void> => {
 		try {
 			output(await handleCommand(command));
@@ -577,14 +658,7 @@ export async function runRpcMode(
 		inFlightCommands.add(task);
 		void task.finally(() => inFlightCommands.delete(task));
 	};
-	const dispatchCommand = (command: RpcCommand): void => {
-		if (CANCELLATION_COMMANDS.has(command.type)) {
-			trackCommand(runCommand(command));
-			return;
-		}
-		orderedChain = orderedChain.then(() => runCommand(command));
-		trackCommand(orderedChain);
-	};
+	const { dispatch: dispatchCommand } = createRpcCommandScheduler(runCommand, trackCommand);
 
 	/**
 	 * Check if shutdown was requested and perform shutdown if so.

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -94,31 +94,33 @@ export const RPC_CANCELLATION_COMMANDS: ReadonlySet<RpcCommand["type"]> = new Se
 ]);
 
 /**
- * Safe read/control commands that also bypass the ordered serial chain so they
- * never head-of-line-block behind a long-running ordered command like
+ * Safe read-only commands that bypass the ordered serial chain so they never
+ * head-of-line-block behind a long-running ordered command like
  * `bash`/`compact`/`handoff`/`login` (#606, issue 13 — the partial fix only
  * fast-laned cancellation).
  *
- * Every command listed here has a dispatch handler that is **fully synchronous**:
- * on the single-threaded event loop it runs to completion between the await
- * points of any in-flight ordered command, so it can neither observe torn state
- * nor mutate state mid-operation. Each is additionally either a pure live-state
- * read or a control-flag setter that only affects *future* turns — never the
- * in-flight command it jumps ahead of. Mutually they preserve arrival order
- * (synchronous handlers run in the read loop's order), and every mutating
- * command still returns its own response, so a client that needs read-your-writes
- * awaits that response rather than a racing read.
+ * Every command listed here has a dispatch handler that is **fully synchronous
+ * and side-effect-free**: on the single-threaded event loop it runs to
+ * completion between the await points of any in-flight ordered command, reading
+ * live state without mutating it. Because such a read performs no causal write,
+ * jumping ahead of an earlier *queued* ordered command is observably harmless —
+ * there is no state change to reorder. Read payloads are additionally
+ * snapshotted inside the handler (e.g. `get_messages` returns a shallow copy of
+ * `session.messages`) so a fast-lane read can never serialize a half-mutated
+ * array that an ordered turn/compaction is rewriting in place.
  *
- * Deliberately excluded (kept ordered): every async/long command (`prompt`,
- * `steer`, `follow_up`, `abort_and_prompt`, `bash`, `compact`, `handoff`,
- * `login`, `new_session`, `switch_session`, `branch`, `export_html`,
- * `set_session_name`, `set_host_tools`, `set_host_uri_schemes`) and causally
- * significant async mutations (`set_model`, `cycle_model`, `set_todos`,
- * `negotiate_unattended`, `workflow_gate_response`). New commands default to the
- * ordered chain (fail-safe).
+ * Deliberately excluded (kept ordered): every async/long command and every
+ * mutating command. In particular the control-flag setters (`set_thinking_level`,
+ * `cycle_thinking_level`, `set_steering_mode`, `set_follow_up_mode`,
+ * `set_interrupt_mode`, `set_auto_compaction`, `set_auto_retry`) stay ordered.
+ * Their handlers are synchronous, so fast-laning one ahead of an already-queued
+ * `prompt`/`bash` would apply the new mode *before* that earlier command runs —
+ * the earlier command would then observe the later setter's value, a
+ * causal-order (arrival-order) regression. Mutations therefore stay on the
+ * chain, and new command types default to ordered (fail-safe).
  */
 export const RPC_SAFE_READ_CONTROL_COMMANDS: ReadonlySet<RpcCommand["type"]> = new Set<RpcCommand["type"]>([
-	// Pure synchronous reads — return a live snapshot at processing time.
+	// Pure synchronous reads — snapshot live state at processing time, never mutate.
 	"get_state",
 	"get_session_stats",
 	"get_available_models",
@@ -126,14 +128,6 @@ export const RPC_SAFE_READ_CONTROL_COMMANDS: ReadonlySet<RpcCommand["type"]> = n
 	"get_last_assistant_text",
 	"get_messages",
 	"get_login_providers",
-	// Synchronous control-flag setters — affect only subsequent turns.
-	"set_thinking_level",
-	"cycle_thinking_level",
-	"set_steering_mode",
-	"set_follow_up_mode",
-	"set_interrupt_mode",
-	"set_auto_compaction",
-	"set_auto_retry",
 ]);
 
 /** True when a command may bypass the ordered serial chain and run immediately. */

--- a/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
@@ -363,7 +363,10 @@ export async function dispatchRpcCommand(
 			}
 
 			case "get_messages": {
-				return rpcSuccess(id, "get_messages", { messages: session.messages });
+				// Fast-lane read: snapshot the live array so a concurrent ordered
+				// turn/compaction mutating session.messages in place cannot make this
+				// response serialize a half-rewritten array (#606, issue 13).
+				return rpcSuccess(id, "get_messages", { messages: [...session.messages] });
 			}
 
 			case "get_login_providers": {

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeFileLockDirForGc } from "@gajae-code/coding-agent/config/file-lock";
+import { fileLocksGcAdapter } from "@gajae-code/coding-agent/config/file-lock-gc";
+import type { GcContext, GcPidProbe, GcRecord } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+
+const DEAD_PID = 525_252;
+const LIVE_PID = 636_363;
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTemp(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "file-lock-toctou-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function writeInfo(lockDir: string, info: { pid: number; timestamp: number }): Promise<void> {
+	await fs.mkdir(lockDir, { recursive: true });
+	await fs.writeFile(path.join(lockDir, "info"), JSON.stringify(info), "utf8");
+}
+
+function ctxWith(spoolDir: string, probe: GcPidProbe): GcContext {
+	return {
+		probe,
+		force: false,
+		env: { ...process.env, GJC_RECEIPT_SPOOL_DIR: spoolDir },
+		cwd: spoolDir,
+	};
+}
+
+function deadLockRecord(lockDir: string): GcRecord {
+	return {
+		store: "file_locks",
+		id: lockDir,
+		path: lockDir,
+		pid: DEAD_PID,
+		pid_status: "dead",
+		status: "dead",
+		stale: true,
+		removable: true,
+		action: "none",
+		reason: "file_lock_owner_pid_dead",
+	};
+}
+
+describe("removeFileLockDirForGc owner-token guard (#606)", () => {
+	test("removes the dir when the on-disk token matches the expected owner", async () => {
+		const base = await makeTemp();
+		const lockDir = path.join(base, "match.lock");
+		const token = { pid: DEAD_PID, timestamp: 1000 };
+		await writeInfo(lockDir, token);
+
+		const outcome = await removeFileLockDirForGc(lockDir, token);
+
+		expect(outcome).toBe("removed");
+		expect(await fs.exists(lockDir)).toBe(false);
+	});
+
+	test("refuses (owner_changed) when a live owner has reclaimed the same path", async () => {
+		const base = await makeTemp();
+		const lockDir = path.join(base, "reclaimed.lock");
+		// On disk: a fresh live owner (different pid + timestamp).
+		await writeInfo(lockDir, { pid: LIVE_PID, timestamp: 2000 });
+
+		// Expected: the dead owner the GC observed earlier.
+		const outcome = await removeFileLockDirForGc(lockDir, { pid: DEAD_PID, timestamp: 1000 });
+
+		expect(outcome).toBe("owner_changed");
+		expect(await fs.exists(lockDir)).toBe(true);
+		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
+		expect(onDisk.pid).toBe(LIVE_PID);
+	});
+
+	test("refuses (owner_changed) when only the timestamp differs (same pid reused)", async () => {
+		const base = await makeTemp();
+		const lockDir = path.join(base, "ts.lock");
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: 9999 });
+
+		const outcome = await removeFileLockDirForGc(lockDir, { pid: DEAD_PID, timestamp: 1000 });
+
+		expect(outcome).toBe("owner_changed");
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("refuses (missing) when the info file is absent (fresh acquirer mid-mkdir)", async () => {
+		const base = await makeTemp();
+		const lockDir = path.join(base, "noinfo.lock");
+		await fs.mkdir(lockDir, { recursive: true });
+
+		const outcome = await removeFileLockDirForGc(lockDir, { pid: DEAD_PID, timestamp: 1000 });
+
+		expect(outcome).toBe("missing");
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+});
+
+describe("fileLocksGcAdapter.prune TOCTOU (#606)", () => {
+	test("prunes a genuinely dead lock (happy path still works)", async () => {
+		const base = await makeTemp();
+		const spoolDir = path.join(base, "spool");
+		const lockDir = path.join(spoolDir, "dead.lock");
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: 1000 });
+		const probe: GcPidProbe = pid => (pid === DEAD_PID ? { status: "dead" } : { status: "keep", reason: "alive" });
+
+		const outcome = await fileLocksGcAdapter.prune(deadLockRecord(lockDir), ctxWith(spoolDir, probe));
+
+		expect(outcome.removed).toBe(true);
+		expect(outcome.skipped).toBeUndefined();
+		expect(await fs.exists(lockDir)).toBe(false);
+	});
+
+	test("fails closed when a live owner reclaims the stale lock between probe and unlink", async () => {
+		const base = await makeTemp();
+		const spoolDir = path.join(base, "spool");
+		const lockDir = path.join(spoolDir, "race.lock");
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: 1000 });
+
+		// The probe reports DEAD (so prune proceeds toward deletion) but, as a
+		// side effect, simulates a live owner reclaiming the stale dir at the same
+		// path with a fresh identity — exactly the probe -> unlink TOCTOU window.
+		let reclaimed = false;
+		const racingProbe: GcPidProbe = pid => {
+			if (pid === DEAD_PID && !reclaimed) {
+				reclaimed = true;
+				writeFileSync(path.join(lockDir, "info"), JSON.stringify({ pid: LIVE_PID, timestamp: 2000 }));
+			}
+			return pid === DEAD_PID ? { status: "dead" } : { status: "keep", reason: "alive" };
+		};
+
+		const outcome = await fileLocksGcAdapter.prune(deadLockRecord(lockDir), ctxWith(spoolDir, racingProbe));
+
+		expect(outcome.removed).toBe(false);
+		expect(outcome.skipped).toBe("file_lock_owner_changed_before_delete");
+		// The freshly recreated LIVE lock must survive untouched.
+		expect(await fs.exists(lockDir)).toBe(true);
+		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
+		expect(onDisk.pid).toBe(LIVE_PID);
+		expect(onDisk.timestamp).toBe(2000);
+	});
+});

--- a/packages/coding-agent/test/rpc-fastlane.test.ts
+++ b/packages/coding-agent/test/rpc-fastlane.test.ts
@@ -6,13 +6,18 @@ import {
 	RPC_SAFE_READ_CONTROL_COMMANDS,
 } from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
 import type { RpcCommand } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
+import {
+	dispatchRpcCommand,
+	type RpcCommandDispatchContext,
+} from "@gajae-code/coding-agent/modes/shared/agent-wire/command-dispatch";
+import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 
 const FAST_LANE_COMMANDS: RpcCommand["type"][] = [
 	// Cancellation (must interrupt in-flight work).
 	"abort",
 	"abort_bash",
 	"abort_retry",
-	// Pure synchronous reads.
+	// Pure read-only snapshots (no causal write to reorder).
 	"get_state",
 	"get_session_stats",
 	"get_available_models",
@@ -20,18 +25,13 @@ const FAST_LANE_COMMANDS: RpcCommand["type"][] = [
 	"get_last_assistant_text",
 	"get_messages",
 	"get_login_providers",
-	// Synchronous control-flag setters.
-	"set_thinking_level",
-	"cycle_thinking_level",
-	"set_steering_mode",
-	"set_follow_up_mode",
-	"set_interrupt_mode",
-	"set_auto_compaction",
-	"set_auto_retry",
 ];
 
-// Commands that MUST stay on the ordered serial chain: async/long work or
-// causally significant async mutations.
+// Commands that MUST stay on the ordered serial chain: async/long work, causally
+// significant async mutations, or synchronous mutating mode/config setters. The
+// setters are kept ordered because a fast-laned setter could overtake an
+// already-queued ordered command (e.g. a prompt submitted before it) and change
+// that command's causal semantics (#618 review).
 const ORDERED_COMMANDS: RpcCommand["type"][] = [
 	"prompt",
 	"steer",
@@ -53,6 +53,14 @@ const ORDERED_COMMANDS: RpcCommand["type"][] = [
 	"export_html",
 	"negotiate_unattended",
 	"workflow_gate_response",
+	// Mutating mode/config setters — causally significant, must not fast-lane.
+	"set_thinking_level",
+	"cycle_thinking_level",
+	"set_steering_mode",
+	"set_follow_up_mode",
+	"set_interrupt_mode",
+	"set_auto_compaction",
+	"set_auto_retry",
 ];
 
 const flushMicrotasks = async (): Promise<void> => {
@@ -80,6 +88,28 @@ describe("RPC fast-lane classification (#606, issue 13)", () => {
 		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("set_model")).toBe(false);
 		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("cycle_model")).toBe(false);
 		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("set_todos")).toBe(false);
+	});
+
+	test("mutating mode/config setters stay ordered (#618 causal-order regression)", () => {
+		const mutatingSetters: RpcCommand["type"][] = [
+			"set_thinking_level",
+			"cycle_thinking_level",
+			"set_steering_mode",
+			"set_follow_up_mode",
+			"set_interrupt_mode",
+			"set_auto_compaction",
+			"set_auto_retry",
+		];
+		for (const type of mutatingSetters) {
+			expect(RPC_SAFE_READ_CONTROL_COMMANDS.has(type)).toBe(false);
+			expect(isFastLaneRpcCommand(type)).toBe(false);
+		}
+	});
+
+	test("the safe read set is read-only (no set_/cycle_ mutating command leaks in)", () => {
+		for (const type of RPC_SAFE_READ_CONTROL_COMMANDS) {
+			expect(type.startsWith("get_")).toBe(true);
+		}
 	});
 
 	test("classification is exhaustive — fast-lane and ordered partition every command type", () => {
@@ -147,6 +177,39 @@ describe("createRpcCommandScheduler ordering behavior", () => {
 		expect(order).toEqual(["bash", "set_model"]);
 	});
 
+	test("a mutating setter does not overtake an earlier queued ordered command (#618)", async () => {
+		const order: string[] = [];
+		let releaseLong: () => void = () => {};
+		const longRunning = new Promise<void>(resolve => {
+			releaseLong = resolve;
+		});
+		const run = async (command: RpcCommand): Promise<void> => {
+			if (command.type === "bash") {
+				await longRunning;
+				order.push("bash");
+				return;
+			}
+			order.push(command.type);
+		};
+		const { dispatch } = createRpcCommandScheduler(run, () => {});
+
+		// Arrival order is the hazard from the review: a long bash holds the chain,
+		// a prompt is queued behind it, then a setter arrives. The setter must NOT
+		// jump ahead and apply before the earlier prompt runs.
+		dispatch({ type: "bash", command: "sleep 1000" } as RpcCommand);
+		dispatch({ type: "prompt", message: "hi" } as RpcCommand);
+		dispatch({ type: "set_thinking_level", level: "high" } as RpcCommand);
+		await flushMicrotasks();
+		// Nothing runs while bash holds the chain — the setter cannot fast-lane.
+		expect(order).toEqual([]);
+
+		releaseLong();
+		await flushMicrotasks();
+		// The setter applies strictly AFTER the earlier queued prompt, so the prompt
+		// runs under the pre-setter mode (arrival-order / causal semantics preserved).
+		expect(order).toEqual(["bash", "prompt", "set_thinking_level"]);
+	});
+
 	test("every dispatched task is tracked for shutdown draining", async () => {
 		const tracked: Promise<void>[] = [];
 		const run = async (): Promise<void> => {};
@@ -158,5 +221,35 @@ describe("createRpcCommandScheduler ordering behavior", () => {
 		dispatch({ type: "bash", command: "x" } as RpcCommand); // ordered
 		expect(tracked).toHaveLength(2);
 		await Promise.allSettled(tracked);
+	});
+});
+
+describe("get_messages fast-lane snapshot (#618)", () => {
+	const ctx = (session: Partial<AgentSession>): RpcCommandDispatchContext => ({
+		session: session as AgentSession,
+		output: () => {},
+		hostToolRegistry: { setTools: () => [] },
+		hostUriRegistry: { setSchemes: () => [] },
+		createUiContext: () => ({ notify: () => {} }),
+	});
+
+	test("returns a defensive copy, not the live session.messages array", async () => {
+		const live = [
+			{ role: "user", content: "a" },
+			{ role: "assistant", content: "b" },
+		] as unknown as AgentSession["messages"];
+		const res = await dispatchRpcCommand({ id: "m1", type: "get_messages" } as RpcCommand, ctx({ messages: live }));
+		expect(res.success).toBe(true);
+		if (!res.success || res.command !== "get_messages") throw new Error("expected get_messages success");
+		const returned = res.data.messages;
+
+		// A snapshot: equal contents but a distinct array reference.
+		expect(returned).not.toBe(live);
+		expect(returned).toEqual(live);
+
+		// Mutating the live array after the read (as an ordered turn/compaction
+		// would) must not retroactively change the already-returned snapshot.
+		live.push({ role: "user", content: "c" } as unknown as (typeof live)[number]);
+		expect(returned).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/rpc-fastlane.test.ts
+++ b/packages/coding-agent/test/rpc-fastlane.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createRpcCommandScheduler,
+	isFastLaneRpcCommand,
+	RPC_CANCELLATION_COMMANDS,
+	RPC_SAFE_READ_CONTROL_COMMANDS,
+} from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
+import type { RpcCommand } from "@gajae-code/coding-agent/modes/rpc/rpc-types";
+
+const FAST_LANE_COMMANDS: RpcCommand["type"][] = [
+	// Cancellation (must interrupt in-flight work).
+	"abort",
+	"abort_bash",
+	"abort_retry",
+	// Pure synchronous reads.
+	"get_state",
+	"get_session_stats",
+	"get_available_models",
+	"get_branch_messages",
+	"get_last_assistant_text",
+	"get_messages",
+	"get_login_providers",
+	// Synchronous control-flag setters.
+	"set_thinking_level",
+	"cycle_thinking_level",
+	"set_steering_mode",
+	"set_follow_up_mode",
+	"set_interrupt_mode",
+	"set_auto_compaction",
+	"set_auto_retry",
+];
+
+// Commands that MUST stay on the ordered serial chain: async/long work or
+// causally significant async mutations.
+const ORDERED_COMMANDS: RpcCommand["type"][] = [
+	"prompt",
+	"steer",
+	"follow_up",
+	"abort_and_prompt",
+	"new_session",
+	"switch_session",
+	"branch",
+	"bash",
+	"compact",
+	"handoff",
+	"login",
+	"set_model",
+	"cycle_model",
+	"set_todos",
+	"set_session_name",
+	"set_host_tools",
+	"set_host_uri_schemes",
+	"export_html",
+	"negotiate_unattended",
+	"workflow_gate_response",
+];
+
+const flushMicrotasks = async (): Promise<void> => {
+	for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+
+describe("RPC fast-lane classification (#606, issue 13)", () => {
+	test("every fast-lane command is recognized", () => {
+		for (const type of FAST_LANE_COMMANDS) {
+			expect(isFastLaneRpcCommand(type)).toBe(true);
+		}
+	});
+
+	test("ordered commands never fast-lane (fail-safe default)", () => {
+		for (const type of ORDERED_COMMANDS) {
+			expect(isFastLaneRpcCommand(type)).toBe(false);
+		}
+	});
+
+	test("the cancellation set is exactly the three abort commands", () => {
+		expect([...RPC_CANCELLATION_COMMANDS].sort()).toEqual(["abort", "abort_bash", "abort_retry"]);
+	});
+
+	test("set_model / cycle_model / set_todos stay ordered (causal mutations)", () => {
+		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("set_model")).toBe(false);
+		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("cycle_model")).toBe(false);
+		expect(RPC_SAFE_READ_CONTROL_COMMANDS.has("set_todos")).toBe(false);
+	});
+
+	test("classification is exhaustive — fast-lane and ordered partition every command type", () => {
+		const all = new Set<RpcCommand["type"]>([...FAST_LANE_COMMANDS, ...ORDERED_COMMANDS]);
+		// No command may appear in both lists.
+		expect(FAST_LANE_COMMANDS.filter(t => ORDERED_COMMANDS.includes(t))).toEqual([]);
+		// Guards against a new command type silently slipping through untested.
+		expect(all.size).toBe(FAST_LANE_COMMANDS.length + ORDERED_COMMANDS.length);
+	});
+});
+
+describe("createRpcCommandScheduler ordering behavior", () => {
+	test("a fast-lane read does not head-of-line-block behind a long ordered command", async () => {
+		const order: string[] = [];
+		let releaseLong: () => void = () => {};
+		const longRunning = new Promise<void>(resolve => {
+			releaseLong = resolve;
+		});
+		const run = async (command: RpcCommand): Promise<void> => {
+			if (command.type === "bash") {
+				await longRunning;
+				order.push("bash");
+				return;
+			}
+			order.push(command.type);
+		};
+		const { dispatch } = createRpcCommandScheduler(run, () => {});
+
+		dispatch({ type: "bash", command: "sleep 1000" } as RpcCommand);
+		dispatch({ type: "get_state" } as RpcCommand);
+		await flushMicrotasks();
+
+		// get_state ran immediately while the long bash is still blocked.
+		expect(order).toEqual(["get_state"]);
+
+		releaseLong();
+		await flushMicrotasks();
+		expect(order).toEqual(["get_state", "bash"]);
+	});
+
+	test("ordered commands behind a long command preserve arrival order", async () => {
+		const order: string[] = [];
+		let releaseLong: () => void = () => {};
+		const longRunning = new Promise<void>(resolve => {
+			releaseLong = resolve;
+		});
+		const run = async (command: RpcCommand): Promise<void> => {
+			if (command.type === "bash") {
+				await longRunning;
+				order.push("bash");
+				return;
+			}
+			order.push(command.type);
+		};
+		const { dispatch } = createRpcCommandScheduler(run, () => {});
+
+		dispatch({ type: "bash", command: "sleep 1000" } as RpcCommand);
+		// set_model is an ordered mutation: it must wait for the in-flight bash.
+		dispatch({ type: "set_model", provider: "p", modelId: "m" } as RpcCommand);
+		await flushMicrotasks();
+		expect(order).toEqual([]);
+
+		releaseLong();
+		await flushMicrotasks();
+		expect(order).toEqual(["bash", "set_model"]);
+	});
+
+	test("every dispatched task is tracked for shutdown draining", async () => {
+		const tracked: Promise<void>[] = [];
+		const run = async (): Promise<void> => {};
+		const { dispatch } = createRpcCommandScheduler(run, task => {
+			tracked.push(task);
+		});
+
+		dispatch({ type: "get_state" } as RpcCommand); // fast-lane
+		dispatch({ type: "bash", command: "x" } as RpcCommand); // ordered
+		expect(tracked).toHaveLength(2);
+		await Promise.allSettled(tracked);
+	});
+});


### PR DESCRIPTION
## Summary

Slice 2 of #606 (post-0.5.0 dogfood/review findings). Slice 1 (#613) landed the unknown-command id, fail-closed token-cost metrics, and `--listen` socket guard. This PR closes the remaining two RPC-control-plane items:

### RPC safe fast-lane allowlist — issue 13 (completes the partial fix)
The prior fast-lane only bypassed cancellation (`abort`/`abort_bash`/`abort_retry`). Safe read/control commands (`get_state`, the other `get_*` reads, and the thinking/steering/follow-up/interrupt/auto-compaction/auto-retry setters) still head-of-line-blocked behind a long-running ordered command (`bash`/`compact`/`handoff`/`login`).

- Extracts explicit allowlists `RPC_CANCELLATION_COMMANDS` + `RPC_SAFE_READ_CONTROL_COMMANDS` and a `createRpcCommandScheduler`.
- Fast-lane commands run immediately; every async/causally-significant command (`prompt`, `steer`, `set_model`, `set_todos`, `negotiate_unattended`, `workflow_gate_response`, …) stays on the ordered serial chain.
- New command types default to ordered (fail-safe). Each fast-laned command has a fully synchronous handler, so it can neither observe torn state nor mutate in-flight state.

### file-lock GC owner-token TOCTOU guard
`prune` deleted a dead lock dir **by path** after a dead re-read/probe, so a live process reclaiming a stale lock at the same path between probe and unlink could be reaped.

- `removeFileLockDirForGc` now re-reads the on-disk `{pid,timestamp}` as close to the unlink as possible and only deletes when it still matches the observed-dead owner.
- Mismatch → `owner_changed`; absent/unreadable info → `missing`; both refuse the delete and leave the dir intact.
- POSIX has no atomic compare-and-delete for a directory, so the residual read→unlink window cannot be fully eliminated, but the reclaim-after-stale scenario the issue describes is now guarded.

## Tests
- `test/rpc-fastlane.test.ts` — fast-lane/ordered classification (exhaustive partition) + scheduler ordering (fast-lane read jumps ahead of a blocked `bash`; ordered commands preserve arrival order; tasks tracked for shutdown drain).
- `test/file-lock-gc-toctou.test.ts` — owner-token guard (match/owner_changed/missing) + `fileLocksGcAdapter.prune` happy-path and reclaim race.
- `bun test` (both files): **14 pass / 0 fail**. `biome check` clean. `tsgo --noEmit` clean.

Relates to #606. Does not merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
