### PR TITLE
test(gjc-runtime): normalize macOS tmpdir realpath in nested-worktree assertion

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -116,7 +116,7 @@ describe("default launch worktrees", () => {
 	});
 
 	it("creates launch worktrees beside the canonical source repo when launched from an existing worktree", async () => {
-		const repo = await createRepo("gjc-launch-nested-source-worktree-");
+		const repo = await fs.realpath(await createRepo("gjc-launch-nested-source-worktree-"));
 		const first = prepareLaunchWorktree(repo, ["--worktree"]);
 		expect(first.worktree.enabled && first.worktree.created).toBe(true);
 


### PR DESCRIPTION
## What

On macOS, `os.tmpdir()` returns `/var/folders/...` (a symlink to `/private/var/folders/...`). The nested-worktree test compares the repo path against `git rev-parse --show-toplevel` (canonical form), causing a path mismatch.

Wrap `createRepo()` in `fs.realpath()` to canonicalize the temp path before the direct `.toBe(repo)` comparison on line 130.

## Why

`/var` is a symlink to `/private/var` on macOS. `mkdtemp(path.join(tmpdir(), ...))` returns the symlinked form, while `git rev-parse` returns the canonical form. This is the same class of fix as #459.

The fix is harmless on Linux CI (`/tmp` has no symlink, `fs.realpath` is identity there) — it only affects macOS developer machines.

## Testing

- `bun test test/gjc-runtime/launch-worktree.test.ts` → 9 pass / 0 fail (was 8 pass / 1 fail on macOS)
- `bunx biome check` → clean
- `bun run check:types` → clean

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)