### PR TITLE
chore: replace console.warn with centralized logger in coding-agent

### DIFF
--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { ModeStateSchema, SkillActiveStateSchema } from "../gjc-runtime/state-schema";
 import { writeJsonAtomic, writeWorkflowEnvelopeAtomic } from "../gjc-runtime/state-writer";
@@ -221,7 +222,7 @@ function skillStatePath(stateDir: string, sessionId?: string): string {
 }
 
 function warnInvalidState(kind: string, filePath: string, error: string): void {
-	console.warn(`gjc skill-state: invalid ${kind} at ${filePath}: ${error}`);
+	logger.warn(`gjc skill-state: invalid ${kind} at ${filePath}: ${error}`);
 }
 
 async function readValidatedJsonFile<T>(

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import type { AgentTool } from "@gajae-code/agent-core";
+import { logger } from "@gajae-code/utils";
 import { expandApplyPatchToEntries } from "../edit/modes/apply-patch";
 import { ModeStateSchema } from "../gjc-runtime/state-schema";
 import { LocalProtocolHandler, resolveLocalUrlToPath } from "../internal-urls/local-protocol";
@@ -78,7 +79,7 @@ function modeStatePath(cwd: string, skill: string, sessionId?: string): string {
 }
 
 function warnInvalidModeState(filePath: string, error: string): void {
-	console.warn(`gjc skill-state: invalid mode-state at ${filePath}: ${error}`);
+	logger.warn(`gjc skill-state: invalid mode-state at ${filePath}: ${error}`);
 }
 
 async function readValidatedModeState(filePath: string): Promise<ModeState | null> {

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -26,7 +26,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@gajae-code/tui";
-import { prompt, untilAborted } from "@gajae-code/utils";
+import { logger, prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import {
 	formatDeepInterviewSelectorPrompt,
@@ -502,7 +502,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				{ sessionId },
 			);
 		} catch (error) {
-			console.warn(
+			logger.warn(
 				`ask: deep-interview round recording failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}


### PR DESCRIPTION
## What

Replace `console.warn` with `logger.warn` from `@gajae-code/utils` in three `packages/coding-agent/` source files:

- `src/hooks/skill-state.ts` — `warnInvalidState()`
- `src/skill-state/deep-interview-mutation-guard.ts` — `warnInvalidModeState()`
- `src/tools/ask.ts` — deep-interview round recording catch block

## Why

AGENTS.md line 113: "Do not use `console.log`, `console.warn`, or `console.error` in `packages/coding-agent/`; it corrupts TUI rendering. Use the centralized logger."

These `console.warn` calls fire during session initialization and tool execution — paths reachable during interactive TUI mode where direct console output corrupts rendering.

## Testing

- `bunx biome check` on all 3 files → clean
- `bun run check:types` (tsgo) → clean
- `grep -rn "console.warn"` in the 3 files → 0 matches

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)