### PR TITLE
fix(ci): repair biome format deviation in goal-mode-integration test

### DIFF
--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -418,9 +418,7 @@ describe("InteractiveMode goal mode integration", () => {
 			for (let i = 0; i < 5; i++) {
 				vi.advanceTimersByTime(800);
 			}
-			const compactingCalls = startPending.mock.calls.filter(
-				call => call[0]?.customType === "goal-continuation",
-			);
+			const compactingCalls = startPending.mock.calls.filter(call => call[0]?.customType === "goal-continuation");
 			expect(compactingCalls.length).toBe(0);
 
 			// Compaction finished: the re-armed continuation fires.


### PR DESCRIPTION
## What

Collapse a multi-line `.filter()` callback onto a single line in `test/goals/goal-mode-integration.test.ts` (biome autofix).

## Why

`bun check` (`biome check .`) fails on clean `dev` due to a format deviation introduced in #616 (`fix(goal): stop AgentBusyError loop`). The `.filter(call => call[0]?.customType === "goal-continuation")` call fits on one line within biomes print width but was left multi-line.

This is a pure formatting change — no functional difference.

## Testing

- `bunx biome check test/goals/goal-mode-integration.test.ts` → clean (was 1 error)
- `bun run check:types` → clean

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)