### PR TITLE
chore: replace ReturnType<typeof setTimeout> with NodeJS.Timeout

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1532,8 +1532,8 @@ export async function waitForReplayProcessWithTimeout(
 	timeoutMs: number,
 	graceMs = 2000,
 ): Promise<number> {
-	let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-	let graceTimer: ReturnType<typeof setTimeout> | undefined;
+	let timeoutTimer: NodeJS.Timeout | undefined;
+	let graceTimer: NodeJS.Timeout | undefined;
 	const timedOut = Symbol("timedOut");
 	const timeout = new Promise<typeof timedOut>(resolve => {
 		timeoutTimer = setTimeout(() => resolve(timedOut), timeoutMs);

--- a/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
+++ b/packages/coding-agent/src/harness-control-plane/rpc-adapter.ts
@@ -120,7 +120,7 @@ export class GajaeCodeRpc implements HarnessRpc {
 	#waiters: {
 		afterCursor: number;
 		resolve: (v: { cursor: number } | null) => void;
-		timer: ReturnType<typeof setTimeout>;
+		timer: NodeJS.Timeout;
 	}[] = [];
 	#frameListeners: ((frame: Record<string, unknown>) => void)[] = [];
 	#lastFrameAt: string | null = null;

--- a/packages/coding-agent/src/tools/cron.ts
+++ b/packages/coding-agent/src/tools/cron.ts
@@ -391,7 +391,7 @@ export function calculateCronFireTimeMs(params: {
 }
 
 function setCronTimeout(callback: () => void, delayMs: number): CronTimerHandle {
-	let handle: ReturnType<typeof setTimeout> | undefined;
+	let handle: NodeJS.Timeout | undefined;
 	let cleared = false;
 	const schedule = (remainingMs: number) => {
 		if (cleared) return;

--- a/packages/coding-agent/test/agent-session-retry-busy-recovery.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-busy-recovery.test.ts
@@ -16,7 +16,7 @@ type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
 function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 	// Uses a real timer (not the mocked scheduler.wait) so it survives the
 	// scheduler.wait spy that skips retry backoff.
-	let timer: ReturnType<typeof setTimeout>;
+	let timer: NodeJS.Timeout;
 	const timeout = new Promise<never>((_, reject) => {
 		timer = setTimeout(() => reject(new Error(`TIMEOUT (session wedged busy): ${label}`)), ms);
 	});

--- a/packages/coding-agent/test/monitor-cron-tools.test.ts
+++ b/packages/coding-agent/test/monitor-cron-tools.test.ts
@@ -106,9 +106,9 @@ async function withFakeTimers<T>(
 		const timer: FakeTimer = { id: nextId, at: now + Math.max(0, Number(delay ?? 0)), callback, cleared: false };
 		nextId += 1;
 		timers.push(timer);
-		return timer.id as unknown as ReturnType<typeof setTimeout>;
+		return timer.id as unknown as NodeJS.Timeout;
 	}) as typeof setTimeout;
-	globalThis.clearTimeout = ((handle?: ReturnType<typeof setTimeout>) => {
+	globalThis.clearTimeout = ((handle?: NodeJS.Timeout) => {
 		const id = Number(handle);
 		for (const timer of timers) {
 			if (timer.id === id) timer.cleared = true;

--- a/packages/coding-agent/test/rpc-live-unattended-e2e.test.ts
+++ b/packages/coding-agent/test/rpc-live-unattended-e2e.test.ts
@@ -91,7 +91,7 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("RPC live unattended lifecycle 
 			const deadlineAt = Date.now() + OVERALL_DEADLINE_MS;
 			const remainingMs = () => Math.max(0, deadlineAt - Date.now());
 			const withDeadline = async <T>(p: Promise<T>, label: string): Promise<T> => {
-				let timer: ReturnType<typeof setTimeout> | undefined;
+				let timer: NodeJS.Timeout | undefined;
 				const guard = new Promise<never>((_, reject) => {
 					timer = setTimeout(() => reject(new Error(`overall deadline exceeded at: ${label}`)), remainingMs());
 				});

--- a/packages/coding-agent/test/rpc-stdio-redteam.test.ts
+++ b/packages/coding-agent/test/rpc-stdio-redteam.test.ts
@@ -118,7 +118,7 @@ function spawnRpcServer(options: { cwd?: string; sessionDir?: string } = {}): Rp
 		proc,
 		stderrText,
 		async nextFrame(timeoutMs = 10_000): Promise<Frame> {
-			let timer: ReturnType<typeof setTimeout> | undefined;
+			let timer: NodeJS.Timeout | undefined;
 			const timeout = new Promise<never>((_, reject) => {
 				timer = setTimeout(() => reject(new Error("Timed out waiting for RPC frame")), timeoutMs);
 			});


### PR DESCRIPTION
## What

Replace all 9 occurrences of `ReturnType<typeof setTimeout>` with the named type `NodeJS.Timeout` across 7 files in `packages/coding-agent/`.

## Why

AGENTS.md line 66: "Never use `ReturnType<>`; write the actual type name."

`NodeJS.Timeout` is already the dominant pattern — 33+ files in the same package use it directly. The two types are identical: `@types/node/timers.d.ts` documents `NodeJS.Timeout` as the object returned from `setTimeout()`, and existing code (e.g., `rpc-client.ts:386-389`) assigns `setTimeout(...)` to a `NodeJS.Timeout` at runtime.

This is a pure type-annotation change — zero runtime semantics.

## Testing

- `bun run check:types` (tsgo) → clean
- `bunx biome check` on all 7 files → clean
- `grep -rn "ReturnType<typeof setTimeout>"` → 0 matches

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)