### PR TITLE
chore: replace ReturnType<typeof setInterval> with NodeJS.Timeout

### DIFF
--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -106,7 +106,7 @@ export class RuntimeOwner {
 	#server: ControlServer;
 	#cursor = 0;
 	#leaseEpoch = 0;
-	#heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+	#heartbeatTimer: NodeJS.Timeout | null = null;
 	#socketPath: string;
 	#finalizeChecks?: FinalizeChecks;
 	#validationCommands?: ValidationCommandSpec[];

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -283,7 +283,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 	autoCompactionEscapeHandler?: () => void;
 	retryEscapeHandler?: () => void;
-	retryCountdownTimer?: ReturnType<typeof setInterval>;
+	retryCountdownTimer?: NodeJS.Timeout;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: SubmittedUserInput) => void;
 	optimisticUserMessageSignature: string | undefined = undefined;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -109,7 +109,7 @@ export interface InteractiveModeContext {
 	retryLoader: Loader | undefined;
 	autoCompactionEscapeHandler?: () => void;
 	retryEscapeHandler?: () => void;
-	retryCountdownTimer?: ReturnType<typeof setInterval>;
+	retryCountdownTimer?: NodeJS.Timeout;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: SubmittedUserInput) => void;
 	optimisticUserMessageSignature: string | undefined;


### PR DESCRIPTION
## What

Replaces the 3 remaining `ReturnType<typeof setInterval>` annotations with the equivalent named type `NodeJS.Timeout`.

| File | Line | Field |
| --- | --- | --- |
| `src/harness-control-plane/owner.ts` | 109 | `#heartbeatTimer` |
| `src/modes/interactive-mode.ts` | 286 | `retryCountdownTimer` |
| `src/modes/types.ts` | 112 | `retryCountdownTimer` (interface) |

## Why

AGENTS.md line 66 requires: `Never use ReturnType<>; write the actual type name.` `NodeJS.Timeout` is exactly `ReturnType<typeof setInterval>` (per `@types/node/web-globals/timers.d.ts:21-26`) and is already the established convention across 26+ files in this codebase, including adjacent interval timers in the same files (`countdown-timer.ts:7`, `interactive-mode.ts:313/334`, `event-controller.ts:60`).

Follow-up to #627 which did the same sweep for `ReturnType<typeof setTimeout>`.

## Testing

- [x] `bun run check:types` (tsgo) passes — zero type errors
- [x] `bunx biome check` on all 3 changed files passes
- [x] Verified `NodeJS.Timeout` is assignment-compatible at all usage sites (`setInterval` assignments, `clearInterval` calls)
- [x] Confirmed zero remaining `ReturnType<typeof setInterval>` in `packages/coding-agent/src`

---

- [x] `bun check` passes (tsgo; biome format pre-existing deviation in `goal-mode-integration.test.ts` tracked separately in #626)
- [x] Tested locally
- [ ] CHANGELOG updated (chore-only, not user-facing)