### PR TITLE
docs: document native build prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,15 @@ The default dark TUI identity is the GJC red-claw theme, while light-appearance 
 
 ## Development
 
-Install dependencies and local defaults:
+Install dependencies, build native bindings, and set up local defaults:
 
 ```sh
 bun install
+bun run build:native
 bun run install:defaults
 ```
+
+The `.node` binary for `@gajae-code/natives` is gitignored and required before any CLI invocation (`install:defaults`, `dev:link`, tests).
 
 ### Canonical: build and link the dev `gjc`
 


### PR DESCRIPTION
## What

Adds a note to the Development section of `README.md` documenting `bun run build:native` as a prerequisite step after `bun install`.

```sh
bun run build:native
```

## Why

The platform-specific `.node` binary for `@gajae-code/natives` is gitignored and is **not** built by `bun install` or `install:dev`. Without building it first:

- **Tests** fail with module-not-found errors from `@gajae-code/natives`
- **`dev:link`** fails its `--smoke-test` because it cannot confirm `@gajae-code/natives` loads

This step was undocumented — a new contributor following the README would hit confusing failures with no guidance on how to fix them.

## Testing

- [x] Verified `bun run build:native` exists in root `package.json` scripts
- [x] Verified the `.node` binary is gitignored (`git check-ignore packages/natives/native/pi_natives.darwin-arm64.node`)
- [x] Confirmed placement fits between install and `dev:link` subsection
- [x] Architect review: APPROVE (no blocking findings)

---

- [x] `bun check` passes (docs-only change, no code affected)
- [x] Tested locally
- [ ] CHANGELOG updated (docs-only, not user-facing)