### PR TITLE
chore: replace Awaited<ReturnType<typeof fs.stat/lstat>> with Stats

### DIFF
--- a/packages/coding-agent/src/config/file-lock-gc.ts
+++ b/packages/coding-agent/src/config/file-lock-gc.ts
@@ -2,6 +2,7 @@
  * GC adapter for config file-locks (`<file>.lock` dirs holding `{pid, timestamp}`).
  */
 
+import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, getConfigRootDir, isEnoent } from "@gajae-code/utils";
@@ -92,7 +93,7 @@ async function walkForLockDirs(
 		return;
 	}
 
-	let stat: Awaited<ReturnType<typeof fs.lstat>>;
+	let stat: Stats;
 	try {
 		stat = await fs.lstat(dir);
 	} catch (error) {

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ActiveSubskillEntry, SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
@@ -113,7 +114,7 @@ export interface GenericHardPruneTarget {
 export interface GenericHardPruneSelectorContext {
 	path: string;
 	category: WriterCategory | string;
-	stat: Awaited<ReturnType<typeof fs.stat>>;
+	stat: Stats;
 	readJson: () => Promise<unknown>;
 }
 
@@ -639,7 +640,7 @@ export async function hardPrune(
 	const removed: string[] = [];
 	for (const target of targets) {
 		const filePath = resolveGjcTarget(target.path, cwd);
-		let stat: Awaited<ReturnType<typeof fs.stat>>;
+		let stat: Stats;
 		try {
 			stat = await fs.stat(filePath);
 		} catch (error) {


### PR DESCRIPTION
## What

Replaces 3 `Awaited<ReturnType<typeof fs.stat/lstat>>` annotations with the concrete `Stats` type name from `node:fs`.

| File | Line | Change |
| --- | --- | --- |
| `src/config/file-lock-gc.ts` | 96 | `Awaited<ReturnType<typeof fs.lstat>>` → `Stats` |
| `src/gjc-runtime/state-writer.ts` | 117 | `Awaited<ReturnType<typeof fs.stat>>` → `Stats` (interface field) |
| `src/gjc-runtime/state-writer.ts` | 643 | `Awaited<ReturnType<typeof fs.stat>>` → `Stats` (local variable) |

Adds `import type { Stats } from "node:fs"` to both files (required because `Stats` is not re-exported from `node:fs/promises`).

## Why

AGENTS.md line 66 requires: `Never use ReturnType<>; write the actual type name.`

`Stats` is exactly `Awaited<ReturnType<typeof fs.stat>>` per `@types/node/fs/promises.d.ts:931` (`function stat(path: PathLike): Promise<Stats>`). The `Stats` type is already the established convention across 6 files (`cursor.ts`, `loader.ts`, `lsp/index.ts`, `connection-manager.ts`, `bash.ts`, `find.ts`).

Follow-up to #627 (`setTimeout`) and #628 (`setInterval`) ReturnType sweeps.

## Testing

- [x] `bun run check:types` (tsgo) passes — zero type errors
- [x] `bunx biome check` on both files passes (import order auto-organized)
- [x] Verified `Stats` type-equivalence against `@types/node` no-options overloads
- [x] Confirmed 0 remaining `ReturnType<typeof fs` occurrences in `packages/coding-agent/src`
- [x] Architect review: APPROVE / CLEAR (zero findings)

---

- [x] `bun check` passes (tsgo; biome format pre-existing deviation in `goal-mode-integration.test.ts` tracked in #626)
- [x] Tested locally
- [ ] CHANGELOG updated (chore-only, not user-facing)