### PR TITLE
chore: replace remaining ReturnType<> with named types

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -52,6 +52,7 @@ import {
 	type StateWriterAuditContext,
 	softDelete,
 	updateWorkflowTransactionJournal,
+	type WorkflowEnvelopeIntegrityMismatch,
 	writeWorkflowEnvelopeAtomic,
 } from "./state-writer";
 import { getSkillManifest, isKnownWorkflowState, isValidTransition, typedArgsFor } from "./workflow-manifest";
@@ -659,7 +660,7 @@ async function warnAndAuditOutOfBandIfNeeded(
 	skill: CanonicalGjcWorkflowSkill,
 	options?: { mutationId?: string; forced?: boolean },
 ): Promise<string | undefined> {
-	let mismatch: Awaited<ReturnType<typeof detectWorkflowEnvelopeIntegrityMismatch>>;
+	let mismatch: WorkflowEnvelopeIntegrityMismatch | undefined;
 	try {
 		mismatch = await detectWorkflowEnvelopeIntegrityMismatch(filePath);
 	} catch {

--- a/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
@@ -11,6 +11,7 @@ import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapt
 import { GJC_TMUX_PROFILE_VALUE } from "./tmux-common";
 import {
 	type GjcTmuxSessionStatus,
+	type GjcTmuxSessionsForGc,
 	listTmuxSessionsForGc,
 	readTmuxSessionTagsForGc,
 	removeGjcTmuxSession,
@@ -124,7 +125,7 @@ export const tmuxSessionsGcAdapter: GcStoreAdapter = {
 	async collect(ctx: GcContext): Promise<GcCollectResult> {
 		const records: GcRecord[] = [];
 		const errors: GcCollectResult["errors"] = [];
-		let sessions: ReturnType<typeof listTmuxSessionsForGc>;
+		let sessions: GjcTmuxSessionsForGc;
 		try {
 			sessions = listTmuxSessionsForGc(ctx.env);
 		} catch (error) {

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import type { AgentWireOwnerObservation } from "../modes/shared/agent-wire/event-contract";
 import { observeRpcOutboundFrame } from "../modes/shared/agent-wire/event-observation";
 import { classifyRecovery } from "./classifier";
 import { ControlServer, type EndpointRequest } from "./control-endpoint";
@@ -199,7 +200,7 @@ export class RuntimeOwner {
 		await this.#emit("info", "rpc_activity", { coalescedFrames });
 	}
 
-	async #emitMapped(mapped: NonNullable<ReturnType<typeof observeRpcOutboundFrame>>): Promise<void> {
+	async #emitMapped(mapped: AgentWireOwnerObservation): Promise<void> {
 		if (mapped.kind === "rpc_agent_completed") {
 			const state = await readSessionState(this.#opts.root, this.#opts.sessionId);
 			if (


### PR DESCRIPTION
## What

Replaces the last 3 non-generic `ReturnType<>` annotations that reference project-defined functions with their concrete named types.

| File | Before | After | Import added |
| --- | --- | --- | --- |
| `src/gjc-runtime/state-runtime.ts` | `Awaited<ReturnType<typeof detectWorkflowEnvelopeIntegrityMismatch>>` | `WorkflowEnvelopeIntegrityMismatch | undefined` | `type WorkflowEnvelopeIntegrityMismatch` (in existing import) |
| `src/gjc-runtime/tmux-gc.ts` | `ReturnType<typeof listTmuxSessionsForGc>` | `GjcTmuxSessionsForGc` | `type GjcTmuxSessionsForGc` (in existing import) |
| `src/harness-control-plane/owner.ts` | `NonNullable<ReturnType<typeof observeRpcOutboundFrame>>` | `AgentWireOwnerObservation` | new `import type` from `event-contract` |

## Why

AGENTS.md line 66 requires: `Never use ReturnType<>; write the actual type name.`

Each function returns a named, exported type — ReturnType was unnecessary indirection. Continues the sweep from #627 (setTimeout), #628 (setInterval), and #630 (fs.Stats). The only remaining ReturnType is a generic proxy in ultragoal-ask-guard.ts (defensible exception, no concrete named type).

## Testing

- [x] `bun run check:types` (tsgo) passes — zero type errors
- [x] `bunx biome check` on all 3 files passes (imports auto-organized)
- [x] All 3 type substitutions verified exactly equivalent against source function signatures
- [x] Architect review: APPROVE (zero runtime change, all replacements type-equivalent)

---

- [x] `bun check` passes (tsgo; biome format pre-existing deviation tracked in #626)
- [x] Tested locally
- [ ] CHANGELOG updated (chore-only, not user-facing)
