### PR TITLE
fix(coding-agent): map legacy codex profile default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Mapped the retired `codex-standard` model profile name to `codex-medium` during profile activation, so older `modelProfile.default: codex-standard` configs no longer block startup after upgrading to the rebuilt profile catalog.
 - Fixed interactive goal-mode auto-continuation looping `Error: Agent is already processing…` (`AgentBusyError`) while the session is busy. A wedged/orphaned subagent turn — or an in-progress compaction — can leave the session non-idle while the interactive loop is back at `getUserInput()`; the 800 ms continuation timer then fired `prompt()`, threw `AgentBusyError`, surfaced it via `showError`, and re-armed — spamming the error roughly every 800 ms. The continuation now skips and re-arms while `isStreaming`/`isCompacting`, firing only once the session returns to idle.
 
 ## [0.5.1] - 2026-06-14

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -11,6 +11,8 @@ import { type GjcModelAssignmentTargetId, isAuthenticated, type ModelRegistry } 
 import { resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
 
+const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
+
 type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel" | "sessionId"> & {
 	setModelTemporary?: AgentSession["setModelTemporary"];
 	setActiveModelProfile?: (name: string | undefined) => void;
@@ -51,12 +53,19 @@ export function formatModelProfileCredentialError(profileName: string, providers
 	return `Model profile "${profileName}" requires credentials for: ${providers.join(", ")}. Run /login and configure the missing provider(s), then retry.`;
 }
 
+function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<string, unknown>): string {
+	const replacement = LEGACY_MODEL_PROFILE_ALIASES.get(profileName);
+	return replacement && profiles.has(replacement) ? replacement : profileName;
+}
+
 export async function prepareModelProfileActivation(
 	options: PrepareModelProfileActivationOptions,
 ): Promise<PreparedModelProfileActivation> {
-	const profile = options.modelRegistry.getModelProfile(options.profileName);
+	const profiles = options.modelRegistry.getModelProfiles();
+	const profileName = resolveModelProfileName(options.profileName, profiles);
+	const profile = profiles.get(profileName) ?? options.modelRegistry.getModelProfile(profileName);
 	if (!profile) {
-		const available = formatAvailableProfileNames(options.modelRegistry.getModelProfiles());
+		const available = formatAvailableProfileNames(profiles);
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
 	}
 
@@ -101,7 +110,7 @@ export async function prepareModelProfileActivation(
 	}
 
 	return {
-		profileName: options.profileName,
+		profileName,
 		session: options.session as PreparedModelProfileActivation["session"],
 		settings: options.settings as PreparedModelProfileActivation["settings"],
 		previousModel: options.session.model,

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -418,9 +418,7 @@ describe("InteractiveMode goal mode integration", () => {
 			for (let i = 0; i < 5; i++) {
 				vi.advanceTimersByTime(800);
 			}
-			const compactingCalls = startPending.mock.calls.filter(
-				call => call[0]?.customType === "goal-continuation",
-			);
+			const compactingCalls = startPending.mock.calls.filter(call => call[0]?.customType === "goal-continuation");
 			expect(compactingCalls.length).toBe(0);
 
 			// Compaction finished: the re-armed continuation fires.

--- a/packages/coding-agent/test/model-profile-legacy-alias.test.ts
+++ b/packages/coding-agent/test/model-profile-legacy-alias.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { activateModelProfile, prepareModelProfileActivation } from "../src/config/model-profile-activation";
+import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import { Settings } from "../src/config/settings";
+
+const codexModel = {
+	id: "gpt-5.5",
+	name: "gpt-5.5",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://codex.example.test",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 272_000,
+	maxTokens: 128_000,
+	thinking: {
+		mode: "effort",
+		minLevel: ThinkingLevel.Low,
+		maxLevel: ThinkingLevel.XHigh,
+	},
+} satisfies Model<"openai-codex-responses">;
+
+interface TestSession {
+	model: Model | undefined;
+	thinkingLevel: ThinkingLevel | undefined;
+	readonly sessionId: string;
+	readonly setModelTemporaryCalls: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel): Promise<void>;
+	setActiveModelProfile(name: string | undefined): void;
+	getActiveModelProfile(): string | undefined;
+}
+
+function fakeRegistry() {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const profile of BUILTIN_MODEL_PROFILES) profiles.set(profile.name, profile);
+	return {
+		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfiles: () => new Map(profiles),
+		getAvailableModelProfileNames: () => [...profiles.keys()].sort(),
+		getApiKeyForProvider: async () => "key-openai-codex",
+		getAll: () => [codexModel],
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	};
+}
+
+function fakeSession() {
+	let activeModelProfile: string | undefined;
+	const session: TestSession = {
+		model: codexModel,
+		thinkingLevel: ThinkingLevel.Low,
+		sessionId: "session-1",
+		setModelTemporaryCalls: [],
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			session.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			session.model = next;
+			session.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+		getActiveModelProfile() {
+			return activeModelProfile;
+		},
+	};
+	return session;
+}
+
+describe("legacy model profile aliases", () => {
+	test("maps retired codex-standard default to codex-medium during activation", async () => {
+		const settings = Settings.isolated({ "modelProfile.default": "codex-standard" });
+		const session = fakeSession();
+
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry(),
+			settings,
+			profileName: settings.get("modelProfile.default") ?? "",
+		});
+
+		expect(session.getActiveModelProfile()).toBe("codex-medium");
+		expect(session.setModelTemporaryCalls).toEqual([{ model: codexModel, thinkingLevel: ThinkingLevel.Medium }]);
+		expect(settings.get("modelProfile.default")).toBe("codex-standard");
+	});
+
+	test("--default persists the canonical replacement name for codex-standard", async () => {
+		const settings = Settings.isolated();
+		const session = fakeSession();
+
+		await activateModelProfile(
+			{ session, modelRegistry: fakeRegistry(), settings, profileName: "codex-standard" },
+			{ persistDefault: true },
+		);
+
+		expect(session.getActiveModelProfile()).toBe("codex-medium");
+		expect(settings.get("modelProfile.default")).toBe("codex-medium");
+	});
+
+	test("preparation exposes the canonical replacement profile name", async () => {
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: fakeRegistry(),
+			settings: Settings.isolated(),
+			profileName: "codex-standard",
+		});
+
+		expect(prepared.profileName).toBe("codex-medium");
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.Medium);
+	});
+});


### PR DESCRIPTION
## Summary
- Map the retired `codex-standard` model profile name to `codex-medium` during activation.
- Keep stale session-only defaults non-mutating, while `--default` persists the canonical replacement name.
- Add regression coverage for stale `modelProfile.default: codex-standard` configs and update the changelog.
- Include one Biome formatting fix in `goal-mode-integration.test.ts` so package-level `bun run check` passes on this branch.

## Verification
- Red/green: `bun test packages/coding-agent/test/model-profile-legacy-alias.test.ts` failed before the fix with `Unknown model profile "codex-standard"`, then passed after the fix.
- `bun test packages/coding-agent/test/model-profile-legacy-alias.test.ts`
- `bun test packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/model-profile-activation-redteam.test.ts packages/coding-agent/test/model-profiles-catalog.test.ts packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bun test packages/coding-agent/test/goals/goal-mode-integration.test.ts`
- `bun run check` from `packages/coding-agent`
- Manual CLI check with a temp `config.yml` containing `modelProfile.default: codex-standard` now reaches credential validation instead of unknown-profile rejection.