### PR TITLE
fix(coding-agent): map legacy codex profile default as fallback only

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Mapped the retired `codex-standard` model profile name to `codex-medium` during profile activation, **as a fallback only** so a user-defined profile literally named `codex-standard` is never shadowed, letting stale `modelProfile.default: codex-standard` configs reach activation instead of blocking startup after the rebuilt profile catalog.
 - Fixed interactive goal-mode auto-continuation looping `Error: Agent is already processing…` (`AgentBusyError`) while the session is busy. A wedged/orphaned subagent turn — or an in-progress compaction — can leave the session non-idle while the interactive loop is back at `getUserInput()`; the 800 ms continuation timer then fired `prompt()`, threw `AgentBusyError`, surfaced it via `showError`, and re-armed — spamming the error roughly every 800 ms. The continuation now skips and re-arms while `isStreaming`/`isCompacting`, firing only once the session returns to idle.
 
 ## [0.5.1] - 2026-06-14

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -11,6 +11,8 @@ import { type GjcModelAssignmentTargetId, isAuthenticated, type ModelRegistry } 
 import { resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
 
+const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
+
 type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel" | "sessionId"> & {
 	setModelTemporary?: AgentSession["setModelTemporary"];
 	setActiveModelProfile?: (name: string | undefined) => void;
@@ -51,12 +53,22 @@ export function formatModelProfileCredentialError(profileName: string, providers
 	return `Model profile "${profileName}" requires credentials for: ${providers.join(", ")}. Run /login and configure the missing provider(s), then retry.`;
 }
 
+function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<string, unknown>): string {
+	// A retired-name alias is fallback-only: never shadow a profile that actually
+	// exists under the requested name (e.g. a user-defined `codex-standard`).
+	if (profiles.has(profileName)) return profileName;
+	const replacement = LEGACY_MODEL_PROFILE_ALIASES.get(profileName);
+	return replacement && profiles.has(replacement) ? replacement : profileName;
+}
+
 export async function prepareModelProfileActivation(
 	options: PrepareModelProfileActivationOptions,
 ): Promise<PreparedModelProfileActivation> {
-	const profile = options.modelRegistry.getModelProfile(options.profileName);
+	const profiles = options.modelRegistry.getModelProfiles();
+	const profileName = resolveModelProfileName(options.profileName, profiles);
+	const profile = profiles.get(profileName) ?? options.modelRegistry.getModelProfile(profileName);
 	if (!profile) {
-		const available = formatAvailableProfileNames(options.modelRegistry.getModelProfiles());
+		const available = formatAvailableProfileNames(profiles);
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
 	}
 
@@ -101,7 +113,7 @@ export async function prepareModelProfileActivation(
 	}
 
 	return {
-		profileName: options.profileName,
+		profileName,
 		session: options.session as PreparedModelProfileActivation["session"],
 		settings: options.settings as PreparedModelProfileActivation["settings"],
 		previousModel: options.session.model,

--- a/packages/coding-agent/test/model-profile-legacy-alias.test.ts
+++ b/packages/coding-agent/test/model-profile-legacy-alias.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { activateModelProfile, prepareModelProfileActivation } from "../src/config/model-profile-activation";
+import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import { Settings } from "../src/config/settings";
+
+const codexModel = {
+	id: "gpt-5.5",
+	name: "gpt-5.5",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://codex.example.test",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 272_000,
+	maxTokens: 128_000,
+	thinking: {
+		mode: "effort",
+		minLevel: ThinkingLevel.Low,
+		maxLevel: ThinkingLevel.XHigh,
+	},
+} satisfies Model<"openai-codex-responses">;
+
+interface TestSession {
+	model: Model | undefined;
+	thinkingLevel: ThinkingLevel | undefined;
+	readonly sessionId: string;
+	readonly setModelTemporaryCalls: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel): Promise<void>;
+	setActiveModelProfile(name: string | undefined): void;
+	getActiveModelProfile(): string | undefined;
+}
+
+function fakeRegistry(extraProfiles: ModelProfileDefinition[] = []) {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const profile of BUILTIN_MODEL_PROFILES) profiles.set(profile.name, profile);
+	for (const profile of extraProfiles) profiles.set(profile.name, profile);
+	return {
+		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfiles: () => new Map(profiles),
+		getAvailableModelProfileNames: () => [...profiles.keys()].sort(),
+		getApiKeyForProvider: async () => "key-openai-codex",
+		getAll: () => [codexModel],
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	};
+}
+
+function fakeSession() {
+	let activeModelProfile: string | undefined;
+	const session: TestSession = {
+		model: codexModel,
+		thinkingLevel: ThinkingLevel.Low,
+		sessionId: "session-1",
+		setModelTemporaryCalls: [],
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			session.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+			session.model = next;
+			session.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+		getActiveModelProfile() {
+			return activeModelProfile;
+		},
+	};
+	return session;
+}
+
+describe("legacy model profile aliases", () => {
+	test("maps retired codex-standard default to codex-medium during activation", async () => {
+		const settings = Settings.isolated({ "modelProfile.default": "codex-standard" });
+		const session = fakeSession();
+
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry(),
+			settings,
+			profileName: settings.get("modelProfile.default") ?? "",
+		});
+
+		expect(session.getActiveModelProfile()).toBe("codex-medium");
+		expect(session.setModelTemporaryCalls).toEqual([{ model: codexModel, thinkingLevel: ThinkingLevel.Medium }]);
+		expect(settings.get("modelProfile.default")).toBe("codex-standard");
+	});
+
+	test("--default persists the canonical replacement name for codex-standard", async () => {
+		const settings = Settings.isolated();
+		const session = fakeSession();
+
+		await activateModelProfile(
+			{ session, modelRegistry: fakeRegistry(), settings, profileName: "codex-standard" },
+			{ persistDefault: true },
+		);
+
+		expect(session.getActiveModelProfile()).toBe("codex-medium");
+		expect(settings.get("modelProfile.default")).toBe("codex-medium");
+	});
+
+	test("preparation exposes the canonical replacement profile name", async () => {
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: fakeRegistry(),
+			settings: Settings.isolated(),
+			profileName: "codex-standard",
+		});
+
+		expect(prepared.profileName).toBe("codex-medium");
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.Medium);
+	});
+
+	test("does not remap codex-standard when a user-defined profile shadows it", async () => {
+		const customCodexStandard: ModelProfileDefinition = {
+			name: "codex-standard",
+			requiredProviders: ["openai-codex"],
+			modelMapping: { default: "openai-codex/gpt-5.5:xhigh" },
+			source: "user",
+		};
+
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: fakeRegistry([customCodexStandard]),
+			settings: Settings.isolated(),
+			profileName: "codex-standard",
+		});
+
+		// The retired-name alias must NOT shadow an explicitly defined profile.
+		expect(prepared.profileName).toBe("codex-standard");
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.XHigh);
+	});
+});


### PR DESCRIPTION
Fresh, re-scoped PR addressing the red-team review on #632 (closed per the "terminal REQUEST_CHANGES → reopen fresh" policy). Targets `dev`.

## Both review blockers addressed

**1. Alias no longer shadows an explicitly-defined profile (the blocking regression).**
`resolveModelProfileName` is now fallback-only — it returns the requested name unchanged when a profile already exists under it, and only maps the retired `codex-standard` → `codex-medium` when no such profile is present:
```ts
function resolveModelProfileName(profileName, profiles) {
  if (profiles.has(profileName)) return profileName; // never shadow an explicit profile
  const replacement = LEGACY_MODEL_PROFILE_ALIASES.get(profileName);
  return replacement && profiles.has(replacement) ? replacement : profileName;
}
```
A user-defined profile literally named `codex-standard` now activates the user's profile, as before the alias.

**2. Unrelated `goal-mode-integration.test.ts` formatter hunk dropped.**
This PR branches off current `origin/dev`, which already carries that Biome fix (PR #624 landed). The hunk is not part of this diff — scope is just the legacy alias behavior.

Non-blocking nits from the review (error message interpolating the original `profileName`; the redundant `?? getModelProfile(...)` branch) are left out of scope to keep this focused; happy to follow up.

## Tests (red/green verified)

New case in `model-profile-legacy-alias.test.ts`: *"does not remap codex-standard when a user-defined profile shadows it"* — injects a user-defined `codex-standard` (default `…:xhigh`) and asserts `prepared.profileName === "codex-standard"` / `defaultThinkingLevel === XHigh`.

- With the fix: **passes**.
- Removing the `profiles.has(profileName)` guard: **fails** with `Expected "codex-standard", Received "codex-medium"` — i.e. it reproduces the exact shadowing regression.

Full run: `model-profile-legacy-alias` + `model-profile-activation` + `…-activation-redteam` + `model-profiles-catalog` + `cli-args-mpreset` → **34 pass / 0 fail**. `tsgo -p tsconfig.json --noEmit` clean; Biome clean on changed files.

Supersedes #632.
