### PR TITLE
chore: replace console.warn with centralized logger in coding-agent

### DIFF
--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import type { SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { ModeStateSchema, SkillActiveStateSchema } from "../gjc-runtime/state-schema";
 import { writeJsonAtomic, writeWorkflowEnvelopeAtomic } from "../gjc-runtime/state-writer";
@@ -221,7 +222,7 @@ function skillStatePath(stateDir: string, sessionId?: string): string {
 }
 
 function warnInvalidState(kind: string, filePath: string, error: string): void {
-	console.warn(`gjc skill-state: invalid ${kind} at ${filePath}: ${error}`);
+	logger.warn(`gjc skill-state: invalid ${kind} at ${filePath}: ${error}`);
 }
 
 async function readValidatedJsonFile<T>(

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import type { AgentTool } from "@gajae-code/agent-core";
+import { logger } from "@gajae-code/utils";
 import { expandApplyPatchToEntries } from "../edit/modes/apply-patch";
 import { ModeStateSchema } from "../gjc-runtime/state-schema";
 import { LocalProtocolHandler, resolveLocalUrlToPath } from "../internal-urls/local-protocol";
@@ -78,7 +79,7 @@ function modeStatePath(cwd: string, skill: string, sessionId?: string): string {
 }
 
 function warnInvalidModeState(filePath: string, error: string): void {
-	console.warn(`gjc skill-state: invalid mode-state at ${filePath}: ${error}`);
+	logger.warn(`gjc skill-state: invalid mode-state at ${filePath}: ${error}`);
 }
 
 async function readValidatedModeState(filePath: string): Promise<ModeState | null> {

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -26,7 +26,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@gajae-code/tui";
-import { prompt, untilAborted } from "@gajae-code/utils";
+import { logger, prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import {
 	formatDeepInterviewSelectorPrompt,
@@ -502,7 +502,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				{ sessionId },
 			);
 		} catch (error) {
-			console.warn(
+			logger.warn(
 				`ask: deep-interview round recording failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,6 +9,7 @@ import {
 	getDeepInterviewMutationDecision,
 } from "@gajae-code/coding-agent/skill-state/deep-interview-mutation-guard";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
+import { logger } from "@gajae-code/utils";
 
 const tempRoots: string[] = [];
 
@@ -282,7 +283,7 @@ describe("deep-interview mutation guard", () => {
 			path.join(cwd, ".gjc", "state", "sessions", "session-a", "deep-interview-state.json"),
 			JSON.stringify({ active: "yes", current_phase: "interviewing", session_id: "session-a" }),
 		);
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const decision = await getDeepInterviewMutationDecision({
 				cwd,
@@ -302,7 +303,7 @@ describe("deep-interview mutation guard", () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);
 		await Bun.write(path.join(cwd, ".gjc", "state", "sessions", "session-a", "deep-interview-state.json"), "{");
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const decision = await getDeepInterviewMutationDecision({
 				cwd,

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../src/config/skill-settings-defaults";
 import { RequiredOnWriteEnvelopeSchema } from "../src/gjc-runtime/state-schema";
 import {
@@ -212,7 +213,7 @@ describe("GJC native skill-state hooks", () => {
 		const stateDir = path.join(root, "custom-state");
 		await fs.mkdir(stateDir, { recursive: true });
 		await fs.writeFile(path.join(stateDir, "skill-active-state.json"), "{");
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			await expect(readVisibleSkillActiveState(root, undefined, stateDir)).resolves.toBeNull();
 			expect(warn).toHaveBeenCalledTimes(1);
@@ -264,7 +265,7 @@ describe("GJC native skill-state hooks", () => {
 			}),
 		);
 		await fs.writeFile(path.join(stateDir, "sessions", "session-corrupt", "team-state.json"), "{");
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const allowed = await dispatchGjcNativeSkillHook(
 				{
@@ -299,7 +300,7 @@ describe("GJC native skill-state hooks", () => {
 			path.join(stateDir, "sessions", "session-invalid", "team-state.json"),
 			JSON.stringify({ active: true, current_phase: 7, session_id: "session-invalid" }),
 		);
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const allowed = await dispatchGjcNativeSkillHook(
 				{
@@ -326,7 +327,7 @@ describe("GJC native skill-state hooks", () => {
 			path.join(stateDir, "ultragoal-state.json"),
 			JSON.stringify({ active: true, current_phase: 7, objective: "ship" }),
 		);
-		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		try {
 			const allowed = await dispatchGjcNativeSkillHook(
 				{


### PR DESCRIPTION
## What

Replace `console.warn` with `logger.warn` from `@gajae-code/utils` in 3 source files, and update 6 affected tests to spy on the centralized logger path.

Reopens #625 (could not reopen the closed PR). The original PR's test regressions are fixed in this push.

### Source changes (commit `b754e879`)
- `src/hooks/skill-state.ts` — `warnInvalidState`: `console.warn` → `logger.warn`
- `src/skill-state/deep-interview-mutation-guard.ts` — `warnInvalidModeState`: `console.warn` → `logger.warn`
- `src/tools/ask.ts` — deep-interview round recording catch: `console.warn` → `logger.warn`

### Test changes (commit `b0c5f642`)
- `test/deep-interview-mutation-guard.test.ts` — 2 tests: `spyOn(console, "warn")` → `vi.spyOn(logger, "warn")`
- `test/gjc-skill-state-hooks.test.ts` — 4 tests: same replacement

Uses the established `vi.spyOn(logger, "warn")` pattern already in `extensions-runner.test.ts` and `agent-session-auto-compaction-continue.test.ts`.

## Why

AGENTS.md line 113: *"Do not use console.log/warn/error in packages/coding-agent/; use logger from @gajae-code/utils."* The centralized logger writes through winston's rotating file transport (console transport OFF by default), making it TUI-safe — it won't corrupt stdout/stderr during interactive sessions.

## Testing

- [x] `bun test test/tools/ask.test.ts test/deep-interview-mutation-guard.test.ts test/gjc-skill-state-hooks.test.ts` → **72 pass / 2 fail** (the 2 failures are pre-existing ultragoal live-proof tests that fail identically on clean `dev`)
- [x] `bunx biome check` → clean
- [x] `tsgo --noEmit` → clean
- [x] Revert → FAIL (8 fail = 6 regressions + 2 pre-existing) → Re-apply → PASS (2 fail = 2 pre-existing only)
- [x] Targets `dev`, not `main`