### PR TITLE
fix(ralplan): keep run-state phase coherent and guard duplicate --write (#638)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -186,7 +186,37 @@ async function readActiveRunId(cwd: string, sessionId: string | undefined): Prom
 	return candidate;
 }
 
-async function persistActiveRunId(cwd: string, sessionId: string | undefined, runId: string): Promise<void> {
+/**
+ * Run-state phases that an artifact write must never reopen. Once ralplan has
+ * reached a terminal/handed-off phase, a stray `--write` must not regress
+ * `current_phase` back to a stage — that would silently re-arm a chain guard or
+ * undo Stop semantics. Every other phase advances to track the stage just
+ * persisted so run-state stays coherent with the active ralplan stage.
+ */
+const PHASE_LOCK = new Set([
+	"final",
+	"handoff",
+	"complete",
+	"completed",
+	"failed",
+	"cancelled",
+	"canceled",
+	"inactive",
+]);
+
+/** Phase that keeps run-state coherent with the stage just written, preserving locked phases. */
+function advanceCurrentPhase(existingPhase: unknown, stage: RalplanStage): string {
+	const current = typeof existingPhase === "string" ? existingPhase.trim() : "";
+	if (current && PHASE_LOCK.has(current)) return current;
+	return stage;
+}
+
+async function persistActiveRunId(
+	cwd: string,
+	sessionId: string | undefined,
+	runId: string,
+	stage: RalplanStage,
+): Promise<void> {
 	const statePath = ralplanStatePath(cwd, sessionId);
 	const existingRead = await readExistingStateForMutation(statePath);
 	if (existingRead.kind === "corrupt") {
@@ -197,11 +227,18 @@ async function persistActiveRunId(cwd: string, sessionId: string | undefined, ru
 	}
 	let existing: Record<string, unknown> = existingRead.kind === "valid" ? existingRead.value : {};
 
-	if (existing.run_id === runId && existing.version === WORKFLOW_STATE_VERSION) return;
+	const nextPhase = advanceCurrentPhase(existing.current_phase, stage);
+	if (
+		existing.run_id === runId &&
+		existing.version === WORKFLOW_STATE_VERSION &&
+		existing.current_phase === nextPhase
+	) {
+		return;
+	}
 	existing.run_id = runId;
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
 	if (typeof existing.active !== "boolean") existing.active = true;
-	if (typeof existing.current_phase !== "string") existing.current_phase = "planner";
+	existing.current_phase = nextPhase;
 	existing = migrateWorkflowState(existing, "ralplan").state;
 	existing.updated_at = new Date().toISOString();
 	await writeWorkflowEnvelopeAtomic(statePath, existing, {
@@ -381,8 +418,6 @@ async function resolveArtifactArgs(args: readonly string[], cwd: string): Promis
 	const explicitRunId = flagValue(args, "--run-id")?.trim();
 	const runId = explicitRunId || (await readActiveRunId(cwd, sessionId)) || sessionIdRaw || defaultRunId();
 	assertSafePathComponent(runId, "run-id");
-	// Persist the active run id so later writes in the same loop land in the same directory.
-	await persistActiveRunId(cwd, sessionId, runId);
 
 	const artifact = await resolveArtifactContent(rawArtifact, cwd);
 	return { stage: stage as RalplanStage, stageN, runId, artifact, sessionId, json: hasFlag(args, "--json") };
@@ -398,18 +433,21 @@ interface PersistedArtifact {
 	pendingApprovalPath?: string;
 }
 
-async function persistArtifact(resolved: ResolvedArtifactArgs, cwd: string): Promise<PersistedArtifact> {
+async function persistArtifact(
+	resolved: ResolvedArtifactArgs,
+	cwd: string,
+	content: string,
+	sha256: string,
+): Promise<PersistedArtifact> {
 	const runDir = path.join(cwd, ".gjc", "plans", "ralplan", resolved.runId);
 
 	const fileName = `stage-${pad2(resolved.stageN)}-${resolved.stage}.md`;
 	const filePath = path.join(runDir, fileName);
-	const content = resolved.artifact.endsWith("\n") ? resolved.artifact : `${resolved.artifact}\n`;
 	await writeArtifact(filePath, content, {
 		cwd,
 		audit: { category: "artifact", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
 	});
 
-	const sha256 = createHash("sha256").update(content).digest("hex");
 	const createdAt = new Date().toISOString();
 	const indexEntry = {
 		stage: resolved.stage,
@@ -441,6 +479,56 @@ async function persistArtifact(resolved: ResolvedArtifactArgs, cwd: string): Pro
 		createdAt,
 		pendingApprovalPath,
 	};
+}
+
+/** The persisted `(stage, stage_n)` artifact recorded in a run's `index.jsonl`. */
+interface ExistingStageArtifact {
+	path: string;
+	sha256: string;
+	createdAt: string;
+}
+
+/**
+ * Find the most recent `index.jsonl` row for a `(stage, stage_n)` pair so a
+ * repeated `--write` can dedupe instead of silently clobbering the artifact and
+ * appending a duplicate ledger row. Best-effort: a missing or unreadable index
+ * yields `undefined`, treated as "no prior artifact". The ledger is the source of
+ * truth for dedup because it is exactly what a duplicate write would corrupt.
+ */
+async function findExistingStageArtifact(
+	cwd: string,
+	runId: string,
+	stage: RalplanStage,
+	stageN: number,
+): Promise<ExistingStageArtifact | undefined> {
+	const indexPath = path.join(cwd, ".gjc", "plans", "ralplan", runId, "index.jsonl");
+	let text: string;
+	try {
+		text = await fs.readFile(indexPath, "utf8");
+	} catch {
+		return undefined;
+	}
+	let match: ExistingStageArtifact | undefined;
+	for (const line of text.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		let row: unknown;
+		try {
+			row = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+		if (!row || typeof row !== "object" || Array.isArray(row)) continue;
+		const record = row as Record<string, unknown>;
+		if (record.stage !== stage || record.stage_n !== stageN) continue;
+		if (typeof record.path !== "string" || typeof record.sha256 !== "string") continue;
+		match = {
+			path: record.path,
+			sha256: record.sha256,
+			createdAt: typeof record.created_at === "string" ? record.created_at : "",
+		};
+	}
+	return match;
 }
 
 /**
@@ -518,7 +606,26 @@ async function buildRalplanHud(options: {
 async function handleArtifactWrite(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
 	const plannerState = parsePlannerStateArgs(args);
 	const resolved = await resolveArtifactArgs(args, cwd);
-	const persisted = await persistArtifact(resolved, cwd);
+	const content = resolved.artifact.endsWith("\n") ? resolved.artifact : `${resolved.artifact}\n`;
+	const sha256 = createHash("sha256").update(content).digest("hex");
+
+	// Duplicate-write guard: a second `--write` for the same (stage, stage_n) must not
+	// silently clobber the artifact or append a duplicate ledger row. Classify before any
+	// state mutation so a conflict never regresses run-state phase.
+	const existingArtifact = await findExistingStageArtifact(cwd, resolved.runId, resolved.stage, resolved.stageN);
+	if (existingArtifact) {
+		if (existingArtifact.sha256 !== sha256) {
+			throw new RalplanCommandError(
+				2,
+				`refusing to overwrite ralplan ${resolved.stage} stage ${resolved.stageN} at ${existingArtifact.path}: an artifact with different content already exists (existing sha256=${existingArtifact.sha256}, new sha256=${sha256}). Use a new --stage_n to record another pass.`,
+			);
+		}
+		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd);
+	}
+
+	// Keep run-state `current_phase` coherent with the stage being persisted.
+	await persistActiveRunId(cwd, resolved.sessionId, resolved.runId, resolved.stage);
+	const persisted = await persistArtifact(resolved, cwd, content, sha256);
 	if (plannerState) {
 		await applyPlannerStateUpdate(cwd, resolved.sessionId, plannerState);
 	}
@@ -544,6 +651,35 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 	const stdout = resolved.json
 		? `${JSON.stringify(payload, null, 2)}\n`
 		: `Persisted ralplan ${persisted.stage} stage ${persisted.stageN} at ${persisted.path}.\n`;
+	return { status: 0, stdout };
+}
+
+/**
+ * Deterministic no-op receipt for an identical repeated `--write`: report the
+ * already-persisted artifact without rewriting the file, appending a ledger row, or
+ * churning run-state. `deduplicated: true` lets callers distinguish it from a fresh write.
+ */
+function buildDeduplicatedResult(
+	resolved: ResolvedArtifactArgs,
+	existing: ExistingStageArtifact,
+	sha256: string,
+	cwd: string,
+): RalplanCommandResult {
+	const payload: Record<string, unknown> = {
+		run_id: resolved.runId,
+		path: existing.path,
+		stage: resolved.stage,
+		stage_n: resolved.stageN,
+		sha256,
+		created_at: existing.createdAt,
+		deduplicated: true,
+	};
+	if (resolved.stage === "final") {
+		payload.pending_approval_path = path.join(cwd, ".gjc", "plans", "ralplan", resolved.runId, "pending-approval.md");
+	}
+	const stdout = resolved.json
+		? `${JSON.stringify(payload, null, 2)}\n`
+		: `ralplan ${resolved.stage} stage ${resolved.stageN} already persisted at ${existing.path} (identical content; no changes written).\n`;
 	return { status: 0, stdout };
 }
 

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -351,6 +351,146 @@ describe("native gjc ralplan runtime — --write artifact path", () => {
 	});
 });
 
+describe("native gjc ralplan runtime — run-state phase coherence", () => {
+	const readPhase = async (root: string): Promise<string> => {
+		const raw = await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8");
+		return (JSON.parse(raw) as { current_phase?: string }).current_phase ?? "";
+	};
+
+	it("advances current_phase to track each stage written after seeding", async () => {
+		const root = await tempDir();
+		const handoff = await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const runId = (JSON.parse(handoff.stdout ?? "{}") as { run_id: string }).run_id;
+		expect(await readPhase(root)).toBe("planner");
+
+		for (const [stage, stageN] of [
+			["planner", "1"],
+			["architect", "2"],
+			["critic", "3"],
+			["revision", "4"],
+			["adr", "5"],
+		] as const) {
+			const result = await runNativeRalplanCommand(
+				["--write", "--stage", stage, "--stage_n", stageN, "--artifact", `# ${stage}`, "--run-id", runId],
+				root,
+			);
+			expect(result.status).toBe(0);
+			expect(await readPhase(root)).toBe(stage);
+		}
+	});
+
+	it("advances current_phase to final on the final stage write", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const runId = (
+			JSON.parse(await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8")) as {
+				run_id: string;
+			}
+		).run_id;
+		await runNativeRalplanCommand(
+			["--write", "--stage", "adr", "--stage_n", "5", "--artifact", "# adr", "--run-id", runId],
+			root,
+		);
+		expect(await readPhase(root)).toBe("adr");
+		await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "6", "--artifact", "# final", "--run-id", runId],
+			root,
+		);
+		expect(await readPhase(root)).toBe("final");
+	});
+
+	it("does not regress a handed-off run-state phase on a stray --write (chain guard intact)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(
+			statePath,
+			JSON.stringify({
+				skill: "ralplan",
+				active: true,
+				current_phase: "handoff",
+				run_id: "locked-run",
+				version: 2,
+			}),
+			"utf-8",
+		);
+		const result = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "locked-run"],
+			root,
+		);
+		expect(result.status).toBe(0);
+		expect(await readPhase(root)).toBe("handoff");
+	});
+});
+
+describe("native gjc ralplan runtime — duplicate --write guard", () => {
+	const runDir = (root: string, runId: string) => path.join(root, ".gjc", "plans", "ralplan", runId);
+
+	it("treats an identical repeated write as a deterministic no-op", async () => {
+		const root = await tempDir();
+		const args = ["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "dup-run"];
+		const first = await runNativeRalplanCommand([...args, "--json"], root);
+		expect(first.status).toBe(0);
+		expect((JSON.parse(first.stdout ?? "{}") as { deduplicated?: boolean }).deduplicated).toBeUndefined();
+
+		const second = await runNativeRalplanCommand([...args, "--json"], root);
+		expect(second.status).toBe(0);
+		const payload = JSON.parse(second.stdout ?? "{}") as { deduplicated?: boolean; sha256: string };
+		expect(payload.deduplicated).toBe(true);
+		expect(payload.sha256).toBe((JSON.parse(first.stdout ?? "{}") as { sha256: string }).sha256);
+
+		const indexLines = (await fs.readFile(path.join(runDir(root, "dup-run"), "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(indexLines.length).toBe(1);
+		const content = await fs.readFile(path.join(runDir(root, "dup-run"), "stage-01-planner.md"), "utf-8");
+		expect(content).toBe("# Plan\n");
+	});
+
+	it("refuses to clobber an existing (stage, stage_n) with different content", async () => {
+		const root = await tempDir();
+		const first = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "v1", "--run-id", "conflict-run"],
+			root,
+		);
+		expect(first.status).toBe(0);
+
+		const second = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "v2", "--run-id", "conflict-run"],
+			root,
+		);
+		expect(second.status).toBe(2);
+		expect(second.stderr).toContain("refusing to overwrite ralplan planner stage 1");
+
+		const indexLines = (await fs.readFile(path.join(runDir(root, "conflict-run"), "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(indexLines.length).toBe(1);
+		const content = await fs.readFile(path.join(runDir(root, "conflict-run"), "stage-01-planner.md"), "utf-8");
+		expect(content).toBe("v1\n");
+	});
+
+	it("allows the same stage at a new stage_n (revision passes are not duplicates)", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "first", "--run-id", "multi-pass"],
+			root,
+		);
+		const second = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "4", "--artifact", "second", "--run-id", "multi-pass"],
+			root,
+		);
+		expect(second.status).toBe(0);
+		const indexLines = (await fs.readFile(path.join(runDir(root, "multi-pass"), "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(indexLines.length).toBe(2);
+	});
+});
+
 describe("native gjc ralplan runtime — persisted Planner state", () => {
 	const statePath = (root: string) => path.join(root, ".gjc", "state", "ralplan-state.json");
 


### PR DESCRIPTION
## Summary

Fixes two run-state defects in the native `gjc ralplan` runtime (`packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts`) reported in #638. Both were reproduced independently before fixing.

### Defect 1 — `current_phase` frozen at seed
`persistActiveRunId` only set `current_phase` when it was *not already a string* and short-circuited as soon as the run id matched. After `seedRalplanState` wrote `current_phase: "planner"`, every subsequent artifact write (architect/critic/adr/final) left the phase stuck at `"planner"`, so `.gjc/state/ralplan-state.json` never reflected the active stage.

**Fix:** the artifact-write path now advances `current_phase` to the stage just persisted via `advanceCurrentPhase`. A `PHASE_LOCK` set (`final`, `handoff`, `complete`, `completed`, `failed`, `cancelled`, `canceled`, `inactive`) prevents a stray `--write` from regressing out of a terminal/handed-off phase, so chain guards and Stop semantics stay intact.

### Defect 2 — no duplicate-write guard
A repeated `--write` for the same `(stage, stage_n)` silently clobbered the stage artifact and appended a duplicate `index.jsonl` ledger row (which also corrupts iteration accounting in `summarizeRalplanIndex`).

**Fix:** a ledger-keyed guard classifies the write before any state mutation:
- **identical content** → deterministic no-op (`deduplicated: true`, no clobber, no extra ledger row, no state churn);
- **conflicting content** (same `stage_n`, different bytes) → exit 2, existing artifact and ledger left untouched.

Classifying before mutation guarantees a conflict never regresses the run-state phase. A *new* `stage_n` for the same stage (revision passes) is still accepted.

## Tests
- `bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts` → **40 pass** (34 existing + 6 new).
- New suites: `run-state phase coherence` (advance per stage, advance to `final`, no terminal regression) and `duplicate --write guard` (no-op, conflict, distinct `stage_n`).
- `tsgo --noEmit` clean; Biome clean on changed files.

Note: 9 unrelated tests in the broader `gjc-runtime` dir fail in this environment due to a missing `pi_natives` native addon — pre-existing on a clean tree, not touched by this change.

Closes #638. Do not merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
