### PR TITLE
fix(session): keep resident materialization warm through revision (#640)

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2158,7 +2158,7 @@ export class SessionManager {
 	#labelRevision = 0;
 	#replayMetadataRevision = 0;
 	#materializedEntriesRevision = -1;
-	#materializedEntriesCache: WeakRef<SessionEntry[]> | undefined;
+	#materializedEntriesCache: SessionEntry[] | undefined;
 	#sessionContextCache: WeakRef<SessionContext> | undefined;
 	#sessionContextEntryRevision = -1;
 	#sessionContextLeafRevision = -1;
@@ -3661,15 +3661,14 @@ export class SessionManager {
 	 * change the leaf pointer. Entries cannot be modified or deleted.
 	 */
 	#getMaterializedEntriesInternal(): SessionEntry[] {
-		if (this.#materializedEntriesRevision === this.#entryRevision) {
-			const cached = this.#materializedEntriesCache?.deref();
-			if (cached) return cached;
+		if (this.#materializedEntriesRevision === this.#entryRevision && this.#materializedEntriesCache) {
+			return this.#materializedEntriesCache;
 		}
 		const resolvedTextBlobCache = new Map<string, string>();
 		const materializedEntries = this.#fileEntries
 			.filter((e): e is SessionEntry => e.type !== "session")
 			.map(entry => materializeResidentEntrySync(entry, this.#residentBlobStores(), resolvedTextBlobCache));
-		this.#materializedEntriesCache = new WeakRef(materializedEntries);
+		this.#materializedEntriesCache = materializedEntries;
 		this.#materializedEntriesRevision = this.#entryRevision;
 		return materializedEntries;
 	}

--- a/packages/coding-agent/test/session-resident-cache.test.ts
+++ b/packages/coding-agent/test/session-resident-cache.test.ts
@@ -216,6 +216,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		expect(JSON.stringify(warmEntries)).toContain(sentinel);
 
 		await fs.promises.rm(residentCacheRoot(sm), { recursive: true, force: true });
+		Bun.gc(true);
 		expect(JSON.stringify(sm.getEntries())).toContain(sentinel);
 
 		sm.appendMessage(assistantMessage("invalidate warm resident view"));


### PR DESCRIPTION
## Summary
- keep the materialized session entries cache strongly referenced for the active entry revision instead of WeakRef-only
- continue resetting the materialized cache on entry revision changes, preserving missing-blob fail-closed behavior after invalidation
- add a forced `Bun.gc(true)` assertion to the warm resident-cache test so the pre-invalidation warm read is deterministic under GC pressure

Fixes #640.
Unblocks #621 by addressing the current-dev resident-cache full-suite flake.

## Verification
```bash
bun test packages/coding-agent/test/session-resident-cache.test.ts
bun test packages/coding-agent/test/resident-materialization.test.ts packages/coding-agent/test/session-resident-lifecycle.test.ts
cd packages/coding-agent && bunx tsc --noEmit -p tsconfig.json
```

All passed locally.
