### PR TITLE
fix(ralplan): re-assert active:true on post-clear --write (#644)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -227,7 +227,11 @@ async function persistActiveRunId(
 	}
 	let existing: Record<string, unknown> = existingRead.kind === "valid" ? existingRead.value : {};
 
-	const nextPhase = advanceCurrentPhase(existing.current_phase, stage);
+	// A new run_id is a fresh run, not a stray write on the prior run: never inherit a
+	// previous run's terminal/locked phase (which would start the new run already
+	// "complete"/"handoff" and disarm the Stop hook). PHASE_LOCK only guards same-run writes.
+	const isNewRun = existing.run_id !== runId;
+	const nextPhase = isNewRun ? stage : advanceCurrentPhase(existing.current_phase, stage);
 	if (
 		existing.run_id === runId &&
 		existing.version === WORKFLOW_STATE_VERSION &&
@@ -237,7 +241,9 @@ async function persistActiveRunId(
 	}
 	existing.run_id = runId;
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
-	if (typeof existing.active !== "boolean") existing.active = true;
+	// A successful persist means ralplan is actively writing this run's artifacts, so always
+	// re-assert active. Fallback-only init left active:false after a clear (#644, sibling of #638).
+	existing.active = true;
 	existing.current_phase = nextPhase;
 	existing = migrateWorkflowState(existing, "ralplan").state;
 	existing.updated_at = new Date().toISOString();

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -829,3 +829,54 @@ describe("native gjc ralplan runtime — persisted Planner state", () => {
 		expect(result.stderr).toContain("missing value for --planner-id");
 	});
 });
+
+describe("native gjc ralplan runtime — post-clear re-activation (#644)", () => {
+	const readState = async (root: string): Promise<{ active?: unknown; current_phase?: unknown; run_id?: unknown }> => {
+		const raw = await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8");
+		return JSON.parse(raw);
+	};
+
+	it("re-asserts active:true and resets phase out of terminal lock when a new run_id is written after a clear", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const seeded = await readState(root);
+		expect(seeded.active).toBe(true);
+
+		// Simulate `gjc state ralplan clear`: active -> false, phase -> complete.
+		await fs.writeFile(statePath, JSON.stringify({ ...seeded, active: false, current_phase: "complete" }), "utf-8");
+
+		// A subsequent --write with a NEW run_id starts a fresh run and must re-arm the skill.
+		const result = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "new-run-after-clear"],
+			root,
+		);
+		expect(result.status).toBe(0);
+
+		const after = await readState(root);
+		expect(after.run_id).toBe("new-run-after-clear");
+		expect(after.active).toBe(true);
+		expect(after.current_phase).toBe("planner");
+	});
+
+	it("does not re-arm a cleared run on a stray same-run-id --write (demote-on-clear preserved)", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const seeded = await readState(root);
+		const seededRunId = seeded.run_id as string;
+
+		await fs.writeFile(statePath, JSON.stringify({ ...seeded, active: false, current_phase: "complete" }), "utf-8");
+
+		// A stray --write reusing the SAME (cleared) run_id must not silently re-arm a finished run.
+		const result = await runNativeRalplanCommand(
+			["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", seededRunId],
+			root,
+		);
+		expect(result.status).toBe(0);
+
+		const after = await readState(root);
+		expect(after.active).toBe(false);
+		expect(after.current_phase).toBe("complete");
+	});
+});


### PR DESCRIPTION
Fixes #644

## Problem

After `gjc state ralplan clear` (which writes `active: false, current_phase: "complete"`), a subsequent `gjc ralplan --write` with a **new** `run_id` updated `run_id` but did **not** re-assert `active: true`. `persistActiveRunId` used fallback-only initialization:

```ts
if (typeof existing.active !== "boolean") existing.active = true;
```

Since `existing.active` was already a boolean (`false`), the field stayed `false`. This silently disarms the handoff-required Stop hook — `modeStateReleasesStop` returns `true` whenever `state.active !== true`, so ralplan could terminate mid-workflow without offering the user a next step. Sibling of #638 (same function, different field).

There was a second, deeper leg of the same bug: even forcing `active: true` is insufficient, because `current_phase` was still inherited from the cleared state (`"complete"`). `current_phase: "complete"` is itself a `STOP_RELEASING_PHASES` value, so the Stop hook would release regardless of `active`. A fresh `run_id` must not inherit the prior run's terminal/locked phase.

## Fix

`packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts` — `persistActiveRunId`:

- **Always** re-assert `existing.active = true` on a successful persist (a write means ralplan is actively producing this run's artifacts).
- When `run_id` changes (a fresh run), bypass `PHASE_LOCK` so the new run advances to the stage being written instead of inheriting the prior run's terminal phase. `PHASE_LOCK` still guards stray **same-run** writes, so a cleared/finished run is **not** re-armed by a duplicate-stage write.

This restores three-way state coherence (mode-state ↔ HUD ↔ global) without weakening the demote-on-clear or chain-guard contracts.

## Tests

Added `packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts` block "post-clear re-activation (#644)":

1. **re-asserts active + resets phase out of terminal lock on a new run_id after clear** — the reported bug. RED before fix (`active` stayed `false`), GREEN after.
2. **does not re-arm a cleared run on a stray same-run-id `--write`** — locks in the safety contract that the fix is scoped to new runs only (`active` stays `false`, phase stays `complete`).

### Verification

- `bun test test/gjc-runtime/ralplan-runtime.test.ts` → 42 pass / 0 fail (40 existing + 2 new), including the existing PHASE_LOCK / phase-coherence and duplicate-write-guard suites.
- `bun test test/gjc-runtime/state-runtime.test.ts` → 20 pass / 0 fail.
- `tsc -p packages/coding-agent/tsconfig.json --noEmit` → clean.
- `biome check` on changed files → clean.

Do not merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
