### PR TITLE
fix(ultragoal): dedup guard for checkpointUltragoalGoal (#645)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2065,6 +2065,26 @@ export async function checkpointUltragoalGoal(input: {
 	if (!goal) throw new Error(`No ultragoal goal found for ${input.goalId}.`);
 	const evidence = input.evidence.trim();
 	if (!evidence) throw new Error("checkpoint evidence is required");
+	const ledgerBefore = await readUltragoalLedger(input.cwd);
+	if (
+		goal.status === input.status &&
+		goal.evidence === evidence &&
+		ledgerBefore.some(
+			event =>
+				event.event === "goal_checkpointed" &&
+				event.goalId === goal.id &&
+				event.status === input.status &&
+				event.evidence === evidence,
+		)
+	) {
+		// Idempotent re-checkpoint: this goal is already recorded in the target status with the same
+		// evidence, so skip the plan rewrite and ledger append to avoid duplicate goal_checkpointed
+		// events. The ledger is the dedup source of truth because it is exactly what a duplicate write
+		// would corrupt (mirrors the ralplan #638 guard). Requiring a matching ledger row means an
+		// interrupted prior write (plan persisted, ledger append lost) still re-appends the event
+		// instead of silently dropping it.
+		return plan;
+	}
 	const qualityGateJson =
 		input.status === "complete"
 			? await readRequiredCompletionQualityGate(input.cwd, input.qualityGateJson)
@@ -2072,7 +2092,6 @@ export async function checkpointUltragoalGoal(input: {
 				? await readStructuredValue(input.cwd, input.qualityGateJson)
 				: undefined;
 	const now = new Date().toISOString();
-	const ledgerBefore = await readUltragoalLedger(input.cwd);
 	const beforeStatus = goal.status;
 	if (input.status === "complete") {
 		const blockedGoalId =

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1268,6 +1268,54 @@ describe("native GJC ultragoal runtime", () => {
 		});
 	});
 
+	it("dedups duplicate checkpoint ledger entries for an unchanged status and evidence (#645)", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		const goalsPath = path.join(root, ".gjc", "ultragoal", "goals.json");
+		const countCheckpoints = async (): Promise<number> =>
+			(await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed").length;
+
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "blocked",
+			evidence: "blocked by obsolete dependency",
+		});
+		expect(await countCheckpoints()).toBe(1);
+		const goalsAfterFirst = await Bun.file(goalsPath).text();
+
+		// Re-checkpoint with identical status + evidence: idempotent — no ledger append, no plan rewrite.
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "blocked",
+			evidence: "blocked by obsolete dependency",
+		});
+		expect(await countCheckpoints()).toBe(1);
+		expect(await Bun.file(goalsPath).text()).toBe(goalsAfterFirst);
+
+		// Whitespace-only differences still resolve to the same checkpoint (evidence is trimmed).
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "blocked",
+			evidence: "  blocked by obsolete dependency  ",
+		});
+		expect(await countCheckpoints()).toBe(1);
+		expect(await Bun.file(goalsPath).text()).toBe(goalsAfterFirst);
+
+		// A genuine change (new evidence) is still recorded as a fresh checkpoint.
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "blocked",
+			evidence: "blocked by a different upstream regression",
+		});
+		expect(await countCheckpoints()).toBe(2);
+	});
+
 	it("accepts full goal get tool result snapshots with millisecond timestamps", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });


### PR DESCRIPTION
## Summary

`checkpointUltragoalGoal` had no dedup guard: calling it twice for the same goal/status/evidence appended a duplicate `goal_checkpointed` ledger event and rewrote the plan file even when nothing changed. This is the same A2 idempotent-lookalike anti-pattern fixed for ralplan in #638. Within the same runtime, `startNextUltragoalGoal` already guards (`if (goal.status !== "active")`) — checkpoint had no equivalent.

## Root cause

`packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts` — `checkpointUltragoalGoal` captured `beforeStatus` but never used it to short-circuit. It always wrote the plan and always called `appendLedger` (a pure `appendJsonl` with a fresh `crypto.randomUUID()` eventId), so every repeated call corrupted the ledger with a duplicate entry.

## Fix

Add a dedup guard mirroring the ralplan #638 pattern. Before any mutation, return the unchanged plan when **all** of:

- the goal is already in the requested `status`,
- `goal.evidence` already equals the requested (trimmed) evidence, and
- a matching `goal_checkpointed` row already exists in the ledger.

Using the **ledger as the dedup source of truth** (not in-memory goal state alone) is deliberate: it is exactly what a duplicate write would corrupt, and it keeps an interrupted prior write self-healing — if the plan was persisted but the ledger append was lost, the missing event is re-appended on retry rather than silently dropped. A genuine change (new evidence) is still recorded as a fresh checkpoint, and the first transition to `complete` still runs the full quality-gate validation (the guard only fires once a goal is already validly recorded in that state).

Evidence is compared after `.trim()`, so whitespace-only differences resolve to the same checkpoint.

## Testing

- Added focused regression test `dedups duplicate checkpoint ledger entries for an unchanged status and evidence (#645)`:
  - first checkpoint → exactly 1 `goal_checkpointed`
  - identical re-checkpoint → still 1, and `goals.json` byte-identical (no rewrite)
  - whitespace-padded same evidence → still 1 (trim handling)
  - new evidence → 2 (genuine changes still recorded)
  - Confirmed it fails on `dev` (received 2, expected 1) and passes after the fix.
- `bun test` across `ultragoal-runtime`, `ultragoal-dogfood`, `ultragoal-review`, and `ultragoal-ask-guard` suites: **113 pass, 0 fail**.
- `tsgo --noEmit` typecheck and `biome check` clean on changed files.

Fixes #645

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
