### PR TITLE
fix(ultragoal): reconcile review mode-state and dedup blocker goals (#643)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2731,6 +2731,18 @@ function executorQaBlockers(executorQa: JsonObject): UltragoalReviewFinding[] {
 	return (blockers ?? []).map(message => ({ severity: "blocker", message: `executorQa.blockers: ${message}` }));
 }
 
+const RESOLVED_REVIEW_BLOCKER_STATUSES = new Set<UltragoalGoalStatus>(["complete", "superseded"]);
+
+function findOpenReviewBlockerGoal(plan: UltragoalPlan, message: string): UltragoalGoal | undefined {
+	const objective = message.trim();
+	return plan.goals.find(
+		goal =>
+			goal.steering?.kind === "review_blocker" &&
+			goal.objective.trim() === objective &&
+			!RESOLVED_REVIEW_BLOCKER_STATUSES.has(goal.status),
+	);
+}
+
 async function recordReviewFindingGoals(cwd: string, findings: readonly UltragoalReviewFinding[]): Promise<string[]> {
 	let plan = await readUltragoalPlan(cwd);
 	const now = new Date().toISOString();
@@ -2745,8 +2757,14 @@ async function recordReviewFindingGoals(cwd: string, findings: readonly Ultragoa
 			goals: [],
 		};
 	}
-	const created: string[] = [];
+	const blockerGoalIds: string[] = [];
+	const createdGoalIds: string[] = [];
 	for (const finding of findings) {
+		const existing = findOpenReviewBlockerGoal(plan, finding.message);
+		if (existing) {
+			if (!blockerGoalIds.includes(existing.id)) blockerGoalIds.push(existing.id);
+			continue;
+		}
 		const id = nextUltragoalGoalId(plan);
 		plan.goals.push({
 			id,
@@ -2757,16 +2775,19 @@ async function recordReviewFindingGoals(cwd: string, findings: readonly Ultragoa
 			updatedAt: now,
 			steering: { kind: "review_blocker" },
 		});
-		created.push(id);
+		blockerGoalIds.push(id);
+		createdGoalIds.push(id);
 	}
-	plan.updatedAt = now;
-	await writePlan(cwd, plan);
-	await appendLedger(cwd, {
-		event: "review_blockers_recorded",
-		blockerGoalIds: created,
-		findings: findings.map(finding => finding.message),
-	});
-	return created;
+	if (createdGoalIds.length > 0) {
+		plan.updatedAt = now;
+		await writePlan(cwd, plan);
+		await appendLedger(cwd, {
+			event: "review_blockers_recorded",
+			blockerGoalIds: createdGoalIds,
+			findings: findings.map(finding => finding.message),
+		});
+	}
+	return blockerGoalIds;
 }
 
 export async function runUltragoalReview(cwd: string, args: readonly string[]): Promise<UltragoalReviewResult> {
@@ -3252,6 +3273,7 @@ const RECONCILE_COMMANDS = new Set([
 	"checkpoint",
 	"steer",
 	"record-review-blockers",
+	"review",
 ]);
 
 /**

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
@@ -201,6 +201,66 @@ async function review(root: string, args: string[]): Promise<Record<string, unkn
 	return JSON.parse(result.stdout ?? "{}");
 }
 
+function modeStatePath(root: string): string {
+	const sessionId = process.env.GJC_SESSION_ID?.trim();
+	if (sessionId) {
+		const encoded = encodeURIComponent(sessionId).replaceAll(".", "%2E");
+		return path.join(root, ".gjc", "state", "sessions", encoded, "ultragoal-state.json");
+	}
+	return path.join(root, ".gjc", "state", "ultragoal-state.json");
+}
+
+async function readModeState(root: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await Bun.file(modeStatePath(root)).text());
+}
+
+function passingQualityGate(): Record<string, unknown> {
+	return {
+		architectReview: {
+			architectureStatus: "CLEAR",
+			productStatus: "CLEAR",
+			codeStatus: "CLEAR",
+			recommendation: "APPROVE",
+			evidence: "architect reviewed architecture, product behavior, and code changes",
+			commands: ["architect-review"],
+			blockers: [],
+		},
+		executorQa: validExecutorQa(),
+		iteration: {
+			status: "passed",
+			evidence: "no verification findings remain after steering iterations",
+			fullRerun: true,
+			rerunCommands: ["bun test:e2e"],
+			blockers: [],
+		},
+	};
+}
+
+async function completeSingleGoal(root: string): Promise<void> {
+	await writeStructuralArtifacts(root);
+	const created = await createUltragoalPlan({ cwd: root, brief: "Ship review reconcile" });
+	await startNextUltragoalGoal({ cwd: root });
+	const checkpoint = await runNativeUltragoalCommand(
+		[
+			"checkpoint",
+			"--goal-id",
+			"G001",
+			"--status",
+			"complete",
+			"--evidence",
+			"final story verified with targeted regression coverage",
+			"--gjc-goal-json",
+			JSON.stringify({
+				goal: { threadId: "test", objective: created.gjcObjective, status: "active", updatedAt: Date.now() },
+			}),
+			"--quality-gate-json",
+			JSON.stringify(passingQualityGate()),
+		],
+		root,
+	);
+	expect(checkpoint.status).toBe(0);
+}
+
 describe("ultragoal review command", () => {
 	it("parses branch and worktree sources and falls back when gh is unavailable for pr", async () => {
 		const root = await tempDir();
@@ -249,6 +309,48 @@ describe("ultragoal review command", () => {
 		expect((output.blockerGoalIds as unknown[]).length).toBeGreaterThan(0);
 		expect(plan?.goals[0]?.status).toBe("pending");
 		expect(plan?.goals[0]?.steering?.kind).toBe("review_blocker");
+	});
+
+	it("review --mode review-start reconciles mode-state after recording blocker goals (#643)", async () => {
+		const root = await tempDir();
+		await completeSingleGoal(root);
+
+		const before = await readModeState(root);
+		expect(before.active).toBe(false);
+		expect(before.current_phase).toBe("complete");
+
+		const output = await review(root, [
+			"--mode",
+			"review-start",
+			"--executor-qa-json",
+			await writeQa(root, invalidInlineOnlyExecutorQa()),
+		]);
+		expect((output.blockerGoalIds as unknown[]).length).toBeGreaterThan(0);
+
+		const plan = await readUltragoalPlan(root);
+		const pendingBlockers = (plan?.goals ?? []).filter(
+			goal => goal.steering?.kind === "review_blocker" && goal.status === "pending",
+		);
+		expect(pendingBlockers.length).toBeGreaterThan(0);
+
+		const after = await readModeState(root);
+		expect(after.active).toBe(true);
+		expect(after.current_phase).toBe("pending");
+	});
+
+	it("review --mode review-start does not duplicate blocker goals on repeat (#643)", async () => {
+		const root = await tempDir();
+		const qaPath = await writeQa(root, invalidInlineOnlyExecutorQa());
+
+		const first = await review(root, ["--mode", "review-start", "--executor-qa-json", qaPath]);
+		const second = await review(root, ["--mode", "review-start", "--executor-qa-json", qaPath]);
+
+		const plan = await readUltragoalPlan(root);
+		const blockerGoals = (plan?.goals ?? []).filter(goal => goal.steering?.kind === "review_blocker");
+		const objectives = blockerGoals.map(goal => goal.objective);
+		expect(new Set(objectives).size).toBe(objectives.length);
+		expect(blockerGoals.length).toBe((first.blockerGoalIds as unknown[]).length);
+		expect(second.blockerGoalIds).toEqual(first.blockerGoalIds);
 	});
 
 	it("rejects the same invalid live artifact as checkpoint", async () => {


### PR DESCRIPTION
## Summary

Fixes #643 — a state-coherence / stop-hook safety regression introduced in #610 (same class as #638).

`gjc ultragoal review --mode review-start` mutates `goals.json` + `ledger.jsonl` (via `recordReviewFindingGoals`) but was **excluded from `RECONCILE_COMMANDS`**, so `reconcileUltragoalState` never ran after it. When review found blockers after all goals were complete, the workflow mode-state stayed stale (`active:false, current_phase:"complete"`) — silently disarming the stop-hook safety mechanism and prematurely releasing Stop with unaddressed blocker goals.

Additionally, `recordReviewFindingGoals` had **no dedup guard**, so calling review twice created duplicate blocker goals with distinct IDs for the same finding (`nextUltragoalGoalId` uses `plan.goals.length`).

## Root cause (verified in code)

- `RECONCILE_COMMANDS` (`packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`) omitted `"review"`, so the post-command reconcile in `runNativeUltragoalCommand` never fired for `review --mode review-start`, even though `runUltragoalReview` → `recordReviewFindingGoals` writes the plan and appends the ledger.
- `recordReviewFindingGoals` created goals unconditionally with no existence check.

## Fix

1. **Missing reconcile** — add `"review"` to `RECONCILE_COMMANDS` so a successful `review` re-derives mode-state from plan/ledger (re-arms `active:true, current_phase:"pending"` once a pending blocker exists).
2. **Dedup** — before creating a blocker goal, check for an existing **open** (`status` not `complete`/`superseded`) `review_blocker` goal with the same finding message; reuse it instead of duplicating. Persist/append the ledger only when a new goal is actually created. A resolved-then-regressed finding still creates a fresh goal so the stop hook re-arms — no weakening of the safety contract.

The dedup return value now reports all open blocker goal ids for the findings (created + reused), so `createdReviewPlan` / `reviewBlockerGoalIds` keep goal mode armed on repeat calls.

## Tests

Added two focused regression tests in `packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts`:

- `review --mode review-start reconciles mode-state after recording blocker goals (#643)` — completes a goal end-to-end (mode-state → `active:false/complete`), then runs `review --mode review-start`; asserts mode-state re-arms to `active:true/current_phase:"pending"`.
- `review --mode review-start does not duplicate blocker goals on repeat (#643)` — runs review-start twice and asserts no duplicate `review_blocker` objectives and identical returned blocker ids.

Both tests **fail on the base commit** (proving the bug) and **pass with the fix**.

## Verification

- `bun test test/gjc-runtime/ultragoal-review.test.ts test/gjc-runtime/ultragoal-runtime.test.ts` → 109 pass / 0 fail
- `bun test test/tools/ultragoal-ask-guard.test.ts test/gjc-runtime/ultragoal-dogfood.test.ts` → 5 pass / 0 fail
- `tsgo --noEmit` → clean
- `biome check` on changed files → clean

Do not merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*