### PR TITLE
fix(state-writer): serialize updateJsonAtomic with cross-process lock (#646)

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs/promises";
-import { isEnoent } from "@gajae-code/utils";
+import { isEnoent } from "@gajae-code/utils/fs-error";
 
 export interface FileLockOptions {
 	staleMs?: number;

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { type FileLockOptions, withFileLock } from "../config/file-lock";
 import type { ActiveSubskillEntry, SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
 import {
 	type AuditEntry,
@@ -81,6 +82,12 @@ export interface StateWriterOptions {
 	cwd?: string;
 	receipt?: StateWriterReceiptContext;
 	audit?: StateWriterAuditContext;
+	/**
+	 * Cross-process lock tuning for read-modify-write paths that route through
+	 * `withWorkflowStateLock` / `updateJsonAtomic`. Omit for the hardened
+	 * `withFileLock` defaults.
+	 */
+	lock?: FileLockOptions;
 }
 
 export interface DeleteIfOwnedOptions extends StateWriterOptions {
@@ -417,17 +424,55 @@ export async function writeTextAtomic(targetPath: string, text: string, options?
 	return filePath;
 }
 
+/**
+ * Serialize a read-modify-write (or any multi-step mutation) against concurrent
+ * writers of the same `.gjc/**` target. Uses the cross-process directory lock
+ * from `withFileLock`, keyed on the resolved file path, so separate CLI/agent
+ * processes (e.g. team-mode workers) cannot interleave one writer's read with
+ * another writer's write and silently drop the first mutation (issue #646).
+ *
+ * The lock is advisory: it only protects callers that route through it, so every
+ * read-modify-write of a given file MUST acquire this lock for the same resolved
+ * path. `atomicWrite`'s temp-file + rename crash-atomicity is preserved; this
+ * layers concurrency-atomicity on top without weakening it.
+ */
+export async function withWorkflowStateLock<T>(
+	targetPath: string,
+	fn: () => Promise<T>,
+	options?: StateWriterOptions,
+): Promise<T> {
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	return lockResolvedWorkflowTarget(filePath, fn, options?.lock);
+}
+
+async function lockResolvedWorkflowTarget<T>(
+	filePath: string,
+	fn: () => Promise<T>,
+	lockOptions?: FileLockOptions,
+): Promise<T> {
+	// `withFileLock` creates the lock dir next to the target with a non-recursive
+	// mkdir, so the parent directory must exist before the lock is acquired.
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	return withFileLock(filePath, fn, lockOptions);
+}
+
 export async function updateJsonAtomic<T = unknown>(
 	targetPath: string,
 	mutator: (current: T | undefined) => T | Promise<T>,
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	const current = (await readJsonIfPresent(filePath)) as T | undefined;
-	const next = await mutator(current);
-	await atomicWrite(filePath, jsonText(withWorkflowReceipt(next, buildReceipt(options))));
-	await maybeAudit(filePath, options);
-	return filePath;
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			const current = (await readJsonIfPresent(filePath)) as T | undefined;
+			const next = await mutator(current);
+			await atomicWrite(filePath, jsonText(withWorkflowReceipt(next, buildReceipt(options))));
+			await maybeAudit(filePath, options);
+			return filePath;
+		},
+		options?.lock,
+	);
 }
 
 export async function appendJsonl(targetPath: string, entry: unknown, options?: StateWriterOptions): Promise<string> {

--- a/packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { updateJsonAtomic, withWorkflowStateLock } from "@gajae-code/coding-agent/gjc-runtime/state-writer";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-state-writer-cas-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterAll(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("state-writer concurrency (issue #646)", () => {
+	it("updateJsonAtomic does not lose concurrent read-modify-write updates", async () => {
+		const root = await tempDir();
+		const target = ".gjc/state/cas-probe.json";
+		const filePath = path.join(root, target);
+		const keys = Array.from({ length: 16 }, (_, index) => `k${index}`);
+
+		// Each mutator yields between read and write, so without serialization
+		// every writer reads the same document and the last write wins, silently
+		// dropping every other mutation (the TOCTOU in issue #646). The
+		// cross-process lock in updateJsonAtomic must serialize these cycles.
+		await Promise.all(
+			keys.map(key =>
+				updateJsonAtomic<Record<string, unknown>>(
+					target,
+					async current => {
+						await sleep(5);
+						return { ...(current ?? {}), [key]: true };
+					},
+					{ cwd: root },
+				),
+			),
+		);
+
+		const final = await readJson(filePath);
+		for (const key of keys) {
+			expect(final[key]).toBe(true);
+		}
+		expect(Object.keys(final)).toHaveLength(keys.length);
+	});
+
+	it("updateJsonAtomic applies sequential increments without losing any", async () => {
+		const root = await tempDir();
+		const target = ".gjc/state/counter.json";
+		const filePath = path.join(root, target);
+		const bumps = 24;
+
+		await Promise.all(
+			Array.from({ length: bumps }, () =>
+				updateJsonAtomic<{ count?: number }>(
+					target,
+					async current => {
+						const count = typeof current?.count === "number" ? current.count : 0;
+						await sleep(2);
+						return { count: count + 1 };
+					},
+					{ cwd: root },
+				),
+			),
+		);
+
+		const final = await readJson(filePath);
+		expect(final.count).toBe(bumps);
+	});
+
+	it("withWorkflowStateLock serializes mutations of the same resolved target", async () => {
+		const root = await tempDir();
+		const target = ".gjc/state/lock-probe.json";
+
+		let active = 0;
+		let maxActive = 0;
+		const runCriticalSection = async (): Promise<void> => {
+			active += 1;
+			maxActive = Math.max(maxActive, active);
+			await sleep(5);
+			active -= 1;
+		};
+
+		await Promise.all(
+			Array.from({ length: 8 }, () => withWorkflowStateLock(target, runCriticalSection, { cwd: root })),
+		);
+
+		// If the lock serializes correctly, only one critical section is ever in
+		// flight, so the observed peak concurrency stays at 1.
+		expect(maxActive).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the TOCTOU / lost-update bug in `updateJsonAtomic` (issue #646). The function was a classic read-modify-write with **no compare-and-swap / concurrency protection**: two concurrent writers could both read the same document, mutate independently, and the second write silently overwrote the first. `atomicWrite`'s temp-file + rename is crash-atomic but **not** concurrency-atomic.

The codebase already had a hardened cross-process lock (`config/file-lock.ts:withFileLock`, hardened in #618) that was **not imported by any `gjc-runtime/` file**. This PR wires it into the state-writer.

## Changes

- `updateJsonAtomic` now routes its read-modify-write through the cross-process `withFileLock`, keyed on the resolved target path, so concurrent cycles on the same file are serialized.
- Exposes `withWorkflowStateLock(targetPath, fn, options)` as the reusable CAS primitive (parent-dir-creating wrapper over `withFileLock`) for callers that need to serialize multi-step mutations of the same target. `updateJsonAtomic` uses it internally.
- Adds `StateWriterOptions.lock?: FileLockOptions` to tune retry/stale behavior; omit for hardened defaults.

## Scope

**Intentionally narrow: state-writer `updateJsonAtomic` CAS/lock hardening + the primitive only.** Migrating the remaining read-modify-write cycles (`state-runtime` reconcile/write/clear/handoff, ralplan, ultragoal, deep-interview) onto the lock is deferred to follow-up PRs so this change stays small and reviewable.

## Evidence

**Repro (unpatched):** 16 concurrent `updateJsonAtomic` writes collapse to **1** key — 15 mutations silently dropped:
```
error: expect(received).toHaveLength(expected)
Expected length: 16
Received length: 1
```

**With the fix:** all 16 land. New focused test `test/gjc-runtime/state-writer-cas.test.ts` (3 tests):
- `updateJsonAtomic does not lose concurrent read-modify-write updates`
- `updateJsonAtomic applies sequential increments without losing any`
- `withWorkflowStateLock serializes mutations of the same resolved target`

```
 3 pass  0 fail  19 expect() calls
```

Regression check — relevant existing suites all green (71 pass): `state-writer-drift`, `state-write-hardening`, `state-concurrency-fuzz`, `state-runtime`, `workflow-state-command`, `state-handoff`, `state-receipts`.

`biome check` + `tsgo --noEmit` clean on changed files.

## Notes

- The lock is advisory: it only protects callers that route through it, so every read-modify-write of a given file must acquire the lock for the same resolved path. Crash-atomicity of `atomicWrite` is preserved; this layers concurrency-atomicity on top.

Closes #646.

**Do not merge.**