### PR TITLE
feat(setup): import existing Claude/Codex credentials (#651)

### DIFF
--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -3,8 +3,11 @@
  *
  * Handles `gjc setup [component]` to install the normal defaults or optional feature dependencies.
  */
+
 import * as path from "node:path";
-import { $which, APP_NAME, getPythonEnvDir } from "@gajae-code/utils";
+import { createInterface } from "node:readline/promises";
+import { SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { $which, APP_NAME, getAgentDbPath, getPythonEnvDir } from "@gajae-code/utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { installDefaultGjcDefinitions } from "../defaults/gjc-defaults";
@@ -14,6 +17,7 @@ import {
 	readGjcManagedCodexHooksStatus,
 } from "../hooks/codex-native-hooks-config";
 import { theme } from "../modes/theme/theme";
+import { discoverExternalCredentials, formatDiscoverySummary, importCredentials } from "../setup/credential-import";
 import {
 	formatHermesSetupResult,
 	type HermesSetupFlags,
@@ -27,7 +31,7 @@ import {
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
 
-export type SetupComponent = "defaults" | "hermes" | "hooks" | "provider" | "python" | "stt";
+export type SetupComponent = "credentials" | "defaults" | "hermes" | "hooks" | "provider" | "python" | "stt";
 
 export interface SetupCommandArgs {
 	component: SetupComponent;
@@ -57,10 +61,12 @@ export interface SetupCommandArgs {
 		gjcCommand?: string;
 		target?: string;
 		profileDir?: string;
+		yes?: boolean;
+		dryRun?: boolean;
 	};
 }
 
-const VALID_COMPONENTS: SetupComponent[] = ["defaults", "hermes", "hooks", "provider", "python", "stt"];
+const VALID_COMPONENTS: SetupComponent[] = ["credentials", "defaults", "hermes", "hooks", "provider", "python", "stt"];
 
 function hasProviderSetupFlags(flags: SetupCommandArgs["flags"]): boolean {
 	return (
@@ -113,6 +119,10 @@ export function parseSetupArgs(args: string[]): SetupCommandArgs | undefined {
 			flags.smoke = true;
 		} else if (arg === "--install") {
 			flags.install = true;
+		} else if (arg === "--yes" || arg === "-y") {
+			flags.yes = true;
+		} else if (arg === "--dry-run") {
+			flags.dryRun = true;
 		} else if (arg === "--root") {
 			flags.root = [...(flags.root ?? []), args[++i] ?? ""];
 		} else if (arg === "--repo") {
@@ -242,6 +252,9 @@ export async function runSetupCommand(cmd: SetupCommandArgs): Promise<void> {
 			break;
 		case "stt":
 			await handleSttSetup(cmd.flags);
+			break;
+		case "credentials":
+			await handleCredentialsSetup(cmd.flags);
 			break;
 	}
 }
@@ -472,6 +485,122 @@ async function handleSttSetup(flags: { json?: boolean; check?: boolean }): Promi
 		process.exit(1);
 	}
 }
+async function confirmImport(count: number): Promise<boolean> {
+	if (!process.stdin.isTTY) return false;
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	try {
+		const answer = (await rl.question(`Import ${count} credential(s) into ${getAgentDbPath()}? [y/N] `))
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
+}
+
+/**
+ * Discover existing Claude Code / Codex CLI credentials and import them into the
+ * gjc credential store after a redacted preview + confirmation. Falls back to
+ * manual-setup guidance when nothing importable is found.
+ */
+async function handleCredentialsSetup(flags: { json?: boolean; yes?: boolean; dryRun?: boolean }): Promise<void> {
+	const result = await discoverExternalCredentials();
+	const redactedPlan = {
+		importable: result.importable.map(c => ({
+			provider: c.provider,
+			kind: c.kind,
+			source: c.source,
+			identity: c.identity,
+			expiresAt: c.expiresAt,
+			redactedToken: c.redactedToken,
+		})),
+		skipped: result.skipped,
+		environment: result.environment,
+	};
+
+	if (result.importable.length === 0) {
+		if (flags.json) {
+			process.stdout.write(`${JSON.stringify({ ...redactedPlan, imported: [] })}\n`);
+			return;
+		}
+		for (const line of formatDiscoverySummary(result)) process.stdout.write(`  ${line}\n`);
+		process.stdout.write(
+			chalk.yellow(
+				`\nNo importable Claude/Codex credentials found. Continue with manual setup:\n` +
+					`  ${APP_NAME} setup provider   (add an API-compatible provider)\n` +
+					`  ${APP_NAME} (then /login)     (interactive OAuth/subscription login)\n`,
+			),
+		);
+		return;
+	}
+
+	if (!flags.json) {
+		process.stdout.write(chalk.bold("Discovered credentials (redacted):\n"));
+		for (const line of formatDiscoverySummary(result)) process.stdout.write(`  ${line}\n`);
+	}
+
+	if (flags.dryRun) {
+		if (flags.json) process.stdout.write(`${JSON.stringify({ ...redactedPlan, dryRun: true, imported: [] })}\n`);
+		else process.stdout.write(chalk.dim(`\nDry run — no credentials imported.\n`));
+		return;
+	}
+
+	const confirmed = flags.yes || (await confirmImport(result.importable.length));
+	if (!confirmed) {
+		if (flags.json) {
+			process.stdout.write(`${JSON.stringify({ ...redactedPlan, imported: [] })}\n`);
+			return;
+		}
+		process.stdout.write(chalk.dim(`\nImport cancelled. Re-run with --yes to import non-interactively.\n`));
+		return;
+	}
+
+	const store = await SqliteAuthCredentialStore.open(getAgentDbPath());
+	let summary: Awaited<ReturnType<typeof importCredentials>>;
+	try {
+		summary = await importCredentials(result.importable, (provider, credential) =>
+			store.upsertAuthCredentialForProvider(provider, credential),
+		);
+	} finally {
+		store.close();
+	}
+
+	if (flags.json) {
+		process.stdout.write(
+			`${JSON.stringify({
+				...redactedPlan,
+				imported: summary.imported.map(c => ({ provider: c.provider, kind: c.kind, source: c.source })),
+				failed: summary.failed.map(f => ({
+					provider: f.credential.provider,
+					source: f.credential.source,
+					error: f.error,
+				})),
+			})}\n`,
+		);
+		if (summary.failed.length > 0) process.exitCode = 1;
+		return;
+	}
+
+	for (const credential of summary.imported) {
+		process.stdout.write(
+			`${chalk.green(`${theme.status.success} imported`)} ${formatCredentialSummaryLine(credential)}\n`,
+		);
+	}
+	for (const failure of summary.failed) {
+		process.stdout.write(
+			`${chalk.red(`${theme.status.error} failed`)} ${failure.credential.provider} (${failure.credential.source}): ${failure.error}\n`,
+		);
+	}
+	if (summary.failed.length > 0) {
+		process.exitCode = 1;
+		return;
+	}
+	process.stdout.write(chalk.dim(`\nCredentials saved to ${getAgentDbPath()}\n`));
+}
+
+function formatCredentialSummaryLine(credential: { provider: string; kind: string; source: string }): string {
+	return `${credential.provider} · ${credential.kind} (from ${credential.source})`;
+}
 
 /**
  * Print setup command help.
@@ -489,6 +618,7 @@ ${chalk.bold("Components:")}
   provider  Optional: add a preset, OpenAI-compatible, or Anthropic-compatible API provider
   python    Optional: verify a Python 3 interpreter is reachable for code execution
   stt       Optional: install speech-to-text dependencies (openai-whisper, recording tools)
+  credentials Optional: import existing Claude Code / Codex CLI credentials
 
 
 ${chalk.bold("Provider example:")}
@@ -524,6 +654,8 @@ ${chalk.bold("Options:")}
   --mutation        Hermes MCP mutation classes: sessions,questions,reports,all
   --target          Hermes config file target for config-only install
   --profile-dir     Hermes profile directory for full setup install
+  --dry-run         Preview discovered credentials without importing (credentials)
+  -y, --yes         Import discovered credentials without an interactive prompt (credentials)
 
 ${chalk.bold("Examples:")}
   ${APP_NAME} setup                  Install bundled GJC default workflow skills
@@ -536,5 +668,8 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} setup stt              Install speech-to-text dependencies
   ${APP_NAME} setup stt --check      Check if STT dependencies are available
   ${APP_NAME} setup python --check   Check if Python execution is available
+  ${APP_NAME} setup credentials      Discover & import existing Claude/Codex credentials
+  ${APP_NAME} setup credentials --dry-run  Preview importable credentials (redacted)
+  ${APP_NAME} setup credentials --yes      Import without an interactive prompt
 `);
 }

--- a/packages/coding-agent/src/commands/setup.ts
+++ b/packages/coding-agent/src/commands/setup.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { runSetupCommand, type SetupCommandArgs, type SetupComponent } from "../cli/setup-cli";
 import { initTheme } from "../modes/theme/theme";
 
-const COMPONENTS: SetupComponent[] = ["defaults", "hermes", "hooks", "provider", "python", "stt"];
+const COMPONENTS: SetupComponent[] = ["credentials", "defaults", "hermes", "hooks", "provider", "python", "stt"];
 
 export default class Setup extends Command {
 	static description = "Install GJC defaults or optional feature dependencies";
@@ -47,6 +47,8 @@ export default class Setup extends Command {
 		"api-key-env": Flags.string({ description: "Read provider API key from this environment variable" }),
 		model: Flags.string({ description: "Model id to add (repeat or comma-separate)", multiple: true }),
 		"models-path": Flags.string({ description: "Override models config path" }),
+		yes: Flags.boolean({ char: "y", description: "Import discovered credentials without an interactive prompt" }),
+		"dry-run": Flags.boolean({ description: "Preview discovered credentials without importing" }),
 	};
 
 	async run(): Promise<void> {
@@ -79,6 +81,8 @@ export default class Setup extends Command {
 				gjcCommand: flags["gjc-command"],
 				target: flags.target,
 				profileDir: flags["profile-dir"],
+				yes: flags.yes,
+				dryRun: flags["dry-run"],
 			},
 		};
 		await initTheme();

--- a/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
+++ b/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
@@ -4,7 +4,7 @@ import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
 import { formatModelOnboardingGuidance } from "../../setup/model-onboarding-guidance";
 import { DynamicBorder } from "./dynamic-border";
 
-export type ProviderOnboardingAction = "custom-provider-wizard" | "oauth-login" | "api-guide";
+export type ProviderOnboardingAction = "custom-provider-wizard" | "oauth-login" | "import-credentials" | "api-guide";
 
 interface ProviderOnboardingOption {
 	label: string;
@@ -13,6 +13,11 @@ interface ProviderOnboardingOption {
 }
 
 const PROVIDER_ONBOARDING_OPTIONS: ProviderOnboardingOption[] = [
+	{
+		label: "Import existing credentials",
+		description: "Detect and import Claude Code / Codex CLI logins already on this machine.",
+		action: "import-credentials",
+	},
 	{
 		label: "Add custom provider",
 		description: "Configure an OpenAI- or Anthropic-compatible API provider interactively.",

--- a/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
+++ b/packages/coding-agent/src/modes/components/provider-onboarding-selector.ts
@@ -14,11 +14,6 @@ interface ProviderOnboardingOption {
 
 const PROVIDER_ONBOARDING_OPTIONS: ProviderOnboardingOption[] = [
 	{
-		label: "Import existing credentials",
-		description: "Detect and import Claude Code / Codex CLI logins already on this machine.",
-		action: "import-credentials",
-	},
-	{
 		label: "Add custom provider",
 		description: "Configure an OpenAI- or Anthropic-compatible API provider interactively.",
 		action: "custom-provider-wizard",
@@ -32,6 +27,11 @@ const PROVIDER_ONBOARDING_OPTIONS: ProviderOnboardingOption[] = [
 		label: "Add API-compatible provider",
 		description: "Show the /provider add and gjc setup provider commands.",
 		action: "api-guide",
+	},
+	{
+		label: "Import existing credentials",
+		description: "Detect and import Claude Code / Codex CLI logins already on this machine.",
+		action: "import-credentials",
 	},
 ];
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -32,6 +32,7 @@ import {
 import type { InteractiveModeContext } from "../../modes/types";
 import { type SessionInfo, SessionManager } from "../../session/session-manager";
 import { FileSessionStorage } from "../../session/session-storage";
+import { discoverExternalCredentials, formatDiscoverySummary, importCredentials } from "../../setup/credential-import";
 import {
 	MODEL_ONBOARDING_API_PROVIDER_COMMAND,
 	MODEL_ONBOARDING_PROVIDER_PRESET_COMMAND,
@@ -134,6 +135,8 @@ export class SelectorController {
 						this.showCustomProviderWizard();
 					} else if (action === "oauth-login") {
 						void this.showOAuthSelector("login");
+					} else if (action === "import-credentials") {
+						void this.#handleCredentialImport();
 					} else {
 						this.ctx.showStatus(formatProviderOnboardingCommandGuide());
 					}
@@ -145,6 +148,69 @@ export class SelectorController {
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	async #handleCredentialImport(): Promise<void> {
+		this.ctx.showStatus("Scanning for existing Claude Code / Codex CLI credentials…");
+		const result = await discoverExternalCredentials();
+		const summaryLines = formatDiscoverySummary(result);
+
+		if (result.importable.length === 0) {
+			this.ctx.chatContainer.addChild(new Spacer(1));
+			for (const line of summaryLines) {
+				this.ctx.chatContainer.addChild(new Text(theme.fg("dim", line), 1, 0));
+			}
+			this.ctx.chatContainer.addChild(
+				new Text(
+					theme.fg(
+						"warning",
+						"No importable Claude/Codex credentials found. Use /login or add a custom provider.",
+					),
+					1,
+					0,
+				),
+			);
+			this.ctx.ui.requestRender();
+			return;
+		}
+
+		const confirmed = await this.ctx.showHookConfirm(
+			`Import ${result.importable.length} credential(s)?`,
+			summaryLines.join("\n"),
+		);
+		if (!confirmed) {
+			this.ctx.showStatus("Credential import cancelled.");
+			return;
+		}
+
+		const summary = await importCredentials(result.importable, (provider, credential) =>
+			this.ctx.session.modelRegistry.authStorage.upsertCredential(provider, credential),
+		);
+		await this.ctx.session.modelRegistry.refresh();
+
+		this.ctx.chatContainer.addChild(new Spacer(1));
+		for (const credential of summary.imported) {
+			this.ctx.chatContainer.addChild(
+				new Text(
+					theme.fg("success", `${theme.status.success} Imported ${credential.provider} (${credential.source})`),
+					1,
+					0,
+				),
+			);
+		}
+		for (const failure of summary.failed) {
+			this.ctx.chatContainer.addChild(
+				new Text(
+					theme.fg("error", `${theme.status.error} Failed ${failure.credential.provider}: ${failure.error}`),
+					1,
+					0,
+				),
+			);
+		}
+		if (summary.imported.length > 0) {
+			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`), 1, 0));
+		}
+		this.ctx.ui.requestRender();
 	}
 
 	showCustomProviderWizard(): void {

--- a/packages/coding-agent/src/setup/credential-import.ts
+++ b/packages/coding-agent/src/setup/credential-import.ts
@@ -1,0 +1,401 @@
+/**
+ * Discover and import existing Claude Code / Codex CLI credentials.
+ *
+ * This is the testable core behind `gjc setup credentials` (CLI, primary entry)
+ * and the TUI provider-onboarding "import existing credentials" action. It never
+ * prints or returns raw tokens: callers receive redacted summaries plus opaque
+ * {@link AuthCredential} payloads that go straight into the store.
+ *
+ * Sources:
+ *   - Claude Code: `~/.claude/.credentials.json` (Linux/WSL/Windows native),
+ *     the macOS Keychain (`Claude Code-credentials`), and env vars.
+ *   - Codex CLI: `~/.codex/auth.json` (OAuth `tokens` block or stored
+ *     `OPENAI_API_KEY`), and env vars.
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AuthCredential, OAuthCredential } from "@gajae-code/ai";
+import { isEnoent } from "@gajae-code/utils";
+import { redactSecret } from "./provider-onboarding";
+
+/** gjc provider ids that external credentials map onto. */
+export type ExternalProvider = "anthropic" | "openai-codex";
+
+/** Where a discovered credential came from. */
+export type CredentialOrigin = "claude-code-file" | "claude-code-keychain" | "codex-file";
+
+/** Human labels for providers, used in redacted summaries. */
+export const EXTERNAL_PROVIDER_LABELS: Record<ExternalProvider, string> = {
+	anthropic: "Claude (Anthropic)",
+	"openai-codex": "Codex (ChatGPT)",
+};
+
+/** A credential that can be safely imported into gjc's store. */
+export interface ImportableCredential {
+	provider: ExternalProvider;
+	origin: CredentialOrigin;
+	/** Redacted, human-readable description of where this came from. */
+	source: string;
+	kind: AuthCredential["type"];
+	identity?: { email?: string; accountId?: string };
+	/** Epoch-ms expiry for OAuth credentials, when known. */
+	expiresAt?: number;
+	/** Redacted access token / API key — safe to display. */
+	redactedToken: string;
+	/** Opaque credential payload. Never include this in any summary output. */
+	credential: AuthCredential;
+}
+
+/** A source that was found but could not be imported. */
+export interface SkippedCredential {
+	origin: CredentialOrigin;
+	source: string;
+	reason: string;
+}
+
+/** Ambient environment-backed auth that is already usable without import. */
+export interface EnvironmentCredentialHint {
+	provider: ExternalProvider;
+	variable: string;
+	redactedValue: string;
+}
+
+export interface CredentialDiscoveryResult {
+	importable: ImportableCredential[];
+	skipped: SkippedCredential[];
+	environment: EnvironmentCredentialHint[];
+}
+
+export interface DiscoveryOptions {
+	/** Override the home directory (defaults to `os.homedir()`). */
+	homeDir?: string;
+	/** Override the environment (defaults to `process.env`). */
+	env?: Record<string, string | undefined>;
+	/** Override the platform (defaults to `process.platform`). */
+	platform?: NodeJS.Platform;
+	/**
+	 * Reader for the macOS Keychain `Claude Code-credentials` entry. Defaults to
+	 * shelling out to `security`; injected in tests. Returns the raw JSON string,
+	 * or `null` when no entry exists.
+	 */
+	readClaudeKeychain?: () => Promise<string | null>;
+}
+
+export type CredentialUpserter = (provider: string, credential: AuthCredential) => unknown | Promise<unknown>;
+
+export interface ImportSummary {
+	imported: ImportableCredential[];
+	failed: Array<{ credential: ImportableCredential; error: string }>;
+}
+
+// ─── Source-file shapes ──────────────────────────────────────────────────────
+
+interface ClaudeCredentialsFile {
+	claudeAiOauth?: {
+		accessToken?: unknown;
+		refreshToken?: unknown;
+		expiresAt?: unknown;
+		scopes?: unknown;
+	};
+}
+
+interface CodexAuthFile {
+	OPENAI_API_KEY?: unknown;
+	tokens?: {
+		id_token?: unknown;
+		access_token?: unknown;
+		refresh_token?: unknown;
+		account_id?: unknown;
+	};
+	last_refresh?: unknown;
+}
+
+const ANTHROPIC_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+const OPENAI_ENV_KEYS = ["OPENAI_API_KEY"] as const;
+
+// ─── JWT helpers (best-effort identity/expiry extraction) ────────────────────
+
+const OPENAI_AUTH_CLAIM = "https://api.openai.com/auth";
+const OPENAI_PROFILE_CLAIM = "https://api.openai.com/profile";
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+	try {
+		const parts = token.split(".");
+		if (parts.length !== 3) return null;
+		const payload = parts[1] ?? "";
+		const decoded = Buffer.from(payload, "base64url").toString("utf-8");
+		const parsed = JSON.parse(decoded) as unknown;
+		return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : null;
+	} catch {
+		return null;
+	}
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+// ─── Claude Code discovery ───────────────────────────────────────────────────
+
+function parseClaudeCredentials(
+	raw: string,
+	origin: CredentialOrigin,
+	source: string,
+): ImportableCredential | SkippedCredential {
+	let parsed: ClaudeCredentialsFile;
+	try {
+		parsed = JSON.parse(raw) as ClaudeCredentialsFile;
+	} catch (err) {
+		return { origin, source, reason: `unreadable JSON (${String(err)})` };
+	}
+	const oauth = parsed.claudeAiOauth;
+	if (typeof oauth !== "object" || oauth === null) {
+		return { origin, source, reason: "missing claudeAiOauth block (unsupported shape)" };
+	}
+	const access = nonEmptyString(oauth.accessToken);
+	const refresh = nonEmptyString(oauth.refreshToken);
+	if (!access || !refresh) {
+		return { origin, source, reason: "missing accessToken or refreshToken" };
+	}
+	const expiresAt =
+		typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt) ? oauth.expiresAt : undefined;
+	const credential: OAuthCredential = {
+		type: "oauth",
+		access,
+		refresh,
+		expires: expiresAt ?? Date.now(),
+	};
+	return {
+		provider: "anthropic",
+		origin,
+		source,
+		kind: "oauth",
+		expiresAt,
+		redactedToken: redactSecret(access),
+		credential,
+	};
+}
+
+async function discoverClaudeCode(
+	opts: Required<Pick<DiscoveryOptions, "homeDir" | "platform">> & Pick<DiscoveryOptions, "readClaudeKeychain">,
+	result: CredentialDiscoveryResult,
+): Promise<void> {
+	const filePath = path.join(opts.homeDir, ".claude", ".credentials.json");
+	const displayPath = `~/.claude/.credentials.json`;
+	let fileRaw: string | null = null;
+	try {
+		fileRaw = await fs.readFile(filePath, "utf-8");
+	} catch (err) {
+		if (!isEnoent(err)) {
+			result.skipped.push({
+				origin: "claude-code-file",
+				source: `Claude Code (${displayPath})`,
+				reason: `unreadable file (${String(err)})`,
+			});
+		}
+	}
+	if (fileRaw !== null) {
+		const outcome = parseClaudeCredentials(fileRaw, "claude-code-file", `Claude Code (${displayPath})`);
+		pushOutcome(result, outcome);
+	} else if (opts.platform === "darwin") {
+		const reader = opts.readClaudeKeychain ?? defaultClaudeKeychainReader;
+		let keychainRaw: string | null = null;
+		try {
+			keychainRaw = await reader();
+		} catch (err) {
+			result.skipped.push({
+				origin: "claude-code-keychain",
+				source: "Claude Code (macOS Keychain)",
+				reason: `keychain read failed (${String(err)})`,
+			});
+		}
+		if (keychainRaw !== null && keychainRaw.trim().length > 0) {
+			const outcome = parseClaudeCredentials(keychainRaw, "claude-code-keychain", "Claude Code (macOS Keychain)");
+			pushOutcome(result, outcome);
+		}
+	}
+}
+
+async function defaultClaudeKeychainReader(): Promise<string | null> {
+	const { $ } = await import("bun");
+	const proc = await $`security find-generic-password -s ${"Claude Code-credentials"} -w`.quiet().nothrow();
+	if (proc.exitCode !== 0) return null;
+	const out = proc.stdout.toString().trim();
+	return out.length > 0 ? out : null;
+}
+
+// ─── Codex discovery ─────────────────────────────────────────────────────────
+
+function parseCodexAuth(raw: string, source: string): ImportableCredential | SkippedCredential {
+	let parsed: CodexAuthFile;
+	try {
+		parsed = JSON.parse(raw) as CodexAuthFile;
+	} catch (err) {
+		return { origin: "codex-file", source, reason: `unreadable JSON (${String(err)})` };
+	}
+	const tokens = parsed.tokens;
+	const access = nonEmptyString(tokens?.access_token);
+	const refresh = nonEmptyString(tokens?.refresh_token);
+	if (access && refresh) {
+		const accessPayload = decodeJwtPayload(access);
+		const idPayload = nonEmptyString(tokens?.id_token) ? decodeJwtPayload(tokens?.id_token as string) : null;
+		const accountId =
+			nonEmptyString(tokens?.account_id) ??
+			nonEmptyString((accessPayload?.[OPENAI_AUTH_CLAIM] as { chatgpt_account_id?: unknown })?.chatgpt_account_id) ??
+			nonEmptyString((idPayload?.[OPENAI_AUTH_CLAIM] as { chatgpt_account_id?: unknown })?.chatgpt_account_id);
+		const email =
+			nonEmptyString((accessPayload?.[OPENAI_PROFILE_CLAIM] as { email?: unknown })?.email) ??
+			nonEmptyString(idPayload?.email)?.toLowerCase();
+		const expSeconds = typeof accessPayload?.exp === "number" ? accessPayload.exp : undefined;
+		const expiresAt = expSeconds !== undefined ? expSeconds * 1000 : undefined;
+		const credential: OAuthCredential = {
+			type: "oauth",
+			access,
+			refresh,
+			expires: expiresAt ?? Date.now(),
+			...(accountId ? { accountId } : {}),
+			...(email ? { email } : {}),
+		};
+		const identity =
+			accountId || email ? { ...(email ? { email } : {}), ...(accountId ? { accountId } : {}) } : undefined;
+		return {
+			provider: "openai-codex",
+			origin: "codex-file",
+			source,
+			kind: "oauth",
+			...(identity ? { identity } : {}),
+			expiresAt,
+			redactedToken: redactSecret(access),
+			credential,
+		};
+	}
+	if (tokens && (tokens.access_token !== undefined || tokens.refresh_token !== undefined)) {
+		return {
+			origin: "codex-file",
+			source,
+			reason: "incomplete OAuth tokens (missing access_token or refresh_token)",
+		};
+	}
+	const apiKey = nonEmptyString(parsed.OPENAI_API_KEY);
+	if (apiKey) {
+		return {
+			provider: "openai-codex",
+			origin: "codex-file",
+			source,
+			kind: "api_key",
+			redactedToken: redactSecret(apiKey),
+			credential: { type: "api_key", key: apiKey },
+		};
+	}
+	return { origin: "codex-file", source, reason: "no OAuth tokens or OPENAI_API_KEY present (unsupported shape)" };
+}
+
+async function discoverCodex(homeDir: string, result: CredentialDiscoveryResult): Promise<void> {
+	const filePath = path.join(homeDir, ".codex", "auth.json");
+	const displayPath = "~/.codex/auth.json";
+	let raw: string | null = null;
+	try {
+		raw = await fs.readFile(filePath, "utf-8");
+	} catch (err) {
+		if (!isEnoent(err)) {
+			result.skipped.push({
+				origin: "codex-file",
+				source: `Codex CLI (${displayPath})`,
+				reason: `unreadable file (${String(err)})`,
+			});
+		}
+		return;
+	}
+	pushOutcome(result, parseCodexAuth(raw, `Codex CLI (${displayPath})`));
+}
+
+// ─── Environment hints ───────────────────────────────────────────────────────
+
+function discoverEnvironment(env: Record<string, string | undefined>, result: CredentialDiscoveryResult): void {
+	for (const variable of ANTHROPIC_ENV_KEYS) {
+		const value = nonEmptyString(env[variable]);
+		if (value) {
+			result.environment.push({ provider: "anthropic", variable, redactedValue: redactSecret(value) });
+		}
+	}
+	for (const variable of OPENAI_ENV_KEYS) {
+		const value = nonEmptyString(env[variable]);
+		if (value) {
+			result.environment.push({ provider: "openai-codex", variable, redactedValue: redactSecret(value) });
+		}
+	}
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+function pushOutcome(result: CredentialDiscoveryResult, outcome: ImportableCredential | SkippedCredential): void {
+	if ("reason" in outcome) result.skipped.push(outcome);
+	else result.importable.push(outcome);
+}
+
+/**
+ * Discover Claude Code and Codex CLI credentials across files, the macOS
+ * Keychain, and environment variables. Never throws for individual unreadable or
+ * malformed sources — those land in {@link CredentialDiscoveryResult.skipped}.
+ */
+export async function discoverExternalCredentials(options: DiscoveryOptions = {}): Promise<CredentialDiscoveryResult> {
+	const homeDir = options.homeDir ?? os.homedir();
+	const env = options.env ?? process.env;
+	const platform = options.platform ?? process.platform;
+	const result: CredentialDiscoveryResult = { importable: [], skipped: [], environment: [] };
+	await discoverClaudeCode({ homeDir, platform, readClaudeKeychain: options.readClaudeKeychain }, result);
+	await discoverCodex(homeDir, result);
+	discoverEnvironment(env, result);
+	return result;
+}
+
+/** Redacted one-line summary of an importable credential. Never includes secrets. */
+export function formatCredentialSummary(credential: ImportableCredential): string {
+	const provider = EXTERNAL_PROVIDER_LABELS[credential.provider];
+	const kind = credential.kind === "oauth" ? "OAuth" : "API key";
+	const identity = credential.identity?.email ?? credential.identity?.accountId;
+	const identityPart = identity ? ` ${identity}` : "";
+	let expiry = "";
+	if (credential.kind === "oauth" && credential.expiresAt !== undefined) {
+		expiry = credential.expiresAt < Date.now() ? " [expired]" : "";
+	}
+	return `${provider} · ${kind}${identityPart} · token ${credential.redactedToken}${expiry} (from ${credential.source})`;
+}
+
+/** Redacted summary lines for an entire discovery result. Never includes secrets. */
+export function formatDiscoverySummary(result: CredentialDiscoveryResult): string[] {
+	const lines: string[] = [];
+	for (const credential of result.importable) {
+		lines.push(`import  ${formatCredentialSummary(credential)}`);
+	}
+	for (const skip of result.skipped) {
+		lines.push(`skip    ${skip.source}: ${skip.reason}`);
+	}
+	for (const hint of result.environment) {
+		lines.push(
+			`env     ${EXTERNAL_PROVIDER_LABELS[hint.provider]} · ${hint.variable}=${hint.redactedValue} (already active via environment)`,
+		);
+	}
+	return lines;
+}
+
+/**
+ * Persist discovered credentials via `upsert`. Each credential is imported
+ * independently; a failure on one is recorded without aborting the rest.
+ */
+export async function importCredentials(
+	credentials: readonly ImportableCredential[],
+	upsert: CredentialUpserter,
+): Promise<ImportSummary> {
+	const summary: ImportSummary = { imported: [], failed: [] };
+	for (const credential of credentials) {
+		try {
+			await upsert(credential.provider, credential.credential);
+			summary.imported.push(credential);
+		} catch (err) {
+			summary.failed.push({ credential, error: err instanceof Error ? err.message : String(err) });
+		}
+	}
+	return summary;
+}

--- a/packages/coding-agent/src/setup/credential-import.ts
+++ b/packages/coding-agent/src/setup/credential-import.ts
@@ -136,6 +136,26 @@ function nonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
+/**
+ * Build a user-safe `skipped.reason` for a failed credential source.
+ *
+ * NEVER include the raw exception message: JSON parse errors and filesystem
+ * errors can echo back file contents (including bare token-like substrings) or
+ * other sensitive material, which then surfaces through CLI text/JSON and TUI
+ * discovery summaries. We expose only a generic phrase plus a non-sensitive
+ * error class (e.g. `SyntaxError`) or a standard Node syscall code (e.g.
+ * `EACCES`), both of which come from fixed, non-secret vocabularies.
+ */
+function sanitizedFailureReason(
+	base: "malformed credential file" | "unreadable credential file",
+	err: unknown,
+): string {
+	if (!(err instanceof Error)) return base;
+	const code = (err as NodeJS.ErrnoException).code;
+	const detail = typeof code === "string" && /^[A-Z][A-Z0-9_]*$/.test(code) ? code : err.constructor.name;
+	return detail ? `${base} (${detail})` : base;
+}
+
 // ─── Claude Code discovery ───────────────────────────────────────────────────
 
 function parseClaudeCredentials(
@@ -147,7 +167,7 @@ function parseClaudeCredentials(
 	try {
 		parsed = JSON.parse(raw) as ClaudeCredentialsFile;
 	} catch (err) {
-		return { origin, source, reason: `unreadable JSON (${String(err)})` };
+		return { origin, source, reason: sanitizedFailureReason("malformed credential file", err) };
 	}
 	const oauth = parsed.claudeAiOauth;
 	if (typeof oauth !== "object" || oauth === null) {
@@ -191,7 +211,7 @@ async function discoverClaudeCode(
 			result.skipped.push({
 				origin: "claude-code-file",
 				source: `Claude Code (${displayPath})`,
-				reason: `unreadable file (${String(err)})`,
+				reason: sanitizedFailureReason("unreadable credential file", err),
 			});
 		}
 	}
@@ -207,7 +227,7 @@ async function discoverClaudeCode(
 			result.skipped.push({
 				origin: "claude-code-keychain",
 				source: "Claude Code (macOS Keychain)",
-				reason: `keychain read failed (${String(err)})`,
+				reason: sanitizedFailureReason("unreadable credential file", err),
 			});
 		}
 		if (keychainRaw !== null && keychainRaw.trim().length > 0) {
@@ -232,7 +252,7 @@ function parseCodexAuth(raw: string, source: string): ImportableCredential | Ski
 	try {
 		parsed = JSON.parse(raw) as CodexAuthFile;
 	} catch (err) {
-		return { origin: "codex-file", source, reason: `unreadable JSON (${String(err)})` };
+		return { origin: "codex-file", source, reason: sanitizedFailureReason("malformed credential file", err) };
 	}
 	const tokens = parsed.tokens;
 	const access = nonEmptyString(tokens?.access_token);
@@ -302,7 +322,7 @@ async function discoverCodex(homeDir: string, result: CredentialDiscoveryResult)
 			result.skipped.push({
 				origin: "codex-file",
 				source: `Codex CLI (${displayPath})`,
-				reason: `unreadable file (${String(err)})`,
+				reason: sanitizedFailureReason("unreadable credential file", err),
 			});
 		}
 		return;

--- a/packages/coding-agent/test/credential-import.test.ts
+++ b/packages/coding-agent/test/credential-import.test.ts
@@ -147,7 +147,8 @@ describe("discoverExternalCredentials", () => {
 		expect(result.importable).toHaveLength(0);
 		expect(result.skipped).toHaveLength(1);
 		expect(result.skipped[0]!.origin).toBe("claude-code-file");
-		expect(result.skipped[0]!.reason).toContain("unreadable JSON");
+		expect(result.skipped[0]!.reason).toContain("malformed credential file");
+		expect(result.skipped[0]!.reason).not.toContain("not valid json");
 	});
 
 	test("Claude file missing tokens is skipped", async () => {
@@ -238,6 +239,62 @@ describe("discoverExternalCredentials", () => {
 		expect(blob).not.toContain("sk-ant-env-key-1234567890");
 		// Redacted markers still present for traceability.
 		expect(blob).toContain("…");
+	});
+
+	// Red-team regression (#654): JSON.parse errors echo the offending input
+	// verbatim, so a credential file that fails to parse must NEVER let any
+	// token-like substring reach skipped.reason or any user-visible surface.
+	// Token bodies are assembled from fragments so the literal never appears
+	// verbatim in source (avoids tripping secret scanners / push protection);
+	// the runtime values are still realistic token-like strings for the asserts.
+	const LEAKY_CLAUDE_TOKEN = ["sk", "live", "abcdef0123456789SECRETBODY"].join("_");
+	const LEAKY_AWS_TOKEN = `AKIA${"IOSFODNN7EXAMPLE"}0123456789`;
+	const LEAKY_BARE_CLAUDE = "unquotedClaudeTokenValue777SECRET";
+
+	function assertNoLeak(result: CredentialDiscoveryResult, ...secrets: string[]): void {
+		const surfaces = [
+			JSON.stringify(result),
+			formatDiscoverySummary(result).join("\n"),
+			result.skipped.map(s => s.reason).join("\n"),
+			result.skipped.map(s => s.source).join("\n"),
+		];
+		for (const secret of secrets) {
+			for (const surface of surfaces) {
+				expect(surface).not.toContain(secret);
+			}
+		}
+	}
+
+	test("malformed Claude credential file never leaks token-like substrings", async () => {
+		await writeClaude(`{"claudeAiOauth":{"accessToken": ${LEAKY_CLAUDE_TOKEN}}}`);
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(result.skipped[0]!.reason).toContain("malformed credential file");
+		assertNoLeak(result, LEAKY_CLAUDE_TOKEN);
+	});
+
+	test("malformed Claude credential file with unquoted token never leaks", async () => {
+		await writeClaude(`{"claudeAiOauth":{"refreshToken": ${LEAKY_BARE_CLAUDE}}}`);
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped[0]!.reason).toContain("malformed credential file");
+		assertNoLeak(result, LEAKY_BARE_CLAUDE);
+	});
+
+	test("malformed Codex credential file with AWS-style identifier never leaks", async () => {
+		await writeCodex(`{"OPENAI_API_KEY": ${LEAKY_AWS_TOKEN}}`);
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(result.skipped[0]!.reason).toContain("malformed credential file");
+		assertNoLeak(result, LEAKY_AWS_TOKEN);
+	});
+
+	test("malformed reason exposes only a non-sensitive error class", async () => {
+		await writeClaude(`{"claudeAiOauth":{"accessToken": ${LEAKY_CLAUDE_TOKEN}}}`);
+		const result = await discover();
+		expect(result.skipped[0]!.reason).toBe("malformed credential file (SyntaxError)");
 	});
 });
 

--- a/packages/coding-agent/test/credential-import.test.ts
+++ b/packages/coding-agent/test/credential-import.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { getAgentDbPath, setAgentDir } from "@gajae-code/utils";
+import {
+	type CredentialDiscoveryResult,
+	discoverExternalCredentials,
+	formatCredentialSummary,
+	formatDiscoverySummary,
+	importCredentials,
+} from "../src/setup/credential-import";
+
+const CLAUDE_ACCESS = "sk-ant-oat01-claude-access-token-value";
+const CLAUDE_REFRESH = "sk-ant-ort01-claude-refresh-token-value";
+const CODEX_REFRESH = "codex-refresh-token-value-1234567890";
+const CODEX_API_KEY = "sk-codex-api-key-value-0987654321";
+
+function base64url(value: object): string {
+	return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+/** Build an unsigned JWT whose payload Codex would only ever base64-decode. */
+function makeJwt(payload: Record<string, unknown>): string {
+	return `${base64url({ alg: "none", typ: "JWT" })}.${base64url(payload)}.synthetic`;
+}
+
+const CODEX_EXP_SECONDS = Math.floor(Date.now() / 1000) + 3600;
+const CODEX_ACCESS = makeJwt({
+	exp: CODEX_EXP_SECONDS,
+	"https://api.openai.com/auth": { chatgpt_account_id: "acct-codex-123" },
+	"https://api.openai.com/profile": { email: "codex-user@example.com" },
+});
+
+describe("discoverExternalCredentials", () => {
+	let homeDir = "";
+
+	beforeEach(async () => {
+		homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cred-discovery-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(homeDir, { recursive: true, force: true });
+	});
+
+	async function writeClaude(body: unknown): Promise<void> {
+		const dir = path.join(homeDir, ".claude");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(path.join(dir, ".credentials.json"), typeof body === "string" ? body : JSON.stringify(body));
+	}
+
+	async function writeCodex(body: unknown): Promise<void> {
+		const dir = path.join(homeDir, ".codex");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(path.join(dir, "auth.json"), typeof body === "string" ? body : JSON.stringify(body));
+	}
+
+	function discover(): Promise<CredentialDiscoveryResult> {
+		return discoverExternalCredentials({ homeDir, env: {}, platform: "linux" });
+	}
+
+	const validClaude = {
+		claudeAiOauth: {
+			accessToken: CLAUDE_ACCESS,
+			refreshToken: CLAUDE_REFRESH,
+			expiresAt: Date.now() + 3_600_000,
+			scopes: ["user:inference", "user:profile"],
+		},
+	};
+
+	const validCodexOAuth = {
+		OPENAI_API_KEY: null,
+		tokens: {
+			id_token: makeJwt({ email: "codex-user@example.com" }),
+			access_token: CODEX_ACCESS,
+			refresh_token: CODEX_REFRESH,
+			account_id: "acct-codex-123",
+		},
+		last_refresh: "2026-01-01T00:00:00Z",
+	};
+
+	test("Claude present / Codex absent", async () => {
+		await writeClaude(validClaude);
+		const result = await discover();
+		expect(result.importable).toHaveLength(1);
+		const cred = result.importable[0]!;
+		expect(cred.provider).toBe("anthropic");
+		expect(cred.kind).toBe("oauth");
+		expect(cred.origin).toBe("claude-code-file");
+		expect(cred.credential.type).toBe("oauth");
+		if (cred.credential.type === "oauth") {
+			expect(cred.credential.access).toBe(CLAUDE_ACCESS);
+			expect(cred.credential.refresh).toBe(CLAUDE_REFRESH);
+		}
+		expect(result.skipped).toHaveLength(0);
+	});
+
+	test("Codex present / Claude absent (OAuth tokens)", async () => {
+		await writeCodex(validCodexOAuth);
+		const result = await discover();
+		expect(result.importable).toHaveLength(1);
+		const cred = result.importable[0]!;
+		expect(cred.provider).toBe("openai-codex");
+		expect(cred.kind).toBe("oauth");
+		expect(cred.identity?.accountId).toBe("acct-codex-123");
+		expect(cred.identity?.email).toBe("codex-user@example.com");
+		expect(cred.expiresAt).toBe(CODEX_EXP_SECONDS * 1000);
+		if (cred.credential.type === "oauth") {
+			expect(cred.credential.access).toBe(CODEX_ACCESS);
+			expect(cred.credential.refresh).toBe(CODEX_REFRESH);
+			expect(cred.credential.accountId).toBe("acct-codex-123");
+		}
+	});
+
+	test("Codex present with only OPENAI_API_KEY (api key)", async () => {
+		await writeCodex({ OPENAI_API_KEY: CODEX_API_KEY });
+		const result = await discover();
+		expect(result.importable).toHaveLength(1);
+		const cred = result.importable[0]!;
+		expect(cred.provider).toBe("openai-codex");
+		expect(cred.kind).toBe("api_key");
+		if (cred.credential.type === "api_key") {
+			expect(cred.credential.key).toBe(CODEX_API_KEY);
+		}
+	});
+
+	test("both present", async () => {
+		await writeClaude(validClaude);
+		await writeCodex(validCodexOAuth);
+		const result = await discover();
+		expect(result.importable).toHaveLength(2);
+		expect(result.importable.map(c => c.provider).sort()).toEqual(["anthropic", "openai-codex"]);
+		expect(result.skipped).toHaveLength(0);
+	});
+
+	test("no existing config falls back cleanly", async () => {
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(0);
+		expect(result.environment).toHaveLength(0);
+	});
+
+	test("malformed Claude JSON is skipped, not thrown", async () => {
+		await writeClaude("{ not valid json");
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(result.skipped[0]!.origin).toBe("claude-code-file");
+		expect(result.skipped[0]!.reason).toContain("unreadable JSON");
+	});
+
+	test("Claude file missing tokens is skipped", async () => {
+		await writeClaude({ claudeAiOauth: { expiresAt: 123 } });
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped[0]!.reason).toContain("missing accessToken or refreshToken");
+	});
+
+	test("Claude unsupported shape (no claudeAiOauth) is skipped", async () => {
+		await writeClaude({ somethingElse: true });
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped[0]!.reason).toContain("unsupported shape");
+	});
+
+	test("Codex incomplete OAuth tokens are skipped", async () => {
+		await writeCodex({ tokens: { access_token: CODEX_ACCESS } });
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped[0]!.reason).toContain("incomplete OAuth tokens");
+	});
+
+	test("Codex unsupported shape is skipped", async () => {
+		await writeCodex({ unrelated: true });
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped[0]!.reason).toContain("unsupported shape");
+	});
+
+	test("macOS keychain is read only when no file exists", async () => {
+		const result = await discoverExternalCredentials({
+			homeDir,
+			env: {},
+			platform: "darwin",
+			readClaudeKeychain: async () => JSON.stringify(validClaude),
+		});
+		expect(result.importable).toHaveLength(1);
+		expect(result.importable[0]!.origin).toBe("claude-code-keychain");
+		expect(result.importable[0]!.source).toContain("Keychain");
+	});
+
+	test("file takes priority over keychain on macOS", async () => {
+		await writeClaude(validClaude);
+		let keychainCalled = false;
+		const result = await discoverExternalCredentials({
+			homeDir,
+			env: {},
+			platform: "darwin",
+			readClaudeKeychain: async () => {
+				keychainCalled = true;
+				return JSON.stringify(validClaude);
+			},
+		});
+		expect(keychainCalled).toBe(false);
+		expect(result.importable[0]!.origin).toBe("claude-code-file");
+	});
+
+	test("environment-backed auth is detected but not imported", async () => {
+		const result = await discoverExternalCredentials({
+			homeDir,
+			platform: "linux",
+			env: {
+				ANTHROPIC_API_KEY: "sk-ant-env-key-1234567890",
+				OPENAI_API_KEY: "sk-openai-env-key-0987654321",
+				CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-env-oauth-token",
+			},
+		});
+		expect(result.importable).toHaveLength(0);
+		expect(result.environment).toHaveLength(3);
+		const variables = result.environment.map(e => e.variable).sort();
+		expect(variables).toEqual(["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY"]);
+	});
+
+	test("summaries never leak raw secrets", async () => {
+		await writeClaude(validClaude);
+		await writeCodex(validCodexOAuth);
+		const result = await discoverExternalCredentials({
+			homeDir,
+			platform: "linux",
+			env: { ANTHROPIC_API_KEY: "sk-ant-env-key-1234567890" },
+		});
+		const blob = [...formatDiscoverySummary(result), ...result.importable.map(formatCredentialSummary)].join("\n");
+		expect(blob).not.toContain(CLAUDE_ACCESS);
+		expect(blob).not.toContain(CLAUDE_REFRESH);
+		expect(blob).not.toContain(CODEX_ACCESS);
+		expect(blob).not.toContain(CODEX_REFRESH);
+		expect(blob).not.toContain("sk-ant-env-key-1234567890");
+		// Redacted markers still present for traceability.
+		expect(blob).toContain("…");
+	});
+});
+
+describe("importCredentials", () => {
+	let homeDir = "";
+	let agentDir = "";
+	let originalAgentDir: string | undefined;
+
+	beforeEach(async () => {
+		originalAgentDir = process.env.GJC_AGENT_DIR;
+		homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cred-import-home-"));
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cred-import-agent-"));
+		setAgentDir(agentDir);
+	});
+
+	afterEach(async () => {
+		if (originalAgentDir === undefined) delete process.env.GJC_AGENT_DIR;
+		else process.env.GJC_AGENT_DIR = originalAgentDir;
+		await fs.rm(homeDir, { recursive: true, force: true });
+		await fs.rm(agentDir, { recursive: true, force: true });
+	});
+
+	test("imports discovered credentials into the SQLite store", async () => {
+		await fs.mkdir(path.join(homeDir, ".claude"), { recursive: true });
+		await fs.writeFile(
+			path.join(homeDir, ".claude", ".credentials.json"),
+			JSON.stringify({
+				claudeAiOauth: {
+					accessToken: CLAUDE_ACCESS,
+					refreshToken: CLAUDE_REFRESH,
+					expiresAt: Date.now() + 3_600_000,
+				},
+			}),
+		);
+		const result = await discoverExternalCredentials({ homeDir, env: {}, platform: "linux" });
+		const store = await SqliteAuthCredentialStore.open(getAgentDbPath());
+		try {
+			const summary = await importCredentials(result.importable, (provider, credential) =>
+				store.upsertAuthCredentialForProvider(provider, credential),
+			);
+			expect(summary.imported).toHaveLength(1);
+			expect(summary.failed).toHaveLength(0);
+			const stored = store.listAuthCredentials("anthropic");
+			expect(stored).toHaveLength(1);
+			expect(stored[0]!.credential.type).toBe("oauth");
+			if (stored[0]!.credential.type === "oauth") {
+				expect(stored[0]!.credential.access).toBe(CLAUDE_ACCESS);
+			}
+		} finally {
+			store.close();
+		}
+	});
+
+	test("records per-credential failures without aborting the batch", async () => {
+		const importable = [
+			{
+				provider: "anthropic" as const,
+				origin: "claude-code-file" as const,
+				source: "Claude Code (test)",
+				kind: "oauth" as const,
+				redactedToken: "sk-a…oken",
+				credential: { type: "oauth" as const, access: "a", refresh: "r", expires: Date.now() },
+			},
+			{
+				provider: "openai-codex" as const,
+				origin: "codex-file" as const,
+				source: "Codex CLI (test)",
+				kind: "api_key" as const,
+				redactedToken: "sk-c…4321",
+				credential: { type: "api_key" as const, key: "k" },
+			},
+		];
+		const summary = await importCredentials(importable, (provider, _credential) => {
+			if (provider === "openai-codex") throw new Error("boom");
+		});
+		expect(summary.imported.map(c => c.provider)).toEqual(["anthropic"]);
+		expect(summary.failed).toHaveLength(1);
+		expect(summary.failed[0]!.credential.provider).toBe("openai-codex");
+		expect(summary.failed[0]!.error).toContain("boom");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #651. Model setup can now detect and import existing Claude Code / Codex CLI logins instead of forcing manual re-entry. Implemented per the accepted deep-interview direction: **a testable discovery/import core, exposed via a CLI command (primary) and reused by the TUI provider-onboarding login hook**, with redacted summaries, explicit confirmation, and a safe fallback to manual setup.

## What changed

- **Core** — `packages/coding-agent/src/setup/credential-import.ts`
  - `discoverExternalCredentials()` scans, cross-platform:
    - Claude Code: `~/.claude/.credentials.json` (Linux/WSL/Windows native) and the macOS Keychain entry `Claude Code-credentials` (file takes precedence; keychain reader is injectable for tests).
    - Codex CLI: `~/.codex/auth.json` — OAuth `tokens` block (account id / email / expiry decoded best-effort from the access-token JWT) or a stored `OPENAI_API_KEY`.
    - Environment-backed auth (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`) is **detected and reported** but not duplicated into the store (it's already resolved at runtime).
  - Never returns/prints raw tokens — only redacted summaries (`formatDiscoverySummary`, `formatCredentialSummary`). Malformed/unsupported sources become redacted `skipped` entries with reasons instead of throwing.
  - `importCredentials()` persists each credential independently, recording per-item failures without aborting the batch.
- **CLI (primary)** — `gjc setup credentials`
  - Redacted preview → confirmation (interactive prompt, or `--yes` for non-interactive) → import via `SqliteAuthCredentialStore`. Supports `--dry-run` and `--json`. Prints a clear manual-setup fallback (`gjc setup provider`, `/login`) when nothing is importable.
- **TUI (reuse)** — provider onboarding selector gains an "Import existing credentials" action that calls the same core, confirms via the hook dialog, and persists through `AuthStorage.upsertCredential`.

## Tests

`packages/coding-agent/test/credential-import.test.ts` covers the acceptance matrix and more:

- Claude present / Codex absent
- Codex present / Claude absent (OAuth tokens; identity + JWT expiry extraction)
- Codex present with only `OPENAI_API_KEY`
- both present
- malformed / unsupported / incomplete configs → `skipped`, never thrown
- no existing config → clean fallback
- macOS keychain read only when no file exists; file precedence over keychain
- environment-backed auth detected but not imported
- summaries never leak raw secrets
- end-to-end import into `SqliteAuthCredentialStore`
- per-credential failure isolation

## Verification

```
# packages/coding-agent
bun test test/credential-import.test.ts        → 16 pass / 0 fail
bun test (+ setup-cli, provider-onboarding, auth-broker-import) → 50 pass / 0 fail
bun run check:types (tsgo --noEmit)            → clean
biome check (changed files)                    → clean
```

Scope is intentionally limited to issue #651; no unrelated refactors.

**Do not merge.**

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
