### PR TITLE
feat(state-writer): shared idempotent JSONL append primitive (#660)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -13,7 +13,12 @@ import {
 } from "./ledger-event-renderer";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { migrateWorkflowState } from "./state-migrations";
-import { appendJsonl, readExistingStateForMutation, writeArtifact, writeWorkflowEnvelopeAtomic } from "./state-writer";
+import {
+	appendJsonlIdempotent,
+	readExistingStateForMutation,
+	writeArtifact,
+	writeWorkflowEnvelopeAtomic,
+} from "./state-writer";
 
 /**
  * Native implementation of `gjc ralplan`.
@@ -439,6 +444,19 @@ interface PersistedArtifact {
 	pendingApprovalPath?: string;
 }
 
+/**
+ * Content-addressed identity for an `index.jsonl` row: a repeated `--write` of the
+ * same `(stage, stage_n)` at identical content (same sha256) is the #638 duplicate
+ * the append must collapse. Rows missing these fields opt out of dedup.
+ */
+function ralplanIndexKey(entry: unknown): string | undefined {
+	if (!entry || typeof entry !== "object" || Array.isArray(entry)) return undefined;
+	const record = entry as Record<string, unknown>;
+	const { stage, stage_n, sha256 } = record;
+	if (typeof stage !== "string" || typeof stage_n !== "number" || typeof sha256 !== "string") return undefined;
+	return `${stage}\u0000${stage_n}\u0000${sha256}`;
+}
+
 async function persistArtifact(
 	resolved: ResolvedArtifactArgs,
 	cwd: string,
@@ -462,9 +480,10 @@ async function persistArtifact(
 		created_at: createdAt,
 		sha256,
 	};
-	await appendJsonl(path.join(runDir, "index.jsonl"), indexEntry, {
+	await appendJsonlIdempotent(path.join(runDir, "index.jsonl"), indexEntry, {
 		cwd,
 		audit: { category: "ledger", verb: "append", owner: "gjc-runtime", skill: "ralplan" },
+		key: ralplanIndexKey,
 	});
 
 	let pendingApprovalPath: string | undefined;

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -483,6 +483,112 @@ export async function appendJsonl(targetPath: string, entry: unknown, options?: 
 	return filePath;
 }
 
+export interface AppendJsonlIdempotentOptions extends StateWriterOptions {
+	/**
+	 * Identity key for an entry. Two entries that produce the same non-`undefined`
+	 * key are duplicates, so only the first is appended. Return `undefined` to opt a
+	 * candidate out of dedup (it is always appended). Use `key` for the common case
+	 * where identity reduces to a single string.
+	 */
+	key?: (entry: unknown) => string | undefined;
+	/**
+	 * Equivalence predicate: return `true` when `existing` already represents
+	 * `candidate`, suppressing the append. Use when identity cannot be reduced to a
+	 * single string key. When both `key` and `equals` are supplied, `equals` wins.
+	 */
+	equals?: (candidate: unknown, existing: unknown) => boolean;
+}
+
+export interface AppendJsonlIdempotentResult {
+	path: string;
+	/** `true` when the entry was written; `false` when an equivalent entry already existed. */
+	appended: boolean;
+	/** The pre-existing entry that suppressed the append, when `appended` is `false`. */
+	duplicate?: unknown;
+}
+
+async function readJsonlEntries(filePath: string): Promise<unknown[]> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(filePath, "utf-8");
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return [];
+		throw error;
+	}
+	const entries: unknown[] = [];
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			entries.push(JSON.parse(trimmed));
+		} catch {
+			// Best-effort: dedup compares parseable rows only. A corrupt line cannot
+			// be matched, so it never suppresses a new append.
+		}
+	}
+	return entries;
+}
+
+function findJsonlDuplicate(
+	existing: readonly unknown[],
+	candidate: unknown,
+	options: AppendJsonlIdempotentOptions,
+): unknown | undefined {
+	if (options.equals) {
+		const equals = options.equals;
+		return existing.find(item => equals(candidate, item));
+	}
+	const key = options.key;
+	if (!key) return undefined;
+	const candidateKey = key(candidate);
+	if (candidateKey === undefined) return undefined;
+	return existing.find(item => key(item) === candidateKey);
+}
+
+/**
+ * Append `entry` to a JSONL file only when no equivalent entry already exists —
+ * the shared idempotent append primitive (issue #660).
+ *
+ * `appendJsonl` is a pure append with no dedup, so every recurring "duplicate
+ * ledger row" bug (#638, #643, #645) had to be patched with bespoke per-call-site
+ * guards. This primitive centralizes the read-check-append cycle: a caller
+ * declares identity once via `key` or `equals` instead of re-deriving the lookup
+ * at each site.
+ *
+ * The read-then-append is serialized through the same cross-process workflow lock
+ * as `updateJsonAtomic`, so two concurrent idempotent appends cannot both observe
+ * "no duplicate" and both write (the #646 TOCTOU that a plain `appendJsonl`
+ * preceded by a manual existence check is still exposed to).
+ *
+ * Scope note: this dedups the *append* only. Call sites whose idempotency must
+ * also skip a coupled mutation — e.g. the plan/state rewrite in #643/#645 — still
+ * need a whole-operation guard; this primitive is the ledger-level half of that.
+ */
+export async function appendJsonlIdempotent(
+	targetPath: string,
+	entry: unknown,
+	options: AppendJsonlIdempotentOptions,
+): Promise<AppendJsonlIdempotentResult> {
+	if (!options.key && !options.equals) {
+		throw new Error("appendJsonlIdempotent requires a `key` or `equals` option to detect duplicates");
+	}
+	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			const existing = await readJsonlEntries(filePath);
+			const duplicate = findJsonlDuplicate(existing, entry, options);
+			if (duplicate !== undefined) {
+				return { path: filePath, appended: false, duplicate };
+			}
+			await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+			await maybeAudit(filePath, options);
+			return { path: filePath, appended: true };
+		},
+		options.lock,
+	);
+}
+
 export async function appendText(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
 	await fs.mkdir(path.dirname(filePath), { recursive: true });

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -489,6 +489,27 @@ describe("native gjc ralplan runtime — duplicate --write guard", () => {
 			.filter(Boolean);
 		expect(indexLines.length).toBe(2);
 	});
+
+	it("collapses concurrent identical writes to a single index.jsonl row (#660 TOCTOU)", async () => {
+		const root = await tempDir();
+		const args = ["--write", "--stage", "planner", "--stage_n", "1", "--artifact", "# Plan", "--run-id", "race-run"];
+
+		// The command-level dedup (findExistingStageArtifact) and the ledger append
+		// are not under one lock, so racing identical writes can both observe an
+		// empty index and both append. The shared appendJsonlIdempotent primitive
+		// serializes the append, so exactly one row survives regardless of the race.
+		const results = await Promise.all(Array.from({ length: 6 }, () => runNativeRalplanCommand([...args], root)));
+		for (const result of results) {
+			expect(result.status).toBe(0);
+		}
+
+		const indexLines = (await fs.readFile(path.join(runDir(root, "race-run"), "index.jsonl"), "utf-8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+		expect(indexLines.length).toBe(1);
+		expect(JSON.parse(indexLines[0]).stage).toBe("planner");
+	});
 });
 
 describe("native gjc ralplan runtime — persisted Planner state", () => {

--- a/packages/coding-agent/test/gjc-runtime/state-writer-idempotent-append.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-idempotent-append.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { appendJsonlIdempotent } from "@gajae-code/coding-agent/gjc-runtime/state-writer";
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-idempotent-append-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterAll(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function readLines(filePath: string): Promise<unknown[]> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(filePath, "utf-8");
+	} catch {
+		return [];
+	}
+	return raw
+		.split(/\r?\n/)
+		.map(line => line.trim())
+		.filter(Boolean)
+		.flatMap(line => {
+			try {
+				return [JSON.parse(line)];
+			} catch {
+				return [];
+			}
+		});
+}
+
+const byId = (entry: unknown): string | undefined => {
+	if (!entry || typeof entry !== "object") return undefined;
+	const id = (entry as Record<string, unknown>).id;
+	return typeof id === "string" ? id : undefined;
+};
+
+describe("appendJsonlIdempotent (issue #660)", () => {
+	it("appends a fresh entry and reports appended: true", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+
+		const result = await appendJsonlIdempotent(target, { id: "a", note: "first" }, { cwd: root, key: byId });
+
+		expect(result.appended).toBe(true);
+		expect(result.duplicate).toBeUndefined();
+		const lines = await readLines(result.path);
+		expect(lines).toEqual([{ id: "a", note: "first" }]);
+	});
+
+	it("skips a duplicate key, leaving the original row untouched", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+
+		await appendJsonlIdempotent(target, { id: "a", note: "first" }, { cwd: root, key: byId });
+		// Same identity key, different payload: the append must collapse and the
+		// pre-existing row (not the new payload) must survive.
+		const second = await appendJsonlIdempotent(target, { id: "a", note: "second" }, { cwd: root, key: byId });
+
+		expect(second.appended).toBe(false);
+		expect(second.duplicate).toEqual({ id: "a", note: "first" });
+		const lines = await readLines(second.path);
+		expect(lines).toEqual([{ id: "a", note: "first" }]);
+	});
+
+	it("appends entries with distinct keys", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+
+		await appendJsonlIdempotent(target, { id: "a" }, { cwd: root, key: byId });
+		const second = await appendJsonlIdempotent(target, { id: "b" }, { cwd: root, key: byId });
+
+		expect(second.appended).toBe(true);
+		const lines = await readLines(second.path);
+		expect(lines).toEqual([{ id: "a" }, { id: "b" }]);
+	});
+
+	it("always appends entries whose key is undefined (dedup opt-out)", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+
+		// `byId` returns undefined for these rows, so dedup must not engage.
+		await appendJsonlIdempotent(target, { kind: "anon" }, { cwd: root, key: byId });
+		const second = await appendJsonlIdempotent(target, { kind: "anon" }, { cwd: root, key: byId });
+
+		expect(second.appended).toBe(true);
+		const lines = await readLines(second.path);
+		expect(lines).toHaveLength(2);
+	});
+
+	it("uses the equals predicate when provided", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+		const equals = (candidate: unknown, existing: unknown): boolean =>
+			(candidate as { tag?: string }).tag === (existing as { tag?: string }).tag;
+
+		await appendJsonlIdempotent(target, { tag: "x", seq: 1 }, { cwd: root, equals });
+		const second = await appendJsonlIdempotent(target, { tag: "x", seq: 2 }, { cwd: root, equals });
+
+		expect(second.appended).toBe(false);
+		expect(second.duplicate).toEqual({ tag: "x", seq: 1 });
+		const lines = await readLines(second.path);
+		expect(lines).toEqual([{ tag: "x", seq: 1 }]);
+	});
+
+	it("prefers equals over key when both are supplied", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+		// key would treat these as distinct, but equals always matches → dedup.
+		const equals = (): boolean => true;
+
+		await appendJsonlIdempotent(target, { id: "a" }, { cwd: root, key: byId, equals });
+		const second = await appendJsonlIdempotent(target, { id: "b" }, { cwd: root, key: byId, equals });
+
+		expect(second.appended).toBe(false);
+		const lines = await readLines(second.path);
+		expect(lines).toEqual([{ id: "a" }]);
+	});
+
+	it("throws when neither key nor equals is supplied", async () => {
+		const root = await tempDir();
+		await expect(
+			appendJsonlIdempotent(".gjc/ledger/index.jsonl", { id: "a" }, { cwd: root } as never),
+		).rejects.toThrow(/requires a `key` or `equals`/);
+	});
+
+	it("ignores corrupt lines when checking for duplicates (best-effort)", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+		const filePath = path.join(root, target);
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, "{ not json\n", "utf-8");
+
+		// A corrupt row cannot be matched, so the new append must still go through.
+		const result = await appendJsonlIdempotent(target, { id: "a" }, { cwd: root, key: byId });
+		expect(result.appended).toBe(true);
+
+		// And a subsequent identical append still dedups against the parseable row.
+		const second = await appendJsonlIdempotent(target, { id: "a" }, { cwd: root, key: byId });
+		expect(second.appended).toBe(false);
+
+		const lines = await readLines(filePath);
+		expect(lines).toEqual([{ id: "a" }]);
+	});
+
+	it("serializes concurrent idempotent appends so a duplicate is written once (TOCTOU)", async () => {
+		const root = await tempDir();
+		const target = ".gjc/ledger/index.jsonl";
+
+		// Without the cross-process lock, every racing append reads "no duplicate"
+		// and all of them write — the issue #646 TOCTOU. The shared primitive must
+		// serialize the read-check-append so exactly one row survives.
+		const results = await Promise.all(
+			Array.from({ length: 12 }, () => appendJsonlIdempotent(target, { id: "race" }, { cwd: root, key: byId })),
+		);
+
+		const appended = results.filter(result => result.appended);
+		expect(appended).toHaveLength(1);
+		const lines = await readLines(path.join(root, target));
+		expect(lines).toEqual([{ id: "race" }]);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the structural root cause behind the recurring duplicate-ledger-row bug family (#638, #643, #645): `appendJsonl` is a pure append with no dedup, so every recurrence had to be patched with a bespoke per-call-site guard.

This PR adds a shared `appendJsonlIdempotent` primitive and migrates **one representative safe site** — the ralplan run `index.jsonl` append — onto it. The 13 ultragoal `appendLedger` sites are intentionally **not** migrated here (see Follow-up).

## What changed

### `appendJsonlIdempotent` (`state-writer.ts`)
- Reads existing rows, checks for an equivalent entry, and appends only when none exists.
- Identity declared once by the caller via `key: (entry) => string | undefined` (single-string identity, `undefined` opts a row out of dedup) or `equals: (candidate, existing) => boolean` (when identity can't reduce to a string). `equals` wins when both are supplied.
- Returns `{ path, appended, duplicate? }` so callers can distinguish a fresh write from a suppressed duplicate.
- The read-check-append runs under the **same cross-process workflow lock** as `updateJsonAtomic`, so two concurrent idempotent appends can't both observe "no duplicate" and both write (the #646 TOCTOU a plain `appendJsonl` + manual existence check is still exposed to).
- Best-effort: unparseable existing lines are skipped during the duplicate scan and never suppress a new append.

### Migrated site: ralplan `index.jsonl` (`ralplan-runtime.ts`)
- `persistArtifact` now uses `appendJsonlIdempotent`, keyed on `(stage, stage_n, sha256)`.
- A repeated `--write` of the same stage at identical content collapses to a single index row (the #638 duplicate).
- The single-threaded happy path is unchanged; the previously unguarded TOCTOU between the command-level `findExistingStageArtifact` check and the ledger append now dedups deterministically.

## Tests
- `state-writer-idempotent-append.test.ts` (new): duplicate-skip, append, distinct keys, `key` opt-out, `equals` predicate (incl. `equals` over `key`), missing-option throw, corrupt-line tolerance, and the concurrency TOCTOU (12 racing appends → exactly one row).
- `ralplan-runtime.test.ts`: new regression asserting 6 concurrent identical `--write` calls yield exactly one `index.jsonl` row.

```
bun test state-writer-idempotent-append.test.ts ralplan-runtime.test.ts state-writer-cas.test.ts state-concurrency-fuzz.test.ts
58 pass / 0 fail
```

## Follow-up (intentionally out of scope)
The 13 `appendLedger` sites in `ultragoal-runtime.ts` each pair the append with a coupled `writePlan(...)` state mutation. Making the append idempotent alone does **not** make the operation idempotent — they need per-event semantic review of (a) the correct identity key (several share `event: "steering_accepted"` for semantically distinct actions) and (b) a whole-operation guard covering the coupled mutation. This is the ledger-level half only; the coupled-mutation half is noted in the primitive's JSDoc scope note and tracked back to #660.

## Notes
- Pre-existing, unrelated: `tsgo` reports one error in `src/tools/ultragoal-ask-guard.ts:33` and `state-writer-drift.test.ts` fails to load the `pi_natives` native addon in this environment. Both reproduce with this PR's changes stashed and are out of scope.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
