### PR TITLE
feat(bridge): opt-in GJC_BRIDGE_ENDPOINTS env to enable session-control endpoints

### DIFF
--- a/packages/coding-agent/src/modes/bridge/bridge-mode.ts
+++ b/packages/coding-agent/src/modes/bridge/bridge-mode.ts
@@ -166,6 +166,25 @@ function parseBridgeScopes(value: string | undefined): readonly BridgeCommandSco
 	return [...scopes];
 }
 
+// Opt-in endpoint enablement via GJC_BRIDGE_ENDPOINTS (default undefined -> fail closed, backward compatible).
+// Accepts "all" or a comma list of matrix keys.
+export function parseBridgeEndpoints(value: string | undefined): Partial<BridgeEndpointMatrix> | undefined {
+	if (!value?.trim()) return undefined;
+	const allowed = new Set<string>(Object.keys(FAIL_CLOSED_BRIDGE_ENDPOINTS));
+	const matrix: Partial<BridgeEndpointMatrix> = {};
+	if (value.trim().toLowerCase() === "all") {
+		for (const key of allowed) matrix[key as keyof BridgeEndpointMatrix] = true;
+		return matrix;
+	}
+	for (const raw of value.split(",")) {
+		const key = raw.trim();
+		if (!key) continue;
+		if (!allowed.has(key)) throw new Error(`Invalid GJC_BRIDGE_ENDPOINTS entry: ${key}`);
+		matrix[key as keyof BridgeEndpointMatrix] = true;
+	}
+	return matrix;
+}
+
 function hasScope(scopes: readonly BridgeCommandScope[] | undefined, scope: BridgeCommandScope): boolean {
 	return new Set(scopes ?? DEFAULT_BRIDGE_SCOPES).has(scope);
 }
@@ -521,6 +540,7 @@ export async function runBridgeMode(
 		throw new Error(`Invalid GJC_BRIDGE_PORT: ${Bun.env.GJC_BRIDGE_PORT}`);
 	}
 	const commandScopes = parseBridgeScopes(Bun.env.GJC_BRIDGE_SCOPES);
+	const endpointMatrix = parseBridgeEndpoints(Bun.env.GJC_BRIDGE_ENDPOINTS);
 
 	const certPath = Bun.env.GJC_BRIDGE_TLS_CERT;
 	const keyPath = Bun.env.GJC_BRIDGE_TLS_KEY;
@@ -625,6 +645,7 @@ export async function runBridgeMode(
 			hostToolBridge,
 			hostUriBridge,
 			commandScopes,
+			endpointMatrix,
 			unattendedControlPlane,
 			commandDispatcher: command =>
 				dispatchRpcCommand(command, {

--- a/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { parseBridgeEndpoints } from "../../src/modes/bridge/bridge-mode";
+
+describe("parseBridgeEndpoints", () => {
+	it("returns undefined for empty/whitespace/undefined (fail-closed default)", () => {
+		expect(parseBridgeEndpoints(undefined)).toBeUndefined();
+		expect(parseBridgeEndpoints("")).toBeUndefined();
+		expect(parseBridgeEndpoints("   ")).toBeUndefined();
+	});
+
+	it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+		expect(parseBridgeEndpoints("all")).toEqual({
+			events: true,
+			commands: true,
+			control: true,
+			uiResponses: true,
+			hostToolResults: true,
+			hostUriResults: true,
+		});
+		expect(parseBridgeEndpoints(" ALL ")).toEqual(parseBridgeEndpoints("all"));
+	});
+
+	it("enables only the listed valid keys", () => {
+		expect(parseBridgeEndpoints("events,commands,control")).toEqual({
+			events: true,
+			commands: true,
+			control: true,
+		});
+	});
+
+	it("ignores blank list entries", () => {
+		expect(parseBridgeEndpoints("events, ,commands")).toEqual({
+			events: true,
+			commands: true,
+		});
+	});
+
+	it("throws on an invalid key", () => {
+		expect(() => parseBridgeEndpoints("events,bogus")).toThrow("Invalid GJC_BRIDGE_ENDPOINTS entry: bogus");
+	});
+});


### PR DESCRIPTION
## Problem

`runBridgeMode` (`src/modes/bridge/bridge-mode.ts`) builds the fetch handler **without ever passing an `endpointMatrix`**, so `bridgeEndpointMatrix()` always falls back to `FAIL_CLOSED_BRIDGE_ENDPOINTS`. Every session-control endpoint (`events`, `commands`, `control`, `uiResponses`, `hostToolResults`, `hostUriResults`) is permanently fail-closed and returns `403 {"error":"endpoint_disabled"}` with no supported way for an operator to enable them.

## Fix

- Add `parseBridgeEndpoints()` that reads `GJC_BRIDGE_ENDPOINTS` (`"all"` or a comma list of matrix keys) into a `Partial<BridgeEndpointMatrix>`; unset/empty stays `undefined` (fail-closed, backward compatible); invalid keys throw.
- Parse it in `runBridgeMode` right after `commandScopes` and thread `endpointMatrix` into the existing `createBridgeFetchHandler({ ... })` options.

No new types needed — `BridgeFetchHandlerOptions.endpointMatrix?` and the `bridgeEndpointMatrix()` merge already exist; only the env → option wiring was missing.

## Behavior

- Unset `GJC_BRIDGE_ENDPOINTS` ⇒ identical fail-closed behavior (no change).
- `GJC_BRIDGE_ENDPOINTS=all` or `events,commands,control` ⇒ those endpoints become reachable.
- Opt-in only, gated behind an explicit env var, alongside existing `GJC_BRIDGE_SCOPES` / TLS / bind-safety controls.

## Tests

Added `test/bridge/bridge-endpoints-parse.test.ts` covering valid keys, `"all"` (case-insensitive), empty ⇒ undefined, blank-entry skip, and invalid ⇒ throw. Full bridge suite (82 tests) passes locally.

Refs probepark/gajae-code#4