### PR TITLE
fix(state-writer): enforce workflow transition invariant on internal envelope writes (#658)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -400,6 +400,11 @@ async function readPersistedPhase(filePath: string): Promise<string | undefined>
 	try {
 		const existing = await readJsonIfPresent(filePath);
 		if (!isPlainObject(existing)) return undefined;
+		// Only an *active* prior envelope is a transition source. A cleared / handed-off
+		// envelope (`active: false`, terminal phase such as `complete` / `handoff`) is outside
+		// active workflow progression, so reactivation from it (e.g. a fresh kickoff) must not
+		// be reported as an invalid transition.
+		if (existing.active !== true) return undefined;
 		const phase = existing.current_phase;
 		return typeof phase === "string" ? phase : undefined;
 	} catch {
@@ -410,7 +415,7 @@ async function readPersistedPhase(filePath: string): Promise<string | undefined>
 	}
 }
 
-async function reportInvalidWorkflowTransition(args: {
+async function recordInvalidWorkflowTransition(args: {
 	filePath: string;
 	skill: CanonicalGjcWorkflowSkill;
 	fromPhase: string;
@@ -418,10 +423,10 @@ async function reportInvalidWorkflowTransition(args: {
 	options?: StateWriterOptions;
 }): Promise<void> {
 	const { filePath, skill, fromPhase, toPhase, options } = args;
-	process.stderr.write(
-		`WARNING: internal ${skill} write persists invalid phase transition ${fromPhase} -> ${toPhase} to ${filePath}: ` +
-			`no ${skill} manifest edge defines it (not blocked; carry audit.forced / use \`gjc state ... --force\` for intentional jumps)\n`,
-	);
+	// Audit-only diagnostic: a successful sanctioned write must NOT emit to stderr — callers
+	// may treat any stderr output as failure or parse stdout/stderr as machine output. The
+	// `invalid_transition_detected` audit entry is the durable, non-intrusive evidence that an
+	// internal write skipped a manifest edge.
 	const cwd = path.resolve(options?.audit?.cwd ?? options?.cwd ?? process.cwd());
 	try {
 		await appendAuditEntry(cwd, {
@@ -485,12 +490,12 @@ export async function writeWorkflowEnvelopeAtomic(
 				);
 			}
 			// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
-			// (caller-supplied `audit.fromPhase`, else the persisted envelope on disk) and flag
-			// edges the manifest does not define. Intentionally NON-blocking — the CLI path
-			// already hard-fails invalid edges before reaching here, and legitimate internal
-			// repairs / ralplan short-mode stage skips move between valid states without a direct
-			// manifest edge. The point is to make such transitions non-silent (audit + stderr),
-			// not to break those flows.
+			// (caller-supplied `audit.fromPhase`, else the active persisted envelope on disk) and
+			// flag edges the manifest does not define. Intentionally NON-blocking and audit-only
+			// — the CLI path already hard-fails invalid edges before reaching here, and legitimate
+			// internal repairs / ralplan short-mode stage skips move between valid states without a
+			// direct manifest edge. It records an `invalid_transition_detected` audit entry (no
+			// stderr) so such transitions are non-silent without breaking those flows.
 			const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
 			if (
 				fromPhase &&
@@ -498,7 +503,7 @@ export async function writeWorkflowEnvelopeAtomic(
 				isKnownWorkflowState(skill, fromPhase) &&
 				!isValidTransition(skill, fromPhase, toPhase)
 			) {
-				await reportInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+				await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
 			}
 		}
 	}

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -396,6 +396,52 @@ export async function writeJsonAtomic(
 	return filePath;
 }
 
+async function readPersistedPhase(filePath: string): Promise<string | undefined> {
+	try {
+		const existing = await readJsonIfPresent(filePath);
+		if (!isPlainObject(existing)) return undefined;
+		const phase = existing.current_phase;
+		return typeof phase === "string" ? phase : undefined;
+	} catch {
+		// Best-effort diagnostic read: a corrupt/unreadable prior envelope simply yields no
+		// `from` phase, so the transition invariant degrades to a no-op rather than failing
+		// the sanctioned write it is observing.
+		return undefined;
+	}
+}
+
+async function reportInvalidWorkflowTransition(args: {
+	filePath: string;
+	skill: CanonicalGjcWorkflowSkill;
+	fromPhase: string;
+	toPhase: string;
+	options?: StateWriterOptions;
+}): Promise<void> {
+	const { filePath, skill, fromPhase, toPhase, options } = args;
+	process.stderr.write(
+		`WARNING: internal ${skill} write persists invalid phase transition ${fromPhase} -> ${toPhase} to ${filePath}: ` +
+			`no ${skill} manifest edge defines it (not blocked; carry audit.forced / use \`gjc state ... --force\` for intentional jumps)\n`,
+	);
+	const cwd = path.resolve(options?.audit?.cwd ?? options?.cwd ?? process.cwd());
+	try {
+		await appendAuditEntry(cwd, {
+			ts: new Date().toISOString(),
+			skill,
+			category: "state",
+			verb: "invalid_transition_detected",
+			owner: options?.audit?.owner ?? "gjc-runtime",
+			mutation_id: options?.audit?.mutationId ?? `${skill}:invalid-transition:${new Date().toISOString()}`,
+			from_phase: fromPhase,
+			to_phase: toPhase,
+			forced: false,
+			paths: [filePath],
+		});
+	} catch {
+		// Audit logging is best-effort diagnostics; never fail a sanctioned write because the
+		// audit append failed (e.g. cwd is not a writable project root).
+	}
+}
+
 export async function writeWorkflowEnvelopeAtomic(
 	targetPath: string,
 	value: unknown,
@@ -411,6 +457,50 @@ export async function writeWorkflowEnvelopeAtomic(
 				.map(issue => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
 				.join("; ")}`,
 		);
+	}
+	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
+	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
+	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
+	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
+	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
+	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
+	//
+	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
+	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
+	// sentinel that is not a per-skill manifest state) leave the transition graph and are
+	// intentionally exempt.
+	if (options?.audit?.forced !== true && parsed.data.active === true) {
+		const toPhase = parsed.data.current_phase.trim();
+		if (toPhase) {
+			// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
+			// module load, and active-state -> state-writer -> workflow-manifest -> active-state
+			// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
+			const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
+			const skill = parsed.data.skill;
+			// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
+			// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
+			if (!isKnownWorkflowState(skill, toPhase)) {
+				throw new Error(
+					`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
+				);
+			}
+			// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
+			// (caller-supplied `audit.fromPhase`, else the persisted envelope on disk) and flag
+			// edges the manifest does not define. Intentionally NON-blocking — the CLI path
+			// already hard-fails invalid edges before reaching here, and legitimate internal
+			// repairs / ralplan short-mode stage skips move between valid states without a direct
+			// manifest edge. The point is to make such transitions non-silent (audit + stderr),
+			// not to break those flows.
+			const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
+			if (
+				fromPhase &&
+				fromPhase !== toPhase &&
+				isKnownWorkflowState(skill, fromPhase) &&
+				!isValidTransition(skill, fromPhase, toPhase)
+			) {
+				await reportInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+			}
+		}
 	}
 	await atomicWrite(filePath, jsonText(stamped));
 	await maybeAudit(filePath, options);

--- a/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
@@ -31,6 +31,18 @@ async function readJson(filePath: string): Promise<Record<string, unknown>> {
 	return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<string, unknown>;
 }
 
+async function readAuditEntries(root: string): Promise<Array<Record<string, unknown>>> {
+	try {
+		const raw = await fs.readFile(path.join(root, ".gjc", "state", "audit.jsonl"), "utf-8");
+		return raw
+			.split("\n")
+			.filter(Boolean)
+			.map(line => JSON.parse(line) as Record<string, unknown>);
+	} catch {
+		return [];
+	}
+}
+
 async function expectPersistedEnvelope(filePath: string): Promise<void> {
 	const value = await readJson(filePath);
 	const parsed = RequiredOnWriteEnvelopeSchema.safeParse(value);
@@ -242,5 +254,148 @@ describe("workflow state writer drift guard", () => {
 				{ cwd: root, receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test incomplete" } },
 			),
 		).rejects.toThrow(/invalid workflow state envelope/);
+	});
+
+	it("rejects an unknown manifest phase on an internal envelope write (#658)", async () => {
+		const root = await tempDir();
+		await expect(
+			writeWorkflowEnvelopeAtomic(
+				path.join(root, ".gjc", "state", "ralplan-state.json"),
+				{
+					skill: "ralplan",
+					version: WORKFLOW_STATE_VERSION,
+					active: true,
+					current_phase: "bogus-phase",
+					updated_at: "2026-01-01T00:00:00.000Z",
+				},
+				{
+					cwd: root,
+					receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test unknown phase" },
+				},
+			),
+		).rejects.toThrow(/unknown ralplan phase "bogus-phase"/);
+	});
+
+	it("allows a valid manifest phase with no direct transition edge (#658 preserves skips)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		// planner -> final has no manifest edge; short-mode skips persist a valid state
+		// directly, so the invariant must accept it (it only rejects non-manifest phases).
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{
+				skill: "ralplan",
+				version: WORKFLOW_STATE_VERSION,
+				active: true,
+				current_phase: "final",
+				updated_at: "2026-01-01T00:00:00.000Z",
+			},
+			{ cwd: root, receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test skip" } },
+		);
+		await expectPersistedEnvelope(statePath);
+		const persisted = await readJson(statePath);
+		expect(persisted.current_phase).toBe("final");
+	});
+
+	it("lets a forced write bypass the unknown-phase invariant (#658 preserves forced writes)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{
+				skill: "ralplan",
+				version: WORKFLOW_STATE_VERSION,
+				active: true,
+				current_phase: "bogus-phase",
+				updated_at: "2026-01-01T00:00:00.000Z",
+			},
+			{
+				cwd: root,
+				receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test forced bypass" },
+				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", forced: true },
+			},
+		);
+		await expectPersistedEnvelope(statePath);
+		const persisted = await readJson(statePath);
+		expect(persisted.current_phase).toBe("bogus-phase");
+	});
+
+	it("flags an invalid phase transition on an internal write but still persists it (#658 transition invariant)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const base = {
+			skill: "ralplan" as const,
+			version: WORKFLOW_STATE_VERSION,
+			active: true,
+			updated_at: "2026-01-01T00:00:00.000Z",
+		};
+		const opts = {
+			cwd: root,
+			receipt: { cwd: root, skill: "ralplan" as const, owner: "gjc-runtime" as const, command: "test transition" },
+		};
+		// Seed a valid prior phase, then jump planner -> final (no manifest edge).
+		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "planner" }, opts);
+		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts);
+
+		// Diagnostic-only: the invalid edge is recorded, not blocked.
+		await expectPersistedEnvelope(statePath);
+		expect((await readJson(statePath)).current_phase).toBe("final");
+		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
+		expect(flagged.length).toBe(1);
+		expect(flagged[0]?.from_phase).toBe("planner");
+		expect(flagged[0]?.to_phase).toBe("final");
+	});
+
+	it("does not flag a valid manifest phase transition on an internal write (#658)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const base = {
+			skill: "ralplan" as const,
+			version: WORKFLOW_STATE_VERSION,
+			active: true,
+			updated_at: "2026-01-01T00:00:00.000Z",
+		};
+		const opts = {
+			cwd: root,
+			receipt: { cwd: root, skill: "ralplan" as const, owner: "gjc-runtime" as const, command: "test valid edge" },
+		};
+		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "planner" }, opts);
+		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "architect" }, opts);
+
+		expect((await readJson(statePath)).current_phase).toBe("architect");
+		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
+		expect(flagged.length).toBe(0);
+	});
+
+	it("lets a forced write bypass the transition invariant (#658)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const base = {
+			skill: "ralplan" as const,
+			version: WORKFLOW_STATE_VERSION,
+			active: true,
+			updated_at: "2026-01-01T00:00:00.000Z",
+		};
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{ ...base, current_phase: "planner" },
+			{
+				cwd: root,
+				receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test forced seed" },
+			},
+		);
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{ ...base, current_phase: "final" },
+			{
+				cwd: root,
+				receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test forced jump" },
+				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", forced: true },
+			},
+		);
+
+		expect((await readJson(statePath)).current_phase).toBe("final");
+		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
+		expect(flagged.length).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
@@ -333,11 +333,25 @@ describe("workflow state writer drift guard", () => {
 			cwd: root,
 			receipt: { cwd: root, skill: "ralplan" as const, owner: "gjc-runtime" as const, command: "test transition" },
 		};
-		// Seed a valid prior phase, then jump planner -> final (no manifest edge).
+		// Seed a valid active prior phase, then jump planner -> final (no manifest edge).
 		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "planner" }, opts);
-		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts);
 
-		// Diagnostic-only: the invalid edge is recorded, not blocked.
+		// The diagnostic-only path must NOT touch stderr (callers may treat stderr as failure
+		// or parse machine output): capture stderr across the invalid-edge write.
+		const originalWrite = process.stderr.write.bind(process.stderr);
+		let stderrCaptured = "";
+		process.stderr.write = ((chunk: unknown) => {
+			stderrCaptured += typeof chunk === "string" ? chunk : String(chunk);
+			return true;
+		}) as typeof process.stderr.write;
+		try {
+			await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts);
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+		expect(stderrCaptured).toBe("");
+
+		// The invalid edge is recorded as audit evidence, not blocked.
 		await expectPersistedEnvelope(statePath);
 		expect((await readJson(statePath)).current_phase).toBe("final");
 		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
@@ -395,6 +409,49 @@ describe("workflow state writer drift guard", () => {
 		);
 
 		expect((await readJson(statePath)).current_phase).toBe("final");
+		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
+		expect(flagged.length).toBe(0);
+	});
+
+	it("does not flag reactivation from an inactive prior envelope (#658)", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "deep-interview-state.json");
+		const opts = {
+			cwd: root,
+			receipt: {
+				cwd: root,
+				skill: "deep-interview" as const,
+				owner: "gjc-runtime" as const,
+				command: "test reactivate",
+			},
+		};
+		// A cleared/terminal prior envelope (active:false, terminal phase) is not a transition
+		// source: a fresh kickoff reactivating to the initial phase must not be flagged even
+		// though `complete -> interviewing` has no manifest edge.
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{
+				skill: "deep-interview",
+				version: WORKFLOW_STATE_VERSION,
+				active: false,
+				current_phase: "complete",
+				updated_at: "2026-01-01T00:00:00.000Z",
+			},
+			opts,
+		);
+		await writeWorkflowEnvelopeAtomic(
+			statePath,
+			{
+				skill: "deep-interview",
+				version: WORKFLOW_STATE_VERSION,
+				active: true,
+				current_phase: "interviewing",
+				updated_at: "2026-01-01T00:00:01.000Z",
+			},
+			opts,
+		);
+
+		expect((await readJson(statePath)).current_phase).toBe("interviewing");
 		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
 		expect(flagged.length).toBe(0);
 	});


### PR DESCRIPTION
Closes #658.

## Problem
`isValidTransition` (`workflow-manifest.ts`) guards per-skill phase transitions but was only invoked on the `gjc state` CLI path (`state-runtime.ts` — the sole call site). Internal runtime writers — `ralplan-runtime` (`persistActiveRunId`), `ultragoal-runtime` (`checkpointUltragoalGoal`, `reconcileUltragoalState`), `deep-interview-runtime`, `team-runtime`, and `reconcileWorkflowSkillState` — persist envelopes directly through `writeWorkflowEnvelopeAtomic`, so an internal-runtime bug could persist an invalid phase transition silently (the class behind #638/#644).

## Fix
Re-assert the gate inside the sanctioned writer (`writeWorkflowEnvelopeAtomic`) for **active** workflow writes:

- **Unknown manifest phase** → hard reject, matching the CLI/reconcile unknown-phase gate.
- **Known phase with no manifest edge from the prior phase** → non-blocking, **audit-only** diagnostic: an `invalid_transition_detected` entry in `audit.jsonl`. This is issue #658's option 2 ("diagnostic-only safety net") — invalid transitions are no longer silent, while legitimate internal repairs and ralplan short-mode stage skips keep working. **No stderr is emitted on the success path** (so JSON/machine-output callers and scripts that treat stderr as failure are unaffected).

The prior phase ("from") is resolved from `audit.fromPhase` when supplied, otherwise read best-effort from the persisted envelope — but only when that prior envelope is `active: true`, so a cleared/handed-off terminal state is not mistaken for a transition source.

### Exemptions
- Forced writes (`audit.forced` / `gjc state … --force`, reconcile repairs).
- Deactivation/teardown writes (`active: false`, e.g. `gjc state clear`, which persists the universal `complete` sentinel that is not a per-skill manifest state and therefore leaves the transition graph).
- Reactivation from an inactive prior (e.g. deep-interview `complete → interviewing` after a clear) is not flagged.

## Scope / reconciliation
- Touches only `state-writer.ts` (+ drift tests). Rebased onto current `dev` (through #656 / #659 / #660); no overlap with #660's `appendJsonlIdempotent`.
- An unrelated stale `docs-index.generated.ts` regen left in the recovered worktree was dropped to keep this PR scoped to #658.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/` + `workflow-state-command` + `gjc-skill-state-hooks` → **517 pass, 0 fail** (8 snapshots, 2513 expect calls).
- Drift cases: invalid transition flagged-but-persisted with **stderr captured-and-empty** + `invalid_transition_detected` audit entry asserted; valid transition not flagged; forced bypass; reactivation from an inactive prior not flagged.
- `bun run check:ts` (biome, json-schemas, node20-baseline, gjc-ui, all workspace `tsgo` type-checks) → green.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
