### PR TITLE
fix(setup): skip credential sources whose JSON root is not an object

### DIFF
--- a/packages/coding-agent/src/setup/credential-import.ts
+++ b/packages/coding-agent/src/setup/credential-import.ts
@@ -163,13 +163,17 @@ function parseClaudeCredentials(
 	origin: CredentialOrigin,
 	source: string,
 ): ImportableCredential | SkippedCredential {
-	let parsed: ClaudeCredentialsFile;
+	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw) as ClaudeCredentialsFile;
 	} catch (err) {
 		return { origin, source, reason: sanitizedFailureReason("malformed credential file", err) };
 	}
-	const oauth = parsed.claudeAiOauth;
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return { origin, source, reason: "unsupported shape (root is not an object)" };
+	}
+	const credentials = parsed as ClaudeCredentialsFile;
+	const oauth = credentials.claudeAiOauth;
 	if (typeof oauth !== "object" || oauth === null) {
 		return { origin, source, reason: "missing claudeAiOauth block (unsupported shape)" };
 	}
@@ -248,13 +252,17 @@ async function defaultClaudeKeychainReader(): Promise<string | null> {
 // ─── Codex discovery ─────────────────────────────────────────────────────────
 
 function parseCodexAuth(raw: string, source: string): ImportableCredential | SkippedCredential {
-	let parsed: CodexAuthFile;
+	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw) as CodexAuthFile;
 	} catch (err) {
 		return { origin: "codex-file", source, reason: sanitizedFailureReason("malformed credential file", err) };
 	}
-	const tokens = parsed.tokens;
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return { origin: "codex-file", source, reason: "unsupported shape (root is not an object)" };
+	}
+	const auth = parsed as CodexAuthFile;
+	const tokens = auth.tokens;
 	const access = nonEmptyString(tokens?.access_token);
 	const refresh = nonEmptyString(tokens?.refresh_token);
 	if (access && refresh) {
@@ -297,7 +305,7 @@ function parseCodexAuth(raw: string, source: string): ImportableCredential | Ski
 			reason: "incomplete OAuth tokens (missing access_token or refresh_token)",
 		};
 	}
-	const apiKey = nonEmptyString(parsed.OPENAI_API_KEY);
+	const apiKey = nonEmptyString(auth.OPENAI_API_KEY);
 	if (apiKey) {
 		return {
 			provider: "openai-codex",

--- a/packages/coding-agent/test/credential-import.test.ts
+++ b/packages/coding-agent/test/credential-import.test.ts
@@ -165,6 +165,20 @@ describe("discoverExternalCredentials", () => {
 		expect(result.skipped[0]!.reason).toContain("unsupported shape");
 	});
 
+	test.each([
+		["null", null, "unsupported shape (root is not an object)"],
+		["number", 42, "unsupported shape (root is not an object)"],
+		["array", ["x"], "unsupported shape (root is not an object)"],
+		["string", '"x"', "unsupported shape (root is not an object)"],
+	])("Claude %s root is skipped, not thrown", async (_label, body, reason) => {
+		await writeClaude(body);
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(result.skipped[0]!.origin).toBe("claude-code-file");
+		expect(result.skipped[0]!.reason).toBe(reason);
+	});
+
 	test("Codex incomplete OAuth tokens are skipped", async () => {
 		await writeCodex({ tokens: { access_token: CODEX_ACCESS } });
 		const result = await discover();
@@ -177,6 +191,20 @@ describe("discoverExternalCredentials", () => {
 		const result = await discover();
 		expect(result.importable).toHaveLength(0);
 		expect(result.skipped[0]!.reason).toContain("unsupported shape");
+	});
+
+	test.each([
+		["null", null, "unsupported shape (root is not an object)"],
+		["number", 42, "unsupported shape (root is not an object)"],
+		["array", ["x"], "unsupported shape (root is not an object)"],
+		["string", '"x"', "unsupported shape (root is not an object)"],
+	])("Codex %s root is skipped, not thrown", async (_label, body, reason) => {
+		await writeCodex(body);
+		const result = await discover();
+		expect(result.importable).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(result.skipped[0]!.origin).toBe("codex-file");
+		expect(result.skipped[0]!.reason).toBe(reason);
 	});
 
 	test("macOS keychain is read only when no file exists", async () => {


### PR DESCRIPTION
## What
`parseClaudeCredentials` / `parseCodexAuth` dereferenced the parsed root (`parsed.claudeAiOauth`, `parsed.tokens`) after a successful `JSON.parse` without confirming the root is a non-null object. A credentials file containing `null` therefore threw `null is not an object` and aborted the whole `discoverExternalCredentials` flow — violating the module's documented "never throws for individual unreadable or malformed sources" contract.

## Fix
Guard the parsed root (`typeof !== "object" || null || Array.isArray`) immediately after `JSON.parse`; non-object roots are returned as `SkippedCredential { reason: "unsupported shape (root is not an object)" }` instead of throwing.

## Test
Added parametrized negative tests (null/number/array/string roots) for both Claude and Codex parsers asserting they are skipped, not thrown. `bun test packages/coding-agent/test/credential-import.test.ts` → 28 pass.

Found via post-0.5.1 dogfood of #654.
