### PR TITLE
fix(ralplan): re-assert active:true on same-run continuation --write

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -240,7 +240,8 @@ async function persistActiveRunId(
 	if (
 		existing.run_id === runId &&
 		existing.version === WORKFLOW_STATE_VERSION &&
-		existing.current_phase === nextPhase
+		existing.current_phase === nextPhase &&
+		(existing.active === true || PHASE_LOCK.has(nextPhase))
 	) {
 		return;
 	}

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -880,6 +880,44 @@ describe("native gjc ralplan runtime — post-clear re-activation (#644)", () =>
 		expect(after.current_phase).toBe("planner");
 	});
 
+	it("re-asserts active:true on a same-run continuation write at the current phase", async () => {
+		const root = await tempDir();
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		await fs.mkdir(path.dirname(statePath), { recursive: true });
+		await fs.writeFile(
+			statePath,
+			JSON.stringify({
+				skill: "ralplan",
+				active: false,
+				current_phase: "planner",
+				run_id: "same-run-continuation",
+				version: 2,
+			}),
+			"utf-8",
+		);
+
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Plan",
+				"--run-id",
+				"same-run-continuation",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+
+		const after = await readState(root);
+		expect(after.run_id).toBe("same-run-continuation");
+		expect(after.active).toBe(true);
+		expect(after.current_phase).toBe("planner");
+	});
+
 	it("does not re-arm a cleared run on a stray same-run-id --write (demote-on-clear preserved)", async () => {
 		const root = await tempDir();
 		await runNativeRalplanCommand(["--deliberate", "task"], root);


### PR DESCRIPTION
## What
`persistActiveRunId`'s early no-op guard returned when `run_id` + `version` + `current_phase` matched **without** checking `existing.active`. A same-run continuation `--write` while the mode-state was `active:false` (e.g. after a prior `gjc state ralplan clear`) left `active:false`, so `modeStateReleasesStop` kept the handoff Stop hook released — silently disarming the safety the #647 fix was meant to re-arm.

## Fix
Only no-op when the state is already `active`, or when the next phase is PHASE_LOCKed (preserving the deliberate demote-on-clear / stray-same-run-write contract). A genuine same-run continuation now falls through and re-asserts `active:true`.

## Test
Added a regression covering same-run re-activation from `active:false`; the existing demote-on-clear tests still pass. `bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts` → 44 pass.

Found via post-0.5.1 dogfood of #647.
