### PR TITLE
fix(file-lock): never reap a live lock owner by elapsed time

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -83,12 +83,19 @@ export async function removeFileLockDirForGc(
 	return "removed";
 }
 
-function isProcessAlive(pid: number): boolean {
+type OwnerLiveness = "alive" | "dead" | "unknown";
+
+function ownerLiveness(pid: number): OwnerLiveness {
+	if (!Number.isFinite(pid) || pid <= 0) return "unknown";
 	try {
 		process.kill(pid, 0);
-		return true;
-	} catch {
-		return false;
+		return "alive";
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return "dead";
+		// EPERM means the process exists but we may not signal it; treat as alive.
+		// Anything else is indeterminate.
+		return code === "EPERM" ? "alive" : "unknown";
 	}
 }
 
@@ -96,11 +103,13 @@ async function isLockStale(lockPath: string, staleMs: number): Promise<boolean> 
 	const info = await readLockInfo(lockPath);
 	if (!info) return true;
 
-	if (!isProcessAlive(info.pid)) return true;
-
-	if (Date.now() - info.timestamp > staleMs) return true;
-
-	return false;
+	// Never reap a live owner by elapsed time: a long legitimate critical section must
+	// not have its lock stolen (#652). Reclaim a dead owner immediately. Only when owner
+	// liveness is indeterminate do we fall back to the staleMs elapsed-time heuristic.
+	const liveness = ownerLiveness(info.pid);
+	if (liveness === "dead") return true;
+	if (liveness === "alive") return false;
+	return Date.now() - info.timestamp > staleMs;
 }
 
 async function tryAcquireLock(lockPath: string): Promise<boolean> {

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { removeFileLockDirForGc } from "@gajae-code/coding-agent/config/file-lock";
+import { removeFileLockDirForGc, withFileLock } from "@gajae-code/coding-agent/config/file-lock";
 import { fileLocksGcAdapter } from "@gajae-code/coding-agent/config/file-lock-gc";
 import type { GcContext, GcPidProbe, GcRecord } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
 
@@ -53,6 +53,55 @@ function deadLockRecord(lockDir: string): GcRecord {
 	};
 }
 
+describe("withFileLock stale owner liveness (#652)", () => {
+	test("does not overlap a live holder that exceeds staleMs", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const events: string[] = [];
+		let waiter: Promise<void> | undefined;
+
+		await withFileLock(
+			lockedFile,
+			async () => {
+				events.push("holder-enter");
+				waiter = withFileLock(
+					lockedFile,
+					async () => {
+						events.push("waiter-enter");
+					},
+					{ staleMs: 1, retries: 50, retryDelayMs: 5 },
+				);
+
+				await Bun.sleep(30);
+				expect(events).toEqual(["holder-enter"]);
+				events.push("holder-exit");
+			},
+			{ staleMs: 1, retries: 1, retryDelayMs: 1 },
+		);
+		await waiter;
+
+		expect(events).toEqual(["holder-enter", "holder-exit", "waiter-enter"]);
+	});
+
+	test("reclaims a stale lock owned by a dead process", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: Date.now() - 10_000 });
+
+		let acquired = false;
+		await withFileLock(
+			lockedFile,
+			async () => {
+				acquired = true;
+			},
+			{ staleMs: 1, retries: 3, retryDelayMs: 1 },
+		);
+
+		expect(acquired).toBe(true);
+		expect(await fs.exists(lockDir)).toBe(false);
+	});
+});
 describe("removeFileLockDirForGc owner-token guard (#606)", () => {
 	test("removes the dir when the on-disk token matches the expected owner", async () => {
 		const base = await makeTemp();


### PR DESCRIPTION
## What
`isLockStale` treated any holder older than `staleMs` (default 10s) as stale and removed its lock dir, even when the owning process was alive. A legitimate critical section longer than `staleMs` (e.g. `withWorkflowStateLock` / `updateJsonAtomic`) could have its lock stolen, allowing a concurrent writer and lost updates.

## Fix
Determine owner liveness via `process.kill(pid, 0)`:
- live owner → never stale (no time-based reap),
- dead owner (`ESRCH`) → reclaimed immediately,
- indeterminate liveness → fall back to the `staleMs` elapsed-time heuristic.

`EPERM` is treated as alive. `staleMs` remains meaningful for the indeterminate case, so callers (e.g. receipt-spool) keep their backstop.

## Test
Added regressions proving a holder live past `staleMs` is not overlapped by a second acquirer, and a dead-PID stale lock is still reclaimed. `bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts` → 8 pass.

Found via post-0.5.1 dogfood of #652.
