### PR TITLE
fix(web-search): apply local-baseUrl guard to direct provider-id mapping

### DIFF
--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -232,6 +232,13 @@ export function inferNativeProviderFromModel(ctx: ActiveSearchModelContext | und
 	return undefined;
 }
 
+function canUseDirectProviderMapping(ctx: ActiveSearchModelContext, id: SearchProviderId): boolean {
+	if (ctx.webSearch === "off") return false;
+	if (id !== "codex") return true;
+	if (!isOpenAICompatWire(ctx.api)) return true;
+	return ctx.webSearch === "on" || !isLocalBaseUrl(ctx.baseUrl);
+}
+
 export async function canUseGenericCredentials(
 	authStorage: AuthStorage,
 	ctx: ActiveSearchModelContext | undefined,
@@ -279,7 +286,8 @@ export async function resolveProviderChain(options: ResolveProviderChainOptions)
 		await appendAvailable(chain, preferredProvider, authStorage);
 	} else if (activeModelContext) {
 		const directId = MODEL_PROVIDER_TO_SEARCH[activeModelContext.provider.toLowerCase()];
-		if (activeModelContext.webSearch !== "off" && directId) await appendAvailable(chain, directId, authStorage);
+		if (directId && canUseDirectProviderMapping(activeModelContext, directId))
+			await appendAvailable(chain, directId, authStorage);
 		const inferred = inferNativeProviderFromModel(activeModelContext);
 		if (inferred) await appendAvailable(chain, inferred, authStorage);
 		if (await shouldTryGenericOpenAICompat(authStorage, activeModelContext, sessionId, signal))

--- a/packages/coding-agent/test/web/search/provider-resolution.test.ts
+++ b/packages/coding-agent/test/web/search/provider-resolution.test.ts
@@ -56,6 +56,36 @@ describe("native web-search provider resolution", () => {
 		).resolves.toEqual(["duckduckgo"]);
 	});
 
+	it("does not map provider id openai to hosted codex for local OpenAI-compatible auto contexts", async () => {
+		await expect(
+			ids(
+				{
+					provider: "openai",
+					modelId: "gpt-oss",
+					api: "openai-responses",
+					baseUrl: "http://localhost:11434/v1",
+					webSearch: "auto",
+				},
+				{ auth: ["openai-codex", "codex"] },
+			),
+		).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("still maps provider id openai to hosted codex for non-local auto contexts", async () => {
+		await expect(
+			ids(
+				{
+					provider: "openai",
+					modelId: "gpt-5",
+					api: "openai-responses",
+					baseUrl: "https://api.openai.com/v1",
+					webSearch: "auto",
+				},
+				{ auth: ["openai-codex", "codex"] },
+			),
+		).resolves.toEqual(["codex", "duckduckgo"]);
+	});
+
 	it("honors forced provider first and dedupes configured fallback plus DuckDuckGo", async () => {
 		await expect(
 			ids(


### PR DESCRIPTION
## What
`resolveProviderChain` appended the hosted search provider from the direct `MODEL_PROVIDER_TO_SEARCH` provider-id map before/around the guarded `inferNativeProviderFromModel`. A context with provider id `openai` + a local/private `baseUrl` + Codex OAuth could get the hosted `codex` search provider appended — bypassing the local-OpenAI-compatible auto guard and risking query egress for a local model.

## Fix
Added `canUseDirectProviderMapping` which applies the same gate as `inferNativeProviderFromModel` (a local OpenAI-compatible context with `webSearch:"auto"` does not auto-select hosted `codex`). Explicit user-forced configurable providers remain available.

## Test
Added tests: local baseUrl + `webSearch:"auto"` yields no hosted provider via native selection; a non-local context still infers `codex`. `bun test packages/coding-agent/test/web/search/` → 63 pass.

Found via post-0.5.1 dogfood of #591.
