### PR TITLE
fix(utils): limit frontmatter trailing-comma recovery to scalar values

### DIFF
--- a/packages/coding-agent/test/discovery/helpers.test.ts
+++ b/packages/coding-agent/test/discovery/helpers.test.ts
@@ -116,6 +116,29 @@ Body content`;
 		expect(result.body).toBe("Body content");
 	});
 
+	test("does not coerce malformed flow collections with trailing commas", () => {
+		const content = `---
+items: [one, two,
+---
+Body content`;
+
+		expect(() => parseFrontmatter(content, { source: "tests:frontmatter", level: "fatal" })).toThrow(
+			/Failed to parse YAML frontmatter/,
+		);
+	});
+
+	test("does not coerce malformed block scalars with trailing commas", () => {
+		const content = `---
+description: |,
+  Body text
+---
+Body content`;
+
+		expect(() => parseFrontmatter(content, { source: "tests:frontmatter", level: "fatal" })).toThrow(
+			/Failed to parse YAML frontmatter/,
+		);
+	});
+
 	test("handles missing frontmatter", () => {
 		const content = "Just body content";
 		const result = parse(content);

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -10,9 +10,9 @@ function stripLooseScalarTrailingCommas(metadata: string): string {
 	return metadata
 		.split("\n")
 		.map(line => {
-			const match = line.match(/^(\s*[\w-]+\s*:\s+.+),(\s*)$/);
-			if (!match) return line;
-			return `${match[1]}${match[2]}`;
+			const match = line.match(/^(\s*[\w-]+\s*:\s+)(.+),(\s*)$/);
+			if (!match || /^[[{|>]/.test(match[2].trimStart())) return line;
+			return `${match[1]}${match[2]}${match[3]}`;
 		})
 		.join("\n");
 }


### PR DESCRIPTION
## What
The loose trailing-comma recovery (`stripLooseScalarTrailingCommas`) stripped a terminal comma from any one-line `key: value`, including flow-collection (`[`/`{`) and block-indicator (`|`/`>`) values. After a strict YAML failure this could coerce malformed non-scalar YAML into a parse, masking genuine errors.

## Fix
Restrict stripping to quoted/plain scalar-shaped values by skipping values that begin with a flow or block indicator. Strict-first parsing, original-error rethrow, inner-comma preservation, and the Cursor-style quoted-scalar-with-trailing-comma case are unchanged.

## Test
Added negative tests proving flow-collection / block-scalar lines ending in a comma are not silently coerced, while quoted-scalar recovery still works. `bun test packages/coding-agent/test/discovery/helpers.test.ts` → 12 pass.

Found via post-0.5.1 dogfood of #608.
