### PR TITLE
Fix compiled GJC crash when loading native tokenizer

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compaction token estimation in Bun standalone binaries by loading the native tokenizer through the sibling native entrypoint instead of package-name dynamic resolution.
+
 ## [0.5.1] - 2026-06-14
 
 - Version aligned with the 0.5.1 monorepo release; no functional changes in this package.

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -5,6 +5,7 @@
  * and after compaction the session is reloaded.
  */
 
+import { createRequire } from "node:module";
 import {
 	type AssistantMessage,
 	Effort,
@@ -13,7 +14,7 @@ import {
 	type Model,
 	type Usage,
 } from "@gajae-code/ai";
-import { logger, prompt } from "@gajae-code/utils";
+import { isCompiledBinary, logger, prompt } from "@gajae-code/utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
 import type { AgentMessage, AgentTool } from "../types";
 import type { CompactionEntry, SessionEntry } from "./entries";
@@ -265,23 +266,44 @@ export function resolveThresholdTokens(
  * matching what providers typically bill for inline images.
  */
 const IMAGE_TOKEN_ESTIMATE = 1200;
+const SOURCE_NATIVE_TOKENIZER_ENTRYPOINT = "../../../natives/native/index.js";
+const COMPILED_NATIVE_TOKENIZER_ENTRYPOINT = "/$bunfs/root/packages/natives/native/index.js";
+
+const requireFromCompaction = createRequire(import.meta.url);
+
+interface NativeTokenizerModule {
+	countTokens(input: string | string[], encoding?: unknown): number;
+}
 
 /**
  * Lazily-required native `countTokens`. `@gajae-code/natives` dlopens a ~39MB
  * addon; importing it at module scope would put that cost on every cold path
  * that touches compaction exports (status line, print mode, context report).
- * Deferring the require to the first context-changing call keeps the trivial
- * `-p` / display paths native-free.
+ * Deferring the require to the first context-changing call keeps display paths
+ * native-free.
+ *
+ * Do not resolve this via a package-name dynamic require of
+ * `@gajae-code/natives`: Bun standalone binaries cannot satisfy those from
+ * `$bunfs`. The sibling-package source path is stable for workspace and
+ * package-install layouts:
+ *
+ * - workspace: `packages/agent` -> `packages/natives`
+ * - npm/bun install: `node_modules/@gajae-code/agent-core` ->
+ *   `node_modules/@gajae-code/natives`
+ *
+ * Bun rewrites `createRequire(import.meta.url)` to the compiled executable
+ * root (`/$bunfs/root/gjc-*`) in standalone binaries, so compiled mode uses the
+ * absolute bunfs module path emitted by the binary build scripts.
  */
 let cachedNativeCountTokens: ((input: string | string[], encoding?: unknown) => number) | null = null;
 
+function nativeTokenizerEntrypoint(): string {
+	return isCompiledBinary() ? COMPILED_NATIVE_TOKENIZER_ENTRYPOINT : SOURCE_NATIVE_TOKENIZER_ENTRYPOINT;
+}
+
 function nativeCountTokens(fragments: string[]): number {
 	if (!cachedNativeCountTokens) {
-		const { createRequire } = require("node:module") as typeof import("node:module");
-		const requireFromHere = createRequire(import.meta.url);
-		const natives = requireFromHere("@gajae-code/natives") as {
-			countTokens: (input: string | string[], encoding?: unknown) => number;
-		};
+		const natives = requireFromCompaction(nativeTokenizerEntrypoint()) as NativeTokenizerModule;
 		cachedNativeCountTokens = natives.countTokens;
 	}
 	return cachedNativeCountTokens(fragments);

--- a/packages/agent/test/compaction-native-tokenizer-entrypoint.test.ts
+++ b/packages/agent/test/compaction-native-tokenizer-entrypoint.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { estimateTokens } from "../src/compaction/compaction";
+import type { AgentMessage } from "../src/types";
+
+const compactionSourcePath = path.join(import.meta.dir, "..", "src", "compaction", "compaction.ts");
+
+describe("compaction native tokenizer loading", () => {
+	it("loads the native tokenizer lazily through the sibling native entrypoint", () => {
+		const message: AgentMessage = {
+			role: "user",
+			content: "compiled binary native tokenizer smoke",
+			timestamp: 0,
+		};
+
+		expect(estimateTokens(message)).toBeGreaterThan(0);
+	});
+
+	it("does not use a package-name dynamic require for @gajae-code/natives", async () => {
+		const source = await Bun.file(compactionSourcePath).text();
+
+		expect(source).toContain('const SOURCE_NATIVE_TOKENIZER_ENTRYPOINT = "../../../natives/native/index.js";');
+		expect(source).toContain(
+			'const COMPILED_NATIVE_TOKENIZER_ENTRYPOINT = "/$bunfs/root/packages/natives/native/index.js";',
+		);
+		expect(source).toContain("requireFromCompaction(nativeTokenizerEntrypoint())");
+		expect(source).not.toContain('requireFromHere("@gajae-code/natives")');
+		expect(source).not.toContain('require("@gajae-code/natives")');
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed v0.5.1-style macOS/Linux standalone binaries crashing before the first model request with `Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc-*'` when pre-prompt context maintenance invokes the native tokenizer.
 - Mapped the retired `codex-standard` model profile name to `codex-medium` during profile activation, **as a fallback only** so a user-defined profile literally named `codex-standard` is never shadowed, letting stale `modelProfile.default: codex-standard` configs reach activation instead of blocking startup after the rebuilt profile catalog.
 - Fixed interactive goal-mode auto-continuation looping `Error: Agent is already processing…` (`AgentBusyError`) while the session is busy. A wedged/orphaned subagent turn — or an in-progress compaction — can leave the session non-idle while the interactive loop is back at `getUserInput()`; the 800 ms continuation timer then fired `prompt()`, threw `AgentBusyError`, surfaced it via `showError`, and re-armed — spamming the error roughly every 800 ms. The continuation now skips and re-arms while `isStreaming`/`isCompacting`, firing only once the session returns to idle.
 - Fixed the built-in `minimax-eco`/`minimax-medium`/`minimax-pro` model profiles 400ing on activation because every role pinned the non-existent `minimax-code/minimax-v3`. All three profiles now pin `minimax-code/minimax-m3`, the canonical `minimax-code` default already present in the bundled models catalog (#656).

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -5,6 +5,12 @@ import * as path from "node:path";
 const packageDir = path.join(import.meta.dir, "..");
 const outputPath = path.join(packageDir, "dist", "gjc");
 const nativeDir = path.join(packageDir, "..", "natives", "native");
+// Lazy native tokenizer entrypoint. `agent-core/compaction` loads this from
+// the explicit native entrypoint instead of a package-name dynamic require of
+// `@gajae-code/natives`, because those fail inside Bun standalone `$bunfs`.
+// Listing the module here makes the absolute target path exist in the compiled
+// bunfs.
+const nativeTokenizerEntrypoint = "../natives/native/index.js";
 
 function shouldAdhocSignDarwinBinary(): boolean {
 	return process.platform === "darwin";
@@ -66,6 +72,7 @@ async function main(): Promise<void> {
 					"../stats/src/sync-worker.ts",
 					"./src/tools/browser/tab-worker-entry.ts",
 					"./src/eval/js/worker-entry.ts",
+					nativeTokenizerEntrypoint,
 					"--outfile",
 					"dist/gjc",
 				],

--- a/packages/coding-agent/test/compiled-native-tokenizer-entrypoint.test.ts
+++ b/packages/coding-agent/test/compiled-native-tokenizer-entrypoint.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+const devBuildScriptPath = path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts");
+const releaseBuildScriptPath = path.join(repoRoot, "scripts/ci-release-build-binaries.ts");
+
+describe("compiled binary native tokenizer entrypoint", () => {
+	it("dev binary build embeds the lazy native tokenizer module", async () => {
+		const source = await Bun.file(devBuildScriptPath).text();
+
+		expect(source).toContain('const nativeTokenizerEntrypoint = "../natives/native/index.js";');
+		expect(source).toContain("nativeTokenizerEntrypoint,");
+	});
+
+	it("release binary build embeds the lazy native tokenizer module", async () => {
+		const source = await Bun.file(releaseBuildScriptPath).text();
+
+		expect(source).toContain('const nativeTokenizerEntrypoint = "./packages/natives/native/index.js";');
+		expect(source).toContain("nativeTokenizerEntrypoint,");
+		expect(source).toContain("...workerEntrypoints,");
+	});
+});

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -14,6 +14,12 @@ interface BinaryTarget {
 const repoRoot = path.join(import.meta.dir, "..");
 const binariesDir = path.join(repoRoot, "packages", "coding-agent", "binaries");
 const entrypoint = "./packages/coding-agent/src/cli.ts";
+// Lazy native tokenizer entrypoint. `agent-core/compaction` loads this from
+// the explicit native entrypoint instead of a package-name dynamic require of
+// `@gajae-code/natives`, because those fail inside Bun standalone `$bunfs`.
+// Listing the module here makes the absolute target path exist in the compiled
+// bunfs.
+const nativeTokenizerEntrypoint = "./packages/natives/native/index.js";
 // Worker entrypoints. Bun's `--compile` static analyzer discovers the
 // literal in `new Worker("…", …)` at each spawn site, but only actually
 // emits the worker into the bunfs root when it is also listed here as an
@@ -130,7 +136,8 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --keep-names --define process.env.PI_COMPILED="true" --root . --external mupdf --target=${target.target} ${entrypoint} ${workerEntrypoints.join(" ")} --outfile ${target.outfile}`);
+		const compileEntrypoints = [...workerEntrypoints, nativeTokenizerEntrypoint].join(" ");
+		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --keep-names --define process.env.PI_COMPILED="true" --root . --external mupdf --target=${target.target} ${entrypoint} ${compileEntrypoints} --outfile ${target.outfile}`);
 		return;
 	}
 
@@ -157,6 +164,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 			target.target,
 			entrypoint,
 			...workerEntrypoints,
+			nativeTokenizerEntrypoint,
 			"--outfile",
 			target.outfile,
 		],


### PR DESCRIPTION
## Summary
- Fix compiled GJC binaries so compaction token estimation loads the native tokenizer through an explicit bundled native entrypoint instead of package-name dynamic resolution.
- Include the native tokenizer entrypoint in both dev and release `bun build --compile` command paths.
- Add regression tests for the lazy native tokenizer loading contract and compiled-binary entrypoint inclusion.

## Root cause
Bun standalone binaries cannot satisfy the lazy package-name dynamic require of `@gajae-code/natives` from the compiled `$bunfs` executable root. Pre-prompt context maintenance can invoke compaction token estimation before the first model request, so the binary could crash before provider traffic.

## Validation
- `bun test packages/agent/test/compaction-native-tokenizer-entrypoint.test.ts packages/coding-agent/test/compiled-native-tokenizer-entrypoint.test.ts packages/agent/test/compaction-estimate-cache.test.ts packages/coding-agent/test/issue-1150-repro.test.ts packages/coding-agent/test/issue-1011-repro.test.ts`
- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/coding-agent run check`
- `bun run check:ts`
- `bun --cwd=packages/coding-agent run build`
- `bun scripts/ci-release-build-binaries.ts --dry-run --targets darwin-arm64`
- `packages/coding-agent/dist/gjc --smoke-test`
- `packages/coding-agent/dist/gjc -p --no-title --no-session --no-tools --model openai-codex/gpt-5.5 'Reply OK only.'`
- `packages/coding-agent/dist/gjc -p --no-title --no-session --no-tools --model grok-build/grok-build 'Reply OK only.'`

## Conflict check
- Base `origin/dev` is an ancestor of this branch.
- Open PRs checked: no blocking textual conflicts. PRs #665 and #635 only overlap on `packages/coding-agent/CHANGELOG.md`; `git merge-tree --write-tree` reports mergeable for both.
- Active non-PR branches include some stale changelog-only conflict possibilities, but no open PR or functional-file conflict was found for this change.

## Notes
- This is not an auth/login/provider issue; Grok Build prompt execution is listed only as the originally observed runtime path used for verification.