### PR TITLE
perf(subagent): gate idle await UI updates on a value-based rendered-state signature (1/3)

### DIFF
--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -4,7 +4,7 @@ import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
-import type { AgentProgress, AgentSource } from "../task/types";
+import type { AgentProgress, AgentSource, TaskToolDetails } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
 import type { ToolSession } from "./index";
 import { replaceTabs } from "./render-utils";
@@ -330,12 +330,21 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		);
 		const watchedJobIds = runningJobs.map(job => job.id);
 		manager.watchJobs(watchedJobIds);
-		const progressTimer = onUpdate
-			? setInterval(() => {
-					onUpdate(this.#progressResult(manager, records, true));
-				}, 500)
-			: undefined;
-		onUpdate?.(this.#progressResult(manager, records, true));
+		let lastEmittedSignature: string | undefined;
+		const emitIfChanged = (force: boolean): void => {
+			if (!onUpdate) return;
+			const result = this.#progressResult(manager, records, true);
+			const signature = subagentAwaitRenderedStateSignature(result.details?.subagents ?? []);
+			if (!force && signature === lastEmittedSignature) return;
+			lastEmittedSignature = signature;
+			onUpdate(result);
+		};
+		const progressTimer = onUpdate ? setInterval(() => emitIfChanged(false), 500) : undefined;
+		// Initial emission so the panel appears immediately; later idle ticks are
+		// gated on a value-based rendered-state signature so unchanged progress no
+		// longer rebuilds the renderer component or mutates transcript lines above
+		// the viewport (the source of the await-panel repaint storms).
+		emitIfChanged(true);
 
 		let timedOut = false;
 		try {
@@ -719,4 +728,135 @@ function previewJobOutput(
 	const normalized = replaceTabs(source.text);
 	const preview = truncateToWidth(normalized, width, Ellipsis.Unicode);
 	return { type: source.type, preview, truncated: preview !== normalized };
+}
+
+/**
+ * Canonical, value-based rendered-state signature for the `subagent` await panel.
+ *
+ * Producer-side await gating compares this signature against the last emitted one
+ * and only fires `onUpdate` when the *rendered* state actually changed. Unchanged
+ * idle ticks therefore stop rebuilding the renderer component and stop mutating
+ * transcript lines above the viewport, which is what triggers TUI full-redraw
+ * storms (`tui.ts` `firstChanged < viewportTop`).
+ *
+ * It is deliberately value-based, never object identity: `AsyncJobManager.record-
+ * SubagentProgress` stores a `structuredClone` but `getSubagentProgress` returns
+ * the retained object by reference, so identity comparison would be both noisy and
+ * unsafe.
+ *
+ * Time-derived fields are intentionally excluded so the panel does not churn while
+ * idle: raw durations (`durationMs`), current-tool elapsed (`currentToolStartMs`),
+ * and retry countdowns (`retryState.startedAtMs`) are omitted. Idle duration and
+ * countdown ticking is sacrificed by design; every real transition still changes
+ * the signature.
+ */
+export function subagentAwaitRenderedStateSignature(subagents: readonly SubagentSnapshot[]): string {
+	return JSON.stringify(subagents.map(canonicalizeSnapshotForSignature));
+}
+
+function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
+	return {
+		id: snapshot.id,
+		jobId: snapshot.jobId,
+		status: snapshot.status,
+		label: snapshot.label,
+		agent: snapshot.agent,
+		agentSource: snapshot.agentSource,
+		description: snapshot.description ?? null,
+		assignment: snapshot.assignment ?? null,
+		resultText: snapshot.resultText ?? null,
+		errorText: snapshot.errorText ?? null,
+		resultPreview: snapshot.resultPreview ?? null,
+		outputRef: snapshot.outputRef ?? null,
+		truncated: snapshot.truncated ?? false,
+		guidance: snapshot.guidance ?? null,
+		liveProgressAvailable: snapshot.liveProgressAvailable ?? null,
+		effectiveModel: snapshot.effectiveModel ?? null,
+		requestedModel: snapshot.requestedModel ?? null,
+		modelFellBack: snapshot.modelFellBack ?? false,
+		// durationMs intentionally excluded (time-derived; would defeat idle gating).
+		progress: snapshot.progress ? canonicalizeProgressForSignature(snapshot.progress) : null,
+	};
+}
+
+function canonicalizeProgressForSignature(progress: AgentProgress): unknown {
+	return {
+		id: progress.id,
+		agent: progress.agent,
+		agentSource: progress.agentSource,
+		status: progress.status,
+		task: progress.task,
+		assignment: progress.assignment ?? null,
+		description: progress.description ?? null,
+		lastIntent: progress.lastIntent ?? null,
+		currentTool: progress.currentTool ?? null,
+		currentToolArgs: progress.currentToolArgs ?? null,
+		// currentToolStartMs intentionally excluded (only drives elapsed rendering).
+		recentTools: progress.recentTools.map(tool => ({ tool: tool.tool, args: tool.args })),
+		recentOutput: progress.recentOutput,
+		toolCount: progress.toolCount,
+		tokens: progress.tokens,
+		contextTokens: progress.contextTokens ?? null,
+		contextWindow: progress.contextWindow ?? null,
+		cost: progress.cost,
+		modelOverride: progress.modelOverride ?? null,
+		modelSubstitutionWarning: progress.modelSubstitutionWarning ?? null,
+		// durationMs intentionally excluded (time-derived).
+		extractedToolData: progress.extractedToolData
+			? canonicalizeExtractedToolDataForSignature(progress.extractedToolData)
+			: null,
+		retryState: progress.retryState
+			? {
+					attempt: progress.retryState.attempt,
+					maxAttempts: progress.retryState.maxAttempts,
+					unbounded: progress.retryState.unbounded ?? false,
+					delayMs: progress.retryState.delayMs,
+					errorMessage: progress.retryState.errorMessage,
+					// startedAtMs intentionally excluded (drives countdown only).
+				}
+			: null,
+		retryFailure: progress.retryFailure ?? null,
+		inflightTaskDetails: progress.inflightTaskDetails
+			? canonicalizeTaskDetailsForSignature(progress.inflightTaskDetails)
+			: null,
+	};
+}
+
+/**
+ * Nested `task` data (`extractedToolData.task` and `inflightTaskDetails`) is the
+ * one place the await signature reaches into a live, ticking structure: nested
+ * `AgentProgress` carries the same time-derived fields excluded above, and
+ * `TaskToolDetails` adds `totalDurationMs` / per-result `durationMs`. Signing it
+ * wholesale would defeat idle gating whenever an awaited subagent is itself inside
+ * a live `task` call, so these helpers canonicalize the rendered, non-time subset
+ * recursively (mutually recursive with `canonicalizeProgressForSignature`).
+ */
+function canonicalizeExtractedToolDataForSignature(data: Record<string, unknown[]>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const key of Object.keys(data)) {
+		// Only the `task` key holds time-ticking `TaskToolDetails`; other handler
+		// data (yield/report_finding/generic) is stable and passes through as-is.
+		out[key] = key === "task" ? (data[key] as TaskToolDetails[]).map(canonicalizeTaskDetailsForSignature) : data[key];
+	}
+	return out;
+}
+
+function canonicalizeTaskDetailsForSignature(details: TaskToolDetails): unknown {
+	// `extractedToolData` is an untyped boundary (`Record<string, unknown[]>`), so
+	// guard each field instead of trusting the `TaskToolDetails` cast.
+	return {
+		// totalDurationMs intentionally excluded (time-derived).
+		results: Array.isArray(details.results) ? details.results.map(canonicalizeTaskResultForSignature) : null,
+		progress: Array.isArray(details.progress) ? details.progress.map(canonicalizeProgressForSignature) : null,
+		async: details.async
+			? { state: details.async.state, jobId: details.async.jobId, type: details.async.type }
+			: null,
+	};
+}
+
+function canonicalizeTaskResultForSignature(result: TaskToolDetails["results"][number]): unknown {
+	// Completed results do not tick, but drop `durationMs` so the only time-derived
+	// field in the receipt can never reintroduce idle churn.
+	const { durationMs: _durationMs, ...rest } = result;
+	return rest;
 }

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AsyncJobManager, type SubagentRecord } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import type { AgentProgress } from "../../src/task/types";
 import { SubagentTool, type ToolSession } from "../../src/tools";
+import { type SubagentSnapshot, subagentAwaitRenderedStateSignature } from "../../src/tools/subagent";
 
 function createSession(agentId = "0-Main"): ToolSession {
 	return {
@@ -316,5 +317,222 @@ describe("AsyncJobManager subagent progress retention", () => {
 		const retained = manager.getSubagentProgress("0-Clone");
 		expect(retained?.recentOutput).toEqual(["one"]);
 		expect(retained?.currentTool).toBeUndefined();
+	});
+});
+
+function makeSnapshot(overrides: Partial<SubagentSnapshot> & Pick<SubagentSnapshot, "id">): SubagentSnapshot {
+	return {
+		jobId: overrides.id,
+		status: "running",
+		label: "subagent",
+		agent: "executor",
+		agentSource: "bundled",
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+describe("subagentAwaitRenderedStateSignature", () => {
+	it("is value-based: equal values from independent clones produce identical signatures", () => {
+		const a = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", currentTool: "read", recentOutput: ["x"] }),
+		});
+		const b = makeSnapshot({
+			id: "0-A",
+			// structuredClone yields a different object reference with equal values.
+			progress: structuredClone(makeProgress({ id: "0-A", currentTool: "read", recentOutput: ["x"] })),
+		});
+		expect(subagentAwaitRenderedStateSignature([a])).toBe(subagentAwaitRenderedStateSignature([b]));
+	});
+
+	it("ignores time-derived churn (durationMs, current-tool elapsed, retry countdown)", () => {
+		const early = makeSnapshot({
+			id: "0-A",
+			durationMs: 1_000,
+			progress: makeProgress({
+				id: "0-A",
+				durationMs: 1_000,
+				currentTool: "read",
+				currentToolStartMs: 1_000,
+				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 1_000 },
+			}),
+		});
+		const later = makeSnapshot({
+			id: "0-A",
+			durationMs: 999_999,
+			progress: makeProgress({
+				id: "0-A",
+				durationMs: 999_999,
+				currentTool: "read",
+				currentToolStartMs: 2_000,
+				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 2_000 },
+			}),
+		});
+		expect(subagentAwaitRenderedStateSignature([later])).toBe(subagentAwaitRenderedStateSignature([early]));
+	});
+
+	it("changes when any rendered field changes", () => {
+		const baseProgress = makeProgress({
+			id: "0-A",
+			status: "running",
+			currentTool: "read",
+			recentOutput: ["x"],
+			toolCount: 1,
+			tokens: 10,
+			cost: 0.1,
+		});
+		const base = makeSnapshot({ id: "0-A", status: "running", progress: baseProgress });
+		const baseSig = subagentAwaitRenderedStateSignature([base]);
+
+		const mutations: Array<(s: SubagentSnapshot) => SubagentSnapshot> = [
+			s => ({ ...s, status: "completed" }),
+			s => ({ ...s, guidance: "still running after the timeout" }),
+			s => ({ ...s, errorText: "boom" }),
+			s => ({ ...s, resultPreview: "ok" }),
+			s => ({ ...s, outputRef: "agent://0-A" }),
+			s => ({ ...s, truncated: true }),
+			s => ({ ...s, liveProgressAvailable: false }),
+			s => ({ ...s, effectiveModel: "model-2" }),
+			s => ({ ...s, requestedModel: "model-1" }),
+			s => ({ ...s, modelFellBack: true }),
+			s => ({ ...s, description: "new description" }),
+			s => ({ ...s, assignment: "new assignment" }),
+			s => ({ ...s, progress: { ...baseProgress, currentTool: "bash" } }),
+			s => ({ ...s, progress: { ...baseProgress, currentToolArgs: "ls -la" } }),
+			s => ({ ...s, progress: { ...baseProgress, lastIntent: "thinking" } }),
+			s => ({ ...s, progress: { ...baseProgress, recentOutput: ["y"] } }),
+			s => ({ ...s, progress: { ...baseProgress, recentTools: [{ tool: "read", args: "f", endMs: 0 }] } }),
+			s => ({ ...s, progress: { ...baseProgress, toolCount: 2 } }),
+			s => ({ ...s, progress: { ...baseProgress, tokens: 20 } }),
+			s => ({ ...s, progress: { ...baseProgress, contextTokens: 100 } }),
+			s => ({ ...s, progress: { ...baseProgress, contextWindow: 200_000 } }),
+			s => ({ ...s, progress: { ...baseProgress, cost: 0.2 } }),
+			s => ({ ...s, progress: { ...baseProgress, status: "completed" } }),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					modelSubstitutionWarning: { requested: "a", effective: "b", reason: "auth_unavailable" },
+				},
+			}),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					retryState: { attempt: 1, maxAttempts: 3, delayMs: 1_000, errorMessage: "429", startedAtMs: 0 },
+				},
+			}),
+			s => ({ ...s, progress: { ...baseProgress, retryFailure: { attempt: 3, errorMessage: "gave up" } } }),
+			s => ({ ...s, progress: { ...baseProgress, extractedToolData: { task: [{ id: "n1", status: "running" }] } } }),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					inflightTaskDetails: { id: "t1" } as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>,
+				},
+			}),
+		];
+
+		for (const mutate of mutations) {
+			expect(subagentAwaitRenderedStateSignature([mutate(base)])).not.toBe(baseSig);
+		}
+	});
+
+	it("recentOutput tail changes are reflected (producer never drops real output progress)", () => {
+		const a = makeSnapshot({ id: "0-A", progress: makeProgress({ id: "0-A", recentOutput: ["a", "b"] }) });
+		const b = makeSnapshot({ id: "0-A", progress: makeProgress({ id: "0-A", recentOutput: ["a", "b", "c"] }) });
+		expect(subagentAwaitRenderedStateSignature([a])).not.toBe(subagentAwaitRenderedStateSignature([b]));
+	});
+
+	it("ignores nested task time churn but reflects nested status changes", () => {
+		const makeInflight = (
+			durationMs: number,
+			nestedStatus: AgentProgress["status"],
+		): NonNullable<AgentProgress["inflightTaskDetails"]> =>
+			({
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: durationMs,
+				progress: [makeProgress({ id: "child", status: nestedStatus, durationMs, currentToolStartMs: durationMs })],
+			}) as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>;
+
+		const early = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(1_000, "running") }),
+		});
+		const later = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(999_999, "running") }),
+		});
+		const statusChanged = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(1_000, "completed") }),
+		});
+
+		// Nested task time churn (totalDurationMs + nested progress duration/elapsed) is ignored.
+		expect(subagentAwaitRenderedStateSignature([later])).toBe(subagentAwaitRenderedStateSignature([early]));
+		// A real nested status change still emits.
+		expect(subagentAwaitRenderedStateSignature([statusChanged])).not.toBe(
+			subagentAwaitRenderedStateSignature([early]),
+		);
+	});
+});
+
+describe("subagent await emit gating", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		AsyncJobManager.resetForTests();
+	});
+
+	it("emits only the initial update for idle concurrent awaits, then exactly once per real change", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const ids = ["0-A", "0-B", "0-C"];
+		const controls = ids.map(() => Promise.withResolvers<void>());
+		ids.forEach((id, i) => {
+			const jobId = manager.register(
+				"task",
+				id,
+				async () => {
+					await controls[i].promise;
+					return "done";
+				},
+				{
+					id: `job-${id}`,
+					ownerId: "0-Main",
+					metadata: { subagent: { id, agent: "executor", agentSource: "bundled" } },
+				},
+			);
+			manager.registerSubagentRecord(runningRecord(id, jobId));
+			manager.recordSubagentProgress(id, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
+		});
+
+		const ac = new AbortController();
+		const spies = ids.map(() => vi.fn());
+		const execs = ids.map((id, i) =>
+			tool.execute(`await-${id}`, { action: "await", ids: [id], timeout_ms: 3_600_000 }, ac.signal, spies[i]),
+		);
+
+		// The initial partial emission runs synchronously when the await starts.
+		await Promise.resolve();
+		for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
+
+		// Idle: 5 interval ticks (2500ms) with unchanged progress must not emit.
+		vi.advanceTimersByTime(2_500);
+		for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
+
+		// A real progress change on 0-A emits exactly once; idle peers stay quiet.
+		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "bash", recentOutput: ["scan"] }));
+		vi.advanceTimersByTime(500);
+		expect(spies[0]).toHaveBeenCalledTimes(2);
+		expect(spies[1]).toHaveBeenCalledTimes(1);
+		expect(spies[2]).toHaveBeenCalledTimes(1);
+
+		ac.abort();
+		for (const control of controls) control.resolve();
+		await Promise.all(execs);
+		await manager.dispose({ timeoutMs: 100 });
 	});
 });


### PR DESCRIPTION
## Summary
Part 1/3 of the subagent-await UI perf work (flicker + CPU/runtime slowdown under multiple concurrent awaits). Consensus plan: Planner→Architect→Critic (ralplan), executed via ultragoal.

**Root cause:** `#awaitSubagents` fires a fresh partial result every 500ms **per await call**, regardless of whether anything rendered changed. Each emit rebuilds the built-in renderer component (cold cache), and when the panel sits above the viewport it trips the TUI full-redraw invariant (`tui.ts` `firstChanged < prevViewportTop`) → full-screen repaint (flicker) + full component-tree re-render. Multiple concurrent awaits multiply it; it worsens as the transcript grows.

## Change (producer-side only)
- Add a pure, **value-based** `subagentAwaitRenderedStateSignature(subagents)` over the await snapshots.
- `#awaitSubagents` now emits via `emitIfChanged(force)`: initial emit forced, **idle ticks no-op**, real changes still emit on the next tick. The 500ms interval and `finally` cleanup are unchanged.
- Signature is **value-based** (not identity): `AsyncJobManager.getSubagentProgress` returns the retained clone by reference.
- **Time-derived fields excluded** so idle panels stop churning: `durationMs`, current-tool elapsed (`currentToolStartMs`), retry countdown (`retryState.startedAtMs`), and nested-task durations. Idle duration/countdown ticking is intentionally sacrificed to stop repaint storms; every real transition still changes the signature.
- Nested `task` data (`extractedToolData.task`, `inflightTaskDetails`) is canonicalized **recursively** so a live nested task can't reintroduce churn; defensive guards at the untyped `extractedToolData` boundary.

## Non-goals / scope
- **No TUI engine change.** The scrollback invariant at `packages/tui/src/tui.ts:1468-1479` is deliberately untouched.
- Renderer-side caching + dynamic/heavy-body split is **PR2**; deterministic-suite + `PI_TUI_METRICS` validation is **PR3**.

## Tests
- New pure signature table tests (per rendered field; value-based clone-equality; time-only churn ignored; nested-task churn ignored vs nested status change reflected).
- Deterministic **fake-timer** emit-gating test: N=3 concurrent idle awaits emit only the initial update across 5×500ms ticks; a real change emits exactly once for the changed subagent only.
- `bun test` (subagent suites): **44 pass / 0 fail**. `tsc` + `biome` clean.

## Review
Architect (3-lane) CLEAR/CLEAR/CLEAR + APPROVE after resolving a nested-signing WATCH; executor red-team passed with no blockers.
