### PR TITLE
perf(subagent): content-addressed await-panel body cache; decouple spinner/time (2/3)

### DIFF
--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -525,6 +525,10 @@ function renderAgentProgress(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	/** When true, omit wall-clock-derived displays (current-tool elapsed, retry
+	 * countdown) so the output is a pure function of `progress` — required when the
+	 * caller caches these lines (the `subagent` await panel). */
+	staticTime = false,
 ): string[] {
 	const lines: string[] = [];
 	const prefix = isLast ? theme.fg("dim", theme.tree.last) : theme.fg("dim", theme.tree.branch);
@@ -587,7 +591,7 @@ function renderAgentProgress(
 			if (toolDetail) {
 				toolLine += `: ${theme.fg("dim", truncateToWidth(replaceTabs(toolDetail), 40))}`;
 			}
-			if (progress.currentToolStartMs) {
+			if (!staticTime && progress.currentToolStartMs) {
 				const elapsed = Date.now() - progress.currentToolStartMs;
 				if (elapsed > 5000) {
 					toolLine += `${theme.sep.dot}${theme.fg("warning", formatDuration(elapsed))}`;
@@ -610,12 +614,17 @@ function renderAgentProgress(
 	// long until the next attempt. Without this, the parent UI would just
 	// keep spinning while a child sleeps on a 3-hour provider rate-limit.
 	if (progress.retryState && progress.status === "running") {
-		const remainingMs = Math.max(0, progress.retryState.startedAtMs + progress.retryState.delayMs - Date.now());
-		const waitLabel = remainingMs > 0 ? `in ${formatDuration(remainingMs)}` : "now";
 		const attemptLabel = progress.retryState.unbounded
 			? `attempt ${progress.retryState.attempt}`
 			: `${progress.retryState.attempt}/${progress.retryState.maxAttempts}`;
-		const summary = `retrying ${attemptLabel} ${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
+		// `staticTime` omits the wall-clock countdown so a cached await body stays a
+		// pure function of its key (the producer already drops time-only churn).
+		let waitLabel = "";
+		if (!staticTime) {
+			const remainingMs = Math.max(0, progress.retryState.startedAtMs + progress.retryState.delayMs - Date.now());
+			waitLabel = remainingMs > 0 ? ` in ${formatDuration(remainingMs)}` : " now";
+		}
+		const summary = `retrying ${attemptLabel}${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("warning", summary)}`);
 	} else if (progress.retryFailure && progress.status !== "running") {
 		const summary = `auto-retry gave up after ${progress.retryFailure.attempt} attempt${
@@ -687,7 +696,7 @@ function renderAgentProgress(
 	const inflight = progress.inflightTaskDetails;
 	if (completedTaskCalls.length > 0 || inflight) {
 		const snapshots = inflight ? [...completedTaskCalls, inflight] : completedTaskCalls;
-		const nestedLines = renderNestedTaskTree(snapshots, expanded, theme, spinnerFrame);
+		const nestedLines = renderNestedTaskTree(snapshots, expanded, theme, spinnerFrame, staticTime);
 		for (const line of nestedLines) {
 			lines.push(`${continuePrefix}${line}`);
 		}
@@ -712,8 +721,9 @@ export function renderSubagentLiveProgress(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	staticTime = false,
 ): string[] {
-	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame);
+	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame, staticTime);
 }
 
 /**
@@ -1051,6 +1061,7 @@ function renderNestedTaskTree(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	staticTime = false,
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
@@ -1066,7 +1077,7 @@ function renderNestedTaskTree(
 		if (inflight && inflight.length > 0) {
 			inflight.forEach((prog, index) => {
 				const isLast = index === inflight.length - 1;
-				lines.push(...renderAgentProgress(prog, isLast, expanded, theme, spinnerFrame));
+				lines.push(...renderAgentProgress(prog, isLast, expanded, theme, spinnerFrame, staticTime));
 			});
 		}
 	}

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -12,7 +12,7 @@ import { Text } from "@gajae-code/tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import { renderSubagentLiveProgress } from "../task/render";
-import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
+import { Ellipsis, Hasher, renderStatusLine } from "../tui";
 import {
 	formatDuration,
 	formatStatusIcon,
@@ -21,11 +21,86 @@ import {
 	type ToolUIStatus,
 	truncateToWidth,
 } from "./render-utils";
-import type { SubagentSnapshot, SubagentToolDetails } from "./subagent";
+import { type SubagentSnapshot, type SubagentToolDetails, subagentAwaitRenderedStateSignature } from "./subagent";
 
 const PREVIEW_LINES_COLLAPSED = 1;
 const PREVIEW_LINES_EXPANDED = 4;
 const PREVIEW_LINE_WIDTH = 80;
+
+/**
+ * Bounded, content-addressed cache for each subagent's heavy body lines (the
+ * indented receipt fields + `renderSubagentLiveProgress` -> `renderAgentProgress`
+ * output). It is module-level so it survives the built-in renderer recreating the
+ * result component on every partial update (`tool-execution.ts` clears the content
+ * box and re-invokes `renderResult`), which a per-component `let cached` cannot.
+ *
+ * The cached body is a PURE function of its key: the per-subagent rendered-state
+ * signature (reused from the producer; excludes time-derived churn), expanded
+ * state, width, and the actual Theme instance identity. `spinnerFrame` and all
+ * wall-clock displays are deliberately kept OUT of the cached body — the animated
+ * spinner and the fresh duration live in the cheap per-subagent status line, and
+ * `renderSubagentLiveProgress` is invoked with `staticTime` so current-tool elapsed
+ * and retry countdowns are never baked into cached lines.
+ */
+const SUBAGENT_BODY_CACHE_MAX = 128;
+const subagentBodyCache = new Map<bigint, string[]>();
+let subagentBodyRenderCount = 0;
+
+// Stable identity per Theme instance so a theme change (preview, symbol preset,
+// color-blind reload, custom-theme reload, or in-memory swap) never reuses stale
+// ANSI/glyph strings — distinct Theme objects get distinct ids even when the theme
+// name is unchanged (e.g. the "<in-memory>" name).
+const themeIdentity = new WeakMap<Theme, number>();
+let nextThemeId = 1;
+function themeIdentityId(theme: Theme): number {
+	let id = themeIdentity.get(theme);
+	if (id === undefined) {
+		id = nextThemeId++;
+		themeIdentity.set(theme, id);
+	}
+	return id;
+}
+
+/** Test-only seam (PR3 deterministic cache-hit assertions). */
+export const subagentBodyCacheTestHooks = {
+	get bodyRenders(): number {
+		return subagentBodyRenderCount;
+	},
+	get size(): number {
+		return subagentBodyCache.size;
+	},
+	reset(): void {
+		subagentBodyRenderCount = 0;
+		subagentBodyCache.clear();
+	},
+};
+
+function renderCachedSubagentBody(
+	snapshot: SubagentSnapshot,
+	signature: string,
+	expanded: boolean,
+	width: number,
+	theme: Theme,
+): string[] {
+	const key = new Hasher().str(signature).bool(expanded).u32(width).u32(themeIdentityId(theme)).digest();
+	const hit = subagentBodyCache.get(key);
+	if (hit) {
+		// Refresh LRU recency.
+		subagentBodyCache.delete(key);
+		subagentBodyCache.set(key, hit);
+		return hit;
+	}
+	const lines = renderSubagentSnapshotBody(snapshot, expanded, theme).map(line =>
+		line.length > 0 ? truncateToWidth(line, width, Ellipsis.Omit) : "",
+	);
+	subagentBodyRenderCount += 1;
+	subagentBodyCache.set(key, lines);
+	if (subagentBodyCache.size > SUBAGENT_BODY_CACHE_MAX) {
+		const oldest = subagentBodyCache.keys().next().value;
+		if (oldest !== undefined) subagentBodyCache.delete(oldest);
+	}
+	return lines;
+}
 
 function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
 	switch (status) {
@@ -44,13 +119,10 @@ function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
 	}
 }
 
-function renderSubagentSnapshot(
-	snapshot: SubagentSnapshot,
-	expanded: boolean,
-	theme: Theme,
-	spinnerFrame: number | undefined,
-): string[] {
-	const lines: string[] = [];
+// Cheap, dynamic per-subagent status line: the spinner may animate and the duration
+// is the snapshot's own (fresh) value, so this line is rebuilt every frame and is
+// NOT part of the cached body.
+function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spinnerFrame: number | undefined): string {
 	const icon = formatStatusIcon(
 		statusIconKind(snapshot.status),
 		theme,
@@ -59,7 +131,14 @@ function renderSubagentSnapshot(
 	const id = theme.fg("muted", snapshot.id);
 	const status = theme.fg("dim", snapshot.status);
 	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
-	lines.push(`${icon} ${id} ${status} ${duration}`);
+	return `${icon} ${id} ${status} ${duration}`;
+}
+
+// Heavy, cacheable per-subagent body: a pure function of (snapshot content, expanded,
+// theme). No spinner frame and no wall-clock displays leak in (live progress uses
+// `staticTime`), so the module body cache can never serve stale or frozen-ticking lines.
+function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolean, theme: Theme): string[] {
+	const lines: string[] = [];
 
 	// Static receipt fields (parity with the markdown content for non-await actions).
 	if (snapshot.jobId !== snapshot.id) lines.push(`  ${theme.fg("dim", `Job: ${snapshot.jobId}`)}`);
@@ -82,13 +161,13 @@ function renderSubagentSnapshot(
 		for (const al of snapshot.assignment.split("\n")) lines.push(`    ${theme.fg("toolOutput", replaceTabs(al))}`);
 	}
 
-	// Defense in depth: the producer only attaches `progress` when a live
-	// producer exists (subagent.ts #liveProgressFields), but the renderer
-	// also honors an explicit `liveProgressAvailable: false` so stale retained
-	// progress can never resurrect a live panel (AC5).
+	// Defense in depth: the producer only attaches `progress` when a live producer
+	// exists (subagent.ts #liveProgressFields), but the renderer also honors an
+	// explicit `liveProgressAvailable: false` so stale retained progress can never
+	// resurrect a live panel (AC5). `staticTime` keeps wall-clock displays out of
+	// these cached lines.
 	if (snapshot.progress && snapshot.liveProgressAvailable !== false) {
-		// Live streaming panel (full task-panel parity), indented under the header.
-		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, spinnerFrame)) {
+		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, true)) {
 			lines.push(`  ${pl}`);
 		}
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
@@ -133,14 +212,17 @@ export const subagentToolRenderer = {
 
 		const runningCount = subagents.filter(s => s.status === "running").length;
 
-		let cached: RenderCache | undefined;
+		// Each snapshot's rendered-state signature is constant for this component
+		// instance, so compute them at most once; the heavy per-subagent bodies are
+		// cached module-side and keyed by that signature.
+		let snapshotSignatures: string[] | undefined;
 		return {
 			render(width: number): string[] {
 				const expanded = options.expanded;
-				const spinnerFrame = options.spinnerFrame ?? 0;
-				const key = new Hasher().bool(expanded).u32(width).u32(spinnerFrame).digest();
-				if (cached?.key === key) return cached.lines;
 
+				// Cheap dynamic header: may animate with `spinnerFrame` and is rebuilt
+				// every frame, but it is a single status line plus an optional hint, so
+				// it is never gated by the heavy body cache.
 				const header = renderStatusLine(
 					{
 						icon: runningCount > 0 ? "info" : "success",
@@ -153,23 +235,31 @@ export const subagentToolRenderer = {
 					},
 					theme,
 				);
-
-				const lines: string[] = [header];
+				const out: string[] = [truncateToWidth(header, width, Ellipsis.Omit)];
 				// Discoverability: the inline panel is a bounded preview; the session
 				// observer (ctrl+s) streams the full per-subagent message history.
 				if (runningCount > 0) {
-					lines.push(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`);
-				}
-				for (const snapshot of subagents) {
-					lines.push(...renderSubagentSnapshot(snapshot, expanded, theme, options.spinnerFrame));
+					out.push(truncateToWidth(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`, width, Ellipsis.Omit));
 				}
 
-				const out = lines.map(l => (l.length > 0 ? truncateToWidth(l, width, Ellipsis.Omit) : ""));
-				cached = { key, lines: out };
+				snapshotSignatures ??= subagents.map(snapshot => subagentAwaitRenderedStateSignature([snapshot]));
+				subagents.forEach((snapshot, index) => {
+					// Fresh per-subagent status line (cheap), then the cached heavy body.
+					out.push(
+						truncateToWidth(
+							renderSubagentStatusLine(snapshot, theme, options.spinnerFrame),
+							width,
+							Ellipsis.Omit,
+						),
+					);
+					out.push(...renderCachedSubagentBody(snapshot, snapshotSignatures![index]!, expanded, width, theme));
+				});
 				return out;
 			},
 			invalidate() {
-				cached = undefined;
+				// The heavy body cache is content-addressed (keyed by the rendered-state
+				// signature, width, expanded, and theme), so there is no instance-local
+				// state to clear here.
 			},
 		};
 	},

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import type { Theme } from "../../src/modes/theme/theme";
 import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
 import type { AgentProgress } from "../../src/task/types";
 import type { SubagentSnapshot, SubagentToolDetails } from "../../src/tools/subagent";
-import { subagentToolRenderer } from "../../src/tools/subagent-render";
+import { subagentBodyCacheTestHooks, subagentToolRenderer } from "../../src/tools/subagent-render";
 
 let theme: Theme;
 
@@ -270,5 +270,131 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("Model: anthropic/claude-opus-4-8");
 		expect(out).toContain("requested openai-codex/gpt-5.5");
 		expect(out).toContain("fell back");
+	});
+});
+
+describe("subagent await renderer body cache (PR2)", () => {
+	beforeEach(() => {
+		subagentBodyCacheTestHooks.reset();
+	});
+
+	const renderWith = (
+		details: SubagentToolDetails,
+		{
+			expanded = true,
+			width = 160,
+			spinnerFrame = 0,
+		}: { expanded?: boolean; width?: number; spinnerFrame?: number } = {},
+	): string[] => {
+		// A fresh component each call models the built-in renderer recreating the
+		// result component on every partial update.
+		const component = subagentToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded, isPartial: true, spinnerFrame },
+			theme,
+		);
+		return component.render(width);
+	};
+
+	const live = (id: string, overrides: Partial<AgentProgress> = {}): SubagentToolDetails => ({
+		subagents: [
+			snapshot({
+				id,
+				liveProgressAvailable: true,
+				progress: progress({ id, currentTool: "read", recentOutput: ["scan"], ...overrides }),
+			}),
+		],
+	});
+
+	it("reuses the cached heavy body across component recreation for identical content", () => {
+		renderWith(live("0-A"));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// New component (new renderResult), identical content -> module cache hit.
+		renderWith(live("0-A"));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("does not re-render the heavy body for spinner-only frame changes", () => {
+		const details = live("0-A");
+		renderWith(details, { spinnerFrame: 0 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		renderWith(details, { spinnerFrame: 1 });
+		renderWith(details, { spinnerFrame: 2 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("re-renders the heavy body when content, width, or expanded changes", () => {
+		renderWith(live("0-A", { currentTool: "read" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// Content change.
+		renderWith(live("0-A", { currentTool: "bash" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+		// Width change.
+		renderWith(live("0-A", { currentTool: "read" }), { width: 100 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(3);
+		// Expanded change.
+		renderWith(live("0-A", { currentTool: "read" }), { expanded: false });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(4);
+		// Back to the first key -> cache hit, no new render.
+		renderWith(live("0-A", { currentTool: "read" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(4);
+	});
+
+	it("ignores time-only churn in the body cache key", () => {
+		const a: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-A",
+					durationMs: 1_000,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-A", durationMs: 1_000, currentTool: "read", currentToolStartMs: 1_000 }),
+				}),
+			],
+		};
+		const b: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-A",
+					durationMs: 999_999,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-A", durationMs: 999_999, currentTool: "read", currentToolStartMs: 2_000 }),
+				}),
+			],
+		};
+		renderWith(a);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// Only time-derived fields differ -> identical signature -> cache hit.
+		renderWith(b);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("invalidates the body cache when the Theme instance changes (no stale ANSI)", async () => {
+		const altTheme = (await getThemeByName("blue-crab"))!;
+		expect(altTheme).toBeDefined();
+		const details = live("0-A");
+		const renderTheme = (t: Theme): string[] =>
+			subagentToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "" }], details },
+					{ expanded: true, isPartial: true, spinnerFrame: 0 },
+					t,
+				)
+				.render(160);
+
+		const first = renderTheme(theme);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// A different Theme instance (distinct object) must re-render the body, even if
+		// the theme name is unchanged — guards against stale themed ANSI/glyph reuse.
+		const second = renderTheme(altTheme);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+		expect(second).not.toEqual(first);
+	});
+
+	it("bounds the cache via LRU eviction", () => {
+		for (let i = 0; i < 140; i++) {
+			renderWith(live(`0-${i}`, { currentTool: `tool-${i}` }));
+		}
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(140);
+		expect(subagentBodyCacheTestHooks.size).toBeLessThanOrEqual(128);
 	});
 });


### PR DESCRIPTION
## Summary
Part 2/3 of the subagent-await UI perf work. **Stacked on #677 (PR1)** — base is `feat/subagent-await-perf-pr1-producer-gating`; reuses PR1's `subagentAwaitRenderedStateSignature`. Rebase onto `dev` after #677 merges.

PR1 stopped redundant *emits*. PR2 stops redundant *heavy rendering*: the built-in subagent renderer recreated its result component on every partial update, so the per-component `RenderCache` was cold each time and the heavy `renderSubagentLiveProgress` → `renderAgentProgress` body re-rendered on every update (and every spinner frame).

## Change
- **Module-level bounded LRU (cap 128)** for each subagent's heavy body, so it survives component recreation. Keyed by per-subagent rendered-state signature + expanded + width + **Theme instance identity**.
- **Cached body is a pure function of its key:**
  - Per-subagent status line (icon + duration) split into cheap dynamic decoration rebuilt each frame → `spinnerFrame` and live duration never invalidate the heavy body.
  - `render.ts` threads `staticTime` through `renderAgentProgress`/`renderNestedTaskTree`/`renderSubagentLiveProgress`; the await body renders with `staticTime=true`, so `Date.now()`-derived current-tool elapsed + retry countdowns are not baked into cached lines. **The inline task panel keeps animating** (`staticTime=false`, default).
  - Theme identity via `WeakMap<Theme, number>` so any theme change (preview, symbol preset, color-blind, custom reload, in-memory swap) invalidates — no stale ANSI/glyphs.

## Non-goals
- No TUI engine change (`packages/tui/src/tui.ts:1468-1479` untouched). PR3 adds the `PI_TUI_METRICS` validation harness.

## Tests
- Cache-hit tests: cross-recreation reuse; spinner-only no re-render; content/width/expanded invalidation; **time-only churn (incl. nested task) ignored & byte-identical**; **theme-instance change re-renders & differs**; LRU eviction.
- `bun test` subagent + task suites: **214 pass / 0 fail**. `tsc` + `biome` clean.

## Review
Two real staleness blockers were caught in review (theme-name-only key; wall-clock body lines frozen by cache), recorded as durable blockers, fixed, and re-verified: Architect CLEAR/CLEAR/CLEAR + APPROVE; executor red-team PASS, no blockers.
