### PR TITLE
test(tui): deterministic PI_TUI_METRICS await-panel redraw-cost repro (3/3)

### DIFF
--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -525,6 +525,10 @@ function renderAgentProgress(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	/** When true, omit wall-clock-derived displays (current-tool elapsed, retry
+	 * countdown) so the output is a pure function of `progress` — required when the
+	 * caller caches these lines (the `subagent` await panel). */
+	staticTime = false,
 ): string[] {
 	const lines: string[] = [];
 	const prefix = isLast ? theme.fg("dim", theme.tree.last) : theme.fg("dim", theme.tree.branch);
@@ -587,7 +591,7 @@ function renderAgentProgress(
 			if (toolDetail) {
 				toolLine += `: ${theme.fg("dim", truncateToWidth(replaceTabs(toolDetail), 40))}`;
 			}
-			if (progress.currentToolStartMs) {
+			if (!staticTime && progress.currentToolStartMs) {
 				const elapsed = Date.now() - progress.currentToolStartMs;
 				if (elapsed > 5000) {
 					toolLine += `${theme.sep.dot}${theme.fg("warning", formatDuration(elapsed))}`;
@@ -610,12 +614,17 @@ function renderAgentProgress(
 	// long until the next attempt. Without this, the parent UI would just
 	// keep spinning while a child sleeps on a 3-hour provider rate-limit.
 	if (progress.retryState && progress.status === "running") {
-		const remainingMs = Math.max(0, progress.retryState.startedAtMs + progress.retryState.delayMs - Date.now());
-		const waitLabel = remainingMs > 0 ? `in ${formatDuration(remainingMs)}` : "now";
 		const attemptLabel = progress.retryState.unbounded
 			? `attempt ${progress.retryState.attempt}`
 			: `${progress.retryState.attempt}/${progress.retryState.maxAttempts}`;
-		const summary = `retrying ${attemptLabel} ${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
+		// `staticTime` omits the wall-clock countdown so a cached await body stays a
+		// pure function of its key (the producer already drops time-only churn).
+		let waitLabel = "";
+		if (!staticTime) {
+			const remainingMs = Math.max(0, progress.retryState.startedAtMs + progress.retryState.delayMs - Date.now());
+			waitLabel = remainingMs > 0 ? ` in ${formatDuration(remainingMs)}` : " now";
+		}
+		const summary = `retrying ${attemptLabel}${waitLabel}: ${truncateToWidth(replaceTabs(progress.retryState.errorMessage), 60)}`;
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("warning", summary)}`);
 	} else if (progress.retryFailure && progress.status !== "running") {
 		const summary = `auto-retry gave up after ${progress.retryFailure.attempt} attempt${
@@ -687,7 +696,7 @@ function renderAgentProgress(
 	const inflight = progress.inflightTaskDetails;
 	if (completedTaskCalls.length > 0 || inflight) {
 		const snapshots = inflight ? [...completedTaskCalls, inflight] : completedTaskCalls;
-		const nestedLines = renderNestedTaskTree(snapshots, expanded, theme, spinnerFrame);
+		const nestedLines = renderNestedTaskTree(snapshots, expanded, theme, spinnerFrame, staticTime);
 		for (const line of nestedLines) {
 			lines.push(`${continuePrefix}${line}`);
 		}
@@ -712,8 +721,9 @@ export function renderSubagentLiveProgress(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	staticTime = false,
 ): string[] {
-	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame);
+	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame, staticTime);
 }
 
 /**
@@ -1051,6 +1061,7 @@ function renderNestedTaskTree(
 	expanded: boolean,
 	theme: Theme,
 	spinnerFrame?: number,
+	staticTime = false,
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
@@ -1066,7 +1077,7 @@ function renderNestedTaskTree(
 		if (inflight && inflight.length > 0) {
 			inflight.forEach((prog, index) => {
 				const isLast = index === inflight.length - 1;
-				lines.push(...renderAgentProgress(prog, isLast, expanded, theme, spinnerFrame));
+				lines.push(...renderAgentProgress(prog, isLast, expanded, theme, spinnerFrame, staticTime));
 			});
 		}
 	}

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -12,7 +12,7 @@ import { Text } from "@gajae-code/tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import { renderSubagentLiveProgress } from "../task/render";
-import { Ellipsis, Hasher, type RenderCache, renderStatusLine } from "../tui";
+import { Ellipsis, Hasher, renderStatusLine } from "../tui";
 import {
 	formatDuration,
 	formatStatusIcon,
@@ -21,11 +21,86 @@ import {
 	type ToolUIStatus,
 	truncateToWidth,
 } from "./render-utils";
-import type { SubagentSnapshot, SubagentToolDetails } from "./subagent";
+import { type SubagentSnapshot, type SubagentToolDetails, subagentAwaitRenderedStateSignature } from "./subagent";
 
 const PREVIEW_LINES_COLLAPSED = 1;
 const PREVIEW_LINES_EXPANDED = 4;
 const PREVIEW_LINE_WIDTH = 80;
+
+/**
+ * Bounded, content-addressed cache for each subagent's heavy body lines (the
+ * indented receipt fields + `renderSubagentLiveProgress` -> `renderAgentProgress`
+ * output). It is module-level so it survives the built-in renderer recreating the
+ * result component on every partial update (`tool-execution.ts` clears the content
+ * box and re-invokes `renderResult`), which a per-component `let cached` cannot.
+ *
+ * The cached body is a PURE function of its key: the per-subagent rendered-state
+ * signature (reused from the producer; excludes time-derived churn), expanded
+ * state, width, and the actual Theme instance identity. `spinnerFrame` and all
+ * wall-clock displays are deliberately kept OUT of the cached body — the animated
+ * spinner and the fresh duration live in the cheap per-subagent status line, and
+ * `renderSubagentLiveProgress` is invoked with `staticTime` so current-tool elapsed
+ * and retry countdowns are never baked into cached lines.
+ */
+const SUBAGENT_BODY_CACHE_MAX = 128;
+const subagentBodyCache = new Map<bigint, string[]>();
+let subagentBodyRenderCount = 0;
+
+// Stable identity per Theme instance so a theme change (preview, symbol preset,
+// color-blind reload, custom-theme reload, or in-memory swap) never reuses stale
+// ANSI/glyph strings — distinct Theme objects get distinct ids even when the theme
+// name is unchanged (e.g. the "<in-memory>" name).
+const themeIdentity = new WeakMap<Theme, number>();
+let nextThemeId = 1;
+function themeIdentityId(theme: Theme): number {
+	let id = themeIdentity.get(theme);
+	if (id === undefined) {
+		id = nextThemeId++;
+		themeIdentity.set(theme, id);
+	}
+	return id;
+}
+
+/** Test-only seam (PR3 deterministic cache-hit assertions). */
+export const subagentBodyCacheTestHooks = {
+	get bodyRenders(): number {
+		return subagentBodyRenderCount;
+	},
+	get size(): number {
+		return subagentBodyCache.size;
+	},
+	reset(): void {
+		subagentBodyRenderCount = 0;
+		subagentBodyCache.clear();
+	},
+};
+
+function renderCachedSubagentBody(
+	snapshot: SubagentSnapshot,
+	signature: string,
+	expanded: boolean,
+	width: number,
+	theme: Theme,
+): string[] {
+	const key = new Hasher().str(signature).bool(expanded).u32(width).u32(themeIdentityId(theme)).digest();
+	const hit = subagentBodyCache.get(key);
+	if (hit) {
+		// Refresh LRU recency.
+		subagentBodyCache.delete(key);
+		subagentBodyCache.set(key, hit);
+		return hit;
+	}
+	const lines = renderSubagentSnapshotBody(snapshot, expanded, theme).map(line =>
+		line.length > 0 ? truncateToWidth(line, width, Ellipsis.Omit) : "",
+	);
+	subagentBodyRenderCount += 1;
+	subagentBodyCache.set(key, lines);
+	if (subagentBodyCache.size > SUBAGENT_BODY_CACHE_MAX) {
+		const oldest = subagentBodyCache.keys().next().value;
+		if (oldest !== undefined) subagentBodyCache.delete(oldest);
+	}
+	return lines;
+}
 
 function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
 	switch (status) {
@@ -44,13 +119,10 @@ function statusIconKind(status: SubagentSnapshot["status"]): ToolUIStatus {
 	}
 }
 
-function renderSubagentSnapshot(
-	snapshot: SubagentSnapshot,
-	expanded: boolean,
-	theme: Theme,
-	spinnerFrame: number | undefined,
-): string[] {
-	const lines: string[] = [];
+// Cheap, dynamic per-subagent status line: the spinner may animate and the duration
+// is the snapshot's own (fresh) value, so this line is rebuilt every frame and is
+// NOT part of the cached body.
+function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spinnerFrame: number | undefined): string {
 	const icon = formatStatusIcon(
 		statusIconKind(snapshot.status),
 		theme,
@@ -59,7 +131,14 @@ function renderSubagentSnapshot(
 	const id = theme.fg("muted", snapshot.id);
 	const status = theme.fg("dim", snapshot.status);
 	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
-	lines.push(`${icon} ${id} ${status} ${duration}`);
+	return `${icon} ${id} ${status} ${duration}`;
+}
+
+// Heavy, cacheable per-subagent body: a pure function of (snapshot content, expanded,
+// theme). No spinner frame and no wall-clock displays leak in (live progress uses
+// `staticTime`), so the module body cache can never serve stale or frozen-ticking lines.
+function renderSubagentSnapshotBody(snapshot: SubagentSnapshot, expanded: boolean, theme: Theme): string[] {
+	const lines: string[] = [];
 
 	// Static receipt fields (parity with the markdown content for non-await actions).
 	if (snapshot.jobId !== snapshot.id) lines.push(`  ${theme.fg("dim", `Job: ${snapshot.jobId}`)}`);
@@ -82,13 +161,13 @@ function renderSubagentSnapshot(
 		for (const al of snapshot.assignment.split("\n")) lines.push(`    ${theme.fg("toolOutput", replaceTabs(al))}`);
 	}
 
-	// Defense in depth: the producer only attaches `progress` when a live
-	// producer exists (subagent.ts #liveProgressFields), but the renderer
-	// also honors an explicit `liveProgressAvailable: false` so stale retained
-	// progress can never resurrect a live panel (AC5).
+	// Defense in depth: the producer only attaches `progress` when a live producer
+	// exists (subagent.ts #liveProgressFields), but the renderer also honors an
+	// explicit `liveProgressAvailable: false` so stale retained progress can never
+	// resurrect a live panel (AC5). `staticTime` keeps wall-clock displays out of
+	// these cached lines.
 	if (snapshot.progress && snapshot.liveProgressAvailable !== false) {
-		// Live streaming panel (full task-panel parity), indented under the header.
-		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, spinnerFrame)) {
+		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, true)) {
 			lines.push(`  ${pl}`);
 		}
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {
@@ -133,14 +212,17 @@ export const subagentToolRenderer = {
 
 		const runningCount = subagents.filter(s => s.status === "running").length;
 
-		let cached: RenderCache | undefined;
+		// Each snapshot's rendered-state signature is constant for this component
+		// instance, so compute them at most once; the heavy per-subagent bodies are
+		// cached module-side and keyed by that signature.
+		let snapshotSignatures: string[] | undefined;
 		return {
 			render(width: number): string[] {
 				const expanded = options.expanded;
-				const spinnerFrame = options.spinnerFrame ?? 0;
-				const key = new Hasher().bool(expanded).u32(width).u32(spinnerFrame).digest();
-				if (cached?.key === key) return cached.lines;
 
+				// Cheap dynamic header: may animate with `spinnerFrame` and is rebuilt
+				// every frame, but it is a single status line plus an optional hint, so
+				// it is never gated by the heavy body cache.
 				const header = renderStatusLine(
 					{
 						icon: runningCount > 0 ? "info" : "success",
@@ -153,23 +235,31 @@ export const subagentToolRenderer = {
 					},
 					theme,
 				);
-
-				const lines: string[] = [header];
+				const out: string[] = [truncateToWidth(header, width, Ellipsis.Omit)];
 				// Discoverability: the inline panel is a bounded preview; the session
 				// observer (ctrl+s) streams the full per-subagent message history.
 				if (runningCount > 0) {
-					lines.push(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`);
-				}
-				for (const snapshot of subagents) {
-					lines.push(...renderSubagentSnapshot(snapshot, expanded, theme, options.spinnerFrame));
+					out.push(truncateToWidth(`  ${theme.fg("dim", "(ctrl+s to observe sessions)")}`, width, Ellipsis.Omit));
 				}
 
-				const out = lines.map(l => (l.length > 0 ? truncateToWidth(l, width, Ellipsis.Omit) : ""));
-				cached = { key, lines: out };
+				snapshotSignatures ??= subagents.map(snapshot => subagentAwaitRenderedStateSignature([snapshot]));
+				subagents.forEach((snapshot, index) => {
+					// Fresh per-subagent status line (cheap), then the cached heavy body.
+					out.push(
+						truncateToWidth(
+							renderSubagentStatusLine(snapshot, theme, options.spinnerFrame),
+							width,
+							Ellipsis.Omit,
+						),
+					);
+					out.push(...renderCachedSubagentBody(snapshot, snapshotSignatures![index]!, expanded, width, theme));
+				});
 				return out;
 			},
 			invalidate() {
-				cached = undefined;
+				// The heavy body cache is content-addressed (keyed by the rendered-state
+				// signature, width, expanded, and theme), so there is no instance-local
+				// state to clear here.
 			},
 		};
 	},

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -4,7 +4,7 @@ import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
-import type { AgentProgress, AgentSource } from "../task/types";
+import type { AgentProgress, AgentSource, TaskToolDetails } from "../task/types";
 import { Ellipsis, truncateToWidth } from "../tui";
 import type { ToolSession } from "./index";
 import { replaceTabs } from "./render-utils";
@@ -330,12 +330,21 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		);
 		const watchedJobIds = runningJobs.map(job => job.id);
 		manager.watchJobs(watchedJobIds);
-		const progressTimer = onUpdate
-			? setInterval(() => {
-					onUpdate(this.#progressResult(manager, records, true));
-				}, 500)
-			: undefined;
-		onUpdate?.(this.#progressResult(manager, records, true));
+		let lastEmittedSignature: string | undefined;
+		const emitIfChanged = (force: boolean): void => {
+			if (!onUpdate) return;
+			const result = this.#progressResult(manager, records, true);
+			const signature = subagentAwaitRenderedStateSignature(result.details?.subagents ?? []);
+			if (!force && signature === lastEmittedSignature) return;
+			lastEmittedSignature = signature;
+			onUpdate(result);
+		};
+		const progressTimer = onUpdate ? setInterval(() => emitIfChanged(false), 500) : undefined;
+		// Initial emission so the panel appears immediately; later idle ticks are
+		// gated on a value-based rendered-state signature so unchanged progress no
+		// longer rebuilds the renderer component or mutates transcript lines above
+		// the viewport (the source of the await-panel repaint storms).
+		emitIfChanged(true);
 
 		let timedOut = false;
 		try {
@@ -719,4 +728,135 @@ function previewJobOutput(
 	const normalized = replaceTabs(source.text);
 	const preview = truncateToWidth(normalized, width, Ellipsis.Unicode);
 	return { type: source.type, preview, truncated: preview !== normalized };
+}
+
+/**
+ * Canonical, value-based rendered-state signature for the `subagent` await panel.
+ *
+ * Producer-side await gating compares this signature against the last emitted one
+ * and only fires `onUpdate` when the *rendered* state actually changed. Unchanged
+ * idle ticks therefore stop rebuilding the renderer component and stop mutating
+ * transcript lines above the viewport, which is what triggers TUI full-redraw
+ * storms (`tui.ts` `firstChanged < viewportTop`).
+ *
+ * It is deliberately value-based, never object identity: `AsyncJobManager.record-
+ * SubagentProgress` stores a `structuredClone` but `getSubagentProgress` returns
+ * the retained object by reference, so identity comparison would be both noisy and
+ * unsafe.
+ *
+ * Time-derived fields are intentionally excluded so the panel does not churn while
+ * idle: raw durations (`durationMs`), current-tool elapsed (`currentToolStartMs`),
+ * and retry countdowns (`retryState.startedAtMs`) are omitted. Idle duration and
+ * countdown ticking is sacrificed by design; every real transition still changes
+ * the signature.
+ */
+export function subagentAwaitRenderedStateSignature(subagents: readonly SubagentSnapshot[]): string {
+	return JSON.stringify(subagents.map(canonicalizeSnapshotForSignature));
+}
+
+function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
+	return {
+		id: snapshot.id,
+		jobId: snapshot.jobId,
+		status: snapshot.status,
+		label: snapshot.label,
+		agent: snapshot.agent,
+		agentSource: snapshot.agentSource,
+		description: snapshot.description ?? null,
+		assignment: snapshot.assignment ?? null,
+		resultText: snapshot.resultText ?? null,
+		errorText: snapshot.errorText ?? null,
+		resultPreview: snapshot.resultPreview ?? null,
+		outputRef: snapshot.outputRef ?? null,
+		truncated: snapshot.truncated ?? false,
+		guidance: snapshot.guidance ?? null,
+		liveProgressAvailable: snapshot.liveProgressAvailable ?? null,
+		effectiveModel: snapshot.effectiveModel ?? null,
+		requestedModel: snapshot.requestedModel ?? null,
+		modelFellBack: snapshot.modelFellBack ?? false,
+		// durationMs intentionally excluded (time-derived; would defeat idle gating).
+		progress: snapshot.progress ? canonicalizeProgressForSignature(snapshot.progress) : null,
+	};
+}
+
+function canonicalizeProgressForSignature(progress: AgentProgress): unknown {
+	return {
+		id: progress.id,
+		agent: progress.agent,
+		agentSource: progress.agentSource,
+		status: progress.status,
+		task: progress.task,
+		assignment: progress.assignment ?? null,
+		description: progress.description ?? null,
+		lastIntent: progress.lastIntent ?? null,
+		currentTool: progress.currentTool ?? null,
+		currentToolArgs: progress.currentToolArgs ?? null,
+		// currentToolStartMs intentionally excluded (only drives elapsed rendering).
+		recentTools: progress.recentTools.map(tool => ({ tool: tool.tool, args: tool.args })),
+		recentOutput: progress.recentOutput,
+		toolCount: progress.toolCount,
+		tokens: progress.tokens,
+		contextTokens: progress.contextTokens ?? null,
+		contextWindow: progress.contextWindow ?? null,
+		cost: progress.cost,
+		modelOverride: progress.modelOverride ?? null,
+		modelSubstitutionWarning: progress.modelSubstitutionWarning ?? null,
+		// durationMs intentionally excluded (time-derived).
+		extractedToolData: progress.extractedToolData
+			? canonicalizeExtractedToolDataForSignature(progress.extractedToolData)
+			: null,
+		retryState: progress.retryState
+			? {
+					attempt: progress.retryState.attempt,
+					maxAttempts: progress.retryState.maxAttempts,
+					unbounded: progress.retryState.unbounded ?? false,
+					delayMs: progress.retryState.delayMs,
+					errorMessage: progress.retryState.errorMessage,
+					// startedAtMs intentionally excluded (drives countdown only).
+				}
+			: null,
+		retryFailure: progress.retryFailure ?? null,
+		inflightTaskDetails: progress.inflightTaskDetails
+			? canonicalizeTaskDetailsForSignature(progress.inflightTaskDetails)
+			: null,
+	};
+}
+
+/**
+ * Nested `task` data (`extractedToolData.task` and `inflightTaskDetails`) is the
+ * one place the await signature reaches into a live, ticking structure: nested
+ * `AgentProgress` carries the same time-derived fields excluded above, and
+ * `TaskToolDetails` adds `totalDurationMs` / per-result `durationMs`. Signing it
+ * wholesale would defeat idle gating whenever an awaited subagent is itself inside
+ * a live `task` call, so these helpers canonicalize the rendered, non-time subset
+ * recursively (mutually recursive with `canonicalizeProgressForSignature`).
+ */
+function canonicalizeExtractedToolDataForSignature(data: Record<string, unknown[]>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const key of Object.keys(data)) {
+		// Only the `task` key holds time-ticking `TaskToolDetails`; other handler
+		// data (yield/report_finding/generic) is stable and passes through as-is.
+		out[key] = key === "task" ? (data[key] as TaskToolDetails[]).map(canonicalizeTaskDetailsForSignature) : data[key];
+	}
+	return out;
+}
+
+function canonicalizeTaskDetailsForSignature(details: TaskToolDetails): unknown {
+	// `extractedToolData` is an untyped boundary (`Record<string, unknown[]>`), so
+	// guard each field instead of trusting the `TaskToolDetails` cast.
+	return {
+		// totalDurationMs intentionally excluded (time-derived).
+		results: Array.isArray(details.results) ? details.results.map(canonicalizeTaskResultForSignature) : null,
+		progress: Array.isArray(details.progress) ? details.progress.map(canonicalizeProgressForSignature) : null,
+		async: details.async
+			? { state: details.async.state, jobId: details.async.jobId, type: details.async.type }
+			: null,
+	};
+}
+
+function canonicalizeTaskResultForSignature(result: TaskToolDetails["results"][number]): unknown {
+	// Completed results do not tick, but drop `durationMs` so the only time-derived
+	// field in the receipt can never reintroduce idle churn.
+	const { durationMs: _durationMs, ...rest } = result;
+	return rest;
 }

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AsyncJobManager, type SubagentRecord } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import type { AgentProgress } from "../../src/task/types";
 import { SubagentTool, type ToolSession } from "../../src/tools";
+import { type SubagentSnapshot, subagentAwaitRenderedStateSignature } from "../../src/tools/subagent";
 
 function createSession(agentId = "0-Main"): ToolSession {
 	return {
@@ -316,5 +317,222 @@ describe("AsyncJobManager subagent progress retention", () => {
 		const retained = manager.getSubagentProgress("0-Clone");
 		expect(retained?.recentOutput).toEqual(["one"]);
 		expect(retained?.currentTool).toBeUndefined();
+	});
+});
+
+function makeSnapshot(overrides: Partial<SubagentSnapshot> & Pick<SubagentSnapshot, "id">): SubagentSnapshot {
+	return {
+		jobId: overrides.id,
+		status: "running",
+		label: "subagent",
+		agent: "executor",
+		agentSource: "bundled",
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+describe("subagentAwaitRenderedStateSignature", () => {
+	it("is value-based: equal values from independent clones produce identical signatures", () => {
+		const a = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", currentTool: "read", recentOutput: ["x"] }),
+		});
+		const b = makeSnapshot({
+			id: "0-A",
+			// structuredClone yields a different object reference with equal values.
+			progress: structuredClone(makeProgress({ id: "0-A", currentTool: "read", recentOutput: ["x"] })),
+		});
+		expect(subagentAwaitRenderedStateSignature([a])).toBe(subagentAwaitRenderedStateSignature([b]));
+	});
+
+	it("ignores time-derived churn (durationMs, current-tool elapsed, retry countdown)", () => {
+		const early = makeSnapshot({
+			id: "0-A",
+			durationMs: 1_000,
+			progress: makeProgress({
+				id: "0-A",
+				durationMs: 1_000,
+				currentTool: "read",
+				currentToolStartMs: 1_000,
+				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 1_000 },
+			}),
+		});
+		const later = makeSnapshot({
+			id: "0-A",
+			durationMs: 999_999,
+			progress: makeProgress({
+				id: "0-A",
+				durationMs: 999_999,
+				currentTool: "read",
+				currentToolStartMs: 2_000,
+				retryState: { attempt: 1, maxAttempts: 3, delayMs: 5_000, errorMessage: "429", startedAtMs: 2_000 },
+			}),
+		});
+		expect(subagentAwaitRenderedStateSignature([later])).toBe(subagentAwaitRenderedStateSignature([early]));
+	});
+
+	it("changes when any rendered field changes", () => {
+		const baseProgress = makeProgress({
+			id: "0-A",
+			status: "running",
+			currentTool: "read",
+			recentOutput: ["x"],
+			toolCount: 1,
+			tokens: 10,
+			cost: 0.1,
+		});
+		const base = makeSnapshot({ id: "0-A", status: "running", progress: baseProgress });
+		const baseSig = subagentAwaitRenderedStateSignature([base]);
+
+		const mutations: Array<(s: SubagentSnapshot) => SubagentSnapshot> = [
+			s => ({ ...s, status: "completed" }),
+			s => ({ ...s, guidance: "still running after the timeout" }),
+			s => ({ ...s, errorText: "boom" }),
+			s => ({ ...s, resultPreview: "ok" }),
+			s => ({ ...s, outputRef: "agent://0-A" }),
+			s => ({ ...s, truncated: true }),
+			s => ({ ...s, liveProgressAvailable: false }),
+			s => ({ ...s, effectiveModel: "model-2" }),
+			s => ({ ...s, requestedModel: "model-1" }),
+			s => ({ ...s, modelFellBack: true }),
+			s => ({ ...s, description: "new description" }),
+			s => ({ ...s, assignment: "new assignment" }),
+			s => ({ ...s, progress: { ...baseProgress, currentTool: "bash" } }),
+			s => ({ ...s, progress: { ...baseProgress, currentToolArgs: "ls -la" } }),
+			s => ({ ...s, progress: { ...baseProgress, lastIntent: "thinking" } }),
+			s => ({ ...s, progress: { ...baseProgress, recentOutput: ["y"] } }),
+			s => ({ ...s, progress: { ...baseProgress, recentTools: [{ tool: "read", args: "f", endMs: 0 }] } }),
+			s => ({ ...s, progress: { ...baseProgress, toolCount: 2 } }),
+			s => ({ ...s, progress: { ...baseProgress, tokens: 20 } }),
+			s => ({ ...s, progress: { ...baseProgress, contextTokens: 100 } }),
+			s => ({ ...s, progress: { ...baseProgress, contextWindow: 200_000 } }),
+			s => ({ ...s, progress: { ...baseProgress, cost: 0.2 } }),
+			s => ({ ...s, progress: { ...baseProgress, status: "completed" } }),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					modelSubstitutionWarning: { requested: "a", effective: "b", reason: "auth_unavailable" },
+				},
+			}),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					retryState: { attempt: 1, maxAttempts: 3, delayMs: 1_000, errorMessage: "429", startedAtMs: 0 },
+				},
+			}),
+			s => ({ ...s, progress: { ...baseProgress, retryFailure: { attempt: 3, errorMessage: "gave up" } } }),
+			s => ({ ...s, progress: { ...baseProgress, extractedToolData: { task: [{ id: "n1", status: "running" }] } } }),
+			s => ({
+				...s,
+				progress: {
+					...baseProgress,
+					inflightTaskDetails: { id: "t1" } as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>,
+				},
+			}),
+		];
+
+		for (const mutate of mutations) {
+			expect(subagentAwaitRenderedStateSignature([mutate(base)])).not.toBe(baseSig);
+		}
+	});
+
+	it("recentOutput tail changes are reflected (producer never drops real output progress)", () => {
+		const a = makeSnapshot({ id: "0-A", progress: makeProgress({ id: "0-A", recentOutput: ["a", "b"] }) });
+		const b = makeSnapshot({ id: "0-A", progress: makeProgress({ id: "0-A", recentOutput: ["a", "b", "c"] }) });
+		expect(subagentAwaitRenderedStateSignature([a])).not.toBe(subagentAwaitRenderedStateSignature([b]));
+	});
+
+	it("ignores nested task time churn but reflects nested status changes", () => {
+		const makeInflight = (
+			durationMs: number,
+			nestedStatus: AgentProgress["status"],
+		): NonNullable<AgentProgress["inflightTaskDetails"]> =>
+			({
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: durationMs,
+				progress: [makeProgress({ id: "child", status: nestedStatus, durationMs, currentToolStartMs: durationMs })],
+			}) as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>;
+
+		const early = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(1_000, "running") }),
+		});
+		const later = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(999_999, "running") }),
+		});
+		const statusChanged = makeSnapshot({
+			id: "0-A",
+			progress: makeProgress({ id: "0-A", inflightTaskDetails: makeInflight(1_000, "completed") }),
+		});
+
+		// Nested task time churn (totalDurationMs + nested progress duration/elapsed) is ignored.
+		expect(subagentAwaitRenderedStateSignature([later])).toBe(subagentAwaitRenderedStateSignature([early]));
+		// A real nested status change still emits.
+		expect(subagentAwaitRenderedStateSignature([statusChanged])).not.toBe(
+			subagentAwaitRenderedStateSignature([early]),
+		);
+	});
+});
+
+describe("subagent await emit gating", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		AsyncJobManager.resetForTests();
+	});
+
+	it("emits only the initial update for idle concurrent awaits, then exactly once per real change", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const ids = ["0-A", "0-B", "0-C"];
+		const controls = ids.map(() => Promise.withResolvers<void>());
+		ids.forEach((id, i) => {
+			const jobId = manager.register(
+				"task",
+				id,
+				async () => {
+					await controls[i].promise;
+					return "done";
+				},
+				{
+					id: `job-${id}`,
+					ownerId: "0-Main",
+					metadata: { subagent: { id, agent: "executor", agentSource: "bundled" } },
+				},
+			);
+			manager.registerSubagentRecord(runningRecord(id, jobId));
+			manager.recordSubagentProgress(id, makeProgress({ id, currentTool: "read", recentOutput: ["scan"] }));
+		});
+
+		const ac = new AbortController();
+		const spies = ids.map(() => vi.fn());
+		const execs = ids.map((id, i) =>
+			tool.execute(`await-${id}`, { action: "await", ids: [id], timeout_ms: 3_600_000 }, ac.signal, spies[i]),
+		);
+
+		// The initial partial emission runs synchronously when the await starts.
+		await Promise.resolve();
+		for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
+
+		// Idle: 5 interval ticks (2500ms) with unchanged progress must not emit.
+		vi.advanceTimersByTime(2_500);
+		for (const spy of spies) expect(spy).toHaveBeenCalledTimes(1);
+
+		// A real progress change on 0-A emits exactly once; idle peers stay quiet.
+		manager.recordSubagentProgress("0-A", makeProgress({ id: "0-A", currentTool: "bash", recentOutput: ["scan"] }));
+		vi.advanceTimersByTime(500);
+		expect(spies[0]).toHaveBeenCalledTimes(2);
+		expect(spies[1]).toHaveBeenCalledTimes(1);
+		expect(spies[2]).toHaveBeenCalledTimes(1);
+
+		ac.abort();
+		for (const control of controls) control.resolve();
+		await Promise.all(execs);
+		await manager.dispose({ timeoutMs: 100 });
 	});
 });

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import type { Theme } from "../../src/modes/theme/theme";
 import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
 import type { AgentProgress } from "../../src/task/types";
 import type { SubagentSnapshot, SubagentToolDetails } from "../../src/tools/subagent";
-import { subagentToolRenderer } from "../../src/tools/subagent-render";
+import { subagentBodyCacheTestHooks, subagentToolRenderer } from "../../src/tools/subagent-render";
 
 let theme: Theme;
 
@@ -270,5 +270,131 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("Model: anthropic/claude-opus-4-8");
 		expect(out).toContain("requested openai-codex/gpt-5.5");
 		expect(out).toContain("fell back");
+	});
+});
+
+describe("subagent await renderer body cache (PR2)", () => {
+	beforeEach(() => {
+		subagentBodyCacheTestHooks.reset();
+	});
+
+	const renderWith = (
+		details: SubagentToolDetails,
+		{
+			expanded = true,
+			width = 160,
+			spinnerFrame = 0,
+		}: { expanded?: boolean; width?: number; spinnerFrame?: number } = {},
+	): string[] => {
+		// A fresh component each call models the built-in renderer recreating the
+		// result component on every partial update.
+		const component = subagentToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded, isPartial: true, spinnerFrame },
+			theme,
+		);
+		return component.render(width);
+	};
+
+	const live = (id: string, overrides: Partial<AgentProgress> = {}): SubagentToolDetails => ({
+		subagents: [
+			snapshot({
+				id,
+				liveProgressAvailable: true,
+				progress: progress({ id, currentTool: "read", recentOutput: ["scan"], ...overrides }),
+			}),
+		],
+	});
+
+	it("reuses the cached heavy body across component recreation for identical content", () => {
+		renderWith(live("0-A"));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// New component (new renderResult), identical content -> module cache hit.
+		renderWith(live("0-A"));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("does not re-render the heavy body for spinner-only frame changes", () => {
+		const details = live("0-A");
+		renderWith(details, { spinnerFrame: 0 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		renderWith(details, { spinnerFrame: 1 });
+		renderWith(details, { spinnerFrame: 2 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("re-renders the heavy body when content, width, or expanded changes", () => {
+		renderWith(live("0-A", { currentTool: "read" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// Content change.
+		renderWith(live("0-A", { currentTool: "bash" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+		// Width change.
+		renderWith(live("0-A", { currentTool: "read" }), { width: 100 });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(3);
+		// Expanded change.
+		renderWith(live("0-A", { currentTool: "read" }), { expanded: false });
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(4);
+		// Back to the first key -> cache hit, no new render.
+		renderWith(live("0-A", { currentTool: "read" }));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(4);
+	});
+
+	it("ignores time-only churn in the body cache key", () => {
+		const a: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-A",
+					durationMs: 1_000,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-A", durationMs: 1_000, currentTool: "read", currentToolStartMs: 1_000 }),
+				}),
+			],
+		};
+		const b: SubagentToolDetails = {
+			subagents: [
+				snapshot({
+					id: "0-A",
+					durationMs: 999_999,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-A", durationMs: 999_999, currentTool: "read", currentToolStartMs: 2_000 }),
+				}),
+			],
+		};
+		renderWith(a);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// Only time-derived fields differ -> identical signature -> cache hit.
+		renderWith(b);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+	});
+
+	it("invalidates the body cache when the Theme instance changes (no stale ANSI)", async () => {
+		const altTheme = (await getThemeByName("blue-crab"))!;
+		expect(altTheme).toBeDefined();
+		const details = live("0-A");
+		const renderTheme = (t: Theme): string[] =>
+			subagentToolRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "" }], details },
+					{ expanded: true, isPartial: true, spinnerFrame: 0 },
+					t,
+				)
+				.render(160);
+
+		const first = renderTheme(theme);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// A different Theme instance (distinct object) must re-render the body, even if
+		// the theme name is unchanged — guards against stale themed ANSI/glyph reuse.
+		const second = renderTheme(altTheme);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+		expect(second).not.toEqual(first);
+	});
+
+	it("bounds the cache via LRU eviction", () => {
+		for (let i = 0; i < 140; i++) {
+			renderWith(live(`0-${i}`, { currentTool: `tool-${i}` }));
+		}
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(140);
+		expect(subagentBodyCacheTestHooks.size).toBeLessThanOrEqual(128);
 	});
 });

--- a/packages/tui/test/await-panel-redraw-metrics.test.ts
+++ b/packages/tui/test/await-panel-redraw-metrics.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, TUI } from "@gajae-code/tui";
+import { renderMetrics } from "@gajae-code/tui/metrics";
+import { VirtualTerminal } from "./virtual-terminal";
+
+/**
+ * Deterministic `PI_TUI_METRICS` repro for the subagent-await UI perf work.
+ *
+ * The flicker/CPU problem is mechanical: when a streaming `subagent` await panel
+ * sits ABOVE the viewport and its lines change, the TUI must full-repaint
+ * (`tui.ts` `firstChanged < viewportTop`) — a full clear + whole-tree re-render.
+ * Per-await 500ms churn turned this into a repaint storm that compounded with the
+ * number of concurrent awaits and the transcript height.
+ *
+ * This test pins that cost model with the shared render metrics and proves the two
+ * post-fix steady states are cheap:
+ *  - PR1 (producer gating) stops idle emits, so the transcript above the viewport
+ *    does not change -> zero `firstChanged < viewportTop` full redraws while idle.
+ *  - In-viewport changes always patch differentially regardless.
+ *
+ * It is fully deterministic: no wall clock, `settle()` drives the nextTick render
+ * coalescing, and assertions are on counts/causes, not durations.
+ */
+class MutableLines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	set(index: number, value: string): void {
+		this.#lines[index] = value;
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+// Viewport of 8 rows over a 30-line transcript: lines 0..21 are above the viewport
+// (earlier subagent await panels), lines 22..29 are visible.
+const VIEWPORT_ROWS = 8;
+const TRANSCRIPT_LINES = 30;
+const ABOVE_VIEWPORT_LINE = 5;
+const BOTTOM_LINE = TRANSCRIPT_LINES - 1;
+
+function setup(): { term: VirtualTerminal; tui: TUI; component: MutableLines } {
+	const term = new VirtualTerminal(40, VIEWPORT_ROWS);
+	const tui = new TUI(term);
+	const component = new MutableLines(Array.from({ length: TRANSCRIPT_LINES }, (_v, i) => `line-${i}`));
+	tui.addChild(component);
+	return { term, tui, component };
+}
+
+describe("subagent await panel above-viewport redraw cost (PI_TUI_METRICS)", () => {
+	let prevTmux: string | undefined;
+	let prevSty: string | undefined;
+	let prevZellij: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		// Force the non-multiplexer full-render path so the cost model is deterministic.
+		// Keep the TUI render-throttle deterministic without sleeping a real frame per
+		// render, so each `requestRender` + `settle` commits its own frame.
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+		prevTmux = Bun.env.TMUX;
+		prevSty = Bun.env.STY;
+		prevZellij = Bun.env.ZELLIJ;
+		delete Bun.env.TMUX;
+		delete Bun.env.STY;
+		delete Bun.env.ZELLIJ;
+		renderMetrics.enable();
+		renderMetrics.reset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		renderMetrics.disable();
+		renderMetrics.reset();
+		if (prevTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = prevTmux;
+		if (prevSty === undefined) delete Bun.env.STY;
+		else Bun.env.STY = prevSty;
+		if (prevZellij === undefined) delete Bun.env.ZELLIJ;
+		else Bun.env.ZELLIJ = prevZellij;
+	});
+
+	it("an above-viewport await-panel line change forces a full redraw on every tick (the cost the fix removes)", async () => {
+		const { term, tui, component } = setup();
+		try {
+			tui.start();
+			await settle(term);
+			renderMetrics.reset();
+			const baseFullRedraws = tui.fullRedraws;
+
+			// Five idle await "ticks" that, pre-fix, mutated an above-viewport panel line.
+			for (let i = 0; i < 5; i++) {
+				component.set(ABOVE_VIEWPORT_LINE, `await-panel tick ${i}`);
+				tui.requestRender();
+				await settle(term);
+			}
+
+			expect(tui.fullRedraws - baseFullRedraws).toBe(5);
+			const snapshot = renderMetrics.snapshot();
+			expect(snapshot.fullRedrawCauses["firstChanged < viewportTop"]).toBe(5);
+			// The render-tree helper timing is recorded — this is the measurement the
+			// effort uses to validate the win.
+			expect(snapshot.helperStats.renderTree?.count ?? 0).toBeGreaterThan(0);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("idle re-renders with no above-viewport change cause zero full redraws (PR1-gated steady state)", async () => {
+		const { term, tui } = setup();
+		try {
+			tui.start();
+			await settle(term);
+			renderMetrics.reset();
+			const baseFullRedraws = tui.fullRedraws;
+
+			// PR1 gating means the await producer no longer emits while idle, so the
+			// transcript lines above the viewport never change.
+			for (let i = 0; i < 5; i++) {
+				tui.requestRender();
+				await settle(term);
+			}
+
+			expect(tui.fullRedraws - baseFullRedraws).toBe(0);
+			const snapshot = renderMetrics.snapshot();
+			expect(snapshot.fullRedrawCauses["firstChanged < viewportTop"] ?? 0).toBe(0);
+			expect(snapshot.repaintStorms).toBe(0);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("an in-viewport (bottom) change patches differentially without a full redraw", async () => {
+		const { term, tui, component } = setup();
+		try {
+			tui.start();
+			await settle(term);
+			renderMetrics.reset();
+			const baseFullRedraws = tui.fullRedraws;
+
+			for (let i = 0; i < 5; i++) {
+				component.set(BOTTOM_LINE, `bottom ${i}`);
+				tui.requestRender();
+				await settle(term);
+			}
+
+			expect(tui.fullRedraws - baseFullRedraws).toBe(0);
+			const snapshot = renderMetrics.snapshot();
+			expect(snapshot.fullRedrawCauses["firstChanged < viewportTop"] ?? 0).toBe(0);
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
Part 3/3 of the subagent-await UI perf work. **Stacked on #680 (PR2)** — base is `feat/subagent-await-perf-pr2-renderer-cache`. Rebase onto `dev` after #677 and #680 merge.

Test-only: a deterministic `PI_TUI_METRICS` repro that pins the cost model PR1+PR2 eliminate, so the win is measurable and regressions are caught.

## Why
The flicker/slowdown is mechanical: when a streaming `subagent` await panel sits **above the viewport** and its lines change, the TUI must full-repaint (`tui.ts` `firstChanged < viewportTop`) — a full clear + whole-tree re-render. Per-await 500ms churn turned this into a repaint storm that compounded with concurrent awaits and transcript height.

## What
New `packages/tui/test/await-panel-redraw-metrics.test.ts` drives a real `TUI` over a `VirtualTerminal` with the shared `renderMetrics` and asserts:
- **Cost (pre-fix):** mutating an above-viewport panel line 5× → `tui.fullRedraws` +5 and `renderMetrics.fullRedrawCauses["firstChanged < viewportTop"] === 5`; `renderTree` helper timing recorded.
- **PR1-gated idle steady state:** 5 no-op renders → **0** full redraws, **0** repaint storms.
- **In-viewport change:** bottom-line change → differential patch, **0** full redraws.

Deterministic: monotonic `performance.now` mock (defeats the 16ms frame-budget throttle), multiplexer env (`TMUX`/`STY`/`ZELLIJ`) isolated to force the non-multiplexer path, shared `renderMetrics` enabled/reset per test then disabled.

## Validation
- `bun test` (await-panel + metrics + render-regressions): **39 pass / 0 fail**. `tsc` + `biome` clean.
- Red-team: 3× repeat green; no `renderMetrics` singleton leak into neighbor tests; **anti-vacuity** confirmed (inverting the above-viewport assertion fails); boundary-size probe confirms behavior follows `firstChanged < viewportTop` (not a hard-coded line).

## Non-goals
No production code / no TUI engine change (`tui.ts:1468-1479` untouched). Producer gating = #677 (PR1); renderer cache = #680 (PR2).
