### PR TITLE
feat(tui): passive active-monitor/cron visualization panel (draft restage)

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -217,6 +217,16 @@ export interface AsyncJobOutputSlice {
 	truncated: boolean;
 }
 
+/** Options for a bounded/incremental output tail read. */
+export interface AsyncJobOutputTailOptions {
+	/** Cap the returned slice to roughly the last N UTF-8 bytes of output. */
+	maxBytes?: number;
+	/** After byte-bounding, keep only the final N newline-separated lines. */
+	maxLines?: number;
+	/** Cursor follow: start from this byte offset (from a prior `nextOffset`). */
+	sinceOffset?: number;
+}
+
 /** Internal: a single chunk of captured stdout/stderr keyed by its byte range. */
 interface AsyncJobOutputChunk {
 	startByte: number;
@@ -906,6 +916,84 @@ export class AsyncJobManager {
 		};
 	}
 
+	/**
+	 * Bounded/incremental tail read of a job's captured output. Unlike
+	 * `readOutputSince(jobId, 0, …)`, this never assembles the whole retained
+	 * buffer: when `maxBytes` is set it only visits chunks overlapping the last
+	 * `maxBytes` bytes, and `maxLines` then keeps only the final lines of that
+	 * already-bounded slice. Intended for the passive panel's expanded live tail,
+	 * polled per visible monitor row.
+	 *
+	 * - `sinceOffset` (cursor follow): start from that byte; if it has fallen
+	 *   behind the retained `startOffset`, the bounded tail is returned with
+	 *   `truncated: true`. When `sinceOffset >= nextOffset` an empty slice is
+	 *   returned (no new bytes).
+	 * - `truncated` is true whenever earlier output exists that the slice omits
+	 *   (retention drop, `maxBytes` clip, or `maxLines` clip).
+	 * - The leading retained chunk is sliced at a UTF-8 codepoint boundary so
+	 *   multibyte characters are never split.
+	 */
+	readOutputTail(
+		jobId: string,
+		options: AsyncJobOutputTailOptions,
+		filter?: AsyncJobFilter,
+	): AsyncJobOutputSlice | undefined {
+		const job = this.#jobs.get(jobId);
+		if (!job) return undefined;
+		if (filter?.ownerId && job.ownerId !== filter.ownerId) return undefined;
+
+		const state = this.#outputState.get(jobId);
+		if (!state) {
+			return { jobId, status: job.status, text: "", startOffset: 0, nextOffset: 0, truncated: false };
+		}
+
+		const maxBytes = options.maxBytes !== undefined ? Math.max(0, Math.floor(options.maxBytes)) : undefined;
+		const maxLines = options.maxLines !== undefined ? Math.max(0, Math.floor(options.maxLines)) : undefined;
+		const requestedFloor =
+			options.sinceOffset !== undefined ? Math.max(0, Math.floor(options.sinceOffset)) : state.startOffset;
+
+		if (options.sinceOffset !== undefined && requestedFloor >= state.nextOffset) {
+			return {
+				jobId,
+				status: job.status,
+				text: "",
+				startOffset: state.startOffset,
+				nextOffset: state.nextOffset,
+				truncated: false,
+			};
+		}
+
+		const retentionTruncated = requestedFloor < state.startOffset;
+		const baseFloor = Math.max(requestedFloor, state.startOffset);
+		let effectiveOffset = baseFloor;
+		if (maxBytes !== undefined) {
+			const tailFloor = state.nextOffset - maxBytes;
+			if (tailFloor > effectiveOffset) effectiveOffset = tailFloor;
+		}
+		let truncated = retentionTruncated || effectiveOffset > baseFloor;
+
+		const parts: string[] = [];
+		for (const chunk of state.chunks) {
+			if (chunk.endByte <= effectiveOffset) continue;
+			if (effectiveOffset > chunk.startByte) {
+				parts.push(sliceTextFromUtf8ByteOffset(chunk.text, effectiveOffset - chunk.startByte));
+				continue;
+			}
+			parts.push(chunk.text);
+		}
+		let text = parts.join("");
+
+		if (maxLines !== undefined) {
+			const trimmed = text.endsWith("\n") ? text.slice(0, -1) : text;
+			const lines = trimmed.length === 0 ? [] : trimmed.split("\n");
+			if (lines.length > maxLines) {
+				truncated = true;
+				text = lines.slice(lines.length - maxLines).join("\n");
+			}
+		}
+
+		return { jobId, status: job.status, text, startOffset: effectiveOffset, nextOffset: state.nextOffset, truncated };
+	}
 	/**
 	 * Register an owner-scoped cleanup callback. Returns an unregister function.
 	 *

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -39,6 +39,8 @@ interface AppKeybindings {
 	"app.session.resume": true;
 	"app.session.observe": true;
 	"app.jobs.open": true;
+	"app.jobs.expand": true;
+	"app.jobs.collapse": true;
 	"app.session.togglePath": true;
 	"app.session.toggleSort": true;
 	"app.session.rename": true;
@@ -154,6 +156,14 @@ export const KEYBINDINGS = {
 	"app.jobs.open": {
 		defaultKeys: "alt+j",
 		description: "Open monitor/cron jobs overlay",
+	},
+	"app.jobs.expand": {
+		defaultKeys: "ctrl+up",
+		description: "Expand the active monitor/cron panel (or scroll up when expanded)",
+	},
+	"app.jobs.collapse": {
+		defaultKeys: "ctrl+down",
+		description: "Collapse the active monitor/cron panel (or scroll down when expanded)",
 	},
 	"app.session.togglePath": {
 		defaultKeys: "ctrl+p",

--- a/packages/coding-agent/src/modes/components/active-jobs-panel-model.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel-model.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure model for the passive ActiveJobsPanel.
+ *
+ * No UI/Component/store dependencies: every function is a deterministic
+ * transform over a `JobsSnapshot` plus an explicit `nowMs`, so terminal-TTL
+ * filtering, collapsed-row capping, and expanded-window scrolling are all
+ * unit-testable (including with fake timers). The component is a thin shell over
+ * these helpers; it owns timers, polling, and rendering only.
+ */
+import type { CronJobView, JobsSnapshot, MonitorJobView } from "../jobs-observer";
+import {
+	compareCronsNewestFirst,
+	compareMonitorsNewestFirst,
+	formatRelative,
+	formatRuntime,
+	previewText,
+} from "./jobs-format";
+
+/** Max job rows shown in the collapsed panel before "+N more". */
+export const COLLAPSED_JOB_ROW_CAP = 4;
+/** How long a completed monitor row lingers after `endTime` before it drops. */
+export const COMPLETED_MONITOR_VISIBLE_MS = 30_000;
+/** How long a failed monitor row lingers after `endTime` (longer, so failures are noticed). */
+export const FAILED_MONITOR_VISIBLE_MS = 300_000;
+/** Max visible columns for a one-line prompt/label preview. */
+export const PROMPT_PREVIEW_MAX = 60;
+/** Poll cadence for expanded live monitor tails. */
+export const TAIL_POLL_MS = 1_000;
+/** Byte cap for each expanded monitor tail read. */
+export const TAIL_MAX_BYTES = 8_192;
+/** Line cap rendered per expanded monitor tail. */
+export const TAIL_MAX_LINES_PER_MONITOR = 3;
+
+export interface PanelRow {
+	kind: "monitor" | "cron";
+	id: string;
+	text: string;
+}
+
+export interface CollapsedView {
+	rows: PanelRow[];
+	/** Count of visible jobs not shown because of the row cap (>= 0). */
+	overflow: number;
+	/** Total visible jobs (monitors + crons) after TTL filtering. */
+	totalVisible: number;
+}
+
+export interface ExpandedRow {
+	kind: "monitor" | "monitor-tail" | "cron";
+	/** Job id (for tail rows, the owning monitor id). */
+	id: string;
+	text: string;
+}
+
+export interface ExpandedWindow {
+	totalRows: number;
+	visibleRows: ExpandedRow[];
+	canScrollUp: boolean;
+	canScrollDown: boolean;
+	/** Monitor ids whose header is in the visible window (poll only these). */
+	visibleMonitorTailIds: string[];
+	/** The scrollOffset after clamping to [0, max(0, totalRows - heightBudget)]. */
+	scrollOffset: number;
+}
+
+export interface FilteredJobs {
+	monitors: MonitorJobView[];
+	crons: CronJobView[];
+}
+
+/**
+ * Whether a monitor row should currently be shown. Running/paused monitors are
+ * always visible; terminal monitors linger for a status-dependent TTL measured
+ * from `endTime`. A terminal monitor missing `endTime` is kept visible (we never
+ * hide work we cannot prove has expired).
+ */
+export function isMonitorVisible(monitor: MonitorJobView, nowMs: number): boolean {
+	if (monitor.status === "running" || monitor.status === "paused") return true;
+	if (monitor.endTime === undefined) return true;
+	const ttl = monitor.status === "failed" ? FAILED_MONITOR_VISIBLE_MS : COMPLETED_MONITOR_VISIBLE_MS;
+	return nowMs - monitor.endTime < ttl;
+}
+
+/** Apply terminal TTL filtering to monitors; crons are always included. */
+export function filterVisibleJobs(snapshot: JobsSnapshot, nowMs: number): FilteredJobs {
+	return {
+		monitors: snapshot.monitors.filter(m => isMonitorVisible(m, nowMs)).sort(compareMonitorsNewestFirst),
+		crons: [...snapshot.crons].sort(compareCronsNewestFirst),
+	};
+}
+
+/** True when at least one monitor or cron is currently visible (auto-show trigger). */
+export function hasVisibleJobs(snapshot: JobsSnapshot, nowMs: number): boolean {
+	const { monitors, crons } = filterVisibleJobs(snapshot, nowMs);
+	return monitors.length > 0 || crons.length > 0;
+}
+
+function monitorRowText(monitor: MonitorJobView, nowMs: number, width?: number): string {
+	const runtime = formatRuntime(monitor.startTime, monitor.endTime, nowMs);
+	const text = `monitor · ${monitor.label} · ${monitor.status} · ${runtime}`;
+	return width !== undefined ? previewText(text, width) : text.replace(/\s+/g, " ").trim();
+}
+
+function cronRowText(cron: CronJobView, nowMs: number, width?: number): string {
+	const next = formatRelative(cron.nextFireAt, nowMs);
+	const prompt = previewText(cron.prompt, PROMPT_PREVIEW_MAX);
+	const text = `cron · ${cron.humanSchedule} · next ${next} · ${prompt}`;
+	return width !== undefined ? previewText(text, width) : text.replace(/\s+/g, " ").trim();
+}
+
+/** Clamp the collapsed cap to the rows actually available (min 1 while any room). */
+export function resolveCollapsedCap(availableRows: number): number {
+	if (availableRows <= 0) return 0;
+	return Math.min(COLLAPSED_JOB_ROW_CAP, Math.floor(availableRows));
+}
+
+/**
+ * Build the collapsed panel rows: visible monitors (newest-first) then visible
+ * crons (newest-first), capped at `cap` total rows with the remainder reported
+ * as `overflow`.
+ */
+export function buildCollapsedRows(
+	snapshot: JobsSnapshot,
+	nowMs: number,
+	opts: { cap?: number; width?: number } = {},
+): CollapsedView {
+	const cap = opts.cap ?? COLLAPSED_JOB_ROW_CAP;
+	const { monitors, crons } = filterVisibleJobs(snapshot, nowMs);
+	const all: PanelRow[] = [
+		...monitors.map(m => ({ kind: "monitor" as const, id: m.id, text: monitorRowText(m, nowMs, opts.width) })),
+		...crons.map(c => ({ kind: "cron" as const, id: c.id, text: cronRowText(c, nowMs, opts.width) })),
+	];
+	const totalVisible = all.length;
+	const shown = cap <= 0 ? [] : all.slice(0, cap);
+	return { rows: shown, overflow: Math.max(0, totalVisible - shown.length), totalVisible };
+}
+
+/** Clamp a scroll offset to a valid window start for the given totals. */
+export function clampScrollOffset(scrollOffset: number, totalRows: number, heightBudget: number): number {
+	const maxOffset = Math.max(0, totalRows - Math.max(0, heightBudget));
+	return Math.min(Math.max(0, Math.floor(scrollOffset)), maxOffset);
+}
+
+/**
+ * Build the expanded, windowed view over a flattened row model:
+ *   [monitor header, ...its tail lines, monitor header, ..., cron, cron, ...]
+ * Every monitor header and cron row is always present, so repeated scrolling
+ * reaches every job. Tail rows appear only for monitors with lines in
+ * `tailByMonitorId` (the component fills these for visible monitors over time).
+ */
+export function buildExpandedWindow(
+	snapshot: JobsSnapshot,
+	nowMs: number,
+	scrollOffset: number,
+	heightBudget: number,
+	tailByMonitorId: Record<string, string[]> = {},
+	width?: number,
+): ExpandedWindow {
+	const { monitors, crons } = filterVisibleJobs(snapshot, nowMs);
+	const flat: ExpandedRow[] = [];
+	for (const m of monitors) {
+		flat.push({ kind: "monitor", id: m.id, text: monitorRowText(m, nowMs, width) });
+		const lines = (tailByMonitorId[m.id] ?? []).slice(-TAIL_MAX_LINES_PER_MONITOR);
+		for (const line of lines) {
+			const rendered = `    ${line}`;
+			flat.push({
+				kind: "monitor-tail",
+				id: m.id,
+				text: width !== undefined ? previewText(rendered, width) : rendered,
+			});
+		}
+	}
+	for (const c of crons) {
+		flat.push({ kind: "cron", id: c.id, text: cronRowText(c, nowMs, width) });
+	}
+
+	const totalRows = flat.length;
+	const budget = Math.max(0, Math.floor(heightBudget));
+	const offset = clampScrollOffset(scrollOffset, totalRows, budget);
+	const end = offset + budget;
+	const visibleRows = flat.slice(offset, end);
+	const visibleMonitorTailIds: string[] = [];
+	flat.forEach((row, index) => {
+		if (row.kind === "monitor" && index >= offset && index < end) visibleMonitorTailIds.push(row.id);
+	});
+
+	return {
+		totalRows,
+		visibleRows,
+		canScrollUp: offset > 0,
+		canScrollDown: end < totalRows,
+		visibleMonitorTailIds,
+		scrollOffset: offset,
+	};
+}

--- a/packages/coding-agent/src/modes/components/active-jobs-panel-model.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel-model.ts
@@ -162,11 +162,11 @@ export function buildExpandedWindow(
 		flat.push({ kind: "monitor", id: m.id, text: monitorRowText(m, nowMs, width) });
 		const lines = (tailByMonitorId[m.id] ?? []).slice(-TAIL_MAX_LINES_PER_MONITOR);
 		for (const line of lines) {
-			const rendered = `    ${line}`;
+			// Tail content only; the component indents tail rows under their monitor.
 			flat.push({
 				kind: "monitor-tail",
 				id: m.id,
-				text: width !== undefined ? previewText(rendered, width) : rendered,
+				text: width !== undefined ? previewText(line, width) : line,
 			});
 		}
 	}

--- a/packages/coding-agent/src/modes/components/active-jobs-panel.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel.ts
@@ -1,0 +1,227 @@
+/**
+ * Passive, read-only inline panel that visualizes active monitor/cron jobs
+ * directly below the input. It auto-surfaces whenever the filtered snapshot has
+ * any visible job and hides otherwise; it never offers destructive actions
+ * (those stay in the alt+j / `/monitors` manage overlay) and never acknowledges
+ * failures.
+ *
+ * Rendering and visibility derive entirely from the pure model in
+ * `active-jobs-panel-model`. The component owns only side effects: a
+ * minute-boundary label refresh while visible and a bounded live-tail poll while
+ * expanded (visible monitor rows only).
+ */
+import { Container } from "@gajae-code/tui";
+import type { AsyncJobOutputSlice, AsyncJobOutputTailOptions } from "../../async";
+import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../jobs-observer";
+import {
+	buildCollapsedRows,
+	buildExpandedWindow,
+	clampScrollOffset,
+	hasVisibleJobs,
+	TAIL_MAX_BYTES,
+	TAIL_MAX_LINES_PER_MONITOR,
+	TAIL_POLL_MS,
+} from "./active-jobs-panel-model";
+
+/** Read-only data access the panel needs (a `JobsObserver` subset). */
+export interface ActiveJobsPanelController {
+	getSnapshot(): JobsSnapshot;
+	getMonitorOutputTail(id: string, options: AsyncJobOutputTailOptions): AsyncJobOutputSlice | undefined;
+}
+
+export interface ActiveJobsPanelCallbacks {
+	requestRender(): void;
+	/** Injectable clock for deterministic tests; defaults to Date.now. */
+	now?(): number;
+}
+
+/** Default max rows the expanded panel may occupy (interactive-mode tightens this from terminal height). */
+const DEFAULT_MAX_ROWS = 10;
+const MS_PER_MINUTE = 60_000;
+
+export class ActiveJobsPanelComponent extends Container {
+	readonly #controller: ActiveJobsPanelController;
+	readonly #requestRender: () => void;
+	readonly #now: () => number;
+
+	#snapshot: JobsSnapshot = EMPTY_JOBS_SNAPSHOT;
+	#expanded = false;
+	#scrollOffset = 0;
+	#maxRows = DEFAULT_MAX_ROWS;
+	#disposed = false;
+	/** Cached last-N tail lines per monitor id (only for visible expanded rows). */
+	readonly #tailLines = new Map<string, string[]>();
+	#visibleMonitorIds: string[] = [];
+	#labelTimer: ReturnType<typeof setTimeout> | undefined;
+	#tailTimer: ReturnType<typeof setInterval> | undefined;
+
+	constructor(controller: ActiveJobsPanelController, callbacks: ActiveJobsPanelCallbacks) {
+		super();
+		this.#controller = controller;
+		this.#requestRender = callbacks.requestRender;
+		this.#now = callbacks.now ?? Date.now;
+		this.#snapshot = controller.getSnapshot();
+		this.#syncTimers();
+	}
+
+	/** Update the data snapshot; collapses + clears tails when nothing is visible. */
+	setSnapshot(snapshot: JobsSnapshot): void {
+		this.#snapshot = snapshot;
+		if (!this.isVisible()) {
+			this.#expanded = false;
+			this.#scrollOffset = 0;
+			this.#tailLines.clear();
+			this.#visibleMonitorIds = [];
+		}
+		this.#syncTimers();
+		this.#requestRender();
+	}
+
+	/** Tighten the max panel height (interactive-mode feeds this from terminal rows). */
+	setMaxRows(rows: number): void {
+		this.#maxRows = Math.max(1, Math.floor(rows));
+	}
+
+	isVisible(): boolean {
+		return hasVisibleJobs(this.#snapshot, this.#now());
+	}
+
+	isExpanded(): boolean {
+		return this.#expanded;
+	}
+
+	/** ctrl+up: expand from collapsed, else scroll up one row. */
+	onExpandUp(): void {
+		if (this.#disposed || !this.isVisible()) return;
+		if (!this.#expanded) {
+			this.#expanded = true;
+			this.#scrollOffset = 0;
+			this.#pollVisibleTails();
+		} else {
+			this.#scrollBy(-1);
+		}
+		this.#syncTimers();
+		this.#requestRender();
+	}
+
+	/** ctrl+down: scroll down while expanded; collapse when already at the top. */
+	onCollapseDown(): void {
+		if (this.#disposed || !this.isVisible() || !this.#expanded) return;
+		if (this.#scrollOffset <= 0) {
+			this.#expanded = false;
+		} else {
+			this.#scrollBy(1);
+		}
+		this.#syncTimers();
+		this.#requestRender();
+	}
+
+	#scrollBy(delta: number): void {
+		const budget = this.#expandedHeightBudget();
+		const win = buildExpandedWindow(this.#snapshot, this.#now(), this.#scrollOffset, budget, this.#tailRecord());
+		this.#scrollOffset = clampScrollOffset(this.#scrollOffset + delta, win.totalRows, budget);
+	}
+
+	#expandedHeightBudget(): number {
+		// Reserve one row for the header/scroll-indicator line.
+		return Math.max(1, this.#maxRows - 1);
+	}
+
+	#tailRecord(): Record<string, string[]> {
+		return Object.fromEntries(this.#tailLines);
+	}
+
+	render(width: number): string[] {
+		const now = this.#now();
+		if (!hasVisibleJobs(this.#snapshot, now)) return [];
+		return this.#expanded ? this.#renderExpanded(width, now) : this.#renderCollapsed(width, now);
+	}
+
+	#renderCollapsed(width: number, now: number): string[] {
+		const view = buildCollapsedRows(this.#snapshot, now, { width });
+		const lines: string[] = [`Active jobs (${view.totalVisible}) — ctrl+↑ expand`];
+		for (const row of view.rows) lines.push(`  ${row.text}`);
+		if (view.overflow > 0) lines.push(`  +${view.overflow} more`);
+		return lines;
+	}
+
+	#renderExpanded(width: number, now: number): string[] {
+		const budget = this.#expandedHeightBudget();
+		const win = buildExpandedWindow(this.#snapshot, now, this.#scrollOffset, budget, this.#tailRecord(), width);
+		this.#visibleMonitorIds = win.visibleMonitorTailIds;
+		const shownStart = win.totalRows === 0 ? 0 : win.scrollOffset + 1;
+		const shownEnd = win.scrollOffset + win.visibleRows.length;
+		const indicators = `${win.canScrollUp ? "↑" : " "}${win.canScrollDown ? "↓" : " "}`;
+		const lines: string[] = [
+			`Active jobs — expanded (${shownStart}-${shownEnd} of ${win.totalRows}) ${indicators} ctrl+↓ collapse`,
+		];
+		for (const row of win.visibleRows) lines.push(`  ${row.text}`);
+		return lines;
+	}
+
+	#pollVisibleTails(): void {
+		if (this.#disposed) return;
+		// Determine which monitors are currently visible by building the window.
+		const budget = this.#expandedHeightBudget();
+		const win = buildExpandedWindow(this.#snapshot, this.#now(), this.#scrollOffset, budget, this.#tailRecord());
+		this.#visibleMonitorIds = win.visibleMonitorTailIds;
+		const live = new Set(this.#visibleMonitorIds);
+		// Drop caches for monitors no longer in the window.
+		for (const id of [...this.#tailLines.keys()]) {
+			if (!live.has(id)) this.#tailLines.delete(id);
+		}
+		for (const id of this.#visibleMonitorIds) {
+			const slice = this.#controller.getMonitorOutputTail(id, {
+				maxBytes: TAIL_MAX_BYTES,
+				maxLines: TAIL_MAX_LINES_PER_MONITOR,
+			});
+			const text = slice?.text ?? "";
+			const lines = text.length === 0 ? [] : text.replace(/\n$/, "").split("\n").slice(-TAIL_MAX_LINES_PER_MONITOR);
+			this.#tailLines.set(id, lines);
+		}
+	}
+
+	#syncTimers(): void {
+		const visible = this.isVisible();
+		// Minute-boundary label refresh while the panel is shown.
+		if (visible && !this.#labelTimer) this.#scheduleLabelRefresh();
+		if (!visible && this.#labelTimer) {
+			clearTimeout(this.#labelTimer);
+			this.#labelTimer = undefined;
+		}
+		// Live-tail poll only while expanded with at least one visible monitor row.
+		const wantTail = visible && this.#expanded;
+		if (wantTail && !this.#tailTimer) {
+			this.#tailTimer = setInterval(() => {
+				if (this.#disposed) return;
+				this.#pollVisibleTails();
+				this.#requestRender();
+			}, TAIL_POLL_MS);
+			this.#tailTimer.unref?.();
+		}
+		if (!wantTail && this.#tailTimer) {
+			clearInterval(this.#tailTimer);
+			this.#tailTimer = undefined;
+		}
+	}
+
+	#scheduleLabelRefresh(): void {
+		const delay = MS_PER_MINUTE - (this.#now() % MS_PER_MINUTE);
+		this.#labelTimer = setTimeout(() => {
+			this.#labelTimer = undefined;
+			if (this.#disposed || !this.isVisible()) return;
+			this.#requestRender();
+			this.#scheduleLabelRefresh();
+		}, delay);
+		this.#labelTimer.unref?.();
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+		if (this.#labelTimer) clearTimeout(this.#labelTimer);
+		if (this.#tailTimer) clearInterval(this.#tailTimer);
+		this.#labelTimer = undefined;
+		this.#tailTimer = undefined;
+		this.#tailLines.clear();
+	}
+}

--- a/packages/coding-agent/src/modes/components/active-jobs-panel.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel.ts
@@ -175,7 +175,10 @@ export class ActiveJobsPanelComponent extends Container {
 		const lines: string[] = [
 			`Active jobs — expanded (${shownStart}-${shownEnd} of ${win.totalRows}) ${indicators} ctrl+↓ collapse`,
 		];
-		for (const row of win.visibleRows) lines.push(`  ${row.text}`);
+		for (const row of win.visibleRows) {
+			// Nest live-tail rows under their monitor with a deeper indent + marker.
+			lines.push(row.kind === "monitor-tail" ? `    ↳ ${row.text}` : `  ${row.text}`);
+		}
 		return lines;
 	}
 

--- a/packages/coding-agent/src/modes/components/active-jobs-panel.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel.ts
@@ -245,9 +245,12 @@ export class ActiveJobsPanelComponent extends Container {
 		const delay = this.#nextRefreshDelay(this.#now());
 		this.#labelTimer = setTimeout(() => {
 			this.#labelTimer = undefined;
-			if (this.#disposed || !this.isVisible()) return;
+			if (this.#disposed) return;
+			// Always redraw at the boundary: if this deadline expired the last
+			// visible job, the render clears the panel. Only keep the timer
+			// running while something remains visible.
 			this.#requestRender();
-			this.#scheduleLabelRefresh();
+			if (this.isVisible()) this.#scheduleLabelRefresh();
 		}, delay);
 		this.#labelTimer.unref?.();
 	}

--- a/packages/coding-agent/src/modes/components/active-jobs-panel.ts
+++ b/packages/coding-agent/src/modes/components/active-jobs-panel.ts
@@ -16,7 +16,11 @@ import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../jobs-observer";
 import {
 	buildCollapsedRows,
 	buildExpandedWindow,
+	COLLAPSED_JOB_ROW_CAP,
+	COMPLETED_MONITOR_VISIBLE_MS,
 	clampScrollOffset,
+	FAILED_MONITOR_VISIBLE_MS,
+	filterVisibleJobs,
 	hasVisibleJobs,
 	TAIL_MAX_BYTES,
 	TAIL_MAX_LINES_PER_MONITOR,
@@ -104,13 +108,16 @@ export class ActiveJobsPanelComponent extends Container {
 		this.#requestRender();
 	}
 
-	/** ctrl+down: scroll down while expanded; collapse when already at the top. */
+	/** ctrl+down: scroll the expanded list down; collapse only once at the bottom. */
 	onCollapseDown(): void {
 		if (this.#disposed || !this.isVisible() || !this.#expanded) return;
-		if (this.#scrollOffset <= 0) {
-			this.#expanded = false;
-		} else {
+		const budget = this.#expandedHeightBudget();
+		const win = buildExpandedWindow(this.#snapshot, this.#now(), this.#scrollOffset, budget, this.#tailRecord());
+		this.#scrollOffset = win.scrollOffset;
+		if (win.canScrollDown) {
 			this.#scrollBy(1);
+		} else {
+			this.#expanded = false;
 		}
 		this.#syncTimers();
 		this.#requestRender();
@@ -138,10 +145,21 @@ export class ActiveJobsPanelComponent extends Container {
 	}
 
 	#renderCollapsed(width: number, now: number): string[] {
-		const view = buildCollapsedRows(this.#snapshot, now, { width });
-		const lines: string[] = [`Active jobs (${view.totalVisible}) — ctrl+↑ expand`];
-		for (const row of view.rows) lines.push(`  ${row.text}`);
-		if (view.overflow > 0) lines.push(`  +${view.overflow} more`);
+		const maxRows = Math.max(1, this.#maxRows);
+		const full = buildCollapsedRows(this.#snapshot, now, { cap: COLLAPSED_JOB_ROW_CAP, width });
+		const header = `Active jobs (${full.totalVisible}) — ctrl+↑ expand`;
+		// On a tiny budget the header alone is the one-line summary.
+		if (maxRows <= 1) return [header];
+		// Reserve the header row; reserve one more for "+N more" only when needed.
+		const rowBudget = maxRows - 1;
+		let shown = full.rows.slice(0, rowBudget);
+		let overflow = full.totalVisible - shown.length;
+		if (overflow > 0 && shown.length === rowBudget) {
+			shown = full.rows.slice(0, Math.max(0, rowBudget - 1));
+			overflow = full.totalVisible - shown.length;
+		}
+		const lines: string[] = [header, ...shown.map(row => `  ${row.text}`)];
+		if (overflow > 0) lines.push(`  +${overflow} more`);
 		return lines;
 	}
 
@@ -149,6 +167,8 @@ export class ActiveJobsPanelComponent extends Container {
 		const budget = this.#expandedHeightBudget();
 		const win = buildExpandedWindow(this.#snapshot, now, this.#scrollOffset, budget, this.#tailRecord(), width);
 		this.#visibleMonitorIds = win.visibleMonitorTailIds;
+		// Keep internal scroll state aligned with the clamped window after job/tail churn.
+		this.#scrollOffset = win.scrollOffset;
 		const shownStart = win.totalRows === 0 ? 0 : win.scrollOffset + 1;
 		const shownEnd = win.scrollOffset + win.visibleRows.length;
 		const indicators = `${win.canScrollUp ? "↑" : " "}${win.canScrollDown ? "↓" : " "}`;
@@ -205,8 +225,24 @@ export class ActiveJobsPanelComponent extends Container {
 		}
 	}
 
+	/**
+	 * Next refresh delay: the earlier of the next minute label boundary and the
+	 * nearest visible terminal-monitor TTL deadline, so completed/failed rows drop
+	 * on time even without an upstream observer event.
+	 */
+	#nextRefreshDelay(now: number): number {
+		let delay = MS_PER_MINUTE - (now % MS_PER_MINUTE);
+		for (const monitor of filterVisibleJobs(this.#snapshot, now).monitors) {
+			if (monitor.status === "running" || monitor.status === "paused" || monitor.endTime === undefined) continue;
+			const ttl = monitor.status === "failed" ? FAILED_MONITOR_VISIBLE_MS : COMPLETED_MONITOR_VISIBLE_MS;
+			const remaining = monitor.endTime + ttl - now;
+			if (remaining > 0 && remaining < delay) delay = remaining;
+		}
+		return Math.max(1, delay);
+	}
+
 	#scheduleLabelRefresh(): void {
-		const delay = MS_PER_MINUTE - (this.#now() % MS_PER_MINUTE);
+		const delay = this.#nextRefreshDelay(this.#now());
 		this.#labelTimer = setTimeout(() => {
 			this.#labelTimer = undefined;
 			if (this.#disposed || !this.isVisible()) return;

--- a/packages/coding-agent/src/modes/components/jobs-format.ts
+++ b/packages/coding-agent/src/modes/components/jobs-format.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared, pure formatting/ordering helpers for the background-jobs surfaces
+ * (the alt+j manage overlay and the passive ActiveJobsPanel).
+ *
+ * Kept free of UI/Component and store dependencies so both surfaces share one
+ * source of truth for job references, text previews, relative/runtime time, and
+ * newest-first ordering — preventing label/format drift between the two views.
+ */
+import type { CronJobView, MonitorJobView } from "../jobs-observer";
+
+export type JobRefKind = "monitor" | "cron";
+
+export interface JobRef {
+	kind: JobRefKind;
+	id: string;
+}
+
+/** Default max visible columns for a one-line prompt/label preview. */
+export const PROMPT_PREVIEW_MAX = 60;
+
+/**
+ * Collapse whitespace and clip to `max` visible columns, appending an ellipsis
+ * when clipped. Pure and width-bounded so callers can pre-truncate untrusted
+ * text before building wrapping Text nodes.
+ */
+export function previewText(text: string, max = PROMPT_PREVIEW_MAX): string {
+	const oneLine = text.replace(/\s+/g, " ").trim();
+	if (max <= 0) return "";
+	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+/** Compact relative time, e.g. "in 5m", "2m ago", "now", "—" when unknown. */
+export function formatRelative(targetMs: number | undefined, nowMs = Date.now()): string {
+	if (targetMs === undefined) return "—";
+	const deltaMs = targetMs - nowMs;
+	const abs = Math.abs(deltaMs);
+	const mins = Math.round(abs / 60_000);
+	if (mins < 1) return "now";
+	const unit = mins >= 60 ? `${Math.round(mins / 60)}h` : `${mins}m`;
+	return deltaMs >= 0 ? `in ${unit}` : `${unit} ago`;
+}
+
+/**
+ * Compact elapsed runtime for a job, frozen once it stops running. While the job
+ * is active (`endTime` undefined) this counts against `nowMs`; after it stops it
+ * returns the fixed `endTime - startTime` span. Mirrors `jobElapsedMs` so a
+ * terminal job's runtime label does not keep growing.
+ */
+export function formatRuntime(startTime: number, endTime?: number, nowMs = Date.now()): string {
+	const elapsedMs = Math.max(0, (endTime ?? nowMs) - startTime);
+	const secs = Math.floor(elapsedMs / 1000);
+	if (secs < 60) return `${secs}s`;
+	const mins = Math.floor(secs / 60);
+	if (mins < 60) return `${mins}m`;
+	const hours = Math.floor(mins / 60);
+	const remMins = mins % 60;
+	return remMins > 0 ? `${hours}h${remMins}m` : `${hours}h`;
+}
+
+/** Parse a `${kind}:${id}` list item value back into a job reference. */
+export function parseJobRef(value: string): JobRef | null {
+	const sep = value.indexOf(":");
+	if (sep === -1) return null;
+	const kind = value.slice(0, sep);
+	const id = value.slice(sep + 1);
+	if ((kind === "monitor" || kind === "cron") && id.length > 0) {
+		return { kind, id };
+	}
+	return null;
+}
+
+/** Stable serialization of a job reference (inverse of `parseJobRef`). */
+export function formatJobRef(ref: JobRef): string {
+	return `${ref.kind}:${ref.id}`;
+}
+
+/** Comparator: monitors newest-first by descending `startTime`. */
+export function compareMonitorsNewestFirst(a: MonitorJobView, b: MonitorJobView): number {
+	return b.startTime - a.startTime;
+}
+
+/** Comparator: crons newest-first by descending `createdAt`. */
+export function compareCronsNewestFirst(a: CronJobView, b: CronJobView): number {
+	return b.createdAt - a.createdAt;
+}

--- a/packages/coding-agent/src/modes/components/jobs-overlay-model.ts
+++ b/packages/coding-agent/src/modes/components/jobs-overlay-model.ts
@@ -4,46 +4,25 @@
  * Kept free of UI/Component dependencies so the grouping/ordering and
  * detail-formatting logic is unit-testable. The selector controller wires these
  * SelectItem lists into nested SelectLists (list -> detail -> confirm).
+ *
+ * Shared job reference / preview / relative-time helpers live in `jobs-format`
+ * so the passive ActiveJobsPanel and this overlay cannot drift apart; they are
+ * re-exported here for backward compatibility with existing imports.
  */
 import type { SelectItem } from "@gajae-code/tui";
 import type { JobsSnapshot } from "../jobs-observer";
+import {
+	formatRelative,
+	type JobRef,
+	type JobRefKind,
+	PROMPT_PREVIEW_MAX,
+	parseJobRef,
+	previewText,
+} from "./jobs-format";
 
-export type JobRefKind = "monitor" | "cron";
+export { formatRelative, type JobRef, type JobRefKind, parseJobRef };
 
-export interface JobRef {
-	kind: JobRefKind;
-	id: string;
-}
-
-const PROMPT_PREVIEW_MAX = 60;
-
-function preview(text: string, max = PROMPT_PREVIEW_MAX): string {
-	const oneLine = text.replace(/\s+/g, " ").trim();
-	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
-}
-
-/** Compact relative time, e.g. "in 5m", "2m ago", "now". */
-export function formatRelative(targetMs: number | undefined, nowMs = Date.now()): string {
-	if (targetMs === undefined) return "—";
-	const deltaMs = targetMs - nowMs;
-	const abs = Math.abs(deltaMs);
-	const mins = Math.round(abs / 60_000);
-	if (mins < 1) return "now";
-	const unit = mins >= 60 ? `${Math.round(mins / 60)}h` : `${mins}m`;
-	return deltaMs >= 0 ? `in ${unit}` : `${unit} ago`;
-}
-
-/** Parse a list item value back into a job reference. */
-export function parseJobRef(value: string): JobRef | null {
-	const sep = value.indexOf(":");
-	if (sep === -1) return null;
-	const kind = value.slice(0, sep);
-	const id = value.slice(sep + 1);
-	if ((kind === "monitor" || kind === "cron") && id.length > 0) {
-		return { kind, id };
-	}
-	return null;
-}
+const preview = previewText;
 
 /**
  * Build the grouped jobs list: monitors first (newest-first), then crons
@@ -107,3 +86,5 @@ export function buildConfirmItems(actionLabel: string): SelectItem[] {
 		{ value: "yes", label: `Yes, ${actionLabel}` },
 	];
 }
+
+export { PROMPT_PREVIEW_MAX };

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -218,6 +218,20 @@ export class InputController {
 		for (const key of this.ctx.keybindings.getKeys("app.jobs.open")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showJobsOverlay());
 		}
+		for (const key of this.ctx.keybindings.getKeys("app.jobs.expand")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				const panel = this.ctx.activeJobsPanel;
+				if (!panel?.isVisible() || this.ctx.editor.isAutocompleteOpen()) return;
+				panel.onExpandUp();
+			});
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.jobs.collapse")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				const panel = this.ctx.activeJobsPanel;
+				if (!panel?.isVisible() || this.ctx.editor.isAutocompleteOpen()) return;
+				panel.onCollapseDown();
+			});
+		}
 
 		this.ctx.editor.onChange = (text: string) => {
 			const wasBashMode = this.ctx.isBashMode;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -75,6 +75,7 @@ import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
+import { ActiveJobsPanelComponent } from "./components/active-jobs-panel";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import { CustomEditor } from "./components/custom-editor";
@@ -249,6 +250,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	editorContainer: Container;
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
+	/** Owned slot for the passive monitor/cron panel, between the editor and below-hook widgets. */
+	activeJobsPanelContainer: Container;
+	/** Passive monitor/cron visualization panel (undefined when background jobs are unavailable). */
+	activeJobsPanel?: ActiveJobsPanelComponent;
 	statusLine: StatusLineComponent;
 
 	isInitialized = false;
@@ -402,6 +407,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.hookWidgetContainerAbove = new Container();
 		this.hookWidgetContainerAbove.addChild(new Spacer(1));
 		this.hookWidgetContainerBelow = new Container();
+		this.activeJobsPanelContainer = new Container();
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor);
 		this.statusLine = new StatusLineComponent(session);
@@ -517,6 +523,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer chrome is rendered by the editor.
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
+		this.ui.addChild(this.activeJobsPanelContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);
 		this.ui.setFocus(this.editor);
 
@@ -540,8 +547,18 @@ export class InteractiveMode implements InteractiveModeContext {
 			const jobsObserver = new JobsObserver(jobManager, this.session.getAgentId());
 			this.#jobsObserver = jobsObserver;
 			this.statusLine.setJobs(jobsObserver.getSnapshot());
+			const activeJobsPanel = new ActiveJobsPanelComponent(jobsObserver, {
+				requestRender: () => this.ui.requestRender(),
+			});
+			activeJobsPanel.setMaxRows(this.#computePanelMaxRows());
+			activeJobsPanel.setSnapshot(jobsObserver.getSnapshot());
+			this.activeJobsPanel = activeJobsPanel;
+			this.activeJobsPanelContainer.addChild(activeJobsPanel);
 			jobsObserver.onChange(() => {
-				this.statusLine.setJobs(jobsObserver.getSnapshot());
+				const snapshot = jobsObserver.getSnapshot();
+				this.statusLine.setJobs(snapshot);
+				activeJobsPanel.setMaxRows(this.#computePanelMaxRows());
+				activeJobsPanel.setSnapshot(snapshot);
 				this.ui.requestRender();
 			});
 		}
@@ -867,8 +884,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		return Math.max(EDITOR_MAX_HEIGHT_MIN, Math.min(EDITOR_MAX_HEIGHT_MAX, maxHeight));
 	}
 
+	/**
+	 * Max rows the passive jobs panel may occupy. Bounded by the space left below
+	 * the editor (terminal rows minus the editor's reserved budget and a small
+	 * chrome margin) and hard-capped, so the panel degrades before it can crowd
+	 * the input.
+	 */
+	#computePanelMaxRows(): number {
+		const rows = this.ui.terminal.rows;
+		const terminalRows = Number.isFinite(rows) && rows > 0 ? rows : EDITOR_FALLBACK_ROWS;
+		const available = terminalRows - EDITOR_RESERVED_ROWS - 2;
+		return Math.max(1, Math.min(10, available));
+	}
+
 	#syncEditorMaxHeight(): void {
 		this.editor.setMaxHeight(this.#computeEditorMaxHeight());
+		this.activeJobsPanel?.setMaxRows(this.#computePanelMaxRows());
 	}
 
 	updateEditorChrome(): void {
@@ -1896,6 +1927,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry.dispose();
 		this.#eventController.dispose();
 		this.statusLine.dispose();
+		this.activeJobsPanel?.dispose();
 		this.#jobsObserver?.dispose();
 		this.editor.dispose();
 		if (this.#resizeHandler) {

--- a/packages/coding-agent/src/modes/jobs-observer.ts
+++ b/packages/coding-agent/src/modes/jobs-observer.ts
@@ -12,7 +12,7 @@
  * until `acknowledgeFailures()` is called (when the overlay opens), so a failed
  * job that evicts before the user looks is not silently lost.
  */
-import type { AsyncJob, AsyncJobManager } from "../async";
+import type { AsyncJob, AsyncJobManager, AsyncJobOutputSlice, AsyncJobOutputTailOptions } from "../async";
 import { deleteCronJobById, listCronSnapshots, onCronChange } from "../tools/cron";
 
 export type JobsWorstState = "none" | "running" | "failed";
@@ -22,6 +22,14 @@ export interface MonitorJobView {
 	label: string;
 	status: AsyncJob["status"];
 	startTime: number;
+	/**
+	 * Wall-clock ms when the monitor left the running state (from
+	 * `AsyncJob.endTime`), or undefined while running. The passive panel uses
+	 * this for deterministic terminal TTL filtering instead of component-local
+	 * observation time, so a job that finished before the panel mounted expires
+	 * on schedule.
+	 */
+	endTime?: number;
 }
 
 export interface CronJobView {
@@ -129,7 +137,13 @@ export class JobsObserver {
 		const activeMonitors = monitorJobs.filter(job => job.status === "running");
 		const cronSnapshots = listCronSnapshots(this.#ownerId);
 		const monitors: MonitorJobView[] = monitorJobs
-			.map(job => ({ id: job.id, label: job.label, status: job.status, startTime: job.startTime }))
+			.map(job => ({
+				id: job.id,
+				label: job.label,
+				status: job.status,
+				startTime: job.startTime,
+				endTime: job.endTime,
+			}))
 			.sort((a, b) => b.startTime - a.startTime);
 		const crons: CronJobView[] = cronSnapshots
 			.map(snapshot => ({
@@ -187,6 +201,16 @@ export class JobsObserver {
 	getMonitorOutput(id: string): string {
 		const slice = this.#manager.readOutputSince(id, 0, this.#ownerId ? { ownerId: this.#ownerId } : undefined);
 		return slice?.text ?? "";
+	}
+
+	/**
+	 * Bounded/incremental tail of a monitor job's output for the passive panel's
+	 * expanded live view. Delegates to the manager's bounded `readOutputTail`
+	 * (owner-scoped) so the panel never assembles the whole retained buffer per
+	 * poll. Returns undefined when the job is absent or owned by another agent.
+	 */
+	getMonitorOutputTail(id: string, options: AsyncJobOutputTailOptions): AsyncJobOutputSlice | undefined {
+		return this.#manager.readOutputTail(id, options, this.#ownerId ? { ownerId: this.#ownerId } : undefined);
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -18,6 +18,7 @@ import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import type { HistoryStorage } from "../session/history-storage";
 import type { SessionContext, SessionManager } from "../session/session-manager";
 import type { LspStartupServerInfo } from "../tools";
+import type { ActiveJobsPanelComponent } from "./components/active-jobs-panel";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import type { CustomEditor } from "./components/custom-editor";
@@ -70,6 +71,8 @@ export interface InteractiveModeContext {
 	editorContainer: Container;
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
+	/** Passive monitor/cron visualization panel rendered below the editor. */
+	activeJobsPanel?: ActiveJobsPanelComponent;
 	statusLine: StatusLineComponent;
 
 	// Session access

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -71,6 +71,8 @@ export interface InteractiveModeContext {
 	editorContainer: Container;
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
+	/** Owned slot for the passive monitor/cron panel (sibling of the hook containers). */
+	activeJobsPanelContainer: Container;
 	/** Passive monitor/cron visualization panel rendered below the editor. */
 	activeJobsPanel?: ActiveJobsPanelComponent;
 	statusLine: StatusLineComponent;

--- a/packages/coding-agent/test/active-jobs-panel-model.test.ts
+++ b/packages/coding-agent/test/active-jobs-panel-model.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildCollapsedRows,
+	buildExpandedWindow,
+	COMPLETED_MONITOR_VISIBLE_MS,
+	clampScrollOffset,
+	FAILED_MONITOR_VISIBLE_MS,
+	filterVisibleJobs,
+	hasVisibleJobs,
+	isMonitorVisible,
+	resolveCollapsedCap,
+} from "../src/modes/components/active-jobs-panel-model";
+import type { CronJobView, JobsSnapshot, MonitorJobView } from "../src/modes/jobs-observer";
+
+const NOW = 10_000_000;
+
+function mon(over: Partial<MonitorJobView> = {}): MonitorJobView {
+	return { id: "m", label: "tail server.log", status: "running", startTime: NOW - 5_000, ...over };
+}
+
+function cron(over: Partial<CronJobView> = {}): CronJobView {
+	return {
+		id: "c",
+		humanSchedule: "every 5m",
+		cronExpression: "*/5 * * * *",
+		prompt: "review the deploy queue",
+		recurring: true,
+		nextFireAt: NOW + 120_000,
+		createdAt: NOW - 1_000,
+		...over,
+	};
+}
+
+function snap(over: Partial<JobsSnapshot> = {}): JobsSnapshot {
+	return {
+		monitors: [],
+		crons: [],
+		activeMonitorCount: 0,
+		activeCronCount: 0,
+		worstState: "none",
+		failedUnacknowledged: false,
+		...over,
+	};
+}
+
+describe("active-jobs-panel-model: TTL", () => {
+	test("running and paused monitors are always visible", () => {
+		expect(isMonitorVisible(mon({ status: "running" }), NOW)).toBe(true);
+		expect(isMonitorVisible(mon({ status: "paused" }), NOW)).toBe(true);
+	});
+
+	test("completed monitor visible just under TTL, gone at TTL", () => {
+		const justUnder = mon({ status: "completed", endTime: NOW - (COMPLETED_MONITOR_VISIBLE_MS - 1) });
+		const atTtl = mon({ status: "completed", endTime: NOW - COMPLETED_MONITOR_VISIBLE_MS });
+		expect(isMonitorVisible(justUnder, NOW)).toBe(true);
+		expect(isMonitorVisible(atTtl, NOW)).toBe(false);
+	});
+
+	test("failed monitor lingers longer than completed", () => {
+		const failedJustUnder = mon({ status: "failed", endTime: NOW - (FAILED_MONITOR_VISIBLE_MS - 1) });
+		const failedAtTtl = mon({ status: "failed", endTime: NOW - FAILED_MONITOR_VISIBLE_MS });
+		expect(isMonitorVisible(failedJustUnder, NOW)).toBe(true);
+		expect(isMonitorVisible(failedAtTtl, NOW)).toBe(false);
+		// at the completed TTL a failed monitor is still visible (longer window)
+		expect(isMonitorVisible(mon({ status: "failed", endTime: NOW - COMPLETED_MONITOR_VISIBLE_MS }), NOW)).toBe(true);
+	});
+
+	test("terminal monitor without endTime is kept visible", () => {
+		expect(isMonitorVisible(mon({ status: "completed", endTime: undefined }), NOW)).toBe(true);
+	});
+
+	test("crons are always included; hasVisibleJobs reflects filtered set", () => {
+		const expired = mon({ id: "old", status: "completed", endTime: NOW - 10 * 60_000 });
+		expect(hasVisibleJobs(snap({ monitors: [expired] }), NOW)).toBe(false);
+		expect(hasVisibleJobs(snap({ monitors: [expired], crons: [cron()] }), NOW)).toBe(true);
+		const filtered = filterVisibleJobs(snap({ monitors: [expired], crons: [cron()] }), NOW);
+		expect(filtered.monitors).toHaveLength(0);
+		expect(filtered.crons).toHaveLength(1);
+	});
+});
+
+describe("active-jobs-panel-model: collapsed", () => {
+	test("caps rows at 4 and reports overflow, monitors before crons", () => {
+		const monitors = [0, 1, 2].map(i => mon({ id: `m${i}`, startTime: NOW - i }));
+		const crons = [0, 1, 2].map(i => cron({ id: `c${i}`, createdAt: NOW - i }));
+		const view = buildCollapsedRows(snap({ monitors, crons }), NOW);
+		expect(view.totalVisible).toBe(6);
+		expect(view.rows).toHaveLength(4);
+		expect(view.overflow).toBe(2);
+		expect(view.rows.slice(0, 3).every(r => r.kind === "monitor")).toBe(true);
+		expect(view.rows[3]?.kind).toBe("cron");
+	});
+
+	test("monitor/cron row text carries the expected fields", () => {
+		const view = buildCollapsedRows(
+			snap({
+				monitors: [mon({ id: "m", label: "tail app.log", status: "running", startTime: NOW - 65_000 })],
+				crons: [cron({ id: "c", humanSchedule: "every 5m", nextFireAt: NOW + 120_000, prompt: "poll deploys" })],
+			}),
+			NOW,
+		);
+		const monitorRow = view.rows.find(r => r.kind === "monitor");
+		expect(monitorRow?.text).toContain("tail app.log");
+		expect(monitorRow?.text).toContain("running");
+		expect(monitorRow?.text).toContain("1m"); // 65s runtime
+		const cronRow = view.rows.find(r => r.kind === "cron");
+		expect(cronRow?.text).toContain("every 5m");
+		expect(cronRow?.text).toContain("in 2m");
+		expect(cronRow?.text).toContain("poll deploys");
+	});
+
+	test("width budget truncates long rows", () => {
+		const view = buildCollapsedRows(snap({ monitors: [mon({ id: "m", label: "x".repeat(200) })] }), NOW, {
+			width: 30,
+		});
+		expect(view.rows[0]?.text.length).toBeLessThanOrEqual(30);
+		expect(view.rows[0]?.text.endsWith("…")).toBe(true);
+	});
+
+	test("resolveCollapsedCap degrades with available rows", () => {
+		expect(resolveCollapsedCap(10)).toBe(4);
+		expect(resolveCollapsedCap(2)).toBe(2);
+		expect(resolveCollapsedCap(0)).toBe(0);
+	});
+});
+
+describe("active-jobs-panel-model: expanded window", () => {
+	test("clampScrollOffset stays within range", () => {
+		expect(clampScrollOffset(-5, 20, 10)).toBe(0);
+		expect(clampScrollOffset(100, 20, 10)).toBe(10);
+		expect(clampScrollOffset(3, 20, 10)).toBe(3);
+	});
+
+	test("interleaves tail rows and reports visible monitor ids", () => {
+		const monitors = [mon({ id: "m0", startTime: NOW })];
+		const win = buildExpandedWindow(snap({ monitors }), NOW, 0, 10, { m0: ["out line a", "out line b"] });
+		expect(win.totalRows).toBe(3); // header + 2 tail lines
+		expect(win.visibleRows[0]?.kind).toBe("monitor");
+		expect(win.visibleRows[1]?.kind).toBe("monitor-tail");
+		expect(win.visibleRows[1]?.text).toContain("out line a");
+		expect(win.visibleMonitorTailIds).toEqual(["m0"]);
+	});
+
+	test("65 jobs are all reachable by scrolling", () => {
+		const monitors = Array.from({ length: 15 }, (_, i) =>
+			mon({ id: `m${i}`, status: "running", startTime: NOW - i }),
+		);
+		const crons = Array.from({ length: 50 }, (_, i) => cron({ id: `c${i}`, createdAt: NOW - i }));
+		const snapshot = snap({ monitors, crons });
+		const height = 10;
+		const first = buildExpandedWindow(snapshot, NOW, 0, height);
+		expect(first.totalRows).toBe(65);
+
+		const seen = new Set<string>();
+		for (let offset = 0; offset <= first.totalRows; offset += height) {
+			const win = buildExpandedWindow(snapshot, NOW, offset, height);
+			for (const row of win.visibleRows) seen.add(`${row.kind}:${row.id}`);
+		}
+		// newest monitor (m0) and oldest cron (c49) both reachable; all 65 ids seen
+		expect(seen.has("monitor:m0")).toBe(true);
+		expect(seen.has("cron:c49")).toBe(true);
+		expect(seen.size).toBe(65);
+
+		const top = buildExpandedWindow(snapshot, NOW, 0, height);
+		expect(top.canScrollUp).toBe(false);
+		expect(top.canScrollDown).toBe(true);
+		const bottom = buildExpandedWindow(snapshot, NOW, 999, height);
+		expect(bottom.canScrollDown).toBe(false);
+		expect(bottom.canScrollUp).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/active-jobs-panel.test.ts
+++ b/packages/coding-agent/test/active-jobs-panel.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import type { AsyncJobOutputSlice, AsyncJobOutputTailOptions } from "../src/async";
+import { ActiveJobsPanelComponent, type ActiveJobsPanelController } from "../src/modes/components/active-jobs-panel";
+import { COMPLETED_MONITOR_VISIBLE_MS } from "../src/modes/components/active-jobs-panel-model";
+import type { CronJobView, JobsSnapshot, MonitorJobView } from "../src/modes/jobs-observer";
+
+const NOW = 5_000_000;
+
+function mon(over: Partial<MonitorJobView> = {}): MonitorJobView {
+	return { id: "m", label: "tail server.log", status: "running", startTime: NOW - 4_000, ...over };
+}
+
+function cron(over: Partial<CronJobView> = {}): CronJobView {
+	return {
+		id: "c",
+		humanSchedule: "every 5m",
+		cronExpression: "*/5 * * * *",
+		prompt: "review deploy queue",
+		recurring: true,
+		nextFireAt: NOW + 120_000,
+		createdAt: NOW - 1_000,
+		...over,
+	};
+}
+
+function snap(over: Partial<JobsSnapshot> = {}): JobsSnapshot {
+	return {
+		monitors: [],
+		crons: [],
+		activeMonitorCount: 0,
+		activeCronCount: 0,
+		worstState: "none",
+		failedUnacknowledged: false,
+		...over,
+	};
+}
+
+function makeController(snapshot: JobsSnapshot, tail = "tail line one\ntail line two\n"): ActiveJobsPanelController {
+	return {
+		getSnapshot: () => snapshot,
+		getMonitorOutputTail: (id: string, _options: AsyncJobOutputTailOptions): AsyncJobOutputSlice | undefined => ({
+			jobId: id,
+			status: "running",
+			text: tail,
+			startOffset: 0,
+			nextOffset: tail.length,
+			truncated: false,
+		}),
+	};
+}
+
+function makePanel(snapshot: JobsSnapshot, tail?: string) {
+	const controller = makeController(snapshot, tail);
+	let renders = 0;
+	const panel = new ActiveJobsPanelComponent(controller, { requestRender: () => renders++, now: () => NOW });
+	panel.setSnapshot(snapshot);
+	return {
+		panel,
+		get renders() {
+			return renders;
+		},
+	};
+}
+
+describe("ActiveJobsPanelComponent", () => {
+	test("renders nothing when no jobs are visible", () => {
+		const { panel } = makePanel(snap());
+		expect(panel.isVisible()).toBe(false);
+		expect(panel.render(80)).toEqual([]);
+		panel.dispose();
+	});
+
+	test("auto-shows a collapsed panel when a monitor or cron exists", () => {
+		const { panel } = makePanel(snap({ monitors: [mon({ id: "m", label: "tail app.log" })] }));
+		expect(panel.isVisible()).toBe(true);
+		const lines = panel.render(80);
+		expect(lines[0]).toContain("Active jobs (1)");
+		expect(lines.join("\n")).toContain("tail app.log");
+		expect(lines.join("\n")).toContain("running");
+		panel.dispose();
+	});
+
+	test("collapsed panel caps at 4 rows and shows +N more", () => {
+		const monitors = Array.from({ length: 6 }, (_, i) => mon({ id: `m${i}`, startTime: NOW - i }));
+		const { panel } = makePanel(snap({ monitors }));
+		const lines = panel.render(120);
+		const jobRows = lines.filter(l => l.includes("monitor ·"));
+		expect(jobRows).toHaveLength(4);
+		expect(lines.join("\n")).toContain("+2 more");
+		panel.dispose();
+	});
+
+	test("expands to show live monitor tail, collapses from the top", () => {
+		const { panel } = makePanel(snap({ monitors: [mon({ id: "m", label: "tail x" })] }));
+		expect(panel.isExpanded()).toBe(false);
+		panel.onExpandUp();
+		expect(panel.isExpanded()).toBe(true);
+		const expanded = panel.render(80).join("\n");
+		expect(expanded).toContain("expanded");
+		expect(expanded).toContain("tail line two");
+		// from the top, ctrl+down collapses
+		panel.onCollapseDown();
+		expect(panel.isExpanded()).toBe(false);
+		panel.dispose();
+	});
+
+	test("expand is a no-op when nothing is visible", () => {
+		const { panel } = makePanel(snap());
+		panel.onExpandUp();
+		expect(panel.isExpanded()).toBe(false);
+		expect(panel.render(80)).toEqual([]);
+		panel.dispose();
+	});
+
+	test("a completed monitor past its TTL is filtered out", () => {
+		const expired = mon({ id: "done", status: "completed", endTime: NOW - COMPLETED_MONITOR_VISIBLE_MS });
+		const { panel } = makePanel(snap({ monitors: [expired] }));
+		expect(panel.isVisible()).toBe(false);
+		expect(panel.render(80)).toEqual([]);
+		panel.dispose();
+	});
+
+	test("setSnapshot to empty hides and resets expansion", () => {
+		const { panel } = makePanel(snap({ crons: [cron()] }));
+		panel.onExpandUp();
+		expect(panel.isExpanded()).toBe(true);
+		panel.setSnapshot(snap());
+		expect(panel.isVisible()).toBe(false);
+		expect(panel.isExpanded()).toBe(false);
+		panel.dispose();
+	});
+});

--- a/packages/coding-agent/test/active-jobs-panel.test.ts
+++ b/packages/coding-agent/test/active-jobs-panel.test.ts
@@ -129,4 +129,40 @@ describe("ActiveJobsPanelComponent", () => {
 		expect(panel.isExpanded()).toBe(false);
 		panel.dispose();
 	});
+	test("ctrl+down scrolls the expanded list to the last job, then collapses at the bottom", () => {
+		const monitors = Array.from({ length: 15 }, (_, i) =>
+			mon({ id: `m${i}`, label: `mon${i}`, status: "running", startTime: NOW - i }),
+		);
+		const crons = Array.from({ length: 50 }, (_, i) =>
+			cron({ id: `c${i}`, prompt: `promptnum${i}`, createdAt: NOW - i }),
+		);
+		const { panel } = makePanel(snap({ monitors, crons }));
+		panel.setMaxRows(8); // small window forces real scrolling
+		panel.onExpandUp();
+		expect(panel.isExpanded()).toBe(true);
+
+		const seen: string[] = [];
+		let guard = 0;
+		while (panel.isExpanded() && guard++ < 1000) {
+			seen.push(...panel.render(120));
+			panel.onCollapseDown();
+		}
+		// last cron (oldest createdAt -> c49) is reachable before the panel collapses
+		expect(seen.some(line => line.includes("promptnum49"))).toBe(true);
+		// and the panel does eventually collapse at the bottom
+		expect(panel.isExpanded()).toBe(false);
+		panel.dispose();
+	});
+
+	test("collapsed render never exceeds the max-row budget", () => {
+		const monitors = Array.from({ length: 6 }, (_, i) => mon({ id: `m${i}`, startTime: NOW - i }));
+		const { panel } = makePanel(snap({ monitors }));
+		for (const max of [1, 2, 3, 5, 10]) {
+			panel.setMaxRows(max);
+			const lines = panel.render(120);
+			expect(lines.length).toBeLessThanOrEqual(max);
+			expect(lines[0]).toContain("Active jobs");
+		}
+		panel.dispose();
+	});
 });

--- a/packages/coding-agent/test/active-jobs-panel.test.ts
+++ b/packages/coding-agent/test/active-jobs-panel.test.ts
@@ -165,4 +165,23 @@ describe("ActiveJobsPanelComponent", () => {
 		}
 		panel.dispose();
 	});
+	test("requests a render and clears itself when the last job expires at its TTL deadline", async () => {
+		let nowValue = NOW;
+		const expiringSoon = mon({ id: "done", status: "completed", endTime: NOW - (COMPLETED_MONITOR_VISIBLE_MS - 60) });
+		const snapshot = snap({ monitors: [expiringSoon] });
+		const controller = makeController(snapshot);
+		let renders = 0;
+		const panel = new ActiveJobsPanelComponent(controller, { requestRender: () => renders++, now: () => nowValue });
+		panel.setSnapshot(snapshot);
+		expect(panel.isVisible()).toBe(true);
+		const before = renders;
+		// Advance time past the completed TTL; the scheduled boundary timer must
+		// redraw (clearing the panel) even though no observer event fires.
+		nowValue = NOW + 200;
+		await new Promise(resolve => setTimeout(resolve, 160));
+		expect(renders).toBeGreaterThan(before);
+		expect(panel.isVisible()).toBe(false);
+		expect(panel.render(80)).toEqual([]);
+		panel.dispose();
+	});
 });

--- a/packages/coding-agent/test/async-job-output-tail.test.ts
+++ b/packages/coding-agent/test/async-job-output-tail.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AsyncJobManager } from "../src/async/job-manager";
+import { JobsObserver } from "../src/modes/jobs-observer";
+
+const OWNER = "0-Main";
+
+function makeManager(): AsyncJobManager {
+	return new AsyncJobManager({ onJobComplete: async () => {} });
+}
+
+function abortable(signal: AbortSignal): Promise<string> {
+	return new Promise<string>(resolve => {
+		if (signal.aborted) return resolve("aborted");
+		signal.addEventListener("abort", () => resolve("aborted"), { once: true });
+	});
+}
+
+function registerMonitor(manager: AsyncJobManager, label = "tail", ownerId = OWNER): string {
+	return manager.register("bash", label, async ({ signal }) => abortable(signal), {
+		ownerId,
+		metadata: { monitor: true },
+	});
+}
+
+afterEach(() => {
+	AsyncJobManager.setInstance(undefined);
+});
+
+describe("AsyncJobManager.readOutputTail", () => {
+	test("maxLines keeps only the final lines and flags truncation", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager);
+		for (const line of ["line1\n", "line2\n", "line3\n", "line4\n"]) manager.appendOutput(id, line);
+
+		const slice = manager.readOutputTail(id, { maxLines: 2 });
+		expect(slice?.text).toBe("line3\nline4");
+		expect(slice?.truncated).toBe(true);
+		expect(slice?.nextOffset).toBe(24);
+
+		const all = manager.readOutputTail(id, { maxLines: 10 });
+		expect(all?.text).toBe("line1\nline2\nline3\nline4\n");
+		expect(all?.truncated).toBe(false);
+		await manager.dispose();
+	});
+
+	test("maxBytes only visits the trailing chunks (bounded read)", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager);
+		for (const line of ["line1\n", "line2\n", "line3\n", "line4\n"]) manager.appendOutput(id, line);
+
+		// 24 bytes total; last 6 bytes is exactly the final "line4\n" chunk.
+		const slice = manager.readOutputTail(id, { maxBytes: 6 });
+		expect(slice?.text).toBe("line4\n");
+		expect(slice?.truncated).toBe(true);
+		expect(slice?.startOffset).toBe(18);
+		expect(slice?.nextOffset).toBe(24);
+		await manager.dispose();
+	});
+
+	test("sinceOffset cursor follow returns only fresh bytes", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager);
+		manager.appendOutput(id, "alpha\n");
+		const first = manager.readOutputTail(id, { maxBytes: 4096 });
+		expect(first?.text).toBe("alpha\n");
+		const cursor = first?.nextOffset ?? 0;
+
+		// caught up -> empty, not truncated
+		const caughtUp = manager.readOutputTail(id, { sinceOffset: cursor, maxBytes: 4096 });
+		expect(caughtUp?.text).toBe("");
+		expect(caughtUp?.truncated).toBe(false);
+
+		// new bytes after the cursor
+		manager.appendOutput(id, "beta\n");
+		const fresh = manager.readOutputTail(id, { sinceOffset: cursor, maxBytes: 4096 });
+		expect(fresh?.text).toBe("beta\n");
+		expect(fresh?.truncated).toBe(false);
+		await manager.dispose();
+	});
+
+	test("retention drop past sinceOffset returns a truncated bounded tail", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager);
+		// Exceed the 512 KiB retention so the oldest chunk is evicted (startOffset advances).
+		const big = "x".repeat(300 * 1024);
+		manager.appendOutput(id, big); // [0, 300K)
+		manager.appendOutput(id, "TAILMARK\n"); // pushes total > 512K, evicts first chunk
+		const slice = manager.readOutputTail(id, { sinceOffset: 0, maxBytes: 64 });
+		expect(slice?.truncated).toBe(true);
+		expect(slice?.text).toContain("TAILMARK");
+		expect(slice?.startOffset).toBeGreaterThan(0);
+		await manager.dispose();
+	});
+
+	test("never splits multibyte characters at the maxBytes boundary", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager);
+		// "é" is 2 UTF-8 bytes; craft output so a naive byte cut would split it.
+		manager.appendOutput(id, "é".repeat(10)); // 20 bytes
+		const slice = manager.readOutputTail(id, { maxBytes: 5 });
+		expect(slice?.text).not.toContain("\uFFFD");
+		// returned suffix is a clean run of é characters
+		expect(/^é*$/.test(slice?.text ?? "")).toBe(true);
+		expect(slice?.truncated).toBe(true);
+		await manager.dispose();
+	});
+
+	test("unknown job and owner mismatch return undefined", async () => {
+		const manager = makeManager();
+		const id = registerMonitor(manager, "tail", OWNER);
+		manager.appendOutput(id, "data\n");
+		expect(manager.readOutputTail("ghost", { maxLines: 3 })).toBeUndefined();
+		expect(manager.readOutputTail(id, { maxLines: 3 }, { ownerId: "other" })).toBeUndefined();
+		await manager.dispose();
+	});
+
+	test("JobsObserver.getMonitorOutputTail delegates with owner scoping", async () => {
+		const manager = makeManager();
+		const observer = new JobsObserver(manager, OWNER);
+		const id = registerMonitor(manager, "tail", OWNER);
+		manager.appendOutput(id, "one\ntwo\nthree\n");
+
+		const slice = observer.getMonitorOutputTail(id, { maxLines: 2 });
+		expect(slice?.text).toBe("two\nthree");
+
+		// snapshot exposes endTime field (undefined while running)
+		const view = observer.getSnapshot().monitors.find(m => m.id === id);
+		expect(view).toBeDefined();
+		expect(view?.endTime).toBeUndefined();
+
+		observer.dispose();
+		await manager.dispose();
+	});
+});

--- a/packages/coding-agent/test/jobs-format.test.ts
+++ b/packages/coding-agent/test/jobs-format.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+	compareCronsNewestFirst,
+	compareMonitorsNewestFirst,
+	formatJobRef,
+	formatRelative,
+	formatRuntime,
+	parseJobRef,
+	previewText,
+} from "../src/modes/components/jobs-format";
+import type { CronJobView, MonitorJobView } from "../src/modes/jobs-observer";
+
+function monitor(over: Partial<MonitorJobView> = {}): MonitorJobView {
+	return { id: "m", label: "l", status: "running", startTime: 0, ...over };
+}
+
+function cron(over: Partial<CronJobView> = {}): CronJobView {
+	return {
+		id: "c",
+		humanSchedule: "every 5m",
+		cronExpression: "*/5 * * * *",
+		prompt: "p",
+		recurring: true,
+		createdAt: 0,
+		...over,
+	};
+}
+
+describe("jobs-format", () => {
+	test("previewText collapses whitespace and clips with an ellipsis", () => {
+		expect(previewText("  a\n\tb   c  ")).toBe("a b c");
+		expect(previewText("abcdef", 4)).toBe("abc…");
+		expect(previewText("abcd", 4)).toBe("abcd");
+		expect(previewText("anything", 0)).toBe("");
+	});
+
+	test("formatRelative renders future/past/unknown", () => {
+		const now = 1_000_000;
+		expect(formatRelative(now + 300_000, now)).toBe("in 5m");
+		expect(formatRelative(now - 120_000, now)).toBe("2m ago");
+		expect(formatRelative(now + 20_000, now)).toBe("now");
+		expect(formatRelative(now + 2 * 3_600_000, now)).toBe("in 2h");
+		expect(formatRelative(undefined, now)).toBe("—");
+	});
+
+	test("formatRuntime freezes at endTime and scales s/m/h", () => {
+		const start = 1_000_000;
+		// running: counts against now
+		expect(formatRuntime(start, undefined, start + 5_000)).toBe("5s");
+		expect(formatRuntime(start, undefined, start + 125_000)).toBe("2m");
+		expect(formatRuntime(start, undefined, start + (3_600_000 + 180_000))).toBe("1h3m");
+		expect(formatRuntime(start, undefined, start + 2 * 3_600_000)).toBe("2h");
+		// terminal: frozen at endTime regardless of now
+		expect(formatRuntime(start, start + 9_000, start + 999_999)).toBe("9s");
+		// guard against negative
+		expect(formatRuntime(start, undefined, start - 50)).toBe("0s");
+	});
+
+	test("parseJobRef / formatJobRef round-trip and reject non-refs", () => {
+		expect(parseJobRef("monitor:abc")).toEqual({ kind: "monitor", id: "abc" });
+		expect(parseJobRef("cron:x")).toEqual({ kind: "cron", id: "x" });
+		expect(parseJobRef("noop")).toBeNull();
+		expect(parseJobRef("other:1")).toBeNull();
+		expect(parseJobRef("monitor:")).toBeNull();
+		expect(formatJobRef({ kind: "monitor", id: "abc" })).toBe("monitor:abc");
+	});
+
+	test("comparators order newest-first", () => {
+		const monitors = [monitor({ id: "old", startTime: 1 }), monitor({ id: "new", startTime: 9 })];
+		expect([...monitors].sort(compareMonitorsNewestFirst).map(m => m.id)).toEqual(["new", "old"]);
+		const crons = [cron({ id: "old", createdAt: 1 }), cron({ id: "new", createdAt: 9 })];
+		expect([...crons].sort(compareCronsNewestFirst).map(c => c.id)).toEqual(["new", "old"]);
+	});
+});


### PR DESCRIPTION
Draft restage of #675, which was merged into `dev` then reverted (revert commit `8498a4a0`) per request. Re-opened as a **draft** for further iteration before any re-merge.

## Summary
Auto-surfacing, read-only inline panel below the input that visualizes active **monitor** and **cron** jobs (no `alt+j` to learn): collapsed list capped at 4 rows + "+N more"; `ctrl+up`/`ctrl+down` expand/scroll/collapse with a bounded live monitor tail; terminal-TTL drop (completed 30s / failed 5m, grounded in `endTime`); built on the existing `JobsObserver` with a new bounded `readOutputTail` API. `alt+j` / `/monitors` stay as the destructive Manage-Jobs overlay.

## Status
- Identical content to #675: 3 commits, +1304/-38 across 14 files (re-applied onto the reverted `dev`).
- Prior review reached architect architecture/product/code CLEAR + APPROVE; 90 tests pass; `check:types` + `biome` clean.
- Intentionally a **draft** — promote to ready when you want to re-merge.
