### PR TITLE
fix(model-selector): preset Down across group boundary skips destination header (#688)

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -154,6 +154,20 @@ interface PresetBrowseRow {
 
 type PresetLandingRow = PresetGroupRow | PresetProfileRow | PresetBrowseRow;
 
+// Stable logical identity for a preset landing row, independent of its current
+// list position. Used to relocate the cursor after the expanded group changes so
+// navigation does not silently overshoot the destination group header/profiles.
+function presetRowIdentity(row: PresetLandingRow): string {
+	switch (row.kind) {
+		case "group":
+			return `group:${row.groupId}`;
+		case "profile":
+			return `profile:${row.groupId}:${row.profile.name}`;
+		case "browse":
+			return "browse";
+	}
+}
+
 const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"default",
 	"executor",
@@ -739,6 +753,18 @@ export class ModelSelectorComponent extends Container {
 		if (selected?.kind === "group") this.#expandedPresetProviderId = selected.groupId;
 		if (selected?.kind === "profile") this.#expandedPresetProviderId = selected.groupId;
 		const rows = this.#getPresetRows();
+		// Expanding/collapsing a group shifts row positions. Relocate the cursor by
+		// the selected row's logical identity so crossing a provider group boundary
+		// keeps it on the same logical row instead of overshooting into the
+		// destination group's profiles (or off the end of the list).
+		if (selected) {
+			const targetIdentity = presetRowIdentity(selected);
+			const relocated = rows.findIndex(row => presetRowIdentity(row) === targetIdentity);
+			if (relocated >= 0) {
+				this.#presetCursor = relocated;
+				return;
+			}
+		}
 		this.#presetCursor = Math.min(this.#presetCursor, Math.max(0, rows.length - 1));
 	}
 

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -66,6 +66,18 @@ const noSuffixProfile: ModelProfileDefinition = {
 	modelMapping: { default: "provider-a/default" },
 	source: "user",
 };
+const codexMedium: ModelProfileDefinition = {
+	name: "codex-medium",
+	requiredProviders: ["openai-codex"],
+	modelMapping: { default: "openai-codex/gpt-5.5:medium" },
+	source: "builtin",
+};
+const codexPro: ModelProfileDefinition = {
+	name: "codex-pro",
+	requiredProviders: ["openai-codex"],
+	modelMapping: { default: "openai-codex/gpt-5.5:high" },
+	source: "builtin",
+};
 
 let testTheme = await getThemeByName("red-claw");
 function installTestTheme(): void {
@@ -125,6 +137,16 @@ async function rendered(selector: ModelSelectorComponent): Promise<string> {
 	await Bun.sleep(10);
 	installTestTheme();
 	return normalizeRenderedText(selector.render(260).join("\n"));
+}
+
+// Returns the label of the row the navigation cursor (❯) currently sits on,
+// with ANSI/whitespace normalized. Used to assert exact cursor placement after
+// preset list navigation.
+function cursorRowLabel(selector: ModelSelectorComponent): string | undefined {
+	installTestTheme();
+	const lines = selector.render(260).map(line => line.replace(/\x1b\[[0-9;]*m/g, ""));
+	const cursorLine = lines.find(line => line.includes("❯"));
+	return cursorLine?.replace("❯", "").replace(/\s+/g, " ").trim();
 }
 
 describe("preset landing adversarial QA", () => {
@@ -262,5 +284,38 @@ describe("preset landing adversarial QA", () => {
 		text = normalizeRenderedText(suffixless.render(260).join("\n"));
 		expect(text).toContain("DEFAULT: provider-a/default");
 		expect(text).not.toContain("DEFAULT: provider-a/default:");
+	});
+
+	test("#688 Down crossing a group boundary lands on the destination group header", async () => {
+		// Regression: pressing Down off the last profile of the expanded group used
+		// to clamp the cursor by numeric index after the source group collapsed,
+		// overshooting past the destination group header onto its first profile.
+		const selector = createSelector();
+		await rendered(selector);
+		selector.handleInput("\x1b[B"); // CODEX header -> Codex Eco profile
+		selector.handleInput("\x1b[B"); // cross boundary into MINIMAX group
+		const label = cursorRowLabel(selector);
+		expect(label).toContain("MINIMAX");
+		expect(label).not.toContain("MiniMax Medium");
+	});
+
+	test("#688 Down from a multi-profile group does not skip the destination header onto Browse", async () => {
+		// With several profiles in the source group, the old numeric clamp could
+		// overshoot the destination group entirely (header + only profile) and land
+		// on the trailing Browse row.
+		const selector = createSelector({ profiles: [codexEco, codexMedium, codexPro, minimax] });
+		await rendered(selector);
+		selector.handleInput("\x1b[B"); // Codex Eco
+		selector.handleInput("\x1b[B"); // Codex Medium
+		selector.handleInput("\x1b[B"); // Codex Pro (last profile of CODEX)
+		selector.handleInput("\x1b[B"); // cross boundary into MINIMAX group
+		const headerLabel = cursorRowLabel(selector);
+		expect(headerLabel).toContain("MINIMAX");
+		expect(headerLabel).not.toContain("Browse all models");
+		expect(headerLabel).not.toContain("MiniMax Medium");
+
+		// Navigation continues correctly through the destination group.
+		selector.handleInput("\x1b[B"); // MINIMAX header -> MiniMax Medium profile
+		expect(cursorRowLabel(selector)).toContain("MiniMax Medium");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #688. On the `/model` preset landing, pressing **Down** to cross a provider group boundary silently skipped the destination group's header (and any leading profiles).

### Root cause
`#updatePresetExpansion()` re-expands the destination group, then collapses the previously expanded source group. The cursor was then repositioned with a numeric clamp (`Math.min(cursor, rows.length - 1)`) against the *old* index. Since the source group's profiles collapsed, that old index now points **past** the destination group header — onto its first profile, or even off the group entirely onto `Browse all models`.

### Fix
Capture the selected row's stable **logical identity** (`group:<id>` / `profile:<id>:<name>` / `browse`) before recomputing the row layout, then relocate the cursor to the row matching that identity. The numeric clamp remains only as a fallback when the row no longer exists.

## Tests
Added two focused regressions to `model-preset-landing-redteam-qa.test.ts`:
- Down crossing a boundary lands on the destination **group header**, not its first profile.
- Down off the last profile of a multi-profile group does not overshoot the whole destination group onto `Browse all models`; subsequent Down then steps into the destination's profiles correctly.

Both fail without the fix (landing on `✓ MiniMax Medium` / `Browse all models`) and pass with it. Full file: 9/9 pass. Typecheck + biome clean.

## Scope
Limited to #688. No merge.