### PR TITLE
feat(model): show per-model fast-mode (⚡) in /model selector and /fast status

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -198,6 +198,7 @@ export class ModelSelectorComponent extends Container {
 	#temporaryOnly: boolean;
 	#currentModel?: Model;
 	#isFastForProvider: (provider?: string) => boolean = () => false;
+	#isFastForSubagentProvider: (provider?: string) => boolean = () => false;
 	#pendingActionItem?: ModelItem | CanonicalModelItem;
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
@@ -232,6 +233,7 @@ export class ModelSelectorComponent extends Container {
 			initialSearchInput?: string;
 			sessionId?: string;
 			isFastForProvider?: (provider?: string) => boolean;
+			isFastForSubagentProvider?: (provider?: string) => boolean;
 		},
 	) {
 		super();
@@ -246,6 +248,7 @@ export class ModelSelectorComponent extends Container {
 		this.#authSessionId = options?.sessionId;
 		this.#currentModel = _currentModel;
 		this.#isFastForProvider = options?.isFastForProvider ?? (() => false);
+		this.#isFastForSubagentProvider = options?.isFastForSubagentProvider ?? (() => false);
 		const initialSearchInput = options?.initialSearchInput;
 		this.#viewMode = this.#temporaryOnly || initialSearchInput || scopedModels.length > 0 ? "models" : "presets";
 
@@ -919,7 +922,13 @@ export class ModelSelectorComponent extends Container {
 					roleMatched = true;
 					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
 					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
-					const fastSuffix = this.#isFastForProvider(assigned.model.provider) ? ` ${theme.icon.fast}` : "";
+					// Subagent roles (task.agentModelOverrides) run under task.serviceTier, so
+					// their ⚡ must reflect the effective subagent tier, not the main session tier.
+					const roleFast =
+						roleInfo.settingsPath === "task.agentModelOverrides"
+							? this.#isFastForSubagentProvider(assigned.model.provider)
+							: this.#isFastForProvider(assigned.model.provider);
+					const fastSuffix = roleFast ? ` ${theme.icon.fast}` : "";
 					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}${fastSuffix}`);
 				}
 			}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -196,6 +196,8 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
+	#currentModel?: Model;
+	#isFastForProvider: (provider?: string) => boolean = () => false;
 	#pendingActionItem?: ModelItem | CanonicalModelItem;
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
@@ -225,7 +227,12 @@ export class ModelSelectorComponent extends Container {
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string; sessionId?: string },
+		options?: {
+			temporaryOnly?: boolean;
+			initialSearchInput?: string;
+			sessionId?: string;
+			isFastForProvider?: (provider?: string) => boolean;
+		},
 	) {
 		super();
 
@@ -237,6 +244,8 @@ export class ModelSelectorComponent extends Container {
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		this.#authSessionId = options?.sessionId;
+		this.#currentModel = _currentModel;
+		this.#isFastForProvider = options?.isFastForProvider ?? (() => false);
 		const initialSearchInput = options?.initialSearchInput;
 		this.#viewMode = this.#temporaryOnly || initialSearchInput || scopedModels.length > 0 ? "models" : "presets";
 
@@ -902,14 +911,28 @@ export class ModelSelectorComponent extends Container {
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
+			let roleMatched = false;
 			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 				const assigned = this.#roles[role];
 				if (roleInfo.tag && assigned && modelsAreEqual(assigned.model, item.model)) {
+					roleMatched = true;
 					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
 					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
-					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+					const fastSuffix = this.#isFastForProvider(assigned.model.provider) ? ` ${theme.icon.fast}` : "";
+					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}${fastSuffix}`);
 				}
+			}
+			// Active/current non-role row: show the fast glyph on the session's current
+			// model row even when it carries no role badge. Skip when a role token for
+			// this row already rendered the glyph (duplicate-glyph guard).
+			if (
+				!roleMatched &&
+				this.#currentModel !== undefined &&
+				modelsAreEqual(this.#currentModel, item.model) &&
+				this.#isFastForProvider(item.model.provider)
+			) {
+				roleBadgeTokens.push(theme.icon.fast);
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -688,6 +688,7 @@ export class SelectorController {
 					...options,
 					sessionId: this.ctx.session.sessionId,
 					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
+					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
 				},
 			);
 			return { component: selector, focus: selector };

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -684,7 +684,11 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				{ ...options, sessionId: this.ctx.session.sessionId },
+				{
+					...options,
+					sessionId: this.ctx.session.sessionId,
+					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6031,6 +6031,30 @@ export class AgentSession {
 	}
 
 	/**
+	 * Effective service tier applied to task-tool subagent sessions
+	 * (executor/architect/planner/critic). They run under `task.serviceTier`
+	 * unless it is `"inherit"`, in which case they inherit the main session
+	 * tier — mirroring `createSubagentSettings`.
+	 */
+	#subagentServiceTier(): ServiceTier | undefined {
+		const configured = this.settings.get("task.serviceTier");
+		if (configured === "inherit") return this.serviceTier;
+		if (configured === "none") return undefined;
+		return configured;
+	}
+
+	/**
+	 * Provider-aware fast-mode predicate for task-tool subagent roles, evaluated
+	 * against the effective subagent tier (`task.serviceTier`) rather than the
+	 * main session tier. Use this for `task.agentModelOverrides` role rows so the
+	 * ⚡ glyph reflects the tier the subagent actually runs under.
+	 */
+	isFastForSubagentProvider(provider?: string): boolean {
+		if (provider === undefined) return false;
+		return resolveServiceTier(this.#subagentServiceTier(), provider) === "priority";
+	}
+
+	/**
 	 * True when the configured `serviceTier` resolves to `"priority"` for the
 	 * *currently selected model's provider*. Returns false for scoped tiers
 	 * that don't match (e.g. `"openai-only"` on an anthropic model) and when

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6018,12 +6018,26 @@ export class AgentSession {
 
 	/**
 	 * True when the configured `serviceTier` resolves to `"priority"` for the
+	 * given model `provider`. Returns false for scoped tiers that don't match
+	 * (e.g. `"openai-only"` on an anthropic provider) and when `provider` is
+	 * undefined. This is the canonical provider-aware fast-mode predicate.
+	 */
+	isFastForProvider(provider?: string): boolean {
+		// Fast mode applies to a concrete model's provider. With no provider
+		// (no model selected) it cannot apply, even under an unscoped `priority`
+		// tier that `resolveServiceTier` would otherwise pass through.
+		if (provider === undefined) return false;
+		return resolveServiceTier(this.serviceTier, provider) === "priority";
+	}
+
+	/**
+	 * True when the configured `serviceTier` resolves to `"priority"` for the
 	 * *currently selected model's provider*. Returns false for scoped tiers
 	 * that don't match (e.g. `"openai-only"` on an anthropic model) and when
 	 * no model is selected.
 	 */
 	isFastModeActive(): boolean {
-		return resolveServiceTier(this.serviceTier, this.model?.provider) === "priority";
+		return this.isFastForProvider(this.model?.provider);
 	}
 
 	setServiceTier(serviceTier: ServiceTier | undefined): void {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -45,10 +45,11 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
 
-function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label: string }> {
+function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label: string; isSubagentRole: boolean }> {
 	return GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => ({
 		id,
 		label: GJC_MODEL_ASSIGNMENT_TARGETS[id].tag ?? id.toUpperCase(),
+		isSubagentRole: GJC_MODEL_ASSIGNMENT_TARGETS[id].settingsPath === "task.agentModelOverrides",
 	}));
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
 import {
@@ -13,6 +14,8 @@ import {
 import { extractExplicitThinkingSelector, formatModelSelectorValue, parseModelPattern } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
+import { DynamicBorder } from "../modes/components/dynamic-border";
+import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { formatModelOnboardingGuidance } from "../setup/model-onboarding-guidance";
 import {
@@ -23,6 +26,7 @@ import {
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
 import { buildContextReportText } from "./helpers/context-report";
+import { buildFastStatusReport } from "./helpers/fast-status-report";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
@@ -40,6 +44,13 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label: string }> {
+	return GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => ({
+		id,
+		label: GJC_MODEL_ASSIGNMENT_TARGETS[id].tag ?? id.toUpperCase(),
+	}));
+}
 
 function parseProviderSetupSlashArgs(args: string): {
 	preset?: string;
@@ -357,7 +368,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (arg === "status") {
-				await runtime.output(`Fast mode is ${runtime.session.isFastModeEnabled() ? "on" : "off"}.`);
+				await runtime.output(
+					buildFastStatusReport({
+						session: runtime.session,
+						roleTargets: fastStatusRoleTargets(),
+						iconFast: theme.icon.fast,
+					}),
+				);
 				return commandConsumed();
 			}
 			return usage("Usage: /fast [on|off|status]", runtime);
@@ -386,8 +403,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 			if (arg === "status") {
-				const enabled = runtime.ctx.session.isFastModeEnabled();
-				runtime.ctx.showStatus(`Fast mode is ${enabled ? "on" : "off"}.`);
+				const report = buildFastStatusReport({
+					session: runtime.ctx.session,
+					roleTargets: fastStatusRoleTargets(),
+					iconFast: theme.icon.fast,
+					formatInactive: text => theme.fg("dim", text),
+				});
+				runtime.ctx.chatContainer.addChild(new Spacer(1));
+				runtime.ctx.chatContainer.addChild(new DynamicBorder());
+				runtime.ctx.chatContainer.addChild(new Text(report, 1, 0));
+				runtime.ctx.chatContainer.addChild(new DynamicBorder());
+				runtime.ctx.ui.requestRender();
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
@@ -1,0 +1,93 @@
+import type { Model } from "@gajae-code/ai";
+
+/**
+ * A single line in the `/fast status` report: a labelled model whose fast-mode
+ * applicability is decided per the model's provider.
+ */
+export interface FastStatusRow {
+	/** Display label, e.g. "현재 모델", "DEFAULT", "EXECUTOR". */
+	label: string;
+	/** Resolved model for this row, if any. */
+	model?: Model;
+}
+
+export interface FormatFastStatusReportArgs {
+	rows: FastStatusRow[];
+	/**
+	 * Provider-aware fast predicate. This MUST be the provider-aware check
+	 * (`AgentSession.isFastForProvider`), never the provider-agnostic
+	 * `isFastModeEnabled()`, so a scoped tier (e.g. `claude-only`) reports
+	 * correctly per row.
+	 */
+	isFastForProvider: (provider?: string) => boolean;
+	/** The active theme's fast icon token (`theme.icon.fast`). */
+	iconFast: string;
+	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
+	formatInactive?: (text: string) => string;
+}
+
+/** Title line of the `/fast status` report. */
+export const FAST_STATUS_TITLE = "Fast 모드 상태";
+
+/** The inactive marker shown for rows where fast mode does not apply. */
+export const FAST_STATUS_OFF = "off";
+
+/**
+ * Format a multiline, provider-aware `/fast status` report. Pure and shared by
+ * the CLI (`handle`) and TUI (`handleTui`) command branches so the two never
+ * drift.
+ */
+export function formatFastStatusReport(args: FormatFastStatusReportArgs): string {
+	const { rows, isFastForProvider, iconFast } = args;
+	const formatInactive = args.formatInactive ?? ((text: string) => text);
+	const lines: string[] = [FAST_STATUS_TITLE];
+	for (const row of rows) {
+		if (!row.model) {
+			lines.push(`${row.label}: ${formatInactive(FAST_STATUS_OFF)}`);
+			continue;
+		}
+		const ref = `${row.model.provider}/${row.model.id}`;
+		const fast = isFastForProvider(row.model.provider);
+		lines.push(`${row.label}: ${ref} ${fast ? iconFast : formatInactive(FAST_STATUS_OFF)}`);
+	}
+	return lines.join("\n");
+}
+
+/** Minimal session surface needed to build the `/fast status` report. */
+export interface FastStatusSessionLike {
+	readonly model?: Model;
+	isFastForProvider(provider?: string): boolean;
+	resolveRoleModelWithThinking(role: string): { model?: Model };
+}
+
+export interface BuildFastStatusReportArgs {
+	session: FastStatusSessionLike;
+	/** Role targets to enumerate, in display order. */
+	roleTargets: ReadonlyArray<{ id: string; label: string }>;
+	/** The active theme's fast icon token (`theme.icon.fast`). */
+	iconFast: string;
+	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
+	formatInactive?: (text: string) => string;
+}
+
+/**
+ * Build the `/fast status` report from a live session: the active/current model
+ * followed by each assigned role (subagent) model. Unassigned roles are skipped
+ * so the report mirrors the `/model` selector, which only badges assigned roles.
+ */
+export function buildFastStatusReport(args: BuildFastStatusReportArgs): string {
+	const { session, roleTargets, iconFast, formatInactive } = args;
+	const rows: FastStatusRow[] = [{ label: "현재 모델", model: session.model }];
+	for (const target of roleTargets) {
+		const resolved = session.resolveRoleModelWithThinking(target.id);
+		if (resolved.model) {
+			rows.push({ label: target.label, model: resolved.model });
+		}
+	}
+	return formatFastStatusReport({
+		rows,
+		isFastForProvider: provider => session.isFastForProvider(provider),
+		iconFast,
+		formatInactive,
+	});
+}

--- a/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
@@ -1,25 +1,23 @@
 import type { Model } from "@gajae-code/ai";
 
 /**
- * A single line in the `/fast status` report: a labelled model whose fast-mode
- * applicability is decided per the model's provider.
+ * A single line in the `/fast status` report: a labelled model and whether fast
+ * mode is effective for it. The `fast` flag is resolved by the caller
+ * (`buildFastStatusReport`) so each row can use the correct service tier — the
+ * main session tier for the current model / `modelRoles` roles, or the subagent
+ * tier (`task.serviceTier`) for `task.agentModelOverrides` roles.
  */
 export interface FastStatusRow {
 	/** Display label, e.g. "현재 모델", "DEFAULT", "EXECUTOR". */
 	label: string;
 	/** Resolved model for this row, if any. */
 	model?: Model;
+	/** Whether fast mode is effective for this row's model. */
+	fast: boolean;
 }
 
 export interface FormatFastStatusReportArgs {
 	rows: FastStatusRow[];
-	/**
-	 * Provider-aware fast predicate. This MUST be the provider-aware check
-	 * (`AgentSession.isFastForProvider`), never the provider-agnostic
-	 * `isFastModeEnabled()`, so a scoped tier (e.g. `claude-only`) reports
-	 * correctly per row.
-	 */
-	isFastForProvider: (provider?: string) => boolean;
 	/** The active theme's fast icon token (`theme.icon.fast`). */
 	iconFast: string;
 	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
@@ -33,12 +31,13 @@ export const FAST_STATUS_TITLE = "Fast 모드 상태";
 export const FAST_STATUS_OFF = "off";
 
 /**
- * Format a multiline, provider-aware `/fast status` report. Pure and shared by
- * the CLI (`handle`) and TUI (`handleTui`) command branches so the two never
- * drift.
+ * Format a multiline `/fast status` report. Pure and shared by the CLI
+ * (`handle`) and TUI (`handleTui`) command branches so the two never drift.
+ * Each row's fast/off state is decided by the caller (see
+ * {@link buildFastStatusReport}) so per-row service-tier differences are honored.
  */
 export function formatFastStatusReport(args: FormatFastStatusReportArgs): string {
-	const { rows, isFastForProvider, iconFast } = args;
+	const { rows, iconFast } = args;
 	const formatInactive = args.formatInactive ?? ((text: string) => text);
 	const lines: string[] = [FAST_STATUS_TITLE];
 	for (const row of rows) {
@@ -47,8 +46,7 @@ export function formatFastStatusReport(args: FormatFastStatusReportArgs): string
 			continue;
 		}
 		const ref = `${row.model.provider}/${row.model.id}`;
-		const fast = isFastForProvider(row.model.provider);
-		lines.push(`${row.label}: ${ref} ${fast ? iconFast : formatInactive(FAST_STATUS_OFF)}`);
+		lines.push(`${row.label}: ${ref} ${row.fast ? iconFast : formatInactive(FAST_STATUS_OFF)}`);
 	}
 	return lines.join("\n");
 }
@@ -56,14 +54,29 @@ export function formatFastStatusReport(args: FormatFastStatusReportArgs): string
 /** Minimal session surface needed to build the `/fast status` report. */
 export interface FastStatusSessionLike {
 	readonly model?: Model;
+	/** Fast predicate against the main session tier (current model + `modelRoles`). */
 	isFastForProvider(provider?: string): boolean;
+	/** Fast predicate against the effective subagent tier (`task.agentModelOverrides` roles). */
+	isFastForSubagentProvider(provider?: string): boolean;
 	resolveRoleModelWithThinking(role: string): { model?: Model };
+}
+
+/** A role to enumerate in the report, with the tier source its subagent runs under. */
+export interface FastStatusRoleTarget {
+	id: string;
+	label: string;
+	/**
+	 * True for `task.agentModelOverrides` roles (executor/architect/planner/critic)
+	 * that run under `task.serviceTier`; false for `modelRoles` roles (default)
+	 * that run under the main session tier.
+	 */
+	isSubagentRole: boolean;
 }
 
 export interface BuildFastStatusReportArgs {
 	session: FastStatusSessionLike;
 	/** Role targets to enumerate, in display order. */
-	roleTargets: ReadonlyArray<{ id: string; label: string }>;
+	roleTargets: ReadonlyArray<FastStatusRoleTarget>;
 	/** The active theme's fast icon token (`theme.icon.fast`). */
 	iconFast: string;
 	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
@@ -74,20 +87,25 @@ export interface BuildFastStatusReportArgs {
  * Build the `/fast status` report from a live session: the active/current model
  * followed by each assigned role (subagent) model. Unassigned roles are skipped
  * so the report mirrors the `/model` selector, which only badges assigned roles.
+ *
+ * Subagent roles (`task.agentModelOverrides`) are evaluated against the
+ * effective subagent tier (`task.serviceTier`), while the current model and
+ * `modelRoles` roles use the main session tier — matching where each model
+ * actually runs.
  */
 export function buildFastStatusReport(args: BuildFastStatusReportArgs): string {
 	const { session, roleTargets, iconFast, formatInactive } = args;
-	const rows: FastStatusRow[] = [{ label: "현재 모델", model: session.model }];
+	const rows: FastStatusRow[] = [
+		{ label: "현재 모델", model: session.model, fast: session.isFastForProvider(session.model?.provider) },
+	];
 	for (const target of roleTargets) {
 		const resolved = session.resolveRoleModelWithThinking(target.id);
 		if (resolved.model) {
-			rows.push({ label: target.label, model: resolved.model });
+			const fast = target.isSubagentRole
+				? session.isFastForSubagentProvider(resolved.model.provider)
+				: session.isFastForProvider(resolved.model.provider);
+			rows.push({ label: target.label, model: resolved.model, fast });
 		}
 	}
-	return formatFastStatusReport({
-		rows,
-		isFastForProvider: provider => session.isFastForProvider(provider),
-		iconFast,
-		formatInactive,
-	});
+	return formatFastStatusReport({ rows, iconFast, formatInactive });
 }

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -21,6 +21,7 @@ import type { Model } from "@gajae-code/ai";
 import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
 import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { ACP_BOOTSTRAP_RACE_GUARD_MS, AcpAgent, createAcpExtensionUiContext } from "../src/modes/acp/acp-agent";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 import type { PlanModeState } from "../src/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "../src/session/agent-session";
 import { SILENT_ABORT_MARKER } from "../src/session/messages";
@@ -305,6 +306,14 @@ class FakeAgentSession {
 		return this.fastMode;
 	}
 
+	isFastForProvider(_provider?: string): boolean {
+		return false;
+	}
+
+	resolveRoleModelWithThinking(_role: string): { model: undefined } {
+		return { model: undefined };
+	}
+
 	setForcedToolChoice(toolName: string): void {
 		this.forcedToolChoice = toolName;
 	}
@@ -458,6 +467,10 @@ async function waitForAvailableCommandsUpdate(harness: AgentHarness, sessionId: 
 }
 
 describe("ACP agent", () => {
+	beforeAll(async () => {
+		const installed = await getThemeByName("red-claw");
+		if (installed) setThemeInstance(installed);
+	});
 	it("supports multiple live ACP sessions with model and lifecycle handlers", async () => {
 		const harness = await createHarness();
 		const first = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
@@ -1651,7 +1664,7 @@ describe("ACP agent", () => {
 				update =>
 					update.update.sessionUpdate === "agent_message_chunk" &&
 					update.update.content.type === "text" &&
-					update.update.content.text === "Fast mode is off.",
+					update.update.content.text.includes("Fast 모드 상태"),
 			),
 		).toBe(true);
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -310,6 +310,10 @@ class FakeAgentSession {
 		return false;
 	}
 
+	isFastForSubagentProvider(_provider?: string): boolean {
+		return false;
+	}
+
 	resolveRoleModelWithThinking(_role: string): { model: undefined } {
 		return { model: undefined };
 	}

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import type { AgentMessage } from "@gajae-code/agent-core";
 import { Settings } from "../src/config/settings";
+import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../src/slash-commands/acp-builtins";
@@ -17,6 +18,8 @@ interface FakeAcpBuiltinSession {
 	toggleFastMode(): boolean;
 	setFastMode(enabled: boolean): void;
 	isFastModeEnabled(): boolean;
+	isFastForProvider(provider?: string): boolean;
+	resolveRoleModelWithThinking(role: string): { model?: { provider: string; id: string } };
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
 	getAsyncJobSnapshot: (opts?: { recentLimit?: number }) => { running: unknown[]; recent: unknown[] } | null;
@@ -75,6 +78,12 @@ function createRuntime() {
 		},
 		isFastModeEnabled() {
 			return this.fastMode;
+		},
+		isFastForProvider(_provider?: string) {
+			return false;
+		},
+		resolveRoleModelWithThinking(_role: string): { model?: { provider: string; id: string } } {
+			return { model: undefined };
 		},
 		setForcedToolChoice(toolName: string) {
 			this.forcedToolChoice = toolName;
@@ -196,12 +205,64 @@ function createRuntime() {
 
 describe("ACP builtin slash commands", () => {
 	it("consumes fast status without returning prompt text", async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for fast status test");
+		setThemeInstance(installed);
 		const { output, runtime } = createRuntime();
 
 		const result = await executeAcpBuiltinSlashCommand("/fast status", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(output).toEqual(["Fast mode is off."]);
+		// No model selected and no roles assigned -> multiline report, active row off.
+		expect(output).toHaveLength(1);
+		expect(output[0]).toContain("Fast 모드 상태");
+		expect(output[0]).toContain("현재 모델: off");
+		expect(output[0]).not.toContain("Fast mode is");
+	});
+
+	it("renders a provider-aware multiline fast status report and never calls isFastModeEnabled", async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for fast status test");
+		setThemeInstance(installed);
+		const { output, runtime } = createRuntime();
+		const session = runtime.session as unknown as {
+			model: { provider: string; id: string } | undefined;
+			isFastForProvider: (provider?: string) => boolean;
+			resolveRoleModelWithThinking: (role: string) => { model?: { provider: string; id: string } };
+			isFastModeEnabled: () => boolean;
+		};
+		session.model = { provider: "anthropic", id: "claude-sonnet-4-5" };
+		session.isFastForProvider = provider => provider === "anthropic";
+		session.resolveRoleModelWithThinking = role =>
+			role === "executor" ? { model: { provider: "openai", id: "gpt-5" } } : { model: undefined };
+		// The status branch must use the provider-aware predicate, never this.
+		session.isFastModeEnabled = () => {
+			throw new Error("/fast status must not call isFastModeEnabled");
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/fast status", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+		expect(output[0]).toContain("EXECUTOR: openai/gpt-5 off");
+		expect(output[0]).not.toContain("Fast mode is");
+	});
+	it("keeps /fast on/off/toggle output and state changes unchanged", async () => {
+		const { output, runtime } = createRuntime();
+
+		await expect(executeAcpBuiltinSlashCommand("/fast on", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(true);
+		expect(output).toEqual(["Fast mode enabled."]);
+
+		output.length = 0;
+		await expect(executeAcpBuiltinSlashCommand("/fast off", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(false);
+		expect(output).toEqual(["Fast mode disabled."]);
+
+		output.length = 0;
+		await expect(executeAcpBuiltinSlashCommand("/fast toggle", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(true);
+		expect(output).toEqual(["Fast mode enabled."]);
 	});
 
 	it("renders provider usage reports when the session can fetch them", async () => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -19,6 +19,7 @@ interface FakeAcpBuiltinSession {
 	setFastMode(enabled: boolean): void;
 	isFastModeEnabled(): boolean;
 	isFastForProvider(provider?: string): boolean;
+	isFastForSubagentProvider(provider?: string): boolean;
 	resolveRoleModelWithThinking(role: string): { model?: { provider: string; id: string } };
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
@@ -80,6 +81,9 @@ function createRuntime() {
 			return this.fastMode;
 		},
 		isFastForProvider(_provider?: string) {
+			return false;
+		},
+		isFastForSubagentProvider(_provider?: string) {
 			return false;
 		},
 		resolveRoleModelWithThinking(_role: string): { model?: { provider: string; id: string } } {
@@ -228,13 +232,18 @@ describe("ACP builtin slash commands", () => {
 		const session = runtime.session as unknown as {
 			model: { provider: string; id: string } | undefined;
 			isFastForProvider: (provider?: string) => boolean;
+			isFastForSubagentProvider: (provider?: string) => boolean;
 			resolveRoleModelWithThinking: (role: string) => { model?: { provider: string; id: string } };
 			isFastModeEnabled: () => boolean;
 		};
 		session.model = { provider: "anthropic", id: "claude-sonnet-4-5" };
 		session.isFastForProvider = provider => provider === "anthropic";
+		// Subagent roles run under task.serviceTier; here it grants no fast mode, so
+		// the EXECUTOR row must be off even though its anthropic model would be fast
+		// under the main session tier.
+		session.isFastForSubagentProvider = () => false;
 		session.resolveRoleModelWithThinking = role =>
-			role === "executor" ? { model: { provider: "openai", id: "gpt-5" } } : { model: undefined };
+			role === "executor" ? { model: { provider: "anthropic", id: "claude-opus-4-1" } } : { model: undefined };
 		// The status branch must use the provider-aware predicate, never this.
 		session.isFastModeEnabled = () => {
 			throw new Error("/fast status must not call isFastModeEnabled");
@@ -244,7 +253,9 @@ describe("ACP builtin slash commands", () => {
 
 		expect(result).toEqual({ consumed: true });
 		expect(output[0]).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
-		expect(output[0]).toContain("EXECUTOR: openai/gpt-5 off");
+		// Subagent role uses the subagent tier -> off despite the anthropic model.
+		expect(output[0]).toContain("EXECUTOR: anthropic/claude-opus-4-1 off");
+		expect(output[0]).not.toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${theme.icon.fast}`);
 		expect(output[0]).not.toContain("Fast mode is");
 	});
 	it("keeps /fast on/off/toggle output and state changes unchanged", async () => {

--- a/packages/coding-agent/test/agent-session-fast-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-fast-mode.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+describe("AgentSession fast-mode predicate", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-fast-mode-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("returns false for an undefined provider even under an unscoped priority tier", () => {
+		session.setServiceTier("priority");
+		// Unscoped priority applies to a concrete provider...
+		expect(session.isFastForProvider("anthropic")).toBe(true);
+		expect(session.isFastForProvider("openai")).toBe(true);
+		// ...but never when there is no provider (no model selected).
+		expect(session.isFastForProvider(undefined)).toBe(false);
+	});
+
+	it("is provider-scoped for claude-only", () => {
+		session.setServiceTier("claude-only");
+		expect(session.isFastForProvider("anthropic")).toBe(true);
+		expect(session.isFastForProvider("openai")).toBe(false);
+		expect(session.isFastForProvider("openai-codex")).toBe(false);
+		expect(session.isFastForProvider(undefined)).toBe(false);
+	});
+
+	it("isFastModeActive reflects the current model's provider and the configured tier", () => {
+		expect(session.isFastModeActive()).toBe(false);
+		session.setServiceTier("priority");
+		// current model is anthropic
+		expect(session.isFastModeActive()).toBe(true);
+		// claude-only still matches the anthropic current model
+		session.setServiceTier("claude-only");
+		expect(session.isFastModeActive()).toBe(true);
+		// openai-only does not match the anthropic current model
+		session.setServiceTier("openai-only");
+		expect(session.isFastModeActive()).toBe(false);
+		session.setServiceTier(undefined);
+		expect(session.isFastModeActive()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/fast-status-report.test.ts
+++ b/packages/coding-agent/test/fast-status-report.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import {
+	buildFastStatusReport,
+	FAST_STATUS_OFF,
+	FAST_STATUS_TITLE,
+	type FastStatusSessionLike,
+	formatFastStatusReport,
+} from "@gajae-code/coding-agent/slash-commands/helpers/fast-status-report";
+
+const ICON = "\u26a1";
+
+function model(provider: string, id: string): Model {
+	return { provider, id } as unknown as Model;
+}
+
+describe("formatFastStatusReport", () => {
+	test("AC-5: formats a multiline active + role-model report with fast/off per row", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+			],
+			isFastForProvider: provider => provider === "anthropic",
+			iconFast: ICON,
+		});
+		const lines = report.split("\n");
+		expect(lines.length).toBeGreaterThan(1);
+		expect(lines[0]).toBe(FAST_STATUS_TITLE);
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+	});
+
+	test("AC-2: claude-only marks anthropic rows fast and openai/openai-codex rows off", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-opus-4-1") },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+				{ label: "ARCHITECT", model: model("openai-codex", "gpt-5-codex") },
+			],
+			isFastForProvider: provider => provider === "anthropic",
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-opus-4-1 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`ARCHITECT: openai-codex/gpt-5-codex ${FAST_STATUS_OFF}`);
+		// Exactly one fast icon (the anthropic active row).
+		expect(report.split(ICON).length - 1).toBe(1);
+	});
+
+	test("AC-3: none tier marks every row off and renders no fast icon", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+			],
+			isFastForProvider: () => false,
+			iconFast: ICON,
+		});
+		expect(report).not.toContain(ICON);
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+	});
+
+	test("AC-6: predicate (not a global on/off flag) drives each row independently", () => {
+		// Mirrors serviceTier="claude-only": the active OpenAI model is off even
+		// though fast mode is globally "enabled", while the Anthropic role is on.
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("openai", "gpt-5") },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
+			],
+			isFastForProvider: provider => provider === "anthropic",
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+	});
+
+	test("AC-7: uses the supplied icon token, never a hardcoded emoji", () => {
+		const report = formatFastStatusReport({
+			rows: [{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") }],
+			isFastForProvider: () => true,
+			iconFast: ">>",
+		});
+		expect(report).toContain("현재 모델: anthropic/claude-sonnet-4-5 >>");
+		expect(report).not.toContain(ICON);
+	});
+
+	test("AC-8: unset service tier (predicate false everywhere) is all off", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
+			],
+			isFastForProvider: () => false,
+			iconFast: ICON,
+		});
+		expect(report).not.toContain(ICON);
+		expect(report.split("\n").every(line => line === FAST_STATUS_TITLE || line.endsWith(FAST_STATUS_OFF))).toBe(true);
+	});
+
+	test("applies the inactive formatter (e.g. TUI dim) to off rows only", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+			],
+			isFastForProvider: provider => provider === "anthropic",
+			iconFast: ICON,
+			formatInactive: text => `<dim>${text}</dim>`,
+		});
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 <dim>${FAST_STATUS_OFF}</dim>`);
+		expect(report).not.toContain(`<dim>${ICON}</dim>`);
+	});
+});
+
+describe("buildFastStatusReport", () => {
+	function fakeSession(args: {
+		model?: Model;
+		roles: Record<string, Model | undefined>;
+		fastProviders: string[];
+	}): FastStatusSessionLike {
+		return {
+			model: args.model,
+			isFastForProvider: provider => provider !== undefined && args.fastProviders.includes(provider),
+			resolveRoleModelWithThinking: role => ({ model: args.roles[role] }),
+		};
+	}
+
+	test("lists the active model and assigned roles, skipping unassigned roles", () => {
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: { default: model("anthropic", "claude-sonnet-4-5"), executor: model("openai", "gpt-5") },
+				fastProviders: ["anthropic"],
+			}),
+			roleTargets: [
+				{ id: "default", label: "DEFAULT" },
+				{ id: "executor", label: "EXECUTOR" },
+				{ id: "architect", label: "ARCHITECT" },
+			],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		// ARCHITECT is unassigned -> skipped entirely.
+		expect(report).not.toContain("ARCHITECT");
+	});
+
+	test("renders the active row off when no model is selected", () => {
+		const report = buildFastStatusReport({
+			session: fakeSession({ model: undefined, roles: {}, fastProviders: ["anthropic"] }),
+			roleTargets: [{ id: "default", label: "DEFAULT" }],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: ${FAST_STATUS_OFF}`);
+		expect(report).not.toContain(ICON);
+	});
+});

--- a/packages/coding-agent/test/fast-status-report.test.ts
+++ b/packages/coding-agent/test/fast-status-report.test.ts
@@ -18,11 +18,10 @@ describe("formatFastStatusReport", () => {
 	test("AC-5: formats a multiline active + role-model report with fast/off per row", () => {
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
-				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
-				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
 			],
-			isFastForProvider: provider => provider === "anthropic",
 			iconFast: ICON,
 		});
 		const lines = report.split("\n");
@@ -33,14 +32,13 @@ describe("formatFastStatusReport", () => {
 		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
 	});
 
-	test("AC-2: claude-only marks anthropic rows fast and openai/openai-codex rows off", () => {
+	test("AC-2: renders fast on anthropic rows and off on openai/openai-codex rows", () => {
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("anthropic", "claude-opus-4-1") },
-				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
-				{ label: "ARCHITECT", model: model("openai-codex", "gpt-5-codex") },
+				{ label: "현재 모델", model: model("anthropic", "claude-opus-4-1"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
+				{ label: "ARCHITECT", model: model("openai-codex", "gpt-5-codex"), fast: false },
 			],
-			isFastForProvider: provider => provider === "anthropic",
 			iconFast: ICON,
 		});
 		expect(report).toContain(`현재 모델: anthropic/claude-opus-4-1 ${ICON}`);
@@ -50,13 +48,12 @@ describe("formatFastStatusReport", () => {
 		expect(report.split(ICON).length - 1).toBe(1);
 	});
 
-	test("AC-3: none tier marks every row off and renders no fast icon", () => {
+	test("AC-3: all rows off renders no fast icon", () => {
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
-				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
 			],
-			isFastForProvider: () => false,
 			iconFast: ICON,
 		});
 		expect(report).not.toContain(ICON);
@@ -64,15 +61,14 @@ describe("formatFastStatusReport", () => {
 		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
 	});
 
-	test("AC-6: predicate (not a global on/off flag) drives each row independently", () => {
+	test("AC-6: each row's fast flag is rendered independently", () => {
 		// Mirrors serviceTier="claude-only": the active OpenAI model is off even
 		// though fast mode is globally "enabled", while the Anthropic role is on.
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("openai", "gpt-5") },
-				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "현재 모델", model: model("openai", "gpt-5"), fast: false },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
 			],
-			isFastForProvider: provider => provider === "anthropic",
 			iconFast: ICON,
 		});
 		expect(report).toContain(`현재 모델: openai/gpt-5 ${FAST_STATUS_OFF}`);
@@ -81,21 +77,19 @@ describe("formatFastStatusReport", () => {
 
 	test("AC-7: uses the supplied icon token, never a hardcoded emoji", () => {
 		const report = formatFastStatusReport({
-			rows: [{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") }],
-			isFastForProvider: () => true,
+			rows: [{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true }],
 			iconFast: ">>",
 		});
 		expect(report).toContain("현재 모델: anthropic/claude-sonnet-4-5 >>");
 		expect(report).not.toContain(ICON);
 	});
 
-	test("AC-8: unset service tier (predicate false everywhere) is all off", () => {
+	test("AC-8: every row off is all off", () => {
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
-				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5") },
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
 			],
-			isFastForProvider: () => false,
 			iconFast: ICON,
 		});
 		expect(report).not.toContain(ICON);
@@ -105,10 +99,9 @@ describe("formatFastStatusReport", () => {
 	test("applies the inactive formatter (e.g. TUI dim) to off rows only", () => {
 		const report = formatFastStatusReport({
 			rows: [
-				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5") },
-				{ label: "EXECUTOR", model: model("openai", "gpt-5") },
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
 			],
-			isFastForProvider: provider => provider === "anthropic",
 			iconFast: ICON,
 			formatInactive: text => `<dim>${text}</dim>`,
 		});
@@ -122,10 +115,13 @@ describe("buildFastStatusReport", () => {
 		model?: Model;
 		roles: Record<string, Model | undefined>;
 		fastProviders: string[];
+		subagentFastProviders?: string[];
 	}): FastStatusSessionLike {
+		const subagentFastProviders = args.subagentFastProviders ?? args.fastProviders;
 		return {
 			model: args.model,
 			isFastForProvider: provider => provider !== undefined && args.fastProviders.includes(provider),
+			isFastForSubagentProvider: provider => provider !== undefined && subagentFastProviders.includes(provider),
 			resolveRoleModelWithThinking: role => ({ model: args.roles[role] }),
 		};
 	}
@@ -138,9 +134,9 @@ describe("buildFastStatusReport", () => {
 				fastProviders: ["anthropic"],
 			}),
 			roleTargets: [
-				{ id: "default", label: "DEFAULT" },
-				{ id: "executor", label: "EXECUTOR" },
-				{ id: "architect", label: "ARCHITECT" },
+				{ id: "default", label: "DEFAULT", isSubagentRole: false },
+				{ id: "executor", label: "EXECUTOR", isSubagentRole: true },
+				{ id: "architect", label: "ARCHITECT", isSubagentRole: true },
 			],
 			iconFast: ICON,
 		});
@@ -154,10 +150,53 @@ describe("buildFastStatusReport", () => {
 	test("renders the active row off when no model is selected", () => {
 		const report = buildFastStatusReport({
 			session: fakeSession({ model: undefined, roles: {}, fastProviders: ["anthropic"] }),
-			roleTargets: [{ id: "default", label: "DEFAULT" }],
+			roleTargets: [{ id: "default", label: "DEFAULT", isSubagentRole: false }],
 			iconFast: ICON,
 		});
 		expect(report).toContain(`현재 모델: ${FAST_STATUS_OFF}`);
 		expect(report).not.toContain(ICON);
+	});
+
+	test("subagent roles use the subagent tier, not the main session tier", () => {
+		// Regression for #691 round-2 blocker: serviceTier=priority but
+		// task.serviceTier=none — the main-session rows are fast while the
+		// task.agentModelOverrides subagent role runs without fast mode.
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: {
+					default: model("anthropic", "claude-sonnet-4-5"),
+					executor: model("anthropic", "claude-opus-4-1"),
+				},
+				fastProviders: ["anthropic", "openai", "openai-codex"],
+				subagentFastProviders: [],
+			}),
+			roleTargets: [
+				{ id: "default", label: "DEFAULT", isSubagentRole: false },
+				{ id: "executor", label: "EXECUTOR", isSubagentRole: true },
+			],
+			iconFast: ICON,
+		});
+		// Main session is fast (current + modelRoles DEFAULT)...
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		// ...but the subagent role is off despite the same provider.
+		expect(report).toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${FAST_STATUS_OFF}`);
+	});
+
+	test("subagent roles can be fast while the main session is off", () => {
+		// Reverse divergence: serviceTier=none but task.serviceTier=priority.
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: { executor: model("anthropic", "claude-opus-4-1") },
+				fastProviders: [],
+				subagentFastProviders: ["anthropic"],
+			}),
+			roleTargets: [{ id: "executor", label: "EXECUTOR", isSubagentRole: true }],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${ICON}`);
 	});
 });

--- a/packages/coding-agent/test/fast-status-tui.test.ts
+++ b/packages/coding-agent/test/fast-status-tui.test.ts
@@ -24,6 +24,7 @@ function createTuiRuntime() {
 	const session = {
 		model: model("anthropic", "claude-sonnet-4-5"),
 		isFastForProvider: (provider?: string) => provider === "anthropic",
+		isFastForSubagentProvider: (provider?: string) => provider === "anthropic",
 		resolveRoleModelWithThinking: (role: string) => {
 			if (role === "default") return { model: model("anthropic", "claude-sonnet-4-5") };
 			if (role === "executor") return { model: model("openai", "gpt-5") };

--- a/packages/coding-agent/test/fast-status-tui.test.ts
+++ b/packages/coding-agent/test/fast-status-tui.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import { Text } from "@gajae-code/tui";
+
+function model(provider: string, id: string): Model {
+	return { provider, id } as unknown as Model;
+}
+
+function stripAnsi(text: string): string {
+	return text
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function createTuiRuntime() {
+	const added: unknown[] = [];
+	const showStatus = vi.fn();
+	const requestRender = vi.fn();
+	const setText = vi.fn();
+	const session = {
+		model: model("anthropic", "claude-sonnet-4-5"),
+		isFastForProvider: (provider?: string) => provider === "anthropic",
+		resolveRoleModelWithThinking: (role: string) => {
+			if (role === "default") return { model: model("anthropic", "claude-sonnet-4-5") };
+			if (role === "executor") return { model: model("openai", "gpt-5") };
+			return { model: undefined };
+		},
+		// The status branch must use the provider-aware predicate, never this.
+		isFastModeEnabled: () => {
+			throw new Error("/fast status must not call isFastModeEnabled");
+		},
+	};
+	const ctx = {
+		session,
+		chatContainer: {
+			addChild: (child: unknown) => {
+				added.push(child);
+			},
+		},
+		ui: { requestRender },
+		editor: { setText },
+		showStatus,
+	};
+	return {
+		runtime: { ctx: ctx as unknown as InteractiveModeContext, handleBackgroundCommand: () => {} },
+		added,
+		showStatus,
+		requestRender,
+		setText,
+	};
+}
+
+describe("/fast status TUI rendering", () => {
+	beforeAll(async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for /fast status TUI test");
+		setThemeInstance(installed);
+	});
+	test("AC-5: renders a multiline transcript panel, clears the editor, and never uses showStatus", async () => {
+		const { runtime, added, showStatus, requestRender, setText } = createTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/fast status", runtime);
+
+		expect(result).toBe(true);
+		// Multiline transcript rendering — not a single-line status toast.
+		expect(showStatus).not.toHaveBeenCalled();
+		expect(requestRender).toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("");
+
+		const textChildren = added.filter((child): child is Text => child instanceof Text);
+		expect(textChildren.length).toBeGreaterThan(0);
+
+		const rendered = stripAnsi(textChildren.map(child => child.render(220).join("\n")).join("\n"));
+		expect(rendered).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+		expect(rendered).toContain("DEFAULT: anthropic/claude-sonnet-4-5");
+		expect(rendered).toContain("EXECUTOR: openai/gpt-5 off");
+		// The OpenAI executor row under claude-only scope shows no fast glyph.
+		expect(rendered).not.toContain(`openai/gpt-5 ${theme.icon.fast}`);
+	});
+});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -4,7 +4,13 @@ import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
-import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import {
+	getThemeByName,
+	setSymbolPreset,
+	setTheme,
+	setThemeInstance,
+	theme,
+} from "@gajae-code/coding-agent/modes/theme/theme";
 import type { TUI } from "@gajae-code/tui";
 
 function normalizeRenderedText(text: string): string {
@@ -597,5 +603,199 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Inherit);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+	if (!needle) return 0;
+	let count = 0;
+	let idx = haystack.indexOf(needle);
+	while (idx !== -1) {
+		count++;
+		idx = haystack.indexOf(needle, idx + needle.length);
+	}
+	return count;
+}
+
+function createFastSelector(args: {
+	models: Model[];
+	settings: Settings;
+	isFastForProvider: (provider?: string) => boolean;
+	currentModel?: Model;
+}): ModelSelectorComponent {
+	const { models, settings, isFastForProvider, currentModel } = args;
+	const modelRegistry = {
+		getAll: () => models,
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	const scoped = models.map(model => ({ model, thinkingLevel: ThinkingLevel.Off }));
+	return new ModelSelectorComponent(
+		ui,
+		currentModel,
+		settings,
+		modelRegistry,
+		scoped,
+		() => {},
+		() => {},
+		{ isFastForProvider },
+	);
+}
+
+describe("ModelSelector fast-mode indicator", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		if (!testTheme) {
+			throw new Error("Failed to load theme for fast-mode indicator tests");
+		}
+	});
+
+	test("AC-1: renders fast glyph after DEFAULT and EXECUTOR badges for priority tier", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain(`EXECUTOR (high) ${iconFast}`);
+		// Duplicate-glyph guard: the current model already carries role glyphs, so no
+		// extra standalone active-row glyph is added.
+		expect(countOccurrences(rendered, iconFast)).toBe(2);
+		// Regression: each badge label and thinking label renders exactly once, in order.
+		expect(countOccurrences(rendered, "DEFAULT")).toBe(1);
+		expect(countOccurrences(rendered, "EXECUTOR")).toBe(1);
+		expect(rendered.indexOf("DEFAULT")).toBeLessThan(rendered.indexOf("(low)"));
+		expect(rendered.indexOf("(low)")).toBeLessThan(rendered.indexOf(iconFast));
+	});
+
+	test("AC-2: claude-only renders fast glyph only on anthropic rows in mixed-provider selector", async () => {
+		installTestTheme();
+		const anthropic = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!anthropic) throw new Error("Expected anthropic model");
+		const openai = createOpenAIModel("openai", "gpt-5-fast-mixed");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${anthropic.provider}/${anthropic.id}:low` },
+			"task.agentModelOverrides": { executor: `${openai.provider}/${openai.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [anthropic, openai],
+			settings,
+			isFastForProvider: provider => provider === "anthropic",
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(`EXECUTOR (high) ${iconFast}`);
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
+
+	test("AC-3: none tier renders no fast glyph but keeps badges", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(iconFast);
+	});
+
+	test("AC-4: active non-role current model row shows fast glyph via currentModel", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toContain("DEFAULT");
+		expect(rendered).not.toContain("EXECUTOR");
+		expect(rendered).toContain(iconFast);
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
+
+	test("AC-7: fast glyph uses theme.icon.fast variant, not a hardcoded emoji", async () => {
+		await setTheme("red-claw");
+		await setSymbolPreset("ascii");
+		try {
+			const asciiIcon = theme.icon.fast;
+			expect(asciiIcon).not.toBe("\u26a1");
+			const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+			if (!model) throw new Error("Expected model");
+			const settings = Settings.isolated({
+				modelRoles: { default: `${model.provider}/${model.id}:low` },
+			});
+			const selector = createFastSelector({
+				models: [model],
+				settings,
+				isFastForProvider: () => true,
+				currentModel: model,
+			});
+			await Bun.sleep(0);
+			const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+			expect(rendered).toContain(asciiIcon);
+			expect(rendered).not.toContain("\u26a1");
+		} finally {
+			await setSymbolPreset("unicode");
+			installTestTheme();
+		}
+	});
+
+	test("AC-8: unset service tier renders no fast glyph", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+		});
+		// serviceTier === undefined is modeled as the predicate returning false everywhere.
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).not.toContain(iconFast);
 	});
 });

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -621,9 +621,13 @@ function createFastSelector(args: {
 	models: Model[];
 	settings: Settings;
 	isFastForProvider: (provider?: string) => boolean;
+	isFastForSubagentProvider?: (provider?: string) => boolean;
 	currentModel?: Model;
 }): ModelSelectorComponent {
 	const { models, settings, isFastForProvider, currentModel } = args;
+	// Subagent roles default to the same predicate as the session unless a test
+	// exercises the session-vs-subagent tier divergence explicitly.
+	const isFastForSubagentProvider = args.isFastForSubagentProvider ?? isFastForProvider;
 	const modelRegistry = {
 		getAll: () => models,
 		getDiscoverableProviders: () => [],
@@ -640,7 +644,7 @@ function createFastSelector(args: {
 		scoped,
 		() => {},
 		() => {},
-		{ isFastForProvider },
+		{ isFastForProvider, isFastForSubagentProvider },
 	);
 }
 
@@ -682,6 +686,35 @@ describe("ModelSelector fast-mode indicator", () => {
 		expect(rendered.indexOf("(low)")).toBeLessThan(rendered.indexOf(iconFast));
 	});
 
+	test("subagent role glyph reflects the subagent tier, not the session tier", async () => {
+		// Regression for #691 round-2 blocker: serviceTier=priority but
+		// task.serviceTier=none. DEFAULT (modelRoles) runs in the main session and is
+		// fast; EXECUTOR (task.agentModelOverrides) runs under the subagent tier and
+		// must show no glyph even with the same anthropic model.
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			isFastForSubagentProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(`EXECUTOR (high) ${iconFast}`);
+		// Only the main-session DEFAULT row lights the glyph.
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
 	test("AC-2: claude-only renders fast glyph only on anthropic rows in mixed-provider selector", async () => {
 		installTestTheme();
 		const anthropic = getBundledModel("anthropic", "claude-sonnet-4-5");


### PR DESCRIPTION
## Summary

Adds a per-model **fast mode** (⚡) indicator to the `/model` selector and `/fast status`, **including subagent / role models**, so users can see at a glance whether priority/fast mode actually applies to each model.

"Fast mode" = the `serviceTier` setting resolving to `priority` for a model's provider (Anthropic `speed:"fast"` / OpenAI `service_tier=priority`). Since `serviceTier` is a single session setting and applicability depends on each model's provider, this surfaces it per row using the existing predicate semantics.

## Changes

- **`agent-session`**: new canonical `isFastForProvider(provider)` predicate (guards an undefined provider → `false`); `isFastModeActive()` now delegates to it.
- **Model selector** (`#updateList`): renders `theme.icon.fast` after role badges and on the active non-role current-model row (identified via `_currentModel`), with a duplicate-glyph guard. The selector receives the predicate via an injected callback and never reads `serviceTier` from settings.
- **Selector controller**: injects `provider => session.isFastForProvider(provider)`.
- **`/fast status`**: provider-aware multiline report listing the active model + each assigned role (subagent) model, shared by the CLI (`runtime.output`) and TUI (`chatContainer` transcript `Text`, not a single-line status toast). Replaces the provider-agnostic single-line `isFastModeEnabled()` output.

## Scope / non-goals

- **Display-only**: no writes to `serviceTier`, `modelRoles`, or `task.agentModelOverrides`.
- The **status line is unchanged** (it already shows a fast icon via `isFastModeActive()`).
- `/fast on|off|toggle` behavior is unchanged.

## Testing

- `bun test` across selector / formatter / TUI / ACP suites + a new `AgentSession` predicate regression test: **131 pass / 0 fail**.
- `check:types` clean; `biome check` clean on all changed files.

Behaviors covered: priority active+role glyph; `claude-only` mixed-provider scoping (anthropic on, openai/openai-codex off) in both the selector and `/fast status`; `none`/unset tier → no glyph; active non-role temporary model; duplicate-glyph guard; theme symbol-variant (no hardcoded emoji); `/fast status` never calls `isFastModeEnabled`; `/fast on|off|toggle` and the status line unchanged.
