### PR TITLE
fix(utils): scrub macOS malloc env from child spawns

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Dropped disabled macOS malloc stack logging variables from forwarded spawn environments so child processes do not repeat runtime warnings inherited from debugger-attached shells.
+
 ## [0.5.1] - 2026-06-14
 
 - Version aligned with the 0.5.1 monorepo release; no functional changes in this package.

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -2,6 +2,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, getConfigRootDir } from "./dirs";
+import { isSafeEnvName, isSafeEnvValue } from "./spawn-env";
+
+export { filterProcessEnv, isSafeEnvName, isSafeEnvValue } from "./spawn-env";
 
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -12,32 +15,6 @@ const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
  */
 export function isValidEnvName(name: string): boolean {
 	return ENV_NAME_RE.test(name);
-}
-
-/**
- * The only names that are genuinely unsafe to forward to a native `execve`
- * spawn: empty, containing `=` (would corrupt the `KEY=VALUE` framing) or
- * NUL (terminates the C string mid-entry). Windows ships standard variables
- * whose names contain parentheses (e.g. `ProgramFiles(x86)`, `CommonProgramFiles(x86)`)
- * — those MUST survive the scrub so downstream resolvers (Git Bash discovery
- * in `procmgr.ts`, etc.) can still read them.
- */
-export function isSafeEnvName(name: string): boolean {
-	return name.length > 0 && !name.includes("=") && !name.includes("\0");
-}
-
-export function isSafeEnvValue(value: string): boolean {
-	return !value.includes("\0");
-}
-
-export function filterProcessEnv(env: Record<string, string | undefined>): Record<string, string> {
-	const result: Record<string, string> = {};
-	for (const key in env) {
-		const value = env[key];
-		if (!isSafeEnvName(key) || value === undefined || !isSafeEnvValue(value)) continue;
-		result[key] = value;
-	}
-	return result;
 }
 
 function stripInlineShellComment(value: string): string {

--- a/packages/utils/src/spawn-env.ts
+++ b/packages/utils/src/spawn-env.ts
@@ -1,0 +1,23 @@
+const MACOS_MALLOC_STACK_LOGGING_ENV = new Set(["MallocStackLogging", "MallocStackLoggingNoCompact"]);
+
+export function isSafeEnvName(name: string): boolean {
+	return name.length > 0 && !name.includes("=") && !name.includes("\0");
+}
+
+export function isSafeEnvValue(value: string): boolean {
+	return !value.includes("\0");
+}
+
+export function shouldForwardSpawnEnvName(name: string): boolean {
+	return isSafeEnvName(name) && !MACOS_MALLOC_STACK_LOGGING_ENV.has(name);
+}
+
+export function filterProcessEnv(env: Record<string, string | undefined>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const key in env) {
+		const value = env[key];
+		if (!shouldForwardSpawnEnvName(key) || value === undefined || !isSafeEnvValue(value)) continue;
+		result[key] = value;
+	}
+	return result;
+}

--- a/packages/utils/test/spawn-env.test.ts
+++ b/packages/utils/test/spawn-env.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { filterProcessEnv } from "../src/env";
+
+describe("filterProcessEnv spawn hygiene", () => {
+	it("drops disabled macOS malloc stack logging variables before spawning children", () => {
+		expect(
+			filterProcessEnv({
+				MallocStackLogging: "0",
+				MallocStackLoggingNoCompact: "0",
+				KEEP: "value",
+			}),
+		).toEqual({
+			KEEP: "value",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- extract spawn environment filtering into a dedicated helper
- stop forwarding `MallocStackLogging` and `MallocStackLoggingNoCompact` to child processes
- add a regression test and utils changelog entry

## Notes
- This cannot suppress the first warning emitted before the current JS process starts. It prevents gajae-code from propagating the inherited macOS malloc env vars into child processes.

## Verification
- `bun --cwd=packages/utils run check`
- `bun --cwd=packages/utils test`