### PR TITLE
fix(utils): harden shutdown stderr diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Prevented `gjc --tmux` partial-launch diagnostics from throwing when stderr is already closed during shutdown.
 - Fixed v0.5.1-style macOS/Linux standalone binaries crashing before the first model request with `Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc-*'` when pre-prompt context maintenance invokes the native tokenizer.
 - Mapped the retired `codex-standard` model profile name to `codex-medium` during profile activation, **as a fallback only** so a user-defined profile literally named `codex-standard` is never shadowed, letting stale `modelProfile.default: codex-standard` configs reach activation instead of blocking startup after the rebuilt profile catalog.
 - Fixed interactive goal-mode auto-continuation looping `Error: Agent is already processing…` (`AgentBusyError`) while the session is busy. A wedged/orphaned subagent turn — or an in-progress compaction — can leave the session non-idle while the interactive loop is back at `getUserInput()`; the 800 ms continuation timer then fired `prompt()`, threw `AgentBusyError`, surfaced it via `showError`, and re-armed — spamming the error roughly every 800 ms. The continuation now skips and re-arms while `isStreaming`/`isCompacting`, firing only once the session returns to idle.

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { safeStderrWrite } from "@gajae-code/utils";
 import type { Args } from "../cli/args";
 import {
 	buildGjcTmuxProfileCommands,
@@ -280,7 +281,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			cleanupCreatedTmuxSession(plan, spawnSync, options);
 			const failure =
 				profile.failures.find(item => item.command.args.includes("@gjc-profile")) ?? profile.failures[0];
-			(context.diagnosticWriter ?? process.stderr.write.bind(process.stderr))(
+			(context.diagnosticWriter ?? safeStderrWrite)(
 				formatTmuxLaunchDiagnostic("profile tagging failed", failure?.stderr),
 			);
 			return true;
@@ -289,8 +290,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	if (created.exitCode !== 0) return false;
 	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", plan.sessionName], options);
 	if (attached.exitCode === 0) return true;
-	(context.diagnosticWriter ?? process.stderr.write.bind(process.stderr))(
-		formatTmuxLaunchDiagnostic("attach failed", attached.stderr),
-	);
+	(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach failed", attached.stderr));
 	return true;
 }

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import type { Args } from "@gajae-code/coding-agent/cli/args";
 import {
 	applyGjcTmuxProfile,
@@ -20,8 +20,19 @@ function args(overrides: Partial<Args> = {}): Args {
 }
 
 const interactiveTty = { stdin: true, stdout: true };
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+function stderrError(code: string): Error {
+	const error = new Error(`${code} from stderr`);
+	Object.defineProperty(error, "code", { value: code });
+	return error;
+}
 
 describe("default GJC tmux launch", () => {
+	afterEach(() => {
+		process.stderr.write = originalStderrWrite;
+	});
+
 	it("does not plan tmux for interactive root launch without --tmux", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"] }),
@@ -312,6 +323,34 @@ describe("default GJC tmux launch", () => {
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
 		expect(diagnostics[0].length).toBeLessThan(320);
+	});
+
+	it("does not throw when the default tmux diagnostic write hits a closed stderr", () => {
+		const writes: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			writes.push(String(chunk));
+			throw stderrError("EIO");
+		}) satisfies typeof process.stderr.write;
+
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			spawnSync: (_command, spawnArgs) => {
+				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
 	});
 
 	it("falls through to direct launch when tmux is unavailable", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Prevented closed stderr descriptors from crashing shutdown diagnostics while preserving unexpected stderr write failures.
 - Tolerate trailing commas on simple frontmatter scalar lines, avoiding noisy rule-discovery warnings for Cursor-style `.mdc` metadata while preserving strict fallback behavior for genuinely malformed YAML.
 
 ## [0.5.1] - 2026-06-14

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,6 +19,7 @@ export * as procmgr from "./procmgr";
 export * as prompt from "./prompt";
 export * as ptree from "./ptree";
 export { AbortError, ChildProcess, Exception, NonZeroExitError } from "./ptree";
+export * from "./safe-stderr";
 export * from "./sanitize-text";
 export * from "./snowflake";
 export * from "./stream";

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -8,6 +8,7 @@
 import inspector from "node:inspector";
 import { isMainThread } from "node:worker_threads";
 import { logger } from ".";
+import { safeStderrWrite } from "./safe-stderr";
 
 // Cleanup reasons, in order of priority/meaning.
 export enum Reason {
@@ -86,17 +87,17 @@ if (isMainThread) {
 			inspectorOpened = true;
 			inspector.open(undefined, undefined, false);
 			const url = inspector.url();
-			process.stderr.write(`Inspector opened: ${url}\n`);
+			safeStderrWrite(`Inspector opened: ${url}\n`);
 		})
 		.on("uncaughtException", async err => {
-			process.stderr.write(formatFatalError("Uncaught Exception", err));
+			safeStderrWrite(formatFatalError("Uncaught Exception", err));
 			logger.error("Uncaught exception", { err, stack: err.stack });
 			await runCleanup(Reason.UNCAUGHT_EXCEPTION);
 			process.exit(1);
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
-			process.stderr.write(formatFatalError("Unhandled Rejection", err));
+			safeStderrWrite(formatFatalError("Unhandled Rejection", err));
 			logger.error("Unhandled rejection", { err, stack: err.stack });
 			await runCleanup(Reason.UNHANDLED_REJECTION);
 			process.exit(1);

--- a/packages/utils/src/safe-stderr.ts
+++ b/packages/utils/src/safe-stderr.ts
@@ -1,0 +1,15 @@
+const CLOSED_STDERR_ERROR_CODES = new Set(["EIO", "EPIPE", "EBADF"]);
+
+function isClosedStderrWriteError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error) || typeof error.code !== "string") return false;
+	return CLOSED_STDERR_ERROR_CODES.has(error.code);
+}
+
+export function safeStderrWrite(message: string): void {
+	try {
+		process.stderr.write(message);
+	} catch (error) {
+		if (isClosedStderrWriteError(error)) return;
+		throw error;
+	}
+}

--- a/packages/utils/test/safe-stderr.test.ts
+++ b/packages/utils/test/safe-stderr.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { safeStderrWrite } from "../src/safe-stderr";
+
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+function stderrError(code: string): Error {
+	const error = new Error(`${code} from stderr`);
+	Object.defineProperty(error, "code", { value: code });
+	return error;
+}
+
+describe("safeStderrWrite", () => {
+	afterEach(() => {
+		process.stderr.write = originalStderrWrite;
+	});
+
+	it("swallows closed stderr write errors during shutdown diagnostics", () => {
+		const calls: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			calls.push(String(chunk));
+			throw stderrError("EIO");
+		}) satisfies typeof process.stderr.write;
+
+		safeStderrWrite("fatal diagnostic\n");
+
+		expect(calls).toEqual(["fatal diagnostic\n"]);
+	});
+
+	it("rethrows unexpected stderr write errors", () => {
+		process.stderr.write = (() => {
+			throw new RangeError("unexpected stderr failure");
+		}) satisfies typeof process.stderr.write;
+
+		expect(() => safeStderrWrite("fatal diagnostic\n")).toThrow(RangeError);
+	});
+});


### PR DESCRIPTION
## Summary
- split the stderr/EIO shutdown fix from the mixed #678 branch into a clean `dev` PR
- add `safeStderrWrite` for last-gasp stderr diagnostics, swallowing only closed-descriptor errors (`EIO`, `EPIPE`, `EBADF`)
- use it for postmortem fatal diagnostics and `gjc --tmux` partial-launch diagnostics
- add regression coverage for the helper and the default tmux diagnostic path

## Notes
- Frontmatter trailing-comma changes from #678 are intentionally not included.
- Unexpected stderr write failures still rethrow, addressing the broad-catch review nit from #678.

## Verification
- `bun --cwd=packages/utils run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/utils test test/safe-stderr.test.ts`
- `bun --cwd=packages/coding-agent test test/gjc-runtime/launch-tmux.test.ts`
- subprocess QA: imported postmortem, patched `process.stderr.write` to throw `EIO`, then triggered an uncaught exception; process reached the expected fatal-handler exit (`1`) instead of crashing inside stderr write