### PR TITLE
feat(runtime): process-lifecycle foundation (F1) — owned-process + resource-owner primitives

### DIFF
--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -159,6 +159,10 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 	let disposed = false;
 	let disposePromise: Promise<void> | undefined;
 	let deregistered = false;
+	// Terminal once teardown/reconciliation has confirmed the group is gone. A
+	// late dispose() must then be a true no-op and never re-probe a pgid the OS
+	// may have recycled into an unrelated group.
+	let terminated = false;
 	let onAbort: (() => void) | undefined;
 
 	const removeAbort = (): void => {
@@ -171,6 +175,7 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 	const deregister = (): void => {
 		if (deregistered) return;
 		deregistered = true;
+		terminated = true;
 		liveOwners.delete(owner);
 		removeAbort();
 	};
@@ -228,6 +233,13 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 			}
 		},
 		dispose(): Promise<void> {
+			// Already terminal (e.g. clean drain reconciled and deregistered):
+			// never re-probe the pgid; treat dispose as a settled no-op.
+			if (terminated) {
+				disposed = true;
+				if (!disposePromise) disposePromise = Promise.resolve();
+				return disposePromise;
+			}
 			if (disposePromise) return disposePromise;
 			disposed = true;
 			removeAbort();

--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -1,0 +1,388 @@
+/**
+ * Shared runtime lifecycle foundation.
+ *
+ * Two minimal, deliberately small primitives that subsystem runtimes
+ * (DAP/LSP/MCP stdio, eval workers, etc.) adopt so spawned children and
+ * non-process resources cannot outlive their owner:
+ *
+ *   F1(a) `spawnOwnedProcess` — wraps `ptree.spawn` with explicit
+ *         process-group ownership, escalating (SIGTERM -> grace -> SIGKILL)
+ *         tree termination, bounded `awaitExit`, abort-listener cleanup on
+ *         settle, idempotent `dispose`, and a single postmortem hook that
+ *         reaps every still-live owned process group on fatal/normal shutdown.
+ *
+ *   F1(b) `registerResourceOwner` — a generic, idempotent postmortem adapter
+ *         for non-process resources (Bun Workers, VM contexts, timers,
+ *         sockets) built on the existing `postmortem.register` facility.
+ *
+ * Ownership is keyed to the *process group*, not the root process. A root that
+ * exits after backgrounding descendants (`sh -c "worker & exit 0"`) keeps the
+ * owner registered until the group is actually gone, so the descendant tree is
+ * still reaped by `dispose()`/postmortem.
+ *
+ * This module intentionally owns only these primitives. It does not migrate
+ * existing call sites; subsystem PRs adopt it incrementally.
+ *
+ * Note: `ptree.spawn` always pipes stdout/stderr. Adopters that expect output
+ * (DAP/LSP/MCP protocol servers) must consume `owner.child.stdout`; F1 does not
+ * drain it, so a chatty child whose stdout is never read can still block on a
+ * full pipe. That draining is the adopter's responsibility.
+ */
+import { logger, postmortem, ptree } from "@gajae-code/utils";
+
+const DEFAULT_GRACEFUL_MS = 2_000;
+// Hard cap for how long `dispose()` waits after SIGKILL before giving up so a
+// wedged, unkillable child can never block shutdown forever.
+const SIGKILL_REAP_CAP_MS = 2_000;
+// After the root process exits on its own, how long to wait for the process
+// group to drain before deregistering. Clean servers drain immediately; a root
+// that backgrounded descendants stays registered past this window.
+const ROOT_EXIT_DRAIN_MS = 250;
+
+const isPosix = process.platform !== "win32";
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => {
+		const timer = setTimeout(resolve, Math.max(0, ms));
+		timer.unref?.();
+	});
+
+/** Poll `predicate` until it is true or `timeoutMs` elapses. Returns the final value. */
+async function pollUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 20): Promise<boolean> {
+	if (predicate()) return true;
+	const deadline = Date.now() + Math.max(0, timeoutMs);
+	while (Date.now() < deadline) {
+		await delay(Math.min(intervalMs, Math.max(0, deadline - Date.now())));
+		if (predicate()) return true;
+	}
+	return predicate();
+}
+
+/** Whether a POSIX process group still has any member (zombies count as alive). */
+function groupAlive(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		// EPERM => the group exists but we cannot signal it; treat as alive.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/** Options for {@link spawnOwnedProcess}. */
+export interface SpawnOwnedOptions {
+	cwd?: string;
+	env?: Record<string, string | undefined>;
+	/** stdin mode passed through to the child. Defaults to `"ignore"`. */
+	stdin?: "pipe" | "ignore";
+	/** When aborted, the owned process tree is disposed (escalating kill). */
+	signal?: AbortSignal;
+	/** Grace period (ms) between SIGTERM and SIGKILL on dispose. Default 2000. */
+	gracefulMs?: number;
+	/**
+	 * Spawn the child as its own process-group leader so the whole descendant
+	 * tree can be signalled on dispose. Defaults to `true` on POSIX. Has no
+	 * effect on Windows, where teardown falls back to single-process kill.
+	 */
+	processGroup?: boolean;
+	/** Label used in diagnostics. */
+	name?: string;
+}
+
+/** Result of a bounded {@link OwnedProcess.awaitExit}. */
+export interface AwaitExitResult {
+	/** `true` when the process has exited; `false` when the timeout fired first. */
+	exited: boolean;
+	/** Exit code if known, else `null`. */
+	code: number | null;
+}
+
+/** A spawned child process owned by the runtime with guaranteed teardown. */
+export interface OwnedProcess {
+	readonly child: ptree.ChildProcess;
+	readonly pid: number | undefined;
+	/** Resolves/rejects when the root child exits (mirrors ptree's `exited`). */
+	readonly exited: Promise<number>;
+	/** `true` once `dispose()` has started. */
+	readonly disposed: boolean;
+	/**
+	 * Wait for the root child to exit, optionally bounded by `timeoutMs`. With no
+	 * timeout it resolves only when the child exits. Never rejects.
+	 */
+	awaitExit(opts?: { timeoutMs?: number }): Promise<AwaitExitResult>;
+	/**
+	 * Idempotently terminate the owned process *group*: SIGTERM the group, wait
+	 * `gracefulMs`, then SIGKILL, polling group liveness throughout. Removes the
+	 * abort listener and deregisters from the live-owner set only after teardown
+	 * has completed. Repeated/concurrent calls return the same in-flight promise.
+	 */
+	dispose(): Promise<void>;
+}
+
+const liveOwners = new Set<OwnedProcess>();
+let ownedPostmortemRegistered = false;
+
+function ensureOwnedPostmortem(): void {
+	if (ownedPostmortemRegistered) return;
+	ownedPostmortemRegistered = true;
+	postmortem.register("runtime:owned-processes", async () => {
+		await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+	});
+}
+
+/**
+ * Spawn a child process owned by the runtime. The returned {@link OwnedProcess}
+ * is registered for postmortem cleanup and tears down its whole process group
+ * on dispose/abort.
+ */
+export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): OwnedProcess {
+	const gracefulMs = opts.gracefulMs ?? DEFAULT_GRACEFUL_MS;
+	const useGroup = (opts.processGroup ?? true) && isPosix;
+
+	ensureOwnedPostmortem();
+
+	// We deliberately do NOT forward `opts.signal` to `ptree.spawn`: ptree's
+	// `attachSignal` only kills the single process, whereas owned teardown must
+	// signal the whole group. We wire our own abort listener below and remove it
+	// on settle so long-lived signals never accumulate listeners.
+	const child = ptree.spawn(cmd, {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdin: opts.stdin ?? "ignore",
+		detached: useGroup,
+	});
+
+	// On POSIX with `detached`, the child is its own process-group leader, so the
+	// group id equals its pid. `undefined` => single-process (Windows/opt-out).
+	const pgid = useGroup ? child.pid : undefined;
+
+	let disposed = false;
+	let disposePromise: Promise<void> | undefined;
+	let deregistered = false;
+	let onAbort: (() => void) | undefined;
+
+	const removeAbort = (): void => {
+		if (onAbort && opts.signal) {
+			opts.signal.removeEventListener("abort", onAbort);
+			onAbort = undefined;
+		}
+	};
+
+	const deregister = (): void => {
+		if (deregistered) return;
+		deregistered = true;
+		liveOwners.delete(owner);
+		removeAbort();
+	};
+
+	const signalTree = (signal: NodeJS.Signals): void => {
+		const pid = child.pid;
+		if (pid === undefined) return;
+		if (pgid !== undefined) {
+			try {
+				// Negative pid signals the entire process group (child is leader).
+				process.kill(-pgid, signal);
+				return;
+			} catch {
+				// Group already gone; nothing to do.
+			}
+			return;
+		}
+		if (signal === "SIGKILL") {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		} else {
+			// ptree's kill terminates the single process via the native handle.
+			child.kill();
+		}
+	};
+
+	const owner: OwnedProcess = {
+		child,
+		get pid() {
+			return child.pid;
+		},
+		get exited() {
+			return child.exited;
+		},
+		get disposed() {
+			return disposed;
+		},
+		async awaitExit({ timeoutMs }: { timeoutMs?: number } = {}): Promise<AwaitExitResult> {
+			const exitedResult = child.exited
+				.then(code => ({ exited: true as const, code: code as number | null }))
+				.catch(() => ({ exited: true as const, code: child.exitCode }));
+			if (timeoutMs === undefined) return exitedResult;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const timeout = new Promise<AwaitExitResult>(resolve => {
+				timer = setTimeout(() => resolve({ exited: false, code: child.exitCode }), Math.max(0, timeoutMs));
+				timer.unref?.();
+			});
+			try {
+				return await Promise.race([exitedResult, timeout]);
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		},
+		dispose(): Promise<void> {
+			if (disposePromise) return disposePromise;
+			disposed = true;
+			removeAbort();
+			disposePromise = (async () => {
+				try {
+					if (pgid !== undefined) {
+						// Group ownership: reap until the whole group is gone, even if
+						// the root has already exited (it may have backgrounded children).
+						if (!groupAlive(pgid)) return;
+						signalTree("SIGTERM");
+						if (await pollUntil(() => !groupAlive(pgid), gracefulMs)) return;
+						signalTree("SIGKILL");
+						if (!(await pollUntil(() => !groupAlive(pgid), SIGKILL_REAP_CAP_MS))) {
+							logger.warn("owned process group still alive after SIGKILL", {
+								name: opts.name,
+								pgid,
+							});
+						}
+						return;
+					}
+					// Single-process fallback (Windows / processGroup:false).
+					if (child.exitCode !== null) return;
+					signalTree("SIGTERM");
+					if ((await owner.awaitExit({ timeoutMs: gracefulMs })).exited) return;
+					signalTree("SIGKILL");
+					await owner.awaitExit({ timeoutMs: SIGKILL_REAP_CAP_MS });
+				} catch (err) {
+					logger.warn("owned process dispose failed", {
+						name: opts.name,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				} finally {
+					// FIX: deregister only after teardown has completed so a postmortem
+					// firing mid-grace still sees the owner and awaits this dispose.
+					deregister();
+				}
+			})();
+			return disposePromise;
+		},
+	};
+
+	liveOwners.add(owner);
+
+	// When the root exits on its own (not via dispose), reconcile ownership by
+	// the *group*. After a short drain window: if the group is empty, deregister;
+	// if descendants are still alive, reap the owned group (no child outlives its
+	// owner). Either way the owner never lingers holding a stale pgid that the OS
+	// could later recycle and a stray dispose could mis-signal.
+	void child.exited
+		.catch(() => undefined)
+		.finally(() => {
+			if (disposed) return; // dispose() owns deregistration
+			if (pgid === undefined) {
+				deregister();
+				return;
+			}
+			void (async () => {
+				const drained = await pollUntil(() => !groupAlive(pgid), ROOT_EXIT_DRAIN_MS);
+				if (disposed) return;
+				if (drained) {
+					deregister();
+					return;
+				}
+				// Root exited but the owned group still has descendants: reap them.
+				// dispose() escalates SIGTERM->SIGKILL and deregisters in its finally.
+				await owner.dispose();
+			})();
+		});
+
+	if (opts.signal) {
+		if (opts.signal.aborted) {
+			void owner.dispose();
+		} else {
+			onAbort = () => void owner.dispose();
+			opts.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	return owner;
+}
+
+/** Number of currently live owned processes. Exposed for leak assertions/tests. */
+export function liveOwnedProcessCount(): number {
+	return liveOwners.size;
+}
+
+/** Dispose every live owned process. For owner-scoped teardown and tests. */
+export async function disposeAllOwnedProcesses(): Promise<void> {
+	await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+}
+
+// ── F1(b) generic resource owners ────────────────────────────────────────────
+
+type ResourceDisposer = () => void | Promise<void>;
+
+const resourceOwners = new Map<string, ResourceDisposer>();
+let resourcePostmortemRegistered = false;
+
+function ensureResourcePostmortem(): void {
+	if (resourcePostmortemRegistered) return;
+	resourcePostmortemRegistered = true;
+	// Postmortem isolates per-callback failures; swallow the aggregate here so
+	// shutdown continues, while direct callers of disposeAllResourceOwners still
+	// observe the AggregateError.
+	postmortem.register("runtime:resource-owners", () =>
+		disposeAllResourceOwners().catch(err => {
+			logger.warn("resource owner postmortem cleanup had failures", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}),
+	);
+}
+
+/**
+ * Register a non-process resource for postmortem/fatal-exit cleanup.
+ *
+ * Idempotent by `name`: re-registering the same name replaces the prior
+ * disposer (last wins). Returns an unregister function that removes the owner
+ * only while it is still the active registration for that name.
+ */
+export function registerResourceOwner(name: string, disposer: ResourceDisposer): () => void {
+	resourceOwners.set(name, disposer);
+	ensureResourcePostmortem();
+	let unregistered = false;
+	return () => {
+		if (unregistered) return;
+		unregistered = true;
+		if (resourceOwners.get(name) === disposer) {
+			resourceOwners.delete(name);
+		}
+	};
+}
+
+/** Number of registered resource owners. Exposed for leak assertions/tests. */
+export function resourceOwnerCount(): number {
+	return resourceOwners.size;
+}
+
+/**
+ * Run and clear every registered resource disposer. Attempts all disposers even
+ * if some throw, then surfaces the failures as an `AggregateError` so callers
+ * can distinguish "all closed" from "a resource may still be alive".
+ */
+export async function disposeAllResourceOwners(): Promise<void> {
+	const disposers = [...resourceOwners.values()];
+	resourceOwners.clear();
+	const errors: unknown[] = [];
+	for (const disposer of disposers) {
+		try {
+			await disposer();
+		} catch (err) {
+			errors.push(err);
+		}
+	}
+	if (errors.length > 0) {
+		throw new AggregateError(errors, `${errors.length} resource disposer(s) failed during teardown`);
+	}
+}

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -191,6 +191,50 @@ describe("process-lifecycle adversarial owned-process invariants", () => {
 			}
 		},
 	);
+	test.skipIf(!isPosix)(
+		"late dispose after a clean drain is a no-op and never re-signals a recycled pgid",
+		async () => {
+			const before = liveOwnedProcessCount();
+			// Root exits cleanly with no backgrounded descendants, so the group
+			// drains within ROOT_EXIT_DRAIN_MS and reconciliation deregisters it.
+			const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], {
+				name: "redteam-late-dispose-recycled-pgid",
+			});
+			const pgid = owner.pid as number;
+			expect(pgid).toBeGreaterThan(0);
+
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(
+				() => liveOwnedProcessCount() === before,
+				2_000,
+				"live count baseline after clean-drain reconciliation",
+			);
+
+			// Simulate the OS recycling the pgid into an unrelated group: sig-0
+			// probes report alive and we record any terminating signal aimed at it.
+			const realKill = process.kill;
+			const terminatingSignals: Array<string | number> = [];
+			process.kill = ((pid: number, signal?: string | number) => {
+				if (pid === -pgid) {
+					if (signal === 0) return true;
+					terminatingSignals.push(signal as string | number);
+					return true;
+				}
+				return (realKill as (p: number, s?: string | number) => boolean).call(process, pid, signal);
+			}) as typeof process.kill;
+
+			try {
+				await expect(owner.dispose()).resolves.toBeUndefined();
+				await expect(owner.dispose()).resolves.toBeUndefined();
+				expect(terminatingSignals).toEqual([]);
+				expect(owner.disposed).toBe(true);
+				expect(liveOwnedProcessCount()).toBe(before);
+			} finally {
+				process.kill = realKill;
+			}
+		},
+	);
 });
 
 describe("process-lifecycle adversarial resource-owner invariants", () => {

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function waitForAsync(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 5_000,
+	label = "condition",
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (await predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function fileContains(path: string, needle: string): Promise<boolean> {
+	try {
+		return (await Bun.file(path).text()).includes(needle);
+	} catch {
+		return false;
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function processGroupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("process-lifecycle adversarial owned-process invariants", () => {
+	test("dispose immediately after spawn wins the startup race and returns to baseline", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "printf ready; sleep 30"], {
+			name: "redteam-immediate-dispose",
+			gracefulMs: 10,
+		});
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after immediate dispose");
+	});
+
+	test("dispose of an already-exited process is a no-op and does not throw", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 7"], { name: "redteam-already-exited" });
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit).toEqual({ exited: true, code: 7 });
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		await waitFor(
+			() => liveOwnedProcessCount() === before,
+			2_000,
+			"live count baseline after already-exited dispose",
+		);
+	});
+
+	test("double and concurrent dispose share one settled result and issue one terminating signal", async () => {
+		const before = liveOwnedProcessCount();
+		const tmp = `/tmp/gjc-process-lifecycle-${process.pid}-${Date.now()}`;
+		const owner = spawnOwnedProcess(
+			["sh", "-c", `trap 'echo term >> ${tmp}; exit 0' TERM; echo up > ${tmp}; while :; do sleep 1; done`],
+			{ name: "redteam-concurrent-dispose", gracefulMs: 500 },
+		);
+		try {
+			await waitForAsync(() => fileContains(tmp, "up"), 2_000, "child readiness marker");
+			const first = owner.dispose();
+			const second = owner.dispose();
+			expect(second).toBe(first);
+			await expect(Promise.all([first, second, owner.dispose()])).resolves.toEqual([
+				undefined,
+				undefined,
+				undefined,
+			]);
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after concurrent dispose");
+			const marker = await Bun.file(tmp).text();
+			expect(marker.split("\n").filter(line => line === "term")).toHaveLength(1);
+		} finally {
+			try {
+				await owner.dispose();
+			} catch {
+				/* already disposed */
+			}
+			await Bun.$`rm -f ${tmp}`.quiet();
+		}
+	});
+
+	test("awaitExit with timeoutMs 0 reports a live long-runner without killing it, then dispose cleans it", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "redteam-zero-timeout",
+			gracefulMs: 10,
+		});
+		try {
+			const probe = await owner.awaitExit({ timeoutMs: 0 });
+			expect(probe.exited).toBe(false);
+			expect(owner.pid === undefined ? false : processAlive(owner.pid)).toBe(true);
+		} finally {
+			await owner.dispose();
+		}
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after zero-timeout dispose");
+	});
+
+	test("liveOwnedProcessCount returns to baseline after a batch of spawn and dispose", async () => {
+		const before = liveOwnedProcessCount();
+		const owners = Array.from({ length: 8 }, (_, index) =>
+			spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+				name: `redteam-batch-${index}`,
+				gracefulMs: 10,
+			}),
+		);
+		expect(liveOwnedProcessCount()).toBeGreaterThanOrEqual(before + owners.length);
+		await Promise.all(owners.map(owner => owner.dispose()));
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after batch dispose");
+	});
+
+	test.skipIf(!isPosix)(
+		"dispose reaps a same-group double-fork grandchild while an unrelated sibling survives",
+		async () => {
+			const before = liveOwnedProcessCount();
+			const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+			const siblingPid = sibling.pid;
+			const owner = spawnOwnedProcess(["sh", "-c", "( ( sleep 30 ) & ) & while :; do sleep 1; done"], {
+				name: "redteam-double-fork-group",
+				gracefulMs: 50,
+			});
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			try {
+				await Bun.sleep(250);
+				await owner.dispose();
+				const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+				expect(exit.exited).toBe(true);
+				await waitFor(() => processGroupGone(pgid as number), 3_000, "owned process group ESRCH");
+				expect(processAlive(siblingPid)).toBe(true);
+				await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after group reap");
+			} finally {
+				try {
+					sibling.kill("SIGKILL");
+				} catch {
+					/* already gone */
+				}
+				await owner.dispose();
+			}
+		},
+	);
+});
+
+describe("process-lifecycle adversarial resource-owner invariants", () => {
+	test("a throwing disposer does not abort disposeAllResourceOwners and other disposers still run", async () => {
+		await disposeAllResourceOwners();
+		const calls: string[] = [];
+		registerResourceOwner("redteam:throws", () => {
+			calls.push("throws");
+			throw new Error("intentional red-team disposer failure");
+		});
+		registerResourceOwner("redteam:after", () => {
+			calls.push("after");
+		});
+		registerResourceOwner("redteam:async", async () => {
+			await Bun.sleep(1);
+			calls.push("async");
+		});
+
+		// All disposers run even when one throws, and the failure is surfaced
+		// (not swallowed) as an AggregateError so callers can detect it.
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(calls).toEqual(["throws", "after", "async"]);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+
+	test("unregister after disposeAllResourceOwners is safe and cannot remove a newer registration", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregister = registerResourceOwner("redteam:late-unregister", () => {
+			first += 1;
+		});
+		await disposeAllResourceOwners();
+		expect(first).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+
+		expect(() => unregister()).not.toThrow();
+		registerResourceOwner("redteam:late-unregister", () => {
+			second += 1;
+		});
+		expect(() => unregister()).not.toThrow();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(second).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllOwnedProcesses,
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+describe("spawnOwnedProcess (F1a)", () => {
+	test("awaits clean exit and deregisters from the live set", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], { name: "clean-exit" });
+		const result = await owner.awaitExit();
+		expect(result.exited).toBe(true);
+		expect(result.code).toBe(0);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("awaitExit honors a bounded timeout for a long runner", async () => {
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "timeout-probe" });
+		try {
+			const result = await owner.awaitExit({ timeoutMs: 100 });
+			expect(result.exited).toBe(false);
+		} finally {
+			await owner.dispose();
+		}
+	});
+
+	test("dispose terminates a long runner and is idempotent", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "dispose-probe" });
+		await Bun.sleep(50);
+		await Promise.all([owner.dispose(), owner.dispose()]);
+		expect(owner.disposed).toBe(true);
+		const result = await owner.awaitExit({ timeoutMs: 1_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("an already-aborted signal disposes the process immediately", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "pre-aborted",
+			signal: AbortSignal.abort(),
+		});
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("aborting mid-run disposes and removes the abort listener", async () => {
+		const before = liveOwnedProcessCount();
+		const controller = new AbortController();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "mid-abort",
+			signal: controller.signal,
+		});
+		await Bun.sleep(50);
+		controller.abort();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+		// Listener removed on settle: a second abort must not throw or re-dispose.
+		controller.abort();
+		expect(owner.disposed).toBe(true);
+	});
+
+	test.skipIf(!isPosix)("dispose reaps the process group while an unrelated sibling survives", async () => {
+		// Unrelated sibling: a directly-spawned detached sleep we must NOT kill.
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		const siblingPid = sibling.pid;
+		try {
+			// Owned tree: a shell that backgrounds a grandchild plus a foreground child.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & sleep 30"], { name: "group-reap" });
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			await Bun.sleep(150); // let the grandchild spawn
+
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 2_000 });
+
+			// The whole owned process group must be gone (ESRCH on group probe).
+			await waitFor(() => {
+				try {
+					process.kill(-(pgid as number), 0);
+					return false; // still alive
+				} catch (err) {
+					return (err as NodeJS.ErrnoException).code === "ESRCH";
+				}
+			});
+
+			// The unrelated sibling must still be alive.
+			expect(alive(siblingPid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+});
+
+describe("registerResourceOwner (F1b)", () => {
+	test("disposer runs once on disposeAllResourceOwners", async () => {
+		await disposeAllResourceOwners(); // clean slate
+		let calls = 0;
+		registerResourceOwner("test:res-a", () => {
+			calls += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+		// Cleared after dispose: a second dispose does not re-invoke.
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+	});
+
+	test("unregister prevents the disposer from running", async () => {
+		await disposeAllResourceOwners();
+		let calls = 0;
+		const unregister = registerResourceOwner("test:res-b", () => {
+			calls += 1;
+		});
+		unregister();
+		expect(resourceOwnerCount()).toBe(0);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(0);
+		// Idempotent unregister.
+		expect(() => unregister()).not.toThrow();
+	});
+
+	test("re-registering the same name replaces the disposer (last wins)", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregisterFirst = registerResourceOwner("test:res-c", () => {
+			first += 1;
+		});
+		registerResourceOwner("test:res-c", () => {
+			second += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		// The stale unregister must not remove the newer registration.
+		unregisterFirst();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(first).toBe(0);
+		expect(second).toBe(1);
+	});
+});
+
+describe("ownership regression: group liveness drives teardown (F1a)", () => {
+	test.skipIf(!isPosix)("reaps backgrounded descendants when the root exits first", async () => {
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// The shell exits 0 immediately but leaves a backgrounded child in the group.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & exit 0"], { name: "root-exits-first" });
+			const pgid = owner.pid as number;
+			const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(rootExit.exited).toBe(true);
+			expect(rootExit.code).toBe(0);
+			await Bun.sleep(50);
+			// The owned group is still alive because of the orphaned background child.
+			expect(groupAliveProbe(pgid)).toBe(true);
+			await owner.dispose();
+			await waitFor(() => groupGone(pgid));
+			// The unrelated sibling must survive.
+			expect(alive(sibling.pid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+
+	test("owner stays tracked until dispose teardown completes", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "tracked-until-done", gracefulMs: 300 });
+		await Bun.sleep(50);
+		const disposing = owner.dispose();
+		// FIX: the owner must remain in the live set until teardown completes, so a
+		// postmortem firing mid-grace still awaits this in-flight dispose.
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+		await disposing;
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test.skipIf(!isPosix)("disposeAllOwnedProcesses escalates SIGKILL for a SIGTERM-ignoring child", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "trap '' TERM; sleep 30"], {
+			name: "term-trap",
+			gracefulMs: 200,
+		});
+		await Bun.sleep(100);
+		// Simulates a postmortem/owner-scoped teardown reaching the in-flight owner.
+		await disposeAllOwnedProcesses();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+});
+
+describe("resource owner failure surfacing (F1b)", () => {
+	test("disposeAllResourceOwners surfaces disposer failures as AggregateError", async () => {
+		await disposeAllResourceOwners().catch(() => undefined);
+		let ran = 0;
+		registerResourceOwner("agg:throws", () => {
+			throw new Error("boom");
+		});
+		registerResourceOwner("agg:ok", () => {
+			ran += 1;
+		});
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(ran).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+});
+
+function groupAliveProbe(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function groupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("ownership regression: no stale pgid after late drain (F1a)", () => {
+	test.skipIf(!isPosix)("reaps and deregisters when descendants outlive the drain window", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 1 & exit 0"], { name: "late-drain" });
+		const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(rootExit.exited).toBe(true);
+		// The backgrounded `sleep 1` outlives ROOT_EXIT_DRAIN_MS; the owner must not
+		// linger with a stale pgid — it is reaped and the live count returns to
+		// baseline rather than being abandoned.
+		await waitFor(() => liveOwnedProcessCount() === before, 8_000);
+		expect(liveOwnedProcessCount()).toBe(before);
+	});
+});


### PR DESCRIPTION
## F1 — TS runtime-lifecycle foundation

Enabling foundation PR for the core-runtime resource/corruption fix campaign (plan: `.gjc/plans/ralplan/core-runtime-fixes-parallel/`). **New files only; no call-site migration.** Adopters: U5 (→ F1b), U7/U8 (→ F1a).

### F1(a) `spawnOwnedProcess`
`ptree.spawn` wrapper giving:
- explicit **process-group** ownership (`detached` leader); teardown signals the whole group
- escalating **SIGTERM → grace → SIGKILL**, keyed to **group liveness** (not root exit), with a hard reap cap
- bounded `awaitExit({timeoutMs})` (never rejects)
- abort-signal wiring that removes its listener on settle
- **idempotent `dispose()`** that deregisters only *after* teardown completes (so a postmortem firing mid-grace still awaits the in-flight kill)
- a single postmortem hook reaping every live owned group
- root-exit reconciliation that reaps orphaned descendants instead of leaving a stale `pgid` (PID-reuse safe)

### F1(b) `registerResourceOwner`
Idempotent (last-wins by name) generic postmortem adapter for non-process resources (Bun Workers, VM contexts, timers, sockets). `disposeAllResourceOwners` attempts all disposers then surfaces failures as `AggregateError`; the postmortem callback swallows the aggregate so shutdown still completes.

### Verification
- `bun test packages/coding-agent/test/runtime/` → **22 pass / 0 fail** (incl. process-group reap + unrelated-sibling-survives, root-exits-first, stale-pgid late-drain, SIGKILL escalation, aggregate disposer-error surfacing)
- red-team suite (`process-lifecycle.redteam.test.ts`) → **8 pass / 0 fail**
- `biome check` clean; `tsgo -p packages/coding-agent/tsconfig.json --noEmit` exit 0
- Quality gate: architect review CLEAR/CLEAR/CLEAR + APPROVE; executor QA/red-team passed.

Base: `dev`.