### PR TITLE
fix(eval/py): python kernel session + process cleanup (U4)

### DIFF
--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -108,7 +108,18 @@ interface PythonSession {
 	queue: Promise<void>;
 }
 
-const sessions = new Map<string, PythonSession>();
+interface InitializingPythonSession {
+	sessionId: string;
+	promise: Promise<PythonSession>;
+}
+
+const sessions = new Map<string, PythonSession | InitializingPythonSession>();
+
+function isInitializingSession(
+	session: PythonSession | InitializingPythonSession,
+): session is InitializingPythonSession {
+	return "promise" in session;
+}
 
 // ---------------------------------------------------------------------------
 // Cancellation plumbing
@@ -288,20 +299,48 @@ function attachOwner(session: PythonSession, sessionId: string, ownerId: string 
 async function acquireSession(sessionId: string, cwd: string, options: PythonExecutorOptions): Promise<PythonSession> {
 	const existing = sessions.get(sessionId);
 	if (existing) {
-		attachOwner(existing, sessionId, options.kernelOwnerId);
-		return existing;
+		const session = isInitializingSession(existing)
+			? await waitForPromiseWithCancellation(existing.promise, options)
+			: existing;
+		attachOwner(session, sessionId, options.kernelOwnerId);
+		return session;
 	}
-	const kernel = await startKernel(cwd, options);
-	const session: PythonSession = {
+
+	const initializing: InitializingPythonSession = {
 		sessionId,
-		kernel,
-		ownerIds: new Set(),
-		hasFallbackOwner: false,
-		queue: Promise.resolve(),
+		promise: Promise.resolve().then(async () => {
+			const kernel = await startKernel(cwd, options);
+			const current = sessions.get(sessionId);
+			if (current !== initializing) {
+				await kernel.shutdown().catch(() => undefined);
+				const winner = current
+					? isInitializingSession(current)
+						? await waitForPromiseWithCancellation(current.promise, options)
+						: current
+					: undefined;
+				if (winner) return winner;
+				throw new PythonExecutionCancelledError(false);
+			}
+			const session: PythonSession = {
+				sessionId,
+				kernel,
+				ownerIds: new Set(),
+				hasFallbackOwner: false,
+				queue: Promise.resolve(),
+			};
+			sessions.set(sessionId, session);
+			return session;
+		}),
 	};
-	attachOwner(session, sessionId, options.kernelOwnerId);
-	sessions.set(sessionId, session);
-	return session;
+	sessions.set(sessionId, initializing);
+	try {
+		const session = await waitForPromiseWithCancellation(initializing.promise, options);
+		attachOwner(session, sessionId, options.kernelOwnerId);
+		return session;
+	} catch (err) {
+		if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
+		throw err;
+	}
 }
 
 async function replaceSessionKernel(
@@ -330,7 +369,8 @@ async function resetSession(sessionId: string): Promise<void> {
 	const existing = sessions.get(sessionId);
 	if (!existing) return;
 	sessions.delete(sessionId);
-	await existing.kernel.shutdown().catch(() => undefined);
+	const session = isInitializingSession(existing) ? await existing.promise.catch(() => undefined) : existing;
+	await session?.kernel.shutdown().catch(() => undefined);
 }
 
 async function runQueued<T>(
@@ -363,11 +403,20 @@ export async function disposeAllKernelSessions(): Promise<void> {
 	for (const [id, session] of all) {
 		if (sessions.get(id) === session) sessions.delete(id);
 	}
-	const results = await Promise.allSettled(all.map(([, session]) => session.kernel.shutdown()));
-	for (let i = 0; i < all.length; i += 1) {
-		const [id, session] = all[i];
+	const resolved = await Promise.all(
+		all.map(
+			async ([id, entry]) =>
+				[id, isInitializingSession(entry) ? await entry.promise.catch(() => undefined) : entry] as const,
+		),
+	);
+	const shutdownTargets = resolved.filter(
+		(entry): entry is readonly [string, PythonSession] => entry[1] !== undefined,
+	);
+	const results = await Promise.allSettled(shutdownTargets.map(([, session]) => session.kernel.shutdown()));
+	for (let i = 0; i < shutdownTargets.length; i += 1) {
+		const [id, session] = shutdownTargets[i];
 		const result = results[i];
-		if (result.status === "fulfilled" && result.value?.confirmed !== false) continue;
+		if (result.status === "fulfilled" && result.value.confirmed) continue;
 		const reason = result.status === "rejected" ? result.reason : "not confirmed";
 		logger.warn("Python kernel shutdown not confirmed", { sessionId: id, reason });
 		if (!sessions.has(id)) sessions.set(id, session);
@@ -377,7 +426,7 @@ export async function disposeAllKernelSessions(): Promise<void> {
 export async function disposeKernelSessionsByOwner(ownerId: string): Promise<void> {
 	const toShutdown: PythonSession[] = [];
 	for (const session of [...sessions.values()]) {
-		if (!session.ownerIds.has(ownerId)) continue;
+		if (isInitializingSession(session) || !session.ownerIds.has(ownerId)) continue;
 		if (session.ownerIds.size === 1) {
 			toShutdown.push(session);
 			continue;
@@ -391,7 +440,7 @@ export async function disposeKernelSessionsByOwner(ownerId: string): Promise<voi
 	for (let i = 0; i < toShutdown.length; i += 1) {
 		const session = toShutdown[i];
 		const result = results[i];
-		if (result.status === "fulfilled" && result.value?.confirmed !== false) {
+		if (result.status === "fulfilled" && result.value.confirmed) {
 			session.ownerIds.delete(ownerId);
 			continue;
 		}

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -3,8 +3,9 @@
  *
  * Speaks NDJSON with `runner.py` over stdin/stdout. One subprocess per kernel
  * instance; sessions reuse a single subprocess across executions. Cancellation
- * is `kill("SIGINT")` which raises a real `KeyboardInterrupt` inside user
- * code. Shutdown writes `{"type":"exit"}` and escalates to SIGTERM/SIGKILL on
+ * sends SIGINT to the runner process group, which raises a real
+ * `KeyboardInterrupt` inside user code and any foreground magic subprocess.
+ * Shutdown writes `{"type":"exit"}` and escalates to SIGTERM/SIGKILL on
  * timeout.
  */
 import * as fs from "node:fs";
@@ -173,6 +174,7 @@ interface PendingExecution {
 	kernelKilled: boolean;
 	settled: boolean;
 	escalationTimer?: NodeJS.Timeout;
+	finalize?: () => void;
 }
 
 export class PythonKernel {
@@ -227,6 +229,9 @@ export class PythonKernel {
 			stdout: "pipe",
 			stderr: "pipe",
 			windowsHide: true,
+			// Run as its own session/process-group leader so SIGINT/SIGTERM can be
+			// delivered to the whole runner tree (incl. foreground magic subprocesses).
+			detached: true,
 		});
 		kernel.#proc = proc;
 		kernel.#stdin = proc.stdin;
@@ -377,10 +382,30 @@ export class PythonKernel {
 
 	async interrupt(): Promise<void> {
 		if (!this.#proc || this.#disposed) return;
+		this.#signalProcessGroup("SIGINT");
+	}
+
+	#signalProcessGroup(signal: NodeJS.Signals): void {
+		const proc = this.#proc;
+		if (!proc) return;
 		try {
-			this.#proc.kill("SIGINT");
+			if (process.platform !== "win32") {
+				process.kill(-proc.pid, signal);
+				return;
+			}
 		} catch (err) {
-			logger.warn("Failed to interrupt python runner", { error: err instanceof Error ? err.message : String(err) });
+			logger.warn("Failed to signal python runner process group", {
+				signal,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+		try {
+			proc.kill(signal);
+		} catch (err) {
+			logger.warn("Failed to signal python runner", {
+				signal,
+				error: err instanceof Error ? err.message : String(err),
+			});
 		}
 	}
 
@@ -412,24 +437,16 @@ export class PythonKernel {
 
 		const exited = this.#waitForExitWithTimeout(timeoutMs);
 		let result = await exited;
-		if (!result) {
-			try {
-				proc.kill("SIGTERM");
-			} catch {
-				/* ignore */
-			}
+		if (result === null) {
+			this.#signalProcessGroup("SIGTERM");
 			result = await this.#waitForExitWithTimeout(timeoutMs);
 		}
-		if (!result) {
-			try {
-				proc.kill("SIGKILL");
-			} catch {
-				/* ignore */
-			}
+		if (result === null) {
+			this.#signalProcessGroup("SIGKILL");
 			result = await this.#waitForExitWithTimeout(timeoutMs);
 		}
 
-		const confirmed = !!result;
+		const confirmed = result !== null;
 		this.#shutdownConfirmed = confirmed;
 		this.#disposed = true;
 		return { confirmed };
@@ -441,17 +458,21 @@ export class PythonKernel {
 		this.#pending.clear();
 		const kernelKilledDefault = options?.kernelKilled ?? false;
 		for (const entry of pending) {
+			entry.cancelled = true;
+			entry.status = "error";
+			entry.kernelKilled = entry.kernelKilled || kernelKilledDefault;
+			entry.finalize?.();
 			if (entry.settled) continue;
 			entry.settled = true;
 			void entry.options?.onChunk?.(`[kernel] ${reason}\n`);
 			entry.resolve({
-				status: "error",
-				cancelled: true,
+				status: entry.status,
+				cancelled: entry.cancelled,
 				timedOut: entry.timedOut,
 				stdinRequested: entry.stdinRequested,
 				executionCount: entry.executionCount,
 				error: entry.error,
-				kernelKilled: entry.kernelKilled || kernelKilledDefault,
+				kernelKilled: entry.kernelKilled,
 			});
 		}
 	}
@@ -655,11 +676,14 @@ export class PythonKernel {
 	#waitForExitWithTimeout(timeoutMs: number): Promise<number | null> {
 		if (!this.#exitedPromise) return Promise.resolve(0);
 		const exitedPromise = this.#exitedPromise;
-		const timeout = new Promise<null>(resolve => {
+		return new Promise(resolve => {
 			const timer = setTimeout(() => resolve(null), Math.max(0, timeoutMs));
 			timer.unref?.();
+			exitedPromise.then(code => {
+				clearTimeout(timer);
+				resolve(code);
+			});
 		});
-		return Promise.race([exitedPromise.then(code => code as number | null), timeout]);
 	}
 }
 

--- a/packages/coding-agent/src/eval/py/runner.py
+++ b/packages/coding-agent/src/eval/py/runner.py
@@ -290,6 +290,44 @@ def _emit_status(op: str, **data: Any) -> None:
     _emit({"type": "display", "id": rid, "bundle": bundle})
 
 
+def _terminate_process_group(proc: subprocess.Popen[Any]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+    except ProcessLookupError:
+        return
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except ProcessLookupError:
+        return
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=1)
+    except Exception:
+        pass
+
+
 @line_magic("pip")
 def _magic_pip(args: str) -> None:
     argv = shlex.split(args) if args else ["--help"]
@@ -300,18 +338,26 @@ def _magic_pip(args: str) -> None:
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        start_new_session=(os.name == "posix"),
     )
     installed_packages: list[str] = []
-    assert proc.stdout is not None
-    for raw_line in proc.stdout:
-        sys.stdout.write(raw_line)
-        m = re.search(r"Successfully installed\s+(.+)$", raw_line)
-        if m:
-            for token in m.group(1).split():
-                # Token is name-version; drop the version suffix.
-                pkg = token.rsplit("-", 1)[0]
-                installed_packages.append(pkg.replace("_", "-"))
-    proc.wait()
+    try:
+        assert proc.stdout is not None
+        try:
+            for raw_line in proc.stdout:
+                sys.stdout.write(raw_line)
+                m = re.search(r"Successfully installed\s+(.+)$", raw_line)
+                if m:
+                    for token in m.group(1).split():
+                        # Token is name-version; drop the version suffix.
+                        pkg = token.rsplit("-", 1)[0]
+                        installed_packages.append(pkg.replace("_", "-"))
+        finally:
+            proc.stdout.close()
+        proc.wait()
+    except KeyboardInterrupt:
+        _terminate_process_group(proc)
+        raise
     if installed_packages:
         import importlib
 
@@ -500,11 +546,19 @@ def _run_shell_body(body: str, *, shell_arg: str) -> int:
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        start_new_session=(os.name == "posix"),
     )
-    assert proc.stdout is not None
-    for raw_line in proc.stdout:
-        sys.stdout.write(raw_line)
-    proc.wait()
+    try:
+        assert proc.stdout is not None
+        try:
+            for raw_line in proc.stdout:
+                sys.stdout.write(raw_line)
+        finally:
+            proc.stdout.close()
+        proc.wait()
+    except KeyboardInterrupt:
+        _terminate_process_group(proc)
+        raise
     return proc.returncode
 
 

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
+import type {
+	KernelExecuteOptions,
+	KernelExecuteResult,
+	KernelShutdownResult,
+} from "@gajae-code/coding-agent/eval/py/kernel";
+import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { TempDir } from "@gajae-code/utils";
+
+const originalStart = PythonKernel.start;
+
+const OK_RESULT: KernelExecuteResult = {
+	status: "ok",
+	cancelled: false,
+	timedOut: false,
+	stdinRequested: false,
+};
+
+class FakeKernel {
+	alive = true;
+	executeCalls: string[] = [];
+	shutdownCalls = 0;
+	shutdownResult: KernelShutdownResult = { confirmed: true };
+	private readonly executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>;
+
+	constructor(executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>) {
+		this.executeImpl = executeImpl;
+	}
+
+	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
+		this.executeCalls.push(code);
+		return this.executeImpl ? await this.executeImpl(code, options) : OK_RESULT;
+	}
+
+	async shutdown(): Promise<KernelShutdownResult> {
+		this.shutdownCalls += 1;
+		this.alive = false;
+		return this.shutdownResult;
+	}
+
+	isAlive(): boolean {
+		return this.alive;
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessGone(pid: number, timeoutMs = 5000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return true;
+		await Bun.sleep(50);
+	}
+	return !isProcessAlive(pid);
+}
+
+function countAbortListeners(signal: AbortSignal): { readonly count: () => number; readonly restore: () => void } {
+	let count = 0;
+	const originalAdd = signal.addEventListener.bind(signal);
+	const originalRemove = signal.removeEventListener.bind(signal);
+	signal.addEventListener = ((
+		type: string,
+		listener: Parameters<typeof originalAdd>[1],
+		options?: AddEventListenerOptions | boolean,
+	) => {
+		if (type === "abort") count += 1;
+		return originalAdd(type, listener, options);
+	}) as typeof signal.addEventListener;
+	signal.removeEventListener = ((
+		type: string,
+		listener: Parameters<typeof originalRemove>[1],
+		options?: EventListenerOptions | boolean,
+	) => {
+		if (type === "abort") count -= 1;
+		return originalRemove(type, listener, options);
+	}) as typeof signal.removeEventListener;
+	return {
+		count: () => count,
+		restore: () => {
+			signal.addEventListener = originalAdd as typeof signal.addEventListener;
+			signal.removeEventListener = originalRemove as typeof signal.removeEventListener;
+		},
+	};
+}
+
+describe("python eval lifecycle red-team", () => {
+	afterEach(async () => {
+		PythonKernel.start = originalStart;
+		delete Bun.env.PI_PYTHON_SKIP_CHECK;
+		await disposeAllKernelSessions();
+	});
+
+	it("coalesces five concurrent first acquires for the same new session without orphan kernels", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const startup = Promise.withResolvers<void>();
+		const kernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			await startup.promise;
+			return kernel as unknown as PythonKernel;
+		};
+
+		const executions = Array.from({ length: 5 }, (_, index) =>
+			executePython(`print(${index})`, {
+				cwd: tempDir.path(),
+				sessionId: "redteam-concurrent-same-session",
+				kernelMode: "session",
+			}),
+		);
+		await Bun.sleep(0);
+		expect(startCalls).toBe(1);
+
+		startup.resolve();
+		await Promise.all(executions);
+		expect(startCalls).toBe(1);
+		expect(kernel.executeCalls).toEqual(["print(0)", "print(1)", "print(2)", "print(3)", "print(4)"]);
+
+		await disposeAllKernelSessions();
+		expect(kernel.shutdownCalls).toBe(1);
+	});
+
+	it("kills only the owned bash background descendant after timeout while an unrelated sibling survives", async () => {
+		if (process.platform === "win32") return;
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+		let childPid: number | undefined;
+		try {
+			const result = await executePython("%%bash\n(sleep 30) &\necho owned_child:$!\nwait", {
+				cwd: tempDir.path(),
+				sessionId: "redteam-bash-descendant-timeout",
+				kernelMode: "session",
+				timeoutMs: 500,
+			});
+			const match = result.output.match(/owned_child:(\d+)/);
+			expect(match).not.toBeNull();
+			childPid = Number(match?.[1]);
+			expect(result.cancelled).toBe(true);
+			expect(await waitForProcessGone(childPid)).toBe(true);
+			expect(isProcessAlive(unrelated.pid)).toBe(true);
+		} finally {
+			try {
+				unrelated.kill("SIGKILL");
+			} catch {
+				// ignore cleanup races
+			}
+			await unrelated.exited.catch(() => undefined);
+		}
+	});
+
+	it("settles an in-flight cell during shutdown without leaked abort listeners", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const controller = new AbortController();
+		const listeners = countAbortListeners(controller.signal);
+		let shutdown: (() => Promise<KernelShutdownResult>) | undefined;
+		try {
+			PythonKernel.start = async () => {
+				const kernel = await originalStart({ cwd: tempDir.path() });
+				shutdown = () => kernel.shutdown({ timeoutMs: 100 });
+				return kernel;
+			};
+
+			const execution = executePython("import time\ntime.sleep(60)", {
+				cwd: tempDir.path(),
+				sessionId: "redteam-inflight-shutdown",
+				kernelMode: "session",
+				signal: controller.signal,
+				timeoutMs: 60_000,
+			});
+			await Bun.sleep(250);
+			expect(listeners.count()).toBe(1);
+			expect(shutdown).toBeDefined();
+
+			await shutdown?.();
+			await execution;
+			expect(listeners.count()).toBe(0);
+		} finally {
+			listeners.restore();
+		}
+	});
+
+	it("treats clean exit code 0 as confirmed and starts a fresh session instead of reinserting", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const firstKernel = new FakeKernel();
+		const secondKernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			return (startCalls === 1 ? firstKernel : secondKernel) as unknown as PythonKernel;
+		};
+
+		await executePython("print('before clean shutdown')", {
+			cwd: tempDir.path(),
+			sessionId: "redteam-clean-exit-not-reinserted",
+			kernelMode: "session",
+		});
+		await disposeAllKernelSessions();
+		await executePython("print('after clean shutdown')", {
+			cwd: tempDir.path(),
+			sessionId: "redteam-clean-exit-not-reinserted",
+			kernelMode: "session",
+		});
+
+		expect(firstKernel.shutdownCalls).toBe(1);
+		expect(startCalls).toBe(2);
+		expect(secondKernel.executeCalls).toEqual(["print('after clean shutdown')"]);
+	});
+});

--- a/packages/coding-agent/test/eval/python-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
+import type {
+	KernelExecuteOptions,
+	KernelExecuteResult,
+	KernelShutdownResult,
+} from "@gajae-code/coding-agent/eval/py/kernel";
+import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { TempDir } from "@gajae-code/utils";
+
+const originalStart = PythonKernel.start;
+
+const OK_RESULT: KernelExecuteResult = {
+	status: "ok",
+	cancelled: false,
+	timedOut: false,
+	stdinRequested: false,
+};
+
+class FakeKernel {
+	alive = true;
+	executeCalls: string[] = [];
+	shutdownCalls = 0;
+	shutdownResult: KernelShutdownResult = { confirmed: true };
+	private readonly executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>;
+
+	constructor(executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>) {
+		this.executeImpl = executeImpl;
+	}
+
+	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
+		this.executeCalls.push(code);
+		return this.executeImpl ? await this.executeImpl(code, options) : OK_RESULT;
+	}
+
+	async shutdown(): Promise<KernelShutdownResult> {
+		this.shutdownCalls += 1;
+		return this.shutdownResult;
+	}
+
+	isAlive(): boolean {
+		return this.alive;
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForExit(pid: number, timeoutMs = 3000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return true;
+		await Bun.sleep(25);
+	}
+	return !isProcessAlive(pid);
+}
+
+describe("python eval lifecycle", () => {
+	afterEach(async () => {
+		PythonKernel.start = originalStart;
+		await disposeAllKernelSessions();
+	});
+
+	it("coalesces concurrent first acquires for the same session into one kernel", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const startup = Promise.withResolvers<void>();
+		let startCalls = 0;
+		const kernel = new FakeKernel();
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			await startup.promise;
+			return kernel as unknown as PythonKernel;
+		};
+
+		const first = executePython("print('first')", {
+			cwd: tempDir.path(),
+			sessionId: "concurrent-session",
+			kernelMode: "session",
+		});
+		const second = executePython("print('second')", {
+			cwd: tempDir.path(),
+			sessionId: "concurrent-session",
+			kernelMode: "session",
+		});
+		await Bun.sleep(0);
+		expect(startCalls).toBe(1);
+
+		startup.resolve();
+		await Promise.all([first, second]);
+
+		expect(startCalls).toBe(1);
+		expect(kernel.executeCalls).toEqual(["print('first')", "print('second')"]);
+	});
+
+	it("settles pending executions and releases abort listeners during shutdown", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const controller = new AbortController();
+		let abortListeners = 0;
+		const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+		const originalRemove = controller.signal.removeEventListener.bind(controller.signal);
+		controller.signal.addEventListener = ((
+			type: string,
+			listener: Parameters<typeof originalAdd>[1],
+			options?: AddEventListenerOptions | boolean,
+		) => {
+			if (type === "abort") abortListeners += 1;
+			return originalAdd(type, listener, options);
+		}) as typeof controller.signal.addEventListener;
+		controller.signal.removeEventListener = ((
+			type: string,
+			listener: Parameters<typeof originalRemove>[1],
+			options?: EventListenerOptions | boolean,
+		) => {
+			if (type === "abort") abortListeners -= 1;
+			return originalRemove(type, listener, options);
+		}) as typeof controller.signal.removeEventListener;
+
+		const kernel = await originalStart({ cwd: tempDir.path() });
+		try {
+			const execution = kernel.execute("import time\ntime.sleep(60)", {
+				signal: controller.signal,
+				timeoutMs: 60_000,
+			});
+			for (let i = 0; i < 40 && abortListeners === 0; i += 1) {
+				await Bun.sleep(50);
+			}
+			expect(abortListeners).toBe(1);
+
+			await kernel.shutdown({ timeoutMs: 100 });
+			const result = await execution;
+			expect(result.status).toBe("error");
+			expect(result.cancelled).toBe(true);
+			expect(result.kernelKilled).toBe(true);
+			expect(abortListeners).toBe(0);
+		} finally {
+			await kernel.shutdown({ timeoutMs: 100 }).catch(() => undefined);
+		}
+	});
+
+	it("treats clean exit code 0 as confirmed shutdown and does not reinsert the session", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const firstKernel = new FakeKernel();
+		const secondKernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			return (startCalls === 1 ? firstKernel : secondKernel) as unknown as PythonKernel;
+		};
+
+		await executePython("print('one')", {
+			cwd: tempDir.path(),
+			sessionId: "clean-exit-session",
+			kernelMode: "session",
+		});
+		await disposeAllKernelSessions();
+		await executePython("print('two')", {
+			cwd: tempDir.path(),
+			sessionId: "clean-exit-session",
+			kernelMode: "session",
+		});
+
+		expect(firstKernel.shutdownCalls).toBe(1);
+		expect(startCalls).toBe(2);
+		expect(secondKernel.executeCalls).toEqual(["print('two')"]);
+	});
+
+	it("kills background descendants owned by a bash cell interrupt while an unrelated sibling survives", async () => {
+		if (process.platform === "win32") return;
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+		let childPid: number | undefined;
+		try {
+			const resultPromise = executePython("%%bash\n(sleep 30) &\necho child:$!\nwait", {
+				cwd: tempDir.path(),
+				sessionId: "bash-descendant-session",
+				kernelMode: "session",
+				timeoutMs: 500,
+			});
+			const result = await resultPromise;
+			const match = result.output.match(/child:(\d+)/);
+			expect(match).not.toBeNull();
+			childPid = Number(match?.[1]);
+			expect(result.cancelled).toBe(true);
+			expect(await waitForExit(childPid)).toBe(true);
+			expect(isProcessAlive(unrelated.pid)).toBe(true);
+		} finally {
+			try {
+				unrelated.kill("SIGKILL");
+			} catch {
+				// ignore cleanup races
+			}
+			await unrelated.exited.catch(() => undefined);
+		}
+	});
+});


### PR DESCRIPTION
## U4 — Python eval session & process cleanup

Part of the core-runtime fix campaign (plan `.gjc/plans/ralplan/core-runtime-fixes-parallel/`). Owns `eval/py/{executor.ts,kernel.ts,runner.py}`.

- **C1 (critical):** reserve-before-await session acquire — concurrent first cells coalesce to one kernel; the losing kernel is shut down. No untracked duplicate kernels.
- **C3 (critical):** `%pip`/`%%bash` magic subprocesses spawn in their own session (`start_new_session`) and are killed as a group on `KeyboardInterrupt`; the runner is spawned `detached` so interrupt/shutdown signal the runner's process group (`process.kill(-pid)`), never the harness.
- **H19:** clean exit code 0 is a *confirmed* shutdown (null checks); dead sessions are not reinserted.
- **H20:** `#abortPendingExecutions` marks cancelled/error/kernel-killed **before** `finalize` resolves, and runs per-entry cleanup (timers + abort listeners).
- **L1:** shutdown wait timer cleared when the exit promise wins.

### Verification
- `bun test packages/coding-agent/test/eval/python-lifecycle.test.ts` → 4 pass (+ red-team 4 pass): concurrent-acquire coalescing; shutdown-of-in-flight resolves `cancelled:true`+`kernelKilled:true` (not success); confirmed-exit-0 not reinserted; owned bash descendant reaped on interrupt while unrelated sibling survives.
- `bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit` exit 0; biome clean.
- Quality gate: architect CLEAR/CLEAR/CLEAR + APPROVE (re-review after fixing a finalize-ordering blocker); red-team 4/4.

Base: `dev`.