### PR TITLE
fix(gjc-runtime): tmux GC never kills live/attached sessions (U10)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 
 import { worktree } from "../utils/git";
 import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapter } from "./gc-runtime";
-import { GJC_TMUX_PROFILE_VALUE } from "./tmux-common";
+import { GJC_TMUX_PROFILE_VALUE, GJC_TMUX_SESSION_PREFIX } from "./tmux-common";
 import {
 	type GjcTmuxSessionStatus,
 	type GjcTmuxSessionsForGc,
@@ -19,6 +19,7 @@ import {
 
 const STORE = "tmux_sessions" as const;
 const TOCTOU_SKIP = "tmux_revalidation_failed_or_became_live";
+const ORPHAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function pathExists(path: string): boolean {
 	try {
@@ -65,39 +66,62 @@ async function hasLiveWorktreeForBranch(project: string, branch: string): Promis
 	return entries.some(entry => branchMatches(entry.branch, branch));
 }
 
+function isSessionLive(session: Pick<GjcTmuxSessionStatus, "attached" | "panePids">): boolean {
+	return session.attached || session.panePids.length > 0;
+}
+
+function liveRecord(session: GjcTmuxSessionStatus, reason: string): GcRecord {
+	return {
+		store: STORE,
+		id: session.name,
+		path: session.project,
+		root: session.project,
+		pid_status: "alive",
+		status: "live",
+		stale: false,
+		removable: false,
+		action: "none",
+		reason,
+		detail: detail(session.project, session.branch),
+	};
+}
+
+function staleRecord(session: GjcTmuxSessionStatus, reason: string): GcRecord {
+	return {
+		store: STORE,
+		id: session.name,
+		path: session.project,
+		root: session.project,
+		pid_status: "none",
+		status: "stale",
+		stale: true,
+		removable: true,
+		action: "none",
+		reason,
+		detail: `${detail(session.project, session.branch) ?? ""} createdAt=${session.createdAt}`.trim(),
+	};
+}
+
+function isOldEnoughForOrphanGc(session: GjcTmuxSessionStatus): boolean {
+	const createdAt = Date.parse(session.createdAt);
+	return Number.isFinite(createdAt) && Date.now() - createdAt >= ORPHAN_MAX_AGE_MS;
+}
+
+function isGjcOwnedOrphan(session: GjcTmuxSessionStatus): boolean {
+	return session.name.startsWith(GJC_TMUX_SESSION_PREFIX) || session.name === "gajae_code";
+}
+
 async function classifyTaggedSession(session: GjcTmuxSessionStatus): Promise<GcRecord> {
 	const { name, project, branch } = session;
-	if (!project || !branch) return unclassifiedRecord(name, "missing_project_or_branch_tag", project, branch);
-	if (!pathExists(project)) {
-		return {
-			store: STORE,
-			id: name,
-			path: project,
-			root: project,
-			pid_status: "none",
-			status: "stale",
-			stale: true,
-			removable: true,
-			action: "none",
-			reason: "project_missing",
-			detail: detail(project, branch),
-		};
+	if (isSessionLive(session)) return liveRecord(session, "tmux_session_attached_or_has_live_panes");
+	if (!project || !branch) {
+		if (isGjcOwnedOrphan(session) && isOldEnoughForOrphanGc(session)) {
+			return staleRecord(session, "metadata_less_gjc_owned_idle_orphan");
+		}
+		return unclassifiedRecord(name, "missing_project_or_branch_tag", project, branch);
 	}
-	if (!(await hasLiveWorktreeForBranch(project, branch))) {
-		return {
-			store: STORE,
-			id: name,
-			path: project,
-			root: project,
-			pid_status: "none",
-			status: "stale",
-			stale: true,
-			removable: true,
-			action: "none",
-			reason: "branch_no_worktree",
-			detail: detail(project, branch),
-		};
-	}
+	if (!pathExists(project)) return staleRecord(session, "project_missing");
+	if (!(await hasLiveWorktreeForBranch(project, branch))) return staleRecord(session, "branch_no_worktree");
 	return {
 		store: STORE,
 		id: name,
@@ -113,9 +137,34 @@ async function classifyTaggedSession(session: GjcTmuxSessionStatus): Promise<GcR
 	};
 }
 
-async function revalidateRemovable(name: string, env: NodeJS.ProcessEnv): Promise<boolean> {
-	const tags = readTmuxSessionTagsForGc(name, env);
-	if (tags.profile !== GJC_TMUX_PROFILE_VALUE || !tags.project || !tags.branch) return false;
+function classifyUntaggedSession(session: GjcTmuxSessionStatus): GcRecord {
+	return unclassifiedRecord(session.name, "untagged_tmux_session");
+}
+
+async function revalidateRemovable(record: GcRecord, env: NodeJS.ProcessEnv): Promise<boolean> {
+	const tags = readTmuxSessionTagsForGc(record.id, env);
+	if (
+		tags.createdAt &&
+		record.detail?.includes("createdAt=") &&
+		!record.detail.includes(`createdAt=${tags.createdAt}`)
+	) {
+		return false;
+	}
+	if (tags.attached || (tags.panePids?.length ?? 0) > 0) return false;
+	if (tags.profile !== GJC_TMUX_PROFILE_VALUE) return false;
+	if (!tags.project || !tags.branch)
+		return (
+			record.reason === "metadata_less_gjc_owned_idle_orphan" &&
+			isGjcOwnedOrphan({
+				name: record.id,
+				attached: false,
+				windows: 0,
+				panes: 0,
+				panePids: [],
+				bindings: "",
+				createdAt: tags.createdAt ?? "",
+			})
+		);
 	if (!pathExists(tags.project)) return true;
 	return !(await hasLiveWorktreeForBranch(tags.project, tags.branch));
 }
@@ -154,8 +203,8 @@ export const tmuxSessionsGcAdapter: GcStoreAdapter = {
 			}
 		}
 
-		for (const name of sessions.untagged) {
-			records.push(unclassifiedRecord(name, "untagged_tmux_session"));
+		for (const session of sessions.untagged) {
+			records.push(classifyUntaggedSession(session));
 		}
 
 		return { records, errors };
@@ -165,7 +214,7 @@ export const tmuxSessionsGcAdapter: GcStoreAdapter = {
 			return { removed: false, skipped: "not_removable_tmux_session" };
 		}
 		try {
-			if (!(await revalidateRemovable(record.id, ctx.env))) {
+			if (!(await revalidateRemovable(record, ctx.env))) {
 				return { removed: false, skipped: TOCTOU_SKIP };
 			}
 			removeGjcTmuxSession(record.id, ctx.env);

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -22,17 +22,23 @@ export interface GjcTmuxSessionStatus {
 	branch?: string;
 	branchSlug?: string;
 	project?: string;
+	panePids: number[];
+	profile?: string;
 }
 
 export interface GjcTmuxSessionTagsForGc {
 	profile?: string;
 	project?: string;
 	branch?: string;
+	branchSlug?: string;
+	createdAt?: string;
+	attached?: boolean;
+	panePids?: number[];
 }
 
 export interface GjcTmuxSessionsForGc {
 	tagged: GjcTmuxSessionStatus[];
-	untagged: string[];
+	untagged: GjcTmuxSessionStatus[];
 }
 
 function runTmux(args: string[], env: NodeJS.ProcessEnv = process.env): string {
@@ -68,21 +74,27 @@ function parseSessionLine(line: string): GjcTmuxSessionStatus | null {
 		profile = "",
 		bindings = "",
 		panes = "0",
+		panePids = "",
 		branch = "",
 		branchSlug = "",
 		project = "",
 	] = line.split("\t");
-	if (!name || profile !== GJC_TMUX_PROFILE_VALUE) return null;
+	if (!name) return null;
 	return {
 		name,
 		attached: parseBooleanFlag(attached),
 		windows: parseNumber(windows),
 		panes: parseNumber(panes),
+		panePids: panePids
+			.split(",")
+			.map(pid => parseNumber(pid))
+			.filter(pid => pid > 0),
 		bindings,
 		createdAt: normalizeTmuxCreatedAt(created),
 		branch: branch || undefined,
 		branchSlug: branchSlug || undefined,
 		project: project || undefined,
+		profile: profile || undefined,
 	};
 }
 
@@ -103,7 +115,7 @@ function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): 
 
 function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
 	return runListSessions(
-		`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
+		`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{pane_pid}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
 		env,
 	);
 }
@@ -115,17 +127,35 @@ function listRawTmuxSessionNames(env: NodeJS.ProcessEnv = process.env): string[]
 export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus[] {
 	return listSessionLines(env)
 		.map(parseSessionLine)
-		.filter((session): session is GjcTmuxSessionStatus => session != null)
+		.filter((session): session is GjcTmuxSessionStatus => session?.profile === GJC_TMUX_PROFILE_VALUE)
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** @internal */
 export function listTmuxSessionsForGc(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionsForGc {
-	const tagged = listGjcTmuxSessions(env);
+	const sessions = listSessionLines(env)
+		.map(parseSessionLine)
+		.filter((session): session is GjcTmuxSessionStatus => session != null);
+	const tagged = sessions
+		.filter(session => session.profile === GJC_TMUX_PROFILE_VALUE)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	const taggedNames = new Set(tagged.map(session => session.name));
+	const byName = new Map(sessions.map(session => [session.name, session]));
 	const untagged = listRawTmuxSessionNames(env)
 		.filter(name => !taggedNames.has(name))
-		.sort((a, b) => a.localeCompare(b));
+		.map(
+			name =>
+				byName.get(name) ?? {
+					name,
+					attached: false,
+					windows: 0,
+					panes: 0,
+					panePids: [],
+					bindings: "",
+					createdAt: "",
+				},
+		)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	return { tagged, untagged };
 }
 
@@ -192,15 +222,23 @@ export function readTmuxSessionTagsForGc(
 	sessionName: string,
 	env: NodeJS.ProcessEnv = process.env,
 ): GjcTmuxSessionTagsForGc {
+	const session = listGjcTmuxSessions(env).find(candidate => candidate.name === sessionName);
 	return {
 		profile: readExactOptionForGc(sessionName, GJC_TMUX_PROFILE_OPTION, env),
 		project: readExactOptionForGc(sessionName, GJC_TMUX_PROJECT_OPTION, env),
 		branch: readExactOptionForGc(sessionName, GJC_TMUX_BRANCH_OPTION, env),
+		branchSlug: readExactOptionForGc(sessionName, GJC_TMUX_BRANCH_SLUG_OPTION, env),
+		createdAt: session?.createdAt,
+		attached: session?.attached,
+		panePids: session?.panePids,
 	};
 }
 
 export function removeGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {
 	const session = statusGjcTmuxSession(sessionName, env);
+	if (session.attached || session.panePids.length > 0) {
+		throw new Error(`gjc_tmux_session_live:${sessionName}`);
+	}
 	if (readProfileForExactTarget(session.name, env) !== GJC_TMUX_PROFILE_VALUE) {
 		throw new Error(`gjc_tmux_session_not_managed:${sessionName}`);
 	}

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
@@ -170,7 +170,10 @@ describe("tmux GC red-team adversarial safety", () => {
 			if (cmd.includes("list-sessions")) {
 				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
 				if (format === "#{session_name}") return spawnResult(0, "gajae_code_idle_orphan\n");
-				return spawnResult(0, sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }));
+				return spawnResult(
+					0,
+					sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }),
+				);
 			}
 			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
 			if (cmd.includes("show-options")) return spawnResult(0, "\n");

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { GcContext } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { tmuxSessionsGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/tmux-gc";
+
+const env = { GJC_TMUX_COMMAND: "tmux-redteam" };
+const cwd = "/tmp/gjc-redteam-project";
+
+type SpawnSyncResult = Bun.SyncSubprocess<"pipe", "pipe">;
+type SpawnSyncSpy = { mockImplementation(implementation: (command: string[]) => SpawnSyncResult): void };
+
+function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+	return {
+		exitCode,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+	} as SpawnSyncResult;
+}
+
+function ctx(): GcContext {
+	return {
+		probe: () => ({ status: "dead" }),
+		force: false,
+		env,
+		cwd,
+	};
+}
+
+function sessionLine(overrides: {
+	name: string;
+	attached?: boolean;
+	created?: number;
+	profile?: string;
+	panes?: number;
+	panePid?: number;
+	branch?: string;
+	project?: string;
+}): string {
+	return [
+		overrides.name,
+		"1",
+		overrides.attached ? "1" : "0",
+		String(overrides.created ?? 1_770_000_000),
+		overrides.profile ?? "1",
+		"root",
+		String(overrides.panes ?? (overrides.panePid ? 1 : 0)),
+		overrides.panePid ? String(overrides.panePid) : "",
+		overrides.branch ?? "",
+		overrides.branch?.replaceAll("/", "-") ?? "",
+		overrides.project ?? "",
+	].join("\t");
+}
+
+function optionValue(cmd: string[], option: string): boolean {
+	return cmd.includes("show-options") && cmd.at(-1) === option;
+}
+
+describe("tmux GC red-team adversarial safety", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not prune an attached GJC session even when project path and branch worktree are gone", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_attached_stale\n");
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_attached_stale",
+						attached: true,
+						branch: "gone-branch",
+						project: "/tmp/gjc-redteam-missing-project",
+					}),
+				);
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_attached_stale");
+
+		expect(result.errors).toEqual([]);
+		expect(record).toMatchObject({ status: "live", stale: false, removable: false, pid_status: "alive" });
+		expect(record?.reason).toBe("tmux_session_attached_or_has_live_panes");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_attached_stale"]);
+	});
+
+	it("revalidates before pruning and skips kill when a stale candidate becomes attached after classification", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_toctou\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_toctou",
+						attached: richListCount > 1,
+						branch: "deleted-branch",
+						project: "/tmp/gjc-redteam-deleted-project",
+					}),
+				);
+			}
+			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
+			if (optionValue(cmd, "@gjc-project")) return spawnResult(0, "/tmp/gjc-redteam-deleted-project\n");
+			if (optionValue(cmd, "@gjc-branch")) return spawnResult(0, "deleted-branch\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_toctou");
+
+		expect(record).toMatchObject({ status: "stale", stale: true, removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "tmux_revalidation_failed_or_became_live",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_toctou"]);
+	});
+
+	it("never prunes a non-GJC untagged session that superficially resembles an idle orphan", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae-code-old-orphan-looking\n");
+				return spawnResult(
+					0,
+					sessionLine({ name: "gajae-code-old-orphan-looking", profile: "", created: 1_600_000_000 }),
+				);
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae-code-old-orphan-looking");
+
+		expect(record).toMatchObject({ status: "unclassified", stale: false, removable: false });
+		expect(record?.reason).toBe("untagged_tmux_session");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae-code-old-orphan-looking"]);
+	});
+
+	it("prunes a genuine GJC-owned metadata-less idle orphan only after ownership, no-attachment, age, and revalidation", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_idle_orphan\n");
+				return spawnResult(0, sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }));
+			}
+			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
+			if (cmd.includes("show-options")) return spawnResult(0, "\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_idle_orphan");
+
+		expect(record).toMatchObject({
+			status: "stale",
+			stale: true,
+			removable: true,
+			reason: "metadata_less_gjc_owned_idle_orphan",
+		});
+		expect(record?.detail).toContain("createdAt=2026-02-02T02:40:00.000Z");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({ removed: true });
+		expect(calls).toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_idle_orphan"]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { GcContext } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { tmuxSessionsGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/tmux-gc";
+
+const env = { GJC_TMUX_COMMAND: "tmux-test" };
+const project = "/tmp/gjc-project";
+
+type SpawnSyncResult = Bun.SyncSubprocess<"pipe", "pipe">;
+type SpawnSyncSpy = { mockImplementation(implementation: (command: string[]) => SpawnSyncResult): void };
+
+function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+	return {
+		exitCode,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+	} as SpawnSyncResult;
+}
+
+function ctx(): GcContext {
+	return {
+		probe: () => ({ status: "dead" }),
+		force: false,
+		env,
+		cwd: project,
+	};
+}
+
+function sessionLine(overrides: {
+	name: string;
+	attached?: boolean;
+	created?: number;
+	profile?: string;
+	panes?: number;
+	panePid?: number;
+	branch?: string;
+	project?: string;
+}): string {
+	return [
+		overrides.name,
+		"1",
+		overrides.attached ? "1" : "0",
+		String(overrides.created ?? 1_770_000_000),
+		overrides.profile ?? "1",
+		"root",
+		String(overrides.panes ?? (overrides.panePid ? 1 : 0)),
+		overrides.panePid ? String(overrides.panePid) : "",
+		overrides.branch ?? "",
+		overrides.branch?.replaceAll("/", "-") ?? "",
+		overrides.project ?? "",
+	].join("\t");
+}
+
+describe("tmux GC safety", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("classifies attached/live tagged sessions with stale metadata as non-removable and does not prune", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		spyOn(Bun, "spawnSync").mockReturnValue(
+			spawnResult(0, sessionLine({ name: "gajae_code_live", attached: true, branch: "stale", project })),
+		);
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_live");
+
+		expect(result.errors).toEqual([]);
+		expect(record).toMatchObject({ status: "live", stale: false, removable: false, pid_status: "alive" });
+		expect(record?.reason).toBe("tmux_session_attached_or_has_live_panes");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(Bun.spawnSync).not.toHaveBeenCalledWith(
+			["tmux-test", "kill-session", "-t", "=gajae_code_live"],
+			expect.any(Object),
+		);
+	});
+
+	it("prunes metadata-less GJC-owned idle orphan only when ownership is proven and not attached", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_orphan\nunrelated_orphan\n");
+				return spawnResult(
+					0,
+					[
+						sessionLine({ name: "gajae_code_orphan", profile: "1", created: 1_770_000_000 }),
+						sessionLine({ name: "unrelated_orphan", profile: "", created: 1_770_000_000 }),
+					].join("\n"),
+				);
+			}
+			if (cmd.includes("show-options")) return spawnResult(0, cmd.at(-1) === "@gjc-profile" ? "1\n" : "\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const orphan = result.records.find(entry => entry.id === "gajae_code_orphan");
+		const unrelated = result.records.find(entry => entry.id === "unrelated_orphan");
+
+		expect(orphan).toMatchObject({ status: "stale", removable: true, reason: "metadata_less_gjc_owned_idle_orphan" });
+		expect(unrelated).toMatchObject({ status: "unclassified", removable: false, reason: "untagged_tmux_session" });
+		expect(await tmuxSessionsGcAdapter.prune(orphan!, ctx())).toEqual({ removed: true });
+		expect(calls).toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_orphan"]);
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=unrelated_orphan"]);
+	});
+
+	it("revalidation skips kill when a removable session becomes attached before prune", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let listCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_race\n");
+				listCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_race",
+						attached: listCount > 1,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "tmux_revalidation_failed_or_became_live",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_race"]);
+	});
+
+	it("final status read blocks kill when a revalidated candidate becomes attached", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_final_race\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_final_race",
+						attached: richListCount > 2,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_final_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toMatchObject({
+			removed: false,
+			error: "gjc_tmux_session_live:gajae_code_final_race",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_final_race"]);
+	});
+
+	it("final status read blocks kill when a detached revalidated candidate has live pane PIDs", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_final_pane_race\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_final_pane_race",
+						attached: false,
+						panePid: richListCount > 2 ? 43210 : undefined,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_final_pane_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toMatchObject({
+			removed: false,
+			error: "gjc_tmux_session_live:gajae_code_final_pane_race",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_final_pane_race"]);
+	});
+
+	it("keeps old detached prefix-named untagged sessions non-removable", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_user_owned\n");
+				return spawnResult(0, sessionLine({ name: "gajae_code_user_owned", profile: "", created: 1_600_000_000 }));
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_user_owned");
+
+		expect(record).toMatchObject({ status: "unclassified", stale: false, removable: false });
+		expect(record?.reason).toBe("untagged_tmux_session");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_user_owned"]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -27,9 +27,9 @@ describe("GJC tmux session management", () => {
 			spawnResult(
 				0,
 				[
-					"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\tfeature/demo\tfeature-demo\t/repo-a",
-					"unrelated\t2\t1\t1770000060\t\troot\t3\t\t",
-					"gajae_code\t1\t1\t1770000120\t\troot\t1\t\t",
+					"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\t12345\tfeature/demo\tfeature-demo\t/repo-a",
+					"unrelated\t2\t1\t1770000060\t\troot\t3\t23456\t\t",
+					"gajae_code\t1\t1\t1770000120\t\troot\t1\t34567\t\t",
 				].join("\n"),
 			),
 		);
@@ -39,6 +39,7 @@ describe("GJC tmux session management", () => {
 		expect(sessions.map(session => session.name)).toEqual(["gajae_code_abc"]);
 		expect(sessions[0].attached).toBe(false);
 		expect(sessions[0].panes).toBe(2);
+		expect(sessions[0].panePids).toEqual([12345]);
 		expect(sessions[0].bindings).toBe("root");
 		expect(sessions[0].createdAt).toBe("2026-02-02T02:40:00.000Z");
 		expect(sessions[0].branch).toBe("feature/demo");
@@ -48,7 +49,7 @@ describe("GJC tmux session management", () => {
 				"tmux-test",
 				"list-sessions",
 				"-F",
-				"#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{@gjc-profile}\t#{session_key_table}\t#{session_panes}\t#{@gjc-branch}\t#{@gjc-branch-slug}\t#{@gjc-project}",
+				"#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{@gjc-profile}\t#{session_key_table}\t#{session_panes}\t#{pane_pid}\t#{@gjc-branch}\t#{@gjc-branch-slug}\t#{@gjc-project}",
 			],
 			expect.any(Object),
 		);
@@ -66,7 +67,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");
@@ -84,7 +85,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "\n");
 			return spawnResult(0, "");
@@ -102,7 +103,7 @@ describe("GJC tmux session management", () => {
 				// The bare `#{session_name}` probe sees the session (psmux ls shows it)...
 				if (format === "#{session_name}") return spawnResult(0, "psmux_session\n");
 				// ...but the full format does not round-trip @gjc-profile, so the profile column is empty.
-				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\n");
+				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\t\n");
 			}
 			return spawnResult(0, "");
 		});
@@ -131,7 +132,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");


### PR DESCRIPTION
## U10 — tmux GC safety

Part of the core-runtime fix campaign. Owns `gjc-runtime/{tmux-gc.ts,tmux-sessions.ts}`.

- **M7:** GC can never prune a live/attached session. Attachment + live pane PIDs are a *primary* classification gate **and** re-checked at prune-time revalidation; the final `removeGjcTmuxSession` kill helper does a fresh status read and **aborts the kill** if the session is attached or has live pane PIDs (fail-closed at the destructive boundary).
- **M8:** metadata-less orphans are pruned only with a durable `@gjc-profile` ownership signal + no attachment + age + revalidation. Name-only `gajae_code*` untagged sessions stay unclassified/non-removable (a name is not ownership proof).

### Verification
- `bun test packages/coding-agent/test/gjc-runtime/{tmux-gc,tmux-gc.redteam,tmux-sessions}.test.ts` → 18 pass / 0 fail: attached stale-metadata session kept; metadata-less idle orphan pruned only when owned; TOCTOU attach-before-prune skips kill; final-read pane-PID liveness aborts kill; non-GJC prefix session never pruned. Parser fixtures aligned to the new `#{pane_pid}` column.
- `bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit` exit 0; biome clean.
- Quality gate: architect CLEAR/CLEAR (product) + red-team 4/4; the prior CODE WATCH (stale parser fixture) is resolved + reverified.

Base: `dev`.