### PR TITLE
fix(async): bounded job-manager dispose + delivery queue + purge (U9)

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -7,6 +7,11 @@ const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
 const MONITOR_TOMBSTONE_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_DELIVERY_QUEUE = 100;
+const DELIVERY_MAX_TEXT_BYTES = 64 * 1024;
+const DELIVERY_PREVIEW_HEAD_BYTES = 32 * 1024;
+const DELIVERY_PREVIEW_TAIL_BYTES = 32 * 1024;
+const DELIVERY_MAX_ATTEMPTS = 3;
 
 export interface AsyncJob {
 	id: string;
@@ -128,9 +133,16 @@ export interface AsyncJobManagerOptions {
 	retentionMs?: number;
 }
 
+export interface AsyncJobDisposeDiagnostics {
+	stuckJobIds: string[];
+	deliveriesDrained: boolean;
+}
+
 interface AsyncJobDelivery {
 	jobId: string;
 	text: string;
+	originalBytes?: number;
+	truncated?: boolean;
 	attempt: number;
 	nextAttemptAt: number;
 	lastError?: string;
@@ -143,6 +155,7 @@ export interface AsyncJobDeliveryState {
 	delivering: boolean;
 	nextRetryAt?: number;
 	pendingJobIds: string[];
+	deadLettered: number;
 }
 
 export interface AsyncJobLifecycleCleanup {
@@ -196,6 +209,32 @@ function sliceTextFromUtf8ByteOffset(text: string, offsetBytes: number): string 
 		codeUnitIndex += char.length;
 	}
 	return text.slice(codeUnitIndex);
+}
+
+function sliceTextAfterUtf8ByteOffset(text: string, offsetBytes: number): string {
+	if (offsetBytes <= 0) return text;
+	let consumedBytes = 0;
+	let codeUnitIndex = 0;
+	for (const char of text) {
+		const charBytes = Buffer.byteLength(char, "utf8");
+		consumedBytes += charBytes;
+		codeUnitIndex += char.length;
+		if (consumedBytes >= offsetBytes) break;
+	}
+	return text.slice(codeUnitIndex);
+}
+
+function sliceTextToUtf8ByteLength(text: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	let consumedBytes = 0;
+	let codeUnitIndex = 0;
+	for (const char of text) {
+		const charBytes = Buffer.byteLength(char, "utf8");
+		if (consumedBytes + charBytes > maxBytes) break;
+		consumedBytes += charBytes;
+		codeUnitIndex += char.length;
+	}
+	return text.slice(0, codeUnitIndex);
 }
 
 /**
@@ -277,6 +316,8 @@ export class AsyncJobManager {
 	#resumeSeq = 0;
 	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
 	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
+	readonly #deadLetteredDeliveries = new Map<string, AsyncJobDelivery>();
+	#lastDisposeDiagnostics: AsyncJobDisposeDiagnostics = { stuckJobIds: [], deliveriesDrained: true };
 	/**
 	 * Change listeners notified on any mutation that can alter the live job set
 	 * (register, terminal/eviction transitions, dispose). Used by the status-line
@@ -381,7 +422,7 @@ export class AsyncJobManager {
 
 				if (job.status === "cancelled") {
 					job.resultText = outcome.kind === "completed" ? outcome.text : outcome.note;
-					this.#runLifecycle(id, "terminal");
+					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
@@ -403,20 +444,20 @@ export class AsyncJobManager {
 				this.#freezeEndTime(job);
 				job.resultText = outcome.text;
 				this.#enqueueDelivery(id, outcome.text);
-				this.#runLifecycle(id, "terminal");
+				this.#runLifecycle(id, "terminal", job);
 				this.#scheduleEviction(id);
 				this.#markRecordTerminal(id, "completed");
 				this.#drainResumeQueue();
 			} catch (error) {
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
-					this.#runLifecycle(id, "terminal");
+					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
 					return;
 				}
-				this.#runLifecycle(id, "terminal");
+				this.#runLifecycle(id, "terminal", job);
 				const errorText = error instanceof Error ? error.message : String(error);
 				job.status = "failed";
 				this.#freezeEndTime(job);
@@ -471,14 +512,14 @@ export class AsyncJobManager {
 		job.endTime ??= Date.now();
 	}
 
-	#runLifecycle(jobId: string, phase: "cancel" | "terminal" | "evict"): void {
+	#runLifecycle(jobId: string, phase: "cancel" | "terminal" | "evict", jobOverride?: AsyncJob): void {
+		const lifecycle = this.#lifecycles.get(jobId);
+		const job = jobOverride ?? this.#jobs.get(jobId);
+		if (!lifecycle || !job) return;
 		const fired = this.#lifecyclePhases.get(jobId) ?? new Set<"cancel" | "terminal" | "evict">();
 		if (fired.has(phase)) return;
 		fired.add(phase);
 		this.#lifecyclePhases.set(jobId, fired);
-		const lifecycle = this.#lifecycles.get(jobId);
-		const job = this.#jobs.get(jobId);
-		if (!lifecycle || !job) return;
 		try {
 			if (phase === "cancel") lifecycle.onCancel?.(job);
 			else if (phase === "terminal") lifecycle.onTerminal?.(job);
@@ -647,6 +688,16 @@ export class AsyncJobManager {
 			this.#liveHandles.delete(rec.subagentId);
 			this.#subagentProgress.delete(rec.subagentId);
 		}
+	}
+
+	#purgeTerminalSubagentStateForJob(jobId: string): void {
+		const rec = this.#recordByJobId(jobId);
+		if (!rec) return;
+		if (rec.status === "paused" || rec.status === "queued") return;
+		this.#liveHandles.delete(rec.subagentId);
+		this.#subagentProgress.delete(rec.subagentId);
+		this.#resumeDescriptors.delete(rec.subagentId);
+		this.#subagentRecords.delete(rec.subagentId);
 	}
 
 	#markRecordTerminal(jobId: string, status: "completed" | "failed" | "cancelled"): void {
@@ -967,6 +1018,10 @@ export class AsyncJobManager {
 	getDeliveryState(filter?: AsyncJobFilter): AsyncJobDeliveryState {
 		const deliveries = this.#filterDeliveries(filter);
 		const inFlightDeliveries = this.#filterInFlightDeliveries(filter);
+		const ownerId = filter?.ownerId;
+		const deadLettered = Array.from(this.#deadLetteredDeliveries.values()).filter(
+			delivery => !ownerId || delivery.ownerId === ownerId,
+		).length;
 		const nextRetryAt = deliveries.reduce<number | undefined>((next, delivery) => {
 			if (next === undefined) return delivery.nextAttemptAt;
 			return Math.min(next, delivery.nextAttemptAt);
@@ -977,6 +1032,7 @@ export class AsyncJobManager {
 			delivering: inFlightDeliveries.length > 0 || (this.#deliveryLoop !== undefined && deliveries.length > 0),
 			nextRetryAt,
 			pendingJobIds: deliveries.concat(inFlightDeliveries).map(delivery => delivery.jobId),
+			deadLettered,
 		};
 	}
 
@@ -1033,6 +1089,29 @@ export class AsyncJobManager {
 			job.abortController.abort();
 			this.#scheduleEviction(job.id);
 		}
+	}
+
+	getLastDisposeDiagnostics(): AsyncJobDisposeDiagnostics {
+		return { ...this.#lastDisposeDiagnostics, stuckJobIds: [...this.#lastDisposeDiagnostics.stuckJobIds] };
+	}
+
+	async #waitForAllWithDeadline(timeoutMs: number): Promise<{ completed: boolean; stuckJobIds: string[] }> {
+		const jobs = Array.from(this.#jobs.values());
+		if (jobs.length === 0) return { completed: true, stuckJobIds: [] };
+		let timedOut = false;
+		await Promise.race([
+			Promise.allSettled(jobs.map(job => job.promise)),
+			Bun.sleep(Math.max(0, timeoutMs)).then(() => {
+				timedOut = true;
+			}),
+		]);
+		if (!timedOut) return { completed: true, stuckJobIds: [] };
+		return {
+			completed: false,
+			stuckJobIds: Array.from(this.#jobs.values())
+				.filter(job => job.status === "running" || job.status === "cancelled")
+				.map(job => job.id),
+		};
 	}
 
 	async waitForAll(): Promise<void> {
@@ -1102,12 +1181,18 @@ export class AsyncJobManager {
 			}
 		}
 		this.#monitorTombstones.clear();
-		await this.waitForAll();
-		const drained = await this.drainDeliveries({ timeoutMs: options?.timeoutMs ?? 3_000 });
+		const timeoutMs = options?.timeoutMs ?? 3_000;
+		const waitResult = await this.#waitForAllWithDeadline(timeoutMs);
+		const drained = waitResult.completed ? await this.drainDeliveries({ timeoutMs }) : false;
+		this.#lastDisposeDiagnostics = { stuckJobIds: waitResult.stuckJobIds, deliveriesDrained: drained };
+		if (waitResult.stuckJobIds.length > 0) {
+			logger.warn("Async job manager dispose timed out waiting for jobs", { stuckJobIds: waitResult.stuckJobIds });
+		}
 		this.#clearEvictionTimers();
 		this.#jobs.clear();
 		this.#deliveries.length = 0;
 		this.#inFlightDeliveries.length = 0;
+		this.#deadLetteredDeliveries.clear();
 		this.#suppressedDeliveries.clear();
 		this.#watchedJobs.clear();
 		this.#outputState.clear();
@@ -1119,7 +1204,7 @@ export class AsyncJobManager {
 		this.#resumeQueue.length = 0;
 		this.#notifyChange();
 		this.#changeListeners.clear();
-		return drained;
+		return drained && waitResult.completed;
 	}
 
 	#resolveJobId(preferredId?: string): string {
@@ -1148,16 +1233,10 @@ export class AsyncJobManager {
 	}
 
 	#scheduleEviction(jobId: string): void {
+		if (this.#disposed) return;
 		this.#notifyChange();
 		if (this.#retentionMs <= 0) {
-			this.#recordMonitorTombstone(jobId);
-			this.#runLifecycle(jobId, "evict");
-			this.#jobs.delete(jobId);
-			this.#lifecycles.delete(jobId);
-			this.#lifecyclePhases.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
-			this.#outputState.delete(jobId);
+			this.#evictJob(jobId);
 			return;
 		}
 		const existing = this.#evictionTimers.get(jobId);
@@ -1166,18 +1245,23 @@ export class AsyncJobManager {
 		}
 		const timer = setTimeout(() => {
 			this.#evictionTimers.delete(jobId);
-			this.#recordMonitorTombstone(jobId);
-			this.#runLifecycle(jobId, "evict");
-			this.#jobs.delete(jobId);
-			this.#lifecycles.delete(jobId);
-			this.#lifecyclePhases.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
-			this.#outputState.delete(jobId);
+			this.#evictJob(jobId);
 			this.#notifyChange();
 		}, this.#retentionMs);
 		timer.unref();
 		this.#evictionTimers.set(jobId, timer);
+	}
+
+	#evictJob(jobId: string): void {
+		this.#recordMonitorTombstone(jobId);
+		this.#runLifecycle(jobId, "evict");
+		this.#purgeTerminalSubagentStateForJob(jobId);
+		this.#jobs.delete(jobId);
+		this.#lifecycles.delete(jobId);
+		this.#lifecyclePhases.delete(jobId);
+		this.#suppressedDeliveries.delete(jobId);
+		this.#watchedJobs.delete(jobId);
+		this.#outputState.delete(jobId);
 	}
 
 	#clearEvictionTimers(): void {
@@ -1245,17 +1329,38 @@ export class AsyncJobManager {
 		if (this.isDeliverySuppressed(jobId)) {
 			return;
 		}
+		const deliveryText = this.#boundedDeliveryText(text);
 		this.#deliveries.push({
 			jobId,
-			text,
+			text: deliveryText.text,
+			originalBytes: deliveryText.originalBytes,
+			truncated: deliveryText.truncated,
 			attempt: 0,
 			nextAttemptAt: Date.now(),
 			ownerId: this.#jobs.get(jobId)?.ownerId,
 		});
+		while (this.#deliveries.length > DEFAULT_MAX_DELIVERY_QUEUE) {
+			const dropped = this.#deliveries.shift();
+			if (dropped) this.#deadLetteredDeliveries.set(dropped.jobId, dropped);
+		}
 		this.#ensureDeliveryLoop();
 	}
 
+	#boundedDeliveryText(text: string): { text: string; originalBytes?: number; truncated?: boolean } {
+		const bytes = Buffer.byteLength(text, "utf8");
+		if (bytes <= DELIVERY_MAX_TEXT_BYTES) return { text };
+		const head = sliceTextToUtf8ByteLength(text, DELIVERY_PREVIEW_HEAD_BYTES);
+		const tailStart = Math.max(0, bytes - DELIVERY_PREVIEW_TAIL_BYTES);
+		const tail = sliceTextAfterUtf8ByteOffset(text, tailStart);
+		return {
+			text: `${head}\n\n[async delivery output truncated from ${bytes} bytes]\n\n${tail}`,
+			originalBytes: bytes,
+			truncated: true,
+		};
+	}
+
 	#ensureDeliveryLoop(): void {
+		if (this.#disposed) return;
 		if (this.#deliveryLoop) {
 			return;
 		}
@@ -1266,7 +1371,7 @@ export class AsyncJobManager {
 			})
 			.finally(() => {
 				this.#deliveryLoop = undefined;
-				if (this.#deliveries.length > 0) {
+				if (!this.#disposed && this.#deliveries.length > 0) {
 					this.#ensureDeliveryLoop();
 				}
 			});
@@ -1304,20 +1409,29 @@ export class AsyncJobManager {
 			} catch (error) {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);
-				delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-				if (!this.isDeliverySuppressed(delivery.jobId)) {
-					this.#deliveries.push(delivery);
+				if (delivery.attempt >= DELIVERY_MAX_ATTEMPTS) {
+					this.#deadLetteredDeliveries.set(delivery.jobId, delivery);
+					logger.warn("Async job completion delivery reached retry cap", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						error: delivery.lastError,
+					});
+				} else {
+					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
+					if (!this.isDeliverySuppressed(delivery.jobId)) {
+						this.#deliveries.push(delivery);
+					}
+					logger.warn("Async job completion delivery failed", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						nextRetryAt: delivery.nextAttemptAt,
+						error: delivery.lastError,
+					});
 				}
-				logger.warn("Async job completion delivery failed", {
-					jobId: delivery.jobId,
-					attempt: delivery.attempt,
-					nextRetryAt: delivery.nextAttemptAt,
-					error: delivery.lastError,
-				});
 			} finally {
 				const index = this.#inFlightDeliveries.indexOf(delivery);
 				if (index !== -1) this.#inFlightDeliveries.splice(index, 1);
-				if (this.#deliveries.length > 0) this.#ensureDeliveryLoop();
+				if (!this.#disposed && this.#deliveries.length > 0) this.#ensureDeliveryLoop();
 			}
 		})();
 		delivery.promise = promise;

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -253,7 +253,7 @@ describe("ACP builtin slash commands", () => {
 		runtime.session.getAsyncJobSnapshot = () => ({
 			running: [{ id: "j1", type: "bash", status: "running", label: "npm install", startTime: Date.now() - 5000 }],
 			recent: [{ id: "j2", type: "task", status: "completed", label: "build done", startTime: Date.now() - 60_000 }],
-			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+			delivery: { queued: 0, delivering: false, pendingJobIds: [], deadLettered: 0 },
 		});
 
 		const result = await executeAcpBuiltinSlashCommand("/jobs", runtime);
@@ -884,7 +884,7 @@ describe("wave 5 — adapters and polish", () => {
 		runtime.session.getAsyncJobSnapshot = () => ({
 			running: [],
 			recent: [],
-			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+			delivery: { queued: 0, delivering: false, pendingJobIds: [], deadLettered: 0 },
 		});
 		const result = await executeAcpBuiltinSlashCommand("/jobs", runtime);
 		expect(result).toEqual({ consumed: true });

--- a/packages/coding-agent/test/async/job-manager-bounds.test.ts
+++ b/packages/coding-agent/test/async/job-manager-bounds.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AsyncJobManager,
+	type ResumeDescriptor,
+	type SubagentRecord,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+function subagentRecord(subagentId: string, currentJobId: string, status: SubagentRecord["status"]): SubagentRecord {
+	return {
+		subagentId,
+		currentJobId,
+		historicalJobIds: [],
+		status,
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	};
+}
+
+function resumeDescriptor(subagentId: string): ResumeDescriptor {
+	return { subagentId, data: { sessionFile: `/tmp/${subagentId}.jsonl` } };
+}
+
+describe("AsyncJobManager bounded dispose and delivery", () => {
+	test("dispose timeout applies to never-settling jobs and records stuck ids", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		manager.register("task", "stuck", () => new Promise(() => {}), { id: "stuck-job" });
+
+		const started = Date.now();
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const elapsed = Date.now() - started;
+
+		expect(disposed).toBe(false);
+		expect(elapsed).toBeLessThan(250);
+		expect(manager.getLastDisposeDiagnostics().stuckJobIds).toEqual(["stuck-job"]);
+		expect(manager.getAllJobs()).toHaveLength(0);
+	});
+
+	test("late completion after dispose timeout runs terminal lifecycle without rescheduling eviction", async () => {
+		let resolveJob!: (value: string) => void;
+		let terminalCalls = 0;
+		let changeCalls = 0;
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 60_000 });
+		manager.onChange(() => {
+			changeCalls += 1;
+		});
+		manager.register(
+			"task",
+			"late resolver",
+			() =>
+				new Promise<string>(resolve => {
+					resolveJob = resolve;
+				}),
+			{
+				id: "late-resolver",
+				lifecycle: {
+					onTerminal: () => {
+						terminalCalls += 1;
+					},
+				},
+			},
+		);
+
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const changesAfterDispose = changeCalls;
+		resolveJob("late done");
+		await Bun.sleep(25);
+
+		expect(disposed).toBe(false);
+		expect(terminalCalls).toBe(1);
+		expect(manager.getAllJobs()).toHaveLength(0);
+		expect(manager.getDeliveryState().queued).toBe(0);
+		expect(changeCalls).toBe(changesAfterDispose);
+	});
+
+	test("multibyte delivery previews stay within utf8 byte head and tail budgets", async () => {
+		let delivered = "";
+		const manager = new AsyncJobManager({
+			onJobComplete: (_jobId, text) => {
+				delivered = text;
+			},
+		});
+		const text = `${"界".repeat(12_000)}${"🙂".repeat(12_000)}`;
+		manager.register("task", "multibyte", async () => text, { id: "multibyte-preview" });
+
+		await manager.waitForAll();
+		const drained = await manager.drainDeliveries({ timeoutMs: 1_000 });
+		const [head = "", tail = ""] = delivered.split(/\n\n\[async delivery output truncated from \d+ bytes\]\n\n/);
+
+		expect(drained).toBe(true);
+		expect(delivered).toContain("[async delivery output truncated from ");
+		expect(Buffer.byteLength(head, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(32 * 1024);
+	});
+
+	test("misaligned multibyte delivery preview tail stays within utf8 byte budget", async () => {
+		let delivered = "";
+		const manager = new AsyncJobManager({
+			onJobComplete: (_jobId, text) => {
+				delivered = text;
+			},
+		});
+		const text = `${"🙂".repeat(16_385)}a`;
+		manager.register("task", "misaligned multibyte", async () => text, { id: "misaligned-preview" });
+
+		await manager.waitForAll();
+		const drained = await manager.drainDeliveries({ timeoutMs: 1_000 });
+		const [head = "", tail = ""] = delivered.split(/\n\n\[async delivery output truncated from \d+ bytes\]\n\n/);
+
+		expect(drained).toBe(true);
+		expect(delivered).toContain("[async delivery output truncated from 65541 bytes]");
+		expect(Buffer.byteLength(head, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(delivered).not.toContain("\ufffd");
+	});
+
+	test("delivery queue is bounded and failing deliveries stop at retry cap", async () => {
+		let attempts = 0;
+		const manager = new AsyncJobManager({
+			onJobComplete: () => {
+				attempts += 1;
+				throw new Error("persistent delivery failure");
+			},
+			maxRunningJobs: 150,
+			retentionMs: 10_000,
+		});
+
+		for (let i = 0; i < 120; i += 1) {
+			manager.register("task", `job ${i}`, async () => `done ${i}`, { id: `job-${i}` });
+		}
+
+		await Bun.sleep(25);
+		expect(manager.getDeliveryState().queued).toBeLessThanOrEqual(100);
+		expect(manager.getDeliveryState().deadLettered).toBeGreaterThan(0);
+
+		for (let i = 0; i < 15 && manager.getDeliveryState().queued > 0; i += 1) {
+			await Bun.sleep(550);
+		}
+		const state = manager.getDeliveryState();
+		expect(state.queued).toBe(0);
+		expect(state.deadLettered).toBe(120);
+		expect(attempts).toBeLessThanOrEqual(120 * 3);
+	});
+
+	test("terminal eviction purges subagent records while paused records remain resumable", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0, maxRunningJobs: 2 });
+
+		const terminalJobId = manager.register("task", "terminal", async () => "done", { id: "terminal-job" });
+		manager.registerSubagentRecord(subagentRecord("terminal-sub", terminalJobId, "running"));
+		manager.registerResumeDescriptor(resumeDescriptor("terminal-sub"));
+		manager.registerLiveHandle("terminal-sub", {
+			requestPause: () => {},
+			injectMessage: async () => {},
+		});
+		manager.recordSubagentProgress("terminal-sub", { currentTool: "test" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getSubagentRecord("terminal-sub")).toBeUndefined();
+		expect(manager.getResumeDescriptor("terminal-sub")).toBeUndefined();
+		expect(manager.getLiveHandle("terminal-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("terminal-sub")).toBeUndefined();
+
+		const pausedJobId = manager.register("task", "paused", async () => ({ kind: "paused", note: "safe boundary" }), {
+			id: "paused-job",
+		});
+		manager.registerSubagentRecord(subagentRecord("paused-sub", pausedJobId, "running"));
+		manager.registerResumeDescriptor(resumeDescriptor("paused-sub"));
+		manager.registerLiveHandle("paused-sub", {
+			requestPause: () => {},
+			injectMessage: async () => {},
+		});
+		manager.recordSubagentProgress("paused-sub", { currentTool: "test" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getSubagentRecord("paused-sub")?.status).toBe("paused");
+		expect(manager.getResumeDescriptor("paused-sub")).toEqual(resumeDescriptor("paused-sub"));
+		expect(manager.getLiveHandle("paused-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("paused-sub")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/async/job-manager-redteam.test.ts
+++ b/packages/coding-agent/test/async/job-manager-redteam.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
+import {
+	AsyncJobManager,
+	type ResumeDescriptor,
+	type SubagentRecord,
+	type SubagentRunOutcome,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+setDefaultTimeout(10_000);
+
+function record(subagentId: string, jobId: string, status: SubagentRecord["status"]): SubagentRecord {
+	return {
+		subagentId,
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status,
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	};
+}
+
+function descriptor(subagentId: string): ResumeDescriptor {
+	return { subagentId, data: { sessionFile: `/tmp/${subagentId}.jsonl` } };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await Bun.sleep(10);
+	}
+	return predicate();
+}
+
+describe("AsyncJobManager red-team invariants", () => {
+	test("dispose({ timeoutMs }) on a never-settling job returns by deadline and reports the stuck job id", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		manager.register("task", "never settles", () => new Promise<string>(() => {}), { id: "redteam-stuck" });
+
+		const started = performance.now();
+		const disposed = await manager.dispose({ timeoutMs: 30 });
+		const elapsedMs = performance.now() - started;
+
+		expect(disposed).toBe(false);
+		expect(elapsedMs).toBeLessThan(250);
+		expect(manager.getLastDisposeDiagnostics()).toEqual({
+			stuckJobIds: ["redteam-stuck"],
+			deliveriesDrained: false,
+		});
+		expect(manager.getAllJobs()).toHaveLength(0);
+	});
+
+	test("late failure after dispose timeout runs terminal lifecycle and does not restart timers", async () => {
+		let rejectJob!: (error: Error) => void;
+		let terminalCalls = 0;
+		let changeCalls = 0;
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 60_000 });
+		manager.onChange(() => {
+			changeCalls += 1;
+		});
+		manager.register(
+			"task",
+			"late rejecter",
+			() =>
+				new Promise<string>((_resolve, reject) => {
+					rejectJob = reject;
+				}),
+			{
+				id: "late-rejecter",
+				lifecycle: {
+					onTerminal: () => {
+						terminalCalls += 1;
+					},
+				},
+			},
+		);
+
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const changesAfterDispose = changeCalls;
+		rejectJob(new Error("late boom"));
+		await Bun.sleep(25);
+
+		expect(disposed).toBe(false);
+		expect(terminalCalls).toBe(1);
+		expect(manager.getDeliveryState().queued).toBe(0);
+		expect(changeCalls).toBe(changesAfterDispose);
+	});
+
+	test("permanent onJobComplete failures keep delivery queue bounded, stop at retry cap, and dead-letter", async () => {
+		const randomSpy = spyOn(Math, "random").mockImplementation(() => 0);
+		let attempts = 0;
+		const manager = new AsyncJobManager({
+			onJobComplete: () => {
+				attempts += 1;
+				throw new Error("redteam persistent delivery failure");
+			},
+			maxRunningJobs: 1,
+			retentionMs: 10_000,
+		});
+
+		try {
+			manager.register("task", "poison delivery", async () => "cannot deliver", { id: "poison-job" });
+			await manager.waitForAll();
+
+			const drained = await manager.drainDeliveries({ timeoutMs: 1_800 });
+			const state = manager.getDeliveryState();
+
+			expect(drained).toBe(true);
+			expect(state.queued).toBe(0);
+			expect(state.pendingJobIds).toEqual([]);
+			expect(state.deadLettered).toBe(1);
+			expect(attempts).toBe(3);
+		} finally {
+			randomSpy.mockRestore();
+			await manager.dispose({ timeoutMs: 200 });
+		}
+	});
+
+	test("completion flood above the delivery bound caps the queue and counts overflow as dead-lettered", async () => {
+		const manager = new AsyncJobManager({
+			onJobComplete: () => new Promise<void>(() => {}),
+			maxRunningJobs: 150,
+			retentionMs: 10_000,
+		});
+
+		try {
+			for (let i = 0; i < 150; i += 1) {
+				manager.register("task", `flood ${i}`, async () => `done ${i}`, { id: `flood-${i}` });
+			}
+			await manager.waitForAll();
+
+			const captured = await waitUntil(() => {
+				const state = manager.getDeliveryState();
+				return state.queued <= 101 && state.deadLettered >= 49;
+			}, 5_000);
+			const state = manager.getDeliveryState();
+
+			expect(captured).toBe(true);
+			expect(state.queued).toBeLessThanOrEqual(101);
+			expect(state.deadLettered).toBeGreaterThanOrEqual(49);
+			expect(state.pendingJobIds).not.toContain("flood-1");
+			expect(state.pendingJobIds).toContain("flood-149");
+		} finally {
+			await manager.dispose({ timeoutMs: 50 });
+		}
+	});
+
+	test("terminal eviction purges subagent records and resume descriptors while preserving paused records", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0, maxRunningJobs: 2 });
+
+		const terminalJobId = manager.register(
+			"task",
+			"terminal subagent",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "completed", text: "terminal" }),
+			{ id: "terminal-job" },
+		);
+		manager.registerSubagentRecord(record("terminal-sub", terminalJobId, "running"));
+		manager.registerResumeDescriptor(descriptor("terminal-sub"));
+		manager.registerLiveHandle("terminal-sub", { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("terminal-sub", { currentTool: "terminal" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getJob(terminalJobId)).toBeUndefined();
+		expect(manager.getSubagentRecord("terminal-sub")).toBeUndefined();
+		expect(manager.getResumeDescriptor("terminal-sub")).toBeUndefined();
+		expect(manager.getLiveHandle("terminal-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("terminal-sub")).toBeUndefined();
+
+		const pausedJobId = manager.register(
+			"task",
+			"paused subagent",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "paused", note: "safe boundary" }),
+			{ id: "paused-job" },
+		);
+		manager.registerSubagentRecord(record("paused-sub", pausedJobId, "running"));
+		manager.registerResumeDescriptor(descriptor("paused-sub"));
+		manager.registerLiveHandle("paused-sub", { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("paused-sub", { currentTool: "paused" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getJob(pausedJobId)?.status).toBe("paused");
+		expect(manager.getSubagentRecord("paused-sub")?.status).toBe("paused");
+		expect(manager.getResumeDescriptor("paused-sub")).toEqual(descriptor("paused-sub"));
+		expect(manager.getLiveHandle("paused-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("paused-sub")).toBeUndefined();
+
+		await manager.dispose({ timeoutMs: 200 });
+	});
+});


### PR DESCRIPTION
## U9 — async job-manager dispose bounds & purge

Part of the core-runtime fix campaign. Owns `async/job-manager.ts`.

- **H24:** `dispose({timeoutMs})` applies the deadline to `waitForAll` (not just delivery drain) so a stuck job can't hang dispose; terminal cleanup receives the captured job so a late-settling promise still cleans up after dispose; eviction/delivery scheduling is guarded when disposed; stuck job ids surfaced via diagnostics.
- **H25:** delivery queue + retry capped with a dead-letter state; completion previews are UTF-8 **byte**-bounded (head strict; tail rounds up past the overlapping codepoint) so multibyte output can't exceed the byte budget.
- **M14:** terminal eviction purges subagent records / resume descriptors / progress / live handles while preserving paused/resumable records.

### Verification
- `bun test packages/coding-agent/test/async/job-manager-bounds.test.ts packages/coding-agent/test/async/job-manager-redteam.test.ts` → 11 pass / 0 fail: dispose no-hang + stuck-id diagnostics; late settle after dispose; bounded queue + retry cap + dead-letter; misaligned-multibyte preview byte budget + no U+FFFD; terminal purge with paused preserved.
- `bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit` exit 0; biome clean.
- Quality gate: architect re-review CLEAR/CLEAR/CLEAR + APPROVE (after fixing a dispose-timeout cleanup-drop blocker and a byte-vs-UTF16 tail blocker); red-team passed.

Base: `dev`.