### PR TITLE
fix(pi-natives): PTY lifecycle + bounded native backpressure (U2)

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -4,6 +4,8 @@
 //! Provides a stateful PTY session that supports streaming output and stdin
 //! passthrough while a command is running.
 
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
 	collections::HashMap,
 	io::{Read, Write},
@@ -25,22 +27,22 @@ use crate::{ps, task};
 #[napi(object)]
 pub struct PtyStartOptions<'env> {
 	/// Command string to execute.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for command execution.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables for this command.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// PTY column count.
-	pub cols:       Option<u16>,
+	pub cols: Option<u16>,
 	/// PTY row count.
-	pub rows:       Option<u16>,
+	pub rows: Option<u16>,
 	/// Shell binary to use (e.g. "sh", "bash", or an absolute path).
 	/// Defaults to "sh" if not provided.
-	pub shell:      Option<String>,
+	pub shell: Option<String>,
 }
 
 /// Result of a PTY command run.
@@ -57,15 +59,16 @@ pub struct PtyRunResult {
 #[derive(Clone)]
 struct PtyRunConfig {
 	command: String,
-	cwd:     Option<String>,
-	env:     Option<HashMap<String, String>>,
-	cols:    u16,
-	rows:    u16,
-	shell:   Option<String>,
+	cwd: Option<String>,
+	env: Option<HashMap<String, String>>,
+	cols: u16,
+	rows: u16,
+	shell: Option<String>,
 }
 
 enum ReaderEvent {
 	Chunk(String),
+	Loss { dropped_chunks: usize, dropped_bytes: usize },
 	Done,
 }
 
@@ -81,9 +84,29 @@ const POST_CANCEL_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 const POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 #[cfg(not(windows))]
 const FINAL_READER_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
+const READER_EVENT_QUEUE_CAPACITY: usize = 1024;
+const READER_LOSS_MARKER_PREFIX: &str = "\n[PTY output truncated: ";
+const TERMINATED_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(windows)]
+static WINDOWS_OPENPTY_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
 struct PtySessionCore {
 	control_tx: mpsc::Sender<ControlMessage>,
+}
+
+impl Drop for PtySessionCore {
+	fn drop(&mut self) {
+		let _ = self.control_tx.send(ControlMessage::Kill);
+	}
+}
+impl Drop for PtySession {
+	fn drop(&mut self) {
+		if let Ok(mut guard) = self.core.lock() {
+			if let Some(core) = guard.take() {
+				let _ = core.control_tx.send(ControlMessage::Kill);
+			}
+		}
+	}
 }
 
 /// Stateful PTY session for interactive stdin/stdout passthrough.
@@ -116,11 +139,11 @@ impl PtySession {
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: options.command,
-			cwd:     options.cwd,
-			env:     options.env,
-			cols:    options.cols.unwrap_or(120).clamp(20, 400),
-			rows:    options.rows.unwrap_or(40).clamp(5, 200),
-			shell:   options.shell,
+			cwd: options.cwd,
+			env: options.env,
+			cols: options.cols.unwrap_or(120).clamp(20, 400),
+			rows: options.rows.unwrap_or(40).clamp(5, 200),
+			shell: options.shell,
 		};
 		let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 		let core = Arc::clone(&self.core);
@@ -136,12 +159,12 @@ impl PtySession {
 			}
 			*guard = Some(PtySessionCore { control_tx });
 		}
-		task::future(env, "pty.start", async move {
+		let future = task::future(env, "pty.start", async move {
 			let run_result =
 				tokio::task::spawn_blocking(move || run_pty_sync(run_config, on_chunk, control_rx, ct))
 					.await;
 
-			// Always clear core regardless of result
+			// Always clear core regardless of result.
 			let mut guard = core
 				.lock()
 				.map_err(|_| Error::from_reason("PTY session lock poisoned"))?;
@@ -152,7 +175,15 @@ impl PtySession {
 				Ok(inner) => inner,
 				Err(err) => Err(Error::from_reason(format!("PTY execution task failed: {err}"))),
 			}
-		})
+		});
+		if future.is_err() {
+			let mut guard = self
+				.core
+				.lock()
+				.map_err(|_| Error::from_reason("PTY session lock poisoned"))?;
+			*guard = None;
+		}
+		future
 	}
 
 	/// Write raw input bytes to PTY stdin.
@@ -210,6 +241,213 @@ fn terminate_pty_processes(
 	let _ = child.kill();
 	targets.signal(ps::KILL_SIGNAL);
 }
+fn reap_terminated_child(
+	child: &mut Box<dyn Child + Send + Sync>,
+	deadline: Instant,
+) -> Result<Option<i32>> {
+	loop {
+		if let Some(status) = child
+			.try_wait()
+			.map_err(|err| Error::from_reason(format!("Failed checking PTY status: {err}")))?
+		{
+			return Ok(Some(i32::try_from(status.exit_code()).unwrap_or(i32::MAX)));
+		}
+		if Instant::now() >= deadline {
+			return Ok(None);
+		}
+		std::thread::sleep(Duration::from_millis(10));
+	}
+}
+struct PostSpawnSetupGuard {
+	child: Option<Box<dyn Child + Send + Sync>>,
+	master: Option<Box<dyn portable_pty::MasterPty + Send>>,
+	writer: Option<Box<dyn Write + Send>>,
+	child_pid: Option<i32>,
+	process_group_id: Option<i32>,
+	disarmed: bool,
+}
+
+impl PostSpawnSetupGuard {
+	fn new(
+		child: Box<dyn Child + Send + Sync>,
+		master: Box<dyn portable_pty::MasterPty + Send>,
+	) -> Self {
+		let child_pid = child
+			.process_id()
+			.and_then(|value| i32::try_from(value).ok());
+		#[cfg(unix)]
+		let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
+		#[cfg(not(unix))]
+		let process_group_id = None;
+		Self {
+			child: Some(child),
+			master: Some(master),
+			writer: None,
+			child_pid,
+			process_group_id,
+			disarmed: false,
+		}
+	}
+
+	fn master(&self) -> &dyn portable_pty::MasterPty {
+		self
+			.master
+			.as_ref()
+			.expect("setup guard owns PTY master")
+			.as_ref()
+	}
+
+	fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
+		let writer = self
+			.master()
+			.take_writer()
+			.map_err(|err| Error::from_reason(format!("Failed to create PTY writer: {err}")))?;
+		Ok(writer)
+	}
+
+	fn set_writer(&mut self, writer: Box<dyn Write + Send>) {
+		self.writer = Some(writer);
+	}
+
+	fn try_clone_reader(&self) -> Result<Box<dyn Read + Send>> {
+		self
+			.master()
+			.try_clone_reader()
+			.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))
+	}
+
+	fn disarm(
+		mut self,
+	) -> (
+		Box<dyn Child + Send + Sync>,
+		Box<dyn portable_pty::MasterPty + Send>,
+		Box<dyn Write + Send>,
+		Option<i32>,
+		Option<i32>,
+	) {
+		self.disarmed = true;
+		(
+			self.child.take().expect("setup guard owns PTY child"),
+			self.master.take().expect("setup guard owns PTY master"),
+			self.writer.take().expect("setup guard owns PTY writer"),
+			self.child_pid,
+			self.process_group_id,
+		)
+	}
+}
+
+impl Drop for PostSpawnSetupGuard {
+	fn drop(&mut self) {
+		if self.disarmed {
+			return;
+		}
+		drop(self.writer.take());
+		if let Some(child) = self.child.as_mut() {
+			terminate_pty_processes(child, self.child_pid, self.process_group_id);
+			let _ = reap_terminated_child(child, Instant::now() + TERMINATED_REAP_TIMEOUT);
+		}
+		drop(self.master.take());
+	}
+}
+
+fn loss_marker(dropped_chunks: usize, dropped_bytes: usize) -> String {
+	format!("{READER_LOSS_MARKER_PREFIX}{dropped_chunks} chunks / {dropped_bytes} bytes dropped]\n")
+}
+
+fn reader_event_len(event: &ReaderEvent) -> usize {
+	match event {
+		ReaderEvent::Chunk(chunk) => chunk.len(),
+		ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+			loss_marker(*dropped_chunks, *dropped_bytes).len()
+		},
+		ReaderEvent::Done => 0,
+	}
+}
+
+fn try_send_reader_event(
+	tx: &mpsc::SyncSender<ReaderEvent>,
+	event: ReaderEvent,
+	dropped_chunks: &mut usize,
+	dropped_bytes: &mut usize,
+) -> bool {
+	if *dropped_chunks > 0 {
+		match tx.try_send(ReaderEvent::Loss {
+			dropped_chunks: *dropped_chunks,
+			dropped_bytes: *dropped_bytes,
+		}) {
+			Ok(()) => {
+				*dropped_chunks = 0;
+				*dropped_bytes = 0;
+			},
+			Err(mpsc::TrySendError::Full(_)) => {},
+			Err(mpsc::TrySendError::Disconnected(_)) => return false,
+		}
+	}
+	match tx.try_send(event) {
+		Ok(()) => true,
+		Err(mpsc::TrySendError::Full(event)) => {
+			if !matches!(event, ReaderEvent::Done) {
+				*dropped_chunks = dropped_chunks.saturating_add(1);
+				*dropped_bytes = dropped_bytes.saturating_add(reader_event_len(&event));
+			}
+			true
+		},
+		Err(mpsc::TrySendError::Disconnected(_)) => false,
+	}
+}
+
+fn send_reader_final_events(
+	tx: &mpsc::SyncSender<ReaderEvent>,
+	dropped_chunks: &mut usize,
+	dropped_bytes: &mut usize,
+) -> bool {
+	if *dropped_chunks > 0 {
+		if tx
+			.send(ReaderEvent::Loss { dropped_chunks: *dropped_chunks, dropped_bytes: *dropped_bytes })
+			.is_err()
+		{
+			return false;
+		}
+		*dropped_chunks = 0;
+		*dropped_bytes = 0;
+	}
+	tx.send(ReaderEvent::Done).is_ok()
+}
+
+fn emit_reader_event(event: ReaderEvent, callback: Option<&ThreadsafeFunction<String>>) -> bool {
+	match event {
+		ReaderEvent::Chunk(chunk) => emit_chunk(&chunk, callback),
+		ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+			emit_chunk(&loss_marker(dropped_chunks, dropped_bytes), callback)
+		},
+		ReaderEvent::Done => true,
+	}
+}
+
+#[cfg(windows)]
+struct WindowsOpenptyAttempt;
+
+#[cfg(windows)]
+impl WindowsOpenptyAttempt {
+	fn acquire() -> Result<Self> {
+		WINDOWS_OPENPTY_IN_FLIGHT
+			.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+			.map(|_| Self)
+			.map_err(|_| {
+				Error::from_reason(
+					"PTY creation is already in progress; refusing to spawn another ConPTY thread",
+				)
+			})
+	}
+}
+
+#[cfg(windows)]
+impl Drop for WindowsOpenptyAttempt {
+	fn drop(&mut self) {
+		WINDOWS_OPENPTY_IN_FLIGHT.store(false, Ordering::Release);
+	}
+}
+
 fn run_pty_sync(
 	config: PtyRunConfig,
 	on_chunk: Option<ThreadsafeFunction<String>>,
@@ -223,35 +461,47 @@ fn run_pty_sync(
 	const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 	let pair = if cfg!(windows) {
 		// Windows ConPTY openpty() can hang indefinitely when the console
-		// subsystem isn't properly initialized. Use a short startup timeout
-		// so the Promise rejects instead of hanging forever.
-		let (tx, rx) = mpsc::channel();
-		std::thread::spawn(move || {
-			let result = pty_system.openpty(PtySize {
-				rows:         config.rows,
-				cols:         config.cols,
-				pixel_width:  0,
-				pixel_height: 0,
+		// subsystem isn't properly initialized. Gate attempts process-wide so
+		// a hung openpty can leave at most one residual blocked thread behind.
+		#[cfg(windows)]
+		{
+			let attempt = WindowsOpenptyAttempt::acquire()?;
+			let (tx, rx) = mpsc::channel();
+			let handle = std::thread::spawn(move || {
+				let result = pty_system.openpty(PtySize {
+					rows: config.rows,
+					cols: config.cols,
+					pixel_width: 0,
+					pixel_height: 0,
+				});
+				let _ = tx.send(result);
 			});
-			let _ = tx.send(result);
-		});
-		match rx.recv_timeout(PTY_STARTUP_TIMEOUT) {
-			Ok(Ok(pair)) => pair,
-			Ok(Err(e)) => return Err(Error::from_reason(format!("Failed to open PTY: {e}"))),
-			Err(_) => {
-				return Err(Error::from_reason(
-					"PTY creation timed out (5s). ConPTY may be unavailable on this system.",
-				));
-			},
+			match rx.recv_timeout(PTY_STARTUP_TIMEOUT) {
+				Ok(Ok(pair)) => {
+					let _ = handle.join();
+					drop(attempt);
+					pair
+				},
+				Ok(Err(e)) => {
+					let _ = handle.join();
+					return Err(Error::from_reason(format!("Failed to open PTY: {e}")));
+				},
+				Err(_) => {
+					// The worker may be permanently stuck inside ConPTY. Keep the
+					// single-flight gate held after timeout so residual leakage is capped
+					// to one outstanding openpty thread for the process lifetime.
+					std::mem::forget(attempt);
+					return Err(Error::from_reason(
+						"PTY creation timed out (5s). ConPTY may be unavailable on this system.",
+					));
+				},
+			}
 		}
+		#[cfg(not(windows))]
+		unreachable!()
 	} else {
 		pty_system
-			.openpty(PtySize {
-				rows:         config.rows,
-				cols:         config.cols,
-				pixel_width:  0,
-				pixel_height: 0,
-			})
+			.openpty(PtySize { rows: config.rows, cols: config.cols, pixel_width: 0, pixel_height: 0 })
 			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?
 	};
 
@@ -279,18 +529,16 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before spawn: {err}")))?;
 
-	let mut child = pair
+	let child = pair
 		.slave
 		.spawn_command(cmd)
 		.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
 	drop(pair.slave);
+	let mut setup_guard = PostSpawnSetupGuard::new(child, pair.master);
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
-	let master = pair.master;
-	let mut writer = master
-		.take_writer()
-		.map_err(|err| Error::from_reason(format!("Failed to create PTY writer: {err}")))?;
+	let mut writer = setup_guard.take_writer()?;
 	// ConPTY sends ESC[6n (cursor position query) and blocks until we reply.
 	// Reply with cursor at 1,1 so it unblocks the child spawn.
 	// Only needed on Windows; on Unix/macOS this would corrupt stdin.
@@ -299,16 +547,17 @@ fn run_pty_sync(
 		let _ = writer.write_all(b"\x1b[1;1R");
 		let _ = writer.flush();
 	}
-	let mut reader = master
-		.try_clone_reader()
-		.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))?;
+	setup_guard.set_writer(writer);
+	let mut reader = setup_guard.try_clone_reader()?;
 
-	let (reader_tx, reader_rx) = mpsc::channel::<ReaderEvent>();
+	let (reader_tx, reader_rx) = mpsc::sync_channel::<ReaderEvent>(READER_EVENT_QUEUE_CAPACITY);
 	let reader_thread = std::thread::spawn(move || {
 		const REPLACEMENT: &str = "\u{FFFD}";
 		const BUF: usize = 65536;
 		let mut buf = vec![0u8; BUF + 4];
 		let mut it = 0;
+		let mut dropped_chunks = 0usize;
+		let mut dropped_bytes = 0usize;
 		loop {
 			match reader.read(&mut buf[it..BUF]) {
 				Ok(0) => {
@@ -320,7 +569,14 @@ fn run_pty_sync(
 						let pending = &buf[..it];
 						match str::from_utf8(pending) {
 							Ok(text) => {
-								let _ = reader_tx.send(ReaderEvent::Chunk(text.to_string()));
+								if !try_send_reader_event(
+									&reader_tx,
+									ReaderEvent::Chunk(text.to_string()),
+									&mut dropped_chunks,
+									&mut dropped_bytes,
+								) {
+									return;
+								}
 								it = 0;
 								break;
 							},
@@ -329,13 +585,27 @@ fn run_pty_sync(
 								if valid_up_to > 0 {
 									// SAFETY: [..valid_up_to] is guaranteed valid UTF-8 by valid_up_to().
 									let text = unsafe { str::from_utf8_unchecked(&pending[..valid_up_to]) };
-									let _ = reader_tx.send(ReaderEvent::Chunk(text.to_string()));
+									if !try_send_reader_event(
+										&reader_tx,
+										ReaderEvent::Chunk(text.to_string()),
+										&mut dropped_chunks,
+										&mut dropped_bytes,
+									) {
+										return;
+									}
 									buf.copy_within(valid_up_to..it, 0);
 									it -= valid_up_to;
 								}
 								match err.error_len() {
 									Some(invalid_len) => {
-										let _ = reader_tx.send(ReaderEvent::Chunk(REPLACEMENT.to_string()));
+										if !try_send_reader_event(
+											&reader_tx,
+											ReaderEvent::Chunk(REPLACEMENT.to_string()),
+											&mut dropped_chunks,
+											&mut dropped_bytes,
+										) {
+											return;
+										}
 										buf.copy_within(invalid_len..it, 0);
 										it -= invalid_len;
 									},
@@ -354,23 +624,29 @@ fn run_pty_sync(
 		}
 		for chunk in buf[..it].utf8_chunks() {
 			let valid = chunk.valid();
-			if !valid.is_empty() {
-				let _ = reader_tx.send(ReaderEvent::Chunk(valid.to_string()));
+			if !valid.is_empty()
+				&& !try_send_reader_event(
+					&reader_tx,
+					ReaderEvent::Chunk(valid.to_string()),
+					&mut dropped_chunks,
+					&mut dropped_bytes,
+				) {
+				return;
 			}
-			if !chunk.invalid().is_empty() {
-				let _ = reader_tx.send(ReaderEvent::Chunk(REPLACEMENT.to_string()));
+			if !chunk.invalid().is_empty()
+				&& !try_send_reader_event(
+					&reader_tx,
+					ReaderEvent::Chunk(REPLACEMENT.to_string()),
+					&mut dropped_chunks,
+					&mut dropped_bytes,
+				) {
+				return;
 			}
 		}
-		let _ = reader_tx.send(ReaderEvent::Done);
+		let _ = send_reader_final_events(&reader_tx, &mut dropped_chunks, &mut dropped_bytes);
 	});
 
-	let child_pid = child
-		.process_id()
-		.and_then(|value| i32::try_from(value).ok());
-	#[cfg(unix)]
-	let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
-	#[cfg(not(unix))]
-	let process_group_id: Option<i32> = None;
+	let (mut child, master, mut writer, child_pid, process_group_id) = setup_guard.disarm();
 	let mut timed_out = false;
 	let mut cancelled = false;
 	let mut reader_done = false;
@@ -411,10 +687,20 @@ fn run_pty_sync(
 
 		for _ in 0..READER_EVENTS_PER_TICK {
 			match reader_rx.try_recv() {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
+				},
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						cancelled = true;
+						if !terminate_requested {
+							terminate_pty_processes(&mut child, child_pid, process_group_id);
+							terminate_requested = true;
+							reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
+						}
+						break;
+					}
 				},
 				Err(mpsc::TryRecvError::Empty) => break,
 				Err(mpsc::TryRecvError::Disconnected) => {
@@ -423,6 +709,7 @@ fn run_pty_sync(
 				},
 			}
 		}
+
 		if exit_code.is_none()
 			&& let Some(status) = child
 				.try_wait()
@@ -446,8 +733,17 @@ fn run_pty_sync(
 					.min(Duration::from_millis(16))
 			});
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => reader_done = true,
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						cancelled = true;
+						if !terminate_requested {
+							terminate_pty_processes(&mut child, child_pid, process_group_id);
+							terminate_requested = true;
+							reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
+						}
+					}
+				},
 				Err(mpsc::RecvTimeoutError::Timeout) => {},
 				Err(mpsc::RecvTimeoutError::Disconnected) => {
 					reader_done = true;
@@ -460,12 +756,7 @@ fn run_pty_sync(
 	}
 	if exit_code.is_none() {
 		if terminate_requested {
-			if let Some(status) = child
-				.try_wait()
-				.map_err(|err| Error::from_reason(format!("Failed checking PTY status: {err}")))?
-			{
-				exit_code = Some(i32::try_from(status.exit_code()).unwrap_or(i32::MAX));
-			}
+			exit_code = reap_terminated_child(&mut child, Instant::now() + TERMINATED_REAP_TIMEOUT)?;
 		} else {
 			// On Windows, child.wait() can hang indefinitely in ConPTY.
 			// Poll try_wait() with a short timeout instead.
@@ -504,6 +795,9 @@ fn run_pty_sync(
 	// After the child exits and input is closed, ConPTY should flush remaining
 	// output and signal EOF on the output pipe, causing the reader thread to exit.
 	// On Windows, use a generous timeout to accommodate ConPTY's async teardown.
+	if exit_code.is_some() && !terminate_requested && !reader_done {
+		terminate_pty_processes(&mut child, child_pid, process_group_id);
+	}
 	if !reader_done {
 		#[cfg(windows)]
 		let drain_timeout = Duration::from_millis(500);
@@ -514,10 +808,14 @@ fn run_pty_sync(
 			let remaining = finalize_deadline.saturating_duration_since(Instant::now());
 			let wait_duration = remaining.min(Duration::from_millis(5));
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
+				},
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						break;
+					}
 				},
 				Err(mpsc::RecvTimeoutError::Timeout) => {},
 				Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -558,8 +856,280 @@ fn run_pty_sync(
 	Ok(PtyRunResult { exit_code, cancelled, timed_out })
 }
 
-fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) {
-	if let Some(callback) = callback {
-		callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking);
+fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) -> bool {
+	let Some(callback) = callback else {
+		return true;
+	};
+	callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking) == napi::Status::Ok
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs,
+		path::PathBuf,
+		sync::{Mutex, mpsc},
+		time::{Duration, Instant},
+	};
+
+	use super::*;
+	static PTY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+	fn test_config(command: &str) -> PtyRunConfig {
+		PtyRunConfig {
+			command: command.to_string(),
+			cwd: None,
+			env: None,
+			cols: 80,
+			rows: 24,
+			shell: Some("sh".to_string()),
+		}
+	}
+
+	#[cfg(unix)]
+	fn process_exists(pid: i32) -> bool {
+		unsafe { libc::kill(pid, 0) == 0 }
+	}
+
+	#[cfg(unix)]
+	fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+		let deadline = Instant::now() + timeout;
+		while Instant::now() < deadline {
+			if !process_exists(pid) {
+				return true;
+			}
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		!process_exists(pid)
+	}
+
+	#[cfg(unix)]
+	fn test_path(name: &str) -> PathBuf {
+		let mut path = std::env::temp_dir();
+		path.push(format!("pi-natives-pty-{name}-{}", std::process::id()));
+		let _ = fs::remove_file(&path);
+		path
+	}
+	#[cfg(unix)]
+	fn post_spawn_setup_error_after_spawn(command: &str, pid_path: &std::path::Path) -> Result<()> {
+		let pty_system = native_pty_system();
+		let pair = pty_system
+			.openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?;
+		let mut cmd = CommandBuilder::new("sh");
+		cmd.arg("-lc");
+		cmd.arg(command);
+		let child = pair
+			.slave
+			.spawn_command(cmd)
+			.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
+		drop(pair.slave);
+		let setup_guard = PostSpawnSetupGuard::new(child, pair.master);
+		if let Some(pid) = setup_guard.child_pid {
+			fs::write(pid_path, pid.to_string())
+				.map_err(|err| Error::from_reason(format!("Failed to write child pid: {err}")))?;
+		}
+		Err(Error::from_reason("simulated post-spawn setup failure"))
+	}
+
+	#[test]
+	fn bounded_reader_channel_reports_success_for_high_output() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let (_tx, rx) = mpsc::channel();
+		let started = Instant::now();
+		let result = run_pty_sync(
+			test_config("i=0; while [ $i -lt 200000 ]; do printf '%080d\\n' \"$i\"; i=$((i+1)); done"),
+			None,
+			rx,
+			task::CancelToken::new(Some(20_000), None),
+		)
+		.expect("high-output PTY run should complete without unbounded buffering");
+		assert!(result.exit_code.is_some());
+		assert!(!result.cancelled);
+		assert!(!result.timed_out);
+		assert!(started.elapsed() < Duration::from_secs(20));
+	}
+
+	#[test]
+	fn final_reader_loss_and_done_are_delivered_when_queue_is_full() {
+		let (tx, rx) = mpsc::sync_channel(READER_EVENT_QUEUE_CAPACITY);
+		let mut dropped_chunks = 0usize;
+		let mut dropped_bytes = 0usize;
+		for i in 0..READER_EVENT_QUEUE_CAPACITY {
+			assert!(try_send_reader_event(
+				&tx,
+				ReaderEvent::Chunk(format!("chunk-{i}")),
+				&mut dropped_chunks,
+				&mut dropped_bytes,
+			));
+		}
+		assert!(try_send_reader_event(
+			&tx,
+			ReaderEvent::Chunk("dropped-tail".to_string()),
+			&mut dropped_chunks,
+			&mut dropped_bytes,
+		));
+		assert_eq!(dropped_chunks, 1);
+		let finalizer = std::thread::spawn(move || {
+			assert!(send_reader_final_events(&tx, &mut dropped_chunks, &mut dropped_bytes));
+		});
+
+		let mut output = String::new();
+		let mut saw_done = false;
+		while let Ok(event) = rx.recv() {
+			match event {
+				ReaderEvent::Chunk(chunk) => output.push_str(&chunk),
+				ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+					assert!(dropped_chunks > 0);
+					assert!(dropped_bytes > 0);
+					output.push_str(&loss_marker(dropped_chunks, dropped_bytes));
+				},
+				ReaderEvent::Done => {
+					saw_done = true;
+					break;
+				},
+			}
+		}
+
+		finalizer.join().expect("final sender should not panic");
+		assert!(saw_done);
+		assert!(output.contains(READER_LOSS_MARKER_PREFIX));
+		assert!(output.contains("1 chunks / 12 bytes dropped"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn dropped_session_core_kills_and_reaps_mid_run_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("drop-pid");
+		let command = format!("printf '%s' $$ > {}; trap '' TERM; sleep 30", pid_path.display());
+		let (tx, rx) = mpsc::channel();
+		let core = PtySessionCore { control_tx: tx };
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+		});
+		let deadline = Instant::now() + Duration::from_secs(2);
+		while !pid_path.exists() && Instant::now() < deadline {
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		drop(core);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("dropped PTY core should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+	#[cfg(unix)]
+	#[test]
+	fn dropped_js_pty_session_kills_and_reaps_mid_run_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("drop-js-session-pid");
+		let command = format!("printf '%s' $$ > {}; trap '' TERM; sleep 30", pid_path.display());
+		let session = PtySession::new();
+		let (tx, rx) = mpsc::channel();
+		{
+			let mut guard = session.core.lock().expect("session lock");
+			*guard = Some(PtySessionCore { control_tx: tx });
+		}
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+		});
+		let deadline = Instant::now() + Duration::from_secs(2);
+		while !pid_path.exists() && Instant::now() < deadline {
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		drop(session);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("dropped JS PTY session should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn post_spawn_setup_error_guard_reaps_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("post-spawn-error-pid");
+		let command = "trap '' TERM; sleep 30";
+		let result = post_spawn_setup_error_after_spawn(command, &pid_path);
+		assert!(result.is_err());
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written before injected failure")
+			.parse()
+			.expect("pid file should contain a pid");
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+
+	#[test]
+	fn kill_path_reaps_sigterm_trapping_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let (tx, rx) = mpsc::channel();
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(
+				test_config("trap '' TERM; printf ready; sleep 30"),
+				None,
+				rx,
+				task::CancelToken::new(Some(10_000), None),
+			)
+		});
+		std::thread::sleep(Duration::from_millis(200));
+		let started = Instant::now();
+		let _ = tx.send(ControlMessage::Kill);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("killed PTY run should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(started.elapsed() < TERMINATED_REAP_TIMEOUT + Duration::from_secs(1));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn background_grandchild_holding_slave_is_reaped_and_unrelated_sibling_survives() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		use std::process::{Command, Stdio};
+
+		let mut sibling = Command::new("sh")
+			.arg("-c")
+			.arg("sleep 30")
+			.stdin(Stdio::null())
+			.stdout(Stdio::null())
+			.stderr(Stdio::null())
+			.spawn()
+			.expect("spawn unrelated sibling");
+		let sibling_pid = i32::try_from(sibling.id()).expect("sibling pid fits i32");
+		let pid_path = test_path("background-pid");
+		let command = format!("sleep 30 & printf '%s' $! > {}; echo done", pid_path.display());
+		let (_tx, rx) = mpsc::channel();
+		let result =
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+				.expect("PTY run should complete after reaping background grandchild");
+		assert!(result.exit_code.is_some());
+		let grandchild_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("grandchild pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		assert!(wait_for_process_exit(grandchild_pid, Duration::from_secs(2)));
+		assert!(process_exists(sibling_pid));
+		let _ = sibling.kill();
+		let _ = sibling.wait();
+		let _ = fs::remove_file(pid_path);
 	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -19,25 +19,27 @@ use pi_shell::{
 };
 
 use crate::task;
+const SHELL_CALLBACK_QUEUE_CAPACITY: usize = 1024;
+const SHELL_LOSS_MARKER_PREFIX: &str = "\n[Shell output truncated: ";
 
 /// N-API opt-in handle for the minimizer.
 #[napi(object)]
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled: Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path: Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash: Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only: Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except: Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
 	pub max_capture_bytes: Option<u32>,
@@ -46,11 +48,11 @@ pub struct MinimizerOptions {
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled:           value.enabled,
-			settings_path:     value.settings_path,
-			settings_hash:     value.settings_hash,
-			only:              value.only,
-			except:            value.except,
+			enabled: value.enabled,
+			settings_path: value.settings_path,
+			settings_hash: value.settings_hash,
+			only: value.only,
+			except: value.except,
 			max_capture_bytes: value.max_capture_bytes,
 		}
 	}
@@ -60,19 +62,19 @@ impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 #[napi(object)]
 pub struct ShellOptions {
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer: Option<MinimizerOptions>,
 }
 
 impl From<ShellOptions> for CoreShellOptions {
 	fn from(value: ShellOptions) -> Self {
 		Self {
-			session_env:   value.session_env,
+			session_env: value.session_env,
 			snapshot_path: value.snapshot_path,
-			minimizer:     value.minimizer.map(Into::into),
+			minimizer: value.minimizer.map(Into::into),
 		}
 	}
 }
@@ -81,36 +83,36 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:       String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:           Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:           Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms:    Option<u32>,
+	pub timeout_ms: Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer: Option<MinimizerOptions>,
 	/// Abort signal for cancelling the operation.
-	pub signal:        Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -124,27 +126,27 @@ pub struct ShellExecuteOptions<'env> {
 pub struct MinimizerResult {
 	/// Dispatch label produced by the minimizer (e.g. `"git"`,
 	/// `"pipeline:gradle"`, `"pipeline+builtin"`).
-	pub filter:        String,
+	pub filter: String,
 	/// The minimized replacement text. Callers that streamed raw chunks
 	/// during execution should clear and replace their accumulated output
 	/// with this text.
-	pub text:          String,
+	pub text: String,
 	/// The full original capture, before minimization.
 	pub original_text: String,
 	/// Captured byte length before minimization.
-	pub input_bytes:   u32,
+	pub input_bytes: u32,
 	/// Byte length of the minimized text the consumer received.
-	pub output_bytes:  u32,
+	pub output_bytes: u32,
 }
 
 impl From<CoreMinimizerResult> for MinimizerResult {
 	fn from(value: CoreMinimizerResult) -> Self {
 		Self {
-			filter:        value.filter,
-			text:          value.text,
+			filter: value.filter,
+			text: value.text,
 			original_text: value.original_text,
-			input_bytes:   value.input_bytes,
-			output_bytes:  value.output_bytes,
+			input_bytes: value.input_bytes,
+			output_bytes: value.output_bytes,
 		}
 	}
 }
@@ -208,9 +210,9 @@ impl Shell {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
-			command:    options.command,
-			cwd:        options.cwd,
-			env:        options.env,
+			command: options.command,
+			cwd: options.cwd,
+			env: options.env,
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
@@ -251,13 +253,13 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 	let exec_options = CoreShellExecuteOptions {
-		command:       options.command,
-		cwd:           options.cwd,
-		env:           options.env,
-		session_env:   options.session_env,
-		timeout_ms:    options.timeout_ms,
+		command: options.command,
+		cwd: options.cwd,
+		env: options.env,
+		session_env: options.session_env,
+		timeout_ms: options.timeout_ms,
 		snapshot_path: options.snapshot_path,
-		minimizer:     options.minimizer.map(Into::into),
+		minimizer: options.minimizer.map(Into::into),
 	};
 	task::future(env, "shell.execute", async move {
 		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -272,6 +274,10 @@ pub fn execute_shell<'env>(
 	})
 }
 
+fn shell_loss_marker(dropped_chunks: usize, dropped_bytes: usize) -> String {
+	format!("{SHELL_LOSS_MARKER_PREFIX}{dropped_chunks} chunks / {dropped_bytes} bytes dropped]\n")
+}
+
 fn bridge_chunks(
 	on_chunk: Option<ThreadsafeFunction<String>>,
 ) -> (Option<mpsc::UnboundedSender<String>>, Option<napi::tokio::task::JoinHandle<()>>) {
@@ -279,10 +285,48 @@ fn bridge_chunks(
 		return (None, None);
 	};
 	let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+	let (bounded_tx, mut bounded_rx) = mpsc::channel::<String>(SHELL_CALLBACK_QUEUE_CAPACITY);
 	let handle = napi::tokio::spawn(async move {
-		while let Some(chunk) = rx.recv().await {
-			on_chunk.call(Ok(chunk), ThreadsafeFunctionCallMode::NonBlocking);
+		let forwarder = napi::tokio::spawn(async move {
+			let mut dropped_chunks = 0usize;
+			let mut dropped_bytes = 0usize;
+			// The upstream pi_shell sender is unbounded; this bridge re-bounds it and
+			// marks dropped output at the N-API callback boundary instead of silently
+			// losing it, so truncation is always observable to the caller.
+			while let Some(chunk) = rx.recv().await {
+				if dropped_chunks > 0 {
+					match bounded_tx.try_send(shell_loss_marker(dropped_chunks, dropped_bytes)) {
+						Ok(()) => {
+							dropped_chunks = 0;
+							dropped_bytes = 0;
+						},
+						Err(mpsc::error::TrySendError::Full(_)) => {},
+						Err(mpsc::error::TrySendError::Closed(_)) => break,
+					}
+				}
+				let chunk_len = chunk.len();
+				match bounded_tx.try_send(chunk) {
+					Ok(()) => {},
+					Err(mpsc::error::TrySendError::Full(_)) => {
+						dropped_chunks = dropped_chunks.saturating_add(1);
+						dropped_bytes = dropped_bytes.saturating_add(chunk_len);
+					},
+					Err(mpsc::error::TrySendError::Closed(_)) => break,
+				}
+			}
+			if dropped_chunks > 0 {
+				let _ = bounded_tx
+					.send(shell_loss_marker(dropped_chunks, dropped_bytes))
+					.await;
+			}
+		});
+		while let Some(chunk) = bounded_rx.recv().await {
+			if on_chunk.call(Ok(chunk), ThreadsafeFunctionCallMode::NonBlocking) != napi::Status::Ok {
+				forwarder.abort();
+				break;
+			}
 		}
+		let _ = forwarder.await;
 	});
 	(Some(tx), Some(handle))
 }
@@ -292,7 +336,7 @@ fn bridge_chunks(
 #[napi(object)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command:  String,
+	pub command: String,
 	/// Substrings removed, in source order — suitable for a user-facing notice.
 	pub stripped: Vec<String>,
 }
@@ -321,9 +365,11 @@ mod tests {
 		ShellRunOptions as CoreShellRunOptions,
 		cancel::{AbortReason, CancelToken},
 	};
-	use tokio::{sync::mpsc, time};
+	use tokio::{sync::mpsc, task::yield_now, time};
 
-	use super::CoreShell;
+	use super::{
+		CoreShell, SHELL_CALLBACK_QUEUE_CAPACITY, SHELL_LOSS_MARKER_PREFIX, shell_loss_marker,
+	};
 
 	mod child_session_action_tests {
 		use pi_shell::{ChildSessionAction, child_session_action};
@@ -370,9 +416,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
 					},
 					Some(tx),
@@ -413,9 +459,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "sh -c 'sleep 30 & wait'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "sh -c 'sleep 30 & wait'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
 					},
 					None,
@@ -432,5 +478,34 @@ mod tests {
 			.expect("shell task should not panic")
 			.expect("shell run should return");
 		assert!(result.cancelled);
+	}
+
+	#[tokio::test]
+	async fn final_shell_loss_marker_is_delivered_when_callback_queue_is_full() {
+		let (tx, mut rx) = mpsc::channel::<String>(SHELL_CALLBACK_QUEUE_CAPACITY);
+		for i in 0..SHELL_CALLBACK_QUEUE_CAPACITY {
+			tx.try_send(format!("chunk-{i}"))
+				.expect("queue fill should succeed");
+		}
+		let final_sender = tokio::spawn(async move {
+			tx.send(shell_loss_marker(1, "dropped-tail".len()))
+				.await
+				.expect("receiver should remain open");
+		});
+
+		yield_now().await;
+		assert!(!final_sender.is_finished(), "final marker send should wait for capacity");
+
+		let mut output = String::new();
+		while let Some(chunk) = rx.recv().await {
+			output.push_str(&chunk);
+			if output.contains(SHELL_LOSS_MARKER_PREFIX) {
+				break;
+			}
+		}
+		final_sender.await.expect("final sender should not panic");
+
+		assert!(output.contains(SHELL_LOSS_MARKER_PREFIX));
+		assert!(output.contains("1 chunks / 12 bytes dropped"));
 	}
 }


### PR DESCRIPTION
## U2 — pi-natives PTY lifecycle & native backpressure

Part of the core-runtime fix campaign. Owns `crates/pi-natives/src/{pty.rs,shell.rs}`.

- **M3:** `PtySession::start` clears `core` on schedule-failure and on completion.
- **H3:** dropping the JS `PtySession` takes the core and sends `Kill` — no orphaned PTY.
- **H2:** a post-spawn RAII guard terminates+reaps the child and closes PTY handles on every setup-error return.
- **H4:** bounded reap loop after kill (no zombies).
- **H1:** foreground-child exit with an open slave terminates the PTY process group before the final reader drain (no indefinitely-retained reader thread / leaked master fd).
- **H5:** Windows openpty single-flight gate caps a hung ConPTY thread to one outstanding attempt.
- **H9:** PTY + shell callback bridges use bounded channels and emit explicit truncation/loss markers, **guaranteed at EOF** via a blocking final send (cancellable if the receiver/TSFN is closed); TSFN `Closing` stops forwarding.

### Verification
- `cargo test -p pi-natives -- --test-threads=1` → **73 pass / 0 fail** (serial; PTY tests manage process groups). Covers drop-kills-running-PTY, post-spawn setup-error reap, SIGTERM-trap kill reap loop, background-grandchild group reap + unrelated sibling survives, high-volume bounded output, and full-queue-at-EOF truncation-marker delivery.
- `cargo fmt -p pi-natives` clean.
- Quality gate: architect re-review CLEAR/CLEAR/CLEAR + APPROVE (after 3 fix rounds: Drop/RAII/Windows-gate, then loss-marker semantics, then guaranteed-EOF-marker delivery); red-team 5/5.

Base: `dev`.