### PR TITLE
fix(eval/js): JS eval worker + VM lifecycle (U5)

### DIFF
--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -1,4 +1,5 @@
 import { isCompiledBinary, logger, Snowflake } from "@gajae-code/utils";
+import { registerResourceOwner } from "../../runtime/process-lifecycle";
 import type { ToolSession } from "../../tools";
 import { ToolAbortError, ToolError } from "../../tools/tool-errors";
 import { callSessionTool, type JsStatusEvent } from "./tool-bridge";
@@ -43,22 +44,66 @@ interface PendingRun {
 	settled: boolean;
 }
 
+interface ReadyDeferred {
+	promise: Promise<JsSession>;
+	resolve(session: JsSession): void;
+	reject(error: Error): void;
+}
+
+interface QueueDeferred {
+	promise: Promise<void>;
+	resolve(): void;
+	reject(error: Error): void;
+}
+
 interface JsSession {
 	sessionKey: string;
-	worker: WorkerHandle;
-	state: "alive" | "dead";
+	worker?: WorkerHandle;
+	state: "starting" | "alive" | "dead";
+	ownerId?: string;
 	pending: Map<string, PendingRun>;
 	queue: Promise<void>;
+	queuedWaiters: Set<(error: Error) => void>;
+	queueTail: QueueDeferred;
+	controllers: Set<AbortController>;
+	runSignal?: AbortSignal;
+	ready: ReadyDeferred;
+	unsubscribe?: () => void;
+	unregistered?: () => void;
 }
 
 const sessions = new Map<string, JsSession>();
+const sessionWaiters = new Map<string, Set<(error: Error) => void>>();
+let vmResourceCleanupRegistered = false;
+
+function ensureVmResourceCleanup(): void {
+	if (vmResourceCleanupRegistered) return;
+	vmResourceCleanupRegistered = true;
+	registerResourceOwner("js-vm-contexts", async () => {
+		try {
+			await disposeAllVmContexts();
+		} finally {
+			vmResourceCleanupRegistered = false;
+		}
+	});
+}
 const READY_TIMEOUT_MS_DEFAULT = 5_000;
+
+function getSessionWaiters(sessionKey: string): Set<(error: Error) => void> {
+	let waiters = sessionWaiters.get(sessionKey);
+	if (!waiters) {
+		waiters = new Set();
+		sessionWaiters.set(sessionKey, waiters);
+	}
+	return waiters;
+}
 
 export async function executeInVmContext(options: {
 	sessionKey: string;
 	sessionId: string;
 	cwd: string;
 	session: ToolSession;
+	ownerId?: string;
 	reset?: boolean;
 	code: string;
 	filename: string;
@@ -68,19 +113,44 @@ export async function executeInVmContext(options: {
 	if (options.reset) {
 		await resetVmContext(options.sessionKey);
 	}
-	const session = await acquireSession(
-		options.sessionKey,
-		{ cwd: options.cwd, sessionId: options.sessionId },
-		options.timeoutMs,
-	);
-	return await runQueued(session, () => runOnce(session, options));
+	const waiters = getSessionWaiters(options.sessionKey);
+	const { promise: contextResetPromise, reject: rejectContextReset } = Promise.withResolvers<never>();
+	contextResetPromise.catch(() => undefined);
+	waiters.add(rejectContextReset);
+	const runPromise = (async (): Promise<{ value: unknown }> => {
+		const session = await acquireSession(
+			options.sessionKey,
+			{ cwd: options.cwd, sessionId: options.sessionId },
+			options.ownerId,
+			options.timeoutMs,
+		);
+		return await runQueued(session, () => runOnce(session, options));
+	})();
+	try {
+		return await Promise.race([runPromise, contextResetPromise]);
+	} finally {
+		waiters.delete(rejectContextReset);
+	}
 }
 
 export async function resetVmContext(sessionKey: string): Promise<void> {
 	const session = sessions.get(sessionKey);
 	if (!session) return;
 	sessions.delete(sessionKey);
+	const waiters = sessionWaiters.get(sessionKey);
+	if (waiters) for (const reject of [...waiters]) reject(new ToolError("JS context reset"));
 	await killSession(session, new ToolError("JS context reset"));
+}
+
+export async function disposeVmContextsByOwner(ownerId: string): Promise<void> {
+	const owned = [...sessions.entries()].filter(
+		([sessionKey, session]) =>
+			session.ownerId === ownerId || sessionKey === ownerId || sessionKey === `js:${ownerId}`,
+	);
+	for (const [sessionKey, session] of owned) {
+		if (sessions.get(sessionKey) === session) sessions.delete(sessionKey);
+	}
+	await Promise.all(owned.map(([, session]) => killSession(session, new ToolError("JS context disposed"))));
 }
 
 export async function disposeAllVmContexts(): Promise<void> {
@@ -89,19 +159,38 @@ export async function disposeAllVmContexts(): Promise<void> {
 	await Promise.all(all.map(session => killSession(session, new ToolError("JS context disposed"))));
 }
 
+export function liveVmContextCount(): number {
+	return [...sessions.values()].filter(session => session.state !== "dead").length;
+}
+
 async function runQueued<T>(session: JsSession, work: () => Promise<T>): Promise<T> {
+	if (session.state !== "alive") throw new ToolError("JS worker is not alive");
 	const previous = session.queue;
-	const { promise, resolve } = Promise.withResolvers<void>();
-	session.queue = promise;
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const queueController = new AbortController();
+	const queueItem: QueueDeferred = { promise, resolve, reject };
+	const rejectWaiter = (error: Error): void => queueItem.reject(error);
+	session.queuedWaiters.add(rejectWaiter);
+	session.controllers.add(queueController);
+	session.queueTail = queueItem;
+	session.queue = (async () => {
+		await previous.catch(() => undefined);
+		await queueItem.promise;
+	})().catch(() => undefined);
 	try {
-		await previous;
-	} catch {
-		// Previous run's failure must not poison this one.
-	}
-	try {
-		return await work();
+		await Promise.race([previous.catch(() => undefined), queueItem.promise, abortPromise(queueController.signal)]);
+		if (session.runSignal?.aborted) throw reasonToError(session.runSignal.reason, "JS worker is not alive");
+		if (session.state !== "alive") throw new ToolError("JS worker is not alive");
+		session.queuedWaiters.delete(rejectWaiter);
+		return await Promise.race([
+			work(),
+			queueItem.promise.then(() => new Promise<never>(() => {})),
+			abortPromise(queueController.signal),
+		]);
 	} finally {
-		resolve();
+		session.queuedWaiters.delete(rejectWaiter);
+		session.controllers.delete(queueController);
+		queueItem.resolve();
 	}
 }
 
@@ -118,6 +207,7 @@ async function runOnce(
 ): Promise<{ value: unknown }> {
 	const runId = `r-${Snowflake.next()}`;
 	const { promise, resolve, reject } = Promise.withResolvers<{ value: unknown }>();
+	const sessionSignal = session.runSignal;
 	const pending: PendingRun = {
 		runId,
 		runState: options.runState,
@@ -145,13 +235,19 @@ async function runOnce(
 	}
 
 	try {
-		session.worker.send({
-			type: "run",
-			runId,
-			code: options.code,
-			filename: options.filename,
-			snapshot: { cwd: options.cwd, sessionId: options.sessionId },
-		});
+		if (sessionSignal?.aborted) throw reasonToError(sessionSignal.reason, "JS worker is not alive");
+		if (
+			!safeSend(session, {
+				type: "run",
+				runId,
+				code: options.code,
+				filename: options.filename,
+				snapshot: { cwd: options.cwd, sessionId: options.sessionId },
+			})
+		) {
+			settleRunWithError(session, pending, new ToolError("JS worker send failed"));
+			return await promise;
+		}
 		return await promise;
 	} finally {
 		options.runState.signal?.removeEventListener("abort", onAbort);
@@ -159,46 +255,76 @@ async function runOnce(
 	}
 }
 
-async function acquireSession(sessionKey: string, snapshot: SessionSnapshot, timeoutMs?: number): Promise<JsSession> {
+async function acquireSession(
+	sessionKey: string,
+	snapshot: SessionSnapshot,
+	ownerId: string | undefined,
+	timeoutMs?: number,
+): Promise<JsSession> {
+	ensureVmResourceCleanup();
 	const existing = sessions.get(sessionKey);
-	if (existing && existing.state === "alive") return existing;
+	if (existing && existing.state !== "dead") return await existing.ready.promise;
 
-	const worker = await spawnJsWorker();
+	const { promise: ready, resolve: resolveSession, reject: rejectSession } = Promise.withResolvers<JsSession>();
+	ready.catch(() => undefined);
 	const session: JsSession = {
 		sessionKey,
-		worker,
-		state: "alive",
+		state: "starting",
+		ownerId,
 		pending: new Map(),
 		queue: Promise.resolve(),
+		queuedWaiters: new Set(),
+		queueTail: settledQueueDeferred(),
+		controllers: new Set(),
+		ready: { promise: ready, resolve: resolveSession, reject: rejectSession },
 	};
-	const { promise: readyPromise, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
-	let resolved = false;
-	const unsubscribe = worker.onMessage(msg => {
-		if (!resolved && msg.type === "ready") {
-			resolved = true;
-			resolveReady();
-			return;
-		}
-		if (!resolved && msg.type === "init-failed") {
-			resolved = true;
-			rejectReady(errorFromPayload(msg.error));
-			return;
-		}
-		handleSessionMessage(session, msg);
-	});
+	sessions.set(sessionKey, session);
+
+	let worker: WorkerHandle | undefined;
 	try {
-		// Cold-start can exceed 5s on slow hosts. Let the caller's per-cell timeout dominate so
-		// users can grant more headroom when they raise `timeout` on a cell.
+		worker = await spawnJsWorker();
+		const current = sessions.get(sessionKey);
+		if (current !== session) {
+			await worker.terminate().catch(() => undefined);
+			return (
+				(await current?.ready.promise) ?? Promise.reject(new ToolError("JS context replaced during initialization"))
+			);
+		}
+		session.worker = worker;
+		const { promise: readyPromise, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
+		let resolved = false;
+		session.unsubscribe = worker.onMessage(msg => {
+			if (!resolved && msg.type === "ready") {
+				resolved = true;
+				resolveReady();
+				return;
+			}
+			if (!resolved && msg.type === "init-failed") {
+				resolved = true;
+				rejectReady(errorFromPayload(msg.error));
+				return;
+			}
+			handleSessionMessage(session, msg);
+		});
 		const readyTimeoutMs = Math.max(READY_TIMEOUT_MS_DEFAULT, timeoutMs ?? 0);
 		await raceWithTimeout(readyPromise, readyTimeoutMs, "Timed out initializing JS eval worker");
+		if (sessions.get(sessionKey) !== session) {
+			await killSession(session, new ToolError("JS context replaced during initialization"));
+			return (
+				(await sessions.get(sessionKey)?.ready.promise) ??
+				Promise.reject(new ToolError("JS context replaced during initialization"))
+			);
+		}
+		worker.send({ type: "init", snapshot });
+		session.state = "alive";
+		session.ready.resolve(session);
+		return session;
 	} catch (error) {
-		unsubscribe();
-		await worker.terminate().catch(() => undefined);
+		if (sessions.get(sessionKey) === session) sessions.delete(sessionKey);
+		await killSession(session, error instanceof Error ? error : new Error(String(error)));
+		session.ready.reject(error instanceof Error ? error : new Error(String(error)));
 		throw error;
 	}
-	worker.send({ type: "init", snapshot });
-	sessions.set(sessionKey, session);
-	return session;
 }
 
 function handleSessionMessage(session: JsSession, msg: WorkerOutbound): void {
@@ -276,22 +402,54 @@ async function killSessionFor(session: JsSession, error: Error): Promise<void> {
 async function killSession(session: JsSession, error: Error): Promise<void> {
 	if (session.state === "dead") return;
 	session.state = "dead";
-	for (const pending of session.pending.values()) {
-		if (pending.settled) continue;
-		pending.settled = true;
-		for (const ctrl of pending.toolCalls.values()) ctrl.abort(error);
-		pending.reject(error);
-	}
+	const unsubscribe = session.unsubscribe;
+	session.unsubscribe = undefined;
+	unsubscribe?.();
+	session.ready.reject(error);
+	session.queueTail.reject(error);
+	for (const controller of [...session.controllers]) controller.abort(error);
+	session.controllers.clear();
+	session.runSignal = AbortSignal.abort(error);
+	for (const reject of [...session.queuedWaiters]) reject(error);
+	session.queuedWaiters.clear();
+	for (const pending of [...session.pending.values()]) settleRunWithError(session, pending, error);
 	session.pending.clear();
-	await session.worker.terminate().catch(() => undefined);
+	void session.worker?.terminate().catch(() => undefined);
 }
 
-function safeSend(session: JsSession, msg: WorkerInbound): void {
-	if (session.state !== "alive") return;
+function settleRunWithError(session: JsSession, pending: PendingRun, error: Error): void {
+	if (pending.settled) return;
+	pending.settled = true;
+	for (const ctrl of pending.toolCalls.values()) ctrl.abort(error);
+	pending.toolCalls.clear();
+	session.pending.delete(pending.runId);
+	pending.reject(error);
+}
+
+function settledQueueDeferred(): QueueDeferred {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	resolve();
+	return { promise, resolve, reject };
+}
+
+function abortPromise(signal: AbortSignal): Promise<never> {
+	if (signal.aborted) return Promise.reject(reasonToError(signal.reason, "JS worker is not alive"));
+	const { promise, reject } = Promise.withResolvers<never>();
+	const onAbort = (): void => reject(reasonToError(signal.reason, "JS worker is not alive"));
+	signal.addEventListener("abort", onAbort, { once: true });
+	promise.finally(() => signal.removeEventListener("abort", onAbort)).catch(() => undefined);
+	return promise;
+}
+
+function safeSend(session: JsSession, msg: WorkerInbound): boolean {
+	if (session.state !== "alive") return false;
 	try {
-		session.worker.send(msg);
+		session.worker?.send(msg);
+		return true;
 	} catch (err) {
 		logger.debug("js worker send failed", { error: err instanceof Error ? err.message : String(err) });
+		void killSessionFor(session, err instanceof Error ? err : new Error(String(err)));
+		return false;
 	}
 }
 
@@ -352,10 +510,15 @@ async function spawnJsWorker(): Promise<WorkerHandle> {
 			: new Worker(new URL("./worker-entry.ts", import.meta.url).href, { type: "module" });
 		return wrapBunWorker(worker);
 	} catch (err) {
-		logger.warn("Bun Worker spawn failed; using inline JS eval worker (no sync-loop guard)", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-		return spawnInlineWorker();
+		if (process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER === "1") {
+			logger.warn("Bun Worker spawn failed; using test-only inline JS eval worker", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return spawnInlineWorker();
+		}
+		throw new ToolError(
+			`JS eval worker is unavailable and inline fallback is disabled because it cannot interrupt synchronous user code: ${err instanceof Error ? err.message : String(err)}`,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -10,6 +10,7 @@ export interface JsExecutorOptions {
 	onChunk?: (chunk: string) => Promise<void> | void;
 	signal?: AbortSignal;
 	sessionId: string;
+	ownerId?: string;
 	reset?: boolean;
 	sessionFile?: string;
 	artifactPath?: string;
@@ -68,6 +69,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 		await executeInVmContext({
 			sessionKey: options.sessionId,
 			sessionId: options.sessionId,
+			ownerId: options.ownerId,
 			cwd: options.cwd ?? options.session.cwd,
 			session: options.session,
 			reset: options.reset,

--- a/packages/coding-agent/src/eval/js/index.ts
+++ b/packages/coding-agent/src/eval/js/index.ts
@@ -23,6 +23,7 @@ export default {
 			deadlineMs: opts.deadlineMs,
 			signal: opts.signal,
 			sessionId: namespaceSessionId(opts.sessionId),
+			ownerId: opts.kernelOwnerId,
 			sessionFile: opts.sessionFile,
 			reset: opts.reset,
 			artifactPath: opts.artifactPath,

--- a/packages/coding-agent/src/eval/js/worker-core.ts
+++ b/packages/coding-agent/src/eval/js/worker-core.ts
@@ -12,6 +12,11 @@ interface ActiveRun {
 	pendingTools: Map<string, PendingTool>;
 }
 
+function rejectPendingTools(active: ActiveRun, error: Error): void {
+	for (const pending of active.pendingTools.values()) pending.reject(error);
+	active.pendingTools.clear();
+}
+
 function errorPayload(error: unknown): RunErrorPayload {
 	if (error instanceof Error) {
 		return {
@@ -99,7 +104,8 @@ export class WorkerCore {
 	async #runOne(runId: string, code: string, filename: string, snapshot: SessionSnapshot): Promise<void> {
 		const runtime = this.#ensureRuntime(snapshot);
 		runtime.setCwd(snapshot.cwd);
-		this.#active = { runId, pendingTools: new Map() };
+		const active: ActiveRun = { runId, pendingTools: new Map() };
+		this.#active = active;
 		try {
 			const value = await runtime.run(code, filename);
 			runtime.displayValue(value);
@@ -107,7 +113,8 @@ export class WorkerCore {
 		} catch (error) {
 			this.#transport.send({ type: "result", runId, ok: false, error: errorPayload(error) });
 		} finally {
-			this.#active = null;
+			rejectPendingTools(active, new ToolError("JS run ended"));
+			if (this.#active === active) this.#active = null;
 		}
 	}
 
@@ -132,10 +139,7 @@ export class WorkerCore {
 	#close(): void {
 		const active = this.#active;
 		if (active) {
-			for (const pending of active.pendingTools.values()) {
-				pending.reject(new ToolError("JS worker closed"));
-			}
-			active.pendingTools.clear();
+			rejectPendingTools(active, new ToolError("JS worker closed"));
 		}
 		this.#active = null;
 		this.#runtime = null;

--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -1,0 +1,388 @@
+/**
+ * Shared runtime lifecycle foundation.
+ *
+ * Two minimal, deliberately small primitives that subsystem runtimes
+ * (DAP/LSP/MCP stdio, eval workers, etc.) adopt so spawned children and
+ * non-process resources cannot outlive their owner:
+ *
+ *   F1(a) `spawnOwnedProcess` — wraps `ptree.spawn` with explicit
+ *         process-group ownership, escalating (SIGTERM -> grace -> SIGKILL)
+ *         tree termination, bounded `awaitExit`, abort-listener cleanup on
+ *         settle, idempotent `dispose`, and a single postmortem hook that
+ *         reaps every still-live owned process group on fatal/normal shutdown.
+ *
+ *   F1(b) `registerResourceOwner` — a generic, idempotent postmortem adapter
+ *         for non-process resources (Bun Workers, VM contexts, timers,
+ *         sockets) built on the existing `postmortem.register` facility.
+ *
+ * Ownership is keyed to the *process group*, not the root process. A root that
+ * exits after backgrounding descendants (`sh -c "worker & exit 0"`) keeps the
+ * owner registered until the group is actually gone, so the descendant tree is
+ * still reaped by `dispose()`/postmortem.
+ *
+ * This module intentionally owns only these primitives. It does not migrate
+ * existing call sites; subsystem PRs adopt it incrementally.
+ *
+ * Note: `ptree.spawn` always pipes stdout/stderr. Adopters that expect output
+ * (DAP/LSP/MCP protocol servers) must consume `owner.child.stdout`; F1 does not
+ * drain it, so a chatty child whose stdout is never read can still block on a
+ * full pipe. That draining is the adopter's responsibility.
+ */
+import { logger, postmortem, ptree } from "@gajae-code/utils";
+
+const DEFAULT_GRACEFUL_MS = 2_000;
+// Hard cap for how long `dispose()` waits after SIGKILL before giving up so a
+// wedged, unkillable child can never block shutdown forever.
+const SIGKILL_REAP_CAP_MS = 2_000;
+// After the root process exits on its own, how long to wait for the process
+// group to drain before deregistering. Clean servers drain immediately; a root
+// that backgrounded descendants stays registered past this window.
+const ROOT_EXIT_DRAIN_MS = 250;
+
+const isPosix = process.platform !== "win32";
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => {
+		const timer = setTimeout(resolve, Math.max(0, ms));
+		timer.unref?.();
+	});
+
+/** Poll `predicate` until it is true or `timeoutMs` elapses. Returns the final value. */
+async function pollUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 20): Promise<boolean> {
+	if (predicate()) return true;
+	const deadline = Date.now() + Math.max(0, timeoutMs);
+	while (Date.now() < deadline) {
+		await delay(Math.min(intervalMs, Math.max(0, deadline - Date.now())));
+		if (predicate()) return true;
+	}
+	return predicate();
+}
+
+/** Whether a POSIX process group still has any member (zombies count as alive). */
+function groupAlive(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		// EPERM => the group exists but we cannot signal it; treat as alive.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/** Options for {@link spawnOwnedProcess}. */
+export interface SpawnOwnedOptions {
+	cwd?: string;
+	env?: Record<string, string | undefined>;
+	/** stdin mode passed through to the child. Defaults to `"ignore"`. */
+	stdin?: "pipe" | "ignore";
+	/** When aborted, the owned process tree is disposed (escalating kill). */
+	signal?: AbortSignal;
+	/** Grace period (ms) between SIGTERM and SIGKILL on dispose. Default 2000. */
+	gracefulMs?: number;
+	/**
+	 * Spawn the child as its own process-group leader so the whole descendant
+	 * tree can be signalled on dispose. Defaults to `true` on POSIX. Has no
+	 * effect on Windows, where teardown falls back to single-process kill.
+	 */
+	processGroup?: boolean;
+	/** Label used in diagnostics. */
+	name?: string;
+}
+
+/** Result of a bounded {@link OwnedProcess.awaitExit}. */
+export interface AwaitExitResult {
+	/** `true` when the process has exited; `false` when the timeout fired first. */
+	exited: boolean;
+	/** Exit code if known, else `null`. */
+	code: number | null;
+}
+
+/** A spawned child process owned by the runtime with guaranteed teardown. */
+export interface OwnedProcess {
+	readonly child: ptree.ChildProcess;
+	readonly pid: number | undefined;
+	/** Resolves/rejects when the root child exits (mirrors ptree's `exited`). */
+	readonly exited: Promise<number>;
+	/** `true` once `dispose()` has started. */
+	readonly disposed: boolean;
+	/**
+	 * Wait for the root child to exit, optionally bounded by `timeoutMs`. With no
+	 * timeout it resolves only when the child exits. Never rejects.
+	 */
+	awaitExit(opts?: { timeoutMs?: number }): Promise<AwaitExitResult>;
+	/**
+	 * Idempotently terminate the owned process *group*: SIGTERM the group, wait
+	 * `gracefulMs`, then SIGKILL, polling group liveness throughout. Removes the
+	 * abort listener and deregisters from the live-owner set only after teardown
+	 * has completed. Repeated/concurrent calls return the same in-flight promise.
+	 */
+	dispose(): Promise<void>;
+}
+
+const liveOwners = new Set<OwnedProcess>();
+let ownedPostmortemRegistered = false;
+
+function ensureOwnedPostmortem(): void {
+	if (ownedPostmortemRegistered) return;
+	ownedPostmortemRegistered = true;
+	postmortem.register("runtime:owned-processes", async () => {
+		await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+	});
+}
+
+/**
+ * Spawn a child process owned by the runtime. The returned {@link OwnedProcess}
+ * is registered for postmortem cleanup and tears down its whole process group
+ * on dispose/abort.
+ */
+export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): OwnedProcess {
+	const gracefulMs = opts.gracefulMs ?? DEFAULT_GRACEFUL_MS;
+	const useGroup = (opts.processGroup ?? true) && isPosix;
+
+	ensureOwnedPostmortem();
+
+	// We deliberately do NOT forward `opts.signal` to `ptree.spawn`: ptree's
+	// `attachSignal` only kills the single process, whereas owned teardown must
+	// signal the whole group. We wire our own abort listener below and remove it
+	// on settle so long-lived signals never accumulate listeners.
+	const child = ptree.spawn(cmd, {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdin: opts.stdin ?? "ignore",
+		detached: useGroup,
+	});
+
+	// On POSIX with `detached`, the child is its own process-group leader, so the
+	// group id equals its pid. `undefined` => single-process (Windows/opt-out).
+	const pgid = useGroup ? child.pid : undefined;
+
+	let disposed = false;
+	let disposePromise: Promise<void> | undefined;
+	let deregistered = false;
+	let onAbort: (() => void) | undefined;
+
+	const removeAbort = (): void => {
+		if (onAbort && opts.signal) {
+			opts.signal.removeEventListener("abort", onAbort);
+			onAbort = undefined;
+		}
+	};
+
+	const deregister = (): void => {
+		if (deregistered) return;
+		deregistered = true;
+		liveOwners.delete(owner);
+		removeAbort();
+	};
+
+	const signalTree = (signal: NodeJS.Signals): void => {
+		const pid = child.pid;
+		if (pid === undefined) return;
+		if (pgid !== undefined) {
+			try {
+				// Negative pid signals the entire process group (child is leader).
+				process.kill(-pgid, signal);
+				return;
+			} catch {
+				// Group already gone; nothing to do.
+			}
+			return;
+		}
+		if (signal === "SIGKILL") {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		} else {
+			// ptree's kill terminates the single process via the native handle.
+			child.kill();
+		}
+	};
+
+	const owner: OwnedProcess = {
+		child,
+		get pid() {
+			return child.pid;
+		},
+		get exited() {
+			return child.exited;
+		},
+		get disposed() {
+			return disposed;
+		},
+		async awaitExit({ timeoutMs }: { timeoutMs?: number } = {}): Promise<AwaitExitResult> {
+			const exitedResult = child.exited
+				.then(code => ({ exited: true as const, code: code as number | null }))
+				.catch(() => ({ exited: true as const, code: child.exitCode }));
+			if (timeoutMs === undefined) return exitedResult;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const timeout = new Promise<AwaitExitResult>(resolve => {
+				timer = setTimeout(() => resolve({ exited: false, code: child.exitCode }), Math.max(0, timeoutMs));
+				timer.unref?.();
+			});
+			try {
+				return await Promise.race([exitedResult, timeout]);
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		},
+		dispose(): Promise<void> {
+			if (disposePromise) return disposePromise;
+			disposed = true;
+			removeAbort();
+			disposePromise = (async () => {
+				try {
+					if (pgid !== undefined) {
+						// Group ownership: reap until the whole group is gone, even if
+						// the root has already exited (it may have backgrounded children).
+						if (!groupAlive(pgid)) return;
+						signalTree("SIGTERM");
+						if (await pollUntil(() => !groupAlive(pgid), gracefulMs)) return;
+						signalTree("SIGKILL");
+						if (!(await pollUntil(() => !groupAlive(pgid), SIGKILL_REAP_CAP_MS))) {
+							logger.warn("owned process group still alive after SIGKILL", {
+								name: opts.name,
+								pgid,
+							});
+						}
+						return;
+					}
+					// Single-process fallback (Windows / processGroup:false).
+					if (child.exitCode !== null) return;
+					signalTree("SIGTERM");
+					if ((await owner.awaitExit({ timeoutMs: gracefulMs })).exited) return;
+					signalTree("SIGKILL");
+					await owner.awaitExit({ timeoutMs: SIGKILL_REAP_CAP_MS });
+				} catch (err) {
+					logger.warn("owned process dispose failed", {
+						name: opts.name,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				} finally {
+					// FIX: deregister only after teardown has completed so a postmortem
+					// firing mid-grace still sees the owner and awaits this dispose.
+					deregister();
+				}
+			})();
+			return disposePromise;
+		},
+	};
+
+	liveOwners.add(owner);
+
+	// When the root exits on its own (not via dispose), reconcile ownership by
+	// the *group*. After a short drain window: if the group is empty, deregister;
+	// if descendants are still alive, reap the owned group (no child outlives its
+	// owner). Either way the owner never lingers holding a stale pgid that the OS
+	// could later recycle and a stray dispose could mis-signal.
+	void child.exited
+		.catch(() => undefined)
+		.finally(() => {
+			if (disposed) return; // dispose() owns deregistration
+			if (pgid === undefined) {
+				deregister();
+				return;
+			}
+			void (async () => {
+				const drained = await pollUntil(() => !groupAlive(pgid), ROOT_EXIT_DRAIN_MS);
+				if (disposed) return;
+				if (drained) {
+					deregister();
+					return;
+				}
+				// Root exited but the owned group still has descendants: reap them.
+				// dispose() escalates SIGTERM->SIGKILL and deregisters in its finally.
+				await owner.dispose();
+			})();
+		});
+
+	if (opts.signal) {
+		if (opts.signal.aborted) {
+			void owner.dispose();
+		} else {
+			onAbort = () => void owner.dispose();
+			opts.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	return owner;
+}
+
+/** Number of currently live owned processes. Exposed for leak assertions/tests. */
+export function liveOwnedProcessCount(): number {
+	return liveOwners.size;
+}
+
+/** Dispose every live owned process. For owner-scoped teardown and tests. */
+export async function disposeAllOwnedProcesses(): Promise<void> {
+	await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+}
+
+// ── F1(b) generic resource owners ────────────────────────────────────────────
+
+type ResourceDisposer = () => void | Promise<void>;
+
+const resourceOwners = new Map<string, ResourceDisposer>();
+let resourcePostmortemRegistered = false;
+
+function ensureResourcePostmortem(): void {
+	if (resourcePostmortemRegistered) return;
+	resourcePostmortemRegistered = true;
+	// Postmortem isolates per-callback failures; swallow the aggregate here so
+	// shutdown continues, while direct callers of disposeAllResourceOwners still
+	// observe the AggregateError.
+	postmortem.register("runtime:resource-owners", () =>
+		disposeAllResourceOwners().catch(err => {
+			logger.warn("resource owner postmortem cleanup had failures", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}),
+	);
+}
+
+/**
+ * Register a non-process resource for postmortem/fatal-exit cleanup.
+ *
+ * Idempotent by `name`: re-registering the same name replaces the prior
+ * disposer (last wins). Returns an unregister function that removes the owner
+ * only while it is still the active registration for that name.
+ */
+export function registerResourceOwner(name: string, disposer: ResourceDisposer): () => void {
+	resourceOwners.set(name, disposer);
+	ensureResourcePostmortem();
+	let unregistered = false;
+	return () => {
+		if (unregistered) return;
+		unregistered = true;
+		if (resourceOwners.get(name) === disposer) {
+			resourceOwners.delete(name);
+		}
+	};
+}
+
+/** Number of registered resource owners. Exposed for leak assertions/tests. */
+export function resourceOwnerCount(): number {
+	return resourceOwners.size;
+}
+
+/**
+ * Run and clear every registered resource disposer. Attempts all disposers even
+ * if some throw, then surfaces the failures as an `AggregateError` so callers
+ * can distinguish "all closed" from "a resource may still be alive".
+ */
+export async function disposeAllResourceOwners(): Promise<void> {
+	const disposers = [...resourceOwners.values()];
+	resourceOwners.clear();
+	const errors: unknown[] = [];
+	for (const disposer of disposers) {
+		try {
+			await disposer();
+		} catch (err) {
+			errors.push(err);
+		}
+	}
+	if (errors.length > 0) {
+		throw new AggregateError(errors, `${errors.length} resource disposer(s) failed during teardown`);
+	}
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -52,6 +52,7 @@ import { resolveConfigValue } from "./config/resolve-config-value";
 import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
 import { BUNDLED_GROK_BUILD_EXTENSION_ID, getBundledGrokBuildExtensionFactory } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
+import { disposeAllVmContexts, disposeVmContextsByOwner } from "./eval/js/context-manager";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
 import { TtsrManager } from "./export/ttsr";
 import type { CustomCommandsLoadResult, LoadedCustomCommand } from "./extensibility/custom-commands";
@@ -570,6 +571,14 @@ function registerPythonCleanup(): void {
 	postmortem.register("python-cleanup", disposeAllKernelSessions);
 }
 
+let jsVmCleanupRegistered = false;
+
+function registerJsVmCleanup(): void {
+	if (jsVmCleanupRegistered) return;
+	jsVmCleanupRegistered = true;
+	postmortem.register("js-vm-cleanup", disposeAllVmContexts);
+}
+
 /**
  * Resolve whether to enable append-only context mode based on the setting and provider.
  *
@@ -806,6 +815,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	registerSshCleanup();
 	registerPythonCleanup();
+	registerJsVmCleanup();
 
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager
@@ -2200,6 +2210,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			} else {
 				if (hasRegistered) agentRegistry.unregister(resolvedAgentId);
 				await disposeKernelSessionsByOwner(evalKernelOwnerId);
+				await disposeVmContextsByOwner(evalKernelOwnerId);
 			}
 		} catch (cleanupError) {
 			logger.warn("Failed to clean up createAgentSession resources after startup error", {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -142,6 +142,7 @@ import { onAppendOnlyModeChanged } from "../config/settings";
 import { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import { loadCapability } from "../discovery";
 import { expandApplyPatchToEntries, normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
+import { disposeVmContextsByOwner } from "../eval/js/context-manager";
 import {
 	disposeKernelSessionsByOwner,
 	executePython as executePythonCommand,
@@ -3194,6 +3195,7 @@ export class AgentSession {
 			);
 		}
 		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
+		await disposeVmContextsByOwner(this.#evalKernelOwnerId);
 		this.#releasePowerAssertion();
 		await this.sessionManager.close();
 		this.#closeAllProviderSessions("dispose");

--- a/packages/coding-agent/test/eval/js-worker-vm-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/js-worker-vm-lifecycle.redteam.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	disposeAllVmContexts,
+	executeInVmContext,
+	liveVmContextCount,
+	resetVmContext,
+} from "../../src/eval/js/context-manager";
+import { WorkerCore } from "../../src/eval/js/worker-core";
+import type { Transport, WorkerInbound, WorkerOutbound } from "../../src/eval/js/worker-protocol";
+import type { ToolSession } from "../../src/tools";
+import { ToolError } from "../../src/tools/tool-errors";
+
+interface FakeTool {
+	execute(
+		toolCallId: string,
+		args: unknown,
+		signal: AbortSignal,
+	): Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+
+function makeSession(tools: Record<string, FakeTool> = {}): ToolSession {
+	return {
+		cwd: process.cwd(),
+		settings: { get: () => undefined } as unknown as ToolSession["settings"],
+		getToolByName: (name: string) => tools[name],
+	} as unknown as ToolSession;
+}
+
+async function expectSettles<T>(promise: Promise<T>, label: string, timeoutMs = 1_500): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(timeoutMs).then(() => {
+			throw new Error(`${label} did not settle`);
+		}),
+	]);
+}
+
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs = 1_500): Promise<void> {
+	const deadline = performance.now() + timeoutMs;
+	while (!predicate()) {
+		if (performance.now() > deadline) throw new Error(`${label} did not become true`);
+		await Bun.sleep(5);
+	}
+}
+
+describe("JS worker VM lifecycle redteam", () => {
+	afterEach(async () => {
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		await disposeAllVmContexts();
+	});
+
+	it("coalesces many concurrent first acquires for one sessionKey to exactly one worker and returns to baseline after dispose", async () => {
+		const baseline = liveVmContextCount();
+		const key = `u5-redteam-concurrent-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const results = await Promise.all(
+			Array.from({ length: 24 }, (_unused, index) =>
+				executeInVmContext({
+					sessionKey: key,
+					sessionId: key,
+					cwd: process.cwd(),
+					session,
+					code: `${index}`,
+					filename: `concurrent-${index}.js`,
+					runState: {},
+				}),
+			),
+		);
+		expect(results).toHaveLength(24);
+		expect(liveVmContextCount()).toBe(baseline + 1);
+		await disposeAllVmContexts();
+		expect(liveVmContextCount()).toBe(baseline);
+	});
+
+	it("rejects pending and queued runs on reset without hanging and releases the queue for a fresh worker", async () => {
+		const key = `u5-redteam-reset-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const pending = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "pending-reset.js",
+			runState: {},
+		});
+		const queued = Array.from({ length: 5 }, (_unused, index) =>
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: `${index}`,
+				filename: `queued-reset-${index}.js`,
+				runState: {},
+			}),
+		);
+		await waitUntil(() => liveVmContextCount() > 0, "worker start");
+		await waitUntil(() => liveVmContextCount() === 1, "worker ready");
+		await resetVmContext(key);
+		const settled = await expectSettles(
+			Promise.all([pending, ...queued].map(run => run.catch(error => error))),
+			"reset batch",
+		);
+		expect(settled).toHaveLength(6);
+		expect(settled.every(value => value instanceof Error)).toBe(true);
+		expect(liveVmContextCount()).toBe(0);
+		const fresh = await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "41 + 1",
+				filename: "fresh-after-reset.js",
+				runState: {},
+			}),
+			"fresh run after reset",
+		);
+		expect(fresh).toEqual({ value: undefined });
+	});
+
+	it("runs a reset:true cell against an existing VM after wiping previous state", async () => {
+		const key = `u5-redteam-reset-own-caller-${crypto.randomUUID()}`;
+		const session = makeSession();
+		await executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "globalThis.__resetSentinel = 1",
+			filename: "seed-before-own-reset.js",
+			runState: {},
+		});
+		await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				reset: true,
+				code: "if (globalThis.__resetSentinel !== undefined) throw new Error('state was not reset'); globalThis.__afterOwnReset = 7;",
+				filename: "own-reset-runs.js",
+				runState: {},
+			}),
+			"own reset run",
+		);
+		await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "if (globalThis.__afterOwnReset !== 7) throw new Error('reset cell did not execute')",
+				filename: "after-own-reset.js",
+				runState: {},
+			}),
+			"post-reset verification run",
+		);
+	});
+
+	it("observes the local pending rejection when worker send throws", async () => {
+		const OriginalWorker = globalThis.Worker;
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			#handlers = new Set<(event: MessageEvent) => void>();
+
+			constructor() {
+				void Bun.sleep(0).then(() => {
+					for (const handler of this.#handlers) handler({ data: { type: "ready" } } as MessageEvent);
+				});
+			}
+
+			postMessage(msg: WorkerInbound): void {
+				if (msg.type === "run") throw new Error("synthetic send failure");
+			}
+
+			addEventListener(type: string, handler: EventListener): void {
+				if (type === "message") this.#handlers.add(handler as (event: MessageEvent) => void);
+			}
+
+			removeEventListener(type: string, handler: EventListener): void {
+				if (type === "message") this.#handlers.delete(handler as (event: MessageEvent) => void);
+			}
+
+			terminate(): void {
+				this.#handlers.clear();
+			}
+		} as unknown as typeof Worker;
+		try {
+			const result = await expectSettles(
+				executeInVmContext({
+					sessionKey: `u5-redteam-send-failure-${crypto.randomUUID()}`,
+					sessionId: "send-failure",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "send-failure.js",
+					runState: {},
+				}).catch(error => error),
+				"send failure rejection",
+			);
+			expect(result).toBeInstanceOf(Error);
+			expect(String((result as Error).message)).toContain("synthetic send failure");
+			await Bun.sleep(20);
+			expect(unhandled).toHaveLength(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+
+	it("rejects pending and queued runs on abort/worker kill without hanging and releases the queue", async () => {
+		const key = `u5-redteam-kill-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const controller = new AbortController();
+		const pending = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "pending-kill.js",
+			runState: { signal: controller.signal },
+		});
+		const queued = Array.from({ length: 5 }, (_unused, index) =>
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: `${index}`,
+				filename: `queued-kill-${index}.js`,
+				runState: {},
+			}),
+		);
+		await waitUntil(() => liveVmContextCount() > 0, "worker start");
+		controller.abort(new Error("redteam abort"));
+		const settled = await expectSettles(
+			Promise.all([pending, ...queued].map(run => run.catch(error => error))),
+			"kill batch",
+		);
+		expect(settled).toHaveLength(6);
+		expect(settled.every(value => value instanceof Error)).toBe(true);
+		const fresh = await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "'queue-released'",
+				filename: "fresh-after-kill.js",
+				runState: {},
+			}),
+			"fresh run after kill",
+		);
+		expect(fresh).toEqual({ value: undefined });
+	});
+
+	it("settles a host-side pending tool call when the run aborts before the tool replies", async () => {
+		const key = `u5-redteam-tool-abort-${crypto.randomUUID()}`;
+		const controller = new AbortController();
+		let toolStarted = false;
+		let toolRejected: unknown;
+		const session = makeSession({
+			slow: {
+				async execute(_toolCallId, _args, signal) {
+					toolStarted = true;
+					return await new Promise((_resolve, reject) => {
+						const onAbort = (): void => {
+							toolRejected = signal.reason;
+							reject(signal.reason);
+						};
+						signal.addEventListener("abort", onAbort, { once: true });
+					});
+				},
+			},
+		});
+		const run = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await tool.slow({ phase: 'before-abort' })",
+			filename: "tool-abort.js",
+			runState: { signal: controller.signal },
+		});
+		await waitUntil(() => toolStarted, "tool call start");
+		controller.abort(new ToolError("abort while tool pending"));
+		const result = await expectSettles(
+			run.catch(error => error),
+			"tool-abort run",
+		);
+		expect(result).toBeInstanceOf(Error);
+		expect(toolRejected).toBeInstanceOf(Error);
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("unsubscribes WorkerCore transport listeners on close so reset/dispose/timeout paths cannot leak handlers", async () => {
+		const hostHandlers = new Set<(msg: WorkerInbound) => void>();
+		const outbound: WorkerOutbound[] = [];
+		let unsubscribeCalls = 0;
+		let closeCalls = 0;
+		const transport: Transport = {
+			send: msg => outbound.push(msg),
+			onMessage: handler => {
+				hostHandlers.add(handler);
+				return () => {
+					unsubscribeCalls += 1;
+					hostHandlers.delete(handler);
+				};
+			},
+			close: () => {
+				closeCalls += 1;
+			},
+		};
+		new WorkerCore(transport);
+		expect(hostHandlers.size).toBe(1);
+		for (const handler of [...hostHandlers]) handler({ type: "close" });
+		expect(unsubscribeCalls).toBe(1);
+		expect(closeCalls).toBe(1);
+		expect(hostHandlers.size).toBe(0);
+		expect(outbound.some(msg => msg.type === "closed")).toBe(true);
+	});
+
+	it("fails closed when inline-worker fallback would be needed in production without the explicit test env", async () => {
+		const OriginalWorker = globalThis.Worker;
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			constructor() {
+				throw new Error("synthetic worker spawn failure");
+			}
+		} as unknown as typeof Worker;
+		try {
+			await expect(
+				executeInVmContext({
+					sessionKey: `u5-redteam-fail-closed-${crypto.randomUUID()}`,
+					sessionId: "fail-closed",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "fail-closed.js",
+					runState: {},
+				}),
+			).rejects.toThrow(
+				/inline fallback is disabled.*cannot interrupt synchronous user code.*synthetic worker spawn failure/,
+			);
+		} finally {
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+});

--- a/packages/coding-agent/test/eval/js-worker-vm-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/js-worker-vm-lifecycle.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	disposeAllVmContexts,
+	disposeVmContextsByOwner,
+	executeInVmContext,
+	liveVmContextCount,
+} from "../../src/eval/js/context-manager";
+import { WorkerCore } from "../../src/eval/js/worker-core";
+import type { Transport, WorkerInbound, WorkerOutbound } from "../../src/eval/js/worker-protocol";
+import { disposeAllResourceOwners } from "../../src/runtime/process-lifecycle";
+import type { ToolSession } from "../../src/tools";
+
+function makeSession(): ToolSession {
+	return {
+		cwd: process.cwd(),
+		settings: { get: () => undefined } as unknown as ToolSession["settings"],
+		getToolByName: () => undefined,
+	} as unknown as ToolSession;
+}
+
+async function expectSettles<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(1_000).then(() => {
+			throw new Error(`${label} did not settle`);
+		}),
+	]);
+}
+
+describe("JS worker VM lifecycle", () => {
+	afterEach(async () => {
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		await disposeAllVmContexts();
+	});
+
+	it("coalesces concurrent first acquire to one worker", async () => {
+		const key = `u5-concurrent-${crypto.randomUUID()}`;
+		const session = makeSession();
+		await Promise.all([
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "1",
+				filename: "a.js",
+				runState: {},
+			}),
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "2",
+				filename: "b.js",
+				runState: {},
+			}),
+		]);
+		expect(liveVmContextCount()).toBe(1);
+	});
+
+	it("worker kill rejects pending and queued runs without hanging", async () => {
+		const key = `u5-kill-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const controller = new AbortController();
+		const first = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "blocked.js",
+			runState: { signal: controller.signal },
+		});
+		const second = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "1",
+			filename: "queued.js",
+			runState: {},
+		});
+		while (liveVmContextCount() === 0) await Bun.sleep(5);
+		await Bun.sleep(20);
+		controller.abort();
+		await expectSettles(
+			first.catch(error => error),
+			"pending run",
+		);
+		const queuedResult = await expectSettles(
+			second.catch(error => error),
+			"queued run",
+		);
+		expect(queuedResult).toBeInstanceOf(Error);
+	});
+
+	it("disposes live VM contexts through resource-owner cleanup", async () => {
+		const key = `u5-owner-${crypto.randomUUID()}`;
+		await executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "globalThis.__u5 = 1",
+			filename: "owner.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("disposes live VM contexts by eval owner rather than session key", async () => {
+		const baseline = liveVmContextCount();
+		const ownerId = `u5-owner-id-${crypto.randomUUID()}`;
+		await executeInVmContext({
+			sessionKey: `js:session:file:cwd:${process.cwd()}`,
+			sessionId: "session-key-does-not-match-owner",
+			ownerId,
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "globalThis.__u5Owner = 1",
+			filename: "owner-dispose.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(baseline + 1);
+		await disposeVmContextsByOwner(ownerId);
+		expect(liveVmContextCount()).toBe(baseline);
+	});
+
+	it("re-registers VM resource cleanup after global resource disposal", async () => {
+		await executeInVmContext({
+			sessionKey: `u5-reregister-first-${crypto.randomUUID()}`,
+			sessionId: "first",
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "1",
+			filename: "first.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+		await executeInVmContext({
+			sessionKey: `u5-reregister-second-${crypto.randomUUID()}`,
+			sessionId: "second",
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "2",
+			filename: "second.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("settles run-local pending tool promises when a run ends", async () => {
+		const hostHandlers = new Set<(msg: WorkerInbound) => void>();
+		const outbound: WorkerOutbound[] = [];
+		const transport: Transport = {
+			send: msg => outbound.push(msg),
+			onMessage: handler => {
+				hostHandlers.add(handler);
+				return () => hostHandlers.delete(handler);
+			},
+			close: () => undefined,
+		};
+		new WorkerCore(transport);
+		for (const handler of hostHandlers)
+			handler({ type: "init", snapshot: { cwd: process.cwd(), sessionId: "tools" } });
+		for (const handler of hostHandlers) {
+			handler({
+				type: "run",
+				runId: "r1",
+				code: "globalThis.toolPromise = tool.never({}).catch(() => undefined); 'done';",
+				filename: "tool.js",
+				snapshot: { cwd: process.cwd(), sessionId: "tools" },
+			});
+		}
+		await expectSettles(
+			(async () => {
+				while (!outbound.some(msg => msg.type === "result")) await Bun.sleep(5);
+			})(),
+			"tool run",
+		);
+		const toolCall = outbound.find(
+			(msg): msg is Extract<WorkerOutbound, { type: "tool-call" }> => msg.type === "tool-call",
+		);
+		expect(toolCall).toBeDefined();
+		for (const handler of hostHandlers)
+			handler({ type: "tool-reply", id: toolCall!.id, reply: { ok: true, value: "late" } });
+		expect(outbound.some(msg => msg.type === "tool-call")).toBe(true);
+		expect(outbound.some(msg => msg.type === "result" && msg.ok)).toBe(true);
+	});
+
+	it("fails closed when Worker construction fails outside explicit inline test mode", async () => {
+		const OriginalWorker = globalThis.Worker;
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			constructor() {
+				throw new Error("worker unavailable");
+			}
+		} as unknown as typeof Worker;
+		try {
+			await expect(
+				executeInVmContext({
+					sessionKey: `u5-fail-${crypto.randomUUID()}`,
+					sessionId: "fail",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "fail.js",
+					runState: {},
+				}),
+			).rejects.toThrow("inline fallback is disabled");
+		} finally {
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function waitForAsync(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 5_000,
+	label = "condition",
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (await predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function fileContains(path: string, needle: string): Promise<boolean> {
+	try {
+		return (await Bun.file(path).text()).includes(needle);
+	} catch {
+		return false;
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function processGroupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("process-lifecycle adversarial owned-process invariants", () => {
+	test("dispose immediately after spawn wins the startup race and returns to baseline", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "printf ready; sleep 30"], {
+			name: "redteam-immediate-dispose",
+			gracefulMs: 10,
+		});
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after immediate dispose");
+	});
+
+	test("dispose of an already-exited process is a no-op and does not throw", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 7"], { name: "redteam-already-exited" });
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit).toEqual({ exited: true, code: 7 });
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		await waitFor(
+			() => liveOwnedProcessCount() === before,
+			2_000,
+			"live count baseline after already-exited dispose",
+		);
+	});
+
+	test("double and concurrent dispose share one settled result and issue one terminating signal", async () => {
+		const before = liveOwnedProcessCount();
+		const tmp = `/tmp/gjc-process-lifecycle-${process.pid}-${Date.now()}`;
+		const owner = spawnOwnedProcess(
+			["sh", "-c", `trap 'echo term >> ${tmp}; exit 0' TERM; echo up > ${tmp}; while :; do sleep 1; done`],
+			{ name: "redteam-concurrent-dispose", gracefulMs: 500 },
+		);
+		try {
+			await waitForAsync(() => fileContains(tmp, "up"), 2_000, "child readiness marker");
+			const first = owner.dispose();
+			const second = owner.dispose();
+			expect(second).toBe(first);
+			await expect(Promise.all([first, second, owner.dispose()])).resolves.toEqual([
+				undefined,
+				undefined,
+				undefined,
+			]);
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after concurrent dispose");
+			const marker = await Bun.file(tmp).text();
+			expect(marker.split("\n").filter(line => line === "term")).toHaveLength(1);
+		} finally {
+			try {
+				await owner.dispose();
+			} catch {
+				/* already disposed */
+			}
+			await Bun.$`rm -f ${tmp}`.quiet();
+		}
+	});
+
+	test("awaitExit with timeoutMs 0 reports a live long-runner without killing it, then dispose cleans it", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "redteam-zero-timeout",
+			gracefulMs: 10,
+		});
+		try {
+			const probe = await owner.awaitExit({ timeoutMs: 0 });
+			expect(probe.exited).toBe(false);
+			expect(owner.pid === undefined ? false : processAlive(owner.pid)).toBe(true);
+		} finally {
+			await owner.dispose();
+		}
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after zero-timeout dispose");
+	});
+
+	test("liveOwnedProcessCount returns to baseline after a batch of spawn and dispose", async () => {
+		const before = liveOwnedProcessCount();
+		const owners = Array.from({ length: 8 }, (_, index) =>
+			spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+				name: `redteam-batch-${index}`,
+				gracefulMs: 10,
+			}),
+		);
+		expect(liveOwnedProcessCount()).toBeGreaterThanOrEqual(before + owners.length);
+		await Promise.all(owners.map(owner => owner.dispose()));
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after batch dispose");
+	});
+
+	test.skipIf(!isPosix)(
+		"dispose reaps a same-group double-fork grandchild while an unrelated sibling survives",
+		async () => {
+			const before = liveOwnedProcessCount();
+			const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+			const siblingPid = sibling.pid;
+			const owner = spawnOwnedProcess(["sh", "-c", "( ( sleep 30 ) & ) & while :; do sleep 1; done"], {
+				name: "redteam-double-fork-group",
+				gracefulMs: 50,
+			});
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			try {
+				await Bun.sleep(250);
+				await owner.dispose();
+				const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+				expect(exit.exited).toBe(true);
+				await waitFor(() => processGroupGone(pgid as number), 3_000, "owned process group ESRCH");
+				expect(processAlive(siblingPid)).toBe(true);
+				await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after group reap");
+			} finally {
+				try {
+					sibling.kill("SIGKILL");
+				} catch {
+					/* already gone */
+				}
+				await owner.dispose();
+			}
+		},
+	);
+});
+
+describe("process-lifecycle adversarial resource-owner invariants", () => {
+	test("a throwing disposer does not abort disposeAllResourceOwners and other disposers still run", async () => {
+		await disposeAllResourceOwners();
+		const calls: string[] = [];
+		registerResourceOwner("redteam:throws", () => {
+			calls.push("throws");
+			throw new Error("intentional red-team disposer failure");
+		});
+		registerResourceOwner("redteam:after", () => {
+			calls.push("after");
+		});
+		registerResourceOwner("redteam:async", async () => {
+			await Bun.sleep(1);
+			calls.push("async");
+		});
+
+		// All disposers run even when one throws, and the failure is surfaced
+		// (not swallowed) as an AggregateError so callers can detect it.
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(calls).toEqual(["throws", "after", "async"]);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+
+	test("unregister after disposeAllResourceOwners is safe and cannot remove a newer registration", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregister = registerResourceOwner("redteam:late-unregister", () => {
+			first += 1;
+		});
+		await disposeAllResourceOwners();
+		expect(first).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+
+		expect(() => unregister()).not.toThrow();
+		registerResourceOwner("redteam:late-unregister", () => {
+			second += 1;
+		});
+		expect(() => unregister()).not.toThrow();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(second).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllOwnedProcesses,
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+describe("spawnOwnedProcess (F1a)", () => {
+	test("awaits clean exit and deregisters from the live set", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], { name: "clean-exit" });
+		const result = await owner.awaitExit();
+		expect(result.exited).toBe(true);
+		expect(result.code).toBe(0);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("awaitExit honors a bounded timeout for a long runner", async () => {
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "timeout-probe" });
+		try {
+			const result = await owner.awaitExit({ timeoutMs: 100 });
+			expect(result.exited).toBe(false);
+		} finally {
+			await owner.dispose();
+		}
+	});
+
+	test("dispose terminates a long runner and is idempotent", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "dispose-probe" });
+		await Bun.sleep(50);
+		await Promise.all([owner.dispose(), owner.dispose()]);
+		expect(owner.disposed).toBe(true);
+		const result = await owner.awaitExit({ timeoutMs: 1_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("an already-aborted signal disposes the process immediately", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "pre-aborted",
+			signal: AbortSignal.abort(),
+		});
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("aborting mid-run disposes and removes the abort listener", async () => {
+		const before = liveOwnedProcessCount();
+		const controller = new AbortController();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "mid-abort",
+			signal: controller.signal,
+		});
+		await Bun.sleep(50);
+		controller.abort();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+		// Listener removed on settle: a second abort must not throw or re-dispose.
+		controller.abort();
+		expect(owner.disposed).toBe(true);
+	});
+
+	test.skipIf(!isPosix)("dispose reaps the process group while an unrelated sibling survives", async () => {
+		// Unrelated sibling: a directly-spawned detached sleep we must NOT kill.
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		const siblingPid = sibling.pid;
+		try {
+			// Owned tree: a shell that backgrounds a grandchild plus a foreground child.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & sleep 30"], { name: "group-reap" });
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			await Bun.sleep(150); // let the grandchild spawn
+
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 2_000 });
+
+			// The whole owned process group must be gone (ESRCH on group probe).
+			await waitFor(() => {
+				try {
+					process.kill(-(pgid as number), 0);
+					return false; // still alive
+				} catch (err) {
+					return (err as NodeJS.ErrnoException).code === "ESRCH";
+				}
+			});
+
+			// The unrelated sibling must still be alive.
+			expect(alive(siblingPid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+});
+
+describe("registerResourceOwner (F1b)", () => {
+	test("disposer runs once on disposeAllResourceOwners", async () => {
+		await disposeAllResourceOwners(); // clean slate
+		let calls = 0;
+		registerResourceOwner("test:res-a", () => {
+			calls += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+		// Cleared after dispose: a second dispose does not re-invoke.
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+	});
+
+	test("unregister prevents the disposer from running", async () => {
+		await disposeAllResourceOwners();
+		let calls = 0;
+		const unregister = registerResourceOwner("test:res-b", () => {
+			calls += 1;
+		});
+		unregister();
+		expect(resourceOwnerCount()).toBe(0);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(0);
+		// Idempotent unregister.
+		expect(() => unregister()).not.toThrow();
+	});
+
+	test("re-registering the same name replaces the disposer (last wins)", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregisterFirst = registerResourceOwner("test:res-c", () => {
+			first += 1;
+		});
+		registerResourceOwner("test:res-c", () => {
+			second += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		// The stale unregister must not remove the newer registration.
+		unregisterFirst();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(first).toBe(0);
+		expect(second).toBe(1);
+	});
+});
+
+describe("ownership regression: group liveness drives teardown (F1a)", () => {
+	test.skipIf(!isPosix)("reaps backgrounded descendants when the root exits first", async () => {
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// The shell exits 0 immediately but leaves a backgrounded child in the group.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & exit 0"], { name: "root-exits-first" });
+			const pgid = owner.pid as number;
+			const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(rootExit.exited).toBe(true);
+			expect(rootExit.code).toBe(0);
+			await Bun.sleep(50);
+			// The owned group is still alive because of the orphaned background child.
+			expect(groupAliveProbe(pgid)).toBe(true);
+			await owner.dispose();
+			await waitFor(() => groupGone(pgid));
+			// The unrelated sibling must survive.
+			expect(alive(sibling.pid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+
+	test("owner stays tracked until dispose teardown completes", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "tracked-until-done", gracefulMs: 300 });
+		await Bun.sleep(50);
+		const disposing = owner.dispose();
+		// FIX: the owner must remain in the live set until teardown completes, so a
+		// postmortem firing mid-grace still awaits this in-flight dispose.
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+		await disposing;
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test.skipIf(!isPosix)("disposeAllOwnedProcesses escalates SIGKILL for a SIGTERM-ignoring child", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "trap '' TERM; sleep 30"], {
+			name: "term-trap",
+			gracefulMs: 200,
+		});
+		await Bun.sleep(100);
+		// Simulates a postmortem/owner-scoped teardown reaching the in-flight owner.
+		await disposeAllOwnedProcesses();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+});
+
+describe("resource owner failure surfacing (F1b)", () => {
+	test("disposeAllResourceOwners surfaces disposer failures as AggregateError", async () => {
+		await disposeAllResourceOwners().catch(() => undefined);
+		let ran = 0;
+		registerResourceOwner("agg:throws", () => {
+			throw new Error("boom");
+		});
+		registerResourceOwner("agg:ok", () => {
+			ran += 1;
+		});
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(ran).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+});
+
+function groupAliveProbe(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function groupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("ownership regression: no stale pgid after late drain (F1a)", () => {
+	test.skipIf(!isPosix)("reaps and deregisters when descendants outlive the drain window", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 1 & exit 0"], { name: "late-drain" });
+		const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(rootExit.exited).toBe(true);
+		// The backgrounded `sleep 1` outlives ROOT_EXIT_DRAIN_MS; the owner must not
+		// linger with a stale pgid — it is reaped and the live count returns to
+		// baseline rather than being abandoned.
+		await waitFor(() => liveOwnedProcessCount() === before, 8_000);
+		expect(liveOwnedProcessCount()).toBe(before);
+	});
+});


### PR DESCRIPTION
## U5 — JS eval worker & VM lifecycle

Part of the core-runtime fix campaign. Owns `eval/js/{context-manager,worker-core,executor,index}.ts` + (exclusively) `sdk.ts`, `session/agent-session.ts`. Depends on F1(b) `registerResourceOwner`.

- **C2:** reserve-before-await session acquire — concurrent first cells coalesce to one worker; losers torn down.
- **H21:** worker kill/reset/abort rejects **queued AND pending** runs and the reservation waiter, releasing the queue so callers never hang. `reset: true` wipes then executes for the initiator while rejecting external waiters.
- **H22:** JS VM disposal wired to F1(b) `registerResourceOwner` + AgentSession/SDK **owner-scoped** `disposeVmContextsByOwner` (worker count returns to baseline after session dispose).
- **M11:** worker `onMessage` unsubscribe stored and called on every terminal path.
- **M12:** worker-core run-local tool promises settled at run end/abort/termination; send failure observed via the run-local promise (no unhandled rejection).
- Inline-worker fallback **fails closed** in production (test-only via `GAJAE_CODE_JS_EVAL_INLINE_WORKER=1`), since it cannot interrupt synchronous user code.

### Verification
- `bun test packages/coding-agent/test/eval/js-worker-vm-lifecycle.test.ts js-worker-vm-lifecycle.redteam.test.ts` → **15 pass / 0 fail**: concurrent coalescing, reset-with-pending+queued settles (no hang), owner-scoped dispose to baseline, reset-wipes-then-runs, send-failure no unobserved rejection, inline fail-closed.
- `bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit` exit 0; biome clean.
- Quality gate: architect final re-review CLEAR + APPROVE (after 3 fix rounds); red-team passed.

Base: `dev`.