### PR TITLE
fix(bash): native shell-session ownership + artifact byte cap (U6)

### DIFF
--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -32,6 +32,8 @@ export interface BashExecutorOptions {
 	/** Artifact path/id for full output storage */
 	artifactPath?: string;
 	artifactId?: string;
+	/** Execute without retaining a native Shell in the persistent session registry. */
+	oneShot?: boolean;
 	/**
 	 * Invoked when the native minimizer rewrote the command's output, giving
 	 * the caller a chance to persist the lossless original capture (typically
@@ -59,6 +61,8 @@ export interface BashResult {
 
 const shellSessions = new Map<string, Shell>();
 const brokenShellSessions = new Set<string>();
+const retiringShellSessions = new Set<Shell>();
+const CANCEL_CLEANUP_WAIT_MS = 1_000;
 
 /** Number of persistent shell sessions currently retained (owner gauge). */
 export function getShellSessionCount(): number {
@@ -76,10 +80,14 @@ export async function disposeAllShellSessions(): Promise<void> {
 	// Snapshot and drop strong references up front so concurrent callers cannot
 	// reuse a session that is being torn down, then await every native abort so
 	// shutdown/signal cleanup does not return before resources are released.
-	const sessions = [...shellSessions.values()];
+	// Include retiring shells whose JS call returned after bounded abort cleanup
+	// while the native run is still unwinding; they are no longer reusable but
+	// remain owned until their run promise settles.
+	const sessions = new Set([...shellSessions.values(), ...retiringShellSessions]);
 	shellSessions.clear();
+	retiringShellSessions.clear();
 	brokenShellSessions.clear();
-	await Promise.allSettled(sessions.map(session => session.abort()));
+	await Promise.allSettled([...sessions].map(session => session.abort()));
 }
 
 postmortem.register("bash-executor:shell-sessions", () => disposeAllShellSessions());
@@ -151,14 +159,12 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		};
 	}
 
+	const usePersistentShell = options?.oneShot !== true;
 	const sessionKey = buildSessionKey(shell, prefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
-	const persistentSessionBroken = brokenShellSessions.has(sessionKey);
-	if (persistentSessionBroken) {
-		shellSessions.delete(sessionKey);
-	}
+	const persistentSessionBroken = usePersistentShell && brokenShellSessions.has(sessionKey);
 
-	let shellSession = persistentSessionBroken ? undefined : shellSessions.get(sessionKey);
-	if (!shellSession && !persistentSessionBroken) {
+	let shellSession = persistentSessionBroken || !usePersistentShell ? undefined : shellSessions.get(sessionKey);
+	if (!shellSession && !persistentSessionBroken && usePersistentShell) {
 		shellSession = new Shell({
 			sessionEnv: shellEnv,
 			snapshotPath: snapshotPath ?? undefined,
@@ -172,15 +178,28 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		if (!runAbortController.signal.aborted) {
 			runAbortController.abort();
 		}
-		if (shellSession) {
-			// Native abort is async; fire-and-forget because the caller races the command separately.
-			void shellSession.abort();
+		if (shellSession && !abortPromise) {
+			abortPromise = shellSession.abort();
 		}
 	};
 	const abortDeferred = Promise.withResolvers<"abort">();
+	let abortPromise: Promise<unknown> | undefined;
 	const abortHandler = () => {
 		abortCurrentExecution();
 		abortDeferred.resolve("abort");
+	};
+	const awaitAbortCleanup = async (runPromise: Promise<unknown>): Promise<boolean> => {
+		const settled = await Promise.race([
+			runPromise.then(
+				() => true,
+				() => true,
+			),
+			Bun.sleep(CANCEL_CLEANUP_WAIT_MS).then(() => false),
+		]);
+		if (abortPromise) {
+			await Promise.race([abortPromise.catch(() => undefined), Bun.sleep(CANCEL_CLEANUP_WAIT_MS)]);
+		}
+		return settled;
 	};
 	if (userSignal) {
 		userSignal.addEventListener("abort", abortHandler, { once: true });
@@ -198,6 +217,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	}
 
 	let resetSession = false;
+	let runSettled = false;
 
 	try {
 		const runPromise = shellSession
@@ -243,8 +263,24 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			acceptingChunks = false;
 			if (shellSession) {
 				resetSession = true;
+				retiringShellSessions.add(shellSession);
 				brokenShellSessions.add(sessionKey);
-				void runPromise.finally(() => brokenShellSessions.delete(sessionKey)).catch(() => undefined);
+				shellSessions.delete(sessionKey);
+				runSettled = await awaitAbortCleanup(runPromise);
+				if (runSettled) {
+					brokenShellSessions.delete(sessionKey);
+					retiringShellSessions.delete(shellSession);
+				} else {
+					void runPromise
+						.finally(() => {
+							brokenShellSessions.delete(sessionKey);
+							retiringShellSessions.delete(shellSession);
+							if (shellSessions.get(sessionKey) === shellSession) {
+								shellSessions.delete(sessionKey);
+							}
+						})
+						.catch(() => undefined);
+				}
 			} else {
 				void runPromise.catch(() => undefined);
 			}
@@ -337,7 +373,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		if (userSignal) {
 			userSignal.removeEventListener("abort", abortHandler);
 		}
-		if (resetSession) {
+		if (resetSession && runSettled && shellSessions.get(sessionKey) === shellSession) {
 			shellSessions.delete(sessionKey);
 		}
 	}

--- a/packages/coding-agent/src/session/artifacts.ts
+++ b/packages/coding-agent/src/session/artifacts.ts
@@ -7,6 +7,11 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import { DEFAULT_ARTIFACT_MAX_BYTES, truncateHeadBytes } from "./streaming-output";
+export interface ArtifactSaveOptions {
+	maxBytes?: number;
+}
+
 /**
  * Manages artifact storage for a session.
  *
@@ -94,9 +99,19 @@ export class ArtifactManager {
 	 * @param toolType Tool name for file extension (e.g., "bash", "read")
 	 * @returns Artifact ID (numeric string)
 	 */
-	async save(content: string, toolType: string): Promise<string> {
+	async save(content: string, toolType: string, options: ArtifactSaveOptions = {}): Promise<string> {
 		const { id, path } = await this.allocatePath(toolType);
-		await Bun.write(path, content);
+		const maxBytes = Math.max(0, options.maxBytes ?? DEFAULT_ARTIFACT_MAX_BYTES);
+		const contentBytes = Buffer.byteLength(content, "utf-8");
+		if (contentBytes > maxBytes) {
+			const truncated = truncateHeadBytes(content, maxBytes);
+			await Bun.write(
+				path,
+				`${truncated.text}\n[artifact truncated after ${truncated.bytes} bytes; omitted at least ${contentBytes - truncated.bytes} bytes]\n`,
+			);
+		} else {
+			await Bun.write(path, content);
+		}
 		return id;
 	}
 

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -15,6 +15,7 @@ function sanitizeOutputChunk(rawChunk: string): string {
 export const DEFAULT_MAX_LINES = 3000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
 export const DEFAULT_MAX_COLUMN = 1024; // Max chars per grep match line
+export const DEFAULT_ARTIFACT_MAX_BYTES = 10 * 1024 * 1024; // 10MB
 
 const NL = "\n";
 
@@ -41,6 +42,8 @@ export interface OutputSummary {
 	columnTruncatedLines?: number;
 	/** Artifact ID for internal URL access (artifact://<id>) when truncated */
 	artifactId?: string;
+	/** Bytes omitted from artifact storage after the artifact hard cap was reached. */
+	artifactTruncatedBytes?: number;
 }
 
 export interface OutputSinkOptions {
@@ -61,6 +64,8 @@ export interface OutputSinkOptions {
 	 * writes still respect the budget. Default 0 = no per-line cap.
 	 */
 	maxColumns?: number;
+	/** Hard cap for artifact writes/pending replay. Default DEFAULT_ARTIFACT_MAX_BYTES. */
+	artifactMaxBytes?: number;
 	onChunk?: (chunk: string) => void;
 	/** Minimum ms between onChunk calls. 0 = every chunk (default). */
 	chunkThrottleMs?: number;
@@ -668,6 +673,9 @@ export class OutputSink {
 	#sawData = false;
 	#truncated = false;
 	#lastChunkTime = 0;
+	#artifactBytes = 0;
+	#artifactTruncatedBytes = 0;
+	#artifactTruncationNoticeWritten = false;
 
 	// Per-line column cap streaming state (persists across `push` calls so a
 	// long line split across chunks still trips the same trigger).
@@ -697,6 +705,7 @@ export class OutputSink {
 	readonly #onRawChunk?: (chunk: string) => void;
 	readonly #chunkThrottleMs: number;
 	readonly #maxColumns: number;
+	readonly #artifactMaxBytes: number;
 
 	constructor(options?: OutputSinkOptions) {
 		const {
@@ -708,6 +717,7 @@ export class OutputSink {
 			onChunk,
 			chunkThrottleMs = 0,
 			onRawChunk,
+			artifactMaxBytes = DEFAULT_ARTIFACT_MAX_BYTES,
 		} = options ?? {};
 		this.#artifactPath = artifactPath;
 		this.#artifactId = artifactId;
@@ -717,6 +727,7 @@ export class OutputSink {
 		this.#onChunk = onChunk;
 		this.#onRawChunk = onRawChunk;
 		this.#chunkThrottleMs = chunkThrottleMs;
+		this.#artifactMaxBytes = Math.max(0, artifactMaxBytes);
 	}
 
 	#headText(): string {
@@ -907,6 +918,40 @@ export class OutputSink {
 		}
 	}
 
+	#artifactTruncationNotice(droppedBytes: number): string {
+		return `\n[artifact truncated after ${this.#artifactBytes} bytes; omitted at least ${droppedBytes} bytes]\n`;
+	}
+
+	#capArtifactChunk(chunk: string, bytes: number): { chunk: string; bytes: number } | null {
+		if (bytes === 0) return null;
+		if (this.#artifactMaxBytes <= 0 || this.#artifactBytes >= this.#artifactMaxBytes) {
+			this.#artifactTruncatedBytes += bytes;
+			return null;
+		}
+		const room = this.#artifactMaxBytes - this.#artifactBytes;
+		if (bytes <= room) {
+			return { chunk, bytes };
+		}
+		const kept = truncateHeadBytes(chunk, room);
+		this.#artifactTruncatedBytes += bytes - kept.bytes;
+		return kept.bytes > 0 ? { chunk: kept.text, bytes: kept.bytes } : null;
+	}
+
+	#writeArtifactTruncationNotice(): void {
+		if (this.#artifactTruncatedBytes <= 0 || this.#artifactTruncationNoticeWritten) return;
+		const notice = this.#artifactTruncationNotice(this.#artifactTruncatedBytes);
+		try {
+			if (this.#fileReady && this.#file) {
+				this.#file.sink.write(notice);
+			} else {
+				this.#queuePendingFileWrite(notice, Buffer.byteLength(notice, "utf-8"));
+			}
+			this.#artifactTruncationNoticeWritten = true;
+		} catch {
+			/* ignore */
+		}
+	}
+
 	#queuePendingFileWrite(chunk: string, bytes = Buffer.byteLength(chunk, "utf-8")): void {
 		if (!this.#pendingFileWrites) this.#pendingFileWrites = [chunk];
 		else this.#pendingFileWrites.push(chunk);
@@ -915,14 +960,17 @@ export class OutputSink {
 	}
 
 	#enqueueFileWrite(chunk: string, bytes: number): void {
+		const capped = this.#capArtifactChunk(chunk, bytes);
+		if (!capped) return;
+		this.#artifactBytes += capped.bytes;
 		if (!this.#fileReady || !this.#file) {
-			this.#queuePendingFileWrite(chunk, bytes);
+			this.#queuePendingFileWrite(capped.chunk, capped.bytes);
 			if (this.#willOverflow(bytes) || this.#pendingFileWriteBytes > this.#spillThreshold) this.#createFileSink();
 			return;
 		}
 
 		try {
-			this.#file.sink.write(chunk);
+			this.#file.sink.write(capped.chunk);
 		} catch {
 			try {
 				void this.#file.sink.end();
@@ -931,7 +979,7 @@ export class OutputSink {
 			}
 			this.#file = undefined;
 			this.#fileReady = false;
-			this.#queuePendingFileWrite(chunk, bytes);
+			this.#queuePendingFileWrite(capped.chunk, capped.bytes);
 			this.#createFileSink();
 		}
 	}
@@ -1019,6 +1067,8 @@ export class OutputSink {
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
 
 		let artifactId: string | undefined;
+		if (this.#artifactTruncatedBytes > 0) this.#createFileSink();
+		this.#writeArtifactTruncationNotice();
 		if (this.#file) {
 			artifactId = this.#file.artifactId;
 			await this.#file.sink.end();
@@ -1095,6 +1145,7 @@ export class OutputSink {
 			elidedLines,
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
+			artifactTruncatedBytes: this.#artifactTruncatedBytes > 0 ? this.#artifactTruncatedBytes : undefined,
 			artifactId,
 		};
 	}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -37,8 +37,13 @@ export const BASH_DEFAULT_PREVIEW_LINES = 10;
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 
-async function saveBashOriginalArtifact(session: ToolSession, originalText: string): Promise<string | undefined> {
+export async function saveBashOriginalArtifactForTests(
+	session: ToolSession,
+	originalText: string,
+): Promise<string | undefined> {
 	try {
+		const manager = session.getArtifactManager?.();
+		if (manager) return await manager.save(originalText, "bash-original");
 		const alloc = await session.allocateOutputArtifact?.("bash-original");
 		if (!alloc?.path || !alloc.id) return undefined;
 		await Bun.write(alloc.path, originalText);
@@ -375,6 +380,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						env: options.resolvedEnv,
 						artifactPath,
 						artifactId,
+						oneShot: true,
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							latestText = tailBuffer.text();
@@ -387,7 +393,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							// path above.
 							manager.appendOutput(jobId, chunk);
 						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 					});
 					const finalResult = this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -675,6 +681,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						env: prepared.resolvedEnv,
 						artifactPath,
 						artifactId,
+						oneShot: true,
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							void reportProgress(tailBuffer.text(), {
@@ -688,7 +695,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							cursorOffset = slice.nextOffset;
 							dispatchLines(slice.text);
 						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 					});
 					flushTrailingLine();
 					this.#buildResultText(result, prepared.timeoutSec, result.output || "(no output)");
@@ -996,7 +1003,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+					onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 				});
 		if (result.cancelled) {
 			if (signal?.aborted) {

--- a/packages/coding-agent/test/tools/bash-resource-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/tools/bash-resource-lifecycle.redteam.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	disposeAllShellSessions,
+	executeBash,
+	getShellSessionCount,
+} from "@gajae-code/coding-agent/exec/bash-executor";
+import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import { DEFAULT_ARTIFACT_MAX_BYTES } from "@gajae-code/coding-agent/session/streaming-output";
+import { BashTool, type ToolSession } from "@gajae-code/coding-agent/tools";
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-redteam-"));
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForFile(filePath: string, timeoutMs = 3_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(filePath)) return true;
+		await Bun.sleep(25);
+	}
+	return fs.existsSync(filePath);
+}
+
+async function waitForSessionCountAtMost(count: number, timeoutMs = 4_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (getShellSessionCount() <= count) return true;
+		await Bun.sleep(25);
+	}
+	return getShellSessionCount() <= count;
+}
+
+function makeToolSession(tempDir: string, settings: Settings): ToolSession {
+	const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+	return {
+		cwd: tempDir,
+		hasUI: false,
+		settings,
+		getSessionId: () => "bash-redteam-test",
+		getAgentId: () => "0-Redteam",
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getArtifactsDir: () => artifacts.dir,
+		getArtifactManager: () => artifacts,
+		allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+	} as unknown as ToolSession;
+}
+
+describe("bash resource lifecycle red-team", () => {
+	let tempDir: string;
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	beforeEach(async () => {
+		tempDir = makeTempDir();
+		resetSettingsForTest();
+		settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		settings.set("async.enabled", true);
+		manager = new AsyncJobManager({ retentionMs: 20, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		await disposeAllShellSessions();
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.resetForTests();
+		await disposeAllShellSessions();
+		resetSettingsForTest();
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("does not leak native shell sessions across many sequential async and monitor bash jobs", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 12; index++) {
+			const started = await tool.execute(`async-${index}`, {
+				command: `printf 'async-${index}\\n'`,
+				async: true,
+				timeout: 5,
+			});
+			const jobId = started.details?.async?.jobId;
+			expect(jobId).toBeString();
+			await manager.waitForAll();
+			expect(manager.getJob(jobId! as string)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+
+			const monitor = await tool.startMonitorJob({ command: `printf 'monitor-${index}\\n'`, timeout: 5 });
+			await manager.waitForAll();
+			expect(manager.getJob(monitor.jobId)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	// U6 owns the JS-layer lifecycle contract: cancelled persistent shell sessions
+	// remain reachable to disposeAllShellSessions during bounded native cleanup,
+	// then leave the registry after native settle. Descendant/grandchild reaping is
+	// delegated to pi-shell and verified by native unit U3; this JS test exercises
+	// the integration again after U3 merges and the dev native addon is rebuilt.
+	it("keeps a cancelled persistent shell disposable through bounded native cleanup", async () => {
+		if (process.platform === "win32") return;
+
+		const baseline = getShellSessionCount();
+		const sibling = Bun.spawn(["python3", "-c", "import time; time.sleep(20)"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const pidFile = path.join(tempDir, "owned-direct-child.pid");
+		const controller = new AbortController();
+		const command = `python3 -c 'import os,time; open(${JSON.stringify(pidFile)}, "w").write(str(os.getpid())); time.sleep(20)'`;
+
+		try {
+			const run = executeBash(command, {
+				cwd: tempDir,
+				timeout: 30_000,
+				signal: controller.signal,
+				sessionKey: "redteam-cancel-disposable",
+			});
+
+			expect(await waitForFile(pidFile)).toBe(true);
+			const directChildPid = Number(fs.readFileSync(pidFile, "utf8"));
+			expect(Number.isInteger(directChildPid)).toBe(true);
+			expect(directChildPid).not.toBe(sibling.pid);
+			expect(processExists(directChildPid)).toBe(true);
+			expect(processExists(sibling.pid)).toBe(true);
+			expect(getShellSessionCount()).toBeGreaterThan(baseline);
+
+			controller.abort();
+			expect(getShellSessionCount()).toBeGreaterThanOrEqual(baseline);
+
+			const cleanupStartedAt = Date.now();
+			await disposeAllShellSessions();
+			const cleanupMs = Date.now() - cleanupStartedAt;
+			expect(cleanupMs).toBeLessThan(2_500);
+			expect(await waitForSessionCountAtMost(baseline)).toBe(true);
+
+			const result = await run;
+			expect(result.cancelled).toBe(true);
+			expect(processExists(sibling.pid)).toBe(true);
+		} finally {
+			sibling.kill("SIGKILL");
+			await sibling.exited.catch(() => undefined);
+		}
+	});
+
+	it("caps huge bash artifacts with truncation metadata instead of unbounded growth", async () => {
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+		const result = await tool.execute("huge-artifact", {
+			command: "python3 -c 'import sys; sys.stdout.write(\"x\" * (12 * 1024 * 1024))'",
+			timeout: 30,
+		});
+
+		const meta = result.details?.meta?.truncation;
+		expect(meta?.artifactId).toBeString();
+		expect(meta?.totalBytes).toBeGreaterThan(DEFAULT_ARTIFACT_MAX_BYTES);
+		expect(meta?.outputBytes).toBeLessThan(meta!.totalBytes);
+
+		const artifactPath = path.join(tempDir, "artifacts", `${meta!.artifactId}.bash.log`);
+		expect(fs.existsSync(artifactPath)).toBe(true);
+		const artifact = fs.readFileSync(artifactPath, "utf8");
+		expect(artifact).toContain("artifact truncated after 10485760 bytes");
+		expect(fs.statSync(artifactPath).size).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES + 512);
+	});
+});

--- a/packages/coding-agent/test/tools/bash-resource-lifecycle.test.ts
+++ b/packages/coding-agent/test/tools/bash-resource-lifecycle.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	disposeAllShellSessions,
+	executeBash,
+	getShellSessionCount,
+} from "@gajae-code/coding-agent/exec/bash-executor";
+import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import { DEFAULT_ARTIFACT_MAX_BYTES, OutputSink } from "@gajae-code/coding-agent/session/streaming-output";
+import { BashTool, type ToolSession } from "@gajae-code/coding-agent/tools";
+import type { Shell } from "@gajae-code/natives";
+import * as piNatives from "@gajae-code/natives";
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-lifecycle-"));
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForGone(pid: number, timeoutMs = 2_500): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!processExists(pid)) return true;
+		await Bun.sleep(50);
+	}
+	return !processExists(pid);
+}
+
+function makeToolSession(tempDir: string, settings: Settings): ToolSession {
+	const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+	return {
+		cwd: tempDir,
+		hasUI: false,
+		settings,
+		getSessionId: () => "bash-lifecycle-test",
+		getAgentId: () => "0-Test",
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getArtifactsDir: () => artifacts.dir,
+		getArtifactManager: () => artifacts,
+		allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+	} as unknown as ToolSession;
+}
+
+describe("bash resource lifecycle", () => {
+	let tempDir: string;
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	beforeEach(async () => {
+		tempDir = makeTempDir();
+		resetSettingsForTest();
+		settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		settings.set("async.enabled", true);
+		manager = new AsyncJobManager({ retentionMs: 20, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		await disposeAllShellSessions();
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.resetForTests();
+		await disposeAllShellSessions();
+		resetSettingsForTest();
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	it("repeated async bash jobs return native shell session count to baseline", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 3; index++) {
+			const started = await tool.execute(`call-${index}`, {
+				command: `printf async-${index}`,
+				async: true,
+				timeout: 5,
+			});
+			const jobId = started.details?.async?.jobId;
+			expect(jobId).toBeString();
+			await manager.waitForAll();
+			expect(manager.getJob(jobId! as string)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	it("repeated monitor jobs return native shell session count to baseline", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 3; index++) {
+			const { jobId } = await tool.startMonitorJob({ command: `printf monitor-${index}`, timeout: 5 });
+			await manager.waitForAll();
+			expect(manager.getJob(jobId)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	it("keeps a cancelled persistent shell reachable until native run settles", async () => {
+		const baseline = getShellSessionCount();
+		const controller = new AbortController();
+		const run = executeBash("sleep 10", {
+			cwd: tempDir,
+			timeout: 10_000,
+			signal: controller.signal,
+			sessionKey: "cancel-reachable",
+		});
+
+		await Bun.sleep(100);
+		expect(getShellSessionCount()).toBeGreaterThan(baseline);
+		controller.abort();
+		const result = await run;
+		expect(result.cancelled).toBe(true);
+		expect(getShellSessionCount()).toBe(baseline);
+		await disposeAllShellSessions();
+		expect(getShellSessionCount()).toBe(baseline);
+	});
+
+	it("reaps owned descendants on cancellation without killing unrelated siblings", async () => {
+		if (process.platform === "win32") return;
+
+		const sibling = Bun.spawn(["python3", "-c", "import time; time.sleep(10)"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const pidFile = path.join(tempDir, "owned.pid");
+		const controller = new AbortController();
+		const run = executeBash(
+			`python3 -c 'import os,time; open(${JSON.stringify(pidFile)}, "w").write(str(os.getpid())); time.sleep(10)'`,
+			{
+				cwd: tempDir,
+				timeout: 10_000,
+				signal: controller.signal,
+				sessionKey: "owned-pid-cancel",
+			},
+		);
+
+		const deadline = Date.now() + 2_000;
+		while (!fs.existsSync(pidFile) && Date.now() < deadline) await Bun.sleep(25);
+		expect(fs.existsSync(pidFile)).toBe(true);
+		const ownedPid = Number(fs.readFileSync(pidFile, "utf8"));
+		expect(processExists(ownedPid)).toBe(true);
+		controller.abort();
+		const result = await run;
+		expect(result.cancelled).toBe(true);
+		expect(await waitForGone(ownedPid)).toBe(true);
+		expect(processExists(sibling.pid)).toBe(true);
+		sibling.kill("SIGKILL");
+		await sibling.exited.catch(() => undefined);
+	});
+
+	it("caps bash artifact output and annotates truncation metadata", async () => {
+		const artifactPath = path.join(tempDir, "capped.log");
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "cap",
+			spillThreshold: 4,
+			artifactMaxBytes: 16,
+		});
+
+		sink.push("a".repeat(40));
+		const summary = await sink.dump();
+		const artifact = fs.readFileSync(artifactPath, "utf8");
+
+		expect(summary.artifactId).toBe("cap");
+		expect(summary.artifactTruncatedBytes).toBeGreaterThan(0);
+		expect(artifact).toContain("artifact truncated after 16 bytes");
+		expect(Buffer.byteLength(artifact, "utf8")).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES);
+		expect(artifact.length).toBeLessThan(120);
+	});
+
+	it("caps direct artifact saves and annotates truncation", async () => {
+		const manager = new ArtifactManager(path.join(tempDir, "direct-artifacts"));
+		const id = await manager.save("x".repeat(64), "bash", { maxBytes: 12 });
+		const savedPath = await manager.getPath(id);
+		expect(savedPath).toBeString();
+		const saved = fs.readFileSync(savedPath!, "utf8");
+		expect(saved).toContain("artifact truncated after 12 bytes");
+		expect(saved.length).toBeLessThan(96);
+	});
+	it("does not let a late-retired shell replace its same-key successor", async () => {
+		const originalRun = piNatives.Shell.prototype.run;
+		let runCalls = 0;
+		let firstRunSettled: (() => void) | undefined;
+		const shells: Shell[] = [];
+		const runSpy = vi.spyOn(piNatives.Shell.prototype, "run").mockImplementation(function (
+			this: Shell,
+			options,
+			onChunk,
+		) {
+			runCalls++;
+			shells.push(this);
+			if (runCalls === 1) {
+				onChunk?.(null, "started\n");
+				return new Promise(resolve => {
+					firstRunSettled = () => resolve({ exitCode: 130, cancelled: true, timedOut: false });
+				});
+			}
+			if (runCalls === 2) {
+				onChunk?.(null, "replacement\n");
+				return Promise.resolve({ exitCode: 0, cancelled: false, timedOut: false });
+			}
+			if (runCalls === 3) {
+				onChunk?.(null, "after-late-settle\n");
+				return Promise.resolve({ exitCode: 0, cancelled: false, timedOut: false });
+			}
+			return originalRun.call(this, options, onChunk);
+		});
+		const abortSpy = vi.spyOn(piNatives.Shell.prototype, "abort").mockResolvedValue(undefined);
+		const controller = new AbortController();
+		const first = executeBash("sleep 10", {
+			cwd: tempDir,
+			timeout: 5_000,
+			signal: controller.signal,
+			sessionKey: "late-retiring-replacement",
+		});
+
+		await Bun.sleep(50);
+		controller.abort();
+		const firstResult = await first;
+		expect(firstResult.cancelled).toBe(true);
+		expect(abortSpy).toHaveBeenCalledTimes(1);
+
+		const replacement = await executeBash("printf replacement", {
+			cwd: tempDir,
+			timeout: 5_000,
+			sessionKey: "late-retiring-replacement",
+		});
+		expect(replacement.output.trim()).toBe("replacement");
+		expect(shells[1]).not.toBe(shells[0]);
+
+		firstRunSettled?.();
+		await Bun.sleep(0);
+
+		const afterLateSettle = await executeBash("printf after-late-settle", {
+			cwd: tempDir,
+			timeout: 5_000,
+			sessionKey: "late-retiring-replacement",
+		});
+		expect(afterLateSettle.output.trim()).toBe("replacement");
+		expect(runCalls).toBe(2);
+
+		runSpy.mockRestore();
+		abortSpy.mockRestore();
+	});
+
+	it("caps minimized raw output artifacts through ArtifactManager", async () => {
+		const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+		const session = {
+			getArtifactManager: () => artifacts,
+			allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+		} as unknown as ToolSession;
+		const originalText = "x".repeat(DEFAULT_ARTIFACT_MAX_BYTES + 1024);
+		const bashModule = await import("@gajae-code/coding-agent/tools/bash");
+		const artifactId = await bashModule.saveBashOriginalArtifactForTests(session, originalText);
+
+		expect(artifactId).toBeString();
+		const artifactPath = path.join(tempDir, "artifacts", `${artifactId}.bash-original.log`);
+		expect(fs.existsSync(artifactPath)).toBe(true);
+		const saved = fs.readFileSync(artifactPath, "utf8");
+		expect(saved).toContain(`artifact truncated after ${DEFAULT_ARTIFACT_MAX_BYTES} bytes`);
+		expect(fs.statSync(artifactPath).size).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES + 512);
+	});
+});


### PR DESCRIPTION
Core-runtime fix campaign U6. C5: async/monitor bash jobs use one-shot execution (no per-job native Shell retained; session count returns to baseline). H23: cancellation observes native Shell.abort with bounded cleanup; retiring shells move to a disposer-owned set that disposeAllShellSessions aborts and are removed from the persistent map (value-guarded) so they neither leak nor get reused. M15: hard byte cap + truncation marker for streaming/ArtifactManager/minimized-raw artifacts. Tests: 11 pass (bash-resource-lifecycle + redteam). tsgo+biome clean. Architect CLEAR/APPROVE. Native grandchild-reaping on cancel delegated to pi-shell U3 (#709). Base dev.