### PR TITLE
fix(dap,lsp): adapter/server process lifecycle via F1 (U7)

### DIFF
--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -1,6 +1,8 @@
-import { logger, ptree } from "@gajae-code/utils";
+import * as fs from "node:fs/promises";
+import { logger } from "@gajae-code/utils";
 import { formatCrashDiagnosticNotice, writeCrashReport } from "../debug/crash-diagnostics";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
+import { type OwnedProcess, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { ToolAbortError } from "../tools/tool-errors";
 import type {
 	DapCapabilities,
@@ -69,10 +71,21 @@ function toErrorMessage(value: unknown): string {
 	return String(value);
 }
 
+async function drainReadable(readable: ReadableStream<Uint8Array>): Promise<void> {
+	const reader = readable.getReader();
+	try {
+		while (!(await reader.read()).done) {}
+	} catch {
+		/* drain best-effort */
+	} finally {
+		reader.releaseLock();
+	}
+}
 export class DapClient {
 	readonly adapter: DapResolvedAdapter;
 	readonly cwd: string;
 	readonly proc: DapClientState["proc"];
+	readonly #owner: OwnedProcess;
 	/** ReadableStream of DAP bytes — from proc.stdout (stdio) or a socket (socket mode). */
 	readonly #readable: ReadableStream<Uint8Array>;
 	/** Write sink — proc.stdin (stdio) or a socket (socket mode). */
@@ -93,14 +106,15 @@ export class DapClient {
 	constructor(
 		adapter: DapResolvedAdapter,
 		cwd: string,
-		proc: DapClientState["proc"],
+		owner: OwnedProcess,
 		options?: { readable?: ReadableStream<Uint8Array>; writeSink?: DapWriteSink; socket?: { end(): void } },
 	) {
 		this.adapter = adapter;
 		this.cwd = cwd;
-		this.proc = proc;
-		this.#readable = options?.readable ?? (proc.stdout as ReadableStream<Uint8Array>);
-		this.#writeSink = options?.writeSink ?? proc.stdin;
+		this.proc = owner.child as DapClientState["proc"];
+		this.#owner = owner;
+		this.#readable = options?.readable ?? (this.proc.stdout as ReadableStream<Uint8Array>);
+		this.#writeSink = options?.writeSink ?? this.proc.stdin;
 		this.#socket = options?.socket;
 	}
 
@@ -116,13 +130,14 @@ export class DapClient {
 			...Bun.env,
 			...NON_INTERACTIVE_ENV,
 		};
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}`,
 		});
-		const client = new DapClient(adapter, cwd, proc);
+		const client = new DapClient(adapter, cwd, owner);
+		const proc = owner.child as DapClientState["proc"];
 		proc.exited.then(() => {
 			client.#handleProcessExit();
 		});
@@ -159,32 +174,44 @@ export class DapClient {
 		env: Record<string, string | undefined>;
 	}): Promise<DapClient> {
 		const socketPath = `/tmp/dap-${adapter.name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`;
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args, `--listen=unix:${socketPath}`], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args, `--listen=unix:${socketPath}`], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}:unix-socket`,
 		});
+		const proc = owner.child as DapClientState["proc"];
+		void drainReadable(proc.stdout);
+		let transport: SocketTransport | undefined;
 
-		// Wait for the socket file to appear (dlv needs to start listening)
-		await waitForCondition(
-			() => {
-				try {
-					Bun.file(socketPath).size;
-					return true;
-				} catch {
-					return false;
-				}
-			},
-			10_000,
-			proc,
-		);
+		try {
+			// Wait for the socket file to appear (dlv needs to start listening)
+			await waitForCondition(
+				() => {
+					try {
+						Bun.file(socketPath).size;
+						return true;
+					} catch {
+						return false;
+					}
+				},
+				10_000,
+				proc,
+			);
 
-		const { readable, writeSink, socket } = await connectSocket({ unix: socketPath });
-		const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });
-		proc.exited.then(() => client.#handleProcessExit());
-		void client.#startMessageReader();
-		return client;
+			transport = await connectSocket({ unix: socketPath }, 10_000);
+			const client = new DapClient(adapter, cwd, owner, transport);
+			proc.exited.then(() => client.#handleProcessExit());
+			void client.#startMessageReader();
+			return client;
+		} catch (err) {
+			transport?.socket.end();
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
+			throw err;
+		} finally {
+			await fs.unlink(socketPath).catch(() => undefined);
+		}
 	}
 
 	/** macOS/other: listen on a random TCP port, spawn adapter with --client-addr, accept connection. */
@@ -214,12 +241,14 @@ export class DapClient {
 		});
 
 		const port = server.port;
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args, `--client-addr=127.0.0.1:${port}`], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args, `--client-addr=127.0.0.1:${port}`], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}:client-addr`,
 		});
+		const proc = owner.child as DapClientState["proc"];
+		void drainReadable(proc.stdout);
 
 		// Wait for dlv to connect (with timeout)
 		let rawSocket: Bun.Socket<undefined>;
@@ -230,13 +259,17 @@ export class DapClient {
 		);
 		try {
 			rawSocket = await Promise.race([connPromise, timeoutPromise]);
+		} catch (err) {
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
+			throw err;
 		} finally {
 			clearTimeout(connectTimeout);
 			server.stop();
 		}
 
 		const { readable, writeSink, socket } = wrapBunSocket(rawSocket);
-		const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });
+		const client = new DapClient(adapter, cwd, owner, { readable, writeSink, socket });
 		proc.exited.then(() => client.#handleProcessExit());
 		void client.#startMessageReader();
 		return client;
@@ -414,14 +447,14 @@ export class DapClient {
 			/* socket may already be closed */
 		}
 		try {
-			this.proc.kill();
+			await this.#owner.dispose();
+			await this.#owner.awaitExit({ timeoutMs: 1_000 });
 		} catch (error) {
-			logger.debug("Failed to kill DAP adapter", {
+			logger.debug("Failed to dispose DAP adapter", {
 				adapter: this.adapter.name,
 				error: toErrorMessage(error),
 			});
 		}
-		await this.proc.exited.catch(() => {});
 	}
 
 	async #startMessageReader(): Promise<void> {
@@ -604,8 +637,8 @@ function socketToSink(socket: Bun.Socket<undefined>): DapWriteSink {
 }
 
 /** Connect to a unix domain socket and return DAP transport streams. */
-async function connectSocket(options: { unix: string }): Promise<SocketTransport> {
-	const { promise, resolve } = Promise.withResolvers<SocketTransport>();
+async function connectSocket(options: { unix: string }, timeoutMs = 10_000): Promise<SocketTransport> {
+	const { promise, resolve, reject } = Promise.withResolvers<SocketTransport>();
 	let streamController: ReadableStreamDefaultController<Uint8Array>;
 
 	const readable = new ReadableStream<Uint8Array>({
@@ -614,15 +647,25 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 		},
 	});
 
+	const timeout = setTimeout(() => reject(new Error(`Socket connect timed out after ${timeoutMs}ms`)), timeoutMs);
+	let settled = false;
+	const settle = (fn: () => void) => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timeout);
+		fn();
+	};
 	Bun.connect({
 		unix: options.unix,
 		socket: {
 			open(socket) {
-				resolve({
-					readable,
-					writeSink: socketToSink(socket),
-					socket,
-				});
+				settle(() =>
+					resolve({
+						readable,
+						writeSink: socketToSink(socket),
+						socket,
+					}),
+				);
 			},
 			data(_socket, data) {
 				streamController.enqueue(new Uint8Array(data));
@@ -635,11 +678,7 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 				}
 			},
 			error(_socket, err) {
-				try {
-					streamController.error(err);
-				} catch {
-					/* already closed */
-				}
+				settle(() => reject(err));
 			},
 		},
 	});

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import * as timers from "node:timers/promises";
-import { logger, ptree, untilAborted } from "@gajae-code/utils";
+import { logger, untilAborted } from "@gajae-code/utils";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
+import { type OwnedProcess, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { DapClient } from "./client";
 import type {
 	DapAttachArguments,
@@ -63,6 +64,24 @@ import type {
 	DapWriteMemoryResponse,
 } from "./types";
 
+function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): void {
+	if (!stream) return;
+	void (async () => {
+		try {
+			const reader = stream.getReader();
+			try {
+				while (!(await reader.read()).done) {
+					// drain only
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		} catch {
+			// Process stream closed or was already consumed.
+		}
+	})();
+}
+
 interface DapSession {
 	id: string;
 	adapter: DapResolvedAdapter;
@@ -87,6 +106,7 @@ interface DapSession {
 	initializedSeen: boolean;
 	needsConfigurationDone: boolean;
 	configurationDoneSent: boolean;
+	runInTerminalProcesses: Set<OwnedProcess>;
 }
 
 export interface DapOutputSnapshot {
@@ -948,6 +968,7 @@ export class DapSessionManager {
 			initializedSeen: false,
 			needsConfigurationDone: false,
 			configurationDoneSent: false,
+			runInTerminalProcesses: new Set(),
 		};
 		client.onReverseRequest("runInTerminal", async rawArgs => {
 			const args = (rawArgs ?? {}) as DapRunInTerminalArguments;
@@ -957,17 +978,21 @@ export class DapSessionManager {
 			const env = Object.fromEntries(
 				Object.entries(args.env ?? {}).filter((entry): entry is [string, string] => entry[1] !== null),
 			);
-			const proc = ptree.spawn(args.args, {
+			const owner = spawnOwnedProcess(args.args, {
 				cwd: args.cwd ?? session.cwd,
-				stdin: "pipe",
+				stdin: "ignore",
 				env: {
 					...Bun.env,
 					...NON_INTERACTIVE_ENV,
 					...env,
 				},
-				detached: true,
+				name: `dap:${session.id}:runInTerminal`,
 			});
-			return { processId: proc.pid } satisfies DapRunInTerminalResponse;
+			drainStream(owner.child.stdout);
+			drainStream(owner.child.stderr);
+			session.runInTerminalProcesses.add(owner);
+			owner.exited.finally(() => session.runInTerminalProcesses.delete(owner));
+			return { processId: owner.pid } satisfies DapRunInTerminalResponse;
 		});
 		client.onReverseRequest("startDebugging", async rawArgs => {
 			const startArgs = (rawArgs ?? {}) as Partial<DapStartDebuggingArguments>;
@@ -1294,12 +1319,24 @@ export class DapSessionManager {
 		return session;
 	}
 
-	#disposeSession(session: DapSession) {
+	async #disposeSession(session: DapSession) {
 		if (this.#activeSessionId === session.id) {
 			this.#activeSessionId = null;
 		}
 		this.#sessions.delete(session.id);
-		void session.client.dispose().catch(() => {});
+		await this.#disposeRunInTerminalProcesses(session);
+		await session.client.dispose().catch(() => {});
+	}
+
+	async #disposeRunInTerminalProcesses(session: DapSession): Promise<void> {
+		const owners = [...session.runInTerminalProcesses];
+		session.runInTerminalProcesses.clear();
+		await Promise.allSettled(
+			owners.map(async owner => {
+				await owner.dispose();
+				await owner.awaitExit({ timeoutMs: 1_000 });
+			}),
+		);
 	}
 }
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,5 +1,6 @@
-import { isEnoent, logger, ptree, untilAborted } from "@gajae-code/utils";
+import { isEnoent, logger, untilAborted } from "@gajae-code/utils";
 import { formatCrashDiagnosticNotice, writeCrashReport } from "../debug/crash-diagnostics";
+import { registerResourceOwner, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
@@ -19,8 +20,10 @@ import { detectLanguageId, fileToUri } from "./utils";
 // =============================================================================
 
 const clients = new Map<string, LspClient>();
+const killedClients = new WeakSet<LspClient>();
 const clientLocks = new Map<string, Promise<LspClient>>();
 const fileOperationLocks = new Map<string, Promise<void>>();
+const lspCleanupOwner = registerResourceOwner("lsp:clients", shutdownAll);
 
 // Idle timeout configuration (disabled by default)
 let idleTimeoutMs: number | null = null;
@@ -65,6 +68,32 @@ export function isIdleCheckerActiveForTests(): boolean {
 	return idleCheckInterval !== null;
 }
 
+function rejectPendingRequests(client: LspClient, error: Error): void {
+	for (const pending of client.pendingRequests.values()) {
+		pending.reject(error);
+	}
+	client.pendingRequests.clear();
+}
+
+function deleteCachedClient(key: string, client: LspClient): void {
+	if (clients.get(key) === client) {
+		clients.delete(key);
+	}
+}
+
+function deleteClientLock(key: string, clientPromise: Promise<LspClient>): void {
+	if (clientLocks.get(key) === clientPromise) {
+		clientLocks.delete(key);
+	}
+}
+
+function evictDeadCachedClient(key: string, client: LspClient): void {
+	if (client.proc.exitCode === null && !client.proc.killed && !client.owner?.disposed && !killedClients.has(client))
+		return;
+	deleteCachedClient(key, client);
+	client.resolveProjectLoaded();
+	rejectPendingRequests(client, new Error("LSP server exited"));
+}
 // =============================================================================
 // Client Capabilities
 // =============================================================================
@@ -432,8 +461,11 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 	// Check if client already exists
 	const existingClient = clients.get(key);
 	if (existingClient) {
-		existingClient.lastActivity = Date.now();
-		return existingClient;
+		evictDeadCachedClient(key, existingClient);
+		if (clients.has(key)) {
+			existingClient.lastActivity = Date.now();
+			return existingClient;
+		}
 	}
 
 	// Check if another coroutine is already creating this client
@@ -443,7 +475,8 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 	}
 
 	// Create new client with lock
-	const clientPromise = (async () => {
+	let clientPromise!: Promise<LspClient>;
+	clientPromise = (async () => {
 		const baseCommand = config.resolvedCommand ?? config.command;
 		const baseArgs = config.args ?? [];
 
@@ -452,11 +485,13 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			? await getLspmuxCommand(baseCommand, baseArgs)
 			: { command: baseCommand, args: baseArgs };
 
-		const proc = ptree.spawn([command, ...args], {
+		const owner = spawnOwnedProcess([command, ...args], {
 			cwd,
 			stdin: "pipe",
 			env: env ? { ...Bun.env, ...env } : undefined,
+			name: `lsp:${config.command}`,
 		});
+		const proc = owner.child;
 
 		let resolveProjectLoaded!: () => void;
 		const projectLoaded = new Promise<void>(resolve => {
@@ -474,6 +509,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			name: key,
 			cwd,
 			proc,
+			owner,
 			config,
 			requestId: 0,
 			diagnostics: new Map(),
@@ -488,12 +524,17 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			projectLoaded,
 			resolveProjectLoaded,
 		};
+		const originalKill = proc.kill.bind(proc);
+		proc.kill = (...args: Parameters<typeof proc.kill>) => {
+			killedClients.add(client);
+			return originalKill(...args);
+		};
 		clients.set(key, client);
 
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(async () => {
-			clients.delete(key);
-			clientLocks.delete(key);
+			deleteCachedClient(key, client);
+			deleteClientLock(key, clientPromise);
 			client.resolveProjectLoaded();
 
 			// Reject any pending requests — the server is gone, they will never complete.
@@ -564,12 +605,12 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			return client;
 		} catch (err) {
 			// Clean up on initialization failure
-			clients.delete(key);
-			clientLocks.delete(key);
-			proc.kill();
+			deleteCachedClient(key, client);
+			deleteClientLock(key, clientPromise);
+			await shutdownClientInstance(client);
 			throw err;
 		} finally {
-			clientLocks.delete(key);
+			deleteClientLock(key, clientPromise);
 		}
 	})();
 
@@ -645,12 +686,7 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
  */
 export async function waitForProjectLoaded(client: LspClient, signal?: AbortSignal): Promise<void> {
 	if (signal?.aborted) return;
-	await Promise.race([
-		client.projectLoaded,
-		...(signal
-			? [new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }))]
-			: []),
-	]);
+	await untilAborted(signal, client.projectLoaded);
 }
 
 /**
@@ -793,16 +829,12 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
  */
 async function shutdownClientInstance(client: LspClient): Promise<void> {
 	const err = new Error("LSP client shutdown");
-	for (const pending of Array.from(client.pendingRequests.values())) {
-		pending.reject(err);
-	}
-	client.pendingRequests.clear();
+	rejectPendingRequests(client, err);
 
-	const timeout = Bun.sleep(5_000);
-	const shutdown = sendRequest(client, "shutdown", null).catch(() => {});
-	await Promise.race([shutdown, timeout]);
-	client.proc.kill();
-	await Promise.race([client.proc.exited.catch(() => {}), Bun.sleep(1_000)]);
+	const shutdown = sendRequest(client, "shutdown", null, undefined, 5_000).catch(() => {});
+	await Promise.race([shutdown, Bun.sleep(5_000)]);
+	await client.owner?.dispose();
+	await client.owner?.awaitExit({ timeoutMs: 1_000 });
 }
 
 export async function shutdownClient(key: string): Promise<void> {
@@ -958,6 +990,12 @@ export function getActiveClients(): LspServerStatus[] {
 if (typeof process !== "undefined") {
 	process.on("beforeExit", () => {
 		void shutdownAll();
+	});
+	process.on("exit", () => {
+		lspCleanupOwner();
+		for (const client of clients.values()) {
+			client.proc.kill();
+		}
 	});
 	process.on("SIGINT", () => {
 		void (async () => {

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -19,6 +19,7 @@ import {
 	sendNotification,
 	sendRequest,
 	setIdleTimeout,
+	shutdownClient,
 	syncContent,
 	WARMUP_TIMEOUT_MS,
 	waitForProjectLoaded,
@@ -400,7 +401,7 @@ async function reloadServer(client: LspClient, serverName: string, signal?: Abor
 		}
 	}
 	if (output.startsWith("Restarted")) {
-		client.proc.kill();
+		await shutdownClient(client.name);
 	}
 	return output;
 }

--- a/packages/coding-agent/src/lsp/lspmux.ts
+++ b/packages/coding-agent/src/lsp/lspmux.ts
@@ -2,6 +2,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { $flag, $which, logger } from "@gajae-code/utils";
 import { TOML } from "bun";
+import { spawnOwnedProcess } from "../runtime/process-lifecycle";
 
 /**
  * lspmux integration for LSP server multiplexing.
@@ -101,19 +102,24 @@ async function parseConfig(): Promise<LspmuxConfig | null> {
  */
 async function checkServerRunning(binaryPath: string): Promise<boolean> {
 	try {
-		const proc = Bun.spawn([binaryPath, "status"], {
-			stdout: "pipe",
-			stderr: "pipe",
-			windowsHide: true,
+		const owner = spawnOwnedProcess([binaryPath, "status"], {
+			stdin: "ignore",
+			name: "lspmux:status",
 		});
+		const proc = owner.child;
+		drainStream(proc.stdout);
+		drainStream(proc.stderr);
 
-		const exited = await Promise.race([
-			proc.exited,
-			new Promise<null>(resolve => setTimeout(() => resolve(null), LIVENESS_TIMEOUT_MS)),
-		]);
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<null>(resolve => {
+			timer = setTimeout(() => resolve(null), LIVENESS_TIMEOUT_MS);
+		});
+		const exited = await Promise.race([proc.exited, timeout]);
+		if (timer) clearTimeout(timer);
 
 		if (exited === null) {
-			proc.kill();
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
 			return false;
 		}
 
@@ -121,6 +127,24 @@ async function checkServerRunning(binaryPath: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): void {
+	if (!stream) return;
+	void (async () => {
+		try {
+			const reader = stream.getReader();
+			try {
+				while (!(await reader.read()).done) {
+					// drain only
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		} catch {
+			// Process stream closed or already consumed.
+		}
+	})();
 }
 
 /**

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -1,5 +1,6 @@
 import type { ptree } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import type { OwnedProcess } from "../runtime/process-lifecycle";
 
 // =============================================================================
 // Tool Schema
@@ -399,6 +400,7 @@ export interface LspClient {
 	cwd: string;
 	config: ServerConfig;
 	proc: ptree.ChildProcess<"pipe">;
+	owner?: OwnedProcess;
 	requestId: number;
 	diagnostics: Map<string, PublishedDiagnostics>;
 	diagnosticsVersion: number;

--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -1,0 +1,388 @@
+/**
+ * Shared runtime lifecycle foundation.
+ *
+ * Two minimal, deliberately small primitives that subsystem runtimes
+ * (DAP/LSP/MCP stdio, eval workers, etc.) adopt so spawned children and
+ * non-process resources cannot outlive their owner:
+ *
+ *   F1(a) `spawnOwnedProcess` — wraps `ptree.spawn` with explicit
+ *         process-group ownership, escalating (SIGTERM -> grace -> SIGKILL)
+ *         tree termination, bounded `awaitExit`, abort-listener cleanup on
+ *         settle, idempotent `dispose`, and a single postmortem hook that
+ *         reaps every still-live owned process group on fatal/normal shutdown.
+ *
+ *   F1(b) `registerResourceOwner` — a generic, idempotent postmortem adapter
+ *         for non-process resources (Bun Workers, VM contexts, timers,
+ *         sockets) built on the existing `postmortem.register` facility.
+ *
+ * Ownership is keyed to the *process group*, not the root process. A root that
+ * exits after backgrounding descendants (`sh -c "worker & exit 0"`) keeps the
+ * owner registered until the group is actually gone, so the descendant tree is
+ * still reaped by `dispose()`/postmortem.
+ *
+ * This module intentionally owns only these primitives. It does not migrate
+ * existing call sites; subsystem PRs adopt it incrementally.
+ *
+ * Note: `ptree.spawn` always pipes stdout/stderr. Adopters that expect output
+ * (DAP/LSP/MCP protocol servers) must consume `owner.child.stdout`; F1 does not
+ * drain it, so a chatty child whose stdout is never read can still block on a
+ * full pipe. That draining is the adopter's responsibility.
+ */
+import { logger, postmortem, ptree } from "@gajae-code/utils";
+
+const DEFAULT_GRACEFUL_MS = 2_000;
+// Hard cap for how long `dispose()` waits after SIGKILL before giving up so a
+// wedged, unkillable child can never block shutdown forever.
+const SIGKILL_REAP_CAP_MS = 2_000;
+// After the root process exits on its own, how long to wait for the process
+// group to drain before deregistering. Clean servers drain immediately; a root
+// that backgrounded descendants stays registered past this window.
+const ROOT_EXIT_DRAIN_MS = 250;
+
+const isPosix = process.platform !== "win32";
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => {
+		const timer = setTimeout(resolve, Math.max(0, ms));
+		timer.unref?.();
+	});
+
+/** Poll `predicate` until it is true or `timeoutMs` elapses. Returns the final value. */
+async function pollUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 20): Promise<boolean> {
+	if (predicate()) return true;
+	const deadline = Date.now() + Math.max(0, timeoutMs);
+	while (Date.now() < deadline) {
+		await delay(Math.min(intervalMs, Math.max(0, deadline - Date.now())));
+		if (predicate()) return true;
+	}
+	return predicate();
+}
+
+/** Whether a POSIX process group still has any member (zombies count as alive). */
+function groupAlive(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		// EPERM => the group exists but we cannot signal it; treat as alive.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/** Options for {@link spawnOwnedProcess}. */
+export interface SpawnOwnedOptions {
+	cwd?: string;
+	env?: Record<string, string | undefined>;
+	/** stdin mode passed through to the child. Defaults to `"ignore"`. */
+	stdin?: "pipe" | "ignore";
+	/** When aborted, the owned process tree is disposed (escalating kill). */
+	signal?: AbortSignal;
+	/** Grace period (ms) between SIGTERM and SIGKILL on dispose. Default 2000. */
+	gracefulMs?: number;
+	/**
+	 * Spawn the child as its own process-group leader so the whole descendant
+	 * tree can be signalled on dispose. Defaults to `true` on POSIX. Has no
+	 * effect on Windows, where teardown falls back to single-process kill.
+	 */
+	processGroup?: boolean;
+	/** Label used in diagnostics. */
+	name?: string;
+}
+
+/** Result of a bounded {@link OwnedProcess.awaitExit}. */
+export interface AwaitExitResult {
+	/** `true` when the process has exited; `false` when the timeout fired first. */
+	exited: boolean;
+	/** Exit code if known, else `null`. */
+	code: number | null;
+}
+
+/** A spawned child process owned by the runtime with guaranteed teardown. */
+export interface OwnedProcess {
+	readonly child: ptree.ChildProcess;
+	readonly pid: number | undefined;
+	/** Resolves/rejects when the root child exits (mirrors ptree's `exited`). */
+	readonly exited: Promise<number>;
+	/** `true` once `dispose()` has started. */
+	readonly disposed: boolean;
+	/**
+	 * Wait for the root child to exit, optionally bounded by `timeoutMs`. With no
+	 * timeout it resolves only when the child exits. Never rejects.
+	 */
+	awaitExit(opts?: { timeoutMs?: number }): Promise<AwaitExitResult>;
+	/**
+	 * Idempotently terminate the owned process *group*: SIGTERM the group, wait
+	 * `gracefulMs`, then SIGKILL, polling group liveness throughout. Removes the
+	 * abort listener and deregisters from the live-owner set only after teardown
+	 * has completed. Repeated/concurrent calls return the same in-flight promise.
+	 */
+	dispose(): Promise<void>;
+}
+
+const liveOwners = new Set<OwnedProcess>();
+let ownedPostmortemRegistered = false;
+
+function ensureOwnedPostmortem(): void {
+	if (ownedPostmortemRegistered) return;
+	ownedPostmortemRegistered = true;
+	postmortem.register("runtime:owned-processes", async () => {
+		await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+	});
+}
+
+/**
+ * Spawn a child process owned by the runtime. The returned {@link OwnedProcess}
+ * is registered for postmortem cleanup and tears down its whole process group
+ * on dispose/abort.
+ */
+export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): OwnedProcess {
+	const gracefulMs = opts.gracefulMs ?? DEFAULT_GRACEFUL_MS;
+	const useGroup = (opts.processGroup ?? true) && isPosix;
+
+	ensureOwnedPostmortem();
+
+	// We deliberately do NOT forward `opts.signal` to `ptree.spawn`: ptree's
+	// `attachSignal` only kills the single process, whereas owned teardown must
+	// signal the whole group. We wire our own abort listener below and remove it
+	// on settle so long-lived signals never accumulate listeners.
+	const child = ptree.spawn(cmd, {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdin: opts.stdin ?? "ignore",
+		detached: useGroup,
+	});
+
+	// On POSIX with `detached`, the child is its own process-group leader, so the
+	// group id equals its pid. `undefined` => single-process (Windows/opt-out).
+	const pgid = useGroup ? child.pid : undefined;
+
+	let disposed = false;
+	let disposePromise: Promise<void> | undefined;
+	let deregistered = false;
+	let onAbort: (() => void) | undefined;
+
+	const removeAbort = (): void => {
+		if (onAbort && opts.signal) {
+			opts.signal.removeEventListener("abort", onAbort);
+			onAbort = undefined;
+		}
+	};
+
+	const deregister = (): void => {
+		if (deregistered) return;
+		deregistered = true;
+		liveOwners.delete(owner);
+		removeAbort();
+	};
+
+	const signalTree = (signal: NodeJS.Signals): void => {
+		const pid = child.pid;
+		if (pid === undefined) return;
+		if (pgid !== undefined) {
+			try {
+				// Negative pid signals the entire process group (child is leader).
+				process.kill(-pgid, signal);
+				return;
+			} catch {
+				// Group already gone; nothing to do.
+			}
+			return;
+		}
+		if (signal === "SIGKILL") {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		} else {
+			// ptree's kill terminates the single process via the native handle.
+			child.kill();
+		}
+	};
+
+	const owner: OwnedProcess = {
+		child,
+		get pid() {
+			return child.pid;
+		},
+		get exited() {
+			return child.exited;
+		},
+		get disposed() {
+			return disposed;
+		},
+		async awaitExit({ timeoutMs }: { timeoutMs?: number } = {}): Promise<AwaitExitResult> {
+			const exitedResult = child.exited
+				.then(code => ({ exited: true as const, code: code as number | null }))
+				.catch(() => ({ exited: true as const, code: child.exitCode }));
+			if (timeoutMs === undefined) return exitedResult;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const timeout = new Promise<AwaitExitResult>(resolve => {
+				timer = setTimeout(() => resolve({ exited: false, code: child.exitCode }), Math.max(0, timeoutMs));
+				timer.unref?.();
+			});
+			try {
+				return await Promise.race([exitedResult, timeout]);
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		},
+		dispose(): Promise<void> {
+			if (disposePromise) return disposePromise;
+			disposed = true;
+			removeAbort();
+			disposePromise = (async () => {
+				try {
+					if (pgid !== undefined) {
+						// Group ownership: reap until the whole group is gone, even if
+						// the root has already exited (it may have backgrounded children).
+						if (!groupAlive(pgid)) return;
+						signalTree("SIGTERM");
+						if (await pollUntil(() => !groupAlive(pgid), gracefulMs)) return;
+						signalTree("SIGKILL");
+						if (!(await pollUntil(() => !groupAlive(pgid), SIGKILL_REAP_CAP_MS))) {
+							logger.warn("owned process group still alive after SIGKILL", {
+								name: opts.name,
+								pgid,
+							});
+						}
+						return;
+					}
+					// Single-process fallback (Windows / processGroup:false).
+					if (child.exitCode !== null) return;
+					signalTree("SIGTERM");
+					if ((await owner.awaitExit({ timeoutMs: gracefulMs })).exited) return;
+					signalTree("SIGKILL");
+					await owner.awaitExit({ timeoutMs: SIGKILL_REAP_CAP_MS });
+				} catch (err) {
+					logger.warn("owned process dispose failed", {
+						name: opts.name,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				} finally {
+					// FIX: deregister only after teardown has completed so a postmortem
+					// firing mid-grace still sees the owner and awaits this dispose.
+					deregister();
+				}
+			})();
+			return disposePromise;
+		},
+	};
+
+	liveOwners.add(owner);
+
+	// When the root exits on its own (not via dispose), reconcile ownership by
+	// the *group*. After a short drain window: if the group is empty, deregister;
+	// if descendants are still alive, reap the owned group (no child outlives its
+	// owner). Either way the owner never lingers holding a stale pgid that the OS
+	// could later recycle and a stray dispose could mis-signal.
+	void child.exited
+		.catch(() => undefined)
+		.finally(() => {
+			if (disposed) return; // dispose() owns deregistration
+			if (pgid === undefined) {
+				deregister();
+				return;
+			}
+			void (async () => {
+				const drained = await pollUntil(() => !groupAlive(pgid), ROOT_EXIT_DRAIN_MS);
+				if (disposed) return;
+				if (drained) {
+					deregister();
+					return;
+				}
+				// Root exited but the owned group still has descendants: reap them.
+				// dispose() escalates SIGTERM->SIGKILL and deregisters in its finally.
+				await owner.dispose();
+			})();
+		});
+
+	if (opts.signal) {
+		if (opts.signal.aborted) {
+			void owner.dispose();
+		} else {
+			onAbort = () => void owner.dispose();
+			opts.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	return owner;
+}
+
+/** Number of currently live owned processes. Exposed for leak assertions/tests. */
+export function liveOwnedProcessCount(): number {
+	return liveOwners.size;
+}
+
+/** Dispose every live owned process. For owner-scoped teardown and tests. */
+export async function disposeAllOwnedProcesses(): Promise<void> {
+	await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+}
+
+// ── F1(b) generic resource owners ────────────────────────────────────────────
+
+type ResourceDisposer = () => void | Promise<void>;
+
+const resourceOwners = new Map<string, ResourceDisposer>();
+let resourcePostmortemRegistered = false;
+
+function ensureResourcePostmortem(): void {
+	if (resourcePostmortemRegistered) return;
+	resourcePostmortemRegistered = true;
+	// Postmortem isolates per-callback failures; swallow the aggregate here so
+	// shutdown continues, while direct callers of disposeAllResourceOwners still
+	// observe the AggregateError.
+	postmortem.register("runtime:resource-owners", () =>
+		disposeAllResourceOwners().catch(err => {
+			logger.warn("resource owner postmortem cleanup had failures", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}),
+	);
+}
+
+/**
+ * Register a non-process resource for postmortem/fatal-exit cleanup.
+ *
+ * Idempotent by `name`: re-registering the same name replaces the prior
+ * disposer (last wins). Returns an unregister function that removes the owner
+ * only while it is still the active registration for that name.
+ */
+export function registerResourceOwner(name: string, disposer: ResourceDisposer): () => void {
+	resourceOwners.set(name, disposer);
+	ensureResourcePostmortem();
+	let unregistered = false;
+	return () => {
+		if (unregistered) return;
+		unregistered = true;
+		if (resourceOwners.get(name) === disposer) {
+			resourceOwners.delete(name);
+		}
+	};
+}
+
+/** Number of registered resource owners. Exposed for leak assertions/tests. */
+export function resourceOwnerCount(): number {
+	return resourceOwners.size;
+}
+
+/**
+ * Run and clear every registered resource disposer. Attempts all disposers even
+ * if some throw, then surfaces the failures as an `AggregateError` so callers
+ * can distinguish "all closed" from "a resource may still be alive".
+ */
+export async function disposeAllResourceOwners(): Promise<void> {
+	const disposers = [...resourceOwners.values()];
+	resourceOwners.clear();
+	const errors: unknown[] = [];
+	for (const disposer of disposers) {
+		try {
+			await disposer();
+		} catch (err) {
+			errors.push(err);
+		}
+	}
+	if (errors.length > 0) {
+		throw new AggregateError(errors, `${errors.length} resource disposer(s) failed during teardown`);
+	}
+}

--- a/packages/coding-agent/test/dap/dap-lifecycle.test.ts
+++ b/packages/coding-agent/test/dap/dap-lifecycle.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DapClient } from "../../src/dap/client";
+import { DapSessionManager } from "../../src/dap/session";
+import type { DapCapabilities, DapClientState, DapEventMessage, DapResolvedAdapter } from "../../src/dap/types";
+import {
+	disposeAllOwnedProcesses,
+	liveOwnedProcessCount,
+	spawnOwnedProcess,
+} from "../../src/runtime/process-lifecycle";
+
+const BUN = process.execPath;
+
+const SOCKET_ADAPTER: DapResolvedAdapter = {
+	name: "fake-socket",
+	command: BUN,
+	args: [],
+	resolvedCommand: BUN,
+	languages: [],
+	fileTypes: [],
+	rootMarkers: [],
+	launchDefaults: {},
+	attachDefaults: {},
+	connectMode: "socket",
+};
+
+const STDIO_ADAPTER: DapResolvedAdapter = {
+	...SOCKET_ADAPTER,
+	name: "fake-stdio",
+	connectMode: "stdio",
+};
+
+type DapEventHandler = (body: unknown, event: DapEventMessage) => void | Promise<void>;
+type DapReverseRequestHandler = (args: unknown) => unknown | Promise<unknown>;
+
+class RunInTerminalFakeClient {
+	readonly adapter = STDIO_ADAPTER;
+	readonly cwd: string;
+	readonly proc: DapClientState["proc"];
+	readonly #handlers = new Map<string, Set<DapEventHandler>>();
+	#reverseHandlers = new Map<string, DapReverseRequestHandler>();
+	#alive = true;
+	readonly #exited = Promise.withResolvers<number>();
+
+	constructor(cwd: string) {
+		this.cwd = cwd;
+		this.proc = {
+			exited: this.#exited.promise,
+			exitCode: null,
+			stdin: { write: () => 0, flush: () => undefined },
+			stdout: new ReadableStream<Uint8Array>(),
+			stderr: new ReadableStream<Uint8Array>(),
+			peekStderr: () => "",
+			kill: () => {
+				this.#alive = false;
+				this.#exited.resolve(0);
+				return true;
+			},
+		} as unknown as DapClientState["proc"];
+	}
+
+	async initialize(): Promise<DapCapabilities> {
+		queueMicrotask(() => this.#emit("initialized", {}));
+		return { supportsConfigurationDoneRequest: true };
+	}
+
+	async sendRequest(command: string): Promise<unknown> {
+		if (command === "launch") {
+			const handler = this.#reverseHandlers.get("runInTerminal");
+			if (!handler) throw new Error("runInTerminal handler was not registered");
+			return handler({ args: [BUN, "-e", "setInterval(() => {}, 1000)"], cwd: this.cwd });
+		}
+		if (command === "configurationDone") return {};
+		if (command === "disconnect") {
+			this.#alive = false;
+			this.#exited.resolve(0);
+			return {};
+		}
+		return {};
+	}
+
+	waitForEvent(event: string): Promise<unknown> {
+		if (event === "stopped" || event === "terminated" || event === "exited") {
+			return Promise.reject(new Error(`DAP event ${event} timed out after 1ms`));
+		}
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const unsubscribe = this.onEvent(event, body => {
+			unsubscribe();
+			resolve(body);
+		});
+		return promise;
+	}
+
+	onEvent(event: string, handler: DapEventHandler): () => void {
+		const handlers = this.#handlers.get(event) ?? new Set<DapEventHandler>();
+		handlers.add(handler);
+		this.#handlers.set(event, handlers);
+		return () => handlers.delete(handler);
+	}
+
+	onReverseRequest(command: string, handler: DapReverseRequestHandler): () => void {
+		this.#reverseHandlers.set(command, handler);
+		return () => this.#reverseHandlers.delete(command);
+	}
+
+	isAlive(): boolean {
+		return this.#alive;
+	}
+
+	async dispose(): Promise<void> {
+		this.#alive = false;
+		this.#exited.resolve(0);
+	}
+
+	#emit(event: string, body: unknown): void {
+		const message: DapEventMessage = { seq: 1, type: "event", event, body };
+		for (const handler of this.#handlers.get(event) ?? []) {
+			void handler(body, message);
+		}
+	}
+}
+
+async function tempDir(prefix: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+afterEach(async () => {
+	await disposeAllOwnedProcesses();
+});
+
+describe("DAP lifecycle behavior", () => {
+	it("socket-mode startup timeout disposes the adapter process", async () => {
+		const cwd = await tempDir("gjc-dap-socket-timeout-");
+		try {
+			const script = path.join(cwd, "adapter.ts");
+			await Bun.write(script, "setInterval(() => {}, 1000);\n");
+			const before = liveOwnedProcessCount();
+
+			await expect(
+				DapClient.spawn({
+					adapter: { ...SOCKET_ADAPTER, args: [script] },
+					cwd,
+				}),
+			).rejects.toThrow(/did not connect within 10s|timed out|Connection refused|ENOENT/);
+
+			expect(liveOwnedProcessCount()).toBe(before);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it.skipIf(process.platform !== "linux")("socket-mode Unix startup failure unlinks the temporary .sock", async () => {
+		const cwd = await tempDir("gjc-dap-unix-socket-timeout-");
+		try {
+			const script = path.join(cwd, "adapter.ts");
+			await Bun.write(
+				script,
+				`const listen = process.argv.find(arg => arg.startsWith("--listen=unix:"));\nif (!listen) throw new Error("missing listen arg");\nawait Bun.write(listen.slice("--listen=unix:".length), "not a socket");\nsetInterval(() => {}, 1000);\n`,
+			);
+
+			await expect(
+				DapClient.spawn({
+					adapter: { ...SOCKET_ADAPTER, args: [script] },
+					cwd,
+				}),
+			).rejects.toThrow();
+
+			const leakedSockets = (await fs.readdir("/tmp")).filter(
+				name => name.startsWith("dap-fake-socket-") && name.endsWith(".sock"),
+			);
+			expect(leakedSockets).toEqual([]);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"dispose reaps adapter child process groups through owned lifecycle",
+		async () => {
+			const cwd = await tempDir("gjc-dap-dispose-owner-");
+			try {
+				const marker = path.join(cwd, "child-ready");
+				const script = path.join(cwd, "adapter.ts");
+				await Bun.write(
+					script,
+					`const child = Bun.spawn([process.execPath, "-e", "await Bun.write(process.argv[1], String(process.pid)); setInterval(() => {}, 1000);", ${JSON.stringify(marker)}], { stdout: "ignore", stderr: "ignore", stdin: "ignore" });\nsetInterval(() => {}, 1000);\n`,
+				);
+				const client = await DapClient.spawn({ adapter: { ...STDIO_ADAPTER, args: [script] }, cwd });
+				await Bun.sleep(1_000);
+				expect(await Bun.file(marker).exists()).toBe(true);
+
+				await client.dispose();
+				expect(client.proc.killed).toBe(true);
+				expect(liveOwnedProcessCount()).toBe(0);
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"tracks runInTerminal debuggees as owned processes and reaps only the session child on dispose",
+		async () => {
+			const cwd = await tempDir("gjc-dap-runterminal-");
+			const unrelated = spawnOwnedProcess([BUN, "-e", "setInterval(() => {}, 1000)"], {
+				name: "dap-test:unrelated",
+			});
+			try {
+				const manager = new DapSessionManager();
+				const fake = new RunInTerminalFakeClient(cwd);
+				const originalSpawn = DapClient.spawn;
+				DapClient.spawn = async () => fake as unknown as DapClient;
+				try {
+					const before = liveOwnedProcessCount();
+					const summary = await manager.launch({ adapter: STDIO_ADAPTER, program: "fake", cwd }, undefined, 25);
+					expect(liveOwnedProcessCount()).toBeGreaterThan(before);
+
+					await manager.terminate(undefined, 25);
+					expect(manager.listSessions().some(session => session.id === summary.id)).toBe(false);
+					expect(unrelated.child.exitCode).toBeNull();
+					expect(liveOwnedProcessCount()).toBe(1);
+				} finally {
+					DapClient.spawn = originalSpawn;
+				}
+			} finally {
+				await unrelated.dispose();
+				await unrelated.awaitExit({ timeoutMs: 1_000 });
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getOrCreateClient, sendRequest, shutdownAll, waitForProjectLoaded } from "../../src/lsp/client";
+import type { ServerConfig } from "../../src/lsp/types";
+import { disposeAllOwnedProcesses } from "../../src/runtime/process-lifecycle";
+
+const BUN = process.execPath;
+const ORIGINAL_PATH = Bun.env.PATH;
+const ORIGINAL_XDG_CONFIG_HOME = Bun.env.XDG_CONFIG_HOME;
+
+async function tempDir(prefix: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+function serverConfig(command: string, args: string[] = []): ServerConfig {
+	return {
+		command,
+		args,
+		fileTypes: ["ts"],
+		rootMarkers: [],
+	};
+}
+
+async function writeFakeLspServer(dir: string): Promise<string> {
+	const script = path.join(dir, "fake-lsp.ts");
+	await Bun.write(
+		script,
+		`let buffer = Buffer.alloc(0);\nfunction write(message) {\n  const body = JSON.stringify(message);\n  process.stdout.write(\`Content-Length: \${Buffer.byteLength(body, "utf8")}\\r\\n\\r\\n\${body}\`);\n}\nfunction handle(message) {\n  if (message.method === "initialize") {\n    write({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });\n    return;\n  }\n  if (message.method === "shutdown") {\n    write({ jsonrpc: "2.0", id: message.id, result: null });\n    process.exit(0);\n    return;\n  }\n}\nprocess.stdin.on("data", chunk => {\n  buffer = Buffer.concat([buffer, chunk]);\n  for (;;) {\n    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");\n    if (headerEnd === -1) return;\n    const header = buffer.subarray(0, headerEnd).toString();\n    const match = /Content-Length: (\\d+)/i.exec(header);\n    if (!match) return;\n    const length = Number(match[1]);\n    const start = headerEnd + 4;\n    const end = start + length;\n    if (buffer.length < end) return;\n    const message = JSON.parse(buffer.subarray(start, end).toString());\n    buffer = buffer.subarray(end);\n    handle(message);\n  }\n});\nsetInterval(() => {}, 1000);\n`,
+	);
+	return script;
+}
+
+afterEach(async () => {
+	await shutdownAll();
+	await disposeAllOwnedProcesses();
+	delete Bun.env.PI_DISABLE_LSPMUX;
+	if (ORIGINAL_XDG_CONFIG_HOME === undefined) {
+		delete Bun.env.XDG_CONFIG_HOME;
+	} else {
+		Bun.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
+	}
+	if (ORIGINAL_PATH === undefined) {
+		delete Bun.env.PATH;
+	} else {
+		Bun.env.PATH = ORIGINAL_PATH;
+	}
+});
+
+describe("LSP lifecycle behavior", () => {
+	it("kill-then-immediately-reacquire evicts the dead cached client before async cleanup", async () => {
+		const cwd = await tempDir("gjc-lsp-reload-");
+		try {
+			const script = await writeFakeLspServer(cwd);
+			const config = serverConfig(BUN, [script]);
+			const first = await getOrCreateClient(config, cwd, 1_000);
+			const pending = sendRequest(first, "workspace/neverResponds", null, undefined, 60_000);
+			const pendingSettled = pending.catch(error => error as Error);
+			expect(first.pendingRequests.size).toBe(1);
+
+			first.proc.kill();
+			const second = await getOrCreateClient(config, cwd, 1_000);
+			expect(await pendingSettled).toHaveProperty("message");
+			await first.proc.exited.catch(() => undefined);
+			const cachedAfterFirstExit = await getOrCreateClient(config, cwd, 1_000);
+
+			expect(second).not.toBe(first);
+			expect(second.proc.exitCode).toBeNull();
+			expect(second.proc.killed).toBe(false);
+			expect(cachedAfterFirstExit).toBe(second);
+			await shutdownAll();
+			await second.proc.exited;
+			expect(second.proc.exitCode).not.toBeNull();
+			expect(first.pendingRequests.size).toBe(0);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("waitForProjectLoaded removes its abort listener after project loading settles", async () => {
+		const controller = new AbortController();
+		let activeAbortListeners = 0;
+		const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+		const originalRemove = controller.signal.removeEventListener.bind(controller.signal);
+		controller.signal.addEventListener = ((type, listener, options) => {
+			if (type === "abort") activeAbortListeners += 1;
+			return originalAdd(type, listener, options);
+		}) as typeof controller.signal.addEventListener;
+		controller.signal.removeEventListener = ((type, listener, options) => {
+			if (type === "abort") activeAbortListeners -= 1;
+			return originalRemove(type, listener, options);
+		}) as typeof controller.signal.removeEventListener;
+
+		const client = {
+			projectLoaded: Promise.resolve(),
+		} as Parameters<typeof waitForProjectLoaded>[0];
+
+		await waitForProjectLoaded(client, controller.signal);
+		expect(activeAbortListeners).toBe(0);
+	});
+
+	it("lspmux status probe clears its timeout and reaps the probe process when status hangs", async () => {
+		const cwd = await tempDir("gjc-lspmux-timeout-");
+		const binDir = path.join(cwd, "bin");
+		const configHome = path.join(cwd, "config");
+		try {
+			await fs.mkdir(binDir, { recursive: true });
+			await fs.mkdir(path.join(configHome, "lspmux"), { recursive: true });
+			await Bun.write(path.join(configHome, "lspmux", "config.toml"), "instance_timeout = 60\n");
+			const lspmux = path.join(binDir, "lspmux");
+			await Bun.write(lspmux, `#!/usr/bin/env ${BUN}\nsetInterval(() => {}, 1000);\n`);
+			await fs.chmod(lspmux, 0o755);
+			const runner = path.join(cwd, "probe.ts");
+			await Bun.write(
+				runner,
+				`import { detectLspmux } from ${JSON.stringify(path.resolve("packages/coding-agent/src/lsp/lspmux.ts"))};\nimport { liveOwnedProcessCount, disposeAllOwnedProcesses } from ${JSON.stringify(path.resolve("packages/coding-agent/src/runtime/process-lifecycle.ts"))};\nconst before = liveOwnedProcessCount();\nconst state = await detectLspmux();\nconst after = liveOwnedProcessCount();\nawait disposeAllOwnedProcesses();\nconsole.log(JSON.stringify({ state, before, after }));\n`,
+			);
+			const proc = Bun.spawn([BUN, runner], {
+				cwd: path.resolve("."),
+				env: {
+					...Bun.env,
+					PATH: ORIGINAL_PATH ? `${binDir}${path.delimiter}${ORIGINAL_PATH}` : binDir,
+					XDG_CONFIG_HOME: configHome,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+			expect(stderr).toBe("");
+			expect(exitCode).toBe(0);
+			const result = JSON.parse(stdout) as {
+				state: { available: boolean; running: boolean };
+				before: number;
+				after: number;
+			};
+			expect(result.state.available).toBe(true);
+			expect(result.state.running).toBe(false);
+			expect(result.after).toBe(result.before);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 3_000);
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function waitForAsync(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 5_000,
+	label = "condition",
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (await predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function fileContains(path: string, needle: string): Promise<boolean> {
+	try {
+		return (await Bun.file(path).text()).includes(needle);
+	} catch {
+		return false;
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function processGroupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("process-lifecycle adversarial owned-process invariants", () => {
+	test("dispose immediately after spawn wins the startup race and returns to baseline", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "printf ready; sleep 30"], {
+			name: "redteam-immediate-dispose",
+			gracefulMs: 10,
+		});
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after immediate dispose");
+	});
+
+	test("dispose of an already-exited process is a no-op and does not throw", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 7"], { name: "redteam-already-exited" });
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit).toEqual({ exited: true, code: 7 });
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		await waitFor(
+			() => liveOwnedProcessCount() === before,
+			2_000,
+			"live count baseline after already-exited dispose",
+		);
+	});
+
+	test("double and concurrent dispose share one settled result and issue one terminating signal", async () => {
+		const before = liveOwnedProcessCount();
+		const tmp = `/tmp/gjc-process-lifecycle-${process.pid}-${Date.now()}`;
+		const owner = spawnOwnedProcess(
+			["sh", "-c", `trap 'echo term >> ${tmp}; exit 0' TERM; echo up > ${tmp}; while :; do sleep 1; done`],
+			{ name: "redteam-concurrent-dispose", gracefulMs: 500 },
+		);
+		try {
+			await waitForAsync(() => fileContains(tmp, "up"), 2_000, "child readiness marker");
+			const first = owner.dispose();
+			const second = owner.dispose();
+			expect(second).toBe(first);
+			await expect(Promise.all([first, second, owner.dispose()])).resolves.toEqual([
+				undefined,
+				undefined,
+				undefined,
+			]);
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after concurrent dispose");
+			const marker = await Bun.file(tmp).text();
+			expect(marker.split("\n").filter(line => line === "term")).toHaveLength(1);
+		} finally {
+			try {
+				await owner.dispose();
+			} catch {
+				/* already disposed */
+			}
+			await Bun.$`rm -f ${tmp}`.quiet();
+		}
+	});
+
+	test("awaitExit with timeoutMs 0 reports a live long-runner without killing it, then dispose cleans it", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "redteam-zero-timeout",
+			gracefulMs: 10,
+		});
+		try {
+			const probe = await owner.awaitExit({ timeoutMs: 0 });
+			expect(probe.exited).toBe(false);
+			expect(owner.pid === undefined ? false : processAlive(owner.pid)).toBe(true);
+		} finally {
+			await owner.dispose();
+		}
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after zero-timeout dispose");
+	});
+
+	test("liveOwnedProcessCount returns to baseline after a batch of spawn and dispose", async () => {
+		const before = liveOwnedProcessCount();
+		const owners = Array.from({ length: 8 }, (_, index) =>
+			spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+				name: `redteam-batch-${index}`,
+				gracefulMs: 10,
+			}),
+		);
+		expect(liveOwnedProcessCount()).toBeGreaterThanOrEqual(before + owners.length);
+		await Promise.all(owners.map(owner => owner.dispose()));
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after batch dispose");
+	});
+
+	test.skipIf(!isPosix)(
+		"dispose reaps a same-group double-fork grandchild while an unrelated sibling survives",
+		async () => {
+			const before = liveOwnedProcessCount();
+			const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+			const siblingPid = sibling.pid;
+			const owner = spawnOwnedProcess(["sh", "-c", "( ( sleep 30 ) & ) & while :; do sleep 1; done"], {
+				name: "redteam-double-fork-group",
+				gracefulMs: 50,
+			});
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			try {
+				await Bun.sleep(250);
+				await owner.dispose();
+				const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+				expect(exit.exited).toBe(true);
+				await waitFor(() => processGroupGone(pgid as number), 3_000, "owned process group ESRCH");
+				expect(processAlive(siblingPid)).toBe(true);
+				await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after group reap");
+			} finally {
+				try {
+					sibling.kill("SIGKILL");
+				} catch {
+					/* already gone */
+				}
+				await owner.dispose();
+			}
+		},
+	);
+});
+
+describe("process-lifecycle adversarial resource-owner invariants", () => {
+	test("a throwing disposer does not abort disposeAllResourceOwners and other disposers still run", async () => {
+		await disposeAllResourceOwners();
+		const calls: string[] = [];
+		registerResourceOwner("redteam:throws", () => {
+			calls.push("throws");
+			throw new Error("intentional red-team disposer failure");
+		});
+		registerResourceOwner("redteam:after", () => {
+			calls.push("after");
+		});
+		registerResourceOwner("redteam:async", async () => {
+			await Bun.sleep(1);
+			calls.push("async");
+		});
+
+		// All disposers run even when one throws, and the failure is surfaced
+		// (not swallowed) as an AggregateError so callers can detect it.
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(calls).toEqual(["throws", "after", "async"]);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+
+	test("unregister after disposeAllResourceOwners is safe and cannot remove a newer registration", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregister = registerResourceOwner("redteam:late-unregister", () => {
+			first += 1;
+		});
+		await disposeAllResourceOwners();
+		expect(first).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+
+		expect(() => unregister()).not.toThrow();
+		registerResourceOwner("redteam:late-unregister", () => {
+			second += 1;
+		});
+		expect(() => unregister()).not.toThrow();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(second).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllOwnedProcesses,
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+describe("spawnOwnedProcess (F1a)", () => {
+	test("awaits clean exit and deregisters from the live set", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], { name: "clean-exit" });
+		const result = await owner.awaitExit();
+		expect(result.exited).toBe(true);
+		expect(result.code).toBe(0);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("awaitExit honors a bounded timeout for a long runner", async () => {
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "timeout-probe" });
+		try {
+			const result = await owner.awaitExit({ timeoutMs: 100 });
+			expect(result.exited).toBe(false);
+		} finally {
+			await owner.dispose();
+		}
+	});
+
+	test("dispose terminates a long runner and is idempotent", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "dispose-probe" });
+		await Bun.sleep(50);
+		await Promise.all([owner.dispose(), owner.dispose()]);
+		expect(owner.disposed).toBe(true);
+		const result = await owner.awaitExit({ timeoutMs: 1_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("an already-aborted signal disposes the process immediately", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "pre-aborted",
+			signal: AbortSignal.abort(),
+		});
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("aborting mid-run disposes and removes the abort listener", async () => {
+		const before = liveOwnedProcessCount();
+		const controller = new AbortController();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "mid-abort",
+			signal: controller.signal,
+		});
+		await Bun.sleep(50);
+		controller.abort();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+		// Listener removed on settle: a second abort must not throw or re-dispose.
+		controller.abort();
+		expect(owner.disposed).toBe(true);
+	});
+
+	test.skipIf(!isPosix)("dispose reaps the process group while an unrelated sibling survives", async () => {
+		// Unrelated sibling: a directly-spawned detached sleep we must NOT kill.
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		const siblingPid = sibling.pid;
+		try {
+			// Owned tree: a shell that backgrounds a grandchild plus a foreground child.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & sleep 30"], { name: "group-reap" });
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			await Bun.sleep(150); // let the grandchild spawn
+
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 2_000 });
+
+			// The whole owned process group must be gone (ESRCH on group probe).
+			await waitFor(() => {
+				try {
+					process.kill(-(pgid as number), 0);
+					return false; // still alive
+				} catch (err) {
+					return (err as NodeJS.ErrnoException).code === "ESRCH";
+				}
+			});
+
+			// The unrelated sibling must still be alive.
+			expect(alive(siblingPid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+});
+
+describe("registerResourceOwner (F1b)", () => {
+	test("disposer runs once on disposeAllResourceOwners", async () => {
+		await disposeAllResourceOwners(); // clean slate
+		let calls = 0;
+		registerResourceOwner("test:res-a", () => {
+			calls += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+		// Cleared after dispose: a second dispose does not re-invoke.
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+	});
+
+	test("unregister prevents the disposer from running", async () => {
+		await disposeAllResourceOwners();
+		let calls = 0;
+		const unregister = registerResourceOwner("test:res-b", () => {
+			calls += 1;
+		});
+		unregister();
+		expect(resourceOwnerCount()).toBe(0);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(0);
+		// Idempotent unregister.
+		expect(() => unregister()).not.toThrow();
+	});
+
+	test("re-registering the same name replaces the disposer (last wins)", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregisterFirst = registerResourceOwner("test:res-c", () => {
+			first += 1;
+		});
+		registerResourceOwner("test:res-c", () => {
+			second += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		// The stale unregister must not remove the newer registration.
+		unregisterFirst();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(first).toBe(0);
+		expect(second).toBe(1);
+	});
+});
+
+describe("ownership regression: group liveness drives teardown (F1a)", () => {
+	test.skipIf(!isPosix)("reaps backgrounded descendants when the root exits first", async () => {
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// The shell exits 0 immediately but leaves a backgrounded child in the group.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & exit 0"], { name: "root-exits-first" });
+			const pgid = owner.pid as number;
+			const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(rootExit.exited).toBe(true);
+			expect(rootExit.code).toBe(0);
+			await Bun.sleep(50);
+			// The owned group is still alive because of the orphaned background child.
+			expect(groupAliveProbe(pgid)).toBe(true);
+			await owner.dispose();
+			await waitFor(() => groupGone(pgid));
+			// The unrelated sibling must survive.
+			expect(alive(sibling.pid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+
+	test("owner stays tracked until dispose teardown completes", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "tracked-until-done", gracefulMs: 300 });
+		await Bun.sleep(50);
+		const disposing = owner.dispose();
+		// FIX: the owner must remain in the live set until teardown completes, so a
+		// postmortem firing mid-grace still awaits this in-flight dispose.
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+		await disposing;
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test.skipIf(!isPosix)("disposeAllOwnedProcesses escalates SIGKILL for a SIGTERM-ignoring child", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "trap '' TERM; sleep 30"], {
+			name: "term-trap",
+			gracefulMs: 200,
+		});
+		await Bun.sleep(100);
+		// Simulates a postmortem/owner-scoped teardown reaching the in-flight owner.
+		await disposeAllOwnedProcesses();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+});
+
+describe("resource owner failure surfacing (F1b)", () => {
+	test("disposeAllResourceOwners surfaces disposer failures as AggregateError", async () => {
+		await disposeAllResourceOwners().catch(() => undefined);
+		let ran = 0;
+		registerResourceOwner("agg:throws", () => {
+			throw new Error("boom");
+		});
+		registerResourceOwner("agg:ok", () => {
+			ran += 1;
+		});
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(ran).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+});
+
+function groupAliveProbe(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function groupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("ownership regression: no stale pgid after late drain (F1a)", () => {
+	test.skipIf(!isPosix)("reaps and deregisters when descendants outlive the drain window", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 1 & exit 0"], { name: "late-drain" });
+		const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(rootExit.exited).toBe(true);
+		// The backgrounded `sleep 1` outlives ROOT_EXIT_DRAIN_MS; the owner must not
+		// linger with a stale pgid — it is reaped and the live count returns to
+		// baseline rather than being abandoned.
+		await waitFor(() => liveOwnedProcessCount() === before, 8_000);
+		expect(liveOwnedProcessCount()).toBe(before);
+	});
+});


### PR DESCRIPTION
Core-runtime fix campaign U7. DAP+LSP adopt F1 spawnOwnedProcess for parent-exit + process-group reap. H11 runInTerminal debuggee tracked/reaped; H12/H13 socket adapters killed on startup timeout + .sock unlinked + bounded connect; H14/M13 parent-exit/fatal cleanup; M9 LSP reload evicts cached killed client (identity-guarded) + fresh client, shutdown via owner.dispose(); M10 abort listeners removed (untilAborted); L2 lspmux probe timer/proc cleanup + socket-mode stdout drain. Tests: dap-lifecycle + lsp-lifecycle 6 pass / 1 linux-skip. tsgo+biome clean. Architect CLEAR/APPROVE. Base dev.