### PR TITLE
fix(tui): harden render loop, component lifecycle & markdown for long sessions

### DIFF
--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -117,6 +117,14 @@ Critical safety checks in `TUI`:
 
 These constraints are runtime guards plus component conventions; renderers should still return width-safe lines rather than rely on truncation.
 
+## Virtual viewport (opt-in, `PI_TUI_VIRTUAL_VIEWPORT`)
+
+By default `#doRender` normalizes/truncates and diffs the full rendered transcript every frame (`O(total lines)`), which becomes a per-frame cost on very long sessions / weak hardware.
+
+Setting `PI_TUI_VIRTUAL_VIEWPORT=1` enables an opt-in fast path: when the terminal width is unchanged and the off-screen raw prefix is unchanged from the previous frame (compared by raw value equality per line, which short-circuits to a fast reference check when components return stable string instances for unchanged lines), the previous frame's normalized prefix is reused and only the visible window (terminal rows + a small overscan) is re-normalized, with the differential diff starting at the window boundary. Output is byte-identical to the default path (reused entries are deterministic normalizations of identical raw lines), so it is a pure performance toggle.
+
+The flag defaults to **off** because it changes a core render path; enable it to reduce per-frame normalize/diff cost on huge transcripts. Any width change, off-screen edit, forced render (`requestRender(true)`), or first frame transparently falls back to the full path. `PI_TUI_METRICS` exposes `lineCounts` gauges (`rendered`, `normalized`, `measured`, `diffed`, and `offscreenScan`) to observe the bound.
+
 ## Resize handling
 
 Resize events are event-driven from `ProcessTerminal` to `TUI.requestRender()`.

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -111,8 +111,16 @@ export class AssistantMessageComponent extends Container {
 		const cached = this.#contentBlocksCache.get(content);
 		if (cached?.source === content.text) return cached.component;
 		const trimmed = content.text.trim();
-		const component =
-			renderDeepInterviewAssistantText(trimmed, theme) ?? new Markdown(trimmed, 1, 0, getMarkdownTheme());
+		const deepInterview = renderDeepInterviewAssistantText(trimmed, theme);
+		// Reuse the same Markdown instance across streaming chunks (update text in place)
+		// instead of constructing a new one each chunk; combined with the markdown
+		// per-code-block highlight cache, appends no longer re-highlight the whole prefix.
+		if (!deepInterview && cached && cached.component instanceof Markdown) {
+			cached.component.setText(trimmed);
+			cached.source = content.text;
+			return cached.component;
+		}
+		const component = deepInterview ?? new Markdown(trimmed, 1, 0, getMarkdownTheme());
 		this.#contentBlocksCache.set(content, { source: content.text, component });
 		return component;
 	}

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -155,7 +155,11 @@ export class BashExecutionComponent extends Container {
 		const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
 
 		// Rebuild content container
-		this.#contentContainer.clear();
+		// Detach (not dispose): #headerText and the running #loader are persistent,
+		// reused instances re-added below. A disposing clear() would stop the loader's
+		// animation timer mid-run. Final teardown still stops the loader via the
+		// component's recursive dispose().
+		this.#contentContainer.detachAll();
 
 		// Command header
 		this.#contentContainer.addChild(this.#headerText);

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -114,7 +114,11 @@ export class EvalExecutionComponent extends Container {
 		const previewLogicalLines = availableLines.slice(-PREVIEW_LINES);
 		const hiddenLineCount = availableLines.length - previewLogicalLines.length;
 
-		this.#contentContainer.clear();
+		// Detach (not dispose): #headerText and the running #loader are persistent,
+		// reused instances re-added below. A disposing clear() would stop the loader's
+		// animation timer mid-run. Final teardown still stops the loader via the
+		// component's recursive dispose().
+		this.#contentContainer.detachAll();
 
 		this.#contentContainer.addChild(this.#headerText);
 

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -65,6 +65,11 @@ export class OAuthSelectorComponent extends Container {
 		this.#validationGeneration += 1;
 		this.#stopSpinner();
 	}
+
+	dispose(): void {
+		this.stopValidation();
+		super.dispose();
+	}
 	#loadProviders(): void {
 		this.#allProviders = getOAuthProviders();
 	}

--- a/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
@@ -131,6 +131,11 @@ export class MCPAddWizard extends Container {
 		| null = null;
 	#onTestConnectionCallback: ((config: MCPServerConfig) => Promise<void>) | null = null;
 	#onRenderCallback: (() => void) | null = null;
+	#disposed = false;
+	#transitionTimers = new Set<NodeJS.Timeout>();
+	#healthCheckSpinner?: NodeJS.Timeout;
+	#healthCheckTimeout?: NodeJS.Timeout;
+	#asyncGeneration = 0;
 
 	constructor(
 		onComplete: (name: string, config: MCPServerConfig, scope: Scope) => void,
@@ -176,6 +181,39 @@ export class MCPAddWizard extends Container {
 
 		// Render first step
 		this.#renderStep();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#asyncGeneration += 1;
+		for (const timer of this.#transitionTimers) {
+			clearTimeout(timer);
+		}
+		this.#transitionTimers.clear();
+		this.#clearHealthCheckTimers();
+		super.dispose();
+	}
+
+	#scheduleTransition(callback: () => void, delay: number): void {
+		if (this.#disposed) return;
+		const timer = setTimeout(() => {
+			this.#transitionTimers.delete(timer);
+			if (this.#disposed) return;
+			callback();
+		}, delay);
+		this.#transitionTimers.add(timer);
+	}
+
+	#clearHealthCheckTimers(): void {
+		if (this.#healthCheckSpinner) {
+			clearInterval(this.#healthCheckSpinner);
+			this.#healthCheckSpinner = undefined;
+		}
+		if (this.#healthCheckTimeout) {
+			clearTimeout(this.#healthCheckTimeout);
+			this.#healthCheckTimeout = undefined;
+		}
 	}
 
 	#requestRender(): void {
@@ -941,6 +979,8 @@ export class MCPAddWizard extends Container {
 	 * Test connection and automatically detect if auth is needed.
 	 */
 	async #testConnectionAndDetectAuth(): Promise<void> {
+		if (this.#disposed) return;
+		const generation = ++this.#asyncGeneration;
 		const testConfig = this.#buildServerConfig();
 
 		if (!this.#onTestConnectionCallback) {
@@ -954,6 +994,7 @@ export class MCPAddWizard extends Container {
 		try {
 			// Try to connect - timeout is handled by the transport layer (5 seconds)
 			await this.#onTestConnectionCallback(testConfig);
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 			// Success! No auth required
 			this.#contentContainer.clear();
@@ -962,7 +1003,7 @@ export class MCPAddWizard extends Container {
 			this.#contentContainer.addChild(new Text("No authentication required", 0, 0));
 			this.#contentContainer.addChild(new Spacer(1));
 
-			setTimeout(() => {
+			this.#scheduleTransition(() => {
 				this.#state.authMethod = "none";
 				this.#currentStep = "scope";
 				this.#selectedIndex = 0;
@@ -978,10 +1019,12 @@ export class MCPAddWizard extends Container {
 				if (!oauth && this.#state.transport !== "stdio" && this.#state.url) {
 					try {
 						oauth = await discoverOAuthEndpoints(this.#state.url, authResult.authServerUrl);
+						if (this.#disposed || generation !== this.#asyncGeneration) return;
 					} catch {
 						// Ignore discovery failures and fallback to manual auth.
 					}
 				}
+				if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 				if (oauth) {
 					this.#state.oauthAuthUrl = oauth.authorizationUrl;
@@ -1019,7 +1062,7 @@ export class MCPAddWizard extends Container {
 				this.#contentContainer.addChild(new Spacer(1));
 				this.#contentContainer.addChild(new Text(theme.fg("muted", "Adding server anyway..."), 0, 0));
 
-				setTimeout(() => {
+				this.#scheduleTransition(() => {
 					this.#state.authMethod = "none";
 					this.#currentStep = "scope";
 					this.#selectedIndex = 0;
@@ -1107,6 +1150,8 @@ export class MCPAddWizard extends Container {
 	}
 
 	async #launchOAuthFlow(): Promise<void> {
+		if (this.#disposed) return;
+		const generation = ++this.#asyncGeneration;
 		if (!this.#onOAuthCallback) {
 			this.#contentContainer.clear();
 			this.#contentContainer.addChild(new Text(theme.fg("error", "OAuth flow not available"), 0, 0));
@@ -1150,6 +1195,7 @@ export class MCPAddWizard extends Container {
 				this.#state.oauthClientSecret,
 				this.#state.oauthScopes,
 			);
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 			// Store credential ID + any dynamically-registered client credentials,
 			// so the final mcp.json entry persists everything needed for refresh.
@@ -1168,7 +1214,8 @@ export class MCPAddWizard extends Container {
 			this.#contentContainer.addChild(healthText);
 
 			let spinnerIndex = 0;
-			const spinner = setInterval(() => {
+			this.#healthCheckSpinner = setInterval(() => {
+				if (this.#disposed || generation !== this.#asyncGeneration) return;
 				healthText.setText(
 					theme.fg("muted", `${spinnerFrames[spinnerIndex % spinnerFrames.length]} Checking server connection...`),
 				);
@@ -1181,7 +1228,7 @@ export class MCPAddWizard extends Container {
 			if (this.#onTestConnectionCallback) {
 				try {
 					const { promise: timeoutPromise, reject: timeoutReject } = Promise.withResolvers<never>();
-					const timer = setTimeout(
+					this.#healthCheckTimeout = setTimeout(
 						() => timeoutReject(new Error("Health check timed out after 10 seconds")),
 						10_000,
 					);
@@ -1191,15 +1238,19 @@ export class MCPAddWizard extends Container {
 							timeoutPromise,
 						]);
 					} finally {
-						clearTimeout(timer);
+						if (this.#healthCheckTimeout) {
+							clearTimeout(this.#healthCheckTimeout);
+							this.#healthCheckTimeout = undefined;
+						}
 					}
 				} catch (error) {
 					healthPassed = false;
 					healthError = sanitize(error instanceof Error ? error.message : String(error));
 				}
 			}
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
-			clearInterval(spinner);
+			this.#clearHealthCheckTimers();
 			if (healthPassed) {
 				healthText.setText(theme.fg("success", "✓ Health check passed"));
 			} else {
@@ -1210,7 +1261,7 @@ export class MCPAddWizard extends Container {
 			this.#requestRender();
 
 			// Move to scope selection after short delay
-			setTimeout(
+			this.#scheduleTransition(
 				() => {
 					this.#currentStep = "scope";
 					this.#selectedIndex = 0;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -375,6 +375,7 @@ export class ToolExecutionComponent extends Container {
 				this.#renderState.spinnerFrame = this.#spinnerFrame;
 				this.#ui.requestRender();
 			}, 80);
+			this.#spinnerInterval?.unref?.();
 		} else if (!needsSpinner && this.#spinnerInterval) {
 			clearInterval(this.#spinnerInterval);
 			this.#spinnerInterval = undefined;
@@ -392,6 +393,11 @@ export class ToolExecutionComponent extends Container {
 		}
 		this.#editDiffAbort?.abort();
 		this.#editDiffAbort = undefined;
+	}
+
+	override dispose(): void {
+		this.stopAnimation();
+		super.dispose();
 	}
 
 	setExpanded(expanded: boolean): void {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -36,8 +36,19 @@ export class ExtensionUiController {
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
 	#hookSelectorMouseReportingEnabled = false;
+	#activeHookCustomComponent?: Component & { dispose?(): void };
+	#activeHookCustomOverlay?: OverlayHandle;
 
 	constructor(private ctx: InteractiveModeContext) {}
+
+	#clearActiveHookCustom(): void {
+		const component = this.#activeHookCustomComponent;
+		const overlay = this.#activeHookCustomOverlay;
+		this.#activeHookCustomComponent = undefined;
+		this.#activeHookCustomOverlay = undefined;
+		component?.dispose?.();
+		overlay?.hide();
+	}
 
 	/**
 	 * Initialize the hook system with TUI-based UI context.
@@ -301,7 +312,11 @@ export class ExtensionUiController {
 		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
-		container.clear();
+		// Detach (not dispose): hook widgets are persistent instances owned by the
+		// #hookWidgets* maps and re-added on every rebuild. Disposal happens only on
+		// explicit removal (#removeHookWidget) or clearHookWidgets(), so a rebuild must
+		// not tear down a still-live widget (e.g. an extension CancellableLoader timer).
+		container.detachAll();
 
 		if (widgets.size === 0) {
 			if (spacerWhenEmpty) {
@@ -840,15 +855,12 @@ export class ExtensionUiController {
 
 		const { promise, resolve } = Promise.withResolvers<T>();
 		let component: (Component & { dispose?(): void }) | undefined;
-		let overlayHandle: OverlayHandle | undefined;
 		let closed = false;
 
 		const close = (result: T) => {
 			if (closed) return;
 			closed = true;
-			component?.dispose?.();
-			overlayHandle?.hide();
-			overlayHandle = undefined;
+			this.#clearActiveHookCustom();
 			if (!options?.overlay) {
 				this.ctx.editorContainer.clear();
 				this.ctx.editorContainer.addChild(this.ctx.editor);
@@ -859,14 +871,16 @@ export class ExtensionUiController {
 			resolve(result);
 		};
 
+		this.#clearActiveHookCustom();
 		Promise.try(() => factory(this.ctx.ui, theme, keybindings, close)).then(c => {
 			if (closed) {
 				c.dispose?.();
 				return;
 			}
 			component = c;
+			this.#activeHookCustomComponent = c;
 			if (options?.overlay) {
-				overlayHandle = this.ctx.ui.showOverlay(component, {
+				this.#activeHookCustomOverlay = this.ctx.ui.showOverlay(component, {
 					anchor: "bottom-center",
 					width: "100%",
 					maxHeight: "100%",
@@ -895,6 +909,7 @@ export class ExtensionUiController {
 	}
 
 	clearHookWidgets(): void {
+		this.#clearActiveHookCustom();
 		for (const widget of this.#hookWidgetsAbove.values()) {
 			widget.dispose?.();
 		}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -680,6 +680,9 @@ export class ExtensionUiController {
 					: undefined,
 			},
 		);
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookSelector);
 		this.ctx.ui.setFocus(this.ctx.hookSelector);
@@ -758,6 +761,9 @@ export class ExtensionUiController {
 				tui: this.ctx.ui,
 			},
 		);
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookInput);
 		this.ctx.ui.setFocus(this.ctx.hookInput);
@@ -806,6 +812,9 @@ export class ExtensionUiController {
 			editorOptions,
 		);
 
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookEditor);
 		this.ctx.ui.setFocus(this.ctx.hookEditor);
@@ -888,6 +897,9 @@ export class ExtensionUiController {
 				});
 				return;
 			}
+			// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+			// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+			this.ctx.editorContainer.detachChild(this.ctx.editor);
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(component);
 			this.ctx.ui.setFocus(component);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -887,6 +887,11 @@ export class InputController {
 		this.ctx.session.agent.hideThinkingSummary = this.ctx.hideThinkingBlock;
 
 		// Rebuild chat from session messages
+		// Detach the live streaming component before the disposing clear() so the
+		// component we re-add below is not torn down (detach != dispose).
+		if (this.ctx.streamingComponent) {
+			this.ctx.chatContainer.detachChild(this.ctx.streamingComponent);
+		}
 		this.ctx.chatContainer.clear();
 		this.ctx.rebuildChatFromMessages();
 

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -706,13 +706,16 @@ export class UiHelpers {
 
 	/** Move pending bash components from pending area to chat */
 	flushPendingBashComponents(): void {
+		// Move (detach, not dispose) the live execution components from the pending
+		// area into the chat transcript — they are reused instances, so a disposing
+		// removeChild() would tear them down before re-adding.
 		for (const component of this.ctx.pendingBashComponents) {
-			this.ctx.pendingMessagesContainer.removeChild(component);
+			this.ctx.pendingMessagesContainer.detachChild(component);
 			this.ctx.chatContainer.addChild(component);
 		}
 		this.ctx.pendingBashComponents = [];
 		for (const component of this.ctx.pendingPythonComponents) {
-			this.ctx.pendingMessagesContainer.removeChild(component);
+			this.ctx.pendingMessagesContainer.detachChild(component);
 			this.ctx.chatContainer.addChild(component);
 		}
 		this.ctx.pendingPythonComponents = [];

--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -11,6 +11,7 @@ type Cache = {
  */
 export class Box implements Component {
 	children: Component[] = [];
+	#disposed = false;
 	#paddingX: number;
 	#paddingY: number;
 	#bgFn?: (text: string) => string;
@@ -34,11 +35,39 @@ export class Box implements Component {
 		if (index !== -1) {
 			this.children.splice(index, 1);
 			this.#invalidateCache();
+			component.dispose?.();
+		}
+	}
+
+	/** Remove a child without disposing it (for detach-then-readd reuse). */
+	detachChild(component: Component): void {
+		const index = this.children.indexOf(component);
+		if (index !== -1) {
+			this.children.splice(index, 1);
+			this.#invalidateCache();
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.children = [];
+		this.#invalidateCache();
+	}
+
+	/** Remove all children without disposing them (for detach-then-readd reuse). */
+	detachAll(): void {
+		this.children = [];
+		this.#invalidateCache();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.#invalidateCache();
 	}
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -78,6 +78,10 @@ export class Loader extends Text {
 		}
 	}
 
+	dispose(): void {
+		this.stop();
+	}
+
 	setMessage(message: string) {
 		this.message = message;
 		this.#updateDisplay();

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -43,6 +43,24 @@ const renderCache = new LRUCache<string, { source: string; lines: string[] }>({ 
 const PARSE_CACHE_MAX = 128;
 const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({ max: PARSE_CACHE_MAX });
 
+// Per-code-block highlight cache (F3): keyed by theme + lang + code so streaming
+// appends only highlight new/changed blocks instead of re-highlighting the whole
+// prefix on every chunk. Bounded LRU; cleared on theme change via clearRenderCache().
+const HIGHLIGHT_CACHE_MAX = 512;
+const highlightCache = new LRUCache<string, string[]>({ max: HIGHLIGHT_CACHE_MAX });
+// F18: cap synchronous (Rust FFI) syntax highlighting so a single huge fenced block
+// cannot stall the UI thread; oversized blocks render plain with a sanitized marker.
+const MAX_HIGHLIGHT_BYTES = 200_000;
+const MAX_HIGHLIGHT_LINES = 2000;
+let highlightCallCount = 0;
+/** Test/diagnostic seam: number of synchronous highlight invocations since the last reset. */
+export function getMarkdownHighlightCallCount(): number {
+	return highlightCallCount;
+}
+export function resetMarkdownHighlightCallCount(): void {
+	highlightCallCount = 0;
+}
+
 // Full-content 64-bit wyhash over every byte (no lossy sampling). Cache hits
 // additionally verify entry.source against the normalized text, so even a
 // hash collision can never return another message's render.
@@ -58,6 +76,7 @@ function wrapTextIfNeeded(line: string, width: number): string[] {
 export function clearRenderCache(): void {
 	renderCache.clear();
 	parseCache.clear();
+	highlightCache.clear();
 }
 
 // Stable numeric IDs for structural theme/style objects (no ID field on type).
@@ -184,6 +203,47 @@ export class Markdown implements Component {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+	}
+
+	#exceedsHighlightCap(code: string): boolean {
+		let newlines = 0;
+		for (let i = 0; i < code.length; i++) {
+			if (code.charCodeAt(i) === 10) newlines += 1;
+		}
+		if (newlines + 1 > MAX_HIGHLIGHT_LINES) return true;
+		// UTF-8 byte length (not UTF-16 code-unit count) so a non-ASCII block cannot
+		// exceed the advertised byte cap and still reach the synchronous highlighter.
+		return Buffer.byteLength(code, "utf8") > MAX_HIGHLIGHT_BYTES;
+	}
+
+	#highlightCodeBlock(code: string, lang: string): string[] | null {
+		if (!this.#theme.highlightCode) return null;
+		if (this.#exceedsHighlightCap(code)) return null;
+		const key = `${objectId(this.#theme)}\x00${lang}\x00${code}`;
+		const cached = highlightCache.get(key);
+		if (cached) return cached;
+		highlightCallCount += 1;
+		const result = this.#theme.highlightCode(code, lang || undefined);
+		highlightCache.set(key, result);
+		return result;
+	}
+
+	#emitCodeBlock(lines: string[], code: string, lang: string, codeIndent: string): void {
+		lines.push(this.#theme.codeBlockBorder(`\`\`\`${lang}`));
+		const highlighted = this.#highlightCodeBlock(code, lang);
+		if (highlighted) {
+			for (const hlLine of highlighted) {
+				lines.push(`${codeIndent}${hlLine}`);
+			}
+		} else {
+			if (this.#theme.highlightCode && this.#exceedsHighlightCap(code)) {
+				lines.push(`${codeIndent}${this.#theme.codeBlock("[syntax highlighting skipped: code block too large]")}`);
+			}
+			for (const codeLine of code.split("\n")) {
+				lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+			}
+		}
+		lines.push(this.#theme.codeBlockBorder("```"));
 	}
 
 	render(width: number): string[] {
@@ -442,20 +502,7 @@ export class Markdown implements Component {
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.#theme.highlightCode) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${codeIndent}${hlLine}`);
-					}
-				} else {
-					// Split code by newlines and style each line
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
-					}
-				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				this.#emitCodeBlock(lines, token.text, token.lang || "", codeIndent);
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}
@@ -725,19 +772,7 @@ export class Markdown implements Component {
 			} else if (token.type === "code") {
 				// Code block in list item
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.#theme.highlightCode) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${codeIndent}${hlLine}`);
-					}
-				} else {
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
-					}
-				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				this.#emitCodeBlock(lines, token.text, token.lang || "", codeIndent);
 			} else {
 				// Other token types - try to render as inline
 				const text = this.#renderInlineTokens([token], styleContext);

--- a/packages/tui/src/metrics.ts
+++ b/packages/tui/src/metrics.ts
@@ -104,6 +104,11 @@ export interface HelperStat {
 	meanMs: number;
 }
 
+export interface LineCountGauge {
+	last: number;
+	max: number;
+}
+
 export interface RenderMetricsSnapshot {
 	enabled: boolean;
 	renderCount: number;
@@ -118,6 +123,7 @@ export interface RenderMetricsSnapshot {
 	ownerGauges: Record<string, number>;
 	timerGauges: Record<string, number>;
 	helperStats: Record<string, HelperStat>;
+	lineCounts: Record<string, LineCountGauge>;
 }
 
 function emptyDurationStats(): DurationStats {
@@ -153,6 +159,7 @@ export class RenderMetrics {
 	#ownerGauges = new Map<string, number>();
 	#timerGauges = new Map<string, number>();
 	#helpers = new Map<string, { count: number; totalMs: number }>();
+	#lineGauges = new Map<string, LineCountGauge>();
 	#rssReturn: number | null = null;
 	#heapBaseline: number | null = null;
 	#heapReturn: number | null = null;
@@ -192,6 +199,7 @@ export class RenderMetrics {
 		this.#ownerGauges.clear();
 		this.#timerGauges.clear();
 		this.#helpers.clear();
+		this.#lineGauges.clear();
 		this.#rssReturn = null;
 		this.#heapBaseline = null;
 		this.#heapReturn = null;
@@ -278,6 +286,16 @@ export class RenderMetrics {
 		this.#helpers.set(retained, cur);
 	}
 
+	/** Record a per-render line-count gauge (e.g. "rendered", "normalized", "diffed"). */
+	recordLineCount(name: string, value: number): void {
+		if (!this.#enabled) return;
+		const retained = retainedLabel(this.#lineGauges, name);
+		const cur = this.#lineGauges.get(retained) ?? { last: 0, max: 0 };
+		cur.last = value;
+		if (value > cur.max) cur.max = value;
+		this.#lineGauges.set(retained, cur);
+	}
+
 	/**
 	 * Force a GC when the runtime exposes one and sample RSS as the post-run
 	 * "return" value used by the memory-leak gate. Callers should drop large
@@ -319,6 +337,14 @@ export class RenderMetrics {
 		return out;
 	}
 
+	#lineCountStats(): Record<string, LineCountGauge> {
+		const out: Record<string, LineCountGauge> = {};
+		for (const [name, v] of this.#lineGauges) {
+			out[name] = { last: v.last, max: v.max };
+		}
+		return out;
+	}
+
 	snapshot(): RenderMetricsSnapshot {
 		return {
 			enabled: this.#enabled,
@@ -347,6 +373,7 @@ export class RenderMetrics {
 			ownerGauges: Object.fromEntries(this.#ownerGauges),
 			timerGauges: Object.fromEntries(this.#timerGauges),
 			helperStats: this.#helperStats(),
+			lineCounts: this.#lineCountStats(),
 		};
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -59,6 +59,14 @@ export interface Component {
 	 * Called when theme changes or when component needs to re-render from scratch.
 	 */
 	invalidate(): void;
+
+	/**
+	 * Optional cleanup hook. Called once when the component is permanently
+	 * removed from the tree via removeChild/clear/dispose. Implementations MUST
+	 * be idempotent. Components meant to be re-added should be detached, not
+	 * removed/cleared.
+	 */
+	dispose?(): void;
 }
 
 /**
@@ -196,6 +204,7 @@ export interface OverlayHandle {
  */
 export class Container implements Component {
 	children: Component[] = [];
+	#disposed = false;
 
 	addChild(component: Component): void {
 		this.children.push(component);
@@ -205,11 +214,36 @@ export class Container implements Component {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			component.dispose?.();
+		}
+	}
+
+	/** Remove a child without disposing it (for detach-then-readd reuse). */
+	detachChild(component: Component): void {
+		const index = this.children.indexOf(component);
+		if (index !== -1) {
+			this.children.splice(index, 1);
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.children = [];
+	}
+
+	/** Remove all children without disposing them (for detach-then-readd reuse). */
+	detachAll(): void {
+		this.children = [];
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 	}
 
 	invalidate(): void {
@@ -222,7 +256,10 @@ export class Container implements Component {
 		width = Math.max(1, width);
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			const childLines = child.render(width);
+			for (let i = 0; i < childLines.length; i++) {
+				lines.push(childLines[i]);
+			}
 		}
 		return lines;
 	}
@@ -239,6 +276,13 @@ type LineNormalizationCacheEntry = {
 export class TUI extends Container {
 	terminal: Terminal;
 	#previousLines: string[] = [];
+	/**
+	 * Raw (pre-normalization) lines from the previous frame, kept only when the
+	 * virtual-viewport flag is on. Used to detect whether the off-screen prefix is
+	 * unchanged (by raw value equality, with a fast reference short-circuit when components
+	 * return stable string instances) so its normalized form can be reused (bounded normalize).
+	 */
+	#previousRaw: string[] = [];
 	#lineNormalizationCache = new Map<string, LineNormalizationCacheEntry>();
 	#lineTruncationCache = new Map<string, string>();
 	#lineNormalizationCacheLimit = 0;
@@ -269,6 +313,9 @@ export class TUI extends Container {
 	#sixelProbeUnsubscribe?: () => void;
 	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
 	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
+	// Opt-in: reuse the previous normalized off-screen prefix and only normalize/diff the
+	// visible window, bounding per-frame work on huge transcripts. Output stays byte-identical.
+	#virtualViewport = $flag("PI_TUI_VIRTUAL_VIEWPORT");
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	#fullRedrawCount = 0;
 	#stopped = false;
@@ -663,6 +710,7 @@ export class TUI extends Container {
 		// focus/listener state is intentionally preserved so input routing survives
 		// a resume.
 		this.#previousLines = [];
+		this.#previousRaw = [];
 		this.#lineNormalizationCache.clear();
 		this.#lineTruncationCache.clear();
 		this.#previousWidth = 0;
@@ -679,6 +727,7 @@ export class TUI extends Container {
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
+			this.#previousRaw = [];
 			this.#lineNormalizationCache.clear();
 			this.#lineTruncationCache.clear();
 			this.#previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
@@ -1204,14 +1253,16 @@ export class TUI extends Container {
 		};
 	}
 
+	/** Normalize + width-fit a single line for emission (image lines pass through). */
+	#normalizeLineForEmit(line: string, width: number): string {
+		if (TERMINAL.isImageLine(line)) return line;
+		const { normalized, terminated } = this.#normalizeLineForRender(line);
+		return this.#lineFitsWidth(normalized, width) ? terminated : this.#truncateNormalizedLine(normalized, width);
+	}
+
 	#applyLineResetsAndTruncate(lines: string[], width: number): string[] {
 		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			if (TERMINAL.isImageLine(line)) continue;
-			const { normalized, terminated } = this.#normalizeLineForRender(line);
-			lines[i] = this.#lineFitsWidth(normalized, width)
-				? terminated
-				: this.#truncateNormalizedLine(normalized, width);
+			lines[i] = this.#normalizeLineForEmit(lines[i], width);
 		}
 		this.#trimLineCachesForRender(lines.length);
 		return lines;
@@ -1247,11 +1298,60 @@ export class TUI extends Container {
 		// (closes SGR + OSC 8 hyperlink state). Must run after cursor extraction
 		// because the marker is embedded mid-line, and before any diff/full render
 		// path so cache comparisons stay byte-accurate.
-		newLines = this.#applyLineResetsAndTruncate(newLines, width);
-
-		// Width changed - need full re-render (line wrapping changes)
+		// Width/height change detection (used for both normalization reuse and full-redraw decisions).
 		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
+
+		// Normalize/truncate lines for emission. With the opt-in virtual-viewport flag
+		// (PI_TUI_VIRTUAL_VIEWPORT) we reuse the previous frame's normalized prefix when the
+		// off-screen raw prefix is unchanged (raw value equality per line; fast reference
+		// short-circuit for cached components), so only the visible window is
+		// re-normalized and the diff starts at the window. Output is byte-identical to the
+		// full path (reused entries are deterministic normalizations of identical raw lines).
+		const VIEWPORT_NORMALIZE_OVERSCAN = 8;
+		const rawLines = newLines;
+		const total = rawLines.length;
+		let diffStart = 0;
+		let usedWindowNormalize = false;
+		if (
+			this.#virtualViewport &&
+			!widthChanged &&
+			this.#previousRaw.length > 0 &&
+			this.#previousLines.length === this.#previousRaw.length
+		) {
+			const winTop = Math.max(0, total - height - VIEWPORT_NORMALIZE_OVERSCAN);
+			if (winTop <= this.#previousLines.length && winTop <= this.#previousRaw.length) {
+				let stable = true;
+				for (let i = 0; i < winTop; i++) {
+					if (rawLines[i] !== this.#previousRaw[i]) {
+						stable = false;
+						break;
+					}
+				}
+				if (stable) {
+					const windowed = this.#previousLines.slice(0, winTop);
+					for (let i = winTop; i < total; i++) {
+						windowed.push(this.#normalizeLineForEmit(rawLines[i], width));
+					}
+					this.#trimLineCachesForRender(total);
+					newLines = windowed;
+					diffStart = winTop;
+					usedWindowNormalize = true;
+				}
+			}
+		}
+		if (!usedWindowNormalize) {
+			newLines = this.#applyLineResetsAndTruncate(this.#virtualViewport ? rawLines.slice() : rawLines, width);
+		}
+		if (this.#virtualViewport) {
+			this.#previousRaw = rawLines;
+		}
+		if (renderMetrics.enabled) {
+			renderMetrics.recordLineCount("rendered", total);
+			renderMetrics.recordLineCount("normalized", total - diffStart);
+			renderMetrics.recordLineCount("measured", total - diffStart);
+			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
+		}
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean, reason = "full render"): void => {
@@ -1390,7 +1490,10 @@ export class TUI extends Container {
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const maxLines = Math.max(newLines.length, this.#previousLines.length);
-		for (let i = 0; i < maxLines; i++) {
+		if (renderMetrics.enabled) renderMetrics.recordLineCount("diffed", maxLines - diffStart);
+		// When the off-screen prefix was reused (virtual viewport), it is verified
+		// unchanged (raw value equality), so the diff can safely start at the window boundary.
+		for (let i = diffStart; i < maxLines; i++) {
 			const oldLine = i < this.#previousLines.length ? this.#previousLines[i] : "";
 			const newLine = i < newLines.length ? newLines[i] : "";
 

--- a/packages/tui/test/cancellable-loader-dispose.test.ts
+++ b/packages/tui/test/cancellable-loader-dispose.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { CancellableLoader, Container, type TUI } from "@gajae-code/tui";
+
+describe("CancellableLoader disposal", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("stops its animation interval when removed by container.clear()", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const container = new Container();
+		let colorTick = 0;
+		const loader = new CancellableLoader(
+			ui,
+			text => text,
+			text => `${text}-${colorTick}`,
+			"Loading",
+			["|", "/"],
+		);
+
+		container.addChild(loader);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+
+		colorTick = 1;
+		vi.advanceTimersByTime(80);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(1);
+
+		container.clear();
+		colorTick = 2;
+		vi.advanceTimersByTime(160);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+});

--- a/packages/tui/test/component-dispose-redteam.test.ts
+++ b/packages/tui/test/component-dispose-redteam.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Box, type Component, Container, Loader, type TUI } from "@gajae-code/tui";
+
+class ProbeComponent implements Component {
+	disposeCount = 0;
+	readonly childContainer?: Container;
+
+	constructor(
+		private readonly label: string,
+		childContainer?: Container,
+	) {
+		this.childContainer = childContainer;
+	}
+
+	invalidate(): void {
+		this.childContainer?.invalidate();
+	}
+
+	render(width: number): string[] {
+		const ownLine = `${this.label}:${width}`;
+		const childLines = this.childContainer?.render(width) ?? [];
+		return [ownLine, ...childLines];
+	}
+
+	dispose(): void {
+		this.disposeCount += 1;
+		this.childContainer?.dispose();
+	}
+}
+
+describe("component disposal lifecycle red-team", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("dispose releases resources without emptying children and detached/readded children still render", () => {
+		const container = new Container();
+		const detachedThenReadded = new ProbeComponent("reuse");
+		const stable = new ProbeComponent("stable");
+
+		container.addChild(detachedThenReadded);
+		container.detachChild(detachedThenReadded);
+		expect(detachedThenReadded.disposeCount).toBe(0);
+		container.addChild(stable);
+		container.addChild(detachedThenReadded);
+
+		container.dispose();
+
+		expect(container.children).toHaveLength(2);
+		expect(stable.disposeCount).toBe(1);
+		expect(detachedThenReadded.disposeCount).toBe(1);
+		expect(container.render(12)).toEqual(["stable:12", "reuse:12"]);
+	});
+
+	it("detachChild and detachAll remove children without disposing them", () => {
+		const container = new Container();
+		const one = new ProbeComponent("one");
+		const two = new ProbeComponent("two");
+		const three = new ProbeComponent("three");
+
+		container.addChild(one);
+		container.addChild(two);
+		container.addChild(three);
+		container.detachChild(two);
+		container.detachAll();
+
+		expect(one.disposeCount).toBe(0);
+		expect(two.disposeCount).toBe(0);
+		expect(three.disposeCount).toBe(0);
+		expect(container.children).toHaveLength(0);
+	});
+
+	it("removeChild and clear dispose present children exactly once and repeated calls stay safe", () => {
+		const container = new Container();
+		const removed = new ProbeComponent("removed");
+		const cleared = new ProbeComponent("cleared");
+
+		container.addChild(removed);
+		container.addChild(cleared);
+
+		container.removeChild(removed);
+		container.removeChild(removed);
+		expect(removed.disposeCount).toBe(1);
+
+		container.clear();
+		container.clear();
+		expect(cleared.disposeCount).toBe(1);
+		expect(removed.disposeCount).toBe(1);
+		expect(container.children).toHaveLength(0);
+	});
+
+	it("outer clear recursively disposes nested Box and its grandchildren", () => {
+		const outer = new Container();
+		const box = new Box(0, 0);
+		const grandchild = new ProbeComponent("grandchild");
+		box.addChild(grandchild);
+		outer.addChild(box);
+
+		outer.clear();
+
+		expect(outer.children).toHaveLength(0);
+		expect(grandchild.disposeCount).toBe(1);
+	});
+
+	it("Box.clear stops a nested Loader interval", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const box = new Box(0, 0);
+		let colorTick = 0;
+		const loader = new Loader(
+			ui,
+			frame => `${frame}:${colorTick++}`,
+			message => `${message}:${colorTick++}`,
+			"busy",
+		);
+		box.addChild(loader);
+
+		vi.advanceTimersByTime(64);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(0);
+
+		box.clear();
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+
+	it("disposed child containers can be reattached without losing render structure", () => {
+		const outer = new Container();
+		const inner = new Container();
+		const leaf = new ProbeComponent("leaf");
+		inner.addChild(leaf);
+		outer.addChild(inner);
+
+		outer.dispose();
+		expect(inner.children).toHaveLength(1);
+		expect(leaf.disposeCount).toBe(1);
+
+		const freshParent = new Container();
+		freshParent.addChild(inner);
+
+		expect(freshParent.render(20)).toEqual(["leaf:20"]);
+		expect(inner.children).toHaveLength(1);
+	});
+});

--- a/packages/tui/test/component-dispose.test.ts
+++ b/packages/tui/test/component-dispose.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, Container, Loader, type TUI } from "@gajae-code/tui";
+
+/** Component that records how many times dispose() was called. */
+class DisposeSpy implements Component {
+	disposeCount = 0;
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return ["spy"];
+	}
+	dispose(): void {
+		this.disposeCount += 1;
+	}
+}
+
+describe("Container disposal lifecycle (W2 / F11)", () => {
+	it("disposes children on clear() and removeChild(), once each", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		const b = new DisposeSpy();
+		container.addChild(a);
+		container.addChild(b);
+
+		container.removeChild(a);
+		expect(a.disposeCount).toBe(1);
+		expect(b.disposeCount).toBe(0);
+
+		container.clear();
+		expect(b.disposeCount).toBe(1);
+	});
+
+	it("does NOT dispose on detachChild()/detachAll() (detach != dispose)", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		const b = new DisposeSpy();
+		container.addChild(a);
+		container.addChild(b);
+
+		container.detachChild(a);
+		expect(a.disposeCount).toBe(0);
+		expect(container.children).not.toContain(a);
+
+		container.detachAll();
+		expect(b.disposeCount).toBe(0);
+		expect(container.children.length).toBe(0);
+	});
+
+	it("recursively disposes nested children via dispose()", () => {
+		const outer = new Container();
+		const inner = new Container();
+		const leaf = new DisposeSpy();
+		inner.addChild(leaf);
+		outer.addChild(inner);
+
+		outer.dispose();
+		expect(leaf.disposeCount).toBe(1);
+	});
+
+	it("dispose() is idempotent (no double child-dispose)", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		container.addChild(a);
+
+		container.dispose();
+		container.dispose();
+		expect(a.disposeCount).toBe(1);
+	});
+
+	it("supports rebuild-from-map: detachAll + re-add reused instances never disposes them", () => {
+		// Mirrors the hook-widget / pending-component rebuild pattern: persistent
+		// instances live in a map and are re-rendered into a container repeatedly.
+		// The container must DETACH (not dispose) on each rebuild; disposal is the
+		// owner's job on explicit removal.
+		const container = new Container();
+		const persistent = new DisposeSpy();
+		for (let rebuild = 0; rebuild < 5; rebuild++) {
+			container.detachAll();
+			container.addChild(persistent);
+		}
+		expect(persistent.disposeCount).toBe(0);
+
+		container.removeChild(persistent);
+		expect(persistent.disposeCount).toBe(1);
+	});
+});
+
+describe("Loader timer cleanup on disposing clear (W2 / F12 mechanism)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("stops the animation interval when its container is cleared", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const container = new Container();
+		// Time-varying spinner colorizer forces a text change every tick, so each
+		// interval tick requests a render (mirrors the tool-execution spinner that
+		// previously leaked and re-rendered the whole transcript forever).
+		let tick = 0;
+		const loader = new Loader(
+			ui,
+			frame => `${frame}${tick++}`,
+			msg => msg,
+			"loading",
+		);
+		container.addChild(loader);
+
+		vi.advanceTimersByTime(64);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(0);
+
+		container.clear(); // disposes the loader -> stop() -> clearInterval
+
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+
+		// dispose() is idempotent / safe to call again.
+		loader.dispose();
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+});

--- a/packages/tui/test/container-spread-safe-redteam.test.ts
+++ b/packages/tui/test/container-spread-safe-redteam.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, Container } from "@gajae-code/tui";
+
+class FixedLines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
+describe("Container spread-safe red-team composition", () => {
+	it("renders an empty container as an empty array", () => {
+		const container = new Container();
+
+		expect(container.render(80)).toEqual([]);
+	});
+
+	it("preserves order and count when empty child outputs are interleaved", () => {
+		const container = new Container();
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["alpha", "beta"]));
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["gamma"]));
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["delta", "epsilon"]));
+
+		const output = container.render(80);
+
+		expect(output).toEqual(["alpha", "beta", "gamma", "delta", "epsilon"]);
+		expect(output).toHaveLength(5);
+	});
+
+	it("composes a single one-million-line child without RangeError", () => {
+		const lineCount = 1_000_000;
+		const lines = Array.from({ length: lineCount }, (_value, index) => `line-${index}`);
+		const container = new Container();
+		container.addChild(new FixedLines(lines));
+
+		const output = container.render(80);
+
+		expect(output).toHaveLength(lineCount);
+		expect(output[0]).toBe("line-0");
+		expect(output[lineCount - 1]).toBe(`line-${lineCount - 1}`);
+	});
+
+	it("composes 1000 small children in child and line order", () => {
+		const container = new Container();
+		for (let childIndex = 0; childIndex < 1000; childIndex++) {
+			container.addChild(
+				new FixedLines([`child-${childIndex}-line-0`, `child-${childIndex}-line-1`, `child-${childIndex}-line-2`]),
+			);
+		}
+
+		const output = container.render(80);
+
+		expect(output).toHaveLength(3000);
+		expect(output[0]).toBe("child-0-line-0");
+		expect(output[1]).toBe("child-0-line-1");
+		expect(output[2]).toBe("child-0-line-2");
+		expect(output[2997]).toBe("child-999-line-0");
+		expect(output[2998]).toBe("child-999-line-1");
+		expect(output[2999]).toBe("child-999-line-2");
+	});
+
+	it("clamps zero and negative widths while still composing child output", () => {
+		const zeroWidthContainer = new Container();
+		zeroWidthContainer.addChild(new FixedLines(["zero-a", "zero-b"]));
+
+		const negativeWidthContainer = new Container();
+		negativeWidthContainer.addChild(new FixedLines(["negative-a"]));
+		negativeWidthContainer.addChild(new FixedLines(["negative-b", "negative-c"]));
+
+		expect(zeroWidthContainer.render(0)).toEqual(["zero-a", "zero-b"]);
+		expect(negativeWidthContainer.render(-5)).toEqual(["negative-a", "negative-b", "negative-c"]);
+	});
+});

--- a/packages/tui/test/container-spread-safe.test.ts
+++ b/packages/tui/test/container-spread-safe.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, Container, renderMetrics, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+/** Minimal component that returns a fixed line array regardless of width. */
+class FixedLines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+describe("Container spread-safe composition (W1a / F2)", () => {
+	it("composes a >500k-line child without RangeError and preserves order", () => {
+		// The previous `lines.push(...child.render(width))` spread threw
+		// `RangeError: Maximum call stack size exceeded` past ~490k elements.
+		const bigCount = 600_000;
+		const big = Array.from({ length: bigCount }, (_v, i) => `row${i}`);
+		const container = new Container();
+		container.addChild(new FixedLines(big));
+		container.addChild(new FixedLines(["tail-a", "tail-b"]));
+
+		const out = container.render(80);
+
+		expect(out.length).toBe(bigCount + 2);
+		expect(out[0]).toBe("row0");
+		expect(out[bigCount - 1]).toBe(`row${bigCount - 1}`);
+		expect(out[bigCount]).toBe("tail-a");
+		expect(out[bigCount + 1]).toBe("tail-b");
+	});
+
+	it("produces output identical to manual child concatenation", () => {
+		const children = [
+			new FixedLines(["a", "b"]),
+			new FixedLines(["c"]),
+			new FixedLines([]),
+			new FixedLines(["d", "e"]),
+		];
+		const container = new Container();
+		for (const child of children) container.addChild(child);
+
+		const out = container.render(80);
+		const expected = children.flatMap(child => child.render(80));
+
+		expect(out).toEqual(expected);
+	});
+});
+
+describe("render line-count metrics (W1a foundation for F1)", () => {
+	let wasEnabled = false;
+	let previousTmux: string | undefined;
+	let previousSty: string | undefined;
+	let previousZellij: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		previousTmux = Bun.env.TMUX;
+		previousSty = Bun.env.STY;
+		previousZellij = Bun.env.ZELLIJ;
+		delete Bun.env.TMUX;
+		delete Bun.env.STY;
+		delete Bun.env.ZELLIJ;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+		wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		renderMetrics.reset();
+		if (!wasEnabled) renderMetrics.disable();
+		if (previousTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = previousTmux;
+		if (previousSty === undefined) delete Bun.env.STY;
+		else Bun.env.STY = previousSty;
+		if (previousZellij === undefined) delete Bun.env.ZELLIJ;
+		else Bun.env.ZELLIJ = previousZellij;
+	});
+
+	it("populates rendered/measured/normalized gauges and diffed on a differential pass", async () => {
+		const term = new VirtualTerminal(40, 10);
+		const tui = new TUI(term);
+		const component = new FixedLines(["alpha", "beta", "gamma"]);
+		tui.addChild(component);
+
+		try {
+			tui.start();
+			await settle(term); // first render (full)
+
+			// Second render exercises the differential diff path, recording "diffed".
+			component.setLines(["alpha", "BETA", "gamma"]);
+			tui.requestRender();
+			await settle(term);
+		} finally {
+			tui.stop();
+		}
+
+		const { lineCounts } = renderMetrics.snapshot();
+		expect(lineCounts.rendered?.last).toBeGreaterThan(0);
+		expect(lineCounts.measured?.last).toBeGreaterThan(0);
+		expect(lineCounts.normalized?.last).toBeGreaterThan(0);
+		expect(lineCounts.diffed?.last).toBeGreaterThan(0);
+	});
+});

--- a/packages/tui/test/markdown-highlight-redteam.test.ts
+++ b/packages/tui/test/markdown-highlight-redteam.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearRenderCache,
+	getMarkdownHighlightCallCount,
+	Markdown,
+	type MarkdownTheme,
+	resetMarkdownHighlightCallCount,
+} from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
+
+type HighlightCall = { code: string; lang: string | undefined };
+
+function makeSpyTheme(prefix: string): MarkdownTheme & { calls: HighlightCall[] } {
+	const calls: HighlightCall[] = [];
+	return {
+		...defaultMarkdownTheme,
+		highlightCode: (code: string, lang?: string): string[] => {
+			calls.push({ code, lang });
+			return code.split("\n").map(line => `${prefix}:${lang ?? "none"}:${line}`);
+		},
+		calls,
+	};
+}
+
+function render(markdown: string, theme: MarkdownTheme, width = 160): string[] {
+	return new Markdown(markdown, 0, 0, theme).render(width);
+}
+
+function joined(markdown: string, theme: MarkdownTheme, width = 160): string {
+	return render(markdown, theme, width).join("\n");
+}
+
+function linesOf(count: number, fill: (index: number) => string): string {
+	return Array.from({ length: count }, (_value, index) => fill(index)).join("\n");
+}
+
+describe("markdown highlight cache + cap red-team", () => {
+	beforeEach(() => {
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+	});
+
+	it("keeps normal code-block output byte-identical across cache states and fresh theme objects", () => {
+		const markdown = [
+			"Intro",
+			"```ts",
+			"const tricky = `literal with backticks`;",
+			"console.log('unicode π 🚀');",
+			"```",
+			"```",
+			"plain fence with empty lang and ``` inside text",
+			"ansi-like \\x1b[31m not terminal escape",
+			"```",
+			"```sh",
+			"printf '%s\\n' \"nested `tick` and café\"",
+			"```",
+		].join("\n");
+
+		const themeA = makeSpyTheme("HL");
+		const first = render(markdown, themeA);
+		expect(getMarkdownHighlightCallCount()).toBe(3);
+
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+		const themeAAgain = makeSpyTheme("HL");
+		const second = render(markdown, themeAAgain);
+		expect(getMarkdownHighlightCallCount()).toBe(3);
+		expect(second).toEqual(first);
+
+		const freshTheme = makeSpyTheme("HL");
+		const freshThemeLines = render(markdown, freshTheme);
+		expect(getMarkdownHighlightCallCount()).toBe(6);
+		expect(freshThemeLines.filter(line => line.includes("HL:"))).toEqual(first.filter(line => line.includes("HL:")));
+	});
+
+	it("highlights the exact 2000-line boundary and skips 2001 lines with the marker", () => {
+		const theme = makeSpyTheme("LINE");
+		const exactly2000 = `\`\`\`ts\n${linesOf(2000, index => `line-${index}`)}\n\`\`\``;
+		const atBoundary = joined(exactly2000, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(atBoundary).toContain("LINE:ts:line-0");
+		expect(atBoundary).toContain("LINE:ts:line-1999");
+		expect(atBoundary).not.toContain("syntax highlighting skipped");
+
+		resetMarkdownHighlightCallCount();
+		const over2000 = `\`\`\`ts\n${linesOf(2001, index => `line-${index}`)}\n\`\`\``;
+		const overBoundary = joined(over2000, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(overBoundary).toContain("[syntax highlighting skipped: code block too large]");
+		expect(overBoundary).toContain("line-0");
+		expect(overBoundary).toContain("line-2000");
+		expect(overBoundary).not.toContain("LINE:ts:line-2000");
+	});
+
+	it("highlights below the byte cap and skips above the byte cap", () => {
+		const theme = makeSpyTheme("BYTE");
+		const belowByteCap = `\`\`\`txt\n${"a".repeat(199_000)}\n\`\`\``;
+		const below = joined(belowByteCap, theme, 250_000);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(below).toContain(`BYTE:txt:${"a".repeat(64)}`);
+		expect(below).not.toContain("syntax highlighting skipped");
+
+		resetMarkdownHighlightCallCount();
+		const aboveByteCap = `\`\`\`txt\n${"b".repeat(201_000)}\n\`\`\``;
+		const above = joined(aboveByteCap, theme, 250_000);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(above).toContain("[syntax highlighting skipped: code block too large]");
+		expect(above).toContain("b".repeat(64));
+		expect(above).not.toContain(`BYTE:txt:${"b".repeat(64)}`);
+	});
+
+	it("only highlights an appended sixth block after a cached five-block prefix", () => {
+		const theme = makeSpyTheme("APPEND");
+		const base = Array.from({ length: 5 }, (_value, index) => `\`\`\`lang${index}\nblock-${index}\n\`\`\``).join(
+			"\n\n",
+		);
+
+		render(base, theme);
+		expect(getMarkdownHighlightCallCount()).toBe(5);
+
+		const grown = `${base}\n\n\`\`\`lang5\nblock-5\n\`\`\``;
+		render(grown, theme);
+		expect(getMarkdownHighlightCallCount()).toBe(6);
+		expect(theme.calls.map(call => call.lang)).toEqual(["lang0", "lang1", "lang2", "lang3", "lang4", "lang5"]);
+	});
+
+	it("uses changed theme highlight output after clearing render caches", () => {
+		const markdown = "```ts\nconst theme = 'must invalidate';\n```";
+		const themeA = makeSpyTheme("THEME-A");
+		expect(joined(markdown, themeA)).toContain("THEME-A:ts:const theme = 'must invalidate';");
+
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+		const themeB = makeSpyTheme("THEME-B");
+		const renderedWithB = joined(markdown, themeB);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(renderedWithB).toContain("THEME-B:ts:const theme = 'must invalidate';");
+		expect(renderedWithB).not.toContain("THEME-A:ts:const theme = 'must invalidate';");
+	});
+
+	it("applies cache and cap behavior to code blocks nested in list items", () => {
+		const theme = makeSpyTheme("LIST");
+		const nestedNormal = ["- item with code", "", "  ```ts", "  const nested = true;", "  ```"].join("\n");
+
+		const first = joined(nestedNormal, theme);
+		const afterFirst = getMarkdownHighlightCallCount();
+		const second = joined(nestedNormal, theme);
+		expect(afterFirst).toBe(1);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(second).toBe(first);
+		expect(second).toContain("LIST:ts:const nested = true;");
+
+		resetMarkdownHighlightCallCount();
+		const nestedHuge = [
+			"- item with oversized code",
+			"",
+			"  ```ts",
+			linesOf(2001, index => `  nested-${index}`),
+			"  ```",
+		].join("\n");
+		const huge = joined(nestedHuge, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(huge).toContain("[syntax highlighting skipped: code block too large]");
+		expect(huge).toContain("nested-2000");
+	});
+});

--- a/packages/tui/test/markdown-highlight.test.ts
+++ b/packages/tui/test/markdown-highlight.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearRenderCache,
+	getMarkdownHighlightCallCount,
+	Markdown,
+	type MarkdownTheme,
+	resetMarkdownHighlightCallCount,
+} from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
+
+function themeWithHighlight(): MarkdownTheme {
+	// A deterministic stand-in for the real Rust-FFI highlighter; the module-level
+	// highlight-call counter increments once per actual (uncached) invocation.
+	return { ...defaultMarkdownTheme, highlightCode: (code: string) => code.split("\n") };
+}
+
+describe("markdown streaming highlight caps + cache (W3 / F3, F18)", () => {
+	beforeEach(() => {
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+	});
+
+	it("does not re-highlight the unchanged prefix when a streamed message grows (F3)", () => {
+		const theme = themeWithHighlight();
+		const base = "```ts\nconst a = 1;\n```\n\n```js\nconst b = 2;\n```\n\n```py\nx = 3\n```";
+		new Markdown(base, 1, 0, theme).render(80);
+		const afterThree = getMarkdownHighlightCallCount();
+		expect(afterThree).toBe(3);
+
+		// Streaming append of a 4th code block (worst case: a fresh component instance).
+		const grown = `${base}\n\n\`\`\`rb\ny = 4\n\`\`\``;
+		new Markdown(grown, 1, 0, theme).render(80);
+		const afterFour = getMarkdownHighlightCallCount();
+
+		// Only the newly-appended block is highlighted; the prior three are served from cache.
+		expect(afterFour - afterThree).toBe(1);
+	});
+
+	it("reuses the per-code-block highlight cache across separate component instances (F3)", () => {
+		const theme = themeWithHighlight();
+		const md = "```ts\nconst z = 9;\n```";
+		new Markdown(md, 1, 0, theme).render(80);
+		new Markdown(md, 1, 0, theme).render(80);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+	});
+
+	it("skips synchronous highlight for oversized code blocks and marks them (F18)", () => {
+		const theme = themeWithHighlight();
+		const bigCode = Array.from({ length: 2500 }, (_v, i) => `line ${i}`).join("\n");
+		const md = `\`\`\`ts\n${bigCode}\n\`\`\``;
+		const lines = new Markdown(md, 1, 0, theme).render(120);
+
+		expect(getMarkdownHighlightCallCount()).toBe(0); // FFI highlighter never called
+		expect(lines.join("\n")).toContain("syntax highlighting skipped");
+		// The code content is still rendered (plain), not dropped.
+		expect(lines.join("\n")).toContain("line 0");
+		expect(lines.join("\n")).toContain("line 2499");
+	});
+
+	it("still highlights normal-sized blocks (regression guard)", () => {
+		const theme = themeWithHighlight();
+		const md = "```ts\nconst ok = true;\n```";
+		const lines = new Markdown(md, 1, 0, theme).render(80);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(lines.join("\n")).not.toContain("syntax highlighting skipped");
+	});
+
+	it("caps highlight by UTF-8 byte length, not UTF-16 code units (F18 non-ASCII)", () => {
+		const theme = themeWithHighlight();
+		// 70k CJK code points on one line: 70k code units (< 200k) but ~210k UTF-8 bytes (> 200k).
+		const cjk = "中".repeat(70_000);
+		expect(cjk.length).toBeLessThan(200_000);
+		expect(Buffer.byteLength(cjk, "utf8")).toBeGreaterThan(200_000);
+		const md = `\`\`\`ts\n${cjk}\n\`\`\``;
+		const lines = new Markdown(md, 1, 0, theme).render(120);
+		expect(getMarkdownHighlightCallCount()).toBe(0); // byte cap trips → FFI skipped
+		expect(lines.join("\n")).toContain("syntax highlighting skipped");
+	});
+});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1210,12 +1210,14 @@ describe("Module-level LRU render cache", () => {
 			},
 		};
 
-		for (let i = 0; i < 300; i++) {
+		// Exceed BOTH the L2 render cache (256) and the per-code-block highlight cache
+		// (512) so message 0 is evicted from each and a re-render must re-highlight it.
+		for (let i = 0; i < 600; i++) {
 			new Markdown(`message ${i}\n\n\`\`\`js\nconst value = ${i};\n\`\`\``, 0, 0, themeWithSpy).render(80);
 		}
 
 		new Markdown("message 0\n\n```js\nconst value = 0;\n```", 0, 0, themeWithSpy).render(80);
-		expect(highlightCallCount).toBe(301);
+		expect(highlightCallCount).toBe(601);
 	});
 
 	it("never serves another message's render on content-key collision attempts", () => {

--- a/packages/tui/test/viewport-virtualization-redteam.test.ts
+++ b/packages/tui/test/viewport-virtualization-redteam.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const FLAG = "PI_TUI_VIRTUAL_VIEWPORT";
+
+type Mutation = (state: ScenarioState, tui: TUI, term: VirtualTerminal) => void;
+
+interface Step {
+	name: string;
+	mutate: Mutation;
+}
+
+interface ScriptedScenario {
+	name: string;
+	initialLines: string[];
+	width?: number;
+	height?: number;
+	steps: Step[];
+}
+
+interface ScenarioState {
+	lines: string[];
+}
+
+abstract class ScriptedLines implements Component {
+	protected lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines.slice();
+	}
+
+	setLines(lines: string[]): void {
+		this.lines = lines.slice();
+	}
+
+	setLine(index: number, value: string): void {
+		const next = this.lines.slice();
+		next[index] = value;
+		this.lines = next;
+	}
+
+	append(value: string): void {
+		this.lines = [...this.lines, value];
+	}
+
+	invalidate(): void {}
+
+	abstract render(width: number): string[];
+}
+
+class CachedLines extends ScriptedLines {
+	render(_width: number): string[] {
+		return this.lines;
+	}
+}
+
+class FreshLines extends ScriptedLines {
+	render(_width: number): string[] {
+		return this.lines.map(line => `${line}`);
+	}
+}
+
+function makeRows(count: number): string[] {
+	return Array.from({ length: count }, (_value, index) => `line-${index}`);
+}
+
+function boundaryRows(count: number): string[] {
+	return Array.from({ length: count }, (_value, index) => `boundary-${index}`);
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function capture(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+function applyLines(state: ScenarioState, component: ScriptedLines): void {
+	component.setLines(state.lines);
+}
+
+const scenarios: ScriptedScenario[] = [
+	{
+		name: "rapid interleaved appends and bottom edits",
+		initialLines: makeRows(48),
+		steps: [
+			{
+				name: "append then edit new bottom line",
+				mutate: state => {
+					state.lines = [...state.lines, "append-A", "append-B"];
+					state.lines[state.lines.length - 1] = "append-B-edited";
+				},
+			},
+			{
+				name: "edit previous bottom and append again",
+				mutate: state => {
+					state.lines[state.lines.length - 2] = "append-A-edited";
+					state.lines = [...state.lines, "append-C"];
+				},
+			},
+			{
+				name: "burst append with newest bottom edit",
+				mutate: state => {
+					state.lines = [...state.lines, "append-D", "append-E", "append-F"];
+					state.lines[state.lines.length - 1] = "append-F-edited";
+				},
+			},
+		],
+	},
+	{
+		name: "off-screen top edit without line-count change",
+		initialLines: makeRows(70),
+		steps: [
+			{
+				name: "edit first hidden line",
+				mutate: state => {
+					state.lines[0] = "line-0-offscreen-edited-same-count";
+				},
+			},
+			{
+				name: "edit second hidden line",
+				mutate: state => {
+					state.lines[1] = "line-1-offscreen-edited-same-count";
+				},
+			},
+		],
+	},
+	{
+		name: "edits around the virtual window boundary",
+		height: 16,
+		initialLines: boundaryRows(64),
+		steps: [
+			{
+				name: "edit line at total minus height minus nine",
+				mutate: state => {
+					const index = state.lines.length - 16 - 9;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+			{
+				name: "edit line at total minus height minus eight",
+				mutate: state => {
+					const index = state.lines.length - 16 - 8;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+			{
+				name: "edit line at total minus height minus seven",
+				mutate: state => {
+					const index = state.lines.length - 16 - 7;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+		],
+	},
+	{
+		name: "shrinking transcript below viewport",
+		height: 18,
+		initialLines: makeRows(44),
+		steps: [
+			{
+				name: "shrink to fewer than terminal rows",
+				mutate: state => {
+					state.lines = ["short-0", "short-1", "short-2"];
+				},
+			},
+			{
+				name: "shrink to a single line",
+				mutate: state => {
+					state.lines = ["single-after-shrink"];
+				},
+			},
+		],
+	},
+	{
+		name: "overlay toggles while appending",
+		initialLines: makeRows(36),
+		steps: [
+			{
+				name: "show overlay after append",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-A"];
+					tui.showOverlay(new CachedLines(["overlay-one", "overlay-two"]), { anchor: "center" });
+				},
+			},
+			{
+				name: "hide overlay after append",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-B"];
+					tui.hideOverlay();
+				},
+			},
+			{
+				name: "show overlay with fresh bottom line",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-C"];
+					tui.showOverlay(new CachedLines(["overlay-three", "overlay-four"]), { anchor: "bottom-center" });
+				},
+			},
+		],
+	},
+	{
+		name: "width resize down then up",
+		width: 48,
+		initialLines: [
+			"width-row-0-abcdefghijklmnopqrstuvwxyz",
+			"width-row-1-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			...makeRows(24),
+		],
+		steps: [
+			{
+				name: "resize width down",
+				mutate: (_state, _tui, term) => {
+					term.resize(24, term.rows);
+				},
+			},
+			{
+				name: "resize width up",
+				mutate: (_state, _tui, term) => {
+					term.resize(56, term.rows);
+				},
+			},
+		],
+	},
+	{
+		name: "height resize",
+		height: 14,
+		initialLines: makeRows(45),
+		steps: [
+			{
+				name: "resize height taller",
+				mutate: (_state, _tui, term) => {
+					term.resize(term.columns, 20);
+				},
+			},
+			{
+				name: "resize height shorter",
+				mutate: (_state, _tui, term) => {
+					term.resize(term.columns, 9);
+				},
+			},
+		],
+	},
+	{
+		name: "wide and bang-fit truncation lines in window",
+		width: 22,
+		initialLines: [
+			...makeRows(34),
+			"wide-ascii-" + "x".repeat(80),
+			"bang-fit-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+			"wide-cjk-界".repeat(20),
+		],
+		steps: [
+			{
+				name: "edit wide visible tail",
+				mutate: state => {
+					state.lines[state.lines.length - 1] = "wide-cjk-edited-界".repeat(20);
+				},
+			},
+			{
+				name: "append additional wide bang line",
+				mutate: state => {
+					state.lines = [...state.lines, "new-bang-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"];
+				},
+			},
+		],
+	},
+	{
+		name: "empty transcript",
+		initialLines: [],
+		steps: [
+			{
+				name: "empty rerender remains empty",
+				mutate: () => {},
+			},
+			{
+				name: "append after empty",
+				mutate: state => {
+					state.lines = ["after-empty"];
+				},
+			},
+		],
+	},
+	{
+		name: "transcript shorter than viewport",
+		height: 12,
+		initialLines: ["short-a", "short-b"],
+		steps: [
+			{
+				name: "edit short transcript line",
+				mutate: state => {
+					state.lines[1] = "short-b-edited";
+				},
+			},
+			{
+				name: "append but remain shorter than viewport",
+				mutate: state => {
+					state.lines = [...state.lines, "short-c"];
+				},
+			},
+		],
+	},
+];
+
+async function runScenario(
+	scenario: ScriptedScenario,
+	componentFactory: (lines: string[]) => ScriptedLines,
+	flagOn: boolean,
+): Promise<string[][]> {
+	if (flagOn) Bun.env[FLAG] = "1";
+	else delete Bun.env[FLAG];
+
+	const term = new VirtualTerminal(scenario.width ?? 40, scenario.height ?? 12);
+	const tui = new TUI(term);
+	const component = componentFactory(scenario.initialLines);
+	const state: ScenarioState = { lines: scenario.initialLines.slice() };
+	const snapshots: string[][] = [];
+	tui.addChild(component);
+
+	try {
+		tui.start();
+		await settle(term);
+		snapshots.push(capture(term));
+
+		for (const step of scenario.steps) {
+			step.mutate(state, tui, term);
+			applyLines(state, component);
+			tui.requestRender();
+			await settle(term);
+			snapshots.push(capture(term));
+		}
+	} finally {
+		tui.stop();
+	}
+
+	return snapshots;
+}
+
+describe("virtual viewport byte-identity red-team scenarios", () => {
+	let previousFlag: string | undefined;
+	let previousTmux: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		previousFlag = Bun.env[FLAG];
+		previousTmux = Bun.env.TMUX;
+		delete Bun.env.TMUX;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (previousFlag === undefined) delete Bun.env[FLAG];
+		else Bun.env[FLAG] = previousFlag;
+		if (previousTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = previousTmux;
+	});
+
+	for (const scenario of scenarios) {
+		it(`${scenario.name} with stable cached line instances`, async () => {
+			const off = await runScenario(scenario, lines => new CachedLines(lines), false);
+			const on = await runScenario(scenario, lines => new CachedLines(lines), true);
+			expect(on).toEqual(off);
+		});
+
+		it(`${scenario.name} with fresh line instances`, async () => {
+			const off = await runScenario(scenario, lines => new FreshLines(lines), false);
+			const on = await runScenario(scenario, lines => new FreshLines(lines), true);
+			expect(on).toEqual(off);
+		});
+	}
+});

--- a/packages/tui/test/viewport-virtualization.test.ts
+++ b/packages/tui/test/viewport-virtualization.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, renderMetrics, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const FLAG = "PI_TUI_VIRTUAL_VIEWPORT";
+
+/**
+ * Component that returns STABLE string instances for unchanged lines (mirroring the
+ * real caching components). The virtual-viewport optimization relies on this: an
+ * unchanged off-screen line keeps its reference, so its normalized form can be reused.
+ */
+class CachedLines implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = lines.slice();
+	}
+	setLine(index: number, value: string): void {
+		const next = this.#lines.slice(); // new array, but unchanged entries keep their instances
+		next[index] = value;
+		this.#lines = next;
+	}
+	append(value: string): void {
+		this.#lines = [...this.#lines, value];
+	}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return this.#lines; // stable array + stable string instances for unchanged lines
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function visible(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+describe("virtual viewport rendering (W1b / F1)", () => {
+	let prevFlag: string | undefined;
+	let prevTmux: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		prevFlag = Bun.env[FLAG];
+		prevTmux = Bun.env.TMUX;
+		delete Bun.env.TMUX;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (prevFlag === undefined) delete Bun.env[FLAG];
+		else Bun.env[FLAG] = prevFlag;
+		if (prevTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = prevTmux;
+	});
+
+	/** Run a scripted transcript scenario and capture the visible viewport after each step. */
+	async function runScenario(flagOn: boolean): Promise<string[][]> {
+		if (flagOn) Bun.env[FLAG] = "1";
+		else delete Bun.env[FLAG];
+		const term = new VirtualTerminal(40, 12);
+		const tui = new TUI(term);
+		const rows = Array.from({ length: 80 }, (_v, i) => `line-${i}`);
+		const content = new CachedLines(rows);
+		tui.addChild(content);
+		const snaps: string[][] = [];
+		try {
+			tui.start();
+			await settle(term);
+			snaps.push(visible(term)); // initial
+
+			// Append (streaming-like): touches only the bottom/viewport.
+			content.append("appended-A");
+			content.append("appended-B");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// In-place change of a visible (bottom) line.
+			content.setLine(81, "appended-A-edited");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Off-screen change (forces the fallback to full normalize/diff).
+			content.setLine(0, "line-0-edited-offscreen");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// No-op re-render (spinner-like): nothing changed.
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Overlay composition (show, then hide).
+			const overlay = new CachedLines(["overlay-row-1", "overlay-row-2"]);
+			tui.showOverlay(overlay, { anchor: "center" });
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			tui.hideOverlay();
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Resize width (forces the full-redraw path) and height.
+			term.resize(30, 12);
+			await settle(term);
+			snaps.push(visible(term));
+
+			term.resize(30, 18);
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Append after resize so the post-resize windowed path is exercised too.
+			content.append("post-resize-append");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+		} finally {
+			tui.stop();
+		}
+		return snaps;
+	}
+
+	it("produces byte-identical visible output with the flag on vs off", async () => {
+		const off = await runScenario(false);
+		const on = await runScenario(true);
+		expect(on).toEqual(off);
+	});
+
+	it("bounds normalize/diff work to ~viewport on a 100k-line transcript (flag on)", async () => {
+		Bun.env[FLAG] = "1";
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		const term = new VirtualTerminal(40, 40);
+		const tui = new TUI(term);
+		const big = Array.from({ length: 100_000 }, (_v, i) => `row-${i}`);
+		const content = new CachedLines(big);
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term); // first render: full normalize (100k)
+
+			const afterFirst = renderMetrics.snapshot().lineCounts;
+			expect(afterFirst.normalized?.max).toBeGreaterThanOrEqual(100_000);
+
+			// Change only the bottom line, then re-render: off-screen prefix is reused.
+			content.setLine(99_999, "row-99999-edited");
+			tui.requestRender();
+			await settle(term);
+
+			const lc = renderMetrics.snapshot().lineCounts;
+			// Visible window is 40 rows + 8 overscan; normalized/diffed last value must be bounded,
+			// not the full 100k transcript.
+			expect(lc.normalized?.last).toBeLessThanOrEqual(60);
+			expect(lc.diffed?.last).toBeLessThanOrEqual(60);
+			expect(lc.offscreenScan?.last).toBeGreaterThan(99_000);
+		} finally {
+			tui.stop();
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
+	});
+});


### PR DESCRIPTION
## Scope
TUI rendering, component lifecycle, and markdown hardening for long-running sessions (part 1/5 of the long-running-session freeze/leak remediation).

Findings addressed: **F1, F2, F3, F11, F12, F16, F18**.

## Changes
- **Spread-safe render (F2 + F1 metrics)** — `Container.render` emits lines via a loop instead of `push(...spread)`, eliminating the `RangeError: Maximum call stack` on huge (~492k-line) frames; adds line-count gauges in `metrics.ts`.
- **Component lifecycle / dispose (F11/F12/F16)** — `Component`/`Container`/`Box` gain `dispose()`. `clear()`/`removeChild()` dispose children; `detachChild()`/`detachAll()` do **not** (reuse-safe). Tool/loader/oauth-selector/mcp-wizard/extension-ui components dispose timers/spinners. Reused live components (streaming, pending bash/python) are detached, not disposed, before re-add.
- **Viewport virtualization (F1)** — opt-in windowed normalize/diff behind `PI_TUI_VIRTUAL_VIEWPORT` (**default OFF**); byte-identical to current output, O(rows) instead of O(scrollback) at 100k+ lines. Documented in `docs/tui-runtime-internals.md`.
- **Markdown highlight bounds (F3/F18)** — per-code-block highlight LRU cache + UTF-8 byte/line cap; assistant-message instance reuse via `setText`.

## Verification
- `bun run check:ts` — green across all workspaces.
- `bun test` (tui targeted): **109 pass / 0 fail** across 10 files (container-spread-safe, component-dispose, cancellable-loader-dispose, markdown-highlight, viewport-virtualization + red-team variants, markdown).

## Safety
Behavior-preserving by default; the only behavioral change (viewport virtualization) is gated OFF behind an env flag and verified byte-identical when enabled.