### PR TITLE
fix(mcp): transport + manager lifecycle cleanup (U8)

### DIFF
--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -74,8 +74,20 @@ function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	return tracked;
 }
 
-function delay(ms: number): Promise<void> {
-	return Bun.sleep(ms);
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (!signal) return Bun.sleep(ms);
+	if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Aborted"));
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal.reason ?? new Error("Aborted"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
 }
 
 /**
@@ -166,10 +178,26 @@ export class MCPManager {
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
 	#disconnectEpochs = new Map<string, number>();
+	#reconnectBackoffs = new Map<string, AbortController>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
+
+	#isCurrentConnection(
+		name: string,
+		_config: MCPServerConfig,
+		globalEpoch: number,
+		disconnectEpoch: number,
+		connection: MCPServerConnection,
+	): boolean {
+		return (
+			this.#serverConfigs.has(name) &&
+			this.#epoch === globalEpoch &&
+			(this.#disconnectEpochs.get(name) ?? 0) === disconnectEpoch &&
+			this.#connections.get(name) === connection
+		);
+	}
 
 	constructor(
 		private cwd: string,
@@ -305,6 +333,8 @@ export class MCPManager {
 			tracked: TrackedPromise<ToolLoadResult>;
 			toolsPromise: Promise<ToolLoadResult>;
 			connectionAbort: AbortController;
+			connectionEpoch: number;
+			disconnectEpoch: number;
 		};
 
 		const errors = new Map<string, string>();
@@ -312,6 +342,7 @@ export class MCPManager {
 		const allTools: CustomTool<TSchema, MCPToolDetails>[] = [];
 		const reportedErrors = new Set<string>();
 		let allowBackgroundLogging = false;
+		let shouldPublishToolSnapshot = true;
 
 		// Prepare connection tasks
 		const connectionTasks: ConnectionTask[] = [];
@@ -352,6 +383,7 @@ export class MCPManager {
 			this.#serverConfigs.set(name, config);
 
 			const connectionEpoch = this.#epoch;
+			const disconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 			const connectionAbort = new AbortController();
 			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
@@ -375,7 +407,10 @@ export class MCPManager {
 						connection._source = sources[name];
 					}
 					const stillPending = this.#pendingConnections.get(name) === connectionPromise;
-					const stillCurrent = this.#epoch === connectionEpoch && this.#serverConfigs.get(name) === config;
+					const stillCurrent =
+						this.#epoch === connectionEpoch &&
+						(this.#disconnectEpochs.get(name) ?? 0) === disconnectEpoch &&
+						this.#serverConfigs.get(name) === config;
 					if (stillPending) {
 						this.#pendingConnections.delete(name);
 						this.#pendingConnectionControllers.delete(name);
@@ -419,24 +454,45 @@ export class MCPManager {
 			this.#pendingConnections.set(name, connectionPromise);
 
 			const toolsPromise = connectionPromise.then(async connection => {
-				const serverTools = await listTools(connection);
+				let serverTools: Awaited<ReturnType<typeof listTools>>;
+				try {
+					serverTools = await listTools(connection);
+				} catch (error) {
+					connection.transport.onClose = undefined;
+					if (this.#connections.get(name) === connection) this.#connections.delete(name);
+					void connection.transport.close().catch(() => {});
+					throw error;
+				}
+				if (!this.#isCurrentConnection(name, config, connectionEpoch, disconnectEpoch, connection)) {
+					connection.transport.onClose = undefined;
+					await connection.transport.close().catch(() => {});
+					throw new Error(`Server "${name}" was disconnected during tool loading`);
+				}
 				return { connection, serverTools };
 			});
 			this.#pendingToolLoads.set(name, toolsPromise);
 
 			const tracked = trackPromise(toolsPromise);
-			connectionTasks.push({ name, config, tracked, toolsPromise, connectionAbort });
+			connectionTasks.push({
+				name,
+				config,
+				tracked,
+				toolsPromise,
+				connectionAbort,
+				connectionEpoch,
+				disconnectEpoch,
+			});
 
 			void toolsPromise
 				.then(async ({ connection, serverTools }) => {
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
+					if (!this.#isCurrentConnection(name, config, connectionEpoch, disconnectEpoch, connection)) return;
 					this.#pendingToolLoads.delete(name);
 					const reconnect = () => this.reconnectServer(name);
 					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 					this.#replaceServerTools(name, customTools);
 					this.#onToolsChanged?.(this.#tools);
 					void this.toolCache?.set(name, config, serverTools);
-
 					await this.#loadServerResourcesAndPrompts(name, connection);
 				})
 				.catch(error => {
@@ -498,6 +554,13 @@ export class MCPManager {
 					const value = task.tracked.value;
 					if (!value) continue;
 					const { connection, serverTools } = value;
+					if (this.#pendingToolLoads.has(name) && this.#pendingToolLoads.get(name) !== task.toolsPromise) continue;
+					if (
+						!this.#isCurrentConnection(name, task.config, task.connectionEpoch, task.disconnectEpoch, connection)
+					) {
+						shouldPublishToolSnapshot = false;
+						continue;
+					}
 					connectedServers.add(name);
 					const reconnect = () => this.reconnectServer(name);
 					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect));
@@ -506,6 +569,9 @@ export class MCPManager {
 						task.tracked.reason instanceof Error ? task.tracked.reason.message : String(task.tracked.reason);
 					errors.set(name, message);
 					reportedErrors.add(name);
+					if ((this.#disconnectEpochs.get(name) ?? 0) !== task.disconnectEpoch) {
+						shouldPublishToolSnapshot = false;
+					}
 				} else {
 					const cached = cachedTools.get(name);
 					if (cached) {
@@ -524,7 +590,7 @@ export class MCPManager {
 		sortMCPToolsByName(allTools);
 
 		// Update cached tools
-		this.#tools = allTools;
+		if (shouldPublishToolSnapshot) this.#tools = allTools;
 		allowBackgroundLogging = true;
 
 		return {
@@ -692,6 +758,8 @@ export class MCPManager {
 		this.#disconnectEpochs.set(name, nextEpoch);
 		this.#pendingConnectionControllers.get(name)?.abort(new Error(`MCP server disconnected: ${name}`));
 		this.#pendingConnectionControllers.delete(name);
+		this.#reconnectBackoffs.get(name)?.abort(new Error(`MCP server disconnected: ${name}`));
+		this.#reconnectBackoffs.delete(name);
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
@@ -742,6 +810,10 @@ export class MCPManager {
 		this.#pendingConnectionControllers.clear();
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();
+		for (const controller of this.#reconnectBackoffs.values()) {
+			controller.abort(new Error("MCP manager disconnected"));
+		}
+		this.#reconnectBackoffs.clear();
 		this.#pendingReconnections.clear();
 		this.#pendingResourceRefresh.clear();
 		this.#sources.clear();
@@ -764,7 +836,9 @@ export class MCPManager {
 
 		const attempt = this.#doReconnect(name);
 		this.#pendingReconnections.set(name, attempt);
-		return attempt.finally(() => this.#pendingReconnections.delete(name));
+		return attempt.finally(() => {
+			if (this.#pendingReconnections.get(name) === attempt) this.#pendingReconnections.delete(name);
+		});
 	}
 
 	async #doReconnect(name: string): Promise<MCPServerConnection | null> {
@@ -777,59 +851,72 @@ export class MCPManager {
 
 		// Close the old transport without removing tools or notifying consumers.
 		// Tools stay available (stale) while we establish the new connection.
-		// Fire-and-forget: don't await the close — HttpTransport.close() sends a
-		// DELETE with config.timeout (30s default), and blocking here delays the
-		// reconnect loop by that amount on every server restart.
-		const reconnectEpoch = this.#epoch;
+		const reconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 		if (oldConnection) {
 			// Detach onClose to prevent re-entrant reconnect from the close itself
 			oldConnection.transport.onClose = undefined;
-			void oldConnection.transport.close().catch(() => {});
+			const closePromise = oldConnection.transport.close().catch(() => {});
+			if (oldConnection.transport.closeBeforeReconnect) {
+				await closePromise;
+			} else {
+				// Fire-and-forget: don't await HTTP/SSE close — HttpTransport.close()
+				// sends a DELETE with config.timeout (30s default), and blocking here
+				// delays the reconnect loop by that amount on every server restart.
+				void closePromise;
+			}
 			this.#connections.delete(name);
 		}
 		this.#pendingConnections.delete(name);
+		const backoffAbort = new AbortController();
+		this.#reconnectBackoffs.set(name, backoffAbort);
 		this.#pendingToolLoads.delete(name);
 
-		// Retry with backoff — the server may still be starting up.
-		const delays = [500, 1000, 2000, 4000];
-		for (let attempt = 0; attempt <= delays.length; attempt++) {
-			if (this.#epoch !== reconnectEpoch) {
-				logger.debug("MCP reconnect aborted before attempt after configuration changed", {
-					path: `mcp:${name}`,
-					storedEpoch: reconnectEpoch,
-					currentEpoch: this.#epoch,
-				});
-				return null;
-			}
-			try {
-				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
-				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
-				return connection;
-			} catch (error) {
-				if (this.#epoch !== reconnectEpoch) {
-					logger.debug("MCP reconnect aborted after configuration changed", {
+		try {
+			// Retry with backoff — the server may still be starting up.
+			const delays = [500, 1000, 2000, 4000];
+			for (let attempt = 0; attempt <= delays.length; attempt++) {
+				if ((this.#disconnectEpochs.get(name) ?? 0) !== reconnectEpoch || backoffAbort.signal.aborted) {
+					logger.debug("MCP reconnect aborted before attempt after server disconnected", {
 						path: `mcp:${name}`,
 						storedEpoch: reconnectEpoch,
-						currentEpoch: this.#epoch,
+						currentEpoch: this.#disconnectEpochs.get(name) ?? 0,
 					});
 					return null;
 				}
+				try {
+					const connection = await this.#connectAndWireServer(name, config, source, this.#epoch, reconnectEpoch);
+					logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
+					return connection;
+				} catch (error) {
+					if ((this.#disconnectEpochs.get(name) ?? 0) !== reconnectEpoch || backoffAbort.signal.aborted) {
+						logger.debug("MCP reconnect aborted after server disconnected", {
+							path: `mcp:${name}`,
+							storedEpoch: reconnectEpoch,
+							currentEpoch: this.#disconnectEpochs.get(name) ?? 0,
+						});
+						return null;
+					}
 
-				const msg = error instanceof Error ? error.message : String(error);
-				if (attempt < delays.length) {
-					logger.debug("MCP reconnect attempt failed, retrying", {
-						path: `mcp:${name}`,
-						attempt: attempt + 1,
-						error: msg,
-					});
-					await Bun.sleep(delays[attempt]);
-				} else {
-					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
-					// Don't remove stale tools — keep them in the registry so they
-					// remain selected. Calls will fail with MCP errors, which
-					// triggers the tool-level reconnect, or the user can run
-					// /mcp reconnect <name> manually.
+					const msg = error instanceof Error ? error.message : String(error);
+					if (attempt < delays.length) {
+						logger.debug("MCP reconnect attempt failed, retrying", {
+							path: `mcp:${name}`,
+							attempt: attempt + 1,
+							error: msg,
+						});
+						await delay(delays[attempt], backoffAbort.signal).catch(() => undefined);
+					} else {
+						logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
+						// Don't remove stale tools — keep them in the registry so they
+						// remain selected. Calls will fail with MCP errors, which
+						// triggers the tool-level reconnect, or the user can run
+						// /mcp reconnect <name> manually.
+					}
 				}
+			}
+		} finally {
+			if (this.#reconnectBackoffs.get(name) === backoffAbort) {
+				this.#reconnectBackoffs.delete(name);
 			}
 		}
 		return null;
@@ -840,7 +927,8 @@ export class MCPManager {
 		name: string,
 		config: MCPServerConfig,
 		source: SourceMeta | undefined,
-		reconnectEpoch: number,
+		globalEpoch: number,
+		disconnectEpoch: number,
 	): Promise<MCPServerConnection> {
 		const resolvedConfig = await this.#resolveAuthConfig(config);
 		const connectionAbort = new AbortController();
@@ -867,7 +955,11 @@ export class MCPManager {
 
 		// Bail out if the server was disconnected or the manager was reset
 		// while we were connecting (e.g. /mcp reload called disconnectAll).
-		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
+		if (
+			!this.#serverConfigs.has(name) ||
+			this.#epoch !== globalEpoch ||
+			(this.#disconnectEpochs.get(name) ?? 0) !== disconnectEpoch
+		) {
 			await connection.transport.close().catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
@@ -890,6 +982,11 @@ export class MCPManager {
 		};
 		try {
 			const serverTools = await listTools(connection);
+			if (!this.#isCurrentConnection(name, config, globalEpoch, disconnectEpoch, connection)) {
+				connection.transport.onClose = undefined;
+				await connection.transport.close().catch(() => {});
+				throw new Error(`Server "${name}" was disconnected during tool loading`);
+			}
 			const reconnect = () => this.reconnectServer(name);
 			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 			void this.toolCache?.set(name, config, serverTools);
@@ -901,7 +998,7 @@ export class MCPManager {
 			// Clean up the connection to avoid zombie transports
 			connection.transport.onClose = undefined;
 			await connection.transport.close().catch(() => {});
-			this.#connections.delete(name);
+			if (this.#connections.get(name) === connection) this.#connections.delete(name);
 			throw error;
 		}
 	}
@@ -941,12 +1038,15 @@ export class MCPManager {
 	async refreshServerTools(name: string): Promise<void> {
 		const connection = this.#connections.get(name);
 		if (!connection) return;
+		const globalEpoch = this.#epoch;
+		const disconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 
 		// Clear cached tools
 		connection.tools = undefined;
 
 		// Reload tools
 		const serverTools = await listTools(connection);
+		if (!this.#isCurrentConnection(name, connection.config, globalEpoch, disconnectEpoch, connection)) return;
 		const reconnect = () => this.reconnectServer(name);
 		const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 		void this.toolCache?.set(name, connection.config, serverTools);

--- a/packages/coding-agent/src/runtime-mcp/transports/http.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/http.ts
@@ -99,6 +99,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {
+			await response.body?.cancel().catch(() => {});
 			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
 			return;
 		}
@@ -209,8 +210,6 @@ export class HttpTransport implements MCPTransport {
 				signal: operationSignal,
 			});
 
-			clearTimeout(timeoutId);
-
 			// Check for session ID in response
 			const newSessionId = response.headers.get("Mcp-Session-Id");
 			if (newSessionId) {
@@ -247,7 +246,6 @@ export class HttpTransport implements MCPTransport {
 
 			return result.result as T;
 		} catch (error) {
-			clearTimeout(timeoutId);
 			if (error instanceof Error && error.name === "AbortError") {
 				if (options?.signal?.aborted) {
 					throw error;
@@ -255,6 +253,8 @@ export class HttpTransport implements MCPTransport {
 				throw new Error(`Request timeout after ${timeout}ms`);
 			}
 			throw error;
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	}
 
@@ -273,12 +273,12 @@ export class HttpTransport implements MCPTransport {
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
 		let captured = false;
 
-		// Drain the SSE stream from a single iterator. We resolve the deferred
-		// promise as soon as the matching response arrives, then keep iterating
-		// in the background to pick up piggybacked notifications/requests.
-		// Re-reading `response.body` after `for await` breaks would lock the
-		// stream a second time and surface as "ReadableStream already has a
-		// controller", so we must not exit the loop early.
+		// Drain this per-request SSE response from a single iterator. Once the
+		// matching response arrives, resolve/reject and abort the reader so the
+		// response body is cancelled instead of lingering in the background.
+		// Re-reading `response.body` would lock the stream a second time and surface
+		// as "ReadableStream already has a controller", so the iterator owns the
+		// stream until it is aborted, completes, or errors.
 		const drainController = abortController;
 		this.#streamControllers.add(drainController);
 		const drain = async (): Promise<void> => {
@@ -293,13 +293,13 @@ export class HttpTransport implements MCPTransport {
 							("result" in message || "error" in message)
 						) {
 							captured = true;
-							clearTimeout(timeoutId);
+							drainController.abort();
 							if (message.error) {
 								reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
 							} else {
 								resolve(message.result as T);
 							}
-							continue;
+							return;
 						}
 						if (!this.#connected) continue;
 						this.#dispatchSSEMessage(message);
@@ -322,6 +322,7 @@ export class HttpTransport implements MCPTransport {
 			} finally {
 				clearTimeout(timeoutId);
 				this.#streamControllers.delete(drainController);
+				await response.body?.cancel().catch(() => {});
 			}
 		};
 

--- a/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
@@ -5,7 +5,8 @@
  * Messages are newline-delimited JSON.
  */
 
-import { getProjectDir, ptree, readJsonl, Snowflake } from "@gajae-code/utils";
+import { getProjectDir, readJsonl, Snowflake } from "@gajae-code/utils";
+import { type OwnedProcess, spawnOwnedProcess } from "../../runtime/process-lifecycle";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -24,7 +25,7 @@ import { toJsonRpcError } from "../../runtime-mcp/types";
 const CLOSE_WAIT_MS = 1_000;
 
 export class StdioTransport implements MCPTransport {
-	#process: ptree.ChildProcess<"pipe"> | null = null;
+	#process: OwnedProcess | null = null;
 	#pendingRequests = new Map<
 		string | number,
 		{
@@ -34,6 +35,8 @@ export class StdioTransport implements MCPTransport {
 	>();
 	#connected = false;
 	#readLoop: Promise<void> | null = null;
+	#stderrLoop: Promise<void> | null = null;
+	#closePromise: Promise<void> | null = null;
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -46,10 +49,17 @@ export class StdioTransport implements MCPTransport {
 		return this.#connected;
 	}
 
+	get closeBeforeReconnect(): true {
+		return true;
+	}
+
 	/**
 	 * Start the subprocess and begin reading.
 	 */
 	async connect(): Promise<void> {
+		if (this.#closePromise) {
+			throw new Error("Transport is closing");
+		}
 		if (this.#connected) return;
 
 		const args = this.config.args ?? [];
@@ -58,11 +68,12 @@ export class StdioTransport implements MCPTransport {
 			...this.config.env,
 		};
 
-		this.#process = ptree.spawn([this.config.command, ...args], {
+		this.#process = spawnOwnedProcess([this.config.command, ...args], {
 			cwd: this.config.cwd ?? getProjectDir(),
 			env,
 			stdin: "pipe",
-			stderr: "full",
+			gracefulMs: CLOSE_WAIT_MS,
+			name: `mcp-stdio:${this.config.command}`,
 		});
 
 		this.#connected = true;
@@ -71,13 +82,13 @@ export class StdioTransport implements MCPTransport {
 		this.#readLoop = this.#startReadLoop();
 
 		// Log stderr for debugging
-		this.#startStderrLoop();
+		this.#stderrLoop = this.#startStderrLoop();
 	}
 
 	async #startReadLoop(): Promise<void> {
-		if (!this.#process?.stdout) return;
+		if (!this.#process?.child.stdout) return;
 		try {
-			for await (const line of readJsonl(this.#process.stdout)) {
+			for await (const line of readJsonl(this.#process.child.stdout)) {
 				if (!this.#connected) break;
 				try {
 					this.#handleMessage(line as JsonRpcMessage);
@@ -95,9 +106,9 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async #startStderrLoop(): Promise<void> {
-		if (!this.#process?.stderr) return;
+		if (!this.#process?.child.stderr) return;
 
-		const reader = this.#process.stderr.getReader();
+		const reader = this.#process.child.stderr.getReader();
 		const decoder = new TextDecoder();
 
 		try {
@@ -168,26 +179,23 @@ export class StdioTransport implements MCPTransport {
 		}
 	}
 
+	#getStdin(): Bun.FileSink | null {
+		const stdin = this.#process?.child.stdin;
+		return typeof stdin === "object" && stdin !== null ? stdin : null;
+	}
+
 	#sendResponse(id: string | number, result?: unknown, error?: JsonRpcError): void {
-		if (!this.#connected || !this.#process?.stdin) return;
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) return;
 		const response = error
 			? { jsonrpc: "2.0" as const, id, error }
 			: { jsonrpc: "2.0" as const, id, result: result ?? {} };
-		this.#process.stdin.write(`${JSON.stringify(response)}\n`);
-		this.#process.stdin.flush();
+		stdin.write(`${JSON.stringify(response)}\n`);
+		stdin.flush();
 	}
 
 	#handleClose(): void {
-		if (!this.#connected) return;
-		this.#connected = false;
-
-		// Reject all pending requests
-		for (const [, pending] of this.#pendingRequests) {
-			pending.reject(new Error("Transport closed"));
-		}
-		this.#pendingRequests.clear();
-
-		this.onClose?.();
+		void this.#closeInternal(true);
 	}
 
 	async request<T = unknown>(
@@ -195,7 +203,8 @@ export class StdioTransport implements MCPTransport {
 		params?: Record<string, unknown>,
 		options?: MCPRequestOptions,
 	): Promise<T> {
-		if (!this.#connected || !this.#process?.stdin) {
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) {
 			throw new Error("Transport not connected");
 		}
 
@@ -261,8 +270,8 @@ export class StdioTransport implements MCPTransport {
 		const message = `${JSON.stringify(request)}\n`;
 		try {
 			// Bun's FileSink has write() method directly
-			this.#process.stdin.write(message);
-			this.#process.stdin.flush();
+			stdin.write(message);
+			stdin.flush();
 		} catch (error: unknown) {
 			cleanup();
 			reject(error instanceof Error ? error : new Error(String(error)));
@@ -272,7 +281,8 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async notify(method: string, params?: Record<string, unknown>): Promise<void> {
-		if (!this.#connected || !this.#process?.stdin) {
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) {
 			throw new Error("Transport not connected");
 		}
 
@@ -284,35 +294,51 @@ export class StdioTransport implements MCPTransport {
 
 		const message = `${JSON.stringify(notification)}\n`;
 		// Bun's FileSink has write() method directly
-		this.#process.stdin.write(message);
-		this.#process.stdin.flush();
+		stdin.write(message);
+		stdin.flush();
 	}
 
 	async close(): Promise<void> {
-		if (!this.#connected) return;
+		await this.#closeInternal(false);
+	}
+
+	#closeInternal(fromReadLoop: boolean): Promise<void> {
+		if (this.#closePromise) return this.#closePromise;
+		this.#closePromise = this.#finishClose(fromReadLoop).finally(() => {
+			this.#closePromise = null;
+		});
+		return this.#closePromise;
+	}
+
+	async #finishClose(fromReadLoop: boolean): Promise<void> {
+		const wasConnected = this.#connected;
 		this.#connected = false;
 
-		// Reject pending requests
 		for (const [, pending] of this.#pendingRequests) {
 			pending.reject(new Error("Transport closed"));
 		}
 		this.#pendingRequests.clear();
 
-		// Terminate the subprocess tree and keep the handle until exit is observed.
+		const stdin = this.#getStdin();
 		const process = this.#process;
+		this.#process = null;
 		if (process) {
-			process.kill();
-			await Promise.race([process.exited.catch(() => {}), Bun.sleep(CLOSE_WAIT_MS)]);
-			this.#process = null;
+			stdin?.end();
+			await process.dispose().catch(() => {});
+			await process.awaitExit({ timeoutMs: CLOSE_WAIT_MS }).catch(() => ({ exited: false, code: null }));
 		}
 
-		// Wait for read loop to finish
-		if (this.#readLoop) {
+		if (!fromReadLoop && this.#readLoop) {
 			await this.#readLoop.catch(() => {});
-			this.#readLoop = null;
+		}
+		this.#readLoop = null;
+
+		if (this.#stderrLoop) {
+			await this.#stderrLoop.catch(() => {});
+			this.#stderrLoop = null;
 		}
 
-		this.onClose?.();
+		if (wasConnected) this.onClose?.();
 	}
 }
 

--- a/packages/coding-agent/src/runtime-mcp/types.ts
+++ b/packages/coding-agent/src/runtime-mcp/types.ts
@@ -225,6 +225,9 @@ export interface MCPTransport {
 	/** Close the transport */
 	close(): Promise<void>;
 
+	/** Whether close must finish before reconnect can safely spawn a replacement. */
+	readonly closeBeforeReconnect?: boolean;
+
 	/** Whether the transport is connected */
 	readonly connected: boolean;
 

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, test } from "bun:test";
+import { MCPManager } from "../../src/runtime-mcp/manager";
+import type { JsonRpcMessage } from "../../src/runtime-mcp/types";
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function readPidList(path: string): Promise<number[]> {
+	const text = await Bun.file(path)
+		.text()
+		.catch(() => "");
+	return text
+		.split(/\n+/)
+		.map(line => Number(line.trim()))
+		.filter(pid => Number.isInteger(pid) && pid > 0);
+}
+
+function stdioServerScript(behavior: "failTools" | "okTools"): string {
+	return `
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' } } }) + '\\n');
+  } else if (msg.method === 'tools/list') {
+    ${behavior === "failTools" ? "process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: 'boom' } }) + '\\n');" : "process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } }) + '\\n');"}
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\\n');
+  }
+});
+setInterval(() => {}, 1000);
+`;
+}
+
+describe("MCP manager lifecycle cleanup", () => {
+	test("initial listTools failure closes transport and does not register server", async () => {
+		const manager = new MCPManager(process.cwd());
+		const result = await manager.connectServers(
+			{
+				bad: { command: "node", args: ["-e", stdioServerScript("failTools")], timeout: 1_000 },
+			},
+			{},
+		);
+
+		expect(result.connectedServers).toEqual([]);
+		expect(result.errors.get("bad")).toContain("boom");
+		expect(manager.getConnectedServers()).toEqual([]);
+		await expect(manager.waitForConnection("bad")).rejects.toThrow("MCP server not connected: bad");
+	});
+
+	test("disconnect cancels an in-flight reconnect backoff", async () => {
+		let failRequests = true;
+		let requestCount = 0;
+		let postDisconnectRequests = 0;
+		let countAfterDisconnect = false;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				requestCount++;
+				if (countAfterDisconnect) postDisconnectRequests++;
+				if (failRequests) return new Response("down", { status: 503 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: {
+							protocolVersion: "2025-03-26",
+							capabilities: { tools: {} },
+							serverInfo: { name: "http-test", version: "1" },
+						},
+					});
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id: "id" in body ? body.id : 0, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			await manager.connectServers(
+				{
+					good: { type: "http", url: server.url.href, timeout: 500 },
+				},
+				{},
+			);
+			failRequests = true;
+			postDisconnectRequests = 0;
+			const reconnect = manager.reconnectServer("good");
+			await waitFor(() => requestCount > 2);
+			await manager.disconnectServer("good");
+			countAfterDisconnect = true;
+			failRequests = false;
+			const afterDisconnect = postDisconnectRequests;
+			await Bun.sleep(700);
+			await expect(reconnect).resolves.toBeNull();
+			expect(postDisconnectRequests).toBe(afterDisconnect);
+			expect(manager.getConnectedServers()).toEqual([]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("disconnect during in-flight reconnect prevents stale same-name re-add from registering", async () => {
+		let initializeCount = 0;
+		let releaseFirstInitialize: (() => void) | undefined;
+		let deleteCount = 0;
+		const firstInitialize = new Promise<void>(resolve => {
+			releaseFirstInitialize = resolve;
+		});
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") {
+					deleteCount++;
+					return new Response(null, { status: 202 });
+				}
+				if (req.method === "GET") {
+					return new Response(null, { status: 405 });
+				}
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					if (initializeCount === 2) await firstInitialize;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale", version: "1" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 500 };
+			const initial = await manager.connectServers({ stale: config }, {});
+			expect(initial.errors.size).toBe(0);
+			expect(initial.connectedServers).toEqual(["stale"]);
+			const reconnect = manager.reconnectServer("stale");
+			await waitFor(() => initializeCount === 2);
+			await manager.disconnectServer("stale");
+			const result = await manager.connectServers({ stale: config }, {});
+			expect(result.errors.size).toBe(0);
+			expect(result.connectedServers).toEqual(["stale"]);
+			expect(manager.getConnectedServers()).toEqual(["stale"]);
+			releaseFirstInitialize?.();
+			await expect(reconnect).resolves.toBeNull();
+			expect(manager.getConnectedServers()).toEqual(["stale"]);
+			await waitFor(() => deleteCount > 0);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale initial tools/list success does not overwrite fresh same-name tools", async () => {
+		let releaseStaleTools: (() => void) | undefined;
+		const staleToolsBlocked = new Promise<void>(resolve => {
+			releaseStaleTools = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-success", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 1) await staleToolsBlocked;
+					const suffix = toolsListCount === 1 ? "stale" : "fresh";
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: suffix, inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const firstConnect = manager.connectServers({ same: config }, {});
+			await waitFor(() => toolsListCount === 1);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+			releaseStaleTools?.();
+			await expect(firstConnect).resolves.toMatchObject({ connectedServers: [] });
+			await Bun.sleep(50);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale initial tools/list failure does not delete fresh same-name connection", async () => {
+		let releaseStaleTools: (() => void) | undefined;
+		const staleToolsBlocked = new Promise<void>(resolve => {
+			releaseStaleTools = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-failure", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 1) {
+						await staleToolsBlocked;
+						return Response.json({ jsonrpc: "2.0", id, error: { code: -32000, message: "stale boom" } });
+					}
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: "fresh", inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const firstConnect = manager.connectServers({ same: config }, {});
+			await waitFor(() => toolsListCount === 1);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+			releaseStaleTools?.();
+			const stale = await firstConnect;
+			expect(stale.errors.get("same")).toContain("stale boom");
+			await Bun.sleep(50);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+			expect(manager.getConnectionStatus("same")).toBe("connected");
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale refresh tools/list success does not overwrite fresh same-name tools", async () => {
+		let releaseStaleRefresh: (() => void) | undefined;
+		const staleRefreshBlocked = new Promise<void>(resolve => {
+			releaseStaleRefresh = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-refresh", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 2) await staleRefreshBlocked;
+					const suffix = toolsListCount === 2 ? "staleRefresh" : toolsListCount === 1 ? "freshOne" : "freshThree";
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: suffix, inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const initial = await manager.connectServers({ same: config }, {});
+			expect(initial.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshone"]);
+
+			const refresh = manager.refreshServerTools("same");
+			await waitFor(() => toolsListCount === 2);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshthree"]);
+
+			releaseStaleRefresh?.();
+			await refresh;
+			await Bun.sleep(50);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshthree"]);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stdio reconnect waits for old process tree to die before spawning replacement", async () => {
+		const pidFile = `/tmp/gjc-mcp-manager-reconnect-${Date.now()}-${Math.random().toString(36).slice(2)}.pid`;
+		const childPidFile = `${pidFile}.child`;
+		const startupOldAliveFile = `${pidFile}.old-alive`;
+		const serverScript = `
+const fs = require("fs");
+const cp = require("child_process");
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch (error) { return error && error.code === "EPERM"; }
+}
+const priorChildren = fs.existsSync(${JSON.stringify(childPidFile)}) ? fs.readFileSync(${JSON.stringify(childPidFile)}, "utf8").trim().split(/\\n+/).filter(Boolean).map(Number) : [];
+if (priorChildren.length > 0) fs.appendFileSync(${JSON.stringify(startupOldAliveFile)}, String(alive(priorChildren[0])) + "\\n");
+const child = cp.spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], { stdio: "ignore" });
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+fs.appendFileSync(${JSON.stringify(childPidFile)}, String(child.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "test", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [] } }) + "\\n");
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} }) + "\\n");
+  }
+});
+setInterval(() => {}, 1000);
+`;
+		const manager = new MCPManager(process.cwd());
+		try {
+			const result = await manager.connectServers(
+				{
+					stdio: { type: "stdio", command: process.execPath, args: ["-e", serverScript], timeout: 1_000 },
+				},
+				{},
+			);
+			expect(result.errors.size).toBe(0);
+			await waitFor(async () => (await readPidList(childPidFile)).length >= 1);
+			const oldChildPid = (await readPidList(childPidFile))[0]!;
+			expect(isAlive(oldChildPid)).toBe(true);
+
+			await expect(manager.reconnectServer("stdio")).resolves.toBeDefined();
+			await waitFor(async () => (await readPidList(childPidFile)).length >= 2);
+			const childPids = await readPidList(childPidFile);
+			const newChildPid = childPids.at(-1)!;
+			expect(newChildPid).not.toBe(oldChildPid);
+			expect(isAlive(oldChildPid)).toBe(false);
+			expect(isAlive(newChildPid)).toBe(true);
+			expect(
+				(
+					await Bun.file(startupOldAliveFile)
+						.text()
+						.catch(() => "")
+				).trim(),
+			).toBe("false");
+		} finally {
+			await manager.disconnectAll().catch(() => {});
+			await Bun.file(pidFile)
+				.delete()
+				.catch(() => {});
+			await Bun.file(childPidFile)
+				.delete()
+				.catch(() => {});
+			await Bun.file(startupOldAliveFile)
+				.delete()
+				.catch(() => {});
+		}
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.redteam.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
+import { MCPManager } from "../../src/runtime-mcp/manager";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+
+const servers: Bun.Server<unknown>[] = [];
+const managers: MCPManager[] = [];
+const tmpFiles: string[] = [];
+
+function tmpPath(name: string): string {
+	const path = join("/tmp", `gjc-u8-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	tmpFiles.push(path);
+	return path;
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function readPidList(path: string): Promise<number[]> {
+	const text = await Bun.file(path)
+		.text()
+		.catch(() => "");
+	return text
+		.split(/\n+/)
+		.map(line => Number(line.trim()))
+		.filter(pid => Number.isInteger(pid) && pid > 0);
+}
+
+afterEach(async () => {
+	for (const manager of managers.splice(0)) {
+		await manager.disconnectAll().catch(() => {});
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop(true);
+	}
+	for (const path of tmpFiles.splice(0)) {
+		await Bun.file(path)
+			.delete()
+			.catch(() => {});
+	}
+});
+
+describe("MCP transport lifecycle red-team regressions", () => {
+	test("stdio stdout EOF while process is alive reconnects after killing the old owned child tree", async () => {
+		const before = liveOwnedProcessCount();
+		const pidFile = tmpPath("stdio-pids");
+		const childPidFile = tmpPath("stdio-child-pids");
+		const serverScript = `
+const fs = require("fs");
+const cp = require("child_process");
+const child = cp.spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], { stdio: "ignore" });
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+fs.appendFileSync(${JSON.stringify(childPidFile)}, String(child.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+let sawTools = false;
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "redteam", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ok", inputSchema: { type: "object" } }] } }) + "\\n", () => {
+      if (!sawTools) {
+        sawTools = true;
+        process.stdout.end();
+      }
+    });
+  }
+});
+setInterval(()=>{},1000);
+`;
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers(
+			{
+				red: {
+					type: "stdio",
+					command: process.execPath,
+					args: ["-e", serverScript],
+					timeout: 1_000,
+				},
+			},
+			{},
+		);
+		expect(result.errors.size).toBe(0);
+		expect(result.connectedServers).toEqual(["red"]);
+
+		await waitFor(async () => (await readPidList(pidFile)).length >= 1, 1_000);
+		const connection = manager.getConnection("red");
+		expect(connection).toBeDefined();
+		connection!.transport.onClose?.();
+		await waitFor(async () => (await readPidList(pidFile)).length >= 2, 3_500);
+		const serverPids = await readPidList(pidFile);
+		const childPids = await readPidList(childPidFile);
+		expect(serverPids.length).toBeGreaterThanOrEqual(2);
+		expect(childPids.length).toBeGreaterThanOrEqual(2);
+		const oldServerPid = serverPids[0]!;
+		const oldChildPid = childPids[0]!;
+		const newServerPid = serverPids.at(-1)!;
+		const newChildPid = childPids.at(-1)!;
+		expect(newServerPid).not.toBe(oldServerPid);
+		expect(newChildPid).not.toBe(oldChildPid);
+		await waitFor(() => !isAlive(oldServerPid) && !isAlive(oldChildPid), 2_000);
+		expect(isAlive(newServerPid)).toBe(true);
+		expect(isAlive(newChildPid)).toBe(true);
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+
+		await manager.disconnectServer("red");
+		await waitFor(() => !isAlive(newServerPid) && !isAlive(newChildPid), 2_000);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000);
+	});
+
+	test("HTTP response that sends headers then stalls its body rejects within configured timeout", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				return new Response(new ReadableStream({ start() {} }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 75 });
+		await transport.connect();
+		const started = Date.now();
+		await expect(transport.request("tools/list")).rejects.toThrow("Request timeout after 75ms");
+		expect(Date.now() - started).toBeLessThan(1_000);
+		await transport.close();
+	});
+
+	test("Streamable HTTP text/event-stream request aborts per-request reader after matching response", async () => {
+		let cancelCount = 0;
+		const originalCancel = ReadableStream.prototype.cancel;
+		ReadableStream.prototype.cancel = function (...args: Parameters<ReadableStream["cancel"]>) {
+			cancelCount++;
+			return originalCancel.apply(this, args);
+		};
+		try {
+			const server = Bun.serve({
+				port: 0,
+				idleTimeout: 255,
+				async fetch(req) {
+					const request = (await req.json()) as { id: string | number };
+					const stream = new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode(
+									`data: ${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n\n`,
+								),
+							);
+						},
+					});
+					return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+				},
+			});
+			servers.push(server);
+			const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 500 });
+			await transport.connect();
+			await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+			await waitFor(() => cancelCount > 0, 1_000);
+			await transport.close();
+		} finally {
+			ReadableStream.prototype.cancel = originalCancel;
+		}
+	});
+
+	test("initial listTools rejection closes transport and leaves server unregistered", async () => {
+		let deleteCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			async fetch(req) {
+				if (req.method === "DELETE") {
+					deleteCount++;
+					return new Response(null, { status: 202 });
+				}
+				if (req.method === "GET") {
+					return new Response(null, { status: 405 });
+				}
+				const request = (await req.json()) as { id: string | number; method: string };
+				if (request.method === "initialize") {
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id: request.id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "bad", version: "1" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": "bad-session" } },
+					);
+				}
+				if (request.method === "initialized" || request.method === "notifications/initialized") {
+					return new Response(null, { status: 202 });
+				}
+				return Response.json({ jsonrpc: "2.0", id: request.id, error: { code: -32000, message: "boom" } });
+			},
+		});
+		servers.push(server);
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers({ bad: { type: "http", url: server.url.href, timeout: 500 } }, {});
+		expect(result.connectedServers).toEqual([]);
+		expect(result.errors.get("bad")).toContain("boom");
+		expect(manager.getConnection("bad")).toBeUndefined();
+		expect(manager.getConnectionStatus("bad")).toBe("disconnected");
+		await waitFor(() => deleteCount > 0, 1_000);
+	});
+
+	test("disconnectServer during reconnect backoff prevents late reconnect and new child spawn", async () => {
+		const pidFile = tmpPath("backoff-pids");
+		const serverScript = `
+const fs = require("fs");
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "backoff", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ok", inputSchema: { type: "object" } }] } }) + "\\n", () => process.exit(0));
+  }
+});
+`;
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers(
+			{ backoff: { type: "stdio", command: process.execPath, args: ["-e", serverScript], timeout: 750 } },
+			{},
+		);
+		expect(result.errors.size).toBe(0);
+		await waitFor(() => manager.getConnectionStatus("backoff") === "connecting", 1_000);
+		await manager.disconnectServer("backoff");
+		const pidsAtDisconnect = await readPidList(pidFile);
+		await Bun.sleep(750);
+		expect(await readPidList(pidFile)).toEqual(pidsAtDisconnect);
+		expect(manager.getConnectionStatus("backoff")).toBe("disconnected");
+	});
+});
+
+mkdirSync("artifacts", { recursive: true });

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+import { StdioTransport } from "../../src/runtime-mcp/transports/stdio";
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+const servers: Bun.Server<unknown>[] = [];
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) {
+		await server.stop(true);
+	}
+});
+
+describe("MCP stdio transport lifecycle", () => {
+	test("close and reconnect dispose the old owned child tree", async () => {
+		const before = liveOwnedProcessCount();
+		const pidFile = `/tmp/gjc-mcp-stdio-${Date.now()}-${Math.random().toString(36).slice(2)}.pid`;
+		const command = [
+			"node",
+			"-e",
+			`const fs=require('fs'); const cp=require('child_process'); const child=cp.spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:false,stdio:'ignore'}); fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid)); setInterval(()=>{},1000);`,
+		];
+		const transport = new StdioTransport({ command: command[0], args: command.slice(1), timeout: 500 });
+		await transport.connect();
+		await waitFor(() => Bun.file(pidFile).exists());
+		const oldChildPid = Number(await Bun.file(pidFile).text());
+		expect(isAlive(oldChildPid)).toBe(true);
+
+		await transport.close();
+		await waitFor(() => !isAlive(oldChildPid));
+		expect(liveOwnedProcessCount()).toBe(before);
+
+		await Bun.write(pidFile, "");
+		await transport.connect();
+		await waitFor(async () => {
+			const text = await Bun.file(pidFile)
+				.text()
+				.catch(() => "");
+			return Number(text) > 0;
+		});
+		const newChildPid = Number(await Bun.file(pidFile).text());
+		expect(newChildPid).not.toBe(oldChildPid);
+		expect(isAlive(oldChildPid)).toBe(false);
+		await transport.close();
+		await waitFor(() => !isAlive(newChildPid));
+	});
+});
+
+describe("MCP HTTP transport lifecycle", () => {
+	test("request timeout covers hanging response bodies after headers", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				return new Response(new ReadableStream({ start() {} }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 100 });
+		await transport.connect();
+		await expect(transport.request("tools/list")).rejects.toThrow("Request timeout after 100ms");
+		await transport.close();
+	});
+
+	test("per-request SSE closes after matching response", async () => {
+		let nextId: string | number = "1";
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			async fetch(req) {
+				const request = (await req.json()) as { id?: string | number };
+				nextId = request.id ?? nextId;
+				const stream = new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								`data: {"jsonrpc":"2.0","id":${JSON.stringify(nextId)},"result":{"ok":true}}\n\n`,
+							),
+						);
+						controller.close();
+					},
+				});
+				return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 1_000 });
+		await transport.connect();
+		await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+
+		await transport.close();
+	});
+
+	test("failed GET SSE listener cancels the response body", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				const stream = new ReadableStream({
+					start(controller) {
+						controller.close();
+					},
+				});
+				return new Response(stream, { status: 500 });
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 1_000 });
+		await transport.connect();
+		await transport.startSSEListener();
+
+		await transport.close();
+	});
+});


### PR DESCRIPTION
Core-runtime fix campaign U8 (final unit). H15: stdio close idempotently terminates the F1-owned child tree (closeBeforeReconnect awaited on reconnect; shared in-flight close promise; connect rejects while closing) so reconnect cannot duplicate a live server. H16: HTTP request timeout covers body consumption (finally). H17: per-request SSE aborted after the matching response. H18: initial tools/list failure closes + does not register + propagates the original error. M4: failed GET SSE body cancelled. M5: stdio parent-exit cleanup via F1. M6: disconnect cancels reconnect backoff (abortable per-server epoch). Plus an identity/epoch freshness guard (#isCurrentConnection) on every post-listTools publication path (initial/reconnect/refreshServerTools) so a stale request cannot republish tools bound to a closed transport; map deletions identity-guarded. Tests: 16 pass (manager + transport lifecycle + red-team). tsgo+biome clean. Architect final re-review CLEAR/APPROVE (after 5 fix rounds). Base dev.