### PR TITLE
fix(session): bound blob-store memory and blob-resume concurrency (F8)

### DIFF
--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -167,10 +167,40 @@ export class EphemeralBlobStore extends BlobStore {
 }
 
 export class MemoryBlobStore extends BlobStore {
+	/**
+	 * Generous byte/count LRU bound (F8). Content-addressed resident blobs are fail-closed
+	 * on miss (callers raise/handle {@link ResidentBlobMissingError}), so evicting the
+	 * least-recently-used entry on an extremely large session is preferable to unbounded
+	 * RAM growth. The caps sit well above normal usage and only trip on pathological sizes.
+	 */
+	static readonly #MAX_BYTES = 64 * 1024 * 1024;
+	static readonly #MAX_COUNT = 4096;
+
 	#blobs = new Map<string, Buffer>();
+	#bytes = 0;
 
 	constructor() {
 		super(":memory:");
+	}
+
+	#store(hash: string, data: Buffer): void {
+		const existing = this.#blobs.get(hash);
+		if (existing) {
+			this.#blobs.delete(hash);
+			this.#bytes -= existing.byteLength;
+		}
+		this.#blobs.set(hash, data);
+		this.#bytes += data.byteLength;
+		while (
+			(this.#bytes > MemoryBlobStore.#MAX_BYTES || this.#blobs.size > MemoryBlobStore.#MAX_COUNT) &&
+			this.#blobs.size > 1
+		) {
+			const oldest = this.#blobs.keys().next().value;
+			if (oldest === undefined) break;
+			const evicted = this.#blobs.get(oldest);
+			this.#blobs.delete(oldest);
+			if (evicted) this.#bytes -= evicted.byteLength;
+		}
 	}
 
 	async put(data: Buffer): Promise<BlobPutResult> {
@@ -179,7 +209,7 @@ export class MemoryBlobStore extends BlobStore {
 
 	putSync(data: Buffer): BlobPutResult {
 		const hash = new Bun.SHA256().update(data).digest("hex");
-		this.#blobs.set(hash, Buffer.from(data));
+		this.#store(hash, Buffer.from(data));
 		return {
 			hash,
 			path: `memory:${hash}`,
@@ -195,7 +225,11 @@ export class MemoryBlobStore extends BlobStore {
 
 	getSync(hash: string): Buffer | null {
 		const data = this.#blobs.get(hash);
-		return data ? Buffer.from(data) : null;
+		if (!data) return null;
+		// Refresh LRU recency on hit so hot blobs survive eviction.
+		this.#blobs.delete(hash);
+		this.#blobs.set(hash, data);
+		return Buffer.from(data);
 	}
 
 	async has(hash: string): Promise<boolean> {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -889,8 +889,27 @@ async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, ke
 	);
 }
 
+/**
+ * Run async tasks with bounded concurrency so an image-heavy resume never materializes
+ * every blob's base64 simultaneously (F8: avoids the transient OOM spike of an unbounded
+ * Promise.all over all historical images).
+ */
+const BLOB_RESOLVE_CONCURRENCY = 8;
+async function runWithConcurrency(tasks: Array<() => Promise<void>>, limit: number): Promise<void> {
+	let next = 0;
+	const worker = async (): Promise<void> => {
+		while (next < tasks.length) {
+			const index = next;
+			next += 1;
+			await tasks[index]!();
+		}
+	};
+	const workerCount = Math.max(1, Math.min(limit, tasks.length));
+	await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}
+
 async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
-	const promises: Promise<void>[] = [];
+	const tasks: Array<() => Promise<void>> = [];
 
 	for (const entry of entries) {
 		if (entry.type === "session") continue;
@@ -902,22 +921,19 @@ async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobSto
 			contentArray = entry.content;
 		}
 
-		if (contentArray) {
-			for (const block of contentArray) {
-				if (isImageBlock(block) && isBlobRef(block.data)) {
-					promises.push(
-						resolveImageData(blobStore, block.data).then(resolved => {
-							block.data = resolved;
-						}),
-					);
+		tasks.push(async () => {
+			if (contentArray) {
+				for (const block of contentArray) {
+					if (isImageBlock(block) && isBlobRef(block.data)) {
+						block.data = await resolveImageData(blobStore, block.data);
+					}
 				}
 			}
-		}
-
-		promises.push(resolvePersistedBlobRefs(entry, blobStore));
+			await resolvePersistedBlobRefs(entry, blobStore);
+		});
 	}
 
-	await Promise.all(promises);
+	await runWithConcurrency(tasks, BLOB_RESOLVE_CONCURRENCY);
 }
 
 /**

--- a/packages/coding-agent/test/blob-store-bound.test.ts
+++ b/packages/coding-agent/test/blob-store-bound.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { MemoryBlobStore } from "@gajae-code/coding-agent/session/blob-store";
+
+describe("MemoryBlobStore byte/count LRU bound (W5 / F8)", () => {
+	it("evicts the least-recently-used blob beyond the count cap instead of growing unbounded", () => {
+		const store = new MemoryBlobStore();
+		const COUNT_CAP = 4096;
+		const hashes: string[] = [];
+		for (let i = 0; i < COUNT_CAP + 8; i++) {
+			hashes.push(store.putSync(Buffer.from(`blob-${i}`)).hash);
+		}
+		// Oldest insertions are evicted; the most recent survive.
+		expect(store.getSync(hashes[0]!)).toBeNull();
+		expect(store.getSync(hashes[7]!)).toBeNull();
+		expect(store.getSync(hashes[hashes.length - 1]!)).not.toBeNull();
+	});
+
+	it("refreshes recency on get so a hot blob survives eviction", () => {
+		const store = new MemoryBlobStore();
+		const COUNT_CAP = 4096;
+		const first = store.putSync(Buffer.from("hot-blob")).hash;
+		const second = store.putSync(Buffer.from("cold-blob")).hash;
+		for (let i = 0; i < COUNT_CAP - 2; i++) store.putSync(Buffer.from(`filler-${i}`));
+		// Touch `first` to move it to the most-recent position.
+		expect(store.getSync(first)).not.toBeNull();
+		// One more put evicts the now-oldest (`second`), not the refreshed `first`.
+		store.putSync(Buffer.from("trigger-eviction"));
+		expect(store.getSync(first)).not.toBeNull();
+		expect(store.getSync(second)).toBeNull();
+	});
+
+	it("round-trips content-addressed blobs under the cap", () => {
+		const store = new MemoryBlobStore();
+		const data = Buffer.from("hello blob");
+		const { hash, ref } = store.putSync(data);
+		expect(ref).toBe(`blob:sha256:${hash}`);
+		expect(store.getSync(hash)?.toString()).toBe("hello blob");
+	});
+});


### PR DESCRIPTION
## Scope
Session blob-store memory bounds (part 3/4 of the long-running-session freeze/leak remediation).

Finding addressed: **F8**.

## Changes
- **`MemoryBlobStore` LRU bound** — capped at 64 MiB / 4096 entries; oldest entries evicted, so blob retention cannot grow unbounded over a long session.
- **Bounded blob-resume concurrency** — session restore resumes blobs with a concurrency limit of 8 instead of all at once, capping peak memory/IO on resume.

## Verification
- `bun run check:ts` — green across all workspaces.
- Targeted tests: `blob-store-bound` **3 pass**.

## Scope note
This is the **F8** slice of the original blob/session-resume story. The remaining items from that story — **F7** (resident-window lazy-load of session messages) and **F10b** (async persistence) — are intentionally **not** included: F10b conflicts with the deliberate synchronous SIGKILL-durability design and both warrant a dedicated, separately-reviewed change. Tracked for follow-up.