### PR TITLE
fix(pi-natives): carry post-merge warning cleanup

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -27,22 +27,22 @@ use crate::{ps, task};
 #[napi(object)]
 pub struct PtyStartOptions<'env> {
 	/// Command string to execute.
-	pub command: String,
+	pub command:    String,
 	/// Working directory for command execution.
-	pub cwd: Option<String>,
+	pub cwd:        Option<String>,
 	/// Environment variables for this command.
-	pub env: Option<HashMap<String, String>>,
+	pub env:        Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:     Option<Unknown<'env>>,
 	/// PTY column count.
-	pub cols: Option<u16>,
+	pub cols:       Option<u16>,
 	/// PTY row count.
-	pub rows: Option<u16>,
+	pub rows:       Option<u16>,
 	/// Shell binary to use (e.g. "sh", "bash", or an absolute path).
 	/// Defaults to "sh" if not provided.
-	pub shell: Option<String>,
+	pub shell:      Option<String>,
 }
 
 /// Result of a PTY command run.
@@ -59,11 +59,11 @@ pub struct PtyRunResult {
 #[derive(Clone)]
 struct PtyRunConfig {
 	command: String,
-	cwd: Option<String>,
-	env: Option<HashMap<String, String>>,
-	cols: u16,
-	rows: u16,
-	shell: Option<String>,
+	cwd:     Option<String>,
+	env:     Option<HashMap<String, String>>,
+	cols:    u16,
+	rows:    u16,
+	shell:   Option<String>,
 }
 
 enum ReaderEvent {
@@ -101,10 +101,10 @@ impl Drop for PtySessionCore {
 }
 impl Drop for PtySession {
 	fn drop(&mut self) {
-		if let Ok(mut guard) = self.core.lock() {
-			if let Some(core) = guard.take() {
-				let _ = core.control_tx.send(ControlMessage::Kill);
-			}
+		if let Ok(mut guard) = self.core.lock()
+			&& let Some(core) = guard.take()
+		{
+			let _ = core.control_tx.send(ControlMessage::Kill);
 		}
 	}
 }
@@ -139,11 +139,11 @@ impl PtySession {
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: options.command,
-			cwd: options.cwd,
-			env: options.env,
-			cols: options.cols.unwrap_or(120).clamp(20, 400),
-			rows: options.rows.unwrap_or(40).clamp(5, 200),
-			shell: options.shell,
+			cwd:     options.cwd,
+			env:     options.env,
+			cols:    options.cols.unwrap_or(120).clamp(20, 400),
+			rows:    options.rows.unwrap_or(40).clamp(5, 200),
+			shell:   options.shell,
 		};
 		let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 		let core = Arc::clone(&self.core);
@@ -258,13 +258,20 @@ fn reap_terminated_child(
 		std::thread::sleep(Duration::from_millis(10));
 	}
 }
+type DisarmedPtyResources = (
+	Box<dyn Child + Send + Sync>,
+	Box<dyn portable_pty::MasterPty + Send>,
+	Box<dyn Write + Send>,
+	Option<i32>,
+	Option<i32>,
+);
 struct PostSpawnSetupGuard {
-	child: Option<Box<dyn Child + Send + Sync>>,
-	master: Option<Box<dyn portable_pty::MasterPty + Send>>,
-	writer: Option<Box<dyn Write + Send>>,
-	child_pid: Option<i32>,
+	child:            Option<Box<dyn Child + Send + Sync>>,
+	master:           Option<Box<dyn portable_pty::MasterPty + Send>>,
+	writer:           Option<Box<dyn Write + Send>>,
+	child_pid:        Option<i32>,
 	process_group_id: Option<i32>,
-	disarmed: bool,
+	disarmed:         bool,
 }
 
 impl PostSpawnSetupGuard {
@@ -297,7 +304,7 @@ impl PostSpawnSetupGuard {
 			.as_ref()
 	}
 
-	fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
+	fn take_writer(&self) -> Result<Box<dyn Write + Send>> {
 		let writer = self
 			.master()
 			.take_writer()
@@ -316,15 +323,7 @@ impl PostSpawnSetupGuard {
 			.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))
 	}
 
-	fn disarm(
-		mut self,
-	) -> (
-		Box<dyn Child + Send + Sync>,
-		Box<dyn portable_pty::MasterPty + Send>,
-		Box<dyn Write + Send>,
-		Option<i32>,
-		Option<i32>,
-	) {
+	fn disarm(mut self) -> DisarmedPtyResources {
 		self.disarmed = true;
 		(
 			self.child.take().expect("setup guard owns PTY child"),
@@ -373,7 +372,7 @@ fn try_send_reader_event(
 	if *dropped_chunks > 0 {
 		match tx.try_send(ReaderEvent::Loss {
 			dropped_chunks: *dropped_chunks,
-			dropped_bytes: *dropped_bytes,
+			dropped_bytes:  *dropped_bytes,
 		}) {
 			Ok(()) => {
 				*dropped_chunks = 0;
@@ -403,7 +402,10 @@ fn send_reader_final_events(
 ) -> bool {
 	if *dropped_chunks > 0 {
 		if tx
-			.send(ReaderEvent::Loss { dropped_chunks: *dropped_chunks, dropped_bytes: *dropped_bytes })
+			.send(ReaderEvent::Loss {
+				dropped_chunks: *dropped_chunks,
+				dropped_bytes:  *dropped_bytes,
+			})
 			.is_err()
 		{
 			return false;
@@ -458,6 +460,7 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before openpty: {err}")))?;
 
+	#[cfg(windows)]
 	const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 	let pair = if cfg!(windows) {
 		// Windows ConPTY openpty() can hang indefinitely when the console
@@ -469,9 +472,9 @@ fn run_pty_sync(
 			let (tx, rx) = mpsc::channel();
 			let handle = std::thread::spawn(move || {
 				let result = pty_system.openpty(PtySize {
-					rows: config.rows,
-					cols: config.cols,
-					pixel_width: 0,
+					rows:         config.rows,
+					cols:         config.cols,
+					pixel_width:  0,
 					pixel_height: 0,
 				});
 				let _ = tx.send(result);
@@ -501,7 +504,12 @@ fn run_pty_sync(
 		unreachable!()
 	} else {
 		pty_system
-			.openpty(PtySize { rows: config.rows, cols: config.cols, pixel_width: 0, pixel_height: 0 })
+			.openpty(PtySize {
+				rows:         config.rows,
+				cols:         config.cols,
+				pixel_width:  0,
+				pixel_height: 0,
+			})
 			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?
 	};
 
@@ -538,6 +546,10 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
+	#[cfg_attr(
+		not(windows),
+		allow(unused_mut, reason = "writer is mutated only in the Windows-gated cursor-reply block")
+	)]
 	let mut writer = setup_guard.take_writer()?;
 	// ConPTY sends ESC[6n (cursor position query) and blocks until we reply.
 	// Reply with cursor at 1,1 so it unblocks the child spawn.
@@ -878,11 +890,11 @@ mod tests {
 	fn test_config(command: &str) -> PtyRunConfig {
 		PtyRunConfig {
 			command: command.to_string(),
-			cwd: None,
-			env: None,
-			cols: 80,
-			rows: 24,
-			shell: Some("sh".to_string()),
+			cwd:     None,
+			env:     None,
+			cols:    80,
+			rows:    24,
+			shell:   Some("sh".to_string()),
 		}
 	}
 

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -27,19 +27,19 @@ const SHELL_LOSS_MARKER_PREFIX: &str = "\n[Shell output truncated: ";
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled: Option<bool>,
+	pub enabled:           Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path: Option<String>,
+	pub settings_path:     Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash: Option<String>,
+	pub settings_hash:     Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only: Option<Vec<String>>,
+	pub only:              Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except: Option<Vec<String>>,
+	pub except:            Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
 	pub max_capture_bytes: Option<u32>,
@@ -48,11 +48,11 @@ pub struct MinimizerOptions {
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled: value.enabled,
-			settings_path: value.settings_path,
-			settings_hash: value.settings_hash,
-			only: value.only,
-			except: value.except,
+			enabled:           value.enabled,
+			settings_path:     value.settings_path,
+			settings_hash:     value.settings_hash,
+			only:              value.only,
+			except:            value.except,
 			max_capture_bytes: value.max_capture_bytes,
 		}
 	}
@@ -62,19 +62,19 @@ impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 #[napi(object)]
 pub struct ShellOptions {
 	/// Environment variables to apply once per session.
-	pub session_env: Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer: Option<MinimizerOptions>,
+	pub minimizer:     Option<MinimizerOptions>,
 }
 
 impl From<ShellOptions> for CoreShellOptions {
 	fn from(value: ShellOptions) -> Self {
 		Self {
-			session_env: value.session_env,
+			session_env:   value.session_env,
 			snapshot_path: value.snapshot_path,
-			minimizer: value.minimizer.map(Into::into),
+			minimizer:     value.minimizer.map(Into::into),
 		}
 	}
 }
@@ -83,36 +83,36 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command: String,
+	pub command:    String,
 	/// Working directory for the command.
-	pub cwd: Option<String>,
+	pub cwd:        Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env: Option<HashMap<String, String>>,
+	pub env:        Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:     Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command: String,
+	pub command:       String,
 	/// Working directory for the command.
-	pub cwd: Option<String>,
+	pub cwd:           Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env: Option<HashMap<String, String>>,
+	pub env:           Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env: Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms: Option<u32>,
+	pub timeout_ms:    Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer: Option<MinimizerOptions>,
+	pub minimizer:     Option<MinimizerOptions>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:        Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -126,27 +126,27 @@ pub struct ShellExecuteOptions<'env> {
 pub struct MinimizerResult {
 	/// Dispatch label produced by the minimizer (e.g. `"git"`,
 	/// `"pipeline:gradle"`, `"pipeline+builtin"`).
-	pub filter: String,
+	pub filter:        String,
 	/// The minimized replacement text. Callers that streamed raw chunks
 	/// during execution should clear and replace their accumulated output
 	/// with this text.
-	pub text: String,
+	pub text:          String,
 	/// The full original capture, before minimization.
 	pub original_text: String,
 	/// Captured byte length before minimization.
-	pub input_bytes: u32,
+	pub input_bytes:   u32,
 	/// Byte length of the minimized text the consumer received.
-	pub output_bytes: u32,
+	pub output_bytes:  u32,
 }
 
 impl From<CoreMinimizerResult> for MinimizerResult {
 	fn from(value: CoreMinimizerResult) -> Self {
 		Self {
-			filter: value.filter,
-			text: value.text,
+			filter:        value.filter,
+			text:          value.text,
 			original_text: value.original_text,
-			input_bytes: value.input_bytes,
-			output_bytes: value.output_bytes,
+			input_bytes:   value.input_bytes,
+			output_bytes:  value.output_bytes,
 		}
 	}
 }
@@ -210,9 +210,9 @@ impl Shell {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
-			command: options.command,
-			cwd: options.cwd,
-			env: options.env,
+			command:    options.command,
+			cwd:        options.cwd,
+			env:        options.env,
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
@@ -253,13 +253,13 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 	let exec_options = CoreShellExecuteOptions {
-		command: options.command,
-		cwd: options.cwd,
-		env: options.env,
-		session_env: options.session_env,
-		timeout_ms: options.timeout_ms,
+		command:       options.command,
+		cwd:           options.cwd,
+		env:           options.env,
+		session_env:   options.session_env,
+		timeout_ms:    options.timeout_ms,
 		snapshot_path: options.snapshot_path,
-		minimizer: options.minimizer.map(Into::into),
+		minimizer:     options.minimizer.map(Into::into),
 	};
 	task::future(env, "shell.execute", async move {
 		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -336,7 +336,7 @@ fn bridge_chunks(
 #[napi(object)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command: String,
+	pub command:  String,
 	/// Substrings removed, in source order — suitable for a user-facing notice.
 	pub stripped: Vec<String>,
 }
@@ -416,9 +416,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
-						cwd: None,
-						env: None,
+						command:    "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
+						cwd:        None,
+						env:        None,
 						timeout_ms: None,
 					},
 					Some(tx),
@@ -459,9 +459,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command: "sh -c 'sleep 30 & wait'".to_string(),
-						cwd: None,
-						env: None,
+						command:    "sh -c 'sleep 30 & wait'".to_string(),
+						cwd:        None,
+						env:        None,
 						timeout_ms: None,
 					},
 					None,


### PR DESCRIPTION
## Scope
Carry the narrow warning cleanup that was left behind in the #708 ci-fix worktree after the PR had already merged.

## Why
The canonical dev dogfood build after the merge train completed successfully, but still emitted two pi-natives warnings:
- non-Windows `writer` does not need to be mutable
- `PTY_STARTUP_TIMEOUT` is only used on Windows

This preserves the behavior from #708 while making the warning cleanup land through a fresh dev PR instead of leaving it stranded on the stale source branch.

## Verification
- `cargo fmt --check`
- `cargo clippy -p pi-natives -- -D warnings`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*