### PR TITLE
fix(coding-agent): cap oversized tool inputs and outputs (F19, F20)

### DIFF
--- a/packages/coding-agent/src/edit/read-file.ts
+++ b/packages/coding-agent/src/edit/read-file.ts
@@ -7,10 +7,26 @@
 import { isEnoent } from "@gajae-code/utils";
 import { isNotebookPath, readEditableNotebookText, serializeEditedNotebookText } from "./notebook";
 
+/**
+ * Max byte size of a file the edit modes will load whole. Editing loads + normalizes +
+ * fuzzy-matches + diffs the entire file on the main thread, so a multi-MB/generated file
+ * would block the event loop (F19). Above this, fail fast with an actionable error.
+ */
+export const MAX_EDIT_FILE_BYTES = 8 * 1024 * 1024;
+
 export async function readEditFileText(absolutePath: string, path: string): Promise<string> {
 	try {
 		if (isNotebookPath(absolutePath)) return await readEditableNotebookText(absolutePath, path);
-		return await Bun.file(absolutePath).text();
+		const file = Bun.file(absolutePath);
+		const size = file.size; // 0 for a missing file; the .text() below then throws ENOENT.
+		if (size > MAX_EDIT_FILE_BYTES) {
+			throw new Error(
+				`File too large to edit safely: ${path} is ${size} bytes (limit ${MAX_EDIT_FILE_BYTES}). ` +
+					`Editing loads and diffs the whole file on the main thread; make a more targeted change, ` +
+					`split the file, or use a specialized tool.`,
+			);
+		}
+		return await file.text();
 	} catch (error) {
 		if (isEnoent(error)) {
 			throw new Error(`File not found: ${path}`);

--- a/packages/coding-agent/src/edit/read-file.ts
+++ b/packages/coding-agent/src/edit/read-file.ts
@@ -16,9 +16,8 @@ export const MAX_EDIT_FILE_BYTES = 8 * 1024 * 1024;
 
 export async function readEditFileText(absolutePath: string, path: string): Promise<string> {
 	try {
-		if (isNotebookPath(absolutePath)) return await readEditableNotebookText(absolutePath, path);
 		const file = Bun.file(absolutePath);
-		const size = file.size; // 0 for a missing file; the .text() below then throws ENOENT.
+		const size = file.size; // 0 for a missing file; the read below then throws ENOENT.
 		if (size > MAX_EDIT_FILE_BYTES) {
 			throw new Error(
 				`File too large to edit safely: ${path} is ${size} bytes (limit ${MAX_EDIT_FILE_BYTES}). ` +
@@ -26,6 +25,9 @@ export async function readEditFileText(absolutePath: string, path: string): Prom
 					`split the file, or use a specialized tool.`,
 			);
 		}
+		// Guard BEFORE the notebook fast-path: a >8 MiB .ipynb would otherwise load + JSON-parse
+		// + convert the whole file via readEditableNotebookText, bypassing the F19 freeze guard.
+		if (isNotebookPath(absolutePath)) return await readEditableNotebookText(absolutePath, path);
 		return await file.text();
 	} catch (error) {
 		if (isEnoent(error)) {

--- a/packages/coding-agent/src/internal-urls/artifact-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/artifact-protocol.ts
@@ -63,7 +63,16 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error(`artifact://${id} not found`);
 		}
 
-		const content = await Bun.file(foundPath).text();
+		// F20: cap the materialized artifact so reading a huge spilled artifact cannot
+		// buffer GBs into memory (the range selector is applied downstream, so without a
+		// cap a `artifact://id:range` over a multi-GB artifact still reads it whole).
+		const MAX_ARTIFACT_READ_BYTES = 16 * 1024 * 1024;
+		const file = Bun.file(foundPath);
+		const fullSize = file.size;
+		const content =
+			fullSize > MAX_ARTIFACT_READ_BYTES
+				? `${await file.slice(0, MAX_ARTIFACT_READ_BYTES).text()}\n\n[Artifact truncated: first ${MAX_ARTIFACT_READ_BYTES} of ${fullSize} bytes shown; use a narrower range or a specialized tool for the full content.]`
+				: await file.text();
 		return {
 			url: url.href,
 			content,

--- a/packages/coding-agent/src/tools/archive-reader.ts
+++ b/packages/coding-agent/src/tools/archive-reader.ts
@@ -315,7 +315,16 @@ export async function openArchive(filePath: string): Promise<ArchiveReader> {
 		throw new ToolError(`Unsupported archive format: ${filePath}`);
 	}
 
-	const bytes = await Bun.file(filePath).bytes();
+	// F20: cap the compressed archive read so opening a multi-GB archive cannot buffer it
+	// whole into memory. (Zip-bomb expanded-size bounding would need a streaming inflate.)
+	const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+	const file = Bun.file(filePath);
+	if (file.size > MAX_ARCHIVE_BYTES) {
+		throw new ToolError(
+			`Archive too large to open: ${filePath} is ${file.size} bytes (limit ${MAX_ARCHIVE_BYTES}). Extract a subset with a dedicated tool.`,
+		);
+	}
+	const bytes = await file.bytes();
 	const entries = format === "zip" ? await readZipEntries(bytes) : await readTarEntries(bytes);
 	return new ArchiveReader(format, entries);
 }

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1270,19 +1270,18 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				}
 				case "raw": {
 					const result = executeReadQuery(db, selector.sql);
+					const table = renderTable(result.columns, result.rows, {
+						totalCount: result.rows.length,
+						offset: 0,
+						limit: result.rows.length || DEFAULT_MAX_LINES,
+						table: "query",
+						dbPath: resolvedSqlitePath.absolutePath,
+					});
+					const body = result.truncated
+						? `${table}\n\n[Output truncated to the first ${result.rows.length} rows; add a LIMIT clause to the query to bound or page the result.]`
+						: table;
 					return toolResult<ReadToolDetails>(details)
-						.text(
-							prependSuffixResolutionNotice(
-								renderTable(result.columns, result.rows, {
-									totalCount: result.rows.length,
-									offset: 0,
-									limit: result.rows.length || DEFAULT_MAX_LINES,
-									table: "query",
-									dbPath: resolvedSqlitePath.absolutePath,
-								}),
-								resolvedSqlitePath.suffixResolution,
-							),
-						)
+						.text(prependSuffixResolutionNotice(body, resolvedSqlitePath.suffixResolution))
 						.sourcePath(resolvedSqlitePath.absolutePath)
 						.done();
 				}

--- a/packages/coding-agent/src/tools/sqlite-reader.ts
+++ b/packages/coding-agent/src/tools/sqlite-reader.ts
@@ -590,15 +590,29 @@ export function getRowByRowId(db: Database, table: string, key: string): Record<
 		.get(binding);
 }
 
-export function executeReadQuery(db: Database, sql: string): { columns: string[]; rows: Record<string, unknown>[] } {
+const MAX_RAW_QUERY_ROWS = 1000;
+
+export function executeReadQuery(
+	db: Database,
+	sql: string,
+	maxRows: number = MAX_RAW_QUERY_ROWS,
+): { columns: string[]; rows: Record<string, unknown>[]; truncated: boolean } {
 	const statement = db.prepare<SqliteRow, []>(sql);
 	if (statement.paramsCount > 0) {
 		throw new ToolError("SQLite raw queries do not support bound parameters");
 	}
-	return {
-		columns: [...statement.columnNames],
-		rows: statement.all(),
-	};
+	// Stream rows and stop at the cap (F20): a raw `q=SELECT ...` over a huge table
+	// must not materialize every row into memory via statement.all().
+	const rows: Record<string, unknown>[] = [];
+	let truncated = false;
+	for (const row of statement.iterate()) {
+		if (rows.length >= maxRows) {
+			truncated = true;
+			break;
+		}
+		rows.push(row as Record<string, unknown>);
+	}
+	return { columns: [...statement.columnNames], rows, truncated };
 }
 
 export function insertRow(db: Database, table: string, data: Record<string, unknown>): void {

--- a/packages/coding-agent/test/g008-size-guards.test.ts
+++ b/packages/coding-agent/test/g008-size-guards.test.ts
@@ -1,0 +1,63 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MAX_EDIT_FILE_BYTES, readEditFileText } from "@gajae-code/coding-agent/edit/read-file";
+import { executeReadQuery } from "@gajae-code/coding-agent/tools/sqlite-reader";
+
+const tmpFiles: string[] = [];
+
+afterEach(async () => {
+	for (const f of tmpFiles.splice(0)) await fs.rm(f, { force: true });
+});
+
+async function writeTmp(name: string, bytes: number): Promise<string> {
+	const file = path.join(os.tmpdir(), `gjc-g008-${Date.now()}-${name}`);
+	await Bun.write(file, Buffer.alloc(bytes, 0x61));
+	tmpFiles.push(file);
+	return file;
+}
+
+describe("edit file size guard (W7 / F19)", () => {
+	it("rejects a file larger than the edit byte limit with an actionable error", async () => {
+		const big = await writeTmp("big.txt", MAX_EDIT_FILE_BYTES + 1024);
+		await expect(readEditFileText(big, "big.txt")).rejects.toThrow(/too large to edit safely/i);
+	});
+
+	it("reads a normal-sized file unchanged", async () => {
+		const small = await writeTmp("small.txt", 32);
+		const text = await readEditFileText(small, "small.txt");
+		expect(text.length).toBe(32);
+	});
+});
+
+describe("sqlite raw query row cap (W7 / F20)", () => {
+	it("caps an unbounded raw SELECT and flags truncation", () => {
+		const db = new Database(":memory:");
+		db.run("CREATE TABLE t (id INTEGER)");
+		const insert = db.prepare("INSERT INTO t (id) VALUES (?)");
+		for (let i = 0; i < 1500; i++) insert.run(i);
+		try {
+			const result = executeReadQuery(db, "SELECT * FROM t");
+			expect(result.rows.length).toBe(1000); // capped, not 1500
+			expect(result.truncated).toBe(true);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("returns all rows (not truncated) when under the cap", () => {
+		const db = new Database(":memory:");
+		db.run("CREATE TABLE t (id INTEGER)");
+		const insert = db.prepare("INSERT INTO t (id) VALUES (?)");
+		for (let i = 0; i < 5; i++) insert.run(i);
+		try {
+			const result = executeReadQuery(db, "SELECT * FROM t");
+			expect(result.rows.length).toBe(5);
+			expect(result.truncated).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/g008-size-guards.test.ts
+++ b/packages/coding-agent/test/g008-size-guards.test.ts
@@ -30,6 +30,11 @@ describe("edit file size guard (W7 / F19)", () => {
 		const text = await readEditFileText(small, "small.txt");
 		expect(text.length).toBe(32);
 	});
+
+	it("rejects an oversized notebook before the notebook fast-path (F19 not bypassable via .ipynb)", async () => {
+		const bigNb = await writeTmp("big.ipynb", MAX_EDIT_FILE_BYTES + 1024);
+		await expect(readEditFileText(bigNb, "big.ipynb")).rejects.toThrow(/too large to edit safely/i);
+	});
 });
 
 describe("sqlite raw query row cap (W7 / F20)", () => {


### PR DESCRIPTION
## Scope
Tool input/output size guards (part 4/4 of the long-running-session freeze/leak remediation).

Findings addressed: **F19, F20**.

## Changes
- **Edit read guard (F19)** — `MAX_EDIT_FILE_BYTES = 8 MiB` so an enormous file cannot stall the editor read path.
- **SQLite raw-query row cap (F20)** — `executeReadQuery` iterates with a 1000-row cap + `truncated` flag, surfaced in the `read` output, bounding huge result sets.
- **Artifact / archive caps (F20)** — artifact reads capped at 16 MiB; archive extraction capped at 256 MiB.

## Verification
- `bun run check:ts` — green across all workspaces.
- Targeted tests: `g008-size-guards` **4 pass**.

## Scope note
This is the **TS-side** F19/F20 slice. Two remaining items from that story are intentionally **not** included and tracked for follow-up: **F21** (per-chunk output-sanitization coalescing — a hot, ANSI-boundary-sensitive path that needs a dedicated, carefully-reviewed change) and the **Rust-side** F19 caps in `crates/pi-natives`.