### PR TITLE
fix(natives): resolve unused-var/import warnings on non-Windows rust build

### DIFF
--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -1183,7 +1183,7 @@ pub const KNOWN_LONG_TAIL_ALIASES: &[&str] = &[
 mod tests {
 	use std::path::Path;
 
-	use ast_grep_core::{Language, matcher::KindMatcher, tree_sitter::LanguageExt};
+	use ast_grep_core::{matcher::KindMatcher, tree_sitter::LanguageExt};
 
 	use super::SupportLang;
 

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -458,13 +458,13 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before openpty: {err}")))?;
 
-	const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 	let pair = if cfg!(windows) {
 		// Windows ConPTY openpty() can hang indefinitely when the console
 		// subsystem isn't properly initialized. Gate attempts process-wide so
 		// a hung openpty can leave at most one residual blocked thread behind.
 		#[cfg(windows)]
 		{
+			const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 			let attempt = WindowsOpenptyAttempt::acquire()?;
 			let (tx, rx) = mpsc::channel();
 			let handle = std::thread::spawn(move || {
@@ -538,15 +538,17 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
-	let mut writer = setup_guard.take_writer()?;
+	let writer = setup_guard.take_writer()?;
 	// ConPTY sends ESC[6n (cursor position query) and blocks until we reply.
 	// Reply with cursor at 1,1 so it unblocks the child spawn.
 	// Only needed on Windows; on Unix/macOS this would corrupt stdin.
 	#[cfg(windows)]
-	{
+	let writer = {
+		let mut writer = writer;
 		let _ = writer.write_all(b"\x1b[1;1R");
 		let _ = writer.flush();
-	}
+		writer
+	};
 	setup_guard.set_writer(writer);
 	let mut reader = setup_guard.try_clone_reader()?;
 


### PR DESCRIPTION
## Summary
Building the native rust crate on non-Windows (macOS/Linux) emitted three `#[warn(unused)]` warnings:

- `pty.rs:461` — `constant \`PTY_STARTUP_TIMEOUT\` is never used` (only referenced inside the `#[cfg(windows)]` openpty branch).
- `pty.rs:541` — `variable does not need to be mutable` for `writer` (only mutated by the `#[cfg(windows)]` ConPTY cursor-reply block).
- `pi-ast/src/language/mod.rs:1186` — unused `Language` import in the test module (surfaced under `--all-features`).

## Fix
- Move `PTY_STARTUP_TIMEOUT` into the `#[cfg(windows)]` block where it is used.
- Keep `writer` immutable by default; shadow it as `mut` only under `#[cfg(windows)]`.
- Drop the unused `Language` import.

No behavior change on any platform — the Windows code path is preserved verbatim.

## Verification
- `cargo check --workspace --all-targets --all-features` → 0 warnings.
- `cargo test -p pi-ast --all-features` → 21 passed.
- `cargo test -p pi-natives pty` → 8 passed.
- Windows-target type-check not runnable locally (no windows-msvc std libs installed); cfg(windows) edits are mechanical/idiomatic.