### PR TITLE
feat(ai): opt-in earliest-reset credential ranking mode

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -96,6 +96,14 @@ When the broker is enabled, the local SQLite credential store is bypassed and al
 
 The gateway has no dedicated env vars — it inherits `GJC_AUTH_BROKER_*`. Its own inbound bearer token lives at `<config-dir>/auth-gateway.token` and is managed via `gjc auth-gateway token`.
 
+### Multi-account credential ranking
+
+When more than one OAuth credential is stored for the same provider (e.g. several Anthropic accounts), `AuthStorage` ranks them at session start to pick which one serves the session. This env var selects the ranking strategy; it is fully opt-in and does not change the default.
+
+| Variable                      | Used for                                          | Required when  | Notes / precedence                                                                                                                                                                                                                                                                                            |
+| ----------------------------- | ------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GJC_CREDENTIAL_RANKING_MODE` | Multi-account OAuth credential selection strategy | Never (opt-in) | `balanced` (default) prefers the least-drained account (spreads load, keeps burst headroom). `earliest-reset` prefers the soonest-to-reset non-blocked account (earliest-expiry-first) so perishable tumbling-window quota (e.g. Claude 5h/7d) is drained before reset. Unset/unknown → `balanced`. Only affects session-start ranking; blocked/exhausted accounts still sort last. |
+
 ---
 
 ## 2) Provider-specific runtime configuration

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `AuthStorageOptions.credentialRankingMode` (`balanced` (default) | `earliest-reset`) for multi-account OAuth credential selection. `earliest-reset` ranks non-blocked credentials earliest-expiry-first — draining the soonest-to-reset account before its perishable tumbling-window quota (e.g. Claude 5h/7d) is lost at reset — keeping the existing drain-rate/used-fraction metrics as tiebreakers. `balanced` is byte-identical to prior behavior, and ranking only runs at session start (or when the session's preferred credential is blocked), so this never thrashes accounts mid-session.
+
 ### Fixed
 
 - Allowed `openai-codex-responses` custom backends to use opaque `apiKey` bearer tokens by omitting `chatgpt-account-id` when the token does not expose a Codex account id.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -288,9 +288,27 @@ export interface CredentialDisabledEvent {
 	disabledCause: string;
 }
 
+/**
+ * How {@link AuthStorage} orders multiple healthy OAuth credentials of the same
+ * provider:type pool when selecting one for a (new) session.
+ *
+ * - `balanced` (default): prefer the least-used / lowest-drain-rate account.
+ *   Spreads load across accounts and keeps burst headroom on every account.
+ * - `earliest-reset`: prefer the non-blocked account whose usage window resets
+ *   soonest (earliest-expiry-first). Tumbling-window quota is perishable —
+ *   unused quota is lost at reset — so draining the soonest-to-reset account
+ *   first minimizes wasted quota. Drain/used metrics remain tiebreakers.
+ *
+ * Only affects ranking, which the `shouldRank` guard already limits to session
+ * start (or when the session's preferred credential is blocked), so this never
+ * thrashes accounts mid-session / cold-starts the server-side prompt cache.
+ */
+export type CredentialRankingMode = "balanced" | "earliest-reset";
+
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	credentialRankingMode?: CredentialRankingMode;
 	usageFetch?: typeof fetch;
 	usageRequestTimeoutMs?: number;
 	usageLogger?: UsageLogger;
@@ -655,6 +673,7 @@ export class AuthStorage {
 	#usageReportsInFlight: Map<string, Promise<UsageReport[] | null>> = new Map();
 	#usageFetch: typeof fetch;
 	#usageRequestTimeoutMs: number;
+	#credentialRankingMode: CredentialRankingMode = "balanced";
 	#usageLogger?: UsageLogger;
 	#fallbackResolver?: (provider: string) => string | undefined;
 	#store: AuthCredentialStore;
@@ -686,6 +705,7 @@ export class AuthStorage {
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		this.#usageFetch = options.usageFetch ?? fetch;
 		this.#usageRequestTimeoutMs = options.usageRequestTimeoutMs ?? DEFAULT_USAGE_REQUEST_TIMEOUT_MS;
+		this.#credentialRankingMode = options.credentialRankingMode ?? "balanced";
 		this.#refreshOAuthCredentialOverride = options.refreshOAuthCredential;
 		this.#fetchUsageReportsOverride = options.fetchUsageReports;
 		this.#sourceLabel = options.sourceLabel;
@@ -2453,6 +2473,7 @@ export class AuthStorage {
 			secondaryDrainRate: number;
 			primaryUsed: number;
 			primaryDrainRate: number;
+			resetAtMs: number;
 			orderPos: number;
 		}> = [];
 		// Pre-fetch usage reports in parallel for non-blocked credentials.
@@ -2522,6 +2543,10 @@ export class AuthStorage {
 				),
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryDrainRate: this.#computeWindowDrainRate(primary, nowMs, strategy.windowDefaults.primaryMs),
+				resetAtMs:
+					this.#resolveWindowResetAt(primary?.window) ??
+					this.#resolveWindowResetAt(secondary?.window) ??
+					Number.POSITIVE_INFINITY,
 				orderPos,
 			});
 		}
@@ -2539,6 +2564,11 @@ export class AuthStorage {
 				if (leftPlanPriority !== rightPlanPriority) return leftPlanPriority - rightPlanPriority;
 			}
 			if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
+			if (this.#credentialRankingMode === "earliest-reset" && left.resetAtMs !== right.resetAtMs) {
+				// Earliest-expiry-first: drain the soonest-to-reset account before
+				// its perishable tumbling-window quota is lost at reset.
+				return left.resetAtMs - right.resetAtMs;
+			}
 			if (left.secondaryDrainRate !== right.secondaryDrainRate)
 				return left.secondaryDrainRate - right.secondaryDrainRate;
 			if (left.secondaryUsed !== right.secondaryUsed) return left.secondaryUsed - right.secondaryUsed;

--- a/packages/ai/test/auth-storage-ranking-mode.test.ts
+++ b/packages/ai/test/auth-storage-ranking-mode.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type AuthCredentialStore,
+	AuthStorage,
+	type CredentialRankingMode,
+	SqliteAuthCredentialStore,
+} from "../src/auth-storage";
+import type { UsageLimit, UsageProvider, UsageReport } from "../src/usage";
+import * as oauthUtils from "../src/utils/oauth";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const FIVE_HOUR_MS = 5 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+type WindowSpec = { usedFraction: number; resetInMs: number };
+
+function createLimit(args: {
+	id: "anthropic:5h" | "anthropic:7d";
+	label: string;
+	durationMs: number;
+	spec: WindowSpec;
+}): UsageLimit {
+	const clamped = Math.min(Math.max(args.spec.usedFraction, 0), 1);
+	const used = clamped * 100;
+	return {
+		id: args.id,
+		label: args.label,
+		scope: { provider: "anthropic", windowId: args.id, shared: false },
+		window: {
+			id: args.id,
+			label: args.label,
+			durationMs: args.durationMs,
+			resetsAt: Date.now() + args.spec.resetInMs,
+		},
+		amount: {
+			unit: "percent",
+			used,
+			limit: 100,
+			remaining: 100 - used,
+			usedFraction: clamped,
+			remainingFraction: Math.max(0, 1 - clamped),
+		},
+		status: clamped >= 1 ? "exhausted" : clamped >= 0.9 ? "warning" : "ok",
+	};
+}
+
+function createClaudeUsageReport(accountId: string, primary: WindowSpec, secondary: WindowSpec): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt: Date.now(),
+		limits: [
+			createLimit({ id: "anthropic:5h", label: "5 Hour", durationMs: FIVE_HOUR_MS, spec: primary }),
+			createLimit({ id: "anthropic:7d", label: "7 Day", durationMs: WEEK_MS, spec: secondary }),
+		],
+		metadata: { accountId },
+	};
+}
+
+function createCredential(accountId: string, email: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+		email,
+	};
+}
+
+describe("AuthStorage credentialRankingMode", () => {
+	let tempDir = "";
+	const stores: AuthCredentialStore[] = [];
+	const usageByAccount = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "anthropic",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			if (!accountId) return null;
+			return usageByAccount.get(accountId) ?? null;
+		},
+	};
+
+	async function makeStorage(mode?: CredentialRankingMode): Promise<AuthStorage> {
+		const store = await SqliteAuthCredentialStore.open(path.join(tempDir, `agent-${stores.length}.db`));
+		stores.push(store);
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "anthropic" ? usageProvider : undefined),
+			credentialRankingMode: mode,
+		});
+		await storage.reload();
+		await storage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-soon", "soon@example.com") },
+			{ type: "oauth", ...createCredential("acct-late", "late@example.com") },
+		]);
+		return storage;
+	}
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-ranking-mode-"));
+		usageByAccount.clear();
+		// acct-soon: 5h window resets in 10m (soonest), but drains its 7d window faster.
+		usageByAccount.set(
+			"acct-soon",
+			createClaudeUsageReport(
+				"acct-soon",
+				{ usedFraction: 0.5, resetInMs: 10 * 60 * 1000 },
+				{ usedFraction: 0.6, resetInMs: 5 * DAY_MS },
+			),
+		);
+		// acct-late: 5h window resets in 4h (later), but is the least-drained account.
+		usageByAccount.set(
+			"acct-late",
+			createClaudeUsageReport(
+				"acct-late",
+				{ usedFraction: 0.3, resetInMs: 4 * HOUR_MS },
+				{ usedFraction: 0.3, resetInMs: 5 * DAY_MS },
+			),
+		);
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials.anthropic as OAuthCredentials | undefined;
+			if (!credential?.accountId) return null;
+			return { apiKey: `api-${credential.accountId}`, newCredentials: credential };
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		for (const store of stores.splice(0)) store.close();
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("default (balanced) prefers the least-drained account", async () => {
+		const storage = await makeStorage();
+		const apiKey = await storage.getApiKey("anthropic", "session-balanced");
+		expect(apiKey).toBe("api-acct-late");
+	});
+
+	test("balanced mode is explicit-equivalent to the default", async () => {
+		const storage = await makeStorage("balanced");
+		const apiKey = await storage.getApiKey("anthropic", "session-balanced-explicit");
+		expect(apiKey).toBe("api-acct-late");
+	});
+
+	test("earliest-reset prefers the soonest-to-reset account (use-it-or-lose-it)", async () => {
+		const storage = await makeStorage("earliest-reset");
+		const apiKey = await storage.getApiKey("anthropic", "session-earliest-reset");
+		expect(apiKey).toBe("api-acct-soon");
+	});
+
+	test("earliest-reset still skips an exhausted soon-to-reset account", async () => {
+		// acct-soon's 5h window resets soonest but is fully exhausted → must fall to acct-late.
+		usageByAccount.set(
+			"acct-soon",
+			createClaudeUsageReport(
+				"acct-soon",
+				{ usedFraction: 1, resetInMs: 10 * 60 * 1000 },
+				{ usedFraction: 1, resetInMs: 10 * 60 * 1000 },
+			),
+		);
+		const storage = await makeStorage("earliest-reset");
+		const apiKey = await storage.getApiKey("anthropic", "session-earliest-reset-exhausted");
+		expect(apiKey).toBe("api-acct-late");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `GJC_CREDENTIAL_RANKING_MODE` env var (`balanced` (default) | `earliest-reset`), wired through `discoverAuthStorage` into `AuthStorage.credentialRankingMode`. `earliest-reset` selects multi-account OAuth credentials earliest-expiry-first so soon-to-reset tumbling-window quota (e.g. Claude 5h/7d) is drained before it is lost at reset; unset/unknown leaves the default `balanced` behavior unchanged.
+
 ### Fixed
 
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -415,6 +415,7 @@ function getDefaultAgentDir(): string {
  */
 export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir()): Promise<AuthStorage> {
 	const brokerConfig = await resolveAuthBrokerConfig();
+	const credentialRankingMode = resolveCredentialRankingMode();
 	if (brokerConfig) {
 		const client = new AuthBrokerClient({ url: brokerConfig.url, token: brokerConfig.token });
 		const initialResult = await client.fetchSnapshot();
@@ -425,6 +426,7 @@ export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir(
 		const storage = new AuthStorage(store, {
 			configValueResolver: resolveConfigValue,
 			sourceLabel: `broker ${brokerConfig.url}`,
+			credentialRankingMode,
 		});
 		await storage.reload();
 		return storage;
@@ -433,9 +435,23 @@ export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir(
 	const storage = await AuthStorage.create(dbPath, {
 		configValueResolver: resolveConfigValue,
 		sourceLabel: `local ${dbPath}`,
+		credentialRankingMode,
 	});
 	await storage.reload();
 	return storage;
+}
+
+/**
+ * Opt-in multi-account credential ranking mode, read from the
+ * `GJC_CREDENTIAL_RANKING_MODE` env var. Unset/unknown → `undefined`, leaving
+ * {@link AuthStorage}'s default (`balanced`) untouched. `earliest-reset`
+ * switches to earliest-expiry-first selection so soon-to-reset tumbling-window
+ * quota is drained before it is lost.
+ */
+function resolveCredentialRankingMode(): "balanced" | "earliest-reset" | undefined {
+	const raw = process.env.GJC_CREDENTIAL_RANKING_MODE?.trim();
+	if (raw === "balanced" || raw === "earliest-reset") return raw;
+	return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fresh, minimal `dev`-based recreation of #635, which was closed because its fork branch diverged into repository-wide add/add conflicts that were unsafe to carry forward as a maintainer rebase. The net change here is unchanged from the **MERGE_READY** red-team review on #635, reapplied cleanly onto current `dev`.

Adds an opt-in multi-account OAuth credential ranking strategy.

## Changes
- **`packages/ai`** — `AuthStorageOptions.credentialRankingMode` (`"balanced"` default | `"earliest-reset"`) and the new `CredentialRankingMode` type. `earliest-reset` ranks non-blocked credentials **earliest-expiry-first** (using each candidate's soonest window `resetAtMs`) so perishable tumbling-window quota (e.g. Claude 5h/7d) is drained before it is lost at reset; the existing drain-rate / used-fraction comparisons remain tiebreakers, and blocked/exhausted accounts still sort last.
- **`packages/coding-agent`** — `discoverAuthStorage` reads the `GJC_CREDENTIAL_RANKING_MODE` env var (`balanced`/`earliest-reset`; unset/unknown → undefined → default) and forwards it to both the broker and local `AuthStorage`.
- Docs (`docs/environment-variables.md`) + both package changelogs.

## Scope / safety
- **Fully opt-in.** `balanced` is byte-identical to prior behavior; ranking only runs at session start (or when the preferred credential is blocked), so accounts never thrash mid-session.

## Testing
- New `packages/ai/test/auth-storage-ranking-mode.test.ts` (4 tests): balanced default, explicit balanced, earliest-reset selection, and earliest-reset skipping an exhausted soon-to-reset account.
- Regression: `auth-storage-codex-selection` + `auth-storage-email-dedupe` + `auth-storage-check-credentials` → 42 pass.
- `check:ts` + `biome check` clean on all changed files.

Closes #635.