### PR TITLE
style(bridge): biome single-quote the parseBridgeEndpoints test title

### DIFF
--- a/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
@@ -8,7 +8,7 @@ describe("parseBridgeEndpoints", () => {
 		expect(parseBridgeEndpoints("   ")).toBeUndefined();
 	});
 
-	it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+	it('enables all matrix keys for "all" (case-insensitive)', () => {
 		expect(parseBridgeEndpoints("all")).toEqual({
 			events: true,
 			commands: true,


### PR DESCRIPTION
One-line biome `check` formatting fix: the `it(...)` title in `bridge-endpoints-parse.test.ts` (added with #663) used escaped double-quotes; biome's formatter prefers single quotes to avoid the escape. This unblocks the affected-path `check` gate that any coding-agent-touching PR now trips. Test still passes (5/5).