### PR TITLE
fix(test): format bridge endpoints parse test

### DIFF
--- a/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
@@ -8,7 +8,7 @@ describe("parseBridgeEndpoints", () => {
 		expect(parseBridgeEndpoints("   ")).toBeUndefined();
 	});
 
-	it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+	it('enables all matrix keys for "all" (case-insensitive)', () => {
 		expect(parseBridgeEndpoints("all")).toEqual({
 			events: true,
 			commands: true,


### PR DESCRIPTION
## Summary

Narrow dev-base CI hotfix. `packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts` had a Biome **format** error on the `it(...)` description at line 11: the outer string used escaped double quotes (`"... \"all\" ..."`). Biome requires single-quoting the outer string so the inner `"all"` literal needs no escaping.

```diff
- it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+ it('enables all matrix keys for "all" (case-insensitive)', () => {
```

Formatting-only change (applied via `biome format --write`); **no logic touched**.

## Why this is a dev-base blocker

The unformatted file lives on dev/base, so it surfaces in GitHub's PR **merge** refs even when the PR head does not include the file:

- **#723** — Affected-path validation failed in `@gajae-code/coding-agent check` on exactly this Biome format error (file absent on #723 head, present from base in the merge ref).
- **#695** — same `test/bridge/bridge-endpoints-parse.test.ts` Biome format error re-failed.
- Latest **Dev CI** (post-#722) and other PR merge refs are expected to hit the same blocker.

## Validation

- `biome check packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts` -> clean (was the failing gate).
- Diff is a single line; no behavioral change to `parseBridgeEndpoints` or its tests.

> Note: unrelated warnings in `src/gjc-runtime/ultragoal-runtime.ts` (seen on #695) are intentionally **not** touched here to keep this hotfix narrow.

Please merge through the normal review gate.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
