### PR TITLE
fix(agent): tear down browser/Python subprocesses on signal exit (#698)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).
 
+- Interactive sessions no longer orphan the `browser` tool's headless/spawned Chrome (and the Python eval kernel) to PID 1 when killed by a signal. The interactive entry now registers a bounded, idempotent `postmortem` cleanup (`session-subprocess-teardown`) that runs `AgentSession.disposeChildSubprocesses()` on `SIGINT`/`SIGTERM`/`SIGHUP`, force-releasing the session's browser tabs (`kill:true`) and disposing its Python/JS kernels — the teardown the graceful `/quit` (`dispose()`) path already performs but that an external `kill`/terminal-close used to bypass. Headless `disposeBrowserHandle` now also SIGTERM/SIGKILLs the captured Chrome process tree as a fallback when forced, so a wedged renderer can't survive a bounded CDP `close()`; graceful release behavior is unchanged. The teardown is time-boxed (5s) so a stuck subprocess can't hang process exit (#698).
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -306,6 +306,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#baseSlashCommands: SlashCommand[] = [];
 	#baseReservedSlashCommandNames: Set<string> = new Set();
 	#cleanupUnsubscribe?: () => void;
+	#subprocessTeardownUnsubscribe?: () => void;
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
 	#planModePreviousTools: string[] | undefined;
@@ -446,6 +447,14 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Register session manager flush for signal handlers (SIGINT, SIGTERM, SIGHUP)
 		this.#cleanupUnsubscribe = postmortem.register("session-manager-flush", () => this.sessionManager.flush());
+
+		// Tear down subprocess-spawning tools (browser Chrome, Python eval kernel) on a
+		// signal kill (SIGINT/SIGTERM/SIGHUP) so they aren't reparented to PID 1 (#698).
+		// The graceful /quit path already releases these via session.dispose(); this hook
+		// is the bounded, idempotent fallback for an external kill that bypasses it.
+		this.#subprocessTeardownUnsubscribe = postmortem.register("session-subprocess-teardown", () =>
+			this.session.disposeChildSubprocesses(),
+		);
 
 		await logger.time(
 			"InteractiveMode.init:slashCommands",
@@ -1907,6 +1916,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (this.#cleanupUnsubscribe) {
 			this.#cleanupUnsubscribe();
+		}
+		if (this.#subprocessTeardownUnsubscribe) {
+			this.#subprocessTeardownUnsubscribe();
 		}
 		if (this.isInitialized) {
 			this.ui.stop();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -550,6 +550,13 @@ function formatRetryFallbackBaseSelector(selector: RetryFallbackSelector): strin
 const IRC_REPLY_MAX_BYTES = 4096;
 
 /**
+ * Hard cap for {@link AgentSession.disposeChildSubprocesses}. A `SIGINT`/`SIGTERM` handler
+ * awaits this teardown before exiting, so it must never block longer than this even if a
+ * subprocess (wedged Chrome renderer, stuck Python cell) refuses to settle.
+ */
+const SIGNAL_TEARDOWN_TIMEOUT_MS = 5_000;
+
+/**
  * Collapse degenerate IRC ephemeral replies before they hit the relay.
  * Models occasionally loop on a single line (~16 reports of N-times-repeated
  * replies); compress runs longer than 3 down to one instance + `[…N×]`, then
@@ -3219,6 +3226,36 @@ export class AgentSession {
 			this.#unsubscribeAppendOnly = undefined;
 		}
 		this.#eventListeners = [];
+	}
+
+	/**
+	 * Bounded, best-effort teardown of the subprocess-spawning resources this session
+	 * owns: the browser tool's headless/spawned Chrome and the Python eval kernel + JS VM
+	 * contexts. Unlike {@link dispose}, this touches only child processes and is time-boxed,
+	 * so a top-level `SIGINT`/`SIGTERM`/`SIGHUP` handler can run it without hanging — without
+	 * it, an external kill bypasses `dispose()` and orphans Chrome/Python to PID 1 (#698).
+	 *
+	 * Idempotent: every step is a no-op once the graceful {@link dispose} path has released
+	 * the resources. Never throws; per-step failures are logged and the whole run is capped
+	 * at `timeoutMs` so a wedged subprocess can't stall process exit.
+	 */
+	async disposeChildSubprocesses(timeoutMs = SIGNAL_TEARDOWN_TIMEOUT_MS): Promise<void> {
+		const sessionId = this.sessionManager.getSessionId();
+		const kernelOwnerId = this.#evalKernelOwnerId;
+		const work = Promise.allSettled([
+			// kill:true so a forced exit also reaps spawned-app Chrome we own (headless
+			// always closes; connected/attached browsers only disconnect — never killed).
+			releaseTabsForOwner(sessionId, { kill: true }).catch((error: unknown) =>
+				logger.warn("signal teardown: releaseTabsForOwner failed", { error }),
+			),
+			disposeKernelSessionsByOwner(kernelOwnerId).catch((error: unknown) =>
+				logger.warn("signal teardown: disposeKernelSessionsByOwner failed", { error }),
+			),
+			disposeVmContextsByOwner(kernelOwnerId).catch((error: unknown) =>
+				logger.warn("signal teardown: disposeVmContextsByOwner failed", { error }),
+			),
+		]);
+		await Promise.race([work, Bun.sleep(timeoutMs)]);
 	}
 
 	#closeAllProviderSessions(reason: string): void {

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -26,6 +26,13 @@ export interface BrowserHandle {
 
 const browsers = new Map<string, BrowserHandle>();
 
+/**
+ * Upper bound on the CDP `browser.close()` round-trip during a forced (signal-path)
+ * teardown before we fall back to killing the Chrome process tree. Only applies when
+ * `kill` is set; graceful release still awaits close() unbounded.
+ */
+const HEADLESS_FORCE_CLOSE_GRACE_MS = 1_500;
+
 function browserKey(kind: BrowserKind): string {
 	switch (kind.kind) {
 		case "headless":
@@ -164,13 +171,22 @@ export async function releaseBrowser(handle: BrowserHandle, opts: { kill: boolea
 
 async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean }): Promise<void> {
 	if (handle.kind.kind === "headless") {
+		// Capture the launched Chrome process before close() so a forced (signal-path)
+		// teardown can SIGTERM/SIGKILL the tree even if the CDP close hangs on a wedged
+		// renderer. Otherwise the headless Chrome reparents to PID 1 (#698).
+		const proc = handle.browser.process();
 		if (handle.browser.connected) {
 			try {
-				await handle.browser.close();
+				const closing = handle.browser.close();
+				// Graceful release waits for close() to finish (it also removes the
+				// puppeteer_dev_chrome_profile-* temp dir). Forced release bounds it so
+				// the kill fallback below still runs within the signal handler's budget.
+				await (opts.kill ? Promise.race([closing, Bun.sleep(HEADLESS_FORCE_CLOSE_GRACE_MS)]) : closing);
 			} catch (err) {
 				logger.debug("Failed to close headless browser", { error: (err as Error).message });
 			}
 		}
+		if (opts.kill && proc?.pid !== undefined) await gracefulKillTreeOnce(proc.pid);
 		return;
 	}
 	if (handle.kind.kind === "connected") {

--- a/packages/coding-agent/test/agent-session-signal-teardown.test.ts
+++ b/packages/coding-agent/test/agent-session-signal-teardown.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import * as contextManager from "@gajae-code/coding-agent/eval/js/context-manager";
+import * as pyExecutor from "@gajae-code/coding-agent/eval/py/executor";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import * as tabSupervisor from "@gajae-code/coding-agent/tools/browser/tab-supervisor";
+import { TempDir } from "@gajae-code/utils";
+
+describe("AgentSession.disposeChildSubprocesses (#698 signal teardown)", () => {
+	let tempDir: TempDir | undefined;
+	let authStorage: AuthStorage | undefined;
+	let session: AgentSession | undefined;
+	let sessionManager: SessionManager;
+	let releaseTabs: ReturnType<typeof vi.fn>;
+	let disposeKernels: ReturnType<typeof vi.fn>;
+	let disposeVms: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@gjc-signal-teardown-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled anthropic model to exist");
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		sessionManager = SessionManager.inMemory();
+		session = new AgentSession({ agent, sessionManager, settings: Settings.isolated(), modelRegistry });
+
+		releaseTabs = vi.spyOn(tabSupervisor, "releaseTabsForOwner").mockResolvedValue(0);
+		disposeKernels = vi.spyOn(pyExecutor, "disposeKernelSessionsByOwner").mockResolvedValue(undefined);
+		disposeVms = vi.spyOn(contextManager, "disposeVmContextsByOwner").mockResolvedValue(undefined);
+	});
+
+	afterEach(async () => {
+		// Ensure the spies resolve so the dispose() teardown below can't hang on a
+		// deliberately-stalled mock left over from the boundedness test.
+		releaseTabs.mockResolvedValue(0);
+		disposeKernels.mockResolvedValue(undefined);
+		disposeVms.mockResolvedValue(undefined);
+		await session?.dispose();
+		session = undefined;
+		authStorage?.close();
+		authStorage = undefined;
+		tempDir?.removeSync();
+		tempDir = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("releases the session's browser tabs (force-kill) and Python/JS kernels", async () => {
+		await session!.disposeChildSubprocesses();
+
+		expect(releaseTabs).toHaveBeenCalledTimes(1);
+		expect(releaseTabs).toHaveBeenCalledWith(sessionManager.getSessionId(), { kill: true });
+		expect(disposeKernels).toHaveBeenCalledTimes(1);
+		expect(disposeVms).toHaveBeenCalledTimes(1);
+		// Browser and eval kernels share no owner id, but both teardowns must fire.
+		expect(disposeKernels.mock.calls[0]?.[0]).toBe(disposeVms.mock.calls[0]?.[0]);
+	});
+
+	it("is idempotent across repeated calls", async () => {
+		await session!.disposeChildSubprocesses();
+		await session!.disposeChildSubprocesses();
+
+		expect(releaseTabs).toHaveBeenCalledTimes(2);
+		expect(disposeKernels).toHaveBeenCalledTimes(2);
+		expect(disposeVms).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns within the time box even when a teardown step hangs", async () => {
+		releaseTabs.mockReturnValue(new Promise<number>(() => {}));
+
+		const start = Date.now();
+		await session!.disposeChildSubprocesses(20);
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(2_000);
+		// The non-hanging steps still ran.
+		expect(disposeKernels).toHaveBeenCalledTimes(1);
+		expect(disposeVms).toHaveBeenCalledTimes(1);
+	});
+
+	it("never rejects when a teardown step throws", async () => {
+		disposeKernels.mockRejectedValue(new Error("kernel shutdown boom"));
+
+		await expect(session!.disposeChildSubprocesses()).resolves.toBeUndefined();
+		expect(releaseTabs).toHaveBeenCalledTimes(1);
+		expect(disposeVms).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
+++ b/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { Browser } from "puppeteer-core";
+import * as attach from "../../src/tools/browser/attach";
+import { type BrowserHandle, releaseBrowser } from "../../src/tools/browser/registry";
+
+interface FakeBrowserOptions {
+	pid?: number;
+	close?: () => Promise<void>;
+}
+
+function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
+	const close = vi.fn(opts.close ?? (async () => {}));
+	const browser = {
+		connected: true,
+		close,
+		process: () => (opts.pid === undefined ? null : ({ pid: opts.pid } as never)),
+	} as unknown as Browser;
+	const handle: BrowserHandle = {
+		key: "headless:1",
+		kind: { kind: "headless", headless: true },
+		browser,
+		refCount: 1,
+		stealth: { browserSession: null, override: null },
+	};
+	return { handle, close };
+}
+
+describe("browser registry headless teardown (#698)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("force-kills the headless Chrome process tree on a forced (signal) release", async () => {
+		const killSpy = vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const { handle, close } = makeHeadlessHandle({ pid: 4242 });
+
+		await releaseBrowser(handle, { kill: true });
+
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(killSpy).toHaveBeenCalledTimes(1);
+		expect(killSpy).toHaveBeenCalledWith(4242);
+	});
+
+	it("kills the captured process even when CDP close hangs on a wedged renderer", async () => {
+		const killSpy = vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		// close() never resolves: bounded by HEADLESS_FORCE_CLOSE_GRACE_MS so the kill still runs.
+		const { handle } = makeHeadlessHandle({ pid: 99, close: () => new Promise<void>(() => {}) });
+
+		await releaseBrowser(handle, { kill: true });
+
+		expect(killSpy).toHaveBeenCalledWith(99);
+	});
+
+	it("closes gracefully without killing on a normal release (kill:false)", async () => {
+		const killSpy = vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const { handle, close } = makeHeadlessHandle({ pid: 4242 });
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(killSpy).not.toHaveBeenCalled();
+	});
+
+	it("only disposes once refCount reaches zero", async () => {
+		const killSpy = vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const { handle, close } = makeHeadlessHandle({ pid: 4242 });
+		handle.refCount = 2;
+
+		await releaseBrowser(handle, { kill: true });
+		expect(close).not.toHaveBeenCalled();
+		expect(killSpy).not.toHaveBeenCalled();
+
+		await releaseBrowser(handle, { kill: true });
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(killSpy).toHaveBeenCalledWith(4242);
+	});
+});


### PR DESCRIPTION
## What

Stop interactive `gjc` sessions from orphaning the `browser` tool's headless/spawned Chrome (and the Python eval kernel) to PID 1 when the process is killed by a signal.

- **`AgentSession.disposeChildSubprocesses()`** — a bounded (5s), idempotent, never-throwing teardown of the subprocess-spawning resources the session owns: its browser tabs (`releaseTabsForOwner(..., { kill: true })`) plus its Python kernel (`disposeKernelSessionsByOwner`) and JS VM contexts (`disposeVmContextsByOwner`). It runs the child-process subset of `dispose()`, in parallel, time-boxed via `Promise.race`, so a signal handler can call it without hanging.
- **Interactive signal hook** — `InteractiveMode.init()` registers a `postmortem` cleanup (`session-subprocess-teardown`) that runs `disposeChildSubprocesses()`. `postmortem` already `await`s registered callbacks on `SIGINT`/`SIGTERM`/`SIGHUP` before `process.exit`. The hook is unregistered in `stop()`, so the graceful `/quit` path (which already tears these down via `dispose()`) never double-runs it.
- **Headless force-close hardening** — on a forced (signal-path) release, `disposeBrowserHandle` now bounds the CDP `browser.close()` and SIGTERM/SIGKILLs the captured Chrome process tree as a fallback, so a wedged renderer can't survive. Graceful release (`kill:false`) behavior is unchanged: it still awaits `close()` (which also removes the `puppeteer_dev_chrome_profile-*` temp dir).

No user-facing behavior change except fewer orphaned processes.

## Why

Fixes #698. Three gaps combined to leak subprocesses:

1. The browser tool only closes Chrome on an explicit tab/browser `close`.
2. Graceful `dispose()` releases browser tabs (added in #717) — but a **signal** kill bypasses `dispose()` entirely.
3. The interactive entry installed **no** `SIGTERM`/`SIGINT`/`SIGHUP` handler, so an external `kill`, cleanup sweep, OOM, or terminal close orphaned Chrome **and** the Python kernel to `ppid=1`.

This PR closes gap #3 (the proven, every-signal-kill case) and makes the headless teardown reliable even for a wedged renderer, while staying scoped to lifecycle cleanup.

## Testing

- `packages/coding-agent/test/tools/browser-registry-teardown.test.ts` — headless force-kill on forced release, kill even when CDP `close()` hangs (bounded), no kill on graceful release, refCount gating. Uses a fake `BrowserHandle` + `vi.spyOn(attach, "gracefulKillTreeOnce")` — **no real Chrome**.
- `packages/coding-agent/test/agent-session-signal-teardown.test.ts` — `disposeChildSubprocesses` delegates to the three teardown functions with the right owner ids and `{ kill: true }`, is idempotent, returns within its time box when a step hangs, and never rejects when a step throws. Uses an in-memory `AgentSession` + spies.

```
bun test packages/coding-agent/test/tools/browser-registry-teardown.test.ts \
         packages/coding-agent/test/agent-session-signal-teardown.test.ts
# 8 pass, 0 fail
```

Also re-ran related suites (browser tools, abort-timeout, python-executor-owner-cleanup) — green. `bun --cwd packages/coding-agent run check:types` passes; `biome check` passes on changed files. (Two pre-existing, unrelated failures in `image-gen` and `bash-resource-lifecycle.redteam` reproduce on the clean `dev` base and are untouched by this change.)

---

- [x] `bun check` passes (type-check + biome on changed files; full `bun check` covers unrelated packages)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
