### PR TITLE
fix(ai): recover stale Codex websocket continuations

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Allowed `openai-codex-responses` custom backends to use opaque `apiKey` bearer tokens by omitting `chatgpt-account-id` when the token does not expose a Codex account id.
+- Fixed OpenAI code websocket continuations to treat codex-lb's `codex_previous_response_stale` response failures as expired `previous_response_id` anchors and retry with full context instead of surfacing the transient failure.
 
 ## [0.5.2] - 2026-06-15
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -96,6 +96,7 @@ const CODEX_WEBSOCKET_IDLE_TIMEOUT_MS = 300000;
 const CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS = 15000;
 const CODEX_WEBSOCKET_RETRY_BUDGET = CODEX_MAX_RETRIES;
 const CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX = "Codex websocket transport error";
+const CODEX_PREVIOUS_RESPONSE_STALE_CODES = new Set(["previous_response_not_found", "codex_previous_response_stale"]);
 const CODEX_RETRYABLE_EVENT_CODES = new Set(["model_error", "server_error", "internal_error"]);
 const CODEX_RETRYABLE_EVENT_MESSAGE =
 	/processing your request|retry your request|temporar(?:y|ily)|overloaded|service.?unavailable|internal error|server error/i;
@@ -1475,7 +1476,11 @@ async function tryReconnectCodexWebSocketOnConnectionLimit(
 }
 
 function isCodexPreviousResponseNotFound(error: unknown): boolean {
-	return error instanceof CodexProviderStreamError && error.code === "previous_response_not_found";
+	return (
+		error instanceof CodexProviderStreamError &&
+		typeof error.code === "string" &&
+		CODEX_PREVIOUS_RESPONSE_STALE_CODES.has(error.code)
+	);
 }
 
 async function tryRecoverCodexPreviousResponseNotFound(
@@ -2669,6 +2674,22 @@ function getString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+function getCodexEventError(rawEvent: Record<string, unknown>): Record<string, unknown> | null {
+	const response = asRecord(rawEvent.response);
+	return asRecord(rawEvent.error) ?? (response ? asRecord(response.error) : null);
+}
+
+function getCodexEventErrorCode(rawEvent: Record<string, unknown>): string {
+	const error = getCodexEventError(rawEvent);
+	return getString(error?.code) ?? getString(error?.type) ?? getString(rawEvent.code) ?? "";
+}
+
+function getCodexEventErrorMessage(rawEvent: Record<string, unknown>): string {
+	const response = asRecord(rawEvent.response);
+	const error = getCodexEventError(rawEvent);
+	return getString(error?.message) ?? getString(rawEvent.message) ?? getString(response?.message) ?? "";
+}
+
 class CodexProviderStreamError extends Error {
 	readonly retryable: boolean;
 	readonly code?: string;
@@ -2682,19 +2703,17 @@ class CodexProviderStreamError extends Error {
 }
 
 function isRetryableCodexFailureEvent(rawEvent: Record<string, unknown>): boolean {
-	const response = asRecord(rawEvent.response);
-	const error = asRecord(rawEvent.error) ?? (response ? asRecord(response.error) : null);
-	const code = getString(error?.code) ?? getString(error?.type) ?? getString(rawEvent.code);
+	const code = getCodexEventErrorCode(rawEvent);
 	if (code && CODEX_RETRYABLE_EVENT_CODES.has(code.toLowerCase())) {
 		return true;
 	}
-	const message = getString(error?.message) ?? getString(rawEvent.message) ?? getString(response?.message);
+	const message = getCodexEventErrorMessage(rawEvent);
 	return !!message && CODEX_RETRYABLE_EVENT_MESSAGE.test(message);
 }
 
 function createCodexProviderStreamError(rawEvent: Record<string, unknown>): CodexProviderStreamError {
-	const code = getString(rawEvent.code) ?? "";
-	const message = getString(rawEvent.message) ?? "";
+	const code = getCodexEventErrorCode(rawEvent);
+	const message = getCodexEventErrorMessage(rawEvent);
 	const formattedMessage =
 		typeof rawEvent.type === "string" && rawEvent.type === "error"
 			? formatCodexErrorEvent(rawEvent, code, message)

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1711,6 +1711,108 @@ describe("openai-codex streaming", () => {
 		});
 	});
 
+	it("retries websocket continuations when codex-lb masks stale previous_response_id", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-lb-stale-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		class MaskedPreviousResponseMissingWebSocket extends MockWebSocket {
+			constructor(url: string, options?: { headers?: WsHeaders }) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			send(data: string): void {
+				const request = JSON.parse(data) as Record<string, unknown>;
+				sentRequests.push(request);
+				const requestIndex = sentRequests.length;
+
+				if (requestIndex === 1) {
+					this.emitCodexResponse({
+						messageId: "msg_1",
+						responseId: "resp_1",
+						text: "First answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				if (requestIndex === 2) {
+					expect(request.previous_response_id).toBe("resp_1");
+					this.sendJson({
+						type: "response.failed",
+						response: {
+							id: "resp_masked_failure",
+							status: "failed",
+							error: {
+								type: "server_error",
+								code: "codex_previous_response_stale",
+								message: "Upstream previous response anchor expired; retry without previous_response_id.",
+							},
+						},
+					});
+					return;
+				}
+
+				if (requestIndex === 3) {
+					expect(request.previous_response_id).toBeUndefined();
+					this.emitCodexResponse({
+						messageId: "msg_3",
+						responseId: "resp_3",
+						text: "Second answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				throw new Error(`Unexpected websocket request index: ${requestIndex}`);
+			}
+		}
+
+		global.WebSocket = MaskedPreviousResponseMissingWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [{ role: "user", content: "First question", timestamp: Date.now() }],
+		};
+		const firstResponse = await streamOpenAICodexResponses(model, firstContext, {
+			apiKey: token,
+			sessionId: "ws-masked-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+		const secondContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [
+				...firstContext.messages,
+				firstResponse,
+				{ role: "user", content: "Second question", timestamp: Date.now() + 1 },
+			],
+		};
+
+		const secondResponse = await streamOpenAICodexResponses(model, secondContext, {
+			apiKey: token,
+			sessionId: "ws-masked-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(JSON.stringify(secondResponse.content)).toContain("Second answer");
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(sentRequests).toHaveLength(3);
+		const retryInput = sentRequests[2]?.input;
+		expect(Array.isArray(retryInput)).toBe(true);
+		expect(JSON.stringify(retryInput)).toContain("First question");
+		expect(JSON.stringify(retryInput)).toContain("Second question");
+	});
+
 	it("uses low Codex text verbosity by default while preserving explicit overrides", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-verbosity-");
 		setAgentDir(tempDir.path());


### PR DESCRIPTION
## Summary

- Treat codex-lb's nested `codex_previous_response_stale` failures as expired Codex `previous_response_id` anchors.
- Normalize Codex stream error extraction across top-level and nested `response.error` event shapes.
- Retry affected WebSocket continuations with full context and no stale `previous_response_id`.
- Add a regression test and changelog entry.

## Root Cause

The existing recovery path only detected `previous_response_not_found` when it appeared as the stream error code. codex-lb can mask the same stale-anchor condition as a `response.failed` event with `response.error.code = codex_previous_response_stale`. Because the nested code and message were not normalized into `CodexProviderStreamError`, GJC surfaced the transient failure instead of retrying the continuation replay.

## Validation

- `bun test packages/ai/test/openai-codex-stream.test.ts`

Fixes https://github.com/Yeachan-Heo/gajae-code/issues/731
