### PR TITLE
fix(coding-agent): write deep-interview Korean directive in Korean to stop malformed output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).
+- Fixed `deep-interview` producing malformed Korean (misspellings and non-existent words like `좍`) when run in a Korean session. The Korean `language.instruction` carried into state is now written in natural Korean itself — priming the model to generate in Korean instead of translating an English directive on the fly — and explicitly requires standard spelling/spacing, forbids invented/transliterated non-words, and keeps code identifiers, file paths, commands, settings/JSON keys, and library/API/technical terms in their original (English) form. The SKILL question/policy steps carry the same technical-term carve-out the spec step already had.
 
 ## [0.5.2] - 2026-06-15
 

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -39,7 +39,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
-- Preserve the user/session language for every user-facing announcement, topology confirmation, option label, and interview question when state includes `language.instruction`; for example Korean initial ideas must receive Korean deep-interview questions unless the user explicitly requests another language
+- Preserve the user/session language for every user-facing announcement, topology confirmation, option label, and interview question when state includes `language.instruction`; for example Korean initial ideas must receive Korean deep-interview questions unless the user explicitly requests another language. Render the preserved language naturally and grammatically (correct spelling/spacing); never invent, calque, or transliterate non-standard words, and keep code identifiers, file paths, commands, settings/JSON keys, and library/API/technical terms in their original form rather than translating them
 - Target the WEAKEST clarity dimension with each question
 - Before Round 1 ambiguity scoring, run a one-time Round 0 topology enumeration gate that confirms the top-level component list and locks it into state
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
@@ -283,7 +283,7 @@ Auto-research must never add a public skill entrypoint, never be slash-command/d
 
 ### Step 2b: Ask the Question
 
-Use the `ask` tool with the generated question. Before rendering the prompt/options, apply `language.instruction` from state when present so the entire user-facing question remains in the preserved session language. Present it clearly with the current ambiguity context:
+Use the `ask` tool with the generated question. Before rendering the prompt/options, apply `language.instruction` from state when present so the entire user-facing question remains in the preserved session language -- phrased in natural, grammatical native text, never with invented/transliterated non-words, and keeping code identifiers, file paths, commands, settings/JSON keys, and library/API/technical terms in their original form. Present it clearly with the current ambiguity context:
 
 ```
 Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_rationale} | Ambiguity: {score}%

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -252,7 +252,7 @@ function resolveDeepInterviewLanguagePreference(idea: string): DeepInterviewLang
 			label: "Korean",
 			source: "initial-idea",
 			instruction:
-				"Ask every user-facing deep-interview question in Korean unless the user explicitly requests another language.",
+				"사용자에게 보이는 모든 deep-interview 질문·옵션·공지를 자연스럽고 어법에 맞는 표준 한국어로 작성하세요. 맞춤법과 띄어쓰기를 지키고, 존재하지 않는 단어나 어색한 직역·음역을 만들지 마세요. 코드 식별자, 파일 경로, 명령어, 설정·JSON 키, 라이브러리·API·제품명 같은 기술 용어는 한국어로 번역하지 말고 원문(영문) 그대로 쓰되, 이미 정착된 표준 한국어 용어가 있을 때만 그 용어를 사용하세요. 사용자가 다른 언어를 명시적으로 요청하면 그 언어를 따르세요.",
 		};
 	}
 	return undefined;

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -205,7 +205,7 @@ describe("native gjc deep-interview runtime", () => {
 			label: "Korean",
 			source: "initial-idea",
 		});
-		expect(payload.language.instruction).toContain("Korean");
+		expect(payload.language.instruction).toContain("한국어");
 
 		const state = JSON.parse(
 			await fs.readFile(path.join(root, ".gjc", "state", "deep-interview-state.json"), "utf-8"),


### PR DESCRIPTION
## Problem

Running `/skill:deep-interview` in a Korean session frequently emits **malformed Korean** — misspellings and non-existent words. Example option label observed in the TUI:

> `1. 둘 다, 단 좍게 시작(권장):`  ← `단 좍게` is not valid Korean

`좍` is a fabricated syllable; a width/truncation bug would *remove* characters, not *add* a jamo, so this is **model generation**, not a rendering defect (the render middleware only re-formats headers and never mangles the question body).

## Root cause

The only language directive injected into the model was a thin English line:

> "Ask every user-facing deep-interview question in Korean unless the user explicitly requests another language."

It had no natural/grammatical-Korean requirement and — critically — **no carve-out to keep technical terms in English**. The model therefore translated identifiers, library/API names, and jargon into invented Korean. The spec-generation step already had this carve-out (`SKILL.md`), but the question/option/announcement steps did not — an asymmetry that only bit at question time.

## Fix

- Rewrite the `ko` `language.instruction` (`deep-interview-runtime.ts`) **in Korean itself**, so the model is primed to generate in Korean instead of translating an English directive on the fly. It now requires standard spelling/spacing, forbids invented/transliterated non-words, and keeps code identifiers, file paths, commands, settings/JSON keys, and library/API/technical terms in their original (English) form. The `en` branch is unchanged.
- Add the same technical-term carve-out to the SKILL question/policy steps (`SKILL.md`), mirroring the spec step.
- Update the runtime test to assert the Korean directive content (`toContain("한국어")`).

This directive is the canonical value carried into `language.instruction`, so it propagates to every place the SKILL applies it (announcements, questions, options, progress, spec).

## Verification

- `bun test` deep-interview runtime / skill-contract / default-gjc-definitions: **43 pass / 0 fail** (incl. Korean language-detection test).
- `bun run check:ts` (biome + tsgo, all workspaces): clean.
- `rebrand-inventory --strict`, `verify-gjc-ui-redesign`, `check-visible-definitions`: PASS.

Targets `dev`.