### PR TITLE
fix(coding-agent): compact skill prompt chip to `[skill] <name>: <args>`

### DIFF
--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -1,6 +1,6 @@
 import type { TextContent } from "@gajae-code/ai";
 import type { Component } from "@gajae-code/tui";
-import { Box, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
+import { Box, Container, Markdown, Spacer, Text, truncateToWidth } from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CustomMessage, SkillPromptDetails } from "../../session/messages";
 
@@ -39,27 +39,35 @@ export class SkillMessageComponent extends Container {
 		this.addChild(this.#box);
 		this.#box.clear();
 
-		const label = theme.fg("customMessageLabel", theme.bold("[skill]"));
-		this.#box.addChild(new Text(label, 0, 0));
-		this.#box.addChild(new Spacer(1));
-
 		const details = this.message.details;
+		const name = details?.name ?? "unknown";
 		const args = details?.args?.trim();
-		const infoLines = [
-			`Skill: ${details?.name ?? "unknown"}`,
-			args ? `Args: ${args}` : undefined,
+
+		// Single compact line: `[skill] <name>: <args>`. The summary is the
+		// args the user typed; with none, just `[skill] <name>`. Collapsed to
+		// one line — path / line-count / full prompt body are debugging detail
+		// and only render once expanded.
+		const summary = args ? truncateToWidth(args.replace(/\s+/g, " "), 72) : undefined;
+		const header = `${theme.fg("customMessageLabel", theme.bold("[skill]"))} ${theme.fg("customMessageText", name)}`;
+		const headerText = summary ? `${header}${theme.fg("customMessageText", `: ${summary}`)}` : header;
+		this.#box.addChild(new Text(headerText, 0, 0));
+
+		if (!this.#expanded) {
+			return;
+		}
+
+		const detailLines = [
 			details?.path ? `Path: ${details.path}` : undefined,
 			typeof details?.lineCount === "number" ? `Prompt: ${details.lineCount} lines` : undefined,
 		].filter((line): line is string => Boolean(line));
 
-		this.#box.addChild(
-			new Markdown(infoLines.join("\n"), 0, 0, getMarkdownTheme(), {
-				color: (value: string) => theme.fg("customMessageText", value),
-			}),
-		);
-
-		if (!this.#expanded) {
-			return;
+		if (detailLines.length > 0) {
+			this.#box.addChild(new Spacer(1));
+			this.#box.addChild(
+				new Markdown(detailLines.join("\n"), 0, 0, getMarkdownTheme(), {
+					color: (value: string) => theme.fg("customMessageText", value),
+				}),
+			);
 		}
 
 		const text = this.#extractText();

--- a/packages/coding-agent/test/modes/components/skill-message-render.test.ts
+++ b/packages/coding-agent/test/modes/components/skill-message-render.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { SkillMessageComponent } from "@gajae-code/coding-agent/modes/components/skill-message";
+import * as themeModule from "@gajae-code/coding-agent/modes/theme/theme";
+import {
+	type CustomMessage,
+	SKILL_PROMPT_MESSAGE_TYPE,
+	type SkillPromptDetails,
+} from "@gajae-code/coding-agent/session/messages";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+function makeMessage(details: SkillPromptDetails, content: string): CustomMessage<SkillPromptDetails> {
+	return {
+		role: "custom",
+		customType: SKILL_PROMPT_MESSAGE_TYPE,
+		content,
+		display: true,
+		details,
+		timestamp: Date.now(),
+	};
+}
+
+function render(message: CustomMessage<SkillPromptDetails>, expanded: boolean): string {
+	const component = new SkillMessageComponent(message);
+	component.setExpanded(expanded);
+	return component
+		.render(120)
+		.map(line => Bun.stripANSI(line))
+		.join("\n");
+}
+
+const DETAILS: SkillPromptDetails = {
+	name: "deep-interview",
+	path: "embedded:gjc/skills/deep-interview/SKILL.md",
+	lineCount: 858,
+};
+
+describe("SkillMessageComponent rendering", () => {
+	it("collapsed view shows `[skill] <name>: <args>` and no debug metadata", () => {
+		const out = render(makeMessage({ ...DETAILS, args: "fix the login bug" }, "PROMPT BODY TEXT"), false);
+
+		expect(out).toContain("[skill] deep-interview: fix the login bug");
+
+		// Debug-only detail must be hidden when collapsed.
+		expect(out).not.toContain("Skill:");
+		expect(out).not.toContain("Args:");
+		expect(out).not.toContain("Path:");
+		expect(out).not.toContain("embedded:gjc/skills/deep-interview/SKILL.md");
+		expect(out).not.toContain("858 lines");
+		expect(out).not.toContain("PROMPT BODY TEXT");
+	});
+
+	it("renders just `[skill] <name>` when there are no args", () => {
+		const out = render(makeMessage(DETAILS, "BODY"), false);
+		expect(out).toContain("[skill] deep-interview");
+		// No colon summary when the user typed nothing.
+		expect(out).not.toContain("deep-interview:");
+	});
+
+	it("truncates over-long args to a single line", () => {
+		const longArgs = `${"A".repeat(90)} ZZZEND`;
+		const out = render(makeMessage({ ...DETAILS, args: longArgs }, "BODY"), false);
+		expect(out).toContain("AAAA");
+		expect(out).not.toContain("ZZZEND");
+	});
+
+	it("expanded view reveals path, line count, and full prompt body", () => {
+		const out = render(makeMessage({ ...DETAILS, args: "fix the login bug" }, "PROMPT BODY TEXT"), true);
+
+		expect(out).toContain("[skill] deep-interview: fix the login bug");
+		expect(out).toContain("Path:");
+		expect(out).toContain("embedded:gjc/skills/deep-interview/SKILL.md");
+		expect(out).toContain("858 lines");
+		expect(out).toContain("Prompt");
+		expect(out).toContain("PROMPT BODY TEXT");
+	});
+
+	it("falls back to 'unknown' when name is missing", () => {
+		const out = render(makeMessage({ path: "", lineCount: 0 } as unknown as SkillPromptDetails, ""), false);
+		expect(out).toContain("unknown");
+	});
+});


### PR DESCRIPTION
> Re-targets #710 (previously closed against `main`) to `dev`. Same change, rebased cleanly onto `dev` (no stray merge commit).

## What

The collapsed skill-prompt chip rendered a verbose 4-line block:

```
[skill]

Skill: deep-interview
Args:
Path: embedded:gjc/skills/deep-interview/SKILL.md
Prompt: 858 lines
```

Most of that is debugging metadata that just adds noise during normal use. This collapses it to a single line:

```
# no args
[skill] deep-interview

# with args (the user's typed input)
[skill] my-skill: fix the login bug
```

The summary after the colon is the user's typed args (truncated to one line). When there are no args, only `[skill] <name>` is shown.

## Where does the full prompt go?

Path, prompt line-count, and the full prompt body now render **only when expanded** via the existing tool-output expand toggle (`Ctrl+O`) — same model as every other tool block:

```
[skill] my-skill: fix the login bug

Path: /p/.gjc/skills/my-skill/SKILL.md
Prompt: 42 lines

Prompt
# Body
(...)
```

## Scope

- Applies uniformly to **built-in and user-added skills** (all flow through `SKILL_PROMPT_MESSAGE_TYPE` → `SkillMessageComponent`; only `details.path` differs).
- Single-file behavior change in `packages/coding-agent/src/modes/components/skill-message.ts`.

## Tests

Adds `test/modes/components/skill-message-render.test.ts` (5 cases): collapsed args summary, no-args name-only, long-args truncation, expanded reveals path/lines/body, unknown-name fallback.

Verified on `dev`: `bun test` green (5/5), `biome check` clean.