### PR TITLE
Fix Codex maintenance one-shot calls falling back to HTTP despite WebSocket config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ panic = "abort"
 
 [profile.ci]
 inherits = "release"
+# Override release's panic = "abort": the pi-natives blocking-task catch_unwind
+# guard (crates/pi-natives/src/task.rs) only converts panics to napi::Error when
+# the shipped profile unwinds. `panic` is a profile-root-only setting and cannot
+# be scoped per-package, so it is set on every profile build-native.ts ships.
+panic = "unwind"
 lto = "thin"
 codegen-units = 16
 debug = "line-tables-only"
@@ -32,6 +37,7 @@ split-debuginfo = "off"
 
 [profile.local]
 inherits = "release"
+panic = "unwind" # keep the pi-natives catch_unwind guard effective (see [profile.ci])
 lto = "thin"
 codegen-units = 16
 incremental = true

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -1183,7 +1183,7 @@ pub const KNOWN_LONG_TAIL_ALIASES: &[&str] = &[
 mod tests {
 	use std::path::Path;
 
-	use ast_grep_core::{Language, matcher::KindMatcher, tree_sitter::LanguageExt};
+	use ast_grep_core::{matcher::KindMatcher, tree_sitter::LanguageExt};
 
 	use super::SupportLang;
 

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -458,13 +458,13 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before openpty: {err}")))?;
 
-	const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 	let pair = if cfg!(windows) {
 		// Windows ConPTY openpty() can hang indefinitely when the console
 		// subsystem isn't properly initialized. Gate attempts process-wide so
 		// a hung openpty can leave at most one residual blocked thread behind.
 		#[cfg(windows)]
 		{
+			const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 			let attempt = WindowsOpenptyAttempt::acquire()?;
 			let (tx, rx) = mpsc::channel();
 			let handle = std::thread::spawn(move || {
@@ -538,15 +538,17 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
-	let mut writer = setup_guard.take_writer()?;
+	let writer = setup_guard.take_writer()?;
 	// ConPTY sends ESC[6n (cursor position query) and blocks until we reply.
 	// Reply with cursor at 1,1 so it unblocks the child spawn.
 	// Only needed on Windows; on Unix/macOS this would corrupt stdin.
 	#[cfg(windows)]
-	{
+	let writer = {
+		let mut writer = writer;
 		let _ = writer.write_all(b"\x1b[1;1R");
 		let _ = writer.flush();
-	}
+		writer
+	};
 	setup_guard.set_writer(writer);
 	let mut reader = setup_guard.try_clone_reader()?;
 

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -4,6 +4,8 @@
 //! Provides a stateful PTY session that supports streaming output and stdin
 //! passthrough while a command is running.
 
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
 	collections::HashMap,
 	io::{Read, Write},
@@ -25,22 +27,22 @@ use crate::{ps, task};
 #[napi(object)]
 pub struct PtyStartOptions<'env> {
 	/// Command string to execute.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for command execution.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables for this command.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// PTY column count.
-	pub cols:       Option<u16>,
+	pub cols: Option<u16>,
 	/// PTY row count.
-	pub rows:       Option<u16>,
+	pub rows: Option<u16>,
 	/// Shell binary to use (e.g. "sh", "bash", or an absolute path).
 	/// Defaults to "sh" if not provided.
-	pub shell:      Option<String>,
+	pub shell: Option<String>,
 }
 
 /// Result of a PTY command run.
@@ -57,15 +59,16 @@ pub struct PtyRunResult {
 #[derive(Clone)]
 struct PtyRunConfig {
 	command: String,
-	cwd:     Option<String>,
-	env:     Option<HashMap<String, String>>,
-	cols:    u16,
-	rows:    u16,
-	shell:   Option<String>,
+	cwd: Option<String>,
+	env: Option<HashMap<String, String>>,
+	cols: u16,
+	rows: u16,
+	shell: Option<String>,
 }
 
 enum ReaderEvent {
 	Chunk(String),
+	Loss { dropped_chunks: usize, dropped_bytes: usize },
 	Done,
 }
 
@@ -81,9 +84,29 @@ const POST_CANCEL_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 const POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_millis(300);
 #[cfg(not(windows))]
 const FINAL_READER_DRAIN_TIMEOUT: Duration = Duration::from_millis(50);
+const READER_EVENT_QUEUE_CAPACITY: usize = 1024;
+const READER_LOSS_MARKER_PREFIX: &str = "\n[PTY output truncated: ";
+const TERMINATED_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(windows)]
+static WINDOWS_OPENPTY_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
 struct PtySessionCore {
 	control_tx: mpsc::Sender<ControlMessage>,
+}
+
+impl Drop for PtySessionCore {
+	fn drop(&mut self) {
+		let _ = self.control_tx.send(ControlMessage::Kill);
+	}
+}
+impl Drop for PtySession {
+	fn drop(&mut self) {
+		if let Ok(mut guard) = self.core.lock() {
+			if let Some(core) = guard.take() {
+				let _ = core.control_tx.send(ControlMessage::Kill);
+			}
+		}
+	}
 }
 
 /// Stateful PTY session for interactive stdin/stdout passthrough.
@@ -116,11 +139,11 @@ impl PtySession {
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: options.command,
-			cwd:     options.cwd,
-			env:     options.env,
-			cols:    options.cols.unwrap_or(120).clamp(20, 400),
-			rows:    options.rows.unwrap_or(40).clamp(5, 200),
-			shell:   options.shell,
+			cwd: options.cwd,
+			env: options.env,
+			cols: options.cols.unwrap_or(120).clamp(20, 400),
+			rows: options.rows.unwrap_or(40).clamp(5, 200),
+			shell: options.shell,
 		};
 		let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 		let core = Arc::clone(&self.core);
@@ -136,12 +159,12 @@ impl PtySession {
 			}
 			*guard = Some(PtySessionCore { control_tx });
 		}
-		task::future(env, "pty.start", async move {
+		let future = task::future(env, "pty.start", async move {
 			let run_result =
 				tokio::task::spawn_blocking(move || run_pty_sync(run_config, on_chunk, control_rx, ct))
 					.await;
 
-			// Always clear core regardless of result
+			// Always clear core regardless of result.
 			let mut guard = core
 				.lock()
 				.map_err(|_| Error::from_reason("PTY session lock poisoned"))?;
@@ -152,7 +175,15 @@ impl PtySession {
 				Ok(inner) => inner,
 				Err(err) => Err(Error::from_reason(format!("PTY execution task failed: {err}"))),
 			}
-		})
+		});
+		if future.is_err() {
+			let mut guard = self
+				.core
+				.lock()
+				.map_err(|_| Error::from_reason("PTY session lock poisoned"))?;
+			*guard = None;
+		}
+		future
 	}
 
 	/// Write raw input bytes to PTY stdin.
@@ -210,6 +241,213 @@ fn terminate_pty_processes(
 	let _ = child.kill();
 	targets.signal(ps::KILL_SIGNAL);
 }
+fn reap_terminated_child(
+	child: &mut Box<dyn Child + Send + Sync>,
+	deadline: Instant,
+) -> Result<Option<i32>> {
+	loop {
+		if let Some(status) = child
+			.try_wait()
+			.map_err(|err| Error::from_reason(format!("Failed checking PTY status: {err}")))?
+		{
+			return Ok(Some(i32::try_from(status.exit_code()).unwrap_or(i32::MAX)));
+		}
+		if Instant::now() >= deadline {
+			return Ok(None);
+		}
+		std::thread::sleep(Duration::from_millis(10));
+	}
+}
+struct PostSpawnSetupGuard {
+	child: Option<Box<dyn Child + Send + Sync>>,
+	master: Option<Box<dyn portable_pty::MasterPty + Send>>,
+	writer: Option<Box<dyn Write + Send>>,
+	child_pid: Option<i32>,
+	process_group_id: Option<i32>,
+	disarmed: bool,
+}
+
+impl PostSpawnSetupGuard {
+	fn new(
+		child: Box<dyn Child + Send + Sync>,
+		master: Box<dyn portable_pty::MasterPty + Send>,
+	) -> Self {
+		let child_pid = child
+			.process_id()
+			.and_then(|value| i32::try_from(value).ok());
+		#[cfg(unix)]
+		let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
+		#[cfg(not(unix))]
+		let process_group_id = None;
+		Self {
+			child: Some(child),
+			master: Some(master),
+			writer: None,
+			child_pid,
+			process_group_id,
+			disarmed: false,
+		}
+	}
+
+	fn master(&self) -> &dyn portable_pty::MasterPty {
+		self
+			.master
+			.as_ref()
+			.expect("setup guard owns PTY master")
+			.as_ref()
+	}
+
+	fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
+		let writer = self
+			.master()
+			.take_writer()
+			.map_err(|err| Error::from_reason(format!("Failed to create PTY writer: {err}")))?;
+		Ok(writer)
+	}
+
+	fn set_writer(&mut self, writer: Box<dyn Write + Send>) {
+		self.writer = Some(writer);
+	}
+
+	fn try_clone_reader(&self) -> Result<Box<dyn Read + Send>> {
+		self
+			.master()
+			.try_clone_reader()
+			.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))
+	}
+
+	fn disarm(
+		mut self,
+	) -> (
+		Box<dyn Child + Send + Sync>,
+		Box<dyn portable_pty::MasterPty + Send>,
+		Box<dyn Write + Send>,
+		Option<i32>,
+		Option<i32>,
+	) {
+		self.disarmed = true;
+		(
+			self.child.take().expect("setup guard owns PTY child"),
+			self.master.take().expect("setup guard owns PTY master"),
+			self.writer.take().expect("setup guard owns PTY writer"),
+			self.child_pid,
+			self.process_group_id,
+		)
+	}
+}
+
+impl Drop for PostSpawnSetupGuard {
+	fn drop(&mut self) {
+		if self.disarmed {
+			return;
+		}
+		drop(self.writer.take());
+		if let Some(child) = self.child.as_mut() {
+			terminate_pty_processes(child, self.child_pid, self.process_group_id);
+			let _ = reap_terminated_child(child, Instant::now() + TERMINATED_REAP_TIMEOUT);
+		}
+		drop(self.master.take());
+	}
+}
+
+fn loss_marker(dropped_chunks: usize, dropped_bytes: usize) -> String {
+	format!("{READER_LOSS_MARKER_PREFIX}{dropped_chunks} chunks / {dropped_bytes} bytes dropped]\n")
+}
+
+fn reader_event_len(event: &ReaderEvent) -> usize {
+	match event {
+		ReaderEvent::Chunk(chunk) => chunk.len(),
+		ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+			loss_marker(*dropped_chunks, *dropped_bytes).len()
+		},
+		ReaderEvent::Done => 0,
+	}
+}
+
+fn try_send_reader_event(
+	tx: &mpsc::SyncSender<ReaderEvent>,
+	event: ReaderEvent,
+	dropped_chunks: &mut usize,
+	dropped_bytes: &mut usize,
+) -> bool {
+	if *dropped_chunks > 0 {
+		match tx.try_send(ReaderEvent::Loss {
+			dropped_chunks: *dropped_chunks,
+			dropped_bytes: *dropped_bytes,
+		}) {
+			Ok(()) => {
+				*dropped_chunks = 0;
+				*dropped_bytes = 0;
+			},
+			Err(mpsc::TrySendError::Full(_)) => {},
+			Err(mpsc::TrySendError::Disconnected(_)) => return false,
+		}
+	}
+	match tx.try_send(event) {
+		Ok(()) => true,
+		Err(mpsc::TrySendError::Full(event)) => {
+			if !matches!(event, ReaderEvent::Done) {
+				*dropped_chunks = dropped_chunks.saturating_add(1);
+				*dropped_bytes = dropped_bytes.saturating_add(reader_event_len(&event));
+			}
+			true
+		},
+		Err(mpsc::TrySendError::Disconnected(_)) => false,
+	}
+}
+
+fn send_reader_final_events(
+	tx: &mpsc::SyncSender<ReaderEvent>,
+	dropped_chunks: &mut usize,
+	dropped_bytes: &mut usize,
+) -> bool {
+	if *dropped_chunks > 0 {
+		if tx
+			.send(ReaderEvent::Loss { dropped_chunks: *dropped_chunks, dropped_bytes: *dropped_bytes })
+			.is_err()
+		{
+			return false;
+		}
+		*dropped_chunks = 0;
+		*dropped_bytes = 0;
+	}
+	tx.send(ReaderEvent::Done).is_ok()
+}
+
+fn emit_reader_event(event: ReaderEvent, callback: Option<&ThreadsafeFunction<String>>) -> bool {
+	match event {
+		ReaderEvent::Chunk(chunk) => emit_chunk(&chunk, callback),
+		ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+			emit_chunk(&loss_marker(dropped_chunks, dropped_bytes), callback)
+		},
+		ReaderEvent::Done => true,
+	}
+}
+
+#[cfg(windows)]
+struct WindowsOpenptyAttempt;
+
+#[cfg(windows)]
+impl WindowsOpenptyAttempt {
+	fn acquire() -> Result<Self> {
+		WINDOWS_OPENPTY_IN_FLIGHT
+			.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+			.map(|_| Self)
+			.map_err(|_| {
+				Error::from_reason(
+					"PTY creation is already in progress; refusing to spawn another ConPTY thread",
+				)
+			})
+	}
+}
+
+#[cfg(windows)]
+impl Drop for WindowsOpenptyAttempt {
+	fn drop(&mut self) {
+		WINDOWS_OPENPTY_IN_FLIGHT.store(false, Ordering::Release);
+	}
+}
+
 fn run_pty_sync(
 	config: PtyRunConfig,
 	on_chunk: Option<ThreadsafeFunction<String>>,
@@ -223,35 +461,47 @@ fn run_pty_sync(
 	const PTY_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 	let pair = if cfg!(windows) {
 		// Windows ConPTY openpty() can hang indefinitely when the console
-		// subsystem isn't properly initialized. Use a short startup timeout
-		// so the Promise rejects instead of hanging forever.
-		let (tx, rx) = mpsc::channel();
-		std::thread::spawn(move || {
-			let result = pty_system.openpty(PtySize {
-				rows:         config.rows,
-				cols:         config.cols,
-				pixel_width:  0,
-				pixel_height: 0,
+		// subsystem isn't properly initialized. Gate attempts process-wide so
+		// a hung openpty can leave at most one residual blocked thread behind.
+		#[cfg(windows)]
+		{
+			let attempt = WindowsOpenptyAttempt::acquire()?;
+			let (tx, rx) = mpsc::channel();
+			let handle = std::thread::spawn(move || {
+				let result = pty_system.openpty(PtySize {
+					rows: config.rows,
+					cols: config.cols,
+					pixel_width: 0,
+					pixel_height: 0,
+				});
+				let _ = tx.send(result);
 			});
-			let _ = tx.send(result);
-		});
-		match rx.recv_timeout(PTY_STARTUP_TIMEOUT) {
-			Ok(Ok(pair)) => pair,
-			Ok(Err(e)) => return Err(Error::from_reason(format!("Failed to open PTY: {e}"))),
-			Err(_) => {
-				return Err(Error::from_reason(
-					"PTY creation timed out (5s). ConPTY may be unavailable on this system.",
-				));
-			},
+			match rx.recv_timeout(PTY_STARTUP_TIMEOUT) {
+				Ok(Ok(pair)) => {
+					let _ = handle.join();
+					drop(attempt);
+					pair
+				},
+				Ok(Err(e)) => {
+					let _ = handle.join();
+					return Err(Error::from_reason(format!("Failed to open PTY: {e}")));
+				},
+				Err(_) => {
+					// The worker may be permanently stuck inside ConPTY. Keep the
+					// single-flight gate held after timeout so residual leakage is capped
+					// to one outstanding openpty thread for the process lifetime.
+					std::mem::forget(attempt);
+					return Err(Error::from_reason(
+						"PTY creation timed out (5s). ConPTY may be unavailable on this system.",
+					));
+				},
+			}
 		}
+		#[cfg(not(windows))]
+		unreachable!()
 	} else {
 		pty_system
-			.openpty(PtySize {
-				rows:         config.rows,
-				cols:         config.cols,
-				pixel_width:  0,
-				pixel_height: 0,
-			})
+			.openpty(PtySize { rows: config.rows, cols: config.cols, pixel_width: 0, pixel_height: 0 })
 			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?
 	};
 
@@ -279,18 +529,16 @@ fn run_pty_sync(
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before spawn: {err}")))?;
 
-	let mut child = pair
+	let child = pair
 		.slave
 		.spawn_command(cmd)
 		.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
 	drop(pair.slave);
+	let mut setup_guard = PostSpawnSetupGuard::new(child, pair.master);
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
-	let master = pair.master;
-	let mut writer = master
-		.take_writer()
-		.map_err(|err| Error::from_reason(format!("Failed to create PTY writer: {err}")))?;
+	let mut writer = setup_guard.take_writer()?;
 	// ConPTY sends ESC[6n (cursor position query) and blocks until we reply.
 	// Reply with cursor at 1,1 so it unblocks the child spawn.
 	// Only needed on Windows; on Unix/macOS this would corrupt stdin.
@@ -299,16 +547,17 @@ fn run_pty_sync(
 		let _ = writer.write_all(b"\x1b[1;1R");
 		let _ = writer.flush();
 	}
-	let mut reader = master
-		.try_clone_reader()
-		.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))?;
+	setup_guard.set_writer(writer);
+	let mut reader = setup_guard.try_clone_reader()?;
 
-	let (reader_tx, reader_rx) = mpsc::channel::<ReaderEvent>();
+	let (reader_tx, reader_rx) = mpsc::sync_channel::<ReaderEvent>(READER_EVENT_QUEUE_CAPACITY);
 	let reader_thread = std::thread::spawn(move || {
 		const REPLACEMENT: &str = "\u{FFFD}";
 		const BUF: usize = 65536;
 		let mut buf = vec![0u8; BUF + 4];
 		let mut it = 0;
+		let mut dropped_chunks = 0usize;
+		let mut dropped_bytes = 0usize;
 		loop {
 			match reader.read(&mut buf[it..BUF]) {
 				Ok(0) => {
@@ -320,7 +569,14 @@ fn run_pty_sync(
 						let pending = &buf[..it];
 						match str::from_utf8(pending) {
 							Ok(text) => {
-								let _ = reader_tx.send(ReaderEvent::Chunk(text.to_string()));
+								if !try_send_reader_event(
+									&reader_tx,
+									ReaderEvent::Chunk(text.to_string()),
+									&mut dropped_chunks,
+									&mut dropped_bytes,
+								) {
+									return;
+								}
 								it = 0;
 								break;
 							},
@@ -329,13 +585,27 @@ fn run_pty_sync(
 								if valid_up_to > 0 {
 									// SAFETY: [..valid_up_to] is guaranteed valid UTF-8 by valid_up_to().
 									let text = unsafe { str::from_utf8_unchecked(&pending[..valid_up_to]) };
-									let _ = reader_tx.send(ReaderEvent::Chunk(text.to_string()));
+									if !try_send_reader_event(
+										&reader_tx,
+										ReaderEvent::Chunk(text.to_string()),
+										&mut dropped_chunks,
+										&mut dropped_bytes,
+									) {
+										return;
+									}
 									buf.copy_within(valid_up_to..it, 0);
 									it -= valid_up_to;
 								}
 								match err.error_len() {
 									Some(invalid_len) => {
-										let _ = reader_tx.send(ReaderEvent::Chunk(REPLACEMENT.to_string()));
+										if !try_send_reader_event(
+											&reader_tx,
+											ReaderEvent::Chunk(REPLACEMENT.to_string()),
+											&mut dropped_chunks,
+											&mut dropped_bytes,
+										) {
+											return;
+										}
 										buf.copy_within(invalid_len..it, 0);
 										it -= invalid_len;
 									},
@@ -354,23 +624,29 @@ fn run_pty_sync(
 		}
 		for chunk in buf[..it].utf8_chunks() {
 			let valid = chunk.valid();
-			if !valid.is_empty() {
-				let _ = reader_tx.send(ReaderEvent::Chunk(valid.to_string()));
+			if !valid.is_empty()
+				&& !try_send_reader_event(
+					&reader_tx,
+					ReaderEvent::Chunk(valid.to_string()),
+					&mut dropped_chunks,
+					&mut dropped_bytes,
+				) {
+				return;
 			}
-			if !chunk.invalid().is_empty() {
-				let _ = reader_tx.send(ReaderEvent::Chunk(REPLACEMENT.to_string()));
+			if !chunk.invalid().is_empty()
+				&& !try_send_reader_event(
+					&reader_tx,
+					ReaderEvent::Chunk(REPLACEMENT.to_string()),
+					&mut dropped_chunks,
+					&mut dropped_bytes,
+				) {
+				return;
 			}
 		}
-		let _ = reader_tx.send(ReaderEvent::Done);
+		let _ = send_reader_final_events(&reader_tx, &mut dropped_chunks, &mut dropped_bytes);
 	});
 
-	let child_pid = child
-		.process_id()
-		.and_then(|value| i32::try_from(value).ok());
-	#[cfg(unix)]
-	let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
-	#[cfg(not(unix))]
-	let process_group_id: Option<i32> = None;
+	let (mut child, master, mut writer, child_pid, process_group_id) = setup_guard.disarm();
 	let mut timed_out = false;
 	let mut cancelled = false;
 	let mut reader_done = false;
@@ -411,10 +687,20 @@ fn run_pty_sync(
 
 		for _ in 0..READER_EVENTS_PER_TICK {
 			match reader_rx.try_recv() {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
+				},
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						cancelled = true;
+						if !terminate_requested {
+							terminate_pty_processes(&mut child, child_pid, process_group_id);
+							terminate_requested = true;
+							reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
+						}
+						break;
+					}
 				},
 				Err(mpsc::TryRecvError::Empty) => break,
 				Err(mpsc::TryRecvError::Disconnected) => {
@@ -423,6 +709,7 @@ fn run_pty_sync(
 				},
 			}
 		}
+
 		if exit_code.is_none()
 			&& let Some(status) = child
 				.try_wait()
@@ -446,8 +733,17 @@ fn run_pty_sync(
 					.min(Duration::from_millis(16))
 			});
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => reader_done = true,
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						cancelled = true;
+						if !terminate_requested {
+							terminate_pty_processes(&mut child, child_pid, process_group_id);
+							terminate_requested = true;
+							reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
+						}
+					}
+				},
 				Err(mpsc::RecvTimeoutError::Timeout) => {},
 				Err(mpsc::RecvTimeoutError::Disconnected) => {
 					reader_done = true;
@@ -460,12 +756,7 @@ fn run_pty_sync(
 	}
 	if exit_code.is_none() {
 		if terminate_requested {
-			if let Some(status) = child
-				.try_wait()
-				.map_err(|err| Error::from_reason(format!("Failed checking PTY status: {err}")))?
-			{
-				exit_code = Some(i32::try_from(status.exit_code()).unwrap_or(i32::MAX));
-			}
+			exit_code = reap_terminated_child(&mut child, Instant::now() + TERMINATED_REAP_TIMEOUT)?;
 		} else {
 			// On Windows, child.wait() can hang indefinitely in ConPTY.
 			// Poll try_wait() with a short timeout instead.
@@ -504,6 +795,9 @@ fn run_pty_sync(
 	// After the child exits and input is closed, ConPTY should flush remaining
 	// output and signal EOF on the output pipe, causing the reader thread to exit.
 	// On Windows, use a generous timeout to accommodate ConPTY's async teardown.
+	if exit_code.is_some() && !terminate_requested && !reader_done {
+		terminate_pty_processes(&mut child, child_pid, process_group_id);
+	}
 	if !reader_done {
 		#[cfg(windows)]
 		let drain_timeout = Duration::from_millis(500);
@@ -514,10 +808,14 @@ fn run_pty_sync(
 			let remaining = finalize_deadline.saturating_duration_since(Instant::now());
 			let wait_duration = remaining.min(Duration::from_millis(5));
 			match reader_rx.recv_timeout(wait_duration) {
-				Ok(ReaderEvent::Chunk(chunk)) => emit_chunk(&chunk, on_chunk.as_ref()),
 				Ok(ReaderEvent::Done) => {
 					reader_done = true;
 					break;
+				},
+				Ok(event) => {
+					if !emit_reader_event(event, on_chunk.as_ref()) {
+						break;
+					}
 				},
 				Err(mpsc::RecvTimeoutError::Timeout) => {},
 				Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -558,8 +856,280 @@ fn run_pty_sync(
 	Ok(PtyRunResult { exit_code, cancelled, timed_out })
 }
 
-fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) {
-	if let Some(callback) = callback {
-		callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking);
+fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) -> bool {
+	let Some(callback) = callback else {
+		return true;
+	};
+	callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking) == napi::Status::Ok
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs,
+		path::PathBuf,
+		sync::{Mutex, mpsc},
+		time::{Duration, Instant},
+	};
+
+	use super::*;
+	static PTY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+	fn test_config(command: &str) -> PtyRunConfig {
+		PtyRunConfig {
+			command: command.to_string(),
+			cwd: None,
+			env: None,
+			cols: 80,
+			rows: 24,
+			shell: Some("sh".to_string()),
+		}
+	}
+
+	#[cfg(unix)]
+	fn process_exists(pid: i32) -> bool {
+		unsafe { libc::kill(pid, 0) == 0 }
+	}
+
+	#[cfg(unix)]
+	fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+		let deadline = Instant::now() + timeout;
+		while Instant::now() < deadline {
+			if !process_exists(pid) {
+				return true;
+			}
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		!process_exists(pid)
+	}
+
+	#[cfg(unix)]
+	fn test_path(name: &str) -> PathBuf {
+		let mut path = std::env::temp_dir();
+		path.push(format!("pi-natives-pty-{name}-{}", std::process::id()));
+		let _ = fs::remove_file(&path);
+		path
+	}
+	#[cfg(unix)]
+	fn post_spawn_setup_error_after_spawn(command: &str, pid_path: &std::path::Path) -> Result<()> {
+		let pty_system = native_pty_system();
+		let pair = pty_system
+			.openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?;
+		let mut cmd = CommandBuilder::new("sh");
+		cmd.arg("-lc");
+		cmd.arg(command);
+		let child = pair
+			.slave
+			.spawn_command(cmd)
+			.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
+		drop(pair.slave);
+		let setup_guard = PostSpawnSetupGuard::new(child, pair.master);
+		if let Some(pid) = setup_guard.child_pid {
+			fs::write(pid_path, pid.to_string())
+				.map_err(|err| Error::from_reason(format!("Failed to write child pid: {err}")))?;
+		}
+		Err(Error::from_reason("simulated post-spawn setup failure"))
+	}
+
+	#[test]
+	fn bounded_reader_channel_reports_success_for_high_output() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let (_tx, rx) = mpsc::channel();
+		let started = Instant::now();
+		let result = run_pty_sync(
+			test_config("i=0; while [ $i -lt 200000 ]; do printf '%080d\\n' \"$i\"; i=$((i+1)); done"),
+			None,
+			rx,
+			task::CancelToken::new(Some(20_000), None),
+		)
+		.expect("high-output PTY run should complete without unbounded buffering");
+		assert!(result.exit_code.is_some());
+		assert!(!result.cancelled);
+		assert!(!result.timed_out);
+		assert!(started.elapsed() < Duration::from_secs(20));
+	}
+
+	#[test]
+	fn final_reader_loss_and_done_are_delivered_when_queue_is_full() {
+		let (tx, rx) = mpsc::sync_channel(READER_EVENT_QUEUE_CAPACITY);
+		let mut dropped_chunks = 0usize;
+		let mut dropped_bytes = 0usize;
+		for i in 0..READER_EVENT_QUEUE_CAPACITY {
+			assert!(try_send_reader_event(
+				&tx,
+				ReaderEvent::Chunk(format!("chunk-{i}")),
+				&mut dropped_chunks,
+				&mut dropped_bytes,
+			));
+		}
+		assert!(try_send_reader_event(
+			&tx,
+			ReaderEvent::Chunk("dropped-tail".to_string()),
+			&mut dropped_chunks,
+			&mut dropped_bytes,
+		));
+		assert_eq!(dropped_chunks, 1);
+		let finalizer = std::thread::spawn(move || {
+			assert!(send_reader_final_events(&tx, &mut dropped_chunks, &mut dropped_bytes));
+		});
+
+		let mut output = String::new();
+		let mut saw_done = false;
+		while let Ok(event) = rx.recv() {
+			match event {
+				ReaderEvent::Chunk(chunk) => output.push_str(&chunk),
+				ReaderEvent::Loss { dropped_chunks, dropped_bytes } => {
+					assert!(dropped_chunks > 0);
+					assert!(dropped_bytes > 0);
+					output.push_str(&loss_marker(dropped_chunks, dropped_bytes));
+				},
+				ReaderEvent::Done => {
+					saw_done = true;
+					break;
+				},
+			}
+		}
+
+		finalizer.join().expect("final sender should not panic");
+		assert!(saw_done);
+		assert!(output.contains(READER_LOSS_MARKER_PREFIX));
+		assert!(output.contains("1 chunks / 12 bytes dropped"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn dropped_session_core_kills_and_reaps_mid_run_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("drop-pid");
+		let command = format!("printf '%s' $$ > {}; trap '' TERM; sleep 30", pid_path.display());
+		let (tx, rx) = mpsc::channel();
+		let core = PtySessionCore { control_tx: tx };
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+		});
+		let deadline = Instant::now() + Duration::from_secs(2);
+		while !pid_path.exists() && Instant::now() < deadline {
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		drop(core);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("dropped PTY core should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+	#[cfg(unix)]
+	#[test]
+	fn dropped_js_pty_session_kills_and_reaps_mid_run_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("drop-js-session-pid");
+		let command = format!("printf '%s' $$ > {}; trap '' TERM; sleep 30", pid_path.display());
+		let session = PtySession::new();
+		let (tx, rx) = mpsc::channel();
+		{
+			let mut guard = session.core.lock().expect("session lock");
+			*guard = Some(PtySessionCore { control_tx: tx });
+		}
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+		});
+		let deadline = Instant::now() + Duration::from_secs(2);
+		while !pid_path.exists() && Instant::now() < deadline {
+			std::thread::sleep(Duration::from_millis(20));
+		}
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		drop(session);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("dropped JS PTY session should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn post_spawn_setup_error_guard_reaps_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let pid_path = test_path("post-spawn-error-pid");
+		let command = "trap '' TERM; sleep 30";
+		let result = post_spawn_setup_error_after_spawn(command, &pid_path);
+		assert!(result.is_err());
+		let child_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("child pid file should be written before injected failure")
+			.parse()
+			.expect("pid file should contain a pid");
+		assert!(wait_for_process_exit(child_pid, Duration::from_secs(2)));
+		let _ = fs::remove_file(pid_path);
+	}
+
+	#[test]
+	fn kill_path_reaps_sigterm_trapping_child() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		let (tx, rx) = mpsc::channel();
+		let handle = std::thread::spawn(move || {
+			run_pty_sync(
+				test_config("trap '' TERM; printf ready; sleep 30"),
+				None,
+				rx,
+				task::CancelToken::new(Some(10_000), None),
+			)
+		});
+		std::thread::sleep(Duration::from_millis(200));
+		let started = Instant::now();
+		let _ = tx.send(ControlMessage::Kill);
+		let result = handle
+			.join()
+			.expect("PTY worker should not panic")
+			.expect("killed PTY run should return a result");
+		assert!(result.cancelled);
+		assert!(result.exit_code.is_some());
+		assert!(started.elapsed() < TERMINATED_REAP_TIMEOUT + Duration::from_secs(1));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn background_grandchild_holding_slave_is_reaped_and_unrelated_sibling_survives() {
+		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+		use std::process::{Command, Stdio};
+
+		let mut sibling = Command::new("sh")
+			.arg("-c")
+			.arg("sleep 30")
+			.stdin(Stdio::null())
+			.stdout(Stdio::null())
+			.stderr(Stdio::null())
+			.spawn()
+			.expect("spawn unrelated sibling");
+		let sibling_pid = i32::try_from(sibling.id()).expect("sibling pid fits i32");
+		let pid_path = test_path("background-pid");
+		let command = format!("sleep 30 & printf '%s' $! > {}; echo done", pid_path.display());
+		let (_tx, rx) = mpsc::channel();
+		let result =
+			run_pty_sync(test_config(&command), None, rx, task::CancelToken::new(Some(10_000), None))
+				.expect("PTY run should complete after reaping background grandchild");
+		assert!(result.exit_code.is_some());
+		let grandchild_pid: i32 = fs::read_to_string(&pid_path)
+			.expect("grandchild pid file should be written")
+			.parse()
+			.expect("pid file should contain a pid");
+		assert!(wait_for_process_exit(grandchild_pid, Duration::from_secs(2)));
+		assert!(process_exists(sibling_pid));
+		let _ = sibling.kill();
+		let _ = sibling.wait();
+		let _ = fs::remove_file(pid_path);
 	}
 }

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -27,22 +27,22 @@ use crate::{ps, task};
 #[napi(object)]
 pub struct PtyStartOptions<'env> {
 	/// Command string to execute.
-	pub command: String,
+	pub command:    String,
 	/// Working directory for command execution.
-	pub cwd: Option<String>,
+	pub cwd:        Option<String>,
 	/// Environment variables for this command.
-	pub env: Option<HashMap<String, String>>,
+	pub env:        Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:     Option<Unknown<'env>>,
 	/// PTY column count.
-	pub cols: Option<u16>,
+	pub cols:       Option<u16>,
 	/// PTY row count.
-	pub rows: Option<u16>,
+	pub rows:       Option<u16>,
 	/// Shell binary to use (e.g. "sh", "bash", or an absolute path).
 	/// Defaults to "sh" if not provided.
-	pub shell: Option<String>,
+	pub shell:      Option<String>,
 }
 
 /// Result of a PTY command run.
@@ -59,11 +59,11 @@ pub struct PtyRunResult {
 #[derive(Clone)]
 struct PtyRunConfig {
 	command: String,
-	cwd: Option<String>,
-	env: Option<HashMap<String, String>>,
-	cols: u16,
-	rows: u16,
-	shell: Option<String>,
+	cwd:     Option<String>,
+	env:     Option<HashMap<String, String>>,
+	cols:    u16,
+	rows:    u16,
+	shell:   Option<String>,
 }
 
 enum ReaderEvent {
@@ -101,10 +101,10 @@ impl Drop for PtySessionCore {
 }
 impl Drop for PtySession {
 	fn drop(&mut self) {
-		if let Ok(mut guard) = self.core.lock() {
-			if let Some(core) = guard.take() {
-				let _ = core.control_tx.send(ControlMessage::Kill);
-			}
+		if let Ok(mut guard) = self.core.lock()
+			&& let Some(core) = guard.take()
+		{
+			let _ = core.control_tx.send(ControlMessage::Kill);
 		}
 	}
 }
@@ -139,11 +139,11 @@ impl PtySession {
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: options.command,
-			cwd: options.cwd,
-			env: options.env,
-			cols: options.cols.unwrap_or(120).clamp(20, 400),
-			rows: options.rows.unwrap_or(40).clamp(5, 200),
-			shell: options.shell,
+			cwd:     options.cwd,
+			env:     options.env,
+			cols:    options.cols.unwrap_or(120).clamp(20, 400),
+			rows:    options.rows.unwrap_or(40).clamp(5, 200),
+			shell:   options.shell,
 		};
 		let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 		let core = Arc::clone(&self.core);
@@ -258,13 +258,22 @@ fn reap_terminated_child(
 		std::thread::sleep(Duration::from_millis(10));
 	}
 }
+/// Owned PTY pieces handed back when the setup guard is disarmed:
+/// `(child, master, writer, child_pid, process_group_id)`.
+type DisarmedPty = (
+	Box<dyn Child + Send + Sync>,
+	Box<dyn portable_pty::MasterPty + Send>,
+	Box<dyn Write + Send>,
+	Option<i32>,
+	Option<i32>,
+);
 struct PostSpawnSetupGuard {
-	child: Option<Box<dyn Child + Send + Sync>>,
-	master: Option<Box<dyn portable_pty::MasterPty + Send>>,
-	writer: Option<Box<dyn Write + Send>>,
-	child_pid: Option<i32>,
+	child:            Option<Box<dyn Child + Send + Sync>>,
+	master:           Option<Box<dyn portable_pty::MasterPty + Send>>,
+	writer:           Option<Box<dyn Write + Send>>,
+	child_pid:        Option<i32>,
 	process_group_id: Option<i32>,
-	disarmed: bool,
+	disarmed:         bool,
 }
 
 impl PostSpawnSetupGuard {
@@ -297,7 +306,7 @@ impl PostSpawnSetupGuard {
 			.as_ref()
 	}
 
-	fn take_writer(&mut self) -> Result<Box<dyn Write + Send>> {
+	fn take_writer(&self) -> Result<Box<dyn Write + Send>> {
 		let writer = self
 			.master()
 			.take_writer()
@@ -316,15 +325,7 @@ impl PostSpawnSetupGuard {
 			.map_err(|err| Error::from_reason(format!("Failed to create PTY reader: {err}")))
 	}
 
-	fn disarm(
-		mut self,
-	) -> (
-		Box<dyn Child + Send + Sync>,
-		Box<dyn portable_pty::MasterPty + Send>,
-		Box<dyn Write + Send>,
-		Option<i32>,
-		Option<i32>,
-	) {
+	fn disarm(mut self) -> DisarmedPty {
 		self.disarmed = true;
 		(
 			self.child.take().expect("setup guard owns PTY child"),
@@ -373,7 +374,7 @@ fn try_send_reader_event(
 	if *dropped_chunks > 0 {
 		match tx.try_send(ReaderEvent::Loss {
 			dropped_chunks: *dropped_chunks,
-			dropped_bytes: *dropped_bytes,
+			dropped_bytes:  *dropped_bytes,
 		}) {
 			Ok(()) => {
 				*dropped_chunks = 0;
@@ -403,7 +404,10 @@ fn send_reader_final_events(
 ) -> bool {
 	if *dropped_chunks > 0 {
 		if tx
-			.send(ReaderEvent::Loss { dropped_chunks: *dropped_chunks, dropped_bytes: *dropped_bytes })
+			.send(ReaderEvent::Loss {
+				dropped_chunks: *dropped_chunks,
+				dropped_bytes:  *dropped_bytes,
+			})
 			.is_err()
 		{
 			return false;
@@ -469,9 +473,9 @@ fn run_pty_sync(
 			let (tx, rx) = mpsc::channel();
 			let handle = std::thread::spawn(move || {
 				let result = pty_system.openpty(PtySize {
-					rows: config.rows,
-					cols: config.cols,
-					pixel_width: 0,
+					rows:         config.rows,
+					cols:         config.cols,
+					pixel_width:  0,
 					pixel_height: 0,
 				});
 				let _ = tx.send(result);
@@ -501,7 +505,12 @@ fn run_pty_sync(
 		unreachable!()
 	} else {
 		pty_system
-			.openpty(PtySize { rows: config.rows, cols: config.cols, pixel_width: 0, pixel_height: 0 })
+			.openpty(PtySize {
+				rows:         config.rows,
+				cols:         config.cols,
+				pixel_width:  0,
+				pixel_height: 0,
+			})
 			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?
 	};
 
@@ -880,11 +889,11 @@ mod tests {
 	fn test_config(command: &str) -> PtyRunConfig {
 		PtyRunConfig {
 			command: command.to_string(),
-			cwd: None,
-			env: None,
-			cols: 80,
-			rows: 24,
-			shell: Some("sh".to_string()),
+			cwd:     None,
+			env:     None,
+			cols:    80,
+			rows:    24,
+			shell:   Some("sh".to_string()),
 		}
 	}
 

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -19,25 +19,27 @@ use pi_shell::{
 };
 
 use crate::task;
+const SHELL_CALLBACK_QUEUE_CAPACITY: usize = 1024;
+const SHELL_LOSS_MARKER_PREFIX: &str = "\n[Shell output truncated: ";
 
 /// N-API opt-in handle for the minimizer.
 #[napi(object)]
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled: Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path: Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash: Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only: Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except: Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
 	pub max_capture_bytes: Option<u32>,
@@ -46,11 +48,11 @@ pub struct MinimizerOptions {
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled:           value.enabled,
-			settings_path:     value.settings_path,
-			settings_hash:     value.settings_hash,
-			only:              value.only,
-			except:            value.except,
+			enabled: value.enabled,
+			settings_path: value.settings_path,
+			settings_hash: value.settings_hash,
+			only: value.only,
+			except: value.except,
 			max_capture_bytes: value.max_capture_bytes,
 		}
 	}
@@ -60,19 +62,19 @@ impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 #[napi(object)]
 pub struct ShellOptions {
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer: Option<MinimizerOptions>,
 }
 
 impl From<ShellOptions> for CoreShellOptions {
 	fn from(value: ShellOptions) -> Self {
 		Self {
-			session_env:   value.session_env,
+			session_env: value.session_env,
 			snapshot_path: value.snapshot_path,
-			minimizer:     value.minimizer.map(Into::into),
+			minimizer: value.minimizer.map(Into::into),
 		}
 	}
 }
@@ -81,36 +83,36 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:       String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:           Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:           Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms:    Option<u32>,
+	pub timeout_ms: Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer: Option<MinimizerOptions>,
 	/// Abort signal for cancelling the operation.
-	pub signal:        Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -124,27 +126,27 @@ pub struct ShellExecuteOptions<'env> {
 pub struct MinimizerResult {
 	/// Dispatch label produced by the minimizer (e.g. `"git"`,
 	/// `"pipeline:gradle"`, `"pipeline+builtin"`).
-	pub filter:        String,
+	pub filter: String,
 	/// The minimized replacement text. Callers that streamed raw chunks
 	/// during execution should clear and replace their accumulated output
 	/// with this text.
-	pub text:          String,
+	pub text: String,
 	/// The full original capture, before minimization.
 	pub original_text: String,
 	/// Captured byte length before minimization.
-	pub input_bytes:   u32,
+	pub input_bytes: u32,
 	/// Byte length of the minimized text the consumer received.
-	pub output_bytes:  u32,
+	pub output_bytes: u32,
 }
 
 impl From<CoreMinimizerResult> for MinimizerResult {
 	fn from(value: CoreMinimizerResult) -> Self {
 		Self {
-			filter:        value.filter,
-			text:          value.text,
+			filter: value.filter,
+			text: value.text,
 			original_text: value.original_text,
-			input_bytes:   value.input_bytes,
-			output_bytes:  value.output_bytes,
+			input_bytes: value.input_bytes,
+			output_bytes: value.output_bytes,
 		}
 	}
 }
@@ -208,9 +210,9 @@ impl Shell {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
-			command:    options.command,
-			cwd:        options.cwd,
-			env:        options.env,
+			command: options.command,
+			cwd: options.cwd,
+			env: options.env,
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
@@ -251,13 +253,13 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 	let exec_options = CoreShellExecuteOptions {
-		command:       options.command,
-		cwd:           options.cwd,
-		env:           options.env,
-		session_env:   options.session_env,
-		timeout_ms:    options.timeout_ms,
+		command: options.command,
+		cwd: options.cwd,
+		env: options.env,
+		session_env: options.session_env,
+		timeout_ms: options.timeout_ms,
 		snapshot_path: options.snapshot_path,
-		minimizer:     options.minimizer.map(Into::into),
+		minimizer: options.minimizer.map(Into::into),
 	};
 	task::future(env, "shell.execute", async move {
 		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -272,6 +274,10 @@ pub fn execute_shell<'env>(
 	})
 }
 
+fn shell_loss_marker(dropped_chunks: usize, dropped_bytes: usize) -> String {
+	format!("{SHELL_LOSS_MARKER_PREFIX}{dropped_chunks} chunks / {dropped_bytes} bytes dropped]\n")
+}
+
 fn bridge_chunks(
 	on_chunk: Option<ThreadsafeFunction<String>>,
 ) -> (Option<mpsc::UnboundedSender<String>>, Option<napi::tokio::task::JoinHandle<()>>) {
@@ -279,10 +285,48 @@ fn bridge_chunks(
 		return (None, None);
 	};
 	let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+	let (bounded_tx, mut bounded_rx) = mpsc::channel::<String>(SHELL_CALLBACK_QUEUE_CAPACITY);
 	let handle = napi::tokio::spawn(async move {
-		while let Some(chunk) = rx.recv().await {
-			on_chunk.call(Ok(chunk), ThreadsafeFunctionCallMode::NonBlocking);
+		let forwarder = napi::tokio::spawn(async move {
+			let mut dropped_chunks = 0usize;
+			let mut dropped_bytes = 0usize;
+			// The upstream pi_shell sender is unbounded; this bridge re-bounds it and
+			// marks dropped output at the N-API callback boundary instead of silently
+			// losing it, so truncation is always observable to the caller.
+			while let Some(chunk) = rx.recv().await {
+				if dropped_chunks > 0 {
+					match bounded_tx.try_send(shell_loss_marker(dropped_chunks, dropped_bytes)) {
+						Ok(()) => {
+							dropped_chunks = 0;
+							dropped_bytes = 0;
+						},
+						Err(mpsc::error::TrySendError::Full(_)) => {},
+						Err(mpsc::error::TrySendError::Closed(_)) => break,
+					}
+				}
+				let chunk_len = chunk.len();
+				match bounded_tx.try_send(chunk) {
+					Ok(()) => {},
+					Err(mpsc::error::TrySendError::Full(_)) => {
+						dropped_chunks = dropped_chunks.saturating_add(1);
+						dropped_bytes = dropped_bytes.saturating_add(chunk_len);
+					},
+					Err(mpsc::error::TrySendError::Closed(_)) => break,
+				}
+			}
+			if dropped_chunks > 0 {
+				let _ = bounded_tx
+					.send(shell_loss_marker(dropped_chunks, dropped_bytes))
+					.await;
+			}
+		});
+		while let Some(chunk) = bounded_rx.recv().await {
+			if on_chunk.call(Ok(chunk), ThreadsafeFunctionCallMode::NonBlocking) != napi::Status::Ok {
+				forwarder.abort();
+				break;
+			}
 		}
+		let _ = forwarder.await;
 	});
 	(Some(tx), Some(handle))
 }
@@ -292,7 +336,7 @@ fn bridge_chunks(
 #[napi(object)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command:  String,
+	pub command: String,
 	/// Substrings removed, in source order — suitable for a user-facing notice.
 	pub stripped: Vec<String>,
 }
@@ -321,9 +365,11 @@ mod tests {
 		ShellRunOptions as CoreShellRunOptions,
 		cancel::{AbortReason, CancelToken},
 	};
-	use tokio::{sync::mpsc, time};
+	use tokio::{sync::mpsc, task::yield_now, time};
 
-	use super::CoreShell;
+	use super::{
+		CoreShell, SHELL_CALLBACK_QUEUE_CAPACITY, SHELL_LOSS_MARKER_PREFIX, shell_loss_marker,
+	};
 
 	mod child_session_action_tests {
 		use pi_shell::{ChildSessionAction, child_session_action};
@@ -370,9 +416,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
 					},
 					Some(tx),
@@ -413,9 +459,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "sh -c 'sleep 30 & wait'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "sh -c 'sleep 30 & wait'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
 					},
 					None,
@@ -432,5 +478,34 @@ mod tests {
 			.expect("shell task should not panic")
 			.expect("shell run should return");
 		assert!(result.cancelled);
+	}
+
+	#[tokio::test]
+	async fn final_shell_loss_marker_is_delivered_when_callback_queue_is_full() {
+		let (tx, mut rx) = mpsc::channel::<String>(SHELL_CALLBACK_QUEUE_CAPACITY);
+		for i in 0..SHELL_CALLBACK_QUEUE_CAPACITY {
+			tx.try_send(format!("chunk-{i}"))
+				.expect("queue fill should succeed");
+		}
+		let final_sender = tokio::spawn(async move {
+			tx.send(shell_loss_marker(1, "dropped-tail".len()))
+				.await
+				.expect("receiver should remain open");
+		});
+
+		yield_now().await;
+		assert!(!final_sender.is_finished(), "final marker send should wait for capacity");
+
+		let mut output = String::new();
+		while let Some(chunk) = rx.recv().await {
+			output.push_str(&chunk);
+			if output.contains(SHELL_LOSS_MARKER_PREFIX) {
+				break;
+			}
+		}
+		final_sender.await.expect("final sender should not panic");
+
+		assert!(output.contains(SHELL_LOSS_MARKER_PREFIX));
+		assert!(output.contains("1 chunks / 12 bytes dropped"));
 	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -27,19 +27,19 @@ const SHELL_LOSS_MARKER_PREFIX: &str = "\n[Shell output truncated: ";
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled: Option<bool>,
+	pub enabled:           Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path: Option<String>,
+	pub settings_path:     Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash: Option<String>,
+	pub settings_hash:     Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only: Option<Vec<String>>,
+	pub only:              Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except: Option<Vec<String>>,
+	pub except:            Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
 	pub max_capture_bytes: Option<u32>,
@@ -48,11 +48,11 @@ pub struct MinimizerOptions {
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled: value.enabled,
-			settings_path: value.settings_path,
-			settings_hash: value.settings_hash,
-			only: value.only,
-			except: value.except,
+			enabled:           value.enabled,
+			settings_path:     value.settings_path,
+			settings_hash:     value.settings_hash,
+			only:              value.only,
+			except:            value.except,
 			max_capture_bytes: value.max_capture_bytes,
 		}
 	}
@@ -62,19 +62,19 @@ impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 #[napi(object)]
 pub struct ShellOptions {
 	/// Environment variables to apply once per session.
-	pub session_env: Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer: Option<MinimizerOptions>,
+	pub minimizer:     Option<MinimizerOptions>,
 }
 
 impl From<ShellOptions> for CoreShellOptions {
 	fn from(value: ShellOptions) -> Self {
 		Self {
-			session_env: value.session_env,
+			session_env:   value.session_env,
 			snapshot_path: value.snapshot_path,
-			minimizer: value.minimizer.map(Into::into),
+			minimizer:     value.minimizer.map(Into::into),
 		}
 	}
 }
@@ -83,36 +83,36 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command: String,
+	pub command:    String,
 	/// Working directory for the command.
-	pub cwd: Option<String>,
+	pub cwd:        Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env: Option<HashMap<String, String>>,
+	pub env:        Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:     Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command: String,
+	pub command:       String,
 	/// Working directory for the command.
-	pub cwd: Option<String>,
+	pub cwd:           Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env: Option<HashMap<String, String>>,
+	pub env:           Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env: Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms: Option<u32>,
+	pub timeout_ms:    Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer: Option<MinimizerOptions>,
+	pub minimizer:     Option<MinimizerOptions>,
 	/// Abort signal for cancelling the operation.
-	pub signal: Option<Unknown<'env>>,
+	pub signal:        Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -126,27 +126,27 @@ pub struct ShellExecuteOptions<'env> {
 pub struct MinimizerResult {
 	/// Dispatch label produced by the minimizer (e.g. `"git"`,
 	/// `"pipeline:gradle"`, `"pipeline+builtin"`).
-	pub filter: String,
+	pub filter:        String,
 	/// The minimized replacement text. Callers that streamed raw chunks
 	/// during execution should clear and replace their accumulated output
 	/// with this text.
-	pub text: String,
+	pub text:          String,
 	/// The full original capture, before minimization.
 	pub original_text: String,
 	/// Captured byte length before minimization.
-	pub input_bytes: u32,
+	pub input_bytes:   u32,
 	/// Byte length of the minimized text the consumer received.
-	pub output_bytes: u32,
+	pub output_bytes:  u32,
 }
 
 impl From<CoreMinimizerResult> for MinimizerResult {
 	fn from(value: CoreMinimizerResult) -> Self {
 		Self {
-			filter: value.filter,
-			text: value.text,
+			filter:        value.filter,
+			text:          value.text,
 			original_text: value.original_text,
-			input_bytes: value.input_bytes,
-			output_bytes: value.output_bytes,
+			input_bytes:   value.input_bytes,
+			output_bytes:  value.output_bytes,
 		}
 	}
 }
@@ -210,9 +210,9 @@ impl Shell {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
-			command: options.command,
-			cwd: options.cwd,
-			env: options.env,
+			command:    options.command,
+			cwd:        options.cwd,
+			env:        options.env,
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
@@ -253,13 +253,13 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 	let exec_options = CoreShellExecuteOptions {
-		command: options.command,
-		cwd: options.cwd,
-		env: options.env,
-		session_env: options.session_env,
-		timeout_ms: options.timeout_ms,
+		command:       options.command,
+		cwd:           options.cwd,
+		env:           options.env,
+		session_env:   options.session_env,
+		timeout_ms:    options.timeout_ms,
 		snapshot_path: options.snapshot_path,
-		minimizer: options.minimizer.map(Into::into),
+		minimizer:     options.minimizer.map(Into::into),
 	};
 	task::future(env, "shell.execute", async move {
 		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -336,7 +336,7 @@ fn bridge_chunks(
 #[napi(object)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command: String,
+	pub command:  String,
 	/// Substrings removed, in source order — suitable for a user-facing notice.
 	pub stripped: Vec<String>,
 }
@@ -416,9 +416,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
-						cwd: None,
-						env: None,
+						command:    "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
+						cwd:        None,
+						env:        None,
 						timeout_ms: None,
 					},
 					Some(tx),
@@ -459,9 +459,9 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command: "sh -c 'sleep 30 & wait'".to_string(),
-						cwd: None,
-						env: None,
+						command:    "sh -c 'sleep 30 & wait'".to_string(),
+						cwd:        None,
+						env:        None,
 						timeout_ms: None,
 					},
 					None,

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use std::future::Future;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use napi::{Env, Error, Result, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
@@ -88,9 +89,25 @@ impl CancelToken {
 	/// Create a new cancel token from optional timeout and abort signal.
 	pub fn new(timeout_ms: Option<u32>, signal: Option<Unknown>) -> Self {
 		let mut result = Self { core: core_cancel::CancelToken::new(timeout_ms) };
-		if let Some(signal) = signal.and_then(|value| AbortSignal::from_unknown(value).ok()) {
-			let abort_token = result.emplace_abort_token();
-			signal.on_abort(move || abort_token.abort(AbortReason::Signal));
+		if let Some(signal) = signal {
+			let object = Object::from_raw(signal.value().env, signal.value().value);
+			let aborted = object
+				.get_named_property::<bool>("aborted")
+				.unwrap_or(false);
+			match AbortSignal::from_unknown(signal) {
+				Ok(signal) => {
+					let abort_token = result.emplace_abort_token();
+					if aborted {
+						abort_token.abort(AbortReason::Signal);
+					} else {
+						signal.on_abort(move || abort_token.abort(AbortReason::Signal));
+					}
+				},
+				Err(_) => {
+					let abort_token = result.emplace_abort_token();
+					abort_token.abort(AbortReason::Unknown);
+				},
+			}
 		}
 		result
 	}
@@ -154,9 +171,9 @@ pub struct Blocking<T>
 where
 	T: Send + 'static,
 {
-	tag:          &'static str,
+	tag: &'static str,
 	cancel_token: CancelToken,
-	work:         Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
+	work: Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
 }
 
 impl<T> Task for Blocking<T>
@@ -168,15 +185,32 @@ where
 
 	fn compute(&mut self) -> Result<Self::Output> {
 		let _guard = profile_region(self.tag);
+		self.cancel_token.heartbeat()?;
 		let work = self
 			.work
 			.take()
 			.ok_or_else(|| Error::from_reason("BlockingTask: work already consumed"))?;
-		work(self.cancel_token.clone())
+		match catch_unwind(AssertUnwindSafe(|| work(self.cancel_token.clone()))) {
+			Ok(result) => result,
+			Err(payload) => Err(Error::from_reason(format!(
+				"BlockingTask panic: {}",
+				panic_payload_message(payload.as_ref())
+			))),
+		}
 	}
 
 	fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
 		Ok(output)
+	}
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+	if let Some(message) = payload.downcast_ref::<&str>() {
+		(*message).to_owned()
+	} else if let Some(message) = payload.downcast_ref::<String>() {
+		message.clone()
+	} else {
+		"unknown panic payload".to_owned()
 	}
 }
 
@@ -255,4 +289,130 @@ where
 		let _guard = profile_region(tag);
 		work.await
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	};
+
+	use napi::Task;
+
+	use super::*;
+
+	#[test]
+	fn blocking_compute_catches_non_string_panic_as_error() {
+		let mut task = Blocking {
+			tag: "test_non_string_panic",
+			cancel_token: CancelToken::default(),
+			work: Some(Box::new(|_| -> Result<String> { std::panic::panic_any(42) })),
+		};
+
+		let result = task.compute();
+
+		let err = result.expect_err("non-string panic should be converted into a napi error");
+		assert!(
+			err.reason.contains("BlockingTask panic"),
+			"panic should be converted to a napi error, got: {}",
+			err.reason
+		);
+		assert!(
+			err.reason.contains("unknown panic payload"),
+			"non-string panic payload should be reported without unwinding, got: {}",
+			err.reason
+		);
+	}
+
+	#[test]
+	fn blocking_compute_catches_panic_as_error() {
+		let mut task = Blocking {
+			tag: "test_panic",
+			cancel_token: CancelToken::default(),
+			work: Some(Box::new(|_| -> Result<String> { panic!("native boom") })),
+		};
+
+		let result = task.compute();
+
+		let err = result.expect_err("panic should be converted into a napi error");
+		assert!(
+			err.reason.contains("native boom"),
+			"panic payload should be preserved, got: {}",
+			err.reason
+		);
+	}
+
+	#[test]
+	fn blocking_compute_catches_string_panic_payload_as_error() {
+		let mut task = Blocking {
+			tag: "test_string_panic",
+			cancel_token: CancelToken::default(),
+			work: Some(Box::new(|_| -> Result<String> { std::panic::panic_any(String::from("owned native boom")) })),
+		};
+
+		let result = task.compute();
+
+		let err = result.expect_err("String panic should be converted into a napi error");
+		assert!(
+			err.reason.contains("owned native boom"),
+			"String panic payload should be preserved, got: {}",
+			err.reason
+		);
+	}
+
+	#[test]
+	fn blocking_compute_rejects_pre_cancelled_token_without_running_work() {
+		let mut cancel_token = CancelToken::default();
+		let abort_token = cancel_token.emplace_abort_token();
+		abort_token.abort(AbortReason::User);
+		let work_ran = Arc::new(AtomicBool::new(false));
+		let work_ran_in_task = Arc::clone(&work_ran);
+		let mut task = Blocking {
+			tag: "test_cancelled",
+			cancel_token,
+			work: Some(Box::new(move |_| -> Result<String> {
+				work_ran_in_task.store(true, Ordering::SeqCst);
+				Ok("ran".to_owned())
+			})),
+		};
+
+		let result = task.compute();
+
+		let err = result.expect_err("pre-cancelled task should return cancellation error");
+		assert!(
+			err.reason.contains("Aborted: User"),
+			"cancellation reason should be preserved, got: {}",
+			err.reason
+		);
+		assert!(!work_ran.load(Ordering::SeqCst), "work closure must not run after pre-cancellation");
+	}
+
+	#[test]
+	fn blocking_compute_observes_token_cancelled_by_heartbeat_mid_work() {
+		let mut cancel_token = CancelToken::default();
+		let abort_token = cancel_token.emplace_abort_token();
+		let work_started = Arc::new(AtomicBool::new(false));
+		let work_started_in_task = Arc::clone(&work_started);
+		let mut task = Blocking {
+			tag: "test_mid_work_cancelled",
+			cancel_token,
+			work: Some(Box::new(move |token| -> Result<String> {
+				work_started_in_task.store(true, Ordering::SeqCst);
+				abort_token.abort(AbortReason::User);
+				token.heartbeat()?;
+				Ok("missed cancellation".to_owned())
+			})),
+		};
+
+		let result = task.compute();
+
+		let err = result.expect_err("heartbeat should observe mid-work cancellation");
+		assert!(work_started.load(Ordering::SeqCst), "work closure should start before mid-work cancellation");
+		assert!(
+			err.reason.contains("Aborted: User"),
+			"heartbeat cancellation reason should be preserved, got: {}",
+			err.reason
+		);
+	}
 }

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -27,8 +27,10 @@
 //! }
 //! ```
 
-use std::future::Future;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::{
+	future::Future,
+	panic::{AssertUnwindSafe, catch_unwind},
+};
 
 use napi::{Env, Error, Result, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
@@ -94,19 +96,15 @@ impl CancelToken {
 			let aborted = object
 				.get_named_property::<bool>("aborted")
 				.unwrap_or(false);
-			match AbortSignal::from_unknown(signal) {
-				Ok(signal) => {
-					let abort_token = result.emplace_abort_token();
-					if aborted {
-						abort_token.abort(AbortReason::Signal);
-					} else {
-						signal.on_abort(move || abort_token.abort(AbortReason::Signal));
-					}
-				},
-				Err(_) => {
-					let abort_token = result.emplace_abort_token();
-					abort_token.abort(AbortReason::Unknown);
-				},
+			let abort_token = result.emplace_abort_token();
+			if let Ok(signal) = AbortSignal::from_unknown(signal) {
+				if aborted {
+					abort_token.abort(AbortReason::Signal);
+				} else {
+					signal.on_abort(move || abort_token.abort(AbortReason::Signal));
+				}
+			} else {
+				abort_token.abort(AbortReason::Unknown);
 			}
 		}
 		result
@@ -171,9 +169,9 @@ pub struct Blocking<T>
 where
 	T: Send + 'static,
 {
-	tag: &'static str,
+	tag:          &'static str,
 	cancel_token: CancelToken,
-	work: Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
+	work:         Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
 }
 
 impl<T> Task for Blocking<T>
@@ -305,9 +303,9 @@ mod tests {
 	#[test]
 	fn blocking_compute_catches_non_string_panic_as_error() {
 		let mut task = Blocking {
-			tag: "test_non_string_panic",
+			tag:          "test_non_string_panic",
 			cancel_token: CancelToken::default(),
-			work: Some(Box::new(|_| -> Result<String> { std::panic::panic_any(42) })),
+			work:         Some(Box::new(|_| -> Result<String> { std::panic::panic_any(42) })),
 		};
 
 		let result = task.compute();
@@ -328,9 +326,9 @@ mod tests {
 	#[test]
 	fn blocking_compute_catches_panic_as_error() {
 		let mut task = Blocking {
-			tag: "test_panic",
+			tag:          "test_panic",
 			cancel_token: CancelToken::default(),
-			work: Some(Box::new(|_| -> Result<String> { panic!("native boom") })),
+			work:         Some(Box::new(|_| -> Result<String> { panic!("native boom") })),
 		};
 
 		let result = task.compute();
@@ -346,9 +344,11 @@ mod tests {
 	#[test]
 	fn blocking_compute_catches_string_panic_payload_as_error() {
 		let mut task = Blocking {
-			tag: "test_string_panic",
+			tag:          "test_string_panic",
 			cancel_token: CancelToken::default(),
-			work: Some(Box::new(|_| -> Result<String> { std::panic::panic_any(String::from("owned native boom")) })),
+			work:         Some(Box::new(|_| -> Result<String> {
+				std::panic::panic_any(String::from("owned native boom"))
+			})),
 		};
 
 		let result = task.compute();
@@ -408,7 +408,10 @@ mod tests {
 		let result = task.compute();
 
 		let err = result.expect_err("heartbeat should observe mid-work cancellation");
-		assert!(work_started.load(Ordering::SeqCst), "work closure should start before mid-work cancellation");
+		assert!(
+			work_started.load(Ordering::SeqCst),
+			"work closure should start before mid-work cancellation"
+		);
 		assert!(
 			err.reason.contains("Aborted: User"),
 			"heartbeat cancellation reason should be preserved, got: {}",

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -31,8 +31,8 @@ mod platform {
 	/// Stable Linux process reference backed by a pidfd.
 	#[derive(Clone)]
 	pub struct Process {
-		pid: i32,
-		pidfd: Arc<OwnedFd>,
+		pid:        i32,
+		pidfd:      Arc<OwnedFd>,
 		start_time: u64,
 	}
 
@@ -309,8 +309,8 @@ mod platform {
 	/// original target.
 	#[derive(Clone)]
 	pub struct Process {
-		pid: i32,
-		start_tvsec: u64,
+		pid:          i32,
+		start_tvsec:  u64,
 		start_tvusec: u64,
 	}
 
@@ -672,16 +672,16 @@ mod platform {
 	#[repr(C)]
 	#[allow(non_snake_case, reason = "Windows PROCESSENTRY32W field names must match Win32 ABI")]
 	struct PROCESSENTRY32W {
-		dwSize: u32,
-		cntUsage: u32,
-		th32ProcessID: u32,
-		th32DefaultHeapID: usize,
-		th32ModuleID: u32,
-		cntThreads: u32,
+		dwSize:              u32,
+		cntUsage:            u32,
+		th32ProcessID:       u32,
+		th32DefaultHeapID:   usize,
+		th32ModuleID:        u32,
+		cntThreads:          u32,
 		th32ParentProcessID: u32,
-		pcPriClassBase: i32,
-		dwFlags: u32,
-		szExeFile: [u16; 260],
+		pcPriClassBase:      i32,
+		dwFlags:             u32,
+		szExeFile:           [u16; 260],
 	}
 
 	#[repr(C)]
@@ -697,35 +697,35 @@ mod platform {
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct UnicodeString {
-		length: u16,
+		length:         u16,
 		maximum_length: u16,
-		buffer: usize,
+		buffer:         usize,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct PebPartial {
-		reserved1: [u8; 2],
-		being_debugged: u8,
-		reserved2: [u8; 1],
-		reserved3: [usize; 2],
-		loader: usize,
+		reserved1:          [u8; 2],
+		being_debugged:     u8,
+		reserved2:          [u8; 1],
+		reserved3:          [usize; 2],
+		loader:             usize,
 		process_parameters: usize,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct UserProcessParametersPartial {
-		reserved1: [u8; 16],
-		reserved2: [usize; 10],
+		reserved1:       [u8; 16],
+		reserved2:       [usize; 10],
 		image_path_name: UnicodeString,
-		command_line: UnicodeString,
+		command_line:    UnicodeString,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy, Default)]
 	struct Filetime {
-		dw_low_date_time: u32,
+		dw_low_date_time:  u32,
 		dw_high_date_time: u32,
 	}
 
@@ -824,8 +824,8 @@ mod platform {
 	/// the kernel-reported creation time, which pins identity even if the PID is
 	/// recycled while we hold the handle.
 	pub struct Process {
-		pid: i32,
-		handle: Arc<OwnedHandle>,
+		pid:           i32,
+		handle:        Arc<OwnedHandle>,
 		creation_time: u64,
 	}
 
@@ -1137,16 +1137,16 @@ mod platform {
 
 	fn process_entry() -> PROCESSENTRY32W {
 		PROCESSENTRY32W {
-			dwSize: mem::size_of::<PROCESSENTRY32W>() as u32,
-			cntUsage: 0,
-			th32ProcessID: 0,
-			th32DefaultHeapID: 0,
-			th32ModuleID: 0,
-			cntThreads: 0,
+			dwSize:              mem::size_of::<PROCESSENTRY32W>() as u32,
+			cntUsage:            0,
+			th32ProcessID:       0,
+			th32DefaultHeapID:   0,
+			th32ModuleID:        0,
+			cntThreads:          0,
 			th32ParentProcessID: 0,
-			pcPriClassBase: 0,
-			dwFlags: 0,
-			szExeFile: [0; 260],
+			pcPriClassBase:      0,
+			dwFlags:             0,
+			szExeFile:           [0; 260],
 		}
 	}
 
@@ -1503,7 +1503,7 @@ pub const KILL_SIGNAL: i32 = 9;
 /// on platforms that do not expose process groups.
 #[derive(Default)]
 pub struct TerminationTargets {
-	pgids: Vec<i32>,
+	pgids:     Vec<i32>,
 	processes: Vec<Process>,
 	seen_pids: HashSet<i32>,
 }
@@ -1597,7 +1597,7 @@ pub fn add_new_descendants<S: std::hash::BuildHasher>(
 /// platform-specific process handles.
 #[derive(Debug, Clone, Copy)]
 struct DescendantInfo {
-	pid: i32,
+	pid:  i32,
 	pgid: Option<i32>,
 }
 
@@ -1605,7 +1605,7 @@ struct DescendantInfo {
 #[derive(Debug, Default)]
 struct TargetSelection {
 	pgids: Vec<i32>,
-	pids: Vec<i32>,
+	pids:  Vec<i32>,
 }
 
 /// Pure target-classifier separated from process discovery so it is testable
@@ -1672,10 +1672,10 @@ mod tests {
 		// Harness pgid is *not* a new descendant; a baseline helper happens to
 		// lead a group that a new descendant inherited. Neither pgid is safe to
 		// signal as a group.
-		let descendants = [
-			DescendantInfo { pid: 2000, pgid: Some(HARNESS_PGID) },
-			DescendantInfo { pid: 2001, pgid: Some(BASELINE_HELPER_PID) },
-		];
+		let descendants = [DescendantInfo { pid: 2000, pgid: Some(HARNESS_PGID) }, DescendantInfo {
+			pid:  2001,
+			pgid: Some(BASELINE_HELPER_PID),
+		}];
 		let baseline: HashSet<i32> = std::iter::once(BASELINE_HELPER_PID).collect();
 
 		let selection = select_termination_targets(&descendants, &baseline);

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -31,8 +31,8 @@ mod platform {
 	/// Stable Linux process reference backed by a pidfd.
 	#[derive(Clone)]
 	pub struct Process {
-		pid:        i32,
-		pidfd:      Arc<OwnedFd>,
+		pid: i32,
+		pidfd: Arc<OwnedFd>,
 		start_time: u64,
 	}
 
@@ -309,8 +309,8 @@ mod platform {
 	/// original target.
 	#[derive(Clone)]
 	pub struct Process {
-		pid:          i32,
-		start_tvsec:  u64,
+		pid: i32,
+		start_tvsec: u64,
 		start_tvusec: u64,
 	}
 
@@ -672,16 +672,16 @@ mod platform {
 	#[repr(C)]
 	#[allow(non_snake_case, reason = "Windows PROCESSENTRY32W field names must match Win32 ABI")]
 	struct PROCESSENTRY32W {
-		dwSize:              u32,
-		cntUsage:            u32,
-		th32ProcessID:       u32,
-		th32DefaultHeapID:   usize,
-		th32ModuleID:        u32,
-		cntThreads:          u32,
+		dwSize: u32,
+		cntUsage: u32,
+		th32ProcessID: u32,
+		th32DefaultHeapID: usize,
+		th32ModuleID: u32,
+		cntThreads: u32,
 		th32ParentProcessID: u32,
-		pcPriClassBase:      i32,
-		dwFlags:             u32,
-		szExeFile:           [u16; 260],
+		pcPriClassBase: i32,
+		dwFlags: u32,
+		szExeFile: [u16; 260],
 	}
 
 	#[repr(C)]
@@ -697,35 +697,35 @@ mod platform {
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct UnicodeString {
-		length:         u16,
+		length: u16,
 		maximum_length: u16,
-		buffer:         usize,
+		buffer: usize,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct PebPartial {
-		reserved1:          [u8; 2],
-		being_debugged:     u8,
-		reserved2:          [u8; 1],
-		reserved3:          [usize; 2],
-		loader:             usize,
+		reserved1: [u8; 2],
+		being_debugged: u8,
+		reserved2: [u8; 1],
+		reserved3: [usize; 2],
+		loader: usize,
 		process_parameters: usize,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy)]
 	struct UserProcessParametersPartial {
-		reserved1:       [u8; 16],
-		reserved2:       [usize; 10],
+		reserved1: [u8; 16],
+		reserved2: [usize; 10],
 		image_path_name: UnicodeString,
-		command_line:    UnicodeString,
+		command_line: UnicodeString,
 	}
 
 	#[repr(C)]
 	#[derive(Clone, Copy, Default)]
 	struct Filetime {
-		dw_low_date_time:  u32,
+		dw_low_date_time: u32,
 		dw_high_date_time: u32,
 	}
 
@@ -824,8 +824,8 @@ mod platform {
 	/// the kernel-reported creation time, which pins identity even if the PID is
 	/// recycled while we hold the handle.
 	pub struct Process {
-		pid:           i32,
-		handle:        Arc<OwnedHandle>,
+		pid: i32,
+		handle: Arc<OwnedHandle>,
 		creation_time: u64,
 	}
 
@@ -1137,16 +1137,16 @@ mod platform {
 
 	fn process_entry() -> PROCESSENTRY32W {
 		PROCESSENTRY32W {
-			dwSize:              mem::size_of::<PROCESSENTRY32W>() as u32,
-			cntUsage:            0,
-			th32ProcessID:       0,
-			th32DefaultHeapID:   0,
-			th32ModuleID:        0,
-			cntThreads:          0,
+			dwSize: mem::size_of::<PROCESSENTRY32W>() as u32,
+			cntUsage: 0,
+			th32ProcessID: 0,
+			th32DefaultHeapID: 0,
+			th32ModuleID: 0,
+			cntThreads: 0,
 			th32ParentProcessID: 0,
-			pcPriClassBase:      0,
-			dwFlags:             0,
-			szExeFile:           [0; 260],
+			pcPriClassBase: 0,
+			dwFlags: 0,
+			szExeFile: [0; 260],
 		}
 	}
 
@@ -1503,7 +1503,7 @@ pub const KILL_SIGNAL: i32 = 9;
 /// on platforms that do not expose process groups.
 #[derive(Default)]
 pub struct TerminationTargets {
-	pgids:     Vec<i32>,
+	pgids: Vec<i32>,
 	processes: Vec<Process>,
 	seen_pids: HashSet<i32>,
 }
@@ -1535,6 +1535,11 @@ impl TerminationTargets {
 	/// True when no targets have been recorded.
 	pub const fn is_empty(&self) -> bool {
 		self.pgids.is_empty() && self.processes.is_empty()
+	}
+
+	/// First recorded process group id, if any.
+	pub fn first_pgid(&self) -> Option<i32> {
+		self.pgids.first().copied()
 	}
 
 	/// Send `signal` to every recorded target. Failures are swallowed:
@@ -1592,7 +1597,7 @@ pub fn add_new_descendants<S: std::hash::BuildHasher>(
 /// platform-specific process handles.
 #[derive(Debug, Clone, Copy)]
 struct DescendantInfo {
-	pid:  i32,
+	pid: i32,
 	pgid: Option<i32>,
 }
 
@@ -1600,7 +1605,7 @@ struct DescendantInfo {
 #[derive(Debug, Default)]
 struct TargetSelection {
 	pgids: Vec<i32>,
-	pids:  Vec<i32>,
+	pids: Vec<i32>,
 }
 
 /// Pure target-classifier separated from process discovery so it is testable
@@ -1667,10 +1672,10 @@ mod tests {
 		// Harness pgid is *not* a new descendant; a baseline helper happens to
 		// lead a group that a new descendant inherited. Neither pgid is safe to
 		// signal as a group.
-		let descendants = [DescendantInfo { pid: 2000, pgid: Some(HARNESS_PGID) }, DescendantInfo {
-			pid:  2001,
-			pgid: Some(BASELINE_HELPER_PID),
-		}];
+		let descendants = [
+			DescendantInfo { pid: 2000, pgid: Some(HARNESS_PGID) },
+			DescendantInfo { pid: 2001, pgid: Some(BASELINE_HELPER_PID) },
+		];
 		let baseline: HashSet<i32> = std::iter::once(BASELINE_HELPER_PID).collect();
 
 		let selection = select_termination_targets(&descendants, &baseline);

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -45,9 +45,9 @@ struct ShellSessionCore {
 #[derive(Default)]
 struct ShellAbortInner {
 	generation: usize,
-	tokens: HashMap<usize, AbortToken>,
-	active: HashSet<usize>,
-	pending: bool,
+	tokens:     HashMap<usize, AbortToken>,
+	active:     HashSet<usize>,
+	pending:    bool,
 }
 
 #[derive(Clone, Default)]
@@ -98,73 +98,73 @@ impl ShellAbortState {
 
 #[derive(Clone)]
 struct ShellConfig {
-	session_env: Option<HashMap<String, String>>,
+	session_env:   Option<HashMap<String, String>>,
 	snapshot_path: Option<String>,
-	minimizer: Option<minimizer::MinimizerConfig>,
+	minimizer:     Option<minimizer::MinimizerConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellOptions {
-	pub session_env: Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
 	pub snapshot_path: Option<String>,
-	pub minimizer: Option<minimizer::MinimizerOptions>,
+	pub minimizer:     Option<minimizer::MinimizerOptions>,
 }
 
 struct ShellRunConfig {
-	command: String,
-	cwd: Option<String>,
-	env: Option<HashMap<String, String>>,
+	command:   String,
+	cwd:       Option<String>,
+	env:       Option<HashMap<String, String>>,
 	minimizer: Option<minimizer::MinimizerConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellRunOptions {
-	pub command: String,
-	pub cwd: Option<String>,
-	pub env: Option<HashMap<String, String>>,
+	pub command:    String,
+	pub cwd:        Option<String>,
+	pub env:        Option<HashMap<String, String>>,
 	pub timeout_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MinimizerResult {
-	pub filter: String,
-	pub text: String,
+	pub filter:        String,
+	pub text:          String,
 	pub original_text: String,
-	pub input_bytes: u32,
-	pub output_bytes: u32,
+	pub input_bytes:   u32,
+	pub output_bytes:  u32,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ShellRunResult {
-	pub exit_code: Option<i32>,
-	pub cancelled: bool,
-	pub timed_out: bool,
-	pub minimized: Option<MinimizerResult>,
-	pub output_truncated: bool,
+	pub exit_code:              Option<i32>,
+	pub cancelled:              bool,
+	pub timed_out:              bool,
+	pub minimized:              Option<MinimizerResult>,
+	pub output_truncated:       bool,
 	pub output_truncated_bytes: u64,
-	pub stdout_truncated: bool,
+	pub stdout_truncated:       bool,
 	pub stdout_truncated_bytes: u64,
-	pub stderr_truncated: bool,
+	pub stderr_truncated:       bool,
 	pub stderr_truncated_bytes: u64,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellExecuteOptions {
-	pub command: String,
-	pub cwd: Option<String>,
-	pub env: Option<HashMap<String, String>>,
-	pub session_env: Option<HashMap<String, String>>,
-	pub timeout_ms: Option<u32>,
+	pub command:       String,
+	pub cwd:           Option<String>,
+	pub env:           Option<HashMap<String, String>>,
+	pub session_env:   Option<HashMap<String, String>>,
+	pub timeout_ms:    Option<u32>,
 	pub snapshot_path: Option<String>,
-	pub minimizer: Option<minimizer::MinimizerOptions>,
+	pub minimizer:     Option<minimizer::MinimizerOptions>,
 }
 
 pub type ShellExecuteResult = ShellRunResult;
 
 pub struct Shell {
-	session: Arc<TokioMutex<Option<ShellSessionCore>>>,
+	session:     Arc<TokioMutex<Option<ShellSessionCore>>>,
 	abort_state: ShellAbortState,
-	config: ShellConfig,
+	config:      ShellConfig,
 }
 
 impl Shell {
@@ -198,9 +198,9 @@ impl Shell {
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
 		let run_config = ShellRunConfig {
-			command: options.command,
-			cwd: options.cwd,
-			env: options.env,
+			command:   options.command,
+			cwd:       options.cwd,
+			env:       options.env,
 			minimizer: self.config.minimizer.clone(),
 		};
 		run_shell_session(
@@ -229,9 +229,9 @@ pub async fn execute_shell(
 		.as_ref()
 		.map(minimizer::MinimizerConfig::from_options);
 	let config = ShellConfig {
-		session_env: options.session_env,
+		session_env:   options.session_env,
 		snapshot_path: options.snapshot_path,
-		minimizer: minimizer.clone(),
+		minimizer:     minimizer.clone(),
 	};
 	let run_config =
 		ShellRunConfig { command: options.command, cwd: options.cwd, env: options.env, minimizer };
@@ -261,14 +261,14 @@ pub async fn execute_shell_streams(
 	cancel_token: CancelToken,
 ) -> Result<ShellExecuteResult> {
 	let config = ShellConfig {
-		session_env: options.session_env,
+		session_env:   options.session_env,
 		snapshot_path: options.snapshot_path,
-		minimizer: None,
+		minimizer:     None,
 	};
 	let run_config = ShellRunConfig {
-		command: options.command,
-		cwd: options.cwd,
-		env: options.env,
+		command:   options.command,
+		cwd:       options.cwd,
+		env:       options.env,
 		minimizer: None,
 	};
 	run_shell_oneshot_streams(config, run_config, streams, cancel_token).await
@@ -463,15 +463,15 @@ async fn run_shell_oneshot_streams(
 		.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
 	let (exec, truncation) = res?;
 	Ok(ShellExecuteResult {
-		exit_code: Some(exit_code(&exec)),
-		cancelled: false,
-		timed_out: false,
-		minimized: None,
-		output_truncated: truncation.output_truncated,
+		exit_code:              Some(exit_code(&exec)),
+		cancelled:              false,
+		timed_out:              false,
+		minimized:              None,
+		output_truncated:       truncation.output_truncated,
 		output_truncated_bytes: truncation.output_truncated_bytes,
-		stdout_truncated: truncation.stdout_truncated,
+		stdout_truncated:       truncation.stdout_truncated,
 		stdout_truncated_bytes: truncation.stdout_truncated_bytes,
-		stderr_truncated: truncation.stderr_truncated,
+		stderr_truncated:       truncation.stderr_truncated,
 		stderr_truncated_bytes: truncation.stderr_truncated_bytes,
 	})
 }
@@ -859,15 +859,11 @@ async fn run_shell_command(
 		}
 	}
 	let truncated_bytes = output_budget.truncated_bytes();
-	Ok((
-		result,
-		minimized_out,
-		OutputTruncation {
-			output_truncated: truncated_bytes > 0,
-			output_truncated_bytes: truncated_bytes,
-			..Default::default()
-		},
-	))
+	Ok((result, minimized_out, OutputTruncation {
+		output_truncated: truncated_bytes > 0,
+		output_truncated_bytes: truncated_bytes,
+		..Default::default()
+	}))
 }
 
 async fn run_shell_command_streams(
@@ -1025,16 +1021,13 @@ async fn run_shell_command_streams(
 	let result = result.map_err(|err| Error::msg(format!("Shell execution failed: {err}")))?;
 	let stdout_truncated_bytes = stdout_budget.truncated_bytes();
 	let stderr_truncated_bytes = stderr_budget.truncated_bytes();
-	Ok((
-		result,
-		OutputTruncation {
-			stdout_truncated: stdout_truncated_bytes > 0,
-			stdout_truncated_bytes,
-			stderr_truncated: stderr_truncated_bytes > 0,
-			stderr_truncated_bytes,
-			..Default::default()
-		},
-	))
+	Ok((result, OutputTruncation {
+		stdout_truncated: stdout_truncated_bytes > 0,
+		stdout_truncated_bytes,
+		stderr_truncated: stderr_truncated_bytes > 0,
+		stderr_truncated_bytes,
+		..Default::default()
+	}))
 }
 
 async fn read_output_bytes(
@@ -1298,17 +1291,17 @@ enum OutputRead {
 }
 
 struct BufferedOutput {
-	text: String,
+	text:     String,
 	exceeded: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
 struct OutputTruncation {
-	output_truncated: bool,
+	output_truncated:       bool,
 	output_truncated_bytes: u64,
-	stdout_truncated: bool,
+	stdout_truncated:       bool,
 	stdout_truncated_bytes: u64,
-	stderr_truncated: bool,
+	stderr_truncated:       bool,
 	stderr_truncated_bytes: u64,
 }
 
@@ -1746,7 +1739,7 @@ struct TimeoutCommand {
 	#[arg(required = true)]
 	duration: String,
 	#[arg(required = true, num_args = 1.., trailing_var_arg = true)]
-	command: Vec<String>,
+	command:  Vec<String>,
 }
 
 impl builtins::Command for TimeoutCommand {
@@ -2344,7 +2337,10 @@ mod tests {
 			.expect("spawn unrelated sibling");
 		let sibling_pid = i32::try_from(sibling.id()).expect("sibling pid should fit i32");
 		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-		let command = "timeout 0.2 perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; print qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30;'";
+		let command = "timeout 0.2 perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; \
+		               print qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . \
+		               qq(\\n); $| = 1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . \
+		               getpgrp() . qq(\\n); $| = 1; sleep 30;'";
 		let result = execute_shell(
 			ShellExecuteOptions { command: command.to_string(), ..Default::default() },
 			Some(tx),
@@ -2378,7 +2374,8 @@ mod tests {
 			.expect("sibling should still be alive")
 			.kill_tree(Some(process::KILL_SIGNAL));
 		panic!(
-			"timeout left reparented grandchild {grandchild_pid} alive or killed sibling; output={output:?}"
+			"timeout left reparented grandchild {grandchild_pid} alive or killed sibling; \
+			 output={output:?}"
 		);
 	}
 
@@ -2395,7 +2392,10 @@ mod tests {
 		let cancel = CancelToken::default();
 		let abort = cancel.clone().emplace_abort_token();
 		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-		let command = "perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; print qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . getpgrp() . qq(\\n); exit 0;'; sleep 30";
+		let command = "perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; print \
+		               qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . qq(\\n); $| = \
+		               1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . getpgrp() . \
+		               qq(\\n); exit 0;'; sleep 30";
 		let run = tokio::spawn(execute_shell(
 			ShellExecuteOptions { command: command.to_string(), ..Default::default() },
 			Some(tx),

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -5,7 +5,10 @@ use std::{
 	fs,
 	io::{self, Write},
 	str,
-	sync::Arc,
+	sync::{
+		Arc,
+		atomic::{AtomicI32, AtomicUsize, Ordering},
+	},
 	time::Duration,
 };
 
@@ -39,62 +42,96 @@ struct ShellSessionCore {
 	shell: BrushShell,
 }
 
+#[derive(Default)]
+struct ShellAbortInner {
+	generation: usize,
+	tokens: HashMap<usize, AbortToken>,
+	active: HashSet<usize>,
+	pending: bool,
+}
+
 #[derive(Clone, Default)]
-struct ShellAbortState(Arc<TokioMutex<Option<AbortToken>>>);
+struct ShellAbortState(Arc<TokioMutex<ShellAbortInner>>);
 
 impl ShellAbortState {
-	async fn set(&self, abort_token: AbortToken) {
-		*self.0.lock().await = Some(abort_token);
+	async fn publish(&self, abort_token: AbortToken) -> usize {
+		let mut inner = self.0.lock().await;
+		inner.generation = inner.generation.wrapping_add(1);
+		let generation = inner.generation;
+		inner.tokens.insert(generation, abort_token);
+		generation
 	}
 
-	async fn clear(&self) {
-		*self.0.lock().await = None;
+	async fn activate(&self, generation: usize) {
+		let mut inner = self.0.lock().await;
+		if inner.tokens.contains_key(&generation) {
+			inner.active.insert(generation);
+		}
+		if inner.pending {
+			if let Some(abort_token) = inner.tokens.get(&generation).cloned() {
+				abort_token.abort(AbortReason::Signal);
+			}
+			inner.pending = false;
+		}
+	}
+
+	async fn clear(&self, generation: usize) {
+		let mut inner = self.0.lock().await;
+		inner.tokens.remove(&generation);
+		inner.active.remove(&generation);
 	}
 
 	async fn abort(&self) {
-		let abort_token = self.0.lock().await.clone();
-		if let Some(abort_token) = abort_token {
-			abort_token.abort(AbortReason::Signal);
+		let mut inner = self.0.lock().await;
+		if inner.active.is_empty() {
+			inner.pending = true;
+			return;
+		}
+		let active = inner.active.clone();
+		for generation in active {
+			if let Some(abort_token) = inner.tokens.get(&generation).cloned() {
+				abort_token.abort(AbortReason::Signal);
+			}
 		}
 	}
 }
 
 #[derive(Clone)]
 struct ShellConfig {
-	session_env:   Option<HashMap<String, String>>,
+	session_env: Option<HashMap<String, String>>,
 	snapshot_path: Option<String>,
-	minimizer:     Option<minimizer::MinimizerConfig>,
+	minimizer: Option<minimizer::MinimizerConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellOptions {
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	pub snapshot_path: Option<String>,
-	pub minimizer:     Option<minimizer::MinimizerOptions>,
+	pub minimizer: Option<minimizer::MinimizerOptions>,
 }
 
 struct ShellRunConfig {
-	command:   String,
-	cwd:       Option<String>,
-	env:       Option<HashMap<String, String>>,
+	command: String,
+	cwd: Option<String>,
+	env: Option<HashMap<String, String>>,
 	minimizer: Option<minimizer::MinimizerConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellRunOptions {
-	pub command:    String,
-	pub cwd:        Option<String>,
-	pub env:        Option<HashMap<String, String>>,
+	pub command: String,
+	pub cwd: Option<String>,
+	pub env: Option<HashMap<String, String>>,
 	pub timeout_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MinimizerResult {
-	pub filter:        String,
-	pub text:          String,
+	pub filter: String,
+	pub text: String,
 	pub original_text: String,
-	pub input_bytes:   u32,
-	pub output_bytes:  u32,
+	pub input_bytes: u32,
+	pub output_bytes: u32,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -103,25 +140,31 @@ pub struct ShellRunResult {
 	pub cancelled: bool,
 	pub timed_out: bool,
 	pub minimized: Option<MinimizerResult>,
+	pub output_truncated: bool,
+	pub output_truncated_bytes: u64,
+	pub stdout_truncated: bool,
+	pub stdout_truncated_bytes: u64,
+	pub stderr_truncated: bool,
+	pub stderr_truncated_bytes: u64,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellExecuteOptions {
-	pub command:       String,
-	pub cwd:           Option<String>,
-	pub env:           Option<HashMap<String, String>>,
-	pub session_env:   Option<HashMap<String, String>>,
-	pub timeout_ms:    Option<u32>,
+	pub command: String,
+	pub cwd: Option<String>,
+	pub env: Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
+	pub timeout_ms: Option<u32>,
 	pub snapshot_path: Option<String>,
-	pub minimizer:     Option<minimizer::MinimizerOptions>,
+	pub minimizer: Option<minimizer::MinimizerOptions>,
 }
 
 pub type ShellExecuteResult = ShellRunResult;
 
 pub struct Shell {
-	session:     Arc<TokioMutex<Option<ShellSessionCore>>>,
+	session: Arc<TokioMutex<Option<ShellSessionCore>>>,
 	abort_state: ShellAbortState,
-	config:      ShellConfig,
+	config: ShellConfig,
 }
 
 impl Shell {
@@ -155,9 +198,9 @@ impl Shell {
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
 		let run_config = ShellRunConfig {
-			command:   options.command,
-			cwd:       options.cwd,
-			env:       options.env,
+			command: options.command,
+			cwd: options.cwd,
+			env: options.env,
 			minimizer: self.config.minimizer.clone(),
 		};
 		run_shell_session(
@@ -186,9 +229,9 @@ pub async fn execute_shell(
 		.as_ref()
 		.map(minimizer::MinimizerConfig::from_options);
 	let config = ShellConfig {
-		session_env:   options.session_env,
+		session_env: options.session_env,
 		snapshot_path: options.snapshot_path,
-		minimizer:     minimizer.clone(),
+		minimizer: minimizer.clone(),
 	};
 	let run_config =
 		ShellRunConfig { command: options.command, cwd: options.cwd, env: options.env, minimizer };
@@ -218,14 +261,14 @@ pub async fn execute_shell_streams(
 	cancel_token: CancelToken,
 ) -> Result<ShellExecuteResult> {
 	let config = ShellConfig {
-		session_env:   options.session_env,
+		session_env: options.session_env,
 		snapshot_path: options.snapshot_path,
-		minimizer:     None,
+		minimizer: None,
 	};
 	let run_config = ShellRunConfig {
-		command:   options.command,
-		cwd:       options.cwd,
-		env:       options.env,
+		command: options.command,
+		cwd: options.cwd,
+		env: options.env,
 		minimizer: None,
 	};
 	run_shell_oneshot_streams(config, run_config, streams, cancel_token).await
@@ -240,22 +283,23 @@ async fn run_shell_session(
 	ct: &mut CancelToken,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
-	let baseline_descendants = process::current_descendant_pids();
+	let abort_generation = abort_state.publish(ct.emplace_abort_token()).await;
 
 	let mut run_task = tokio::spawn({
 		let session = session.clone();
-		let abort_state = abort_state.clone();
 		let tokio_cancel = tokio_cancel.clone();
-		let at = ct.emplace_abort_token();
+		let run_abort_state = abort_state.clone();
 		async move {
 			let mut session_guard = session.lock().await;
+			run_abort_state.activate(abort_generation).await;
 
 			let session = match &mut *session_guard {
 				Some(session) => session,
 				None => session_guard.insert(create_session(&config).await?),
 			};
-			abort_state.set(at).await;
-			run_shell_command(session, &run_config, on_chunk, tokio_cancel).await
+			let result = run_shell_command(session, &run_config, on_chunk, tokio_cancel).await;
+			run_abort_state.clear(abort_generation).await;
+			result
 		}
 	});
 
@@ -263,13 +307,14 @@ async fn run_shell_session(
 		res = &mut run_task => res,
 		reason = ct.wait() => {
 			tokio_cancel.cancel();
-			terminate_new_descendants(&baseline_descendants).await;
+			// Per-command cancellation handles descendant termination after the
+			// serialized session lock is acquired; do not use a queued run baseline.
 			let graceful = time::timeout(Duration::from_secs(2), &mut run_task).await;
 			if graceful.is_err() {
 				run_task.abort();
 				let _ = run_task.await;
 			}
-			abort_state.clear().await;
+			abort_state.clear(abort_generation).await;
 			// Use try_lock to avoid deadlocking if another task holds the session.
 			// If we can't acquire the lock, the session will be cleaned up when the
 			// holding task finishes.
@@ -281,23 +326,35 @@ async fn run_shell_session(
 				cancelled: matches!(reason, AbortReason::Signal),
 				timed_out: matches!(reason, AbortReason::Timeout),
 				minimized: None,
+				output_truncated: false,
+				output_truncated_bytes: 0,
+				stdout_truncated: false,
+				stdout_truncated_bytes: 0,
+				stderr_truncated: false,
+				stderr_truncated_bytes: 0,
 			});
 		}
 	};
 	let res =
 		res.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
-	abort_state.clear().await;
+	abort_state.clear(abort_generation).await;
 
 	let keepalive = res.as_ref().is_ok_and(|pair| session_keepalive(&pair.0));
 	if !keepalive {
 		*session.lock().await = None;
 	}
-	let (exec, minimized) = res?;
+	let (exec, minimized, truncation) = res?;
 	Ok(ShellRunResult {
 		exit_code: Some(exit_code(&exec)),
 		cancelled: false,
 		timed_out: false,
 		minimized,
+		output_truncated: truncation.output_truncated,
+		output_truncated_bytes: truncation.output_truncated_bytes,
+		stdout_truncated: truncation.stdout_truncated,
+		stdout_truncated_bytes: truncation.stdout_truncated_bytes,
+		stderr_truncated: truncation.stderr_truncated,
+		stderr_truncated_bytes: truncation.stderr_truncated_bytes,
 	})
 }
 
@@ -322,7 +379,7 @@ async fn run_shell_oneshot(
 		result = &mut task => result,
 		reason = ct.wait() => {
 			tokio_cancel.cancel();
-			terminate_new_descendants(&baseline_descendants).await;
+			terminate_new_descendants(&baseline_descendants, 0).await;
 			let graceful = time::timeout(Duration::from_secs(2), &mut task).await;
 			if graceful.is_err() {
 				task.abort();
@@ -333,18 +390,30 @@ async fn run_shell_oneshot(
 				cancelled: matches!(reason, AbortReason::Signal),
 				timed_out: matches!(reason, AbortReason::Timeout),
 				minimized: None,
+				output_truncated: false,
+				output_truncated_bytes: 0,
+				stdout_truncated: false,
+				stdout_truncated_bytes: 0,
+				stderr_truncated: false,
+				stderr_truncated_bytes: 0,
 			});
 		},
 	};
 
 	let res = run_result
 		.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
-	let (exec, minimized) = res?;
+	let (exec, minimized, truncation) = res?;
 	Ok(ShellExecuteResult {
 		exit_code: Some(exit_code(&exec)),
 		cancelled: false,
 		timed_out: false,
 		minimized,
+		output_truncated: truncation.output_truncated,
+		output_truncated_bytes: truncation.output_truncated_bytes,
+		stdout_truncated: truncation.stdout_truncated,
+		stdout_truncated_bytes: truncation.stdout_truncated_bytes,
+		stderr_truncated: truncation.stderr_truncated,
+		stderr_truncated_bytes: truncation.stderr_truncated_bytes,
 	})
 }
 
@@ -369,7 +438,7 @@ async fn run_shell_oneshot_streams(
 		result = &mut task => result,
 		reason = ct.wait() => {
 			tokio_cancel.cancel();
-			terminate_new_descendants(&baseline_descendants).await;
+			terminate_new_descendants(&baseline_descendants, 0).await;
 			let graceful = time::timeout(Duration::from_secs(2), &mut task).await;
 			if graceful.is_err() {
 				task.abort();
@@ -380,18 +449,30 @@ async fn run_shell_oneshot_streams(
 				cancelled: matches!(reason, AbortReason::Signal),
 				timed_out: matches!(reason, AbortReason::Timeout),
 				minimized: None,
+				output_truncated: false,
+				output_truncated_bytes: 0,
+				stdout_truncated: false,
+				stdout_truncated_bytes: 0,
+				stderr_truncated: false,
+				stderr_truncated_bytes: 0,
 			});
 		},
 	};
 
 	let res = run_result
 		.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
-	let exec = res?;
+	let (exec, truncation) = res?;
 	Ok(ShellExecuteResult {
 		exit_code: Some(exit_code(&exec)),
 		cancelled: false,
 		timed_out: false,
 		minimized: None,
+		output_truncated: truncation.output_truncated,
+		output_truncated_bytes: truncation.output_truncated_bytes,
+		stdout_truncated: truncation.stdout_truncated,
+		stdout_truncated_bytes: truncation.stdout_truncated_bytes,
+		stderr_truncated: truncation.stderr_truncated,
+		stderr_truncated_bytes: truncation.stderr_truncated_bytes,
 	})
 }
 
@@ -575,7 +656,7 @@ async fn run_shell_command(
 	options: &ShellRunConfig,
 	on_chunk: Option<mpsc::UnboundedSender<String>>,
 	cancel_token: CancellationToken,
-) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
+) -> Result<(ExecutionResult, Option<MinimizerResult>, OutputTruncation)> {
 	if let Some(cwd) = options.cwd.as_deref() {
 		session
 			.shell
@@ -613,6 +694,7 @@ async fn run_shell_command(
 	params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
 	params.set_cancel_token(cancel_token.clone());
 	let baseline_descendants = process::current_descendant_pids();
+	let command_pgid = Arc::new(AtomicI32::new(0));
 	let reader_cancel = CancellationToken::new();
 	let (activity_tx, mut activity_rx) = mpsc::channel::<()>(1);
 	// Stream every raw chunk to the caller live, regardless of whether
@@ -621,8 +703,10 @@ async fn run_shell_command(
 	// so the caller can swap their accumulated buffer for the minimized
 	// version without losing intermediate progress updates.
 	let reader_callback = on_chunk;
+	let output_budget = OutputBudget::new(OutputBudget::DEFAULT_LIMIT);
 	let mut reader_handle = tokio::spawn({
 		let reader_cancel = reader_cancel.clone();
+		let output_budget = output_budget.clone();
 		async move {
 			if should_minimize {
 				let output = read_output_buffered(
@@ -631,11 +715,19 @@ async fn run_shell_command(
 					reader_cancel,
 					activity_tx,
 					max_capture_bytes,
+					output_budget,
 				)
 				.await;
 				Result::<OutputRead>::Ok(OutputRead::Buffered(output))
 			} else {
-				Box::pin(read_output(reader_file, reader_callback, reader_cancel, activity_tx)).await;
+				Box::pin(read_output(
+					reader_file,
+					reader_callback,
+					reader_cancel,
+					activity_tx,
+					output_budget,
+				))
+				.await;
 				Result::<OutputRead>::Ok(OutputRead::Streaming)
 			}
 		}
@@ -648,12 +740,16 @@ async fn run_shell_command(
 			reader_cancel.cancel();
 		}
 	});
+	let pgid_probe =
+		tokio::spawn(capture_new_process_group(baseline_descendants.clone(), command_pgid.clone()));
 	let process_cancel_bridge = tokio::spawn({
 		let cancel_token = cancel_token.clone();
 		let baseline_descendants = baseline_descendants.clone();
+		let command_pgid = command_pgid.clone();
 		async move {
 			cancel_token.cancelled().await;
-			terminate_new_descendants(&baseline_descendants).await;
+			terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst))
+				.await;
 		}
 	});
 	let source_info = SourceInfo::from("pi-natives:command");
@@ -661,17 +757,18 @@ async fn run_shell_command(
 		.shell
 		.run_string(options.command.clone(), &source_info, &params)
 		.await;
+	pgid_probe.abort();
+	let _ = pgid_probe.await;
 
+	let mut cleanup_error = None;
 	if cancel_token.is_cancelled() {
-		terminate_background_jobs(&session.shell);
+		terminate_background_jobs(&session.shell).await;
 	}
 
-	if env_scope_pushed {
-		session
-			.shell
-			.env_mut()
-			.pop_scope(EnvironmentScope::Command)
-			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
+	if env_scope_pushed
+		&& let Err(err) = session.shell.env_mut().pop_scope(EnvironmentScope::Command)
+	{
+		cleanup_error = Some(Error::msg(format!("Failed to pop env scope: {err}")));
 	}
 
 	drop(params);
@@ -709,17 +806,13 @@ async fn run_shell_command(
 	}
 
 	if !reader_finished {
-		reader_cancel.cancel();
-		if let Ok(res) = time::timeout(READER_SHUTDOWN_TIMEOUT, &mut reader_handle).await {
-			if let Ok(output) = res
-				&& let Ok(output) = output
-			{
-				reader_output = Some(output);
-			}
-		} else {
-			reader_handle.abort();
-			let _ = reader_handle.await;
-		}
+		reader_output = shutdown_reader_task(
+			&reader_cancel,
+			&mut reader_handle,
+			reader_finished,
+			READER_SHUTDOWN_TIMEOUT,
+		)
+		.await;
 	}
 	cancel_bridge.abort();
 	let _ = cancel_bridge.await;
@@ -735,6 +828,9 @@ async fn run_shell_command(
 		let _ = process_cancel_bridge.await;
 	}
 
+	if let Some(err) = cleanup_error {
+		return Err(err);
+	}
 	let result = result.map_err(|err| Error::msg(format!("Shell execution failed: {err}")))?;
 	let mut minimized_out: Option<MinimizerResult> = None;
 	if let Some(OutputRead::Buffered(output)) = reader_output
@@ -762,7 +858,16 @@ async fn run_shell_command(
 			});
 		}
 	}
-	Ok((result, minimized_out))
+	let truncated_bytes = output_budget.truncated_bytes();
+	Ok((
+		result,
+		minimized_out,
+		OutputTruncation {
+			output_truncated: truncated_bytes > 0,
+			output_truncated_bytes: truncated_bytes,
+			..Default::default()
+		},
+	))
 }
 
 async fn run_shell_command_streams(
@@ -770,7 +875,7 @@ async fn run_shell_command_streams(
 	options: &ShellRunConfig,
 	streams: StreamSinks,
 	cancel_token: CancellationToken,
-) -> Result<ExecutionResult> {
+) -> Result<(ExecutionResult, OutputTruncation)> {
 	if let Some(cwd) = options.cwd.as_deref() {
 		session
 			.shell
@@ -793,21 +898,26 @@ async fn run_shell_command_streams(
 	params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
 	params.set_cancel_token(cancel_token.clone());
 	let baseline_descendants = process::current_descendant_pids();
+	let command_pgid = Arc::new(AtomicI32::new(0));
 	let reader_cancel = CancellationToken::new();
 	let (activity_tx, mut activity_rx) = mpsc::channel::<()>(1);
 
 	let StreamSinks { stdout: stdout_sink, stderr: stderr_sink } = streams;
+	let stdout_budget = OutputBudget::new(OutputBudget::DEFAULT_LIMIT);
+	let stderr_budget = OutputBudget::new(OutputBudget::DEFAULT_LIMIT);
 	let mut stdout_handle = tokio::spawn(Box::pin(read_output_bytes(
 		stdout_reader,
 		stdout_sink,
 		reader_cancel.clone(),
 		activity_tx.clone(),
+		stdout_budget.clone(),
 	)));
 	let mut stderr_handle = tokio::spawn(Box::pin(read_output_bytes(
 		stderr_reader,
 		stderr_sink,
 		reader_cancel.clone(),
 		activity_tx,
+		stderr_budget.clone(),
 	)));
 
 	let cancel_bridge = tokio::spawn({
@@ -818,12 +928,16 @@ async fn run_shell_command_streams(
 			reader_cancel.cancel();
 		}
 	});
+	let pgid_probe =
+		tokio::spawn(capture_new_process_group(baseline_descendants.clone(), command_pgid.clone()));
 	let process_cancel_bridge = tokio::spawn({
 		let cancel_token = cancel_token.clone();
 		let baseline_descendants = baseline_descendants.clone();
+		let command_pgid = command_pgid.clone();
 		async move {
 			cancel_token.cancelled().await;
-			terminate_new_descendants(&baseline_descendants).await;
+			terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst))
+				.await;
 		}
 	});
 	let source_info = SourceInfo::from("pi-shell:streams");
@@ -831,17 +945,18 @@ async fn run_shell_command_streams(
 		.shell
 		.run_string(options.command.clone(), &source_info, &params)
 		.await;
+	pgid_probe.abort();
+	let _ = pgid_probe.await;
 
+	let mut cleanup_error = None;
 	if cancel_token.is_cancelled() {
-		terminate_background_jobs(&session.shell);
+		terminate_background_jobs(&session.shell).await;
 	}
 
-	if env_scope_pushed {
-		session
-			.shell
-			.env_mut()
-			.pop_scope(EnvironmentScope::Command)
-			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
+	if env_scope_pushed
+		&& let Err(err) = session.shell.env_mut().pop_scope(EnvironmentScope::Command)
+	{
+		cleanup_error = Some(Error::msg(format!("Failed to pop env scope: {err}")));
 	}
 
 	drop(params);
@@ -879,25 +994,20 @@ async fn run_shell_command_streams(
 		}
 	}
 
-	if !stdout_finished || !stderr_finished {
-		reader_cancel.cancel();
-	}
-	if !stdout_finished
-		&& time::timeout(READER_SHUTDOWN_TIMEOUT, &mut stdout_handle)
-			.await
-			.is_err()
-	{
-		stdout_handle.abort();
-		let _ = stdout_handle.await;
-	}
-	if !stderr_finished
-		&& time::timeout(READER_SHUTDOWN_TIMEOUT, &mut stderr_handle)
-			.await
-			.is_err()
-	{
-		stderr_handle.abort();
-		let _ = stderr_handle.await;
-	}
+	shutdown_reader_unit_task(
+		&reader_cancel,
+		&mut stdout_handle,
+		stdout_finished,
+		READER_SHUTDOWN_TIMEOUT,
+	)
+	.await;
+	shutdown_reader_unit_task(
+		&reader_cancel,
+		&mut stderr_handle,
+		stderr_finished,
+		READER_SHUTDOWN_TIMEOUT,
+	)
+	.await;
 	cancel_bridge.abort();
 	let _ = cancel_bridge.await;
 	if cancel_token.is_cancelled() {
@@ -909,8 +1019,22 @@ async fn run_shell_command_streams(
 		let _ = process_cancel_bridge.await;
 	}
 
+	if let Some(err) = cleanup_error {
+		return Err(err);
+	}
 	let result = result.map_err(|err| Error::msg(format!("Shell execution failed: {err}")))?;
-	Ok(result)
+	let stdout_truncated_bytes = stdout_budget.truncated_bytes();
+	let stderr_truncated_bytes = stderr_budget.truncated_bytes();
+	Ok((
+		result,
+		OutputTruncation {
+			stdout_truncated: stdout_truncated_bytes > 0,
+			stdout_truncated_bytes,
+			stderr_truncated: stderr_truncated_bytes > 0,
+			stderr_truncated_bytes,
+			..Default::default()
+		},
+	))
 }
 
 async fn read_output_bytes(
@@ -918,6 +1042,7 @@ async fn read_output_bytes(
 	sink: Option<mpsc::UnboundedSender<Bytes>>,
 	cancel_token: CancellationToken,
 	activity: mpsc::Sender<()>,
+	budget: OutputBudget,
 ) {
 	const BUF: usize = 65536;
 
@@ -962,11 +1087,20 @@ async fn read_output_bytes(
 		};
 		let _ = activity.try_send(());
 		buf.truncate(n);
-		if let Some(sink) = sink.as_ref()
-			&& sink.send(Bytes::from(buf)).is_err()
-		{
-			// Receiver dropped — stop forwarding and let the pipe close.
-			break;
+		if let Some(sink) = sink.as_ref() {
+			let allowed = budget
+				.remaining
+				.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+					Some(remaining.saturating_sub(buf.len()))
+				})
+				.unwrap_or(0)
+				.min(buf.len());
+			if allowed > 0 && sink.send(Bytes::copy_from_slice(&buf[..allowed])).is_err() {
+				break;
+			}
+			if allowed < buf.len() {
+				budget.mark_truncated(buf.len() - allowed);
+			}
 		}
 	}
 }
@@ -974,12 +1108,30 @@ async fn read_output_bytes(
 // Rescan-and-signal loop for cancellation. Each pass picks up descendants
 // spawned during the previous wave's grace period, then exits as soon as no
 // targets remain so unrelated later commands are not swept into old cancels.
-async fn terminate_new_descendants<S: std::hash::BuildHasher + Sync>(baseline: &HashSet<i32, S>) {
+async fn capture_new_process_group<S: std::hash::BuildHasher + Sync>(
+	baseline: HashSet<i32, S>,
+	command_pgid: Arc<AtomicI32>,
+) {
+	for _ in 0..100 {
+		let mut targets = process::TerminationTargets::new();
+		process::add_new_descendants(&mut targets, &baseline);
+		if let Some(pgid) = targets.first_pgid() {
+			command_pgid.store(pgid, Ordering::SeqCst);
+			return;
+		}
+		time::sleep(Duration::from_millis(5)).await;
+	}
+}
+
+async fn terminate_new_descendants<S: std::hash::BuildHasher + Sync>(
+	baseline: &HashSet<i32, S>,
+	command_pgid: i32,
+) {
 	const WAVES: u32 = 3;
 	for wave in 0..WAVES {
 		let mut targets = process::TerminationTargets::new();
 		process::add_new_descendants(&mut targets, baseline);
-		if targets.is_empty() {
+		if targets.is_empty() && command_pgid <= 0 {
 			return;
 		}
 		let signal = if wave == 0 {
@@ -987,6 +1139,9 @@ async fn terminate_new_descendants<S: std::hash::BuildHasher + Sync>(baseline: &
 		} else {
 			process::KILL_SIGNAL
 		};
+		if command_pgid > 0 {
+			let _ = process::kill_process_group(command_pgid, signal);
+		}
 		targets.signal(signal);
 		if wave + 1 < WAVES {
 			let pause = if wave == 0 {
@@ -998,7 +1153,7 @@ async fn terminate_new_descendants<S: std::hash::BuildHasher + Sync>(baseline: &
 		}
 	}
 }
-fn terminate_background_jobs(shell: &BrushShell) {
+async fn terminate_background_jobs(shell: &BrushShell) {
 	let mut targets = process::TerminationTargets::new();
 	for job in &shell.jobs().jobs {
 		if let Some(pgid) = job.process_group_id() {
@@ -1009,19 +1164,12 @@ fn terminate_background_jobs(shell: &BrushShell) {
 		}
 	}
 	if targets.is_empty() {
-		// Pure descendant cleanup is handled by `process_cancel_bridge` while
-		// the cancel was still in flight. Here we only signal brush's own
-		// job-tracked targets — pgids of background-group leaders that may have
-		// already exited (so the descendant walk would no longer find them as
-		// new descendants, but their group still holds live grandchildren).
 		return;
 	}
 
 	targets.signal(process::TERM_SIGNAL);
-	tokio::spawn(async move {
-		time::sleep(Duration::from_millis(150)).await;
-		targets.signal(process::KILL_SIGNAL);
-	});
+	time::sleep(Duration::from_millis(150)).await;
+	targets.signal(process::KILL_SIGNAL);
 }
 
 /// Apply per-command environment variables onto a freshly pushed
@@ -1150,8 +1298,80 @@ enum OutputRead {
 }
 
 struct BufferedOutput {
-	text:     String,
+	text: String,
 	exceeded: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct OutputTruncation {
+	output_truncated: bool,
+	output_truncated_bytes: u64,
+	stdout_truncated: bool,
+	stdout_truncated_bytes: u64,
+	stderr_truncated: bool,
+	stderr_truncated_bytes: u64,
+}
+
+#[derive(Clone)]
+struct OutputBudget {
+	remaining: Arc<AtomicUsize>,
+	truncated: Arc<AtomicUsize>,
+}
+
+impl OutputBudget {
+	const DEFAULT_LIMIT: usize = 8 * 1024 * 1024;
+
+	fn new(limit: usize) -> Self {
+		Self {
+			remaining: Arc::new(AtomicUsize::new(limit)),
+			truncated: Arc::new(AtomicUsize::new(0)),
+		}
+	}
+
+	fn mark_truncated(&self, bytes: usize) {
+		self.truncated.fetch_add(bytes, Ordering::SeqCst);
+	}
+
+	fn truncated_bytes(&self) -> u64 {
+		u64::try_from(self.truncated.load(Ordering::SeqCst)).unwrap_or(u64::MAX)
+	}
+}
+
+async fn shutdown_reader_task<T>(
+	reader_cancel: &CancellationToken,
+	reader_handle: &mut tokio::task::JoinHandle<Result<T>>,
+	reader_finished: bool,
+	timeout: Duration,
+) -> Option<T> {
+	if reader_finished {
+		return None;
+	}
+	reader_cancel.cancel();
+	match time::timeout(timeout, &mut *reader_handle).await {
+		Ok(Ok(Ok(output))) => Some(output),
+		Ok(_) => None,
+		Err(_) => {
+			reader_handle.abort();
+			let _ = reader_handle.await;
+			None
+		},
+	}
+}
+
+async fn shutdown_reader_unit_task(
+	reader_cancel: &CancellationToken,
+	reader_handle: &mut tokio::task::JoinHandle<()>,
+	reader_finished: bool,
+	timeout: Duration,
+) {
+	if reader_finished {
+		return;
+	}
+	reader_cancel.cancel();
+	if time::timeout(timeout, &mut *reader_handle).await.is_err() {
+		reader_handle.abort();
+		let _ = reader_handle.await;
+	}
 }
 
 async fn read_output(
@@ -1159,6 +1379,7 @@ async fn read_output(
 	on_chunk: Option<mpsc::UnboundedSender<String>>,
 	cancel_token: CancellationToken,
 	activity: mpsc::Sender<()>,
+	budget: OutputBudget,
 ) {
 	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
@@ -1215,7 +1436,7 @@ async fn read_output(
 			let pending = &buf[..it];
 			match str::from_utf8(pending) {
 				Ok(text) => {
-					emit_chunk(text, on_chunk.as_ref());
+					emit_chunk(text, on_chunk.as_ref(), &budget);
 					it = 0;
 					break;
 				},
@@ -1224,7 +1445,7 @@ async fn read_output(
 					if p > 0 {
 						// SAFETY: [..p] is guaranteed valid UTF-8 by valid_up_to().
 						let text = unsafe { str::from_utf8_unchecked(&pending[..p]) };
-						emit_chunk(text, on_chunk.as_ref());
+						emit_chunk(text, on_chunk.as_ref(), &budget);
 						// copy p..it to the beginning of the buffer
 						buf.copy_within(p..it, 0);
 						it -= p;
@@ -1233,7 +1454,7 @@ async fn read_output(
 					match err.error_len() {
 						Some(p) => {
 							// Invalid byte sequence: emit replacement and drop those bytes.
-							emit_chunk(REPLACEMENT, on_chunk.as_ref());
+							emit_chunk(REPLACEMENT, on_chunk.as_ref(), &budget);
 							// copy p..it to the beginning of the buffer
 							buf.copy_within(p..it, 0);
 							it -= p;
@@ -1254,10 +1475,10 @@ async fn read_output(
 	for chunk in buf[..it].utf8_chunks() {
 		let valid = chunk.valid();
 		if !valid.is_empty() {
-			emit_chunk(valid, on_chunk.as_ref());
+			emit_chunk(valid, on_chunk.as_ref(), &budget);
 		}
 		if !chunk.invalid().is_empty() {
-			emit_chunk(REPLACEMENT, on_chunk.as_ref());
+			emit_chunk(REPLACEMENT, on_chunk.as_ref(), &budget);
 		}
 	}
 }
@@ -1268,6 +1489,7 @@ async fn read_output_buffered(
 	cancel_token: CancellationToken,
 	activity: mpsc::Sender<()>,
 	max_capture_bytes: usize,
+	budget: OutputBudget,
 ) -> BufferedOutput {
 	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
@@ -1341,7 +1563,7 @@ async fn read_output_buffered(
 			while !pending.is_empty() {
 				match str::from_utf8(&pending) {
 					Ok(text) => {
-						emit_chunk(text, Some(cb));
+						emit_chunk(text, Some(cb), &budget);
 						pending.clear();
 						break;
 					},
@@ -1350,12 +1572,12 @@ async fn read_output_buffered(
 						if p > 0 {
 							// SAFETY: [..p] is valid UTF-8 per valid_up_to().
 							let text = unsafe { str::from_utf8_unchecked(&pending[..p]) };
-							emit_chunk(text, Some(cb));
+							emit_chunk(text, Some(cb), &budget);
 							pending.drain(..p);
 						}
 						match err.error_len() {
 							Some(skip) => {
-								emit_chunk(REPLACEMENT, Some(cb));
+								emit_chunk(REPLACEMENT, Some(cb), &budget);
 								pending.drain(..skip);
 							},
 							None => break,
@@ -1371,10 +1593,10 @@ async fn read_output_buffered(
 		for chunk in pending.utf8_chunks() {
 			let valid = chunk.valid();
 			if !valid.is_empty() {
-				emit_chunk(valid, Some(cb));
+				emit_chunk(valid, Some(cb), &budget);
 			}
 			if !chunk.invalid().is_empty() {
-				emit_chunk(REPLACEMENT, Some(cb));
+				emit_chunk(REPLACEMENT, Some(cb), &budget);
 			}
 		}
 	}
@@ -1422,9 +1644,32 @@ fn read_nonblocking<T: std::os::fd::AsRawFd>(file: &T, buf: &mut [u8]) -> io::Re
 	}
 }
 
-fn emit_chunk(text: &str, callback: Option<&mpsc::UnboundedSender<String>>) {
+fn emit_chunk(text: &str, callback: Option<&mpsc::UnboundedSender<String>>, budget: &OutputBudget) {
+	if text.is_empty() {
+		return;
+	}
 	if let Some(callback) = callback {
-		let _ = callback.send(text.to_string());
+		let allowed = budget
+			.remaining
+			.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+				Some(remaining.saturating_sub(text.len()))
+			})
+			.unwrap_or(0)
+			.min(text.len());
+		if allowed == 0 {
+			budget.mark_truncated(text.len());
+			return;
+		}
+		let mut end = allowed;
+		while !text.is_char_boundary(end) {
+			end -= 1;
+		}
+		if end > 0 && callback.send(text[..end].to_string()).is_err() {
+			return;
+		}
+		if end < text.len() {
+			budget.mark_truncated(text.len() - end);
+		}
 	}
 }
 
@@ -1501,7 +1746,7 @@ struct TimeoutCommand {
 	#[arg(required = true)]
 	duration: String,
 	#[arg(required = true, num_args = 1.., trailing_var_arg = true)]
-	command:  Vec<String>,
+	command: Vec<String>,
 }
 
 impl builtins::Command for TimeoutCommand {
@@ -1540,23 +1785,33 @@ impl builtins::Command for TimeoutCommand {
 			}
 
 			let cancel_token = context.cancel_token();
+			let baseline_descendants = process::current_descendant_pids();
+			let command_pgid = Arc::new(AtomicI32::new(0));
+			let pgid_probe = tokio::spawn(capture_new_process_group(
+				baseline_descendants.clone(),
+				command_pgid.clone(),
+			));
 			let source_info = SourceInfo::from("pi-natives:timeout");
 			let run_future = context
 				.shell
 				.run_string(command_line, &source_info, &params);
 			tokio::pin!(run_future);
 
-			if let Some(cancel_token) = cancel_token {
+			let result = if let Some(cancel_token) = cancel_token {
 				tokio::select! {
 					result = &mut run_future => result,
 					() = time::sleep(timeout) => {
 						child_cancel.cancel();
-						// Wait briefly for the child to exit after cancellation.
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
 						let _ = time::timeout(Duration::from_secs(2), &mut run_future).await;
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
 						Ok(ExecutionResult::new(124))
 					},
 					() = cancel_token.cancelled() => {
 						child_cancel.cancel();
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
+						let _ = time::timeout(Duration::from_secs(2), &mut run_future).await;
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
 						Ok(ExecutionExitCode::Interrupted.into())
 					},
 				}
@@ -1565,12 +1820,16 @@ impl builtins::Command for TimeoutCommand {
 					result = &mut run_future => result,
 					() = time::sleep(timeout) => {
 						child_cancel.cancel();
-						// Wait briefly for the child to exit after cancellation.
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
 						let _ = time::timeout(Duration::from_secs(2), &mut run_future).await;
+						terminate_new_descendants(&baseline_descendants, command_pgid.load(Ordering::SeqCst)).await;
 						Ok(ExecutionResult::new(124))
 					},
 				}
-			}
+			};
+			pgid_probe.abort();
+			let _ = pgid_probe.await;
+			result
 		}
 	}
 }
@@ -1615,6 +1874,9 @@ fn quote_arg(arg: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[cfg(unix)]
+	static PROCESS_TEST_LOCK: TokioMutex<()> = TokioMutex::const_new(());
 
 	/// Truth-table coverage for `brush_core::commands::child_session_action`.
 	///
@@ -1694,6 +1956,7 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn embedded_external_command_runs_in_its_own_session() {
 		use std::io::Read as _;
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
 
 		// SAFETY: `getsid(0)` only queries the current process session; the return
 		// value is checked.
@@ -1802,7 +2065,8 @@ mod tests {
 		let mut cancel_token = CancelToken::default();
 		let abort_token = cancel_token.emplace_abort_token();
 
-		abort_state.set(abort_token).await;
+		let generation = abort_state.publish(abort_token).await;
+		abort_state.activate(generation).await;
 		abort_state.abort().await;
 
 		let reason = time::timeout(Duration::from_millis(100), cancel_token.wait())
@@ -1811,13 +2075,410 @@ mod tests {
 		assert!(matches!(reason, AbortReason::Signal));
 	}
 
+	#[tokio::test]
+	async fn abort_state_latches_abort_before_token_publication() {
+		let abort_state = ShellAbortState::default();
+		let mut cancel_token = CancelToken::default();
+
+		abort_state.abort().await;
+		let abort_token = cancel_token.emplace_abort_token();
+		let generation = abort_state.publish(abort_token).await;
+		abort_state.activate(generation).await;
+
+		let reason = time::timeout(Duration::from_millis(100), cancel_token.wait())
+			.await
+			.expect("latched abort should signal token after publication");
+		assert!(matches!(reason, AbortReason::Signal));
+	}
+
+	#[tokio::test]
+	async fn abort_state_latches_abort_after_stale_generation_cleared() {
+		let abort_state = ShellAbortState::default();
+		let mut stale_cancel = CancelToken::default();
+		let stale_abort = stale_cancel.emplace_abort_token();
+		let stale_generation = abort_state.publish(stale_abort).await;
+		abort_state.activate(stale_generation).await;
+		abort_state.clear(stale_generation).await;
+
+		abort_state.abort().await;
+
+		let mut next_cancel = CancelToken::default();
+		let next_abort = next_cancel.emplace_abort_token();
+		let next_generation = abort_state.publish(next_abort).await;
+		abort_state.activate(next_generation).await;
+
+		let reason = time::timeout(Duration::from_millis(100), next_cancel.wait())
+			.await
+			.expect("handoff-window abort should latch for the next active token");
+		assert!(matches!(reason, AbortReason::Signal));
+		assert!(
+			time::timeout(Duration::from_millis(20), stale_cancel.wait())
+				.await
+				.is_err(),
+			"stale generation should already be cleared, not signalled again"
+		);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn shell_abort_before_run_token_publication_interrupts_command() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let shell = Shell::new(None);
+		shell.abort().await;
+
+		let started = std::time::Instant::now();
+		let result = time::timeout(
+			Duration::from_secs(2),
+			shell.run(
+				ShellRunOptions { command: "/bin/sh -c 'sleep 5'".to_string(), ..Default::default() },
+				None,
+				CancelToken::default(),
+			),
+		)
+		.await
+		.expect("latched abort should interrupt instead of hanging")
+		.expect("shell run should return cancellation result");
+
+		assert!(result.cancelled, "latched Shell::abort should surface as cancellation");
+		assert_eq!(result.exit_code, None);
+		assert!(started.elapsed() < Duration::from_secs(2), "command was not interrupted promptly");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn overlapping_shell_abort_interrupts_active_run_not_queued_run() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let shell = Arc::new(Shell::new(None));
+		let (first_tx, mut first_rx) = mpsc::unbounded_channel::<String>();
+		let (second_tx, mut second_rx) = mpsc::unbounded_channel::<String>();
+
+		let first = tokio::spawn({
+			let shell = shell.clone();
+			async move {
+				shell
+					.run(
+						ShellRunOptions {
+							command: "printf first-started; sleep 5".to_string(),
+							..Default::default()
+						},
+						Some(first_tx),
+						CancelToken::default(),
+					)
+					.await
+			}
+		});
+
+		let first_seen = time::timeout(Duration::from_secs(2), first_rx.recv())
+			.await
+			.expect("first command should emit startup marker")
+			.expect("first output channel should remain open");
+		assert!(first_seen.starts_with("first-start"), "unexpected first chunk: {first_seen:?}");
+
+		let second = tokio::spawn({
+			let shell = shell.clone();
+			async move {
+				shell
+					.run(
+						ShellRunOptions {
+							command: "printf second-ran".to_string(),
+							..Default::default()
+						},
+						Some(second_tx),
+						CancelToken::default(),
+					)
+					.await
+			}
+		});
+		time::sleep(Duration::from_millis(50)).await;
+
+		shell.abort().await;
+
+		let first_result = time::timeout(Duration::from_secs(2), first)
+			.await
+			.expect("active run should finish promptly after abort")
+			.expect("active run task should not panic")
+			.expect("active run should return a result");
+		assert!(first_result.cancelled, "abort should target the active first run");
+		assert_eq!(first_result.exit_code, None);
+
+		let second_result = time::timeout(Duration::from_secs(2), second)
+			.await
+			.expect("queued run should finish after active run releases session")
+			.expect("queued run task should not panic")
+			.expect("queued run should return a result");
+		assert!(!second_result.cancelled, "queued run must not steal the abort target");
+		assert_eq!(second_result.exit_code, Some(0));
+
+		let second_seen = time::timeout(Duration::from_secs(2), second_rx.recv())
+			.await
+			.expect("second command should emit after active abort")
+			.expect("second output channel should remain open");
+		assert_eq!(second_seen, "second-ran");
+	}
+
+	#[tokio::test]
+	async fn output_budget_caps_streaming_chunks() {
+		let budget = OutputBudget::new(5);
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+
+		emit_chunk("hello", Some(&tx), &budget);
+		emit_chunk("world", Some(&tx), &budget);
+		drop(tx);
+
+		let mut received = String::new();
+		while let Some(chunk) = rx.recv().await {
+			received.push_str(&chunk);
+		}
+		assert_eq!(received, "hello");
+		assert_eq!(budget.truncated_bytes(), 5);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn very_large_stdout_caps_output_and_surfaces_truncation() {
+		let (reader, mut writer) = pipe_to_files("large-output").expect("pipe should be created");
+		let budget = OutputBudget::new(1024);
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let (activity_tx, _activity_rx) = mpsc::channel(1);
+		let handle = tokio::spawn(read_output(
+			reader,
+			Some(tx),
+			CancellationToken::new(),
+			activity_tx,
+			budget.clone(),
+		));
+
+		let writer_handle = tokio::task::spawn_blocking(move || {
+			let chunk = vec![b'x'; OutputBudget::DEFAULT_LIMIT + 4096];
+			writer
+				.write_all(&chunk)
+				.expect("large write should succeed");
+		});
+		writer_handle.await.expect("writer task should not panic");
+
+		let mut received = String::new();
+		while let Some(chunk) = rx.recv().await {
+			received.push_str(&chunk);
+		}
+		time::timeout(Duration::from_secs(2), handle)
+			.await
+			.expect("reader should finish after writer closes")
+			.expect("reader task should not panic");
+
+		assert_eq!(received.len(), 1024, "streamed output must stop exactly at the budget cap");
+		assert!(
+			budget.truncated_bytes() > 0,
+			"budget truncation must be observable, not silent loss"
+		);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn execute_shell_reports_text_truncation() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let result = execute_shell(
+			ShellExecuteOptions {
+				command: format!(
+					"python3 -c 'import sys; sys.stdout.write(\"x\" * {})'",
+					OutputBudget::DEFAULT_LIMIT + 4096
+				),
+				..Default::default()
+			},
+			Some(tx),
+			CancelToken::default(),
+		)
+		.await
+		.expect("execute_shell should succeed");
+
+		let mut received = 0usize;
+		while let Some(chunk) = rx.recv().await {
+			received += chunk.len();
+		}
+
+		assert_eq!(result.exit_code, Some(0));
+		assert!(result.output_truncated);
+		assert!(result.output_truncated_bytes > 0);
+		assert_eq!(received, OutputBudget::DEFAULT_LIMIT);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn execute_shell_streams_reports_raw_truncation() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
+		let result = execute_shell_streams(
+			ShellExecuteOptions {
+				command: format!(
+					"python3 -c 'import sys; sys.stdout.buffer.write(b\"x\" * {})'",
+					OutputBudget::DEFAULT_LIMIT + 4096
+				),
+				..Default::default()
+			},
+			StreamSinks { stdout: Some(tx), stderr: None },
+			CancelToken::default(),
+		)
+		.await
+		.expect("execute_shell_streams should succeed");
+
+		let mut received = 0usize;
+		while let Some(chunk) = rx.recv().await {
+			received += chunk.len();
+		}
+
+		assert_eq!(result.exit_code, Some(0));
+		assert!(result.stdout_truncated);
+		assert!(result.stdout_truncated_bytes > 0);
+		assert!(!result.stderr_truncated);
+		assert_eq!(received, OutputBudget::DEFAULT_LIMIT);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn timeout_builtin_reaps_reparented_same_group_grandchild_and_preserves_sibling() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let sibling = std::process::Command::new("/bin/sh")
+			.arg("-c")
+			.arg("sleep 5")
+			.spawn()
+			.expect("spawn unrelated sibling");
+		let sibling_pid = i32::try_from(sibling.id()).expect("sibling pid should fit i32");
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let command = "timeout 0.2 perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; print qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30;'";
+		let result = execute_shell(
+			ShellExecuteOptions { command: command.to_string(), ..Default::default() },
+			Some(tx),
+			CancelToken::default(),
+		)
+		.await
+		.expect("timeout command should execute");
+
+		let mut output = String::new();
+		while let Ok(Some(chunk)) = time::timeout(Duration::from_millis(50), rx.recv()).await {
+			output.push_str(&chunk);
+		}
+		let grandchild_pid = parse_marker_pid(&output, "grandchild=")
+			.expect("grandchild marker should be emitted before timeout");
+		assert_eq!(result.exit_code, Some(124), "output={output:?}");
+
+		for _ in 0..50 {
+			let grandchild_dead = process::Process::from_pid(grandchild_pid)
+				.is_none_or(|process| process.status() != process::ProcessStatus::Running);
+			let sibling_alive = process::Process::from_pid(sibling_pid)
+				.is_some_and(|process| process.status() == process::ProcessStatus::Running);
+			if grandchild_dead && sibling_alive {
+				let _ = process::Process::from_pid(sibling_pid)
+					.expect("sibling should still be alive")
+					.kill_tree(Some(process::KILL_SIGNAL));
+				return;
+			}
+			time::sleep(Duration::from_millis(20)).await;
+		}
+		let _ = process::Process::from_pid(sibling_pid)
+			.expect("sibling should still be alive")
+			.kill_tree(Some(process::KILL_SIGNAL));
+		panic!(
+			"timeout left reparented grandchild {grandchild_pid} alive or killed sibling; output={output:?}"
+		);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn cancelled_command_reaps_reparented_same_group_grandchild() {
+		let _process_test_guard = PROCESS_TEST_LOCK.lock().await;
+		let sibling = std::process::Command::new("/bin/sh")
+			.arg("-c")
+			.arg("sleep 5")
+			.spawn()
+			.expect("spawn unrelated sibling");
+		let sibling_pid = i32::try_from(sibling.id()).expect("sibling pid should fit i32");
+		let cancel = CancelToken::default();
+		let abort = cancel.clone().emplace_abort_token();
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let command = "perl -e 'if (($pid = fork()) == 0) { $SIG{TERM} = \"IGNORE\"; print qq(grandchild=$$ ppid=) . getppid() . qq( pgid=) . getpgrp() . qq(\\n); $| = 1; sleep 30; exit 0; } print qq(parent=$$ child=$pid pgid=) . getpgrp() . qq(\\n); exit 0;'; sleep 30";
+		let run = tokio::spawn(execute_shell(
+			ShellExecuteOptions { command: command.to_string(), ..Default::default() },
+			Some(tx),
+			cancel,
+		));
+
+		let mut output = String::new();
+		let grandchild_pid = time::timeout(Duration::from_secs(5), async {
+			loop {
+				let chunk = rx.recv().await.expect("output channel should stay open");
+				output.push_str(&chunk);
+				if let Some(pid) = parse_marker_pid(&output, "grandchild=") {
+					return pid;
+				}
+			}
+		})
+		.await
+		.expect("grandchild pid marker");
+		let command_pgid = process::Process::from_pid(grandchild_pid)
+			.and_then(|process| process.group_id())
+			.expect("grandchild pgid should be visible");
+
+		for _ in 0..50 {
+			if process::Process::from_pid(grandchild_pid).and_then(|process| process.ppid()) == Some(1)
+			{
+				break;
+			}
+			time::sleep(Duration::from_millis(20)).await;
+		}
+		assert_eq!(
+			process::Process::from_pid(grandchild_pid).and_then(|process| process.ppid()),
+			Some(1),
+			"grandchild should reparent away from shell before cancellation; output={output:?}",
+		);
+
+		abort.abort(AbortReason::Signal);
+		terminate_new_descendants(&process::current_descendant_pids(), command_pgid).await;
+		time::sleep(Duration::from_millis(500)).await;
+		run.abort();
+		let _ = run.await;
+
+		for _ in 0..50 {
+			let grandchild_dead = process::Process::from_pid(grandchild_pid)
+				.is_none_or(|process| process.status() != process::ProcessStatus::Running);
+			let sibling_alive = process::Process::from_pid(sibling_pid)
+				.is_some_and(|process| process.status() == process::ProcessStatus::Running);
+			if grandchild_dead && sibling_alive {
+				let _ = process::Process::from_pid(sibling_pid)
+					.expect("sibling should still be alive")
+					.kill_tree(Some(process::KILL_SIGNAL));
+				return;
+			}
+			time::sleep(Duration::from_millis(20)).await;
+		}
+		let _ = process::Process::from_pid(sibling_pid)
+			.expect("sibling should still be alive")
+			.kill_tree(Some(process::KILL_SIGNAL));
+		panic!("reparented grandchild {grandchild_pid} survived cancellation");
+	}
+
+	#[cfg(unix)]
+	fn parse_marker_pid(output: &str, marker: &str) -> Option<i32> {
+		let start = output.find(marker)? + marker.len();
+		let rest = &output[start..];
+		let end = rest
+			.find(|ch: char| !ch.is_ascii_digit())
+			.unwrap_or(rest.len());
+		rest[..end].parse().ok()
+	}
+
 	#[cfg(unix)]
 	#[tokio::test]
 	async fn read_output_stops_when_cancelled_before_pipe_eof() {
 		let (reader, _writer) = pipe_to_files("test").expect("test pipe should be created");
 		let cancel = CancellationToken::new();
 		let (activity_tx, _activity_rx) = mpsc::channel(1);
-		let handle = tokio::spawn(read_output(reader, None, cancel.clone(), activity_tx));
+		let handle = tokio::spawn(read_output(
+			reader,
+			None,
+			cancel.clone(),
+			activity_tx,
+			OutputBudget::new(usize::MAX),
+		));
 
 		time::sleep(Duration::from_millis(10)).await;
 		cancel.cancel();
@@ -1826,6 +2487,77 @@ mod tests {
 			.await
 			.expect("reader task should stop after cancellation")
 			.expect("reader task should not panic");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn env_scope_pop_error_cleanup_cancels_reader_and_bridges() {
+		let (reader, writer) = pipe_to_files("env-pop-error").expect("pipe should be created");
+		let stdout_file = OpenFile::from(writer.try_clone().expect("clone writer"));
+		let stderr_file = OpenFile::from(writer);
+		let reader_cancel = CancellationToken::new();
+		let command_cancel = CancellationToken::new();
+		let (activity_tx, _activity_rx) = mpsc::channel::<()>(1);
+		let mut reader_handle = tokio::spawn(read_output(
+			reader,
+			None,
+			reader_cancel.clone(),
+			activity_tx,
+			OutputBudget::new(usize::MAX),
+		));
+		let cancel_bridge = tokio::spawn({
+			let command_cancel = command_cancel.clone();
+			let reader_cancel = reader_cancel.clone();
+			async move {
+				command_cancel.cancelled().await;
+				reader_cancel.cancel();
+			}
+		});
+		let process_cancel_bridge = tokio::spawn({
+			let command_cancel = command_cancel.clone();
+			async move {
+				command_cancel.cancelled().await;
+			}
+		});
+
+		let config = ShellConfig { session_env: None, snapshot_path: None, minimizer: None };
+		let mut session = create_session(&config).await.expect("create_session");
+		let mut env = HashMap::new();
+		env.insert("U3_POP_ERROR".to_string(), "1".to_string());
+		assert!(apply_command_env(&mut session.shell, Some(&env)).expect("push command env"));
+
+		let mut params = session.shell.default_exec_params();
+		params.set_fd(OpenFiles::STDIN_FD, null_file().expect("null stdin"));
+		params.set_fd(OpenFiles::STDOUT_FD, stdout_file);
+		params.set_fd(OpenFiles::STDERR_FD, stderr_file);
+		params.set_cancel_token(command_cancel.clone());
+		let source_info = SourceInfo::from("pi-natives:env-pop-error-test");
+		let exec = session
+			.shell
+			.run_string("printf done", &source_info, &params)
+			.await
+			.expect("command should run before forced cleanup error");
+		assert!(matches!(exec.exit_code, ExecutionExitCode::Success));
+
+		session.shell.env_mut().push_scope(EnvironmentScope::Local);
+		let cleanup_error = session.shell.env_mut().pop_scope(EnvironmentScope::Command);
+		assert!(cleanup_error.is_err(), "forced local scope should make command pop fail");
+		drop(params);
+
+		reader_cancel.cancel();
+		time::timeout(Duration::from_secs(2), &mut reader_handle)
+			.await
+			.expect("reader must stop even when env cleanup errors")
+			.expect("reader task should not panic");
+		command_cancel.cancel();
+		time::timeout(Duration::from_secs(2), cancel_bridge)
+			.await
+			.expect("reader cancel bridge should not leak")
+			.expect("reader cancel bridge should not panic");
+		time::timeout(Duration::from_secs(2), process_cancel_bridge)
+			.await
+			.expect("process cancel bridge should not leak")
+			.expect("process cancel bridge should not panic");
 	}
 
 	#[cfg(unix)]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -2161,11 +2161,18 @@ mod tests {
 			}
 		});
 
-		let first_seen = time::timeout(Duration::from_secs(2), first_rx.recv())
-			.await
-			.expect("first command should emit startup marker")
-			.expect("first output channel should remain open");
-		assert!(first_seen.starts_with("first-start"), "unexpected first chunk: {first_seen:?}");
+		// Output may arrive in multiple chunks: the reader emits whatever bytes
+		// are decodable per pipe read, so a logical marker can be split across
+		// chunks (e.g. a lone "f"). Accumulate until the full marker is present.
+		let mut first_seen = String::new();
+		while !first_seen.starts_with("first-started") {
+			let chunk = time::timeout(Duration::from_secs(2), first_rx.recv())
+				.await
+				.expect("first command should emit startup marker")
+				.expect("first output channel should remain open");
+			first_seen.push_str(&chunk);
+		}
+		assert!(first_seen.starts_with("first-started"), "unexpected first output: {first_seen:?}");
 
 		let second = tokio::spawn({
 			let shell = shell.clone();
@@ -2202,10 +2209,16 @@ mod tests {
 		assert!(!second_result.cancelled, "queued run must not steal the abort target");
 		assert_eq!(second_result.exit_code, Some(0));
 
-		let second_seen = time::timeout(Duration::from_secs(2), second_rx.recv())
-			.await
-			.expect("second command should emit after active abort")
-			.expect("second output channel should remain open");
+		// The queued run's `printf second-ran` output can likewise be split
+		// across chunks; accumulate until the full marker is received.
+		let mut second_seen = String::new();
+		while second_seen != "second-ran" {
+			let chunk = time::timeout(Duration::from_secs(2), second_rx.recv())
+				.await
+				.expect("second command should emit after active abort")
+				.expect("second output channel should remain open");
+			second_seen.push_str(&chunk);
+		}
 		assert_eq!(second_seen, "second-ran");
 	}
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -96,6 +96,14 @@ When the broker is enabled, the local SQLite credential store is bypassed and al
 
 The gateway has no dedicated env vars — it inherits `GJC_AUTH_BROKER_*`. Its own inbound bearer token lives at `<config-dir>/auth-gateway.token` and is managed via `gjc auth-gateway token`.
 
+### Multi-account credential ranking
+
+When more than one OAuth credential is stored for the same provider (e.g. several Anthropic accounts), `AuthStorage` ranks them at session start to pick which one serves the session. This env var selects the ranking strategy; it is fully opt-in and does not change the default.
+
+| Variable                      | Used for                                          | Required when  | Notes / precedence                                                                                                                                                                                                                                                                                            |
+| ----------------------------- | ------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GJC_CREDENTIAL_RANKING_MODE` | Multi-account OAuth credential selection strategy | Never (opt-in) | `balanced` (default) prefers the least-drained account (spreads load, keeps burst headroom). `earliest-reset` prefers the soonest-to-reset non-blocked account (earliest-expiry-first) so perishable tumbling-window quota (e.g. Claude 5h/7d) is drained before reset. Unset/unknown → `balanced`. Only affects session-start ranking; blocked/exhausted accounts still sort last. |
+
 ---
 
 ## 2) Provider-specific runtime configuration

--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -117,6 +117,14 @@ Critical safety checks in `TUI`:
 
 These constraints are runtime guards plus component conventions; renderers should still return width-safe lines rather than rely on truncation.
 
+## Virtual viewport (opt-in, `PI_TUI_VIRTUAL_VIEWPORT`)
+
+By default `#doRender` normalizes/truncates and diffs the full rendered transcript every frame (`O(total lines)`), which becomes a per-frame cost on very long sessions / weak hardware.
+
+Setting `PI_TUI_VIRTUAL_VIEWPORT=1` enables an opt-in fast path: when the terminal width is unchanged and the off-screen raw prefix is unchanged from the previous frame (compared by raw value equality per line, which short-circuits to a fast reference check when components return stable string instances for unchanged lines), the previous frame's normalized prefix is reused and only the visible window (terminal rows + a small overscan) is re-normalized, with the differential diff starting at the window boundary. Output is byte-identical to the default path (reused entries are deterministic normalizations of identical raw lines), so it is a pure performance toggle.
+
+The flag defaults to **off** because it changes a core render path; enable it to reduce per-frame normalize/diff cost on huge transcripts. Any width change, off-screen edit, forced render (`requestRender(true)`), or first frame transparently falls back to the full path. `PI_TUI_METRICS` exposes `lineCounts` gauges (`rendered`, `normalized`, `measured`, `diffed`, and `offscreenScan`) to observe the bound.
+
 ## Resize handling
 
 Resize events are event-driven from `ProcessTerminal` to `TUI.requestRender()`.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Forwarded local summary, handoff, and branch-summary transport/session options to one-shot model calls so callers can preserve provider session state and WebSocket preferences.
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -827,7 +827,10 @@ export class Agent {
 	}
 
 	appendMessage(m: AgentMessage) {
-		this.#state.messages = [...this.#state.messages, m];
+		// In-place push (not [...messages, m]): appending M messages over a session of
+		// N is O(N+M), not O(M*N). Consumers read state.messages fresh; run() snapshots
+		// via slice() at the API boundary, so no caller relies on per-append array identity.
+		this.#state.messages.push(m);
 	}
 
 	popMessage(): AgentMessage | undefined {

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -199,8 +199,8 @@ export class AppendOnlyContextManager {
 	readonly log = new AppendOnlyLog();
 	/** How many normalized messages were synced into the log as of the last sync. */
 	#lastSyncCount = 0;
-	/** Fingerprint plus source bytes of synced message content — detects in-place rewrites with no hash-only equality. */
-	#syncedDigest = emptyMessageDigest();
+	/** Per-synced-message content hashes (rolling digest). Detects in-place rewrites without retaining a full serialized-history string. */
+	#syncedHashes: (number | bigint)[] = [];
 	/** Number of provider-normalized messages that were seeded before child-local messages. */
 	#seededPrefixCount = 0;
 
@@ -236,35 +236,41 @@ export class AppendOnlyContextManager {
 		const includesSeedPrefix =
 			seededPrefixLength > 0 &&
 			normalizedMessages.length >= seededPrefixLength &&
-			this.#computeDigestRange(normalizedMessages, 0, seededPrefixLength).source ===
-				this.#computeDigestRange(this.log.entries(), 0, seededPrefixLength).source;
+			this.#rangeHashesEqual(normalizedMessages, this.log.entries(), seededPrefixLength);
 		const messagesToSync =
 			seededPrefixLength > 0 && !includesSeedPrefix
 				? [...this.log.entries().slice(0, seededPrefixLength), ...normalizedMessages]
 				: normalizedMessages;
 
-		// Detect in-place rewrites of already-synced messages.
+		// Detect in-place rewrites of already-synced messages via per-message content
+		// hashes (no retained full serialized-history string; F5).
 		if (
 			this.#lastSyncCount > 0 &&
 			this.#lastSyncCount <= messagesToSync.length &&
-			this.#computeDigestRange(messagesToSync, 0, this.#lastSyncCount).source !== this.#syncedDigest.source
+			this.#prefixChanged(messagesToSync, this.#lastSyncCount)
 		) {
 			if (this.#seededPrefixCount > 0) {
-				throw new Error("AppendOnlyContextManager.syncMessages() seed prefix changed");
+				// F9: a seeded fork whose inherited prefix changed (e.g. after compaction)
+				// rebases onto the new provider context instead of throwing.
+				this.#rebaseToBaseline(normalizedMessages);
+				return;
 			}
 			this.log.clear();
 			this.#lastSyncCount = 0;
+			this.#syncedHashes = [];
 		}
 
-		// Compaction — array shrunk. Seeded forks preserve the inherited prefix
-		// and append child-local deltas, so a shorter child message array is not a
-		// compaction signal while a seed prefix is active.
+		// Compaction — array shrunk. Seeded forks preserve the inherited prefix and
+		// append child-local deltas, so a shorter child array is not a compaction signal
+		// while a seed prefix is active; a genuine seeded compaction rebases (F9).
 		if (messagesToSync.length < this.#lastSyncCount) {
 			if (this.#seededPrefixCount > 0) {
-				throw new Error("AppendOnlyContextManager.syncMessages() cannot compact a seeded fork without reset");
+				this.#rebaseToBaseline(normalizedMessages);
+				return;
 			}
 			this.log.clear();
 			this.#lastSyncCount = 0;
+			this.#syncedHashes = [];
 		}
 
 		const newMsgs = messagesToSync.slice(this.#lastSyncCount);
@@ -273,7 +279,7 @@ export class AppendOnlyContextManager {
 		}
 
 		this.#lastSyncCount = messagesToSync.length;
-		this.#syncedDigest = this.#computeDigest(messagesToSync);
+		this.#syncedHashes = this.#hashRange(messagesToSync, 0, messagesToSync.length);
 	}
 
 	seedNormalizedMessages(messages: readonly Message[], options?: { reset?: boolean }): void {
@@ -284,7 +290,7 @@ export class AppendOnlyContextManager {
 		this.log.clear();
 		this.log.extend(clonedMessages);
 		this.#lastSyncCount = clonedMessages.length;
-		this.#syncedDigest = this.#computeDigest(clonedMessages);
+		this.#syncedHashes = this.#hashRange(clonedMessages, 0, clonedMessages.length);
 		this.#seededPrefixCount = clonedMessages.length;
 	}
 
@@ -293,7 +299,7 @@ export class AppendOnlyContextManager {
 		this.prefix.invalidate();
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = emptyMessageDigest();
+		this.#syncedHashes = [];
 		this.#seededPrefixCount = 0;
 	}
 
@@ -301,7 +307,7 @@ export class AppendOnlyContextManager {
 	resetSyncCursor(): void {
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = emptyMessageDigest();
+		this.#syncedHashes = [];
 		this.#seededPrefixCount = 0;
 	}
 
@@ -321,43 +327,51 @@ export class AppendOnlyContextManager {
 		this.prefix.invalidate();
 		this.log.clear();
 		this.#lastSyncCount = 0;
-		this.#syncedDigest = emptyMessageDigest();
+		this.#syncedHashes = [];
 		this.#seededPrefixCount = 0;
 		this.prefix.build(context, options);
 	}
 
-	/**
-	 * Deterministic digest over the provider-visible message payload. The source
-	 * string is kept and compared for equality so the hash is only a fast summary,
-	 * never the authority for accepting append-only sync state.
-	 */
-	#computeDigest(messages: readonly unknown[]): MessageDigest {
-		return this.#computeDigestRange(messages, 0, messages.length);
+	#hashMessage(message: unknown): number | bigint {
+		return hashSource(JSON.stringify(message) ?? "null");
 	}
 
-	#computeDigestRange(messages: readonly unknown[], start: number, end: number): MessageDigest {
-		let source = "[";
-		for (let i = start; i < end; i++) {
-			if (i > start) source += ",";
-			source += JSON.stringify(messages[i]) ?? "null";
+	#hashRange(messages: readonly unknown[], start: number, end: number): (number | bigint)[] {
+		const out: (number | bigint)[] = [];
+		for (let i = start; i < end; i++) out.push(this.#hashMessage(messages[i]));
+		return out;
+	}
+
+	/** True when the first `count` messages of `a` and `b` are content-equal by per-message hash. */
+	#rangeHashesEqual(a: readonly unknown[], b: readonly unknown[], count: number): boolean {
+		for (let i = 0; i < count; i++) {
+			if (this.#hashMessage(a[i]) !== this.#hashMessage(b[i])) return false;
 		}
-		source += "]";
-		return { hash: hashSource(source), source };
+		return true;
+	}
+
+	/** True when any of the first `count` already-synced messages changed content (in-place rewrite). */
+	#prefixChanged(messages: readonly unknown[], count: number): boolean {
+		if (count > this.#syncedHashes.length) return false;
+		for (let i = 0; i < count; i++) {
+			if (this.#hashMessage(messages[i]) !== this.#syncedHashes[i]) return true;
+		}
+		return false;
+	}
+
+	/** F9: reset the seeded log to a new provider-visible baseline (seeded compaction/rebase). */
+	#rebaseToBaseline(messages: readonly unknown[]): void {
+		this.log.clear();
+		this.log.extend([...messages]);
+		this.#lastSyncCount = messages.length;
+		this.#seededPrefixCount = 0;
+		this.#syncedHashes = this.#hashRange(messages, 0, messages.length);
 	}
 }
 
 // ---------------------------------------------------------------------------
 // Snapshot helpers
 // ---------------------------------------------------------------------------
-
-type MessageDigest = {
-	hash: number | bigint;
-	source: string;
-};
-
-function emptyMessageDigest(): MessageDigest {
-	return { hash: hashSource("[]"), source: "[]" };
-}
 
 function hashSource(source: string): number | bigint {
 	return typeof Bun !== "undefined" ? Bun.hash(source) : hashString32(source);

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -5,7 +5,7 @@
  * a summary of the branch being left so context isn't lost.
  */
 
-import type { Model } from "@gajae-code/ai";
+import type { Model, ProviderSessionState } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
 import type { AgentMessage } from "../types";
@@ -79,6 +79,10 @@ export interface GenerateBranchSummaryOptions {
 	reserveTokens?: number;
 	/** Optional metadata forwarded to the underlying API request (e.g. user_id for session attribution). */
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
+	authCredentialType?: "api_key" | "oauth";
 	/** Convert app-specific messages before serializing the branch summary prompt. */
 	convertToLlm?: ConvertToLlm;
 	/**
@@ -307,7 +311,16 @@ export async function generateBranchSummary(
 	const response = await instrumentedCompleteSimple(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
-		{ apiKey, signal, maxTokens: 2048, metadata },
+		{
+			apiKey,
+			signal,
+			maxTokens: 2048,
+			metadata,
+			sessionId: options.sessionId,
+			providerSessionState: options.providerSessionState,
+			preferWebsockets: options.preferWebsockets,
+			authCredentialType: options.authCredentialType,
+		},
 		{ telemetry: options.telemetry, oneshotKind: "branch_summary" },
 	);
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -236,6 +236,56 @@ export function shouldCompact(
 	return contextTokens > thresholdTokens;
 }
 
+/** Reason a compaction was triggered. `token` is the normal user-configurable path; the rest are emergency floors. */
+export type CompactionTriggerReason = "token" | "heap" | "providerBytes" | "messageCount" | "imageBytes";
+
+/** A point-in-time resource sample. Supplied by an injectable sampler so tests never read real RSS. */
+export interface EmergencyCompactionSample {
+	/** Resident heap bytes (e.g. process.memoryUsage().heapUsed). */
+	heapUsedBytes: number;
+	/** Approximate serialized provider-context bytes. */
+	providerBytes: number;
+	/** Provider-visible message count. */
+	messageCount: number;
+	/** Approximate inline image bytes in the provider context. */
+	imageBytes: number;
+}
+
+export interface EmergencyCompactionLimits {
+	heapUsedBytes: number;
+	providerBytes: number;
+	messageCount: number;
+	imageBytes: number;
+}
+
+/**
+ * Non-disableable emergency floors. These sit well above normal usage and exist so a
+ * long session on weak hardware compacts before OOM even when token-based compaction is
+ * disabled or its threshold is set too high. They are NOT user-tunable down to zero.
+ */
+export const DEFAULT_EMERGENCY_COMPACTION_LIMITS: EmergencyCompactionLimits = {
+	heapUsedBytes: 1_536 * 1024 * 1024, // 1.5 GiB resident heap
+	providerBytes: 24 * 1024 * 1024, // 24 MiB serialized provider context
+	messageCount: 4000,
+	imageBytes: 64 * 1024 * 1024, // 64 MiB inline image bytes
+};
+
+/**
+ * Returns the first emergency limit exceeded (heap > providerBytes > imageBytes > messageCount),
+ * or null when none is. Pure and sampler-injected; the caller routes the result through the
+ * normal pair-safe `compact()` cut logic so a tool_use/tool_result pair is never split.
+ */
+export function emergencyCompactionReason(
+	sample: EmergencyCompactionSample,
+	limits: EmergencyCompactionLimits = DEFAULT_EMERGENCY_COMPACTION_LIMITS,
+): CompactionTriggerReason | null {
+	if (sample.heapUsedBytes > limits.heapUsedBytes) return "heap";
+	if (sample.providerBytes > limits.providerBytes) return "providerBytes";
+	if (sample.imageBytes > limits.imageBytes) return "imageBytes";
+	if (sample.messageCount > limits.messageCount) return "messageCount";
+	return null;
+}
+
 export function resolveThresholdTokens(
 	contextWindow: number,
 	settings: CompactionSettings,
@@ -301,7 +351,18 @@ function nativeTokenizerEntrypoint(): string {
 	return isCompiledBinary() ? COMPILED_NATIVE_TOKENIZER_ENTRYPOINT : SOURCE_NATIVE_TOKENIZER_ENTRYPOINT;
 }
 
+/** Max total fragment chars sent to the synchronous native tokenizer (F22). */
+const MAX_NATIVE_TOKENIZE_CHARS = 2 * 1024 * 1024;
+
 function nativeCountTokens(fragments: string[]): number {
+	let totalChars = 0;
+	for (const fragment of fragments) totalChars += fragment.length;
+	if (totalChars > MAX_NATIVE_TOKENIZE_CHARS) {
+		// F22: skip the synchronous native BPE tokenizer (materializes a ~39MB table and is
+		// O(text)) on pathologically large inputs; the cheap chars/token heuristic is more
+		// than accurate enough for size/budget decisions and never blocks the event loop.
+		return estimateTextTokensHeuristic(fragments);
+	}
 	if (!cachedNativeCountTokens) {
 		const natives = requireFromCompaction(nativeTokenizerEntrypoint()) as NativeTokenizerModule;
 		cachedNativeCountTokens = natives.countTokens;

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -12,6 +12,7 @@ import {
 	type Message,
 	type MessageAttribution,
 	type Model,
+	type ProviderSessionState,
 	type Usage,
 } from "@gajae-code/ai";
 import { isCompiledBinary, logger, prompt } from "@gajae-code/utils";
@@ -726,6 +727,9 @@ export interface SummaryOptions {
 	remoteInstructions?: string;
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
 	convertToLlm?: ConvertToLlm;
 	/**
 	 * Optional telemetry handle. When provided, every LLM call emitted during
@@ -801,6 +805,10 @@ export async function generateSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_summary" },
 	);
@@ -830,6 +838,9 @@ export interface HandoffOptions {
 	convertToLlm?: ConvertToLlm;
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
 	/**
 	 * Optional telemetry handle. When provided, the handoff LLM call is
 	 * wrapped in an OTEL chat span tagged with `pi.gen_ai.oneshot.kind = "handoff"`.
@@ -877,6 +888,10 @@ export async function generateHandoff(
 			toolChoice: "none",
 			initiatorOverride: options.initiatorOverride,
 			metadata: options.metadata,
+			sessionId: options.sessionId,
+			providerSessionState: options.providerSessionState,
+			preferWebsockets: options.preferWebsockets,
+			authCredentialType: options.authCredentialType,
 		},
 		{ telemetry: options.telemetry, oneshotKind: "handoff" },
 	);
@@ -936,6 +951,10 @@ async function generateShortSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_short_summary" },
 	);
@@ -1118,8 +1137,12 @@ export async function compact(
 		remoteInstructions: options?.remoteInstructions,
 		initiatorOverride: options?.initiatorOverride,
 		metadata: options?.metadata,
+		sessionId: options?.sessionId,
+		providerSessionState: options?.providerSessionState,
+		preferWebsockets: options?.preferWebsockets,
 		convertToLlm: options?.convertToLlm,
 		telemetry: options?.telemetry,
+		authCredentialType: options?.authCredentialType,
 	};
 
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
@@ -1160,10 +1183,9 @@ export async function compact(
 	let summary: string;
 
 	if (isSplitTurn && turnPrefixMessages.length > 0) {
-		// Generate both summaries in parallel
-		const [historyResult, turnPrefixResult] = await Promise.all([
+		const historyResult =
 			messagesToSummarize.length > 0
-				? generateSummary(
+				? await generateSummary(
 						messagesToSummarize,
 						model,
 						settings.reserveTokens,
@@ -1173,9 +1195,15 @@ export async function compact(
 						previousSummary,
 						summaryOptions,
 					)
-				: Promise.resolve("No prior history."),
-			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal, summaryOptions),
-		]);
+				: "No prior history.";
+		const turnPrefixResult = await generateTurnPrefixSummary(
+			turnPrefixMessages,
+			model,
+			settings.reserveTokens,
+			apiKey,
+			signal,
+			summaryOptions,
+		);
 		// Merge into single summary
 		summary = `${historyResult}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult}`;
 	} else if (messagesToSummarize.length > 0) {
@@ -1205,13 +1233,7 @@ export async function compact(
 		settings.reserveTokens,
 		apiKey,
 		signal,
-		{
-			extraContext: options?.extraContext,
-			remoteEndpoint: summaryOptions.remoteEndpoint,
-			initiatorOverride: summaryOptions.initiatorOverride,
-			metadata: summaryOptions.metadata,
-			telemetry: summaryOptions.telemetry,
-		},
+		summaryOptions,
 	);
 
 	// Compute file lists and append to summary
@@ -1266,6 +1288,10 @@ async function generateTurnPrefixSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_turn_prefix" },
 	);

--- a/packages/agent/test/agent-memory-redteam.test.ts
+++ b/packages/agent/test/agent-memory-redteam.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "bun:test";
+import {
+	emergencyCompactionReason,
+	DEFAULT_EMERGENCY_COMPACTION_LIMITS as LIM,
+} from "@gajae-code/agent-core/compaction";
+import type { Message } from "@gajae-code/ai";
+import { AppendOnlyContextManager, type BuildOptions } from "../src/append-only-context";
+import type { AgentContext } from "../src/types";
+
+const BUILD_OPTS: BuildOptions = { intentTracing: false };
+
+function makeContext(): AgentContext {
+	return { systemPrompt: ["sys"], messages: [], tools: [] };
+}
+
+function message(content: unknown, role: Message["role"] = "user"): Message {
+	return { role, content } as Message;
+}
+
+function contents(manager: AppendOnlyContextManager): unknown[] {
+	return manager.build(makeContext(), BUILD_OPTS).messages.map(m => m.content);
+}
+
+function installClearCounter(manager: AppendOnlyContextManager): () => number {
+	let clears = 0;
+	const originalClear = manager.log.clear.bind(manager.log);
+	manager.log.clear = () => {
+		clears++;
+		originalClear();
+	};
+	return () => clears;
+}
+
+describe("agent memory red-team: F5 append-only rewrite detection", () => {
+	it("detects in-place rewrites of nested, array, number, boolean, and null content without ref-equality masking", () => {
+		const manager = new AppendOnlyContextManager();
+		const clearCount = installClearCounter(manager);
+		const synced = [
+			message({
+				blocks: [{ type: "text", text: "original", score: 1, enabled: true, maybe: "present" }],
+				meta: { count: 2, flags: [true, false], empty: null },
+			}),
+			message(["tail", { nested: { value: 7 } }], "assistant"),
+		];
+
+		manager.syncMessages(synced);
+		expect(clearCount()).toBe(0);
+
+		const content = synced[0]!.content as unknown as {
+			blocks: Array<{ type: string; text: string; score: number; enabled: boolean; maybe: string | null }>;
+			meta: { count: number; flags: boolean[]; empty: null | { filled: boolean } };
+		};
+		content.blocks[0]!.text = "rewritten";
+		content.blocks[0]!.score = 99;
+		content.blocks[0]!.enabled = false;
+		content.blocks[0]!.maybe = null;
+		content.meta.count = 3;
+		content.meta.flags.push(true);
+		content.meta.empty = { filled: true };
+
+		manager.syncMessages(synced);
+		expect(clearCount()).toBe(1);
+		expect(contents(manager)).toEqual([
+			{
+				blocks: [{ type: "text", text: "rewritten", score: 99, enabled: false, maybe: null }],
+				meta: { count: 3, flags: [true, false, true], empty: { filled: true } },
+			},
+			["tail", { nested: { value: 7 } }],
+		]);
+		expect(manager.log.length).toBe(2);
+	});
+
+	it("does not rebuild or grow on identical content supplied as new object instances", () => {
+		const manager = new AppendOnlyContextManager();
+		const clearCount = installClearCounter(manager);
+		const first = [
+			message({ nested: { value: 1 }, list: [1, true, null] }),
+			message({ nested: { value: 2 }, list: [2, false, null] }, "assistant"),
+		];
+		const second = [
+			message({ nested: { value: 1 }, list: [1, true, null] }),
+			message({ nested: { value: 2 }, list: [2, false, null] }, "assistant"),
+		];
+
+		manager.syncMessages(first);
+		manager.syncMessages(second);
+
+		expect(clearCount()).toBe(0);
+		expect(manager.log.length).toBe(2);
+		expect(contents(manager)).toEqual([
+			{ nested: { value: 1 }, list: [1, true, null] },
+			{ nested: { value: 2 }, list: [2, false, null] },
+		]);
+	});
+
+	it("clears and resyncs when a non-seeded provider context compacts to a shorter array", () => {
+		const manager = new AppendOnlyContextManager();
+		const clearCount = installClearCounter(manager);
+
+		manager.syncMessages([message("one"), message("two", "assistant"), message("three")]);
+		manager.syncMessages([message("summary")]);
+
+		expect(clearCount()).toBe(1);
+		expect(manager.log.length).toBe(1);
+		expect(contents(manager)).toEqual(["summary"]);
+	});
+});
+
+describe("agent memory red-team: F9 seeded rebase", () => {
+	it("rebases instead of throwing when a seeded fork grows then shrinks below last sync while preserving seed prefix", () => {
+		const seed = [message("seed-1"), message("seed-2", "assistant")];
+		const manager = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		const clearCount = installClearCounter(manager);
+
+		manager.syncMessages([...seed, message("child-1"), message("child-2", "assistant")]);
+		expect(contents(manager)).toEqual(["seed-1", "seed-2", "child-1", "child-2"]);
+
+		expect(() => manager.syncMessages([...seed, message("child-1-rebased")])).not.toThrow();
+		expect(clearCount()).toBe(1);
+		expect(contents(manager)).toEqual(["seed-1", "seed-2", "child-1-rebased"]);
+
+		manager.syncMessages([...seed, message("child-1-rebased"), message("normal-append", "assistant")]);
+		expect(contents(manager)).toEqual(["seed-1", "seed-2", "child-1-rebased", "normal-append"]);
+	});
+
+	it("rebases instead of throwing after an in-place rewrite of a synced child and then drops seeded binding", () => {
+		const seed = [message("seed-1")];
+		const manager = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		const clearCount = installClearCounter(manager);
+		const child = message({ tool: { calls: [{ id: 1, ok: true, value: null }] } });
+		const synced = [...seed, child];
+
+		manager.syncMessages(synced);
+		const childContent = child.content as unknown as {
+			tool: { calls: Array<{ id: number; ok: boolean; value: null | string }> };
+		};
+		childContent.tool.calls[0]!.id = 2;
+		childContent.tool.calls[0]!.ok = false;
+		childContent.tool.calls[0]!.value = "rewritten";
+
+		expect(() => manager.syncMessages(synced)).not.toThrow();
+		expect(clearCount()).toBe(1);
+		expect(contents(manager)).toEqual(["seed-1", { tool: { calls: [{ id: 2, ok: false, value: "rewritten" }] } }]);
+
+		manager.syncMessages([...synced, message("normal-after-rebase", "assistant")]);
+		expect(contents(manager)).toEqual([
+			"seed-1",
+			{ tool: { calls: [{ id: 2, ok: false, value: "rewritten" }] } },
+			"normal-after-rebase",
+		]);
+	});
+});
+
+describe("agent memory red-team: F6 emergency compaction guard", () => {
+	const zeroish = { heapUsedBytes: 0, providerBytes: 0, messageCount: 0, imageBytes: 0 };
+
+	it("uses strict greater-than boundaries for every default emergency limit", () => {
+		expect(
+			emergencyCompactionReason({
+				heapUsedBytes: LIM.heapUsedBytes,
+				providerBytes: LIM.providerBytes,
+				messageCount: LIM.messageCount,
+				imageBytes: LIM.imageBytes,
+			}),
+		).toBeNull();
+		expect(emergencyCompactionReason({ ...zeroish, heapUsedBytes: LIM.heapUsedBytes + 1 })).toBe("heap");
+		expect(emergencyCompactionReason({ ...zeroish, providerBytes: LIM.providerBytes + 1 })).toBe("providerBytes");
+		expect(emergencyCompactionReason({ ...zeroish, imageBytes: LIM.imageBytes + 1 })).toBe("imageBytes");
+		expect(emergencyCompactionReason({ ...zeroish, messageCount: LIM.messageCount + 1 })).toBe("messageCount");
+	});
+
+	it("prioritizes heap before provider bytes before image bytes before message count", () => {
+		expect(
+			emergencyCompactionReason({
+				heapUsedBytes: LIM.heapUsedBytes + 1,
+				providerBytes: LIM.providerBytes + 1,
+				imageBytes: LIM.imageBytes + 1,
+				messageCount: LIM.messageCount + 1,
+			}),
+		).toBe("heap");
+		expect(
+			emergencyCompactionReason({
+				...zeroish,
+				providerBytes: LIM.providerBytes + 1,
+				imageBytes: LIM.imageBytes + 1,
+				messageCount: LIM.messageCount + 1,
+			}),
+		).toBe("providerBytes");
+		expect(
+			emergencyCompactionReason({ ...zeroish, imageBytes: LIM.imageBytes + 1, messageCount: LIM.messageCount + 1 }),
+		).toBe("imageBytes");
+	});
+
+	it("honors custom limits and never triggers on a zero-ish sample", () => {
+		const limits = { heapUsedBytes: 10, providerBytes: 20, imageBytes: 30, messageCount: 40 };
+		expect(emergencyCompactionReason(zeroish, limits)).toBeNull();
+		expect(emergencyCompactionReason({ ...zeroish, heapUsedBytes: 10 }, limits)).toBeNull();
+		expect(emergencyCompactionReason({ ...zeroish, heapUsedBytes: 11 }, limits)).toBe("heap");
+		expect(emergencyCompactionReason({ ...zeroish, providerBytes: 21 }, limits)).toBe("providerBytes");
+		expect(emergencyCompactionReason({ ...zeroish, imageBytes: 31 }, limits)).toBe("imageBytes");
+		expect(emergencyCompactionReason({ ...zeroish, messageCount: 41 }, limits)).toBe("messageCount");
+	});
+});

--- a/packages/agent/test/append-only-seeded-rebase.test.ts
+++ b/packages/agent/test/append-only-seeded-rebase.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import type { Message } from "@gajae-code/ai";
+import { AppendOnlyContextManager, type BuildOptions } from "../src/append-only-context";
+import type { AgentContext } from "../src/types";
+
+const BUILD_OPTS: BuildOptions = { intentTracing: false };
+
+function makeContext(): AgentContext {
+	return { systemPrompt: ["sys"], messages: [], tools: [] };
+}
+const msg = (content: string, role: Message["role"] = "user"): Message => ({ role, content }) as Message;
+const contents = (mgr: AppendOnlyContextManager): unknown[] =>
+	mgr.build(makeContext(), BUILD_OPTS).messages.map(m => m.content);
+
+describe("AppendOnlyContextManager seeded-fork rebase (W4 / F9)", () => {
+	it("rebases (not throws) when a seeded fork's provider context shrinks below the last sync", () => {
+		const seed = [msg("s1"), msg("s2", "assistant")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		// Grow: seed + child turns (still starts with the seed prefix).
+		mgr.syncMessages([...seed, msg("c1"), msg("c2", "assistant"), msg("c3")]);
+		expect(contents(mgr)).toEqual(["s1", "s2", "c1", "c2", "c3"]);
+
+		// Provider compacts to a SHORTER array that still begins with the seed prefix.
+		expect(() => mgr.syncMessages([...seed, msg("c1")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "c1"]);
+
+		// After rebase the seed binding is gone; further syncs behave as a normal baseline.
+		mgr.syncMessages([...seed, msg("c1"), msg("c4", "assistant")]);
+		expect(contents(mgr)).toEqual(["s1", "s2", "c1", "c4"]);
+	});
+
+	it("rebases (not throws) when an already-synced message in a seeded fork is rewritten in place", () => {
+		const seed = [msg("s1"), msg("s2", "assistant")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		mgr.syncMessages([...seed, msg("c1")]);
+		expect(contents(mgr)).toEqual(["s1", "s2", "c1"]);
+
+		// Same length, but the synced child message changed content (in-place rewrite).
+		expect(() => mgr.syncMessages([seed[0]!, seed[1]!, msg("c1-rewritten")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "c1-rewritten"]);
+	});
+
+	it("still appends normally for a seeded fork that grows without rewriting the seed", () => {
+		const seed = [msg("s1")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		mgr.syncMessages([...seed, msg("a", "assistant")]);
+		mgr.syncMessages([...seed, msg("a", "assistant"), msg("b")]);
+		expect(contents(mgr)).toEqual(["s1", "a", "b"]);
+	});
+});

--- a/packages/agent/test/compaction-telemetry.test.ts
+++ b/packages/agent/test/compaction-telemetry.test.ts
@@ -25,7 +25,7 @@ import {
 	resolveTelemetry,
 } from "@gajae-code/agent-core/telemetry";
 import type { AgentMessage } from "@gajae-code/agent-core/types";
-import type { AssistantMessage, Model, Usage } from "@gajae-code/ai";
+import type { AssistantMessage, Model, ProviderSessionState, Usage } from "@gajae-code/ai";
 import * as ai from "@gajae-code/ai";
 import { SpanStatusCode } from "@opentelemetry/api";
 import {
@@ -163,6 +163,60 @@ describe("compaction oneshot telemetry", () => {
 		expect(spansByOneshotKind(chats, "compaction_short_summary")).toHaveLength(1);
 	});
 
+	it("runs split-turn compaction summary requests sequentially", async () => {
+		let inFlight = false;
+		let maxConcurrent = 0;
+		let currentConcurrent = 0;
+		const spy = vi.spyOn(ai, "completeSimple").mockImplementation(async () => {
+			if (inFlight) throw new Error("provider rejected parallel request");
+			inFlight = true;
+			currentConcurrent += 1;
+			maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+			await Bun.sleep(1);
+			currentConcurrent -= 1;
+			inFlight = false;
+			return makeAssistantMessage("ok");
+		});
+
+		const preparation = makePreparation({
+			isSplitTurn: true,
+			turnPrefixMessages: [makeUserMessage("Inline mid-turn instruction")],
+		});
+		await compact(preparation, MODEL, "test-api-key", undefined, undefined, {
+			sessionId: "provider-session-1",
+			providerSessionState: new Map<string, ProviderSessionState>(),
+			preferWebsockets: true,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		expect(maxConcurrent).toBe(1);
+	});
+
+	it("forwards transport options to every local compaction summary request", async () => {
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce(makeAssistantMessage("history summary"))
+			.mockResolvedValueOnce(makeAssistantMessage("short summary"));
+
+		await compact(makePreparation(), MODEL, "test-api-key", undefined, undefined, {
+			sessionId: "provider-session-1",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
+		});
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		for (const call of spy.mock.calls) {
+			const options = call[2];
+			if (!options) throw new Error("expected completeSimple options");
+			expect(options.sessionId).toBe("provider-session-1");
+			expect(options.providerSessionState).toBe(providerSessionState);
+			expect(options.preferWebsockets).toBe(true);
+			expect(options.authCredentialType).toBe("oauth");
+		}
+	});
+
 	it("emits no spans when telemetry is undefined", async () => {
 		vi.spyOn(ai, "completeSimple")
 			.mockResolvedValueOnce(makeAssistantMessage("history"))
@@ -211,6 +265,7 @@ describe("handoff oneshot telemetry", () => {
 		const spy = vi.spyOn(ai, "completeSimple").mockResolvedValueOnce(makeAssistantMessage("## Goal\nContinue"));
 
 		const telemetry = resolveTelemetry(makeTelemetryConfig(), "session-handoff");
+		const providerSessionState = new Map<string, ProviderSessionState>();
 		const messages: AgentMessage[] = [makeUserMessage("start"), makeAssistantMessage("starting")];
 
 		const document = await generateHandoff(messages, MODEL, "test-api-key", {
@@ -218,10 +273,19 @@ describe("handoff oneshot telemetry", () => {
 			tools: [],
 			initiatorOverride: "agent",
 			telemetry,
+			sessionId: "provider-session-handoff",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
 		});
 
 		expect(document).toContain("Goal");
 		expect(spy).toHaveBeenCalledTimes(1);
+		const options = spy.mock.calls[0]?.[2];
+		expect(options?.sessionId).toBe("provider-session-handoff");
+		expect(options?.providerSessionState).toBe(providerSessionState);
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.authCredentialType).toBe("oauth");
 
 		const chats = chatSpans(exporter.getFinishedSpans());
 		expect(chats).toHaveLength(1);
@@ -238,6 +302,7 @@ describe("branch summary oneshot telemetry", () => {
 			.mockResolvedValueOnce(makeAssistantMessage("branch summary text", makeUsage(50, 30)));
 
 		const telemetry = resolveTelemetry(makeTelemetryConfig(), "session-branch");
+		const providerSessionState = new Map<string, ProviderSessionState>();
 		const entries = [
 			{
 				type: "message" as const,
@@ -260,10 +325,19 @@ describe("branch summary oneshot telemetry", () => {
 			apiKey: "test-api-key",
 			signal: new AbortController().signal,
 			telemetry,
+			sessionId: "provider-session-branch",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
 		});
 
 		expect(result.summary).toContain("branch summary text");
 		expect(spy).toHaveBeenCalledTimes(1);
+		const options = spy.mock.calls[0]?.[2];
+		expect(options?.sessionId).toBe("provider-session-branch");
+		expect(options?.providerSessionState).toBe(providerSessionState);
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.authCredentialType).toBe("oauth");
 
 		const chats = chatSpans(exporter.getFinishedSpans());
 		expect(chats).toHaveLength(1);

--- a/packages/agent/test/emergency-compaction.test.ts
+++ b/packages/agent/test/emergency-compaction.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import {
+	emergencyCompactionReason,
+	DEFAULT_EMERGENCY_COMPACTION_LIMITS as LIM,
+} from "@gajae-code/agent-core/compaction";
+
+const under = { heapUsedBytes: 1, providerBytes: 1, messageCount: 1, imageBytes: 1 };
+
+describe("emergencyCompactionReason (W4 / F6)", () => {
+	it("returns null when every resource is under its floor", () => {
+		expect(emergencyCompactionReason(under)).toBeNull();
+		expect(
+			emergencyCompactionReason({
+				heapUsedBytes: LIM.heapUsedBytes,
+				providerBytes: LIM.providerBytes,
+				messageCount: LIM.messageCount,
+				imageBytes: LIM.imageBytes,
+			}),
+		).toBeNull(); // strictly greater-than required
+	});
+
+	it("flags each exceeded floor by name", () => {
+		expect(emergencyCompactionReason({ ...under, heapUsedBytes: LIM.heapUsedBytes + 1 })).toBe("heap");
+		expect(emergencyCompactionReason({ ...under, providerBytes: LIM.providerBytes + 1 })).toBe("providerBytes");
+		expect(emergencyCompactionReason({ ...under, imageBytes: LIM.imageBytes + 1 })).toBe("imageBytes");
+		expect(emergencyCompactionReason({ ...under, messageCount: LIM.messageCount + 1 })).toBe("messageCount");
+	});
+
+	it("prioritizes heap > providerBytes > imageBytes > messageCount", () => {
+		expect(
+			emergencyCompactionReason({
+				heapUsedBytes: LIM.heapUsedBytes + 1,
+				providerBytes: LIM.providerBytes + 1,
+				imageBytes: LIM.imageBytes + 1,
+				messageCount: LIM.messageCount + 1,
+			}),
+		).toBe("heap");
+		expect(
+			emergencyCompactionReason({
+				...under,
+				providerBytes: LIM.providerBytes + 1,
+				imageBytes: LIM.imageBytes + 1,
+				messageCount: LIM.messageCount + 1,
+			}),
+		).toBe("providerBytes");
+		expect(
+			emergencyCompactionReason({ ...under, imageBytes: LIM.imageBytes + 1, messageCount: LIM.messageCount + 1 }),
+		).toBe("imageBytes");
+	});
+
+	it("honors injected custom limits (non-disableable floor is just a different number, never off)", () => {
+		const limits = { heapUsedBytes: 1e15, providerBytes: 1e15, messageCount: 10, imageBytes: 1e15 };
+		expect(emergencyCompactionReason({ ...under, messageCount: 11 }, limits)).toBe("messageCount");
+		expect(emergencyCompactionReason({ ...under, messageCount: 10 }, limits)).toBeNull();
+	});
+});

--- a/packages/agent/test/g009-token-guard-redteam.test.ts
+++ b/packages/agent/test/g009-token-guard-redteam.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { spawn } from "node:child_process";
+import type { Message } from "@gajae-code/ai";
+import { estimateMessageTokensHeuristic, estimateTokens } from "../src/compaction/compaction";
+
+const MIB = 1024 * 1024;
+const NATIVE_CAP_CHARS = 2 * MIB;
+
+function userTextMessage(text: string): Message {
+	return { role: "user", content: text } as Message;
+}
+
+function expectFastTokenEstimate(message: Message, maxMs: number): number {
+	const start = performance.now();
+	const tokens = estimateTokens(message);
+	const elapsedMs = performance.now() - start;
+	expect(tokens).toBeGreaterThan(0);
+	expect(elapsedMs).toBeLessThan(maxMs);
+	return tokens;
+}
+
+function expectHeuristicFallback(message: Message, maxMs: number): number {
+	const heuristic = estimateMessageTokensHeuristic(message);
+	const tokens = expectFastTokenEstimate(message, maxMs);
+	expect(tokens).toBe(heuristic);
+	return tokens;
+}
+async function runBelowCapProbe(chars: number): Promise<{ timedOut: boolean; stdout: string; stderr: string }> {
+	return await new Promise(resolve => {
+		const child = spawn(
+			process.execPath,
+			[
+				"--eval",
+				`import { estimateTokens } from "./src/compaction/compaction"; console.log(estimateTokens({ role: "user", content: "b".repeat(${chars}) }));`,
+			],
+			{ cwd: import.meta.dir.replace(/\/test$/, "") },
+		);
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGKILL");
+		}, 3_000);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		child.on("close", () => {
+			clearTimeout(timer);
+			resolve({ timedOut, stdout, stderr });
+		});
+	});
+}
+
+describe("oversized token-count guard red-team (G009 / W8 / F22)", () => {
+	it("switches at the 2 MiB boundary and keeps the above-cap path fast", async () => {
+		const justBelowChars = NATIVE_CAP_CHARS - 1;
+		const justAbove = userTextMessage("a".repeat(NATIVE_CAP_CHARS + 1));
+
+		const belowProbe = await runBelowCapProbe(justBelowChars);
+		if (!belowProbe.timedOut) {
+			expect(Number(belowProbe.stdout.trim())).toBeGreaterThan(0);
+			expect(belowProbe.stderr).toBe("");
+		}
+		expect(typeof belowProbe.timedOut).toBe("boolean");
+
+		const aboveTokens = expectHeuristicFallback(justAbove, 1_000);
+		expect(aboveTokens).toBe(estimateMessageTokensHeuristic(justAbove));
+	});
+
+	it("bounds a huge 8 MiB message without hanging or producing an unbounded native count", () => {
+		const huge = userTextMessage("h".repeat(8 * MIB));
+		const tokens = expectHeuristicFallback(huge, 1_000);
+		expect(tokens).toBeLessThanOrEqual(Math.ceil((8 * MIB) / 4));
+	});
+
+	it("falls back for multi-block assistant text and thinking content above the cap", () => {
+		const multiBlock = {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "t".repeat(MIB) },
+				{ type: "thinking", thinking: "r".repeat(MIB) },
+				{ type: "text", text: "u".repeat(64) },
+			],
+		} as unknown as Message;
+
+		expectHeuristicFallback(multiBlock, 1_000);
+	});
+
+	it("still returns a positive native count for normal small content", () => {
+		const small = userTextMessage("normal small message for native token counting");
+		expect(estimateTokens(small)).toBeGreaterThan(0);
+	});
+
+	it("is deterministic for the same huge message", () => {
+		const huge = userTextMessage("d".repeat(8 * MIB));
+		expect(estimateTokens(huge)).toBe(estimateTokens(huge));
+	});
+});

--- a/packages/agent/test/g009-token-guard.test.ts
+++ b/packages/agent/test/g009-token-guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import type { Message } from "@gajae-code/ai";
+import { estimateMessageTokensHeuristic, estimateTokens } from "../src/compaction/compaction";
+
+describe("oversized token-count guard (W8 / F22)", () => {
+	it("falls back to the cheap heuristic for a message above the native-tokenize cap (no sync BPE freeze)", () => {
+		const huge = { role: "user", content: "x".repeat(3 * 1024 * 1024) } as Message;
+		const native = estimateTokens(huge);
+		const heuristic = estimateMessageTokensHeuristic(huge);
+		// Above the 2 MiB cap the native path returns the heuristic, so the two agree closely
+		// and the ~39MB BPE tokenizer is never invoked (the call returns immediately).
+		expect(native).toBeGreaterThan(0);
+		expect(Math.abs(native - heuristic) / heuristic).toBeLessThan(0.2);
+	});
+
+	it("still produces a positive native count for a normal-sized message", () => {
+		const small = { role: "user", content: "hello world, this is a normal message" } as Message;
+		expect(estimateTokens(small)).toBeGreaterThan(0);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `AuthStorageOptions.credentialRankingMode` (`balanced` (default) | `earliest-reset`) for multi-account OAuth credential selection. `earliest-reset` ranks non-blocked credentials earliest-expiry-first — draining the soonest-to-reset account before its perishable tumbling-window quota (e.g. Claude 5h/7d) is lost at reset — keeping the existing drain-rate/used-fraction metrics as tiebreakers. `balanced` is byte-identical to prior behavior, and ranking only runs at session start (or when the session's preferred credential is blocked), so this never thrashes accounts mid-session.
+
 ### Fixed
 
 - Allowed `openai-codex-responses` custom backends to use opaque `apiKey` bearer tokens by omitting `chatgpt-account-id` when the token does not expose a Codex account id.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allowed `openai-codex-responses` custom backends to use opaque `apiKey` bearer tokens by omitting `chatgpt-account-id` when the token does not expose a Codex account id.
+
 ## [0.5.2] - 2026-06-15
 
 ### Changed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Allowed `openai-codex-responses` custom backends to use opaque `apiKey` bearer tokens by omitting `chatgpt-account-id` when the token does not expose a Codex account id.
+- Fixed OpenAI code websocket continuations to treat codex-lb's `codex_previous_response_stale` response failures as expired `previous_response_id` anchors and retry with full context instead of surfacing the transient failure.
 
 ## [0.5.2] - 2026-06-15
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -288,9 +288,27 @@ export interface CredentialDisabledEvent {
 	disabledCause: string;
 }
 
+/**
+ * How {@link AuthStorage} orders multiple healthy OAuth credentials of the same
+ * provider:type pool when selecting one for a (new) session.
+ *
+ * - `balanced` (default): prefer the least-used / lowest-drain-rate account.
+ *   Spreads load across accounts and keeps burst headroom on every account.
+ * - `earliest-reset`: prefer the non-blocked account whose usage window resets
+ *   soonest (earliest-expiry-first). Tumbling-window quota is perishable —
+ *   unused quota is lost at reset — so draining the soonest-to-reset account
+ *   first minimizes wasted quota. Drain/used metrics remain tiebreakers.
+ *
+ * Only affects ranking, which the `shouldRank` guard already limits to session
+ * start (or when the session's preferred credential is blocked), so this never
+ * thrashes accounts mid-session / cold-starts the server-side prompt cache.
+ */
+export type CredentialRankingMode = "balanced" | "earliest-reset";
+
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	credentialRankingMode?: CredentialRankingMode;
 	usageFetch?: typeof fetch;
 	usageRequestTimeoutMs?: number;
 	usageLogger?: UsageLogger;
@@ -655,6 +673,7 @@ export class AuthStorage {
 	#usageReportsInFlight: Map<string, Promise<UsageReport[] | null>> = new Map();
 	#usageFetch: typeof fetch;
 	#usageRequestTimeoutMs: number;
+	#credentialRankingMode: CredentialRankingMode = "balanced";
 	#usageLogger?: UsageLogger;
 	#fallbackResolver?: (provider: string) => string | undefined;
 	#store: AuthCredentialStore;
@@ -686,6 +705,7 @@ export class AuthStorage {
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		this.#usageFetch = options.usageFetch ?? fetch;
 		this.#usageRequestTimeoutMs = options.usageRequestTimeoutMs ?? DEFAULT_USAGE_REQUEST_TIMEOUT_MS;
+		this.#credentialRankingMode = options.credentialRankingMode ?? "balanced";
 		this.#refreshOAuthCredentialOverride = options.refreshOAuthCredential;
 		this.#fetchUsageReportsOverride = options.fetchUsageReports;
 		this.#sourceLabel = options.sourceLabel;
@@ -2453,6 +2473,7 @@ export class AuthStorage {
 			secondaryDrainRate: number;
 			primaryUsed: number;
 			primaryDrainRate: number;
+			resetAtMs: number;
 			orderPos: number;
 		}> = [];
 		// Pre-fetch usage reports in parallel for non-blocked credentials.
@@ -2522,6 +2543,10 @@ export class AuthStorage {
 				),
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryDrainRate: this.#computeWindowDrainRate(primary, nowMs, strategy.windowDefaults.primaryMs),
+				resetAtMs:
+					this.#resolveWindowResetAt(primary?.window) ??
+					this.#resolveWindowResetAt(secondary?.window) ??
+					Number.POSITIVE_INFINITY,
 				orderPos,
 			});
 		}
@@ -2539,6 +2564,11 @@ export class AuthStorage {
 				if (leftPlanPriority !== rightPlanPriority) return leftPlanPriority - rightPlanPriority;
 			}
 			if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
+			if (this.#credentialRankingMode === "earliest-reset" && left.resetAtMs !== right.resetAtMs) {
+				// Earliest-expiry-first: drain the soonest-to-reset account before
+				// its perishable tumbling-window quota is lost at reset.
+				return left.resetAtMs - right.resetAtMs;
+			}
 			if (left.secondaryDrainRate !== right.secondaryDrainRate)
 				return left.secondaryDrainRate - right.secondaryDrainRate;
 			if (left.secondaryUsed !== right.secondaryUsed) return left.secondaryUsed - right.secondaryUsed;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -136,6 +136,38 @@ export const CURSOR_CLIENT_VERSION = "cli-2026.01.09-231024f";
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
 
+// F15: bound the module-global conversation caches so long-lived / many-session use cannot
+// grow them without limit. LRU by conversation count + TTL on idle conversations.
+const CURSOR_MAX_CONVERSATIONS = 64;
+const CURSOR_CONVERSATION_TTL_MS = 60 * 60 * 1000;
+const conversationLastAccess = new Map<string, number>();
+
+/** Drop all cached state + blob bytes for a conversation (F15 bound + session-teardown hook). */
+export function disposeCursorConversation(conversationId: string): void {
+	conversationStateCache.delete(conversationId);
+	conversationBlobStores.delete(conversationId);
+	conversationLastAccess.delete(conversationId);
+}
+
+/** Refresh recency for a conversation and evict TTL-stale / LRU-overflow entries (F15). */
+function touchCursorConversation(conversationId: string): void {
+	const now = Date.now();
+	for (const [id, ts] of conversationLastAccess) {
+		if (id !== conversationId && now - ts > CURSOR_CONVERSATION_TTL_MS) disposeCursorConversation(id);
+	}
+	conversationLastAccess.set(conversationId, now);
+	const state = conversationStateCache.get(conversationId);
+	if (state !== undefined) {
+		conversationStateCache.delete(conversationId);
+		conversationStateCache.set(conversationId, state);
+	}
+	while (conversationStateCache.size > CURSOR_MAX_CONVERSATIONS) {
+		const oldest = conversationStateCache.keys().next().value;
+		if (oldest === undefined || oldest === conversationId) break;
+		disposeCursorConversation(oldest);
+	}
+}
+
 export interface CursorOptions extends StreamOptions {
 	customSystemPrompt?: string;
 	conversationId?: string;
@@ -349,6 +381,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				conversationState: cachedState,
 			});
 			conversationStateCache.set(conversationId, conversationState);
+			touchCursorConversation(conversationId);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
@@ -405,6 +438,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 			const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
 				conversationStateCache.set(conversationId, checkpoint);
+				touchCursorConversation(conversationId);
 			};
 
 			let resolveH2: (() => void) | undefined;

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -96,6 +96,7 @@ const CODEX_WEBSOCKET_IDLE_TIMEOUT_MS = 300000;
 const CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS = 15000;
 const CODEX_WEBSOCKET_RETRY_BUDGET = CODEX_MAX_RETRIES;
 const CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX = "Codex websocket transport error";
+const CODEX_PREVIOUS_RESPONSE_STALE_CODES = new Set(["previous_response_not_found", "codex_previous_response_stale"]);
 const CODEX_RETRYABLE_EVENT_CODES = new Set(["model_error", "server_error", "internal_error"]);
 const CODEX_RETRYABLE_EVENT_MESSAGE =
 	/processing your request|retry your request|temporar(?:y|ily)|overloaded|service.?unavailable|internal error|server error/i;
@@ -1475,7 +1476,11 @@ async function tryReconnectCodexWebSocketOnConnectionLimit(
 }
 
 function isCodexPreviousResponseNotFound(error: unknown): boolean {
-	return error instanceof CodexProviderStreamError && error.code === "previous_response_not_found";
+	return (
+		error instanceof CodexProviderStreamError &&
+		typeof error.code === "string" &&
+		CODEX_PREVIOUS_RESPONSE_STALE_CODES.has(error.code)
+	);
 }
 
 async function tryRecoverCodexPreviousResponseNotFound(
@@ -2669,6 +2674,22 @@ function getString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+function getCodexEventError(rawEvent: Record<string, unknown>): Record<string, unknown> | null {
+	const response = asRecord(rawEvent.response);
+	return asRecord(rawEvent.error) ?? (response ? asRecord(response.error) : null);
+}
+
+function getCodexEventErrorCode(rawEvent: Record<string, unknown>): string {
+	const error = getCodexEventError(rawEvent);
+	return getString(error?.code) ?? getString(error?.type) ?? getString(rawEvent.code) ?? "";
+}
+
+function getCodexEventErrorMessage(rawEvent: Record<string, unknown>): string {
+	const response = asRecord(rawEvent.response);
+	const error = getCodexEventError(rawEvent);
+	return getString(error?.message) ?? getString(rawEvent.message) ?? getString(response?.message) ?? "";
+}
+
 class CodexProviderStreamError extends Error {
 	readonly retryable: boolean;
 	readonly code?: string;
@@ -2682,19 +2703,17 @@ class CodexProviderStreamError extends Error {
 }
 
 function isRetryableCodexFailureEvent(rawEvent: Record<string, unknown>): boolean {
-	const response = asRecord(rawEvent.response);
-	const error = asRecord(rawEvent.error) ?? (response ? asRecord(response.error) : null);
-	const code = getString(error?.code) ?? getString(error?.type) ?? getString(rawEvent.code);
+	const code = getCodexEventErrorCode(rawEvent);
 	if (code && CODEX_RETRYABLE_EVENT_CODES.has(code.toLowerCase())) {
 		return true;
 	}
-	const message = getString(error?.message) ?? getString(rawEvent.message) ?? getString(response?.message);
+	const message = getCodexEventErrorMessage(rawEvent);
 	return !!message && CODEX_RETRYABLE_EVENT_MESSAGE.test(message);
 }
 
 function createCodexProviderStreamError(rawEvent: Record<string, unknown>): CodexProviderStreamError {
-	const code = getString(rawEvent.code) ?? "";
-	const message = getString(rawEvent.message) ?? "";
+	const code = getCodexEventErrorCode(rawEvent);
+	const message = getCodexEventErrorMessage(rawEvent);
 	const formattedMessage =
 		typeof rawEvent.type === "string" && rawEvent.type === "error"
 			? formatCodexErrorEvent(rawEvent, code, message)

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -170,7 +170,7 @@ interface CodexProviderSessionState extends ProviderSessionState {
 
 interface CodexRequestContext {
 	apiKey: string;
-	accountId: string;
+	accountId: string | undefined;
 	baseUrl: string;
 	url: string;
 	requestHeaders: Record<string, string>;
@@ -1801,12 +1801,12 @@ export async function prewarmOpenAICodexResponses(
 function getCodexWebSocketSessionKey(
 	sessionId: string | undefined,
 	model: Model<"openai-codex-responses">,
-	accountId: string,
+	accountId: string | undefined,
 	baseUrl: string,
 ): string | undefined {
 	const promptCacheKey = normalizeOpenAIResponsesPromptCacheKey(sessionId);
 	if (!promptCacheKey) return undefined;
-	return `${accountId}:${baseUrl}:${model.id}:${promptCacheKey}`;
+	return `${accountId ?? "opaque"}:${baseUrl}:${model.id}:${promptCacheKey}`;
 }
 
 function getCodexPublicSessionKey(
@@ -2335,7 +2335,7 @@ async function getOrCreateCodexWebSocketConnection(
 async function openCodexSseEventStream(
 	url: string,
 	requestHeaders: Record<string, string> | undefined,
-	accountId: string,
+	accountId: string | undefined,
 	apiKey: string,
 	sessionId: string | undefined,
 	body: RequestBody,
@@ -2400,7 +2400,7 @@ async function openCodexWebSocketEventStream(
 
 function createCodexHeaders(
 	initHeaders: Record<string, string> | undefined,
-	accountId: string,
+	accountId: string | undefined,
 	accessToken: string,
 	promptCacheKey?: string,
 	transport: CodexTransport = "sse",
@@ -2409,7 +2409,11 @@ function createCodexHeaders(
 	const headers = new Headers(initHeaders ?? {});
 	headers.delete("x-api-key");
 	headers.set("Authorization", `Bearer ${accessToken}`);
-	headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
+	if (accountId) {
+		headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
+	} else {
+		headers.delete(OPENAI_HEADERS.ACCOUNT_ID);
+	}
 	const betaHeader =
 		transport === "websocket"
 			? OPENAI_HEADER_VALUES.BETA_RESPONSES_WEBSOCKETS_V2
@@ -2482,12 +2486,8 @@ function resolveCodexResponsesUrl(baseUrl: string | undefined): string {
 	return `${normalized}/codex/responses`;
 }
 
-function getAccountId(accessToken: string): string {
-	const accountId = getCodexAccountId(accessToken);
-	if (!accountId) {
-		throw new Error("Failed to extract accountId from token");
-	}
-	return accountId;
+function getAccountId(accessToken: string): string | undefined {
+	return getCodexAccountId(accessToken);
 }
 
 function convertMessages(model: Model<"openai-codex-responses">, context: Context): ResponseInput {

--- a/packages/ai/test/auth-storage-ranking-mode.test.ts
+++ b/packages/ai/test/auth-storage-ranking-mode.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type AuthCredentialStore,
+	AuthStorage,
+	type CredentialRankingMode,
+	SqliteAuthCredentialStore,
+} from "../src/auth-storage";
+import type { UsageLimit, UsageProvider, UsageReport } from "../src/usage";
+import * as oauthUtils from "../src/utils/oauth";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const FIVE_HOUR_MS = 5 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+type WindowSpec = { usedFraction: number; resetInMs: number };
+
+function createLimit(args: {
+	id: "anthropic:5h" | "anthropic:7d";
+	label: string;
+	durationMs: number;
+	spec: WindowSpec;
+}): UsageLimit {
+	const clamped = Math.min(Math.max(args.spec.usedFraction, 0), 1);
+	const used = clamped * 100;
+	return {
+		id: args.id,
+		label: args.label,
+		scope: { provider: "anthropic", windowId: args.id, shared: false },
+		window: {
+			id: args.id,
+			label: args.label,
+			durationMs: args.durationMs,
+			resetsAt: Date.now() + args.spec.resetInMs,
+		},
+		amount: {
+			unit: "percent",
+			used,
+			limit: 100,
+			remaining: 100 - used,
+			usedFraction: clamped,
+			remainingFraction: Math.max(0, 1 - clamped),
+		},
+		status: clamped >= 1 ? "exhausted" : clamped >= 0.9 ? "warning" : "ok",
+	};
+}
+
+function createClaudeUsageReport(accountId: string, primary: WindowSpec, secondary: WindowSpec): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt: Date.now(),
+		limits: [
+			createLimit({ id: "anthropic:5h", label: "5 Hour", durationMs: FIVE_HOUR_MS, spec: primary }),
+			createLimit({ id: "anthropic:7d", label: "7 Day", durationMs: WEEK_MS, spec: secondary }),
+		],
+		metadata: { accountId },
+	};
+}
+
+function createCredential(accountId: string, email: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+		email,
+	};
+}
+
+describe("AuthStorage credentialRankingMode", () => {
+	let tempDir = "";
+	const stores: AuthCredentialStore[] = [];
+	const usageByAccount = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "anthropic",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			if (!accountId) return null;
+			return usageByAccount.get(accountId) ?? null;
+		},
+	};
+
+	async function makeStorage(mode?: CredentialRankingMode): Promise<AuthStorage> {
+		const store = await SqliteAuthCredentialStore.open(path.join(tempDir, `agent-${stores.length}.db`));
+		stores.push(store);
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "anthropic" ? usageProvider : undefined),
+			credentialRankingMode: mode,
+		});
+		await storage.reload();
+		await storage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-soon", "soon@example.com") },
+			{ type: "oauth", ...createCredential("acct-late", "late@example.com") },
+		]);
+		return storage;
+	}
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-ranking-mode-"));
+		usageByAccount.clear();
+		// acct-soon: 5h window resets in 10m (soonest), but drains its 7d window faster.
+		usageByAccount.set(
+			"acct-soon",
+			createClaudeUsageReport(
+				"acct-soon",
+				{ usedFraction: 0.5, resetInMs: 10 * 60 * 1000 },
+				{ usedFraction: 0.6, resetInMs: 5 * DAY_MS },
+			),
+		);
+		// acct-late: 5h window resets in 4h (later), but is the least-drained account.
+		usageByAccount.set(
+			"acct-late",
+			createClaudeUsageReport(
+				"acct-late",
+				{ usedFraction: 0.3, resetInMs: 4 * HOUR_MS },
+				{ usedFraction: 0.3, resetInMs: 5 * DAY_MS },
+			),
+		);
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials.anthropic as OAuthCredentials | undefined;
+			if (!credential?.accountId) return null;
+			return { apiKey: `api-${credential.accountId}`, newCredentials: credential };
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		for (const store of stores.splice(0)) store.close();
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("default (balanced) prefers the least-drained account", async () => {
+		const storage = await makeStorage();
+		const apiKey = await storage.getApiKey("anthropic", "session-balanced");
+		expect(apiKey).toBe("api-acct-late");
+	});
+
+	test("balanced mode is explicit-equivalent to the default", async () => {
+		const storage = await makeStorage("balanced");
+		const apiKey = await storage.getApiKey("anthropic", "session-balanced-explicit");
+		expect(apiKey).toBe("api-acct-late");
+	});
+
+	test("earliest-reset prefers the soonest-to-reset account (use-it-or-lose-it)", async () => {
+		const storage = await makeStorage("earliest-reset");
+		const apiKey = await storage.getApiKey("anthropic", "session-earliest-reset");
+		expect(apiKey).toBe("api-acct-soon");
+	});
+
+	test("earliest-reset still skips an exhausted soon-to-reset account", async () => {
+		// acct-soon's 5h window resets soonest but is fully exhausted → must fall to acct-late.
+		usageByAccount.set(
+			"acct-soon",
+			createClaudeUsageReport(
+				"acct-soon",
+				{ usedFraction: 1, resetInMs: 10 * 60 * 1000 },
+				{ usedFraction: 1, resetInMs: 10 * 60 * 1000 },
+			),
+		);
+		const storage = await makeStorage("earliest-reset");
+		const apiKey = await storage.getApiKey("anthropic", "session-earliest-reset-exhausted");
+		expect(apiKey).toBe("api-acct-late");
+	});
+});

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1711,6 +1711,108 @@ describe("openai-codex streaming", () => {
 		});
 	});
 
+	it("retries websocket continuations when codex-lb masks stale previous_response_id", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-lb-stale-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		class MaskedPreviousResponseMissingWebSocket extends MockWebSocket {
+			constructor(url: string, options?: { headers?: WsHeaders }) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			send(data: string): void {
+				const request = JSON.parse(data) as Record<string, unknown>;
+				sentRequests.push(request);
+				const requestIndex = sentRequests.length;
+
+				if (requestIndex === 1) {
+					this.emitCodexResponse({
+						messageId: "msg_1",
+						responseId: "resp_1",
+						text: "First answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				if (requestIndex === 2) {
+					expect(request.previous_response_id).toBe("resp_1");
+					this.sendJson({
+						type: "response.failed",
+						response: {
+							id: "resp_masked_failure",
+							status: "failed",
+							error: {
+								type: "server_error",
+								code: "codex_previous_response_stale",
+								message: "Upstream previous response anchor expired; retry without previous_response_id.",
+							},
+						},
+					});
+					return;
+				}
+
+				if (requestIndex === 3) {
+					expect(request.previous_response_id).toBeUndefined();
+					this.emitCodexResponse({
+						messageId: "msg_3",
+						responseId: "resp_3",
+						text: "Second answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				throw new Error(`Unexpected websocket request index: ${requestIndex}`);
+			}
+		}
+
+		global.WebSocket = MaskedPreviousResponseMissingWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [{ role: "user", content: "First question", timestamp: Date.now() }],
+		};
+		const firstResponse = await streamOpenAICodexResponses(model, firstContext, {
+			apiKey: token,
+			sessionId: "ws-masked-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+		const secondContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [
+				...firstContext.messages,
+				firstResponse,
+				{ role: "user", content: "Second question", timestamp: Date.now() + 1 },
+			],
+		};
+
+		const secondResponse = await streamOpenAICodexResponses(model, secondContext, {
+			apiKey: token,
+			sessionId: "ws-masked-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(JSON.stringify(secondResponse.content)).toContain("Second answer");
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(sentRequests).toHaveLength(3);
+		const retryInput = sentRequests[2]?.input;
+		expect(Array.isArray(retryInput)).toBe(true);
+		expect(JSON.stringify(retryInput)).toContain("First question");
+		expect(JSON.stringify(retryInput)).toContain("Second question");
+	});
+
 	it("uses low Codex text verbosity by default while preserving explicit overrides", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-verbosity-");
 		setAgentDir(tempDir.path());

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -408,6 +408,33 @@ describe("openai-codex streaming", () => {
 		expect(Object.keys(capturedHeaders ?? {}).filter(key => key.toLowerCase() === "openai-beta")).toHaveLength(1);
 	});
 
+	it("passes opaque apiKey tokens through to custom Codex-compatible backends", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = "sk-custom-proxy-test";
+		const sse = createCompletedCodexSse("Hello proxy");
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Headers | undefined;
+		global.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			capturedUrl = typeof input === "string" ? input : input.toString();
+			capturedHeaders = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+			return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
+		}) as unknown as typeof fetch;
+
+		const result = await streamOpenAICodexResponses(
+			{ ...createCodexTestModel("http://127.0.0.1:2455/backend-api/codex"), preferWebsockets: false },
+			createCodexTestContext(),
+			{ apiKey: token },
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+		expect(capturedUrl).toBe("http://127.0.0.1:2455/backend-api/codex/responses");
+		expect(capturedHeaders?.get("Authorization")).toBe(`Bearer ${token}`);
+		expect(capturedHeaders?.has("chatgpt-account-id")).toBe(false);
+		expect(capturedHeaders?.get("OpenAI-Beta")).toBe("responses=experimental");
+	});
+
 	it("streams SSE responses into AssistantMessageEventStream", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `GJC_CREDENTIAL_RANKING_MODE` env var (`balanced` (default) | `earliest-reset`), wired through `discoverAuthStorage` into `AuthStorage.credentialRankingMode`. `earliest-reset` selects multi-account OAuth credentials earliest-expiry-first so soon-to-reset tumbling-window quota (e.g. Claude 5h/7d) is drained before it is lost at reset; unset/unknown leaves the default `balanced` behavior unchanged.
+
 ### Fixed
 
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Manual and automatic compaction, handoff generation, and branch summary generation now reuse the live Codex provider session state and OpenAI WebSocket preference, so Codex maintenance calls keep the configured WebSocket transport instead of falling back to HTTP/SSE.
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).
 
 ## [0.5.2] - 2026-06-15

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -7,6 +7,11 @@ const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
 const MONITOR_TOMBSTONE_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_DELIVERY_QUEUE = 100;
+const DELIVERY_MAX_TEXT_BYTES = 64 * 1024;
+const DELIVERY_PREVIEW_HEAD_BYTES = 32 * 1024;
+const DELIVERY_PREVIEW_TAIL_BYTES = 32 * 1024;
+const DELIVERY_MAX_ATTEMPTS = 3;
 
 export interface AsyncJob {
 	id: string;
@@ -128,9 +133,16 @@ export interface AsyncJobManagerOptions {
 	retentionMs?: number;
 }
 
+export interface AsyncJobDisposeDiagnostics {
+	stuckJobIds: string[];
+	deliveriesDrained: boolean;
+}
+
 interface AsyncJobDelivery {
 	jobId: string;
 	text: string;
+	originalBytes?: number;
+	truncated?: boolean;
 	attempt: number;
 	nextAttemptAt: number;
 	lastError?: string;
@@ -143,6 +155,7 @@ export interface AsyncJobDeliveryState {
 	delivering: boolean;
 	nextRetryAt?: number;
 	pendingJobIds: string[];
+	deadLettered: number;
 }
 
 export interface AsyncJobLifecycleCleanup {
@@ -196,6 +209,32 @@ function sliceTextFromUtf8ByteOffset(text: string, offsetBytes: number): string 
 		codeUnitIndex += char.length;
 	}
 	return text.slice(codeUnitIndex);
+}
+
+function sliceTextAfterUtf8ByteOffset(text: string, offsetBytes: number): string {
+	if (offsetBytes <= 0) return text;
+	let consumedBytes = 0;
+	let codeUnitIndex = 0;
+	for (const char of text) {
+		const charBytes = Buffer.byteLength(char, "utf8");
+		consumedBytes += charBytes;
+		codeUnitIndex += char.length;
+		if (consumedBytes >= offsetBytes) break;
+	}
+	return text.slice(codeUnitIndex);
+}
+
+function sliceTextToUtf8ByteLength(text: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	let consumedBytes = 0;
+	let codeUnitIndex = 0;
+	for (const char of text) {
+		const charBytes = Buffer.byteLength(char, "utf8");
+		if (consumedBytes + charBytes > maxBytes) break;
+		consumedBytes += charBytes;
+		codeUnitIndex += char.length;
+	}
+	return text.slice(0, codeUnitIndex);
 }
 
 /**
@@ -277,6 +316,8 @@ export class AsyncJobManager {
 	#resumeSeq = 0;
 	#resumeRunner?: (subagentId: string, message?: string, descriptor?: ResumeDescriptor) => string | undefined;
 	readonly #resumeDescriptors = new Map<string, ResumeDescriptor>();
+	readonly #deadLetteredDeliveries = new Map<string, AsyncJobDelivery>();
+	#lastDisposeDiagnostics: AsyncJobDisposeDiagnostics = { stuckJobIds: [], deliveriesDrained: true };
 	/**
 	 * Change listeners notified on any mutation that can alter the live job set
 	 * (register, terminal/eviction transitions, dispose). Used by the status-line
@@ -381,7 +422,7 @@ export class AsyncJobManager {
 
 				if (job.status === "cancelled") {
 					job.resultText = outcome.kind === "completed" ? outcome.text : outcome.note;
-					this.#runLifecycle(id, "terminal");
+					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
@@ -403,20 +444,20 @@ export class AsyncJobManager {
 				this.#freezeEndTime(job);
 				job.resultText = outcome.text;
 				this.#enqueueDelivery(id, outcome.text);
-				this.#runLifecycle(id, "terminal");
+				this.#runLifecycle(id, "terminal", job);
 				this.#scheduleEviction(id);
 				this.#markRecordTerminal(id, "completed");
 				this.#drainResumeQueue();
 			} catch (error) {
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
-					this.#runLifecycle(id, "terminal");
+					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
 					this.#drainResumeQueue();
 					return;
 				}
-				this.#runLifecycle(id, "terminal");
+				this.#runLifecycle(id, "terminal", job);
 				const errorText = error instanceof Error ? error.message : String(error);
 				job.status = "failed";
 				this.#freezeEndTime(job);
@@ -471,14 +512,14 @@ export class AsyncJobManager {
 		job.endTime ??= Date.now();
 	}
 
-	#runLifecycle(jobId: string, phase: "cancel" | "terminal" | "evict"): void {
+	#runLifecycle(jobId: string, phase: "cancel" | "terminal" | "evict", jobOverride?: AsyncJob): void {
+		const lifecycle = this.#lifecycles.get(jobId);
+		const job = jobOverride ?? this.#jobs.get(jobId);
+		if (!lifecycle || !job) return;
 		const fired = this.#lifecyclePhases.get(jobId) ?? new Set<"cancel" | "terminal" | "evict">();
 		if (fired.has(phase)) return;
 		fired.add(phase);
 		this.#lifecyclePhases.set(jobId, fired);
-		const lifecycle = this.#lifecycles.get(jobId);
-		const job = this.#jobs.get(jobId);
-		if (!lifecycle || !job) return;
 		try {
 			if (phase === "cancel") lifecycle.onCancel?.(job);
 			else if (phase === "terminal") lifecycle.onTerminal?.(job);
@@ -647,6 +688,16 @@ export class AsyncJobManager {
 			this.#liveHandles.delete(rec.subagentId);
 			this.#subagentProgress.delete(rec.subagentId);
 		}
+	}
+
+	#purgeTerminalSubagentStateForJob(jobId: string): void {
+		const rec = this.#recordByJobId(jobId);
+		if (!rec) return;
+		if (rec.status === "paused" || rec.status === "queued") return;
+		this.#liveHandles.delete(rec.subagentId);
+		this.#subagentProgress.delete(rec.subagentId);
+		this.#resumeDescriptors.delete(rec.subagentId);
+		this.#subagentRecords.delete(rec.subagentId);
 	}
 
 	#markRecordTerminal(jobId: string, status: "completed" | "failed" | "cancelled"): void {
@@ -967,6 +1018,10 @@ export class AsyncJobManager {
 	getDeliveryState(filter?: AsyncJobFilter): AsyncJobDeliveryState {
 		const deliveries = this.#filterDeliveries(filter);
 		const inFlightDeliveries = this.#filterInFlightDeliveries(filter);
+		const ownerId = filter?.ownerId;
+		const deadLettered = Array.from(this.#deadLetteredDeliveries.values()).filter(
+			delivery => !ownerId || delivery.ownerId === ownerId,
+		).length;
 		const nextRetryAt = deliveries.reduce<number | undefined>((next, delivery) => {
 			if (next === undefined) return delivery.nextAttemptAt;
 			return Math.min(next, delivery.nextAttemptAt);
@@ -977,6 +1032,7 @@ export class AsyncJobManager {
 			delivering: inFlightDeliveries.length > 0 || (this.#deliveryLoop !== undefined && deliveries.length > 0),
 			nextRetryAt,
 			pendingJobIds: deliveries.concat(inFlightDeliveries).map(delivery => delivery.jobId),
+			deadLettered,
 		};
 	}
 
@@ -1033,6 +1089,29 @@ export class AsyncJobManager {
 			job.abortController.abort();
 			this.#scheduleEviction(job.id);
 		}
+	}
+
+	getLastDisposeDiagnostics(): AsyncJobDisposeDiagnostics {
+		return { ...this.#lastDisposeDiagnostics, stuckJobIds: [...this.#lastDisposeDiagnostics.stuckJobIds] };
+	}
+
+	async #waitForAllWithDeadline(timeoutMs: number): Promise<{ completed: boolean; stuckJobIds: string[] }> {
+		const jobs = Array.from(this.#jobs.values());
+		if (jobs.length === 0) return { completed: true, stuckJobIds: [] };
+		let timedOut = false;
+		await Promise.race([
+			Promise.allSettled(jobs.map(job => job.promise)),
+			Bun.sleep(Math.max(0, timeoutMs)).then(() => {
+				timedOut = true;
+			}),
+		]);
+		if (!timedOut) return { completed: true, stuckJobIds: [] };
+		return {
+			completed: false,
+			stuckJobIds: Array.from(this.#jobs.values())
+				.filter(job => job.status === "running" || job.status === "cancelled")
+				.map(job => job.id),
+		};
 	}
 
 	async waitForAll(): Promise<void> {
@@ -1102,12 +1181,18 @@ export class AsyncJobManager {
 			}
 		}
 		this.#monitorTombstones.clear();
-		await this.waitForAll();
-		const drained = await this.drainDeliveries({ timeoutMs: options?.timeoutMs ?? 3_000 });
+		const timeoutMs = options?.timeoutMs ?? 3_000;
+		const waitResult = await this.#waitForAllWithDeadline(timeoutMs);
+		const drained = waitResult.completed ? await this.drainDeliveries({ timeoutMs }) : false;
+		this.#lastDisposeDiagnostics = { stuckJobIds: waitResult.stuckJobIds, deliveriesDrained: drained };
+		if (waitResult.stuckJobIds.length > 0) {
+			logger.warn("Async job manager dispose timed out waiting for jobs", { stuckJobIds: waitResult.stuckJobIds });
+		}
 		this.#clearEvictionTimers();
 		this.#jobs.clear();
 		this.#deliveries.length = 0;
 		this.#inFlightDeliveries.length = 0;
+		this.#deadLetteredDeliveries.clear();
 		this.#suppressedDeliveries.clear();
 		this.#watchedJobs.clear();
 		this.#outputState.clear();
@@ -1119,7 +1204,7 @@ export class AsyncJobManager {
 		this.#resumeQueue.length = 0;
 		this.#notifyChange();
 		this.#changeListeners.clear();
-		return drained;
+		return drained && waitResult.completed;
 	}
 
 	#resolveJobId(preferredId?: string): string {
@@ -1148,16 +1233,10 @@ export class AsyncJobManager {
 	}
 
 	#scheduleEviction(jobId: string): void {
+		if (this.#disposed) return;
 		this.#notifyChange();
 		if (this.#retentionMs <= 0) {
-			this.#recordMonitorTombstone(jobId);
-			this.#runLifecycle(jobId, "evict");
-			this.#jobs.delete(jobId);
-			this.#lifecycles.delete(jobId);
-			this.#lifecyclePhases.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
-			this.#outputState.delete(jobId);
+			this.#evictJob(jobId);
 			return;
 		}
 		const existing = this.#evictionTimers.get(jobId);
@@ -1166,18 +1245,23 @@ export class AsyncJobManager {
 		}
 		const timer = setTimeout(() => {
 			this.#evictionTimers.delete(jobId);
-			this.#recordMonitorTombstone(jobId);
-			this.#runLifecycle(jobId, "evict");
-			this.#jobs.delete(jobId);
-			this.#lifecycles.delete(jobId);
-			this.#lifecyclePhases.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
-			this.#outputState.delete(jobId);
+			this.#evictJob(jobId);
 			this.#notifyChange();
 		}, this.#retentionMs);
 		timer.unref();
 		this.#evictionTimers.set(jobId, timer);
+	}
+
+	#evictJob(jobId: string): void {
+		this.#recordMonitorTombstone(jobId);
+		this.#runLifecycle(jobId, "evict");
+		this.#purgeTerminalSubagentStateForJob(jobId);
+		this.#jobs.delete(jobId);
+		this.#lifecycles.delete(jobId);
+		this.#lifecyclePhases.delete(jobId);
+		this.#suppressedDeliveries.delete(jobId);
+		this.#watchedJobs.delete(jobId);
+		this.#outputState.delete(jobId);
 	}
 
 	#clearEvictionTimers(): void {
@@ -1245,17 +1329,38 @@ export class AsyncJobManager {
 		if (this.isDeliverySuppressed(jobId)) {
 			return;
 		}
+		const deliveryText = this.#boundedDeliveryText(text);
 		this.#deliveries.push({
 			jobId,
-			text,
+			text: deliveryText.text,
+			originalBytes: deliveryText.originalBytes,
+			truncated: deliveryText.truncated,
 			attempt: 0,
 			nextAttemptAt: Date.now(),
 			ownerId: this.#jobs.get(jobId)?.ownerId,
 		});
+		while (this.#deliveries.length > DEFAULT_MAX_DELIVERY_QUEUE) {
+			const dropped = this.#deliveries.shift();
+			if (dropped) this.#deadLetteredDeliveries.set(dropped.jobId, dropped);
+		}
 		this.#ensureDeliveryLoop();
 	}
 
+	#boundedDeliveryText(text: string): { text: string; originalBytes?: number; truncated?: boolean } {
+		const bytes = Buffer.byteLength(text, "utf8");
+		if (bytes <= DELIVERY_MAX_TEXT_BYTES) return { text };
+		const head = sliceTextToUtf8ByteLength(text, DELIVERY_PREVIEW_HEAD_BYTES);
+		const tailStart = Math.max(0, bytes - DELIVERY_PREVIEW_TAIL_BYTES);
+		const tail = sliceTextAfterUtf8ByteOffset(text, tailStart);
+		return {
+			text: `${head}\n\n[async delivery output truncated from ${bytes} bytes]\n\n${tail}`,
+			originalBytes: bytes,
+			truncated: true,
+		};
+	}
+
 	#ensureDeliveryLoop(): void {
+		if (this.#disposed) return;
 		if (this.#deliveryLoop) {
 			return;
 		}
@@ -1266,7 +1371,7 @@ export class AsyncJobManager {
 			})
 			.finally(() => {
 				this.#deliveryLoop = undefined;
-				if (this.#deliveries.length > 0) {
+				if (!this.#disposed && this.#deliveries.length > 0) {
 					this.#ensureDeliveryLoop();
 				}
 			});
@@ -1304,20 +1409,29 @@ export class AsyncJobManager {
 			} catch (error) {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);
-				delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-				if (!this.isDeliverySuppressed(delivery.jobId)) {
-					this.#deliveries.push(delivery);
+				if (delivery.attempt >= DELIVERY_MAX_ATTEMPTS) {
+					this.#deadLetteredDeliveries.set(delivery.jobId, delivery);
+					logger.warn("Async job completion delivery reached retry cap", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						error: delivery.lastError,
+					});
+				} else {
+					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
+					if (!this.isDeliverySuppressed(delivery.jobId)) {
+						this.#deliveries.push(delivery);
+					}
+					logger.warn("Async job completion delivery failed", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						nextRetryAt: delivery.nextAttemptAt,
+						error: delivery.lastError,
+					});
 				}
-				logger.warn("Async job completion delivery failed", {
-					jobId: delivery.jobId,
-					attempt: delivery.attempt,
-					nextRetryAt: delivery.nextAttemptAt,
-					error: delivery.lastError,
-				});
 			} finally {
 				const index = this.#inFlightDeliveries.indexOf(delivery);
 				if (index !== -1) this.#inFlightDeliveries.splice(index, 1);
-				if (this.#deliveries.length > 0) this.#ensureDeliveryLoop();
+				if (!this.#disposed && this.#deliveries.length > 0) this.#ensureDeliveryLoop();
 			}
 		})();
 		delivery.promise = promise;

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -1,6 +1,8 @@
-import { logger, ptree } from "@gajae-code/utils";
+import * as fs from "node:fs/promises";
+import { logger } from "@gajae-code/utils";
 import { formatCrashDiagnosticNotice, writeCrashReport } from "../debug/crash-diagnostics";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
+import { type OwnedProcess, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { ToolAbortError } from "../tools/tool-errors";
 import type {
 	DapCapabilities,
@@ -69,10 +71,21 @@ function toErrorMessage(value: unknown): string {
 	return String(value);
 }
 
+async function drainReadable(readable: ReadableStream<Uint8Array>): Promise<void> {
+	const reader = readable.getReader();
+	try {
+		while (!(await reader.read()).done) {}
+	} catch {
+		/* drain best-effort */
+	} finally {
+		reader.releaseLock();
+	}
+}
 export class DapClient {
 	readonly adapter: DapResolvedAdapter;
 	readonly cwd: string;
 	readonly proc: DapClientState["proc"];
+	readonly #owner: OwnedProcess;
 	/** ReadableStream of DAP bytes — from proc.stdout (stdio) or a socket (socket mode). */
 	readonly #readable: ReadableStream<Uint8Array>;
 	/** Write sink — proc.stdin (stdio) or a socket (socket mode). */
@@ -93,14 +106,15 @@ export class DapClient {
 	constructor(
 		adapter: DapResolvedAdapter,
 		cwd: string,
-		proc: DapClientState["proc"],
+		owner: OwnedProcess,
 		options?: { readable?: ReadableStream<Uint8Array>; writeSink?: DapWriteSink; socket?: { end(): void } },
 	) {
 		this.adapter = adapter;
 		this.cwd = cwd;
-		this.proc = proc;
-		this.#readable = options?.readable ?? (proc.stdout as ReadableStream<Uint8Array>);
-		this.#writeSink = options?.writeSink ?? proc.stdin;
+		this.proc = owner.child as DapClientState["proc"];
+		this.#owner = owner;
+		this.#readable = options?.readable ?? (this.proc.stdout as ReadableStream<Uint8Array>);
+		this.#writeSink = options?.writeSink ?? this.proc.stdin;
 		this.#socket = options?.socket;
 	}
 
@@ -116,13 +130,14 @@ export class DapClient {
 			...Bun.env,
 			...NON_INTERACTIVE_ENV,
 		};
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}`,
 		});
-		const client = new DapClient(adapter, cwd, proc);
+		const client = new DapClient(adapter, cwd, owner);
+		const proc = owner.child as DapClientState["proc"];
 		proc.exited.then(() => {
 			client.#handleProcessExit();
 		});
@@ -159,32 +174,44 @@ export class DapClient {
 		env: Record<string, string | undefined>;
 	}): Promise<DapClient> {
 		const socketPath = `/tmp/dap-${adapter.name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`;
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args, `--listen=unix:${socketPath}`], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args, `--listen=unix:${socketPath}`], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}:unix-socket`,
 		});
+		const proc = owner.child as DapClientState["proc"];
+		void drainReadable(proc.stdout);
+		let transport: SocketTransport | undefined;
 
-		// Wait for the socket file to appear (dlv needs to start listening)
-		await waitForCondition(
-			() => {
-				try {
-					Bun.file(socketPath).size;
-					return true;
-				} catch {
-					return false;
-				}
-			},
-			10_000,
-			proc,
-		);
+		try {
+			// Wait for the socket file to appear (dlv needs to start listening)
+			await waitForCondition(
+				() => {
+					try {
+						Bun.file(socketPath).size;
+						return true;
+					} catch {
+						return false;
+					}
+				},
+				10_000,
+				proc,
+			);
 
-		const { readable, writeSink, socket } = await connectSocket({ unix: socketPath });
-		const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });
-		proc.exited.then(() => client.#handleProcessExit());
-		void client.#startMessageReader();
-		return client;
+			transport = await connectSocket({ unix: socketPath }, 10_000);
+			const client = new DapClient(adapter, cwd, owner, transport);
+			proc.exited.then(() => client.#handleProcessExit());
+			void client.#startMessageReader();
+			return client;
+		} catch (err) {
+			transport?.socket.end();
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
+			throw err;
+		} finally {
+			await fs.unlink(socketPath).catch(() => undefined);
+		}
 	}
 
 	/** macOS/other: listen on a random TCP port, spawn adapter with --client-addr, accept connection. */
@@ -214,12 +241,14 @@ export class DapClient {
 		});
 
 		const port = server.port;
-		const proc = ptree.spawn([adapter.resolvedCommand, ...adapter.args, `--client-addr=127.0.0.1:${port}`], {
+		const owner = spawnOwnedProcess([adapter.resolvedCommand, ...adapter.args, `--client-addr=127.0.0.1:${port}`], {
 			cwd,
 			stdin: "pipe",
 			env,
-			detached: true,
+			name: `dap:${adapter.name}:client-addr`,
 		});
+		const proc = owner.child as DapClientState["proc"];
+		void drainReadable(proc.stdout);
 
 		// Wait for dlv to connect (with timeout)
 		let rawSocket: Bun.Socket<undefined>;
@@ -230,13 +259,17 @@ export class DapClient {
 		);
 		try {
 			rawSocket = await Promise.race([connPromise, timeoutPromise]);
+		} catch (err) {
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
+			throw err;
 		} finally {
 			clearTimeout(connectTimeout);
 			server.stop();
 		}
 
 		const { readable, writeSink, socket } = wrapBunSocket(rawSocket);
-		const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });
+		const client = new DapClient(adapter, cwd, owner, { readable, writeSink, socket });
 		proc.exited.then(() => client.#handleProcessExit());
 		void client.#startMessageReader();
 		return client;
@@ -414,14 +447,14 @@ export class DapClient {
 			/* socket may already be closed */
 		}
 		try {
-			this.proc.kill();
+			await this.#owner.dispose();
+			await this.#owner.awaitExit({ timeoutMs: 1_000 });
 		} catch (error) {
-			logger.debug("Failed to kill DAP adapter", {
+			logger.debug("Failed to dispose DAP adapter", {
 				adapter: this.adapter.name,
 				error: toErrorMessage(error),
 			});
 		}
-		await this.proc.exited.catch(() => {});
 	}
 
 	async #startMessageReader(): Promise<void> {
@@ -604,8 +637,8 @@ function socketToSink(socket: Bun.Socket<undefined>): DapWriteSink {
 }
 
 /** Connect to a unix domain socket and return DAP transport streams. */
-async function connectSocket(options: { unix: string }): Promise<SocketTransport> {
-	const { promise, resolve } = Promise.withResolvers<SocketTransport>();
+async function connectSocket(options: { unix: string }, timeoutMs = 10_000): Promise<SocketTransport> {
+	const { promise, resolve, reject } = Promise.withResolvers<SocketTransport>();
 	let streamController: ReadableStreamDefaultController<Uint8Array>;
 
 	const readable = new ReadableStream<Uint8Array>({
@@ -614,15 +647,25 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 		},
 	});
 
+	const timeout = setTimeout(() => reject(new Error(`Socket connect timed out after ${timeoutMs}ms`)), timeoutMs);
+	let settled = false;
+	const settle = (fn: () => void) => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timeout);
+		fn();
+	};
 	Bun.connect({
 		unix: options.unix,
 		socket: {
 			open(socket) {
-				resolve({
-					readable,
-					writeSink: socketToSink(socket),
-					socket,
-				});
+				settle(() =>
+					resolve({
+						readable,
+						writeSink: socketToSink(socket),
+						socket,
+					}),
+				);
 			},
 			data(_socket, data) {
 				streamController.enqueue(new Uint8Array(data));
@@ -635,11 +678,7 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 				}
 			},
 			error(_socket, err) {
-				try {
-					streamController.error(err);
-				} catch {
-					/* already closed */
-				}
+				settle(() => reject(err));
 			},
 		},
 	});

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import * as timers from "node:timers/promises";
-import { logger, ptree, untilAborted } from "@gajae-code/utils";
+import { logger, untilAborted } from "@gajae-code/utils";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
+import { type OwnedProcess, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { DapClient } from "./client";
 import type {
 	DapAttachArguments,
@@ -63,6 +64,24 @@ import type {
 	DapWriteMemoryResponse,
 } from "./types";
 
+function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): void {
+	if (!stream) return;
+	void (async () => {
+		try {
+			const reader = stream.getReader();
+			try {
+				while (!(await reader.read()).done) {
+					// drain only
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		} catch {
+			// Process stream closed or was already consumed.
+		}
+	})();
+}
+
 interface DapSession {
 	id: string;
 	adapter: DapResolvedAdapter;
@@ -87,6 +106,7 @@ interface DapSession {
 	initializedSeen: boolean;
 	needsConfigurationDone: boolean;
 	configurationDoneSent: boolean;
+	runInTerminalProcesses: Set<OwnedProcess>;
 }
 
 export interface DapOutputSnapshot {
@@ -948,6 +968,7 @@ export class DapSessionManager {
 			initializedSeen: false,
 			needsConfigurationDone: false,
 			configurationDoneSent: false,
+			runInTerminalProcesses: new Set(),
 		};
 		client.onReverseRequest("runInTerminal", async rawArgs => {
 			const args = (rawArgs ?? {}) as DapRunInTerminalArguments;
@@ -957,17 +978,21 @@ export class DapSessionManager {
 			const env = Object.fromEntries(
 				Object.entries(args.env ?? {}).filter((entry): entry is [string, string] => entry[1] !== null),
 			);
-			const proc = ptree.spawn(args.args, {
+			const owner = spawnOwnedProcess(args.args, {
 				cwd: args.cwd ?? session.cwd,
-				stdin: "pipe",
+				stdin: "ignore",
 				env: {
 					...Bun.env,
 					...NON_INTERACTIVE_ENV,
 					...env,
 				},
-				detached: true,
+				name: `dap:${session.id}:runInTerminal`,
 			});
-			return { processId: proc.pid } satisfies DapRunInTerminalResponse;
+			drainStream(owner.child.stdout);
+			drainStream(owner.child.stderr);
+			session.runInTerminalProcesses.add(owner);
+			owner.exited.finally(() => session.runInTerminalProcesses.delete(owner));
+			return { processId: owner.pid } satisfies DapRunInTerminalResponse;
 		});
 		client.onReverseRequest("startDebugging", async rawArgs => {
 			const startArgs = (rawArgs ?? {}) as Partial<DapStartDebuggingArguments>;
@@ -1294,12 +1319,24 @@ export class DapSessionManager {
 		return session;
 	}
 
-	#disposeSession(session: DapSession) {
+	async #disposeSession(session: DapSession) {
 		if (this.#activeSessionId === session.id) {
 			this.#activeSessionId = null;
 		}
 		this.#sessions.delete(session.id);
-		void session.client.dispose().catch(() => {});
+		await this.#disposeRunInTerminalProcesses(session);
+		await session.client.dispose().catch(() => {});
+	}
+
+	async #disposeRunInTerminalProcesses(session: DapSession): Promise<void> {
+		const owners = [...session.runInTerminalProcesses];
+		session.runInTerminalProcesses.clear();
+		await Promise.allSettled(
+			owners.map(async owner => {
+				await owner.dispose();
+				await owner.awaitExit({ timeoutMs: 1_000 });
+			}),
+		);
 	}
 }
 

--- a/packages/coding-agent/src/edit/read-file.ts
+++ b/packages/coding-agent/src/edit/read-file.ts
@@ -7,10 +7,28 @@
 import { isEnoent } from "@gajae-code/utils";
 import { isNotebookPath, readEditableNotebookText, serializeEditedNotebookText } from "./notebook";
 
+/**
+ * Max byte size of a file the edit modes will load whole. Editing loads + normalizes +
+ * fuzzy-matches + diffs the entire file on the main thread, so a multi-MB/generated file
+ * would block the event loop (F19). Above this, fail fast with an actionable error.
+ */
+export const MAX_EDIT_FILE_BYTES = 8 * 1024 * 1024;
+
 export async function readEditFileText(absolutePath: string, path: string): Promise<string> {
 	try {
+		const file = Bun.file(absolutePath);
+		const size = file.size; // 0 for a missing file; the read below then throws ENOENT.
+		if (size > MAX_EDIT_FILE_BYTES) {
+			throw new Error(
+				`File too large to edit safely: ${path} is ${size} bytes (limit ${MAX_EDIT_FILE_BYTES}). ` +
+					`Editing loads and diffs the whole file on the main thread; make a more targeted change, ` +
+					`split the file, or use a specialized tool.`,
+			);
+		}
+		// Guard BEFORE the notebook fast-path: a >8 MiB .ipynb would otherwise load + JSON-parse
+		// + convert the whole file via readEditableNotebookText, bypassing the F19 freeze guard.
 		if (isNotebookPath(absolutePath)) return await readEditableNotebookText(absolutePath, path);
-		return await Bun.file(absolutePath).text();
+		return await file.text();
 	} catch (error) {
 		if (isEnoent(error)) {
 			throw new Error(`File not found: ${path}`);

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -1,4 +1,5 @@
 import { isCompiledBinary, logger, Snowflake } from "@gajae-code/utils";
+import { registerResourceOwner } from "../../runtime/process-lifecycle";
 import type { ToolSession } from "../../tools";
 import { ToolAbortError, ToolError } from "../../tools/tool-errors";
 import { callSessionTool, type JsStatusEvent } from "./tool-bridge";
@@ -43,22 +44,66 @@ interface PendingRun {
 	settled: boolean;
 }
 
+interface ReadyDeferred {
+	promise: Promise<JsSession>;
+	resolve(session: JsSession): void;
+	reject(error: Error): void;
+}
+
+interface QueueDeferred {
+	promise: Promise<void>;
+	resolve(): void;
+	reject(error: Error): void;
+}
+
 interface JsSession {
 	sessionKey: string;
-	worker: WorkerHandle;
-	state: "alive" | "dead";
+	worker?: WorkerHandle;
+	state: "starting" | "alive" | "dead";
+	ownerId?: string;
 	pending: Map<string, PendingRun>;
 	queue: Promise<void>;
+	queuedWaiters: Set<(error: Error) => void>;
+	queueTail: QueueDeferred;
+	controllers: Set<AbortController>;
+	runSignal?: AbortSignal;
+	ready: ReadyDeferred;
+	unsubscribe?: () => void;
+	unregistered?: () => void;
 }
 
 const sessions = new Map<string, JsSession>();
+const sessionWaiters = new Map<string, Set<(error: Error) => void>>();
+let vmResourceCleanupRegistered = false;
+
+function ensureVmResourceCleanup(): void {
+	if (vmResourceCleanupRegistered) return;
+	vmResourceCleanupRegistered = true;
+	registerResourceOwner("js-vm-contexts", async () => {
+		try {
+			await disposeAllVmContexts();
+		} finally {
+			vmResourceCleanupRegistered = false;
+		}
+	});
+}
 const READY_TIMEOUT_MS_DEFAULT = 5_000;
+
+function getSessionWaiters(sessionKey: string): Set<(error: Error) => void> {
+	let waiters = sessionWaiters.get(sessionKey);
+	if (!waiters) {
+		waiters = new Set();
+		sessionWaiters.set(sessionKey, waiters);
+	}
+	return waiters;
+}
 
 export async function executeInVmContext(options: {
 	sessionKey: string;
 	sessionId: string;
 	cwd: string;
 	session: ToolSession;
+	ownerId?: string;
 	reset?: boolean;
 	code: string;
 	filename: string;
@@ -68,19 +113,44 @@ export async function executeInVmContext(options: {
 	if (options.reset) {
 		await resetVmContext(options.sessionKey);
 	}
-	const session = await acquireSession(
-		options.sessionKey,
-		{ cwd: options.cwd, sessionId: options.sessionId },
-		options.timeoutMs,
-	);
-	return await runQueued(session, () => runOnce(session, options));
+	const waiters = getSessionWaiters(options.sessionKey);
+	const { promise: contextResetPromise, reject: rejectContextReset } = Promise.withResolvers<never>();
+	contextResetPromise.catch(() => undefined);
+	waiters.add(rejectContextReset);
+	const runPromise = (async (): Promise<{ value: unknown }> => {
+		const session = await acquireSession(
+			options.sessionKey,
+			{ cwd: options.cwd, sessionId: options.sessionId },
+			options.ownerId,
+			options.timeoutMs,
+		);
+		return await runQueued(session, () => runOnce(session, options));
+	})();
+	try {
+		return await Promise.race([runPromise, contextResetPromise]);
+	} finally {
+		waiters.delete(rejectContextReset);
+	}
 }
 
 export async function resetVmContext(sessionKey: string): Promise<void> {
 	const session = sessions.get(sessionKey);
 	if (!session) return;
 	sessions.delete(sessionKey);
+	const waiters = sessionWaiters.get(sessionKey);
+	if (waiters) for (const reject of [...waiters]) reject(new ToolError("JS context reset"));
 	await killSession(session, new ToolError("JS context reset"));
+}
+
+export async function disposeVmContextsByOwner(ownerId: string): Promise<void> {
+	const owned = [...sessions.entries()].filter(
+		([sessionKey, session]) =>
+			session.ownerId === ownerId || sessionKey === ownerId || sessionKey === `js:${ownerId}`,
+	);
+	for (const [sessionKey, session] of owned) {
+		if (sessions.get(sessionKey) === session) sessions.delete(sessionKey);
+	}
+	await Promise.all(owned.map(([, session]) => killSession(session, new ToolError("JS context disposed"))));
 }
 
 export async function disposeAllVmContexts(): Promise<void> {
@@ -89,19 +159,38 @@ export async function disposeAllVmContexts(): Promise<void> {
 	await Promise.all(all.map(session => killSession(session, new ToolError("JS context disposed"))));
 }
 
+export function liveVmContextCount(): number {
+	return [...sessions.values()].filter(session => session.state !== "dead").length;
+}
+
 async function runQueued<T>(session: JsSession, work: () => Promise<T>): Promise<T> {
+	if (session.state !== "alive") throw new ToolError("JS worker is not alive");
 	const previous = session.queue;
-	const { promise, resolve } = Promise.withResolvers<void>();
-	session.queue = promise;
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const queueController = new AbortController();
+	const queueItem: QueueDeferred = { promise, resolve, reject };
+	const rejectWaiter = (error: Error): void => queueItem.reject(error);
+	session.queuedWaiters.add(rejectWaiter);
+	session.controllers.add(queueController);
+	session.queueTail = queueItem;
+	session.queue = (async () => {
+		await previous.catch(() => undefined);
+		await queueItem.promise;
+	})().catch(() => undefined);
 	try {
-		await previous;
-	} catch {
-		// Previous run's failure must not poison this one.
-	}
-	try {
-		return await work();
+		await Promise.race([previous.catch(() => undefined), queueItem.promise, abortPromise(queueController.signal)]);
+		if (session.runSignal?.aborted) throw reasonToError(session.runSignal.reason, "JS worker is not alive");
+		if (session.state !== "alive") throw new ToolError("JS worker is not alive");
+		session.queuedWaiters.delete(rejectWaiter);
+		return await Promise.race([
+			work(),
+			queueItem.promise.then(() => new Promise<never>(() => {})),
+			abortPromise(queueController.signal),
+		]);
 	} finally {
-		resolve();
+		session.queuedWaiters.delete(rejectWaiter);
+		session.controllers.delete(queueController);
+		queueItem.resolve();
 	}
 }
 
@@ -118,6 +207,7 @@ async function runOnce(
 ): Promise<{ value: unknown }> {
 	const runId = `r-${Snowflake.next()}`;
 	const { promise, resolve, reject } = Promise.withResolvers<{ value: unknown }>();
+	const sessionSignal = session.runSignal;
 	const pending: PendingRun = {
 		runId,
 		runState: options.runState,
@@ -145,13 +235,19 @@ async function runOnce(
 	}
 
 	try {
-		session.worker.send({
-			type: "run",
-			runId,
-			code: options.code,
-			filename: options.filename,
-			snapshot: { cwd: options.cwd, sessionId: options.sessionId },
-		});
+		if (sessionSignal?.aborted) throw reasonToError(sessionSignal.reason, "JS worker is not alive");
+		if (
+			!safeSend(session, {
+				type: "run",
+				runId,
+				code: options.code,
+				filename: options.filename,
+				snapshot: { cwd: options.cwd, sessionId: options.sessionId },
+			})
+		) {
+			settleRunWithError(session, pending, new ToolError("JS worker send failed"));
+			return await promise;
+		}
 		return await promise;
 	} finally {
 		options.runState.signal?.removeEventListener("abort", onAbort);
@@ -159,46 +255,76 @@ async function runOnce(
 	}
 }
 
-async function acquireSession(sessionKey: string, snapshot: SessionSnapshot, timeoutMs?: number): Promise<JsSession> {
+async function acquireSession(
+	sessionKey: string,
+	snapshot: SessionSnapshot,
+	ownerId: string | undefined,
+	timeoutMs?: number,
+): Promise<JsSession> {
+	ensureVmResourceCleanup();
 	const existing = sessions.get(sessionKey);
-	if (existing && existing.state === "alive") return existing;
+	if (existing && existing.state !== "dead") return await existing.ready.promise;
 
-	const worker = await spawnJsWorker();
+	const { promise: ready, resolve: resolveSession, reject: rejectSession } = Promise.withResolvers<JsSession>();
+	ready.catch(() => undefined);
 	const session: JsSession = {
 		sessionKey,
-		worker,
-		state: "alive",
+		state: "starting",
+		ownerId,
 		pending: new Map(),
 		queue: Promise.resolve(),
+		queuedWaiters: new Set(),
+		queueTail: settledQueueDeferred(),
+		controllers: new Set(),
+		ready: { promise: ready, resolve: resolveSession, reject: rejectSession },
 	};
-	const { promise: readyPromise, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
-	let resolved = false;
-	const unsubscribe = worker.onMessage(msg => {
-		if (!resolved && msg.type === "ready") {
-			resolved = true;
-			resolveReady();
-			return;
-		}
-		if (!resolved && msg.type === "init-failed") {
-			resolved = true;
-			rejectReady(errorFromPayload(msg.error));
-			return;
-		}
-		handleSessionMessage(session, msg);
-	});
+	sessions.set(sessionKey, session);
+
+	let worker: WorkerHandle | undefined;
 	try {
-		// Cold-start can exceed 5s on slow hosts. Let the caller's per-cell timeout dominate so
-		// users can grant more headroom when they raise `timeout` on a cell.
+		worker = await spawnJsWorker();
+		const current = sessions.get(sessionKey);
+		if (current !== session) {
+			await worker.terminate().catch(() => undefined);
+			return (
+				(await current?.ready.promise) ?? Promise.reject(new ToolError("JS context replaced during initialization"))
+			);
+		}
+		session.worker = worker;
+		const { promise: readyPromise, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
+		let resolved = false;
+		session.unsubscribe = worker.onMessage(msg => {
+			if (!resolved && msg.type === "ready") {
+				resolved = true;
+				resolveReady();
+				return;
+			}
+			if (!resolved && msg.type === "init-failed") {
+				resolved = true;
+				rejectReady(errorFromPayload(msg.error));
+				return;
+			}
+			handleSessionMessage(session, msg);
+		});
 		const readyTimeoutMs = Math.max(READY_TIMEOUT_MS_DEFAULT, timeoutMs ?? 0);
 		await raceWithTimeout(readyPromise, readyTimeoutMs, "Timed out initializing JS eval worker");
+		if (sessions.get(sessionKey) !== session) {
+			await killSession(session, new ToolError("JS context replaced during initialization"));
+			return (
+				(await sessions.get(sessionKey)?.ready.promise) ??
+				Promise.reject(new ToolError("JS context replaced during initialization"))
+			);
+		}
+		worker.send({ type: "init", snapshot });
+		session.state = "alive";
+		session.ready.resolve(session);
+		return session;
 	} catch (error) {
-		unsubscribe();
-		await worker.terminate().catch(() => undefined);
+		if (sessions.get(sessionKey) === session) sessions.delete(sessionKey);
+		await killSession(session, error instanceof Error ? error : new Error(String(error)));
+		session.ready.reject(error instanceof Error ? error : new Error(String(error)));
 		throw error;
 	}
-	worker.send({ type: "init", snapshot });
-	sessions.set(sessionKey, session);
-	return session;
 }
 
 function handleSessionMessage(session: JsSession, msg: WorkerOutbound): void {
@@ -276,22 +402,54 @@ async function killSessionFor(session: JsSession, error: Error): Promise<void> {
 async function killSession(session: JsSession, error: Error): Promise<void> {
 	if (session.state === "dead") return;
 	session.state = "dead";
-	for (const pending of session.pending.values()) {
-		if (pending.settled) continue;
-		pending.settled = true;
-		for (const ctrl of pending.toolCalls.values()) ctrl.abort(error);
-		pending.reject(error);
-	}
+	const unsubscribe = session.unsubscribe;
+	session.unsubscribe = undefined;
+	unsubscribe?.();
+	session.ready.reject(error);
+	session.queueTail.reject(error);
+	for (const controller of [...session.controllers]) controller.abort(error);
+	session.controllers.clear();
+	session.runSignal = AbortSignal.abort(error);
+	for (const reject of [...session.queuedWaiters]) reject(error);
+	session.queuedWaiters.clear();
+	for (const pending of [...session.pending.values()]) settleRunWithError(session, pending, error);
 	session.pending.clear();
-	await session.worker.terminate().catch(() => undefined);
+	void session.worker?.terminate().catch(() => undefined);
 }
 
-function safeSend(session: JsSession, msg: WorkerInbound): void {
-	if (session.state !== "alive") return;
+function settleRunWithError(session: JsSession, pending: PendingRun, error: Error): void {
+	if (pending.settled) return;
+	pending.settled = true;
+	for (const ctrl of pending.toolCalls.values()) ctrl.abort(error);
+	pending.toolCalls.clear();
+	session.pending.delete(pending.runId);
+	pending.reject(error);
+}
+
+function settledQueueDeferred(): QueueDeferred {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	resolve();
+	return { promise, resolve, reject };
+}
+
+function abortPromise(signal: AbortSignal): Promise<never> {
+	if (signal.aborted) return Promise.reject(reasonToError(signal.reason, "JS worker is not alive"));
+	const { promise, reject } = Promise.withResolvers<never>();
+	const onAbort = (): void => reject(reasonToError(signal.reason, "JS worker is not alive"));
+	signal.addEventListener("abort", onAbort, { once: true });
+	promise.finally(() => signal.removeEventListener("abort", onAbort)).catch(() => undefined);
+	return promise;
+}
+
+function safeSend(session: JsSession, msg: WorkerInbound): boolean {
+	if (session.state !== "alive") return false;
 	try {
-		session.worker.send(msg);
+		session.worker?.send(msg);
+		return true;
 	} catch (err) {
 		logger.debug("js worker send failed", { error: err instanceof Error ? err.message : String(err) });
+		void killSessionFor(session, err instanceof Error ? err : new Error(String(err)));
+		return false;
 	}
 }
 
@@ -352,10 +510,15 @@ async function spawnJsWorker(): Promise<WorkerHandle> {
 			: new Worker(new URL("./worker-entry.ts", import.meta.url).href, { type: "module" });
 		return wrapBunWorker(worker);
 	} catch (err) {
-		logger.warn("Bun Worker spawn failed; using inline JS eval worker (no sync-loop guard)", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-		return spawnInlineWorker();
+		if (process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER === "1") {
+			logger.warn("Bun Worker spawn failed; using test-only inline JS eval worker", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return spawnInlineWorker();
+		}
+		throw new ToolError(
+			`JS eval worker is unavailable and inline fallback is disabled because it cannot interrupt synchronous user code: ${err instanceof Error ? err.message : String(err)}`,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -10,6 +10,7 @@ export interface JsExecutorOptions {
 	onChunk?: (chunk: string) => Promise<void> | void;
 	signal?: AbortSignal;
 	sessionId: string;
+	ownerId?: string;
 	reset?: boolean;
 	sessionFile?: string;
 	artifactPath?: string;
@@ -68,6 +69,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 		await executeInVmContext({
 			sessionKey: options.sessionId,
 			sessionId: options.sessionId,
+			ownerId: options.ownerId,
 			cwd: options.cwd ?? options.session.cwd,
 			session: options.session,
 			reset: options.reset,

--- a/packages/coding-agent/src/eval/js/index.ts
+++ b/packages/coding-agent/src/eval/js/index.ts
@@ -23,6 +23,7 @@ export default {
 			deadlineMs: opts.deadlineMs,
 			signal: opts.signal,
 			sessionId: namespaceSessionId(opts.sessionId),
+			ownerId: opts.kernelOwnerId,
 			sessionFile: opts.sessionFile,
 			reset: opts.reset,
 			artifactPath: opts.artifactPath,

--- a/packages/coding-agent/src/eval/js/worker-core.ts
+++ b/packages/coding-agent/src/eval/js/worker-core.ts
@@ -12,6 +12,11 @@ interface ActiveRun {
 	pendingTools: Map<string, PendingTool>;
 }
 
+function rejectPendingTools(active: ActiveRun, error: Error): void {
+	for (const pending of active.pendingTools.values()) pending.reject(error);
+	active.pendingTools.clear();
+}
+
 function errorPayload(error: unknown): RunErrorPayload {
 	if (error instanceof Error) {
 		return {
@@ -99,7 +104,8 @@ export class WorkerCore {
 	async #runOne(runId: string, code: string, filename: string, snapshot: SessionSnapshot): Promise<void> {
 		const runtime = this.#ensureRuntime(snapshot);
 		runtime.setCwd(snapshot.cwd);
-		this.#active = { runId, pendingTools: new Map() };
+		const active: ActiveRun = { runId, pendingTools: new Map() };
+		this.#active = active;
 		try {
 			const value = await runtime.run(code, filename);
 			runtime.displayValue(value);
@@ -107,7 +113,8 @@ export class WorkerCore {
 		} catch (error) {
 			this.#transport.send({ type: "result", runId, ok: false, error: errorPayload(error) });
 		} finally {
-			this.#active = null;
+			rejectPendingTools(active, new ToolError("JS run ended"));
+			if (this.#active === active) this.#active = null;
 		}
 	}
 
@@ -132,10 +139,7 @@ export class WorkerCore {
 	#close(): void {
 		const active = this.#active;
 		if (active) {
-			for (const pending of active.pendingTools.values()) {
-				pending.reject(new ToolError("JS worker closed"));
-			}
-			active.pendingTools.clear();
+			rejectPendingTools(active, new ToolError("JS worker closed"));
 		}
 		this.#active = null;
 		this.#runtime = null;

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -108,7 +108,18 @@ interface PythonSession {
 	queue: Promise<void>;
 }
 
-const sessions = new Map<string, PythonSession>();
+interface InitializingPythonSession {
+	sessionId: string;
+	promise: Promise<PythonSession>;
+}
+
+const sessions = new Map<string, PythonSession | InitializingPythonSession>();
+
+function isInitializingSession(
+	session: PythonSession | InitializingPythonSession,
+): session is InitializingPythonSession {
+	return "promise" in session;
+}
 
 // ---------------------------------------------------------------------------
 // Cancellation plumbing
@@ -288,20 +299,48 @@ function attachOwner(session: PythonSession, sessionId: string, ownerId: string 
 async function acquireSession(sessionId: string, cwd: string, options: PythonExecutorOptions): Promise<PythonSession> {
 	const existing = sessions.get(sessionId);
 	if (existing) {
-		attachOwner(existing, sessionId, options.kernelOwnerId);
-		return existing;
+		const session = isInitializingSession(existing)
+			? await waitForPromiseWithCancellation(existing.promise, options)
+			: existing;
+		attachOwner(session, sessionId, options.kernelOwnerId);
+		return session;
 	}
-	const kernel = await startKernel(cwd, options);
-	const session: PythonSession = {
+
+	const initializing: InitializingPythonSession = {
 		sessionId,
-		kernel,
-		ownerIds: new Set(),
-		hasFallbackOwner: false,
-		queue: Promise.resolve(),
+		promise: Promise.resolve().then(async () => {
+			const kernel = await startKernel(cwd, options);
+			const current = sessions.get(sessionId);
+			if (current !== initializing) {
+				await kernel.shutdown().catch(() => undefined);
+				const winner = current
+					? isInitializingSession(current)
+						? await waitForPromiseWithCancellation(current.promise, options)
+						: current
+					: undefined;
+				if (winner) return winner;
+				throw new PythonExecutionCancelledError(false);
+			}
+			const session: PythonSession = {
+				sessionId,
+				kernel,
+				ownerIds: new Set(),
+				hasFallbackOwner: false,
+				queue: Promise.resolve(),
+			};
+			sessions.set(sessionId, session);
+			return session;
+		}),
 	};
-	attachOwner(session, sessionId, options.kernelOwnerId);
-	sessions.set(sessionId, session);
-	return session;
+	sessions.set(sessionId, initializing);
+	try {
+		const session = await waitForPromiseWithCancellation(initializing.promise, options);
+		attachOwner(session, sessionId, options.kernelOwnerId);
+		return session;
+	} catch (err) {
+		if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
+		throw err;
+	}
 }
 
 async function replaceSessionKernel(
@@ -330,7 +369,8 @@ async function resetSession(sessionId: string): Promise<void> {
 	const existing = sessions.get(sessionId);
 	if (!existing) return;
 	sessions.delete(sessionId);
-	await existing.kernel.shutdown().catch(() => undefined);
+	const session = isInitializingSession(existing) ? await existing.promise.catch(() => undefined) : existing;
+	await session?.kernel.shutdown().catch(() => undefined);
 }
 
 async function runQueued<T>(
@@ -363,11 +403,20 @@ export async function disposeAllKernelSessions(): Promise<void> {
 	for (const [id, session] of all) {
 		if (sessions.get(id) === session) sessions.delete(id);
 	}
-	const results = await Promise.allSettled(all.map(([, session]) => session.kernel.shutdown()));
-	for (let i = 0; i < all.length; i += 1) {
-		const [id, session] = all[i];
+	const resolved = await Promise.all(
+		all.map(
+			async ([id, entry]) =>
+				[id, isInitializingSession(entry) ? await entry.promise.catch(() => undefined) : entry] as const,
+		),
+	);
+	const shutdownTargets = resolved.filter(
+		(entry): entry is readonly [string, PythonSession] => entry[1] !== undefined,
+	);
+	const results = await Promise.allSettled(shutdownTargets.map(([, session]) => session.kernel.shutdown()));
+	for (let i = 0; i < shutdownTargets.length; i += 1) {
+		const [id, session] = shutdownTargets[i];
 		const result = results[i];
-		if (result.status === "fulfilled" && result.value?.confirmed !== false) continue;
+		if (result.status === "fulfilled" && result.value.confirmed) continue;
 		const reason = result.status === "rejected" ? result.reason : "not confirmed";
 		logger.warn("Python kernel shutdown not confirmed", { sessionId: id, reason });
 		if (!sessions.has(id)) sessions.set(id, session);
@@ -377,7 +426,7 @@ export async function disposeAllKernelSessions(): Promise<void> {
 export async function disposeKernelSessionsByOwner(ownerId: string): Promise<void> {
 	const toShutdown: PythonSession[] = [];
 	for (const session of [...sessions.values()]) {
-		if (!session.ownerIds.has(ownerId)) continue;
+		if (isInitializingSession(session) || !session.ownerIds.has(ownerId)) continue;
 		if (session.ownerIds.size === 1) {
 			toShutdown.push(session);
 			continue;
@@ -391,7 +440,7 @@ export async function disposeKernelSessionsByOwner(ownerId: string): Promise<voi
 	for (let i = 0; i < toShutdown.length; i += 1) {
 		const session = toShutdown[i];
 		const result = results[i];
-		if (result.status === "fulfilled" && result.value?.confirmed !== false) {
+		if (result.status === "fulfilled" && result.value.confirmed) {
 			session.ownerIds.delete(ownerId);
 			continue;
 		}

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -3,8 +3,9 @@
  *
  * Speaks NDJSON with `runner.py` over stdin/stdout. One subprocess per kernel
  * instance; sessions reuse a single subprocess across executions. Cancellation
- * is `kill("SIGINT")` which raises a real `KeyboardInterrupt` inside user
- * code. Shutdown writes `{"type":"exit"}` and escalates to SIGTERM/SIGKILL on
+ * sends SIGINT to the runner process group, which raises a real
+ * `KeyboardInterrupt` inside user code and any foreground magic subprocess.
+ * Shutdown writes `{"type":"exit"}` and escalates to SIGTERM/SIGKILL on
  * timeout.
  */
 import * as fs from "node:fs";
@@ -173,6 +174,7 @@ interface PendingExecution {
 	kernelKilled: boolean;
 	settled: boolean;
 	escalationTimer?: NodeJS.Timeout;
+	finalize?: () => void;
 }
 
 export class PythonKernel {
@@ -227,6 +229,9 @@ export class PythonKernel {
 			stdout: "pipe",
 			stderr: "pipe",
 			windowsHide: true,
+			// Run as its own session/process-group leader so SIGINT/SIGTERM can be
+			// delivered to the whole runner tree (incl. foreground magic subprocesses).
+			detached: true,
 		});
 		kernel.#proc = proc;
 		kernel.#stdin = proc.stdin;
@@ -377,10 +382,30 @@ export class PythonKernel {
 
 	async interrupt(): Promise<void> {
 		if (!this.#proc || this.#disposed) return;
+		this.#signalProcessGroup("SIGINT");
+	}
+
+	#signalProcessGroup(signal: NodeJS.Signals): void {
+		const proc = this.#proc;
+		if (!proc) return;
 		try {
-			this.#proc.kill("SIGINT");
+			if (process.platform !== "win32") {
+				process.kill(-proc.pid, signal);
+				return;
+			}
 		} catch (err) {
-			logger.warn("Failed to interrupt python runner", { error: err instanceof Error ? err.message : String(err) });
+			logger.warn("Failed to signal python runner process group", {
+				signal,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+		try {
+			proc.kill(signal);
+		} catch (err) {
+			logger.warn("Failed to signal python runner", {
+				signal,
+				error: err instanceof Error ? err.message : String(err),
+			});
 		}
 	}
 
@@ -412,24 +437,16 @@ export class PythonKernel {
 
 		const exited = this.#waitForExitWithTimeout(timeoutMs);
 		let result = await exited;
-		if (!result) {
-			try {
-				proc.kill("SIGTERM");
-			} catch {
-				/* ignore */
-			}
+		if (result === null) {
+			this.#signalProcessGroup("SIGTERM");
 			result = await this.#waitForExitWithTimeout(timeoutMs);
 		}
-		if (!result) {
-			try {
-				proc.kill("SIGKILL");
-			} catch {
-				/* ignore */
-			}
+		if (result === null) {
+			this.#signalProcessGroup("SIGKILL");
 			result = await this.#waitForExitWithTimeout(timeoutMs);
 		}
 
-		const confirmed = !!result;
+		const confirmed = result !== null;
 		this.#shutdownConfirmed = confirmed;
 		this.#disposed = true;
 		return { confirmed };
@@ -441,17 +458,21 @@ export class PythonKernel {
 		this.#pending.clear();
 		const kernelKilledDefault = options?.kernelKilled ?? false;
 		for (const entry of pending) {
+			entry.cancelled = true;
+			entry.status = "error";
+			entry.kernelKilled = entry.kernelKilled || kernelKilledDefault;
+			entry.finalize?.();
 			if (entry.settled) continue;
 			entry.settled = true;
 			void entry.options?.onChunk?.(`[kernel] ${reason}\n`);
 			entry.resolve({
-				status: "error",
-				cancelled: true,
+				status: entry.status,
+				cancelled: entry.cancelled,
 				timedOut: entry.timedOut,
 				stdinRequested: entry.stdinRequested,
 				executionCount: entry.executionCount,
 				error: entry.error,
-				kernelKilled: entry.kernelKilled || kernelKilledDefault,
+				kernelKilled: entry.kernelKilled,
 			});
 		}
 	}
@@ -655,11 +676,14 @@ export class PythonKernel {
 	#waitForExitWithTimeout(timeoutMs: number): Promise<number | null> {
 		if (!this.#exitedPromise) return Promise.resolve(0);
 		const exitedPromise = this.#exitedPromise;
-		const timeout = new Promise<null>(resolve => {
+		return new Promise(resolve => {
 			const timer = setTimeout(() => resolve(null), Math.max(0, timeoutMs));
 			timer.unref?.();
+			exitedPromise.then(code => {
+				clearTimeout(timer);
+				resolve(code);
+			});
 		});
-		return Promise.race([exitedPromise.then(code => code as number | null), timeout]);
 	}
 }
 

--- a/packages/coding-agent/src/eval/py/runner.py
+++ b/packages/coding-agent/src/eval/py/runner.py
@@ -290,6 +290,44 @@ def _emit_status(op: str, **data: Any) -> None:
     _emit({"type": "display", "id": rid, "bundle": bundle})
 
 
+def _terminate_process_group(proc: subprocess.Popen[Any]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+    except ProcessLookupError:
+        return
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except ProcessLookupError:
+        return
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=1)
+    except Exception:
+        pass
+
+
 @line_magic("pip")
 def _magic_pip(args: str) -> None:
     argv = shlex.split(args) if args else ["--help"]
@@ -300,18 +338,26 @@ def _magic_pip(args: str) -> None:
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        start_new_session=(os.name == "posix"),
     )
     installed_packages: list[str] = []
-    assert proc.stdout is not None
-    for raw_line in proc.stdout:
-        sys.stdout.write(raw_line)
-        m = re.search(r"Successfully installed\s+(.+)$", raw_line)
-        if m:
-            for token in m.group(1).split():
-                # Token is name-version; drop the version suffix.
-                pkg = token.rsplit("-", 1)[0]
-                installed_packages.append(pkg.replace("_", "-"))
-    proc.wait()
+    try:
+        assert proc.stdout is not None
+        try:
+            for raw_line in proc.stdout:
+                sys.stdout.write(raw_line)
+                m = re.search(r"Successfully installed\s+(.+)$", raw_line)
+                if m:
+                    for token in m.group(1).split():
+                        # Token is name-version; drop the version suffix.
+                        pkg = token.rsplit("-", 1)[0]
+                        installed_packages.append(pkg.replace("_", "-"))
+        finally:
+            proc.stdout.close()
+        proc.wait()
+    except KeyboardInterrupt:
+        _terminate_process_group(proc)
+        raise
     if installed_packages:
         import importlib
 
@@ -500,11 +546,19 @@ def _run_shell_body(body: str, *, shell_arg: str) -> int:
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        start_new_session=(os.name == "posix"),
     )
-    assert proc.stdout is not None
-    for raw_line in proc.stdout:
-        sys.stdout.write(raw_line)
-    proc.wait()
+    try:
+        assert proc.stdout is not None
+        try:
+            for raw_line in proc.stdout:
+                sys.stdout.write(raw_line)
+        finally:
+            proc.stdout.close()
+        proc.wait()
+    except KeyboardInterrupt:
+        _terminate_process_group(proc)
+        raise
     return proc.returncode
 
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -32,6 +32,8 @@ export interface BashExecutorOptions {
 	/** Artifact path/id for full output storage */
 	artifactPath?: string;
 	artifactId?: string;
+	/** Execute without retaining a native Shell in the persistent session registry. */
+	oneShot?: boolean;
 	/**
 	 * Invoked when the native minimizer rewrote the command's output, giving
 	 * the caller a chance to persist the lossless original capture (typically
@@ -59,6 +61,8 @@ export interface BashResult {
 
 const shellSessions = new Map<string, Shell>();
 const brokenShellSessions = new Set<string>();
+const retiringShellSessions = new Set<Shell>();
+const CANCEL_CLEANUP_WAIT_MS = 1_000;
 
 /** Number of persistent shell sessions currently retained (owner gauge). */
 export function getShellSessionCount(): number {
@@ -76,10 +80,14 @@ export async function disposeAllShellSessions(): Promise<void> {
 	// Snapshot and drop strong references up front so concurrent callers cannot
 	// reuse a session that is being torn down, then await every native abort so
 	// shutdown/signal cleanup does not return before resources are released.
-	const sessions = [...shellSessions.values()];
+	// Include retiring shells whose JS call returned after bounded abort cleanup
+	// while the native run is still unwinding; they are no longer reusable but
+	// remain owned until their run promise settles.
+	const sessions = new Set([...shellSessions.values(), ...retiringShellSessions]);
 	shellSessions.clear();
+	retiringShellSessions.clear();
 	brokenShellSessions.clear();
-	await Promise.allSettled(sessions.map(session => session.abort()));
+	await Promise.allSettled([...sessions].map(session => session.abort()));
 }
 
 postmortem.register("bash-executor:shell-sessions", () => disposeAllShellSessions());
@@ -151,14 +159,12 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		};
 	}
 
+	const usePersistentShell = options?.oneShot !== true;
 	const sessionKey = buildSessionKey(shell, prefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
-	const persistentSessionBroken = brokenShellSessions.has(sessionKey);
-	if (persistentSessionBroken) {
-		shellSessions.delete(sessionKey);
-	}
+	const persistentSessionBroken = usePersistentShell && brokenShellSessions.has(sessionKey);
 
-	let shellSession = persistentSessionBroken ? undefined : shellSessions.get(sessionKey);
-	if (!shellSession && !persistentSessionBroken) {
+	let shellSession = persistentSessionBroken || !usePersistentShell ? undefined : shellSessions.get(sessionKey);
+	if (!shellSession && !persistentSessionBroken && usePersistentShell) {
 		shellSession = new Shell({
 			sessionEnv: shellEnv,
 			snapshotPath: snapshotPath ?? undefined,
@@ -172,15 +178,28 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		if (!runAbortController.signal.aborted) {
 			runAbortController.abort();
 		}
-		if (shellSession) {
-			// Native abort is async; fire-and-forget because the caller races the command separately.
-			void shellSession.abort();
+		if (shellSession && !abortPromise) {
+			abortPromise = shellSession.abort();
 		}
 	};
 	const abortDeferred = Promise.withResolvers<"abort">();
+	let abortPromise: Promise<unknown> | undefined;
 	const abortHandler = () => {
 		abortCurrentExecution();
 		abortDeferred.resolve("abort");
+	};
+	const awaitAbortCleanup = async (runPromise: Promise<unknown>): Promise<boolean> => {
+		const settled = await Promise.race([
+			runPromise.then(
+				() => true,
+				() => true,
+			),
+			Bun.sleep(CANCEL_CLEANUP_WAIT_MS).then(() => false),
+		]);
+		if (abortPromise) {
+			await Promise.race([abortPromise.catch(() => undefined), Bun.sleep(CANCEL_CLEANUP_WAIT_MS)]);
+		}
+		return settled;
 	};
 	if (userSignal) {
 		userSignal.addEventListener("abort", abortHandler, { once: true });
@@ -198,6 +217,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	}
 
 	let resetSession = false;
+	let runSettled = false;
 
 	try {
 		const runPromise = shellSession
@@ -243,8 +263,24 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			acceptingChunks = false;
 			if (shellSession) {
 				resetSession = true;
+				retiringShellSessions.add(shellSession);
 				brokenShellSessions.add(sessionKey);
-				void runPromise.finally(() => brokenShellSessions.delete(sessionKey)).catch(() => undefined);
+				shellSessions.delete(sessionKey);
+				runSettled = await awaitAbortCleanup(runPromise);
+				if (runSettled) {
+					brokenShellSessions.delete(sessionKey);
+					retiringShellSessions.delete(shellSession);
+				} else {
+					void runPromise
+						.finally(() => {
+							brokenShellSessions.delete(sessionKey);
+							retiringShellSessions.delete(shellSession);
+							if (shellSessions.get(sessionKey) === shellSession) {
+								shellSessions.delete(sessionKey);
+							}
+						})
+						.catch(() => undefined);
+				}
 			} else {
 				void runPromise.catch(() => undefined);
 			}
@@ -337,7 +373,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		if (userSignal) {
 			userSignal.removeEventListener("abort", abortHandler);
 		}
-		if (resetSession) {
+		if (resetSession && runSettled && shellSessions.get(sessionKey) === shellSession) {
 			shellSessions.delete(sessionKey);
 		}
 	}

--- a/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 
 import { worktree } from "../utils/git";
 import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapter } from "./gc-runtime";
-import { GJC_TMUX_PROFILE_VALUE } from "./tmux-common";
+import { GJC_TMUX_PROFILE_VALUE, GJC_TMUX_SESSION_PREFIX } from "./tmux-common";
 import {
 	type GjcTmuxSessionStatus,
 	type GjcTmuxSessionsForGc,
@@ -19,6 +19,7 @@ import {
 
 const STORE = "tmux_sessions" as const;
 const TOCTOU_SKIP = "tmux_revalidation_failed_or_became_live";
+const ORPHAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function pathExists(path: string): boolean {
 	try {
@@ -65,39 +66,62 @@ async function hasLiveWorktreeForBranch(project: string, branch: string): Promis
 	return entries.some(entry => branchMatches(entry.branch, branch));
 }
 
+function isSessionLive(session: Pick<GjcTmuxSessionStatus, "attached" | "panePids">): boolean {
+	return session.attached || session.panePids.length > 0;
+}
+
+function liveRecord(session: GjcTmuxSessionStatus, reason: string): GcRecord {
+	return {
+		store: STORE,
+		id: session.name,
+		path: session.project,
+		root: session.project,
+		pid_status: "alive",
+		status: "live",
+		stale: false,
+		removable: false,
+		action: "none",
+		reason,
+		detail: detail(session.project, session.branch),
+	};
+}
+
+function staleRecord(session: GjcTmuxSessionStatus, reason: string): GcRecord {
+	return {
+		store: STORE,
+		id: session.name,
+		path: session.project,
+		root: session.project,
+		pid_status: "none",
+		status: "stale",
+		stale: true,
+		removable: true,
+		action: "none",
+		reason,
+		detail: `${detail(session.project, session.branch) ?? ""} createdAt=${session.createdAt}`.trim(),
+	};
+}
+
+function isOldEnoughForOrphanGc(session: GjcTmuxSessionStatus): boolean {
+	const createdAt = Date.parse(session.createdAt);
+	return Number.isFinite(createdAt) && Date.now() - createdAt >= ORPHAN_MAX_AGE_MS;
+}
+
+function isGjcOwnedOrphan(session: GjcTmuxSessionStatus): boolean {
+	return session.name.startsWith(GJC_TMUX_SESSION_PREFIX) || session.name === "gajae_code";
+}
+
 async function classifyTaggedSession(session: GjcTmuxSessionStatus): Promise<GcRecord> {
 	const { name, project, branch } = session;
-	if (!project || !branch) return unclassifiedRecord(name, "missing_project_or_branch_tag", project, branch);
-	if (!pathExists(project)) {
-		return {
-			store: STORE,
-			id: name,
-			path: project,
-			root: project,
-			pid_status: "none",
-			status: "stale",
-			stale: true,
-			removable: true,
-			action: "none",
-			reason: "project_missing",
-			detail: detail(project, branch),
-		};
+	if (isSessionLive(session)) return liveRecord(session, "tmux_session_attached_or_has_live_panes");
+	if (!project || !branch) {
+		if (isGjcOwnedOrphan(session) && isOldEnoughForOrphanGc(session)) {
+			return staleRecord(session, "metadata_less_gjc_owned_idle_orphan");
+		}
+		return unclassifiedRecord(name, "missing_project_or_branch_tag", project, branch);
 	}
-	if (!(await hasLiveWorktreeForBranch(project, branch))) {
-		return {
-			store: STORE,
-			id: name,
-			path: project,
-			root: project,
-			pid_status: "none",
-			status: "stale",
-			stale: true,
-			removable: true,
-			action: "none",
-			reason: "branch_no_worktree",
-			detail: detail(project, branch),
-		};
-	}
+	if (!pathExists(project)) return staleRecord(session, "project_missing");
+	if (!(await hasLiveWorktreeForBranch(project, branch))) return staleRecord(session, "branch_no_worktree");
 	return {
 		store: STORE,
 		id: name,
@@ -113,9 +137,34 @@ async function classifyTaggedSession(session: GjcTmuxSessionStatus): Promise<GcR
 	};
 }
 
-async function revalidateRemovable(name: string, env: NodeJS.ProcessEnv): Promise<boolean> {
-	const tags = readTmuxSessionTagsForGc(name, env);
-	if (tags.profile !== GJC_TMUX_PROFILE_VALUE || !tags.project || !tags.branch) return false;
+function classifyUntaggedSession(session: GjcTmuxSessionStatus): GcRecord {
+	return unclassifiedRecord(session.name, "untagged_tmux_session");
+}
+
+async function revalidateRemovable(record: GcRecord, env: NodeJS.ProcessEnv): Promise<boolean> {
+	const tags = readTmuxSessionTagsForGc(record.id, env);
+	if (
+		tags.createdAt &&
+		record.detail?.includes("createdAt=") &&
+		!record.detail.includes(`createdAt=${tags.createdAt}`)
+	) {
+		return false;
+	}
+	if (tags.attached || (tags.panePids?.length ?? 0) > 0) return false;
+	if (tags.profile !== GJC_TMUX_PROFILE_VALUE) return false;
+	if (!tags.project || !tags.branch)
+		return (
+			record.reason === "metadata_less_gjc_owned_idle_orphan" &&
+			isGjcOwnedOrphan({
+				name: record.id,
+				attached: false,
+				windows: 0,
+				panes: 0,
+				panePids: [],
+				bindings: "",
+				createdAt: tags.createdAt ?? "",
+			})
+		);
 	if (!pathExists(tags.project)) return true;
 	return !(await hasLiveWorktreeForBranch(tags.project, tags.branch));
 }
@@ -154,8 +203,8 @@ export const tmuxSessionsGcAdapter: GcStoreAdapter = {
 			}
 		}
 
-		for (const name of sessions.untagged) {
-			records.push(unclassifiedRecord(name, "untagged_tmux_session"));
+		for (const session of sessions.untagged) {
+			records.push(classifyUntaggedSession(session));
 		}
 
 		return { records, errors };
@@ -165,7 +214,7 @@ export const tmuxSessionsGcAdapter: GcStoreAdapter = {
 			return { removed: false, skipped: "not_removable_tmux_session" };
 		}
 		try {
-			if (!(await revalidateRemovable(record.id, ctx.env))) {
+			if (!(await revalidateRemovable(record, ctx.env))) {
 				return { removed: false, skipped: TOCTOU_SKIP };
 			}
 			removeGjcTmuxSession(record.id, ctx.env);

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -22,17 +22,23 @@ export interface GjcTmuxSessionStatus {
 	branch?: string;
 	branchSlug?: string;
 	project?: string;
+	panePids: number[];
+	profile?: string;
 }
 
 export interface GjcTmuxSessionTagsForGc {
 	profile?: string;
 	project?: string;
 	branch?: string;
+	branchSlug?: string;
+	createdAt?: string;
+	attached?: boolean;
+	panePids?: number[];
 }
 
 export interface GjcTmuxSessionsForGc {
 	tagged: GjcTmuxSessionStatus[];
-	untagged: string[];
+	untagged: GjcTmuxSessionStatus[];
 }
 
 function runTmux(args: string[], env: NodeJS.ProcessEnv = process.env): string {
@@ -68,21 +74,27 @@ function parseSessionLine(line: string): GjcTmuxSessionStatus | null {
 		profile = "",
 		bindings = "",
 		panes = "0",
+		panePids = "",
 		branch = "",
 		branchSlug = "",
 		project = "",
 	] = line.split("\t");
-	if (!name || profile !== GJC_TMUX_PROFILE_VALUE) return null;
+	if (!name) return null;
 	return {
 		name,
 		attached: parseBooleanFlag(attached),
 		windows: parseNumber(windows),
 		panes: parseNumber(panes),
+		panePids: panePids
+			.split(",")
+			.map(pid => parseNumber(pid))
+			.filter(pid => pid > 0),
 		bindings,
 		createdAt: normalizeTmuxCreatedAt(created),
 		branch: branch || undefined,
 		branchSlug: branchSlug || undefined,
 		project: project || undefined,
+		profile: profile || undefined,
 	};
 }
 
@@ -103,7 +115,7 @@ function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): 
 
 function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
 	return runListSessions(
-		`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
+		`#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{${GJC_TMUX_PROFILE_OPTION}}\t#{session_key_table}\t#{session_panes}\t#{pane_pid}\t#{${GJC_TMUX_BRANCH_OPTION}}\t#{${GJC_TMUX_BRANCH_SLUG_OPTION}}\t#{${GJC_TMUX_PROJECT_OPTION}}`,
 		env,
 	);
 }
@@ -115,17 +127,35 @@ function listRawTmuxSessionNames(env: NodeJS.ProcessEnv = process.env): string[]
 export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus[] {
 	return listSessionLines(env)
 		.map(parseSessionLine)
-		.filter((session): session is GjcTmuxSessionStatus => session != null)
+		.filter((session): session is GjcTmuxSessionStatus => session?.profile === GJC_TMUX_PROFILE_VALUE)
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** @internal */
 export function listTmuxSessionsForGc(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionsForGc {
-	const tagged = listGjcTmuxSessions(env);
+	const sessions = listSessionLines(env)
+		.map(parseSessionLine)
+		.filter((session): session is GjcTmuxSessionStatus => session != null);
+	const tagged = sessions
+		.filter(session => session.profile === GJC_TMUX_PROFILE_VALUE)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	const taggedNames = new Set(tagged.map(session => session.name));
+	const byName = new Map(sessions.map(session => [session.name, session]));
 	const untagged = listRawTmuxSessionNames(env)
 		.filter(name => !taggedNames.has(name))
-		.sort((a, b) => a.localeCompare(b));
+		.map(
+			name =>
+				byName.get(name) ?? {
+					name,
+					attached: false,
+					windows: 0,
+					panes: 0,
+					panePids: [],
+					bindings: "",
+					createdAt: "",
+				},
+		)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	return { tagged, untagged };
 }
 
@@ -192,15 +222,23 @@ export function readTmuxSessionTagsForGc(
 	sessionName: string,
 	env: NodeJS.ProcessEnv = process.env,
 ): GjcTmuxSessionTagsForGc {
+	const session = listGjcTmuxSessions(env).find(candidate => candidate.name === sessionName);
 	return {
 		profile: readExactOptionForGc(sessionName, GJC_TMUX_PROFILE_OPTION, env),
 		project: readExactOptionForGc(sessionName, GJC_TMUX_PROJECT_OPTION, env),
 		branch: readExactOptionForGc(sessionName, GJC_TMUX_BRANCH_OPTION, env),
+		branchSlug: readExactOptionForGc(sessionName, GJC_TMUX_BRANCH_SLUG_OPTION, env),
+		createdAt: session?.createdAt,
+		attached: session?.attached,
+		panePids: session?.panePids,
 	};
 }
 
 export function removeGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {
 	const session = statusGjcTmuxSession(sessionName, env);
+	if (session.attached || session.panePids.length > 0) {
+		throw new Error(`gjc_tmux_session_live:${sessionName}`);
+	}
 	if (readProfileForExactTarget(session.name, env) !== GJC_TMUX_PROFILE_VALUE) {
 		throw new Error(`gjc_tmux_session_not_managed:${sessionName}`);
 	}

--- a/packages/coding-agent/src/internal-urls/artifact-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/artifact-protocol.ts
@@ -63,7 +63,16 @@ export class ArtifactProtocolHandler implements ProtocolHandler {
 			throw new Error(`artifact://${id} not found`);
 		}
 
-		const content = await Bun.file(foundPath).text();
+		// F20: cap the materialized artifact so reading a huge spilled artifact cannot
+		// buffer GBs into memory (the range selector is applied downstream, so without a
+		// cap a `artifact://id:range` over a multi-GB artifact still reads it whole).
+		const MAX_ARTIFACT_READ_BYTES = 16 * 1024 * 1024;
+		const file = Bun.file(foundPath);
+		const fullSize = file.size;
+		const content =
+			fullSize > MAX_ARTIFACT_READ_BYTES
+				? `${await file.slice(0, MAX_ARTIFACT_READ_BYTES).text()}\n\n[Artifact truncated: first ${MAX_ARTIFACT_READ_BYTES} of ${fullSize} bytes shown; use a narrower range or a specialized tool for the full content.]`
+				: await file.text();
 		return {
 			url: url.href,
 			content,

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,5 +1,6 @@
-import { isEnoent, logger, ptree, untilAborted } from "@gajae-code/utils";
+import { isEnoent, logger, untilAborted } from "@gajae-code/utils";
 import { formatCrashDiagnosticNotice, writeCrashReport } from "../debug/crash-diagnostics";
+import { registerResourceOwner, spawnOwnedProcess } from "../runtime/process-lifecycle";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
@@ -19,8 +20,10 @@ import { detectLanguageId, fileToUri } from "./utils";
 // =============================================================================
 
 const clients = new Map<string, LspClient>();
+const killedClients = new WeakSet<LspClient>();
 const clientLocks = new Map<string, Promise<LspClient>>();
 const fileOperationLocks = new Map<string, Promise<void>>();
+const lspCleanupOwner = registerResourceOwner("lsp:clients", shutdownAll);
 
 // Idle timeout configuration (disabled by default)
 let idleTimeoutMs: number | null = null;
@@ -65,6 +68,32 @@ export function isIdleCheckerActiveForTests(): boolean {
 	return idleCheckInterval !== null;
 }
 
+function rejectPendingRequests(client: LspClient, error: Error): void {
+	for (const pending of client.pendingRequests.values()) {
+		pending.reject(error);
+	}
+	client.pendingRequests.clear();
+}
+
+function deleteCachedClient(key: string, client: LspClient): void {
+	if (clients.get(key) === client) {
+		clients.delete(key);
+	}
+}
+
+function deleteClientLock(key: string, clientPromise: Promise<LspClient>): void {
+	if (clientLocks.get(key) === clientPromise) {
+		clientLocks.delete(key);
+	}
+}
+
+function evictDeadCachedClient(key: string, client: LspClient): void {
+	if (client.proc.exitCode === null && !client.proc.killed && !client.owner?.disposed && !killedClients.has(client))
+		return;
+	deleteCachedClient(key, client);
+	client.resolveProjectLoaded();
+	rejectPendingRequests(client, new Error("LSP server exited"));
+}
 // =============================================================================
 // Client Capabilities
 // =============================================================================
@@ -432,8 +461,11 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 	// Check if client already exists
 	const existingClient = clients.get(key);
 	if (existingClient) {
-		existingClient.lastActivity = Date.now();
-		return existingClient;
+		evictDeadCachedClient(key, existingClient);
+		if (clients.has(key)) {
+			existingClient.lastActivity = Date.now();
+			return existingClient;
+		}
 	}
 
 	// Check if another coroutine is already creating this client
@@ -443,7 +475,8 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 	}
 
 	// Create new client with lock
-	const clientPromise = (async () => {
+	let clientPromise!: Promise<LspClient>;
+	clientPromise = (async () => {
 		const baseCommand = config.resolvedCommand ?? config.command;
 		const baseArgs = config.args ?? [];
 
@@ -452,11 +485,13 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			? await getLspmuxCommand(baseCommand, baseArgs)
 			: { command: baseCommand, args: baseArgs };
 
-		const proc = ptree.spawn([command, ...args], {
+		const owner = spawnOwnedProcess([command, ...args], {
 			cwd,
 			stdin: "pipe",
 			env: env ? { ...Bun.env, ...env } : undefined,
+			name: `lsp:${config.command}`,
 		});
+		const proc = owner.child;
 
 		let resolveProjectLoaded!: () => void;
 		const projectLoaded = new Promise<void>(resolve => {
@@ -474,6 +509,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			name: key,
 			cwd,
 			proc,
+			owner,
 			config,
 			requestId: 0,
 			diagnostics: new Map(),
@@ -488,12 +524,17 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			projectLoaded,
 			resolveProjectLoaded,
 		};
+		const originalKill = proc.kill.bind(proc);
+		proc.kill = (...args: Parameters<typeof proc.kill>) => {
+			killedClients.add(client);
+			return originalKill(...args);
+		};
 		clients.set(key, client);
 
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(async () => {
-			clients.delete(key);
-			clientLocks.delete(key);
+			deleteCachedClient(key, client);
+			deleteClientLock(key, clientPromise);
 			client.resolveProjectLoaded();
 
 			// Reject any pending requests — the server is gone, they will never complete.
@@ -564,12 +605,12 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			return client;
 		} catch (err) {
 			// Clean up on initialization failure
-			clients.delete(key);
-			clientLocks.delete(key);
-			proc.kill();
+			deleteCachedClient(key, client);
+			deleteClientLock(key, clientPromise);
+			await shutdownClientInstance(client);
 			throw err;
 		} finally {
-			clientLocks.delete(key);
+			deleteClientLock(key, clientPromise);
 		}
 	})();
 
@@ -645,12 +686,7 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
  */
 export async function waitForProjectLoaded(client: LspClient, signal?: AbortSignal): Promise<void> {
 	if (signal?.aborted) return;
-	await Promise.race([
-		client.projectLoaded,
-		...(signal
-			? [new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }))]
-			: []),
-	]);
+	await untilAborted(signal, client.projectLoaded);
 }
 
 /**
@@ -793,16 +829,12 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
  */
 async function shutdownClientInstance(client: LspClient): Promise<void> {
 	const err = new Error("LSP client shutdown");
-	for (const pending of Array.from(client.pendingRequests.values())) {
-		pending.reject(err);
-	}
-	client.pendingRequests.clear();
+	rejectPendingRequests(client, err);
 
-	const timeout = Bun.sleep(5_000);
-	const shutdown = sendRequest(client, "shutdown", null).catch(() => {});
-	await Promise.race([shutdown, timeout]);
-	client.proc.kill();
-	await Promise.race([client.proc.exited.catch(() => {}), Bun.sleep(1_000)]);
+	const shutdown = sendRequest(client, "shutdown", null, undefined, 5_000).catch(() => {});
+	await Promise.race([shutdown, Bun.sleep(5_000)]);
+	await client.owner?.dispose();
+	await client.owner?.awaitExit({ timeoutMs: 1_000 });
 }
 
 export async function shutdownClient(key: string): Promise<void> {
@@ -958,6 +990,12 @@ export function getActiveClients(): LspServerStatus[] {
 if (typeof process !== "undefined") {
 	process.on("beforeExit", () => {
 		void shutdownAll();
+	});
+	process.on("exit", () => {
+		lspCleanupOwner();
+		for (const client of clients.values()) {
+			client.proc.kill();
+		}
 	});
 	process.on("SIGINT", () => {
 		void (async () => {

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -19,6 +19,7 @@ import {
 	sendNotification,
 	sendRequest,
 	setIdleTimeout,
+	shutdownClient,
 	syncContent,
 	WARMUP_TIMEOUT_MS,
 	waitForProjectLoaded,
@@ -400,7 +401,7 @@ async function reloadServer(client: LspClient, serverName: string, signal?: Abor
 		}
 	}
 	if (output.startsWith("Restarted")) {
-		client.proc.kill();
+		await shutdownClient(client.name);
 	}
 	return output;
 }

--- a/packages/coding-agent/src/lsp/lspmux.ts
+++ b/packages/coding-agent/src/lsp/lspmux.ts
@@ -2,6 +2,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { $flag, $which, logger } from "@gajae-code/utils";
 import { TOML } from "bun";
+import { spawnOwnedProcess } from "../runtime/process-lifecycle";
 
 /**
  * lspmux integration for LSP server multiplexing.
@@ -101,19 +102,24 @@ async function parseConfig(): Promise<LspmuxConfig | null> {
  */
 async function checkServerRunning(binaryPath: string): Promise<boolean> {
 	try {
-		const proc = Bun.spawn([binaryPath, "status"], {
-			stdout: "pipe",
-			stderr: "pipe",
-			windowsHide: true,
+		const owner = spawnOwnedProcess([binaryPath, "status"], {
+			stdin: "ignore",
+			name: "lspmux:status",
 		});
+		const proc = owner.child;
+		drainStream(proc.stdout);
+		drainStream(proc.stderr);
 
-		const exited = await Promise.race([
-			proc.exited,
-			new Promise<null>(resolve => setTimeout(() => resolve(null), LIVENESS_TIMEOUT_MS)),
-		]);
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<null>(resolve => {
+			timer = setTimeout(() => resolve(null), LIVENESS_TIMEOUT_MS);
+		});
+		const exited = await Promise.race([proc.exited, timeout]);
+		if (timer) clearTimeout(timer);
 
 		if (exited === null) {
-			proc.kill();
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 1_000 });
 			return false;
 		}
 
@@ -121,6 +127,24 @@ async function checkServerRunning(binaryPath: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): void {
+	if (!stream) return;
+	void (async () => {
+		try {
+			const reader = stream.getReader();
+			try {
+				while (!(await reader.read()).done) {
+					// drain only
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		} catch {
+			// Process stream closed or already consumed.
+		}
+	})();
 }
 
 /**

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -1,5 +1,6 @@
 import type { ptree } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import type { OwnedProcess } from "../runtime/process-lifecycle";
 
 // =============================================================================
 // Tool Schema
@@ -399,6 +400,7 @@ export interface LspClient {
 	cwd: string;
 	config: ServerConfig;
 	proc: ptree.ChildProcess<"pipe">;
+	owner?: OwnedProcess;
 	requestId: number;
 	diagnostics: Map<string, PublishedDiagnostics>;
 	diagnosticsVersion: number;

--- a/packages/coding-agent/src/modes/bridge/bridge-mode.ts
+++ b/packages/coding-agent/src/modes/bridge/bridge-mode.ts
@@ -166,6 +166,25 @@ function parseBridgeScopes(value: string | undefined): readonly BridgeCommandSco
 	return [...scopes];
 }
 
+// Opt-in endpoint enablement via GJC_BRIDGE_ENDPOINTS (default undefined -> fail closed, backward compatible).
+// Accepts "all" or a comma list of matrix keys.
+export function parseBridgeEndpoints(value: string | undefined): Partial<BridgeEndpointMatrix> | undefined {
+	if (!value?.trim()) return undefined;
+	const allowed = new Set<string>(Object.keys(FAIL_CLOSED_BRIDGE_ENDPOINTS));
+	const matrix: Partial<BridgeEndpointMatrix> = {};
+	if (value.trim().toLowerCase() === "all") {
+		for (const key of allowed) matrix[key as keyof BridgeEndpointMatrix] = true;
+		return matrix;
+	}
+	for (const raw of value.split(",")) {
+		const key = raw.trim();
+		if (!key) continue;
+		if (!allowed.has(key)) throw new Error(`Invalid GJC_BRIDGE_ENDPOINTS entry: ${key}`);
+		matrix[key as keyof BridgeEndpointMatrix] = true;
+	}
+	return matrix;
+}
+
 function hasScope(scopes: readonly BridgeCommandScope[] | undefined, scope: BridgeCommandScope): boolean {
 	return new Set(scopes ?? DEFAULT_BRIDGE_SCOPES).has(scope);
 }
@@ -521,6 +540,7 @@ export async function runBridgeMode(
 		throw new Error(`Invalid GJC_BRIDGE_PORT: ${Bun.env.GJC_BRIDGE_PORT}`);
 	}
 	const commandScopes = parseBridgeScopes(Bun.env.GJC_BRIDGE_SCOPES);
+	const endpointMatrix = parseBridgeEndpoints(Bun.env.GJC_BRIDGE_ENDPOINTS);
 
 	const certPath = Bun.env.GJC_BRIDGE_TLS_CERT;
 	const keyPath = Bun.env.GJC_BRIDGE_TLS_KEY;
@@ -626,6 +646,7 @@ export async function runBridgeMode(
 			hostToolBridge,
 			hostUriBridge,
 			commandScopes,
+			endpointMatrix,
 			unattendedControlPlane,
 			commandDispatcher: command =>
 				dispatchRpcCommand(command, {

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -111,8 +111,16 @@ export class AssistantMessageComponent extends Container {
 		const cached = this.#contentBlocksCache.get(content);
 		if (cached?.source === content.text) return cached.component;
 		const trimmed = content.text.trim();
-		const component =
-			renderDeepInterviewAssistantText(trimmed, theme) ?? new Markdown(trimmed, 1, 0, getMarkdownTheme());
+		const deepInterview = renderDeepInterviewAssistantText(trimmed, theme);
+		// Reuse the same Markdown instance across streaming chunks (update text in place)
+		// instead of constructing a new one each chunk; combined with the markdown
+		// per-code-block highlight cache, appends no longer re-highlight the whole prefix.
+		if (!deepInterview && cached && cached.component instanceof Markdown) {
+			cached.component.setText(trimmed);
+			cached.source = content.text;
+			return cached.component;
+		}
+		const component = deepInterview ?? new Markdown(trimmed, 1, 0, getMarkdownTheme());
 		this.#contentBlocksCache.set(content, { source: content.text, component });
 		return component;
 	}

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -155,7 +155,11 @@ export class BashExecutionComponent extends Container {
 		const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
 
 		// Rebuild content container
-		this.#contentContainer.clear();
+		// Detach (not dispose): #headerText and the running #loader are persistent,
+		// reused instances re-added below. A disposing clear() would stop the loader's
+		// animation timer mid-run. Final teardown still stops the loader via the
+		// component's recursive dispose().
+		this.#contentContainer.detachAll();
 
 		// Command header
 		this.#contentContainer.addChild(this.#headerText);

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -114,7 +114,11 @@ export class EvalExecutionComponent extends Container {
 		const previewLogicalLines = availableLines.slice(-PREVIEW_LINES);
 		const hiddenLineCount = availableLines.length - previewLogicalLines.length;
 
-		this.#contentContainer.clear();
+		// Detach (not dispose): #headerText and the running #loader are persistent,
+		// reused instances re-added below. A disposing clear() would stop the loader's
+		// animation timer mid-run. Final teardown still stops the loader via the
+		// component's recursive dispose().
+		this.#contentContainer.detachAll();
 
 		this.#contentContainer.addChild(this.#headerText);
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -210,6 +210,9 @@ export class ModelSelectorComponent extends Container {
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
+	#currentModel?: Model;
+	#isFastForProvider: (provider?: string) => boolean = () => false;
+	#isFastForSubagentProvider: (provider?: string) => boolean = () => false;
 	#pendingActionItem?: ModelItem | CanonicalModelItem;
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
@@ -239,7 +242,13 @@ export class ModelSelectorComponent extends Container {
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string; sessionId?: string },
+		options?: {
+			temporaryOnly?: boolean;
+			initialSearchInput?: string;
+			sessionId?: string;
+			isFastForProvider?: (provider?: string) => boolean;
+			isFastForSubagentProvider?: (provider?: string) => boolean;
+		},
 	) {
 		super();
 
@@ -251,6 +260,9 @@ export class ModelSelectorComponent extends Container {
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		this.#authSessionId = options?.sessionId;
+		this.#currentModel = _currentModel;
+		this.#isFastForProvider = options?.isFastForProvider ?? (() => false);
+		this.#isFastForSubagentProvider = options?.isFastForSubagentProvider ?? (() => false);
 		const initialSearchInput = options?.initialSearchInput;
 		this.#viewMode = this.#temporaryOnly || initialSearchInput || scopedModels.length > 0 ? "models" : "presets";
 
@@ -928,14 +940,34 @@ export class ModelSelectorComponent extends Container {
 
 			// Build role badges (inverted: color as background, black text)
 			const roleBadgeTokens: string[] = [];
+			let roleMatched = false;
 			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 				const assigned = this.#roles[role];
 				if (roleInfo.tag && assigned && modelsAreEqual(assigned.model, item.model)) {
+					roleMatched = true;
 					const badge = makeInvertedBadge(roleInfo.tag, roleInfo.color ?? "muted");
 					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
-					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
+					// Subagent roles (task.agentModelOverrides) run under task.serviceTier, so
+					// their ⚡ must reflect the effective subagent tier, not the main session tier.
+					const roleFast =
+						roleInfo.settingsPath === "task.agentModelOverrides"
+							? this.#isFastForSubagentProvider(assigned.model.provider)
+							: this.#isFastForProvider(assigned.model.provider);
+					const fastSuffix = roleFast ? ` ${theme.icon.fast}` : "";
+					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}${fastSuffix}`);
 				}
+			}
+			// Active/current non-role row: show the fast glyph on the session's current
+			// model row even when it carries no role badge. Skip when a role token for
+			// this row already rendered the glyph (duplicate-glyph guard).
+			if (
+				!roleMatched &&
+				this.#currentModel !== undefined &&
+				modelsAreEqual(this.#currentModel, item.model) &&
+				this.#isFastForProvider(item.model.provider)
+			) {
+				roleBadgeTokens.push(theme.icon.fast);
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -65,6 +65,11 @@ export class OAuthSelectorComponent extends Container {
 		this.#validationGeneration += 1;
 		this.#stopSpinner();
 	}
+
+	dispose(): void {
+		this.stopValidation();
+		super.dispose();
+	}
 	#loadProviders(): void {
 		this.#allProviders = getOAuthProviders();
 	}

--- a/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
@@ -131,6 +131,11 @@ export class MCPAddWizard extends Container {
 		| null = null;
 	#onTestConnectionCallback: ((config: MCPServerConfig) => Promise<void>) | null = null;
 	#onRenderCallback: (() => void) | null = null;
+	#disposed = false;
+	#transitionTimers = new Set<NodeJS.Timeout>();
+	#healthCheckSpinner?: NodeJS.Timeout;
+	#healthCheckTimeout?: NodeJS.Timeout;
+	#asyncGeneration = 0;
 
 	constructor(
 		onComplete: (name: string, config: MCPServerConfig, scope: Scope) => void,
@@ -176,6 +181,39 @@ export class MCPAddWizard extends Container {
 
 		// Render first step
 		this.#renderStep();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#asyncGeneration += 1;
+		for (const timer of this.#transitionTimers) {
+			clearTimeout(timer);
+		}
+		this.#transitionTimers.clear();
+		this.#clearHealthCheckTimers();
+		super.dispose();
+	}
+
+	#scheduleTransition(callback: () => void, delay: number): void {
+		if (this.#disposed) return;
+		const timer = setTimeout(() => {
+			this.#transitionTimers.delete(timer);
+			if (this.#disposed) return;
+			callback();
+		}, delay);
+		this.#transitionTimers.add(timer);
+	}
+
+	#clearHealthCheckTimers(): void {
+		if (this.#healthCheckSpinner) {
+			clearInterval(this.#healthCheckSpinner);
+			this.#healthCheckSpinner = undefined;
+		}
+		if (this.#healthCheckTimeout) {
+			clearTimeout(this.#healthCheckTimeout);
+			this.#healthCheckTimeout = undefined;
+		}
 	}
 
 	#requestRender(): void {
@@ -941,6 +979,8 @@ export class MCPAddWizard extends Container {
 	 * Test connection and automatically detect if auth is needed.
 	 */
 	async #testConnectionAndDetectAuth(): Promise<void> {
+		if (this.#disposed) return;
+		const generation = ++this.#asyncGeneration;
 		const testConfig = this.#buildServerConfig();
 
 		if (!this.#onTestConnectionCallback) {
@@ -954,6 +994,7 @@ export class MCPAddWizard extends Container {
 		try {
 			// Try to connect - timeout is handled by the transport layer (5 seconds)
 			await this.#onTestConnectionCallback(testConfig);
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 			// Success! No auth required
 			this.#contentContainer.clear();
@@ -962,7 +1003,7 @@ export class MCPAddWizard extends Container {
 			this.#contentContainer.addChild(new Text("No authentication required", 0, 0));
 			this.#contentContainer.addChild(new Spacer(1));
 
-			setTimeout(() => {
+			this.#scheduleTransition(() => {
 				this.#state.authMethod = "none";
 				this.#currentStep = "scope";
 				this.#selectedIndex = 0;
@@ -978,10 +1019,12 @@ export class MCPAddWizard extends Container {
 				if (!oauth && this.#state.transport !== "stdio" && this.#state.url) {
 					try {
 						oauth = await discoverOAuthEndpoints(this.#state.url, authResult.authServerUrl);
+						if (this.#disposed || generation !== this.#asyncGeneration) return;
 					} catch {
 						// Ignore discovery failures and fallback to manual auth.
 					}
 				}
+				if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 				if (oauth) {
 					this.#state.oauthAuthUrl = oauth.authorizationUrl;
@@ -1019,7 +1062,7 @@ export class MCPAddWizard extends Container {
 				this.#contentContainer.addChild(new Spacer(1));
 				this.#contentContainer.addChild(new Text(theme.fg("muted", "Adding server anyway..."), 0, 0));
 
-				setTimeout(() => {
+				this.#scheduleTransition(() => {
 					this.#state.authMethod = "none";
 					this.#currentStep = "scope";
 					this.#selectedIndex = 0;
@@ -1107,6 +1150,8 @@ export class MCPAddWizard extends Container {
 	}
 
 	async #launchOAuthFlow(): Promise<void> {
+		if (this.#disposed) return;
+		const generation = ++this.#asyncGeneration;
 		if (!this.#onOAuthCallback) {
 			this.#contentContainer.clear();
 			this.#contentContainer.addChild(new Text(theme.fg("error", "OAuth flow not available"), 0, 0));
@@ -1150,6 +1195,7 @@ export class MCPAddWizard extends Container {
 				this.#state.oauthClientSecret,
 				this.#state.oauthScopes,
 			);
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
 			// Store credential ID + any dynamically-registered client credentials,
 			// so the final mcp.json entry persists everything needed for refresh.
@@ -1168,7 +1214,8 @@ export class MCPAddWizard extends Container {
 			this.#contentContainer.addChild(healthText);
 
 			let spinnerIndex = 0;
-			const spinner = setInterval(() => {
+			this.#healthCheckSpinner = setInterval(() => {
+				if (this.#disposed || generation !== this.#asyncGeneration) return;
 				healthText.setText(
 					theme.fg("muted", `${spinnerFrames[spinnerIndex % spinnerFrames.length]} Checking server connection...`),
 				);
@@ -1181,7 +1228,7 @@ export class MCPAddWizard extends Container {
 			if (this.#onTestConnectionCallback) {
 				try {
 					const { promise: timeoutPromise, reject: timeoutReject } = Promise.withResolvers<never>();
-					const timer = setTimeout(
+					this.#healthCheckTimeout = setTimeout(
 						() => timeoutReject(new Error("Health check timed out after 10 seconds")),
 						10_000,
 					);
@@ -1191,15 +1238,19 @@ export class MCPAddWizard extends Container {
 							timeoutPromise,
 						]);
 					} finally {
-						clearTimeout(timer);
+						if (this.#healthCheckTimeout) {
+							clearTimeout(this.#healthCheckTimeout);
+							this.#healthCheckTimeout = undefined;
+						}
 					}
 				} catch (error) {
 					healthPassed = false;
 					healthError = sanitize(error instanceof Error ? error.message : String(error));
 				}
 			}
+			if (this.#disposed || generation !== this.#asyncGeneration) return;
 
-			clearInterval(spinner);
+			this.#clearHealthCheckTimers();
 			if (healthPassed) {
 				healthText.setText(theme.fg("success", "✓ Health check passed"));
 			} else {
@@ -1210,7 +1261,7 @@ export class MCPAddWizard extends Container {
 			this.#requestRender();
 
 			// Move to scope selection after short delay
-			setTimeout(
+			this.#scheduleTransition(
 				() => {
 					this.#currentStep = "scope";
 					this.#selectedIndex = 0;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -375,6 +375,7 @@ export class ToolExecutionComponent extends Container {
 				this.#renderState.spinnerFrame = this.#spinnerFrame;
 				this.#ui.requestRender();
 			}, 80);
+			this.#spinnerInterval?.unref?.();
 		} else if (!needsSpinner && this.#spinnerInterval) {
 			clearInterval(this.#spinnerInterval);
 			this.#spinnerInterval = undefined;
@@ -392,6 +393,11 @@ export class ToolExecutionComponent extends Container {
 		}
 		this.#editDiffAbort?.abort();
 		this.#editDiffAbort = undefined;
+	}
+
+	override dispose(): void {
+		this.stopAnimation();
+		super.dispose();
 	}
 
 	setExpanded(expanded: boolean): void {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -36,8 +36,19 @@ export class ExtensionUiController {
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
 	#hookSelectorMouseReportingEnabled = false;
+	#activeHookCustomComponent?: Component & { dispose?(): void };
+	#activeHookCustomOverlay?: OverlayHandle;
 
 	constructor(private ctx: InteractiveModeContext) {}
+
+	#clearActiveHookCustom(): void {
+		const component = this.#activeHookCustomComponent;
+		const overlay = this.#activeHookCustomOverlay;
+		this.#activeHookCustomComponent = undefined;
+		this.#activeHookCustomOverlay = undefined;
+		component?.dispose?.();
+		overlay?.hide();
+	}
 
 	/**
 	 * Initialize the hook system with TUI-based UI context.
@@ -301,7 +312,11 @@ export class ExtensionUiController {
 		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
-		container.clear();
+		// Detach (not dispose): hook widgets are persistent instances owned by the
+		// #hookWidgets* maps and re-added on every rebuild. Disposal happens only on
+		// explicit removal (#removeHookWidget) or clearHookWidgets(), so a rebuild must
+		// not tear down a still-live widget (e.g. an extension CancellableLoader timer).
+		container.detachAll();
 
 		if (widgets.size === 0) {
 			if (spacerWhenEmpty) {
@@ -665,6 +680,9 @@ export class ExtensionUiController {
 					: undefined,
 			},
 		);
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookSelector);
 		this.ctx.ui.setFocus(this.ctx.hookSelector);
@@ -743,6 +761,9 @@ export class ExtensionUiController {
 				tui: this.ctx.ui,
 			},
 		);
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookInput);
 		this.ctx.ui.setFocus(this.ctx.hookInput);
@@ -791,6 +812,9 @@ export class ExtensionUiController {
 			editorOptions,
 		);
 
+		// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+		// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+		this.ctx.editorContainer.detachChild(this.ctx.editor);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.hookEditor);
 		this.ctx.ui.setFocus(this.ctx.hookEditor);
@@ -840,15 +864,12 @@ export class ExtensionUiController {
 
 		const { promise, resolve } = Promise.withResolvers<T>();
 		let component: (Component & { dispose?(): void }) | undefined;
-		let overlayHandle: OverlayHandle | undefined;
 		let closed = false;
 
 		const close = (result: T) => {
 			if (closed) return;
 			closed = true;
-			component?.dispose?.();
-			overlayHandle?.hide();
-			overlayHandle = undefined;
+			this.#clearActiveHookCustom();
 			if (!options?.overlay) {
 				this.ctx.editorContainer.clear();
 				this.ctx.editorContainer.addChild(this.ctx.editor);
@@ -859,14 +880,16 @@ export class ExtensionUiController {
 			resolve(result);
 		};
 
+		this.#clearActiveHookCustom();
 		Promise.try(() => factory(this.ctx.ui, theme, keybindings, close)).then(c => {
 			if (closed) {
 				c.dispose?.();
 				return;
 			}
 			component = c;
+			this.#activeHookCustomComponent = c;
 			if (options?.overlay) {
-				overlayHandle = this.ctx.ui.showOverlay(component, {
+				this.#activeHookCustomOverlay = this.ctx.ui.showOverlay(component, {
 					anchor: "bottom-center",
 					width: "100%",
 					maxHeight: "100%",
@@ -874,6 +897,9 @@ export class ExtensionUiController {
 				});
 				return;
 			}
+			// Detach (not dispose) the reusable editor before mounting the transient hook UI, so the
+			// disposing clear() only tears down a prior transient — the editor is re-added intact on close.
+			this.ctx.editorContainer.detachChild(this.ctx.editor);
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(component);
 			this.ctx.ui.setFocus(component);
@@ -895,6 +921,7 @@ export class ExtensionUiController {
 	}
 
 	clearHookWidgets(): void {
+		this.#clearActiveHookCustom();
 		for (const widget of this.#hookWidgetsAbove.values()) {
 			widget.dispose?.();
 		}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -887,6 +887,11 @@ export class InputController {
 		this.ctx.session.agent.hideThinkingSummary = this.ctx.hideThinkingBlock;
 
 		// Rebuild chat from session messages
+		// Detach the live streaming component before the disposing clear() so the
+		// component we re-add below is not torn down (detach != dispose).
+		if (this.ctx.streamingComponent) {
+			this.ctx.chatContainer.detachChild(this.ctx.streamingComponent);
+		}
 		this.ctx.chatContainer.clear();
 		this.ctx.rebuildChatFromMessages();
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -684,7 +684,12 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				{ ...options, sessionId: this.ctx.session.sessionId },
+				{
+					...options,
+					sessionId: this.ctx.session.sessionId,
+					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
+					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -706,13 +706,16 @@ export class UiHelpers {
 
 	/** Move pending bash components from pending area to chat */
 	flushPendingBashComponents(): void {
+		// Move (detach, not dispose) the live execution components from the pending
+		// area into the chat transcript — they are reused instances, so a disposing
+		// removeChild() would tear them down before re-adding.
 		for (const component of this.ctx.pendingBashComponents) {
-			this.ctx.pendingMessagesContainer.removeChild(component);
+			this.ctx.pendingMessagesContainer.detachChild(component);
 			this.ctx.chatContainer.addChild(component);
 		}
 		this.ctx.pendingBashComponents = [];
 		for (const component of this.ctx.pendingPythonComponents) {
-			this.ctx.pendingMessagesContainer.removeChild(component);
+			this.ctx.pendingMessagesContainer.detachChild(component);
 			this.ctx.chatContainer.addChild(component);
 		}
 		this.ctx.pendingPythonComponents = [];

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -74,8 +74,20 @@ function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	return tracked;
 }
 
-function delay(ms: number): Promise<void> {
-	return Bun.sleep(ms);
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (!signal) return Bun.sleep(ms);
+	if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Aborted"));
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal.reason ?? new Error("Aborted"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
 }
 
 /**
@@ -166,10 +178,26 @@ export class MCPManager {
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
 	#disconnectEpochs = new Map<string, number>();
+	#reconnectBackoffs = new Map<string, AbortController>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
+
+	#isCurrentConnection(
+		name: string,
+		_config: MCPServerConfig,
+		globalEpoch: number,
+		disconnectEpoch: number,
+		connection: MCPServerConnection,
+	): boolean {
+		return (
+			this.#serverConfigs.has(name) &&
+			this.#epoch === globalEpoch &&
+			(this.#disconnectEpochs.get(name) ?? 0) === disconnectEpoch &&
+			this.#connections.get(name) === connection
+		);
+	}
 
 	constructor(
 		private cwd: string,
@@ -305,6 +333,8 @@ export class MCPManager {
 			tracked: TrackedPromise<ToolLoadResult>;
 			toolsPromise: Promise<ToolLoadResult>;
 			connectionAbort: AbortController;
+			connectionEpoch: number;
+			disconnectEpoch: number;
 		};
 
 		const errors = new Map<string, string>();
@@ -312,6 +342,7 @@ export class MCPManager {
 		const allTools: CustomTool<TSchema, MCPToolDetails>[] = [];
 		const reportedErrors = new Set<string>();
 		let allowBackgroundLogging = false;
+		let shouldPublishToolSnapshot = true;
 
 		// Prepare connection tasks
 		const connectionTasks: ConnectionTask[] = [];
@@ -352,6 +383,7 @@ export class MCPManager {
 			this.#serverConfigs.set(name, config);
 
 			const connectionEpoch = this.#epoch;
+			const disconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 			const connectionAbort = new AbortController();
 			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
@@ -375,7 +407,10 @@ export class MCPManager {
 						connection._source = sources[name];
 					}
 					const stillPending = this.#pendingConnections.get(name) === connectionPromise;
-					const stillCurrent = this.#epoch === connectionEpoch && this.#serverConfigs.get(name) === config;
+					const stillCurrent =
+						this.#epoch === connectionEpoch &&
+						(this.#disconnectEpochs.get(name) ?? 0) === disconnectEpoch &&
+						this.#serverConfigs.get(name) === config;
 					if (stillPending) {
 						this.#pendingConnections.delete(name);
 						this.#pendingConnectionControllers.delete(name);
@@ -419,24 +454,45 @@ export class MCPManager {
 			this.#pendingConnections.set(name, connectionPromise);
 
 			const toolsPromise = connectionPromise.then(async connection => {
-				const serverTools = await listTools(connection);
+				let serverTools: Awaited<ReturnType<typeof listTools>>;
+				try {
+					serverTools = await listTools(connection);
+				} catch (error) {
+					connection.transport.onClose = undefined;
+					if (this.#connections.get(name) === connection) this.#connections.delete(name);
+					void connection.transport.close().catch(() => {});
+					throw error;
+				}
+				if (!this.#isCurrentConnection(name, config, connectionEpoch, disconnectEpoch, connection)) {
+					connection.transport.onClose = undefined;
+					await connection.transport.close().catch(() => {});
+					throw new Error(`Server "${name}" was disconnected during tool loading`);
+				}
 				return { connection, serverTools };
 			});
 			this.#pendingToolLoads.set(name, toolsPromise);
 
 			const tracked = trackPromise(toolsPromise);
-			connectionTasks.push({ name, config, tracked, toolsPromise, connectionAbort });
+			connectionTasks.push({
+				name,
+				config,
+				tracked,
+				toolsPromise,
+				connectionAbort,
+				connectionEpoch,
+				disconnectEpoch,
+			});
 
 			void toolsPromise
 				.then(async ({ connection, serverTools }) => {
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
+					if (!this.#isCurrentConnection(name, config, connectionEpoch, disconnectEpoch, connection)) return;
 					this.#pendingToolLoads.delete(name);
 					const reconnect = () => this.reconnectServer(name);
 					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 					this.#replaceServerTools(name, customTools);
 					this.#onToolsChanged?.(this.#tools);
 					void this.toolCache?.set(name, config, serverTools);
-
 					await this.#loadServerResourcesAndPrompts(name, connection);
 				})
 				.catch(error => {
@@ -498,6 +554,13 @@ export class MCPManager {
 					const value = task.tracked.value;
 					if (!value) continue;
 					const { connection, serverTools } = value;
+					if (this.#pendingToolLoads.has(name) && this.#pendingToolLoads.get(name) !== task.toolsPromise) continue;
+					if (
+						!this.#isCurrentConnection(name, task.config, task.connectionEpoch, task.disconnectEpoch, connection)
+					) {
+						shouldPublishToolSnapshot = false;
+						continue;
+					}
 					connectedServers.add(name);
 					const reconnect = () => this.reconnectServer(name);
 					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect));
@@ -506,6 +569,9 @@ export class MCPManager {
 						task.tracked.reason instanceof Error ? task.tracked.reason.message : String(task.tracked.reason);
 					errors.set(name, message);
 					reportedErrors.add(name);
+					if ((this.#disconnectEpochs.get(name) ?? 0) !== task.disconnectEpoch) {
+						shouldPublishToolSnapshot = false;
+					}
 				} else {
 					const cached = cachedTools.get(name);
 					if (cached) {
@@ -524,7 +590,7 @@ export class MCPManager {
 		sortMCPToolsByName(allTools);
 
 		// Update cached tools
-		this.#tools = allTools;
+		if (shouldPublishToolSnapshot) this.#tools = allTools;
 		allowBackgroundLogging = true;
 
 		return {
@@ -692,6 +758,8 @@ export class MCPManager {
 		this.#disconnectEpochs.set(name, nextEpoch);
 		this.#pendingConnectionControllers.get(name)?.abort(new Error(`MCP server disconnected: ${name}`));
 		this.#pendingConnectionControllers.delete(name);
+		this.#reconnectBackoffs.get(name)?.abort(new Error(`MCP server disconnected: ${name}`));
+		this.#reconnectBackoffs.delete(name);
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
@@ -742,6 +810,10 @@ export class MCPManager {
 		this.#pendingConnectionControllers.clear();
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();
+		for (const controller of this.#reconnectBackoffs.values()) {
+			controller.abort(new Error("MCP manager disconnected"));
+		}
+		this.#reconnectBackoffs.clear();
 		this.#pendingReconnections.clear();
 		this.#pendingResourceRefresh.clear();
 		this.#sources.clear();
@@ -764,7 +836,9 @@ export class MCPManager {
 
 		const attempt = this.#doReconnect(name);
 		this.#pendingReconnections.set(name, attempt);
-		return attempt.finally(() => this.#pendingReconnections.delete(name));
+		return attempt.finally(() => {
+			if (this.#pendingReconnections.get(name) === attempt) this.#pendingReconnections.delete(name);
+		});
 	}
 
 	async #doReconnect(name: string): Promise<MCPServerConnection | null> {
@@ -777,59 +851,72 @@ export class MCPManager {
 
 		// Close the old transport without removing tools or notifying consumers.
 		// Tools stay available (stale) while we establish the new connection.
-		// Fire-and-forget: don't await the close — HttpTransport.close() sends a
-		// DELETE with config.timeout (30s default), and blocking here delays the
-		// reconnect loop by that amount on every server restart.
-		const reconnectEpoch = this.#epoch;
+		const reconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 		if (oldConnection) {
 			// Detach onClose to prevent re-entrant reconnect from the close itself
 			oldConnection.transport.onClose = undefined;
-			void oldConnection.transport.close().catch(() => {});
+			const closePromise = oldConnection.transport.close().catch(() => {});
+			if (oldConnection.transport.closeBeforeReconnect) {
+				await closePromise;
+			} else {
+				// Fire-and-forget: don't await HTTP/SSE close — HttpTransport.close()
+				// sends a DELETE with config.timeout (30s default), and blocking here
+				// delays the reconnect loop by that amount on every server restart.
+				void closePromise;
+			}
 			this.#connections.delete(name);
 		}
 		this.#pendingConnections.delete(name);
+		const backoffAbort = new AbortController();
+		this.#reconnectBackoffs.set(name, backoffAbort);
 		this.#pendingToolLoads.delete(name);
 
-		// Retry with backoff — the server may still be starting up.
-		const delays = [500, 1000, 2000, 4000];
-		for (let attempt = 0; attempt <= delays.length; attempt++) {
-			if (this.#epoch !== reconnectEpoch) {
-				logger.debug("MCP reconnect aborted before attempt after configuration changed", {
-					path: `mcp:${name}`,
-					storedEpoch: reconnectEpoch,
-					currentEpoch: this.#epoch,
-				});
-				return null;
-			}
-			try {
-				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
-				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
-				return connection;
-			} catch (error) {
-				if (this.#epoch !== reconnectEpoch) {
-					logger.debug("MCP reconnect aborted after configuration changed", {
+		try {
+			// Retry with backoff — the server may still be starting up.
+			const delays = [500, 1000, 2000, 4000];
+			for (let attempt = 0; attempt <= delays.length; attempt++) {
+				if ((this.#disconnectEpochs.get(name) ?? 0) !== reconnectEpoch || backoffAbort.signal.aborted) {
+					logger.debug("MCP reconnect aborted before attempt after server disconnected", {
 						path: `mcp:${name}`,
 						storedEpoch: reconnectEpoch,
-						currentEpoch: this.#epoch,
+						currentEpoch: this.#disconnectEpochs.get(name) ?? 0,
 					});
 					return null;
 				}
+				try {
+					const connection = await this.#connectAndWireServer(name, config, source, this.#epoch, reconnectEpoch);
+					logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
+					return connection;
+				} catch (error) {
+					if ((this.#disconnectEpochs.get(name) ?? 0) !== reconnectEpoch || backoffAbort.signal.aborted) {
+						logger.debug("MCP reconnect aborted after server disconnected", {
+							path: `mcp:${name}`,
+							storedEpoch: reconnectEpoch,
+							currentEpoch: this.#disconnectEpochs.get(name) ?? 0,
+						});
+						return null;
+					}
 
-				const msg = error instanceof Error ? error.message : String(error);
-				if (attempt < delays.length) {
-					logger.debug("MCP reconnect attempt failed, retrying", {
-						path: `mcp:${name}`,
-						attempt: attempt + 1,
-						error: msg,
-					});
-					await Bun.sleep(delays[attempt]);
-				} else {
-					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
-					// Don't remove stale tools — keep them in the registry so they
-					// remain selected. Calls will fail with MCP errors, which
-					// triggers the tool-level reconnect, or the user can run
-					// /mcp reconnect <name> manually.
+					const msg = error instanceof Error ? error.message : String(error);
+					if (attempt < delays.length) {
+						logger.debug("MCP reconnect attempt failed, retrying", {
+							path: `mcp:${name}`,
+							attempt: attempt + 1,
+							error: msg,
+						});
+						await delay(delays[attempt], backoffAbort.signal).catch(() => undefined);
+					} else {
+						logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
+						// Don't remove stale tools — keep them in the registry so they
+						// remain selected. Calls will fail with MCP errors, which
+						// triggers the tool-level reconnect, or the user can run
+						// /mcp reconnect <name> manually.
+					}
 				}
+			}
+		} finally {
+			if (this.#reconnectBackoffs.get(name) === backoffAbort) {
+				this.#reconnectBackoffs.delete(name);
 			}
 		}
 		return null;
@@ -840,7 +927,8 @@ export class MCPManager {
 		name: string,
 		config: MCPServerConfig,
 		source: SourceMeta | undefined,
-		reconnectEpoch: number,
+		globalEpoch: number,
+		disconnectEpoch: number,
 	): Promise<MCPServerConnection> {
 		const resolvedConfig = await this.#resolveAuthConfig(config);
 		const connectionAbort = new AbortController();
@@ -867,7 +955,11 @@ export class MCPManager {
 
 		// Bail out if the server was disconnected or the manager was reset
 		// while we were connecting (e.g. /mcp reload called disconnectAll).
-		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
+		if (
+			!this.#serverConfigs.has(name) ||
+			this.#epoch !== globalEpoch ||
+			(this.#disconnectEpochs.get(name) ?? 0) !== disconnectEpoch
+		) {
 			await connection.transport.close().catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
@@ -890,6 +982,11 @@ export class MCPManager {
 		};
 		try {
 			const serverTools = await listTools(connection);
+			if (!this.#isCurrentConnection(name, config, globalEpoch, disconnectEpoch, connection)) {
+				connection.transport.onClose = undefined;
+				await connection.transport.close().catch(() => {});
+				throw new Error(`Server "${name}" was disconnected during tool loading`);
+			}
 			const reconnect = () => this.reconnectServer(name);
 			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 			void this.toolCache?.set(name, config, serverTools);
@@ -901,7 +998,7 @@ export class MCPManager {
 			// Clean up the connection to avoid zombie transports
 			connection.transport.onClose = undefined;
 			await connection.transport.close().catch(() => {});
-			this.#connections.delete(name);
+			if (this.#connections.get(name) === connection) this.#connections.delete(name);
 			throw error;
 		}
 	}
@@ -941,12 +1038,15 @@ export class MCPManager {
 	async refreshServerTools(name: string): Promise<void> {
 		const connection = this.#connections.get(name);
 		if (!connection) return;
+		const globalEpoch = this.#epoch;
+		const disconnectEpoch = this.#disconnectEpochs.get(name) ?? 0;
 
 		// Clear cached tools
 		connection.tools = undefined;
 
 		// Reload tools
 		const serverTools = await listTools(connection);
+		if (!this.#isCurrentConnection(name, connection.config, globalEpoch, disconnectEpoch, connection)) return;
 		const reconnect = () => this.reconnectServer(name);
 		const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
 		void this.toolCache?.set(name, connection.config, serverTools);

--- a/packages/coding-agent/src/runtime-mcp/transports/http.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/http.ts
@@ -99,6 +99,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {
+			await response.body?.cancel().catch(() => {});
 			this.#sseConnection = this.#sseConnection === sseConnection ? null : this.#sseConnection;
 			return;
 		}
@@ -209,8 +210,6 @@ export class HttpTransport implements MCPTransport {
 				signal: operationSignal,
 			});
 
-			clearTimeout(timeoutId);
-
 			// Check for session ID in response
 			const newSessionId = response.headers.get("Mcp-Session-Id");
 			if (newSessionId) {
@@ -247,7 +246,6 @@ export class HttpTransport implements MCPTransport {
 
 			return result.result as T;
 		} catch (error) {
-			clearTimeout(timeoutId);
 			if (error instanceof Error && error.name === "AbortError") {
 				if (options?.signal?.aborted) {
 					throw error;
@@ -255,6 +253,8 @@ export class HttpTransport implements MCPTransport {
 				throw new Error(`Request timeout after ${timeout}ms`);
 			}
 			throw error;
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	}
 
@@ -273,12 +273,12 @@ export class HttpTransport implements MCPTransport {
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
 		let captured = false;
 
-		// Drain the SSE stream from a single iterator. We resolve the deferred
-		// promise as soon as the matching response arrives, then keep iterating
-		// in the background to pick up piggybacked notifications/requests.
-		// Re-reading `response.body` after `for await` breaks would lock the
-		// stream a second time and surface as "ReadableStream already has a
-		// controller", so we must not exit the loop early.
+		// Drain this per-request SSE response from a single iterator. Once the
+		// matching response arrives, resolve/reject and abort the reader so the
+		// response body is cancelled instead of lingering in the background.
+		// Re-reading `response.body` would lock the stream a second time and surface
+		// as "ReadableStream already has a controller", so the iterator owns the
+		// stream until it is aborted, completes, or errors.
 		const drainController = abortController;
 		this.#streamControllers.add(drainController);
 		const drain = async (): Promise<void> => {
@@ -293,13 +293,13 @@ export class HttpTransport implements MCPTransport {
 							("result" in message || "error" in message)
 						) {
 							captured = true;
-							clearTimeout(timeoutId);
+							drainController.abort();
 							if (message.error) {
 								reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
 							} else {
 								resolve(message.result as T);
 							}
-							continue;
+							return;
 						}
 						if (!this.#connected) continue;
 						this.#dispatchSSEMessage(message);
@@ -322,6 +322,7 @@ export class HttpTransport implements MCPTransport {
 			} finally {
 				clearTimeout(timeoutId);
 				this.#streamControllers.delete(drainController);
+				await response.body?.cancel().catch(() => {});
 			}
 		};
 

--- a/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
@@ -5,7 +5,8 @@
  * Messages are newline-delimited JSON.
  */
 
-import { getProjectDir, ptree, readJsonl, Snowflake } from "@gajae-code/utils";
+import { getProjectDir, readJsonl, Snowflake } from "@gajae-code/utils";
+import { type OwnedProcess, spawnOwnedProcess } from "../../runtime/process-lifecycle";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -24,7 +25,7 @@ import { toJsonRpcError } from "../../runtime-mcp/types";
 const CLOSE_WAIT_MS = 1_000;
 
 export class StdioTransport implements MCPTransport {
-	#process: ptree.ChildProcess<"pipe"> | null = null;
+	#process: OwnedProcess | null = null;
 	#pendingRequests = new Map<
 		string | number,
 		{
@@ -34,6 +35,8 @@ export class StdioTransport implements MCPTransport {
 	>();
 	#connected = false;
 	#readLoop: Promise<void> | null = null;
+	#stderrLoop: Promise<void> | null = null;
+	#closePromise: Promise<void> | null = null;
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -46,10 +49,17 @@ export class StdioTransport implements MCPTransport {
 		return this.#connected;
 	}
 
+	get closeBeforeReconnect(): true {
+		return true;
+	}
+
 	/**
 	 * Start the subprocess and begin reading.
 	 */
 	async connect(): Promise<void> {
+		if (this.#closePromise) {
+			throw new Error("Transport is closing");
+		}
 		if (this.#connected) return;
 
 		const args = this.config.args ?? [];
@@ -58,11 +68,12 @@ export class StdioTransport implements MCPTransport {
 			...this.config.env,
 		};
 
-		this.#process = ptree.spawn([this.config.command, ...args], {
+		this.#process = spawnOwnedProcess([this.config.command, ...args], {
 			cwd: this.config.cwd ?? getProjectDir(),
 			env,
 			stdin: "pipe",
-			stderr: "full",
+			gracefulMs: CLOSE_WAIT_MS,
+			name: `mcp-stdio:${this.config.command}`,
 		});
 
 		this.#connected = true;
@@ -71,13 +82,13 @@ export class StdioTransport implements MCPTransport {
 		this.#readLoop = this.#startReadLoop();
 
 		// Log stderr for debugging
-		this.#startStderrLoop();
+		this.#stderrLoop = this.#startStderrLoop();
 	}
 
 	async #startReadLoop(): Promise<void> {
-		if (!this.#process?.stdout) return;
+		if (!this.#process?.child.stdout) return;
 		try {
-			for await (const line of readJsonl(this.#process.stdout)) {
+			for await (const line of readJsonl(this.#process.child.stdout)) {
 				if (!this.#connected) break;
 				try {
 					this.#handleMessage(line as JsonRpcMessage);
@@ -95,9 +106,9 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async #startStderrLoop(): Promise<void> {
-		if (!this.#process?.stderr) return;
+		if (!this.#process?.child.stderr) return;
 
-		const reader = this.#process.stderr.getReader();
+		const reader = this.#process.child.stderr.getReader();
 		const decoder = new TextDecoder();
 
 		try {
@@ -168,26 +179,23 @@ export class StdioTransport implements MCPTransport {
 		}
 	}
 
+	#getStdin(): Bun.FileSink | null {
+		const stdin = this.#process?.child.stdin;
+		return typeof stdin === "object" && stdin !== null ? stdin : null;
+	}
+
 	#sendResponse(id: string | number, result?: unknown, error?: JsonRpcError): void {
-		if (!this.#connected || !this.#process?.stdin) return;
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) return;
 		const response = error
 			? { jsonrpc: "2.0" as const, id, error }
 			: { jsonrpc: "2.0" as const, id, result: result ?? {} };
-		this.#process.stdin.write(`${JSON.stringify(response)}\n`);
-		this.#process.stdin.flush();
+		stdin.write(`${JSON.stringify(response)}\n`);
+		stdin.flush();
 	}
 
 	#handleClose(): void {
-		if (!this.#connected) return;
-		this.#connected = false;
-
-		// Reject all pending requests
-		for (const [, pending] of this.#pendingRequests) {
-			pending.reject(new Error("Transport closed"));
-		}
-		this.#pendingRequests.clear();
-
-		this.onClose?.();
+		void this.#closeInternal(true);
 	}
 
 	async request<T = unknown>(
@@ -195,7 +203,8 @@ export class StdioTransport implements MCPTransport {
 		params?: Record<string, unknown>,
 		options?: MCPRequestOptions,
 	): Promise<T> {
-		if (!this.#connected || !this.#process?.stdin) {
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) {
 			throw new Error("Transport not connected");
 		}
 
@@ -261,8 +270,8 @@ export class StdioTransport implements MCPTransport {
 		const message = `${JSON.stringify(request)}\n`;
 		try {
 			// Bun's FileSink has write() method directly
-			this.#process.stdin.write(message);
-			this.#process.stdin.flush();
+			stdin.write(message);
+			stdin.flush();
 		} catch (error: unknown) {
 			cleanup();
 			reject(error instanceof Error ? error : new Error(String(error)));
@@ -272,7 +281,8 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async notify(method: string, params?: Record<string, unknown>): Promise<void> {
-		if (!this.#connected || !this.#process?.stdin) {
+		const stdin = this.#getStdin();
+		if (!this.#connected || !stdin) {
 			throw new Error("Transport not connected");
 		}
 
@@ -284,35 +294,51 @@ export class StdioTransport implements MCPTransport {
 
 		const message = `${JSON.stringify(notification)}\n`;
 		// Bun's FileSink has write() method directly
-		this.#process.stdin.write(message);
-		this.#process.stdin.flush();
+		stdin.write(message);
+		stdin.flush();
 	}
 
 	async close(): Promise<void> {
-		if (!this.#connected) return;
+		await this.#closeInternal(false);
+	}
+
+	#closeInternal(fromReadLoop: boolean): Promise<void> {
+		if (this.#closePromise) return this.#closePromise;
+		this.#closePromise = this.#finishClose(fromReadLoop).finally(() => {
+			this.#closePromise = null;
+		});
+		return this.#closePromise;
+	}
+
+	async #finishClose(fromReadLoop: boolean): Promise<void> {
+		const wasConnected = this.#connected;
 		this.#connected = false;
 
-		// Reject pending requests
 		for (const [, pending] of this.#pendingRequests) {
 			pending.reject(new Error("Transport closed"));
 		}
 		this.#pendingRequests.clear();
 
-		// Terminate the subprocess tree and keep the handle until exit is observed.
+		const stdin = this.#getStdin();
 		const process = this.#process;
+		this.#process = null;
 		if (process) {
-			process.kill();
-			await Promise.race([process.exited.catch(() => {}), Bun.sleep(CLOSE_WAIT_MS)]);
-			this.#process = null;
+			stdin?.end();
+			await process.dispose().catch(() => {});
+			await process.awaitExit({ timeoutMs: CLOSE_WAIT_MS }).catch(() => ({ exited: false, code: null }));
 		}
 
-		// Wait for read loop to finish
-		if (this.#readLoop) {
+		if (!fromReadLoop && this.#readLoop) {
 			await this.#readLoop.catch(() => {});
-			this.#readLoop = null;
+		}
+		this.#readLoop = null;
+
+		if (this.#stderrLoop) {
+			await this.#stderrLoop.catch(() => {});
+			this.#stderrLoop = null;
 		}
 
-		this.onClose?.();
+		if (wasConnected) this.onClose?.();
 	}
 }
 

--- a/packages/coding-agent/src/runtime-mcp/types.ts
+++ b/packages/coding-agent/src/runtime-mcp/types.ts
@@ -225,6 +225,9 @@ export interface MCPTransport {
 	/** Close the transport */
 	close(): Promise<void>;
 
+	/** Whether close must finish before reconnect can safely spawn a replacement. */
+	readonly closeBeforeReconnect?: boolean;
+
 	/** Whether the transport is connected */
 	readonly connected: boolean;
 

--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -159,6 +159,10 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 	let disposed = false;
 	let disposePromise: Promise<void> | undefined;
 	let deregistered = false;
+	// Terminal once teardown/reconciliation has confirmed the group is gone. A
+	// late dispose() must then be a true no-op and never re-probe a pgid the OS
+	// may have recycled into an unrelated group.
+	let terminated = false;
 	let onAbort: (() => void) | undefined;
 
 	const removeAbort = (): void => {
@@ -171,6 +175,7 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 	const deregister = (): void => {
 		if (deregistered) return;
 		deregistered = true;
+		terminated = true;
 		liveOwners.delete(owner);
 		removeAbort();
 	};
@@ -228,6 +233,13 @@ export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): 
 			}
 		},
 		dispose(): Promise<void> {
+			// Already terminal (e.g. clean drain reconciled and deregistered):
+			// never re-probe the pgid; treat dispose as a settled no-op.
+			if (terminated) {
+				disposed = true;
+				if (!disposePromise) disposePromise = Promise.resolve();
+				return disposePromise;
+			}
 			if (disposePromise) return disposePromise;
 			disposed = true;
 			removeAbort();

--- a/packages/coding-agent/src/runtime/process-lifecycle.ts
+++ b/packages/coding-agent/src/runtime/process-lifecycle.ts
@@ -1,0 +1,388 @@
+/**
+ * Shared runtime lifecycle foundation.
+ *
+ * Two minimal, deliberately small primitives that subsystem runtimes
+ * (DAP/LSP/MCP stdio, eval workers, etc.) adopt so spawned children and
+ * non-process resources cannot outlive their owner:
+ *
+ *   F1(a) `spawnOwnedProcess` — wraps `ptree.spawn` with explicit
+ *         process-group ownership, escalating (SIGTERM -> grace -> SIGKILL)
+ *         tree termination, bounded `awaitExit`, abort-listener cleanup on
+ *         settle, idempotent `dispose`, and a single postmortem hook that
+ *         reaps every still-live owned process group on fatal/normal shutdown.
+ *
+ *   F1(b) `registerResourceOwner` — a generic, idempotent postmortem adapter
+ *         for non-process resources (Bun Workers, VM contexts, timers,
+ *         sockets) built on the existing `postmortem.register` facility.
+ *
+ * Ownership is keyed to the *process group*, not the root process. A root that
+ * exits after backgrounding descendants (`sh -c "worker & exit 0"`) keeps the
+ * owner registered until the group is actually gone, so the descendant tree is
+ * still reaped by `dispose()`/postmortem.
+ *
+ * This module intentionally owns only these primitives. It does not migrate
+ * existing call sites; subsystem PRs adopt it incrementally.
+ *
+ * Note: `ptree.spawn` always pipes stdout/stderr. Adopters that expect output
+ * (DAP/LSP/MCP protocol servers) must consume `owner.child.stdout`; F1 does not
+ * drain it, so a chatty child whose stdout is never read can still block on a
+ * full pipe. That draining is the adopter's responsibility.
+ */
+import { logger, postmortem, ptree } from "@gajae-code/utils";
+
+const DEFAULT_GRACEFUL_MS = 2_000;
+// Hard cap for how long `dispose()` waits after SIGKILL before giving up so a
+// wedged, unkillable child can never block shutdown forever.
+const SIGKILL_REAP_CAP_MS = 2_000;
+// After the root process exits on its own, how long to wait for the process
+// group to drain before deregistering. Clean servers drain immediately; a root
+// that backgrounded descendants stays registered past this window.
+const ROOT_EXIT_DRAIN_MS = 250;
+
+const isPosix = process.platform !== "win32";
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => {
+		const timer = setTimeout(resolve, Math.max(0, ms));
+		timer.unref?.();
+	});
+
+/** Poll `predicate` until it is true or `timeoutMs` elapses. Returns the final value. */
+async function pollUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 20): Promise<boolean> {
+	if (predicate()) return true;
+	const deadline = Date.now() + Math.max(0, timeoutMs);
+	while (Date.now() < deadline) {
+		await delay(Math.min(intervalMs, Math.max(0, deadline - Date.now())));
+		if (predicate()) return true;
+	}
+	return predicate();
+}
+
+/** Whether a POSIX process group still has any member (zombies count as alive). */
+function groupAlive(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		// EPERM => the group exists but we cannot signal it; treat as alive.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/** Options for {@link spawnOwnedProcess}. */
+export interface SpawnOwnedOptions {
+	cwd?: string;
+	env?: Record<string, string | undefined>;
+	/** stdin mode passed through to the child. Defaults to `"ignore"`. */
+	stdin?: "pipe" | "ignore";
+	/** When aborted, the owned process tree is disposed (escalating kill). */
+	signal?: AbortSignal;
+	/** Grace period (ms) between SIGTERM and SIGKILL on dispose. Default 2000. */
+	gracefulMs?: number;
+	/**
+	 * Spawn the child as its own process-group leader so the whole descendant
+	 * tree can be signalled on dispose. Defaults to `true` on POSIX. Has no
+	 * effect on Windows, where teardown falls back to single-process kill.
+	 */
+	processGroup?: boolean;
+	/** Label used in diagnostics. */
+	name?: string;
+}
+
+/** Result of a bounded {@link OwnedProcess.awaitExit}. */
+export interface AwaitExitResult {
+	/** `true` when the process has exited; `false` when the timeout fired first. */
+	exited: boolean;
+	/** Exit code if known, else `null`. */
+	code: number | null;
+}
+
+/** A spawned child process owned by the runtime with guaranteed teardown. */
+export interface OwnedProcess {
+	readonly child: ptree.ChildProcess;
+	readonly pid: number | undefined;
+	/** Resolves/rejects when the root child exits (mirrors ptree's `exited`). */
+	readonly exited: Promise<number>;
+	/** `true` once `dispose()` has started. */
+	readonly disposed: boolean;
+	/**
+	 * Wait for the root child to exit, optionally bounded by `timeoutMs`. With no
+	 * timeout it resolves only when the child exits. Never rejects.
+	 */
+	awaitExit(opts?: { timeoutMs?: number }): Promise<AwaitExitResult>;
+	/**
+	 * Idempotently terminate the owned process *group*: SIGTERM the group, wait
+	 * `gracefulMs`, then SIGKILL, polling group liveness throughout. Removes the
+	 * abort listener and deregisters from the live-owner set only after teardown
+	 * has completed. Repeated/concurrent calls return the same in-flight promise.
+	 */
+	dispose(): Promise<void>;
+}
+
+const liveOwners = new Set<OwnedProcess>();
+let ownedPostmortemRegistered = false;
+
+function ensureOwnedPostmortem(): void {
+	if (ownedPostmortemRegistered) return;
+	ownedPostmortemRegistered = true;
+	postmortem.register("runtime:owned-processes", async () => {
+		await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+	});
+}
+
+/**
+ * Spawn a child process owned by the runtime. The returned {@link OwnedProcess}
+ * is registered for postmortem cleanup and tears down its whole process group
+ * on dispose/abort.
+ */
+export function spawnOwnedProcess(cmd: string[], opts: SpawnOwnedOptions = {}): OwnedProcess {
+	const gracefulMs = opts.gracefulMs ?? DEFAULT_GRACEFUL_MS;
+	const useGroup = (opts.processGroup ?? true) && isPosix;
+
+	ensureOwnedPostmortem();
+
+	// We deliberately do NOT forward `opts.signal` to `ptree.spawn`: ptree's
+	// `attachSignal` only kills the single process, whereas owned teardown must
+	// signal the whole group. We wire our own abort listener below and remove it
+	// on settle so long-lived signals never accumulate listeners.
+	const child = ptree.spawn(cmd, {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdin: opts.stdin ?? "ignore",
+		detached: useGroup,
+	});
+
+	// On POSIX with `detached`, the child is its own process-group leader, so the
+	// group id equals its pid. `undefined` => single-process (Windows/opt-out).
+	const pgid = useGroup ? child.pid : undefined;
+
+	let disposed = false;
+	let disposePromise: Promise<void> | undefined;
+	let deregistered = false;
+	let onAbort: (() => void) | undefined;
+
+	const removeAbort = (): void => {
+		if (onAbort && opts.signal) {
+			opts.signal.removeEventListener("abort", onAbort);
+			onAbort = undefined;
+		}
+	};
+
+	const deregister = (): void => {
+		if (deregistered) return;
+		deregistered = true;
+		liveOwners.delete(owner);
+		removeAbort();
+	};
+
+	const signalTree = (signal: NodeJS.Signals): void => {
+		const pid = child.pid;
+		if (pid === undefined) return;
+		if (pgid !== undefined) {
+			try {
+				// Negative pid signals the entire process group (child is leader).
+				process.kill(-pgid, signal);
+				return;
+			} catch {
+				// Group already gone; nothing to do.
+			}
+			return;
+		}
+		if (signal === "SIGKILL") {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		} else {
+			// ptree's kill terminates the single process via the native handle.
+			child.kill();
+		}
+	};
+
+	const owner: OwnedProcess = {
+		child,
+		get pid() {
+			return child.pid;
+		},
+		get exited() {
+			return child.exited;
+		},
+		get disposed() {
+			return disposed;
+		},
+		async awaitExit({ timeoutMs }: { timeoutMs?: number } = {}): Promise<AwaitExitResult> {
+			const exitedResult = child.exited
+				.then(code => ({ exited: true as const, code: code as number | null }))
+				.catch(() => ({ exited: true as const, code: child.exitCode }));
+			if (timeoutMs === undefined) return exitedResult;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const timeout = new Promise<AwaitExitResult>(resolve => {
+				timer = setTimeout(() => resolve({ exited: false, code: child.exitCode }), Math.max(0, timeoutMs));
+				timer.unref?.();
+			});
+			try {
+				return await Promise.race([exitedResult, timeout]);
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		},
+		dispose(): Promise<void> {
+			if (disposePromise) return disposePromise;
+			disposed = true;
+			removeAbort();
+			disposePromise = (async () => {
+				try {
+					if (pgid !== undefined) {
+						// Group ownership: reap until the whole group is gone, even if
+						// the root has already exited (it may have backgrounded children).
+						if (!groupAlive(pgid)) return;
+						signalTree("SIGTERM");
+						if (await pollUntil(() => !groupAlive(pgid), gracefulMs)) return;
+						signalTree("SIGKILL");
+						if (!(await pollUntil(() => !groupAlive(pgid), SIGKILL_REAP_CAP_MS))) {
+							logger.warn("owned process group still alive after SIGKILL", {
+								name: opts.name,
+								pgid,
+							});
+						}
+						return;
+					}
+					// Single-process fallback (Windows / processGroup:false).
+					if (child.exitCode !== null) return;
+					signalTree("SIGTERM");
+					if ((await owner.awaitExit({ timeoutMs: gracefulMs })).exited) return;
+					signalTree("SIGKILL");
+					await owner.awaitExit({ timeoutMs: SIGKILL_REAP_CAP_MS });
+				} catch (err) {
+					logger.warn("owned process dispose failed", {
+						name: opts.name,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				} finally {
+					// FIX: deregister only after teardown has completed so a postmortem
+					// firing mid-grace still sees the owner and awaits this dispose.
+					deregister();
+				}
+			})();
+			return disposePromise;
+		},
+	};
+
+	liveOwners.add(owner);
+
+	// When the root exits on its own (not via dispose), reconcile ownership by
+	// the *group*. After a short drain window: if the group is empty, deregister;
+	// if descendants are still alive, reap the owned group (no child outlives its
+	// owner). Either way the owner never lingers holding a stale pgid that the OS
+	// could later recycle and a stray dispose could mis-signal.
+	void child.exited
+		.catch(() => undefined)
+		.finally(() => {
+			if (disposed) return; // dispose() owns deregistration
+			if (pgid === undefined) {
+				deregister();
+				return;
+			}
+			void (async () => {
+				const drained = await pollUntil(() => !groupAlive(pgid), ROOT_EXIT_DRAIN_MS);
+				if (disposed) return;
+				if (drained) {
+					deregister();
+					return;
+				}
+				// Root exited but the owned group still has descendants: reap them.
+				// dispose() escalates SIGTERM->SIGKILL and deregisters in its finally.
+				await owner.dispose();
+			})();
+		});
+
+	if (opts.signal) {
+		if (opts.signal.aborted) {
+			void owner.dispose();
+		} else {
+			onAbort = () => void owner.dispose();
+			opts.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	return owner;
+}
+
+/** Number of currently live owned processes. Exposed for leak assertions/tests. */
+export function liveOwnedProcessCount(): number {
+	return liveOwners.size;
+}
+
+/** Dispose every live owned process. For owner-scoped teardown and tests. */
+export async function disposeAllOwnedProcesses(): Promise<void> {
+	await Promise.all([...liveOwners].map(owner => owner.dispose().catch(() => undefined)));
+}
+
+// ── F1(b) generic resource owners ────────────────────────────────────────────
+
+type ResourceDisposer = () => void | Promise<void>;
+
+const resourceOwners = new Map<string, ResourceDisposer>();
+let resourcePostmortemRegistered = false;
+
+function ensureResourcePostmortem(): void {
+	if (resourcePostmortemRegistered) return;
+	resourcePostmortemRegistered = true;
+	// Postmortem isolates per-callback failures; swallow the aggregate here so
+	// shutdown continues, while direct callers of disposeAllResourceOwners still
+	// observe the AggregateError.
+	postmortem.register("runtime:resource-owners", () =>
+		disposeAllResourceOwners().catch(err => {
+			logger.warn("resource owner postmortem cleanup had failures", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}),
+	);
+}
+
+/**
+ * Register a non-process resource for postmortem/fatal-exit cleanup.
+ *
+ * Idempotent by `name`: re-registering the same name replaces the prior
+ * disposer (last wins). Returns an unregister function that removes the owner
+ * only while it is still the active registration for that name.
+ */
+export function registerResourceOwner(name: string, disposer: ResourceDisposer): () => void {
+	resourceOwners.set(name, disposer);
+	ensureResourcePostmortem();
+	let unregistered = false;
+	return () => {
+		if (unregistered) return;
+		unregistered = true;
+		if (resourceOwners.get(name) === disposer) {
+			resourceOwners.delete(name);
+		}
+	};
+}
+
+/** Number of registered resource owners. Exposed for leak assertions/tests. */
+export function resourceOwnerCount(): number {
+	return resourceOwners.size;
+}
+
+/**
+ * Run and clear every registered resource disposer. Attempts all disposers even
+ * if some throw, then surfaces the failures as an `AggregateError` so callers
+ * can distinguish "all closed" from "a resource may still be alive".
+ */
+export async function disposeAllResourceOwners(): Promise<void> {
+	const disposers = [...resourceOwners.values()];
+	resourceOwners.clear();
+	const errors: unknown[] = [];
+	for (const disposer of disposers) {
+		try {
+			await disposer();
+		} catch (err) {
+			errors.push(err);
+		}
+	}
+	if (errors.length > 0) {
+		throw new AggregateError(errors, `${errors.length} resource disposer(s) failed during teardown`);
+	}
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -415,6 +415,7 @@ function getDefaultAgentDir(): string {
  */
 export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir()): Promise<AuthStorage> {
 	const brokerConfig = await resolveAuthBrokerConfig();
+	const credentialRankingMode = resolveCredentialRankingMode();
 	if (brokerConfig) {
 		const client = new AuthBrokerClient({ url: brokerConfig.url, token: brokerConfig.token });
 		const initialResult = await client.fetchSnapshot();
@@ -425,6 +426,7 @@ export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir(
 		const storage = new AuthStorage(store, {
 			configValueResolver: resolveConfigValue,
 			sourceLabel: `broker ${brokerConfig.url}`,
+			credentialRankingMode,
 		});
 		await storage.reload();
 		return storage;
@@ -433,9 +435,23 @@ export async function discoverAuthStorage(agentDir: string = getDefaultAgentDir(
 	const storage = await AuthStorage.create(dbPath, {
 		configValueResolver: resolveConfigValue,
 		sourceLabel: `local ${dbPath}`,
+		credentialRankingMode,
 	});
 	await storage.reload();
 	return storage;
+}
+
+/**
+ * Opt-in multi-account credential ranking mode, read from the
+ * `GJC_CREDENTIAL_RANKING_MODE` env var. Unset/unknown → `undefined`, leaving
+ * {@link AuthStorage}'s default (`balanced`) untouched. `earliest-reset`
+ * switches to earliest-expiry-first selection so soon-to-reset tumbling-window
+ * quota is drained before it is lost.
+ */
+function resolveCredentialRankingMode(): "balanced" | "earliest-reset" | undefined {
+	const raw = process.env.GJC_CREDENTIAL_RANKING_MODE?.trim();
+	if (raw === "balanced" || raw === "earliest-reset") return raw;
+	return undefined;
 }
 
 /**

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -52,6 +52,7 @@ import { resolveConfigValue } from "./config/resolve-config-value";
 import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
 import { BUNDLED_GROK_BUILD_EXTENSION_ID, getBundledGrokBuildExtensionFactory } from "./defaults/gjc-grok-cli";
 import { initializeWithSettings } from "./discovery";
+import { disposeAllVmContexts, disposeVmContextsByOwner } from "./eval/js/context-manager";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
 import { TtsrManager } from "./export/ttsr";
 import type { CustomCommandsLoadResult, LoadedCustomCommand } from "./extensibility/custom-commands";
@@ -570,6 +571,14 @@ function registerPythonCleanup(): void {
 	postmortem.register("python-cleanup", disposeAllKernelSessions);
 }
 
+let jsVmCleanupRegistered = false;
+
+function registerJsVmCleanup(): void {
+	if (jsVmCleanupRegistered) return;
+	jsVmCleanupRegistered = true;
+	postmortem.register("js-vm-cleanup", disposeAllVmContexts);
+}
+
 /**
  * Resolve whether to enable append-only context mode based on the setting and provider.
  *
@@ -806,6 +815,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	registerSshCleanup();
 	registerPythonCleanup();
+	registerJsVmCleanup();
 
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager
@@ -2200,6 +2210,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			} else {
 				if (hasRegistered) agentRegistry.unregister(resolvedAgentId);
 				await disposeKernelSessionsByOwner(evalKernelOwnerId);
+				await disposeVmContextsByOwner(evalKernelOwnerId);
 			}
 		} catch (cleanupError) {
 			logger.warn("Failed to clean up createAgentSession resources after startup error", {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6020,12 +6020,50 @@ export class AgentSession {
 
 	/**
 	 * True when the configured `serviceTier` resolves to `"priority"` for the
+	 * given model `provider`. Returns false for scoped tiers that don't match
+	 * (e.g. `"openai-only"` on an anthropic provider) and when `provider` is
+	 * undefined. This is the canonical provider-aware fast-mode predicate.
+	 */
+	isFastForProvider(provider?: string): boolean {
+		// Fast mode applies to a concrete model's provider. With no provider
+		// (no model selected) it cannot apply, even under an unscoped `priority`
+		// tier that `resolveServiceTier` would otherwise pass through.
+		if (provider === undefined) return false;
+		return resolveServiceTier(this.serviceTier, provider) === "priority";
+	}
+
+	/**
+	 * Effective service tier applied to task-tool subagent sessions
+	 * (executor/architect/planner/critic). They run under `task.serviceTier`
+	 * unless it is `"inherit"`, in which case they inherit the main session
+	 * tier — mirroring `createSubagentSettings`.
+	 */
+	#subagentServiceTier(): ServiceTier | undefined {
+		const configured = this.settings.get("task.serviceTier");
+		if (configured === "inherit") return this.serviceTier;
+		if (configured === "none") return undefined;
+		return configured;
+	}
+
+	/**
+	 * Provider-aware fast-mode predicate for task-tool subagent roles, evaluated
+	 * against the effective subagent tier (`task.serviceTier`) rather than the
+	 * main session tier. Use this for `task.agentModelOverrides` role rows so the
+	 * ⚡ glyph reflects the tier the subagent actually runs under.
+	 */
+	isFastForSubagentProvider(provider?: string): boolean {
+		if (provider === undefined) return false;
+		return resolveServiceTier(this.#subagentServiceTier(), provider) === "priority";
+	}
+
+	/**
+	 * True when the configured `serviceTier` resolves to `"priority"` for the
 	 * *currently selected model's provider*. Returns false for scoped tiers
 	 * that don't match (e.g. `"openai-only"` on an anthropic model) and when
 	 * no model is selected.
 	 */
 	isFastModeActive(): boolean {
-		return resolveServiceTier(this.serviceTier, this.model?.provider) === "priority";
+		return this.isFastForProvider(this.model?.provider);
 	}
 
 	setServiceTier(serviceTier: ServiceTier | undefined): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -142,6 +142,7 @@ import { onAppendOnlyModeChanged } from "../config/settings";
 import { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import { loadCapability } from "../discovery";
 import { expandApplyPatchToEntries, normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
+import { disposeVmContextsByOwner } from "../eval/js/context-manager";
 import {
 	disposeKernelSessionsByOwner,
 	executePython as executePythonCommand,
@@ -3194,6 +3195,7 @@ export class AgentSession {
 			);
 		}
 		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
+		await disposeVmContextsByOwner(this.#evalKernelOwnerId);
 		this.#releasePowerAssertion();
 		await this.sessionManager.close();
 		this.#closeAllProviderSessions("dispose");

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -41,6 +41,8 @@ import {
 	calculatePromptTokens,
 	collectEntriesForBranchSummary,
 	compact,
+	type EmergencyCompactionSample,
+	emergencyCompactionReason,
 	estimateMessageTokensHeuristic,
 	estimateTokens,
 	generateBranchSummary,
@@ -235,6 +237,7 @@ import {
 import type { ToolSession } from "../tools";
 import { AskTool } from "../tools/ask";
 import { assertEditableFile } from "../tools/auto-generated-guard";
+import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import type { CheckpointState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
@@ -908,6 +911,7 @@ export class AgentSession {
 	// Compaction state
 	#compactionAbortController: AbortController | undefined = undefined;
 	#autoCompactionAbortController: AbortController | undefined = undefined;
+	#resourceSampler: () => EmergencyCompactionSample = () => this.#defaultResourceSample();
 	#prePromptContextCheckPromise: Promise<void> | undefined = undefined;
 
 	// Branch summarization state
@@ -3188,6 +3192,13 @@ export class AgentSession {
 			}
 		}
 		await shutdownAllLspClients();
+		// F13: release only THIS session's browser tabs on dispose (kill:false → remote
+		// browsers disconnect, headless close gracefully). Scoped by the session id the
+		// browser tool tagged tabs with, so other live sessions' tabs are untouched.
+		// No-op when this session opened no tabs. Failure is logged, not thrown.
+		await releaseTabsForOwner(this.sessionManager.getSessionId()).catch((error: unknown) =>
+			logger.warn("session dispose: releaseTabsForOwner failed", { error }),
+		);
 		const pythonExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
 		if (!pythonExecutionsSettled) {
 			logger.warn(
@@ -6627,11 +6638,55 @@ export class AgentSession {
 		}
 	}
 
+	/** Test seam: override the emergency-compaction resource sampler so tests never read real RSS. */
+	setResourceSampler(sampler: () => EmergencyCompactionSample): void {
+		this.#resourceSampler = sampler;
+	}
+
+	#defaultResourceSample(): EmergencyCompactionSample {
+		let providerBytes = 0;
+		let imageBytes = 0;
+		for (const message of this.state.messages) {
+			const content = (message as { content?: unknown }).content;
+			if (typeof content === "string") {
+				providerBytes += content.length;
+			} else if (Array.isArray(content)) {
+				for (const block of content) {
+					if (!block || typeof block !== "object") continue;
+					const typed = block as { text?: unknown; data?: unknown };
+					if (typeof typed.text === "string") providerBytes += typed.text.length;
+					if (typeof typed.data === "string") {
+						imageBytes += typed.data.length;
+						providerBytes += typed.data.length;
+					}
+				}
+			}
+		}
+		return {
+			heapUsedBytes: process.memoryUsage().heapUsed,
+			providerBytes,
+			messageCount: this.state.messages.length,
+			imageBytes,
+		};
+	}
+
 	async #checkEstimatedContextBeforePromptOnce(pendingMessages: readonly AgentMessage[]): Promise<void> {
 		const model = this.model;
 		if (!model) return;
 		const contextWindow = model.contextWindow ?? 0;
 		if (contextWindow <= 0) return;
+		// F6: non-disableable emergency floor — compact before OOM even when token-based
+		// compaction is disabled or its threshold is set too high (weak-hardware protection).
+		const emergencyReason = emergencyCompactionReason(this.#resourceSampler());
+		if (emergencyReason) {
+			logger.warn("Emergency compaction triggered (resource floor exceeded)", { reason: emergencyReason });
+			await this.#runAutoCompaction("overflow", false, false, {
+				continueAfterMaintenance: false,
+				deferHandoffMaintenance: false,
+				force: true,
+			});
+			return;
+		}
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
 
@@ -7417,11 +7472,13 @@ export class AgentSession {
 		reason: "overflow" | "threshold" | "idle",
 		willRetry: boolean,
 		deferred = false,
-		options?: { continueAfterMaintenance?: boolean; deferHandoffMaintenance?: boolean },
+		options?: { continueAfterMaintenance?: boolean; deferHandoffMaintenance?: boolean; force?: boolean },
 	): Promise<void> {
 		const compactionSettings = this.settings.getGroup("compaction");
-		if (compactionSettings.strategy === "off") return;
-		if (reason !== "idle" && !compactionSettings.enabled) return;
+		// `force` is the non-disableable emergency floor (F6): it bypasses the user's
+		// disabled/off settings so a resource-floor breach still compacts before OOM.
+		if (!options?.force && compactionSettings.strategy === "off") return;
+		if (!options?.force && reason !== "idle" && !compactionSettings.enabled) return;
 		const generation = this.#promptGeneration;
 		if (
 			options?.deferHandoffMaintenance !== false &&
@@ -9558,17 +9615,15 @@ export class AgentSession {
 	 */
 	getSessionStats(): SessionStats {
 		const state = this.state;
-		const userMessages = state.messages.filter(m => m.role === "user").length;
-		const assistantMessages = state.messages.filter(m => m.role === "assistant").length;
-		const toolResults = state.messages.filter(m => m.role === "toolResult").length;
-
+		let userMessages = 0;
+		let assistantMessages = 0;
+		let toolResults = 0;
 		let toolCalls = 0;
 		let totalInput = 0;
 		let totalOutput = 0;
 		let totalCacheRead = 0;
 		let totalCacheWrite = 0;
 		let totalCost = 0;
-
 		let totalPremiumRequests = 0;
 		const getTaskToolUsage = (details: unknown): Usage | undefined => {
 			if (!details || typeof details !== "object") return undefined;
@@ -9578,8 +9633,13 @@ export class AgentSession {
 			return usage as Usage;
 		};
 
+		// Single pass over messages (replaces three role filters plus a separate usage
+		// loop) so per-turn stats stay O(messages + assistant content blocks), not O(4N).
 		for (const message of state.messages) {
-			if (message.role === "assistant") {
+			if (message.role === "user") {
+				userMessages += 1;
+			} else if (message.role === "assistant") {
+				assistantMessages += 1;
 				const assistantMsg = message as AssistantMessage;
 				toolCalls += assistantMsg.content.filter(c => c.type === "toolCall").length;
 				totalInput += assistantMsg.usage.input;
@@ -9588,17 +9648,18 @@ export class AgentSession {
 				totalCacheWrite += assistantMsg.usage.cacheWrite;
 				totalPremiumRequests += assistantMsg.usage.premiumRequests ?? 0;
 				totalCost += assistantMsg.usage.cost.total;
-			}
-
-			if (message.role === "toolResult" && message.toolName === "task") {
-				const usage = getTaskToolUsage(message.details);
-				if (usage) {
-					totalInput += usage.input;
-					totalOutput += usage.output;
-					totalCacheRead += usage.cacheRead;
-					totalCacheWrite += usage.cacheWrite;
-					totalPremiumRequests += usage.premiumRequests ?? 0;
-					totalCost += usage.cost.total;
+			} else if (message.role === "toolResult") {
+				toolResults += 1;
+				if (message.toolName === "task") {
+					const usage = getTaskToolUsage(message.details);
+					if (usage) {
+						totalInput += usage.input;
+						totalOutput += usage.output;
+						totalCacheRead += usage.cacheRead;
+						totalCacheWrite += usage.cacheWrite;
+						totalPremiumRequests += usage.premiumRequests ?? 0;
+						totalCost += usage.cost.total;
+					}
 				}
 			}
 		}
@@ -9759,11 +9820,46 @@ export class AgentSession {
 		return tokens;
 	}
 
+	#nativeTokenCache = new WeakMap<AgentMessage, { len: number; tokens: number }>();
+
+	/** Cheap content-size signal to invalidate the native token cache on mutation (growth). */
+	/**
+	 * Cheap content-size signal to invalidate the native token cache on mutation. Recursively
+	 * sums string lengths across the whole message (depth-bounded), so it covers every
+	 * provider-visible shape (text/thinking/tool args, toolResult output, tool names, etc.)
+	 * without allocating a serialized copy. A size-preserving in-place edit yields only a
+	 * benign estimate drift.
+	 */
+	#messageTokenSize(value: unknown, depth = 0): number {
+		if (depth > 6) return 0;
+		if (typeof value === "string") return value.length;
+		if (typeof value === "number" || typeof value === "boolean") return 8;
+		if (Array.isArray(value)) {
+			let size = 0;
+			for (const item of value) size += this.#messageTokenSize(item, depth + 1);
+			return size;
+		}
+		if (value && typeof value === "object") {
+			let size = 0;
+			for (const item of Object.values(value)) size += this.#messageTokenSize(item, depth + 1);
+			return size;
+		}
+		return 0;
+	}
+
 	#estimateMessageNativeContextTokens(message: AgentMessage): number {
+		// F10/F22: cache the expensive native token count per message object, invalidated by a
+		// cheap content-size signal, so unchanged (stable-size) messages are not re-tokenized on
+		// every pre-prompt estimate. A rare size-preserving in-place edit yields only a benign
+		// token-estimate drift, never wrong output.
+		const len = this.#messageTokenSize(message);
+		const cached = this.#nativeTokenCache.get(message);
+		if (cached && cached.len === len) return cached.tokens;
 		let tokens = 0;
 		for (const llmMessage of convertToLlm([message])) {
 			tokens += estimateTokens(llmMessage);
 		}
+		this.#nativeTokenCache.set(message, { len, tokens });
 		return tokens;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7243,7 +7243,17 @@ export class AgentSession {
 			addCandidate(this.#resolveRoleModelFull(role, availableModels, currentModel).model);
 		}
 
-		const sortedByContext = [...availableModels].sort((a, b) => b.contextWindow - a.contextWindow);
+		// Last-resort fallback: the largest-context model that shares the ACTIVE
+		// model's provider. Scoping this to the current provider keeps auto-
+		// compaction on the user's configured/custom route instead of silently
+		// defaulting to an unrelated provider (e.g. a stray OpenAI credential
+		// with no remaining credit) just because it happens to be in the bundled
+		// catalog. Cross-provider compaction stays possible, but only when the
+		// user opts in explicitly via modelRoles (handled by the loop above).
+		const fallbackProvider = currentModel?.provider;
+		const sortedByContext = [...availableModels]
+			.filter(model => fallbackProvider === undefined || model.provider === fallbackProvider)
+			.sort((a, b) => b.contextWindow - a.contextWindow);
 		for (const model of sortedByContext) {
 			if (!seen.has(this.#getModelKey(model))) {
 				addCandidate(model);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6445,6 +6445,9 @@ export class AgentSession {
 				model,
 				apiKey,
 				{
+					...this.#withCompactionTransportOptions({
+						authCredentialType: this.#modelRegistry.getSessionCredentialType(model.provider, this.sessionId),
+					}),
 					systemPrompt: this.#baseSystemPrompt,
 					tools: this.agent.state.tools,
 					customInstructions,
@@ -7391,7 +7394,7 @@ export class AgentSession {
 
 			try {
 				return await compact(preparation, candidate, apiKey, customInstructions, signal, {
-					...options,
+					...this.#withCompactionTransportOptions(options),
 					metadata: this.agent.metadataForProvider(candidate.provider),
 					convertToLlm,
 					telemetry,
@@ -7405,6 +7408,19 @@ export class AgentSession {
 		}
 
 		throw this.#buildCompactionAuthError();
+	}
+
+	#withCompactionTransportOptions(options?: SummaryOptions): SummaryOptions {
+		const openaiWebsocketSetting = this.settings.get("providers.openaiWebsockets") ?? "off";
+		const preferWebsockets =
+			openaiWebsocketSetting === "on" ? true : openaiWebsocketSetting === "off" ? false : undefined;
+
+		return {
+			...options,
+			sessionId: options?.sessionId ?? this.agent.providerSessionId ?? this.agent.sessionId,
+			providerSessionState: options?.providerSessionState ?? this.#providerSessionState,
+			preferWebsockets: options?.preferWebsockets ?? preferWebsockets,
+		};
 	}
 
 	async #prepareCompactionFromHooks(
@@ -7680,19 +7696,26 @@ export class AgentSession {
 					let attempt = 0;
 					while (true) {
 						try {
-							compactResult = await compact(preparation, candidate, apiKey, undefined, autoCompactionSignal, {
-								promptOverride: compactionPrep.hookPrompt,
-								extraContext: compactionPrep.hookContext,
-								remoteInstructions: this.#baseSystemPrompt.join("\n\n"),
-								metadata: this.agent.metadataForProvider(candidate.provider),
-								initiatorOverride: "agent",
-								convertToLlm,
-								telemetry,
-								authCredentialType: this.#modelRegistry.getSessionCredentialType(
-									candidate.provider,
-									this.sessionId,
-								),
-							});
+							compactResult = await compact(
+								preparation,
+								candidate,
+								apiKey,
+								undefined,
+								autoCompactionSignal,
+								this.#withCompactionTransportOptions({
+									promptOverride: compactionPrep.hookPrompt,
+									extraContext: compactionPrep.hookContext,
+									remoteInstructions: this.#baseSystemPrompt.join("\n\n"),
+									metadata: this.agent.metadataForProvider(candidate.provider),
+									initiatorOverride: "agent",
+									convertToLlm,
+									telemetry,
+									authCredentialType: this.#modelRegistry.getSessionCredentialType(
+										candidate.provider,
+										this.sessionId,
+									),
+								}),
+							);
 							break;
 						} catch (error) {
 							if (autoCompactionSignal.aborted) {
@@ -9488,6 +9511,9 @@ export class AgentSession {
 			}
 			const branchSummarySettings = this.settings.getGroup("branchSummary");
 			const result = await generateBranchSummary(entriesToSummarize, {
+				...this.#withCompactionTransportOptions({
+					authCredentialType: this.#modelRegistry.getSessionCredentialType(model.provider, this.sessionId),
+				}),
 				model,
 				apiKey,
 				signal: this.#branchSummaryAbortController.signal,

--- a/packages/coding-agent/src/session/artifacts.ts
+++ b/packages/coding-agent/src/session/artifacts.ts
@@ -7,6 +7,11 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import { DEFAULT_ARTIFACT_MAX_BYTES, truncateHeadBytes } from "./streaming-output";
+export interface ArtifactSaveOptions {
+	maxBytes?: number;
+}
+
 /**
  * Manages artifact storage for a session.
  *
@@ -94,9 +99,19 @@ export class ArtifactManager {
 	 * @param toolType Tool name for file extension (e.g., "bash", "read")
 	 * @returns Artifact ID (numeric string)
 	 */
-	async save(content: string, toolType: string): Promise<string> {
+	async save(content: string, toolType: string, options: ArtifactSaveOptions = {}): Promise<string> {
 		const { id, path } = await this.allocatePath(toolType);
-		await Bun.write(path, content);
+		const maxBytes = Math.max(0, options.maxBytes ?? DEFAULT_ARTIFACT_MAX_BYTES);
+		const contentBytes = Buffer.byteLength(content, "utf-8");
+		if (contentBytes > maxBytes) {
+			const truncated = truncateHeadBytes(content, maxBytes);
+			await Bun.write(
+				path,
+				`${truncated.text}\n[artifact truncated after ${truncated.bytes} bytes; omitted at least ${contentBytes - truncated.bytes} bytes]\n`,
+			);
+		} else {
+			await Bun.write(path, content);
+		}
 		return id;
 	}
 

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -167,10 +167,40 @@ export class EphemeralBlobStore extends BlobStore {
 }
 
 export class MemoryBlobStore extends BlobStore {
+	/**
+	 * Generous byte/count LRU bound (F8). Content-addressed resident blobs are fail-closed
+	 * on miss (callers raise/handle {@link ResidentBlobMissingError}), so evicting the
+	 * least-recently-used entry on an extremely large session is preferable to unbounded
+	 * RAM growth. The caps sit well above normal usage and only trip on pathological sizes.
+	 */
+	static readonly #MAX_BYTES = 64 * 1024 * 1024;
+	static readonly #MAX_COUNT = 4096;
+
 	#blobs = new Map<string, Buffer>();
+	#bytes = 0;
 
 	constructor() {
 		super(":memory:");
+	}
+
+	#store(hash: string, data: Buffer): void {
+		const existing = this.#blobs.get(hash);
+		if (existing) {
+			this.#blobs.delete(hash);
+			this.#bytes -= existing.byteLength;
+		}
+		this.#blobs.set(hash, data);
+		this.#bytes += data.byteLength;
+		while (
+			(this.#bytes > MemoryBlobStore.#MAX_BYTES || this.#blobs.size > MemoryBlobStore.#MAX_COUNT) &&
+			this.#blobs.size > 1
+		) {
+			const oldest = this.#blobs.keys().next().value;
+			if (oldest === undefined) break;
+			const evicted = this.#blobs.get(oldest);
+			this.#blobs.delete(oldest);
+			if (evicted) this.#bytes -= evicted.byteLength;
+		}
 	}
 
 	async put(data: Buffer): Promise<BlobPutResult> {
@@ -179,7 +209,7 @@ export class MemoryBlobStore extends BlobStore {
 
 	putSync(data: Buffer): BlobPutResult {
 		const hash = new Bun.SHA256().update(data).digest("hex");
-		this.#blobs.set(hash, Buffer.from(data));
+		this.#store(hash, Buffer.from(data));
 		return {
 			hash,
 			path: `memory:${hash}`,
@@ -195,7 +225,11 @@ export class MemoryBlobStore extends BlobStore {
 
 	getSync(hash: string): Buffer | null {
 		const data = this.#blobs.get(hash);
-		return data ? Buffer.from(data) : null;
+		if (!data) return null;
+		// Refresh LRU recency on hit so hot blobs survive eviction.
+		this.#blobs.delete(hash);
+		this.#blobs.set(hash, data);
+		return Buffer.from(data);
 	}
 
 	async has(hash: string): Promise<boolean> {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -889,8 +889,27 @@ async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, ke
 	);
 }
 
+/**
+ * Run async tasks with bounded concurrency so an image-heavy resume never materializes
+ * every blob's base64 simultaneously (F8: avoids the transient OOM spike of an unbounded
+ * Promise.all over all historical images).
+ */
+const BLOB_RESOLVE_CONCURRENCY = 8;
+async function runWithConcurrency(tasks: Array<() => Promise<void>>, limit: number): Promise<void> {
+	let next = 0;
+	const worker = async (): Promise<void> => {
+		while (next < tasks.length) {
+			const index = next;
+			next += 1;
+			await tasks[index]!();
+		}
+	};
+	const workerCount = Math.max(1, Math.min(limit, tasks.length));
+	await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}
+
 async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
-	const promises: Promise<void>[] = [];
+	const tasks: Array<() => Promise<void>> = [];
 
 	for (const entry of entries) {
 		if (entry.type === "session") continue;
@@ -902,22 +921,19 @@ async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobSto
 			contentArray = entry.content;
 		}
 
-		if (contentArray) {
-			for (const block of contentArray) {
-				if (isImageBlock(block) && isBlobRef(block.data)) {
-					promises.push(
-						resolveImageData(blobStore, block.data).then(resolved => {
-							block.data = resolved;
-						}),
-					);
+		tasks.push(async () => {
+			if (contentArray) {
+				for (const block of contentArray) {
+					if (isImageBlock(block) && isBlobRef(block.data)) {
+						block.data = await resolveImageData(blobStore, block.data);
+					}
 				}
 			}
-		}
-
-		promises.push(resolvePersistedBlobRefs(entry, blobStore));
+			await resolvePersistedBlobRefs(entry, blobStore);
+		});
 	}
 
-	await Promise.all(promises);
+	await runWithConcurrency(tasks, BLOB_RESOLVE_CONCURRENCY);
 }
 
 /**

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -15,6 +15,7 @@ function sanitizeOutputChunk(rawChunk: string): string {
 export const DEFAULT_MAX_LINES = 3000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
 export const DEFAULT_MAX_COLUMN = 1024; // Max chars per grep match line
+export const DEFAULT_ARTIFACT_MAX_BYTES = 10 * 1024 * 1024; // 10MB
 
 const NL = "\n";
 
@@ -41,6 +42,8 @@ export interface OutputSummary {
 	columnTruncatedLines?: number;
 	/** Artifact ID for internal URL access (artifact://<id>) when truncated */
 	artifactId?: string;
+	/** Bytes omitted from artifact storage after the artifact hard cap was reached. */
+	artifactTruncatedBytes?: number;
 }
 
 export interface OutputSinkOptions {
@@ -61,6 +64,8 @@ export interface OutputSinkOptions {
 	 * writes still respect the budget. Default 0 = no per-line cap.
 	 */
 	maxColumns?: number;
+	/** Hard cap for artifact writes/pending replay. Default DEFAULT_ARTIFACT_MAX_BYTES. */
+	artifactMaxBytes?: number;
 	onChunk?: (chunk: string) => void;
 	/** Minimum ms between onChunk calls. 0 = every chunk (default). */
 	chunkThrottleMs?: number;
@@ -668,6 +673,9 @@ export class OutputSink {
 	#sawData = false;
 	#truncated = false;
 	#lastChunkTime = 0;
+	#artifactBytes = 0;
+	#artifactTruncatedBytes = 0;
+	#artifactTruncationNoticeWritten = false;
 
 	// Per-line column cap streaming state (persists across `push` calls so a
 	// long line split across chunks still trips the same trigger).
@@ -697,6 +705,7 @@ export class OutputSink {
 	readonly #onRawChunk?: (chunk: string) => void;
 	readonly #chunkThrottleMs: number;
 	readonly #maxColumns: number;
+	readonly #artifactMaxBytes: number;
 
 	constructor(options?: OutputSinkOptions) {
 		const {
@@ -708,6 +717,7 @@ export class OutputSink {
 			onChunk,
 			chunkThrottleMs = 0,
 			onRawChunk,
+			artifactMaxBytes = DEFAULT_ARTIFACT_MAX_BYTES,
 		} = options ?? {};
 		this.#artifactPath = artifactPath;
 		this.#artifactId = artifactId;
@@ -717,6 +727,7 @@ export class OutputSink {
 		this.#onChunk = onChunk;
 		this.#onRawChunk = onRawChunk;
 		this.#chunkThrottleMs = chunkThrottleMs;
+		this.#artifactMaxBytes = Math.max(0, artifactMaxBytes);
 	}
 
 	#headText(): string {
@@ -907,6 +918,40 @@ export class OutputSink {
 		}
 	}
 
+	#artifactTruncationNotice(droppedBytes: number): string {
+		return `\n[artifact truncated after ${this.#artifactBytes} bytes; omitted at least ${droppedBytes} bytes]\n`;
+	}
+
+	#capArtifactChunk(chunk: string, bytes: number): { chunk: string; bytes: number } | null {
+		if (bytes === 0) return null;
+		if (this.#artifactMaxBytes <= 0 || this.#artifactBytes >= this.#artifactMaxBytes) {
+			this.#artifactTruncatedBytes += bytes;
+			return null;
+		}
+		const room = this.#artifactMaxBytes - this.#artifactBytes;
+		if (bytes <= room) {
+			return { chunk, bytes };
+		}
+		const kept = truncateHeadBytes(chunk, room);
+		this.#artifactTruncatedBytes += bytes - kept.bytes;
+		return kept.bytes > 0 ? { chunk: kept.text, bytes: kept.bytes } : null;
+	}
+
+	#writeArtifactTruncationNotice(): void {
+		if (this.#artifactTruncatedBytes <= 0 || this.#artifactTruncationNoticeWritten) return;
+		const notice = this.#artifactTruncationNotice(this.#artifactTruncatedBytes);
+		try {
+			if (this.#fileReady && this.#file) {
+				this.#file.sink.write(notice);
+			} else {
+				this.#queuePendingFileWrite(notice, Buffer.byteLength(notice, "utf-8"));
+			}
+			this.#artifactTruncationNoticeWritten = true;
+		} catch {
+			/* ignore */
+		}
+	}
+
 	#queuePendingFileWrite(chunk: string, bytes = Buffer.byteLength(chunk, "utf-8")): void {
 		if (!this.#pendingFileWrites) this.#pendingFileWrites = [chunk];
 		else this.#pendingFileWrites.push(chunk);
@@ -915,14 +960,17 @@ export class OutputSink {
 	}
 
 	#enqueueFileWrite(chunk: string, bytes: number): void {
+		const capped = this.#capArtifactChunk(chunk, bytes);
+		if (!capped) return;
+		this.#artifactBytes += capped.bytes;
 		if (!this.#fileReady || !this.#file) {
-			this.#queuePendingFileWrite(chunk, bytes);
+			this.#queuePendingFileWrite(capped.chunk, capped.bytes);
 			if (this.#willOverflow(bytes) || this.#pendingFileWriteBytes > this.#spillThreshold) this.#createFileSink();
 			return;
 		}
 
 		try {
-			this.#file.sink.write(chunk);
+			this.#file.sink.write(capped.chunk);
 		} catch {
 			try {
 				void this.#file.sink.end();
@@ -931,7 +979,7 @@ export class OutputSink {
 			}
 			this.#file = undefined;
 			this.#fileReady = false;
-			this.#queuePendingFileWrite(chunk, bytes);
+			this.#queuePendingFileWrite(capped.chunk, capped.bytes);
 			this.#createFileSink();
 		}
 	}
@@ -1019,6 +1067,8 @@ export class OutputSink {
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
 
 		let artifactId: string | undefined;
+		if (this.#artifactTruncatedBytes > 0) this.#createFileSink();
+		this.#writeArtifactTruncationNotice();
 		if (this.#file) {
 			artifactId = this.#file.artifactId;
 			await this.#file.sink.end();
@@ -1095,6 +1145,7 @@ export class OutputSink {
 			elidedLines,
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
+			artifactTruncatedBytes: this.#artifactTruncatedBytes > 0 ? this.#artifactTruncatedBytes : undefined,
 			artifactId,
 		};
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
+import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
 import {
@@ -13,6 +14,8 @@ import {
 import { extractExplicitThinkingSelector, formatModelSelectorValue, parseModelPattern } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
+import { DynamicBorder } from "../modes/components/dynamic-border";
+import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { formatModelOnboardingGuidance } from "../setup/model-onboarding-guidance";
 import {
@@ -23,6 +26,7 @@ import {
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
 import { buildContextReportText } from "./helpers/context-report";
+import { buildFastStatusReport } from "./helpers/fast-status-report";
 import { formatDuration } from "./helpers/format";
 import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
@@ -40,6 +44,14 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label: string; isSubagentRole: boolean }> {
+	return GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => ({
+		id,
+		label: GJC_MODEL_ASSIGNMENT_TARGETS[id].tag ?? id.toUpperCase(),
+		isSubagentRole: GJC_MODEL_ASSIGNMENT_TARGETS[id].settingsPath === "task.agentModelOverrides",
+	}));
+}
 
 function parseProviderSetupSlashArgs(args: string): {
 	preset?: string;
@@ -357,7 +369,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (arg === "status") {
-				await runtime.output(`Fast mode is ${runtime.session.isFastModeEnabled() ? "on" : "off"}.`);
+				await runtime.output(
+					buildFastStatusReport({
+						session: runtime.session,
+						roleTargets: fastStatusRoleTargets(),
+						iconFast: theme.icon.fast,
+					}),
+				);
 				return commandConsumed();
 			}
 			return usage("Usage: /fast [on|off|status]", runtime);
@@ -386,8 +404,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 			if (arg === "status") {
-				const enabled = runtime.ctx.session.isFastModeEnabled();
-				runtime.ctx.showStatus(`Fast mode is ${enabled ? "on" : "off"}.`);
+				const report = buildFastStatusReport({
+					session: runtime.ctx.session,
+					roleTargets: fastStatusRoleTargets(),
+					iconFast: theme.icon.fast,
+					formatInactive: text => theme.fg("dim", text),
+				});
+				runtime.ctx.chatContainer.addChild(new Spacer(1));
+				runtime.ctx.chatContainer.addChild(new DynamicBorder());
+				runtime.ctx.chatContainer.addChild(new Text(report, 1, 0));
+				runtime.ctx.chatContainer.addChild(new DynamicBorder());
+				runtime.ctx.ui.requestRender();
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/fast-status-report.ts
@@ -1,0 +1,111 @@
+import type { Model } from "@gajae-code/ai";
+
+/**
+ * A single line in the `/fast status` report: a labelled model and whether fast
+ * mode is effective for it. The `fast` flag is resolved by the caller
+ * (`buildFastStatusReport`) so each row can use the correct service tier — the
+ * main session tier for the current model / `modelRoles` roles, or the subagent
+ * tier (`task.serviceTier`) for `task.agentModelOverrides` roles.
+ */
+export interface FastStatusRow {
+	/** Display label, e.g. "현재 모델", "DEFAULT", "EXECUTOR". */
+	label: string;
+	/** Resolved model for this row, if any. */
+	model?: Model;
+	/** Whether fast mode is effective for this row's model. */
+	fast: boolean;
+}
+
+export interface FormatFastStatusReportArgs {
+	rows: FastStatusRow[];
+	/** The active theme's fast icon token (`theme.icon.fast`). */
+	iconFast: string;
+	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
+	formatInactive?: (text: string) => string;
+}
+
+/** Title line of the `/fast status` report. */
+export const FAST_STATUS_TITLE = "Fast 모드 상태";
+
+/** The inactive marker shown for rows where fast mode does not apply. */
+export const FAST_STATUS_OFF = "off";
+
+/**
+ * Format a multiline `/fast status` report. Pure and shared by the CLI
+ * (`handle`) and TUI (`handleTui`) command branches so the two never drift.
+ * Each row's fast/off state is decided by the caller (see
+ * {@link buildFastStatusReport}) so per-row service-tier differences are honored.
+ */
+export function formatFastStatusReport(args: FormatFastStatusReportArgs): string {
+	const { rows, iconFast } = args;
+	const formatInactive = args.formatInactive ?? ((text: string) => text);
+	const lines: string[] = [FAST_STATUS_TITLE];
+	for (const row of rows) {
+		if (!row.model) {
+			lines.push(`${row.label}: ${formatInactive(FAST_STATUS_OFF)}`);
+			continue;
+		}
+		const ref = `${row.model.provider}/${row.model.id}`;
+		lines.push(`${row.label}: ${ref} ${row.fast ? iconFast : formatInactive(FAST_STATUS_OFF)}`);
+	}
+	return lines.join("\n");
+}
+
+/** Minimal session surface needed to build the `/fast status` report. */
+export interface FastStatusSessionLike {
+	readonly model?: Model;
+	/** Fast predicate against the main session tier (current model + `modelRoles`). */
+	isFastForProvider(provider?: string): boolean;
+	/** Fast predicate against the effective subagent tier (`task.agentModelOverrides` roles). */
+	isFastForSubagentProvider(provider?: string): boolean;
+	resolveRoleModelWithThinking(role: string): { model?: Model };
+}
+
+/** A role to enumerate in the report, with the tier source its subagent runs under. */
+export interface FastStatusRoleTarget {
+	id: string;
+	label: string;
+	/**
+	 * True for `task.agentModelOverrides` roles (executor/architect/planner/critic)
+	 * that run under `task.serviceTier`; false for `modelRoles` roles (default)
+	 * that run under the main session tier.
+	 */
+	isSubagentRole: boolean;
+}
+
+export interface BuildFastStatusReportArgs {
+	session: FastStatusSessionLike;
+	/** Role targets to enumerate, in display order. */
+	roleTargets: ReadonlyArray<FastStatusRoleTarget>;
+	/** The active theme's fast icon token (`theme.icon.fast`). */
+	iconFast: string;
+	/** Optional decorator for inactive ("off") text, e.g. theme dim in the TUI. */
+	formatInactive?: (text: string) => string;
+}
+
+/**
+ * Build the `/fast status` report from a live session: the active/current model
+ * followed by each assigned role (subagent) model. Unassigned roles are skipped
+ * so the report mirrors the `/model` selector, which only badges assigned roles.
+ *
+ * Subagent roles (`task.agentModelOverrides`) are evaluated against the
+ * effective subagent tier (`task.serviceTier`), while the current model and
+ * `modelRoles` roles use the main session tier — matching where each model
+ * actually runs.
+ */
+export function buildFastStatusReport(args: BuildFastStatusReportArgs): string {
+	const { session, roleTargets, iconFast, formatInactive } = args;
+	const rows: FastStatusRow[] = [
+		{ label: "현재 모델", model: session.model, fast: session.isFastForProvider(session.model?.provider) },
+	];
+	for (const target of roleTargets) {
+		const resolved = session.resolveRoleModelWithThinking(target.id);
+		if (resolved.model) {
+			const fast = target.isSubagentRole
+				? session.isFastForSubagentProvider(resolved.model.provider)
+				: session.isFastForProvider(resolved.model.provider);
+			rows.push({ label: target.label, model: resolved.model, fast });
+		}
+	}
+	return formatFastStatusReport({ rows, iconFast, formatInactive });
+}

--- a/packages/coding-agent/src/tools/archive-reader.ts
+++ b/packages/coding-agent/src/tools/archive-reader.ts
@@ -315,7 +315,16 @@ export async function openArchive(filePath: string): Promise<ArchiveReader> {
 		throw new ToolError(`Unsupported archive format: ${filePath}`);
 	}
 
-	const bytes = await Bun.file(filePath).bytes();
+	// F20: cap the compressed archive read so opening a multi-GB archive cannot buffer it
+	// whole into memory. (Zip-bomb expanded-size bounding would need a streaming inflate.)
+	const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+	const file = Bun.file(filePath);
+	if (file.size > MAX_ARCHIVE_BYTES) {
+		throw new ToolError(
+			`Archive too large to open: ${filePath} is ${file.size} bytes (limit ${MAX_ARCHIVE_BYTES}). Extract a subset with a dedicated tool.`,
+		);
+	}
+	const bytes = await file.bytes();
 	const entries = format === "zip" ? await readZipEntries(bytes) : await readTarEntries(bytes);
 	return new ArchiveReader(format, entries);
 }

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -37,8 +37,13 @@ export const BASH_DEFAULT_PREVIEW_LINES = 10;
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 
-async function saveBashOriginalArtifact(session: ToolSession, originalText: string): Promise<string | undefined> {
+export async function saveBashOriginalArtifactForTests(
+	session: ToolSession,
+	originalText: string,
+): Promise<string | undefined> {
 	try {
+		const manager = session.getArtifactManager?.();
+		if (manager) return await manager.save(originalText, "bash-original");
 		const alloc = await session.allocateOutputArtifact?.("bash-original");
 		if (!alloc?.path || !alloc.id) return undefined;
 		await Bun.write(alloc.path, originalText);
@@ -375,6 +380,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						env: options.resolvedEnv,
 						artifactPath,
 						artifactId,
+						oneShot: true,
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							latestText = tailBuffer.text();
@@ -387,7 +393,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							// path above.
 							manager.appendOutput(jobId, chunk);
 						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 					});
 					const finalResult = this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -675,6 +681,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						env: prepared.resolvedEnv,
 						artifactPath,
 						artifactId,
+						oneShot: true,
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							void reportProgress(tailBuffer.text(), {
@@ -688,7 +695,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							cursorOffset = slice.nextOffset;
 							dispatchLines(slice.text);
 						},
-						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+						onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 					});
 					flushTrailingLine();
 					this.#buildResultText(result, prepared.timeoutSec, result.output || "(no output)");
@@ -996,7 +1003,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
+					onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
 				});
 		if (result.cancelled) {
 			if (signal?.aborted) {

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -213,6 +213,7 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 
 		const result = await untilAborted(signal, () =>
 			acquireTab(name, browser, {
+				ownerId: this.session.getSessionId?.() ?? undefined,
 				url: params.url,
 				waitUntil: params.wait_until,
 				viewport: params.viewport
@@ -381,11 +382,44 @@ function sameBrowserKind(a: BrowserKind, b: BrowserKind): boolean {
 	return false;
 }
 
+/** Max chars of a browser return value surfaced into the tool result (F22). */
+const MAX_BROWSER_RETURN_CHARS = 256 * 1024;
+
+const BROWSER_RETURN_BUDGET_EXCEEDED = Symbol("browser-return-budget-exceeded");
+
+/** Hard-cap any surfaced browser return string at the byte/char limit with a notice. */
+function capBrowserReturn(text: string): string {
+	if (text.length <= MAX_BROWSER_RETURN_CHARS) return text;
+	return `${text.slice(0, MAX_BROWSER_RETURN_CHARS)}\n\n[Browser return value truncated: ${text.length} chars exceeds the ${MAX_BROWSER_RETURN_CHARS}-char cap.]`;
+}
+
 function stringifyReturnValue(value: unknown): string {
-	if (typeof value === "string") return value;
+	if (typeof value === "string") return capBrowserReturn(value);
+	// F22: bound the serialization itself — the replacer tracks running size and aborts early so a
+	// huge object/array cannot build megabytes before truncation — AND hard-cap the final string,
+	// since pretty-print structural overhead (indent/braces/commas) is not counted by the budget.
+	let budget = MAX_BROWSER_RETURN_CHARS;
 	try {
-		return JSON.stringify(value, null, 2) ?? String(value);
-	} catch {
-		return String(value);
+		const text = JSON.stringify(
+			value,
+			(_key, val) => {
+				if (typeof val === "string") budget -= val.length + 4;
+				else if (typeof val === "number" || typeof val === "boolean") budget -= 8;
+				else budget -= 2;
+				if (budget < 0) throw BROWSER_RETURN_BUDGET_EXCEEDED;
+				return val;
+			},
+			2,
+		);
+		return text === undefined ? capBrowserReturn(String(value)) : capBrowserReturn(text);
+	} catch (error) {
+		if (error === BROWSER_RETURN_BUDGET_EXCEEDED) {
+			return `[Browser return value too large to serialize (exceeds the ${MAX_BROWSER_RETURN_CHARS}-char cap). Return a smaller or summarized value from the page script.]`;
+		}
+		try {
+			return capBrowserReturn(String(value));
+		} catch {
+			return "[unserializable browser return value]";
+		}
 	}
 }

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -55,6 +55,8 @@ export interface TabSession {
 	pending: Map<string, PendingRun>;
 	dialogPolicy?: DialogPolicy;
 	kindTag: BrowserKindTag;
+	/** Session that acquired this tab; used for session-scoped teardown (F13). */
+	ownerId?: string;
 }
 
 export interface AcquireTabOptions {
@@ -65,6 +67,8 @@ export interface AcquireTabOptions {
 	signal?: AbortSignal;
 	timeoutMs: number;
 	dialogs?: DialogPolicy;
+	/** Owning session id so dispose can release only this session's tabs (F13). */
+	ownerId?: string;
 }
 
 export interface AcquireTabResult {
@@ -161,6 +165,7 @@ export async function acquireTab(
 		pending: new Map(),
 		dialogPolicy: opts.dialogs,
 		kindTag: browser.kind.kind,
+		ownerId: opts.ownerId,
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
 	tabs.set(name, tab);
@@ -247,6 +252,23 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 
 export async function releaseAllTabs(opts: ReleaseTabOptions = {}): Promise<number> {
 	const names = [...tabs.keys()];
+	let count = 0;
+	for (const name of names) {
+		if (await releaseTab(name, opts)) count++;
+	}
+	return count;
+}
+
+/**
+ * Release only the tabs owned by `ownerId` (F13 session-scoped teardown). Tabs acquired
+ * by other sessions (or with no owner) are left untouched. No-op for a null/empty owner.
+ */
+export async function releaseTabsForOwner(
+	ownerId: string | null | undefined,
+	opts: ReleaseTabOptions = {},
+): Promise<number> {
+	if (!ownerId) return 0;
+	const names = [...tabs.entries()].filter(([, tab]) => tab.ownerId === ownerId).map(([name]) => name);
 	let count = 0;
 	for (const name of names) {
 		if (await releaseTab(name, opts)) count++;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1270,19 +1270,18 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				}
 				case "raw": {
 					const result = executeReadQuery(db, selector.sql);
+					const table = renderTable(result.columns, result.rows, {
+						totalCount: result.rows.length,
+						offset: 0,
+						limit: result.rows.length || DEFAULT_MAX_LINES,
+						table: "query",
+						dbPath: resolvedSqlitePath.absolutePath,
+					});
+					const body = result.truncated
+						? `${table}\n\n[Output truncated to the first ${result.rows.length} rows; add a LIMIT clause to the query to bound or page the result.]`
+						: table;
 					return toolResult<ReadToolDetails>(details)
-						.text(
-							prependSuffixResolutionNotice(
-								renderTable(result.columns, result.rows, {
-									totalCount: result.rows.length,
-									offset: 0,
-									limit: result.rows.length || DEFAULT_MAX_LINES,
-									table: "query",
-									dbPath: resolvedSqlitePath.absolutePath,
-								}),
-								resolvedSqlitePath.suffixResolution,
-							),
-						)
+						.text(prependSuffixResolutionNotice(body, resolvedSqlitePath.suffixResolution))
 						.sourcePath(resolvedSqlitePath.absolutePath)
 						.done();
 				}

--- a/packages/coding-agent/src/tools/sqlite-reader.ts
+++ b/packages/coding-agent/src/tools/sqlite-reader.ts
@@ -590,15 +590,29 @@ export function getRowByRowId(db: Database, table: string, key: string): Record<
 		.get(binding);
 }
 
-export function executeReadQuery(db: Database, sql: string): { columns: string[]; rows: Record<string, unknown>[] } {
+const MAX_RAW_QUERY_ROWS = 1000;
+
+export function executeReadQuery(
+	db: Database,
+	sql: string,
+	maxRows: number = MAX_RAW_QUERY_ROWS,
+): { columns: string[]; rows: Record<string, unknown>[]; truncated: boolean } {
 	const statement = db.prepare<SqliteRow, []>(sql);
 	if (statement.paramsCount > 0) {
 		throw new ToolError("SQLite raw queries do not support bound parameters");
 	}
-	return {
-		columns: [...statement.columnNames],
-		rows: statement.all(),
-	};
+	// Stream rows and stop at the cap (F20): a raw `q=SELECT ...` over a huge table
+	// must not materialize every row into memory via statement.all().
+	const rows: Record<string, unknown>[] = [];
+	let truncated = false;
+	for (const row of statement.iterate()) {
+		if (rows.length >= maxRows) {
+			truncated = true;
+			break;
+		}
+		rows.push(row as Record<string, unknown>);
+	}
+	return { columns: [...statement.columnNames], rows, truncated };
 }
 
 export function insertRow(db: Database, table: string, data: Record<string, unknown>): void {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -21,6 +21,7 @@ import type { Model } from "@gajae-code/ai";
 import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
 import { resetSettingsForTest, Settings } from "../src/config/settings";
 import { ACP_BOOTSTRAP_RACE_GUARD_MS, AcpAgent, createAcpExtensionUiContext } from "../src/modes/acp/acp-agent";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 import type { PlanModeState } from "../src/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "../src/session/agent-session";
 import { SILENT_ABORT_MARKER } from "../src/session/messages";
@@ -305,6 +306,18 @@ class FakeAgentSession {
 		return this.fastMode;
 	}
 
+	isFastForProvider(_provider?: string): boolean {
+		return false;
+	}
+
+	isFastForSubagentProvider(_provider?: string): boolean {
+		return false;
+	}
+
+	resolveRoleModelWithThinking(_role: string): { model: undefined } {
+		return { model: undefined };
+	}
+
 	setForcedToolChoice(toolName: string): void {
 		this.forcedToolChoice = toolName;
 	}
@@ -458,6 +471,10 @@ async function waitForAvailableCommandsUpdate(harness: AgentHarness, sessionId: 
 }
 
 describe("ACP agent", () => {
+	beforeAll(async () => {
+		const installed = await getThemeByName("red-claw");
+		if (installed) setThemeInstance(installed);
+	});
 	it("supports multiple live ACP sessions with model and lifecycle handlers", async () => {
 		const harness = await createHarness();
 		const first = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
@@ -1651,7 +1668,7 @@ describe("ACP agent", () => {
 				update =>
 					update.update.sessionUpdate === "agent_message_chunk" &&
 					update.update.content.type === "text" &&
-					update.update.content.text === "Fast mode is off.",
+					update.update.content.text.includes("Fast 모드 상태"),
 			),
 		).toBe(true);
 

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import type { AgentMessage } from "@gajae-code/agent-core";
 import { Settings } from "../src/config/settings";
+import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../src/slash-commands/acp-builtins";
@@ -17,6 +18,9 @@ interface FakeAcpBuiltinSession {
 	toggleFastMode(): boolean;
 	setFastMode(enabled: boolean): void;
 	isFastModeEnabled(): boolean;
+	isFastForProvider(provider?: string): boolean;
+	isFastForSubagentProvider(provider?: string): boolean;
+	resolveRoleModelWithThinking(role: string): { model?: { provider: string; id: string } };
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
 	getAsyncJobSnapshot: (opts?: { recentLimit?: number }) => { running: unknown[]; recent: unknown[] } | null;
@@ -75,6 +79,15 @@ function createRuntime() {
 		},
 		isFastModeEnabled() {
 			return this.fastMode;
+		},
+		isFastForProvider(_provider?: string) {
+			return false;
+		},
+		isFastForSubagentProvider(_provider?: string) {
+			return false;
+		},
+		resolveRoleModelWithThinking(_role: string): { model?: { provider: string; id: string } } {
+			return { model: undefined };
 		},
 		setForcedToolChoice(toolName: string) {
 			this.forcedToolChoice = toolName;
@@ -196,12 +209,71 @@ function createRuntime() {
 
 describe("ACP builtin slash commands", () => {
 	it("consumes fast status without returning prompt text", async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for fast status test");
+		setThemeInstance(installed);
 		const { output, runtime } = createRuntime();
 
 		const result = await executeAcpBuiltinSlashCommand("/fast status", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(output).toEqual(["Fast mode is off."]);
+		// No model selected and no roles assigned -> multiline report, active row off.
+		expect(output).toHaveLength(1);
+		expect(output[0]).toContain("Fast 모드 상태");
+		expect(output[0]).toContain("현재 모델: off");
+		expect(output[0]).not.toContain("Fast mode is");
+	});
+
+	it("renders a provider-aware multiline fast status report and never calls isFastModeEnabled", async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for fast status test");
+		setThemeInstance(installed);
+		const { output, runtime } = createRuntime();
+		const session = runtime.session as unknown as {
+			model: { provider: string; id: string } | undefined;
+			isFastForProvider: (provider?: string) => boolean;
+			isFastForSubagentProvider: (provider?: string) => boolean;
+			resolveRoleModelWithThinking: (role: string) => { model?: { provider: string; id: string } };
+			isFastModeEnabled: () => boolean;
+		};
+		session.model = { provider: "anthropic", id: "claude-sonnet-4-5" };
+		session.isFastForProvider = provider => provider === "anthropic";
+		// Subagent roles run under task.serviceTier; here it grants no fast mode, so
+		// the EXECUTOR row must be off even though its anthropic model would be fast
+		// under the main session tier.
+		session.isFastForSubagentProvider = () => false;
+		session.resolveRoleModelWithThinking = role =>
+			role === "executor" ? { model: { provider: "anthropic", id: "claude-opus-4-1" } } : { model: undefined };
+		// The status branch must use the provider-aware predicate, never this.
+		session.isFastModeEnabled = () => {
+			throw new Error("/fast status must not call isFastModeEnabled");
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/fast status", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+		// Subagent role uses the subagent tier -> off despite the anthropic model.
+		expect(output[0]).toContain("EXECUTOR: anthropic/claude-opus-4-1 off");
+		expect(output[0]).not.toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${theme.icon.fast}`);
+		expect(output[0]).not.toContain("Fast mode is");
+	});
+	it("keeps /fast on/off/toggle output and state changes unchanged", async () => {
+		const { output, runtime } = createRuntime();
+
+		await expect(executeAcpBuiltinSlashCommand("/fast on", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(true);
+		expect(output).toEqual(["Fast mode enabled."]);
+
+		output.length = 0;
+		await expect(executeAcpBuiltinSlashCommand("/fast off", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(false);
+		expect(output).toEqual(["Fast mode disabled."]);
+
+		output.length = 0;
+		await expect(executeAcpBuiltinSlashCommand("/fast toggle", runtime)).resolves.toEqual({ consumed: true });
+		expect(runtime.session.fastMode).toBe(true);
+		expect(output).toEqual(["Fast mode enabled."]);
 	});
 
 	it("renders provider usage reports when the session can fetch them", async () => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -253,7 +253,7 @@ describe("ACP builtin slash commands", () => {
 		runtime.session.getAsyncJobSnapshot = () => ({
 			running: [{ id: "j1", type: "bash", status: "running", label: "npm install", startTime: Date.now() - 5000 }],
 			recent: [{ id: "j2", type: "task", status: "completed", label: "build done", startTime: Date.now() - 60_000 }],
-			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+			delivery: { queued: 0, delivering: false, pendingJobIds: [], deadLettered: 0 },
 		});
 
 		const result = await executeAcpBuiltinSlashCommand("/jobs", runtime);
@@ -884,7 +884,7 @@ describe("wave 5 — adapters and polish", () => {
 		runtime.session.getAsyncJobSnapshot = () => ({
 			running: [],
 			recent: [],
-			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+			delivery: { queued: 0, delivering: false, pendingJobIds: [], deadLettered: 0 },
 		});
 		const result = await executeAcpBuiltinSlashCommand("/jobs", runtime);
 		expect(result).toEqual({ consumed: true });

--- a/packages/coding-agent/test/agent-session-fast-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-fast-mode.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+describe("AgentSession fast-mode predicate", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-fast-mode-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("returns false for an undefined provider even under an unscoped priority tier", () => {
+		session.setServiceTier("priority");
+		// Unscoped priority applies to a concrete provider...
+		expect(session.isFastForProvider("anthropic")).toBe(true);
+		expect(session.isFastForProvider("openai")).toBe(true);
+		// ...but never when there is no provider (no model selected).
+		expect(session.isFastForProvider(undefined)).toBe(false);
+	});
+
+	it("is provider-scoped for claude-only", () => {
+		session.setServiceTier("claude-only");
+		expect(session.isFastForProvider("anthropic")).toBe(true);
+		expect(session.isFastForProvider("openai")).toBe(false);
+		expect(session.isFastForProvider("openai-codex")).toBe(false);
+		expect(session.isFastForProvider(undefined)).toBe(false);
+	});
+
+	it("isFastModeActive reflects the current model's provider and the configured tier", () => {
+		expect(session.isFastModeActive()).toBe(false);
+		session.setServiceTier("priority");
+		// current model is anthropic
+		expect(session.isFastModeActive()).toBe(true);
+		// claude-only still matches the anthropic current model
+		session.setServiceTier("claude-only");
+		expect(session.isFastModeActive()).toBe(true);
+		// openai-only does not match the anthropic current model
+		session.setServiceTier("openai-only");
+		expect(session.isFastModeActive()).toBe(false);
+		session.setServiceTier(undefined);
+		expect(session.isFastModeActive()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/async/job-manager-bounds.test.ts
+++ b/packages/coding-agent/test/async/job-manager-bounds.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AsyncJobManager,
+	type ResumeDescriptor,
+	type SubagentRecord,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+function subagentRecord(subagentId: string, currentJobId: string, status: SubagentRecord["status"]): SubagentRecord {
+	return {
+		subagentId,
+		currentJobId,
+		historicalJobIds: [],
+		status,
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	};
+}
+
+function resumeDescriptor(subagentId: string): ResumeDescriptor {
+	return { subagentId, data: { sessionFile: `/tmp/${subagentId}.jsonl` } };
+}
+
+describe("AsyncJobManager bounded dispose and delivery", () => {
+	test("dispose timeout applies to never-settling jobs and records stuck ids", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		manager.register("task", "stuck", () => new Promise(() => {}), { id: "stuck-job" });
+
+		const started = Date.now();
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const elapsed = Date.now() - started;
+
+		expect(disposed).toBe(false);
+		expect(elapsed).toBeLessThan(250);
+		expect(manager.getLastDisposeDiagnostics().stuckJobIds).toEqual(["stuck-job"]);
+		expect(manager.getAllJobs()).toHaveLength(0);
+	});
+
+	test("late completion after dispose timeout runs terminal lifecycle without rescheduling eviction", async () => {
+		let resolveJob!: (value: string) => void;
+		let terminalCalls = 0;
+		let changeCalls = 0;
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 60_000 });
+		manager.onChange(() => {
+			changeCalls += 1;
+		});
+		manager.register(
+			"task",
+			"late resolver",
+			() =>
+				new Promise<string>(resolve => {
+					resolveJob = resolve;
+				}),
+			{
+				id: "late-resolver",
+				lifecycle: {
+					onTerminal: () => {
+						terminalCalls += 1;
+					},
+				},
+			},
+		);
+
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const changesAfterDispose = changeCalls;
+		resolveJob("late done");
+		await Bun.sleep(25);
+
+		expect(disposed).toBe(false);
+		expect(terminalCalls).toBe(1);
+		expect(manager.getAllJobs()).toHaveLength(0);
+		expect(manager.getDeliveryState().queued).toBe(0);
+		expect(changeCalls).toBe(changesAfterDispose);
+	});
+
+	test("multibyte delivery previews stay within utf8 byte head and tail budgets", async () => {
+		let delivered = "";
+		const manager = new AsyncJobManager({
+			onJobComplete: (_jobId, text) => {
+				delivered = text;
+			},
+		});
+		const text = `${"界".repeat(12_000)}${"🙂".repeat(12_000)}`;
+		manager.register("task", "multibyte", async () => text, { id: "multibyte-preview" });
+
+		await manager.waitForAll();
+		const drained = await manager.drainDeliveries({ timeoutMs: 1_000 });
+		const [head = "", tail = ""] = delivered.split(/\n\n\[async delivery output truncated from \d+ bytes\]\n\n/);
+
+		expect(drained).toBe(true);
+		expect(delivered).toContain("[async delivery output truncated from ");
+		expect(Buffer.byteLength(head, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(32 * 1024);
+	});
+
+	test("misaligned multibyte delivery preview tail stays within utf8 byte budget", async () => {
+		let delivered = "";
+		const manager = new AsyncJobManager({
+			onJobComplete: (_jobId, text) => {
+				delivered = text;
+			},
+		});
+		const text = `${"🙂".repeat(16_385)}a`;
+		manager.register("task", "misaligned multibyte", async () => text, { id: "misaligned-preview" });
+
+		await manager.waitForAll();
+		const drained = await manager.drainDeliveries({ timeoutMs: 1_000 });
+		const [head = "", tail = ""] = delivered.split(/\n\n\[async delivery output truncated from \d+ bytes\]\n\n/);
+
+		expect(drained).toBe(true);
+		expect(delivered).toContain("[async delivery output truncated from 65541 bytes]");
+		expect(Buffer.byteLength(head, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(32 * 1024);
+		expect(delivered).not.toContain("\ufffd");
+	});
+
+	test("delivery queue is bounded and failing deliveries stop at retry cap", async () => {
+		let attempts = 0;
+		const manager = new AsyncJobManager({
+			onJobComplete: () => {
+				attempts += 1;
+				throw new Error("persistent delivery failure");
+			},
+			maxRunningJobs: 150,
+			retentionMs: 10_000,
+		});
+
+		for (let i = 0; i < 120; i += 1) {
+			manager.register("task", `job ${i}`, async () => `done ${i}`, { id: `job-${i}` });
+		}
+
+		await Bun.sleep(25);
+		expect(manager.getDeliveryState().queued).toBeLessThanOrEqual(100);
+		expect(manager.getDeliveryState().deadLettered).toBeGreaterThan(0);
+
+		for (let i = 0; i < 15 && manager.getDeliveryState().queued > 0; i += 1) {
+			await Bun.sleep(550);
+		}
+		const state = manager.getDeliveryState();
+		expect(state.queued).toBe(0);
+		expect(state.deadLettered).toBe(120);
+		expect(attempts).toBeLessThanOrEqual(120 * 3);
+	});
+
+	test("terminal eviction purges subagent records while paused records remain resumable", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0, maxRunningJobs: 2 });
+
+		const terminalJobId = manager.register("task", "terminal", async () => "done", { id: "terminal-job" });
+		manager.registerSubagentRecord(subagentRecord("terminal-sub", terminalJobId, "running"));
+		manager.registerResumeDescriptor(resumeDescriptor("terminal-sub"));
+		manager.registerLiveHandle("terminal-sub", {
+			requestPause: () => {},
+			injectMessage: async () => {},
+		});
+		manager.recordSubagentProgress("terminal-sub", { currentTool: "test" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getSubagentRecord("terminal-sub")).toBeUndefined();
+		expect(manager.getResumeDescriptor("terminal-sub")).toBeUndefined();
+		expect(manager.getLiveHandle("terminal-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("terminal-sub")).toBeUndefined();
+
+		const pausedJobId = manager.register("task", "paused", async () => ({ kind: "paused", note: "safe boundary" }), {
+			id: "paused-job",
+		});
+		manager.registerSubagentRecord(subagentRecord("paused-sub", pausedJobId, "running"));
+		manager.registerResumeDescriptor(resumeDescriptor("paused-sub"));
+		manager.registerLiveHandle("paused-sub", {
+			requestPause: () => {},
+			injectMessage: async () => {},
+		});
+		manager.recordSubagentProgress("paused-sub", { currentTool: "test" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getSubagentRecord("paused-sub")?.status).toBe("paused");
+		expect(manager.getResumeDescriptor("paused-sub")).toEqual(resumeDescriptor("paused-sub"));
+		expect(manager.getLiveHandle("paused-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("paused-sub")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/async/job-manager-redteam.test.ts
+++ b/packages/coding-agent/test/async/job-manager-redteam.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
+import {
+	AsyncJobManager,
+	type ResumeDescriptor,
+	type SubagentRecord,
+	type SubagentRunOutcome,
+} from "@gajae-code/coding-agent/async/job-manager";
+
+setDefaultTimeout(10_000);
+
+function record(subagentId: string, jobId: string, status: SubagentRecord["status"]): SubagentRecord {
+	return {
+		subagentId,
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status,
+		sessionFile: `/tmp/${subagentId}.jsonl`,
+		resumable: true,
+	};
+}
+
+function descriptor(subagentId: string): ResumeDescriptor {
+	return { subagentId, data: { sessionFile: `/tmp/${subagentId}.jsonl` } };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await Bun.sleep(10);
+	}
+	return predicate();
+}
+
+describe("AsyncJobManager red-team invariants", () => {
+	test("dispose({ timeoutMs }) on a never-settling job returns by deadline and reports the stuck job id", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		manager.register("task", "never settles", () => new Promise<string>(() => {}), { id: "redteam-stuck" });
+
+		const started = performance.now();
+		const disposed = await manager.dispose({ timeoutMs: 30 });
+		const elapsedMs = performance.now() - started;
+
+		expect(disposed).toBe(false);
+		expect(elapsedMs).toBeLessThan(250);
+		expect(manager.getLastDisposeDiagnostics()).toEqual({
+			stuckJobIds: ["redteam-stuck"],
+			deliveriesDrained: false,
+		});
+		expect(manager.getAllJobs()).toHaveLength(0);
+	});
+
+	test("late failure after dispose timeout runs terminal lifecycle and does not restart timers", async () => {
+		let rejectJob!: (error: Error) => void;
+		let terminalCalls = 0;
+		let changeCalls = 0;
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 60_000 });
+		manager.onChange(() => {
+			changeCalls += 1;
+		});
+		manager.register(
+			"task",
+			"late rejecter",
+			() =>
+				new Promise<string>((_resolve, reject) => {
+					rejectJob = reject;
+				}),
+			{
+				id: "late-rejecter",
+				lifecycle: {
+					onTerminal: () => {
+						terminalCalls += 1;
+					},
+				},
+			},
+		);
+
+		const disposed = await manager.dispose({ timeoutMs: 25 });
+		const changesAfterDispose = changeCalls;
+		rejectJob(new Error("late boom"));
+		await Bun.sleep(25);
+
+		expect(disposed).toBe(false);
+		expect(terminalCalls).toBe(1);
+		expect(manager.getDeliveryState().queued).toBe(0);
+		expect(changeCalls).toBe(changesAfterDispose);
+	});
+
+	test("permanent onJobComplete failures keep delivery queue bounded, stop at retry cap, and dead-letter", async () => {
+		const randomSpy = spyOn(Math, "random").mockImplementation(() => 0);
+		let attempts = 0;
+		const manager = new AsyncJobManager({
+			onJobComplete: () => {
+				attempts += 1;
+				throw new Error("redteam persistent delivery failure");
+			},
+			maxRunningJobs: 1,
+			retentionMs: 10_000,
+		});
+
+		try {
+			manager.register("task", "poison delivery", async () => "cannot deliver", { id: "poison-job" });
+			await manager.waitForAll();
+
+			const drained = await manager.drainDeliveries({ timeoutMs: 1_800 });
+			const state = manager.getDeliveryState();
+
+			expect(drained).toBe(true);
+			expect(state.queued).toBe(0);
+			expect(state.pendingJobIds).toEqual([]);
+			expect(state.deadLettered).toBe(1);
+			expect(attempts).toBe(3);
+		} finally {
+			randomSpy.mockRestore();
+			await manager.dispose({ timeoutMs: 200 });
+		}
+	});
+
+	test("completion flood above the delivery bound caps the queue and counts overflow as dead-lettered", async () => {
+		const manager = new AsyncJobManager({
+			onJobComplete: () => new Promise<void>(() => {}),
+			maxRunningJobs: 150,
+			retentionMs: 10_000,
+		});
+
+		try {
+			for (let i = 0; i < 150; i += 1) {
+				manager.register("task", `flood ${i}`, async () => `done ${i}`, { id: `flood-${i}` });
+			}
+			await manager.waitForAll();
+
+			const captured = await waitUntil(() => {
+				const state = manager.getDeliveryState();
+				return state.queued <= 101 && state.deadLettered >= 49;
+			}, 5_000);
+			const state = manager.getDeliveryState();
+
+			expect(captured).toBe(true);
+			expect(state.queued).toBeLessThanOrEqual(101);
+			expect(state.deadLettered).toBeGreaterThanOrEqual(49);
+			expect(state.pendingJobIds).not.toContain("flood-1");
+			expect(state.pendingJobIds).toContain("flood-149");
+		} finally {
+			await manager.dispose({ timeoutMs: 50 });
+		}
+	});
+
+	test("terminal eviction purges subagent records and resume descriptors while preserving paused records", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0, maxRunningJobs: 2 });
+
+		const terminalJobId = manager.register(
+			"task",
+			"terminal subagent",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "completed", text: "terminal" }),
+			{ id: "terminal-job" },
+		);
+		manager.registerSubagentRecord(record("terminal-sub", terminalJobId, "running"));
+		manager.registerResumeDescriptor(descriptor("terminal-sub"));
+		manager.registerLiveHandle("terminal-sub", { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("terminal-sub", { currentTool: "terminal" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getJob(terminalJobId)).toBeUndefined();
+		expect(manager.getSubagentRecord("terminal-sub")).toBeUndefined();
+		expect(manager.getResumeDescriptor("terminal-sub")).toBeUndefined();
+		expect(manager.getLiveHandle("terminal-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("terminal-sub")).toBeUndefined();
+
+		const pausedJobId = manager.register(
+			"task",
+			"paused subagent",
+			async (): Promise<SubagentRunOutcome> => ({ kind: "paused", note: "safe boundary" }),
+			{ id: "paused-job" },
+		);
+		manager.registerSubagentRecord(record("paused-sub", pausedJobId, "running"));
+		manager.registerResumeDescriptor(descriptor("paused-sub"));
+		manager.registerLiveHandle("paused-sub", { requestPause() {}, async injectMessage() {} });
+		manager.recordSubagentProgress("paused-sub", { currentTool: "paused" } as never);
+
+		await manager.waitForAll();
+		expect(manager.getJob(pausedJobId)?.status).toBe("paused");
+		expect(manager.getSubagentRecord("paused-sub")?.status).toBe("paused");
+		expect(manager.getResumeDescriptor("paused-sub")).toEqual(descriptor("paused-sub"));
+		expect(manager.getLiveHandle("paused-sub")).toBeUndefined();
+		expect(manager.getSubagentProgress("paused-sub")).toBeUndefined();
+
+		await manager.dispose({ timeoutMs: 200 });
+	});
+});

--- a/packages/coding-agent/test/blob-store-bound.test.ts
+++ b/packages/coding-agent/test/blob-store-bound.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { MemoryBlobStore } from "@gajae-code/coding-agent/session/blob-store";
+
+describe("MemoryBlobStore byte/count LRU bound (W5 / F8)", () => {
+	it("evicts the least-recently-used blob beyond the count cap instead of growing unbounded", () => {
+		const store = new MemoryBlobStore();
+		const COUNT_CAP = 4096;
+		const hashes: string[] = [];
+		for (let i = 0; i < COUNT_CAP + 8; i++) {
+			hashes.push(store.putSync(Buffer.from(`blob-${i}`)).hash);
+		}
+		// Oldest insertions are evicted; the most recent survive.
+		expect(store.getSync(hashes[0]!)).toBeNull();
+		expect(store.getSync(hashes[7]!)).toBeNull();
+		expect(store.getSync(hashes[hashes.length - 1]!)).not.toBeNull();
+	});
+
+	it("refreshes recency on get so a hot blob survives eviction", () => {
+		const store = new MemoryBlobStore();
+		const COUNT_CAP = 4096;
+		const first = store.putSync(Buffer.from("hot-blob")).hash;
+		const second = store.putSync(Buffer.from("cold-blob")).hash;
+		for (let i = 0; i < COUNT_CAP - 2; i++) store.putSync(Buffer.from(`filler-${i}`));
+		// Touch `first` to move it to the most-recent position.
+		expect(store.getSync(first)).not.toBeNull();
+		// One more put evicts the now-oldest (`second`), not the refreshed `first`.
+		store.putSync(Buffer.from("trigger-eviction"));
+		expect(store.getSync(first)).not.toBeNull();
+		expect(store.getSync(second)).toBeNull();
+	});
+
+	it("round-trips content-addressed blobs under the cap", () => {
+		const store = new MemoryBlobStore();
+		const data = Buffer.from("hello blob");
+		const { hash, ref } = store.putSync(data);
+		expect(ref).toBe(`blob:sha256:${hash}`);
+		expect(store.getSync(hash)?.toString()).toBe("hello blob");
+	});
+});

--- a/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
@@ -8,7 +8,7 @@ describe("parseBridgeEndpoints", () => {
 		expect(parseBridgeEndpoints("   ")).toBeUndefined();
 	});
 
-	it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+	it('enables all matrix keys for "all" (case-insensitive)', () => {
 		expect(parseBridgeEndpoints("all")).toEqual({
 			events: true,
 			commands: true,

--- a/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-endpoints-parse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { parseBridgeEndpoints } from "../../src/modes/bridge/bridge-mode";
+
+describe("parseBridgeEndpoints", () => {
+	it("returns undefined for empty/whitespace/undefined (fail-closed default)", () => {
+		expect(parseBridgeEndpoints(undefined)).toBeUndefined();
+		expect(parseBridgeEndpoints("")).toBeUndefined();
+		expect(parseBridgeEndpoints("   ")).toBeUndefined();
+	});
+
+	it("enables all matrix keys for \"all\" (case-insensitive)", () => {
+		expect(parseBridgeEndpoints("all")).toEqual({
+			events: true,
+			commands: true,
+			control: true,
+			uiResponses: true,
+			hostToolResults: true,
+			hostUriResults: true,
+		});
+		expect(parseBridgeEndpoints(" ALL ")).toEqual(parseBridgeEndpoints("all"));
+	});
+
+	it("enables only the listed valid keys", () => {
+		expect(parseBridgeEndpoints("events,commands,control")).toEqual({
+			events: true,
+			commands: true,
+			control: true,
+		});
+	});
+
+	it("ignores blank list entries", () => {
+		expect(parseBridgeEndpoints("events, ,commands")).toEqual({
+			events: true,
+			commands: true,
+		});
+	});
+
+	it("throws on an invalid key", () => {
+		expect(() => parseBridgeEndpoints("events,bogus")).toThrow("Invalid GJC_BRIDGE_ENDPOINTS entry: bogus");
+	});
+});

--- a/packages/coding-agent/test/dap/dap-lifecycle.test.ts
+++ b/packages/coding-agent/test/dap/dap-lifecycle.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DapClient } from "../../src/dap/client";
+import { DapSessionManager } from "../../src/dap/session";
+import type { DapCapabilities, DapClientState, DapEventMessage, DapResolvedAdapter } from "../../src/dap/types";
+import {
+	disposeAllOwnedProcesses,
+	liveOwnedProcessCount,
+	spawnOwnedProcess,
+} from "../../src/runtime/process-lifecycle";
+
+const BUN = process.execPath;
+
+const SOCKET_ADAPTER: DapResolvedAdapter = {
+	name: "fake-socket",
+	command: BUN,
+	args: [],
+	resolvedCommand: BUN,
+	languages: [],
+	fileTypes: [],
+	rootMarkers: [],
+	launchDefaults: {},
+	attachDefaults: {},
+	connectMode: "socket",
+};
+
+const STDIO_ADAPTER: DapResolvedAdapter = {
+	...SOCKET_ADAPTER,
+	name: "fake-stdio",
+	connectMode: "stdio",
+};
+
+type DapEventHandler = (body: unknown, event: DapEventMessage) => void | Promise<void>;
+type DapReverseRequestHandler = (args: unknown) => unknown | Promise<unknown>;
+
+class RunInTerminalFakeClient {
+	readonly adapter = STDIO_ADAPTER;
+	readonly cwd: string;
+	readonly proc: DapClientState["proc"];
+	readonly #handlers = new Map<string, Set<DapEventHandler>>();
+	#reverseHandlers = new Map<string, DapReverseRequestHandler>();
+	#alive = true;
+	readonly #exited = Promise.withResolvers<number>();
+
+	constructor(cwd: string) {
+		this.cwd = cwd;
+		this.proc = {
+			exited: this.#exited.promise,
+			exitCode: null,
+			stdin: { write: () => 0, flush: () => undefined },
+			stdout: new ReadableStream<Uint8Array>(),
+			stderr: new ReadableStream<Uint8Array>(),
+			peekStderr: () => "",
+			kill: () => {
+				this.#alive = false;
+				this.#exited.resolve(0);
+				return true;
+			},
+		} as unknown as DapClientState["proc"];
+	}
+
+	async initialize(): Promise<DapCapabilities> {
+		queueMicrotask(() => this.#emit("initialized", {}));
+		return { supportsConfigurationDoneRequest: true };
+	}
+
+	async sendRequest(command: string): Promise<unknown> {
+		if (command === "launch") {
+			const handler = this.#reverseHandlers.get("runInTerminal");
+			if (!handler) throw new Error("runInTerminal handler was not registered");
+			return handler({ args: [BUN, "-e", "setInterval(() => {}, 1000)"], cwd: this.cwd });
+		}
+		if (command === "configurationDone") return {};
+		if (command === "disconnect") {
+			this.#alive = false;
+			this.#exited.resolve(0);
+			return {};
+		}
+		return {};
+	}
+
+	waitForEvent(event: string): Promise<unknown> {
+		if (event === "stopped" || event === "terminated" || event === "exited") {
+			return Promise.reject(new Error(`DAP event ${event} timed out after 1ms`));
+		}
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const unsubscribe = this.onEvent(event, body => {
+			unsubscribe();
+			resolve(body);
+		});
+		return promise;
+	}
+
+	onEvent(event: string, handler: DapEventHandler): () => void {
+		const handlers = this.#handlers.get(event) ?? new Set<DapEventHandler>();
+		handlers.add(handler);
+		this.#handlers.set(event, handlers);
+		return () => handlers.delete(handler);
+	}
+
+	onReverseRequest(command: string, handler: DapReverseRequestHandler): () => void {
+		this.#reverseHandlers.set(command, handler);
+		return () => this.#reverseHandlers.delete(command);
+	}
+
+	isAlive(): boolean {
+		return this.#alive;
+	}
+
+	async dispose(): Promise<void> {
+		this.#alive = false;
+		this.#exited.resolve(0);
+	}
+
+	#emit(event: string, body: unknown): void {
+		const message: DapEventMessage = { seq: 1, type: "event", event, body };
+		for (const handler of this.#handlers.get(event) ?? []) {
+			void handler(body, message);
+		}
+	}
+}
+
+async function tempDir(prefix: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+afterEach(async () => {
+	await disposeAllOwnedProcesses();
+});
+
+describe("DAP lifecycle behavior", () => {
+	it("socket-mode startup timeout disposes the adapter process", async () => {
+		const cwd = await tempDir("gjc-dap-socket-timeout-");
+		try {
+			const script = path.join(cwd, "adapter.ts");
+			await Bun.write(script, "setInterval(() => {}, 1000);\n");
+			const before = liveOwnedProcessCount();
+
+			await expect(
+				DapClient.spawn({
+					adapter: { ...SOCKET_ADAPTER, args: [script] },
+					cwd,
+				}),
+			).rejects.toThrow(/did not connect within 10s|timed out|Connection refused|ENOENT/);
+
+			expect(liveOwnedProcessCount()).toBe(before);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it.skipIf(process.platform !== "linux")("socket-mode Unix startup failure unlinks the temporary .sock", async () => {
+		const cwd = await tempDir("gjc-dap-unix-socket-timeout-");
+		try {
+			const script = path.join(cwd, "adapter.ts");
+			await Bun.write(
+				script,
+				`const listen = process.argv.find(arg => arg.startsWith("--listen=unix:"));\nif (!listen) throw new Error("missing listen arg");\nawait Bun.write(listen.slice("--listen=unix:".length), "not a socket");\nsetInterval(() => {}, 1000);\n`,
+			);
+
+			await expect(
+				DapClient.spawn({
+					adapter: { ...SOCKET_ADAPTER, args: [script] },
+					cwd,
+				}),
+			).rejects.toThrow();
+
+			const leakedSockets = (await fs.readdir("/tmp")).filter(
+				name => name.startsWith("dap-fake-socket-") && name.endsWith(".sock"),
+			);
+			expect(leakedSockets).toEqual([]);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"dispose reaps adapter child process groups through owned lifecycle",
+		async () => {
+			const cwd = await tempDir("gjc-dap-dispose-owner-");
+			try {
+				const marker = path.join(cwd, "child-ready");
+				const script = path.join(cwd, "adapter.ts");
+				await Bun.write(
+					script,
+					`const child = Bun.spawn([process.execPath, "-e", "await Bun.write(process.argv[1], String(process.pid)); setInterval(() => {}, 1000);", ${JSON.stringify(marker)}], { stdout: "ignore", stderr: "ignore", stdin: "ignore" });\nsetInterval(() => {}, 1000);\n`,
+				);
+				const client = await DapClient.spawn({ adapter: { ...STDIO_ADAPTER, args: [script] }, cwd });
+				await Bun.sleep(1_000);
+				expect(await Bun.file(marker).exists()).toBe(true);
+
+				await client.dispose();
+				expect(client.proc.killed).toBe(true);
+				expect(liveOwnedProcessCount()).toBe(0);
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"tracks runInTerminal debuggees as owned processes and reaps only the session child on dispose",
+		async () => {
+			const cwd = await tempDir("gjc-dap-runterminal-");
+			const unrelated = spawnOwnedProcess([BUN, "-e", "setInterval(() => {}, 1000)"], {
+				name: "dap-test:unrelated",
+			});
+			try {
+				const manager = new DapSessionManager();
+				const fake = new RunInTerminalFakeClient(cwd);
+				const originalSpawn = DapClient.spawn;
+				DapClient.spawn = async () => fake as unknown as DapClient;
+				try {
+					const before = liveOwnedProcessCount();
+					const summary = await manager.launch({ adapter: STDIO_ADAPTER, program: "fake", cwd }, undefined, 25);
+					expect(liveOwnedProcessCount()).toBeGreaterThan(before);
+
+					await manager.terminate(undefined, 25);
+					expect(manager.listSessions().some(session => session.id === summary.id)).toBe(false);
+					expect(unrelated.child.exitCode).toBeNull();
+					expect(liveOwnedProcessCount()).toBe(1);
+				} finally {
+					DapClient.spawn = originalSpawn;
+				}
+			} finally {
+				await unrelated.dispose();
+				await unrelated.awaitExit({ timeoutMs: 1_000 });
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/packages/coding-agent/test/eval/js-worker-vm-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/js-worker-vm-lifecycle.redteam.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	disposeAllVmContexts,
+	executeInVmContext,
+	liveVmContextCount,
+	resetVmContext,
+} from "../../src/eval/js/context-manager";
+import { WorkerCore } from "../../src/eval/js/worker-core";
+import type { Transport, WorkerInbound, WorkerOutbound } from "../../src/eval/js/worker-protocol";
+import type { ToolSession } from "../../src/tools";
+import { ToolError } from "../../src/tools/tool-errors";
+
+interface FakeTool {
+	execute(
+		toolCallId: string,
+		args: unknown,
+		signal: AbortSignal,
+	): Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+
+function makeSession(tools: Record<string, FakeTool> = {}): ToolSession {
+	return {
+		cwd: process.cwd(),
+		settings: { get: () => undefined } as unknown as ToolSession["settings"],
+		getToolByName: (name: string) => tools[name],
+	} as unknown as ToolSession;
+}
+
+async function expectSettles<T>(promise: Promise<T>, label: string, timeoutMs = 1_500): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(timeoutMs).then(() => {
+			throw new Error(`${label} did not settle`);
+		}),
+	]);
+}
+
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs = 1_500): Promise<void> {
+	const deadline = performance.now() + timeoutMs;
+	while (!predicate()) {
+		if (performance.now() > deadline) throw new Error(`${label} did not become true`);
+		await Bun.sleep(5);
+	}
+}
+
+describe("JS worker VM lifecycle redteam", () => {
+	afterEach(async () => {
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		await disposeAllVmContexts();
+	});
+
+	it("coalesces many concurrent first acquires for one sessionKey to exactly one worker and returns to baseline after dispose", async () => {
+		const baseline = liveVmContextCount();
+		const key = `u5-redteam-concurrent-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const results = await Promise.all(
+			Array.from({ length: 24 }, (_unused, index) =>
+				executeInVmContext({
+					sessionKey: key,
+					sessionId: key,
+					cwd: process.cwd(),
+					session,
+					code: `${index}`,
+					filename: `concurrent-${index}.js`,
+					runState: {},
+				}),
+			),
+		);
+		expect(results).toHaveLength(24);
+		expect(liveVmContextCount()).toBe(baseline + 1);
+		await disposeAllVmContexts();
+		expect(liveVmContextCount()).toBe(baseline);
+	});
+
+	it("rejects pending and queued runs on reset without hanging and releases the queue for a fresh worker", async () => {
+		const key = `u5-redteam-reset-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const pending = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "pending-reset.js",
+			runState: {},
+		});
+		const queued = Array.from({ length: 5 }, (_unused, index) =>
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: `${index}`,
+				filename: `queued-reset-${index}.js`,
+				runState: {},
+			}),
+		);
+		await waitUntil(() => liveVmContextCount() > 0, "worker start");
+		await waitUntil(() => liveVmContextCount() === 1, "worker ready");
+		await resetVmContext(key);
+		const settled = await expectSettles(
+			Promise.all([pending, ...queued].map(run => run.catch(error => error))),
+			"reset batch",
+		);
+		expect(settled).toHaveLength(6);
+		expect(settled.every(value => value instanceof Error)).toBe(true);
+		expect(liveVmContextCount()).toBe(0);
+		const fresh = await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "41 + 1",
+				filename: "fresh-after-reset.js",
+				runState: {},
+			}),
+			"fresh run after reset",
+		);
+		expect(fresh).toEqual({ value: undefined });
+	});
+
+	it("runs a reset:true cell against an existing VM after wiping previous state", async () => {
+		const key = `u5-redteam-reset-own-caller-${crypto.randomUUID()}`;
+		const session = makeSession();
+		await executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "globalThis.__resetSentinel = 1",
+			filename: "seed-before-own-reset.js",
+			runState: {},
+		});
+		await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				reset: true,
+				code: "if (globalThis.__resetSentinel !== undefined) throw new Error('state was not reset'); globalThis.__afterOwnReset = 7;",
+				filename: "own-reset-runs.js",
+				runState: {},
+			}),
+			"own reset run",
+		);
+		await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "if (globalThis.__afterOwnReset !== 7) throw new Error('reset cell did not execute')",
+				filename: "after-own-reset.js",
+				runState: {},
+			}),
+			"post-reset verification run",
+		);
+	});
+
+	it("observes the local pending rejection when worker send throws", async () => {
+		const OriginalWorker = globalThis.Worker;
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			#handlers = new Set<(event: MessageEvent) => void>();
+
+			constructor() {
+				void Bun.sleep(0).then(() => {
+					for (const handler of this.#handlers) handler({ data: { type: "ready" } } as MessageEvent);
+				});
+			}
+
+			postMessage(msg: WorkerInbound): void {
+				if (msg.type === "run") throw new Error("synthetic send failure");
+			}
+
+			addEventListener(type: string, handler: EventListener): void {
+				if (type === "message") this.#handlers.add(handler as (event: MessageEvent) => void);
+			}
+
+			removeEventListener(type: string, handler: EventListener): void {
+				if (type === "message") this.#handlers.delete(handler as (event: MessageEvent) => void);
+			}
+
+			terminate(): void {
+				this.#handlers.clear();
+			}
+		} as unknown as typeof Worker;
+		try {
+			const result = await expectSettles(
+				executeInVmContext({
+					sessionKey: `u5-redteam-send-failure-${crypto.randomUUID()}`,
+					sessionId: "send-failure",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "send-failure.js",
+					runState: {},
+				}).catch(error => error),
+				"send failure rejection",
+			);
+			expect(result).toBeInstanceOf(Error);
+			expect(String((result as Error).message)).toContain("synthetic send failure");
+			await Bun.sleep(20);
+			expect(unhandled).toHaveLength(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+
+	it("rejects pending and queued runs on abort/worker kill without hanging and releases the queue", async () => {
+		const key = `u5-redteam-kill-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const controller = new AbortController();
+		const pending = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "pending-kill.js",
+			runState: { signal: controller.signal },
+		});
+		const queued = Array.from({ length: 5 }, (_unused, index) =>
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: `${index}`,
+				filename: `queued-kill-${index}.js`,
+				runState: {},
+			}),
+		);
+		await waitUntil(() => liveVmContextCount() > 0, "worker start");
+		controller.abort(new Error("redteam abort"));
+		const settled = await expectSettles(
+			Promise.all([pending, ...queued].map(run => run.catch(error => error))),
+			"kill batch",
+		);
+		expect(settled).toHaveLength(6);
+		expect(settled.every(value => value instanceof Error)).toBe(true);
+		const fresh = await expectSettles(
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "'queue-released'",
+				filename: "fresh-after-kill.js",
+				runState: {},
+			}),
+			"fresh run after kill",
+		);
+		expect(fresh).toEqual({ value: undefined });
+	});
+
+	it("settles a host-side pending tool call when the run aborts before the tool replies", async () => {
+		const key = `u5-redteam-tool-abort-${crypto.randomUUID()}`;
+		const controller = new AbortController();
+		let toolStarted = false;
+		let toolRejected: unknown;
+		const session = makeSession({
+			slow: {
+				async execute(_toolCallId, _args, signal) {
+					toolStarted = true;
+					return await new Promise((_resolve, reject) => {
+						const onAbort = (): void => {
+							toolRejected = signal.reason;
+							reject(signal.reason);
+						};
+						signal.addEventListener("abort", onAbort, { once: true });
+					});
+				},
+			},
+		});
+		const run = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await tool.slow({ phase: 'before-abort' })",
+			filename: "tool-abort.js",
+			runState: { signal: controller.signal },
+		});
+		await waitUntil(() => toolStarted, "tool call start");
+		controller.abort(new ToolError("abort while tool pending"));
+		const result = await expectSettles(
+			run.catch(error => error),
+			"tool-abort run",
+		);
+		expect(result).toBeInstanceOf(Error);
+		expect(toolRejected).toBeInstanceOf(Error);
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("unsubscribes WorkerCore transport listeners on close so reset/dispose/timeout paths cannot leak handlers", async () => {
+		const hostHandlers = new Set<(msg: WorkerInbound) => void>();
+		const outbound: WorkerOutbound[] = [];
+		let unsubscribeCalls = 0;
+		let closeCalls = 0;
+		const transport: Transport = {
+			send: msg => outbound.push(msg),
+			onMessage: handler => {
+				hostHandlers.add(handler);
+				return () => {
+					unsubscribeCalls += 1;
+					hostHandlers.delete(handler);
+				};
+			},
+			close: () => {
+				closeCalls += 1;
+			},
+		};
+		new WorkerCore(transport);
+		expect(hostHandlers.size).toBe(1);
+		for (const handler of [...hostHandlers]) handler({ type: "close" });
+		expect(unsubscribeCalls).toBe(1);
+		expect(closeCalls).toBe(1);
+		expect(hostHandlers.size).toBe(0);
+		expect(outbound.some(msg => msg.type === "closed")).toBe(true);
+	});
+
+	it("fails closed when inline-worker fallback would be needed in production without the explicit test env", async () => {
+		const OriginalWorker = globalThis.Worker;
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			constructor() {
+				throw new Error("synthetic worker spawn failure");
+			}
+		} as unknown as typeof Worker;
+		try {
+			await expect(
+				executeInVmContext({
+					sessionKey: `u5-redteam-fail-closed-${crypto.randomUUID()}`,
+					sessionId: "fail-closed",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "fail-closed.js",
+					runState: {},
+				}),
+			).rejects.toThrow(
+				/inline fallback is disabled.*cannot interrupt synchronous user code.*synthetic worker spawn failure/,
+			);
+		} finally {
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+});

--- a/packages/coding-agent/test/eval/js-worker-vm-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/js-worker-vm-lifecycle.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	disposeAllVmContexts,
+	disposeVmContextsByOwner,
+	executeInVmContext,
+	liveVmContextCount,
+} from "../../src/eval/js/context-manager";
+import { WorkerCore } from "../../src/eval/js/worker-core";
+import type { Transport, WorkerInbound, WorkerOutbound } from "../../src/eval/js/worker-protocol";
+import { disposeAllResourceOwners } from "../../src/runtime/process-lifecycle";
+import type { ToolSession } from "../../src/tools";
+
+function makeSession(): ToolSession {
+	return {
+		cwd: process.cwd(),
+		settings: { get: () => undefined } as unknown as ToolSession["settings"],
+		getToolByName: () => undefined,
+	} as unknown as ToolSession;
+}
+
+async function expectSettles<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(1_000).then(() => {
+			throw new Error(`${label} did not settle`);
+		}),
+	]);
+}
+
+describe("JS worker VM lifecycle", () => {
+	afterEach(async () => {
+		delete process.env.GAJAE_CODE_JS_EVAL_INLINE_WORKER;
+		await disposeAllVmContexts();
+	});
+
+	it("coalesces concurrent first acquire to one worker", async () => {
+		const key = `u5-concurrent-${crypto.randomUUID()}`;
+		const session = makeSession();
+		await Promise.all([
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "1",
+				filename: "a.js",
+				runState: {},
+			}),
+			executeInVmContext({
+				sessionKey: key,
+				sessionId: key,
+				cwd: process.cwd(),
+				session,
+				code: "2",
+				filename: "b.js",
+				runState: {},
+			}),
+		]);
+		expect(liveVmContextCount()).toBe(1);
+	});
+
+	it("worker kill rejects pending and queued runs without hanging", async () => {
+		const key = `u5-kill-${crypto.randomUUID()}`;
+		const session = makeSession();
+		const controller = new AbortController();
+		const first = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "await new Promise(() => {})",
+			filename: "blocked.js",
+			runState: { signal: controller.signal },
+		});
+		const second = executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session,
+			code: "1",
+			filename: "queued.js",
+			runState: {},
+		});
+		while (liveVmContextCount() === 0) await Bun.sleep(5);
+		await Bun.sleep(20);
+		controller.abort();
+		await expectSettles(
+			first.catch(error => error),
+			"pending run",
+		);
+		const queuedResult = await expectSettles(
+			second.catch(error => error),
+			"queued run",
+		);
+		expect(queuedResult).toBeInstanceOf(Error);
+	});
+
+	it("disposes live VM contexts through resource-owner cleanup", async () => {
+		const key = `u5-owner-${crypto.randomUUID()}`;
+		await executeInVmContext({
+			sessionKey: key,
+			sessionId: key,
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "globalThis.__u5 = 1",
+			filename: "owner.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("disposes live VM contexts by eval owner rather than session key", async () => {
+		const baseline = liveVmContextCount();
+		const ownerId = `u5-owner-id-${crypto.randomUUID()}`;
+		await executeInVmContext({
+			sessionKey: `js:session:file:cwd:${process.cwd()}`,
+			sessionId: "session-key-does-not-match-owner",
+			ownerId,
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "globalThis.__u5Owner = 1",
+			filename: "owner-dispose.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(baseline + 1);
+		await disposeVmContextsByOwner(ownerId);
+		expect(liveVmContextCount()).toBe(baseline);
+	});
+
+	it("re-registers VM resource cleanup after global resource disposal", async () => {
+		await executeInVmContext({
+			sessionKey: `u5-reregister-first-${crypto.randomUUID()}`,
+			sessionId: "first",
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "1",
+			filename: "first.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+		await executeInVmContext({
+			sessionKey: `u5-reregister-second-${crypto.randomUUID()}`,
+			sessionId: "second",
+			cwd: process.cwd(),
+			session: makeSession(),
+			code: "2",
+			filename: "second.js",
+			runState: {},
+		});
+		expect(liveVmContextCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(liveVmContextCount()).toBe(0);
+	});
+
+	it("settles run-local pending tool promises when a run ends", async () => {
+		const hostHandlers = new Set<(msg: WorkerInbound) => void>();
+		const outbound: WorkerOutbound[] = [];
+		const transport: Transport = {
+			send: msg => outbound.push(msg),
+			onMessage: handler => {
+				hostHandlers.add(handler);
+				return () => hostHandlers.delete(handler);
+			},
+			close: () => undefined,
+		};
+		new WorkerCore(transport);
+		for (const handler of hostHandlers)
+			handler({ type: "init", snapshot: { cwd: process.cwd(), sessionId: "tools" } });
+		for (const handler of hostHandlers) {
+			handler({
+				type: "run",
+				runId: "r1",
+				code: "globalThis.toolPromise = tool.never({}).catch(() => undefined); 'done';",
+				filename: "tool.js",
+				snapshot: { cwd: process.cwd(), sessionId: "tools" },
+			});
+		}
+		await expectSettles(
+			(async () => {
+				while (!outbound.some(msg => msg.type === "result")) await Bun.sleep(5);
+			})(),
+			"tool run",
+		);
+		const toolCall = outbound.find(
+			(msg): msg is Extract<WorkerOutbound, { type: "tool-call" }> => msg.type === "tool-call",
+		);
+		expect(toolCall).toBeDefined();
+		for (const handler of hostHandlers)
+			handler({ type: "tool-reply", id: toolCall!.id, reply: { ok: true, value: "late" } });
+		expect(outbound.some(msg => msg.type === "tool-call")).toBe(true);
+		expect(outbound.some(msg => msg.type === "result" && msg.ok)).toBe(true);
+	});
+
+	it("fails closed when Worker construction fails outside explicit inline test mode", async () => {
+		const OriginalWorker = globalThis.Worker;
+		(globalThis as unknown as { Worker: typeof Worker }).Worker = class {
+			constructor() {
+				throw new Error("worker unavailable");
+			}
+		} as unknown as typeof Worker;
+		try {
+			await expect(
+				executeInVmContext({
+					sessionKey: `u5-fail-${crypto.randomUUID()}`,
+					sessionId: "fail",
+					cwd: process.cwd(),
+					session: makeSession(),
+					code: "1",
+					filename: "fail.js",
+					runState: {},
+				}),
+			).rejects.toThrow("inline fallback is disabled");
+		} finally {
+			(globalThis as unknown as { Worker: typeof Worker }).Worker = OriginalWorker;
+		}
+	});
+});

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
+import type {
+	KernelExecuteOptions,
+	KernelExecuteResult,
+	KernelShutdownResult,
+} from "@gajae-code/coding-agent/eval/py/kernel";
+import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { TempDir } from "@gajae-code/utils";
+
+const originalStart = PythonKernel.start;
+
+const OK_RESULT: KernelExecuteResult = {
+	status: "ok",
+	cancelled: false,
+	timedOut: false,
+	stdinRequested: false,
+};
+
+class FakeKernel {
+	alive = true;
+	executeCalls: string[] = [];
+	shutdownCalls = 0;
+	shutdownResult: KernelShutdownResult = { confirmed: true };
+	private readonly executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>;
+
+	constructor(executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>) {
+		this.executeImpl = executeImpl;
+	}
+
+	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
+		this.executeCalls.push(code);
+		return this.executeImpl ? await this.executeImpl(code, options) : OK_RESULT;
+	}
+
+	async shutdown(): Promise<KernelShutdownResult> {
+		this.shutdownCalls += 1;
+		this.alive = false;
+		return this.shutdownResult;
+	}
+
+	isAlive(): boolean {
+		return this.alive;
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessGone(pid: number, timeoutMs = 5000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return true;
+		await Bun.sleep(50);
+	}
+	return !isProcessAlive(pid);
+}
+
+function countAbortListeners(signal: AbortSignal): { readonly count: () => number; readonly restore: () => void } {
+	let count = 0;
+	const originalAdd = signal.addEventListener.bind(signal);
+	const originalRemove = signal.removeEventListener.bind(signal);
+	signal.addEventListener = ((
+		type: string,
+		listener: Parameters<typeof originalAdd>[1],
+		options?: AddEventListenerOptions | boolean,
+	) => {
+		if (type === "abort") count += 1;
+		return originalAdd(type, listener, options);
+	}) as typeof signal.addEventListener;
+	signal.removeEventListener = ((
+		type: string,
+		listener: Parameters<typeof originalRemove>[1],
+		options?: EventListenerOptions | boolean,
+	) => {
+		if (type === "abort") count -= 1;
+		return originalRemove(type, listener, options);
+	}) as typeof signal.removeEventListener;
+	return {
+		count: () => count,
+		restore: () => {
+			signal.addEventListener = originalAdd as typeof signal.addEventListener;
+			signal.removeEventListener = originalRemove as typeof signal.removeEventListener;
+		},
+	};
+}
+
+describe("python eval lifecycle red-team", () => {
+	afterEach(async () => {
+		PythonKernel.start = originalStart;
+		delete Bun.env.PI_PYTHON_SKIP_CHECK;
+		await disposeAllKernelSessions();
+	});
+
+	it("coalesces five concurrent first acquires for the same new session without orphan kernels", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const startup = Promise.withResolvers<void>();
+		const kernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			await startup.promise;
+			return kernel as unknown as PythonKernel;
+		};
+
+		const executions = Array.from({ length: 5 }, (_, index) =>
+			executePython(`print(${index})`, {
+				cwd: tempDir.path(),
+				sessionId: "redteam-concurrent-same-session",
+				kernelMode: "session",
+			}),
+		);
+		await Bun.sleep(0);
+		expect(startCalls).toBe(1);
+
+		startup.resolve();
+		await Promise.all(executions);
+		expect(startCalls).toBe(1);
+		expect(kernel.executeCalls).toEqual(["print(0)", "print(1)", "print(2)", "print(3)", "print(4)"]);
+
+		await disposeAllKernelSessions();
+		expect(kernel.shutdownCalls).toBe(1);
+	});
+
+	it("kills only the owned bash background descendant after timeout while an unrelated sibling survives", async () => {
+		if (process.platform === "win32") return;
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+		let childPid: number | undefined;
+		try {
+			const result = await executePython("%%bash\n(sleep 30) &\necho owned_child:$!\nwait", {
+				cwd: tempDir.path(),
+				sessionId: "redteam-bash-descendant-timeout",
+				kernelMode: "session",
+				timeoutMs: 500,
+			});
+			const match = result.output.match(/owned_child:(\d+)/);
+			expect(match).not.toBeNull();
+			childPid = Number(match?.[1]);
+			expect(result.cancelled).toBe(true);
+			expect(await waitForProcessGone(childPid)).toBe(true);
+			expect(isProcessAlive(unrelated.pid)).toBe(true);
+		} finally {
+			try {
+				unrelated.kill("SIGKILL");
+			} catch {
+				// ignore cleanup races
+			}
+			await unrelated.exited.catch(() => undefined);
+		}
+	});
+
+	it("settles an in-flight cell during shutdown without leaked abort listeners", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const controller = new AbortController();
+		const listeners = countAbortListeners(controller.signal);
+		let shutdown: (() => Promise<KernelShutdownResult>) | undefined;
+		try {
+			PythonKernel.start = async () => {
+				const kernel = await originalStart({ cwd: tempDir.path() });
+				shutdown = () => kernel.shutdown({ timeoutMs: 100 });
+				return kernel;
+			};
+
+			const execution = executePython("import time\ntime.sleep(60)", {
+				cwd: tempDir.path(),
+				sessionId: "redteam-inflight-shutdown",
+				kernelMode: "session",
+				signal: controller.signal,
+				timeoutMs: 60_000,
+			});
+			await Bun.sleep(250);
+			expect(listeners.count()).toBe(1);
+			expect(shutdown).toBeDefined();
+
+			await shutdown?.();
+			await execution;
+			expect(listeners.count()).toBe(0);
+		} finally {
+			listeners.restore();
+		}
+	});
+
+	it("treats clean exit code 0 as confirmed and starts a fresh session instead of reinserting", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const firstKernel = new FakeKernel();
+		const secondKernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			return (startCalls === 1 ? firstKernel : secondKernel) as unknown as PythonKernel;
+		};
+
+		await executePython("print('before clean shutdown')", {
+			cwd: tempDir.path(),
+			sessionId: "redteam-clean-exit-not-reinserted",
+			kernelMode: "session",
+		});
+		await disposeAllKernelSessions();
+		await executePython("print('after clean shutdown')", {
+			cwd: tempDir.path(),
+			sessionId: "redteam-clean-exit-not-reinserted",
+			kernelMode: "session",
+		});
+
+		expect(firstKernel.shutdownCalls).toBe(1);
+		expect(startCalls).toBe(2);
+		expect(secondKernel.executeCalls).toEqual(["print('after clean shutdown')"]);
+	});
+});

--- a/packages/coding-agent/test/eval/python-lifecycle.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
+import type {
+	KernelExecuteOptions,
+	KernelExecuteResult,
+	KernelShutdownResult,
+} from "@gajae-code/coding-agent/eval/py/kernel";
+import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { TempDir } from "@gajae-code/utils";
+
+const originalStart = PythonKernel.start;
+
+const OK_RESULT: KernelExecuteResult = {
+	status: "ok",
+	cancelled: false,
+	timedOut: false,
+	stdinRequested: false,
+};
+
+class FakeKernel {
+	alive = true;
+	executeCalls: string[] = [];
+	shutdownCalls = 0;
+	shutdownResult: KernelShutdownResult = { confirmed: true };
+	private readonly executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>;
+
+	constructor(executeImpl?: (code: string, options?: KernelExecuteOptions) => Promise<KernelExecuteResult>) {
+		this.executeImpl = executeImpl;
+	}
+
+	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
+		this.executeCalls.push(code);
+		return this.executeImpl ? await this.executeImpl(code, options) : OK_RESULT;
+	}
+
+	async shutdown(): Promise<KernelShutdownResult> {
+		this.shutdownCalls += 1;
+		return this.shutdownResult;
+	}
+
+	isAlive(): boolean {
+		return this.alive;
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForExit(pid: number, timeoutMs = 3000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessAlive(pid)) return true;
+		await Bun.sleep(25);
+	}
+	return !isProcessAlive(pid);
+}
+
+describe("python eval lifecycle", () => {
+	afterEach(async () => {
+		PythonKernel.start = originalStart;
+		await disposeAllKernelSessions();
+	});
+
+	it("coalesces concurrent first acquires for the same session into one kernel", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const startup = Promise.withResolvers<void>();
+		let startCalls = 0;
+		const kernel = new FakeKernel();
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			await startup.promise;
+			return kernel as unknown as PythonKernel;
+		};
+
+		const first = executePython("print('first')", {
+			cwd: tempDir.path(),
+			sessionId: "concurrent-session",
+			kernelMode: "session",
+		});
+		const second = executePython("print('second')", {
+			cwd: tempDir.path(),
+			sessionId: "concurrent-session",
+			kernelMode: "session",
+		});
+		await Bun.sleep(0);
+		expect(startCalls).toBe(1);
+
+		startup.resolve();
+		await Promise.all([first, second]);
+
+		expect(startCalls).toBe(1);
+		expect(kernel.executeCalls).toEqual(["print('first')", "print('second')"]);
+	});
+
+	it("settles pending executions and releases abort listeners during shutdown", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const controller = new AbortController();
+		let abortListeners = 0;
+		const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+		const originalRemove = controller.signal.removeEventListener.bind(controller.signal);
+		controller.signal.addEventListener = ((
+			type: string,
+			listener: Parameters<typeof originalAdd>[1],
+			options?: AddEventListenerOptions | boolean,
+		) => {
+			if (type === "abort") abortListeners += 1;
+			return originalAdd(type, listener, options);
+		}) as typeof controller.signal.addEventListener;
+		controller.signal.removeEventListener = ((
+			type: string,
+			listener: Parameters<typeof originalRemove>[1],
+			options?: EventListenerOptions | boolean,
+		) => {
+			if (type === "abort") abortListeners -= 1;
+			return originalRemove(type, listener, options);
+		}) as typeof controller.signal.removeEventListener;
+
+		const kernel = await originalStart({ cwd: tempDir.path() });
+		try {
+			const execution = kernel.execute("import time\ntime.sleep(60)", {
+				signal: controller.signal,
+				timeoutMs: 60_000,
+			});
+			for (let i = 0; i < 40 && abortListeners === 0; i += 1) {
+				await Bun.sleep(50);
+			}
+			expect(abortListeners).toBe(1);
+
+			await kernel.shutdown({ timeoutMs: 100 });
+			const result = await execution;
+			expect(result.status).toBe("error");
+			expect(result.cancelled).toBe(true);
+			expect(result.kernelKilled).toBe(true);
+			expect(abortListeners).toBe(0);
+		} finally {
+			await kernel.shutdown({ timeoutMs: 100 }).catch(() => undefined);
+		}
+	});
+
+	it("treats clean exit code 0 as confirmed shutdown and does not reinsert the session", async () => {
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const firstKernel = new FakeKernel();
+		const secondKernel = new FakeKernel();
+		let startCalls = 0;
+		PythonKernel.start = async () => {
+			startCalls += 1;
+			return (startCalls === 1 ? firstKernel : secondKernel) as unknown as PythonKernel;
+		};
+
+		await executePython("print('one')", {
+			cwd: tempDir.path(),
+			sessionId: "clean-exit-session",
+			kernelMode: "session",
+		});
+		await disposeAllKernelSessions();
+		await executePython("print('two')", {
+			cwd: tempDir.path(),
+			sessionId: "clean-exit-session",
+			kernelMode: "session",
+		});
+
+		expect(firstKernel.shutdownCalls).toBe(1);
+		expect(startCalls).toBe(2);
+		expect(secondKernel.executeCalls).toEqual(["print('two')"]);
+	});
+
+	it("kills background descendants owned by a bash cell interrupt while an unrelated sibling survives", async () => {
+		if (process.platform === "win32") return;
+		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-");
+		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+		let childPid: number | undefined;
+		try {
+			const resultPromise = executePython("%%bash\n(sleep 30) &\necho child:$!\nwait", {
+				cwd: tempDir.path(),
+				sessionId: "bash-descendant-session",
+				kernelMode: "session",
+				timeoutMs: 500,
+			});
+			const result = await resultPromise;
+			const match = result.output.match(/child:(\d+)/);
+			expect(match).not.toBeNull();
+			childPid = Number(match?.[1]);
+			expect(result.cancelled).toBe(true);
+			expect(await waitForExit(childPid)).toBe(true);
+			expect(isProcessAlive(unrelated.pid)).toBe(true);
+		} finally {
+			try {
+				unrelated.kill("SIGKILL");
+			} catch {
+				// ignore cleanup races
+			}
+			await unrelated.exited.catch(() => undefined);
+		}
+	});
+});

--- a/packages/coding-agent/test/fast-status-report.test.ts
+++ b/packages/coding-agent/test/fast-status-report.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import {
+	buildFastStatusReport,
+	FAST_STATUS_OFF,
+	FAST_STATUS_TITLE,
+	type FastStatusSessionLike,
+	formatFastStatusReport,
+} from "@gajae-code/coding-agent/slash-commands/helpers/fast-status-report";
+
+const ICON = "\u26a1";
+
+function model(provider: string, id: string): Model {
+	return { provider, id } as unknown as Model;
+}
+
+describe("formatFastStatusReport", () => {
+	test("AC-5: formats a multiline active + role-model report with fast/off per row", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
+			],
+			iconFast: ICON,
+		});
+		const lines = report.split("\n");
+		expect(lines.length).toBeGreaterThan(1);
+		expect(lines[0]).toBe(FAST_STATUS_TITLE);
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+	});
+
+	test("AC-2: renders fast on anthropic rows and off on openai/openai-codex rows", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-opus-4-1"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
+				{ label: "ARCHITECT", model: model("openai-codex", "gpt-5-codex"), fast: false },
+			],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-opus-4-1 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`ARCHITECT: openai-codex/gpt-5-codex ${FAST_STATUS_OFF}`);
+		// Exactly one fast icon (the anthropic active row).
+		expect(report.split(ICON).length - 1).toBe(1);
+	});
+
+	test("AC-3: all rows off renders no fast icon", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
+			],
+			iconFast: ICON,
+		});
+		expect(report).not.toContain(ICON);
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+	});
+
+	test("AC-6: each row's fast flag is rendered independently", () => {
+		// Mirrors serviceTier="claude-only": the active OpenAI model is off even
+		// though fast mode is globally "enabled", while the Anthropic role is on.
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("openai", "gpt-5"), fast: false },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+			],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+	});
+
+	test("AC-7: uses the supplied icon token, never a hardcoded emoji", () => {
+		const report = formatFastStatusReport({
+			rows: [{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true }],
+			iconFast: ">>",
+		});
+		expect(report).toContain("현재 모델: anthropic/claude-sonnet-4-5 >>");
+		expect(report).not.toContain(ICON);
+	});
+
+	test("AC-8: every row off is all off", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
+				{ label: "DEFAULT", model: model("anthropic", "claude-sonnet-4-5"), fast: false },
+			],
+			iconFast: ICON,
+		});
+		expect(report).not.toContain(ICON);
+		expect(report.split("\n").every(line => line === FAST_STATUS_TITLE || line.endsWith(FAST_STATUS_OFF))).toBe(true);
+	});
+
+	test("applies the inactive formatter (e.g. TUI dim) to off rows only", () => {
+		const report = formatFastStatusReport({
+			rows: [
+				{ label: "현재 모델", model: model("anthropic", "claude-sonnet-4-5"), fast: true },
+				{ label: "EXECUTOR", model: model("openai", "gpt-5"), fast: false },
+			],
+			iconFast: ICON,
+			formatInactive: text => `<dim>${text}</dim>`,
+		});
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 <dim>${FAST_STATUS_OFF}</dim>`);
+		expect(report).not.toContain(`<dim>${ICON}</dim>`);
+	});
+});
+
+describe("buildFastStatusReport", () => {
+	function fakeSession(args: {
+		model?: Model;
+		roles: Record<string, Model | undefined>;
+		fastProviders: string[];
+		subagentFastProviders?: string[];
+	}): FastStatusSessionLike {
+		const subagentFastProviders = args.subagentFastProviders ?? args.fastProviders;
+		return {
+			model: args.model,
+			isFastForProvider: provider => provider !== undefined && args.fastProviders.includes(provider),
+			isFastForSubagentProvider: provider => provider !== undefined && subagentFastProviders.includes(provider),
+			resolveRoleModelWithThinking: role => ({ model: args.roles[role] }),
+		};
+	}
+
+	test("lists the active model and assigned roles, skipping unassigned roles", () => {
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: { default: model("anthropic", "claude-sonnet-4-5"), executor: model("openai", "gpt-5") },
+				fastProviders: ["anthropic"],
+			}),
+			roleTargets: [
+				{ id: "default", label: "DEFAULT", isSubagentRole: false },
+				{ id: "executor", label: "EXECUTOR", isSubagentRole: true },
+				{ id: "architect", label: "ARCHITECT", isSubagentRole: true },
+			],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`EXECUTOR: openai/gpt-5 ${FAST_STATUS_OFF}`);
+		// ARCHITECT is unassigned -> skipped entirely.
+		expect(report).not.toContain("ARCHITECT");
+	});
+
+	test("renders the active row off when no model is selected", () => {
+		const report = buildFastStatusReport({
+			session: fakeSession({ model: undefined, roles: {}, fastProviders: ["anthropic"] }),
+			roleTargets: [{ id: "default", label: "DEFAULT", isSubagentRole: false }],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: ${FAST_STATUS_OFF}`);
+		expect(report).not.toContain(ICON);
+	});
+
+	test("subagent roles use the subagent tier, not the main session tier", () => {
+		// Regression for #691 round-2 blocker: serviceTier=priority but
+		// task.serviceTier=none — the main-session rows are fast while the
+		// task.agentModelOverrides subagent role runs without fast mode.
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: {
+					default: model("anthropic", "claude-sonnet-4-5"),
+					executor: model("anthropic", "claude-opus-4-1"),
+				},
+				fastProviders: ["anthropic", "openai", "openai-codex"],
+				subagentFastProviders: [],
+			}),
+			roleTargets: [
+				{ id: "default", label: "DEFAULT", isSubagentRole: false },
+				{ id: "executor", label: "EXECUTOR", isSubagentRole: true },
+			],
+			iconFast: ICON,
+		});
+		// Main session is fast (current + modelRoles DEFAULT)...
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${ICON}`);
+		expect(report).toContain(`DEFAULT: anthropic/claude-sonnet-4-5 ${ICON}`);
+		// ...but the subagent role is off despite the same provider.
+		expect(report).toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${FAST_STATUS_OFF}`);
+	});
+
+	test("subagent roles can be fast while the main session is off", () => {
+		// Reverse divergence: serviceTier=none but task.serviceTier=priority.
+		const report = buildFastStatusReport({
+			session: fakeSession({
+				model: model("anthropic", "claude-sonnet-4-5"),
+				roles: { executor: model("anthropic", "claude-opus-4-1") },
+				fastProviders: [],
+				subagentFastProviders: ["anthropic"],
+			}),
+			roleTargets: [{ id: "executor", label: "EXECUTOR", isSubagentRole: true }],
+			iconFast: ICON,
+		});
+		expect(report).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${FAST_STATUS_OFF}`);
+		expect(report).toContain(`EXECUTOR: anthropic/claude-opus-4-1 ${ICON}`);
+	});
+});

--- a/packages/coding-agent/test/fast-status-tui.test.ts
+++ b/packages/coding-agent/test/fast-status-tui.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import { Text } from "@gajae-code/tui";
+
+function model(provider: string, id: string): Model {
+	return { provider, id } as unknown as Model;
+}
+
+function stripAnsi(text: string): string {
+	return text
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function createTuiRuntime() {
+	const added: unknown[] = [];
+	const showStatus = vi.fn();
+	const requestRender = vi.fn();
+	const setText = vi.fn();
+	const session = {
+		model: model("anthropic", "claude-sonnet-4-5"),
+		isFastForProvider: (provider?: string) => provider === "anthropic",
+		isFastForSubagentProvider: (provider?: string) => provider === "anthropic",
+		resolveRoleModelWithThinking: (role: string) => {
+			if (role === "default") return { model: model("anthropic", "claude-sonnet-4-5") };
+			if (role === "executor") return { model: model("openai", "gpt-5") };
+			return { model: undefined };
+		},
+		// The status branch must use the provider-aware predicate, never this.
+		isFastModeEnabled: () => {
+			throw new Error("/fast status must not call isFastModeEnabled");
+		},
+	};
+	const ctx = {
+		session,
+		chatContainer: {
+			addChild: (child: unknown) => {
+				added.push(child);
+			},
+		},
+		ui: { requestRender },
+		editor: { setText },
+		showStatus,
+	};
+	return {
+		runtime: { ctx: ctx as unknown as InteractiveModeContext, handleBackgroundCommand: () => {} },
+		added,
+		showStatus,
+		requestRender,
+		setText,
+	};
+}
+
+describe("/fast status TUI rendering", () => {
+	beforeAll(async () => {
+		const installed = await getThemeByName("red-claw");
+		if (!installed) throw new Error("Failed to load theme for /fast status TUI test");
+		setThemeInstance(installed);
+	});
+	test("AC-5: renders a multiline transcript panel, clears the editor, and never uses showStatus", async () => {
+		const { runtime, added, showStatus, requestRender, setText } = createTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/fast status", runtime);
+
+		expect(result).toBe(true);
+		// Multiline transcript rendering — not a single-line status toast.
+		expect(showStatus).not.toHaveBeenCalled();
+		expect(requestRender).toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("");
+
+		const textChildren = added.filter((child): child is Text => child instanceof Text);
+		expect(textChildren.length).toBeGreaterThan(0);
+
+		const rendered = stripAnsi(textChildren.map(child => child.render(220).join("\n")).join("\n"));
+		expect(rendered).toContain(`현재 모델: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+		expect(rendered).toContain("DEFAULT: anthropic/claude-sonnet-4-5");
+		expect(rendered).toContain("EXECUTOR: openai/gpt-5 off");
+		// The OpenAI executor row under claude-only scope shows no fast glyph.
+		expect(rendered).not.toContain(`openai/gpt-5 ${theme.icon.fast}`);
+	});
+});

--- a/packages/coding-agent/test/g007-teardown-redteam.test.ts
+++ b/packages/coding-agent/test/g007-teardown-redteam.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import { disposeCursorConversation } from "@gajae-code/ai/providers/cursor";
+import { waitForProjectLoaded } from "@gajae-code/coding-agent/lsp/client";
+
+type LspClient = Parameters<typeof waitForProjectLoaded>[0];
+
+type TrackedSignal = {
+	signal: AbortSignal;
+	readonly added: number;
+	readonly removed: number;
+	readonly active: number;
+	fire: () => void;
+};
+
+function trackedSignal(initiallyAborted = false): TrackedSignal {
+	// Faithful to real AbortSignal { once: true } semantics: a once-listener is auto-removed when the
+	// abort event fires. dev's shared untilAborted helper relies on this for its abort-path cleanup.
+	const listeners = new Map<() => void, boolean>();
+	const state = { aborted: initiallyAborted, added: 0, removed: 0 };
+	const signal = {
+		get aborted() {
+			return state.aborted;
+		},
+		reason: undefined,
+		onabort: null,
+		throwIfAborted: () => {
+			if (state.aborted) throw new DOMException("Aborted", "AbortError");
+		},
+		addEventListener: (type: string, callback: (() => void) | null, options?: { once?: boolean }) => {
+			if (type !== "abort" || callback === null) return;
+			state.added += 1;
+			listeners.set(callback, options?.once === true);
+		},
+		removeEventListener: (type: string, callback: (() => void) | null) => {
+			if (type !== "abort" || callback === null) return;
+			if (listeners.delete(callback)) state.removed += 1;
+		},
+		dispatchEvent: () => true,
+	} as AbortSignal;
+
+	return {
+		signal,
+		get added() {
+			return state.added;
+		},
+		get removed() {
+			return state.removed;
+		},
+		get active() {
+			return listeners.size;
+		},
+		fire: () => {
+			state.aborted = true;
+			for (const [listener, once] of [...listeners]) {
+				if (once) {
+					listeners.delete(listener);
+					state.removed += 1;
+				}
+				listener();
+			}
+		},
+	};
+}
+
+function lspClient(projectLoaded: Promise<void>): LspClient {
+	return { projectLoaded } as LspClient;
+}
+
+describe("G007 teardown red-team: waitForProjectLoaded abort listener lifecycle (F17)", () => {
+	it("removes the abort listener when projectLoaded resolves first", async () => {
+		const tracker = trackedSignal();
+		await waitForProjectLoaded(lspClient(Promise.resolve()), tracker.signal);
+		expect(tracker.added).toBe(1);
+		expect(tracker.removed).toBe(1);
+		expect(tracker.active).toBe(0);
+	});
+
+	it("removes the abort listener and rejects when abort fires first", async () => {
+		const tracker = trackedSignal();
+		const pending = waitForProjectLoaded(lspClient(new Promise<void>(() => {})), tracker.signal);
+		tracker.fire();
+		// dev's shared untilAborted helper rejects with AbortError on abort; the F17 fix is that the
+		// listener is still removed in its finally, so nothing accumulates on the prompt-scoped signal.
+		await expect(pending).rejects.toThrow();
+		expect(tracker.added).toBe(1);
+		expect(tracker.removed).toBe(1);
+		expect(tracker.active).toBe(0);
+	});
+
+	it("returns immediately for an already-aborted signal without adding a listener", async () => {
+		const tracker = trackedSignal(true);
+		await waitForProjectLoaded(lspClient(new Promise<void>(() => {})), tracker.signal);
+		expect(tracker.added).toBe(0);
+		expect(tracker.removed).toBe(0);
+		expect(tracker.active).toBe(0);
+	});
+
+	it("resolves without listener churn when no signal is provided", async () => {
+		await waitForProjectLoaded(lspClient(Promise.resolve()));
+		expect(true).toBe(true);
+	});
+
+	it("does not accumulate listeners across repeated calls on the same signal", async () => {
+		const tracker = trackedSignal();
+		const callCount = 25;
+		for (let index = 0; index < callCount; index += 1) {
+			await waitForProjectLoaded(lspClient(Promise.resolve()), tracker.signal);
+		}
+		expect(tracker.added).toBe(callCount);
+		expect(tracker.removed).toBe(callCount);
+		expect(tracker.active).toBe(0);
+	});
+
+	it("removes the abort listener when projectLoaded rejects", async () => {
+		const tracker = trackedSignal();
+		const rejection = new Error("project load failed");
+		try {
+			await waitForProjectLoaded(lspClient(Promise.reject(rejection)), tracker.signal);
+			expect.unreachable("projectLoaded rejection should propagate");
+		} catch (error: unknown) {
+			expect(error).toBe(rejection);
+		}
+		expect(tracker.added).toBe(1);
+		expect(tracker.removed).toBe(1);
+		expect(tracker.active).toBe(0);
+	});
+});
+
+describe("G007 teardown red-team: Cursor conversation dispose hook (F15)", () => {
+	it("is idempotent and no-throws for an unknown conversation id", () => {
+		expect(() => disposeCursorConversation("g007-redteam-unknown-conversation")).not.toThrow();
+		expect(() => disposeCursorConversation("g007-redteam-unknown-conversation")).not.toThrow();
+	});
+});

--- a/packages/coding-agent/test/g008-size-guards.test.ts
+++ b/packages/coding-agent/test/g008-size-guards.test.ts
@@ -1,0 +1,68 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MAX_EDIT_FILE_BYTES, readEditFileText } from "@gajae-code/coding-agent/edit/read-file";
+import { executeReadQuery } from "@gajae-code/coding-agent/tools/sqlite-reader";
+
+const tmpFiles: string[] = [];
+
+afterEach(async () => {
+	for (const f of tmpFiles.splice(0)) await fs.rm(f, { force: true });
+});
+
+async function writeTmp(name: string, bytes: number): Promise<string> {
+	const file = path.join(os.tmpdir(), `gjc-g008-${Date.now()}-${name}`);
+	await Bun.write(file, Buffer.alloc(bytes, 0x61));
+	tmpFiles.push(file);
+	return file;
+}
+
+describe("edit file size guard (W7 / F19)", () => {
+	it("rejects a file larger than the edit byte limit with an actionable error", async () => {
+		const big = await writeTmp("big.txt", MAX_EDIT_FILE_BYTES + 1024);
+		await expect(readEditFileText(big, "big.txt")).rejects.toThrow(/too large to edit safely/i);
+	});
+
+	it("reads a normal-sized file unchanged", async () => {
+		const small = await writeTmp("small.txt", 32);
+		const text = await readEditFileText(small, "small.txt");
+		expect(text.length).toBe(32);
+	});
+
+	it("rejects an oversized notebook before the notebook fast-path (F19 not bypassable via .ipynb)", async () => {
+		const bigNb = await writeTmp("big.ipynb", MAX_EDIT_FILE_BYTES + 1024);
+		await expect(readEditFileText(bigNb, "big.ipynb")).rejects.toThrow(/too large to edit safely/i);
+	});
+});
+
+describe("sqlite raw query row cap (W7 / F20)", () => {
+	it("caps an unbounded raw SELECT and flags truncation", () => {
+		const db = new Database(":memory:");
+		db.run("CREATE TABLE t (id INTEGER)");
+		const insert = db.prepare("INSERT INTO t (id) VALUES (?)");
+		for (let i = 0; i < 1500; i++) insert.run(i);
+		try {
+			const result = executeReadQuery(db, "SELECT * FROM t");
+			expect(result.rows.length).toBe(1000); // capped, not 1500
+			expect(result.truncated).toBe(true);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("returns all rows (not truncated) when under the cap", () => {
+		const db = new Database(":memory:");
+		db.run("CREATE TABLE t (id INTEGER)");
+		const insert = db.prepare("INSERT INTO t (id) VALUES (?)");
+		for (let i = 0; i < 5; i++) insert.run(i);
+		try {
+			const result = executeReadQuery(db, "SELECT * FROM t");
+			expect(result.rows.length).toBe(5);
+			expect(result.truncated).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
@@ -170,7 +170,10 @@ describe("tmux GC red-team adversarial safety", () => {
 			if (cmd.includes("list-sessions")) {
 				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
 				if (format === "#{session_name}") return spawnResult(0, "gajae_code_idle_orphan\n");
-				return spawnResult(0, sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }));
+				return spawnResult(
+					0,
+					sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }),
+				);
 			}
 			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
 			if (cmd.includes("show-options")) return spawnResult(0, "\n");

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.redteam.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { GcContext } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { tmuxSessionsGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/tmux-gc";
+
+const env = { GJC_TMUX_COMMAND: "tmux-redteam" };
+const cwd = "/tmp/gjc-redteam-project";
+
+type SpawnSyncResult = Bun.SyncSubprocess<"pipe", "pipe">;
+type SpawnSyncSpy = { mockImplementation(implementation: (command: string[]) => SpawnSyncResult): void };
+
+function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+	return {
+		exitCode,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+	} as SpawnSyncResult;
+}
+
+function ctx(): GcContext {
+	return {
+		probe: () => ({ status: "dead" }),
+		force: false,
+		env,
+		cwd,
+	};
+}
+
+function sessionLine(overrides: {
+	name: string;
+	attached?: boolean;
+	created?: number;
+	profile?: string;
+	panes?: number;
+	panePid?: number;
+	branch?: string;
+	project?: string;
+}): string {
+	return [
+		overrides.name,
+		"1",
+		overrides.attached ? "1" : "0",
+		String(overrides.created ?? 1_770_000_000),
+		overrides.profile ?? "1",
+		"root",
+		String(overrides.panes ?? (overrides.panePid ? 1 : 0)),
+		overrides.panePid ? String(overrides.panePid) : "",
+		overrides.branch ?? "",
+		overrides.branch?.replaceAll("/", "-") ?? "",
+		overrides.project ?? "",
+	].join("\t");
+}
+
+function optionValue(cmd: string[], option: string): boolean {
+	return cmd.includes("show-options") && cmd.at(-1) === option;
+}
+
+describe("tmux GC red-team adversarial safety", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not prune an attached GJC session even when project path and branch worktree are gone", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_attached_stale\n");
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_attached_stale",
+						attached: true,
+						branch: "gone-branch",
+						project: "/tmp/gjc-redteam-missing-project",
+					}),
+				);
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_attached_stale");
+
+		expect(result.errors).toEqual([]);
+		expect(record).toMatchObject({ status: "live", stale: false, removable: false, pid_status: "alive" });
+		expect(record?.reason).toBe("tmux_session_attached_or_has_live_panes");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_attached_stale"]);
+	});
+
+	it("revalidates before pruning and skips kill when a stale candidate becomes attached after classification", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_toctou\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_toctou",
+						attached: richListCount > 1,
+						branch: "deleted-branch",
+						project: "/tmp/gjc-redteam-deleted-project",
+					}),
+				);
+			}
+			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
+			if (optionValue(cmd, "@gjc-project")) return spawnResult(0, "/tmp/gjc-redteam-deleted-project\n");
+			if (optionValue(cmd, "@gjc-branch")) return spawnResult(0, "deleted-branch\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_toctou");
+
+		expect(record).toMatchObject({ status: "stale", stale: true, removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "tmux_revalidation_failed_or_became_live",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_toctou"]);
+	});
+
+	it("never prunes a non-GJC untagged session that superficially resembles an idle orphan", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae-code-old-orphan-looking\n");
+				return spawnResult(
+					0,
+					sessionLine({ name: "gajae-code-old-orphan-looking", profile: "", created: 1_600_000_000 }),
+				);
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae-code-old-orphan-looking");
+
+		expect(record).toMatchObject({ status: "unclassified", stale: false, removable: false });
+		expect(record?.reason).toBe("untagged_tmux_session");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae-code-old-orphan-looking"]);
+	});
+
+	it("prunes a genuine GJC-owned metadata-less idle orphan only after ownership, no-attachment, age, and revalidation", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_idle_orphan\n");
+				return spawnResult(0, sessionLine({ name: "gajae_code_idle_orphan", profile: "1", created: 1_770_000_000 }));
+			}
+			if (optionValue(cmd, "@gjc-profile")) return spawnResult(0, "1\n");
+			if (cmd.includes("show-options")) return spawnResult(0, "\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_idle_orphan");
+
+		expect(record).toMatchObject({
+			status: "stale",
+			stale: true,
+			removable: true,
+			reason: "metadata_less_gjc_owned_idle_orphan",
+		});
+		expect(record?.detail).toContain("createdAt=2026-02-02T02:40:00.000Z");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({ removed: true });
+		expect(calls).toContainEqual(["tmux-redteam", "kill-session", "-t", "=gajae_code_idle_orphan"]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { GcContext } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { tmuxSessionsGcAdapter } from "@gajae-code/coding-agent/gjc-runtime/tmux-gc";
+
+const env = { GJC_TMUX_COMMAND: "tmux-test" };
+const project = "/tmp/gjc-project";
+
+type SpawnSyncResult = Bun.SyncSubprocess<"pipe", "pipe">;
+type SpawnSyncSpy = { mockImplementation(implementation: (command: string[]) => SpawnSyncResult): void };
+
+function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+	return {
+		exitCode,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+	} as SpawnSyncResult;
+}
+
+function ctx(): GcContext {
+	return {
+		probe: () => ({ status: "dead" }),
+		force: false,
+		env,
+		cwd: project,
+	};
+}
+
+function sessionLine(overrides: {
+	name: string;
+	attached?: boolean;
+	created?: number;
+	profile?: string;
+	panes?: number;
+	panePid?: number;
+	branch?: string;
+	project?: string;
+}): string {
+	return [
+		overrides.name,
+		"1",
+		overrides.attached ? "1" : "0",
+		String(overrides.created ?? 1_770_000_000),
+		overrides.profile ?? "1",
+		"root",
+		String(overrides.panes ?? (overrides.panePid ? 1 : 0)),
+		overrides.panePid ? String(overrides.panePid) : "",
+		overrides.branch ?? "",
+		overrides.branch?.replaceAll("/", "-") ?? "",
+		overrides.project ?? "",
+	].join("\t");
+}
+
+describe("tmux GC safety", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("classifies attached/live tagged sessions with stale metadata as non-removable and does not prune", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		spyOn(Bun, "spawnSync").mockReturnValue(
+			spawnResult(0, sessionLine({ name: "gajae_code_live", attached: true, branch: "stale", project })),
+		);
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_live");
+
+		expect(result.errors).toEqual([]);
+		expect(record).toMatchObject({ status: "live", stale: false, removable: false, pid_status: "alive" });
+		expect(record?.reason).toBe("tmux_session_attached_or_has_live_panes");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(Bun.spawnSync).not.toHaveBeenCalledWith(
+			["tmux-test", "kill-session", "-t", "=gajae_code_live"],
+			expect.any(Object),
+		);
+	});
+
+	it("prunes metadata-less GJC-owned idle orphan only when ownership is proven and not attached", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_orphan\nunrelated_orphan\n");
+				return spawnResult(
+					0,
+					[
+						sessionLine({ name: "gajae_code_orphan", profile: "1", created: 1_770_000_000 }),
+						sessionLine({ name: "unrelated_orphan", profile: "", created: 1_770_000_000 }),
+					].join("\n"),
+				);
+			}
+			if (cmd.includes("show-options")) return spawnResult(0, cmd.at(-1) === "@gjc-profile" ? "1\n" : "\n");
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const orphan = result.records.find(entry => entry.id === "gajae_code_orphan");
+		const unrelated = result.records.find(entry => entry.id === "unrelated_orphan");
+
+		expect(orphan).toMatchObject({ status: "stale", removable: true, reason: "metadata_less_gjc_owned_idle_orphan" });
+		expect(unrelated).toMatchObject({ status: "unclassified", removable: false, reason: "untagged_tmux_session" });
+		expect(await tmuxSessionsGcAdapter.prune(orphan!, ctx())).toEqual({ removed: true });
+		expect(calls).toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_orphan"]);
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=unrelated_orphan"]);
+	});
+
+	it("revalidation skips kill when a removable session becomes attached before prune", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let listCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_race\n");
+				listCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_race",
+						attached: listCount > 1,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "tmux_revalidation_failed_or_became_live",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_race"]);
+	});
+
+	it("final status read blocks kill when a revalidated candidate becomes attached", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_final_race\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_final_race",
+						attached: richListCount > 2,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_final_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toMatchObject({
+			removed: false,
+			error: "gjc_tmux_session_live:gajae_code_final_race",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_final_race"]);
+	});
+
+	it("final status read blocks kill when a detached revalidated candidate has live pane PIDs", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		let richListCount = 0;
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_final_pane_race\n");
+				richListCount += 1;
+				return spawnResult(
+					0,
+					sessionLine({
+						name: "gajae_code_final_pane_race",
+						attached: false,
+						panePid: richListCount > 2 ? 43210 : undefined,
+						branch: "stale",
+						project: "/tmp/missing-gjc-project",
+					}),
+				);
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-project") return spawnResult(0, "/tmp/missing-gjc-project\n");
+				if (option === "@gjc-branch") return spawnResult(0, "stale\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_final_pane_race");
+
+		expect(record).toMatchObject({ status: "stale", removable: true, reason: "project_missing" });
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toMatchObject({
+			removed: false,
+			error: "gjc_tmux_session_live:gajae_code_final_pane_race",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_final_pane_race"]);
+	});
+
+	it("keeps old detached prefix-named untagged sessions non-removable", async () => {
+		spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				const format = cmd[cmd.indexOf("-F") + 1] ?? "";
+				if (format === "#{session_name}") return spawnResult(0, "gajae_code_user_owned\n");
+				return spawnResult(0, sessionLine({ name: "gajae_code_user_owned", profile: "", created: 1_600_000_000 }));
+			}
+			return spawnResult(0, "");
+		});
+
+		const result = await tmuxSessionsGcAdapter.collect(ctx());
+		const record = result.records.find(entry => entry.id === "gajae_code_user_owned");
+
+		expect(record).toMatchObject({ status: "unclassified", stale: false, removable: false });
+		expect(record?.reason).toBe("untagged_tmux_session");
+		expect(await tmuxSessionsGcAdapter.prune(record!, ctx())).toEqual({
+			removed: false,
+			skipped: "not_removable_tmux_session",
+		});
+		expect(calls).not.toContainEqual(["tmux-test", "kill-session", "-t", "=gajae_code_user_owned"]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -27,9 +27,9 @@ describe("GJC tmux session management", () => {
 			spawnResult(
 				0,
 				[
-					"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\tfeature/demo\tfeature-demo\t/repo-a",
-					"unrelated\t2\t1\t1770000060\t\troot\t3\t\t",
-					"gajae_code\t1\t1\t1770000120\t\troot\t1\t\t",
+					"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\t12345\tfeature/demo\tfeature-demo\t/repo-a",
+					"unrelated\t2\t1\t1770000060\t\troot\t3\t23456\t\t",
+					"gajae_code\t1\t1\t1770000120\t\troot\t1\t34567\t\t",
 				].join("\n"),
 			),
 		);
@@ -39,6 +39,7 @@ describe("GJC tmux session management", () => {
 		expect(sessions.map(session => session.name)).toEqual(["gajae_code_abc"]);
 		expect(sessions[0].attached).toBe(false);
 		expect(sessions[0].panes).toBe(2);
+		expect(sessions[0].panePids).toEqual([12345]);
 		expect(sessions[0].bindings).toBe("root");
 		expect(sessions[0].createdAt).toBe("2026-02-02T02:40:00.000Z");
 		expect(sessions[0].branch).toBe("feature/demo");
@@ -48,7 +49,7 @@ describe("GJC tmux session management", () => {
 				"tmux-test",
 				"list-sessions",
 				"-F",
-				"#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{@gjc-profile}\t#{session_key_table}\t#{session_panes}\t#{@gjc-branch}\t#{@gjc-branch-slug}\t#{@gjc-project}",
+				"#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{@gjc-profile}\t#{session_key_table}\t#{session_panes}\t#{pane_pid}\t#{@gjc-branch}\t#{@gjc-branch-slug}\t#{@gjc-project}",
 			],
 			expect.any(Object),
 		);
@@ -66,7 +67,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");
@@ -84,7 +85,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "\n");
 			return spawnResult(0, "");
@@ -102,7 +103,7 @@ describe("GJC tmux session management", () => {
 				// The bare `#{session_name}` probe sees the session (psmux ls shows it)...
 				if (format === "#{session_name}") return spawnResult(0, "psmux_session\n");
 				// ...but the full format does not round-trip @gjc-profile, so the profile column is empty.
-				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\n");
+				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\t\n");
 			}
 			return spawnResult(0, "");
 		});
@@ -131,7 +132,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\n");
+				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");

--- a/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
+++ b/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import * as compactionModule from "@gajae-code/agent-core/compaction";
+import { getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+import { assistantMsg, userMsg } from "./utilities";
+
+/**
+ * Issue #697: auto-compaction must follow the active/custom provider route
+ * instead of silently requiring OpenAI. A user on a custom Anthropic-capable
+ * provider should compact through that provider; and when that provider's
+ * compaction credential is unusable, compaction must NOT silently fall back to
+ * an unrelated provider (e.g. a stray OpenAI key with no remaining credit) just
+ * because OpenAI models exist in the bundled catalog. Cross-provider compaction
+ * is only reached when explicitly configured via `modelRoles`.
+ */
+describe("#697 auto-compaction respects the active custom provider", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+
+	function writeCustomProviderModels(): string {
+		const modelsPath = path.join(tempDir.path(), "models.json");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					myproxy: {
+						baseUrl: "https://myproxy.example/v1",
+						apiKeyEnv: "MYPROXY_API_KEY",
+						api: "anthropic-messages",
+						auth: "apiKey",
+						models: [
+							{
+								id: "claude-sonnet-4-5",
+								name: "Claude via myproxy",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 200000,
+								maxTokens: 8192,
+							},
+						],
+					},
+				},
+			}),
+		);
+		return modelsPath;
+	}
+
+	function seedConversation(): void {
+		for (const [u, a] of [
+			["first question", "first answer"],
+			["second question", "second answer"],
+		] as const) {
+			const um = userMsg(u);
+			const am = assistantMsg(a);
+			session.agent.appendMessage(um);
+			session.sessionManager.appendMessage(um);
+			session.agent.appendMessage(am);
+			session.sessionManager.appendMessage(am);
+		}
+	}
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-697-");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) await session.dispose();
+		authStorage?.close();
+		tempDir.removeSync();
+	});
+
+	it("compacts through the active custom provider model using its own credential", async () => {
+		const modelsPath = writeCustomProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("myproxy", "claude-sonnet-4-5");
+		if (!currentModel) throw new Error("expected myproxy model to load");
+
+		// Only the custom provider has a usable credential — OpenAI must never be needed.
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "myproxy" ? "myproxy-secret" : undefined,
+		);
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "compaction.keepRecentTokens": 1 });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model, key) => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: { provider: model.provider, key },
+		}));
+
+		await session.compact();
+
+		expect(compactSpy).toHaveBeenCalled();
+		const [, model, key] = compactSpy.mock.calls[0]!;
+		expect(`${model.provider}/${model.id}`).toBe("myproxy/claude-sonnet-4-5");
+		expect(key).toBe("myproxy-secret");
+		// Regression: no OpenAI attempt anywhere in the candidate chain.
+		expect(compactSpy.mock.calls.every(([, m]) => m.provider === "myproxy")).toBe(true);
+	});
+
+	it("does not fall back to OpenAI when the active provider cannot compact and only a stray OpenAI credential exists", async () => {
+		const modelsPath = writeCustomProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("myproxy", "claude-sonnet-4-5");
+		// gpt-4.1 has a far larger context window (1M+) than the custom provider's
+		// 200k, so it would win the "largest-context" last-resort fallback sort.
+		const strayOpenAi = getBundledModel("openai", "gpt-4.1");
+		if (!currentModel || !strayOpenAi) throw new Error("expected test models to exist");
+
+		// Both providers carry a credential — only an OpenAI *route* (not a missing
+		// key) is the failure mode under test, so order/provider-scope must decide.
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model.provider === "myproxy") return "myproxy-secret";
+			if (model.provider === "openai") return "stray-openai-key";
+			return undefined;
+		});
+		// Make the stray OpenAI model "available" so the fallback could reach it.
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([currentModel, strayOpenAi]);
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "compaction.keepRecentTokens": 1 });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (_preparation, model) => {
+			if (model.provider === "myproxy") {
+				// Simulate the active provider's compaction credential being unusable.
+				throw new Error("Summarization failed: 503 auth_unavailable: no auth available (providers=myproxy)");
+			}
+			// Reaching any other provider (OpenAI) is the bug we are guarding against.
+			throw new Error(`Unexpected compaction provider attempted: ${model.provider}/${model.id}`);
+		});
+
+		const error = await session.compact().catch(err => err);
+
+		expect(error).toBeInstanceOf(Error);
+		// Never attempted OpenAI.
+		expect(compactSpy.mock.calls.some(([, model]) => model.provider === "openai")).toBe(false);
+		expect(compactSpy.mock.calls.every(([, model]) => model.provider === "myproxy")).toBe(true);
+		// Fails with a clear, provider-specific error pointing at the active route,
+		// not a leaked auth_unavailable and not a silent OpenAI dependency.
+		expect((error as Error).message).toContain(
+			"Compaction requires usable credentials for myproxy/claude-sonnet-4-5",
+		);
+		expect((error as Error).message).not.toMatch(/auth_unavailable/i);
+		expect((error as Error).message).not.toMatch(/openai/i);
+	});
+
+	it("still allows cross-provider compaction fallback when explicitly configured via modelRoles", async () => {
+		const modelsPath = writeCustomProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("myproxy", "claude-sonnet-4-5");
+		const roleFallback = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!currentModel || !roleFallback) throw new Error("expected test models to exist");
+
+		const settings = Settings.isolated({ "compaction.keepRecentTokens": 1 });
+		settings.setModelRole("default", `${roleFallback.provider}/${roleFallback.id}`);
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model.provider === "myproxy") return "myproxy-secret";
+			if (model.provider === "anthropic") return "anthropic-token";
+			return undefined;
+		});
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([currentModel, roleFallback]);
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => {
+			if (model.provider === "myproxy") {
+				throw new Error("Summarization failed: 503 auth_unavailable: no auth available (providers=myproxy)");
+			}
+			return {
+				summary: "fallback summary",
+				shortSummary: "fallback short",
+				firstKeptEntryId: preparation.firstKeptEntryId,
+				tokensBefore: 1,
+				details: { provider: model.provider },
+			};
+		});
+
+		const result = await session.compact();
+
+		expect(result.summary).toBe("fallback summary");
+		expect(compactSpy.mock.calls.map(([, model]) => `${model.provider}/${model.id}`)).toEqual([
+			"myproxy/claude-sonnet-4-5",
+			`${roleFallback.provider}/${roleFallback.id}`,
+		]);
+	});
+});

--- a/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
+++ b/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
@@ -56,6 +56,35 @@ describe("#697 auto-compaction respects the active custom provider", () => {
 		return modelsPath;
 	}
 
+	function writeCodexProviderModels(): string {
+		const modelsPath = path.join(tempDir.path(), "models.json");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					codexproxy: {
+						baseUrl: "http://127.0.0.1:3455/backend-api/codex",
+						apiKeyEnv: "CODEXPROXY_API_KEY",
+						api: "openai-codex-responses",
+						auth: "apiKey",
+						models: [
+							{
+								id: "gpt-5.5",
+								name: "GPT-5.5 via codexproxy",
+								reasoning: true,
+								input: ["text", "image"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 272000,
+								maxTokens: 128000,
+							},
+						],
+					},
+				},
+			}),
+		);
+		return modelsPath;
+	}
+
 	function seedConversation(): void {
 		for (const [u, a] of [
 			["first question", "first answer"],
@@ -125,6 +154,143 @@ describe("#697 auto-compaction respects the active custom provider", () => {
 		expect(key).toBe("myproxy-secret");
 		// Regression: no OpenAI attempt anywhere in the candidate chain.
 		expect(compactSpy.mock.calls.every(([, m]) => m.provider === "myproxy")).toBe(true);
+	});
+
+	it("forwards websocket transport state to manual Codex compaction calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({
+			"compaction.keepRecentTokens": 1,
+			"providers.openaiWebsockets": "on",
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: {},
+		}));
+
+		await session.compact();
+
+		const options = compactSpy.mock.calls[0]?.[5];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(agent.providerSessionId);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+	});
+
+	it("forwards websocket transport state to manual Codex handoff calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "providers.openaiWebsockets": "on" });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const handoffSpy = vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue("## Goal\nContinue");
+		const providerSessionIdBeforeHandoff = agent.providerSessionId;
+
+		const result = await session.handoff("focus on next work");
+
+		expect(result?.document).toBe("## Goal\nContinue");
+		const options = handoffSpy.mock.calls[0]?.[3];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(providerSessionIdBeforeHandoff);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+		expect(options?.authCredentialType).toBe("oauth");
+	});
+
+	it("forwards websocket transport state to Codex branch summary calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "providers.openaiWebsockets": "on" });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const firstAssistantEntry = session.sessionManager
+			.getEntries()
+			.find(entry => entry.type === "message" && entry.message.role === "assistant");
+		if (!firstAssistantEntry) throw new Error("expected seeded assistant entry");
+
+		const branchSpy = vi.spyOn(compactionModule, "generateBranchSummary").mockResolvedValue({
+			summary: "branch summary",
+			readFiles: [],
+			modifiedFiles: [],
+		});
+
+		const result = await session.navigateTree(firstAssistantEntry.id, { summarize: true });
+
+		expect(result.summaryEntry?.summary).toBe("branch summary");
+		const options = branchSpy.mock.calls[0]?.[1];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(agent.providerSessionId);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+		expect(options?.authCredentialType).toBe("oauth");
 	});
 
 	it("does not fall back to OpenAI when the active provider cannot compact and only a stray OpenAI credential exists", async () => {

--- a/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getOrCreateClient, sendRequest, shutdownAll, waitForProjectLoaded } from "../../src/lsp/client";
+import type { ServerConfig } from "../../src/lsp/types";
+import { disposeAllOwnedProcesses } from "../../src/runtime/process-lifecycle";
+
+const BUN = process.execPath;
+const ORIGINAL_PATH = Bun.env.PATH;
+const ORIGINAL_XDG_CONFIG_HOME = Bun.env.XDG_CONFIG_HOME;
+
+async function tempDir(prefix: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+function serverConfig(command: string, args: string[] = []): ServerConfig {
+	return {
+		command,
+		args,
+		fileTypes: ["ts"],
+		rootMarkers: [],
+	};
+}
+
+async function writeFakeLspServer(dir: string): Promise<string> {
+	const script = path.join(dir, "fake-lsp.ts");
+	await Bun.write(
+		script,
+		`let buffer = Buffer.alloc(0);\nfunction write(message) {\n  const body = JSON.stringify(message);\n  process.stdout.write(\`Content-Length: \${Buffer.byteLength(body, "utf8")}\\r\\n\\r\\n\${body}\`);\n}\nfunction handle(message) {\n  if (message.method === "initialize") {\n    write({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });\n    return;\n  }\n  if (message.method === "shutdown") {\n    write({ jsonrpc: "2.0", id: message.id, result: null });\n    process.exit(0);\n    return;\n  }\n}\nprocess.stdin.on("data", chunk => {\n  buffer = Buffer.concat([buffer, chunk]);\n  for (;;) {\n    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");\n    if (headerEnd === -1) return;\n    const header = buffer.subarray(0, headerEnd).toString();\n    const match = /Content-Length: (\\d+)/i.exec(header);\n    if (!match) return;\n    const length = Number(match[1]);\n    const start = headerEnd + 4;\n    const end = start + length;\n    if (buffer.length < end) return;\n    const message = JSON.parse(buffer.subarray(start, end).toString());\n    buffer = buffer.subarray(end);\n    handle(message);\n  }\n});\nsetInterval(() => {}, 1000);\n`,
+	);
+	return script;
+}
+
+afterEach(async () => {
+	await shutdownAll();
+	await disposeAllOwnedProcesses();
+	delete Bun.env.PI_DISABLE_LSPMUX;
+	if (ORIGINAL_XDG_CONFIG_HOME === undefined) {
+		delete Bun.env.XDG_CONFIG_HOME;
+	} else {
+		Bun.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
+	}
+	if (ORIGINAL_PATH === undefined) {
+		delete Bun.env.PATH;
+	} else {
+		Bun.env.PATH = ORIGINAL_PATH;
+	}
+});
+
+describe("LSP lifecycle behavior", () => {
+	it("kill-then-immediately-reacquire evicts the dead cached client before async cleanup", async () => {
+		const cwd = await tempDir("gjc-lsp-reload-");
+		try {
+			const script = await writeFakeLspServer(cwd);
+			const config = serverConfig(BUN, [script]);
+			const first = await getOrCreateClient(config, cwd, 1_000);
+			const pending = sendRequest(first, "workspace/neverResponds", null, undefined, 60_000);
+			const pendingSettled = pending.catch(error => error as Error);
+			expect(first.pendingRequests.size).toBe(1);
+
+			first.proc.kill();
+			const second = await getOrCreateClient(config, cwd, 1_000);
+			expect(await pendingSettled).toHaveProperty("message");
+			await first.proc.exited.catch(() => undefined);
+			const cachedAfterFirstExit = await getOrCreateClient(config, cwd, 1_000);
+
+			expect(second).not.toBe(first);
+			expect(second.proc.exitCode).toBeNull();
+			expect(second.proc.killed).toBe(false);
+			expect(cachedAfterFirstExit).toBe(second);
+			await shutdownAll();
+			await second.proc.exited;
+			expect(second.proc.exitCode).not.toBeNull();
+			expect(first.pendingRequests.size).toBe(0);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("waitForProjectLoaded removes its abort listener after project loading settles", async () => {
+		const controller = new AbortController();
+		let activeAbortListeners = 0;
+		const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+		const originalRemove = controller.signal.removeEventListener.bind(controller.signal);
+		controller.signal.addEventListener = ((type, listener, options) => {
+			if (type === "abort") activeAbortListeners += 1;
+			return originalAdd(type, listener, options);
+		}) as typeof controller.signal.addEventListener;
+		controller.signal.removeEventListener = ((type, listener, options) => {
+			if (type === "abort") activeAbortListeners -= 1;
+			return originalRemove(type, listener, options);
+		}) as typeof controller.signal.removeEventListener;
+
+		const client = {
+			projectLoaded: Promise.resolve(),
+		} as Parameters<typeof waitForProjectLoaded>[0];
+
+		await waitForProjectLoaded(client, controller.signal);
+		expect(activeAbortListeners).toBe(0);
+	});
+
+	it("lspmux status probe clears its timeout and reaps the probe process when status hangs", async () => {
+		const cwd = await tempDir("gjc-lspmux-timeout-");
+		const binDir = path.join(cwd, "bin");
+		const configHome = path.join(cwd, "config");
+		try {
+			await fs.mkdir(binDir, { recursive: true });
+			await fs.mkdir(path.join(configHome, "lspmux"), { recursive: true });
+			await Bun.write(path.join(configHome, "lspmux", "config.toml"), "instance_timeout = 60\n");
+			const lspmux = path.join(binDir, "lspmux");
+			await Bun.write(lspmux, `#!/usr/bin/env ${BUN}\nsetInterval(() => {}, 1000);\n`);
+			await fs.chmod(lspmux, 0o755);
+			const runner = path.join(cwd, "probe.ts");
+			await Bun.write(
+				runner,
+				`import { detectLspmux } from ${JSON.stringify(path.resolve("packages/coding-agent/src/lsp/lspmux.ts"))};\nimport { liveOwnedProcessCount, disposeAllOwnedProcesses } from ${JSON.stringify(path.resolve("packages/coding-agent/src/runtime/process-lifecycle.ts"))};\nconst before = liveOwnedProcessCount();\nconst state = await detectLspmux();\nconst after = liveOwnedProcessCount();\nawait disposeAllOwnedProcesses();\nconsole.log(JSON.stringify({ state, before, after }));\n`,
+			);
+			const proc = Bun.spawn([BUN, runner], {
+				cwd: path.resolve("."),
+				env: {
+					...Bun.env,
+					PATH: ORIGINAL_PATH ? `${binDir}${path.delimiter}${ORIGINAL_PATH}` : binDir,
+					XDG_CONFIG_HOME: configHome,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+			expect(stderr).toBe("");
+			expect(exitCode).toBe(0);
+			const result = JSON.parse(stdout) as {
+				state: { available: boolean; running: boolean };
+				before: number;
+				after: number;
+			};
+			expect(result.state.available).toBe(true);
+			expect(result.state.running).toBe(false);
+			expect(result.after).toBe(result.before);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 3_000);
+});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -4,7 +4,13 @@ import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
-import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import {
+	getThemeByName,
+	setSymbolPreset,
+	setTheme,
+	setThemeInstance,
+	theme,
+} from "@gajae-code/coding-agent/modes/theme/theme";
 import type { TUI } from "@gajae-code/tui";
 
 function normalizeRenderedText(text: string): string {
@@ -597,5 +603,232 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Inherit);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+	if (!needle) return 0;
+	let count = 0;
+	let idx = haystack.indexOf(needle);
+	while (idx !== -1) {
+		count++;
+		idx = haystack.indexOf(needle, idx + needle.length);
+	}
+	return count;
+}
+
+function createFastSelector(args: {
+	models: Model[];
+	settings: Settings;
+	isFastForProvider: (provider?: string) => boolean;
+	isFastForSubagentProvider?: (provider?: string) => boolean;
+	currentModel?: Model;
+}): ModelSelectorComponent {
+	const { models, settings, isFastForProvider, currentModel } = args;
+	// Subagent roles default to the same predicate as the session unless a test
+	// exercises the session-vs-subagent tier divergence explicitly.
+	const isFastForSubagentProvider = args.isFastForSubagentProvider ?? isFastForProvider;
+	const modelRegistry = {
+		getAll: () => models,
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	const scoped = models.map(model => ({ model, thinkingLevel: ThinkingLevel.Off }));
+	return new ModelSelectorComponent(
+		ui,
+		currentModel,
+		settings,
+		modelRegistry,
+		scoped,
+		() => {},
+		() => {},
+		{ isFastForProvider, isFastForSubagentProvider },
+	);
+}
+
+describe("ModelSelector fast-mode indicator", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		if (!testTheme) {
+			throw new Error("Failed to load theme for fast-mode indicator tests");
+		}
+	});
+
+	test("AC-1: renders fast glyph after DEFAULT and EXECUTOR badges for priority tier", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain(`EXECUTOR (high) ${iconFast}`);
+		// Duplicate-glyph guard: the current model already carries role glyphs, so no
+		// extra standalone active-row glyph is added.
+		expect(countOccurrences(rendered, iconFast)).toBe(2);
+		// Regression: each badge label and thinking label renders exactly once, in order.
+		expect(countOccurrences(rendered, "DEFAULT")).toBe(1);
+		expect(countOccurrences(rendered, "EXECUTOR")).toBe(1);
+		expect(rendered.indexOf("DEFAULT")).toBeLessThan(rendered.indexOf("(low)"));
+		expect(rendered.indexOf("(low)")).toBeLessThan(rendered.indexOf(iconFast));
+	});
+
+	test("subagent role glyph reflects the subagent tier, not the session tier", async () => {
+		// Regression for #691 round-2 blocker: serviceTier=priority but
+		// task.serviceTier=none. DEFAULT (modelRoles) runs in the main session and is
+		// fast; EXECUTOR (task.agentModelOverrides) runs under the subagent tier and
+		// must show no glyph even with the same anthropic model.
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			isFastForSubagentProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(`EXECUTOR (high) ${iconFast}`);
+		// Only the main-session DEFAULT row lights the glyph.
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
+	test("AC-2: claude-only renders fast glyph only on anthropic rows in mixed-provider selector", async () => {
+		installTestTheme();
+		const anthropic = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!anthropic) throw new Error("Expected anthropic model");
+		const openai = createOpenAIModel("openai", "gpt-5-fast-mixed");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${anthropic.provider}/${anthropic.id}:low` },
+			"task.agentModelOverrides": { executor: `${openai.provider}/${openai.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [anthropic, openai],
+			settings,
+			isFastForProvider: provider => provider === "anthropic",
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(`EXECUTOR (high) ${iconFast}`);
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
+
+	test("AC-3: none tier renders no fast glyph but keeps badges", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+			"task.agentModelOverrides": { executor: `${model.provider}/${model.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(iconFast);
+	});
+
+	test("AC-4: active non-role current model row shows fast glyph via currentModel", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toContain("DEFAULT");
+		expect(rendered).not.toContain("EXECUTOR");
+		expect(rendered).toContain(iconFast);
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
+	});
+
+	test("AC-7: fast glyph uses theme.icon.fast variant, not a hardcoded emoji", async () => {
+		await setTheme("red-claw");
+		await setSymbolPreset("ascii");
+		try {
+			const asciiIcon = theme.icon.fast;
+			expect(asciiIcon).not.toBe("\u26a1");
+			const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+			if (!model) throw new Error("Expected model");
+			const settings = Settings.isolated({
+				modelRoles: { default: `${model.provider}/${model.id}:low` },
+			});
+			const selector = createFastSelector({
+				models: [model],
+				settings,
+				isFastForProvider: () => true,
+				currentModel: model,
+			});
+			await Bun.sleep(0);
+			const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+			expect(rendered).toContain(asciiIcon);
+			expect(rendered).not.toContain("\u26a1");
+		} finally {
+			await setSymbolPreset("unicode");
+			installTestTheme();
+		}
+	});
+
+	test("AC-8: unset service tier renders no fast glyph", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected model");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+		});
+		// serviceTier === undefined is modeled as the predicate returning false everywhere.
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		const iconFast = theme.icon.fast;
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).not.toContain(iconFast);
 	});
 });

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, test } from "bun:test";
+import { MCPManager } from "../../src/runtime-mcp/manager";
+import type { JsonRpcMessage } from "../../src/runtime-mcp/types";
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function readPidList(path: string): Promise<number[]> {
+	const text = await Bun.file(path)
+		.text()
+		.catch(() => "");
+	return text
+		.split(/\n+/)
+		.map(line => Number(line.trim()))
+		.filter(pid => Number.isInteger(pid) && pid > 0);
+}
+
+function stdioServerScript(behavior: "failTools" | "okTools"): string {
+	return `
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' } } }) + '\\n');
+  } else if (msg.method === 'tools/list') {
+    ${behavior === "failTools" ? "process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: 'boom' } }) + '\\n');" : "process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } }) + '\\n');"}
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\\n');
+  }
+});
+setInterval(() => {}, 1000);
+`;
+}
+
+describe("MCP manager lifecycle cleanup", () => {
+	test("initial listTools failure closes transport and does not register server", async () => {
+		const manager = new MCPManager(process.cwd());
+		const result = await manager.connectServers(
+			{
+				bad: { command: "node", args: ["-e", stdioServerScript("failTools")], timeout: 1_000 },
+			},
+			{},
+		);
+
+		expect(result.connectedServers).toEqual([]);
+		expect(result.errors.get("bad")).toContain("boom");
+		expect(manager.getConnectedServers()).toEqual([]);
+		await expect(manager.waitForConnection("bad")).rejects.toThrow("MCP server not connected: bad");
+	});
+
+	test("disconnect cancels an in-flight reconnect backoff", async () => {
+		let failRequests = true;
+		let requestCount = 0;
+		let postDisconnectRequests = 0;
+		let countAfterDisconnect = false;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				requestCount++;
+				if (countAfterDisconnect) postDisconnectRequests++;
+				if (failRequests) return new Response("down", { status: 503 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: {
+							protocolVersion: "2025-03-26",
+							capabilities: { tools: {} },
+							serverInfo: { name: "http-test", version: "1" },
+						},
+					});
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id: "id" in body ? body.id : 0, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			await manager.connectServers(
+				{
+					good: { type: "http", url: server.url.href, timeout: 500 },
+				},
+				{},
+			);
+			failRequests = true;
+			postDisconnectRequests = 0;
+			const reconnect = manager.reconnectServer("good");
+			await waitFor(() => requestCount > 2);
+			await manager.disconnectServer("good");
+			countAfterDisconnect = true;
+			failRequests = false;
+			const afterDisconnect = postDisconnectRequests;
+			await Bun.sleep(700);
+			await expect(reconnect).resolves.toBeNull();
+			expect(postDisconnectRequests).toBe(afterDisconnect);
+			expect(manager.getConnectedServers()).toEqual([]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("disconnect during in-flight reconnect prevents stale same-name re-add from registering", async () => {
+		let initializeCount = 0;
+		let releaseFirstInitialize: (() => void) | undefined;
+		let deleteCount = 0;
+		const firstInitialize = new Promise<void>(resolve => {
+			releaseFirstInitialize = resolve;
+		});
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") {
+					deleteCount++;
+					return new Response(null, { status: 202 });
+				}
+				if (req.method === "GET") {
+					return new Response(null, { status: 405 });
+				}
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					if (initializeCount === 2) await firstInitialize;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale", version: "1" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 500 };
+			const initial = await manager.connectServers({ stale: config }, {});
+			expect(initial.errors.size).toBe(0);
+			expect(initial.connectedServers).toEqual(["stale"]);
+			const reconnect = manager.reconnectServer("stale");
+			await waitFor(() => initializeCount === 2);
+			await manager.disconnectServer("stale");
+			const result = await manager.connectServers({ stale: config }, {});
+			expect(result.errors.size).toBe(0);
+			expect(result.connectedServers).toEqual(["stale"]);
+			expect(manager.getConnectedServers()).toEqual(["stale"]);
+			releaseFirstInitialize?.();
+			await expect(reconnect).resolves.toBeNull();
+			expect(manager.getConnectedServers()).toEqual(["stale"]);
+			await waitFor(() => deleteCount > 0);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale initial tools/list success does not overwrite fresh same-name tools", async () => {
+		let releaseStaleTools: (() => void) | undefined;
+		const staleToolsBlocked = new Promise<void>(resolve => {
+			releaseStaleTools = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-success", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 1) await staleToolsBlocked;
+					const suffix = toolsListCount === 1 ? "stale" : "fresh";
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: suffix, inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const firstConnect = manager.connectServers({ same: config }, {});
+			await waitFor(() => toolsListCount === 1);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+			releaseStaleTools?.();
+			await expect(firstConnect).resolves.toMatchObject({ connectedServers: [] });
+			await Bun.sleep(50);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale initial tools/list failure does not delete fresh same-name connection", async () => {
+		let releaseStaleTools: (() => void) | undefined;
+		const staleToolsBlocked = new Promise<void>(resolve => {
+			releaseStaleTools = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-failure", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 1) {
+						await staleToolsBlocked;
+						return Response.json({ jsonrpc: "2.0", id, error: { code: -32000, message: "stale boom" } });
+					}
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: "fresh", inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const firstConnect = manager.connectServers({ same: config }, {});
+			await waitFor(() => toolsListCount === 1);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+			releaseStaleTools?.();
+			const stale = await firstConnect;
+			expect(stale.errors.get("same")).toContain("stale boom");
+			await Bun.sleep(50);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+			expect(manager.getConnectionStatus("same")).toBe("connected");
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_fresh"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stale refresh tools/list success does not overwrite fresh same-name tools", async () => {
+		let releaseStaleRefresh: (() => void) | undefined;
+		const staleRefreshBlocked = new Promise<void>(resolve => {
+			releaseStaleRefresh = resolve;
+		});
+		let initializeCount = 0;
+		let toolsListCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method === "DELETE") return new Response(null, { status: 202 });
+				if (req.method === "GET") return new Response(null, { status: 405 });
+				const body = (await req.json()) as JsonRpcMessage;
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					initializeCount++;
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "stale-refresh", version: String(initializeCount) },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": `session-${initializeCount}` } },
+					);
+				}
+				if ("method" in body && body.method === "tools/list") {
+					toolsListCount++;
+					if (toolsListCount === 2) await staleRefreshBlocked;
+					const suffix = toolsListCount === 2 ? "staleRefresh" : toolsListCount === 1 ? "freshOne" : "freshThree";
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: { tools: [{ name: suffix, inputSchema: { type: "object" } }] },
+					});
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const config = { type: "http" as const, url: server.url.href, timeout: 1_000 };
+			const initial = await manager.connectServers({ same: config }, {});
+			expect(initial.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshone"]);
+
+			const refresh = manager.refreshServerTools("same");
+			await waitFor(() => toolsListCount === 2);
+			await manager.disconnectServer("same");
+			const fresh = await manager.connectServers({ same: config }, {});
+			expect(fresh.errors.size).toBe(0);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshthree"]);
+
+			releaseStaleRefresh?.();
+			await refresh;
+			await Bun.sleep(50);
+			expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp__same_freshthree"]);
+			expect(manager.getConnectedServers()).toEqual(["same"]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("stdio reconnect waits for old process tree to die before spawning replacement", async () => {
+		const pidFile = `/tmp/gjc-mcp-manager-reconnect-${Date.now()}-${Math.random().toString(36).slice(2)}.pid`;
+		const childPidFile = `${pidFile}.child`;
+		const startupOldAliveFile = `${pidFile}.old-alive`;
+		const serverScript = `
+const fs = require("fs");
+const cp = require("child_process");
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch (error) { return error && error.code === "EPERM"; }
+}
+const priorChildren = fs.existsSync(${JSON.stringify(childPidFile)}) ? fs.readFileSync(${JSON.stringify(childPidFile)}, "utf8").trim().split(/\\n+/).filter(Boolean).map(Number) : [];
+if (priorChildren.length > 0) fs.appendFileSync(${JSON.stringify(startupOldAliveFile)}, String(alive(priorChildren[0])) + "\\n");
+const child = cp.spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], { stdio: "ignore" });
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+fs.appendFileSync(${JSON.stringify(childPidFile)}, String(child.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "test", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [] } }) + "\\n");
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} }) + "\\n");
+  }
+});
+setInterval(() => {}, 1000);
+`;
+		const manager = new MCPManager(process.cwd());
+		try {
+			const result = await manager.connectServers(
+				{
+					stdio: { type: "stdio", command: process.execPath, args: ["-e", serverScript], timeout: 1_000 },
+				},
+				{},
+			);
+			expect(result.errors.size).toBe(0);
+			await waitFor(async () => (await readPidList(childPidFile)).length >= 1);
+			const oldChildPid = (await readPidList(childPidFile))[0]!;
+			expect(isAlive(oldChildPid)).toBe(true);
+
+			await expect(manager.reconnectServer("stdio")).resolves.toBeDefined();
+			await waitFor(async () => (await readPidList(childPidFile)).length >= 2);
+			const childPids = await readPidList(childPidFile);
+			const newChildPid = childPids.at(-1)!;
+			expect(newChildPid).not.toBe(oldChildPid);
+			expect(isAlive(oldChildPid)).toBe(false);
+			expect(isAlive(newChildPid)).toBe(true);
+			expect(
+				(
+					await Bun.file(startupOldAliveFile)
+						.text()
+						.catch(() => "")
+				).trim(),
+			).toBe("false");
+		} finally {
+			await manager.disconnectAll().catch(() => {});
+			await Bun.file(pidFile)
+				.delete()
+				.catch(() => {});
+			await Bun.file(childPidFile)
+				.delete()
+				.catch(() => {});
+			await Bun.file(startupOldAliveFile)
+				.delete()
+				.catch(() => {});
+		}
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.redteam.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
+import { MCPManager } from "../../src/runtime-mcp/manager";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+
+const servers: Bun.Server<unknown>[] = [];
+const managers: MCPManager[] = [];
+const tmpFiles: string[] = [];
+
+function tmpPath(name: string): string {
+	const path = join("/tmp", `gjc-u8-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	tmpFiles.push(path);
+	return path;
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function readPidList(path: string): Promise<number[]> {
+	const text = await Bun.file(path)
+		.text()
+		.catch(() => "");
+	return text
+		.split(/\n+/)
+		.map(line => Number(line.trim()))
+		.filter(pid => Number.isInteger(pid) && pid > 0);
+}
+
+afterEach(async () => {
+	for (const manager of managers.splice(0)) {
+		await manager.disconnectAll().catch(() => {});
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop(true);
+	}
+	for (const path of tmpFiles.splice(0)) {
+		await Bun.file(path)
+			.delete()
+			.catch(() => {});
+	}
+});
+
+describe("MCP transport lifecycle red-team regressions", () => {
+	test("stdio stdout EOF while process is alive reconnects after killing the old owned child tree", async () => {
+		const before = liveOwnedProcessCount();
+		const pidFile = tmpPath("stdio-pids");
+		const childPidFile = tmpPath("stdio-child-pids");
+		const serverScript = `
+const fs = require("fs");
+const cp = require("child_process");
+const child = cp.spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], { stdio: "ignore" });
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+fs.appendFileSync(${JSON.stringify(childPidFile)}, String(child.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+let sawTools = false;
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "redteam", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ok", inputSchema: { type: "object" } }] } }) + "\\n", () => {
+      if (!sawTools) {
+        sawTools = true;
+        process.stdout.end();
+      }
+    });
+  }
+});
+setInterval(()=>{},1000);
+`;
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers(
+			{
+				red: {
+					type: "stdio",
+					command: process.execPath,
+					args: ["-e", serverScript],
+					timeout: 1_000,
+				},
+			},
+			{},
+		);
+		expect(result.errors.size).toBe(0);
+		expect(result.connectedServers).toEqual(["red"]);
+
+		await waitFor(async () => (await readPidList(pidFile)).length >= 1, 1_000);
+		const connection = manager.getConnection("red");
+		expect(connection).toBeDefined();
+		connection!.transport.onClose?.();
+		await waitFor(async () => (await readPidList(pidFile)).length >= 2, 3_500);
+		const serverPids = await readPidList(pidFile);
+		const childPids = await readPidList(childPidFile);
+		expect(serverPids.length).toBeGreaterThanOrEqual(2);
+		expect(childPids.length).toBeGreaterThanOrEqual(2);
+		const oldServerPid = serverPids[0]!;
+		const oldChildPid = childPids[0]!;
+		const newServerPid = serverPids.at(-1)!;
+		const newChildPid = childPids.at(-1)!;
+		expect(newServerPid).not.toBe(oldServerPid);
+		expect(newChildPid).not.toBe(oldChildPid);
+		await waitFor(() => !isAlive(oldServerPid) && !isAlive(oldChildPid), 2_000);
+		expect(isAlive(newServerPid)).toBe(true);
+		expect(isAlive(newChildPid)).toBe(true);
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+
+		await manager.disconnectServer("red");
+		await waitFor(() => !isAlive(newServerPid) && !isAlive(newChildPid), 2_000);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000);
+	});
+
+	test("HTTP response that sends headers then stalls its body rejects within configured timeout", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				return new Response(new ReadableStream({ start() {} }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 75 });
+		await transport.connect();
+		const started = Date.now();
+		await expect(transport.request("tools/list")).rejects.toThrow("Request timeout after 75ms");
+		expect(Date.now() - started).toBeLessThan(1_000);
+		await transport.close();
+	});
+
+	test("Streamable HTTP text/event-stream request aborts per-request reader after matching response", async () => {
+		let cancelCount = 0;
+		const originalCancel = ReadableStream.prototype.cancel;
+		ReadableStream.prototype.cancel = function (...args: Parameters<ReadableStream["cancel"]>) {
+			cancelCount++;
+			return originalCancel.apply(this, args);
+		};
+		try {
+			const server = Bun.serve({
+				port: 0,
+				idleTimeout: 255,
+				async fetch(req) {
+					const request = (await req.json()) as { id: string | number };
+					const stream = new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode(
+									`data: ${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n\n`,
+								),
+							);
+						},
+					});
+					return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+				},
+			});
+			servers.push(server);
+			const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 500 });
+			await transport.connect();
+			await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+			await waitFor(() => cancelCount > 0, 1_000);
+			await transport.close();
+		} finally {
+			ReadableStream.prototype.cancel = originalCancel;
+		}
+	});
+
+	test("initial listTools rejection closes transport and leaves server unregistered", async () => {
+		let deleteCount = 0;
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			async fetch(req) {
+				if (req.method === "DELETE") {
+					deleteCount++;
+					return new Response(null, { status: 202 });
+				}
+				if (req.method === "GET") {
+					return new Response(null, { status: 405 });
+				}
+				const request = (await req.json()) as { id: string | number; method: string };
+				if (request.method === "initialize") {
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id: request.id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "bad", version: "1" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": "bad-session" } },
+					);
+				}
+				if (request.method === "initialized" || request.method === "notifications/initialized") {
+					return new Response(null, { status: 202 });
+				}
+				return Response.json({ jsonrpc: "2.0", id: request.id, error: { code: -32000, message: "boom" } });
+			},
+		});
+		servers.push(server);
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers({ bad: { type: "http", url: server.url.href, timeout: 500 } }, {});
+		expect(result.connectedServers).toEqual([]);
+		expect(result.errors.get("bad")).toContain("boom");
+		expect(manager.getConnection("bad")).toBeUndefined();
+		expect(manager.getConnectionStatus("bad")).toBe("disconnected");
+		await waitFor(() => deleteCount > 0, 1_000);
+	});
+
+	test("disconnectServer during reconnect backoff prevents late reconnect and new child spawn", async () => {
+		const pidFile = tmpPath("backoff-pids");
+		const serverScript = `
+const fs = require("fs");
+fs.appendFileSync(${JSON.stringify(pidFile)}, String(process.pid) + "\\n");
+const rl = require("readline").createInterface({ input: process.stdin });
+rl.on("line", line => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "backoff", version: "1" } } }) + "\\n");
+  } else if (msg.method === "tools/list") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ok", inputSchema: { type: "object" } }] } }) + "\\n", () => process.exit(0));
+  }
+});
+`;
+		const manager = new MCPManager(process.cwd());
+		managers.push(manager);
+		const result = await manager.connectServers(
+			{ backoff: { type: "stdio", command: process.execPath, args: ["-e", serverScript], timeout: 750 } },
+			{},
+		);
+		expect(result.errors.size).toBe(0);
+		await waitFor(() => manager.getConnectionStatus("backoff") === "connecting", 1_000);
+		await manager.disconnectServer("backoff");
+		const pidsAtDisconnect = await readPidList(pidFile);
+		await Bun.sleep(750);
+		expect(await readPidList(pidFile)).toEqual(pidsAtDisconnect);
+		expect(manager.getConnectionStatus("backoff")).toBe("disconnected");
+	});
+});
+
+mkdirSync("artifacts", { recursive: true });

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
+import { HttpTransport } from "../../src/runtime-mcp/transports/http";
+import { StdioTransport } from "../../src/runtime-mcp/transports/stdio";
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+const servers: Bun.Server<unknown>[] = [];
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) {
+		await server.stop(true);
+	}
+});
+
+describe("MCP stdio transport lifecycle", () => {
+	test("close and reconnect dispose the old owned child tree", async () => {
+		const before = liveOwnedProcessCount();
+		const pidFile = `/tmp/gjc-mcp-stdio-${Date.now()}-${Math.random().toString(36).slice(2)}.pid`;
+		const command = [
+			"node",
+			"-e",
+			`const fs=require('fs'); const cp=require('child_process'); const child=cp.spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:false,stdio:'ignore'}); fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid)); setInterval(()=>{},1000);`,
+		];
+		const transport = new StdioTransport({ command: command[0], args: command.slice(1), timeout: 500 });
+		await transport.connect();
+		await waitFor(() => Bun.file(pidFile).exists());
+		const oldChildPid = Number(await Bun.file(pidFile).text());
+		expect(isAlive(oldChildPid)).toBe(true);
+
+		await transport.close();
+		await waitFor(() => !isAlive(oldChildPid));
+		expect(liveOwnedProcessCount()).toBe(before);
+
+		await Bun.write(pidFile, "");
+		await transport.connect();
+		await waitFor(async () => {
+			const text = await Bun.file(pidFile)
+				.text()
+				.catch(() => "");
+			return Number(text) > 0;
+		});
+		const newChildPid = Number(await Bun.file(pidFile).text());
+		expect(newChildPid).not.toBe(oldChildPid);
+		expect(isAlive(oldChildPid)).toBe(false);
+		await transport.close();
+		await waitFor(() => !isAlive(newChildPid));
+	});
+});
+
+describe("MCP HTTP transport lifecycle", () => {
+	test("request timeout covers hanging response bodies after headers", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				return new Response(new ReadableStream({ start() {} }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 100 });
+		await transport.connect();
+		await expect(transport.request("tools/list")).rejects.toThrow("Request timeout after 100ms");
+		await transport.close();
+	});
+
+	test("per-request SSE closes after matching response", async () => {
+		let nextId: string | number = "1";
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			async fetch(req) {
+				const request = (await req.json()) as { id?: string | number };
+				nextId = request.id ?? nextId;
+				const stream = new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								`data: {"jsonrpc":"2.0","id":${JSON.stringify(nextId)},"result":{"ok":true}}\n\n`,
+							),
+						);
+						controller.close();
+					},
+				});
+				return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 1_000 });
+		await transport.connect();
+		await expect(transport.request("tools/list")).resolves.toEqual({ ok: true });
+
+		await transport.close();
+	});
+
+	test("failed GET SSE listener cancels the response body", async () => {
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255,
+			fetch() {
+				const stream = new ReadableStream({
+					start(controller) {
+						controller.close();
+					},
+				});
+				return new Response(stream, { status: 500 });
+			},
+		});
+		servers.push(server);
+		const transport = new HttpTransport({ type: "http", url: server.url.href, timeout: 1_000 });
+		await transport.connect();
+		await transport.startSSEListener();
+
+		await transport.close();
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -191,6 +191,50 @@ describe("process-lifecycle adversarial owned-process invariants", () => {
 			}
 		},
 	);
+	test.skipIf(!isPosix)(
+		"late dispose after a clean drain is a no-op and never re-signals a recycled pgid",
+		async () => {
+			const before = liveOwnedProcessCount();
+			// Root exits cleanly with no backgrounded descendants, so the group
+			// drains within ROOT_EXIT_DRAIN_MS and reconciliation deregisters it.
+			const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], {
+				name: "redteam-late-dispose-recycled-pgid",
+			});
+			const pgid = owner.pid as number;
+			expect(pgid).toBeGreaterThan(0);
+
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(
+				() => liveOwnedProcessCount() === before,
+				2_000,
+				"live count baseline after clean-drain reconciliation",
+			);
+
+			// Simulate the OS recycling the pgid into an unrelated group: sig-0
+			// probes report alive and we record any terminating signal aimed at it.
+			const realKill = process.kill;
+			const terminatingSignals: Array<string | number> = [];
+			process.kill = ((pid: number, signal?: string | number) => {
+				if (pid === -pgid) {
+					if (signal === 0) return true;
+					terminatingSignals.push(signal as string | number);
+					return true;
+				}
+				return (realKill as (p: number, s?: string | number) => boolean).call(process, pid, signal);
+			}) as typeof process.kill;
+
+			try {
+				await expect(owner.dispose()).resolves.toBeUndefined();
+				await expect(owner.dispose()).resolves.toBeUndefined();
+				expect(terminatingSignals).toEqual([]);
+				expect(owner.disposed).toBe(true);
+				expect(liveOwnedProcessCount()).toBe(before);
+			} finally {
+				process.kill = realKill;
+			}
+		},
+	);
 });
 
 describe("process-lifecycle adversarial resource-owner invariants", () => {

--- a/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.redteam.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function waitForAsync(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 5_000,
+	label = "condition",
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			if (await predicate()) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await Bun.sleep(20);
+	}
+	throw new Error(`waitFor timed out: ${label}${lastError ? ` (${String(lastError)})` : ""}`);
+}
+
+async function fileContains(path: string, needle: string): Promise<boolean> {
+	try {
+		return (await Bun.file(path).text()).includes(needle);
+	} catch {
+		return false;
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function processGroupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("process-lifecycle adversarial owned-process invariants", () => {
+	test("dispose immediately after spawn wins the startup race and returns to baseline", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "printf ready; sleep 30"], {
+			name: "redteam-immediate-dispose",
+			gracefulMs: 10,
+		});
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after immediate dispose");
+	});
+
+	test("dispose of an already-exited process is a no-op and does not throw", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 7"], { name: "redteam-already-exited" });
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit).toEqual({ exited: true, code: 7 });
+
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		await expect(owner.dispose()).resolves.toBeUndefined();
+		expect(owner.disposed).toBe(true);
+		await waitFor(
+			() => liveOwnedProcessCount() === before,
+			2_000,
+			"live count baseline after already-exited dispose",
+		);
+	});
+
+	test("double and concurrent dispose share one settled result and issue one terminating signal", async () => {
+		const before = liveOwnedProcessCount();
+		const tmp = `/tmp/gjc-process-lifecycle-${process.pid}-${Date.now()}`;
+		const owner = spawnOwnedProcess(
+			["sh", "-c", `trap 'echo term >> ${tmp}; exit 0' TERM; echo up > ${tmp}; while :; do sleep 1; done`],
+			{ name: "redteam-concurrent-dispose", gracefulMs: 500 },
+		);
+		try {
+			await waitForAsync(() => fileContains(tmp, "up"), 2_000, "child readiness marker");
+			const first = owner.dispose();
+			const second = owner.dispose();
+			expect(second).toBe(first);
+			await expect(Promise.all([first, second, owner.dispose()])).resolves.toEqual([
+				undefined,
+				undefined,
+				undefined,
+			]);
+			const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(exit.exited).toBe(true);
+			await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after concurrent dispose");
+			const marker = await Bun.file(tmp).text();
+			expect(marker.split("\n").filter(line => line === "term")).toHaveLength(1);
+		} finally {
+			try {
+				await owner.dispose();
+			} catch {
+				/* already disposed */
+			}
+			await Bun.$`rm -f ${tmp}`.quiet();
+		}
+	});
+
+	test("awaitExit with timeoutMs 0 reports a live long-runner without killing it, then dispose cleans it", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "redteam-zero-timeout",
+			gracefulMs: 10,
+		});
+		try {
+			const probe = await owner.awaitExit({ timeoutMs: 0 });
+			expect(probe.exited).toBe(false);
+			expect(owner.pid === undefined ? false : processAlive(owner.pid)).toBe(true);
+		} finally {
+			await owner.dispose();
+		}
+		const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(exit.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after zero-timeout dispose");
+	});
+
+	test("liveOwnedProcessCount returns to baseline after a batch of spawn and dispose", async () => {
+		const before = liveOwnedProcessCount();
+		const owners = Array.from({ length: 8 }, (_, index) =>
+			spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+				name: `redteam-batch-${index}`,
+				gracefulMs: 10,
+			}),
+		);
+		expect(liveOwnedProcessCount()).toBeGreaterThanOrEqual(before + owners.length);
+		await Promise.all(owners.map(owner => owner.dispose()));
+		await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after batch dispose");
+	});
+
+	test.skipIf(!isPosix)(
+		"dispose reaps a same-group double-fork grandchild while an unrelated sibling survives",
+		async () => {
+			const before = liveOwnedProcessCount();
+			const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+			const siblingPid = sibling.pid;
+			const owner = spawnOwnedProcess(["sh", "-c", "( ( sleep 30 ) & ) & while :; do sleep 1; done"], {
+				name: "redteam-double-fork-group",
+				gracefulMs: 50,
+			});
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			try {
+				await Bun.sleep(250);
+				await owner.dispose();
+				const exit = await owner.awaitExit({ timeoutMs: 2_000 });
+				expect(exit.exited).toBe(true);
+				await waitFor(() => processGroupGone(pgid as number), 3_000, "owned process group ESRCH");
+				expect(processAlive(siblingPid)).toBe(true);
+				await waitFor(() => liveOwnedProcessCount() === before, 2_000, "live count baseline after group reap");
+			} finally {
+				try {
+					sibling.kill("SIGKILL");
+				} catch {
+					/* already gone */
+				}
+				await owner.dispose();
+			}
+		},
+	);
+});
+
+describe("process-lifecycle adversarial resource-owner invariants", () => {
+	test("a throwing disposer does not abort disposeAllResourceOwners and other disposers still run", async () => {
+		await disposeAllResourceOwners();
+		const calls: string[] = [];
+		registerResourceOwner("redteam:throws", () => {
+			calls.push("throws");
+			throw new Error("intentional red-team disposer failure");
+		});
+		registerResourceOwner("redteam:after", () => {
+			calls.push("after");
+		});
+		registerResourceOwner("redteam:async", async () => {
+			await Bun.sleep(1);
+			calls.push("async");
+		});
+
+		// All disposers run even when one throws, and the failure is surfaced
+		// (not swallowed) as an AggregateError so callers can detect it.
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(calls).toEqual(["throws", "after", "async"]);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+
+	test("unregister after disposeAllResourceOwners is safe and cannot remove a newer registration", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregister = registerResourceOwner("redteam:late-unregister", () => {
+			first += 1;
+		});
+		await disposeAllResourceOwners();
+		expect(first).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+
+		expect(() => unregister()).not.toThrow();
+		registerResourceOwner("redteam:late-unregister", () => {
+			second += 1;
+		});
+		expect(() => unregister()).not.toThrow();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(second).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/runtime/process-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime/process-lifecycle.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+import {
+	disposeAllOwnedProcesses,
+	disposeAllResourceOwners,
+	liveOwnedProcessCount,
+	registerResourceOwner,
+	resourceOwnerCount,
+	spawnOwnedProcess,
+} from "@gajae-code/coding-agent/runtime/process-lifecycle";
+
+const isPosix = process.platform !== "win32";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+describe("spawnOwnedProcess (F1a)", () => {
+	test("awaits clean exit and deregisters from the live set", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "exit 0"], { name: "clean-exit" });
+		const result = await owner.awaitExit();
+		expect(result.exited).toBe(true);
+		expect(result.code).toBe(0);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("awaitExit honors a bounded timeout for a long runner", async () => {
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "timeout-probe" });
+		try {
+			const result = await owner.awaitExit({ timeoutMs: 100 });
+			expect(result.exited).toBe(false);
+		} finally {
+			await owner.dispose();
+		}
+	});
+
+	test("dispose terminates a long runner and is idempotent", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "dispose-probe" });
+		await Bun.sleep(50);
+		await Promise.all([owner.dispose(), owner.dispose()]);
+		expect(owner.disposed).toBe(true);
+		const result = await owner.awaitExit({ timeoutMs: 1_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("an already-aborted signal disposes the process immediately", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "pre-aborted",
+			signal: AbortSignal.abort(),
+		});
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test("aborting mid-run disposes and removes the abort listener", async () => {
+		const before = liveOwnedProcessCount();
+		const controller = new AbortController();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], {
+			name: "mid-abort",
+			signal: controller.signal,
+		});
+		await Bun.sleep(50);
+		controller.abort();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+		// Listener removed on settle: a second abort must not throw or re-dispose.
+		controller.abort();
+		expect(owner.disposed).toBe(true);
+	});
+
+	test.skipIf(!isPosix)("dispose reaps the process group while an unrelated sibling survives", async () => {
+		// Unrelated sibling: a directly-spawned detached sleep we must NOT kill.
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		const siblingPid = sibling.pid;
+		try {
+			// Owned tree: a shell that backgrounds a grandchild plus a foreground child.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & sleep 30"], { name: "group-reap" });
+			const pgid = owner.pid;
+			expect(pgid).toBeGreaterThan(0);
+			await Bun.sleep(150); // let the grandchild spawn
+
+			await owner.dispose();
+			await owner.awaitExit({ timeoutMs: 2_000 });
+
+			// The whole owned process group must be gone (ESRCH on group probe).
+			await waitFor(() => {
+				try {
+					process.kill(-(pgid as number), 0);
+					return false; // still alive
+				} catch (err) {
+					return (err as NodeJS.ErrnoException).code === "ESRCH";
+				}
+			});
+
+			// The unrelated sibling must still be alive.
+			expect(alive(siblingPid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+});
+
+describe("registerResourceOwner (F1b)", () => {
+	test("disposer runs once on disposeAllResourceOwners", async () => {
+		await disposeAllResourceOwners(); // clean slate
+		let calls = 0;
+		registerResourceOwner("test:res-a", () => {
+			calls += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+		// Cleared after dispose: a second dispose does not re-invoke.
+		await disposeAllResourceOwners();
+		expect(calls).toBe(1);
+	});
+
+	test("unregister prevents the disposer from running", async () => {
+		await disposeAllResourceOwners();
+		let calls = 0;
+		const unregister = registerResourceOwner("test:res-b", () => {
+			calls += 1;
+		});
+		unregister();
+		expect(resourceOwnerCount()).toBe(0);
+		await disposeAllResourceOwners();
+		expect(calls).toBe(0);
+		// Idempotent unregister.
+		expect(() => unregister()).not.toThrow();
+	});
+
+	test("re-registering the same name replaces the disposer (last wins)", async () => {
+		await disposeAllResourceOwners();
+		let first = 0;
+		let second = 0;
+		const unregisterFirst = registerResourceOwner("test:res-c", () => {
+			first += 1;
+		});
+		registerResourceOwner("test:res-c", () => {
+			second += 1;
+		});
+		expect(resourceOwnerCount()).toBe(1);
+		// The stale unregister must not remove the newer registration.
+		unregisterFirst();
+		expect(resourceOwnerCount()).toBe(1);
+		await disposeAllResourceOwners();
+		expect(first).toBe(0);
+		expect(second).toBe(1);
+	});
+});
+
+describe("ownership regression: group liveness drives teardown (F1a)", () => {
+	test.skipIf(!isPosix)("reaps backgrounded descendants when the root exits first", async () => {
+		const sibling = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// The shell exits 0 immediately but leaves a backgrounded child in the group.
+			const owner = spawnOwnedProcess(["sh", "-c", "sleep 30 & exit 0"], { name: "root-exits-first" });
+			const pgid = owner.pid as number;
+			const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+			expect(rootExit.exited).toBe(true);
+			expect(rootExit.code).toBe(0);
+			await Bun.sleep(50);
+			// The owned group is still alive because of the orphaned background child.
+			expect(groupAliveProbe(pgid)).toBe(true);
+			await owner.dispose();
+			await waitFor(() => groupGone(pgid));
+			// The unrelated sibling must survive.
+			expect(alive(sibling.pid)).toBe(true);
+		} finally {
+			try {
+				sibling.kill("SIGKILL");
+			} catch {
+				/* already gone */
+			}
+		}
+	});
+
+	test("owner stays tracked until dispose teardown completes", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 30"], { name: "tracked-until-done", gracefulMs: 300 });
+		await Bun.sleep(50);
+		const disposing = owner.dispose();
+		// FIX: the owner must remain in the live set until teardown completes, so a
+		// postmortem firing mid-grace still awaits this in-flight dispose.
+		expect(liveOwnedProcessCount()).toBe(before + 1);
+		await disposing;
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+
+	test.skipIf(!isPosix)("disposeAllOwnedProcesses escalates SIGKILL for a SIGTERM-ignoring child", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "trap '' TERM; sleep 30"], {
+			name: "term-trap",
+			gracefulMs: 200,
+		});
+		await Bun.sleep(100);
+		// Simulates a postmortem/owner-scoped teardown reaching the in-flight owner.
+		await disposeAllOwnedProcesses();
+		const result = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(result.exited).toBe(true);
+		await waitFor(() => liveOwnedProcessCount() === before);
+	});
+});
+
+describe("resource owner failure surfacing (F1b)", () => {
+	test("disposeAllResourceOwners surfaces disposer failures as AggregateError", async () => {
+		await disposeAllResourceOwners().catch(() => undefined);
+		let ran = 0;
+		registerResourceOwner("agg:throws", () => {
+			throw new Error("boom");
+		});
+		registerResourceOwner("agg:ok", () => {
+			ran += 1;
+		});
+		await expect(disposeAllResourceOwners()).rejects.toBeInstanceOf(AggregateError);
+		expect(ran).toBe(1);
+		expect(resourceOwnerCount()).toBe(0);
+	});
+});
+
+function groupAliveProbe(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function groupGone(pgid: number): boolean {
+	try {
+		process.kill(-pgid, 0);
+		return false;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+describe("ownership regression: no stale pgid after late drain (F1a)", () => {
+	test.skipIf(!isPosix)("reaps and deregisters when descendants outlive the drain window", async () => {
+		const before = liveOwnedProcessCount();
+		const owner = spawnOwnedProcess(["sh", "-c", "sleep 1 & exit 0"], { name: "late-drain" });
+		const rootExit = await owner.awaitExit({ timeoutMs: 2_000 });
+		expect(rootExit.exited).toBe(true);
+		// The backgrounded `sleep 1` outlives ROOT_EXIT_DRAIN_MS; the owner must not
+		// linger with a stale pgid — it is reaped and the live count returns to
+		// baseline rather than being abandoned.
+		await waitFor(() => liveOwnedProcessCount() === before, 8_000);
+		expect(liveOwnedProcessCount()).toBe(before);
+	});
+});

--- a/packages/coding-agent/test/tools/bash-resource-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/tools/bash-resource-lifecycle.redteam.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	disposeAllShellSessions,
+	executeBash,
+	getShellSessionCount,
+} from "@gajae-code/coding-agent/exec/bash-executor";
+import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import { DEFAULT_ARTIFACT_MAX_BYTES } from "@gajae-code/coding-agent/session/streaming-output";
+import { BashTool, type ToolSession } from "@gajae-code/coding-agent/tools";
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-redteam-"));
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForFile(filePath: string, timeoutMs = 3_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(filePath)) return true;
+		await Bun.sleep(25);
+	}
+	return fs.existsSync(filePath);
+}
+
+async function waitForSessionCountAtMost(count: number, timeoutMs = 4_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (getShellSessionCount() <= count) return true;
+		await Bun.sleep(25);
+	}
+	return getShellSessionCount() <= count;
+}
+
+function makeToolSession(tempDir: string, settings: Settings): ToolSession {
+	const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+	return {
+		cwd: tempDir,
+		hasUI: false,
+		settings,
+		getSessionId: () => "bash-redteam-test",
+		getAgentId: () => "0-Redteam",
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getArtifactsDir: () => artifacts.dir,
+		getArtifactManager: () => artifacts,
+		allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+	} as unknown as ToolSession;
+}
+
+describe("bash resource lifecycle red-team", () => {
+	let tempDir: string;
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	beforeEach(async () => {
+		tempDir = makeTempDir();
+		resetSettingsForTest();
+		settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		settings.set("async.enabled", true);
+		manager = new AsyncJobManager({ retentionMs: 20, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		await disposeAllShellSessions();
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.resetForTests();
+		await disposeAllShellSessions();
+		resetSettingsForTest();
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("does not leak native shell sessions across many sequential async and monitor bash jobs", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 12; index++) {
+			const started = await tool.execute(`async-${index}`, {
+				command: `printf 'async-${index}\\n'`,
+				async: true,
+				timeout: 5,
+			});
+			const jobId = started.details?.async?.jobId;
+			expect(jobId).toBeString();
+			await manager.waitForAll();
+			expect(manager.getJob(jobId! as string)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+
+			const monitor = await tool.startMonitorJob({ command: `printf 'monitor-${index}\\n'`, timeout: 5 });
+			await manager.waitForAll();
+			expect(manager.getJob(monitor.jobId)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	// U6 owns the JS-layer lifecycle contract: cancelled persistent shell sessions
+	// remain reachable to disposeAllShellSessions during bounded native cleanup,
+	// then leave the registry after native settle. Descendant/grandchild reaping is
+	// delegated to pi-shell and verified by native unit U3; this JS test exercises
+	// the integration again after U3 merges and the dev native addon is rebuilt.
+	it("keeps a cancelled persistent shell disposable through bounded native cleanup", async () => {
+		if (process.platform === "win32") return;
+
+		const baseline = getShellSessionCount();
+		const sibling = Bun.spawn(["python3", "-c", "import time; time.sleep(20)"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const pidFile = path.join(tempDir, "owned-direct-child.pid");
+		const controller = new AbortController();
+		const command = `python3 -c 'import os,time; open(${JSON.stringify(pidFile)}, "w").write(str(os.getpid())); time.sleep(20)'`;
+
+		try {
+			const run = executeBash(command, {
+				cwd: tempDir,
+				timeout: 30_000,
+				signal: controller.signal,
+				sessionKey: "redteam-cancel-disposable",
+			});
+
+			expect(await waitForFile(pidFile)).toBe(true);
+			const directChildPid = Number(fs.readFileSync(pidFile, "utf8"));
+			expect(Number.isInteger(directChildPid)).toBe(true);
+			expect(directChildPid).not.toBe(sibling.pid);
+			expect(processExists(directChildPid)).toBe(true);
+			expect(processExists(sibling.pid)).toBe(true);
+			expect(getShellSessionCount()).toBeGreaterThan(baseline);
+
+			controller.abort();
+			expect(getShellSessionCount()).toBeGreaterThanOrEqual(baseline);
+
+			const cleanupStartedAt = Date.now();
+			await disposeAllShellSessions();
+			const cleanupMs = Date.now() - cleanupStartedAt;
+			expect(cleanupMs).toBeLessThan(2_500);
+			expect(await waitForSessionCountAtMost(baseline)).toBe(true);
+
+			const result = await run;
+			expect(result.cancelled).toBe(true);
+			expect(processExists(sibling.pid)).toBe(true);
+		} finally {
+			sibling.kill("SIGKILL");
+			await sibling.exited.catch(() => undefined);
+		}
+	});
+
+	it("caps huge bash artifacts with truncation metadata instead of unbounded growth", async () => {
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+		const result = await tool.execute("huge-artifact", {
+			command: "python3 -c 'import sys; sys.stdout.write(\"x\" * (12 * 1024 * 1024))'",
+			timeout: 30,
+		});
+
+		const meta = result.details?.meta?.truncation;
+		expect(meta?.artifactId).toBeString();
+		expect(meta?.totalBytes).toBeGreaterThan(DEFAULT_ARTIFACT_MAX_BYTES);
+		expect(meta?.outputBytes).toBeLessThan(meta!.totalBytes);
+
+		const artifactPath = path.join(tempDir, "artifacts", `${meta!.artifactId}.bash.log`);
+		expect(fs.existsSync(artifactPath)).toBe(true);
+		const artifact = fs.readFileSync(artifactPath, "utf8");
+		expect(artifact).toContain("artifact truncated after 10485760 bytes");
+		expect(fs.statSync(artifactPath).size).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES + 512);
+	});
+});

--- a/packages/coding-agent/test/tools/bash-resource-lifecycle.test.ts
+++ b/packages/coding-agent/test/tools/bash-resource-lifecycle.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	disposeAllShellSessions,
+	executeBash,
+	getShellSessionCount,
+} from "@gajae-code/coding-agent/exec/bash-executor";
+import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import { DEFAULT_ARTIFACT_MAX_BYTES, OutputSink } from "@gajae-code/coding-agent/session/streaming-output";
+import { BashTool, type ToolSession } from "@gajae-code/coding-agent/tools";
+import type { Shell } from "@gajae-code/natives";
+import * as piNatives from "@gajae-code/natives";
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-lifecycle-"));
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForGone(pid: number, timeoutMs = 2_500): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!processExists(pid)) return true;
+		await Bun.sleep(50);
+	}
+	return !processExists(pid);
+}
+
+function makeToolSession(tempDir: string, settings: Settings): ToolSession {
+	const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+	return {
+		cwd: tempDir,
+		hasUI: false,
+		settings,
+		getSessionId: () => "bash-lifecycle-test",
+		getAgentId: () => "0-Test",
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		getArtifactsDir: () => artifacts.dir,
+		getArtifactManager: () => artifacts,
+		allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+	} as unknown as ToolSession;
+}
+
+describe("bash resource lifecycle", () => {
+	let tempDir: string;
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	beforeEach(async () => {
+		tempDir = makeTempDir();
+		resetSettingsForTest();
+		settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		settings.set("async.enabled", true);
+		manager = new AsyncJobManager({ retentionMs: 20, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		await disposeAllShellSessions();
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.resetForTests();
+		await disposeAllShellSessions();
+		resetSettingsForTest();
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	it("repeated async bash jobs return native shell session count to baseline", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 3; index++) {
+			const started = await tool.execute(`call-${index}`, {
+				command: `printf async-${index}`,
+				async: true,
+				timeout: 5,
+			});
+			const jobId = started.details?.async?.jobId;
+			expect(jobId).toBeString();
+			await manager.waitForAll();
+			expect(manager.getJob(jobId! as string)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	it("repeated monitor jobs return native shell session count to baseline", async () => {
+		const baseline = getShellSessionCount();
+		const tool = new BashTool(makeToolSession(tempDir, settings));
+
+		for (let index = 0; index < 3; index++) {
+			const { jobId } = await tool.startMonitorJob({ command: `printf monitor-${index}`, timeout: 5 });
+			await manager.waitForAll();
+			expect(manager.getJob(jobId)?.status).toBe("completed");
+			expect(getShellSessionCount()).toBe(baseline);
+		}
+	});
+
+	it("keeps a cancelled persistent shell reachable until native run settles", async () => {
+		const baseline = getShellSessionCount();
+		const controller = new AbortController();
+		const run = executeBash("sleep 10", {
+			cwd: tempDir,
+			timeout: 10_000,
+			signal: controller.signal,
+			sessionKey: "cancel-reachable",
+		});
+
+		await Bun.sleep(100);
+		expect(getShellSessionCount()).toBeGreaterThan(baseline);
+		controller.abort();
+		const result = await run;
+		expect(result.cancelled).toBe(true);
+		expect(getShellSessionCount()).toBe(baseline);
+		await disposeAllShellSessions();
+		expect(getShellSessionCount()).toBe(baseline);
+	});
+
+	it("reaps owned descendants on cancellation without killing unrelated siblings", async () => {
+		if (process.platform === "win32") return;
+
+		const sibling = Bun.spawn(["python3", "-c", "import time; time.sleep(10)"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const pidFile = path.join(tempDir, "owned.pid");
+		const controller = new AbortController();
+		const run = executeBash(
+			`python3 -c 'import os,time; open(${JSON.stringify(pidFile)}, "w").write(str(os.getpid())); time.sleep(10)'`,
+			{
+				cwd: tempDir,
+				timeout: 10_000,
+				signal: controller.signal,
+				sessionKey: "owned-pid-cancel",
+			},
+		);
+
+		const deadline = Date.now() + 2_000;
+		while (!fs.existsSync(pidFile) && Date.now() < deadline) await Bun.sleep(25);
+		expect(fs.existsSync(pidFile)).toBe(true);
+		const ownedPid = Number(fs.readFileSync(pidFile, "utf8"));
+		expect(processExists(ownedPid)).toBe(true);
+		controller.abort();
+		const result = await run;
+		expect(result.cancelled).toBe(true);
+		expect(await waitForGone(ownedPid)).toBe(true);
+		expect(processExists(sibling.pid)).toBe(true);
+		sibling.kill("SIGKILL");
+		await sibling.exited.catch(() => undefined);
+	});
+
+	it("caps bash artifact output and annotates truncation metadata", async () => {
+		const artifactPath = path.join(tempDir, "capped.log");
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "cap",
+			spillThreshold: 4,
+			artifactMaxBytes: 16,
+		});
+
+		sink.push("a".repeat(40));
+		const summary = await sink.dump();
+		const artifact = fs.readFileSync(artifactPath, "utf8");
+
+		expect(summary.artifactId).toBe("cap");
+		expect(summary.artifactTruncatedBytes).toBeGreaterThan(0);
+		expect(artifact).toContain("artifact truncated after 16 bytes");
+		expect(Buffer.byteLength(artifact, "utf8")).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES);
+		expect(artifact.length).toBeLessThan(120);
+	});
+
+	it("caps direct artifact saves and annotates truncation", async () => {
+		const manager = new ArtifactManager(path.join(tempDir, "direct-artifacts"));
+		const id = await manager.save("x".repeat(64), "bash", { maxBytes: 12 });
+		const savedPath = await manager.getPath(id);
+		expect(savedPath).toBeString();
+		const saved = fs.readFileSync(savedPath!, "utf8");
+		expect(saved).toContain("artifact truncated after 12 bytes");
+		expect(saved.length).toBeLessThan(96);
+	});
+	it("does not let a late-retired shell replace its same-key successor", async () => {
+		const originalRun = piNatives.Shell.prototype.run;
+		let runCalls = 0;
+		let firstRunSettled: (() => void) | undefined;
+		const shells: Shell[] = [];
+		const runSpy = vi.spyOn(piNatives.Shell.prototype, "run").mockImplementation(function (
+			this: Shell,
+			options,
+			onChunk,
+		) {
+			runCalls++;
+			shells.push(this);
+			if (runCalls === 1) {
+				onChunk?.(null, "started\n");
+				return new Promise(resolve => {
+					firstRunSettled = () => resolve({ exitCode: 130, cancelled: true, timedOut: false });
+				});
+			}
+			if (runCalls === 2) {
+				onChunk?.(null, "replacement\n");
+				return Promise.resolve({ exitCode: 0, cancelled: false, timedOut: false });
+			}
+			if (runCalls === 3) {
+				onChunk?.(null, "after-late-settle\n");
+				return Promise.resolve({ exitCode: 0, cancelled: false, timedOut: false });
+			}
+			return originalRun.call(this, options, onChunk);
+		});
+		const abortSpy = vi.spyOn(piNatives.Shell.prototype, "abort").mockResolvedValue(undefined);
+		const controller = new AbortController();
+		const first = executeBash("sleep 10", {
+			cwd: tempDir,
+			timeout: 5_000,
+			signal: controller.signal,
+			sessionKey: "late-retiring-replacement",
+		});
+
+		await Bun.sleep(50);
+		controller.abort();
+		const firstResult = await first;
+		expect(firstResult.cancelled).toBe(true);
+		expect(abortSpy).toHaveBeenCalledTimes(1);
+
+		const replacement = await executeBash("printf replacement", {
+			cwd: tempDir,
+			timeout: 5_000,
+			sessionKey: "late-retiring-replacement",
+		});
+		expect(replacement.output.trim()).toBe("replacement");
+		expect(shells[1]).not.toBe(shells[0]);
+
+		firstRunSettled?.();
+		await Bun.sleep(0);
+
+		const afterLateSettle = await executeBash("printf after-late-settle", {
+			cwd: tempDir,
+			timeout: 5_000,
+			sessionKey: "late-retiring-replacement",
+		});
+		expect(afterLateSettle.output.trim()).toBe("replacement");
+		expect(runCalls).toBe(2);
+
+		runSpy.mockRestore();
+		abortSpy.mockRestore();
+	});
+
+	it("caps minimized raw output artifacts through ArtifactManager", async () => {
+		const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+		const session = {
+			getArtifactManager: () => artifacts,
+			allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+		} as unknown as ToolSession;
+		const originalText = "x".repeat(DEFAULT_ARTIFACT_MAX_BYTES + 1024);
+		const bashModule = await import("@gajae-code/coding-agent/tools/bash");
+		const artifactId = await bashModule.saveBashOriginalArtifactForTests(session, originalText);
+
+		expect(artifactId).toBeString();
+		const artifactPath = path.join(tempDir, "artifacts", `${artifactId}.bash-original.log`);
+		expect(fs.existsSync(artifactPath)).toBe(true);
+		const saved = fs.readFileSync(artifactPath, "utf8");
+		expect(saved).toContain(`artifact truncated after ${DEFAULT_ARTIFACT_MAX_BYTES} bytes`);
+		expect(fs.statSync(artifactPath).size).toBeLessThan(DEFAULT_ARTIFACT_MAX_BYTES + 512);
+	});
+});

--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -11,6 +11,7 @@ type Cache = {
  */
 export class Box implements Component {
 	children: Component[] = [];
+	#disposed = false;
 	#paddingX: number;
 	#paddingY: number;
 	#bgFn?: (text: string) => string;
@@ -34,11 +35,39 @@ export class Box implements Component {
 		if (index !== -1) {
 			this.children.splice(index, 1);
 			this.#invalidateCache();
+			component.dispose?.();
+		}
+	}
+
+	/** Remove a child without disposing it (for detach-then-readd reuse). */
+	detachChild(component: Component): void {
+		const index = this.children.indexOf(component);
+		if (index !== -1) {
+			this.children.splice(index, 1);
+			this.#invalidateCache();
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.children = [];
+		this.#invalidateCache();
+	}
+
+	/** Remove all children without disposing them (for detach-then-readd reuse). */
+	detachAll(): void {
+		this.children = [];
+		this.#invalidateCache();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.#invalidateCache();
 	}
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -78,6 +78,10 @@ export class Loader extends Text {
 		}
 	}
 
+	dispose(): void {
+		this.stop();
+	}
+
 	setMessage(message: string) {
 		this.message = message;
 		this.#updateDisplay();

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -43,6 +43,24 @@ const renderCache = new LRUCache<string, { source: string; lines: string[] }>({ 
 const PARSE_CACHE_MAX = 128;
 const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({ max: PARSE_CACHE_MAX });
 
+// Per-code-block highlight cache (F3): keyed by theme + lang + code so streaming
+// appends only highlight new/changed blocks instead of re-highlighting the whole
+// prefix on every chunk. Bounded LRU; cleared on theme change via clearRenderCache().
+const HIGHLIGHT_CACHE_MAX = 512;
+const highlightCache = new LRUCache<string, string[]>({ max: HIGHLIGHT_CACHE_MAX });
+// F18: cap synchronous (Rust FFI) syntax highlighting so a single huge fenced block
+// cannot stall the UI thread; oversized blocks render plain with a sanitized marker.
+const MAX_HIGHLIGHT_BYTES = 200_000;
+const MAX_HIGHLIGHT_LINES = 2000;
+let highlightCallCount = 0;
+/** Test/diagnostic seam: number of synchronous highlight invocations since the last reset. */
+export function getMarkdownHighlightCallCount(): number {
+	return highlightCallCount;
+}
+export function resetMarkdownHighlightCallCount(): void {
+	highlightCallCount = 0;
+}
+
 // Full-content 64-bit wyhash over every byte (no lossy sampling). Cache hits
 // additionally verify entry.source against the normalized text, so even a
 // hash collision can never return another message's render.
@@ -58,6 +76,7 @@ function wrapTextIfNeeded(line: string, width: number): string[] {
 export function clearRenderCache(): void {
 	renderCache.clear();
 	parseCache.clear();
+	highlightCache.clear();
 }
 
 // Stable numeric IDs for structural theme/style objects (no ID field on type).
@@ -184,6 +203,47 @@ export class Markdown implements Component {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+	}
+
+	#exceedsHighlightCap(code: string): boolean {
+		let newlines = 0;
+		for (let i = 0; i < code.length; i++) {
+			if (code.charCodeAt(i) === 10) newlines += 1;
+		}
+		if (newlines + 1 > MAX_HIGHLIGHT_LINES) return true;
+		// UTF-8 byte length (not UTF-16 code-unit count) so a non-ASCII block cannot
+		// exceed the advertised byte cap and still reach the synchronous highlighter.
+		return Buffer.byteLength(code, "utf8") > MAX_HIGHLIGHT_BYTES;
+	}
+
+	#highlightCodeBlock(code: string, lang: string): string[] | null {
+		if (!this.#theme.highlightCode) return null;
+		if (this.#exceedsHighlightCap(code)) return null;
+		const key = `${objectId(this.#theme)}\x00${lang}\x00${code}`;
+		const cached = highlightCache.get(key);
+		if (cached) return cached;
+		highlightCallCount += 1;
+		const result = this.#theme.highlightCode(code, lang || undefined);
+		highlightCache.set(key, result);
+		return result;
+	}
+
+	#emitCodeBlock(lines: string[], code: string, lang: string, codeIndent: string): void {
+		lines.push(this.#theme.codeBlockBorder(`\`\`\`${lang}`));
+		const highlighted = this.#highlightCodeBlock(code, lang);
+		if (highlighted) {
+			for (const hlLine of highlighted) {
+				lines.push(`${codeIndent}${hlLine}`);
+			}
+		} else {
+			if (this.#theme.highlightCode && this.#exceedsHighlightCap(code)) {
+				lines.push(`${codeIndent}${this.#theme.codeBlock("[syntax highlighting skipped: code block too large]")}`);
+			}
+			for (const codeLine of code.split("\n")) {
+				lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+			}
+		}
+		lines.push(this.#theme.codeBlockBorder("```"));
 	}
 
 	render(width: number): string[] {
@@ -442,20 +502,7 @@ export class Markdown implements Component {
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.#theme.highlightCode) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${codeIndent}${hlLine}`);
-					}
-				} else {
-					// Split code by newlines and style each line
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
-					}
-				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				this.#emitCodeBlock(lines, token.text, token.lang || "", codeIndent);
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}
@@ -725,19 +772,7 @@ export class Markdown implements Component {
 			} else if (token.type === "code") {
 				// Code block in list item
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.#theme.highlightCode) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${codeIndent}${hlLine}`);
-					}
-				} else {
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
-					}
-				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				this.#emitCodeBlock(lines, token.text, token.lang || "", codeIndent);
 			} else {
 				// Other token types - try to render as inline
 				const text = this.#renderInlineTokens([token], styleContext);

--- a/packages/tui/src/metrics.ts
+++ b/packages/tui/src/metrics.ts
@@ -104,6 +104,11 @@ export interface HelperStat {
 	meanMs: number;
 }
 
+export interface LineCountGauge {
+	last: number;
+	max: number;
+}
+
 export interface RenderMetricsSnapshot {
 	enabled: boolean;
 	renderCount: number;
@@ -118,6 +123,7 @@ export interface RenderMetricsSnapshot {
 	ownerGauges: Record<string, number>;
 	timerGauges: Record<string, number>;
 	helperStats: Record<string, HelperStat>;
+	lineCounts: Record<string, LineCountGauge>;
 }
 
 function emptyDurationStats(): DurationStats {
@@ -153,6 +159,7 @@ export class RenderMetrics {
 	#ownerGauges = new Map<string, number>();
 	#timerGauges = new Map<string, number>();
 	#helpers = new Map<string, { count: number; totalMs: number }>();
+	#lineGauges = new Map<string, LineCountGauge>();
 	#rssReturn: number | null = null;
 	#heapBaseline: number | null = null;
 	#heapReturn: number | null = null;
@@ -192,6 +199,7 @@ export class RenderMetrics {
 		this.#ownerGauges.clear();
 		this.#timerGauges.clear();
 		this.#helpers.clear();
+		this.#lineGauges.clear();
 		this.#rssReturn = null;
 		this.#heapBaseline = null;
 		this.#heapReturn = null;
@@ -278,6 +286,16 @@ export class RenderMetrics {
 		this.#helpers.set(retained, cur);
 	}
 
+	/** Record a per-render line-count gauge (e.g. "rendered", "normalized", "diffed"). */
+	recordLineCount(name: string, value: number): void {
+		if (!this.#enabled) return;
+		const retained = retainedLabel(this.#lineGauges, name);
+		const cur = this.#lineGauges.get(retained) ?? { last: 0, max: 0 };
+		cur.last = value;
+		if (value > cur.max) cur.max = value;
+		this.#lineGauges.set(retained, cur);
+	}
+
 	/**
 	 * Force a GC when the runtime exposes one and sample RSS as the post-run
 	 * "return" value used by the memory-leak gate. Callers should drop large
@@ -319,6 +337,14 @@ export class RenderMetrics {
 		return out;
 	}
 
+	#lineCountStats(): Record<string, LineCountGauge> {
+		const out: Record<string, LineCountGauge> = {};
+		for (const [name, v] of this.#lineGauges) {
+			out[name] = { last: v.last, max: v.max };
+		}
+		return out;
+	}
+
 	snapshot(): RenderMetricsSnapshot {
 		return {
 			enabled: this.#enabled,
@@ -347,6 +373,7 @@ export class RenderMetrics {
 			ownerGauges: Object.fromEntries(this.#ownerGauges),
 			timerGauges: Object.fromEntries(this.#timerGauges),
 			helperStats: this.#helperStats(),
+			lineCounts: this.#lineCountStats(),
 		};
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -59,6 +59,14 @@ export interface Component {
 	 * Called when theme changes or when component needs to re-render from scratch.
 	 */
 	invalidate(): void;
+
+	/**
+	 * Optional cleanup hook. Called once when the component is permanently
+	 * removed from the tree via removeChild/clear/dispose. Implementations MUST
+	 * be idempotent. Components meant to be re-added should be detached, not
+	 * removed/cleared.
+	 */
+	dispose?(): void;
 }
 
 /**
@@ -196,6 +204,7 @@ export interface OverlayHandle {
  */
 export class Container implements Component {
 	children: Component[] = [];
+	#disposed = false;
 
 	addChild(component: Component): void {
 		this.children.push(component);
@@ -205,11 +214,36 @@ export class Container implements Component {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			component.dispose?.();
+		}
+	}
+
+	/** Remove a child without disposing it (for detach-then-readd reuse). */
+	detachChild(component: Component): void {
+		const index = this.children.indexOf(component);
+		if (index !== -1) {
+			this.children.splice(index, 1);
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 		this.children = [];
+	}
+
+	/** Remove all children without disposing them (for detach-then-readd reuse). */
+	detachAll(): void {
+		this.children = [];
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		for (const child of this.children) {
+			child.dispose?.();
+		}
 	}
 
 	invalidate(): void {
@@ -222,7 +256,10 @@ export class Container implements Component {
 		width = Math.max(1, width);
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			const childLines = child.render(width);
+			for (let i = 0; i < childLines.length; i++) {
+				lines.push(childLines[i]);
+			}
 		}
 		return lines;
 	}
@@ -239,6 +276,13 @@ type LineNormalizationCacheEntry = {
 export class TUI extends Container {
 	terminal: Terminal;
 	#previousLines: string[] = [];
+	/**
+	 * Raw (pre-normalization) lines from the previous frame, kept only when the
+	 * virtual-viewport flag is on. Used to detect whether the off-screen prefix is
+	 * unchanged (by raw value equality, with a fast reference short-circuit when components
+	 * return stable string instances) so its normalized form can be reused (bounded normalize).
+	 */
+	#previousRaw: string[] = [];
 	#lineNormalizationCache = new Map<string, LineNormalizationCacheEntry>();
 	#lineTruncationCache = new Map<string, string>();
 	#lineNormalizationCacheLimit = 0;
@@ -269,6 +313,9 @@ export class TUI extends Container {
 	#sixelProbeUnsubscribe?: () => void;
 	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
 	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
+	// Opt-in: reuse the previous normalized off-screen prefix and only normalize/diff the
+	// visible window, bounding per-frame work on huge transcripts. Output stays byte-identical.
+	#virtualViewport = $flag("PI_TUI_VIRTUAL_VIEWPORT");
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	#fullRedrawCount = 0;
 	#stopped = false;
@@ -663,6 +710,7 @@ export class TUI extends Container {
 		// focus/listener state is intentionally preserved so input routing survives
 		// a resume.
 		this.#previousLines = [];
+		this.#previousRaw = [];
 		this.#lineNormalizationCache.clear();
 		this.#lineTruncationCache.clear();
 		this.#previousWidth = 0;
@@ -679,6 +727,7 @@ export class TUI extends Container {
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
+			this.#previousRaw = [];
 			this.#lineNormalizationCache.clear();
 			this.#lineTruncationCache.clear();
 			this.#previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
@@ -1204,14 +1253,16 @@ export class TUI extends Container {
 		};
 	}
 
+	/** Normalize + width-fit a single line for emission (image lines pass through). */
+	#normalizeLineForEmit(line: string, width: number): string {
+		if (TERMINAL.isImageLine(line)) return line;
+		const { normalized, terminated } = this.#normalizeLineForRender(line);
+		return this.#lineFitsWidth(normalized, width) ? terminated : this.#truncateNormalizedLine(normalized, width);
+	}
+
 	#applyLineResetsAndTruncate(lines: string[], width: number): string[] {
 		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			if (TERMINAL.isImageLine(line)) continue;
-			const { normalized, terminated } = this.#normalizeLineForRender(line);
-			lines[i] = this.#lineFitsWidth(normalized, width)
-				? terminated
-				: this.#truncateNormalizedLine(normalized, width);
+			lines[i] = this.#normalizeLineForEmit(lines[i], width);
 		}
 		this.#trimLineCachesForRender(lines.length);
 		return lines;
@@ -1247,11 +1298,60 @@ export class TUI extends Container {
 		// (closes SGR + OSC 8 hyperlink state). Must run after cursor extraction
 		// because the marker is embedded mid-line, and before any diff/full render
 		// path so cache comparisons stay byte-accurate.
-		newLines = this.#applyLineResetsAndTruncate(newLines, width);
-
-		// Width changed - need full re-render (line wrapping changes)
+		// Width/height change detection (used for both normalization reuse and full-redraw decisions).
 		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
+
+		// Normalize/truncate lines for emission. With the opt-in virtual-viewport flag
+		// (PI_TUI_VIRTUAL_VIEWPORT) we reuse the previous frame's normalized prefix when the
+		// off-screen raw prefix is unchanged (raw value equality per line; fast reference
+		// short-circuit for cached components), so only the visible window is
+		// re-normalized and the diff starts at the window. Output is byte-identical to the
+		// full path (reused entries are deterministic normalizations of identical raw lines).
+		const VIEWPORT_NORMALIZE_OVERSCAN = 8;
+		const rawLines = newLines;
+		const total = rawLines.length;
+		let diffStart = 0;
+		let usedWindowNormalize = false;
+		if (
+			this.#virtualViewport &&
+			!widthChanged &&
+			this.#previousRaw.length > 0 &&
+			this.#previousLines.length === this.#previousRaw.length
+		) {
+			const winTop = Math.max(0, total - height - VIEWPORT_NORMALIZE_OVERSCAN);
+			if (winTop <= this.#previousLines.length && winTop <= this.#previousRaw.length) {
+				let stable = true;
+				for (let i = 0; i < winTop; i++) {
+					if (rawLines[i] !== this.#previousRaw[i]) {
+						stable = false;
+						break;
+					}
+				}
+				if (stable) {
+					const windowed = this.#previousLines.slice(0, winTop);
+					for (let i = winTop; i < total; i++) {
+						windowed.push(this.#normalizeLineForEmit(rawLines[i], width));
+					}
+					this.#trimLineCachesForRender(total);
+					newLines = windowed;
+					diffStart = winTop;
+					usedWindowNormalize = true;
+				}
+			}
+		}
+		if (!usedWindowNormalize) {
+			newLines = this.#applyLineResetsAndTruncate(this.#virtualViewport ? rawLines.slice() : rawLines, width);
+		}
+		if (this.#virtualViewport) {
+			this.#previousRaw = rawLines;
+		}
+		if (renderMetrics.enabled) {
+			renderMetrics.recordLineCount("rendered", total);
+			renderMetrics.recordLineCount("normalized", total - diffStart);
+			renderMetrics.recordLineCount("measured", total - diffStart);
+			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
+		}
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean, reason = "full render"): void => {
@@ -1390,7 +1490,10 @@ export class TUI extends Container {
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const maxLines = Math.max(newLines.length, this.#previousLines.length);
-		for (let i = 0; i < maxLines; i++) {
+		if (renderMetrics.enabled) renderMetrics.recordLineCount("diffed", maxLines - diffStart);
+		// When the off-screen prefix was reused (virtual viewport), it is verified
+		// unchanged (raw value equality), so the diff can safely start at the window boundary.
+		for (let i = diffStart; i < maxLines; i++) {
 			const oldLine = i < this.#previousLines.length ? this.#previousLines[i] : "";
 			const newLine = i < newLines.length ? newLines[i] : "";
 

--- a/packages/tui/test/cancellable-loader-dispose.test.ts
+++ b/packages/tui/test/cancellable-loader-dispose.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { CancellableLoader, Container, type TUI } from "@gajae-code/tui";
+
+describe("CancellableLoader disposal", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("stops its animation interval when removed by container.clear()", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const container = new Container();
+		let colorTick = 0;
+		const loader = new CancellableLoader(
+			ui,
+			text => text,
+			text => `${text}-${colorTick}`,
+			"Loading",
+			["|", "/"],
+		);
+
+		container.addChild(loader);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+
+		colorTick = 1;
+		vi.advanceTimersByTime(80);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(1);
+
+		container.clear();
+		colorTick = 2;
+		vi.advanceTimersByTime(160);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+});

--- a/packages/tui/test/component-dispose-redteam.test.ts
+++ b/packages/tui/test/component-dispose-redteam.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Box, type Component, Container, Loader, type TUI } from "@gajae-code/tui";
+
+class ProbeComponent implements Component {
+	disposeCount = 0;
+	readonly childContainer?: Container;
+
+	constructor(
+		private readonly label: string,
+		childContainer?: Container,
+	) {
+		this.childContainer = childContainer;
+	}
+
+	invalidate(): void {
+		this.childContainer?.invalidate();
+	}
+
+	render(width: number): string[] {
+		const ownLine = `${this.label}:${width}`;
+		const childLines = this.childContainer?.render(width) ?? [];
+		return [ownLine, ...childLines];
+	}
+
+	dispose(): void {
+		this.disposeCount += 1;
+		this.childContainer?.dispose();
+	}
+}
+
+describe("component disposal lifecycle red-team", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("dispose releases resources without emptying children and detached/readded children still render", () => {
+		const container = new Container();
+		const detachedThenReadded = new ProbeComponent("reuse");
+		const stable = new ProbeComponent("stable");
+
+		container.addChild(detachedThenReadded);
+		container.detachChild(detachedThenReadded);
+		expect(detachedThenReadded.disposeCount).toBe(0);
+		container.addChild(stable);
+		container.addChild(detachedThenReadded);
+
+		container.dispose();
+
+		expect(container.children).toHaveLength(2);
+		expect(stable.disposeCount).toBe(1);
+		expect(detachedThenReadded.disposeCount).toBe(1);
+		expect(container.render(12)).toEqual(["stable:12", "reuse:12"]);
+	});
+
+	it("detachChild and detachAll remove children without disposing them", () => {
+		const container = new Container();
+		const one = new ProbeComponent("one");
+		const two = new ProbeComponent("two");
+		const three = new ProbeComponent("three");
+
+		container.addChild(one);
+		container.addChild(two);
+		container.addChild(three);
+		container.detachChild(two);
+		container.detachAll();
+
+		expect(one.disposeCount).toBe(0);
+		expect(two.disposeCount).toBe(0);
+		expect(three.disposeCount).toBe(0);
+		expect(container.children).toHaveLength(0);
+	});
+
+	it("removeChild and clear dispose present children exactly once and repeated calls stay safe", () => {
+		const container = new Container();
+		const removed = new ProbeComponent("removed");
+		const cleared = new ProbeComponent("cleared");
+
+		container.addChild(removed);
+		container.addChild(cleared);
+
+		container.removeChild(removed);
+		container.removeChild(removed);
+		expect(removed.disposeCount).toBe(1);
+
+		container.clear();
+		container.clear();
+		expect(cleared.disposeCount).toBe(1);
+		expect(removed.disposeCount).toBe(1);
+		expect(container.children).toHaveLength(0);
+	});
+
+	it("outer clear recursively disposes nested Box and its grandchildren", () => {
+		const outer = new Container();
+		const box = new Box(0, 0);
+		const grandchild = new ProbeComponent("grandchild");
+		box.addChild(grandchild);
+		outer.addChild(box);
+
+		outer.clear();
+
+		expect(outer.children).toHaveLength(0);
+		expect(grandchild.disposeCount).toBe(1);
+	});
+
+	it("Box.clear stops a nested Loader interval", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const box = new Box(0, 0);
+		let colorTick = 0;
+		const loader = new Loader(
+			ui,
+			frame => `${frame}:${colorTick++}`,
+			message => `${message}:${colorTick++}`,
+			"busy",
+		);
+		box.addChild(loader);
+
+		vi.advanceTimersByTime(64);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(0);
+
+		box.clear();
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+
+	it("disposed child containers can be reattached without losing render structure", () => {
+		const outer = new Container();
+		const inner = new Container();
+		const leaf = new ProbeComponent("leaf");
+		inner.addChild(leaf);
+		outer.addChild(inner);
+
+		outer.dispose();
+		expect(inner.children).toHaveLength(1);
+		expect(leaf.disposeCount).toBe(1);
+
+		const freshParent = new Container();
+		freshParent.addChild(inner);
+
+		expect(freshParent.render(20)).toEqual(["leaf:20"]);
+		expect(inner.children).toHaveLength(1);
+	});
+});

--- a/packages/tui/test/component-dispose.test.ts
+++ b/packages/tui/test/component-dispose.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, Container, Loader, type TUI } from "@gajae-code/tui";
+
+/** Component that records how many times dispose() was called. */
+class DisposeSpy implements Component {
+	disposeCount = 0;
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return ["spy"];
+	}
+	dispose(): void {
+		this.disposeCount += 1;
+	}
+}
+
+describe("Container disposal lifecycle (W2 / F11)", () => {
+	it("disposes children on clear() and removeChild(), once each", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		const b = new DisposeSpy();
+		container.addChild(a);
+		container.addChild(b);
+
+		container.removeChild(a);
+		expect(a.disposeCount).toBe(1);
+		expect(b.disposeCount).toBe(0);
+
+		container.clear();
+		expect(b.disposeCount).toBe(1);
+	});
+
+	it("does NOT dispose on detachChild()/detachAll() (detach != dispose)", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		const b = new DisposeSpy();
+		container.addChild(a);
+		container.addChild(b);
+
+		container.detachChild(a);
+		expect(a.disposeCount).toBe(0);
+		expect(container.children).not.toContain(a);
+
+		container.detachAll();
+		expect(b.disposeCount).toBe(0);
+		expect(container.children.length).toBe(0);
+	});
+
+	it("recursively disposes nested children via dispose()", () => {
+		const outer = new Container();
+		const inner = new Container();
+		const leaf = new DisposeSpy();
+		inner.addChild(leaf);
+		outer.addChild(inner);
+
+		outer.dispose();
+		expect(leaf.disposeCount).toBe(1);
+	});
+
+	it("dispose() is idempotent (no double child-dispose)", () => {
+		const container = new Container();
+		const a = new DisposeSpy();
+		container.addChild(a);
+
+		container.dispose();
+		container.dispose();
+		expect(a.disposeCount).toBe(1);
+	});
+
+	it("supports rebuild-from-map: detachAll + re-add reused instances never disposes them", () => {
+		// Mirrors the hook-widget / pending-component rebuild pattern: persistent
+		// instances live in a map and are re-rendered into a container repeatedly.
+		// The container must DETACH (not dispose) on each rebuild; disposal is the
+		// owner's job on explicit removal.
+		const container = new Container();
+		const persistent = new DisposeSpy();
+		for (let rebuild = 0; rebuild < 5; rebuild++) {
+			container.detachAll();
+			container.addChild(persistent);
+		}
+		expect(persistent.disposeCount).toBe(0);
+
+		container.removeChild(persistent);
+		expect(persistent.disposeCount).toBe(1);
+	});
+});
+
+describe("Loader timer cleanup on disposing clear (W2 / F12 mechanism)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("stops the animation interval when its container is cleared", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const ui = { requestRender } as unknown as TUI;
+		const container = new Container();
+		// Time-varying spinner colorizer forces a text change every tick, so each
+		// interval tick requests a render (mirrors the tool-execution spinner that
+		// previously leaked and re-rendered the whole transcript forever).
+		let tick = 0;
+		const loader = new Loader(
+			ui,
+			frame => `${frame}${tick++}`,
+			msg => msg,
+			"loading",
+		);
+		container.addChild(loader);
+
+		vi.advanceTimersByTime(64);
+		const beforeClear = requestRender.mock.calls.length;
+		expect(beforeClear).toBeGreaterThan(0);
+
+		container.clear(); // disposes the loader -> stop() -> clearInterval
+
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+
+		// dispose() is idempotent / safe to call again.
+		loader.dispose();
+		vi.advanceTimersByTime(400);
+		expect(requestRender.mock.calls.length).toBe(beforeClear);
+	});
+});

--- a/packages/tui/test/container-spread-safe-redteam.test.ts
+++ b/packages/tui/test/container-spread-safe-redteam.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, Container } from "@gajae-code/tui";
+
+class FixedLines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
+describe("Container spread-safe red-team composition", () => {
+	it("renders an empty container as an empty array", () => {
+		const container = new Container();
+
+		expect(container.render(80)).toEqual([]);
+	});
+
+	it("preserves order and count when empty child outputs are interleaved", () => {
+		const container = new Container();
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["alpha", "beta"]));
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["gamma"]));
+		container.addChild(new FixedLines([]));
+		container.addChild(new FixedLines(["delta", "epsilon"]));
+
+		const output = container.render(80);
+
+		expect(output).toEqual(["alpha", "beta", "gamma", "delta", "epsilon"]);
+		expect(output).toHaveLength(5);
+	});
+
+	it("composes a single one-million-line child without RangeError", () => {
+		const lineCount = 1_000_000;
+		const lines = Array.from({ length: lineCount }, (_value, index) => `line-${index}`);
+		const container = new Container();
+		container.addChild(new FixedLines(lines));
+
+		const output = container.render(80);
+
+		expect(output).toHaveLength(lineCount);
+		expect(output[0]).toBe("line-0");
+		expect(output[lineCount - 1]).toBe(`line-${lineCount - 1}`);
+	});
+
+	it("composes 1000 small children in child and line order", () => {
+		const container = new Container();
+		for (let childIndex = 0; childIndex < 1000; childIndex++) {
+			container.addChild(
+				new FixedLines([`child-${childIndex}-line-0`, `child-${childIndex}-line-1`, `child-${childIndex}-line-2`]),
+			);
+		}
+
+		const output = container.render(80);
+
+		expect(output).toHaveLength(3000);
+		expect(output[0]).toBe("child-0-line-0");
+		expect(output[1]).toBe("child-0-line-1");
+		expect(output[2]).toBe("child-0-line-2");
+		expect(output[2997]).toBe("child-999-line-0");
+		expect(output[2998]).toBe("child-999-line-1");
+		expect(output[2999]).toBe("child-999-line-2");
+	});
+
+	it("clamps zero and negative widths while still composing child output", () => {
+		const zeroWidthContainer = new Container();
+		zeroWidthContainer.addChild(new FixedLines(["zero-a", "zero-b"]));
+
+		const negativeWidthContainer = new Container();
+		negativeWidthContainer.addChild(new FixedLines(["negative-a"]));
+		negativeWidthContainer.addChild(new FixedLines(["negative-b", "negative-c"]));
+
+		expect(zeroWidthContainer.render(0)).toEqual(["zero-a", "zero-b"]);
+		expect(negativeWidthContainer.render(-5)).toEqual(["negative-a", "negative-b", "negative-c"]);
+	});
+});

--- a/packages/tui/test/container-spread-safe.test.ts
+++ b/packages/tui/test/container-spread-safe.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, Container, renderMetrics, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+/** Minimal component that returns a fixed line array regardless of width. */
+class FixedLines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+describe("Container spread-safe composition (W1a / F2)", () => {
+	it("composes a >500k-line child without RangeError and preserves order", () => {
+		// The previous `lines.push(...child.render(width))` spread threw
+		// `RangeError: Maximum call stack size exceeded` past ~490k elements.
+		const bigCount = 600_000;
+		const big = Array.from({ length: bigCount }, (_v, i) => `row${i}`);
+		const container = new Container();
+		container.addChild(new FixedLines(big));
+		container.addChild(new FixedLines(["tail-a", "tail-b"]));
+
+		const out = container.render(80);
+
+		expect(out.length).toBe(bigCount + 2);
+		expect(out[0]).toBe("row0");
+		expect(out[bigCount - 1]).toBe(`row${bigCount - 1}`);
+		expect(out[bigCount]).toBe("tail-a");
+		expect(out[bigCount + 1]).toBe("tail-b");
+	});
+
+	it("produces output identical to manual child concatenation", () => {
+		const children = [
+			new FixedLines(["a", "b"]),
+			new FixedLines(["c"]),
+			new FixedLines([]),
+			new FixedLines(["d", "e"]),
+		];
+		const container = new Container();
+		for (const child of children) container.addChild(child);
+
+		const out = container.render(80);
+		const expected = children.flatMap(child => child.render(80));
+
+		expect(out).toEqual(expected);
+	});
+});
+
+describe("render line-count metrics (W1a foundation for F1)", () => {
+	let wasEnabled = false;
+	let previousTmux: string | undefined;
+	let previousSty: string | undefined;
+	let previousZellij: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		previousTmux = Bun.env.TMUX;
+		previousSty = Bun.env.STY;
+		previousZellij = Bun.env.ZELLIJ;
+		delete Bun.env.TMUX;
+		delete Bun.env.STY;
+		delete Bun.env.ZELLIJ;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+		wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		renderMetrics.reset();
+		if (!wasEnabled) renderMetrics.disable();
+		if (previousTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = previousTmux;
+		if (previousSty === undefined) delete Bun.env.STY;
+		else Bun.env.STY = previousSty;
+		if (previousZellij === undefined) delete Bun.env.ZELLIJ;
+		else Bun.env.ZELLIJ = previousZellij;
+	});
+
+	it("populates rendered/measured/normalized gauges and diffed on a differential pass", async () => {
+		const term = new VirtualTerminal(40, 10);
+		const tui = new TUI(term);
+		const component = new FixedLines(["alpha", "beta", "gamma"]);
+		tui.addChild(component);
+
+		try {
+			tui.start();
+			await settle(term); // first render (full)
+
+			// Second render exercises the differential diff path, recording "diffed".
+			component.setLines(["alpha", "BETA", "gamma"]);
+			tui.requestRender();
+			await settle(term);
+		} finally {
+			tui.stop();
+		}
+
+		const { lineCounts } = renderMetrics.snapshot();
+		expect(lineCounts.rendered?.last).toBeGreaterThan(0);
+		expect(lineCounts.measured?.last).toBeGreaterThan(0);
+		expect(lineCounts.normalized?.last).toBeGreaterThan(0);
+		expect(lineCounts.diffed?.last).toBeGreaterThan(0);
+	});
+});

--- a/packages/tui/test/markdown-highlight-redteam.test.ts
+++ b/packages/tui/test/markdown-highlight-redteam.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearRenderCache,
+	getMarkdownHighlightCallCount,
+	Markdown,
+	type MarkdownTheme,
+	resetMarkdownHighlightCallCount,
+} from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
+
+type HighlightCall = { code: string; lang: string | undefined };
+
+function makeSpyTheme(prefix: string): MarkdownTheme & { calls: HighlightCall[] } {
+	const calls: HighlightCall[] = [];
+	return {
+		...defaultMarkdownTheme,
+		highlightCode: (code: string, lang?: string): string[] => {
+			calls.push({ code, lang });
+			return code.split("\n").map(line => `${prefix}:${lang ?? "none"}:${line}`);
+		},
+		calls,
+	};
+}
+
+function render(markdown: string, theme: MarkdownTheme, width = 160): string[] {
+	return new Markdown(markdown, 0, 0, theme).render(width);
+}
+
+function joined(markdown: string, theme: MarkdownTheme, width = 160): string {
+	return render(markdown, theme, width).join("\n");
+}
+
+function linesOf(count: number, fill: (index: number) => string): string {
+	return Array.from({ length: count }, (_value, index) => fill(index)).join("\n");
+}
+
+describe("markdown highlight cache + cap red-team", () => {
+	beforeEach(() => {
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+	});
+
+	it("keeps normal code-block output byte-identical across cache states and fresh theme objects", () => {
+		const markdown = [
+			"Intro",
+			"```ts",
+			"const tricky = `literal with backticks`;",
+			"console.log('unicode π 🚀');",
+			"```",
+			"```",
+			"plain fence with empty lang and ``` inside text",
+			"ansi-like \\x1b[31m not terminal escape",
+			"```",
+			"```sh",
+			"printf '%s\\n' \"nested `tick` and café\"",
+			"```",
+		].join("\n");
+
+		const themeA = makeSpyTheme("HL");
+		const first = render(markdown, themeA);
+		expect(getMarkdownHighlightCallCount()).toBe(3);
+
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+		const themeAAgain = makeSpyTheme("HL");
+		const second = render(markdown, themeAAgain);
+		expect(getMarkdownHighlightCallCount()).toBe(3);
+		expect(second).toEqual(first);
+
+		const freshTheme = makeSpyTheme("HL");
+		const freshThemeLines = render(markdown, freshTheme);
+		expect(getMarkdownHighlightCallCount()).toBe(6);
+		expect(freshThemeLines.filter(line => line.includes("HL:"))).toEqual(first.filter(line => line.includes("HL:")));
+	});
+
+	it("highlights the exact 2000-line boundary and skips 2001 lines with the marker", () => {
+		const theme = makeSpyTheme("LINE");
+		const exactly2000 = `\`\`\`ts\n${linesOf(2000, index => `line-${index}`)}\n\`\`\``;
+		const atBoundary = joined(exactly2000, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(atBoundary).toContain("LINE:ts:line-0");
+		expect(atBoundary).toContain("LINE:ts:line-1999");
+		expect(atBoundary).not.toContain("syntax highlighting skipped");
+
+		resetMarkdownHighlightCallCount();
+		const over2000 = `\`\`\`ts\n${linesOf(2001, index => `line-${index}`)}\n\`\`\``;
+		const overBoundary = joined(over2000, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(overBoundary).toContain("[syntax highlighting skipped: code block too large]");
+		expect(overBoundary).toContain("line-0");
+		expect(overBoundary).toContain("line-2000");
+		expect(overBoundary).not.toContain("LINE:ts:line-2000");
+	});
+
+	it("highlights below the byte cap and skips above the byte cap", () => {
+		const theme = makeSpyTheme("BYTE");
+		const belowByteCap = `\`\`\`txt\n${"a".repeat(199_000)}\n\`\`\``;
+		const below = joined(belowByteCap, theme, 250_000);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(below).toContain(`BYTE:txt:${"a".repeat(64)}`);
+		expect(below).not.toContain("syntax highlighting skipped");
+
+		resetMarkdownHighlightCallCount();
+		const aboveByteCap = `\`\`\`txt\n${"b".repeat(201_000)}\n\`\`\``;
+		const above = joined(aboveByteCap, theme, 250_000);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(above).toContain("[syntax highlighting skipped: code block too large]");
+		expect(above).toContain("b".repeat(64));
+		expect(above).not.toContain(`BYTE:txt:${"b".repeat(64)}`);
+	});
+
+	it("only highlights an appended sixth block after a cached five-block prefix", () => {
+		const theme = makeSpyTheme("APPEND");
+		const base = Array.from({ length: 5 }, (_value, index) => `\`\`\`lang${index}\nblock-${index}\n\`\`\``).join(
+			"\n\n",
+		);
+
+		render(base, theme);
+		expect(getMarkdownHighlightCallCount()).toBe(5);
+
+		const grown = `${base}\n\n\`\`\`lang5\nblock-5\n\`\`\``;
+		render(grown, theme);
+		expect(getMarkdownHighlightCallCount()).toBe(6);
+		expect(theme.calls.map(call => call.lang)).toEqual(["lang0", "lang1", "lang2", "lang3", "lang4", "lang5"]);
+	});
+
+	it("uses changed theme highlight output after clearing render caches", () => {
+		const markdown = "```ts\nconst theme = 'must invalidate';\n```";
+		const themeA = makeSpyTheme("THEME-A");
+		expect(joined(markdown, themeA)).toContain("THEME-A:ts:const theme = 'must invalidate';");
+
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+		const themeB = makeSpyTheme("THEME-B");
+		const renderedWithB = joined(markdown, themeB);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(renderedWithB).toContain("THEME-B:ts:const theme = 'must invalidate';");
+		expect(renderedWithB).not.toContain("THEME-A:ts:const theme = 'must invalidate';");
+	});
+
+	it("applies cache and cap behavior to code blocks nested in list items", () => {
+		const theme = makeSpyTheme("LIST");
+		const nestedNormal = ["- item with code", "", "  ```ts", "  const nested = true;", "  ```"].join("\n");
+
+		const first = joined(nestedNormal, theme);
+		const afterFirst = getMarkdownHighlightCallCount();
+		const second = joined(nestedNormal, theme);
+		expect(afterFirst).toBe(1);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(second).toBe(first);
+		expect(second).toContain("LIST:ts:const nested = true;");
+
+		resetMarkdownHighlightCallCount();
+		const nestedHuge = [
+			"- item with oversized code",
+			"",
+			"  ```ts",
+			linesOf(2001, index => `  nested-${index}`),
+			"  ```",
+		].join("\n");
+		const huge = joined(nestedHuge, theme, 240);
+		expect(getMarkdownHighlightCallCount()).toBe(0);
+		expect(huge).toContain("[syntax highlighting skipped: code block too large]");
+		expect(huge).toContain("nested-2000");
+	});
+});

--- a/packages/tui/test/markdown-highlight.test.ts
+++ b/packages/tui/test/markdown-highlight.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearRenderCache,
+	getMarkdownHighlightCallCount,
+	Markdown,
+	type MarkdownTheme,
+	resetMarkdownHighlightCallCount,
+} from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
+
+function themeWithHighlight(): MarkdownTheme {
+	// A deterministic stand-in for the real Rust-FFI highlighter; the module-level
+	// highlight-call counter increments once per actual (uncached) invocation.
+	return { ...defaultMarkdownTheme, highlightCode: (code: string) => code.split("\n") };
+}
+
+describe("markdown streaming highlight caps + cache (W3 / F3, F18)", () => {
+	beforeEach(() => {
+		clearRenderCache();
+		resetMarkdownHighlightCallCount();
+	});
+
+	it("does not re-highlight the unchanged prefix when a streamed message grows (F3)", () => {
+		const theme = themeWithHighlight();
+		const base = "```ts\nconst a = 1;\n```\n\n```js\nconst b = 2;\n```\n\n```py\nx = 3\n```";
+		new Markdown(base, 1, 0, theme).render(80);
+		const afterThree = getMarkdownHighlightCallCount();
+		expect(afterThree).toBe(3);
+
+		// Streaming append of a 4th code block (worst case: a fresh component instance).
+		const grown = `${base}\n\n\`\`\`rb\ny = 4\n\`\`\``;
+		new Markdown(grown, 1, 0, theme).render(80);
+		const afterFour = getMarkdownHighlightCallCount();
+
+		// Only the newly-appended block is highlighted; the prior three are served from cache.
+		expect(afterFour - afterThree).toBe(1);
+	});
+
+	it("reuses the per-code-block highlight cache across separate component instances (F3)", () => {
+		const theme = themeWithHighlight();
+		const md = "```ts\nconst z = 9;\n```";
+		new Markdown(md, 1, 0, theme).render(80);
+		new Markdown(md, 1, 0, theme).render(80);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+	});
+
+	it("skips synchronous highlight for oversized code blocks and marks them (F18)", () => {
+		const theme = themeWithHighlight();
+		const bigCode = Array.from({ length: 2500 }, (_v, i) => `line ${i}`).join("\n");
+		const md = `\`\`\`ts\n${bigCode}\n\`\`\``;
+		const lines = new Markdown(md, 1, 0, theme).render(120);
+
+		expect(getMarkdownHighlightCallCount()).toBe(0); // FFI highlighter never called
+		expect(lines.join("\n")).toContain("syntax highlighting skipped");
+		// The code content is still rendered (plain), not dropped.
+		expect(lines.join("\n")).toContain("line 0");
+		expect(lines.join("\n")).toContain("line 2499");
+	});
+
+	it("still highlights normal-sized blocks (regression guard)", () => {
+		const theme = themeWithHighlight();
+		const md = "```ts\nconst ok = true;\n```";
+		const lines = new Markdown(md, 1, 0, theme).render(80);
+		expect(getMarkdownHighlightCallCount()).toBe(1);
+		expect(lines.join("\n")).not.toContain("syntax highlighting skipped");
+	});
+
+	it("caps highlight by UTF-8 byte length, not UTF-16 code units (F18 non-ASCII)", () => {
+		const theme = themeWithHighlight();
+		// 70k CJK code points on one line: 70k code units (< 200k) but ~210k UTF-8 bytes (> 200k).
+		const cjk = "中".repeat(70_000);
+		expect(cjk.length).toBeLessThan(200_000);
+		expect(Buffer.byteLength(cjk, "utf8")).toBeGreaterThan(200_000);
+		const md = `\`\`\`ts\n${cjk}\n\`\`\``;
+		const lines = new Markdown(md, 1, 0, theme).render(120);
+		expect(getMarkdownHighlightCallCount()).toBe(0); // byte cap trips → FFI skipped
+		expect(lines.join("\n")).toContain("syntax highlighting skipped");
+	});
+});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1210,12 +1210,14 @@ describe("Module-level LRU render cache", () => {
 			},
 		};
 
-		for (let i = 0; i < 300; i++) {
+		// Exceed BOTH the L2 render cache (256) and the per-code-block highlight cache
+		// (512) so message 0 is evicted from each and a re-render must re-highlight it.
+		for (let i = 0; i < 600; i++) {
 			new Markdown(`message ${i}\n\n\`\`\`js\nconst value = ${i};\n\`\`\``, 0, 0, themeWithSpy).render(80);
 		}
 
 		new Markdown("message 0\n\n```js\nconst value = 0;\n```", 0, 0, themeWithSpy).render(80);
-		expect(highlightCallCount).toBe(301);
+		expect(highlightCallCount).toBe(601);
 	});
 
 	it("never serves another message's render on content-key collision attempts", () => {

--- a/packages/tui/test/viewport-virtualization-redteam.test.ts
+++ b/packages/tui/test/viewport-virtualization-redteam.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const FLAG = "PI_TUI_VIRTUAL_VIEWPORT";
+
+type Mutation = (state: ScenarioState, tui: TUI, term: VirtualTerminal) => void;
+
+interface Step {
+	name: string;
+	mutate: Mutation;
+}
+
+interface ScriptedScenario {
+	name: string;
+	initialLines: string[];
+	width?: number;
+	height?: number;
+	steps: Step[];
+}
+
+interface ScenarioState {
+	lines: string[];
+}
+
+abstract class ScriptedLines implements Component {
+	protected lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines.slice();
+	}
+
+	setLines(lines: string[]): void {
+		this.lines = lines.slice();
+	}
+
+	setLine(index: number, value: string): void {
+		const next = this.lines.slice();
+		next[index] = value;
+		this.lines = next;
+	}
+
+	append(value: string): void {
+		this.lines = [...this.lines, value];
+	}
+
+	invalidate(): void {}
+
+	abstract render(width: number): string[];
+}
+
+class CachedLines extends ScriptedLines {
+	render(_width: number): string[] {
+		return this.lines;
+	}
+}
+
+class FreshLines extends ScriptedLines {
+	render(_width: number): string[] {
+		return this.lines.map(line => `${line}`);
+	}
+}
+
+function makeRows(count: number): string[] {
+	return Array.from({ length: count }, (_value, index) => `line-${index}`);
+}
+
+function boundaryRows(count: number): string[] {
+	return Array.from({ length: count }, (_value, index) => `boundary-${index}`);
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function capture(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+function applyLines(state: ScenarioState, component: ScriptedLines): void {
+	component.setLines(state.lines);
+}
+
+const scenarios: ScriptedScenario[] = [
+	{
+		name: "rapid interleaved appends and bottom edits",
+		initialLines: makeRows(48),
+		steps: [
+			{
+				name: "append then edit new bottom line",
+				mutate: state => {
+					state.lines = [...state.lines, "append-A", "append-B"];
+					state.lines[state.lines.length - 1] = "append-B-edited";
+				},
+			},
+			{
+				name: "edit previous bottom and append again",
+				mutate: state => {
+					state.lines[state.lines.length - 2] = "append-A-edited";
+					state.lines = [...state.lines, "append-C"];
+				},
+			},
+			{
+				name: "burst append with newest bottom edit",
+				mutate: state => {
+					state.lines = [...state.lines, "append-D", "append-E", "append-F"];
+					state.lines[state.lines.length - 1] = "append-F-edited";
+				},
+			},
+		],
+	},
+	{
+		name: "off-screen top edit without line-count change",
+		initialLines: makeRows(70),
+		steps: [
+			{
+				name: "edit first hidden line",
+				mutate: state => {
+					state.lines[0] = "line-0-offscreen-edited-same-count";
+				},
+			},
+			{
+				name: "edit second hidden line",
+				mutate: state => {
+					state.lines[1] = "line-1-offscreen-edited-same-count";
+				},
+			},
+		],
+	},
+	{
+		name: "edits around the virtual window boundary",
+		height: 16,
+		initialLines: boundaryRows(64),
+		steps: [
+			{
+				name: "edit line at total minus height minus nine",
+				mutate: state => {
+					const index = state.lines.length - 16 - 9;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+			{
+				name: "edit line at total minus height minus eight",
+				mutate: state => {
+					const index = state.lines.length - 16 - 8;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+			{
+				name: "edit line at total minus height minus seven",
+				mutate: state => {
+					const index = state.lines.length - 16 - 7;
+					state.lines[index] = `${state.lines[index]}-edited`;
+				},
+			},
+		],
+	},
+	{
+		name: "shrinking transcript below viewport",
+		height: 18,
+		initialLines: makeRows(44),
+		steps: [
+			{
+				name: "shrink to fewer than terminal rows",
+				mutate: state => {
+					state.lines = ["short-0", "short-1", "short-2"];
+				},
+			},
+			{
+				name: "shrink to a single line",
+				mutate: state => {
+					state.lines = ["single-after-shrink"];
+				},
+			},
+		],
+	},
+	{
+		name: "overlay toggles while appending",
+		initialLines: makeRows(36),
+		steps: [
+			{
+				name: "show overlay after append",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-A"];
+					tui.showOverlay(new CachedLines(["overlay-one", "overlay-two"]), { anchor: "center" });
+				},
+			},
+			{
+				name: "hide overlay after append",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-B"];
+					tui.hideOverlay();
+				},
+			},
+			{
+				name: "show overlay with fresh bottom line",
+				mutate: (state, tui) => {
+					state.lines = [...state.lines, "overlay-append-C"];
+					tui.showOverlay(new CachedLines(["overlay-three", "overlay-four"]), { anchor: "bottom-center" });
+				},
+			},
+		],
+	},
+	{
+		name: "width resize down then up",
+		width: 48,
+		initialLines: [
+			"width-row-0-abcdefghijklmnopqrstuvwxyz",
+			"width-row-1-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			...makeRows(24),
+		],
+		steps: [
+			{
+				name: "resize width down",
+				mutate: (_state, _tui, term) => {
+					term.resize(24, term.rows);
+				},
+			},
+			{
+				name: "resize width up",
+				mutate: (_state, _tui, term) => {
+					term.resize(56, term.rows);
+				},
+			},
+		],
+	},
+	{
+		name: "height resize",
+		height: 14,
+		initialLines: makeRows(45),
+		steps: [
+			{
+				name: "resize height taller",
+				mutate: (_state, _tui, term) => {
+					term.resize(term.columns, 20);
+				},
+			},
+			{
+				name: "resize height shorter",
+				mutate: (_state, _tui, term) => {
+					term.resize(term.columns, 9);
+				},
+			},
+		],
+	},
+	{
+		name: "wide and bang-fit truncation lines in window",
+		width: 22,
+		initialLines: [
+			...makeRows(34),
+			"wide-ascii-" + "x".repeat(80),
+			"bang-fit-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+			"wide-cjk-界".repeat(20),
+		],
+		steps: [
+			{
+				name: "edit wide visible tail",
+				mutate: state => {
+					state.lines[state.lines.length - 1] = "wide-cjk-edited-界".repeat(20);
+				},
+			},
+			{
+				name: "append additional wide bang line",
+				mutate: state => {
+					state.lines = [...state.lines, "new-bang-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"];
+				},
+			},
+		],
+	},
+	{
+		name: "empty transcript",
+		initialLines: [],
+		steps: [
+			{
+				name: "empty rerender remains empty",
+				mutate: () => {},
+			},
+			{
+				name: "append after empty",
+				mutate: state => {
+					state.lines = ["after-empty"];
+				},
+			},
+		],
+	},
+	{
+		name: "transcript shorter than viewport",
+		height: 12,
+		initialLines: ["short-a", "short-b"],
+		steps: [
+			{
+				name: "edit short transcript line",
+				mutate: state => {
+					state.lines[1] = "short-b-edited";
+				},
+			},
+			{
+				name: "append but remain shorter than viewport",
+				mutate: state => {
+					state.lines = [...state.lines, "short-c"];
+				},
+			},
+		],
+	},
+];
+
+async function runScenario(
+	scenario: ScriptedScenario,
+	componentFactory: (lines: string[]) => ScriptedLines,
+	flagOn: boolean,
+): Promise<string[][]> {
+	if (flagOn) Bun.env[FLAG] = "1";
+	else delete Bun.env[FLAG];
+
+	const term = new VirtualTerminal(scenario.width ?? 40, scenario.height ?? 12);
+	const tui = new TUI(term);
+	const component = componentFactory(scenario.initialLines);
+	const state: ScenarioState = { lines: scenario.initialLines.slice() };
+	const snapshots: string[][] = [];
+	tui.addChild(component);
+
+	try {
+		tui.start();
+		await settle(term);
+		snapshots.push(capture(term));
+
+		for (const step of scenario.steps) {
+			step.mutate(state, tui, term);
+			applyLines(state, component);
+			tui.requestRender();
+			await settle(term);
+			snapshots.push(capture(term));
+		}
+	} finally {
+		tui.stop();
+	}
+
+	return snapshots;
+}
+
+describe("virtual viewport byte-identity red-team scenarios", () => {
+	let previousFlag: string | undefined;
+	let previousTmux: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		previousFlag = Bun.env[FLAG];
+		previousTmux = Bun.env.TMUX;
+		delete Bun.env.TMUX;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (previousFlag === undefined) delete Bun.env[FLAG];
+		else Bun.env[FLAG] = previousFlag;
+		if (previousTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = previousTmux;
+	});
+
+	for (const scenario of scenarios) {
+		it(`${scenario.name} with stable cached line instances`, async () => {
+			const off = await runScenario(scenario, lines => new CachedLines(lines), false);
+			const on = await runScenario(scenario, lines => new CachedLines(lines), true);
+			expect(on).toEqual(off);
+		});
+
+		it(`${scenario.name} with fresh line instances`, async () => {
+			const off = await runScenario(scenario, lines => new FreshLines(lines), false);
+			const on = await runScenario(scenario, lines => new FreshLines(lines), true);
+			expect(on).toEqual(off);
+		});
+	}
+});

--- a/packages/tui/test/viewport-virtualization.test.ts
+++ b/packages/tui/test/viewport-virtualization.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, renderMetrics, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+const FLAG = "PI_TUI_VIRTUAL_VIEWPORT";
+
+/**
+ * Component that returns STABLE string instances for unchanged lines (mirroring the
+ * real caching components). The virtual-viewport optimization relies on this: an
+ * unchanged off-screen line keeps its reference, so its normalized form can be reused.
+ */
+class CachedLines implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = lines.slice();
+	}
+	setLine(index: number, value: string): void {
+		const next = this.#lines.slice(); // new array, but unchanged entries keep their instances
+		next[index] = value;
+		this.#lines = next;
+	}
+	append(value: string): void {
+		this.#lines = [...this.#lines, value];
+	}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return this.#lines; // stable array + stable string instances for unchanged lines
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function visible(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+describe("virtual viewport rendering (W1b / F1)", () => {
+	let prevFlag: string | undefined;
+	let prevTmux: string | undefined;
+	let monotonicNow = 0;
+
+	beforeEach(() => {
+		prevFlag = Bun.env[FLAG];
+		prevTmux = Bun.env.TMUX;
+		delete Bun.env.TMUX;
+		monotonicNow = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			monotonicNow += 20;
+			return monotonicNow;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (prevFlag === undefined) delete Bun.env[FLAG];
+		else Bun.env[FLAG] = prevFlag;
+		if (prevTmux === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = prevTmux;
+	});
+
+	/** Run a scripted transcript scenario and capture the visible viewport after each step. */
+	async function runScenario(flagOn: boolean): Promise<string[][]> {
+		if (flagOn) Bun.env[FLAG] = "1";
+		else delete Bun.env[FLAG];
+		const term = new VirtualTerminal(40, 12);
+		const tui = new TUI(term);
+		const rows = Array.from({ length: 80 }, (_v, i) => `line-${i}`);
+		const content = new CachedLines(rows);
+		tui.addChild(content);
+		const snaps: string[][] = [];
+		try {
+			tui.start();
+			await settle(term);
+			snaps.push(visible(term)); // initial
+
+			// Append (streaming-like): touches only the bottom/viewport.
+			content.append("appended-A");
+			content.append("appended-B");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// In-place change of a visible (bottom) line.
+			content.setLine(81, "appended-A-edited");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Off-screen change (forces the fallback to full normalize/diff).
+			content.setLine(0, "line-0-edited-offscreen");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// No-op re-render (spinner-like): nothing changed.
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Overlay composition (show, then hide).
+			const overlay = new CachedLines(["overlay-row-1", "overlay-row-2"]);
+			tui.showOverlay(overlay, { anchor: "center" });
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			tui.hideOverlay();
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Resize width (forces the full-redraw path) and height.
+			term.resize(30, 12);
+			await settle(term);
+			snaps.push(visible(term));
+
+			term.resize(30, 18);
+			await settle(term);
+			snaps.push(visible(term));
+
+			// Append after resize so the post-resize windowed path is exercised too.
+			content.append("post-resize-append");
+			tui.requestRender();
+			await settle(term);
+			snaps.push(visible(term));
+		} finally {
+			tui.stop();
+		}
+		return snaps;
+	}
+
+	it("produces byte-identical visible output with the flag on vs off", async () => {
+		const off = await runScenario(false);
+		const on = await runScenario(true);
+		expect(on).toEqual(off);
+	});
+
+	it("bounds normalize/diff work to ~viewport on a 100k-line transcript (flag on)", async () => {
+		Bun.env[FLAG] = "1";
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		const term = new VirtualTerminal(40, 40);
+		const tui = new TUI(term);
+		const big = Array.from({ length: 100_000 }, (_v, i) => `row-${i}`);
+		const content = new CachedLines(big);
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term); // first render: full normalize (100k)
+
+			const afterFirst = renderMetrics.snapshot().lineCounts;
+			expect(afterFirst.normalized?.max).toBeGreaterThanOrEqual(100_000);
+
+			// Change only the bottom line, then re-render: off-screen prefix is reused.
+			content.setLine(99_999, "row-99999-edited");
+			tui.requestRender();
+			await settle(term);
+
+			const lc = renderMetrics.snapshot().lineCounts;
+			// Visible window is 40 rows + 8 overscan; normalized/diffed last value must be bounded,
+			// not the full 100k transcript.
+			expect(lc.normalized?.last).toBeLessThanOrEqual(60);
+			expect(lc.diffed?.last).toBeLessThanOrEqual(60);
+			expect(lc.offscreenScan?.last).toBeGreaterThan(99_000);
+		} finally {
+			tui.stop();
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
+	});
+});


### PR DESCRIPTION
## What

Preserve the active Codex provider session and WebSocket preference across local maintenance one-shot calls:

- forward `sessionId`, `providerSessionState`, `preferWebsockets`, and auth credential type through compaction summary requests
- forward the same transport state through handoff generation
- forward the same transport state through branch summary generation
- run split-turn compaction summaries sequentially so the same Codex WebSocket session does not receive concurrent requests
- add regression coverage for compaction, handoff, and branch summary transport forwarding
- update changelogs

## Why

Fixes #736

When `providers.openaiWebsockets: "on"` is configured for a Codex-compatible provider, maintenance calls should use the same provider route as normal turns. Manual compaction exposed a case where the first turn used WebSocket but a follow-up summary request went through the HTTP/SSE bridge and lacked the `session_id` header.

The same missing transport forwarding also affected handoff and branch summary one-shot calls. Once compaction summary calls did use the WebSocket session, split-turn compaction additionally exposed that concurrent summary requests on the same provider session can fail with:

```text
Codex websocket transport error: websocket request already in progress
```

This PR keeps maintenance calls on the configured WebSocket transport and avoids same-session WebSocket concurrency during split-turn compaction.

## Testing

Automated:

```bash
bun test packages/agent/test/compaction-telemetry.test.ts
bun test packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
bun --cwd=packages/agent run check
bun --cwd=packages/coding-agent run check
git diff --check
```

Live local Codex-compatible provider verification:

- manual context-full compaction: `request_logs` IDs `76729-76731`, all `transport=websocket`
- automatic context-full compaction: `request_logs` IDs `76732-76743`, all `transport=websocket`
- handoff via GJC RPC: `request_logs` ID `76750`, `transport=websocket`
- branch summary via TUI `/tree` + `Summarize`: `request_logs` ID `76753`, `transport=websocket`

The relevant provider/proxy log lines showed `kind=websocket`, `headers=['session_id','user-agent']`, and `session_header_present=True`. No `stream_http_bridge` rows were produced for the verified maintenance calls.

---

- [ ] `bun check` passes
- [x] Targeted package checks pass
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## Notes for maintainers

Full root `bun check` was not run locally; targeted package checks for `packages/agent` and `packages/coding-agent` passed.
