### PR TITLE
Bug: preserve WebSocket transport for Codex maintenance one-shot calls

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Forwarded local summary, handoff, and branch-summary transport/session options to one-shot model calls so callers can preserve provider session state and WebSocket preferences.
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -5,7 +5,7 @@
  * a summary of the branch being left so context isn't lost.
  */
 
-import type { Model } from "@gajae-code/ai";
+import type { Model, ProviderSessionState } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
 import type { AgentMessage } from "../types";
@@ -79,6 +79,10 @@ export interface GenerateBranchSummaryOptions {
 	reserveTokens?: number;
 	/** Optional metadata forwarded to the underlying API request (e.g. user_id for session attribution). */
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
+	authCredentialType?: "api_key" | "oauth";
 	/** Convert app-specific messages before serializing the branch summary prompt. */
 	convertToLlm?: ConvertToLlm;
 	/**
@@ -307,7 +311,16 @@ export async function generateBranchSummary(
 	const response = await instrumentedCompleteSimple(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
-		{ apiKey, signal, maxTokens: 2048, metadata },
+		{
+			apiKey,
+			signal,
+			maxTokens: 2048,
+			metadata,
+			sessionId: options.sessionId,
+			providerSessionState: options.providerSessionState,
+			preferWebsockets: options.preferWebsockets,
+			authCredentialType: options.authCredentialType,
+		},
 		{ telemetry: options.telemetry, oneshotKind: "branch_summary" },
 	);
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -12,6 +12,7 @@ import {
 	type Message,
 	type MessageAttribution,
 	type Model,
+	type ProviderSessionState,
 	type Usage,
 } from "@gajae-code/ai";
 import { isCompiledBinary, logger, prompt } from "@gajae-code/utils";
@@ -726,6 +727,9 @@ export interface SummaryOptions {
 	remoteInstructions?: string;
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
 	convertToLlm?: ConvertToLlm;
 	/**
 	 * Optional telemetry handle. When provided, every LLM call emitted during
@@ -801,6 +805,10 @@ export async function generateSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_summary" },
 	);
@@ -830,6 +838,9 @@ export interface HandoffOptions {
 	convertToLlm?: ConvertToLlm;
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
+	sessionId?: string;
+	providerSessionState?: Map<string, ProviderSessionState>;
+	preferWebsockets?: boolean;
 	/**
 	 * Optional telemetry handle. When provided, the handoff LLM call is
 	 * wrapped in an OTEL chat span tagged with `pi.gen_ai.oneshot.kind = "handoff"`.
@@ -877,6 +888,10 @@ export async function generateHandoff(
 			toolChoice: "none",
 			initiatorOverride: options.initiatorOverride,
 			metadata: options.metadata,
+			sessionId: options.sessionId,
+			providerSessionState: options.providerSessionState,
+			preferWebsockets: options.preferWebsockets,
+			authCredentialType: options.authCredentialType,
 		},
 		{ telemetry: options.telemetry, oneshotKind: "handoff" },
 	);
@@ -936,6 +951,10 @@ async function generateShortSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_short_summary" },
 	);
@@ -1118,8 +1137,12 @@ export async function compact(
 		remoteInstructions: options?.remoteInstructions,
 		initiatorOverride: options?.initiatorOverride,
 		metadata: options?.metadata,
+		sessionId: options?.sessionId,
+		providerSessionState: options?.providerSessionState,
+		preferWebsockets: options?.preferWebsockets,
 		convertToLlm: options?.convertToLlm,
 		telemetry: options?.telemetry,
+		authCredentialType: options?.authCredentialType,
 	};
 
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
@@ -1160,10 +1183,9 @@ export async function compact(
 	let summary: string;
 
 	if (isSplitTurn && turnPrefixMessages.length > 0) {
-		// Generate both summaries in parallel
-		const [historyResult, turnPrefixResult] = await Promise.all([
+		const historyResult =
 			messagesToSummarize.length > 0
-				? generateSummary(
+				? await generateSummary(
 						messagesToSummarize,
 						model,
 						settings.reserveTokens,
@@ -1173,9 +1195,15 @@ export async function compact(
 						previousSummary,
 						summaryOptions,
 					)
-				: Promise.resolve("No prior history."),
-			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal, summaryOptions),
-		]);
+				: "No prior history.";
+		const turnPrefixResult = await generateTurnPrefixSummary(
+			turnPrefixMessages,
+			model,
+			settings.reserveTokens,
+			apiKey,
+			signal,
+			summaryOptions,
+		);
 		// Merge into single summary
 		summary = `${historyResult}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult}`;
 	} else if (messagesToSummarize.length > 0) {
@@ -1205,13 +1233,7 @@ export async function compact(
 		settings.reserveTokens,
 		apiKey,
 		signal,
-		{
-			extraContext: options?.extraContext,
-			remoteEndpoint: summaryOptions.remoteEndpoint,
-			initiatorOverride: summaryOptions.initiatorOverride,
-			metadata: summaryOptions.metadata,
-			telemetry: summaryOptions.telemetry,
-		},
+		summaryOptions,
 	);
 
 	// Compute file lists and append to summary
@@ -1266,6 +1288,10 @@ async function generateTurnPrefixSummary(
 			reasoning: Effort.High,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
+			sessionId: options?.sessionId,
+			providerSessionState: options?.providerSessionState,
+			preferWebsockets: options?.preferWebsockets,
+			authCredentialType: options?.authCredentialType,
 		},
 		{ telemetry: options?.telemetry, oneshotKind: "compaction_turn_prefix" },
 	);

--- a/packages/agent/test/compaction-telemetry.test.ts
+++ b/packages/agent/test/compaction-telemetry.test.ts
@@ -25,7 +25,7 @@ import {
 	resolveTelemetry,
 } from "@gajae-code/agent-core/telemetry";
 import type { AgentMessage } from "@gajae-code/agent-core/types";
-import type { AssistantMessage, Model, Usage } from "@gajae-code/ai";
+import type { AssistantMessage, Model, ProviderSessionState, Usage } from "@gajae-code/ai";
 import * as ai from "@gajae-code/ai";
 import { SpanStatusCode } from "@opentelemetry/api";
 import {
@@ -163,6 +163,60 @@ describe("compaction oneshot telemetry", () => {
 		expect(spansByOneshotKind(chats, "compaction_short_summary")).toHaveLength(1);
 	});
 
+	it("runs split-turn compaction summary requests sequentially", async () => {
+		let inFlight = false;
+		let maxConcurrent = 0;
+		let currentConcurrent = 0;
+		const spy = vi.spyOn(ai, "completeSimple").mockImplementation(async () => {
+			if (inFlight) throw new Error("provider rejected parallel request");
+			inFlight = true;
+			currentConcurrent += 1;
+			maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+			await Bun.sleep(1);
+			currentConcurrent -= 1;
+			inFlight = false;
+			return makeAssistantMessage("ok");
+		});
+
+		const preparation = makePreparation({
+			isSplitTurn: true,
+			turnPrefixMessages: [makeUserMessage("Inline mid-turn instruction")],
+		});
+		await compact(preparation, MODEL, "test-api-key", undefined, undefined, {
+			sessionId: "provider-session-1",
+			providerSessionState: new Map<string, ProviderSessionState>(),
+			preferWebsockets: true,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		expect(maxConcurrent).toBe(1);
+	});
+
+	it("forwards transport options to every local compaction summary request", async () => {
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce(makeAssistantMessage("history summary"))
+			.mockResolvedValueOnce(makeAssistantMessage("short summary"));
+
+		await compact(makePreparation(), MODEL, "test-api-key", undefined, undefined, {
+			sessionId: "provider-session-1",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
+		});
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		for (const call of spy.mock.calls) {
+			const options = call[2];
+			if (!options) throw new Error("expected completeSimple options");
+			expect(options.sessionId).toBe("provider-session-1");
+			expect(options.providerSessionState).toBe(providerSessionState);
+			expect(options.preferWebsockets).toBe(true);
+			expect(options.authCredentialType).toBe("oauth");
+		}
+	});
+
 	it("emits no spans when telemetry is undefined", async () => {
 		vi.spyOn(ai, "completeSimple")
 			.mockResolvedValueOnce(makeAssistantMessage("history"))
@@ -211,6 +265,7 @@ describe("handoff oneshot telemetry", () => {
 		const spy = vi.spyOn(ai, "completeSimple").mockResolvedValueOnce(makeAssistantMessage("## Goal\nContinue"));
 
 		const telemetry = resolveTelemetry(makeTelemetryConfig(), "session-handoff");
+		const providerSessionState = new Map<string, ProviderSessionState>();
 		const messages: AgentMessage[] = [makeUserMessage("start"), makeAssistantMessage("starting")];
 
 		const document = await generateHandoff(messages, MODEL, "test-api-key", {
@@ -218,10 +273,19 @@ describe("handoff oneshot telemetry", () => {
 			tools: [],
 			initiatorOverride: "agent",
 			telemetry,
+			sessionId: "provider-session-handoff",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
 		});
 
 		expect(document).toContain("Goal");
 		expect(spy).toHaveBeenCalledTimes(1);
+		const options = spy.mock.calls[0]?.[2];
+		expect(options?.sessionId).toBe("provider-session-handoff");
+		expect(options?.providerSessionState).toBe(providerSessionState);
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.authCredentialType).toBe("oauth");
 
 		const chats = chatSpans(exporter.getFinishedSpans());
 		expect(chats).toHaveLength(1);
@@ -238,6 +302,7 @@ describe("branch summary oneshot telemetry", () => {
 			.mockResolvedValueOnce(makeAssistantMessage("branch summary text", makeUsage(50, 30)));
 
 		const telemetry = resolveTelemetry(makeTelemetryConfig(), "session-branch");
+		const providerSessionState = new Map<string, ProviderSessionState>();
 		const entries = [
 			{
 				type: "message" as const,
@@ -260,10 +325,19 @@ describe("branch summary oneshot telemetry", () => {
 			apiKey: "test-api-key",
 			signal: new AbortController().signal,
 			telemetry,
+			sessionId: "provider-session-branch",
+			providerSessionState,
+			preferWebsockets: true,
+			authCredentialType: "oauth",
 		});
 
 		expect(result.summary).toContain("branch summary text");
 		expect(spy).toHaveBeenCalledTimes(1);
+		const options = spy.mock.calls[0]?.[2];
+		expect(options?.sessionId).toBe("provider-session-branch");
+		expect(options?.providerSessionState).toBe(providerSessionState);
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.authCredentialType).toBe("oauth");
 
 		const chats = chatSpans(exporter.getFinishedSpans());
 		expect(chats).toHaveLength(1);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Manual and automatic compaction, handoff generation, and branch summary generation now reuse the live Codex provider session state and OpenAI WebSocket preference, so Codex maintenance calls keep the configured WebSocket transport instead of falling back to HTTP/SSE.
 - Auto-compaction no longer silently requires OpenAI when the active route is a custom Anthropic-capable provider. The compaction model-candidate selection already prefers the active session model, but its last-resort "largest-context model" fallback scanned the entire bundled catalog across all providers, so a stray OpenAI credential (e.g. an out-of-credit key left in the environment) could be picked when the active provider's compaction credential was unusable — turning OpenAI into an implicit hard dependency. The implicit fallback is now scoped to the active model's provider; cross-provider compaction still works but only when explicitly configured via `modelRoles`. When the active provider cannot compact and no role is configured, compaction now fails with the existing clear, provider-specific credential error instead of reaching for OpenAI (#697).
 
 ## [0.5.2] - 2026-06-15

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6445,6 +6445,9 @@ export class AgentSession {
 				model,
 				apiKey,
 				{
+					...this.#withCompactionTransportOptions({
+						authCredentialType: this.#modelRegistry.getSessionCredentialType(model.provider, this.sessionId),
+					}),
 					systemPrompt: this.#baseSystemPrompt,
 					tools: this.agent.state.tools,
 					customInstructions,
@@ -7391,7 +7394,7 @@ export class AgentSession {
 
 			try {
 				return await compact(preparation, candidate, apiKey, customInstructions, signal, {
-					...options,
+					...this.#withCompactionTransportOptions(options),
 					metadata: this.agent.metadataForProvider(candidate.provider),
 					convertToLlm,
 					telemetry,
@@ -7405,6 +7408,19 @@ export class AgentSession {
 		}
 
 		throw this.#buildCompactionAuthError();
+	}
+
+	#withCompactionTransportOptions(options?: SummaryOptions): SummaryOptions {
+		const openaiWebsocketSetting = this.settings.get("providers.openaiWebsockets") ?? "off";
+		const preferWebsockets =
+			openaiWebsocketSetting === "on" ? true : openaiWebsocketSetting === "off" ? false : undefined;
+
+		return {
+			...options,
+			sessionId: options?.sessionId ?? this.agent.providerSessionId ?? this.agent.sessionId,
+			providerSessionState: options?.providerSessionState ?? this.#providerSessionState,
+			preferWebsockets: options?.preferWebsockets ?? preferWebsockets,
+		};
 	}
 
 	async #prepareCompactionFromHooks(
@@ -7680,19 +7696,26 @@ export class AgentSession {
 					let attempt = 0;
 					while (true) {
 						try {
-							compactResult = await compact(preparation, candidate, apiKey, undefined, autoCompactionSignal, {
-								promptOverride: compactionPrep.hookPrompt,
-								extraContext: compactionPrep.hookContext,
-								remoteInstructions: this.#baseSystemPrompt.join("\n\n"),
-								metadata: this.agent.metadataForProvider(candidate.provider),
-								initiatorOverride: "agent",
-								convertToLlm,
-								telemetry,
-								authCredentialType: this.#modelRegistry.getSessionCredentialType(
-									candidate.provider,
-									this.sessionId,
-								),
-							});
+							compactResult = await compact(
+								preparation,
+								candidate,
+								apiKey,
+								undefined,
+								autoCompactionSignal,
+								this.#withCompactionTransportOptions({
+									promptOverride: compactionPrep.hookPrompt,
+									extraContext: compactionPrep.hookContext,
+									remoteInstructions: this.#baseSystemPrompt.join("\n\n"),
+									metadata: this.agent.metadataForProvider(candidate.provider),
+									initiatorOverride: "agent",
+									convertToLlm,
+									telemetry,
+									authCredentialType: this.#modelRegistry.getSessionCredentialType(
+										candidate.provider,
+										this.sessionId,
+									),
+								}),
+							);
 							break;
 						} catch (error) {
 							if (autoCompactionSignal.aborted) {
@@ -9488,6 +9511,9 @@ export class AgentSession {
 			}
 			const branchSummarySettings = this.settings.getGroup("branchSummary");
 			const result = await generateBranchSummary(entriesToSummarize, {
+				...this.#withCompactionTransportOptions({
+					authCredentialType: this.#modelRegistry.getSessionCredentialType(model.provider, this.sessionId),
+				}),
 				model,
 				apiKey,
 				signal: this.#branchSummaryAbortController.signal,

--- a/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
+++ b/packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
@@ -56,6 +56,35 @@ describe("#697 auto-compaction respects the active custom provider", () => {
 		return modelsPath;
 	}
 
+	function writeCodexProviderModels(): string {
+		const modelsPath = path.join(tempDir.path(), "models.json");
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					codexproxy: {
+						baseUrl: "http://127.0.0.1:3455/backend-api/codex",
+						apiKeyEnv: "CODEXPROXY_API_KEY",
+						api: "openai-codex-responses",
+						auth: "apiKey",
+						models: [
+							{
+								id: "gpt-5.5",
+								name: "GPT-5.5 via codexproxy",
+								reasoning: true,
+								input: ["text", "image"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 272000,
+								maxTokens: 128000,
+							},
+						],
+					},
+				},
+			}),
+		);
+		return modelsPath;
+	}
+
 	function seedConversation(): void {
 		for (const [u, a] of [
 			["first question", "first answer"],
@@ -125,6 +154,143 @@ describe("#697 auto-compaction respects the active custom provider", () => {
 		expect(key).toBe("myproxy-secret");
 		// Regression: no OpenAI attempt anywhere in the candidate chain.
 		expect(compactSpy.mock.calls.every(([, m]) => m.provider === "myproxy")).toBe(true);
+	});
+
+	it("forwards websocket transport state to manual Codex compaction calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({
+			"compaction.keepRecentTokens": 1,
+			"providers.openaiWebsockets": "on",
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "ok",
+			shortSummary: "ok short",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 1,
+			details: {},
+		}));
+
+		await session.compact();
+
+		const options = compactSpy.mock.calls[0]?.[5];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(agent.providerSessionId);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+	});
+
+	it("forwards websocket transport state to manual Codex handoff calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "providers.openaiWebsockets": "on" });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const handoffSpy = vi.spyOn(compactionModule, "generateHandoff").mockResolvedValue("## Goal\nContinue");
+		const providerSessionIdBeforeHandoff = agent.providerSessionId;
+
+		const result = await session.handoff("focus on next work");
+
+		expect(result?.document).toBe("## Goal\nContinue");
+		const options = handoffSpy.mock.calls[0]?.[3];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(providerSessionIdBeforeHandoff);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+		expect(options?.authCredentialType).toBe("oauth");
+	});
+
+	it("forwards websocket transport state to Codex branch summary calls", async () => {
+		const modelsPath = writeCodexProviderModels();
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, modelsPath);
+		const configError = modelRegistry.getError();
+		if (configError) throw new Error(`models config error: ${configError.message}`);
+
+		const currentModel = modelRegistry.find("codexproxy", "gpt-5.5");
+		if (!currentModel) throw new Error("expected codexproxy model to load");
+
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model =>
+			model.provider === "codexproxy" ? "codexproxy-secret" : undefined,
+		);
+		vi.spyOn(modelRegistry, "getSessionCredentialType").mockReturnValue("oauth");
+
+		const agent = new Agent({
+			initialState: { model: currentModel, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		const settings = Settings.isolated({ "providers.openaiWebsockets": "on" });
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+		seedConversation();
+
+		const firstAssistantEntry = session.sessionManager
+			.getEntries()
+			.find(entry => entry.type === "message" && entry.message.role === "assistant");
+		if (!firstAssistantEntry) throw new Error("expected seeded assistant entry");
+
+		const branchSpy = vi.spyOn(compactionModule, "generateBranchSummary").mockResolvedValue({
+			summary: "branch summary",
+			readFiles: [],
+			modifiedFiles: [],
+		});
+
+		const result = await session.navigateTree(firstAssistantEntry.id, { summarize: true });
+
+		expect(result.summaryEntry?.summary).toBe("branch summary");
+		const options = branchSpy.mock.calls[0]?.[1];
+		expect(options?.preferWebsockets).toBe(true);
+		expect(options?.sessionId).toBe(agent.providerSessionId);
+		expect(options?.providerSessionState).toBe(session.providerSessionState);
+		expect(options?.authCredentialType).toBe("oauth");
 	});
 
 	it("does not fall back to OpenAI when the active provider cannot compact and only a stray OpenAI credential exists", async () => {


### PR DESCRIPTION
## What

Preserve the active Codex provider session and WebSocket preference across local maintenance one-shot calls:

- forward `sessionId`, `providerSessionState`, `preferWebsockets`, and auth credential type through compaction summary requests
- forward the same transport state through handoff generation
- forward the same transport state through branch summary generation
- run split-turn compaction summaries sequentially so the same Codex WebSocket session does not receive concurrent requests
- add regression coverage for compaction, handoff, and branch summary transport forwarding
- update changelogs

## Why

Fixes #736

When `providers.openaiWebsockets: "on"` is configured for a Codex-compatible provider, maintenance calls should use the same provider route as normal turns. Manual compaction exposed a case where the first turn used WebSocket but a follow-up summary request went through the HTTP/SSE bridge and lacked the `session_id` header.

The same missing transport forwarding also affected handoff and branch summary one-shot calls. Once compaction summary calls did use the WebSocket session, split-turn compaction additionally exposed that concurrent summary requests on the same provider session can fail with:

```text
Codex websocket transport error: websocket request already in progress
```

This PR keeps maintenance calls on the configured WebSocket transport and avoids same-session WebSocket concurrency during split-turn compaction.

## Testing

Automated:

```bash
bun test packages/agent/test/compaction-telemetry.test.ts
bun test packages/coding-agent/test/issue-697-compaction-provider-route.test.ts
bun --cwd=packages/agent run check
bun --cwd=packages/coding-agent run check
git diff --check
```

Live local Codex-compatible provider verification:

- manual context-full compaction: `request_logs` IDs `76729-76731`, all `transport=websocket`
- automatic context-full compaction: `request_logs` IDs `76732-76743`, all `transport=websocket`
- handoff via GJC RPC: `request_logs` ID `76750`, `transport=websocket`
- branch summary via TUI `/tree` + `Summarize`: `request_logs` ID `76753`, `transport=websocket`

The relevant provider/proxy log lines showed `kind=websocket`, `headers=['session_id','user-agent']`, and `session_header_present=True`. No `stream_http_bridge` rows were produced for the verified maintenance calls.

---

- [ ] `bun check` passes
- [x] Targeted package checks pass
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## Notes for maintainers

Full root `bun check` was not run locally; targeted package checks for `packages/agent` and `packages/coding-agent` passed.
