### PR TITLE
fix(natives): cap oversized input to synchronous native entrypoints (F19 defense-in-depth)

### DIFF
--- a/crates/pi-natives/src/edit_fuzzy.rs
+++ b/crates/pi-natives/src/edit_fuzzy.rs
@@ -3,9 +3,18 @@ use std::collections::HashMap;
 use napi::{JsString, bindgen_prelude::*};
 use napi_derive::napi;
 
+use crate::env_uint;
+
 const FALLBACK_THRESHOLD: f64 = 0.8;
 const SEQUENCE_FUZZY_THRESHOLD: f64 = 0.92;
 const MAX_RECORDED_MATCHES: usize = 5;
+
+env_uint! {
+	// Above this many UTF-16 units in content or target, `h01_find_best_fuzzy_match` skips the
+	// O(content*target) fuzzy search and reports no match. Defense-in-depth (F19): TS callers cap the
+	// file at 8 MiB before this runs, but this bounds every native caller. Generous; env-overridable.
+	static MAX_FUZZY_UNITS: usize = "PI_NATIVE_MAX_FUZZY_UNITS" or 16 * 1024 * 1024 => [0, usize::MAX];
+}
 
 #[napi(object)]
 pub struct H01BestFuzzyMatch {
@@ -469,6 +478,15 @@ pub fn h01_find_best_fuzzy_match(
 	}
 	if target_units.last() == Some(&0) {
 		target_units = &target_units[..target_units.len() - 1];
+	}
+	// Defense-in-depth (F19): above the cap, skip the O(content*target) fuzzy search over the whole
+	// file and report no match so a pathological edit input cannot block a native thread.
+	if content_units.len() > *MAX_FUZZY_UNITS || target_units.len() > *MAX_FUZZY_UNITS {
+		return Ok(H01BestFuzzyMatchResult {
+			best:                  None,
+			above_threshold_count: 0,
+			second_best_score:     0.0,
+		});
 	}
 	let content_units = content_units.to_vec();
 	let target_units = target_units.to_vec();

--- a/crates/pi-natives/src/highlight.rs
+++ b/crates/pi-natives/src/highlight.rs
@@ -10,8 +10,17 @@ use std::{cell::RefCell, collections::HashMap, sync::OnceLock};
 use napi_derive::napi;
 use syntect::parsing::{ParseState, Scope, ScopeStack, ScopeStackOp, SyntaxReference, SyntaxSet};
 
+use crate::env_uint;
+
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static SCOPE_MATCHERS: OnceLock<ScopeMatchers> = OnceLock::new();
+
+env_uint! {
+	// Above this many input bytes, `highlight_code` skips the synchronous syntect highlight (O(code);
+	// builds per-line parse state) and returns the original code unchanged. Defense-in-depth (F19/F3):
+	// TS callers cap lower, but this bounds every native caller. Generous default; env-overridable.
+	static MAX_HIGHLIGHT_BYTES: usize = "PI_NATIVE_MAX_HIGHLIGHT_BYTES" or 16 * 1024 * 1024 => [0, usize::MAX];
+}
 
 // Thread-local cache for scope -> color index lookups
 thread_local! {
@@ -122,7 +131,7 @@ fn get_scope_matchers() -> &'static ScopeMatchers {
 
 /// Theme colors for syntax highlighting.
 /// Each color is an ANSI escape sequence (e.g., "\x1b[38;2;255;0;0m").
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[napi(object)]
 pub struct HighlightColors {
 	/// ANSI color for comments.
@@ -357,6 +366,11 @@ fn find_syntax<'a>(ss: &'a SyntaxSet, lang: &str) -> Option<&'a SyntaxReference>
 /// fails.
 #[napi]
 pub fn highlight_code(code: String, lang: Option<String>, colors: HighlightColors) -> String {
+	// Defense-in-depth (F19/F3): above the cap, skip the synchronous highlight and return the
+	// original code — the same fallback used when highlighting fails.
+	if code.len() > *MAX_HIGHLIGHT_BYTES {
+		return code;
+	}
 	let inserted = colors.inserted.as_deref().unwrap_or("");
 	let deleted = colors.deleted.as_deref().unwrap_or("");
 
@@ -465,4 +479,16 @@ pub fn supports_language(lang: String) -> bool {
 pub fn get_supported_languages() -> Vec<String> {
 	let ss = get_syntax_set();
 	ss.syntaxes().iter().map(|s| s.name.clone()).collect()
+}
+
+#[cfg(test)]
+mod cap_tests {
+	use super::*;
+
+	#[test]
+	fn oversized_code_is_returned_unhighlighted() {
+		let code = "x".repeat(17 * 1024 * 1024);
+		let out = highlight_code(code.clone(), Some("rust".to_string()), HighlightColors::default());
+		assert_eq!(out, code, "above the cap highlight_code must return the original code unchanged");
+	}
 }

--- a/crates/pi-natives/src/tokens.rs
+++ b/crates/pi-natives/src/tokens.rs
@@ -23,6 +23,8 @@ use napi_derive::napi;
 use rayon::prelude::*;
 use tiktoken_rs::{CoreBPE, o200k_base};
 
+use crate::env_uint;
+
 /// Tokenizer encoding to use.
 #[napi(string_enum)]
 pub enum Encoding {
@@ -44,6 +46,19 @@ fn encoder(encoding: Option<Encoding>) -> &'static CoreBPE {
 	}
 }
 
+env_uint! {
+	// Above this many input bytes, `count_tokens` returns the cheap chars/4 heuristic instead of the
+	// synchronous BPE tokenizer (O(text); it also builds a large merge table). Defense-in-depth
+	// (F19/F22): TS callers already cap lower, but this bounds every native caller so a pathological
+	// input can never block a native thread. Generous default; env-overridable.
+	static MAX_TOKENIZE_BYTES: usize = "PI_NATIVE_MAX_TOKENIZE_BYTES" or 16 * 1024 * 1024 => [0, usize::MAX];
+}
+
+/// Cheap chars/4 token estimate used above [`MAX_TOKENIZE_BYTES`].
+const fn heuristic_token_count(len: usize) -> u32 {
+	crate::utils::clamp_u32((len as u64).div_ceil(4))
+}
+
 /// Count tokens in `input`.
 ///
 /// `input` may be a single string or an array of strings; an array returns
@@ -59,11 +74,22 @@ fn encoder(encoding: Option<Encoding>) -> &'static CoreBPE {
 pub fn count_tokens(input: Either<String, Vec<String>>, encoding: Option<Encoding>) -> u32 {
 	let bpe = encoder(encoding);
 	match input {
-		Either::A(text) => bpe.encode_ordinary(&text).len() as u32,
-		Either::B(texts) => texts
-			.par_iter()
-			.map(|s| bpe.encode_ordinary(s).len() as u32)
-			.sum(),
+		Either::A(text) => {
+			if text.len() > *MAX_TOKENIZE_BYTES {
+				return heuristic_token_count(text.len());
+			}
+			bpe.encode_ordinary(&text).len() as u32
+		}
+		Either::B(texts) => {
+			let total: usize = texts.iter().map(String::len).sum();
+			if total > *MAX_TOKENIZE_BYTES {
+				return texts.iter().map(|s| heuristic_token_count(s.len())).sum();
+			}
+			texts
+				.par_iter()
+				.map(|s| bpe.encode_ordinary(s).len() as u32)
+				.sum()
+		}
 	}
 }
 #[cfg(test)]
@@ -93,5 +119,16 @@ mod tests {
 			.map(|s| count_tokens(Either::A(s.clone()), None))
 			.sum();
 		assert_eq!(sum, manual);
+	}
+
+	#[test]
+	fn oversized_input_uses_heuristic_without_bpe() {
+		let huge = "a".repeat(17 * 1024 * 1024);
+		let n = count_tokens(Either::A(huge.clone()), None);
+		assert_eq!(
+			n,
+			heuristic_token_count(huge.len()),
+			"above the cap count_tokens must return the heuristic"
+		);
 	}
 }

--- a/crates/pi-natives/src/tokens.rs
+++ b/crates/pi-natives/src/tokens.rs
@@ -72,19 +72,21 @@ const fn heuristic_token_count(len: usize) -> u32 {
 /// compatibility alias). Exact for o200k only.
 #[napi]
 pub fn count_tokens(input: Either<String, Vec<String>>, encoding: Option<Encoding>) -> u32 {
-	let bpe = encoder(encoding);
+	// Check the byte caps BEFORE initializing the encoder so an oversized input never touches the
+	// synchronous BPE table; the heuristic is computed from the aggregate length to stay panic-free.
 	match input {
 		Either::A(text) => {
 			if text.len() > *MAX_TOKENIZE_BYTES {
 				return heuristic_token_count(text.len());
 			}
-			bpe.encode_ordinary(&text).len() as u32
+			encoder(encoding).encode_ordinary(&text).len() as u32
 		}
 		Either::B(texts) => {
 			let total: usize = texts.iter().map(String::len).sum();
 			if total > *MAX_TOKENIZE_BYTES {
-				return texts.iter().map(|s| heuristic_token_count(s.len())).sum();
+				return heuristic_token_count(total);
 			}
+			let bpe = encoder(encoding);
 			texts
 				.par_iter()
 				.map(|s| bpe.encode_ordinary(s).len() as u32)


### PR DESCRIPTION
## Scope
Rust-side defense-in-depth byte/size caps on the synchronous native entrypoints in `crates/pi-natives`, completing the **F19** slice of the long-running-session freeze remediation (the TS-side `MAX_EDIT_FILE_BYTES` guard already merged in #721).

## Changes
Each cap is a generous, env-overridable limit; **normal inputs are unaffected** (TS callers cap lower). Above the cap, each function returns a bounded/graceful result instead of blocking a native thread:
- **`count_tokens`** (tokens.rs) → chars/4 heuristic above `PI_NATIVE_MAX_TOKENIZE_BYTES` (16 MiB) instead of the synchronous BPE tokenizer (O(text) + large merge table).
- **`highlight_code`** (highlight.rs) → returns the original code above `PI_NATIVE_MAX_HIGHLIGHT_BYTES` (16 MiB) — the documented "or the original code if highlighting fails" fallback.
- **`h01_find_best_fuzzy_match`** (edit_fuzzy.rs) → reports no match above `PI_NATIVE_MAX_FUZZY_UNITS` (16 Mi UTF-16 units) instead of the O(content×target) fuzzy search.

## Verification
- `cargo test -p pi-natives` — oversized-input cap tests pass (tokens → heuristic; highlight → unchanged); full suite green except one pre-existing `shell` process-lifecycle test that flakes only under parallel run (passes in isolation).
- `cargo clippy -p pi-natives` — clean for the changed code.

## Safety
Behavior-preserving for all real inputs; caps are generous (16 MiB) and only engage on pathological input, returning the same graceful fallback each function already documents. `HighlightColors` gains a `Default` derive (additive) to support the new test.