### PR TITLE
deep-interview: silently self-proofread session-language output (best-effort)

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -40,6 +40,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
 - Preserve the user/session language for every user-facing announcement, topology confirmation, option label, and interview question when state includes `language.instruction`; for example Korean initial ideas must receive Korean deep-interview questions unless the user explicitly requests another language
+- Before emitting any user-facing natural-language prose governed by `language.instruction`, perform one silent, best-effort self-proofread in the preserved session language. Apply it only to newly generated prose and never announce the proofreading, show before/after text, apologize for it, or re-emit a corrected copy. For Korean prose, check once for spacing, spelling/standard wording, particles, endings/conjugation, contextual word choice, and loanword/technical-term notation. Do not alter code blocks or identifiers, file paths, CLI commands, JSON/configuration keys, `ask` metadata keys, table/round structure, fixed labels, numeric scores, component ids, status tokens, user quotes or source text, Phase 0 threshold markers such as `Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`, or fixed paths such as `.gjc/specs/deep-interview-{slug}.md`; still apply the self-proofread to generated natural-language clauses or cells inside those structures, including Why now rationale, gap text, next-target phrasing, and coverage notes
 - Target the WEAKEST clarity dimension with each question
 - Before Round 1 ambiguity scoring, run a one-time Round 0 topology enumeration gate that confirms the top-level component list and locks it into state
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
@@ -175,6 +176,8 @@ The first line of this announcement MUST be exactly the Phase 0 threshold marker
 > **Project type:** {greenfield|brownfield}
 > **Current ambiguity:** 100% (we haven't started yet)
 
+Before emitting the prose lines in this announcement, apply the `<Execution_Policy>` self-proofread once; keep the required threshold marker and the quoted `{initial_idea}` unchanged.
+
 ## Round 0: Topology Enumeration Gate
 
 Run this gate exactly once after Phase 1 initialization and before any Phase 2 ambiguity scoring. The goal is to lock the **shape** of the user's scope before depth-first Socratic questioning can overfit to the most-described component.
@@ -292,6 +295,8 @@ Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} 
 ```
 
 Options should include contextually relevant choices plus free-text, translated/localized according to `language.instruction` when present.
+
+After applying `language.instruction` to the visible question, options, and generated rationale, apply the self-proofread once to new prose only; preserve only the Round/Component/Targeting/Ambiguity line structure, fixed labels, numeric ambiguity value, component/target identifiers, and `deepInterview.*` metadata keys. Do not exempt generated natural-language rationale such as Why now.
 
 When calling `ask`, SHOULD include optional structured metadata so the runtime can record the round without manual state writes: `deepInterview.round_id?`, `deepInterview.round`, `deepInterview.component`, `deepInterview.dimension`, and `deepInterview.ambiguity`. Keep this metadata aligned with the visible Round/Component/Targeting/Ambiguity line; if metadata cannot be supplied, the legacy formatted question text remains the fallback.
 
@@ -436,6 +441,8 @@ Round {n} complete.
 
 Apply `language.instruction` when present before showing this progress report so status text, gaps, and next-target phrasing stay in the preserved session language.
 
+Then apply the self-proofread once to narrative status text, generated prose cells, gaps, and next-target phrasing; preserve only table structure, fixed status labels, scores, weights, component ids, and trigger tokens.
+
 ### Step 2e: Update State
 
 Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round `gjc state write` is required for the answer shell; only scoring enrichment/state maintenance remains. When metadata is absent, use the legacy `gjc state write` path to persist the new round and never patch `.gjc/state` directly unless an explicit force override is active.
@@ -486,6 +493,7 @@ When ambiguity ≤ threshold (or hard cap / early exit):
 
 1. **Generate the specification** using opus model with the prompt-safe transcript. If the full interview transcript or initial context is too large, include the summary plus all concrete decisions, acceptance criteria, unresolved gaps, and ontology snapshots; never overflow the prompt with raw oversized context.
    - Apply `language.instruction` when present so user-facing prose in the spec preserves the session language; keep code identifiers, file paths, commands, JSON/settings keys, and quoted source text unchanged.
+   - Apply the self-proofread once to newly generated spec prose before persistence, including generated natural-language table cells such as coverage notes, while preserving transcript answers, quoted/source text, code identifiers, file paths, commands, JSON/settings keys, table structure/fixed labels, and `.gjc/specs/deep-interview-{slug}.md` unchanged.
 2. **Write the final spec through the workflow CLI**: persist the artifact at `.gjc/specs/deep-interview-{slug}.md`
    - Always use this exact final spec path. Do not write temporary working files to the repo root or other ad hoc paths; repos may allowlist `.gjc/` for planning artifacts while protecting product branches.
    - Use the native deep-interview write command with `--write --stage final --slug {slug} --spec <markdown-or-path> [--json]` for artifact and state persistence; direct `.gjc/` file edits are forbidden unless an explicit force override is active.
@@ -785,6 +793,7 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 <Final_Checklist>
 - [ ] Phase 0 ran before anything: threshold resolved and first line emitted as `Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`; state and spec metadata record both `threshold` and `threshold_source`
 - [ ] `language.instruction` preserved across announcements, questions, options, progress reports, and spec prose when present
+- [ ] User-facing natural-language prose, including generated prose clauses/cells inside round lines or tables, was silently self-proofread once according to `language.instruction`, while code/paths/commands/keys/table or round structure/fixed labels/status tokens/quotes/threshold markers/fixed paths remained unchanged
 - [ ] Oversized initial context/history summarized before scoring, question generation, spec generation, or handoff
 - [ ] Round 0 topology gate completed before scoring; `topology.confirmed_at` persisted
 - [ ] Ambiguity scored and displayed every round, naming the weakest component/dimension target (rotating across active components when N > 1)


### PR DESCRIPTION
## Summary

Adds a behavioral rule to the **deep-interview** skill so the agent **silently, best-effort self-proofreads** the user-facing natural-language prose it emits, in the preserved session language, before sending it. Motivated by occasional spelling/spacing errors observed in Korean deep-interview output.

This is a **prompt/docs-only change** to a single file: `packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md`. No runtime/code/dependency changes.

## Why here (not in runtime code)

`deep-interview-runtime.ts` only seeds state and persists the final spec; it never intercepts the agent's interactive chat text. So the only place that can govern interactive output is the SKILL.md prompt policy. The control surface is policy, and the quality target is **best-effort compliance**, not enforced correctness.

## What changed (single file, +9 lines)

1. **`<Execution_Policy>` central rule** — added immediately after the existing `language.instruction` preservation bullet. One silent, best-effort self-proofread in the session language, applied only to newly generated prose, with a Korean error-class checklist (spacing / spelling / particles / endings & conjugation / context / loanword & technical-term notation).
2. **Four short, non-duplicative references** at the emission points: Phase 1 announcement, Step 2b question/options, Step 2d progress report, Phase 4 spec prose.
3. **One `<Final_Checklist>` item** to keep the behavior auditable.

## Safety guard: structure vs. generated prose

The guard **preserves** structure and fixed literals — code/identifiers, file paths, CLI commands, JSON/config keys, `ask` metadata keys, table/round structure, fixed labels, numeric scores, component ids, status tokens, user quotes/source text, Phase 0 threshold markers (`Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`), and fixed paths like `.gjc/specs/deep-interview-{slug}.md`.

It **still proofreads** generated natural-language clauses/cells *inside* those structures — `Why now` rationale, gap text, next-target phrasing, and coverage notes — so proofreading is not over-suppressed for prose that happens to live in a table or a Round line.

## Non-goals

- No deterministic / zero-error guarantee (best-effort only).
- No external spell-check API/library or separate LLM call; no runtime code change.
- Silent + prospective-only: never announces the proofread, shows before/after, apologizes, or re-emits a corrected copy; never retroactively rewrites existing specs/transcripts/quotes/state.
- Out of scope: applying the same rule to other GJC skills.

## Verification

- `git diff` is limited to `SKILL.md` (1 file, 9 insertions, 0 deletions). No runtime/config/dependency changes.
- Markdown structure intact; Phase 0 threshold marker and fixed paths are byte-for-byte unchanged.

### Non-runtime demonstration (review-note only)

These illustrate intended behavior; they are **not** shown in real deep-interview output (which stays silent). Fixed literals stay byte-for-byte identical.

**Sample 1 — prose vs. fixed path**
- In:  `지금 부터 딥 인터뷰를 시작 할께요. 질문은 한개 씩 드림니다. 경로는 .gjc/specs/deep-interview-{slug}.md 입니다.`
- Out: `지금부터 딥 인터뷰를 시작할게요. 질문은 한 개씩 드립니다. 경로는 .gjc/specs/deep-interview-{slug}.md 입니다.`
- Invariant: `.gjc/specs/deep-interview-{slug}.md` unchanged.

**Sample 2 — threshold marker + JSON key preserved**
- In:  `현재 모호도 점수을 확인 햇습니다. JSON 키 deepInterview.round 는 바꾸지 않습니다.`
- Out: `현재 모호도 점수를 확인했습니다. JSON 키 deepInterview.round 는 바꾸지 않습니다.`
- Invariant: Phase 0 threshold marker and `deepInterview.round` unchanged.

**Sample 3 — generated prose inside a Round line / table**
- In:  `Round 2 | Component: output-spellcheck | Targeting: Constraints | Why now: 세션 언어 규칙이 아직 불명확 해요 | Ambiguity: 21%` and a Gap cell `안전 가드가 표 전체를 제외 할수 있음`
- Out: `... | Why now: 세션 언어 규칙이 아직 불명확해요 | ...` and Gap cell `안전 가드가 표 전체를 제외할 수 있음`
- Invariant: `Round`, `Component`, `Targeting`, `Ambiguity`, `output-spellcheck`, `21%`, table structure, labels, and scores unchanged; only the `Why now` rationale and Gap prose are corrected.
