### PR TITLE
fix(session): opt-in output-sanitization coalescing for many-small-chunk output (F21)

### DIFF
--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -8,6 +8,13 @@ function sanitizeOutputChunk(rawChunk: string): string {
 	return sanitizeWithOptionalSixelPassthrough(rawChunk, sanitizeText);
 }
 
+/**
+ * Flush threshold for the opt-in sanitize-coalescing path (F21). When coalescing is enabled, raw
+ * chunks accumulate until they reach this many chars, then are sanitized + delivered as one batch,
+ * so many-small-chunk output pays one sanitize pass per batch instead of one per tiny chunk.
+ */
+const COALESCE_FLUSH_CHARS = 64 * 1024;
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -80,6 +87,13 @@ export interface OutputSinkOptions {
 	 * relative to the sink (the sink does not catch errors from this callback).
 	 */
 	onRawChunk?: (chunk: string) => void;
+	/**
+	 * Opt-in (F21): when true, sanitization + live callback delivery + retention are coalesced over
+	 * batched raw chunks instead of run per chunk, bounding sync CPU for many-small-chunk output. The
+	 * raw artifact mirror stays byte-correct. Defaults to the PI_OUTPUT_SANITIZE_COALESCE env flag
+	 * (default OFF — the per-chunk path is byte-identical to historical behavior).
+	 */
+	coalesceSanitize?: boolean;
 }
 
 export interface TruncationResult {
@@ -706,6 +720,8 @@ export class OutputSink {
 	readonly #chunkThrottleMs: number;
 	readonly #maxColumns: number;
 	readonly #artifactMaxBytes: number;
+	readonly #coalesceSanitize: boolean;
+	#coalesceBuf = "";
 
 	constructor(options?: OutputSinkOptions) {
 		const {
@@ -718,6 +734,7 @@ export class OutputSink {
 			chunkThrottleMs = 0,
 			onRawChunk,
 			artifactMaxBytes = DEFAULT_ARTIFACT_MAX_BYTES,
+			coalesceSanitize = process.env.PI_OUTPUT_SANITIZE_COALESCE === "1",
 		} = options ?? {};
 		this.#artifactPath = artifactPath;
 		this.#artifactId = artifactId;
@@ -728,6 +745,7 @@ export class OutputSink {
 		this.#onRawChunk = onRawChunk;
 		this.#chunkThrottleMs = chunkThrottleMs;
 		this.#artifactMaxBytes = Math.max(0, artifactMaxBytes);
+		this.#coalesceSanitize = coalesceSanitize;
 	}
 
 	#headText(): string {
@@ -765,7 +783,28 @@ export class OutputSink {
 	 * visible retention windows are selected from the sanitized/column-capped
 	 * stream so production-default display matches the historical processed view.
 	 */
+	// F21: with coalescing enabled, accumulate raw chunks and process them in batches; the default
+	// (disabled) path calls #ingest directly and is byte-identical to the historical per-chunk path.
 	push(chunk: string): void {
+		if (!this.#coalesceSanitize) {
+			this.#ingest(chunk);
+			return;
+		}
+		this.#coalesceBuf += chunk;
+		if (this.#coalesceBuf.length >= COALESCE_FLUSH_CHARS) {
+			this.#flushCoalesced();
+		}
+	}
+
+	/** Process any buffered coalesced chunks as a single batch (F21). */
+	#flushCoalesced(): void {
+		if (this.#coalesceBuf.length === 0) return;
+		const batch = this.#coalesceBuf;
+		this.#coalesceBuf = "";
+		this.#ingest(batch);
+	}
+
+	#ingest(chunk: string): void {
 		const rawChunk = chunk;
 
 		// Live callbacks historically observe sanitized, uncapped chunks. The same
@@ -1046,6 +1085,7 @@ export class OutputSink {
 	 * branch in `dump()` against stale totals.
 	 */
 	replace(text: string): void {
+		this.#coalesceBuf = "";
 		this.#setTail(text);
 		this.#head = "";
 		this.#headBytes = 0;
@@ -1063,6 +1103,7 @@ export class OutputSink {
 	}
 
 	async dump(notice?: string): Promise<OutputSummary> {
+		this.#flushCoalesced();
 		const noticeLine = notice ? `[${notice}]\n` : "";
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
 

--- a/packages/coding-agent/test/streaming-output-coalesce.test.ts
+++ b/packages/coding-agent/test/streaming-output-coalesce.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { OutputSink } from "../src/session/streaming-output";
+
+interface FeedOptions {
+	coalesceSanitize?: boolean;
+	spillThreshold?: number;
+	onRawChunk?: (chunk: string) => void;
+}
+
+async function feed(chunks: string[], options: FeedOptions): Promise<string> {
+	const sink = new OutputSink(options);
+	for (const chunk of chunks) sink.push(chunk);
+	return (await sink.dump()).output;
+}
+
+describe("output sanitize coalescing (F21, default OFF)", () => {
+	test("coalesced output is byte-identical to per-chunk output for clean text (incl. mid-stream flush)", async () => {
+		// ~160 KB across 20k tiny chunks, crossing the 64 KB coalesce flush threshold several times.
+		const chunks = Array.from({ length: 20_000 }, (_, i) => `line ${i}\n`);
+		const big = 16 * 1024 * 1024; // disable truncation so we compare full output
+		const perChunk = await feed(chunks, { coalesceSanitize: false, spillThreshold: big });
+		const coalesced = await feed(chunks, { coalesceSanitize: true, spillThreshold: big });
+		expect(coalesced).toBe(perChunk);
+	});
+
+	test("coalescing batches live callbacks while preserving the concatenated sanitized stream", async () => {
+		const chunks = Array.from({ length: 1000 }, () => "x");
+		let perChunkCalls = 0;
+		let perChunkRaw = "";
+		await feed(chunks, {
+			coalesceSanitize: false,
+			onRawChunk: chunk => {
+				perChunkCalls += 1;
+				perChunkRaw += chunk;
+			},
+		});
+		let coalescedCalls = 0;
+		let coalescedRaw = "";
+		await feed(chunks, {
+			coalesceSanitize: true,
+			onRawChunk: chunk => {
+				coalescedCalls += 1;
+				coalescedRaw += chunk;
+			},
+		});
+		expect(coalescedRaw).toBe(perChunkRaw); // same total sanitized bytes delivered
+		expect(perChunkCalls).toBe(1000);
+		expect(coalescedCalls).toBeLessThan(perChunkCalls); // batched into far fewer callbacks
+	});
+
+	test("default (flag unset) delivers one callback per chunk", async () => {
+		let calls = 0;
+		await feed(["a", "b", "c"], { onRawChunk: () => (calls += 1) });
+		expect(calls).toBe(3);
+	});
+});


### PR DESCRIPTION
## Scope
Completes **F21** of the long-running-session freeze remediation: an opt-in coalescing path in `OutputSink` so noisy, many-small-chunk process output doesn't pay one synchronous sanitize pass + live-callback delivery per tiny chunk.

## Changes (`packages/coding-agent/src/session/streaming-output.ts`)
- New `coalesceSanitize` option (defaults to the `PI_OUTPUT_SANITIZE_COALESCE` env flag, **default OFF**).
- `push()` body extracted to `#ingest()`. With coalescing **off**, `push()` calls `#ingest()` directly — **byte-identical** to historical behavior. With coalescing **on**, raw chunks accumulate in `#coalesceBuf` and are flushed (sanitized + callbacks + retention as one batch) every 64 KB and on `dump()`; `replace()` clears the buffer.
- The **raw artifact mirror stays byte-correct** (raw bytes written per batch = same bytes).

## Verification
- `bun run check:ts` — green across all workspaces.
- `bun test` streaming suites: **89 existing tests pass** (proves the default-OFF path is byte-identical).
- New `streaming-output-coalesce.test.ts` (**3 pass**): coalesced output == per-chunk output across a 160 KB / 20k-chunk stream (exercises mid-stream flush); live callbacks are batched into far fewer invocations while delivering the same concatenated sanitized stream; flag-unset delivers one callback per chunk.

## Safety
Pure opt-in behind a default-OFF env flag/option; no behavior change unless explicitly enabled. Reconciled against current dev (post-U6 artifact-cap streaming-output changes).