### PR TITLE
ci(dev): fan out state gates and narrow deep-interview checks

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -64,12 +64,15 @@ jobs:
         if: steps.flags.outputs.relevant == 'true'
         run: bun scripts/ci-dev-affected.ts
 
-  # Branch protection must add the always-present `gjc-state-gates` status as required.
-  gjc-state-gates:
-    name: gjc-state-gates
+  gjc-state-gates-matrix:
+    name: gjc-state-gates / ${{ matrix.group }}
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: [self-hosted, Linux, X64, gajae-code-fast]
-    timeout-minutes: 15
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-3990x-2]
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [static, runtime, integrity, read]
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -91,5 +94,19 @@ jobs:
           restore-keys: |
             bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
-      - name: Run GJC state gates
-        run: bun scripts/ci-gjc-state-gates.ts
+      - name: Run GJC state gate shard
+        run: bun scripts/ci-gjc-state-gates.ts --group=${{ matrix.group }}
+
+  # Branch protection must keep requiring this stable aggregate status.
+  gjc-state-gates:
+    name: gjc-state-gates
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: [gjc-state-gates-matrix]
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-3990x-2]
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate GJC state gate shards
+        run: |
+          result='${{ needs.gjc-state-gates-matrix.result }}'
+          echo "gjc-state-gates shard result: $result"
+          test "$result" = success

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -57,6 +57,22 @@ describe("planTasks command shape (issue #622)", () => {
 	});
 });
 
+	describe("deep-interview selector narrowing", () => {
+		test("deep-interview-only changes avoid native/full workspace validation", () => {
+			const tasks = planForPaths([
+				"packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md",
+				"packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts",
+				"packages/coding-agent/test/default-gjc-definitions.test.ts",
+				"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
+			]);
+			expect(tasks.map(task => task.key)).toEqual([
+				"deep-interview-definitions",
+				"deep-interview-runtime",
+			]);
+			expect(tasks.some(task => task.key.includes("native") || task.key === "root-test")).toBe(false);
+		});
+	});
+
 describe("runCommand executes package scripts in the target cwd (issue #622)", () => {
 	const tempDirs: string[] = [];
 

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -226,9 +226,16 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	const publishChanged = paths.some(isReleasePublishPath);
 	const wrapperChanged = paths.some(isUnscopedWrapperPath);
 	const toolingScriptChanged = paths.some(isToolingScriptPath);
-	const needsNativeRuntime = paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace;
+	const deepInterviewOnly = isDeepInterviewOnly(paths);
+	const needsNativeRuntime = !deepInterviewOnly && (paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace);
 	const workflowHarnessOnly = paths.length > 0 && paths.every(isWorkflowHarnessPath);
 	const ciOnly = paths.length > 0 && paths.every(changedPath => changedPath.startsWith(".github/"));
+
+	if (deepInterviewOnly) {
+		add(tasks, "deep-interview-definitions", "Deep interview default definition tests", ["bun", "test", "packages/coding-agent/test/default-gjc-definitions.test.ts"]);
+		add(tasks, "deep-interview-runtime", "Deep interview runtime tests", ["bun", "test", "packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts"]);
+		return Array.from(tasks.values());
+	}
 
 	if (needsNativeRuntime) {
 		add(tasks, "native-build", "Build native addon for CLI/test smoke", ["bun", "run", "build:native"]);
@@ -407,6 +414,16 @@ function isInstallPath(changedPath: string): boolean {
 
 function isCodingAgentRuntimePath(changedPath: string): boolean {
 	return changedPath.startsWith("packages/coding-agent/") || changedPath.startsWith("packages/agent/") || changedPath.startsWith("packages/ai/");
+}
+
+function isDeepInterviewOnly(paths: readonly string[]): boolean {
+	const allowed = new Set([
+		"packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md",
+		"packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts",
+		"packages/coding-agent/test/default-gjc-definitions.test.ts",
+		"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
+	]);
+	return paths.length > 0 && paths.every(changedPath => allowed.has(changedPath));
 }
 
 function isWorkflowOrScriptPath(changedPath: string): boolean {

--- a/scripts/ci-gjc-state-gates.ts
+++ b/scripts/ci-gjc-state-gates.ts
@@ -25,23 +25,30 @@ const relevantPathPrefixes = [
 	"tsconfig.tools.json",
 ];
 
-const boundedGateCommands = [
+const boundedGateGroups: Record<string, readonly (readonly string[])[]> = {
+	static: [
 	["bun", "scripts/verify-gjc-state-writers.ts", "--fail"],
 	["bun", "scripts/generate-gjc-workflow-manifest.ts", "--check"],
 	["bun", "scripts/verify-gjc-skill-docs.ts", "--fail"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-schema.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-migrations.test.ts"],
+	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-schema-corpus.test.ts"],
+	],
+	runtime: [
 	// NOTE: state-writer-drift.test.ts imports recordSkillActivation (hooks) and
 	// persistGjcTeamModeStateSummary (team-runtime), which load the @gajae-code/natives
 	// addon transitively, so it runs in the heavier "Affected path validation" job, not
 	// this native-free gate.
-	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-schema-corpus.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-runtime.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-handoff.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-receipts.test.ts"],
+	],
+	integrity: [
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-integrity.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-graph.test.ts"],
+	],
+	read: [
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-read-markdown.test.ts"],
 	["bun", "test", "packages/coding-agent/test/gjc-runtime/state-token-thrift.test.ts"],
 	// Lane H read-only doctor: imports only the native-free state-runtime module.
@@ -49,7 +56,15 @@ const boundedGateCommands = [
 	// NOTE: deep-interview-mutation-guard, gjc-skill-state-hooks, and skill-active-state
 	// load the @gajae-code/natives addon transitively via the tool/hook runtime, so they
 	// run in the heavier "Affected path validation" job rather than this native-free gate.
-];
+	],
+};
+
+const groupNames = Object.keys(boundedGateGroups);
+
+function printGroupsJson(): never {
+	console.log(JSON.stringify(groupNames.map(group => ({ group }))));
+	process.exit(0);
+}
 
 async function changedFiles(): Promise<string[]> {
 	if (process.env.GITHUB_EVENT_NAME === "pull_request" && process.env.GITHUB_BASE_SHA) {
@@ -72,6 +87,17 @@ function isRelevant(file: string): boolean {
 	return relevantPathPrefixes.some(prefix => file === prefix || file.startsWith(prefix));
 }
 
+if (process.argv.includes("--groups-json")) {
+	printGroupsJson();
+}
+
+const groupArg = process.argv.find(arg => arg.startsWith("--group="));
+const selectedGroup = groupArg?.slice("--group=".length) || "all";
+if (selectedGroup !== "all" && !boundedGateGroups[selectedGroup]) {
+	console.error(`gjc-state-gates: unknown group '${selectedGroup}'. Known groups: ${groupNames.join(", ")}`);
+	process.exit(2);
+}
+
 const files = await changedFiles();
 const relevantFiles = files.filter(isRelevant);
 
@@ -81,14 +107,15 @@ if (relevantFiles.length === 0) {
 	process.exit(0);
 }
 
-console.log("gjc-state-gates: relevant paths changed; running bounded gates.");
+console.log(`gjc-state-gates: relevant paths changed; running group ${selectedGroup}.`);
 for (const file of relevantFiles) {
 	console.log(`gjc-state-gates: relevant ${file}`);
 }
 
-for (const command of boundedGateCommands) {
+const commands = selectedGroup === "all" ? groupNames.flatMap(group => boundedGateGroups[group]) : boundedGateGroups[selectedGroup];
+for (const command of commands) {
 	console.log(`gjc-state-gates: running ${command.join(" ")}`);
 	await $`${command}`.cwd(repoRoot);
 }
 
-console.log("gjc-state-gates: bounded gates passed.");
+console.log(`gjc-state-gates: group ${selectedGroup} passed.`);


### PR DESCRIPTION
## Summary
- fan out `gjc-state-gates` into four matrix shards while preserving the required aggregate `gjc-state-gates` status
- run state-gate shards on the broad 192.168.0.54 runner label to avoid artificial fast/heavy queue bottlenecks
- narrow deep-interview-only PRs to their focused definition/runtime tests instead of native build + full coding-agent/dependent package validation

## Validation
- `bun test scripts/ci-dev-affected.test.ts`
- `bun scripts/check-workflow-yaml.ts`
- `bun scripts/ci-gjc-state-gates.ts --groups-json`
- `CI_DEV_CHANGED_PATHS=...deep-interview... bun scripts/ci-dev-affected.ts --dry-run`

## Notes
This is the first safe cut for CI speed. It keeps branch-protection status names stable and avoids weakening runtime validation; the state gates are still run, just concurrently.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*