### PR TITLE
fix(pi-natives): widen Windows budget for high-output PTY backpressure test (v0.5.3 release blocker)

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -947,18 +947,28 @@ mod tests {
 	fn bounded_reader_channel_reports_success_for_high_output() {
 		let _guard = PTY_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
 		let (_tx, rx) = mpsc::channel();
+		// GitHub-hosted Windows runners drive the `sh` printf loop through
+		// ConPTY far more slowly than Unix, so this synthetic high-output
+		// workload needs a more generous budget there. The bounded reader's
+		// backpressure behavior is platform-independent; this budget only
+		// guards against deadlock / unbounded buffering, not raw shell
+		// throughput (Unix completes the same run in ~3s).
+		#[cfg(windows)]
+		let budget_ms: u32 = 60_000;
+		#[cfg(not(windows))]
+		let budget_ms: u32 = 20_000;
 		let started = Instant::now();
 		let result = run_pty_sync(
 			test_config("i=0; while [ $i -lt 200000 ]; do printf '%080d\\n' \"$i\"; i=$((i+1)); done"),
 			None,
 			rx,
-			task::CancelToken::new(Some(20_000), None),
+			task::CancelToken::new(Some(budget_ms), None),
 		)
 		.expect("high-output PTY run should complete without unbounded buffering");
 		assert!(result.exit_code.is_some());
 		assert!(!result.cancelled);
 		assert!(!result.timed_out);
-		assert!(started.elapsed() < Duration::from_secs(20));
+		assert!(started.elapsed() < Duration::from_millis(u64::from(budget_ms)));
 	}
 
 	#[test]


### PR DESCRIPTION
## Release-blocker diagnosis — v0.5.3 Windows native_release failure

**Failing CI:** tag/release run `27592189831` (workflow CI, `headBranch v0.5.3`)
**Only failing job:** `native_release (windows-latest, win32, x64, baseline)`
**Failing test:** `pi-natives pty::tests::bounded_reader_channel_reports_success_for_high_output`
(`assertion failed: !result.timed_out`; 277 passed / 1 failed, ~20s)

### Root cause — too-strict test budget on GitHub-hosted Windows, **not** a product bug

The test drives a 200,000-iteration `sh` `printf` loop and asserts the run
finishes inside a **20s** cancel-token budget:

```
test_config("i=0; while [ $i -lt 200000 ]; do printf '%080d\n' \"$i\"; i=$((i+1)); done")
task::CancelToken::new(Some(20_000), None)
...
assert!(!result.timed_out);
assert!(started.elapsed() < Duration::from_secs(20));
```

On GitHub-hosted `windows-latest`, that loop runs through the MSYS `sh` shell
under **ConPTY**, which is dramatically slower than Unix at high-throughput
shell I/O. Under CI load the workload exceeds 20s, the cancel token fires
(`timed_out = true`), and `assert!(!result.timed_out)` fails.

**Evidence it is environmental, not a reader defect:**
- linux x64, linux arm64, and macOS arm64 native jobs ran the **identical**
  test and passed.
- Locally on Linux the same test completes in **~2-3s** — ~7x under budget.
- The dedicated backpressure unit test
  `final_reader_loss_and_done_are_delivered_when_queue_is_full` passes.
- `crates/pi-natives/src/pty.rs` reader code was **not** modified for v0.5.3
  (last change predates the release; #744 capped native input on synchronous
  entrypoints and did not touch `pty.rs`). If the bounded reader actually
  deadlocked under backpressure, every platform would time out — not just
  Windows.

If the reader had a real backpressure bug, the child would block on writes and
the run would hang on **all** platforms; instead only the slowest CI host trips
a wall-clock assertion. This is a flaky/too-strict timing budget.

### Fix (test-only, minimal)

Give the Windows path a 60s budget while keeping the strict 20s guard on Unix.
The bounded reader's behavior is platform-independent; the budget only guards
against deadlock / unbounded buffering, not raw shell throughput.

```rust
#[cfg(windows)]
let budget_ms: u32 = 60_000;
#[cfg(not(windows))]
let budget_ms: u32 = 20_000;
...
task::CancelToken::new(Some(budget_ms), None),
...
assert!(started.elapsed() < Duration::from_millis(u64::from(budget_ms)));
```

No product code changed. 1 file, +12/-2.

### Validation
- `cargo fmt -p pi-natives -- --check` — clean
- `cargo clippy -p pi-natives -- -D warnings` — clean
- `cargo nextest run -p pi-natives` — **80/80 passed** on Linux (the changed
  test exercises the `not(windows)` 20s branch and passes in ~2s)
- **Windows-only validation needed:** the `cfg(windows)` 60s branch cannot be
  exercised on this Linux host. The authoritative check is re-running the
  `native_release (windows-latest, win32, x64, baseline)` job in CI on this
  branch; expect the high-output test to pass well within the 60s budget.

### Branch / base note
Branched from and targeted at **`dev`**. The `v0.5.3` tag is 101 commits ahead
of `dev` (the release merge), so a tag-based branch would produce an
unmergeable diff; `dev` carries the identical `pty.rs`, so this lands as the
minimal one-file fix and remains cleanly cherry-pickable to `main`/a
release-hotfix branch **if the owner explicitly requests one**.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
