### PR TITLE
ci(dev): fan out Affected path validation into a task matrix

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -44,10 +44,12 @@ jobs:
         id: plan
         run: bun scripts/ci-dev-affected.ts --matrix-json
 
-  # Native addon build runs once per run on the heavy runner (Rust + native
-  # compile is the only genuinely heavy step) and publishes the built `.node`
-  # files as an artifact the runtime-dependent shards download. Skipped when the
-  # plan needs no native build.
+  # Native addon build runs at most once per run and publishes the built `.node`
+  # files as an artifact the runtime-dependent shards download. A content-hash
+  # cache of the native sources lets PRs that don't touch crates/natives restore
+  # the prebuilt addon and skip the Rust/native source build entirely; only a
+  # cache miss (native source actually changed) recompiles. Skipped when the plan
+  # needs no native build at all.
   affected-native:
     name: Affected path validation / native-build
     needs: [affected-plan]
@@ -64,24 +66,36 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - name: Restore cached native addon
+        id: native-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: packages/natives/native/pi_natives.*.node
+          key: dev-affected-native-${{ runner.os }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'scripts/ci-build-native.ts', 'scripts/host-detect.ts') }}
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        if: steps.native-cache.outputs.cache-hit != 'true'
         with:
           toolchain: nightly-2026-04-29
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        if: steps.native-cache.outputs.cache-hit != 'true'
         with:
           shared-key: dev-affected-native-linux-x64
           cache-on-failure: true
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           cache-workspace-crates: true
       - name: Cache bun dependencies
+        if: steps.native-cache.outputs.cache-hit != 'true'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - name: Install system deps
+        if: steps.native-cache.outputs.cache-hit != 'true'
         run: bash scripts/ci-install-system-deps.sh
-      - run: bun install --frozen-lockfile
+      - if: steps.native-cache.outputs.cache-hit != 'true'
+        run: bun install --frozen-lockfile
       - name: Build affected native addon(s)
+        if: steps.native-cache.outputs.cache-hit != 'true'
         run: bun scripts/ci-dev-affected.ts --native-build
       - name: Upload native addon(s)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -12,11 +12,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  affected:
-    name: Affected path validation
+  # Planner: resolve changed-path relevance and the affected task plan once, then
+  # fan the plan out into per-task shards. Emits the matrix, has_tasks/has_native
+  # flags, and the resolved changed paths so every downstream job reuses this
+  # exact diff via CI_DEV_CHANGED_PATHS instead of re-resolving the base ref.
+  affected-plan:
+    name: Affected path validation / plan
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: [self-hosted, Linux, X64, gajae-code-heavy]
-    timeout-minutes: 30
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-3990x-2]
+    timeout-minutes: 10
+    outputs:
+      relevant: ${{ steps.relevance.outputs.relevant }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      has_tasks: ${{ steps.plan.outputs.has_tasks }}
+      has_native: ${{ steps.plan.outputs.has_native }}
+      changed_paths: ${{ steps.plan.outputs.changed_paths }}
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -24,29 +34,42 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - name: Compute changed-path relevance
+        id: relevance
+        run: bun scripts/ci-job-relevance.ts
+      - name: Compute affected task matrix
+        id: plan
+        run: bun scripts/ci-dev-affected.ts --matrix-json
+
+  # Native addon build runs once per run on the heavy runner (Rust + native
+  # compile is the only genuinely heavy step) and publishes the built `.node`
+  # files as an artifact the runtime-dependent shards download. Skipped when the
+  # plan needs no native build.
+  affected-native:
+    name: Affected path validation / native-build
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_native == 'true' }}
+    runs-on: [self-hosted, Linux, X64, gajae-code-heavy]
+    timeout-minutes: 30
+    env:
+      CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
-      - name: Compute affected flags
-        id: flags
-        run: |
-          bun scripts/ci-job-relevance.ts
-          bun scripts/ci-dev-affected.ts --emit-flags
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
-        if: steps.flags.outputs.relevant == 'true' && (steps.flags.outputs.rust == 'true' || steps.flags.outputs.native == 'true')
         with:
           toolchain: nightly-2026-04-29
-      - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e  # v2
-        if: steps.flags.outputs.relevant == 'true' && steps.flags.outputs.rust == 'true'
-        with:
-          tool: nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
-        if: steps.flags.outputs.relevant == 'true' && (steps.flags.outputs.rust == 'true' || steps.flags.outputs.native == 'true')
         with:
-          shared-key: dev-affected-linux-x64
+          shared-key: dev-affected-native-linux-x64
           cache-on-failure: true
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           cache-workspace-crates: true
@@ -56,13 +79,97 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - name: Install system deps
-        if: steps.flags.outputs.relevant == 'true'
         run: bash scripts/ci-install-system-deps.sh
-      - if: steps.flags.outputs.relevant == 'true'
-        run: bun install --frozen-lockfile
-      - name: Run affected path checks and tests
-        if: steps.flags.outputs.relevant == 'true'
-        run: bun scripts/ci-dev-affected.ts
+      - run: bun install --frozen-lockfile
+      - name: Build affected native addon(s)
+        run: bun scripts/ci-dev-affected.ts --native-build
+      - name: Upload native addon(s)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dev-affected-native-${{ github.run_id }}
+          path: packages/natives/native/pi_natives.*.node
+          if-no-files-found: error
+          retention-days: 1
+
+  # One shard per planned task on the broad runner. Native build tasks are
+  # excluded (they run in affected-native); shards that load the native addon at
+  # runtime download the prebuilt artifact instead of rebuilding it.
+  affected-shards:
+    name: Affected path validation / ${{ matrix.key }}
+    needs: [affected-plan, affected-native]
+    if: ${{ always() && needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-native.result != 'failure' && needs.affected-native.result != 'cancelled' }}
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-3990x-2]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.affected-plan.outputs.matrix) }}
+    env:
+      CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "24"
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        if: ${{ matrix.rust }}
+        with:
+          toolchain: nightly-2026-04-29
+      - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e  # v2
+        if: ${{ matrix.rust }}
+        with:
+          tool: nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        if: ${{ matrix.rust }}
+        with:
+          shared-key: dev-affected-rust-linux-x64
+          cache-on-failure: true
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+          cache-workspace-crates: true
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - name: Install system deps
+        run: bash scripts/ci-install-system-deps.sh
+      - run: bun install --frozen-lockfile
+      - name: Download native addon(s)
+        if: ${{ matrix.native }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dev-affected-native-${{ github.run_id }}
+          path: packages/natives/native
+      - name: Run affected task shard
+        env:
+          AFFECTED_TASK_KEY: ${{ matrix.key }}
+        run: bun scripts/ci-dev-affected.ts --task="$AFFECTED_TASK_KEY"
+
+  # Branch protection must keep requiring this stable aggregate status. It runs
+  # no validation itself; it passes iff the planner succeeded and no shard or the
+  # native build failed (skipped shards/native are fine for no-op or docs-only
+  # changes). The job name must stay exactly "Affected path validation".
+  affected:
+    name: Affected path validation
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: [affected-plan, affected-native, affected-shards]
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-3990x-2]
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate affected path validation shards
+        run: |
+          plan='${{ needs.affected-plan.result }}'
+          native='${{ needs.affected-native.result }}'
+          shards='${{ needs.affected-shards.result }}'
+          echo "affected-plan: $plan"
+          echo "affected-native: $native"
+          echo "affected-shards: $shards"
+          test "$plan" = success || { echo "planner did not succeed"; exit 1; }
+          case "$native" in success|skipped) ;; *) echo "native build did not pass"; exit 1 ;; esac
+          case "$shards" in success|skipped) ;; *) echo "one or more affected shards did not pass"; exit 1 ;; esac
+          echo "Affected path validation: all required shards passed"
 
   gjc-state-gates-matrix:
     name: gjc-state-gates / ${{ matrix.group }}

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { packageScriptCommand, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
+import { describeTasks, packageScriptCommand, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
 
 const packages: WorkspacePackage[] = [
 	{
@@ -130,5 +130,122 @@ describe("runCommand executes package scripts in the target cwd (issue #622)", (
 		expect(exitCode).toBe(0); // false green
 		expect(await Bun.file(markerPath).exists()).toBe(false); // script never ran
 		expect(output).toContain("Usage: bun run"); // it only printed help
+	});
+});
+
+describe("describeTasks matrix emission", () => {
+	test("package test task needs native, native build task is flagged, check does not", () => {
+		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
+		const nativeBuild = entries.find(entry => entry.key === "native-linux-x64");
+		const pkgTest = entries.find(entry => entry.key === "test:@gajae-code/example");
+		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
+
+		expect(nativeBuild?.nativeBuild).toBe(true);
+		expect(nativeBuild?.native).toBe(false);
+		expect(pkgTest?.native).toBe(true);
+		expect(pkgTest?.nativeBuild).toBe(false);
+		expect(pkgCheck?.native).toBe(false);
+		expect(pkgCheck?.nativeBuild).toBe(false);
+
+		// Every descriptor carries the serialized command plus boolean setup flags.
+		for (const entry of entries) {
+			expect(Array.isArray(entry.command)).toBe(true);
+			expect(typeof entry.native).toBe("boolean");
+			expect(typeof entry.rust).toBe("boolean");
+			expect(typeof entry.nativeBuild).toBe("boolean");
+		}
+	});
+
+	test("rust tasks are flagged rust and need no native addon", () => {
+		const entries = describeTasks(planTasks(["crates/pi-natives/src/lib.rs"], packages));
+		const check = entries.find(entry => entry.key === "rust-check");
+		const runTest = entries.find(entry => entry.key === "rust-test");
+
+		expect(check?.rust).toBe(true);
+		expect(check?.native).toBe(false);
+		expect(runTest?.rust).toBe(true);
+		expect(entries.every(entry => !entry.nativeBuild)).toBe(true);
+	});
+
+	test("cwd is emitted repo-relative for package-scoped tasks", () => {
+		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
+		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
+		expect(pkgCheck?.cwd).toBe("packages/example");
+	});
+});
+
+describe("--matrix-json and --task CLI fan-out", () => {
+	const scriptPath = path.join(import.meta.dir, "ci-dev-affected.ts");
+	const repoRoot = path.join(import.meta.dir, "..");
+	const tempDirs: string[] = [];
+
+	afterAll(async () => {
+		await Promise.all(tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+	});
+
+	async function runScript(
+		args: readonly string[],
+		changedPaths: string,
+		extraEnv: Record<string, string> = {},
+	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		const proc = Bun.spawn(["bun", scriptPath, ...args], {
+			cwd: repoRoot,
+			env: { ...process.env, CI_DEV_CHANGED_PATHS: changedPaths, ...extraEnv },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		return { stdout, stderr, exitCode };
+	}
+
+	test("--matrix-json emits JSON descriptors and GitHub planner outputs", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-matrix-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+
+		const { stdout, exitCode } = await runScript(["--matrix-json"], "crates/pi-natives/src/lib.rs", {
+			GITHUB_OUTPUT: outputFile,
+		});
+		expect(exitCode).toBe(0);
+
+		const entries = JSON.parse(stdout.trim());
+		expect(entries.some((entry: { key: string; rust: boolean; native: boolean }) => entry.key === "rust-check" && entry.rust === true && entry.native === false)).toBe(true);
+
+		const output = await Bun.file(outputFile).text();
+		expect(output).toContain("has_tasks=true");
+		expect(output).toContain("has_native=false");
+		expect(output).toContain("changed_paths<<");
+
+		const matrixLine = output.split("\n").find(line => line.startsWith("matrix="));
+		expect(matrixLine).toBeDefined();
+		const matrix = JSON.parse((matrixLine as string).slice("matrix=".length));
+		expect(matrix.include.some((shard: { key: string }) => shard.key === "rust-check")).toBe(true);
+		// Native build tasks never appear as shards.
+		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
+	});
+
+	test("--task runs exactly the selected planned task", async () => {
+		const { stdout, exitCode } = await runScript(["--task=affected-dry-run"], "scripts/ci-dev-affected.ts");
+		expect(exitCode).toBe(0);
+		// The selected task's group header proves the right single task was chosen,
+		// and the nested --dry-run output proves it actually executed.
+		expect(stdout).toContain("Affected CI selector self-check");
+		expect(stdout).toContain("Dev affected-path CI");
+	});
+
+	test("--task fails loudly on a key absent from the current plan", async () => {
+		const { stderr, exitCode } = await runScript(["--task=does-not-exist"], "docs/readme.md");
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("not in the current plan");
+	});
+
+	test("--native-build is a no-op when the plan has no native build task", async () => {
+		const { stdout, exitCode } = await runScript(["--native-build"], "docs/readme.md");
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("no native build tasks in plan");
 	});
 });

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -58,7 +58,7 @@ describe("planTasks command shape (issue #622)", () => {
 });
 
 	describe("deep-interview selector narrowing", () => {
-		test("deep-interview-only changes avoid native/full workspace validation", () => {
+		test("deep-interview-only changes avoid full workspace validation but still provide native artifacts", () => {
 			const tasks = planForPaths([
 				"packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md",
 				"packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts",
@@ -66,10 +66,15 @@ describe("planTasks command shape (issue #622)", () => {
 				"packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts",
 			]);
 			expect(tasks.map(task => task.key)).toEqual([
+				"native-linux-x64",
 				"deep-interview-definitions",
 				"deep-interview-runtime",
 			]);
-			expect(tasks.some(task => task.key.includes("native") || task.key === "root-test")).toBe(false);
+			const entries = describeTasks(tasks);
+			expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
+			expect(entries.find(entry => entry.key === "deep-interview-definitions")?.native).toBe(true);
+			expect(entries.find(entry => entry.key === "deep-interview-runtime")?.native).toBe(true);
+			expect(tasks.some(task => task.key === "root-test")).toBe(false);
 		});
 	});
 

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, packageScriptCommand, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
+import { describeTasks, packageScriptCommand, planTargetedTasks, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
 
 const packages: WorkspacePackage[] = [
 	{
@@ -190,7 +190,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		const proc = Bun.spawn(["bun", scriptPath, ...args], {
 			cwd: repoRoot,
-			env: { ...process.env, CI_DEV_CHANGED_PATHS: changedPaths, ...extraEnv },
+			// Default to push (broad) mode so these CLI cases stay deterministic
+			// regardless of the GITHUB_EVENT_NAME of the CI run executing them;
+			// PR-mode behavior is asserted via planTargetedTasks unit tests.
+			env: { ...process.env, GITHUB_EVENT_NAME: "push", CI_DEV_CHANGED_PATHS: changedPaths, ...extraEnv },
 			stdout: "pipe",
 			stderr: "pipe",
 		});
@@ -247,5 +250,88 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		const { stdout, exitCode } = await runScript(["--native-build"], "docs/readme.md");
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("no native build tasks in plan");
+	});
+});
+
+describe("planTargetedTasks PR-mode targeting", () => {
+	const codingAgent: WorkspacePackage = {
+		name: "@gajae-code/coding-agent",
+		dir: "packages/coding-agent",
+		manifest: { name: "@gajae-code/coding-agent", scripts: { check: "biome check .", test: "bun test" } },
+	};
+	const targetingPackages: WorkspacePackage[] = [codingAgent];
+	const testFiles = [
+		"packages/coding-agent/test/edit/foo.test.ts",
+		"packages/coding-agent/test/edit/bar.test.ts",
+		"packages/coding-agent/test/cli.test.ts",
+	];
+
+	function targeted(paths: readonly string[]) {
+		return planTargetedTasks(paths, targetingPackages, testFiles);
+	}
+
+	test("a single coding-agent test change runs only that test, not the whole package suite", () => {
+		const tasks = targeted(["packages/coding-agent/test/edit/foo.test.ts"]);
+		const keys = tasks.map(task => task.key);
+		expect(keys).toContain("test:packages/coding-agent/test/edit/foo.test.ts");
+		// No broad package-wide test, and no other coding-agent test file.
+		expect(keys).not.toContain("test:@gajae-code/coding-agent");
+		expect(keys).not.toContain("test:packages/coding-agent/test/edit/bar.test.ts");
+		const testTask = tasks.find(task => task.key === "test:packages/coding-agent/test/edit/foo.test.ts");
+		expect(testTask?.command).toEqual(["bun", "test", "packages/coding-agent/test/edit/foo.test.ts"]);
+	});
+
+	test("a source file with a directly-named test maps to exactly that test", () => {
+		const tasks = targeted(["packages/coding-agent/src/edit/foo.ts"]);
+		const keys = tasks.map(task => task.key);
+		expect(keys).toContain("test:packages/coding-agent/test/edit/foo.test.ts");
+		expect(keys).not.toContain("test:@gajae-code/coding-agent");
+		expect(keys).not.toContain("check:@gajae-code/coding-agent");
+	});
+
+	test("a source file with no mapped test runs the owning package check, not its test suite", () => {
+		const tasks = targeted(["packages/coding-agent/src/edit/unmapped.ts"]);
+		const keys = tasks.map(task => task.key);
+		expect(keys).toContain("check:@gajae-code/coding-agent");
+		expect(keys).toContain("cli-smoke"); // coding-agent runtime smoke
+		expect(keys.some(key => key.startsWith("test:"))).toBe(false);
+	});
+
+	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run only", () => {
+		const tasks = targeted([".github/workflows/dev-ci.yml"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "yaml-parse"]);
+	});
+
+	test("a CI harness script change plans ci-selftest + ci-dry-run (no yaml-parse)", () => {
+		const tasks = targeted(["scripts/ci-dev-affected.ts"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
+	});
+
+	test("docs/changelog-only changes plan nothing expensive", () => {
+		expect(targeted(["docs/guide.md", "CHANGELOG.md", "packages/coding-agent/README.md"])).toEqual([]);
+	});
+
+	test("native-consuming test files pull in a single native build task", () => {
+		const tasks = targeted(["packages/coding-agent/test/cli.test.ts"]);
+		const keys = tasks.map(task => task.key);
+		expect(keys).toContain("test:packages/coding-agent/test/cli.test.ts");
+		// ensureNativeBuild adds exactly one native build task (built once, shared).
+		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
+	});
+});
+
+describe("push-mode broad planning still runs the fuller suite", () => {
+	const codingAgent: WorkspacePackage = {
+		name: "@gajae-code/coding-agent",
+		dir: "packages/coding-agent",
+		manifest: { name: "@gajae-code/coding-agent", scripts: { check: "biome check .", test: "bun test" } },
+	};
+
+	test("push mode plans the package-wide test for a coding-agent change", () => {
+		const tasks = planTasks(["packages/coding-agent/src/edit/foo.ts"], [codingAgent]);
+		const keys = tasks.map(task => task.key);
+		// Broad planner keeps the package-wide test (the post-merge fuller suite).
+		expect(keys).toContain("test:@gajae-code/coding-agent");
+		expect(keys).toContain("check:@gajae-code/coding-agent");
 	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -172,7 +172,14 @@ function isNativeBuildKey(key: string): boolean {
 // planTasks) every such task only appears in a plan that also includes a native
 // build task, so the shard can always download the artifact built once upstream.
 function taskNeedsNative(key: string): boolean {
-	return key === "root-test" || key === "cli-smoke" || key === "wrapper-version" || key.startsWith("test:");
+	return (
+		key === "root-test" ||
+		key === "cli-smoke" ||
+		key === "wrapper-version" ||
+		key === "deep-interview-definitions" ||
+		key === "deep-interview-runtime" ||
+		key.startsWith("test:")
+	);
 }
 
 // Tasks that need the Rust toolchain (and nextest) provisioned on their shard.
@@ -412,6 +419,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	const ciOnly = paths.length > 0 && paths.every(changedPath => changedPath.startsWith(".github/"));
 
 	if (deepInterviewOnly) {
+		addNativeBuild(tasks);
 		add(tasks, "deep-interview-definitions", "Deep interview default definition tests", ["bun", "test", "packages/coding-agent/test/default-gjc-definitions.test.ts"]);
 		add(tasks, "deep-interview-runtime", "Deep interview runtime tests", ["bun", "test", "packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts"]);
 		return Array.from(tasks.values());

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -72,8 +72,7 @@ async function main(): Promise<void> {
 		return;
 	}
 	const changedPaths = await getChangedPaths();
-	const workspaces = await getWorkspacePackages();
-	const tasks = planTasks(changedPaths, workspaces);
+	const tasks = await resolvePlannedTasks(changedPaths);
 
 	printPlan(changedPaths, tasks);
 
@@ -95,6 +94,48 @@ if (import.meta.main) {
 	await main();
 }
 
+// CI runs in one of two planning modes:
+//   - "pr": pull_request runs get a fast, narrowly targeted plan (run only the
+//     tests/checks directly relevant to the changed paths).
+//   - "push": push-to-dev (and any non-PR event) gets the broader/full affected
+//     suite so the complete validation still runs once a change lands on dev.
+// The mode is derived from GITHUB_EVENT_NAME, which GitHub sets on every job of
+// a run, so the planner and every shard resolve the same mode deterministically.
+export type PlanMode = "pr" | "push";
+
+export function resolvePlanMode(): PlanMode {
+	return Bun.env.GITHUB_EVENT_NAME?.trim() === "pull_request" ? "pr" : "push";
+}
+
+// Resolve the plan for the current changed paths and CI mode. PR mode builds the
+// targeted plan from a filesystem index of test files (for source→test mapping);
+// push mode reuses the broad affected planner unchanged.
+async function resolvePlannedTasks(paths: readonly string[]): Promise<Task[]> {
+	const packages = await getWorkspacePackages();
+	if (resolvePlanMode() === "pr") {
+		const testFiles = await gatherTestFiles();
+		return planTargetedTasks(paths, packages, testFiles);
+	}
+	return planTasks(paths, packages);
+}
+
+// Repo-relative list of TypeScript test files, used by PR-mode targeting to map
+// a changed source file to its directly-named test. node_modules is excluded so
+// the index is identical whether or not dependencies are installed (the planner
+// job skips install; shards install before running) — keeping plans stable.
+async function gatherTestFiles(): Promise<string[]> {
+	const patterns = ["packages/**/*.test.ts", "packages/**/*.test.tsx", "scripts/**/*.test.ts"];
+	const found = new Set<string>();
+	for (const pattern of patterns) {
+		for await (const entry of new Bun.Glob(pattern).scan({ cwd: repoRoot })) {
+			const normalized = entry.split(path.sep).join("/");
+			if (!normalized.includes("node_modules/")) {
+				found.add(normalized);
+			}
+		}
+	}
+	return Array.from(found).sort();
+}
 // `--emit-flags` resolves changed paths exactly as a normal run does, then
 // reports whether the resulting plan needs the Rust toolchain (rust-check /
 // rust-test) and/or a native build, so dev-ci can gate its Rust setup. It
@@ -161,8 +202,7 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 // instead of re-resolving the base ref on each runner.
 async function emitMatrix(): Promise<void> {
 	const paths = await getChangedPaths();
-	const packages = await getWorkspacePackages();
-	const tasks = planTasks(paths, packages);
+	const tasks = await resolvePlannedTasks(paths);
 	const entries = describeTasks(tasks);
 
 	console.log(JSON.stringify(entries));
@@ -192,8 +232,7 @@ async function emitMatrix(): Promise<void> {
 // compile happens a single time per run instead of on each runtime shard.
 async function runNativeBuild(): Promise<void> {
 	const paths = await getChangedPaths();
-	const packages = await getWorkspacePackages();
-	const tasks = planTasks(paths, packages).filter(task => isNativeBuildKey(task.key));
+	const tasks = (await resolvePlannedTasks(paths)).filter(task => isNativeBuildKey(task.key));
 	if (tasks.length === 0) {
 		console.log("ci-dev-affected: no native build tasks in plan; nothing to build.");
 		return;
@@ -214,8 +253,7 @@ async function runNativeBuild(): Promise<void> {
 // silently skipping validation.
 async function runSingleTask(key: string): Promise<void> {
 	const paths = await getChangedPaths();
-	const packages = await getWorkspacePackages();
-	const tasks = planTasks(paths, packages);
+	const tasks = await resolvePlannedTasks(paths);
 	const task = tasks.find(candidate => candidate.key === key);
 	if (!task) {
 		const known = tasks.map(candidate => candidate.key).join(", ") || "(none)";
@@ -440,6 +478,170 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	}
 
 	return Array.from(tasks.values());
+}
+
+// PR-mode targeted planner. For each changed path it emits the smallest safe set
+// of tasks instead of the broad affected suite:
+//   - docs/changelog-only -> nothing expensive
+//   - workflow / CI harness scripts -> yaml-parse + ci-selftest + ci-dry-run
+//   - a changed test file -> run exactly that test file (test:<path>)
+//   - a source file with a directly-named test -> run that test file only
+//   - a source file with no mapped test -> owning package check + relevant smoke
+//   - rust/python/web/install changes -> their scoped check+test
+// A genuine full-workspace config change still escalates to root check + test.
+// Native builds are added once (native-linux-x64) only when a planned task needs
+// the addon at runtime; the dedicated job restores it from cache when no native
+// source changed, so PRs never rebuild native per shard.
+export function planTargetedTasks(paths: readonly string[], packages: readonly WorkspacePackage[], testFiles: readonly string[]): Task[] {
+	const tasks = new Map<string, Task>();
+	const relevant = paths.filter(changedPath => !isDocOrChangelogPath(changedPath));
+	if (relevant.length === 0) {
+		return [];
+	}
+
+	const fullWorkspace = relevant.some(isFullWorkspacePath) && !isRootPackageReleaseHarnessOnly(relevant);
+	let needCiSelftest = false;
+	let needYamlParse = false;
+
+	if (fullWorkspace) {
+		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
+		addNativeBuild(tasks);
+		add(tasks, "root-test", "Root workspace TypeScript tests", ["bun", "run", "test:ts"]);
+	}
+
+	for (const changedPath of relevant) {
+		if (isFullWorkspacePath(changedPath)) continue;
+		if (isWorkflowPath(changedPath)) {
+			needYamlParse = true;
+			needCiSelftest = true;
+			continue;
+		}
+		if (isCiHarnessScriptPath(changedPath)) {
+			needCiSelftest = true;
+			continue;
+		}
+		if (isPythonPath(changedPath)) {
+			add(tasks, "python-lint", "Python lint", ["bun", "run", "lint:py"]);
+			add(tasks, "python-test", "Python tests", ["bun", "run", "test:py"]);
+			continue;
+		}
+		if (isWebPath(changedPath)) {
+			add(tasks, "robogjc-web-typecheck", "robogjc web typecheck", packageScriptCommand("typecheck"), resolvePackageCwd("python/robogjc/web"));
+			add(tasks, "robogjc-web-build", "robogjc web build", packageScriptCommand("build"), resolvePackageCwd("python/robogjc/web"));
+			continue;
+		}
+		if (isRustPath(changedPath)) {
+			add(tasks, "rust-check", "Rust check", ["bun", "run", "check:rs"]);
+			add(tasks, "rust-test", "Rust tests", ["bun", "run", "test:rs"]);
+			continue;
+		}
+		if (isInstallPath(changedPath)) {
+			add(tasks, "install-methods", "Install method smoke tests", ["bun", "run", "ci:test:install-methods"]);
+			continue;
+		}
+
+		const mappedTests = mappedTestsFor(changedPath, packages, testFiles);
+		if (mappedTests.length > 0) {
+			for (const testFile of mappedTests) {
+				addTestFileTask(tasks, testFile);
+			}
+			continue;
+		}
+
+		const owner = owningPackage(changedPath, packages);
+		if (owner) {
+			if (owner.manifest.scripts?.check) {
+				add(tasks, `check:${owner.name}`, `Check ${owner.name}`, packageScriptCommand("check"), resolvePackageCwd(owner.dir));
+			}
+			if (isCodingAgentRuntimePath(changedPath)) {
+				add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
+			}
+			if (isUnscopedWrapperPath(changedPath)) {
+				add(tasks, "wrapper-version", "Unscoped wrapper CLI version smoke", ["bun", "packages/gajae-code/bin/gjc.js", "--version"]);
+			}
+			if (isReleasePublishPath(changedPath)) {
+				add(tasks, "release-publish-contract", "Release publish contract tests", ["bun", "run", "test:release"]);
+				add(tasks, "release-publish-dry-run", "Release publish dry-run", ["bun", "scripts/ci-release-publish.ts", "--dry-run"]);
+			}
+			continue;
+		}
+
+		// Unmapped root-level code/config (no owning package, no mapped test):
+		// fall back to the root tooling typecheck rather than the full suite.
+		if (isCodeIshPath(changedPath)) {
+			add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
+		}
+	}
+
+	if (needCiSelftest) {
+		add(tasks, "ci-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts"]);
+		add(tasks, "ci-dry-run", "Affected CI selector dry-run", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
+	}
+	if (needYamlParse) {
+		add(tasks, "yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
+	}
+
+	ensureNativeBuild(tasks);
+
+	return Array.from(tasks.values());
+}
+
+// Add a task that runs exactly one test file. Keyed as `test:<repo-relative-path>`
+// so the matrix shard name stays small and directly traceable to the file.
+function addTestFileTask(tasks: Map<string, Task>, testFile: string): void {
+	add(tasks, `test:${testFile}`, `Test ${testFile}`, ["bun", "test", testFile]);
+}
+
+// Resolve the directly-named test(s) for a changed path: the changed file itself
+// if it is a test, otherwise test files whose basename is `<base>.test.ts(x)` and
+// which live within the changed file's owning package (or its directory for
+// root-level files). Returns [] when there is no direct mapping.
+function mappedTestsFor(changedPath: string, packages: readonly WorkspacePackage[], testFiles: readonly string[]): string[] {
+	if (isTestFilePath(changedPath)) {
+		return [changedPath];
+	}
+	const base = path.posix.basename(changedPath).replace(/\.(tsx?|jsx?|mts|cts)$/, "");
+	if (base === "") {
+		return [];
+	}
+	const wanted = new Set([`${base}.test.ts`, `${base}.test.tsx`]);
+	const owner = owningPackage(changedPath, packages);
+	const scopePrefix = owner ? `${owner.dir}/` : `${path.posix.dirname(changedPath)}/`;
+	return testFiles.filter(testFile => wanted.has(path.posix.basename(testFile)) && testFile.startsWith(scopePrefix));
+}
+
+function owningPackage(changedPath: string, packages: readonly WorkspacePackage[]): WorkspacePackage | undefined {
+	return packages.find(workspacePackage => changedPath === workspacePackage.dir || changedPath.startsWith(`${workspacePackage.dir}/`));
+}
+
+// Ensure a single native build task is present whenever any planned task loads
+// the native addon at runtime, preserving the invariant that native-consuming
+// shards always have an artifact to download.
+function ensureNativeBuild(tasks: Map<string, Task>): void {
+	const keys = Array.from(tasks.keys());
+	if (keys.some(taskNeedsNative) && !keys.some(isNativeBuildKey)) {
+		addNativeBuild(tasks);
+	}
+}
+
+function isDocOrChangelogPath(changedPath: string): boolean {
+	return changedPath.endsWith(".md") || changedPath.startsWith("docs/") || changedPath.startsWith(".gjc/");
+}
+
+function isTestFilePath(changedPath: string): boolean {
+	return /\.test\.tsx?$/.test(changedPath);
+}
+
+function isCiHarnessScriptPath(changedPath: string): boolean {
+	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+}
+
+function isWebPath(changedPath: string): boolean {
+	return changedPath.startsWith("python/robogjc/web/");
+}
+
+function isCodeIshPath(changedPath: string): boolean {
+	return /\.(tsx?|jsx?|mts|cts|mjs|cjs|json|jsonc|toml|ya?ml|sh)$/.test(changedPath) || changedPath === "bun.lock";
 }
 
 

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -7,6 +7,12 @@ import * as fs from "node:fs/promises";
 const repoRoot = path.join(import.meta.dir, "..");
 const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+// Keys for tasks that compile the @gajae-code/natives addon. They run once in
+// the dedicated dev-ci native-build job (not as matrix shards) and publish the
+// built `.node` files as an artifact the runtime-dependent shards download.
+// Declared here (before the top-level `await main()`) so it is initialized for
+// every CLI mode despite top-level await halting later module statements.
+const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-linux-x64"]);
 
 export interface PackageManifest {
 	name?: string;
@@ -30,12 +36,39 @@ export interface Task {
 	cwd?: string;
 }
 
+// Machine-readable descriptor for one planned task, emitted by `--matrix-json`
+// so dev-ci can fan the plan out across runners. `native`/`rust` declare the
+// per-task setup a single shard needs (prebuilt native addon / Rust toolchain);
+// `nativeBuild` marks the addon-compilation tasks that run once in the dedicated
+// native-build job rather than as shards.
+export interface TaskMatrixEntry {
+	key: string;
+	description: string;
+	command: readonly string[];
+	cwd?: string;
+	native: boolean;
+	rust: boolean;
+	nativeBuild: boolean;
+}
+
 async function main(): Promise<void> {
 	const dryRun = process.argv.includes("--dry-run");
-	const emitFlags = process.argv.includes("--emit-flags");
 
-	if (emitFlags) {
+	if (process.argv.includes("--emit-flags")) {
 		await emitAffectedFlags();
+		return;
+	}
+	if (process.argv.includes("--matrix-json")) {
+		await emitMatrix();
+		return;
+	}
+	if (process.argv.includes("--native-build")) {
+		await runNativeBuild();
+		return;
+	}
+	const taskArg = process.argv.find(arg => arg.startsWith("--task="));
+	if (taskArg) {
+		await runSingleTask(taskArg.slice("--task=".length));
 		return;
 	}
 	const changedPaths = await getChangedPaths();
@@ -86,6 +119,115 @@ async function emitAffectedFlags(): Promise<void> {
 	}
 	if (process.env.GITHUB_OUTPUT) {
 		await fs.appendFile(process.env.GITHUB_OUTPUT, `rust=${rust}\nnative=${native}\n`);
+	}
+}
+
+function isNativeBuildKey(key: string): boolean {
+	return NATIVE_BUILD_KEYS.has(key);
+}
+
+// Tasks that load the @gajae-code/natives addon at runtime and therefore need a
+// prebuilt `.node` present in `packages/natives/native/`. By construction (see
+// planTasks) every such task only appears in a plan that also includes a native
+// build task, so the shard can always download the artifact built once upstream.
+function taskNeedsNative(key: string): boolean {
+	return key === "root-test" || key === "cli-smoke" || key === "wrapper-version" || key.startsWith("test:");
+}
+
+// Tasks that need the Rust toolchain (and nextest) provisioned on their shard.
+function taskNeedsRust(key: string): boolean {
+	return key === "rust-check" || key === "rust-test";
+}
+
+// Build the machine-readable descriptor list for the current changed-path plan.
+// `cwd` is emitted repo-relative so the JSON stays portable across runners.
+export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
+	return tasks.map(task => ({
+		key: task.key,
+		description: task.description,
+		command: task.command,
+		cwd: task.cwd ? path.relative(repoRoot, task.cwd) || "." : undefined,
+		native: taskNeedsNative(task.key),
+		rust: taskNeedsRust(task.key),
+		nativeBuild: isNativeBuildKey(task.key),
+	}));
+}
+
+// `--matrix-json` prints the planned tasks as a JSON array on stdout (consumed
+// by tests and for debugging). Under GitHub Actions it also appends the dev-ci
+// planner outputs: `matrix` (the shard include list, excluding native-build
+// tasks), `has_tasks`, `has_native`, and the resolved `changed_paths` so every
+// downstream job reuses the planner's exact diff via CI_DEV_CHANGED_PATHS
+// instead of re-resolving the base ref on each runner.
+async function emitMatrix(): Promise<void> {
+	const paths = await getChangedPaths();
+	const packages = await getWorkspacePackages();
+	const tasks = planTasks(paths, packages);
+	const entries = describeTasks(tasks);
+
+	console.log(JSON.stringify(entries));
+
+	const githubOutput = process.env.GITHUB_OUTPUT;
+	if (!githubOutput) {
+		return;
+	}
+	const shards = entries
+		.filter(entry => !entry.nativeBuild)
+		.map(entry => ({ key: entry.key, description: entry.description, native: entry.native, rust: entry.rust }));
+	const hasNative = entries.some(entry => entry.nativeBuild);
+	const lines = [
+		`matrix=${JSON.stringify({ include: shards })}`,
+		`has_tasks=${shards.length > 0}`,
+		`has_native=${hasNative}`,
+		"changed_paths<<__GJC_PATHS_EOF__",
+		...paths,
+		"__GJC_PATHS_EOF__",
+		"",
+	];
+	await fs.appendFile(githubOutput, lines.join("\n"));
+}
+
+// `--native-build` runs every native build task in the current plan exactly
+// once. The dedicated dev-ci native-build job uses it so the expensive native
+// compile happens a single time per run instead of on each runtime shard.
+async function runNativeBuild(): Promise<void> {
+	const paths = await getChangedPaths();
+	const packages = await getWorkspacePackages();
+	const tasks = planTasks(paths, packages).filter(task => isNativeBuildKey(task.key));
+	if (tasks.length === 0) {
+		console.log("ci-dev-affected: no native build tasks in plan; nothing to build.");
+		return;
+	}
+	for (const task of tasks) {
+		console.log(`\n::group::${task.description}`);
+		const exitCode = await runCommand(task.command, task.cwd ?? repoRoot);
+		console.log("::endgroup::");
+		if (exitCode !== 0) {
+			process.exit(exitCode);
+		}
+	}
+}
+
+// `--task=<key>` runs exactly one planned task selected by key. Matrix shards
+// use this to execute their single assigned task. An unknown key is a hard
+// error so plan drift between the planner and a shard fails loudly instead of
+// silently skipping validation.
+async function runSingleTask(key: string): Promise<void> {
+	const paths = await getChangedPaths();
+	const packages = await getWorkspacePackages();
+	const tasks = planTasks(paths, packages);
+	const task = tasks.find(candidate => candidate.key === key);
+	if (!task) {
+		const known = tasks.map(candidate => candidate.key).join(", ") || "(none)";
+		console.error(`ci-dev-affected: task '${key}' is not in the current plan. Planned tasks: ${known}`);
+		process.exit(1);
+		return;
+	}
+	console.log(`\n::group::${task.description}`);
+	const exitCode = await runCommand(task.command, task.cwd ?? repoRoot);
+	console.log("::endgroup::");
+	if (exitCode !== 0) {
+		process.exit(exitCode);
 	}
 }
 


### PR DESCRIPTION
## What

Parallelizes **Affected path validation** by fanning the affected-path plan out
into a CI task matrix, mirroring the `gjc-state-gates` shard + aggregate pattern
from #750. Previously this was a single serial job that ran every planned task
sequentially via `bun scripts/ci-dev-affected.ts`.

### `scripts/ci-dev-affected.ts`
- `--matrix-json`: emits the planned tasks as JSON descriptors on stdout
  (`key`, `description`, `command`, `cwd`, and `native`/`rust`/`nativeBuild`
  flags). Under GitHub Actions it also appends the planner outputs: `matrix`
  (the shard include list, excluding native-build tasks), `has_tasks`,
  `has_native`, and the resolved `changed_paths` so every downstream job reuses
  the planner's exact diff via `CI_DEV_CHANGED_PATHS` instead of re-resolving
  the base ref on each runner.
- `--task=<key>`: runs exactly one planned task; an unknown key fails loudly so
  planner/shard plan drift never silently skips validation.
- `--native-build`: runs the plan's native build tasks exactly once (used by the
  dedicated native-build job).

### `.github/workflows/dev-ci.yml`
- **`affected-plan`** — computes changed-path relevance + the task matrix once
  on the broad `gajae-layofflabs-3990x-2` runner.
- **`affected-native`** — builds the `@gajae-code/natives` addon once on the
  heavy runner (the only genuinely heavy step) and uploads it as an artifact;
  runtime-dependent shards download it instead of rebuilding. Skipped when the
  plan needs no native build.
- **`affected-shards`** — one shard per planned task on the broad runner,
  provisioning the Rust toolchain only when a shard needs it (`matrix.rust`) and
  downloading the prebuilt native addon only when needed (`matrix.native`).
  `fail-fast: false`.
- **`affected`** (aggregate) — keeps the **exact** required status name
  `Affected path validation`, depends on all shards, and passes/fails on shard
  results.

## Native builds run once
`native-build` / `native-linux-x64` remain separate tasks but run only in the
dedicated `affected-native` job and publish a shared artifact, so no shard
rebuilds native. By construction every runtime task that loads the addon
(`test:*`, `root-test`, `cli-smoke`, `wrapper-version`) only appears in a plan
that also includes a native build, so the artifact is always available.

## Status names preserved
- Required aggregate status `Affected path validation` is unchanged.
- New shards report as `Affected path validation / <key>` (plus
  `… / plan` and `… / native-build`), distinct from the aggregate.
- Fork-PR skip behavior preserved: every job carries the same
  `head.repo.full_name == github.repository` guard as before.

## Validation
- `bun test scripts/ci-dev-affected.test.ts` → 14 pass (added matrix-emission
  and task-selection tests).
- `bun scripts/check-workflow-yaml.ts` → `dev-ci.yml` parses.
- Manual `--matrix-json` checks: full-workspace change emits `has_native=true`
  with native builds excluded from shards and `root-test`/`cli-smoke` flagged
  `native=true`; rust-only change emits rust shards with `native=false`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
