### PR TITLE
test(coding-agent): stabilize timing-sensitive dev suite cases

### DIFF
--- a/packages/coding-agent/test/interactive-star-reminder.test.ts
+++ b/packages/coding-agent/test/interactive-star-reminder.test.ts
@@ -26,6 +26,21 @@ function tick(ms = 30): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Poll until `predicate` is satisfied or the deadline elapses. The launch nudge
+ * is fire-and-forget (`setTimeout(0)` -> async gh check + temp-file writes), so a
+ * fixed sleep races the deferred work under full-suite load. Waiting on the
+ * observable outcome makes the assertion deterministic without a blanket skip.
+ */
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 5000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await predicate()) return;
+		if (Date.now() >= deadline) return;
+		await new Promise(resolve => setTimeout(resolve, 5));
+	}
+}
+
 afterEach(async () => {
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
@@ -52,7 +67,10 @@ describe("scheduleLaunchStarReminderAfterFirstRender", () => {
 		expect(ghCalls).toBe(0);
 		expect(confirmCalls).toBe(0);
 
-		await tick();
+		// Deferred work persists `declined` last, so once it is true the gh check
+		// and confirm prompt have both run. Poll the outcome instead of a fixed sleep.
+		await waitFor(async () => (await readStarReminderStateUnlocked(statePath)).declined === true);
+		expect(ghCalls).toBe(1);
 		expect(ghCalls).toBe(1);
 		expect(confirmCalls).toBe(1);
 		expect((await readStarReminderStateUnlocked(statePath)).declined).toBe(true);

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1141,7 +1141,10 @@ function b() {
 						testDir,
 						Settings.isolated({
 							"bash.autoBackground.enabled": true,
-							"bash.autoBackground.thresholdMs": 50,
+							// Generous threshold so a trivial `echo` always finishes inline; a tight
+							// budget (e.g. 50ms) races process-spawn overhead under full-suite load
+							// and flakily backgrounds an instant command.
+							"bash.autoBackground.thresholdMs": 30_000,
 						}),
 						{
 							getSessionId: () => "test-session",


### PR DESCRIPTION
## Summary
- Make the star-reminder schedule assertion wait for the observable pending-reminder state instead of relying on one fixed 30ms tick.
- Raise the bash auto-background threshold in the focused exec test so slow CI does not flip the tool into background mode before the inline assertion.

## Validation
- `bun test packages/coding-agent/test/interactive-star-reminder.test.ts packages/coding-agent/test/tools.test.ts` → 94 pass / 1 skip
- Repeated the same focused pair 3x locally; all passed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*