### PR TITLE
fix(computer-use): positional native ABI dispatch + COMPUTER_* error mapping

### DIFF
--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -104,15 +104,15 @@ export interface ComputerToolDetails {
 }
 
 type NativeController = {
-	screenshot?: (payload?: unknown, options?: { signal?: AbortSignal }) => Promise<NativeScreenshot> | NativeScreenshot;
-	click?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	doubleClick?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	move?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	drag?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	scroll?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	type?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	keypress?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
-	wait?: (payload: unknown, options?: { signal?: AbortSignal }) => Promise<unknown> | unknown;
+	screenshot?: () => Promise<NativeScreenshot> | NativeScreenshot;
+	click?: (expectedEpoch: number | undefined, x: number, y: number, button?: string) => void;
+	doubleClick?: (expectedEpoch: number | undefined, x: number, y: number, button?: string) => void;
+	move?: (expectedEpoch: number | undefined, x: number, y: number) => void;
+	drag?: (expectedEpoch: number | undefined, x: number, y: number, toX: number, toY: number, button?: string) => void;
+	scroll?: (expectedEpoch: number | undefined, x: number, y: number, scrollX: number, scrollY: number) => void;
+	type?: (expectedEpoch: number | undefined, text: string) => void;
+	keypress?: (expectedEpoch: number | undefined, keys: string[]) => void;
+	wait?: (expectedEpoch: number | undefined, ms: number) => void;
 };
 
 type NativeScreenshot = {
@@ -228,10 +228,10 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 		try {
 			throwIfAborted(signal);
 			const timeoutSeconds = clampTimeout("computer", params.timeout);
-			const timeoutSignal = timeoutSeconds > 0 ? AbortSignal.timeout(timeoutSeconds * 1000) : undefined;
-			const combinedSignal =
-				signal && timeoutSignal ? AbortSignal.any([signal, timeoutSignal]) : (signal ?? timeoutSignal);
-			const result = await dispatchComputerAction(controllerFactory(), params, combinedSignal);
+			const timeoutMs = timeoutSeconds > 0 ? timeoutSeconds * 1000 : undefined;
+			// Native ComputerController methods are synchronous and accept no AbortSignal,
+			// so cancellation is honored before dispatch and wait() is bounded by timeoutMs.
+			const result = await dispatchComputerAction(controllerFactory(), params, timeoutMs);
 			const screenshot = normalizeScreenshot(result);
 			if (screenshot) details.screenshot = screenshot;
 			details.status = "success";
@@ -248,91 +248,32 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 	}
 }
 
-async function dispatchComputerAction(
+function dispatchComputerAction(
 	controller: NativeController,
 	params: ComputerParams,
-	signal?: AbortSignal,
-): Promise<unknown> {
-	const options = { signal };
+	timeoutMs: number | undefined,
+): Promise<unknown> | unknown {
+	// expectedEpoch is undefined until lossless epoch transport lands (follow-up):
+	// the native gate skips the stale-display check when the epoch is absent.
 	switch (params.action) {
 		case "screenshot":
-			return controller.screenshot?.(
-				{ timeoutMs: secondsToMs(params.timeout), includeScreenshot: params.include_screenshot },
-				options,
-			);
+			return controller.screenshot?.();
 		case "click":
-			return controller.click?.(
-				{
-					x: params.x,
-					y: params.y,
-					button: params.button ?? "left",
-					timeoutMs: secondsToMs(params.timeout),
-					includeScreenshot: params.include_screenshot,
-				},
-				options,
-			);
+			return controller.click?.(undefined, params.x, params.y, params.button ?? "left");
 		case "double_click":
-			return controller.doubleClick?.(
-				{
-					x: params.x,
-					y: params.y,
-					button: params.button ?? "left",
-					timeoutMs: secondsToMs(params.timeout),
-					includeScreenshot: params.include_screenshot,
-				},
-				options,
-			);
+			return controller.doubleClick?.(undefined, params.x, params.y, params.button ?? "left");
 		case "move":
-			return controller.move?.(
-				{
-					x: params.x,
-					y: params.y,
-					button: params.button,
-					timeoutMs: secondsToMs(params.timeout),
-					includeScreenshot: params.include_screenshot,
-				},
-				options,
-			);
+			return controller.move?.(undefined, params.x, params.y);
 		case "drag":
-			return controller.drag?.(
-				{
-					x: params.x,
-					y: params.y,
-					toX: params.to_x,
-					toY: params.to_y,
-					button: params.button ?? "left",
-					timeoutMs: secondsToMs(params.timeout),
-					includeScreenshot: params.include_screenshot,
-				},
-				options,
-			);
+			return controller.drag?.(undefined, params.x, params.y, params.to_x, params.to_y, params.button ?? "left");
 		case "scroll":
-			return controller.scroll?.(
-				{
-					x: params.x,
-					y: params.y,
-					scrollX: params.scroll_x,
-					scrollY: params.scroll_y,
-					timeoutMs: secondsToMs(params.timeout),
-					includeScreenshot: params.include_screenshot,
-				},
-				options,
-			);
+			return controller.scroll?.(undefined, params.x, params.y, params.scroll_x, params.scroll_y);
 		case "type":
-			return controller.type?.(
-				{ text: params.text, timeoutMs: secondsToMs(params.timeout), includeScreenshot: params.include_screenshot },
-				options,
-			);
+			return controller.type?.(undefined, params.text);
 		case "keypress":
-			return controller.keypress?.(
-				{ keys: params.keys, timeoutMs: secondsToMs(params.timeout), includeScreenshot: params.include_screenshot },
-				options,
-			);
+			return controller.keypress?.(undefined, params.keys);
 		case "wait":
-			return controller.wait?.(
-				{ ms: params.ms, timeoutMs: secondsToMs(params.timeout), includeScreenshot: params.include_screenshot },
-				options,
-			);
+			return controller.wait?.(undefined, capWaitMs(params.ms, timeoutMs));
 	}
 }
 
@@ -350,8 +291,11 @@ function detailsFromParams(params: ComputerParams): ComputerToolDetails {
 	return details;
 }
 
-function secondsToMs(seconds: number | undefined): number | undefined {
-	return typeof seconds === "number" ? seconds * 1000 : undefined;
+const MAX_COMPUTER_WAIT_MS = 60_000;
+
+function capWaitMs(ms: number, timeoutMs: number | undefined): number {
+	const ceiling = timeoutMs && timeoutMs > 0 ? timeoutMs : MAX_COMPUTER_WAIT_MS;
+	return Math.min(Math.max(0, ms), ceiling);
 }
 
 function normalizeScreenshot(value: unknown): ComputerScreenshotDetails | undefined {
@@ -383,15 +327,19 @@ function getPngByteLength(png: NativeScreenshot["png"]): number | undefined {
 }
 
 function mapComputerError(error: unknown): { code: string; message: string } {
-	if (error instanceof Error && error.name === "AbortError") {
+	if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
 		return { code: "COMPUTER_CANCELLED", message: "Computer action was cancelled." };
 	}
 	const maybe = error as { code?: unknown; message?: unknown };
-	const rawCode = typeof maybe?.code === "string" ? maybe.code : undefined;
-	const code =
-		rawCode && (NATIVE_ERROR_CODES.has(rawCode) || rawCode.startsWith("COMPUTER_")) ? rawCode : "COMPUTER_ERROR";
 	const message =
 		typeof maybe?.message === "string" && maybe.message.length > 0 ? maybe.message : "Computer action failed.";
+	const rawCode = typeof maybe?.code === "string" ? maybe.code : undefined;
+	const isComputerCode = (value: string | undefined): value is string =>
+		value !== undefined && (NATIVE_ERROR_CODES.has(value) || value.startsWith("COMPUTER_"));
+	// Native NAPI errors carry the stable code in the message ("CODE: reason") with
+	// error.code set to the NAPI status, so fall back to the message prefix.
+	const messageCode = /^(COMPUTER_[A-Z_]+):/.exec(message)?.[1];
+	const code = isComputerCode(rawCode) ? rawCode : (messageCode ?? "COMPUTER_ERROR");
 	return { code, message };
 }
 

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -127,39 +127,47 @@ describe("computer tool dispatch", () => {
 		setComputerPlatformForTests(undefined);
 	});
 
-	it("maps snake_case model actions to native controller methods and forwards AbortSignal", async () => {
+	it("maps snake_case model actions to native controller methods positionally", async () => {
 		setComputerPlatformForTests("darwin");
-		const calls: Array<{ method: string; payload: unknown; signal?: AbortSignal }> = [];
+		const calls: Array<{ method: string; args: unknown[] }> = [];
 		setComputerControllerFactoryForTests(() => ({
-			screenshot: (payload, options) => {
-				calls.push({ method: "screenshot", payload, signal: options?.signal });
+			screenshot: () => {
+				calls.push({ method: "screenshot", args: [] });
 				return { widthPx: 20, heightPx: 10, png: new Uint8Array([1, 2, 3]), captureId: "cap-1" };
 			},
-			doubleClick: (payload, options) => calls.push({ method: "doubleClick", payload, signal: options?.signal }),
-			drag: (payload, options) => calls.push({ method: "drag", payload, signal: options?.signal }),
-			scroll: (payload, options) => calls.push({ method: "scroll", payload, signal: options?.signal }),
+			doubleClick: (...args) => {
+				calls.push({ method: "doubleClick", args });
+			},
+			drag: (...args) => {
+				calls.push({ method: "drag", args });
+			},
+			scroll: (...args) => {
+				calls.push({ method: "scroll", args });
+			},
 		}));
 		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
-		const controller = new AbortController();
-		const shot = await tool.execute("shot", { action: "screenshot", timeout: 2 }, controller.signal);
-		await tool.execute("dbl", { action: "double_click", x: 1, y: 2, button: "right" }, controller.signal);
-		await tool.execute("drag", { action: "drag", x: 1, y: 2, to_x: 3, to_y: 4 }, controller.signal);
-		await tool.execute("scroll", { action: "scroll", x: 1, y: 2, scroll_x: 5, scroll_y: -6 }, controller.signal);
+		const shot = await tool.execute("shot", { action: "screenshot", timeout: 2 });
+		await tool.execute("dbl", { action: "double_click", x: 1, y: 2, button: "right" });
+		await tool.execute("drag", { action: "drag", x: 1, y: 2, to_x: 3, to_y: 4 });
+		await tool.execute("scroll", { action: "scroll", x: 1, y: 2, scroll_x: 5, scroll_y: -6 });
 
 		expect(shot.details?.screenshot).toMatchObject({ widthPx: 20, heightPx: 10, pngBytes: 3, captureId: "cap-1" });
 		expect(calls.map(call => call.method)).toEqual(["screenshot", "doubleClick", "drag", "scroll"]);
-		expect(calls[1].payload).toMatchObject({ x: 1, y: 2, button: "right" });
-		expect(calls[2].payload).toMatchObject({ x: 1, y: 2, toX: 3, toY: 4, button: "left" });
-		expect(calls[3].payload).toMatchObject({ x: 1, y: 2, scrollX: 5, scrollY: -6 });
-		expect(calls.every(call => call.signal instanceof AbortSignal)).toBe(true);
+		// Positional native ABI: (expectedEpoch, x, y, ...rest)
+		expect(calls[1].args).toEqual([undefined, 1, 2, "right"]);
+		expect(calls[2].args).toEqual([undefined, 1, 2, 3, 4, "left"]);
+		expect(calls[3].args).toEqual([undefined, 1, 2, 5, -6]);
 	});
 
-	it("maps native COMPUTER_* errors into bounded tool errors", async () => {
+	it("maps native COMPUTER_* errors carried in the message into bounded tool errors", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerControllerFactoryForTests(() => ({
 			click: () => {
-				const error = new Error("supervisor is not live") as Error & { code: string };
-				error.code = "COMPUTER_SUPERVISOR_NOT_LIVE";
+				// Mirror the real NAPI error: stable code in the message, generic .code.
+				const error = new Error("COMPUTER_SUPERVISOR_NOT_LIVE: supervisor is not live") as Error & {
+					code: string;
+				};
+				error.code = "GenericFailure";
 				throw error;
 			},
 		}));


### PR DESCRIPTION
Follow-up to #695 (merged). Fixes the two TS-side blockers found in conservative red-team review of the merged computer-use tool.

## Problem
The TS `computer` tool is the only model-facing surface, and macOS is its only callable platform — but it was **broken on macOS**:

1. **Positional ABI mismatch.** `dispatchComputerAction` called the napi `ComputerController` with an *object* payload `{x,y,button,…}, {signal}`, but the generated binding (`native/index.d.ts`) and `controller.rs` are **positional + synchronous**: `click(expectedEpoch, x, y, button)`. So `expectedEpoch` received the whole object and every enabled action threw at the napi boundary. CI missed it because the unit-test fakes mirrored the wrong object shape.
2. **Error codes lost.** Native errors carry the stable code in `error.message` (`"COMPUTER_X: reason"`) with `error.code = "GenericFailure"`, so `mapComputerError` collapsed everything to `COMPUTER_ERROR`, hiding suspended/permission/supervisor/stale reasons.

## Fix
- Rewrite `dispatchComputerAction` and the `NativeController` type to the real positional ABI; drop the unsupported `options/signal` arg (native methods are synchronous and take no `AbortSignal`).
- Cap `wait()` ms by the effective tool timeout.
- Parse the leading `COMPUTER_*` token from `error.message` when `error.code` isn't a computer code; also treat `TimeoutError` as cancellation.
- Tests now assert the **positional** ABI and the **message-carried** code (so CI catches regressions).

Verified: `biome` format+lint, `tsc -p packages/coding-agent`, and `bun test computer.test.ts` (10 pass).

## Deferred to a coordinated Rust+TS follow-up (not in this PR)
These also came out of the review and need native work + live re-verification:
- **Listener heartbeat** — the hotkey listener refreshes the supervisor heartbeat once at startup; with `HEARTBEAT_FRESH_MS=2000` the production napi path fails closed after ~2s. The tool won't function end-to-end until the listener owns a periodic heartbeat.
- **`CGEventCreateScrollWheelEvent`** declared fixed-arity but is C-variadic → unsound scroll on arm64.
- **Lossless display-epoch transport** (u64 shipped as f64) + threading the screenshot epoch so coordinate actions enforce `COMPUTER_DISPLAY_STALE`.

So this PR makes the tool *dispatch correctly and surface real errors*, but the tool is not fully functional end-to-end until the heartbeat fix lands.