### PR TITLE
fix(pi-natives): CGEventCreateScrollWheelEvent C-variadic ABI (arm64 soundness)

### DIFF
--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -340,7 +340,9 @@ mod mac {
 			units: u32,
 			wheel_count: u32,
 			wheel1: i32,
-			wheel2: i32,
+			// `CGEventCreateScrollWheelEvent` is C-variadic (wheel1, ...); wheel2/wheel3
+			// are passed as varargs. Declaring fixed-arity is ABI-unsound on arm64.
+			...
 		) -> CgEventRef;
 		fn CGEventCreateKeyboardEvent(
 			source: CgEventSourceRef,


### PR DESCRIPTION
Follow-up to #695 (merged); part of the computer-use red-team remediation (paired with #759).

`CGEventCreateScrollWheelEvent` is **C-variadic** — `(source, units, wheelCount, wheel1, ...)` — but was declared as a fixed-arity Rust extern (`wheel1: i32, wheel2: i32`). On Apple silicon the variadic calling convention is not ABI-interchangeable with fixed parameters, so the scroll injection call was **unsound** (it happened not to crash, but is UB).

Fix: declare the extern variadic (`wheel1: i32, ...`) so the second wheel delta is passed via the correct C vararg path. Call site unchanged.

Verified: `cargo test -p pi-natives computer::input` (9 pass), clippy clean, nightly rustfmt applied. The RecordingSink unit tests don't exercise the real CGEvent FFI, so a **live macOS scroll re-verification** is recommended once the listener-heartbeat fix lands (the tool currently fails closed after ~2s without it).