### PR TITLE
test: relax memory watermark timeout

### DIFF
--- a/packages/coding-agent/test/memories-storage.test.ts
+++ b/packages/coding-agent/test/memories-storage.test.ts
@@ -141,7 +141,7 @@ describe("memories/storage", () => {
 		expect(row.retry_remaining).toBe(3);
 		expect(row.retry_at).toBeNull();
 		closeMemoryDb(db);
-	});
+	}, 10_000);
 
 	test("clearMemoryData removes thread/output/job state", () => {
 		const db = openMemoryDb(dbPath);


### PR DESCRIPTION
## Summary
- Give the memory watermark force-dirty regression test a focused 10s timeout
- Leaves storage behavior unchanged; CI showed this single synchronous sqlite test exceeding Bun's default 5s during cold suite startup while the rest of the file continued to pass

## Verification
- bun --cwd=packages/coding-agent test test/memories-storage.test.ts -t "enqueueGlobalWatermark force-dirties when watermark does not advance"
- bun --cwd=packages/coding-agent test test/memories-storage.test.ts
- bun --cwd=packages/coding-agent run check:types