### PR TITLE
deep-interview: language-agnostic silent self-proofread of output (best-effort) + contract test

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -40,6 +40,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
 - Default to English when no language preference is explicit or obvious. Preserve the user/session language for every user-facing announcement, topology confirmation, option label, and interview question when state includes `language.instruction`; do not add language-specific special cases
+- Before emitting any user-facing natural-language prose governed by `language.instruction`, perform one silent, best-effort self-proofread in the preserved session language for obvious spelling, spacing, grammar, inflection/particle, and word-choice errors, using the same language-agnostic pass for whatever language is active rather than special-casing any single language. Apply it only to newly generated prose and never announce the proofreading, show before/after text, apologize for it, or re-emit a corrected copy. Do not alter code blocks or identifiers, file paths, CLI commands, JSON/configuration keys, `ask` metadata keys, table/round structure, fixed labels, numeric scores, component ids, status tokens, user quotes or source text, Phase 0 threshold markers such as `Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`, or fixed paths such as `.gjc/specs/deep-interview-{slug}.md`; still apply the self-proofread to generated natural-language clauses or cells inside those structures, including Why now rationale, gap text, next-target phrasing, and coverage notes
 - Target the WEAKEST clarity dimension with each question
 - Before Round 1 ambiguity scoring, run a one-time Round 0 topology enumeration gate that confirms the top-level component list and locks it into state
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
@@ -175,6 +176,8 @@ The first line of this announcement MUST be exactly the Phase 0 threshold marker
 > **Project type:** {greenfield|brownfield}
 > **Current ambiguity:** 100% (we haven't started yet)
 
+Before emitting the prose lines in this announcement, apply the `<Execution_Policy>` self-proofread once; keep the required threshold marker and the quoted `{initial_idea}` unchanged.
+
 ## Round 0: Topology Enumeration Gate
 
 Run this gate exactly once after Phase 1 initialization and before any Phase 2 ambiguity scoring. The goal is to lock the **shape** of the user's scope before depth-first Socratic questioning can overfit to the most-described component.
@@ -292,6 +295,8 @@ Round {n} | Component: {target_component_name} | Targeting: {weakest_dimension} 
 ```
 
 Options should include contextually relevant choices plus free-text, translated/localized according to `language.instruction` when present.
+
+After applying `language.instruction` to the visible question, options, and generated rationale, apply the self-proofread once to new prose only; preserve only the Round/Component/Targeting/Ambiguity line structure, fixed labels, numeric ambiguity value, component/target identifiers, and `deepInterview.*` metadata keys. Do not exempt generated natural-language rationale such as Why now.
 
 When calling `ask`, SHOULD include optional structured metadata so the runtime can record the round without manual state writes: `deepInterview.round_id?`, `deepInterview.round`, `deepInterview.component`, `deepInterview.dimension`, and `deepInterview.ambiguity`. Keep this metadata aligned with the visible Round/Component/Targeting/Ambiguity line; if metadata cannot be supplied, the legacy formatted question text remains the fallback.
 
@@ -436,6 +441,8 @@ Round {n} complete.
 
 Apply `language.instruction` when present before showing this progress report so status text, gaps, and next-target phrasing stay in the preserved session language.
 
+Then apply the self-proofread once to narrative status text, generated prose cells, gaps, and next-target phrasing; preserve only table structure, fixed status labels, scores, weights, component ids, and trigger tokens.
+
 ### Step 2e: Update State
 
 Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round `gjc state write` is required for the answer shell; only scoring enrichment/state maintenance remains. When metadata is absent, use the legacy `gjc state write` path to persist the new round and never patch `.gjc/state` directly unless an explicit force override is active.
@@ -486,6 +493,7 @@ When ambiguity ≤ threshold (or hard cap / early exit):
 
 1. **Generate the specification** using opus model with the prompt-safe transcript. If the full interview transcript or initial context is too large, include the summary plus all concrete decisions, acceptance criteria, unresolved gaps, and ontology snapshots; never overflow the prompt with raw oversized context.
    - Apply `language.instruction` when present so user-facing prose in the spec preserves the session language; keep code identifiers, file paths, commands, JSON/settings keys, and quoted source text unchanged.
+   - Apply the self-proofread once to newly generated spec prose before persistence, including generated natural-language table cells such as coverage notes, while preserving transcript answers, quoted/source text, code identifiers, file paths, commands, JSON/settings keys, table structure/fixed labels, and `.gjc/specs/deep-interview-{slug}.md` unchanged.
 2. **Write the final spec through the workflow CLI**: persist the artifact at `.gjc/specs/deep-interview-{slug}.md`
    - Always use this exact final spec path. Do not write temporary working files to the repo root or other ad hoc paths; repos may allowlist `.gjc/` for planning artifacts while protecting product branches.
    - Use the native deep-interview write command with `--write --stage final --slug {slug} --spec <markdown-or-path> [--json]` for artifact and state persistence; direct `.gjc/` file edits are forbidden unless an explicit force override is active.
@@ -785,6 +793,7 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 <Final_Checklist>
 - [ ] Phase 0 ran before anything: threshold resolved and first line emitted as `Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`; state and spec metadata record both `threshold` and `threshold_source`
 - [ ] `language.instruction` preserved across announcements, questions, options, progress reports, and spec prose when present
+- [ ] User-facing natural-language prose, including generated prose clauses/cells inside round lines or tables, was silently self-proofread once according to `language.instruction`, while code/paths/commands/keys/table or round structure/fixed labels/status tokens/quotes/threshold markers/fixed paths remained unchanged
 - [ ] Oversized initial context/history summarized before scoring, question generation, spec generation, or handoff
 - [ ] Round 0 topology gate completed before scoring; `topology.confirmed_at` persisted
 - [ ] Ambiguity scored and displayed every round, naming the weakest component/dimension target (rotating across active components when N > 1)

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -45,3 +45,34 @@ describe("deep-interview skill conflict-aware scoring contract", () => {
 		expect(skill).toMatch(/Bidirectional scoring is the pacing mechanism/i);
 	});
 });
+
+describe("deep-interview self-proofread output rule", () => {
+	it("adds a silent, best-effort self-proofread rule in Execution_Policy", () => {
+		expect(skill).toContain("one silent, best-effort self-proofread in the preserved session language");
+		expect(skill).toContain("natural-language prose governed by");
+		expect(skill).toContain("Apply it only to newly generated prose and never announce the proofreading");
+	});
+
+	it("covers generic error classes without language-specific special cases", () => {
+		expect(skill).toContain("obvious spelling, spacing, grammar, inflection/particle, and word-choice errors");
+		expect(skill).toContain("rather than special-casing any single language");
+	});
+
+	it("separates fixed-literal preservation from generated-prose proofreading", () => {
+		expect(skill).toContain(
+			"still apply the self-proofread to generated natural-language clauses or cells inside those structures",
+		);
+		expect(skill).toMatch(/Do not alter code blocks or identifiers/);
+	});
+
+	it("references the self-proofread at the four emission points", () => {
+		expect(skill).toContain("Before emitting the prose lines in this announcement, apply the");
+		expect(skill).toContain("apply the self-proofread once to new prose only");
+		expect(skill).toContain("apply the self-proofread once to narrative status text, generated prose cells, gaps, and next-target phrasing");
+		expect(skill).toContain("Apply the self-proofread once to newly generated spec prose before persistence");
+	});
+
+	it("adds a Final_Checklist item for the silent self-proofread", () => {
+		expect(skill).toContain("was silently self-proofread once according to");
+	});
+});


### PR DESCRIPTION
Re-submission of #745/#746 (both closed) against current `dev`, with the review blockers addressed.

## What the previous review flagged, and how this fixes it

1. **Conflict with current `dev` (`mergeable=false`, `DIRTY`).** `dev` changed the `<Execution_Policy>` language bullet to *"Default to English… do not add language-specific special cases."* This branch is now **rebased onto current `dev`** and the self-proofread rule is **reconciled to be language-agnostic**: it proofreads the preserved session language for obvious spelling, spacing, grammar, inflection/particle, and word-choice errors using the same pass for whatever language is active, **rather than special-casing any single language**. No Korean-specific checklist. Local merge probe against `origin/dev` is clean.
2. **No runnable validation path.** Added a contract test that reads the bundled `SKILL.md` and asserts the rule + invariants, making this prompt change CI-verifiable.

## What changed

**1. `packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md` (+9)**
- `<Execution_Policy>` rule, immediately after the new "Default to English… no language-specific special cases" bullet: one silent, best-effort, language-agnostic self-proofread of the preserved session language, applied only to newly generated prose.
- Four short, non-duplicative references (Phase 1 announcement, Step 2b question/options, Step 2d progress report, Phase 4 spec prose) and one `<Final_Checklist>` item.

**2. `packages/coding-agent/test/deep-interview-skill-contract.test.ts` (+31)**
- New `deep-interview self-proofread output rule` suite: rule presence, **generic error classes with no language-specific special cases**, structure-vs-prose split, four emission references, `<Final_Checklist>` item.

## Runnable validation path

```
bun test test/deep-interview-skill-contract.test.ts
# 10 pass, 0 fail, 32 expect() calls
```

(The fork-gated workflows still need a trusted CI run on your side; this provides a concrete, focused gate that runs without native artifacts.)

## Safety guard: structure vs. generated prose

Preserves structure/fixed literals — code/identifiers, file paths, CLI commands, JSON/config keys, `ask` metadata keys, table/round structure, fixed labels, numeric scores, component ids, status tokens, user quotes/source text, Phase 0 threshold markers (`Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThresholdSource>)`), fixed paths like `.gjc/specs/deep-interview-{slug}.md` — while still proofreading generated natural-language clauses/cells inside those structures (Why now rationale, gap text, next-target phrasing, coverage notes).

## Non-goals

- No deterministic / zero-error guarantee (best-effort only).
- No external spell-check API/library or separate LLM call; no runtime/dependency change.
- Silent + prospective-only: never announces the proofread, shows before/after, apologizes, or re-emits; never retroactively rewrites existing specs/transcripts/quotes/state.
- No language-specific special cases (aligned with the current `dev` language policy).

## Diff scope

2 files, +40 / -0. No runtime/config/dependency changes; existing prose, code, paths, and the Phase 0 marker are byte-for-byte unchanged.
