### PR TITLE
fix(tui): add spacing between status line and composer

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -178,7 +178,6 @@ const EDITOR_MAX_HEIGHT_MIN = 6;
 const EDITOR_MAX_HEIGHT_MAX = 18;
 const EDITOR_RESERVED_ROWS = 12;
 const EDITOR_FALLBACK_ROWS = 24;
-const COMPOSER_STATUS_SPACING_ROWS = 1;
 
 const HUD_NOTE_SUP_DIGITS: Record<string, string> = {
 	"0": "\u2070",
@@ -525,7 +524,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.todoContainer);
 		this.ui.addChild(this.btwContainer);
 		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer chrome is rendered by the editor.
-		this.ui.addChild(new Spacer(COMPOSER_STATUS_SPACING_ROWS));
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -178,6 +178,7 @@ const EDITOR_MAX_HEIGHT_MIN = 6;
 const EDITOR_MAX_HEIGHT_MAX = 18;
 const EDITOR_RESERVED_ROWS = 12;
 const EDITOR_FALLBACK_ROWS = 24;
+const COMPOSER_STATUS_SPACING_ROWS = 1;
 
 const HUD_NOTE_SUP_DIGITS: Record<string, string> = {
 	"0": "\u2070",
@@ -524,6 +525,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.todoContainer);
 		this.ui.addChild(this.btwContainer);
 		this.ui.addChild(this.statusLine); // Main status rail + hook statuses; composer chrome is rendered by the editor.
+		this.ui.addChild(new Spacer(COMPOSER_STATUS_SPACING_ROWS));
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -72,13 +72,19 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
-	it("renders one blank row immediately above the composer", () => {
-		const rendered = mode.ui.render(48).map(line => stripVTControlCharacters(line));
-		const composerIndex = rendered.findIndex(line => line.startsWith("┌") && line.endsWith("┐"));
+	it("renders one blank row immediately above the composer", async () => {
+		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
 
-		expect(composerIndex).toBeGreaterThan(0);
-		expect(rendered[composerIndex - 1]).toBe("");
-		expect(rendered.slice(0, composerIndex - 1).some(line => line.trim().length > 0)).toBe(true);
+		await mode.init();
+
+		const editorIndex = mode.ui.children.indexOf(mode.editorContainer);
+		const spacer = mode.ui.children[editorIndex - 2];
+		const hookContainer = mode.ui.children[editorIndex - 1];
+
+		expect(editorIndex).toBeGreaterThan(1);
+		expect(hookContainer).toBe(mode.hookWidgetContainerAbove);
+		expect(spacer?.render(48)).toEqual([""]);
+		expect(mode.hookWidgetContainerAbove.render(48)).toEqual([""]);
 	});
 
 	it("keeps closed square composer chrome for one-line, multiline, and narrow prompts", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -72,6 +72,16 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
+	it("renders one blank row between status line and composer", () => {
+		const rendered = mode.ui.render(48).map(line => stripVTControlCharacters(line));
+		const statusIndex = rendered.findIndex(line => line.includes("claude-sonnet-4-5"));
+		const composerIndex = rendered.findIndex(line => line.startsWith("┌") && line.endsWith("┐"));
+
+		expect(statusIndex).toBeGreaterThanOrEqual(0);
+		expect(composerIndex).toBeGreaterThan(statusIndex);
+		expect(rendered.slice(statusIndex + 1, composerIndex)).toEqual([""]);
+	});
+
 	it("keeps closed square composer chrome for one-line, multiline, and narrow prompts", () => {
 		for (const [width, text] of [
 			[48, "Ask gjc to improve the composer"],

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -72,14 +72,13 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
-	it("renders one blank row between status line and composer", () => {
+	it("renders one blank row immediately above the composer", () => {
 		const rendered = mode.ui.render(48).map(line => stripVTControlCharacters(line));
-		const statusIndex = rendered.findIndex(line => line.includes("claude-sonnet-4-5"));
 		const composerIndex = rendered.findIndex(line => line.startsWith("┌") && line.endsWith("┐"));
 
-		expect(statusIndex).toBeGreaterThanOrEqual(0);
-		expect(composerIndex).toBeGreaterThan(statusIndex);
-		expect(rendered.slice(statusIndex + 1, composerIndex)).toEqual([""]);
+		expect(composerIndex).toBeGreaterThan(0);
+		expect(rendered[composerIndex - 1]).toBe("");
+		expect(rendered.slice(0, composerIndex - 1).some(line => line.trim().length > 0)).toBe(true);
 	});
 
 	it("keeps closed square composer chrome for one-line, multiline, and narrow prompts", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -72,19 +72,21 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
-	it("renders one blank row immediately above the composer", async () => {
+	it("renders one visible blank row between status line and composer without hook widgets", async () => {
 		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
 
 		await mode.init();
 
-		const editorIndex = mode.ui.children.indexOf(mode.editorContainer);
-		const spacer = mode.ui.children[editorIndex - 2];
-		const hookContainer = mode.ui.children[editorIndex - 1];
+		const rendered = mode.ui.render(48).map(line => stripVTControlCharacters(line));
+		const composerIndex = rendered.findIndex(line => line.startsWith("┌") && line.endsWith("┐"));
+		let lastStatusIndex = -1;
+		for (let index = 0; index < composerIndex; index += 1) {
+			if (rendered[index] !== "") lastStatusIndex = index;
+		}
 
-		expect(editorIndex).toBeGreaterThan(1);
-		expect(hookContainer).toBe(mode.hookWidgetContainerAbove);
-		expect(spacer?.render(48)).toEqual([""]);
-		expect(mode.hookWidgetContainerAbove.render(48)).toEqual([""]);
+		expect(composerIndex).toBeGreaterThan(0);
+		expect(lastStatusIndex).toBeGreaterThanOrEqual(0);
+		expect(rendered.slice(lastStatusIndex + 1, composerIndex)).toEqual([""]);
 	});
 
 	it("keeps closed square composer chrome for one-line, multiline, and narrow prompts", () => {


### PR DESCRIPTION
## Summary
- Add one spacer row between the status line and composer/input box.
- Cover the layout with a focused interactive-mode editor component test.

## Verification
- Local targeted test attempted: `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts` and package-scoped variant; local harness failed before assertions due missing workspace dependency/linkage (`@gajae-code/agent-core` / test harness dependency setup). CI should validate in the PR environment.

Closes #758.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*