### PR TITLE
fix: reconcile RALPLAN HUD phase with canonical run state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RALPLAN HUD/status reconciliation so stale derived active-state snapshots cannot show `ralplan:revision` after the canonical run state reaches `final`, and `gjc ralplan doctor` reports active/HUD phase drift.
+
 ## [0.5.3] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "./ledger-event-renderer";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { migrateWorkflowState } from "./state-migrations";
+import { runNativeStateCommand } from "./state-runtime";
 import {
 	appendJsonlIdempotent,
 	readExistingStateForMutation,
@@ -23,7 +24,7 @@ import {
 /**
  * Native implementation of `gjc ralplan`.
  *
- * Two invocation shapes are handled natively:
+ * Three invocation shapes are handled natively:
  *
  * 1. **Consensus handoff**: `gjc ralplan [--interactive] [--deliberate] [--architect <kind>]
  *    [--critic <kind>] [--session-id <id>] "<task>"` validates the documented flag surface,
@@ -37,6 +38,10 @@ import {
  *    / Critic / revision / ADR / final markdown under `.gjc/plans/ralplan/<run-id>/`, maintains
  *    an `index.jsonl` audit log, copies `final` stages to `pending-approval.md`, and advances
  *    the HUD chip to reflect the latest persisted stage.
+ *
+ * 3. **Doctor**: `gjc ralplan doctor [--json] [--session-id <id>]` delegates to
+ *    `gjc state doctor --skill ralplan` so RALPLAN-specific active/HUD cache drift is
+ *    reported without starting a new planning run.
  */
 
 export interface RalplanCommandResult {
@@ -102,6 +107,53 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 
 export function isRalplanArtifactWriteInvocation(args: readonly string[]): boolean {
 	return hasFlag(args, "--write");
+}
+function firstPositionalArg(args: readonly string[]): string | undefined {
+	let skipNext = false;
+	for (const arg of args) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (VALUE_FLAGS.has(arg)) {
+			skipNext = true;
+			continue;
+		}
+		if (!arg.startsWith("-")) return arg;
+	}
+	return undefined;
+}
+
+function isRalplanDoctorInvocation(args: readonly string[]): boolean {
+	return firstPositionalArg(args) === "doctor";
+}
+
+function ralplanDoctorStateArgs(args: readonly string[]): string[] {
+	const stateArgs = ["doctor", "--skill", "ralplan"];
+	let skipNext = false;
+	for (const arg of args) {
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		if (arg === "doctor") continue;
+		if (arg === "--json") {
+			stateArgs.push("--json");
+			continue;
+		}
+		if (arg === "--session-id") {
+			const sessionId = flagValue(args, "--session-id")?.trim();
+			if (sessionId) {
+				assertSafePathComponent(sessionId, "session-id");
+				stateArgs.push("--session-id", sessionId);
+			}
+			skipNext = true;
+			continue;
+		}
+		if (arg.startsWith("-")) throw new RalplanCommandError(2, `unknown flag for gjc ralplan doctor: ${arg}`);
+		throw new RalplanCommandError(2, `unexpected argument for gjc ralplan doctor: ${arg}`);
+	}
+	return stateArgs;
 }
 
 function assertSafePathComponent(value: string, label: string): void {
@@ -215,13 +267,31 @@ function advanceCurrentPhase(existingPhase: unknown, stage: RalplanStage): strin
 	if (current && PHASE_LOCK.has(current)) return current;
 	return stage;
 }
+interface RalplanRunStateSnapshot {
+	active: boolean;
+	currentPhase: string;
+	runId: string;
+}
+
+function ralplanRunStateSnapshot(
+	state: Record<string, unknown>,
+	fallbackRunId: string,
+	fallbackPhase: string,
+): RalplanRunStateSnapshot {
+	const currentPhase =
+		typeof state.current_phase === "string" && state.current_phase.trim()
+			? state.current_phase.trim()
+			: fallbackPhase;
+	const runId = typeof state.run_id === "string" && state.run_id.trim() ? state.run_id.trim() : fallbackRunId;
+	return { active: state.active !== false, currentPhase, runId };
+}
 
 async function persistActiveRunId(
 	cwd: string,
 	sessionId: string | undefined,
 	runId: string,
 	stage: RalplanStage,
-): Promise<void> {
+): Promise<RalplanRunStateSnapshot> {
 	const statePath = ralplanStatePath(cwd, sessionId);
 	const existingRead = await readExistingStateForMutation(statePath);
 	if (existingRead.kind === "corrupt") {
@@ -243,7 +313,7 @@ async function persistActiveRunId(
 		existing.current_phase === nextPhase &&
 		(existing.active === true || PHASE_LOCK.has(nextPhase))
 	) {
-		return;
+		return ralplanRunStateSnapshot(existing, runId, nextPhase);
 	}
 	existing.run_id = runId;
 	if (typeof existing.skill !== "string") existing.skill = "ralplan";
@@ -258,6 +328,7 @@ async function persistActiveRunId(
 		receipt: { cwd, skill: "ralplan", owner: "gjc-runtime", command: "gjc ralplan persist-run-id", sessionId },
 		audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan" },
 	});
+	return ralplanRunStateSnapshot(existing, runId, nextPhase);
 }
 
 /* --------------------------- planner run-state --------------------------- */
@@ -584,12 +655,13 @@ async function syncRalplanHud(options: {
 	iteration?: number;
 	runId?: string;
 	latestSummary?: string;
+	active?: boolean;
 }): Promise<void> {
 	try {
 		await syncSkillActiveState({
 			cwd: options.cwd,
 			skill: "ralplan",
-			active: !options.pendingApproval || options.stage === "final",
+			active: options.active ?? (!options.pendingApproval || options.stage === "final"),
 			phase: options.stage,
 			sessionId: options.sessionId,
 			source: "gjc-ralplan-native",
@@ -649,20 +721,25 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 		return buildDeduplicatedResult(resolved, existingArtifact, sha256, cwd);
 	}
 
-	// Keep run-state `current_phase` coherent with the stage being persisted.
-	await persistActiveRunId(cwd, resolved.sessionId, resolved.runId, resolved.stage);
+	// Keep run-state `current_phase` coherent with the stage being persisted. The
+	// returned phase is canonical for HUD too: locked terminal phases (notably
+	// `final`/`handoff`) must not be visually reopened by a stray older stage write.
+	const runState = await persistActiveRunId(cwd, resolved.sessionId, resolved.runId, resolved.stage);
 	const persisted = await persistArtifact(resolved, cwd, content, sha256);
 	if (plannerState) {
 		await applyPlannerStateUpdate(cwd, resolved.sessionId, plannerState);
 	}
+	const hudStage = runState.currentPhase || persisted.stage;
 	await syncRalplanHud({
 		cwd,
 		sessionId: resolved.sessionId,
-		stage: persisted.stage,
-		runId: persisted.runId,
-		pendingApproval: persisted.stage === "final",
-		iteration: persisted.stageN,
-		latestSummary: `persisted ${persisted.stage} stage ${persisted.stageN}`,
+		stage: hudStage,
+		runId: runState.runId,
+		active: runState.active,
+		pendingApproval: hudStage === "final",
+		iteration: hudStage === persisted.stage ? persisted.stageN : undefined,
+		latestSummary:
+			hudStage === persisted.stage ? `persisted ${persisted.stage} stage ${persisted.stageN}` : `${hudStage} phase`,
 	});
 	const payload: Record<string, unknown> = {
 		run_id: persisted.runId,
@@ -858,6 +935,7 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 
 export async function runNativeRalplanCommand(args: string[], cwd = process.cwd()): Promise<RalplanCommandResult> {
 	try {
+		if (isRalplanDoctorInvocation(args)) return await runNativeStateCommand(ralplanDoctorStateArgs(args), cwd);
 		if (isRalplanArtifactWriteInvocation(args)) return await handleArtifactWrite(args, cwd);
 		return await handleConsensusHandoff(args, cwd);
 	} catch (error) {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -449,6 +449,31 @@ function skillFromActiveValue(value: unknown): string | undefined {
 function activeFlag(value: unknown): boolean {
 	return isPlainObject(value) && value.active !== false;
 }
+function phaseFromActiveValue(value: unknown): string | undefined {
+	if (!isPlainObject(value)) return undefined;
+	const phase = typeof value.phase === "string" ? value.phase.trim() : "";
+	const currentPhase = typeof value.current_phase === "string" ? value.current_phase.trim() : "";
+	return phase || currentPhase || undefined;
+}
+
+function phaseFromModeState(value: unknown): string | undefined {
+	if (!isPlainObject(value)) return undefined;
+	const currentPhase = typeof value.current_phase === "string" ? value.current_phase.trim() : "";
+	const phase = typeof value.phase === "string" ? value.phase.trim() : "";
+	return currentPhase || phase || undefined;
+}
+
+async function hasModeStateIntegrityMismatch(filePath: string): Promise<boolean> {
+	try {
+		return Boolean(await detectWorkflowEnvelopeIntegrityMismatch(filePath));
+	} catch {
+		return true;
+	}
+}
+
+function phaseRepairCommand(skill: CanonicalGjcWorkflowSkill, phase: string): string {
+	return `gjc state ${skill} write --input '${JSON.stringify({ current_phase: phase })}'`;
+}
 
 async function collectDoctorSummary(
 	cwd: string,
@@ -531,11 +556,13 @@ async function collectDoctorSummary(
 		if (snapshot.exists) filesScanned += 1;
 		const entryFiles = await listJsonFiles(activeEntryDir(cwd, scopeSessionId));
 		const entrySkills = new Set<string>();
+		const rawEntriesBySkill = new Map<string, { path: string; value: unknown }>();
 		for (const entryPath of entryFiles) {
 			filesScanned += 1;
 			const entry = await readRawJson(entryPath);
 			const entrySkill = skillFromActiveValue(entry.value) ?? path.basename(entryPath, ".json");
 			entrySkills.add(entrySkill);
+			rawEntriesBySkill.set(entrySkill, { path: entryPath, value: entry.value });
 			const canonical = canonicalWorkflowSkill(entrySkill);
 			if (canonical && !skills.includes(canonical)) continue;
 			const statePath = canonical
@@ -550,6 +577,28 @@ async function collectDoctorSummary(
 						`active entry for ${entrySkill} does not match a live active mode-state`,
 						canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
 						canonical ?? undefined,
+					),
+				);
+			}
+			const entryPhase = phaseFromActiveValue(entry.value);
+			const statePhase = phaseFromModeState(state.value);
+			const stateIntegrityMismatch = canonical ? await hasModeStateIntegrityMismatch(statePath) : false;
+			if (
+				canonical &&
+				!stateIntegrityMismatch &&
+				activeFlag(entry.value) &&
+				activeFlag(state.value) &&
+				entryPhase &&
+				statePhase &&
+				entryPhase !== statePhase
+			) {
+				problems.push(
+					doctorProblem(
+						"stale_active_state",
+						entryPath,
+						`active entry for ${entrySkill} reports phase ${entryPhase} but live mode-state current_phase is ${statePhase}`,
+						phaseRepairCommand(canonical, statePhase),
+						canonical,
 					),
 				);
 			}
@@ -568,6 +617,27 @@ async function collectDoctorSummary(
 							snapshotPath,
 							`active snapshot lists ${entrySkill} but no raw per-skill active entry exists`,
 							canonical ? `gjc state ${canonical} clear` : "gjc state prune --hard",
+							canonical ?? undefined,
+						),
+					);
+				}
+				const rawEntry = rawEntriesBySkill.get(entrySkill);
+				const snapshotPhase = phaseFromActiveValue(entry);
+				const rawPhase = phaseFromActiveValue(rawEntry?.value);
+				if (
+					rawEntry &&
+					activeFlag(entry) &&
+					activeFlag(rawEntry.value) &&
+					snapshotPhase &&
+					rawPhase &&
+					snapshotPhase !== rawPhase
+				) {
+					problems.push(
+						doctorProblem(
+							"stale_active_state",
+							snapshotPath,
+							`active snapshot lists ${entrySkill} phase ${snapshotPhase} but raw active entry ${rawEntry.path} reports ${rawPhase}`,
+							canonical ? phaseRepairCommand(canonical, rawPhase) : "gjc state prune --hard",
 							canonical ?? undefined,
 						),
 					);

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import {
 	type ActiveSessionScope,
+	readActiveEntries,
 	rebuildActiveSnapshot,
 	removeActiveEntry,
 	writeActiveEntry,
@@ -253,6 +254,11 @@ function entryKey(entry: Pick<SkillActiveEntry, "skill" | "session_id">): string
 	return `${entry.skill}::${safeString(entry.session_id).trim()}`;
 }
 
+function normalizedEntryPhase(record: Record<string, unknown>): string | undefined {
+	const phase = safeString(record.phase).trim() || safeString(record.current_phase).trim();
+	return phase || undefined;
+}
+
 function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 	if (!raw || typeof raw !== "object") return null;
 	const record = raw as Record<string, unknown>;
@@ -264,7 +270,7 @@ function normalizeEntry(raw: unknown): SkillActiveEntry | null {
 	return {
 		...record,
 		skill,
-		phase: safeString(record.phase).trim() || undefined,
+		phase: normalizedEntryPhase(record),
 		active: record.active !== false,
 		activated_at: safeString(record.activated_at).trim() || undefined,
 		updated_at: safeString(record.updated_at).trim() || undefined,
@@ -416,9 +422,9 @@ function rawActiveEntries(state: SkillActiveState | null): SkillActiveEntry[] {
 	return out;
 }
 
-function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
+function filterRootEntriesForSession(entries: readonly SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
 	const normalizedSessionId = safeString(sessionId).trim();
-	if (!normalizedSessionId) return entries;
+	if (!normalizedSessionId) return [...entries];
 	return entries.filter(entry => {
 		const entrySessionId = safeString(entry.session_id).trim();
 		return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
@@ -538,28 +544,57 @@ export function collapsePlanningPipeline(entries: readonly SkillActiveEntry[]): 
 	return entries.filter(entry => !PLANNING_PIPELINE_SKILLS.has(entry.skill) || entry === current);
 }
 
+function normalizeEntryList(entries: readonly SkillActiveEntry[]): SkillActiveEntry[] {
+	return entries.map(entry => normalizeEntry(entry)).filter((entry): entry is SkillActiveEntry => entry !== null);
+}
+
+async function readActiveEntryFiles(
+	cwd: string,
+	sessionScope?: string | ActiveSessionScope,
+): Promise<SkillActiveEntry[]> {
+	try {
+		return normalizeEntryList(await readActiveEntries(cwd, sessionScope));
+	} catch {
+		return [];
+	}
+}
+
 function mergeVisibleEntries(
 	sessionState: SkillActiveState | null,
 	rootState: SkillActiveState | null,
-	sessionId?: string,
+	sessionId: string | undefined,
+	rootActiveEntries: readonly SkillActiveEntry[] = [],
+	sessionActiveEntries: readonly SkillActiveEntry[] = [],
 ): SkillActiveEntry[] {
 	// Use the raw (active + inactive) rows so a handoff demotion stays visible
 	// long enough to supersede a stale same-skill row before the active filter.
-	const rootEntries = filterRootEntriesForSession(rawActiveEntries(rootState), sessionId);
-	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of rawActiveEntries(sessionState)) {
-		merged.set(entryKey(entry), entry);
-	}
+	// Per-skill files under `.gjc/state/active/` are authoritative; the adjacent
+	// `skill-active-state.json` snapshot is a derived cache and must not win when
+	// a crash or older writer leaves it stale.
+	const merged = new Map<string, SkillActiveEntry>();
+	const put = (entry: SkillActiveEntry) => merged.set(entryKey(entry), entry);
+	for (const entry of filterRootEntriesForSession(rawActiveEntries(rootState), sessionId)) put(entry);
+	for (const entry of filterRootEntriesForSession(rootActiveEntries, sessionId)) put(entry);
+	for (const entry of rawActiveEntries(sessionState)) put(entry);
+	for (const entry of sessionActiveEntries) put(entry);
 	return dedupeVisibleBySkill([...merged.values()], sessionId).filter(entry => entry.active !== false);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
-	const [rootState, sessionState] = await Promise.all([
+	const [rootState, sessionState, rootActiveEntries, sessionActiveEntries] = await Promise.all([
 		readRawActiveStateForHandoff(rootPath, false),
 		sessionPath ? readRawActiveStateForHandoff(sessionPath, false) : Promise.resolve(null),
+		readActiveEntryFiles(cwd),
+		sessionId ? readActiveEntryFiles(cwd, { sessionId }) : Promise.resolve([]),
 	]);
-	const activeSkills = mergeVisibleEntries(sessionState, rootState, sessionId);
+	const activeSkills = mergeVisibleEntries(
+		sessionState,
+		rootState,
+		sessionId,
+		rootActiveEntries,
+		sessionActiveEntries,
+	);
 	if (activeSkills.length === 0) return null;
 	const primary = activeSkills[0];
 	return {
@@ -618,11 +653,19 @@ async function activeSubskillsForExistingEntry(
 	skill: string,
 ): Promise<ActiveSubskillEntry[] | undefined> {
 	const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
-	const [rootState, sessionState] = await Promise.all([
+	const [rootState, sessionState, rootActiveEntries, sessionActiveEntries] = await Promise.all([
 		readRawActiveStateForHandoff(rootPath, false),
 		sessionPath ? readRawActiveStateForHandoff(sessionPath, false) : Promise.resolve(null),
+		readActiveEntryFiles(cwd),
+		sessionId ? readActiveEntryFiles(cwd, { sessionId }) : Promise.resolve([]),
 	]);
-	const existing = mergeVisibleEntries(sessionState, rootState, sessionId).find(entry => entry.skill === skill);
+	const existing = mergeVisibleEntries(
+		sessionState,
+		rootState,
+		sessionId,
+		rootActiveEntries,
+		sessionActiveEntries,
+	).find(entry => entry.skill === skill);
 	return existing?.active_subskills;
 }
 

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import { GJC_RESTRICTED_ROLE_AGENT_BASH_ENV } from "@gajae-code/coding-agent/gjc-runtime/restricted-role-agent-bash";
+import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
+import { renderSkillHudBar } from "../../src/modes/components/skill-hud/render";
 
 const tempRoots: string[] = [];
 
@@ -397,6 +399,65 @@ describe("native gjc ralplan runtime — run-state phase coherence", () => {
 			root,
 		);
 		expect(await readPhase(root)).toBe("final");
+	});
+
+	it("does not let stale revision HUD cache override a final run state", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const runId = (
+			JSON.parse(await fs.readFile(path.join(root, ".gjc", "state", "ralplan-state.json"), "utf-8")) as {
+				run_id: string;
+			}
+		).run_id;
+
+		await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "6", "--artifact", "# final", "--run-id", runId],
+			root,
+		);
+		await fs.writeFile(
+			path.join(root, ".gjc", "state", "skill-active-state.json"),
+			JSON.stringify({
+				version: 1,
+				active: true,
+				skill: "ralplan",
+				phase: "revision",
+				active_skills: [
+					{
+						skill: "ralplan",
+						active: true,
+						phase: "revision",
+						updated_at: "2026-06-15T22:21:44.200Z",
+						hud: {
+							version: 1,
+							summary: "persisted revision stage 4",
+							chips: [{ label: "stage", value: "revision", priority: 10 }],
+						},
+					},
+				],
+			}),
+			"utf-8",
+		);
+
+		let active = await readVisibleSkillActiveState(root);
+		let rendered = Bun.stripANSI(renderSkillHudBar(active?.active_skills ?? [], 200) ?? "");
+		expect(rendered).toContain("ralplan:final");
+		expect(rendered).not.toContain("ralplan:revision");
+		const staleDoctor = await runNativeRalplanCommand(["doctor", "--json"], root);
+		expect(staleDoctor.status).toBe(1);
+		expect(staleDoctor.stdout).toContain("stale_active_state");
+
+		const strayRevision = await runNativeRalplanCommand(
+			["--write", "--stage", "revision", "--stage_n", "7", "--artifact", "# late revision", "--run-id", runId],
+			root,
+		);
+		expect(strayRevision.status).toBe(0);
+		active = await readVisibleSkillActiveState(root);
+		rendered = Bun.stripANSI(renderSkillHudBar(active?.active_skills ?? [], 200) ?? "");
+		expect(rendered).toContain("ralplan:final");
+		expect(rendered).not.toContain("ralplan:revision");
+
+		const doctor = await runNativeRalplanCommand(["doctor", "--json"], root);
+		expect(doctor.status).toBe(0);
 	});
 
 	it("does not regress a handed-off run-state phase on a stray --write (chain guard intact)", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -208,4 +208,30 @@ describe("gjc state doctor", () => {
 			}),
 		]);
 	});
+
+	it("detects active-entry phase drift from live ralplan mode-state", async () => {
+		const root = await tempDir();
+		await writeStampedState(root, "ralplan", {
+			active: true,
+			current_phase: "final",
+			run_id: "doctor-run",
+		});
+		const activeEntryPath = path.join(root, ".gjc", "state", "active", "ralplan.json");
+		await writeJson(activeEntryPath, { skill: "ralplan", active: true, phase: "revision" });
+		await writeJson(path.join(root, ".gjc", "state", "audit.jsonl"), { seeded: true });
+
+		const result = await runDoctorUnchanged(root, ["doctor", "--skill", "ralplan", "--json"]);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}");
+		expect(parsed.problems).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "stale_active_state",
+					skill: "ralplan",
+					path: activeEntryPath,
+					fixCommand: `gjc state ralplan write --input '${JSON.stringify({ current_phase: "final" })}'`,
+				}),
+			]),
+		);
+	});
 });

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -118,6 +118,30 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
+	it("prefers raw per-skill active entries over stale snapshot cache", async () => {
+		await withTempCwd(async cwd => {
+			const stateRoot = path.join(cwd, ".gjc", "state");
+			await fs.mkdir(path.join(stateRoot, "active"), { recursive: true });
+			await fs.writeFile(
+				path.join(stateRoot, "skill-active-state.json"),
+				JSON.stringify({
+					version: 1,
+					active: true,
+					skill: "ralplan",
+					phase: "revision",
+					active_skills: [{ skill: "ralplan", active: true, phase: "revision" }],
+				}),
+			);
+			await fs.writeFile(
+				path.join(stateRoot, "active", "ralplan.json"),
+				JSON.stringify({ skill: "ralplan", active: true, current_phase: "final" }),
+			);
+
+			const visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.active_skills?.[0]).toMatchObject({ skill: "ralplan", phase: "final" });
+		});
+	});
+
 	it("normalizes and preserves HUD summaries during root/session merge", async () => {
 		await withTempCwd(async cwd => {
 			await syncSkillActiveState({


### PR DESCRIPTION
## What

- Prefer authoritative per-skill active entries over stale `skill-active-state.json` when reading visible skill state.
- Normalize active-entry phase from either `phase` or legacy/run-style `current_phase`.
- Keep RALPLAN HUD sync aligned with canonical persisted run phase so a later stale `revision` write cannot visually reopen a `final` run.
- Add `gjc ralplan doctor` delegation to `gjc state doctor --skill ralplan`.
- Extend doctor detection for active-entry phase drift from live RALPLAN mode-state and stale snapshot phase drift versus raw active entry.
- Add regression coverage for stale RALPLAN HUD/cache reconciliation.
- Update the coding-agent changelog.

## Why

Fixes #770.

Follow-up to #638 / #639. That fix made canonical RALPLAN run-state phase coherent and terminal-locked; this closes a remaining display reconciliation path where derived active-state cache could still show `ralplan:revision` after canonical state reached `final`.

## Testing

- `bun test test/skill-active-state.test.ts test/gjc-runtime/ralplan-runtime.test.ts test/gjc-runtime/state-doctor.test.ts` from `packages/coding-agent` → 68 pass, 0 fail, 299 expect() calls.
- `bun run check` from `packages/coding-agent` → completed; existing Biome warnings remain in `src/gjc-runtime/ultragoal-runtime.ts`.
- `git diff --cached --check` → pass.
- Privacy pass on staged additions → no private paths, downstream repo names, proxies/gateways, request IDs, tokens, or raw runtime state dumps.

Notes:
- Root `bun run check` was attempted from a clean `dev` worktree but is blocked by pre-existing baseline issues outside this PR: out-of-date `schemas/config.schema.json` plus existing warnings unrelated to this diff.

---
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
