### PR TITLE
fix: reconcile RALPLAN HUD final state

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "./ledger-event-renderer";
 import { isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
 import { migrateWorkflowState } from "./state-migrations";
+import { runNativeStateCommand } from "./state-runtime";
 import {
 	appendJsonlIdempotent,
 	readExistingStateForMutation,
@@ -102,6 +103,10 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 
 export function isRalplanArtifactWriteInvocation(args: readonly string[]): boolean {
 	return hasFlag(args, "--write");
+}
+
+function isRalplanDoctorInvocation(args: readonly string[]): boolean {
+	return args[0] === "doctor";
 }
 
 function assertSafePathComponent(value: string, label: string): void {
@@ -854,10 +859,15 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 	return { status: 0, stdout };
 }
 
+async function handleDoctor(args: readonly string[], cwd: string): Promise<RalplanCommandResult> {
+	return await runNativeStateCommand(["doctor", "--skill", "ralplan", ...args.slice(1)], cwd);
+}
+
 /* -------------------------------- entry --------------------------------- */
 
 export async function runNativeRalplanCommand(args: string[], cwd = process.cwd()): Promise<RalplanCommandResult> {
 	try {
+		if (isRalplanDoctorInvocation(args)) return await handleDoctor(args, cwd);
 		if (isRalplanArtifactWriteInvocation(args)) return await handleArtifactWrite(args, cwd);
 		return await handleConsensusHandoff(args, cwd);
 	} catch (error) {

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -450,6 +450,39 @@ function activeFlag(value: unknown): boolean {
 	return isPlainObject(value) && value.active !== false;
 }
 
+function phaseFromActiveValue(value: unknown): string | undefined {
+	if (!isPlainObject(value) || typeof value.phase !== "string") return undefined;
+	const phase = value.phase.trim();
+	return phase || undefined;
+}
+
+function modeStatePhase(value: unknown): string | undefined {
+	if (!isPlainObject(value) || value.active === false || typeof value.current_phase !== "string") return undefined;
+	const phase = value.current_phase.trim();
+	return phase || undefined;
+}
+
+function pushPhaseDriftProblem(options: {
+	problems: DoctorProblem[];
+	pathValue: string;
+	skill: CanonicalGjcWorkflowSkill;
+	entryKind: "active entry" | "active snapshot";
+	entrySkill: string;
+	entryPhase: string | undefined;
+	statePhase: string | undefined;
+}): void {
+	if (!options.entryPhase || !options.statePhase || options.entryPhase === options.statePhase) return;
+	options.problems.push(
+		doctorProblem(
+			"stale_active_state",
+			options.pathValue,
+			`${options.entryKind} for ${options.entrySkill} phase ${options.entryPhase} differs from canonical mode-state phase ${options.statePhase}`,
+			`gjc state ${options.skill} clear`,
+			options.skill,
+		),
+	);
+}
+
 async function collectDoctorSummary(
 	cwd: string,
 	skill: CanonicalGjcWorkflowSkill | undefined,
@@ -460,6 +493,7 @@ async function collectDoctorSummary(
 	const problems: DoctorProblem[] = [];
 	let filesScanned = 0;
 	let journalsScanned = 0;
+	const invalidModeStates = new Set<string>();
 
 	for (const currentSkill of skills) {
 		const filePath = modeStateFile(cwd, currentSkill, sessionId);
@@ -476,6 +510,7 @@ async function collectDoctorSummary(
 					currentSkill,
 				),
 			);
+			invalidModeStates.add(currentSkill);
 			continue;
 		}
 		const validation = validateWorkflowStateEnvelope(currentSkill, raw.value);
@@ -489,6 +524,7 @@ async function collectDoctorSummary(
 					currentSkill,
 				),
 			);
+			invalidModeStates.add(currentSkill);
 		}
 		const mismatch = await detectWorkflowEnvelopeIntegrityMismatch(filePath);
 		if (mismatch) {
@@ -501,6 +537,7 @@ async function collectDoctorSummary(
 					currentSkill,
 				),
 			);
+			invalidModeStates.add(currentSkill);
 		}
 	}
 
@@ -553,6 +590,17 @@ async function collectDoctorSummary(
 					),
 				);
 			}
+			if (canonical && activeFlag(entry.value) && !invalidModeStates.has(canonical)) {
+				pushPhaseDriftProblem({
+					problems,
+					pathValue: entryPath,
+					skill: canonical,
+					entryKind: "active entry",
+					entrySkill,
+					entryPhase: phaseFromActiveValue(entry.value),
+					statePhase: modeStatePhase(state.value),
+				});
+			}
 		}
 		if (isPlainObject(snapshot.value)) {
 			const activeSkills = Array.isArray(snapshot.value.active_skills) ? snapshot.value.active_skills : [];
@@ -571,6 +619,18 @@ async function collectDoctorSummary(
 							canonical ?? undefined,
 						),
 					);
+				}
+				if (canonical && activeFlag(entry) && !invalidModeStates.has(canonical)) {
+					const state = await readRawJson(modeStateFile(cwd, canonical, scopeSessionId));
+					pushPhaseDriftProblem({
+						problems,
+						pathValue: snapshotPath,
+						skill: canonical,
+						entryKind: "active snapshot",
+						entrySkill,
+						entryPhase: phaseFromActiveValue(entry),
+						statePhase: modeStatePhase(state.value),
+					});
 				}
 			}
 		}

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -456,10 +456,23 @@ function phaseFromActiveValue(value: unknown): string | undefined {
 	return phase || undefined;
 }
 
+const RALPLAN_CANONICAL_PHASE_OVERRIDES = new Set([
+	"final",
+	"handoff",
+	"complete",
+	"completed",
+	"failed",
+	"cancelled",
+	"canceled",
+	"inactive",
+]);
+
 function modeStatePhase(value: unknown): string | undefined {
-	if (!isPlainObject(value) || value.active === false || typeof value.current_phase !== "string") return undefined;
+	if (!isPlainObject(value) || typeof value.current_phase !== "string") return undefined;
 	const phase = value.current_phase.trim();
-	return phase || undefined;
+	if (!phase) return undefined;
+	if (value.active === false && !RALPLAN_CANONICAL_PHASE_OVERRIDES.has(phase)) return undefined;
+	return phase;
 }
 
 function pushPhaseDriftProblem(options: {

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import {
 	type ActiveSessionScope,
+	readActiveEntries,
 	rebuildActiveSnapshot,
 	removeActiveEntry,
 	writeActiveEntry,
@@ -416,6 +417,61 @@ function rawActiveEntries(state: SkillActiveState | null): SkillActiveEntry[] {
 	return out;
 }
 
+async function readModeStatePhase(
+	cwd: string,
+	sessionId: string | undefined,
+	skill: CanonicalGjcWorkflowSkill,
+): Promise<string | undefined> {
+	const stateDir = path.join(cwd, ".gjc", "state");
+	const normalizedSessionId = safeString(sessionId).trim();
+	const filePath = normalizedSessionId
+		? path.join(stateDir, "sessions", encodePathSegment(normalizedSessionId), `${skill}-state.json`)
+		: path.join(stateDir, `${skill}-state.json`);
+	try {
+		const parsed = JSON.parse(await Bun.file(filePath).text());
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+		const record = parsed as Record<string, unknown>;
+		if (record.active === false) return undefined;
+		const phase = safeString(record.current_phase).trim();
+		return phase || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+const RALPLAN_CANONICAL_PHASE_OVERRIDES = new Set([
+	"final",
+	"handoff",
+	"complete",
+	"completed",
+	"failed",
+	"cancelled",
+	"canceled",
+	"inactive",
+]);
+
+function withCanonicalRalplanPhase(entry: SkillActiveEntry, canonicalPhase: string | undefined): SkillActiveEntry {
+	if (
+		entry.skill !== "ralplan" ||
+		!canonicalPhase ||
+		!RALPLAN_CANONICAL_PHASE_OVERRIDES.has(canonicalPhase) ||
+		entry.phase === canonicalPhase
+	) {
+		return entry;
+	}
+	const hud = entry.hud
+		? {
+				...entry.hud,
+				chips: entry.hud.chips?.map(chip => (chip.label === "stage" ? { ...chip, value: canonicalPhase } : chip)),
+			}
+		: undefined;
+	return {
+		...entry,
+		phase: canonicalPhase,
+		...(hud ? { hud } : {}),
+	};
+}
+
 function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
 	const normalizedSessionId = safeString(sessionId).trim();
 	if (!normalizedSessionId) return entries;
@@ -538,19 +594,32 @@ export function collapsePlanningPipeline(entries: readonly SkillActiveEntry[]): 
 	return entries.filter(entry => !PLANNING_PIPELINE_SKILLS.has(entry.skill) || entry === current);
 }
 
-function mergeVisibleEntries(
+async function mergeVisibleEntries(
+	cwd: string,
 	sessionState: SkillActiveState | null,
 	rootState: SkillActiveState | null,
 	sessionId?: string,
-): SkillActiveEntry[] {
+): Promise<SkillActiveEntry[]> {
 	// Use the raw (active + inactive) rows so a handoff demotion stays visible
 	// long enough to supersede a stale same-skill row before the active filter.
-	const rootEntries = filterRootEntriesForSession(rawActiveEntries(rootState), sessionId);
+	// Per-skill files in active/<skill>.json are authoritative and are merged
+	// after the derived snapshot cache, so a stale skill-active-state.json row
+	// cannot override the latest entry file.
+	const rootEntries = filterRootEntriesForSession(
+		[...rawActiveEntries(rootState), ...(await readActiveEntries(cwd))],
+		sessionId,
+	);
 	const merged = new Map(rootEntries.map(entry => [entryKey(entry), entry]));
-	for (const entry of rawActiveEntries(sessionState)) {
+	const sessionEntries = sessionId
+		? [...rawActiveEntries(sessionState), ...(await readActiveEntries(cwd, { sessionId }))]
+		: rawActiveEntries(sessionState);
+	for (const entry of sessionEntries) {
 		merged.set(entryKey(entry), entry);
 	}
-	return dedupeVisibleBySkill([...merged.values()], sessionId).filter(entry => entry.active !== false);
+	const canonicalRalplanPhase = await readModeStatePhase(cwd, sessionId, "ralplan");
+	return dedupeVisibleBySkill([...merged.values()], sessionId)
+		.filter(entry => entry.active !== false)
+		.map(entry => withCanonicalRalplanPhase(entry, canonicalRalplanPhase));
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {
@@ -559,7 +628,7 @@ export async function readVisibleSkillActiveState(cwd: string, sessionId?: strin
 		readRawActiveStateForHandoff(rootPath, false),
 		sessionPath ? readRawActiveStateForHandoff(sessionPath, false) : Promise.resolve(null),
 	]);
-	const activeSkills = mergeVisibleEntries(sessionState, rootState, sessionId);
+	const activeSkills = await mergeVisibleEntries(cwd, sessionState, rootState, sessionId);
 	if (activeSkills.length === 0) return null;
 	const primary = activeSkills[0];
 	return {
@@ -622,7 +691,9 @@ async function activeSubskillsForExistingEntry(
 		readRawActiveStateForHandoff(rootPath, false),
 		sessionPath ? readRawActiveStateForHandoff(sessionPath, false) : Promise.resolve(null),
 	]);
-	const existing = mergeVisibleEntries(sessionState, rootState, sessionId).find(entry => entry.skill === skill);
+	const existing = (await mergeVisibleEntries(cwd, sessionState, rootState, sessionId)).find(
+		entry => entry.skill === skill,
+	);
 	return existing?.active_subskills;
 }
 

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -431,9 +431,10 @@ async function readModeStatePhase(
 		const parsed = JSON.parse(await Bun.file(filePath).text());
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
 		const record = parsed as Record<string, unknown>;
-		if (record.active === false) return undefined;
 		const phase = safeString(record.current_phase).trim();
-		return phase || undefined;
+		if (!phase) return undefined;
+		if (record.active === false && !RALPLAN_CANONICAL_PHASE_OVERRIDES.has(phase)) return undefined;
+		return phase;
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { runNativeRalplanCommand } from "@gajae-code/coding-agent/gjc-runtime/ralplan-runtime";
 import { GJC_RESTRICTED_ROLE_AGENT_BASH_ENV } from "@gajae-code/coding-agent/gjc-runtime/restricted-role-agent-bash";
+import { readVisibleSkillActiveState } from "@gajae-code/coding-agent/skill-state/active-state";
 
 const tempRoots: string[] = [];
 
@@ -107,6 +108,49 @@ describe("native gjc ralplan runtime — consensus handoff", () => {
 		const chips = entry?.hud?.chips ?? [];
 		expect(chips.some(c => c.label === "stage" && c.value === "planner")).toBe(true);
 		expect(chips.some(c => c.label === "iter" && c.value === "1")).toBe(true);
+	});
+
+	it("visible HUD prefers canonical final over a stale active-state snapshot", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const runId = (JSON.parse(await fs.readFile(statePath, "utf-8")) as { run_id: string }).run_id;
+		await runNativeRalplanCommand(
+			["--write", "--stage", "revision", "--stage_n", "4", "--artifact", "# revision", "--run-id", runId],
+			root,
+		);
+		const snapshotPath = path.join(root, ".gjc", "state", "skill-active-state.json");
+		const staleSnapshot = JSON.parse(await fs.readFile(snapshotPath, "utf-8")) as {
+			active_skills?: Array<{
+				skill: string;
+				phase?: string;
+				hud?: { chips?: Array<{ label: string; value?: string }> };
+			}>;
+		};
+		await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "6", "--artifact", "# final", "--run-id", runId],
+			root,
+		);
+		await fs.writeFile(snapshotPath, `${JSON.stringify(staleSnapshot, null, 2)}\n`, "utf-8");
+		await fs.writeFile(
+			path.join(root, ".gjc", "state", "active", "ralplan.json"),
+			`${JSON.stringify(
+				{
+					skill: "ralplan",
+					active: true,
+					phase: "revision",
+					hud: { version: 1, chips: [{ label: "stage", value: "revision" }] },
+				},
+				null,
+				2,
+			)}\n`,
+			"utf-8",
+		);
+
+		const visible = await readVisibleSkillActiveState(root);
+		const entry = visible?.active_skills?.find(item => item.skill === "ralplan");
+		expect(entry?.phase).toBe("final");
+		expect(entry?.hud?.chips?.some(chip => chip.label === "stage" && chip.value === "final")).toBe(true);
 	});
 
 	it("rejects unknown --architect kinds with exit 2", async () => {
@@ -420,6 +464,43 @@ describe("native gjc ralplan runtime — run-state phase coherence", () => {
 		);
 		expect(result.status).toBe(0);
 		expect(await readPhase(root)).toBe("handoff");
+	});
+
+	it("doctor reports active-state phase drift from canonical final", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const runId = (JSON.parse(await fs.readFile(statePath, "utf-8")) as { run_id: string }).run_id;
+		await runNativeRalplanCommand(
+			["--write", "--stage", "revision", "--stage_n", "4", "--artifact", "# revision", "--run-id", runId],
+			root,
+		);
+		const snapshotPath = path.join(root, ".gjc", "state", "skill-active-state.json");
+		const staleSnapshot = JSON.parse(await fs.readFile(snapshotPath, "utf-8"));
+		await runNativeRalplanCommand(
+			["--write", "--stage", "final", "--stage_n", "6", "--artifact", "# final", "--run-id", runId],
+			root,
+		);
+		await fs.writeFile(snapshotPath, `${JSON.stringify(staleSnapshot, null, 2)}\n`, "utf-8");
+		await fs.writeFile(
+			path.join(root, ".gjc", "state", "active", "ralplan.json"),
+			`${JSON.stringify({ skill: "ralplan", active: true, phase: "revision" }, null, 2)}\n`,
+			"utf-8",
+		);
+
+		const result = await runNativeRalplanCommand(["doctor", "--json"], root);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}") as {
+			problems?: Array<{ type: string; skill?: string; path: string; message: string }>;
+		};
+		const driftProblems = (parsed.problems ?? []).filter(
+			problem =>
+				problem.type === "stale_active_state" &&
+				problem.skill === "ralplan" &&
+				problem.message.includes("differs from canonical mode-state phase final"),
+		);
+		expect(driftProblems.some(problem => problem.path.endsWith(path.join("active", "ralplan.json")))).toBe(true);
+		expect(driftProblems.some(problem => problem.path.endsWith("skill-active-state.json"))).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -153,6 +153,44 @@ describe("native gjc ralplan runtime — consensus handoff", () => {
 		expect(entry?.hud?.chips?.some(chip => chip.label === "stage" && chip.value === "final")).toBe(true);
 	});
 
+	it("visible HUD prefers canonical inactive handoff over stale active entries", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const runId = (JSON.parse(await fs.readFile(statePath, "utf-8")) as { run_id: string }).run_id;
+		await runNativeRalplanCommand(
+			["--write", "--stage", "revision", "--stage_n", "4", "--artifact", "# revision", "--run-id", runId],
+			root,
+		);
+		const snapshotPath = path.join(root, ".gjc", "state", "skill-active-state.json");
+		const staleSnapshot = JSON.parse(await fs.readFile(snapshotPath, "utf-8"));
+		await fs.writeFile(
+			statePath,
+			`${JSON.stringify({ skill: "ralplan", active: false, current_phase: "handoff", run_id: runId, version: 2 }, null, 2)}\n`,
+			"utf-8",
+		);
+		await fs.writeFile(snapshotPath, `${JSON.stringify(staleSnapshot, null, 2)}\n`, "utf-8");
+		await fs.writeFile(
+			path.join(root, ".gjc", "state", "active", "ralplan.json"),
+			`${JSON.stringify(
+				{
+					skill: "ralplan",
+					active: true,
+					phase: "revision",
+					hud: { version: 1, chips: [{ label: "stage", value: "revision" }] },
+				},
+				null,
+				2,
+			)}\n`,
+			"utf-8",
+		);
+
+		const visible = await readVisibleSkillActiveState(root);
+		const entry = visible?.active_skills?.find(item => item.skill === "ralplan");
+		expect(entry?.phase).toBe("handoff");
+		expect(entry?.hud?.chips?.some(chip => chip.label === "stage" && chip.value === "handoff")).toBe(true);
+	});
+
 	it("rejects unknown --architect kinds with exit 2", async () => {
 		const root = await tempDir();
 		const result = await runNativeRalplanCommand(["--architect", "nope", "task"], root);
@@ -498,6 +536,44 @@ describe("native gjc ralplan runtime — run-state phase coherence", () => {
 				problem.type === "stale_active_state" &&
 				problem.skill === "ralplan" &&
 				problem.message.includes("differs from canonical mode-state phase final"),
+		);
+		expect(driftProblems.some(problem => problem.path.endsWith(path.join("active", "ralplan.json")))).toBe(true);
+		expect(driftProblems.some(problem => problem.path.endsWith("skill-active-state.json"))).toBe(true);
+	});
+
+	it("doctor reports drift from canonical inactive handoff", async () => {
+		const root = await tempDir();
+		await runNativeRalplanCommand(["--deliberate", "--json", "task"], root);
+		const statePath = path.join(root, ".gjc", "state", "ralplan-state.json");
+		const runId = (JSON.parse(await fs.readFile(statePath, "utf-8")) as { run_id: string }).run_id;
+		await runNativeRalplanCommand(
+			["--write", "--stage", "revision", "--stage_n", "4", "--artifact", "# revision", "--run-id", runId],
+			root,
+		);
+		const snapshotPath = path.join(root, ".gjc", "state", "skill-active-state.json");
+		const staleSnapshot = JSON.parse(await fs.readFile(snapshotPath, "utf-8"));
+		await fs.writeFile(
+			statePath,
+			`${JSON.stringify({ skill: "ralplan", active: false, current_phase: "handoff", run_id: runId, version: 2 }, null, 2)}\n`,
+			"utf-8",
+		);
+		await fs.writeFile(snapshotPath, `${JSON.stringify(staleSnapshot, null, 2)}\n`, "utf-8");
+		await fs.writeFile(
+			path.join(root, ".gjc", "state", "active", "ralplan.json"),
+			`${JSON.stringify({ skill: "ralplan", active: true, phase: "revision" }, null, 2)}\n`,
+			"utf-8",
+		);
+
+		const result = await runNativeRalplanCommand(["doctor", "--json"], root);
+		expect(result.status).toBe(1);
+		const parsed = JSON.parse(result.stdout ?? "{}") as {
+			problems?: Array<{ type: string; skill?: string; path: string; message: string }>;
+		};
+		const driftProblems = (parsed.problems ?? []).filter(
+			problem =>
+				problem.type === "stale_active_state" &&
+				problem.skill === "ralplan" &&
+				problem.message.includes("differs from canonical mode-state phase handoff"),
 		);
 		expect(driftProblems.some(problem => problem.path.endsWith(path.join("active", "ralplan.json")))).toBe(true);
 		expect(driftProblems.some(problem => problem.path.endsWith("skill-active-state.json"))).toBe(true);


### PR DESCRIPTION
## Summary
- Make visible skill active-state reconciliation consult canonical RALPLAN mode-state for terminal/locked phases so `final`/`handoff` win over stale raw or derived active entries.
- Keep raw per-skill active entries authoritative over derived `skill-active-state.json` cache, then apply canonical RALPLAN terminal phase to the visible entry and HUD stage chip.
- Add RALPLAN doctor drift detection for raw active entries and derived snapshots whose phase differs from canonical mode-state, and expose `gjc ralplan doctor --json` through the native RALPLAN command.

## Tests
- `bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-doctor.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Fixes #770