### PR TITLE
test(coding-agent): format deep interview assertion

### DIFF
--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -68,7 +68,9 @@ describe("deep-interview self-proofread output rule", () => {
 	it("references the self-proofread at the four emission points", () => {
 		expect(skill).toContain("Before emitting the prose lines in this announcement, apply the");
 		expect(skill).toContain("apply the self-proofread once to new prose only");
-		expect(skill).toContain("apply the self-proofread once to narrative status text, generated prose cells, gaps, and next-target phrasing");
+		expect(skill).toContain(
+			"apply the self-proofread once to narrative status text, generated prose cells, gaps, and next-target phrasing",
+		);
 		expect(skill).toContain("Apply the self-proofread once to newly generated spec prose before persistence");
 	});
 


### PR DESCRIPTION
## Summary

Fixes the dev CI failure from run 27617943502 by applying the Biome-required wrap to the deep-interview skill contract assertion.

## Verification

- CI failure source: `Affected path validation / check:@gajae-code/coding-agent` in run 27617943502
- Local change is limited to the formatter-requested assertion wrap.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*