### PR TITLE
fix(xiaomi): address review blockers for token-plan provider activation

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1641,6 +1641,24 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "xiaomi-token-plan-sgp": {
+				const { loginXiaomiTokenPlan } = await import("./utils/oauth/xiaomi");
+				const apiKey = await loginXiaomiTokenPlan(ctrl, "sgp");
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "xiaomi-token-plan-ams": {
+				const { loginXiaomiTokenPlan } = await import("./utils/oauth/xiaomi");
+				const apiKey = await loginXiaomiTokenPlan(ctrl, "ams");
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "xiaomi-token-plan-cn": {
+				const { loginXiaomiTokenPlan } = await import("./utils/oauth/xiaomi");
+				const apiKey = await loginXiaomiTokenPlan(ctrl, "cn");
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "zenmux": {
 				const { loginZenMux } = await import("./utils/oauth/zenmux");
 				const apiKey = await loginZenMux(ctrl);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -285,6 +285,34 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"qwen3.7-plus": {
+			"id": "qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "alibaba-coding-plan",
+			"baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"amazon-bedrock": {
@@ -430,7 +458,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"anthropic.claude-opus-4-7": {
@@ -455,7 +490,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"anthropic.claude-opus-4-8": {
@@ -480,7 +522,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -530,7 +579,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"au.anthropic.claude-opus-4-8": {
@@ -555,7 +611,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -858,6 +921,31 @@
 			"contextWindow": 200000,
 			"maxTokens": 4096
 		},
+		"eu.anthropic.claude-fable-5": {
+			"id": "eu.anthropic.claude-fable-5",
+			"name": "Anthropic Fable 5 (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Anthropic Haiku 4.5 (EU)",
@@ -980,7 +1068,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"eu.anthropic.claude-opus-4-7": {
@@ -1005,7 +1100,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"eu.anthropic.claude-opus-4-8": {
@@ -1030,7 +1132,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"eu.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -1095,10 +1204,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
+				"input": 3.3,
+				"output": 16.5,
+				"cacheRead": 0.33,
+				"cacheWrite": 4.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
@@ -1114,7 +1223,7 @@
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -1126,11 +1235,41 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 4096,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"global.anthropic.claude-fable-5": {
+			"id": "global.anthropic.claude-fable-5",
+			"name": "Anthropic Fable 5 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1155,7 +1294,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Anthropic Opus 4.5 (Global)",
+			"name": "Anthropic Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1200,7 +1339,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"global.anthropic.claude-opus-4-7": {
@@ -1225,7 +1371,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"global.anthropic.claude-opus-4-8": {
@@ -1250,7 +1403,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -1280,7 +1440,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1305,7 +1465,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6 (Global)",
+			"name": "Anthropic Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1390,7 +1550,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"jp.anthropic.claude-opus-4-8": {
@@ -1415,7 +1582,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -1932,13 +2106,63 @@
 				"maxLevel": "high"
 			}
 		},
-		"openai.gpt-oss-120b-1:0": {
-			"id": "openai.gpt-oss-120b-1:0",
+		"openai.gpt-5.4": {
+			"id": "openai.gpt-5.4",
+			"name": "GPT-5.4",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.75,
+				"output": 16.5,
+				"cacheRead": 0.275,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai.gpt-5.5": {
+			"id": "openai.gpt-5.5",
+			"name": "GPT-5.5",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 33,
+				"cacheRead": 0.55,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai.gpt-oss-120b": {
+			"id": "openai.gpt-oss-120b",
 			"name": "gpt-oss-120b",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -1949,15 +2173,44 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
-		"openai.gpt-oss-20b-1:0": {
-			"id": "openai.gpt-oss-20b-1:0",
+		"openai.gpt-oss-120b-1:0": {
+			"id": "openai.gpt-oss-120b-1:0",
+			"name": "gpt-oss-120b",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"openai.gpt-oss-20b": {
+			"id": "openai.gpt-oss-20b",
 			"name": "gpt-oss-20b",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -1968,7 +2221,36 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"openai.gpt-oss-20b-1:0": {
+			"id": "openai.gpt-oss-20b-1:0",
+			"name": "gpt-oss-20b",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.07,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"openai.gpt-oss-safeguard-120b": {
 			"id": "openai.gpt-oss-safeguard-120b",
@@ -2256,6 +2538,31 @@
 			"contextWindow": 200000,
 			"maxTokens": 8192
 		},
+		"us.anthropic.claude-fable-5": {
+			"id": "us.anthropic.claude-fable-5",
+			"name": "Anthropic Fable 5 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Anthropic Haiku 4.5 (US)",
@@ -2283,7 +2590,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Anthropic Opus 4.1 (US)",
+			"name": "Anthropic Opus 4.1",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -2378,7 +2685,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"us.anthropic.claude-opus-4-7": {
@@ -2403,7 +2717,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"us.anthropic.claude-opus-4-8": {
@@ -2428,7 +2749,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"us.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -2629,7 +2957,7 @@
 		},
 		"us.meta.llama4-maverick-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-maverick-17b-instruct-v1:0",
-			"name": "Llama 4 Maverick 17B Instruct",
+			"name": "Llama 4 Maverick 17B Instruct (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -2649,7 +2977,7 @@
 		},
 		"us.meta.llama4-scout-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-scout-17b-instruct-v1:0",
-			"name": "Llama 4 Scout 17B Instruct",
+			"name": "Llama 4 Scout 17B Instruct (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -3071,7 +3399,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"claude-opus-4-7": {
@@ -3096,7 +3431,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-opus-4-8": {
@@ -3121,7 +3456,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-sonnet-4-0": {
@@ -3373,13 +3708,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.69,
+				"input": 0.35,
+				"output": 0.75,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 32768,
+			"maxTokens": 40960,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -3468,7 +3803,7 @@
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"baseUrl": "https://api.cerebras.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -3479,7 +3814,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 40000
+			"maxTokens": 40960,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"cloudflare-ai-gateway": {
@@ -3603,6 +3943,31 @@
 			"contextWindow": 200000,
 			"maxTokens": 8192
 		},
+		"anthropic/claude-fable-5": {
+			"id": "anthropic/claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-haiku-4-5": {
 			"id": "anthropic/claude-haiku-4-5",
 			"name": "Anthropic Haiku 4.5 (latest)",
@@ -3725,7 +4090,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"anthropic/claude-opus-4-7": {
@@ -3750,7 +4122,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"anthropic/claude-opus-4-8": {
@@ -3775,7 +4147,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"anthropic/claude-sonnet-4": {
@@ -4124,7 +4496,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -5352,7 +5724,8 @@
 					"low": "high",
 					"medium": "high",
 					"high": "high",
-					"xhigh": "max"
+					"xhigh": "max",
+					"max": "max"
 				},
 				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
@@ -5397,7 +5770,8 @@
 					"low": "high",
 					"medium": "high",
 					"high": "high",
-					"xhigh": "max"
+					"xhigh": "max",
+					"max": "max"
 				},
 				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
@@ -5638,9 +6012,42 @@
 		}
 	},
 	"github-copilot": {
+		"claude-fable-5": {
+			"id": "claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5650,10 +6057,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -5669,7 +6076,7 @@
 		},
 		"claude-opus-4.5": {
 			"id": "claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5679,10 +6086,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5707,10 +6114,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 168000,
 			"maxTokens": 32000,
@@ -5721,7 +6128,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"claude-opus-4.7": {
@@ -5736,10 +6150,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5749,7 +6163,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-opus-4.8": {
@@ -5764,10 +6178,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -5777,12 +6191,12 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
-			"name": "Anthropic Sonnet 4",
+			"name": "Anthropic Sonnet 4 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5792,10 +6206,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 216000,
 			"maxTokens": 16000,
@@ -5810,7 +6224,7 @@
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5820,10 +6234,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5848,10 +6262,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5870,15 +6284,15 @@
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5890,11 +6304,16 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
-			"name": "Gemini 3 Flash",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5904,9 +6323,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 3,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5974,9 +6393,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -6011,9 +6430,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -6044,9 +6463,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -6119,7 +6538,7 @@
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
-			"name": "GPT-5-mini",
+			"name": "GPT-5 Mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6129,9 +6548,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 264000,
@@ -6269,9 +6688,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6287,7 +6706,7 @@
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
-			"name": "GPT-5.2-OpenAI code",
+			"name": "GPT-5.2 OpenAI code",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6297,9 +6716,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6315,7 +6734,7 @@
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
-			"name": "GPT-5.3-OpenAI code",
+			"name": "GPT-5.3 OpenAI code",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6325,9 +6744,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6353,9 +6772,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6371,7 +6790,7 @@
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6381,9 +6800,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6392,6 +6811,34 @@
 				"User-Agent": "opencode/1.3.15"
 			},
 			"premiumMultiplier": 0.33,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4-nano": {
+			"id": "gpt-5.4-nano",
+			"name": "GPT-5.4 nano",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 1.25,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -6410,9 +6857,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -6424,8 +6871,7 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "github-copilot/gpt-5.4"
+			}
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -6454,6 +6900,39 @@
 				"supportsReasoningEffort": false
 			},
 			"premiumMultiplier": 0.25,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"raptor-mini": {
+			"id": "raptor-mini",
+			"name": "Raptor mini",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -7644,6 +8123,56 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"gemma-4-E2B-it": {
+			"id": "gemma-4-E2B-it",
+			"name": "Gemma 4 E2B IT",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gemma-4-E4B-it": {
+			"id": "gemma-4-E4B-it",
+			"name": "Gemma 4 E4B IT",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"google-antigravity": {
@@ -8626,7 +9155,7 @@
 		},
 		"llama-3.1-8b-instant": {
 			"id": "llama-3.1-8b-instant",
-			"name": "Llama 3.1 8B Instant",
+			"name": "Llama 3.1 8B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -8645,7 +9174,7 @@
 		},
 		"llama-3.3-70b-versatile": {
 			"id": "llama-3.3-70b-versatile",
-			"name": "Llama 3.3 70B Versatile",
+			"name": "Llama 3.3 70B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -8722,7 +9251,7 @@
 		},
 		"meta-llama/llama-4-scout-17b-16e-instruct": {
 			"id": "meta-llama/llama-4-scout-17b-16e-instruct",
-			"name": "Llama 4 Scout 17B",
+			"name": "Llama 4 Scout 17B 16E",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -8780,7 +9309,7 @@
 		},
 		"moonshotai/kimi-k2-instruct-0905": {
 			"id": "moonshotai/kimi-k2-instruct-0905",
-			"name": "Kimi K2 Instruct 0905",
+			"name": "Kimi K2 0905",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -8895,7 +9424,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -9847,11 +10376,11 @@
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
-			"name": "Anthropic: Anthropic Opus 4.8 (new)",
+			"name": "Anthropic Opus 4.8",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -9862,8 +10391,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
@@ -11218,13 +11752,14 @@
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
-			"name": "Google: Gemini 3.1 Flash Lite",
+			"name": "Gemini 3.1 Flash Lite",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -11232,8 +11767,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"google/gemini-3.1-flash-lite-preview": {
 			"id": "google/gemini-3.1-flash-lite-preview",
@@ -11305,13 +11845,14 @@
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
-			"name": "Google: Gemini 3.5 Flash",
+			"name": "Gemini 3.5 Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -11319,8 +11860,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
@@ -11381,7 +11927,7 @@
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
-			"name": "Gemma-3-27B-IT",
+			"name": "Google: Gemma 3 27B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -11396,8 +11942,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -11721,7 +12267,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -11731,8 +12277,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262000,
+			"maxTokens": 65000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"inclusionai/ring-2.6-1t:free": {
 			"id": "inclusionai/ring-2.6-1t:free",
@@ -12059,7 +12610,7 @@
 		},
 		"meta-llama/llama-3-70b-instruct": {
 			"id": "meta-llama/llama-3-70b-instruct",
-			"name": "Meta: Llama 3 70B Instruct",
+			"name": "Meta: Llama 3 70B Instruct (retires Jun 19)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -12386,10 +12937,9 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -12398,12 +12948,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 8192
 		},
 		"microsoft/wizardlm-2-8x22b": {
 			"id": "microsoft/wizardlm-2-8x22b",
@@ -12590,6 +13135,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131070,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -13201,8 +13771,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 262000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -13296,6 +13866,31 @@
 			},
 			"contextWindow": 222222,
 			"maxTokens": 8888
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"morph-warp-grep-v2": {
 			"id": "morph-warp-grep-v2",
@@ -13395,6 +13990,25 @@
 		"nex-agi/deepseek-v3.1-nex-n1": {
 			"id": "nex-agi/deepseek-v3.1-nex-n1",
 			"name": "Nex AGI: DeepSeek V3.1 Nex N1",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"nex-agi/nex-n2-pro:free": {
+			"id": "nex-agi/nex-n2-pro:free",
+			"name": "Nex AGI: Nex-N2-Pro (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13638,6 +14252,68 @@
 		"nvidia/nemotron-3-super-120b-a12b:free": {
 			"id": "nvidia/nemotron-3-super-120b-a12b:free",
 			"name": "NVIDIA: Nemotron 3 Super (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b",
+			"name": "Nemotron 3 Ultra 550B A55B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b:free": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+			"name": "NVIDIA: Nemotron 3 Ultra (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"nvidia/nemotron-3.5-content-safety:free": {
+			"id": "nvidia/nemotron-3.5-content-safety:free",
+			"name": "NVIDIA: Nemotron 3.5 Content Safety (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14653,7 +15329,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -14678,7 +15354,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -15132,6 +15808,25 @@
 		"openrouter/free": {
 			"id": "openrouter/free",
 			"name": "Free Models Router",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"openrouter/fusion": {
+			"id": "openrouter/fusion",
+			"name": "OpenRouter: Fusion",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15744,7 +16439,7 @@
 		},
 		"qwen/qwen3-30b-a3b": {
 			"id": "qwen/qwen3-30b-a3b",
-			"name": "Qwen: Qwen3 30B A3B (retires Jun 5)",
+			"name": "Qwen: Qwen3 30B A3B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15801,7 +16496,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16020,7 +16715,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3-Next-80B-A3B-Thinking",
+			"name": "Qwen: Qwen3 Next 80B A3B Thinking",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16034,8 +16729,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -16479,11 +17174,11 @@
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
-			"name": "Qwen: Qwen3.7 Max",
+			"name": "Qwen3.7 Max",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -16493,8 +17188,38 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen/qwen3.7-plus": {
+			"id": "qwen/qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -16860,13 +17585,14 @@
 		},
 		"stepfun/step-3.7-flash": {
 			"id": "stepfun/step-3.7-flash",
-			"name": "StepFun: Step 3.7 Flash",
+			"name": "Step 3.7 Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -16874,8 +17600,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"stepfun/step-3.7-flash:free": {
 			"id": "stepfun/step-3.7-flash:free",
@@ -17358,13 +18089,14 @@
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
-			"name": "xAI: Grok 4.3",
+			"name": "Grok 4.3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -17372,18 +18104,24 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
-			"name": "xAI: Grok Build 0.1",
+			"name": "Grok Build 0.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -17391,8 +18129,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -24036,7 +24779,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 130000,
 			"thinking": {
 				"mode": "effort",
@@ -27480,9 +28223,10 @@
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -27491,7 +28235,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -28972,7 +29721,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -28998,7 +29747,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -29845,7 +30594,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -33571,13 +34320,14 @@
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
-			"name": "x-ai/grok-4.3",
+			"name": "Grok 4.3",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -33585,8 +34335,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -34227,7 +34982,7 @@
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -34238,7 +34993,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 40000
+			"maxTokens": 40000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"zai-org/glm-4.5": {
 			"id": "zai-org/glm-4.5",
@@ -34697,6 +35457,31 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "anthropic-messages",
+			"provider": "minimax",
+			"baseUrl": "https://api.minimax.io/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
 			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "minimax",
@@ -34892,6 +35677,31 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "anthropic-messages",
+			"provider": "minimax-cn",
+			"baseUrl": "https://api.minimaxi.com/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
 			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "minimax-cn",
@@ -35159,6 +35969,37 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "openai-completions",
+			"provider": "minimax-code",
+			"baseUrl": "https://api.minimax.io/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
 			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "minimax-code",
@@ -35463,6 +36304,37 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "openai-completions",
+			"provider": "minimax-code-cn",
+			"baseUrl": "https://api.minimaxi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
 			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "minimax-code-cn",
@@ -35515,6 +36387,25 @@
 		},
 		"devstral-2512": {
 			"id": "devstral-2512",
+			"name": "Devstral 2",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
+		"devstral-latest": {
+			"id": "devstral-latest",
 			"name": "Devstral 2",
 			"api": "openai-completions",
 			"provider": "mistral",
@@ -35844,24 +36735,19 @@
 			"api": "openai-completions",
 			"provider": "mistral",
 			"baseUrl": "https://api.mistral.ai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 1.5,
-				"output": 7.5,
+				"input": 0.4,
+				"output": 2,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 262144
 		},
 		"mistral-nemo": {
 			"id": "mistral-nemo",
@@ -35970,6 +36856,25 @@
 			},
 			"contextWindow": 8000,
 			"maxTokens": 8000
+		},
+		"open-mistral-nemo": {
+			"id": "open-mistral-nemo",
+			"name": "Open Mistral Nemo",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 128000
 		},
 		"open-mixtral-8x22b": {
 			"id": "open-mixtral-8x22b",
@@ -40521,7 +41426,7 @@
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
-			"name": "Google: Gemini 3.1 Flash Lite",
+			"name": "Gemini 3.1 Flash Lite",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -40662,13 +41567,14 @@
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
-			"name": "google/gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -40676,8 +41582,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"google/gemini-3.5-flash-thinking": {
 			"id": "google/gemini-3.5-flash-thinking",
@@ -41192,11 +42103,11 @@
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
-			"name": "inclusionai/ring-2.6-1t",
+			"name": "inclusionAI: Ring-2.6-1T",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -41206,8 +42117,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262000,
+			"maxTokens": 65000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"Infermatic/MN-12B-Inferor-v0.0": {
 			"id": "Infermatic/MN-12B-Inferor-v0.0",
@@ -43349,9 +44265,10 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -43360,7 +44277,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -44895,7 +45817,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -45755,7 +46677,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49151,13 +50073,14 @@
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
-			"name": "x-ai/grok-4.3",
+			"name": "Grok 4.3",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -49165,18 +50088,24 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
-			"name": "x-ai/grok-build-0.1",
+			"name": "Grok Build 0.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -49184,8 +50113,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
@@ -50622,10 +51556,9 @@
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -50634,12 +51567,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 8192
 		},
 		"minimaxai/minimax-m2": {
 			"id": "minimaxai/minimax-m2",
@@ -50927,9 +51855,10 @@
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -50938,7 +51867,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"mistralai/mixtral-8x22b-instruct": {
 			"id": "mistralai/mixtral-8x22b-instruct",
@@ -51316,6 +52250,30 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"nvidia/nemotron-3-ultra-550b-a55b": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b",
+			"name": "Nemotron 3 Ultra 550B A55B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"nvidia/nemotron-4-340b-instruct": {
 			"id": "nvidia/nemotron-4-340b-instruct",
 			"name": "Nemotron 4 340b Instruct",
@@ -51391,6 +52349,30 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-oss-120b": {
+			"id": "openai/gpt-oss-120b",
+			"name": "GPT-OSS-120B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -52659,15 +53641,14 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform",
-			"contextPromotionTarget": "openai/gpt-5.4"
+			"applyPatchToolType": "freeform"
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -52686,15 +53667,14 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform",
-			"contextPromotionTarget": "openai/gpt-5.4"
+			"applyPatchToolType": "freeform"
 		},
 		"o1": {
 			"id": "o1",
@@ -53627,6 +54607,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"mimo-v2-omni": {
 			"id": "mimo-v2-omni",
 			"name": "MiMo-V2-Omni",
@@ -53773,6 +54778,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.4,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
@@ -53815,7 +54845,7 @@
 				"cacheRead": 0.05,
 				"cacheWrite": 0.625
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1000000,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -53838,6 +54868,31 @@
 				"output": 7.5,
 				"cacheRead": 0.5,
 				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"qwen3.7-plus": {
+			"id": "qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 1.6,
+				"cacheRead": 0.04,
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -53990,7 +55045,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"claude-opus-4-7": {
@@ -54015,7 +55077,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-opus-4-8": {
@@ -54040,7 +55102,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-sonnet-4": {
@@ -54118,6 +55180,30 @@
 				"maxLevel": "high"
 			}
 		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"deepseek-v4-flash-free": {
 			"id": "deepseek-v4-flash-free",
 			"name": "DeepSeek V4 Flash Free",
@@ -54136,6 +55222,30 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.74,
+				"output": 3.84,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -54738,14 +55848,13 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "opencode-zen/gpt-5.4"
+			}
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -54764,14 +55873,13 @@
 				"cacheRead": 30,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "opencode-zen/gpt-5.4"
+			}
 		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
@@ -55024,8 +56132,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
+			"contextWindow": 200000,
+			"maxTokens": 32000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55152,6 +56260,54 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"nemotron-3-ultra-free": {
+			"id": "nemotron-3-ultra-free",
+			"name": "Nemotron 3 Ultra Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"north-mini-code-free": {
+			"id": "north-mini-code-free",
+			"name": "North Mini Code Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
@@ -55271,6 +56427,31 @@
 		}
 	},
 	"openrouter": {
+		"~anthropic/claude-fable-latest": {
+			"id": "~anthropic/claude-fable-latest",
+			"name": "Anthropic: Anthropic Fable Latest",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
 			"name": "Anthropic Anthropic Haiku Latest",
@@ -55408,13 +56589,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.684,
-				"output": 3.42,
-				"cacheRead": 0.144,
+				"input": 0.6799999999999999,
+				"output": 3.41,
+				"cacheRead": 0.33999999999999997,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55759,6 +56940,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"anthropic/claude-fable-5": {
+			"id": "anthropic/claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
 			"name": "Anthropic Haiku 4.5",
@@ -55956,7 +57162,7 @@
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
-			"name": "Anthropic: Anthropic Opus 4.8",
+			"name": "Anthropic Opus 4.8",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -56483,8 +57689,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2288,
-				"output": 0.9144,
+				"input": 0.20020000000000002,
+				"output": 0.8000999999999999,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -56646,13 +57852,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.252,
-				"output": 0.378,
+				"input": 0.2288,
+				"output": 0.3432,
 				"cacheRead": 0.0252,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -56694,13 +57900,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0983,
-				"output": 0.1966,
-				"cacheRead": 0.019700000000000002,
+				"input": 0.098,
+				"output": 0.196,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -57040,7 +58246,7 @@
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
-			"name": "Google: Gemini 3.1 Flash Lite",
+			"name": "Gemini 3.1 Flash Lite",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -57143,7 +58349,7 @@
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
-			"name": "Google: Gemini 3.5 Flash",
+			"name": "Gemini 3.5 Flash",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -57178,8 +58384,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.13,
+				"input": 0.049999999999999996,
+				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -57188,7 +58394,7 @@
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
-			"name": "Gemma-3-27B-IT",
+			"name": "Google: Gemma 3 27B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -57294,12 +58500,12 @@
 			],
 			"cost": {
 				"input": 0.12,
-				"output": 0.37,
-				"cacheRead": 0.019999999499999997,
+				"output": 0.35,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -57662,7 +58868,7 @@
 			],
 			"cost": {
 				"input": 0.02,
-				"output": 0.049999999999999996,
+				"output": 0.03,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -57739,7 +58945,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.08,
+				"input": 0.09999999999999999,
 				"output": 0.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -57831,8 +59037,8 @@
 			],
 			"cost": {
 				"input": 0.15,
-				"output": 1.15,
-				"cacheRead": 0.03,
+				"output": 0.8999999999999999,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -57881,13 +59087,38 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 1.2,
-				"cacheRead": 0.059,
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131070,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -58503,13 +59734,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 1.9,
+				"input": 0.375,
+				"output": 2.025,
 				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -58528,13 +59759,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.684,
-				"output": 3.42,
-				"cacheRead": 0.144,
+				"input": 0.6799999999999999,
+				"output": 3.41,
+				"cacheRead": 0.33999999999999997,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -58566,6 +59797,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"nex-agi/deepseek-v3.1-nex-n1": {
 			"id": "nex-agi/deepseek-v3.1-nex-n1",
 			"name": "Nex AGI: DeepSeek V3.1 Nex N1",
@@ -58584,6 +59840,31 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840
+		},
+		"nex-agi/nex-n2-pro:free": {
+			"id": "nex-agi/nex-n2-pro:free",
+			"name": "Nex AGI: Nex-N2-Pro (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"nousresearch/deephermes-3-mistral-24b-preview": {
 			"id": "nousresearch/deephermes-3-mistral-24b-preview",
@@ -58663,7 +59944,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.39999999999999997,
 				"output": 0.39999999999999997,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -58791,6 +60072,54 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b",
+			"name": "Nemotron 3 Ultra 550B A55B",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b:free": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+			"name": "NVIDIA: Nemotron 3 Ultra (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -59781,7 +61110,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -59806,7 +61135,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -60692,7 +62021,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.071,
+				"input": 0.09,
 				"output": 0.09999999999999999,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -60740,13 +62069,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.44999999999999996,
+				"input": 0.12,
+				"output": 0.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 20000,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -60764,13 +62093,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
+				"input": 0.04815,
+				"output": 0.19305,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 131072,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -60798,7 +62127,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3 32B",
+			"name": "Qwen3-32B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -61113,7 +62442,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3-Next-80B-A3B-Thinking",
+			"name": "Qwen: Qwen3 Next 80B A3B Thinking",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -61358,7 +62687,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61377,13 +62706,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 2.34,
+				"input": 0.385,
+				"output": 2.4499999999999997,
 				"cacheRead": 0.195,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"contextWindow": 256000,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61402,13 +62731,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.04,
+				"input": 0.09999999999999999,
 				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61502,8 +62831,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.29,
-				"output": 3.1999999999999997,
+				"input": 0.28850000000000003,
+				"output": 3.17,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -61527,13 +62856,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
+				"input": 0.15,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262140,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -61664,7 +62993,7 @@
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
-			"name": "Qwen: Qwen3.7 Max",
+			"name": "Qwen3.7 Max",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -61677,6 +63006,31 @@
 				"output": 3.75,
 				"cacheRead": 0.25,
 				"cacheWrite": 1.5625
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen/qwen3.7-plus": {
+			"id": "qwen/qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.32,
+				"output": 1.28,
+				"cacheRead": 0.064,
+				"cacheWrite": 0.39999999999999997
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -61858,7 +63212,7 @@
 		},
 		"stepfun/step-3.7-flash": {
 			"id": "stepfun/step-3.7-flash",
-			"name": "StepFun: Step 3.7 Flash",
+			"name": "Step 3.7 Flash",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -61895,13 +63249,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.063,
-				"output": 0.21,
-				"cacheRead": 0.020999999999999998,
+				"input": 0.06599999999999999,
+				"output": 0.26,
+				"cacheRead": 0.029,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 64000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62279,7 +63633,7 @@
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
-			"name": "xAI: Grok 4.3",
+			"name": "Grok 4.3",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -62295,7 +63649,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 8888,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62304,7 +63658,7 @@
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
-			"name": "xAI: Grok Build 0.1",
+			"name": "Grok Build 0.1",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -62320,7 +63674,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
-			"maxTokens": 8888,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62527,13 +63881,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.125,
+				"input": 0.13,
 				"output": 0.85,
-				"cacheRead": 0.06,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131070,
+			"maxTokens": 98304,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62651,11 +64005,11 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.8999999999999999,
-				"cacheRead": 0.049999999999999996,
+				"cacheRead": 0.055,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 24000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62750,7 +64104,7 @@
 				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 262144,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -63503,6 +64857,34 @@
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
+			}
+		},
+		"claude-fable-5": {
+			"id": "claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"claude-opus-4-5": {
@@ -64725,6 +66107,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"kimi-k2-7-code": {
+			"id": "kimi-k2-7-code",
+			"name": "kimi-k2-7-code",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"kimi-k2-thinking": {
 			"id": "kimi-k2-thinking",
 			"name": "Kimi K2 Thinking",
@@ -64894,6 +66298,56 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3 (3x usage)",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax-m3-preview": {
+			"id": "minimax-m3-preview",
+			"name": "minimax-m3-preview",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"mistral-31-24b": {
 			"id": "mistral-31-24b",
 			"name": "Venice Medium",
@@ -64984,6 +66438,28 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"nvidia-nemotron-3-ultra-550b-a55b": {
+			"id": "nvidia-nemotron-3-ultra-550b-a55b",
+			"name": "nvidia-nemotron-3-ultra-550b-a55b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -65335,6 +66811,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"qwen-3-7-plus": {
+			"id": "qwen-3-7-plus",
+			"name": "qwen-3-7-plus",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"qwen3-235b-a22b-instruct-2507": {
 			"id": "qwen3-235b-a22b-instruct-2507",
 			"name": "Qwen 3 235B A22B Instruct 2507",
@@ -65588,6 +67086,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"tencent-hy3-preview": {
+			"id": "tencent-hy3-preview",
+			"name": "tencent-hy3-preview",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"venice-uncensored": {
 			"id": "venice-uncensored",
 			"name": "Venice Uncensored 1.1",
@@ -65649,6 +67169,28 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"xiaomi-mimo-v2-5": {
+			"id": "xiaomi-mimo-v2-5",
+			"name": "xiaomi-mimo-v2-5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -65855,7 +67397,7 @@
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -65866,7 +67408,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen-3-30b": {
 			"id": "alibaba/qwen-3-30b",
@@ -65879,8 +67426,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.29,
+				"input": 0.12,
+				"output": 0.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -65972,7 +67519,7 @@
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -65983,7 +67530,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen3-coder-30b-a3b": {
 			"id": "alibaba/qwen3-coder-30b-a3b",
@@ -66108,6 +67660,49 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3-next-80b-a3b-instruct": {
+			"id": "alibaba/qwen3-next-80b-a3b-instruct",
+			"name": "Qwen3 Next 80B A3B Instruct",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768
+		},
+		"alibaba/qwen3-next-80b-a3b-thinking": {
+			"id": "alibaba/qwen3-next-80b-a3b-thinking",
+			"name": "Qwen3 Next 80B A3B Thinking",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -66257,6 +67852,31 @@
 				"cacheWrite": 1.5625
 			},
 			"contextWindow": 991000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3.7-plus": {
+			"id": "alibaba/qwen3.7-plus",
+			"name": "Qwen 3.7 Plus",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.08,
+				"cacheWrite": 0.5
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -66486,7 +68106,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"anthropic/claude-opus-4.7": {
@@ -66511,7 +68138,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"anthropic/claude-opus-4.8": {
@@ -66536,7 +68163,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"anthropic/claude-sonnet-4": {
@@ -66735,17 +68362,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.77,
-				"output": 0.77,
-				"cacheRead": 0,
+				"input": 0.27,
+				"output": 1.12,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 16384
+			"maxTokens": 163840
 		},
 		"deepseek/deepseek-v3.1": {
 			"id": "deepseek/deepseek-v3.1",
-			"name": "DeepSeek-V3.1",
+			"name": "DeepSeek V3.1",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -66823,7 +68450,8 @@
 			"provider": "vercel-ai-gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.62,
@@ -67206,19 +68834,24 @@
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.39999999999999997,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -67660,6 +69293,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax-M3",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"mistral/codestral": {
 			"id": "mistral/codestral",
 			"name": "Mistral Codestral",
@@ -67817,6 +69475,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"mistral/mistral-nemo": {
+			"id": "mistral/mistral-nemo",
+			"name": "Mistral Nemo 12B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.02,
+				"output": 0.04,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"mistral/mistral-small": {
 			"id": "mistral/mistral-small",
@@ -68027,6 +69704,79 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 262000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3-super-120b-a12b": {
+			"id": "nvidia/nemotron-3-super-120b-a12b",
+			"name": "Nemotron 3 Super",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.65,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b",
+			"name": "Nemotron 3 Ultra 550B A55B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -68751,7 +70501,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -68776,7 +70526,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -68795,13 +70545,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.5,
-				"cacheRead": 0,
+				"input": 0.35,
+				"output": 0.75,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 131000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -69068,6 +70818,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"stepfun/step-3.5-flash": {
+			"id": "stepfun/step-3.5-flash",
+			"name": "Step 3.5 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.09,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0.02
+			},
+			"contextWindow": 262114,
+			"maxTokens": 262114
 		},
 		"stepfun/step-3.7-flash": {
 			"id": "stepfun/step-3.7-flash",
@@ -69931,7 +71700,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 1.4,
@@ -70394,7 +72164,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 1000000,
 			"maxTokens": 30000
 		},
 		"grok-4.20-0309-reasoning": {
@@ -70414,7 +72184,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 1000000,
 			"maxTokens": 30000,
 			"thinking": {
 				"mode": "effort",
@@ -70654,19 +72424,12 @@
 			"maxTokens": 65536,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2-omni": {
@@ -70690,19 +72453,12 @@
 			"maxTokens": 131072,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2-pro": {
@@ -70725,19 +72481,12 @@
 			"maxTokens": 131072,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2.5": {
@@ -70761,19 +72510,12 @@
 			"maxTokens": 131072,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2.5-pro": {
@@ -70796,19 +72538,12 @@
 			"maxTokens": 131072,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2.5-pro-ultraspeed": {
@@ -70831,19 +72566,547 @@
 			"maxTokens": 131072,
 			"compat": {
 				"supportsStore": false,
-				"thinkingFormat": "zai",
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"allowsSyntheticReasoningContentForToolCalls": false
+				"thinkingFormat": "zai"
 			},
 			"thinking": {
 				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
+	"xiaomi-token-plan-ams": {
+		"mimo-v2-flash": {
+			"id": "mimo-v2-flash",
+			"name": "MiMo-V2-Flash",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-omni": {
+			"id": "mimo-v2-omni",
+			"name": "MiMo-V2-Omni",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-pro": {
+			"id": "mimo-v2-pro",
+			"name": "MiMo-V2-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo-V2.5",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo-V2.5-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro-ultraspeed": {
+			"id": "mimo-v2.5-pro-ultraspeed",
+			"name": "MiMo-V2.5-Pro-UltraSpeed",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-ams",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.305,
+				"output": 2.61,
+				"cacheRead": 0.0108,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
+	"xiaomi-token-plan-cn": {
+		"mimo-v2-flash": {
+			"id": "mimo-v2-flash",
+			"name": "MiMo-V2-Flash",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-omni": {
+			"id": "mimo-v2-omni",
+			"name": "MiMo-V2-Omni",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-pro": {
+			"id": "mimo-v2-pro",
+			"name": "MiMo-V2-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo-V2.5",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo-V2.5-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro-ultraspeed": {
+			"id": "mimo-v2.5-pro-ultraspeed",
+			"name": "MiMo-V2.5-Pro-UltraSpeed",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-cn",
+			"baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.305,
+				"output": 2.61,
+				"cacheRead": 0.0108,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
+	"xiaomi-token-plan-sgp": {
+		"mimo-v2-flash": {
+			"id": "mimo-v2-flash",
+			"name": "MiMo-V2-Flash",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-omni": {
+			"id": "mimo-v2-omni",
+			"name": "MiMo-V2-Omni",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-pro": {
+			"id": "mimo-v2-pro",
+			"name": "MiMo-V2-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo-V2.5",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-asr": {
+			"id": "mimo-v2.5-asr",
+			"name": "mimo-v2.5-asr",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo-V2.5-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro-ultraspeed": {
+			"id": "mimo-v2.5-pro-ultraspeed",
+			"name": "MiMo-V2.5-Pro-UltraSpeed",
+			"api": "openai-completions",
+			"provider": "xiaomi-token-plan-sgp",
+			"baseUrl": "https://token-plan-sgp.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.305,
+				"output": 2.61,
+				"cacheRead": 0.0108,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		}
 	},
@@ -71154,7 +73417,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
@@ -71248,6 +73511,31 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-fable-5": {
+			"id": "anthropic/claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "anthropic-messages",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -71371,7 +73659,14 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
 			}
 		},
 		"anthropic/claude-opus-4.7": {
@@ -71396,7 +73691,32 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
+			}
+		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
 			}
 		},
 		"anthropic/claude-sonnet-4": {
@@ -72122,7 +74442,7 @@
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
-			"name": "Google: Gemini 3.1 Flash Lite",
+			"name": "Gemini 3.1 Flash Lite",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -72138,7 +74458,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8888,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72196,7 +74516,7 @@
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
-			"name": "Google: Gemini 3.5 Flash",
+			"name": "Gemini 3.5 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -72212,7 +74532,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8888,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72457,8 +74777,8 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"contextWindow": 262000,
+			"maxTokens": 65000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72772,6 +75092,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
 			"name": "Mistral: Mistral Large 3",
@@ -72922,6 +75267,56 @@
 			},
 			"contextWindow": 262140,
 			"maxTokens": 262140,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"moonshotai/kimi-k2.7-code-free": {
+			"id": "moonshotai/kimi-k2.7-code-free",
+			"name": "Kimi K2.7 Code (Free)",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -73536,7 +75931,32 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-5.5-instant": {
+			"id": "openai/gpt-5.5-instant",
+			"name": "GPT-5.5 Instant",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -73561,7 +75981,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 400000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -73892,7 +76312,7 @@
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
-			"name": "Qwen: Qwen3.7-Max",
+			"name": "Qwen3.7 Max",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -73903,11 +76323,36 @@
 			"cost": {
 				"input": 2.5,
 				"output": 7.5,
-				"cacheRead": 0.25,
+				"cacheRead": 0.5,
 				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 8888,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen/qwen3.7-plus": {
+			"id": "qwen/qwen3.7-plus",
+			"name": "Qwen3.7 Plus",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 1.6,
+				"cacheRead": 0.08,
+				"cacheWrite": 0.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -74070,6 +76515,56 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 1.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"stepfun/step-3.7-flash-free": {
+			"id": "stepfun/step-3.7-flash-free",
+			"name": "Step 3.7 Flash (Free)",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -74455,11 +76950,11 @@
 		},
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
-			"name": "xAI: Grok 4.3",
+			"name": "Grok 4.3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -74471,7 +76966,37 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 8888
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"x-ai/grok-build-0.1": {
+			"id": "x-ai/grok-build-0.1",
+			"name": "Grok Build 0.1",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -70637,9 +70637,9 @@
 		"mimo-v2-flash": {
 			"id": "mimo-v2-flash",
 			"name": "MiMo-V2-Flash",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -70652,18 +70652,29 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		},
 		"mimo-v2-omni": {
 			"id": "mimo-v2-omni",
 			"name": "MiMo-V2-Omni",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -70677,18 +70688,29 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		},
 		"mimo-v2-pro": {
 			"id": "mimo-v2-pro",
 			"name": "MiMo-V2-Pro",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -70701,18 +70723,29 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
 			"name": "MiMo-V2.5",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -70726,18 +70759,29 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
 			"name": "MiMo-V2.5-Pro",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -70750,10 +70794,56 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"mimo-v2.5-pro-ultraspeed": {
+			"id": "mimo-v2.5-pro-ultraspeed",
+			"name": "MiMo-V2.5-Pro-UltraSpeed",
+			"api": "openai-completions",
+			"provider": "xiaomi",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.305,
+				"output": 2.61,
+				"cacheRead": 0.0108,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		}
 	},

--- a/packages/ai/src/provider-models/descriptor-types.ts
+++ b/packages/ai/src/provider-models/descriptor-types.ts
@@ -1,0 +1,79 @@
+import type { ModelManagerOptions } from "../model-manager";
+import type { Api, FetchImpl } from "../types";
+
+/** Config passed to a provider's runtime model-manager factory. */
+export type ModelManagerConfig = { apiKey?: string; baseUrl?: string; fetch?: FetchImpl };
+
+/** Catalog discovery configuration for providers that support endpoint-based model listing. */
+export interface CatalogDiscoveryConfig {
+	/** Human-readable name for log messages. */
+	label: string;
+	/**
+	 * Environment variables to check for API keys during catalog generation.
+	 * Defaults to the entry-level `envVars` when omitted.
+	 */
+	envVars?: readonly string[];
+	/** OAuth provider for credential refresh during catalog generation. */
+	oauthProvider?: string;
+	/** When true, catalog discovery proceeds even without credentials. */
+	allowUnauthenticated?: boolean;
+}
+
+/** Unified provider descriptor used by both runtime discovery and catalog generation. */
+export interface ProviderDescriptor {
+	providerId: string;
+	createModelManagerOptions(config: ModelManagerConfig): ModelManagerOptions<Api>;
+	/** Preferred model ID when no explicit selection is made. */
+	defaultModel: string;
+	/** When true, the runtime creates a model manager even without a valid API key (e.g. ollama). */
+	allowUnauthenticated?: boolean;
+	/** When true, successful runtime discovery replaces bundled provider models instead of merging fallback-only IDs. */
+	dynamicModelsAuthoritative?: boolean;
+	/** Catalog discovery configuration. Only providers with this field participate in generate-models.ts. */
+	catalogDiscovery?: CatalogDiscoveryConfig;
+}
+
+/** A provider descriptor that has catalog discovery configured. */
+export type CatalogProviderDescriptor = ProviderDescriptor & { catalogDiscovery: CatalogDiscoveryConfig };
+
+/** Type guard for descriptors with catalog discovery. */
+export function isCatalogDescriptor(d: ProviderDescriptor): d is CatalogProviderDescriptor {
+	return d.catalogDiscovery != null;
+}
+
+/** Whether catalog discovery may run without provider credentials. */
+export function allowsUnauthenticatedCatalogDiscovery(descriptor: CatalogProviderDescriptor): boolean {
+	return descriptor.catalogDiscovery.allowUnauthenticated ?? descriptor.allowUnauthenticated ?? false;
+}
+
+/**
+ * One model provider's catalog-side description. The auth half of a provider
+ * (env keys, OAuth login/refresh flows) lives in `@oh-my-pi/pi-ai`'s registry;
+ * the catalog table below is the single source of truth for ids, default
+ * models, and discovery wiring.
+ *
+ * - Every entry is a member of `KnownProvider`.
+ * - `createModelManagerOptions` present (and not `specialModelManager`) ⇒
+ *   appears in `PROVIDER_DESCRIPTORS` for runtime model discovery.
+ * - `catalogDiscovery` present ⇒ participates in `generate-models.ts`.
+ */
+export interface ProviderCatalogEntry {
+	readonly id: string;
+	/** Preferred model ID when no explicit selection is made. */
+	readonly defaultModel: string;
+	/** Environment variables consulted (in order) for the provider's runtime API-key env fallback. */
+	readonly envVars?: readonly string[];
+	/** Runtime model-manager factory. Omitted for catalog-only providers. */
+	readonly createModelManagerOptions?: (config: ModelManagerConfig) => ModelManagerOptions<Api>;
+	/** When true, the runtime creates a model manager even without a valid API key. */
+	readonly allowUnauthenticated?: boolean;
+	/** When true, successful runtime discovery replaces bundled provider models. */
+	readonly dynamicModelsAuthoritative?: boolean;
+	/** Catalog discovery configuration for generate-models.ts. */
+	readonly catalogDiscovery?: CatalogDiscoveryConfig;
+	/**
+	 * Built bespoke by the coding-agent runtime (OAuth-token-driven managers);
+	 * excluded from `PROVIDER_DESCRIPTORS` even though models are discoverable.
+	 */
+	readonly specialModelManager?: boolean;
+}

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -275,6 +275,24 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("Xiaomi", ["XIAOMI_API_KEY"]),
 	),
 	catalogDescriptor(
+		"xiaomi-token-plan-ams",
+		"mimo-v2.5",
+		config => xiaomiModelManagerOptions({ ...config, providerId: "xiaomi-token-plan-ams", tokenPlanRegion: "ams" }),
+		catalog("Xiaomi Token Plan (Europe)", ["XIAOMI_TOKEN_PLAN_AMS_API_KEY"]),
+	),
+	catalogDescriptor(
+		"xiaomi-token-plan-cn",
+		"mimo-v2.5",
+		config => xiaomiModelManagerOptions({ ...config, providerId: "xiaomi-token-plan-cn", tokenPlanRegion: "cn" }),
+		catalog("Xiaomi Token Plan (China)", ["XIAOMI_TOKEN_PLAN_CN_API_KEY"]),
+	),
+	catalogDescriptor(
+		"xiaomi-token-plan-sgp",
+		"mimo-v2.5",
+		config => xiaomiModelManagerOptions({ ...config, providerId: "xiaomi-token-plan-sgp", tokenPlanRegion: "sgp" }),
+		catalog("Xiaomi Token Plan (Singapore)", ["XIAOMI_TOKEN_PLAN_SGP_API_KEY"]),
+	),
+	catalogDescriptor(
 		"zenmux",
 		"anthropic/claude-opus-4.6",
 		config => zenmuxModelManagerOptions(config),

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1414,64 +1414,79 @@ export function cloudflareAiGatewayModelManagerOptions(
 // ---------------------------------------------------------------------------
 // 20. Xiaomi
 // ---------------------------------------------------------------------------
+// 20. Xiaomi
+// ---------------------------------------------------------------------------
+/** Region codes for Xiaomi Token Plan clusters exposed as separate login providers. */
+export type XiaomiTokenPlanRegion = "sgp" | "ams" | "cn";
 
+/** Configures Xiaomi standard or regional Token Plan OpenAI-compatible model discovery. */
 export interface XiaomiModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
+	fetch?: FetchImpl;
+	providerId?: Provider;
+	tokenPlanRegion?: XiaomiTokenPlanRegion;
 }
+const XIAOMI_TOKEN_PLAN_BASE_URLS: Record<XiaomiTokenPlanRegion, string> = {
+	sgp: "https://token-plan-sgp.xiaomimimo.com/v1",
+	ams: "https://token-plan-ams.xiaomimimo.com/v1",
+	cn: "https://token-plan-cn.xiaomimimo.com/v1",
+};
 
+const XIAOMI_TOKEN_PLAN_FALLBACK_BASE_URLS = [
+	XIAOMI_TOKEN_PLAN_BASE_URLS.sgp,
+	XIAOMI_TOKEN_PLAN_BASE_URLS.ams,
+	XIAOMI_TOKEN_PLAN_BASE_URLS.cn,
+];
+
+/** Builds a Xiaomi model manager, preserving Token Plan region provider ids during discovery. */
 export function xiaomiModelManagerOptions(
 	config?: XiaomiModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
-	// Xiaomi splits API keys across two backends: standard `sk-` keys hit
-	// api.xiaomimimo.com; "token plan" `tp-` keys hit either the SG or EU
-	// token-plan host. Try SGP first; if discovery fails, retry AMS.
-	const TOKEN_PLAN_SGP_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
-	const TOKEN_PLAN_AMS_BASE_URL = "https://token-plan-ams.xiaomimimo.com/v1";
-	const defaultBaseUrl = apiKey?.startsWith("tp-") ? TOKEN_PLAN_SGP_BASE_URL : "https://api.xiaomimimo.com/v1";
-	// Token-plan keys always use the TP baseUrl; config?.baseUrl (from catalog)
+	const providerId = config?.providerId ?? "xiaomi";
+	const tokenPlanBaseUrls = config?.tokenPlanRegion
+		? [XIAOMI_TOKEN_PLAN_BASE_URLS[config.tokenPlanRegion]]
+		: XIAOMI_TOKEN_PLAN_FALLBACK_BASE_URLS;
+	const XIAOMI_STANDARD_BASE_URL = "https://api.xiaomimimo.com/v1";
+	const isTokenPlanProvider = config?.tokenPlanRegion !== undefined || providerId.startsWith("xiaomi-token-plan-");
+	const isTokenPlanKey = isTokenPlanProvider || apiKey?.startsWith("tp-");
+	// Token-plan keys always use a TP cluster; config?.baseUrl (from catalog)
 	// would incorrectly pin to the standard endpoint (api.xiaomimimo.com).
-	const baseUrl = apiKey?.startsWith("tp-") ? defaultBaseUrl : (config?.baseUrl ?? defaultBaseUrl);
+	const baseUrl = isTokenPlanKey ? tokenPlanBaseUrls[0] : (config?.baseUrl ?? XIAOMI_STANDARD_BASE_URL);
 	const references = createBundledReferenceMap<"openai-completions">("xiaomi");
+	const fetchModels = (url: string) =>
+		fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: providerId,
+			baseUrl: url,
+			apiKey,
+			filterModel: (_entry, model) => !model.id.includes("-tts"),
+			mapModel: (entry, defaults) => {
+				const reference = references.get(defaults.id);
+				const model = mapWithBundledReference(entry, defaults, reference);
+				return {
+					...model,
+					api: "openai-completions",
+					provider: providerId,
+					baseUrl: defaults.baseUrl,
+					name: toModelName(entry.display_name, model.name),
+				};
+			},
+			fetch: config?.fetch,
+		});
 	return {
-		providerId: "xiaomi",
+		providerId,
 		...(apiKey && {
 			fetchDynamicModels: async () => {
-				const sgpResult = await fetchOpenAICompatibleModels({
-					api: "openai-completions",
-					provider: "xiaomi",
-					baseUrl,
-					apiKey,
-					filterModel: (_entry, model) => !model.id.includes("-tts"),
-					mapModel: (entry, defaults) => {
-						const reference = references.get(defaults.id);
-						const model = mapWithBundledReference(entry, defaults, reference);
-						return {
-							...model,
-							name: toModelName(entry.display_name, model.name),
-						};
-					},
-				});
-				if (sgpResult || !apiKey?.startsWith("tp-")) {
-					return sgpResult;
+				if (!isTokenPlanKey) {
+					return fetchModels(baseUrl);
 				}
-				// Token-plan discovery failed with SGP; retry with AMS
-				return fetchOpenAICompatibleModels({
-					api: "openai-completions",
-					provider: "xiaomi",
-					baseUrl: TOKEN_PLAN_AMS_BASE_URL,
-					apiKey,
-					filterModel: (_entry, model) => !model.id.includes("-tts"),
-					mapModel: (entry, defaults) => {
-						const reference = references.get(defaults.id);
-						const model = mapWithBundledReference(entry, defaults, reference);
-						return {
-							...model,
-							name: toModelName(entry.display_name, model.name),
-						};
-					},
-				});
+				for (const url of tokenPlanBaseUrls) {
+					const result = await fetchModels(url);
+					if (result) return result;
+				}
+				return null;
 			},
 		}),
 	};
@@ -2166,9 +2181,13 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	// --- zAI ---
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Xiaomi ---
-	anthropicMessagesDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/anthropic", {
+	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,
 		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+		},
 	}),
 	// --- MiniMax Coding Plan ---
 	openAiCompletionsDescriptor("minimax-coding-plan", "minimax-code", "https://api.minimax.io/v1", {

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1414,8 +1414,6 @@ export function cloudflareAiGatewayModelManagerOptions(
 // ---------------------------------------------------------------------------
 // 20. Xiaomi
 // ---------------------------------------------------------------------------
-// 20. Xiaomi
-// ---------------------------------------------------------------------------
 /** Region codes for Xiaomi Token Plan clusters exposed as separate login providers. */
 export type XiaomiTokenPlanRegion = "sgp" | "ams" | "cn";
 
@@ -1455,6 +1453,13 @@ export function xiaomiModelManagerOptions(
 	// would incorrectly pin to the standard endpoint (api.xiaomimimo.com).
 	const baseUrl = isTokenPlanKey ? tokenPlanBaseUrls[0] : (config?.baseUrl ?? XIAOMI_STANDARD_BASE_URL);
 	const references = createBundledReferenceMap<"openai-completions">("xiaomi");
+	const throwOnAuthFetch: typeof globalThis.fetch = async (url, init) => {
+		const response = await (config?.fetch ?? globalThis.fetch)(url, init);
+		if (response.status === 401 || response.status === 403) {
+			throw new Error(`Authentication failed (${response.status}) for ${url}`);
+		}
+		return response;
+	};
 	const fetchModels = (url: string) =>
 		fetchOpenAICompatibleModels({
 			api: "openai-completions",
@@ -1473,7 +1478,7 @@ export function xiaomiModelManagerOptions(
 					name: toModelName(entry.display_name, model.name),
 				};
 			},
-			fetch: config?.fetch,
+			fetch: throwOnAuthFetch,
 		});
 	return {
 		providerId,
@@ -1483,8 +1488,15 @@ export function xiaomiModelManagerOptions(
 					return fetchModels(baseUrl);
 				}
 				for (const url of tokenPlanBaseUrls) {
-					const result = await fetchModels(url);
-					if (result) return result;
+					try {
+						const result = await fetchModels(url);
+						if (result) return result;
+					} catch (error) {
+						// Auth errors (401/403) should fail fast, not retry other regions
+						const message = error instanceof Error ? error.message : String(error);
+						if (message.includes("Authentication failed")) throw error;
+						// Network/timeout errors: try next URL
+					}
 				}
 				return null;
 			},
@@ -2182,6 +2194,30 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
+		defaultContextWindow: 262144,
+		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+		},
+	}),
+	openAiCompletionsDescriptor("xiaomi", "xiaomi-token-plan-sgp", "https://token-plan-sgp.xiaomimimo.com/v1", {
+		defaultContextWindow: 262144,
+		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+		},
+	}),
+	openAiCompletionsDescriptor("xiaomi", "xiaomi-token-plan-ams", "https://token-plan-ams.xiaomimimo.com/v1", {
+		defaultContextWindow: 262144,
+		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+		},
+	}),
+	openAiCompletionsDescriptor("xiaomi", "xiaomi-token-plan-cn", "https://token-plan-cn.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,
 		defaultMaxTokens: 8192,
 		compat: {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -141,6 +141,9 @@ export type KnownProvider =
 	| "venice"
 	| "vllm"
 	| "xiaomi"
+	| "xiaomi-token-plan-sgp"
+	| "xiaomi-token-plan-ams"
+	| "xiaomi-token-plan-cn"
 	| "zenmux"
 	| "lm-studio";
 export type Provider = KnownProvider | string;

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -141,6 +141,21 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "xiaomi-token-plan-sgp",
+		name: "Xiaomi Token Plan (Singapore)",
+		available: true,
+	},
+	{
+		id: "xiaomi-token-plan-ams",
+		name: "Xiaomi Token Plan (Europe)",
+		available: true,
+	},
+	{
+		id: "xiaomi-token-plan-cn",
+		name: "Xiaomi Token Plan (China)",
+		available: true,
+	},
+	{
 		id: "opencode-zen",
 		name: "OpenCode Zen",
 		available: true,

--- a/packages/ai/src/utils/oauth/xiaomi.ts
+++ b/packages/ai/src/utils/oauth/xiaomi.ts
@@ -4,23 +4,44 @@
  * Xiaomi MiMo provides OpenAI-compatible models via
  * https://api.xiaomimimo.com/v1.
  *
- * This is not OAuth - it's a simple API key flow:
- * 1. Open browser to Xiaomi MiMo API key console
- * 2. User copies their API key
- * 3. User pastes the API key into the CLI
+ * Standard Xiaomi login opens the pay-as-you-go API key console. Token Plan
+ * login opens plan management so users copy the regional `tp-...` key.
  */
 
+import type { FetchImpl } from "../../types";
 import type { OAuthController } from "./types";
 
 const PROVIDER_ID = "xiaomi";
 const PROVIDER_NAME = "Xiaomi MiMo";
 const STANDARD_AUTH_URL = "https://platform.xiaomimimo.com/#/console/api-keys";
+const TOKEN_PLAN_AUTH_URL = "https://platform.xiaomimimo.com/console/plan-manage";
 const STANDARD_API_BASE_URL = "https://api.xiaomimimo.com/v1";
-const TOKEN_PLAN_SGP_API_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
-const TOKEN_PLAN_AMS_API_BASE_URL = "https://token-plan-ams.xiaomimimo.com/v1";
 const TOKEN_PLAN_KEY_PREFIX = "tp-";
 const STANDARD_VALIDATION_MODEL = "mimo-v2-flash";
 const TOKEN_PLAN_VALIDATION_MODEL = "mimo-v2.5";
+const TOKEN_PLAN_SGP_API_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
+const TOKEN_PLAN_AMS_API_BASE_URL = "https://token-plan-ams.xiaomimimo.com/v1";
+const TOKEN_PLAN_CN_API_BASE_URL = "https://token-plan-cn.xiaomimimo.com/v1";
+
+/** Region codes accepted by the Xiaomi Token Plan login flow. */
+export type XiaomiTokenPlanRegion = "sgp" | "ams" | "cn";
+
+type XiaomiValidationEndpoint = {
+	baseUrl: string;
+	model: string;
+};
+
+const TOKEN_PLAN_VALIDATION_ENDPOINTS: Record<XiaomiTokenPlanRegion, XiaomiValidationEndpoint> = {
+	sgp: { baseUrl: TOKEN_PLAN_SGP_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
+	ams: { baseUrl: TOKEN_PLAN_AMS_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
+	cn: { baseUrl: TOKEN_PLAN_CN_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
+};
+
+const TOKEN_PLAN_REGION_NAMES: Record<XiaomiTokenPlanRegion, string> = {
+	sgp: "Singapore",
+	ams: "Europe",
+	cn: "China",
+};
 
 function isTokenPlanKey(apiKey: string): boolean {
 	return apiKey.startsWith(TOKEN_PLAN_KEY_PREFIX);
@@ -28,15 +49,24 @@ function isTokenPlanKey(apiKey: string): boolean {
 
 const VALIDATION_TIMEOUT_MS = 15_000;
 
-async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promise<void> {
-	// For token-plan keys try SGP first, then AMS as fallback.
-	// Standard sk- keys only hit the one endpoint.
-	const endpoints = isTokenPlanKey(apiKey)
-		? [
-				{ baseUrl: TOKEN_PLAN_SGP_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
-				{ baseUrl: TOKEN_PLAN_AMS_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
-			]
-		: [{ baseUrl: STANDARD_API_BASE_URL, model: STANDARD_VALIDATION_MODEL }];
+async function validateXiaomiApiKey(
+	apiKey: string,
+	tokenPlanRegion: XiaomiTokenPlanRegion | undefined,
+	signal?: AbortSignal,
+	fetchOverride?: FetchImpl,
+): Promise<void> {
+	const fetchImpl = fetchOverride ?? fetch;
+	// Region-specific Token Plan logins must validate against the selected
+	// cluster. Generic Xiaomi login keeps the historical SGP → AMS → CN fallback.
+	const endpoints = tokenPlanRegion
+		? [TOKEN_PLAN_VALIDATION_ENDPOINTS[tokenPlanRegion]]
+		: isTokenPlanKey(apiKey)
+			? [
+					TOKEN_PLAN_VALIDATION_ENDPOINTS.sgp,
+					TOKEN_PLAN_VALIDATION_ENDPOINTS.ams,
+					TOKEN_PLAN_VALIDATION_ENDPOINTS.cn,
+				]
+			: [{ baseUrl: STANDARD_API_BASE_URL, model: STANDARD_VALIDATION_MODEL }];
 
 	let lastError: Error | null = null;
 
@@ -47,11 +77,11 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
 		const timeoutSignal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
 		const requestSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 		try {
-			const response = await fetch(`${ep.baseUrl}/chat/completions`, {
+			const response = await fetchImpl(`${ep.baseUrl}/chat/completions`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-api-key": apiKey,
+					Authorization: `Bearer ${apiKey}`,
 				},
 				body: JSON.stringify({
 					model: ep.model,
@@ -112,6 +142,7 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
  * Returns the API key directly (not OAuthCredentials - this isn't OAuth).
  */
 export async function loginXiaomi(options: OAuthController): Promise<string> {
+	const fetchImpl = options.fetch ?? fetch;
 	if (!options.onPrompt) {
 		throw new Error(`${PROVIDER_NAME} login requires onPrompt callback`);
 	}
@@ -132,6 +163,37 @@ export async function loginXiaomi(options: OAuthController): Promise<string> {
 	}
 
 	options.onProgress?.(`Validating ${PROVIDER_ID} API key...`);
-	await validateXiaomiApiKey(trimmed, options.signal);
+	await validateXiaomiApiKey(trimmed, undefined, options.signal, fetchImpl);
+	return trimmed;
+}
+
+/**
+ * Login to a regional Xiaomi Token Plan endpoint.
+ *
+ * Prompts for a token-plan API key and validates it against the selected region.
+ */
+export async function loginXiaomiTokenPlan(options: OAuthController, region: XiaomiTokenPlanRegion): Promise<string> {
+	const fetchImpl = options.fetch ?? fetch;
+	if (!options.onPrompt) {
+		throw new Error(`Xiaomi Token Plan (${TOKEN_PLAN_REGION_NAMES[region]}) login requires onPrompt callback`);
+	}
+	options.onAuth?.({
+		url: TOKEN_PLAN_AUTH_URL,
+		instructions: `Copy your token-plan API key for the ${TOKEN_PLAN_REGION_NAMES[region]} region`,
+	});
+	const apiKey = await options.onPrompt({
+		message: `Paste your Xiaomi Token Plan ${TOKEN_PLAN_REGION_NAMES[region]} API key (tp-...)`,
+		placeholder: "tp-...",
+	});
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	options.onProgress?.(`Validating Xiaomi Token Plan (${TOKEN_PLAN_REGION_NAMES[region]}) API key...`);
+	await validateXiaomiApiKey(trimmed, region, options.signal, fetchImpl);
 	return trimmed;
 }

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -61,6 +61,41 @@ function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<stri
 	return replacement && profiles.has(replacement) ? replacement : profileName;
 }
 
+/**
+ * Rewrite model selectors to use an authenticated provider when the original
+ * provider in the selector is not authenticated.  This allows profiles with
+ * multiple fallback providers (e.g. xiaomi / xiaomi-token-plan-sgp) to work
+ * when only one of them is logged in.
+ */
+function rewriteSelectorProvider(selector: string, authenticatedProviders: readonly string[]): string {
+	const slash = selector.indexOf("/");
+	if (slash < 0) return selector;
+	const provider = selector.substring(0, slash);
+	if (authenticatedProviders.includes(provider)) return selector;
+	// Pick the first authenticated provider as replacement
+	const replacement = authenticatedProviders[0];
+	if (!replacement) return selector;
+	return replacement + selector.substring(slash);
+}
+
+function rewriteBindingsProviders(
+	bindings: { defaultSelector?: string; agentModelOverrides: Record<string, string> },
+	authenticatedProviders: readonly string[],
+): { defaultSelector?: string; agentModelOverrides: Record<string, string> } {
+	if (authenticatedProviders.length === 0) return bindings;
+	return {
+		defaultSelector: bindings.defaultSelector
+			? rewriteSelectorProvider(bindings.defaultSelector, authenticatedProviders)
+			: undefined,
+		agentModelOverrides: Object.fromEntries(
+			Object.entries(bindings.agentModelOverrides).map(([role, sel]) => [
+				role,
+				rewriteSelectorProvider(sel, authenticatedProviders),
+			]),
+		),
+	};
+}
+
 export async function prepareModelProfileActivation(
 	options: PrepareModelProfileActivationOptions,
 ): Promise<PreparedModelProfileActivation> {
@@ -72,19 +107,30 @@ export async function prepareModelProfileActivation(
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
 	}
 
+	const allProviders = aggregateModelProfileRequiredProviders(profile.requiredProviders, profile);
 	const missingProviders: string[] = [];
-	for (const provider of aggregateModelProfileRequiredProviders(profile.requiredProviders, profile)) {
+	const authenticatedProviders: string[] = [];
+	for (const provider of allProviders) {
 		const apiKey = await options.modelRegistry.getApiKeyForProvider(provider, options.session.sessionId);
 		if (!isAuthenticated(apiKey)) {
 			missingProviders.push(provider);
+		} else {
+			authenticatedProviders.push(provider);
 		}
 	}
-	if (missingProviders.length > 0) {
+	// Allow profile activation when at least one provider is authenticated.
+	// Fallback chain handles runtime provider selection.
+	if (authenticatedProviders.length === 0) {
 		throw new Error(formatModelProfileCredentialError(options.profileName, missingProviders));
 	}
 
 	const availableModels = options.modelRegistry.getAll();
-	const bindings = resolveProfileBindings(profile);
+	let bindings = resolveProfileBindings(profile);
+	// Rewrite selectors to use an authenticated provider when the original
+	// provider is not logged in (e.g. xiaomi → xiaomi-token-plan-sgp).
+	if (missingProviders.length > 0) {
+		bindings = rewriteBindingsProviders(bindings, authenticatedProviders);
+	}
 	const resolvedDefault = bindings.defaultSelector
 		? resolveModelRoleValue(bindings.defaultSelector, availableModels, {
 				settings: options.settings as Settings,

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -108,6 +108,9 @@ export async function prepareModelProfileActivation(
 	}
 
 	const allProviders = aggregateModelProfileRequiredProviders(profile.requiredProviders, profile);
+	const alternativeGroups = profile.alternativeProviderGroups ?? [];
+	const alternativeSet = new Set(alternativeGroups.flat());
+
 	const missingProviders: string[] = [];
 	const authenticatedProviders: string[] = [];
 	for (const provider of allProviders) {
@@ -118,8 +121,21 @@ export async function prepareModelProfileActivation(
 			authenticatedProviders.push(provider);
 		}
 	}
-	// Allow profile activation when at least one provider is authenticated.
-	// Fallback chain handles runtime provider selection.
+
+	// Check strict (non-alternative) providers — all must be authenticated.
+	const strictMissing = missingProviders.filter(p => !alternativeSet.has(p));
+	if (strictMissing.length > 0) {
+		throw new Error(formatModelProfileCredentialError(options.profileName, strictMissing));
+	}
+
+	// Check alternative groups — at least one provider per group must be authenticated.
+	for (const group of alternativeGroups) {
+		const groupAuthenticated = group.some(p => authenticatedProviders.includes(p));
+		if (!groupAuthenticated) {
+			throw new Error(formatModelProfileCredentialError(options.profileName, [...group]));
+		}
+	}
+
 	if (authenticatedProviders.length === 0) {
 		throw new Error(formatModelProfileCredentialError(options.profileName, missingProviders));
 	}
@@ -127,8 +143,10 @@ export async function prepareModelProfileActivation(
 	const availableModels = options.modelRegistry.getAll();
 	let bindings = resolveProfileBindings(profile);
 	// Rewrite selectors to use an authenticated provider when the original
-	// provider is not logged in (e.g. xiaomi → xiaomi-token-plan-sgp).
-	if (missingProviders.length > 0) {
+	// provider is not logged in, but only for alternative provider groups
+	// (e.g. xiaomi → xiaomi-token-plan-sgp). Strict providers are already
+	// validated above, so missing providers here are all alternative-group members.
+	if (missingProviders.length > 0 && alternativeGroups.length > 0) {
 		bindings = rewriteBindingsProviders(bindings, authenticatedProviders);
 	}
 	const resolvedDefault = bindings.defaultSelector

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -6,6 +6,16 @@ export type ModelProfileRole = GjcModelAssignmentTargetId;
 export interface ModelProfileDefinition {
 	name: string;
 	requiredProviders: string[];
+	/**
+	 * Optional groups of providers that are interchangeable fallbacks.
+	 * Each group is an array of provider ids where at least one must be
+	 * authenticated. Providers NOT in any group are treated as strict
+	 * requirements (all must be authenticated).
+	 *
+	 * Example: `[["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"]]`
+	 * means any single xiaomi credential satisfies the group.
+	 */
+	alternativeProviderGroups?: readonly (readonly string[])[];
 	modelMapping: Partial<Record<ModelProfileRole, string>>;
 	source: "builtin" | "user";
 }
@@ -46,9 +56,11 @@ const profile = (
 	name: string,
 	requiredProviders: string[],
 	modelMapping: Record<ModelProfileRole, string>,
+	alternativeProviderGroups?: readonly (readonly string[])[],
 ): ModelProfileDefinition => ({
 	name,
 	requiredProviders: aggregateModelProfileRequiredProviders(requiredProviders, { modelMapping }),
+	alternativeProviderGroups,
 	modelMapping,
 	source: "builtin",
 });
@@ -138,20 +150,30 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "xiaomi/mimo-v2.5-pro:medium",
 		architect: "xiaomi/mimo-v2.5-pro:high",
 	}),
-	profile("mimo-medium", ["xiaomi", "xiaomi-token-plan-sgp"], {
-		default: "xiaomi/mimo-v2.5-pro:medium",
-		executor: "xiaomi/mimo-v2.5-pro:low",
-		planner: "xiaomi/mimo-v2.5-pro:medium",
-		critic: "xiaomi/mimo-v2.5-pro:high",
-		architect: "xiaomi/mimo-v2.5-pro:xhigh",
-	}),
-	profile("mimo-pro", ["xiaomi", "xiaomi-token-plan-sgp"], {
-		default: "xiaomi/mimo-v2.5-pro:xhigh",
-		executor: "xiaomi/mimo-v2.5-pro:medium",
-		planner: "xiaomi/mimo-v2.5-pro:high",
-		critic: "xiaomi/mimo-v2.5-pro:xhigh",
-		architect: "xiaomi/mimo-v2.5-pro:xhigh",
-	}),
+	profile(
+		"mimo-medium",
+		["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"],
+		{
+			default: "xiaomi/mimo-v2.5-pro:medium",
+			executor: "xiaomi/mimo-v2.5-pro:low",
+			planner: "xiaomi/mimo-v2.5-pro:medium",
+			critic: "xiaomi/mimo-v2.5-pro:high",
+			architect: "xiaomi/mimo-v2.5-pro:xhigh",
+		},
+		[["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"]],
+	),
+	profile(
+		"mimo-pro",
+		["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"],
+		{
+			default: "xiaomi/mimo-v2.5-pro:xhigh",
+			executor: "xiaomi/mimo-v2.5-pro:medium",
+			planner: "xiaomi/mimo-v2.5-pro:high",
+			critic: "xiaomi/mimo-v2.5-pro:xhigh",
+			architect: "xiaomi/mimo-v2.5-pro:xhigh",
+		},
+		[["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"]],
+	),
 	profile("grok-eco", ["xai"], {
 		default: "xai/grok-4.3:low",
 		executor: "xai/grok-4.3:minimal",

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -131,21 +131,21 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "kimi-code/kimi-k2.7-code:xhigh",
 		architect: "kimi-code/kimi-k2.7-code:xhigh",
 	}),
-	profile("mimo-eco", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
+	profile("mimo-eco", ["xiaomi"], {
 		default: "xiaomi/mimo-v2.5-pro:low",
 		executor: "xiaomi/mimo-v2.5-pro:minimal",
 		planner: "xiaomi/mimo-v2.5-pro:low",
 		critic: "xiaomi/mimo-v2.5-pro:medium",
 		architect: "xiaomi/mimo-v2.5-pro:high",
 	}),
-	profile("mimo-medium", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
+	profile("mimo-medium", ["xiaomi", "xiaomi-token-plan-sgp"], {
 		default: "xiaomi/mimo-v2.5-pro:medium",
 		executor: "xiaomi/mimo-v2.5-pro:low",
 		planner: "xiaomi/mimo-v2.5-pro:medium",
 		critic: "xiaomi/mimo-v2.5-pro:high",
 		architect: "xiaomi/mimo-v2.5-pro:xhigh",
 	}),
-	profile("mimo-pro", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
+	profile("mimo-pro", ["xiaomi", "xiaomi-token-plan-sgp"], {
 		default: "xiaomi/mimo-v2.5-pro:xhigh",
 		executor: "xiaomi/mimo-v2.5-pro:medium",
 		planner: "xiaomi/mimo-v2.5-pro:high",

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -131,21 +131,21 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "kimi-code/kimi-k2.7-code:xhigh",
 		architect: "kimi-code/kimi-k2.7-code:xhigh",
 	}),
-	profile("mimo-eco", ["xiaomi"], {
+	profile("mimo-eco", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
 		default: "xiaomi/mimo-v2.5-pro:low",
 		executor: "xiaomi/mimo-v2.5-pro:minimal",
 		planner: "xiaomi/mimo-v2.5-pro:low",
 		critic: "xiaomi/mimo-v2.5-pro:medium",
 		architect: "xiaomi/mimo-v2.5-pro:high",
 	}),
-	profile("mimo-medium", ["xiaomi"], {
+	profile("mimo-medium", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
 		default: "xiaomi/mimo-v2.5-pro:medium",
 		executor: "xiaomi/mimo-v2.5-pro:low",
 		planner: "xiaomi/mimo-v2.5-pro:medium",
 		critic: "xiaomi/mimo-v2.5-pro:high",
 		architect: "xiaomi/mimo-v2.5-pro:xhigh",
 	}),
-	profile("mimo-pro", ["xiaomi"], {
+	profile("mimo-pro", ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"], {
 		default: "xiaomi/mimo-v2.5-pro:xhigh",
 		executor: "xiaomi/mimo-v2.5-pro:medium",
 		planner: "xiaomi/mimo-v2.5-pro:high",

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
 	activateModelProfile,
 	applyPreparedModelProfileActivation,
+	formatModelProfileCredentialError,
 	prepareModelProfileActivation,
 } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
-import { BUILTIN_MODEL_PROFILES } from "../src/config/model-profiles";
+import { BUILTIN_MODEL_PROFILES, mergeModelProfiles } from "../src/config/model-profiles";
+import type { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 
 const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
@@ -249,5 +251,174 @@ describe("model profile activation", () => {
 			executor: "explicit/executor",
 			architect: "provider-a/architect",
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Xiaomi Token Plan region activation tests
+// ---------------------------------------------------------------------------
+
+function stubXiaomiRegistry(
+	authenticatedProviders: string[],
+): Pick<
+	ModelRegistry,
+	| "getModelProfile"
+	| "getModelProfiles"
+	| "getAvailableModelProfileNames"
+	| "getApiKeyForProvider"
+	| "getAll"
+	| "resolveCanonicalModel"
+	| "getCanonicalVariants"
+	| "getCanonicalId"
+> {
+	const profiles = mergeModelProfiles();
+	const xiaomiProviders = ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"];
+	const models = xiaomiProviders.flatMap(provider => [
+		{ id: `${provider}/mimo-v2.5-pro`, provider, api: "openai-completions" },
+	]);
+	return {
+		getModelProfiles: () => profiles,
+		getModelProfile: name => profiles.get(name) ?? undefined,
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		getApiKeyForProvider: async (provider: string) => {
+			if (authenticatedProviders.includes(provider)) {
+				return { type: "api_key" as const, key: "test-key" };
+			}
+			return undefined;
+		},
+		getAll: () => models as never[],
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: (id: string) => id,
+	};
+}
+
+function stubXiaomiSession() {
+	return {
+		model: undefined,
+		thinkingLevel: "medium" as const,
+		sessionId: "test-session",
+		setModelTemporary: async () => {},
+		setActiveModelProfile: () => {},
+		getActiveModelProfile: () => undefined,
+	};
+}
+
+function stubXiaomiSettings() {
+	const overrides: Record<string, unknown> = {};
+	return {
+		get: (key: string) => overrides[key],
+		override: (key: string, value: unknown) => {
+			overrides[key] = value;
+		},
+		set: (_key: string, _value: unknown) => {},
+		flush: async () => {},
+	};
+}
+
+describe("model-profile-activation: xiaomi token-plan regions", () => {
+	it("mimo-pro includes all four xiaomi providers in requiredProviders", () => {
+		const profiles = mergeModelProfiles();
+		const mimoPro = profiles.get("mimo-pro");
+		expect(mimoPro).toBeDefined();
+		const providers = mimoPro!.requiredProviders;
+		expect(providers).toContain("xiaomi");
+		expect(providers).toContain("xiaomi-token-plan-sgp");
+		expect(providers).toContain("xiaomi-token-plan-ams");
+		expect(providers).toContain("xiaomi-token-plan-cn");
+	});
+
+	it("mimo-medium includes all four xiaomi providers in requiredProviders", () => {
+		const profiles = mergeModelProfiles();
+		const mimoMedium = profiles.get("mimo-medium");
+		expect(mimoMedium).toBeDefined();
+		const providers = mimoMedium!.requiredProviders;
+		expect(providers).toContain("xiaomi");
+		expect(providers).toContain("xiaomi-token-plan-sgp");
+		expect(providers).toContain("xiaomi-token-plan-ams");
+		expect(providers).toContain("xiaomi-token-plan-cn");
+	});
+
+	it("mimo-eco only requires xiaomi (no token-plan fallback)", () => {
+		const profiles = mergeModelProfiles();
+		const mimoEco = profiles.get("mimo-eco");
+		expect(mimoEco).toBeDefined();
+		expect(mimoEco!.requiredProviders).toEqual(["xiaomi"]);
+	});
+
+	it("activation succeeds with only xiaomi-token-plan-sgp", async () => {
+		const registry = stubXiaomiRegistry(["xiaomi-token-plan-sgp"]);
+		const session = stubXiaomiSession();
+		const settings = stubXiaomiSettings();
+		const prepared = await prepareModelProfileActivation({
+			session,
+			modelRegistry: registry as unknown as ModelRegistry,
+			settings,
+			profileName: "mimo-pro",
+		});
+		expect(prepared.profileName).toBe("mimo-pro");
+	});
+
+	it("activation succeeds with only xiaomi-token-plan-ams", async () => {
+		const registry = stubXiaomiRegistry(["xiaomi-token-plan-ams"]);
+		const session = stubXiaomiSession();
+		const settings = stubXiaomiSettings();
+		const prepared = await prepareModelProfileActivation({
+			session,
+			modelRegistry: registry as unknown as ModelRegistry,
+			settings,
+			profileName: "mimo-pro",
+		});
+		expect(prepared.profileName).toBe("mimo-pro");
+	});
+
+	it("activation succeeds with only xiaomi-token-plan-cn", async () => {
+		const registry = stubXiaomiRegistry(["xiaomi-token-plan-cn"]);
+		const session = stubXiaomiSession();
+		const settings = stubXiaomiSettings();
+		const prepared = await prepareModelProfileActivation({
+			session,
+			modelRegistry: registry as unknown as ModelRegistry,
+			settings,
+			profileName: "mimo-pro",
+		});
+		expect(prepared.profileName).toBe("mimo-pro");
+	});
+
+	it("activation fails with no xiaomi credentials", async () => {
+		const registry = stubXiaomiRegistry([]);
+		const session = stubXiaomiSession();
+		const settings = stubXiaomiSettings();
+		await expect(
+			prepareModelProfileActivation({
+				session,
+				modelRegistry: registry as unknown as ModelRegistry,
+				settings,
+				profileName: "mimo-pro",
+			}),
+		).rejects.toThrow(
+			formatModelProfileCredentialError("mimo-pro", [
+				"xiaomi",
+				"xiaomi-token-plan-sgp",
+				"xiaomi-token-plan-ams",
+				"xiaomi-token-plan-cn",
+			]),
+		);
+	});
+
+	it("profiles without alternativeProviderGroups require ALL providers strictly", async () => {
+		// codex-eco requires openai-codex. If only anthropic is authenticated,
+		// activation should fail (not treat them as interchangeable).
+		const registry = stubXiaomiRegistry(["anthropic"]);
+		const session = stubXiaomiSession();
+		const settings = stubXiaomiSettings();
+		await expect(
+			prepareModelProfileActivation({
+				session,
+				modelRegistry: registry as unknown as ModelRegistry,
+				settings,
+				profileName: "codex-eco",
+			}),
+		).rejects.toThrow(/requires credentials/);
 	});
 });

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -152,7 +152,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 	},
 	{
 		name: "mimo-medium",
-		requiredProviders: ["xiaomi"],
+		requiredProviders: ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"],
 		mapping: {
 			default: "xiaomi/mimo-v2.5-pro:medium",
 			executor: "xiaomi/mimo-v2.5-pro:low",
@@ -163,7 +163,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 	},
 	{
 		name: "mimo-pro",
-		requiredProviders: ["xiaomi"],
+		requiredProviders: ["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"],
 		mapping: {
 			default: "xiaomi/mimo-v2.5-pro:xhigh",
 			executor: "xiaomi/mimo-v2.5-pro:medium",


### PR DESCRIPTION
## Summary

Addresses all three blockers from the review of #774, plus additional issues found during self-review and further reviewer feedback.

### Blocker 1: Activation scoped to alternative provider groups

**Problem**: `prepareModelProfileActivation` treated ALL multi-provider profiles as either/or fallback, breaking profiles like `opus-codex` that require BOTH `anthropic` AND `openai-codex`.

**Fix**: Added `alternativeProviderGroups` field to `ModelProfileDefinition`:
- Providers NOT in any group: **strict** — all must be authenticated
- Providers in a group: **alternative** — at least one per group must be authenticated
- Selector rewrite only applies to alternative-group members

For xiaomi profiles, the group is `[["xiaomi", "xiaomi-token-plan-sgp", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn"]]`. Profiles without `alternativeProviderGroups` (like `opus-codex`, `codex-eco`) retain strict all-or-nothing behavior.

### Blocker 2: Catalog test updated
- `model-profiles-catalog.test.ts` now expects mimo-medium/mimo-pro to require all 4 xiaomi providers.

### Blocker 3: models.json regeneration
- Regenerated from descriptors. The generator fetches live upstream data, so unrelated provider changes exist in the diff. Xiaomi entries verified:
  - `xiaomi`: 6 models, `api=openai-completions`
  - `xiaomi-token-plan-sgp`: 7 models
  - `xiaomi-token-plan-ams`: 6 models
  - `xiaomi-token-plan-cn`: 6 models

### Additional fixes
- **Auth fail-fast**: Token-plan fallback loop throws on 401/403 instead of retrying all regions.
- **Duplicate section header**: Removed.
- **Test imports**: Consolidated to file top per biome.
- **New regression test**: Profiles without `alternativeProviderGroups` still require ALL providers strictly.

## Test plan
- `bun test packages/coding-agent/test/model-profile-activation.test.ts` — 16 pass, 0 fail
- `bun test packages/coding-agent/test/model-profiles-catalog.test.ts` — 8 pass, 0 fail
- `bun run check:ts` — no new errors

—
*[PR by hanbinnoh via Hermes Agent]*