### PR TITLE
feat(coding-agent): opt-in `gjc rlm` research mode (v1, interactive)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in `gjc rlm` research mode (v1, interactive): a Jupyter-notebook-style research session over the existing agent loop, backed by the shared persistent Python kernel. It loads a distinct research system prompt, restricts the toolset to a hard-gated allowlist (`python` + `read` + `web_search`, asserted after tool-registry assembly — no `bash`/edit/arbitrary mutation), optionally loads a project-root `DATA.md` (overridable via `--data <path>`), aggregates every executed cell live into `.gjc/rlm/<session>/notebook.ipynb` (single-queue atomic temp-rename writes with post-write validation), and synthesizes `.gjc/rlm/<session>/report.md` on session exit. Autonomous goal-arg runs, `--resume`, managed per-workspace venv provisioning, and the optional `>=N` completion gate are deferred follow-ups.
+
 ## [0.5.3] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -42,6 +42,7 @@ const commands: CommandEntry[] = [
 		load: () => import("./commands/contribution-prep").then(m => m.default),
 	},
 	{ name: "deep-interview", load: () => import("./commands/deep-interview").then(m => m.default) },
+	{ name: "rlm", load: () => import("./commands/rlm").then(m => m.default) },
 	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
 ];

--- a/packages/coding-agent/src/commands/rlm.ts
+++ b/packages/coding-agent/src/commands/rlm.ts
@@ -1,0 +1,19 @@
+/**
+ * `gjc rlm` — opt-in Jupyter-style research session with a persistent Python kernel.
+ */
+import { Command } from "@gajae-code/utils/cli";
+import { runRlmCommand } from "../rlm";
+
+export default class Rlm extends Command {
+	static description = "Opt-in research session: persistent Python kernel, live notebook, synthesized report";
+	static strict = false;
+	static examples = [
+		"# Start an interactive research session\n  gjc rlm",
+		'# Seed the session with an initial question\n  gjc rlm "What drives the spike in the orders table?"',
+		"# Point the session at a data description\n  gjc rlm --data ./datasets/DATA.md",
+	];
+
+	async run(): Promise<void> {
+		await runRlmCommand(this.argv);
+	}
+}

--- a/packages/coding-agent/src/edit/notebook.ts
+++ b/packages/coding-agent/src/edit/notebook.ts
@@ -49,7 +49,7 @@ function cloneCell(cell: NotebookCell): NotebookCell {
 	return structuredClone(cell);
 }
 
-function createNotebookCell(cellType: NotebookCellType, source: string): NotebookCell {
+export function createNotebookCell(cellType: NotebookCellType, source: string): NotebookCell {
 	const cell: NotebookCell = {
 		cell_type: cellType,
 		metadata: {},
@@ -62,13 +62,17 @@ function createNotebookCell(cellType: NotebookCellType, source: string): Noteboo
 	return cell;
 }
 
-function createEmptyNotebook(): NotebookDocument {
+export function createEmptyNotebook(): NotebookDocument {
 	return {
 		cells: [],
 		metadata: {},
 		nbformat: 4,
 		nbformat_minor: 5,
 	};
+}
+
+export function serializeNotebookDocument(notebook: NotebookDocument): string {
+	return JSON.stringify(notebook, null, 1);
 }
 
 function validateNotebook(value: unknown, displayPath: string): NotebookDocument {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -705,11 +705,22 @@ async function buildSessionOptions(
 	return { options };
 }
 
+/**
+ * Research-mode (RLM) preset hook. Lets `gjc rlm` augment the session options
+ * (system prompt, restricted toolset, custom python tool) and assert the tool
+ * boundary once the session's tool registry is fully assembled.
+ */
+export interface RlmPreset {
+	applyOptions: (options: CreateAgentSessionOptions, settings: Settings) => void;
+	onSessionCreated?: (session: AgentSession) => void | Promise<void>;
+}
+
 interface RunRootCommandDependencies {
 	createAgentSession?: typeof createAgentSession;
 	discoverAuthStorage?: typeof discoverAuthStorage;
 	runAcpMode?: (createSession: AcpSessionFactory) => Promise<void>;
 	settings?: Settings;
+	rlmPreset?: RlmPreset;
 }
 
 export async function runRootCommand(
@@ -897,6 +908,9 @@ export async function runRootCommand(
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
 
+	// Research-mode (RLM) preset: augment session options before session creation.
+	deps.rlmPreset?.applyOptions(sessionOptions, settingsInstance);
+
 	// Handle CLI --api-key as runtime override (not persisted)
 	if (parsedArgs.apiKey) {
 		if (!sessionOptions.model && !sessionOptions.modelPattern) {
@@ -937,6 +951,11 @@ export async function runRootCommand(
 			await createSession(sessionOptions);
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
+		}
+
+		// Research-mode (RLM) preset: hard tool-boundary assertion after the registry is assembled.
+		if (deps.rlmPreset?.onSessionCreated) {
+			await deps.rlmPreset.onSessionCreated(session);
 		}
 
 		await applyStartupModelProfilesOrExit({

--- a/packages/coding-agent/src/prompts/system/rlm-research.md
+++ b/packages/coding-agent/src/prompts/system/rlm-research.md
@@ -1,0 +1,22 @@
+You are operating in **RLM research mode** — a Jupyter-notebook-style research session backed by a persistent Python kernel. Your job is to investigate a question or dataset through iterative, reproducible Python analysis and then synthesize what you found.
+
+## How you work
+
+- Drive the investigation with the `python` tool. The kernel is **persistent**: variables, imports, and loaded data survive across calls, exactly like notebook cells. Build up state incrementally instead of re-running everything each time.
+- Each `python` call is recorded as a notebook cell (code + output) in this session's `notebook.ipynb`. Write focused cells that each make one clear step of progress.
+- Prefer the scientific stack commonly available in research environments (`numpy`, `pandas`, `matplotlib`, `polars`). If a needed package is missing, say so plainly rather than guessing — managed-environment provisioning is out of scope for this mode.
+- Use `read` to inspect local files and `web_search` to gather external facts. You do **not** have shell, file-editing, or arbitrary-mutation tools in this mode by design: keep all work inside the Python kernel and the notebook/report artifacts.
+
+## Evidence discipline
+
+- Ground every claim in an actual cell output you can point to. Do not report a metric, finding, or conclusion you have not computed and seen.
+- When a cell fails, read the error, fix the specific cause, and continue — do not paper over failures.
+- Distinguish what the data shows from what you infer. State assumptions explicitly.
+
+## Data context
+
+- If a `DATA.md` file (or a `--data` path) was provided, treat it as the authoritative description of the available data and honor it.
+
+## Reporting
+
+- When the investigation is complete (or when asked), produce a clear Markdown research report covering the question, the method, the key findings with their supporting evidence, and the conclusions and caveats. The session's `report.md` is synthesized from your notebook and final summary.

--- a/packages/coding-agent/src/rlm/artifacts.ts
+++ b/packages/coding-agent/src/rlm/artifacts.ts
@@ -1,0 +1,38 @@
+/**
+ * RLM session artifact layout under <cwd>/.gjc/rlm/<sessionId>/.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { RlmArtifactPaths } from "./types";
+
+export const RLM_DIR_SEGMENT = path.join(".gjc", "rlm");
+
+const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export function isValidRlmSessionId(sessionId: string): boolean {
+	return sessionId.length > 0 && sessionId.length <= 128 && SESSION_ID_RE.test(sessionId);
+}
+
+/** Generate a filesystem-safe, sortable session id (timestamp + random suffix). */
+export function generateRlmSessionId(now: Date = new Date()): string {
+	const stamp = now.toISOString().replace(/[:.]/g, "").replace("T", "-").replace("Z", "");
+	const suffix = Math.random().toString(36).slice(2, 8);
+	return `${stamp}-${suffix}`;
+}
+
+export function resolveRlmArtifactPaths(cwd: string, sessionId: string): RlmArtifactPaths {
+	if (!isValidRlmSessionId(sessionId)) {
+		throw new Error(`Invalid RLM session id: ${JSON.stringify(sessionId)}`);
+	}
+	const dir = path.join(cwd, RLM_DIR_SEGMENT, sessionId);
+	return {
+		dir,
+		notebookPath: path.join(dir, "notebook.ipynb"),
+		reportPath: path.join(dir, "report.md"),
+		metadataPath: path.join(dir, "metadata.json"),
+	};
+}
+
+export async function ensureRlmSessionDir(paths: RlmArtifactPaths): Promise<void> {
+	await fs.mkdir(paths.dir, { recursive: true });
+}

--- a/packages/coding-agent/src/rlm/data-context.ts
+++ b/packages/coding-agent/src/rlm/data-context.ts
@@ -1,0 +1,26 @@
+/**
+ * Optional research data description loading for RLM mode.
+ *
+ * Precedence: an explicit --data <path> (required to exist) overrides the
+ * project-root DATA.md, which auto-loads when present and is silently skipped
+ * when absent.
+ */
+import * as path from "node:path";
+
+export interface RlmDataContext {
+	/** Absolute path the content was loaded from. */
+	path: string;
+	content: string;
+}
+
+export async function loadRlmDataContext(cwd: string, dataFlag: string | undefined): Promise<RlmDataContext | null> {
+	const target = dataFlag ? path.resolve(cwd, dataFlag) : path.join(cwd, "DATA.md");
+	const file = Bun.file(target);
+	if (!(await file.exists())) {
+		if (dataFlag) {
+			throw new Error(`--data file not found: ${target}`);
+		}
+		return null;
+	}
+	return { path: target, content: await file.text() };
+}

--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -1,0 +1,93 @@
+/**
+ * RLM (research) mode entry point.
+ *
+ * Composes an interactive research session over the existing agent/session loop
+ * via a research preset: a distinct system prompt, a hard-gated research toolset
+ * (python kernel + read + web_search), optional DATA.md context, a live
+ * notebook.ipynb, and a synthesized report.md on session exit.
+ */
+import { getProjectDir } from "@gajae-code/utils";
+import { parseArgs } from "../cli/args";
+import { type RlmPreset, runRootCommand } from "../main";
+import { ensureRlmSessionDir, generateRlmSessionId, resolveRlmArtifactPaths } from "./artifacts";
+import { loadRlmDataContext } from "./data-context";
+import { RlmNotebookWriter } from "./notebook";
+import { assertRlmToolAllowlist, buildRlmSystemPrompt } from "./preset";
+import { createRlmPythonTool } from "./python-tool";
+import { synthesizeRlmReport } from "./report";
+import type { RlmSessionMetadata } from "./types";
+
+interface ExtractedDataFlag {
+	dataPath: string | undefined;
+	rest: string[];
+}
+
+/** Pull `--data <path>` / `--data=<path>` out of argv; the remainder is forwarded to the root command. */
+export function extractDataFlag(argv: string[]): ExtractedDataFlag {
+	const rest: string[] = [];
+	let dataPath: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--data") {
+			dataPath = argv[i + 1];
+			i += 1;
+		} else if (arg.startsWith("--data=")) {
+			dataPath = arg.slice("--data=".length);
+		} else {
+			rest.push(arg);
+		}
+	}
+	return { dataPath, rest };
+}
+
+export async function runRlmCommand(argv: string[]): Promise<void> {
+	const cwd = getProjectDir();
+	const { dataPath, rest } = extractDataFlag(argv);
+	const dataContext = await loadRlmDataContext(cwd, dataPath);
+
+	const sessionId = generateRlmSessionId();
+	const paths = resolveRlmArtifactPaths(cwd, sessionId);
+	await ensureRlmSessionDir(paths);
+
+	const notebook = new RlmNotebookWriter(paths.notebookPath);
+	const pythonTool = createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
+
+	const preset: RlmPreset = {
+		applyOptions: (options, settings) => {
+			options.systemPrompt = buildRlmSystemPrompt(dataContext);
+			options.customTools = [pythonTool, ...(options.customTools ?? [])];
+			options.toolNames = ["read", "web_search"];
+			options.requireYieldTool = false;
+			options.skills = [];
+			options.rules = [];
+			options.disableExtensionDiscovery = true;
+			// Disable goal-mode tool injection so the research surface stays exactly the allowlist.
+			settings.override("goal.enabled", false);
+		},
+		onSessionCreated: session => {
+			// Hard boundary: fail launch if any non-allowlisted tool slipped into the active set.
+			assertRlmToolAllowlist(session.getActiveToolNames());
+		},
+	};
+
+	const parsed = parseArgs(rest);
+	try {
+		await runRootCommand(parsed, rest, { rlmPreset: preset });
+	} finally {
+		await notebook.flush();
+		const report = synthesizeRlmReport({
+			title: `RLM research session ${sessionId}`,
+			notebook: notebook.document,
+			dataPath: dataContext?.path ?? null,
+		});
+		await Bun.write(paths.reportPath, report);
+		const metadata: RlmSessionMetadata = {
+			sessionId,
+			createdAt: new Date().toISOString(),
+			cwd,
+			dataPath: dataContext?.path ?? null,
+			cellCount: notebook.cellCount,
+		};
+		await Bun.write(paths.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+	}
+}

--- a/packages/coding-agent/src/rlm/notebook.ts
+++ b/packages/coding-agent/src/rlm/notebook.ts
@@ -1,0 +1,108 @@
+/**
+ * RLM live notebook writer: appends executed cells to notebook.ipynb with a
+ * single per-session write queue and atomic temp-file-then-rename writes, then
+ * validates the persisted file via readNotebookDocument.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	createEmptyNotebook,
+	createNotebookCell,
+	type NotebookDocument,
+	readNotebookDocument,
+	serializeNotebookDocument,
+	splitNotebookSource,
+} from "../edit/notebook";
+import type { RlmCellResult } from "./types";
+
+function buildCodeOutputs(result: RlmCellResult): unknown[] {
+	const outputs: unknown[] = [];
+	if (result.output.length > 0) {
+		outputs.push({
+			output_type: "stream",
+			name: result.exitCode !== undefined && result.exitCode !== 0 ? "stderr" : "stdout",
+			text: splitNotebookSource(result.output),
+		});
+	}
+	for (const display of result.displayOutputs) {
+		if (display.type === "image") {
+			outputs.push({ output_type: "display_data", data: { [display.mimeType]: display.data }, metadata: {} });
+		} else if (display.type === "json") {
+			outputs.push({ output_type: "display_data", data: { "application/json": display.data }, metadata: {} });
+		}
+	}
+	if (result.cancelled) {
+		outputs.push({ output_type: "stream", name: "stderr", text: ["[cell cancelled]\n"] });
+	}
+	if (result.truncated) {
+		outputs.push({ output_type: "stream", name: "stderr", text: ["[output truncated]\n"] });
+	}
+	return outputs;
+}
+
+export class RlmNotebookWriter {
+	readonly #notebookPath: string;
+	readonly #document: NotebookDocument;
+	#queue: Promise<void> = Promise.resolve();
+
+	constructor(notebookPath: string, initial?: NotebookDocument) {
+		this.#notebookPath = notebookPath;
+		this.#document = initial ?? createEmptyNotebook();
+	}
+
+	get document(): NotebookDocument {
+		return this.#document;
+	}
+
+	get cellCount(): number {
+		return this.#document.cells.length;
+	}
+
+	appendMarkdown(source: string): Promise<void> {
+		this.#document.cells.push(createNotebookCell("markdown", source));
+		return this.#enqueueWrite();
+	}
+
+	appendCode(code: string, result: RlmCellResult): Promise<void> {
+		const cell = createNotebookCell("code", code);
+		cell.execution_count = this.#nextExecutionCount();
+		cell.outputs = buildCodeOutputs(result);
+		this.#document.cells.push(cell);
+		return this.#enqueueWrite();
+	}
+
+	/** Resolve once all queued writes have flushed. */
+	flush(): Promise<void> {
+		return this.#queue;
+	}
+
+	#nextExecutionCount(): number {
+		let max = 0;
+		for (const cell of this.#document.cells) {
+			const count = cell.execution_count;
+			if (typeof count === "number" && count > max) max = count;
+		}
+		return max + 1;
+	}
+
+	#enqueueWrite(): Promise<void> {
+		const snapshot = serializeNotebookDocument(this.#document);
+		this.#queue = this.#queue.then(() => this.#atomicWrite(snapshot));
+		return this.#queue;
+	}
+
+	async #atomicWrite(content: string): Promise<void> {
+		const dir = path.dirname(this.#notebookPath);
+		const base = path.basename(this.#notebookPath);
+		const tmp = path.join(dir, `.${base}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`);
+		await Bun.write(tmp, content);
+		try {
+			await fs.rename(tmp, this.#notebookPath);
+		} catch (error) {
+			await fs.rm(tmp, { force: true });
+			throw error;
+		}
+		// Post-write validation: surfaces corruption immediately.
+		await readNotebookDocument(this.#notebookPath, this.#notebookPath);
+	}
+}

--- a/packages/coding-agent/src/rlm/preset.ts
+++ b/packages/coding-agent/src/rlm/preset.ts
@@ -1,0 +1,50 @@
+/**
+ * RLM research preset: the static research system prompt, the exact tool
+ * allowlist, and a hard boundary assertion that fails launch if any
+ * non-allowlisted tool is active.
+ */
+import rlmResearchPrompt from "../prompts/system/rlm-research.md" with { type: "text" };
+import type { RlmDataContext } from "./data-context";
+
+/**
+ * Tools the model may use in RLM mode. `python` is the RLM research execution
+ * tool; `read` and `web_search` are the existing built-ins. Everything else
+ * (bash, edit, write, goal, task, skill, browser, eval-js, ...) is excluded.
+ */
+export const RLM_TOOL_ALLOWLIST: readonly string[] = ["python", "read", "web_search", "search_tool_bm25"];
+
+export function isRlmToolAllowed(name: string): boolean {
+	return RLM_TOOL_ALLOWLIST.includes(name.toLowerCase());
+}
+
+/**
+ * Hard boundary: throws if any active tool is outside the allowlist. Call this
+ * after the session's tool registry is fully assembled and before running, so a
+ * tool leaked in by defaults/discovery/extensions fails the launch loudly.
+ */
+export function assertRlmToolAllowlist(activeToolNames: readonly string[]): void {
+	const leaked = activeToolNames.filter(name => !isRlmToolAllowed(name));
+	if (leaked.length > 0) {
+		throw new Error(
+			`RLM tool boundary violation: non-allowlisted active tool(s) [${leaked.join(", ")}]. ` +
+				`RLM mode allows only: ${RLM_TOOL_ALLOWLIST.join(", ")}.`,
+		);
+	}
+}
+
+/** The research prompt text (exported for testing / prompt assembly). */
+export const RLM_RESEARCH_PROMPT: string = rlmResearchPrompt;
+
+/**
+ * Build the systemPrompt transform for createAgentSession: appends the research
+ * prompt and (when present) the data-context block to the default blocks.
+ */
+export function buildRlmSystemPrompt(dataContext: RlmDataContext | null): (defaultPrompt: string[]) => string[] {
+	return (defaultPrompt: string[]): string[] => {
+		const blocks = [...defaultPrompt, rlmResearchPrompt];
+		if (dataContext) {
+			blocks.push(`# Data context (from ${dataContext.path})\n\n${dataContext.content}`);
+		}
+		return blocks;
+	};
+}

--- a/packages/coding-agent/src/rlm/python-tool.ts
+++ b/packages/coding-agent/src/rlm/python-tool.ts
@@ -19,7 +19,9 @@ export interface RlmPythonToolContext {
 }
 
 const paramsSchema = z.object({
-	code: z.string().describe("Python source to execute in the persistent research kernel. State persists across calls."),
+	code: z
+		.string()
+		.describe("Python source to execute in the persistent research kernel. State persists across calls."),
 });
 
 export function createRlmPythonTool(rlm: RlmPythonToolContext): CustomTool<typeof paramsSchema> {

--- a/packages/coding-agent/src/rlm/python-tool.ts
+++ b/packages/coding-agent/src/rlm/python-tool.ts
@@ -1,0 +1,59 @@
+/**
+ * RLM `python` tool: the model-facing research execution tool. Wraps the shared
+ * persistent Python kernel executor and records every call as a notebook cell.
+ */
+import type { AgentToolResult } from "@gajae-code/agent-core";
+import { type Static, z } from "@gajae-code/ai";
+import { executePython } from "../eval/py/executor";
+import type { CustomTool } from "../extensibility/custom-tools/types";
+import type { RlmNotebookWriter } from "./notebook";
+import type { RlmCellResult } from "./types";
+
+export const RLM_PYTHON_TOOL_NAME = "python";
+
+export interface RlmPythonToolContext {
+	cwd: string;
+	sessionId: string;
+	artifactsDir: string;
+	notebook: RlmNotebookWriter;
+}
+
+const paramsSchema = z.object({
+	code: z.string().describe("Python source to execute in the persistent research kernel. State persists across calls."),
+});
+
+export function createRlmPythonTool(rlm: RlmPythonToolContext): CustomTool<typeof paramsSchema> {
+	return {
+		name: RLM_PYTHON_TOOL_NAME,
+		label: "Python",
+		description:
+			"Execute Python in the persistent research kernel. Variables, imports, and loaded data persist across calls like notebook cells. Every call is recorded as a cell in the session notebook.",
+		parameters: paramsSchema,
+		async execute(
+			_toolCallId: string,
+			params: Static<typeof paramsSchema>,
+			_onUpdate,
+			_ctx,
+			signal?: AbortSignal,
+		): Promise<AgentToolResult> {
+			const result = await executePython(params.code, {
+				cwd: rlm.cwd,
+				kernelMode: "session",
+				sessionId: `rlm:${rlm.sessionId}`,
+				kernelOwnerId: `rlm:${rlm.sessionId}`,
+				artifactsDir: rlm.artifactsDir,
+				signal,
+			});
+			const cell: RlmCellResult = {
+				output: result.output,
+				exitCode: result.exitCode,
+				cancelled: result.cancelled,
+				truncated: result.truncated,
+				displayOutputs: result.displayOutputs,
+			};
+			await rlm.notebook.appendCode(params.code, cell);
+			const text = result.output.length > 0 ? result.output : "(no output)";
+			return { content: [{ type: "text", text }] };
+		},
+	};
+}

--- a/packages/coding-agent/src/rlm/report.ts
+++ b/packages/coding-agent/src/rlm/report.ts
@@ -1,0 +1,70 @@
+/**
+ * Deterministic RLM report synthesis: turns the accumulated notebook (plus an
+ * optional model-provided summary) into a Markdown research report.
+ */
+import type { NotebookCell, NotebookDocument } from "../edit/notebook";
+
+export interface RlmReportInput {
+	title: string;
+	summary?: string;
+	notebook: NotebookDocument;
+	dataPath?: string | null;
+	generatedAt?: string;
+	maxOutputChars?: number;
+}
+
+function cellText(value: string | string[] | undefined): string {
+	if (value === undefined) return "";
+	return Array.isArray(value) ? value.join("") : value;
+}
+
+function streamOutputText(cell: NotebookCell): string {
+	const outputs = Array.isArray(cell.outputs) ? cell.outputs : [];
+	const parts: string[] = [];
+	for (const out of outputs) {
+		if (out && typeof out === "object" && (out as Record<string, unknown>).output_type === "stream") {
+			parts.push(cellText((out as Record<string, unknown>).text as string | string[] | undefined));
+		}
+	}
+	return parts.join("");
+}
+
+export function synthesizeRlmReport(input: RlmReportInput): string {
+	const generatedAt = input.generatedAt ?? new Date().toISOString();
+	const maxOutput = input.maxOutputChars ?? 4000;
+	const codeCells = input.notebook.cells.filter(cell => cell.cell_type === "code");
+
+	const lines: string[] = [];
+	lines.push(`# ${input.title}`, "");
+	lines.push(`- Generated: ${generatedAt}`);
+	lines.push(`- Cells executed: ${codeCells.length}`);
+	if (input.dataPath) {
+		lines.push(`- Data context: ${input.dataPath}`);
+	}
+	lines.push("");
+
+	if (input.summary && input.summary.trim().length > 0) {
+		lines.push("## Summary", "", input.summary.trim(), "");
+	}
+
+	lines.push("## Notebook", "");
+	let codeIndex = 0;
+	for (const cell of input.notebook.cells) {
+		if (cell.cell_type === "markdown") {
+			const text = cellText(cell.source).trim();
+			if (text.length > 0) {
+				lines.push(text, "");
+			}
+		} else if (cell.cell_type === "code") {
+			codeIndex += 1;
+			lines.push(`### Cell ${codeIndex}`, "", "```python", cellText(cell.source).trimEnd(), "```", "");
+			const output = streamOutputText(cell).trimEnd();
+			if (output.length > 0) {
+				const shown = output.length > maxOutput ? `${output.slice(0, maxOutput)}\n... [truncated]` : output;
+				lines.push("```", shown, "```", "");
+			}
+		}
+	}
+
+	return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/packages/coding-agent/src/rlm/types.ts
+++ b/packages/coding-agent/src/rlm/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared types for RLM (research) mode.
+ */
+import type { KernelDisplayOutput } from "../eval/py/kernel";
+
+export interface RlmArtifactPaths {
+	/** Absolute session directory: <cwd>/.gjc/rlm/<sessionId>/ */
+	dir: string;
+	/** Absolute path to the live notebook.ipynb */
+	notebookPath: string;
+	/** Absolute path to the synthesized report.md */
+	reportPath: string;
+	/** Absolute path to the session metadata.json */
+	metadataPath: string;
+}
+
+/** Outcome of a single RLM python cell execution. */
+export interface RlmCellResult {
+	output: string;
+	exitCode: number | undefined;
+	cancelled: boolean;
+	truncated: boolean;
+	displayOutputs: KernelDisplayOutput[];
+}
+
+export interface RlmSessionMetadata {
+	sessionId: string;
+	createdAt: string;
+	cwd: string;
+	dataPath: string | null;
+	cellCount: number;
+}

--- a/packages/coding-agent/test/rlm-e2e.test.ts
+++ b/packages/coding-agent/test/rlm-e2e.test.ts
@@ -1,0 +1,143 @@
+/**
+ * End-to-end RLM pipeline test with real example data.
+ *
+ * Drives the real surface: the RLM `python` tool executes against the shared
+ * persistent Python kernel (a real subprocess), state persists across cells,
+ * each cell is aggregated into a real notebook.ipynb, and report.md is
+ * synthesized from it. Uses Python stdlib only (no numpy/pandas dependency) so
+ * it runs anywhere a python3 interpreter is available.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
+import { disposeKernelSessionsByOwner } from "@gajae-code/coding-agent/eval/py/executor";
+import type { CustomToolContext } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
+import {
+	ensureRlmSessionDir,
+	generateRlmSessionId,
+	resolveRlmArtifactPaths,
+} from "@gajae-code/coding-agent/rlm/artifacts";
+import { loadRlmDataContext } from "@gajae-code/coding-agent/rlm/data-context";
+import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
+import { createRlmPythonTool } from "@gajae-code/coding-agent/rlm/python-tool";
+import { synthesizeRlmReport } from "@gajae-code/coding-agent/rlm/report";
+
+const SALES_CSV = `region,amount
+north,100
+north,150
+south,200
+south,50
+east,300
+`;
+
+let cwd: string;
+let sessionId: string;
+
+beforeEach(async () => {
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-e2e-"));
+	sessionId = generateRlmSessionId();
+});
+
+afterEach(async () => {
+	await disposeKernelSessionsByOwner(`rlm:${sessionId}`);
+	await fs.rm(cwd, { recursive: true, force: true });
+});
+
+function makeTool(notebook: RlmNotebookWriter) {
+	const paths = resolveRlmArtifactPaths(cwd, sessionId);
+	return createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
+}
+
+async function runCell(tool: ReturnType<typeof createRlmPythonTool>, code: string): Promise<string> {
+	const result = await tool.execute(
+		`call-${Math.random().toString(36).slice(2)}`,
+		{ code },
+		undefined,
+		{} as unknown as CustomToolContext,
+		undefined,
+	);
+	const part = result.content[0];
+	return part?.type === "text" ? part.text : "";
+}
+
+describe("rlm end-to-end with real example data", () => {
+	test("real CSV analysis flows through kernel -> notebook -> report", async () => {
+		await Bun.write(path.join(cwd, "data.csv"), SALES_CSV);
+		await Bun.write(path.join(cwd, "DATA.md"), "Sales CSV with columns region, amount across 5 rows.");
+
+		// DATA.md auto-loads.
+		const dataContext = await loadRlmDataContext(cwd, undefined);
+		expect(dataContext?.content).toContain("Sales CSV");
+
+		const paths = resolveRlmArtifactPaths(cwd, sessionId);
+		await ensureRlmSessionDir(paths);
+		const notebook = new RlmNotebookWriter(paths.notebookPath);
+		const tool = makeTool(notebook);
+
+		// Cell 1: load the real dataset into kernel state.
+		const out1 = await runCell(
+			tool,
+			["import csv", "rows = list(csv.DictReader(open('data.csv')))", "print('rows', len(rows))"].join("\n"),
+		);
+		expect(out1).toContain("rows 5");
+
+		// Cell 2: depends on Cell 1 state (proves kernel persistence) and computes real stats.
+		const out2 = await runCell(
+			tool,
+			[
+				"import statistics",
+				"amounts = [float(r['amount']) for r in rows]",
+				"print('total', int(sum(amounts)))",
+				"print('mean', int(statistics.mean(amounts)))",
+				"by_region = {}",
+				"for r in rows: by_region[r['region']] = by_region.get(r['region'], 0) + float(r['amount'])",
+				"print('north', int(by_region['north']))",
+			].join("\n"),
+		);
+		expect(out2).toContain("total 800");
+		expect(out2).toContain("mean 160");
+		expect(out2).toContain("north 250");
+
+		// Notebook aggregated the real cells + outputs, and is valid .ipynb.
+		await notebook.flush();
+		const doc = await readNotebookDocument(paths.notebookPath, paths.notebookPath);
+		const codeCells = doc.cells.filter(cell => cell.cell_type === "code");
+		expect(codeCells.length).toBe(2);
+		const serialized = JSON.stringify(doc);
+		expect(serialized).toContain("rows 5");
+		expect(serialized).toContain("total 800");
+
+		// Report synthesized from the real notebook contains the computed evidence.
+		const report = synthesizeRlmReport({
+			title: "Sales analysis",
+			summary: "Total sales were 800 across 5 rows.",
+			notebook: doc,
+			dataPath: dataContext?.path ?? null,
+		});
+		await Bun.write(paths.reportPath, report);
+		const reportText = await Bun.file(paths.reportPath).text();
+		expect(reportText).toContain("# Sales analysis");
+		expect(reportText).toContain("Cells executed: 2");
+		expect(reportText).toContain("total 800");
+		expect(reportText).toContain("north 250");
+		expect(reportText).toContain("Total sales were 800");
+	}, 90_000);
+
+	test("a failing cell is recorded as a stderr cell without breaking the notebook", async () => {
+		const paths = resolveRlmArtifactPaths(cwd, sessionId);
+		await ensureRlmSessionDir(paths);
+		const notebook = new RlmNotebookWriter(paths.notebookPath);
+		const tool = makeTool(notebook);
+
+		const out = await runCell(tool, "raise ValueError('boom')");
+		expect(out.toLowerCase()).toContain("valueerror");
+
+		await notebook.flush();
+		const doc = await readNotebookDocument(paths.notebookPath, paths.notebookPath);
+		expect(doc.cells.length).toBe(1);
+		const outputs = doc.cells[0].outputs as Array<Record<string, unknown>>;
+		expect(outputs[0].name).toBe("stderr");
+	}, 90_000);
+});

--- a/packages/coding-agent/test/rlm.test.ts
+++ b/packages/coding-agent/test/rlm.test.ts
@@ -89,7 +89,13 @@ describe("rlm notebook writer", () => {
 	test("error cells route to stderr stream and do not corrupt the notebook", async () => {
 		const nbPath = path.join(tmp, "notebook.ipynb");
 		const writer = new RlmNotebookWriter(nbPath);
-		await writer.appendCode("boom()", { output: "NameError\n", exitCode: 1, cancelled: false, truncated: false, displayOutputs: [] });
+		await writer.appendCode("boom()", {
+			output: "NameError\n",
+			exitCode: 1,
+			cancelled: false,
+			truncated: false,
+			displayOutputs: [],
+		});
 		await writer.flush();
 		const doc = await readNotebookDocument(nbPath, nbPath);
 		const outputs = doc.cells[0].outputs as Array<Record<string, unknown>>;
@@ -138,7 +144,15 @@ describe("rlm report synthesis", () => {
 		expect(report).toContain("print('hi')");
 		expect(report).toContain("hi");
 		// Deterministic: same input → same output.
-		expect(synthesizeRlmReport({ title: "My Research", summary: "Found something.", notebook, dataPath: "/tmp/DATA.md", generatedAt: "2026-01-01T00:00:00Z" })).toBe(report);
+		expect(
+			synthesizeRlmReport({
+				title: "My Research",
+				summary: "Found something.",
+				notebook,
+				dataPath: "/tmp/DATA.md",
+				generatedAt: "2026-01-01T00:00:00Z",
+			}),
+		).toBe(report);
 	});
 });
 

--- a/packages/coding-agent/test/rlm.test.ts
+++ b/packages/coding-agent/test/rlm.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createEmptyNotebook, readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
+import {
+	ensureRlmSessionDir,
+	generateRlmSessionId,
+	isValidRlmSessionId,
+	resolveRlmArtifactPaths,
+} from "@gajae-code/coding-agent/rlm/artifacts";
+import { loadRlmDataContext } from "@gajae-code/coding-agent/rlm/data-context";
+import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
+import {
+	assertRlmToolAllowlist,
+	buildRlmSystemPrompt,
+	isRlmToolAllowed,
+	RLM_RESEARCH_PROMPT,
+	RLM_TOOL_ALLOWLIST,
+} from "@gajae-code/coding-agent/rlm/preset";
+import { synthesizeRlmReport } from "@gajae-code/coding-agent/rlm/report";
+import type { RlmCellResult } from "@gajae-code/coding-agent/rlm/types";
+
+let tmp: string;
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+const okCell = (output: string): RlmCellResult => ({
+	output,
+	exitCode: 0,
+	cancelled: false,
+	truncated: false,
+	displayOutputs: [],
+});
+
+describe("rlm artifacts", () => {
+	test("validates session ids", () => {
+		expect(isValidRlmSessionId("2026-06-16-abc")).toBe(true);
+		expect(isValidRlmSessionId("../escape")).toBe(false);
+		expect(isValidRlmSessionId("has space")).toBe(false);
+		expect(isValidRlmSessionId("")).toBe(false);
+	});
+
+	test("generated ids are valid and unique", () => {
+		const a = generateRlmSessionId();
+		const b = generateRlmSessionId();
+		expect(isValidRlmSessionId(a)).toBe(true);
+		expect(a).not.toBe(b);
+	});
+
+	test("resolves artifact paths under .gjc/rlm/<id> and creates the dir", async () => {
+		const paths = resolveRlmArtifactPaths(tmp, "sess1");
+		expect(paths.dir).toBe(path.join(tmp, ".gjc", "rlm", "sess1"));
+		expect(paths.notebookPath.endsWith(path.join("sess1", "notebook.ipynb"))).toBe(true);
+		expect(paths.reportPath.endsWith("report.md")).toBe(true);
+		await ensureRlmSessionDir(paths);
+		expect((await fs.stat(paths.dir)).isDirectory()).toBe(true);
+	});
+
+	test("rejects invalid session ids when resolving paths", () => {
+		expect(() => resolveRlmArtifactPaths(tmp, "../escape")).toThrow();
+	});
+});
+
+describe("rlm notebook writer", () => {
+	test("appends code cells live with valid, re-readable .ipynb", async () => {
+		const nbPath = path.join(tmp, "notebook.ipynb");
+		const writer = new RlmNotebookWriter(nbPath);
+		await writer.appendMarkdown("# Investigation");
+		await writer.appendCode("x = 1\nprint(x)", okCell("1\n"));
+		await writer.flush();
+
+		const doc = await readNotebookDocument(nbPath, nbPath);
+		expect(doc.cells.length).toBe(2);
+		expect(doc.cells[0].cell_type).toBe("markdown");
+		expect(doc.cells[1].cell_type).toBe("code");
+		expect(doc.cells[1].execution_count).toBe(1);
+		const outputs = doc.cells[1].outputs as Array<Record<string, unknown>>;
+		expect(outputs[0].output_type).toBe("stream");
+		expect(outputs[0].name).toBe("stdout");
+	});
+
+	test("error cells route to stderr stream and do not corrupt the notebook", async () => {
+		const nbPath = path.join(tmp, "notebook.ipynb");
+		const writer = new RlmNotebookWriter(nbPath);
+		await writer.appendCode("boom()", { output: "NameError\n", exitCode: 1, cancelled: false, truncated: false, displayOutputs: [] });
+		await writer.flush();
+		const doc = await readNotebookDocument(nbPath, nbPath);
+		const outputs = doc.cells[0].outputs as Array<Record<string, unknown>>;
+		expect(outputs[0].name).toBe("stderr");
+	});
+
+	test("concurrent appends serialize without corrupting the file", async () => {
+		const nbPath = path.join(tmp, "notebook.ipynb");
+		const writer = new RlmNotebookWriter(nbPath);
+		await Promise.all([
+			writer.appendCode("a=1", okCell("a\n")),
+			writer.appendCode("b=2", okCell("b\n")),
+			writer.appendCode("c=3", okCell("c\n")),
+		]);
+		await writer.flush();
+		const doc = await readNotebookDocument(nbPath, nbPath);
+		expect(doc.cells.length).toBe(3);
+		const counts = doc.cells.map(cell => cell.execution_count);
+		expect(new Set(counts).size).toBe(3);
+	});
+});
+
+describe("rlm report synthesis", () => {
+	test("produces deterministic markdown with cells, outputs, and summary", () => {
+		const notebook = createEmptyNotebook();
+		notebook.cells.push({ cell_type: "markdown", source: "intro" });
+		notebook.cells.push({
+			cell_type: "code",
+			source: "print('hi')",
+			execution_count: 1,
+			outputs: [{ output_type: "stream", name: "stdout", text: ["hi\n"] }],
+		});
+		const report = synthesizeRlmReport({
+			title: "My Research",
+			summary: "Found something.",
+			notebook,
+			dataPath: "/tmp/DATA.md",
+			generatedAt: "2026-01-01T00:00:00Z",
+		});
+		expect(report).toContain("# My Research");
+		expect(report).toContain("Cells executed: 1");
+		expect(report).toContain("Data context: /tmp/DATA.md");
+		expect(report).toContain("## Summary");
+		expect(report).toContain("Found something.");
+		expect(report).toContain("### Cell 1");
+		expect(report).toContain("print('hi')");
+		expect(report).toContain("hi");
+		// Deterministic: same input → same output.
+		expect(synthesizeRlmReport({ title: "My Research", summary: "Found something.", notebook, dataPath: "/tmp/DATA.md", generatedAt: "2026-01-01T00:00:00Z" })).toBe(report);
+	});
+});
+
+describe("rlm data context", () => {
+	test("auto-loads project-root DATA.md when present", async () => {
+		await Bun.write(path.join(tmp, "DATA.md"), "rows: 100");
+		const ctx = await loadRlmDataContext(tmp, undefined);
+		expect(ctx?.content).toBe("rows: 100");
+		expect(ctx?.path).toBe(path.join(tmp, "DATA.md"));
+	});
+
+	test("returns null when no DATA.md and no flag", async () => {
+		expect(await loadRlmDataContext(tmp, undefined)).toBeNull();
+	});
+
+	test("--data overrides and is required to exist", async () => {
+		await Bun.write(path.join(tmp, "custom.md"), "custom data");
+		const ctx = await loadRlmDataContext(tmp, "custom.md");
+		expect(ctx?.content).toBe("custom data");
+		await expect(loadRlmDataContext(tmp, "missing.md")).rejects.toThrow(/not found/);
+	});
+});
+
+describe("rlm preset tool boundary", () => {
+	test("allowlist membership is case-insensitive and excludes dangerous tools", () => {
+		expect(isRlmToolAllowed("python")).toBe(true);
+		expect(isRlmToolAllowed("READ")).toBe(true);
+		expect(isRlmToolAllowed("web_search")).toBe(true);
+		expect(isRlmToolAllowed("bash")).toBe(false);
+		expect(isRlmToolAllowed("edit")).toBe(false);
+		expect(isRlmToolAllowed("goal")).toBe(false);
+		expect(RLM_TOOL_ALLOWLIST).not.toContain("bash");
+	});
+
+	test("assertRlmToolAllowlist passes for allowed sets", () => {
+		expect(() => assertRlmToolAllowlist(["python", "read", "web_search"])).not.toThrow();
+	});
+
+	test("assertRlmToolAllowlist throws naming the leaked tools", () => {
+		expect(() => assertRlmToolAllowlist(["python", "bash", "edit"])).toThrow(/bash/);
+		expect(() => assertRlmToolAllowlist(["goal"])).toThrow(/goal/);
+	});
+
+	test("system prompt builder appends the research prompt and data context", () => {
+		const noData = buildRlmSystemPrompt(null)(["base"]);
+		expect(noData[0]).toBe("base");
+		expect(noData).toContain(RLM_RESEARCH_PROMPT);
+
+		const withData = buildRlmSystemPrompt({ path: "/tmp/DATA.md", content: "schema: x" })(["base"]);
+		expect(withData.some(block => block.includes("schema: x") && block.includes("/tmp/DATA.md"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adds an **opt-in `gjc rlm` research mode** — a Jupyter-notebook-style research session over the **existing** GJC agent loop, backed by the **shared persistent Python kernel** (`eval/py/kernel.ts`). This is a CLI command + research preset, **not** a fifth workflow skill and **not** a bespoke loop.

Design came from a full `deep-interview` (12 rounds, ambiguity 4.65%) → `ralplan` consensus (2 iterations, Critic OKAY) → scoped `ultragoal` execution (G001). This PR is the **interactive-only v1** slice; heavier pieces are tracked as deferred stories.

## What's included (v1)

- **`gjc rlm` command** (`src/commands/rlm.ts`, registered in `cli.ts`) — optional seed question + `--data <path>`.
- **Research preset** (`src/rlm/preset.ts`): distinct static system prompt (`src/prompts/system/rlm-research.md`) + a **hard tool-gating allowlist** (`python` + `read` + `web_search`) asserted after the session's tool registry is assembled, via a new additive `rlmPreset` hook on `runRootCommand` (`main.ts`). Goal/discovery/skills/rules/extensions are disabled for the session; `bash`/edit/arbitrary mutation are excluded and fail launch if leaked.
- **Persistent kernel reuse** (`src/rlm/python-tool.ts`): the model-facing `python` tool wraps the shared executor; state persists across cells; every call is recorded.
- **Live notebook aggregation** (`src/rlm/notebook.ts`): single per-session write queue, atomic temp-file-then-rename writes, post-write `readNotebookDocument` validation. Helpers exported from `src/edit/notebook.ts`.
- **Optional `DATA.md`** (`src/rlm/data-context.ts`): project-root auto-load, overridable via `--data`.
- **Report synthesis** (`src/rlm/report.ts`): deterministic `report.md` on session exit. Artifacts under `.gjc/rlm/<session>/`.

## Deferred (follow-up stories)

Autonomous `gjc rlm "<goal>"` run-to-completion (`shouldPause` stop seam + `complete_research` tool), `--resume`, managed per-workspace venv (BYO uv/Poetry/venv else seeded venv), and the optional `>=N`-successful-runs completion gate. v1 uses ambient/BYO Python as-is.

## Verification

- `bun run check:types` (coding-agent): **pass**
- `biome check`: clean for changed files (one pre-existing unrelated tui-test lint info remains)
- `bun test test/rlm.test.ts`: **15 pass / 0 fail** (artifacts, notebook integrity incl. concurrent appends + error cells, report synthesis, data-context, tool-boundary allowlist)
- Default-surface gates: `check-visible-definitions.ts` **pass**, `default-gjc-definitions.test.ts` **20 pass** — `gjc rlm` is correctly a CLI command, the four-workflow-skill surface is unchanged.
- `gjc rlm --help` dispatches.
- Note: `verify-g002-gates.ts` reports a **pre-existing** MCP/README quarantine finding unrelated to this change (no RLM/MCP files involved); all RLM-relevant gate sections pass.
- Live interactive TUI launch is not auto-tested (requires a TTY); the launch path is wired through the existing `runRootCommand`/`InteractiveMode` flow.

## Notes

`.gjc/` planning artifacts (deep-interview spec, ralplan plan, ultragoal ledger) are gitignored and not part of this diff.
