### PR TITLE
test(coding-agent): include rlm in CLI command surface

### DIFF
--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -32,6 +32,7 @@ describe("GJC public CLI command surface", () => {
 			"mcp-serve",
 			"contribute-pr",
 			"deep-interview",
+			"rlm",
 			"update",
 			"launch",
 		]);


### PR DESCRIPTION
## Summary
- include the newly added `rlm` command in the retained public CLI command surface expectation
- fixes the post-merge Dev CI regression from #778 where implementation already registered `gjc rlm` but the surface test expected list omitted it

Fixes #784.

## Verification
- `bun --cwd=packages/natives run build` — passed; required locally because native addon was absent
- `bun test packages/coding-agent/test/cli-command-surface.test.ts -t "registers launch plus retained workflow/runtime utility endpoints"` — passed
- `bun test packages/coding-agent/test/cli-command-surface.test.ts` — passed
- `bun --cwd=packages/coding-agent run check` — passed with two pre-existing Biome warnings in `src/gjc-runtime/ultragoal-runtime.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*