### PR TITLE
Fix Codex web search default model

### DIFF
--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -19,8 +19,9 @@ import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
-const FALLBACK_MODEL = "gpt-5.4";
+const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
+	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
 	"gpt-5",
@@ -453,12 +454,12 @@ async function callCodexSearch(
  * Executes a web search using OpenAI code provider's built-in web search tool.
  *
  * Default-model behavior:
- * - If `PI_OPENAI_CODE_WEB_SEARCH_MODEL` is set, use it exactly once and surface any
+ * - If `PI_CODEX_WEB_SEARCH_MODEL` is set, use it exactly once and surface any
  *   upstream error verbatim.
- * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.4, GPT-5
- *   OpenAI code backend, GPT-5, …) and retry the next candidate only when OpenAI code backend returns the
+ * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.5, GPT-5.4,
+ *   GPT-5 code backend, …) and retry the next candidate only when OpenAI code backend returns the
  *   known 400 "model is not supported" family. This avoids selecting
- *   `gpt-5-OpenAI code backend-mini` first on ChatGPT accounts, which OpenAI rejects.
+ *   `gpt-5-codex-mini` first on ChatGPT accounts, which OpenAI rejects.
  */
 export async function searchCodex(params: SearchParams): Promise<SearchResponse> {
 	const auth = await findCodexAuth(params.authStorage, params.sessionId, params.signal);

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -223,26 +223,26 @@ describe("searchCodex model selection", () => {
 
 	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		using _hook = mockCodexFetch("gpt-5.4");
+		using _hook = mockCodexFetch("gpt-5.5");
 
 		const result = await searchCodex(makeSearchParams("default codex model"));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4");
-		expect(result.model).toBe("gpt-5.4");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
+		expect(result.model).toBe("gpt-5.5");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		using _hook = mockCodexFetch("gpt-5.4");
+		using _hook = mockCodexFetch("gpt-5.5");
 
 		const result = await searchCodex(makeSearchParams("blank codex model"));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4");
-		expect(result.model).toBe("gpt-5.4");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
+		expect(result.model).toBe("gpt-5.5");
 	});
 	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
@@ -258,17 +258,17 @@ describe("searchCodex model selection", () => {
 
 			const requestedModel = capturedRequest.body?.model;
 			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.4");
+				expect(requestedModel).toBe("gpt-5.5");
 				return new Response(
 					JSON.stringify({
-						detail: "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+						detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
 					}),
 					{ status: 400, headers: { "Content-Type": "application/json" } },
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5-codex");
-			return new Response(makeSseResponse("gpt-5-codex"), {
+			expect(requestedModel).toBe("gpt-5.4");
+			return new Response(makeSseResponse("gpt-5.4"), {
 				status: 200,
 				headers: { "Content-Type": "text/event-stream" },
 			});
@@ -277,7 +277,7 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("retry unsupported default"));
 
 		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5-codex");
+		expect(result.model).toBe("gpt-5.4");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 


### PR DESCRIPTION
## Summary

- Prefer `gpt-5.5` as the first default model for Codex/OpenAI web search.
- Keep `gpt-5.4` as the next fallback candidate.
- Update Codex web search model-selection tests to match the new supported default.
- Fix stale doc comment naming for `PI_CODEX_WEB_SEARCH_MODEL`.

## Why

ChatGPT-backed Codex web search can reject several previously preferred models with:

`400: model is not supported when using Codex with a ChatGPT account`

That caused GJC to fall back to DuckDuckGo even when OpenAI/Codex OAuth was valid. Live testing showed `gpt-5.5` works for Codex web search with the current ChatGPT account flow.

## Verification

- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts`
  - 9 pass, 0 fail
- Manual live Codex search
  - provider: `codex`
  - model: `gpt-5.5`
  - error: `null`
