### PR TITLE
feat(goals): expose pause op on the goal tool

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Exposed the existing goal-pause capability through the `goal` tool as `goal({op:"pause"})`. The runtime `pauseGoal()` method and `paused` status already existed and were reachable via the `/goal pause` slash command and the goal menu, but the agent-facing `goal` tool only enumerated `create | get | complete | resume | drop` — so an agent could not park a goal whose remaining work was blocked on human input. It was forced to either `drop` (clearing the goal) or leave the goal `active`, which re-fired the hidden autonomous-continuation steer every turn with no exit condition. `pause` reuses the existing `paused` status and continuation gate (`buildContinuationPrompt` already returns `undefined` when `enabled=false`), parks the goal without dropping it, persists as `goal_paused`, and is resumable via the existing `resume` op. The active-goal and continuation prompts now instruct the agent to pause when every remaining deliverable is genuinely human-blocked.
 
 ## [0.5.3] - 2026-06-16
 

--- a/packages/coding-agent/src/goals/state.ts
+++ b/packages/coding-agent/src/goals/state.ts
@@ -19,7 +19,7 @@ export interface GoalModeState {
 	goal: Goal;
 }
 export interface GoalToolDetails {
-	op: "create" | "get" | "complete" | "resume" | "drop";
+	op: "create" | "get" | "complete" | "resume" | "drop" | "pause";
 	goal?: Goal | null;
 }
 

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -17,9 +17,9 @@ import type { Goal, GoalStatus, GoalToolDetails } from "../state";
 
 const goalSchema = z.object({
 	op: z
-		.enum(["create", "get", "complete", "resume", "drop"])
+		.enum(["create", "get", "complete", "resume", "drop", "pause"])
 		.describe(
-			"op: get | create | complete | drop | resume — drop clears the active goal without exiting goal mode (tool stays callable for the next create)",
+			"op: get | create | complete | drop | resume | pause — drop clears the active goal without exiting goal mode (tool stays callable for the next create); pause parks an active goal whose remaining work is blocked on human input so the autonomous continuation loop stops until resume",
 		),
 	objective: z.string().describe("goal objective").optional(),
 });
@@ -86,6 +86,10 @@ async function executeGoalOperation(session: ToolSession, params: GoalToolInput)
 		const resumed = await runtime.resumeGoal();
 		return buildGoalToolResponse(resumed.goal);
 	}
+	if (params.op === "pause") {
+		const paused = await runtime.pauseGoal();
+		return buildGoalToolResponse(paused?.goal ?? null);
+	}
 	if (params.op === "drop") {
 		const dropped = await runtime.dropGoal();
 		return buildGoalToolResponse(dropped ?? null);
@@ -135,6 +139,8 @@ function describeOp(op: string | undefined): string {
 			return "check";
 		case "resume":
 			return "resume";
+		case "pause":
+			return "pause";
 		case "drop":
 			return "drop";
 		default:

--- a/packages/coding-agent/src/prompts/goals/goal-continuation.md
+++ b/packages/coding-agent/src/prompts/goals/goal-continuation.md
@@ -23,3 +23,4 @@ Before calling `goal({op:"complete"})`, you MUST perform a completion audit agai
 Call `goal({op:"complete"})` only when every deliverable has direct, current-state evidence proving it is satisfied. The completion call is a load-bearing claim; it ends the autonomous loop and surfaces a "done" report to the user.
 
 If the work is not done, just keep working. Do not narrate that you are continuing — execute.
+If every outstanding deliverable is genuinely blocked on human input or action only the user can perform (e.g. the user must sing, record, edit, approve, or carry out a manual/physical step) and no further autonomous progress is possible, call `goal({op:"pause"})` to park the goal. This stops the autonomous continuation loop without falsely completing or dropping the objective. State the human blocker, pause, then stop. When the user later unblocks the work, they (or you) resume via `goal({op:"resume"})`.

--- a/packages/coding-agent/src/prompts/goals/goal-mode-active.md
+++ b/packages/coding-agent/src/prompts/goals/goal-mode-active.md
@@ -12,6 +12,7 @@ Usage:
 Use the `goal` tool to inspect or complete the active goal:
 - `goal({op:"get"})` returns the current goal and usage state.
 - `goal({op:"complete"})` is only for verified completion.
+- `goal({op:"pause"})` parks the goal when every outstanding deliverable is blocked on human input only the user can perform; it stops the autonomous continuation loop and is resumed with `goal({op:"resume"})`.
 
 You MUST keep the full objective intact across turns. Do not redefine success around a smaller, easier, or already-completed subset.
 

--- a/packages/coding-agent/src/prompts/tools/goal.md
+++ b/packages/coding-agent/src/prompts/tools/goal.md
@@ -6,13 +6,16 @@ Use a single `op` field:
 - `resume` re-activates a paused goal so work can continue.
 - `complete` marks the goal complete after you have verified every deliverable against current evidence.
 - `drop` discards the current goal without completing it.
+- `pause` parks an active goal without completing or dropping it. The autonomous continuation loop stops while the goal is paused, so the agent is not re-activated every turn. Use `pause` (not `drop`) when the goal is genuinely still alive but every outstanding deliverable is blocked on human input or action only the user can perform — e.g. the user must sing, record, edit, approve, or perform a manual/physical step — and no further autonomous progress is possible. A paused goal keeps its progress and is fully resumable via `resume`.
 
 Examples:
 - `goal({"op":"create","objective":"Implement feature X"})`
 - `goal({"op":"get"})`
 - `goal({"op":"resume"})`
+- `goal({"op":"pause"})`
 - `goal({"op":"complete"})`
 - `goal({"op":"drop"})`
 
 Call `complete` only when the goal is actually done and verified.
 If `get` shows a paused goal, call `resume` before continuing work on it.
+Do not `pause` as a substitute for `complete`; pause only when the outstanding work is human-blocked.

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -311,6 +311,52 @@ describe("GoalTool", () => {
 		expect(result.details?.goal?.status).toBe("active");
 		expect(harness.getState()?.enabled).toBe(true);
 	});
+	it("op=pause parks an active goal and stops the continuation loop", async () => {
+		const harness = createRuntimeHarness({
+			enabled: true,
+			mode: "active",
+			goal: createGoal({ objective: "Sing the vocal layers" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		// continuation is armed while the goal is active
+		expect(harness.runtime.buildContinuationPrompt()).toBeTypeOf("string");
+
+		const result = await tool.execute("call-pause", { op: "pause" });
+		expect(result.details?.op).toBe("pause");
+		expect(result.details?.goal?.status).toBe("paused");
+		expect(harness.getState()?.enabled).toBe(false);
+
+		// pausing suppresses the autonomous continuation steer
+		expect(harness.runtime.buildContinuationPrompt()).toBeUndefined();
+	});
+
+	it("a paused goal resumes back to active and re-arms continuation", async () => {
+		const harness = createRuntimeHarness({
+			enabled: true,
+			mode: "active",
+			goal: createGoal({ objective: "Sing the vocal layers" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		await tool.execute("call-pause", { op: "pause" });
+		expect(harness.runtime.buildContinuationPrompt()).toBeUndefined();
+
+		const resumed = await tool.execute("call-resume", { op: "resume" });
+		expect(resumed.details?.goal?.status).toBe("active");
+		expect(harness.getState()?.enabled).toBe(true);
+		expect(harness.runtime.buildContinuationPrompt()).toBeTypeOf("string");
+	});
 
 	it("op=drop clears goal state", async () => {
 		const harness = createRuntimeHarness({
@@ -331,11 +377,11 @@ describe("GoalTool", () => {
 		expect(harness.getState()).toBeUndefined();
 	});
 
-	it("exposes the schema describe enumerating all five ops", () => {
+	it("exposes the schema describe enumerating all six ops", () => {
 		const tool = new GoalTool(createToolSession({}));
 		const opDescribe = (tool.parameters as any).shape.op.description;
 		expect(opDescribe).toBe(
-			"op: get | create | complete | drop | resume — drop clears the active goal without exiting goal mode (tool stays callable for the next create)",
+			"op: get | create | complete | drop | resume | pause — drop clears the active goal without exiting goal mode (tool stays callable for the next create); pause parks an active goal whose remaining work is blocked on human input so the autonomous continuation loop stops until resume",
 		);
 	});
 
@@ -347,6 +393,7 @@ describe("GoalTool", () => {
 		expect(opDescribe).toContain("complete");
 		expect(opDescribe).toContain("drop");
 		expect(opDescribe).toContain("resume");
+		expect(opDescribe).toContain("pause");
 		expect(opDescribe).toContain("without exiting goal mode");
 	});
 });


### PR DESCRIPTION
## What

Exposes the existing goal-pause capability through the agent-facing `goal` tool as `goal({op:"pause"})`. The tool's op enum goes from `create | get | complete | resume | drop` to include `pause`.

The runtime already had `pauseGoal()`, a `paused` status, a `goal_paused` persist mode, and a continuation gate (`buildContinuationPrompt`) that returns `undefined` when the goal is not `enabled && status==="active"`. That capability was reachable via the `/goal pause` slash command and the goal menu — just not through the `goal` tool the agent itself calls.

## Why

An agent whose remaining work is entirely blocked on human input had no way to park a goal. Its only tool options were `drop` (which clears the goal entirely) or leaving the goal `active`. An active goal re-fires the hidden autonomous-continuation steer every turn with no exit condition, because the loop keys off `active` and an active goal is neither `completed` nor `dropped`. The agent re-activates, re-audits, and re-reports the identical blocked state turn after turn — even though zero autonomous progress is possible. A user explicitly flagged this as "very disruptive."

This is the smallest fix that resolves it. It adds no new status, no new runtime method, no heuristic human-blocked detection, and no new continuation gate. It reuses `pauseGoal()` / `paused` / `resume` verbatim:

- `goal({op:"pause"})` → `runtime.pauseGoal()` → `status: "paused"`, `enabled: false`, persisted as `goal_paused`.
- `buildContinuationPrompt()` already returns `undefined` for a paused goal, so the autonomous loop stops.
- `goal({op:"resume"})` (already present) re-activates it; continuation resumes.
- A paused goal keeps its progress and is not reported as `completed` or `dropped`.

The active-goal and continuation prompts now instruct the agent to `pause` (then stop) when every outstanding deliverable is genuinely human-blocked, rather than spinning.

## Testing

- Added two focused tests in `goal-tool.test.ts`:
  - `op=pause parks an active goal and stops the continuation loop` — asserts status flips to `paused`, `enabled=false`, and `buildContinuationPrompt()` returns `undefined` after pause.
  - `a paused goal resumes back to active and re-arms continuation` — pause → resume round-trip re-arms the continuation prompt.
- Updated the two schema-description assertions (now enumerate six ops, include the `pause` token).
- `bun test packages/coding-agent/test/goals/` — 34 pass.
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts` + `agent-session-goal-reminder.test.ts` — green (default surface unchanged).
- `bun --cwd=packages/coding-agent run check:types` — clean.
- `bun biome check` on the changed TS files — OK.
- `bun scripts/check-visible-definitions.ts` — default surface OK (still exactly 4 skills + 4 role agents).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)