### PR TITLE
fix(coding-agent): preserve skill invocation args preview

### DIFF
--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -1,9 +1,20 @@
 import type { TextContent } from "@gajae-code/ai";
 import type { Component } from "@gajae-code/tui";
-import { Box, Container, Markdown, Spacer, Text, truncateToWidth } from "@gajae-code/tui";
+import {
+	Box,
+	Container,
+	Markdown,
+	replaceTabs,
+	Spacer,
+	Text,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CustomMessage, SkillPromptDetails } from "../../session/messages";
 
+const COLLAPSED_ARGS_PREVIEW_WIDTH = 96;
+const COLLAPSED_ARGS_PREVIEW_LINES = 6;
 export class SkillMessageComponent extends Container {
 	#box: Box;
 	#contentComponent?: Component;
@@ -43,14 +54,16 @@ export class SkillMessageComponent extends Container {
 		const name = details?.name ?? "unknown";
 		const args = details?.args?.trim();
 
-		// Single compact line: `[skill] <name>: <args>`. The summary is the
-		// args the user typed; with none, just `[skill] <name>`. Collapsed to
-		// one line — path / line-count / full prompt body are debugging detail
-		// and only render once expanded.
-		const summary = args ? truncateToWidth(args.replace(/\s+/g, " "), 72) : undefined;
+		// Collapsed view keeps args readable without exposing the full prompt body.
+		// Each visual line is bounded, but multi-line arguments remain multi-line so
+		// the invocation context is not mistaken for a one-line truncated payload.
+		const argsPreview = args ? this.#formatArgsPreview(args) : [];
 		const header = `${theme.fg("customMessageLabel", theme.bold("[skill]"))} ${theme.fg("customMessageText", name)}`;
-		const headerText = summary ? `${header}${theme.fg("customMessageText", `: ${summary}`)}` : header;
-		this.#box.addChild(new Text(headerText, 0, 0));
+		this.#box.addChild(new Text(header, 0, 0));
+		if (argsPreview.length > 0) {
+			this.#box.addChild(new Spacer(1));
+			this.#box.addChild(new Text(argsPreview.map(line => theme.fg("customMessageText", line)).join("\n"), 0, 0));
+		}
 
 		if (!this.#expanded) {
 			return;
@@ -70,6 +83,18 @@ export class SkillMessageComponent extends Container {
 			);
 		}
 
+		if (args) {
+			this.#box.addChild(new Spacer(1));
+			const argsHeader = theme.fg("customMessageLabel", theme.bold("Arguments"));
+			this.#box.addChild(new Text(argsHeader, 0, 0));
+			this.#box.addChild(new Spacer(1));
+			this.#box.addChild(
+				new Markdown(replaceTabs(args), 0, 0, getMarkdownTheme(), {
+					color: (value: string) => theme.fg("customMessageText", value),
+				}),
+			);
+		}
+
 		const text = this.#extractText();
 		if (!text) {
 			return;
@@ -84,6 +109,35 @@ export class SkillMessageComponent extends Container {
 			color: (value: string) => theme.fg("customMessageText", value),
 		});
 		this.#box.addChild(this.#contentComponent);
+	}
+
+	#formatArgsPreview(args: string): string[] {
+		const preview: string[] = [];
+		let omitted = false;
+		const sourceLines = replaceTabs(args).split(/\r?\n/);
+		for (let index = 0; index < sourceLines.length; index += 1) {
+			const sourceLine = sourceLines[index]?.trimEnd() ?? "";
+			const wrapped = wrapTextWithAnsi(sourceLine.length > 0 ? sourceLine : " ", COLLAPSED_ARGS_PREVIEW_WIDTH);
+			for (const line of wrapped.length > 0 ? wrapped : [""]) {
+				if (preview.length >= COLLAPSED_ARGS_PREVIEW_LINES) {
+					omitted = true;
+					break;
+				}
+				preview.push(truncateToWidth(line, COLLAPSED_ARGS_PREVIEW_WIDTH));
+			}
+			if (omitted) break;
+		}
+		if (sourceLines.length > 0 && preview.length === COLLAPSED_ARGS_PREVIEW_LINES) {
+			const visibleSource = preview.join("\n");
+			omitted ||= replaceTabs(args).trimEnd().length > visibleSource.trimEnd().length;
+		}
+		if (omitted && preview.length > 0) {
+			preview[preview.length - 1] = truncateToWidth(
+				`${preview[preview.length - 1]} …`,
+				COLLAPSED_ARGS_PREVIEW_WIDTH,
+			);
+		}
+		return preview;
 	}
 
 	#extractText(): string {

--- a/packages/coding-agent/test/modes/components/skill-message-render.test.ts
+++ b/packages/coding-agent/test/modes/components/skill-message-render.test.ts
@@ -41,10 +41,11 @@ const DETAILS: SkillPromptDetails = {
 };
 
 describe("SkillMessageComponent rendering", () => {
-	it("collapsed view shows `[skill] <name>: <args>` and no debug metadata", () => {
+	it("collapsed view shows `[skill] <name>` with readable args and no debug metadata", () => {
 		const out = render(makeMessage({ ...DETAILS, args: "fix the login bug" }, "PROMPT BODY TEXT"), false);
 
-		expect(out).toContain("[skill] deep-interview: fix the login bug");
+		expect(out).toContain("[skill] deep-interview");
+		expect(out).toContain("fix the login bug");
 
 		// Debug-only detail must be hidden when collapsed.
 		expect(out).not.toContain("Skill:");
@@ -62,17 +63,35 @@ describe("SkillMessageComponent rendering", () => {
 		expect(out).not.toContain("deep-interview:");
 	});
 
-	it("truncates over-long args to a single line", () => {
-		const longArgs = `${"A".repeat(90)} ZZZEND`;
-		const out = render(makeMessage({ ...DETAILS, args: longArgs }, "BODY"), false);
-		expect(out).toContain("AAAA");
-		expect(out).not.toContain("ZZZEND");
+	it("collapsed view preserves multi-line args in a bounded preview", () => {
+		const args = [
+			"to re-architect our problem banks into source-based architecture, and",
+			"make sure gaebal-gajae skill-invocation modal does not truncate skill args,",
+			"even though we need few lines to use.",
+		].join("\n");
+		const out = render(makeMessage({ ...DETAILS, args }, "BODY"), false);
+
+		expect(out).toContain("[skill] deep-interview");
+		expect(out).toContain("to re-architect our problem banks");
+		expect(out).toContain("make sure gaebal-gajae skill-invocation modal");
+		expect(out).toContain("even though we need few lines to use.");
 	});
 
-	it("expanded view reveals path, line count, and full prompt body", () => {
+	it("bounds over-long args without leaking the full payload", () => {
+		const longArgs = Array.from({ length: 8 }, (_, index) => `line ${index + 1} ${"A".repeat(120)}`).join("\n");
+		const out = render(makeMessage({ ...DETAILS, args: longArgs }, "BODY"), false);
+
+		expect(out).toContain("line 1");
+		expect(out).toContain("…");
+		expect(out).not.toContain("line 8");
+	});
+
+	it("expanded view reveals path, line count, args, and full prompt body", () => {
 		const out = render(makeMessage({ ...DETAILS, args: "fix the login bug" }, "PROMPT BODY TEXT"), true);
 
-		expect(out).toContain("[skill] deep-interview: fix the login bug");
+		expect(out).toContain("[skill] deep-interview");
+		expect(out).toContain("Arguments");
+		expect(out).toContain("fix the login bug");
 		expect(out).toContain("Path:");
 		expect(out).toContain("embedded:gjc/skills/deep-interview/SKILL.md");
 		expect(out).toContain("858 lines");

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { type Skill as CapabilitySkill, skillCapability } from "@gajae-code/coding-agent/capability/skill";
 import { getCapability } from "@gajae-code/coding-agent/discovery";
 import {
+	buildSkillPromptMessage,
 	loadSkills,
 	loadSkillsFromDir,
 	parseSkillInvocations,
@@ -47,6 +48,18 @@ describe("parseSkillInvocations", () => {
 		expect(parseSkillInvocations("/skill:alpha first /skill:beta second /not-a-skill", skillsByCommandName)).toEqual([
 			{ commandName: "skill:alpha", args: "first", skill: alpha },
 			{ commandName: "skill:beta", args: "second /not-a-skill", skill: beta },
+		]);
+	});
+
+	it("preserves multi-line and long arguments in invocation payloads", () => {
+		const args = [
+			"to re-architect our problem banks into source-based architecture, and",
+			"make sure gaebal-gajae skill-invocation modal does not truncate skill args,",
+			`${"even though we need few lines to use. ".repeat(20)}END`,
+		].join("\n");
+
+		expect(parseSkillInvocations(`/skill:alpha ${args}`, skillsByCommandName)).toEqual([
+			{ commandName: "skill:alpha", args, skill: alpha },
 		]);
 	});
 
@@ -471,6 +484,26 @@ description: Skill loaded from a tilde-expanded custom directory.
 			expect(skillMap.get("calendar")?.source).toBe("first");
 			expect(collisionWarnings).toHaveLength(1);
 			expect(collisionWarnings[0].message).toContain("name collision");
+		});
+	});
+
+	describe("buildSkillPromptMessage", () => {
+		it("preserves multi-line and long args in the actual prompt payload and details", async () => {
+			const args = [
+				"to re-architect our problem banks into source-based architecture, and",
+				"make sure gaebal-gajae skill-invocation modal does not truncate skill args,",
+				`${"even though we need few lines to use. ".repeat(20)}END`,
+			].join("\n");
+			const skill = {
+				...makeSkill("alpha"),
+				content: "---\nname: alpha\ndescription: Alpha\n---\n\n# Alpha\nDo work.",
+			};
+
+			const built = await buildSkillPromptMessage(skill, args);
+
+			expect(built.details.args).toBe(args);
+			expect(built.message).toContain(`User: ${args}`);
+			expect(built.message).toContain("END");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Preserve multi-line and long `/skill:<name>` args in parser/prompt payload tests.
- Render skill invocation args as a bounded multi-line preview in the collapsed skill message instead of flattening to one truncated line.
- Show full invocation arguments in expanded skill message details while keeping the full skill prompt behind expansion.

## Verification
- bun test packages/coding-agent/test/modes/components/skill-message-render.test.ts packages/coding-agent/test/skills.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/modes/components/skill-message.ts packages/coding-agent/test/modes/components/skill-message-render.test.ts packages/coding-agent/test/skills.test.ts

Fixes #797

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*