### PR TITLE
Improve JSON tree rendering for long strings

### DIFF
--- a/packages/coding-agent/src/tools/json-tree.ts
+++ b/packages/coding-agent/src/tools/json-tree.ts
@@ -81,6 +81,25 @@ function buildTreePrefix(theme: Theme, ancestors: readonly boolean[]): string {
 	return ancestors.map(hasNext => (hasNext ? `${theme.tree.vertical}  ` : "   ")).join("");
 }
 
+function splitByDisplayWidth(value: string, maxWidth: number): string[] {
+	const width = Math.max(1, maxWidth);
+	const fragments: string[] = [];
+	let current = "";
+	let currentWidth = 0;
+	for (const char of value) {
+		const charWidth = Math.max(1, Bun.stringWidth(char));
+		if (current && currentWidth + charWidth > width) {
+			fragments.push(current);
+			current = "";
+			currentWidth = 0;
+		}
+		current += char;
+		currentWidth += charWidth;
+	}
+	if (current || fragments.length === 0) fragments.push(current);
+	return fragments;
+}
+
 /**
  * Render a JSON value as tree lines.
  */
@@ -121,38 +140,32 @@ export function renderJsonTreeLines(
 			// Handle scalars
 			if (val === null || val === undefined || typeof val !== "object") {
 				const label = key ? theme.fg("muted", key) : theme.fg("muted", "value");
-
-				// Special handling for multiline strings
-				if (typeof val === "string" && val.includes("\n")) {
-					const strLines = val.split("\n");
-					const maxStrLines = Math.min(strLines.length, Math.max(1, maxLines - lines.length - 1));
+				if (typeof val === "string") {
+					const escaped = val.replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+					const marker = "…";
+					const firstFragmentWidth = Math.max(1, maxScalarLen - 2);
+					const continuationWidth = Math.max(1, maxScalarLen - Bun.stringWidth(marker) - 1);
+					const firstFragments = splitByDisplayWidth(escaped, firstFragmentWidth);
+					const firstFragment = firstFragments[0] ?? "";
+					const remainder = firstFragments.slice(1).join("");
+					const continuationFragments = remainder ? splitByDisplayWidth(remainder, continuationWidth) : [];
+					const fragments = [firstFragment, ...continuationFragments];
+					const lineBudget = Math.max(1, maxLines - lines.length);
+					const visibleCount = Math.min(fragments.length, lineBudget);
 					const continuePrefix = buildTreePrefix(theme, ancestors);
+					const isStringTruncated = visibleCount < fragments.length;
 
-					// First line with label
-					const firstLine = truncateToWidth(strLines[0], maxScalarLen);
-					pushLine(`${prefix}${iconScalar} ${label}: ${theme.fg("dim", `"${firstLine}`)}`);
-
-					// Subsequent lines indented
-					for (let i = 1; i < maxStrLines; i++) {
-						if (lines.length >= maxLines) {
-							truncated = true;
-							break;
-						}
-						const line = truncateToWidth(strLines[i], maxScalarLen);
-						pushLine(`${continuePrefix}   ${theme.fg("dim", ` ${line}`)}`);
+					for (let i = 0; i < visibleCount; i++) {
+						const isFirst = i === 0;
+						const isFinalVisible = i === visibleCount - 1;
+						const suffix = isStringTruncated && isFinalVisible ? `${marker}"` : isFinalVisible ? '"' : "";
+						const rendered = isFirst ? `"${fragments[i]}${suffix}` : `↳ ${fragments[i]}${suffix}`;
+						const line = isFirst
+							? `${prefix}${iconScalar} ${label}: ${theme.fg("dim", rendered)}`
+							: `${continuePrefix}   ${theme.fg("dim", rendered)}`;
+						if (!pushLine(line)) break;
 					}
-
-					// Show truncation and closing quote
-					if (strLines.length > maxStrLines) {
-						truncated = true;
-						pushLine(
-							`${continuePrefix}   ${theme.fg("dim", ` …(${strLines.length - maxStrLines} more lines)"`)}`,
-						);
-					} else {
-						// Add closing quote to last line - need to modify the last pushed line
-						const lastIdx = lines.length - 1;
-						lines[lastIdx] = `${lines[lastIdx]}${theme.fg("dim", '"')}`;
-					}
+					if (isStringTruncated) truncated = true;
 					return;
 				}
 

--- a/packages/coding-agent/test/tools/json-tree.test.ts
+++ b/packages/coding-agent/test/tools/json-tree.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { renderJsonTreeLines } from "../../src/tools/json-tree";
+
+type JsonTreeTheme = Parameters<typeof renderJsonTreeLines>[1];
+const theme = {
+	fg: (_color: string, text: string) => text,
+	styledSymbol: (_key: string, _color: string) => "",
+	tree: {
+		branch: "├─",
+		last: "└─",
+		vertical: "│",
+		horizontal: "─",
+		hook: "└",
+	},
+} as JsonTreeTheme;
+
+describe("renderJsonTreeLines", () => {
+	function testTheme() {
+		return theme;
+	}
+
+	function stripLines(lines: string[]): string[] {
+		return lines.map(line => Bun.stripANSI(line));
+	}
+
+	it("wraps long path-like string values as deterministic continuations", async () => {
+		const theme = await testTheme();
+		const target = "../../../gajae-code.gajae-code-worktrees/release-0-5-4-64d49adc/packages/coding-agent";
+
+		const tree = renderJsonTreeLines({ target }, theme, 2, 10, 32);
+		const lines = stripLines(tree.lines);
+
+		expect(tree.truncated).toBe(false);
+		expect(lines.length).toBeGreaterThan(1);
+		expect(lines[0]).toContain('target: "../../../gajae-code.gajae-code');
+		expect(lines[0]).not.toContain(
+			'"../../../gajae-code.gajae-code-worktrees/release-0-5-4-64d49adc/packages/coding-agent"',
+		);
+		expect(lines.slice(1).every(line => line.includes("↳ "))).toBe(true);
+		expect(lines.at(-1)).toContain('"');
+		expect(lines.join("\n")).toContain("worktrees/release-0-5-4-64d49");
+		expect(lines.join("\n")).toContain("packages/coding-agent");
+	});
+
+	it("marks long string values truncated when continuation lines exhaust the line budget", async () => {
+		const theme = await testTheme();
+		const real =
+			"/Users/example/Documents/Workspace/gajae-code.gajae-code-worktrees/release-0-5-4-64d49adc/packages/coding-agent/src/tools/json-tree.ts";
+
+		const tree = renderJsonTreeLines({ real, isSymbolicLink: true }, theme, 2, 2, 36);
+		const lines = stripLines(tree.lines);
+
+		expect(tree.truncated).toBe(true);
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toContain('real: "');
+		expect(lines[1]).toContain("↳ ");
+		expect(lines[1]).toContain('…"');
+		expect(lines.join("\n")).not.toContain("isSymbolicLink");
+	});
+
+	it("keeps escaped tabs readable in wrapped string values", async () => {
+		const theme = await testTheme();
+		const value = "node_modules/@gajae-code/coding-agent\tpackages/coding-agent/src/tools/json-tree.ts";
+
+		const tree = renderJsonTreeLines({ value }, theme, 2, 10, 28);
+		const lines = stripLines(tree.lines);
+
+		expect(tree.truncated).toBe(false);
+		expect(lines.join("\n")).toContain("\\t");
+		expect(lines.join("\n")).not.toContain("\t");
+		expect(lines.at(-1)).toContain('"');
+	});
+
+	it("escapes newlines and tabs through the same continuation path", async () => {
+		const theme = await testTheme();
+		const value = "alpha\tbeta\ngamma\tdelta/packages/coding-agent/src/tools/json-tree.ts";
+
+		const tree = renderJsonTreeLines({ value }, theme, 2, 10, 24);
+		const lines = stripLines(tree.lines);
+
+		expect(tree.truncated).toBe(false);
+		expect(lines.join("\n")).toContain("\\t");
+		expect(lines.join("\n")).toContain("\\n");
+		expect(lines.join("\n")).not.toContain("\t");
+		expect(lines.slice(1).every(line => line.includes("↳ "))).toBe(true);
+	});
+
+	it("does not change non-string scalar rendering", async () => {
+		const theme = await testTheme();
+		const tree = renderJsonTreeLines({ ok: true, count: 42, empty: null }, theme, 2, 10, 12);
+		const lines = stripLines(tree.lines);
+
+		expect(tree.truncated).toBe(false);
+		expect(lines.some(line => line.includes("ok: true"))).toBe(true);
+		expect(lines.some(line => line.includes("count: 42"))).toBe(true);
+		expect(lines.some(line => line.includes("empty: null"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Render long JSON string values in `renderJsonTreeLines` as deterministic display-width fragments with `↳` continuation lines.
- Preserve explicit quote/truncation markers and escape tabs/newlines before wrapping.
- Add focused coverage for path-like strings, line-budget truncation, escaped controls, and non-string scalar compatibility.

## Verification
- `bun test packages/coding-agent/test/tools/json-tree.test.ts packages/coding-agent/test/tools/render-utils.test.ts`
- `bunx biome check packages/coding-agent/src/tools/json-tree.ts packages/coding-agent/test/tools/json-tree.test.ts --no-errors-on-unmatched`
- `bun --cwd=packages/coding-agent run check:types`

Fixes #793

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*