### PR TITLE
test(coding-agent): format live RLM e2e

### DIFF
--- a/packages/coding-agent/test/rlm-live-model-e2e.test.ts
+++ b/packages/coding-agent/test/rlm-live-model-e2e.test.ts
@@ -18,7 +18,6 @@ import * as path from "node:path";
 const LIVE = process.env.GJC_RLM_LIVE === "1";
 const SALES_CSV = "region,amount\nnorth,100\nnorth,150\nsouth,200\nsouth,50\neast,300\n";
 
-
 describe("rlm live model-driven e2e", () => {
 	test.skipIf(!LIVE)(
 		"real model drives the python tool and the report captures computed totals",


### PR DESCRIPTION
## Summary
- Remove the extra blank line in the live RLM e2e test so Biome formatting passes on dev.
- Leave unrelated ultragoal-runtime warnings untouched.

## Verification
- Reproduced failure with `bun run @gajae-code/coding-agent/check`: Biome failed on `packages/coding-agent/test/rlm-live-model-e2e.test.ts` formatting, plus unrelated warnings.
- `bun --cwd=packages/coding-agent biome check test/rlm-live-model-e2e.test.ts`
- `bun run @gajae-code/coding-agent/check`