### PR TITLE
Fix tmux GC handling for non-repo project metadata

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-gc.ts
@@ -6,7 +6,7 @@
 
 import * as fs from "node:fs";
 
-import { worktree } from "../utils/git";
+import { GitCommandError, worktree } from "../utils/git";
 import type { GcCollectResult, GcContext, GcPruneOutcome, GcRecord, GcStoreAdapter } from "./gc-runtime";
 import { readTerminalRuntimeStateMarker } from "./session-state-sidecar";
 import { GJC_TMUX_PROFILE_VALUE, GJC_TMUX_SESSION_PREFIX } from "./tmux-common";
@@ -61,10 +61,18 @@ function branchMatches(candidate: string | undefined, branch: string): boolean {
 	]);
 	return branchNames.has(candidate);
 }
+function isNotGitRepositoryError(error: unknown): boolean {
+	return error instanceof GitCommandError && /not a git repository/i.test(error.message);
+}
 
 async function hasLiveWorktreeForBranch(project: string, branch: string): Promise<boolean> {
-	const entries = await worktree.list(project);
-	return entries.some(entry => branchMatches(entry.branch, branch));
+	try {
+		const entries = await worktree.list(project);
+		return entries.some(entry => branchMatches(entry.branch, branch));
+	} catch (error) {
+		if (isNotGitRepositoryError(error)) return false;
+		throw error;
+	}
 }
 
 function isSessionLive(session: Pick<GjcTmuxSessionStatus, "attached" | "panePids">): boolean {

--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
@@ -175,7 +175,7 @@ describe("tmux GC safety", () => {
 
 	it("keeps stale project or branch metadata non-removable without a terminal marker", async () => {
 		const missingProject = "/tmp/gjc-missing-project";
-		const liveProject = process.cwd();
+		const nonRepoProject = "/tmp";
 		const calls: string[][] = [];
 		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
@@ -191,7 +191,7 @@ describe("tmux GC safety", () => {
 						sessionLine({
 							name: "gajae_code_no_worktree",
 							branch: "definitely-missing-gjc-branch",
-							project: liveProject,
+							project: nonRepoProject,
 						}),
 					].join("\n"),
 				);


### PR DESCRIPTION
## Summary
- Treat git worktree-list "not a git repository" failures as no live worktree instead of generic worktree-list failure.
- Keep markerless stale branch/project tmux metadata non-removable and preserve the branch_no_worktree_without_terminal_marker classification for non-repo projects like /tmp.
- Pin the regression test to /tmp to match the dev CI environment-sensitive failure.

## Verification
- bun test packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts -t "keeps stale project or branch metadata"
- bun test packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
- bun --cwd=packages/coding-agent run check:types

Signed-off-by: GJC <gjc@gajae-code.local>