### PR TITLE
fix(ask): expand large paste custom input

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -518,7 +518,7 @@ export class HookSelectorComponent extends Container {
 			return;
 		}
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return")) {
-			this.#customInput?.onSubmit(editor.getText());
+			this.#customInput?.onSubmit(editor.getExpandedText());
 			return;
 		}
 		editor.handleInput(keyData);

--- a/packages/coding-agent/test/hook-selector-inline-input.test.ts
+++ b/packages/coding-agent/test/hook-selector-inline-input.test.ts
@@ -125,6 +125,26 @@ describe("HookSelectorComponent inline custom input", () => {
 		expect(calls.cancelled).toBe(0);
 	});
 
+	it("submits expanded large paste content instead of the display marker", () => {
+		const { component, calls } = createSelector();
+		moveToOther(component);
+		component.handleInput("\r");
+
+		const pastedText = Array.from({ length: 12 }, (_, index) => `pasted line ${index + 1}`).join("\n");
+		component.handleInput(`\x1b[200~${pastedText}\x1b[201~`);
+
+		const rendered = renderText(component);
+		expect(rendered).toContain("[paste #");
+		expect(calls.submitted).toEqual([]);
+
+		component.handleInput("\r");
+
+		expect(calls.submitted).toEqual([pastedText]);
+		expect(calls.submitted[0]).not.toContain("[paste #");
+		expect(calls.selected).toEqual([]);
+		expect(calls.cancelled).toBe(0);
+	});
+
 	it("escape returns to option selection without cancelling the dialog", () => {
 		const { component, calls } = createSelector();
 		moveToOther(component);


### PR DESCRIPTION
Fixes the ask/deep-interview inline custom-input path so large bracketed pastes reach the model as the original pasted text instead of the visible `[paste #N ...]` marker.

## Problem
Large pastes are intentionally rendered in the editor as compact markers such as `[paste #1 +42 lines]`, while the real pasted body is stored privately by `Editor`. The normal editor submit path expands those markers, but `HookSelectorComponent` disables the editor's submit handling for inline `Other (type your own)` input and submitted `editor.getText()` directly. That leaked the display marker into ask/deep-interview answers, making the pasted source unavailable to the model.

## Solution
- Submit inline custom input with `editor.getExpandedText()` instead of `editor.getText()`.
- Keep the visible editor marker behavior unchanged.
- Add a focused regression that sends a real bracketed paste sequence, verifies the marker is visible before submit, and verifies the submitted value is the original pasted text.

## Validation
- `bun test packages/coding-agent/test/hook-selector-inline-input.test.ts`
  - 11 pass
  - 0 fail

## Review
- Read-only architect review: CLEAR / APPROVE, no blockers.
