### PR TITLE
fix(ci): run dev checks for fork PRs

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -18,7 +18,6 @@ jobs:
   # exact diff via CI_DEV_CHANGED_PATHS instead of re-resolving the base ref.
   affected-plan:
     name: Affected path validation / plan
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
@@ -173,7 +172,7 @@ jobs:
   # changes). The job name must stay exactly "Affected path validation".
   affected:
     name: Affected path validation
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ always() }}
     needs: [affected-plan, affected-native, affected-shards]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -193,7 +192,6 @@ jobs:
 
   gjc-state-gates-matrix:
     name: gjc-state-gates / ${{ matrix.group }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -227,7 +225,7 @@ jobs:
   # Branch protection must keep requiring this stable aggregate status.
   gjc-state-gates:
     name: gjc-state-gates
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ always() }}
     needs: [gjc-state-gates-matrix]
     runs-on: ubuntu-22.04
     timeout-minutes: 5


### PR DESCRIPTION
Fixes fork PR CI being approved but then fully skipped.

## Problem
`dev-ci.yml` guarded the planner and both stable aggregate checks with:

```yaml
github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

That means external/fork PRs such as #807 skip the entire validation graph even after maintainer approval. The result is misleading `skipped` branch-protection checks instead of real affected-path/state-gate validation.

## Fix
- Allow `affected-plan` to run for fork PRs.
- Keep the stable aggregate jobs (`Affected path validation`, `gjc-state-gates`) running with `always()` so branch protection gets a real pass/fail result.
- Allow state gate shards to run for fork PRs.
- Existing cache-save conditions remain push-to-dev-only, so fork PRs do not write caches.

## Context
This was found while triaging #807: the run was approved but all jobs skipped.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*