### PR TITLE
test(telegram-remote): wait for async chunk delivery

### DIFF
--- a/packages/telegram-remote/test/rpc-event-bridge.test.ts
+++ b/packages/telegram-remote/test/rpc-event-bridge.test.ts
@@ -67,6 +67,14 @@ async function flush() {
 	}
 }
 
+async function waitForSent(out: ReturnType<typeof outbound>, count: number) {
+	for (let index = 0; index < 25; index += 1) {
+		if (out.sent.length >= count) return;
+		await Promise.resolve();
+		await new Promise(resolve => setTimeout(resolve, 0));
+	}
+}
+
 describe("RpcEventBridge", () => {
 	test("turn_end delivers the last assistant message escaped in ordered <=4096 chunks", async () => {
 		const store = await storeWith();
@@ -84,6 +92,7 @@ describe("RpcEventBridge", () => {
 		await flush();
 
 		const expected = chunkForDelivery(raw);
+		await waitForSent(out, expected.length);
 		expect(out.sent.map(item => item.reply.text)).toEqual(expected);
 		expect(out.sent.every(item => item.reply.text.length <= 4096)).toBe(true);
 		expect(out.sent.join(" ")).not.toContain("<");


### PR DESCRIPTION
Fixes the red Dev CI after #807 by removing a race in the telegram-remote event bridge chunking test.

## Problem
Dev CI run `27676518861` failed in:

- `Affected path validation / test:@gajae-code/telegram-remote`
- `RpcEventBridge > turn_end delivers the last assistant message escaped in ordered <=4096 chunks`

The failure was `expected chunks` vs `[]`: the event bridge had selected the right message identity, but the test asserted immediately after a fixed short flush before async outbound delivery completed.

## Fix
Add a bounded `waitForSent()` helper and wait for the expected number of chunks before asserting the delivered text.

## Verification
- CI log diagnosis from run `27676518861`.
- Local isolated worktree cannot run the package test because it lacks the native addon artifact; this PR relies on CI, which provides the native artifact through the affected-path workflow.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*