### PR TITLE
Support Intel Mac native binary installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
             include:
                - { os: ubuntu-22.04, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu }
                - { os: macos-14, platform: darwin, arch: arm64 }
+               - { os: macos-13, platform: darwin, arch: x64 }
                - { os: windows-latest, platform: win32, arch: x64, variant: baseline }
       runs-on: ${{ matrix.os }}
       steps:
@@ -386,6 +387,13 @@ jobs:
                     arch: arm64,
                     target_id: darwin-arm64,
                     binary_path: packages/coding-agent/binaries/gjc-darwin-arm64,
+                 }
+               - {
+                    os: macos-13,
+                    platform: darwin,
+                    arch: x64,
+                    target_id: darwin-x64,
+                    binary_path: packages/coding-agent/binaries/gjc-darwin-x64,
                  }
                - {
                     os: windows-latest,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ bun install -g gajae-code
 
 The scoped package is also available as `@gajae-code/coding-agent`.
 
+### macOS Intel native binary install
+
+Release artifacts include both Apple Silicon (`gjc-darwin-arm64`) and Intel (`gjc-darwin-x64`) macOS standalone binaries. On Intel Macs, the binary installer selects `gjc-darwin-x64` automatically:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh -s -- --binary
+```
+
+If an older release is missing `gjc-darwin-x64`, install through the npm/Bun package path instead, or choose a newer release that includes the Intel macOS asset:
+
+```sh
+bun install -g gajae-code
+# or
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh -s -- --source
+```
+
 ### Windows (native install)
 
 On a clean Windows 11 machine, install Bun first, then install `gjc` with Bun's

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added an opt-in `gjc rlm` research mode (v1, interactive): a Jupyter-notebook-style research session over the existing agent loop, backed by the shared persistent Python kernel. It loads a distinct research system prompt, restricts the toolset to a hard-gated allowlist (`python` + `read` + `web_search`, asserted after tool-registry assembly — no `bash`/edit/arbitrary mutation), optionally loads a project-root `DATA.md` (overridable via `--data <path>`), aggregates every executed cell live into `.gjc/rlm/<session>/notebook.ipynb` (single-queue atomic temp-rename writes with post-write validation), and synthesizes `.gjc/rlm/<session>/report.md` on session exit. Autonomous goal-arg runs, `--resume`, managed per-workspace venv provisioning, and the optional `>=N` completion gate are deferred follow-ups.
 - Added an experimental opt-in `computer` desktop-control tool surface for local macOS screenshot/input coordination, backed by native `ComputerController`/`computerScreenshot` bindings and gated through settings/tool registration so it can continue stabilizing on `dev` outside the 0.5.4 patch release.
+- Added Intel macOS (`darwin-x64`) native release-binary coverage and clearer installer/docs guidance for missing older release assets (#812).
 
 ## [0.5.4] - 2026-06-17
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -228,7 +228,21 @@ install_binary() {
     # Download binary
     BINARY_URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}"
     echo "Downloading ${BINARY}..."
-    curl -fsSL "$BINARY_URL" -o "${INSTALL_DIR}/gjc"
+    if ! curl -fsSL "$BINARY_URL" -o "${INSTALL_DIR}/gjc"; then
+        rm -f "${INSTALL_DIR}/gjc"
+        echo ""
+        echo "No prebuilt GJC binary was found for ${PLATFORM}-${ARCH} in ${LATEST}."
+        if [ "$PLATFORM" = "darwin" ] && [ "$ARCH" = "x64" ]; then
+            echo "Intel macOS native binaries are supported by releases that include the gjc-darwin-x64 asset."
+            echo "This release may predate that asset or the upload may have failed."
+        fi
+        echo "Fallback options:"
+        echo "  - Install via Bun/npm source package: bun install -g gajae-code"
+        echo "  - Re-run this installer with --source to build/use the npm package path"
+        echo "  - Choose a release that publishes ${BINARY}"
+        echo "Expected asset URL: $BINARY_URL"
+        exit 1
+    fi
     chmod +x "${INSTALL_DIR}/gjc"
     echo ""
     echo "✓ Installed gjc to ${INSTALL_DIR}/gjc"

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -78,3 +78,23 @@ describe("release bump set equals publish set", () => {
 		expect([...publishDirs].sort()).toEqual([...bumpableDirs].sort());
 	});
 });
+
+describe("native release binary coverage", () => {
+	test("release workflow builds and publishes Intel macOS binaries", async () => {
+		const workflow = await Bun.file(path.join(repoRoot, ".github/workflows/ci.yml")).text();
+
+		expect(workflow).toContain("{ os: macos-13, platform: darwin, arch: x64 }");
+		expect(workflow).toContain("target_id: darwin-x64");
+		expect(workflow).toContain("binary_path: packages/coding-agent/binaries/gjc-darwin-x64");
+		expect(workflow).toContain("pattern: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}*-h${{ needs.rust-hash.outputs.hash }}");
+	});
+
+	test("installer explains missing Intel macOS release assets", async () => {
+		const installer = await Bun.file(path.join(repoRoot, "scripts/install.sh")).text();
+
+		expect(installer).toContain("No prebuilt GJC binary was found for ${PLATFORM}-${ARCH} in ${LATEST}.");
+		expect(installer).toContain("Intel macOS native binaries are supported by releases that include the gjc-darwin-x64 asset.");
+		expect(installer).toContain("Re-run this installer with --source");
+		expect(installer).toContain("Expected asset URL: $BINARY_URL");
+	});
+});


### PR DESCRIPTION
Fixes #812.

## Summary
- add macOS Intel (`darwin-x64`) native addon and release-binary jobs on `macos-13`
- document Intel Mac native installs and older-release fallback paths
- make `scripts/install.sh --binary` report a clear missing-asset message with source/npm fallback guidance
- add focused release/installer coverage assertions

## Verification
- `bun test scripts/release-publish-order.test.ts`
- `bun scripts/check-workflow-yaml.ts`
- `bun run check:ts` (passes type/workspace checks; existing Biome warnings remain in unrelated files: `packages/tui/test/viewport-virtualization-redteam.test.ts`, `packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`, and vendored Biome schema notices)

## Caveat
- The new `darwin-x64` binary artifact will exist starting with releases cut after this workflow change; older tags that lack `gjc-darwin-x64` now produce a direct fallback message.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*