### PR TITLE
feat(coding-agent): add TUI /copy slash command

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -450,6 +450,23 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "copy",
+		description: "Copy last response as markdown",
+		// Public `/copy` is strict zero-argument, but `allowArgs` lets the
+		// TUI dispatcher route `/copy <arg>` here so it can be rejected locally
+		// instead of falling through as a model prompt.
+		allowArgs: true,
+		handleTui: (command, runtime) => {
+			if (command.args.trim().length > 0) {
+				runtime.ctx.showError("Usage: /copy");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.handleCopyCommand(undefined);
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "dump",
 		description: "Copy session transcript to clipboard",
 		acpDescription: "Return full transcript as plain text",

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -4,7 +4,7 @@ import { Settings } from "../src/config/settings";
 import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
-import { executeAcpBuiltinSlashCommand } from "../src/slash-commands/acp-builtins";
+import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../src/slash-commands/acp-builtins";
 import * as sshConfig from "../src/ssh/config-writer";
 
 interface FakeAcpBuiltinSession {
@@ -562,7 +562,9 @@ describe("ACP builtin slash commands", () => {
 
 		expect(configNotified).toBe(0);
 	});
-
+	it("does not advertise /copy to ACP clients", () => {
+		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "copy")).toBe(false);
+	});
 	// TUI-only and dropped commands fall through as false
 	it("TUI-only and dropped commands return false (fall through to model)", async () => {
 		const fallthroughCommands = [

--- a/packages/coding-agent/test/modes/controllers/copy-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/copy-command.test.ts
@@ -24,6 +24,19 @@ describe("/copy command", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("copies the latest assistant text", () => {
+		const copySpy = vi.spyOn(native, "copyToClipboard").mockImplementation(() => undefined);
+		const { controller, showStatus, showError } = createController({
+			assistantText: "latest **markdown** response",
+		});
+
+		controller.handleCopyCommand();
+
+		expect(copySpy).toHaveBeenCalledWith("latest **markdown** response");
+		expect(showStatus).toHaveBeenCalledWith("Copied last agent message to clipboard");
+		expect(showError).not.toHaveBeenCalled();
+	});
+
 	it("falls back to the fresh handoff context when no assistant message exists", () => {
 		const copySpy = vi.spyOn(native, "copyToClipboard").mockImplementation(() => undefined);
 		const { controller, showStatus, showError } = createController({
@@ -42,6 +55,19 @@ describe("/copy command", () => {
 		const { controller, showStatus, showError } = createController({
 			hasAssistantMessage: true,
 			handoffText: "<handoff-context>\n## Goal\nContinue\n</handoff-context>",
+		});
+
+		controller.handleCopyCommand();
+
+		expect(copySpy).not.toHaveBeenCalled();
+		expect(showStatus).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("No agent messages to copy yet.");
+	});
+
+	it("shows an error when no assistant message or handoff context exists", () => {
+		const copySpy = vi.spyOn(native, "copyToClipboard").mockImplementation(() => undefined);
+		const { controller, showStatus, showError } = createController({
+			hasAssistantMessage: false,
 		});
 
 		controller.handleCopyCommand();

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import {
+	BUILTIN_SLASH_COMMAND_DEFS,
+	BUILTIN_SLASH_COMMANDS_INTERNAL,
+	executeBuiltinSlashCommand,
+} from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+
+function createTuiRuntime() {
+	const handleCopyCommand = vi.fn();
+	const showError = vi.fn();
+	const setText = vi.fn();
+	const ctx = {
+		handleCopyCommand,
+		showError,
+		editor: { setText },
+	} as unknown as InteractiveModeContext;
+
+	return {
+		runtime: { ctx, handleBackgroundCommand: () => undefined },
+		handleCopyCommand,
+		showError,
+		setText,
+	};
+}
+
+describe("builtin /copy slash command", () => {
+	it("is discoverable as a TUI builtin without public subcommands and does not register /clear", () => {
+		const copyCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "copy");
+
+		expect(copyCommand).toBeDefined();
+		expect(copyCommand?.description).toBe("Copy last response as markdown");
+		expect(copyCommand?.subcommands).toBeUndefined();
+		expect(copyCommand?.inlineHint).toBeUndefined();
+		expect(BUILTIN_SLASH_COMMAND_DEFS.some(command => command.name === "clear")).toBe(false);
+		expect(BUILTIN_SLASH_COMMANDS_INTERNAL.some(command => command.name === "clear")).toBe(false);
+	});
+
+	it("dispatches zero-argument /copy to the existing copy controller path", async () => {
+		const { runtime, handleCopyCommand, showError, setText } = createTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/copy", runtime);
+
+		expect(result).toBe(true);
+		expect(handleCopyCommand).toHaveBeenCalledWith(undefined);
+		expect(showError).not.toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("");
+	});
+
+	it("rejects /copy arguments locally instead of falling through", async () => {
+		const { runtime, handleCopyCommand, showError, setText } = createTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/copy last", runtime);
+
+		expect(result).toBe(true);
+		expect(handleCopyCommand).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("Usage: /copy");
+		expect(setText).toHaveBeenCalledWith("");
+	});
+
+	it("rejects colon-form /copy arguments locally", async () => {
+		const { runtime, handleCopyCommand, showError, setText } = createTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/copy:last", runtime);
+
+		expect(result).toBe(true);
+		expect(handleCopyCommand).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("Usage: /copy");
+		expect(setText).toHaveBeenCalledWith("");
+	});
+});


### PR DESCRIPTION
Adds a Codex-style `/copy` command to the interactive Gajae Code TUI so users can copy the most recent assistant response without reaching for terminal selection or dumping the whole transcript.

## Problem
Codex exposes `/copy` as a small convenience command for copying the last response as markdown. Gajae Code already had the underlying copy behavior in `CommandController.handleCopyCommand()`, but that behavior was not reachable from the builtin slash-command surface. The closest existing command, `/dump`, copies the entire session transcript, which is a different mental model and too broad when the user only wants the last AI response.

There was also a subtle dispatch risk: if `/copy` were registered as a normal no-arg builtin, `/copy something` would fall through to the model because the TUI dispatcher refuses argument-bearing commands before the handler sees them.

## Solution
- Add a TUI-only builtin `/copy` command with the description `Copy last response as markdown`.
- Reuse the existing `runtime.ctx.handleCopyCommand(undefined)` path instead of adding a second clipboard/message-selection implementation.
- Keep ACP/text-mode clean by providing only `handleTui`, so `/copy` is not advertised to ACP clients and ACP `/copy` still falls through as before.
- Use `allowArgs: true` only as a documented dispatcher trap so `/copy <arg>` and `/copy:last` are rejected locally with `Usage: /copy` instead of becoming model prompts.

## Side effects / compatibility
- `/dump` remains the transcript-copy command; it is not changed.
- Existing copy semantics are preserved, including assistant text copy, fresh handoff fallback, textless-assistant stale-handoff rejection, and no-copyable-message errors.
- Hidden copy controller subcommands (`code`, `all`, `cmd`, `last`) are not advertised or exposed through the public `/copy` slash command.
- ACP command discovery remains unchanged for `/copy` because the command has no text-mode `handle`.

## Validation
- `bun test packages/coding-agent/test/modes/controllers/copy-command.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts`
  - 59 pass
  - 0 fail
- `bun run check:ts`
  - completed successfully
  - existing unrelated warnings remain in `packages/tui/test/viewport-virtualization-redteam.test.ts` and `packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`

## Review
- Ralplan consensus: Architect CLEAR / APPROVE, Critic OKAY.
- Ultragoal quality gate: cleanup sweep had no blocking findings; final architecture/product/code review CLEAR / APPROVE; QA/red-team passed.
