### PR TITLE
feat(rlm): autonomous mode, resume, managed venv, completion gate (G002-G005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ No sprawling default skill zoo: GJC improves by making this small method better.
 | Claude Code | `gjc --tmux` or `gjc --tmux --worktree <name>` | GJC does not become a Claude Code extension. |
 | OpenCode | `gjc` or `gjc --tmux` | External-runner workflow only today. |
 | Claw Code | `gjc --tmux --worktree <name>` | GJC does not install into or replace Claw Code. |
-| External controller / bot | `gjc mcp-serve coordinator` plus `gjc setup hermes` for compatible config, or `gjc --mode rpc` for a subprocess worker | Any MCP/RPC-capable bot drives GJC through the generic coordinator/RPC contract, not scrollback scraping. |
+| External controller / bot | `gjc --mode rpc` for a subprocess worker, or Bridge/HTTPS surfaces where configured | External controllers drive GJC through generic RPC/bridge contracts, not scrollback scraping. |
 
-For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across MCP, RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/hermes-mcp-bridge.md`](docs/hermes-mcp-bridge.md), [`docs/rpc.md`](docs/rpc.md), and [`docs/bridge.md`](docs/bridge.md). For the remote operator surfaces roadmap, see [`docs/gajae-remote.md`](docs/gajae-remote.md) (web steering wheel) and [`docs/telegram-remote.md`](docs/telegram-remote.md) (Telegram lifecycle button).
+For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/hermes-mcp-bridge.md`](docs/hermes-mcp-bridge.md), [`docs/rpc.md`](docs/rpc.md), and [`docs/bridge.md`](docs/bridge.md). For the remote operator surfaces roadmap, see [`docs/gajae-remote.md`](docs/gajae-remote.md) (web steering wheel) and [`docs/telegram-remote.md`](docs/telegram-remote.md) (Telegram lifecycle button).
 
 ## Configuration
 

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -12,6 +12,7 @@ import {
 	type KernelExecuteResult,
 	PythonKernel,
 } from "./kernel";
+import type { PythonRuntimeOptions } from "./runtime";
 import { ensurePyToolBridge, registerPyToolBridge } from "./tool-bridge";
 
 export type PythonKernelMode = "session" | "per-call";
@@ -44,6 +45,8 @@ export interface PythonExecutorOptions {
 	 * preferred over `PI_SESSION_FILE`-derived paths.
 	 */
 	artifactsDir?: string;
+	/** Runtime resolution/provisioning options (RLM managed workspace venv, package seeding). */
+	runtimeOptions?: PythonRuntimeOptions;
 	/** Artifact path/id for full output storage */
 	artifactPath?: string;
 	artifactId?: string;
@@ -276,6 +279,7 @@ async function startKernel(cwd: string, options: PythonExecutorOptions): Promise
 	return await PythonKernel.start({
 		cwd,
 		env: buildKernelEnv(options),
+		runtimeOptions: options.runtimeOptions,
 		signal: options.signal,
 		deadlineMs: options.deadlineMs,
 	});
@@ -562,7 +566,10 @@ async function executeWithKernel(
 }
 
 async function ensureKernelAvailable(cwd: string, options: PythonExecutorOptions): Promise<void> {
-	const availability = await waitForPromiseWithCancellation(checkPythonKernelAvailability(cwd), options);
+	const availability = await waitForPromiseWithCancellation(
+		checkPythonKernelAvailability(cwd, options.runtimeOptions),
+		options,
+	);
 	if (!availability.ok) {
 		throw new Error(availability.reason ?? "Python kernel unavailable");
 	}

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -18,7 +18,7 @@ import { Settings } from "../../config/settings";
 import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
-import { filterEnv, resolvePythonRuntime } from "./runtime";
+import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./runtime";
 
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
@@ -89,6 +89,7 @@ interface KernelLifecycleOptions {
 interface KernelStartOptions extends KernelLifecycleOptions {
 	cwd: string;
 	env?: Record<string, string | undefined>;
+	runtimeOptions?: PythonRuntimeOptions;
 }
 
 interface KernelShutdownOptions {
@@ -120,7 +121,10 @@ function throwIfAborted(signal: AbortSignal | undefined, fallbackReason: string)
 	throw createAbortError("AbortError", typeof reason === "string" ? reason : fallbackReason);
 }
 
-export async function checkPythonKernelAvailability(cwd: string): Promise<PythonKernelAvailability> {
+export async function checkPythonKernelAvailability(
+	cwd: string,
+	runtimeOptions?: PythonRuntimeOptions,
+): Promise<PythonKernelAvailability> {
 	if (isBunTestRuntime() || $flag("PI_PYTHON_SKIP_CHECK")) {
 		return { ok: true };
 	}
@@ -128,7 +132,7 @@ export async function checkPythonKernelAvailability(cwd: string): Promise<Python
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
 		const baseEnv = filterEnv(env);
-		const runtime = resolvePythonRuntime(cwd, baseEnv);
+		const runtime = await ensurePythonRuntime(cwd, baseEnv, runtimeOptions);
 		const probe = await $`${runtime.pythonPath} -c "import sys;sys.exit(0)"`
 			.quiet()
 			.nothrow()
@@ -199,6 +203,7 @@ export class PythonKernel {
 			"PythonKernel.start:availabilityCheck",
 			checkPythonKernelAvailability,
 			options.cwd,
+			options.runtimeOptions,
 		);
 		if (!availability.ok) {
 			throw new Error(availability.reason ?? "Python kernel unavailable");
@@ -207,7 +212,7 @@ export class PythonKernel {
 		const settings = await Settings.init();
 		const { env: shellEnv } = settings.getShellConfig();
 		const baseEnv = filterEnv(shellEnv);
-		const runtime = resolvePythonRuntime(options.cwd, baseEnv);
+		const runtime = await ensurePythonRuntime(options.cwd, baseEnv, options.runtimeOptions);
 		const spawnEnv: Record<string, string> = {};
 		for (const [key, value] of Object.entries(runtime.env)) {
 			if (typeof value === "string") spawnEnv[key] = value;

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -1,12 +1,22 @@
 /**
  * Python runtime resolution utilities.
  *
- * Centralizes environment filtering, venv detection, and Python executable resolution
- * for both the shared gateway and local kernel spawning.
+ * Centralizes environment filtering, venv detection, managed workspace venv
+ * provisioning, and Python executable resolution for both the shared gateway
+ * and local kernel spawning.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $env, $which, getPythonEnvDir } from "@gajae-code/utils";
+
+export const RLM_MANAGED_PYTHON_PACKAGES: readonly string[] = ["numpy", "pandas", "matplotlib", "polars"];
+
+export interface PythonRuntimeOptions {
+	/** Create/use <cwd>/.gjc/python-env when no BYO venv/conda env is present. */
+	managedWorkspaceVenv?: boolean;
+	/** Packages to seed into the managed workspace venv when provisioning it. */
+	seedPackages?: readonly string[];
+}
 
 const DEFAULT_ENV_ALLOWLIST = new Set([
 	"PATH",
@@ -104,15 +114,22 @@ function resolvePathKey(env: Record<string, string | undefined>): string {
 	return match ?? "PATH";
 }
 
-function resolveManagedPythonEnv(): string {
+function resolveGlobalManagedPythonEnv(): string {
 	return getPythonEnvDir();
 }
 
-function resolveManagedPythonCandidate(): { venvPath: string; pythonPath: string } {
-	const venvPath = resolveManagedPythonEnv();
+function resolvePythonCandidateInVenv(venvPath: string): { venvPath: string; pythonPath: string; binDir: string } {
 	const binDir = process.platform === "win32" ? path.join(venvPath, "Scripts") : path.join(venvPath, "bin");
 	const pythonPath = path.join(binDir, process.platform === "win32" ? "python.exe" : "python");
-	return { venvPath, pythonPath };
+	return { venvPath, pythonPath, binDir };
+}
+
+function resolveManagedPythonCandidate(): { venvPath: string; pythonPath: string; binDir: string } {
+	return resolvePythonCandidateInVenv(resolveGlobalManagedPythonEnv());
+}
+
+function resolveWorkspaceManagedPythonCandidate(cwd: string): { venvPath: string; pythonPath: string; binDir: string } {
+	return resolvePythonCandidateInVenv(path.join(cwd, ".gjc", "python-env"));
 }
 
 export interface PythonRuntime {
@@ -122,6 +139,23 @@ export interface PythonRuntime {
 	env: Record<string, string | undefined>;
 	/** Path to virtual environment, if detected */
 	venvPath?: string;
+}
+
+function runtimeFromVenv(
+	venvPath: string,
+	pythonPath: string,
+	binDir: string,
+	env: Record<string, string | undefined>,
+): PythonRuntime {
+	env.VIRTUAL_ENV = venvPath;
+	const pathKey = resolvePathKey(env);
+	const currentPath = env[pathKey];
+	env[pathKey] = currentPath ? `${binDir}${path.delimiter}${currentPath}` : binDir;
+	return {
+		pythonPath,
+		env,
+		venvPath,
+	};
 }
 
 /**
@@ -161,42 +195,110 @@ export function resolveVenvPath(cwd: string): string | undefined {
 	return undefined;
 }
 
+async function runRuntimeCommand(
+	cmd: string[],
+	cwd: string,
+	env: Record<string, string | undefined>,
+	description: string,
+): Promise<void> {
+	const spawnEnv: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value === "string") spawnEnv[key] = value;
+	}
+	const proc = Bun.spawn(cmd, {
+		cwd,
+		env: spawnEnv,
+		stdout: "pipe",
+		stderr: "pipe",
+		windowsHide: true,
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if (exitCode !== 0) {
+		const output = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+		throw new Error(`${description} failed with exit code ${exitCode}${output ? `: ${output}` : ""}`);
+	}
+}
+
+async function ensureWorkspaceManagedVenv(
+	cwd: string,
+	baseEnv: Record<string, string | undefined>,
+	seedPackages: readonly string[],
+): Promise<void> {
+	const managed = resolveWorkspaceManagedPythonCandidate(cwd);
+	if (!fs.existsSync(managed.pythonPath)) {
+		const basePython = $which("python3") ?? $which("python");
+		if (!basePython) throw new Error("Python executable not found on PATH");
+		await fs.promises.mkdir(path.dirname(managed.venvPath), { recursive: true });
+		await runRuntimeCommand(
+			[basePython, "-m", "venv", managed.venvPath],
+			cwd,
+			baseEnv,
+			"Managed Python venv creation",
+		);
+	}
+	if (seedPackages.length === 0) return;
+	const markerPath = path.join(managed.venvPath, ".gjc-seeded.json");
+	let seeded = false;
+	try {
+		const marker = JSON.parse(await fs.promises.readFile(markerPath, "utf8")) as { packages?: unknown };
+		const packages = Array.isArray(marker.packages) ? marker.packages : [];
+		seeded = seedPackages.every(pkg => packages.includes(pkg));
+	} catch {
+		seeded = false;
+	}
+	if (seeded) return;
+	const runtimeEnv = runtimeFromVenv(managed.venvPath, managed.pythonPath, managed.binDir, { ...baseEnv }).env;
+	await runRuntimeCommand(
+		[managed.pythonPath, "-m", "pip", "install", "--upgrade", "pip"],
+		cwd,
+		runtimeEnv,
+		"Managed Python pip bootstrap",
+	);
+	await runRuntimeCommand(
+		[managed.pythonPath, "-m", "pip", "install", ...seedPackages],
+		cwd,
+		runtimeEnv,
+		"Managed Python package seed",
+	);
+	await fs.promises.writeFile(
+		markerPath,
+		`${JSON.stringify({ packages: seedPackages, seededAt: new Date().toISOString() }, null, 2)}\n`,
+		"utf8",
+	);
+}
+
 /**
  * Resolve Python runtime including executable path, environment, and venv detection.
  */
-export function resolvePythonRuntime(cwd: string, baseEnv: Record<string, string | undefined>): PythonRuntime {
+export function resolvePythonRuntime(
+	cwd: string,
+	baseEnv: Record<string, string | undefined>,
+	options: PythonRuntimeOptions = {},
+): PythonRuntime {
 	const env = { ...baseEnv };
 	const venvPath = env.VIRTUAL_ENV ?? resolveVenvPath(cwd);
 
 	if (venvPath) {
-		env.VIRTUAL_ENV = venvPath;
-		const binDir = process.platform === "win32" ? path.join(venvPath, "Scripts") : path.join(venvPath, "bin");
-		const pythonCandidate = path.join(binDir, process.platform === "win32" ? "python.exe" : "python");
-		if (fs.existsSync(pythonCandidate)) {
-			const pathKey = resolvePathKey(env);
-			const currentPath = env[pathKey];
-			env[pathKey] = currentPath ? `${binDir}${path.delimiter}${currentPath}` : binDir;
-			return {
-				pythonPath: pythonCandidate,
-				env,
-				venvPath,
-			};
+		const candidate = resolvePythonCandidateInVenv(venvPath);
+		if (fs.existsSync(candidate.pythonPath)) {
+			return runtimeFromVenv(candidate.venvPath, candidate.pythonPath, candidate.binDir, env);
 		}
 	}
 
-	const managed = resolveManagedPythonCandidate();
-	if (fs.existsSync(managed.pythonPath)) {
-		env.VIRTUAL_ENV = managed.venvPath;
-		const pathKey = resolvePathKey(env);
-		const currentPath = env[pathKey];
-		const managedBin =
-			process.platform === "win32" ? path.join(managed.venvPath, "Scripts") : path.join(managed.venvPath, "bin");
-		env[pathKey] = currentPath ? `${managedBin}${path.delimiter}${currentPath}` : managedBin;
-		return {
-			pythonPath: managed.pythonPath,
-			env,
-			venvPath: managed.venvPath,
-		};
+	if (options.managedWorkspaceVenv) {
+		const workspaceManaged = resolveWorkspaceManagedPythonCandidate(cwd);
+		if (fs.existsSync(workspaceManaged.pythonPath)) {
+			return runtimeFromVenv(workspaceManaged.venvPath, workspaceManaged.pythonPath, workspaceManaged.binDir, env);
+		}
+	} else {
+		const managed = resolveManagedPythonCandidate();
+		if (fs.existsSync(managed.pythonPath)) {
+			return runtimeFromVenv(managed.venvPath, managed.pythonPath, managed.binDir, env);
+		}
 	}
 
 	const pythonPath = $which("python") ?? $which("python3");
@@ -207,4 +309,23 @@ export function resolvePythonRuntime(cwd: string, baseEnv: Record<string, string
 		pythonPath,
 		env,
 	};
+}
+
+export async function ensurePythonRuntime(
+	cwd: string,
+	baseEnv: Record<string, string | undefined>,
+	options: PythonRuntimeOptions = {},
+): Promise<PythonRuntime> {
+	if (options.managedWorkspaceVenv) {
+		const env = { ...baseEnv };
+		const venvPath = env.VIRTUAL_ENV ?? resolveVenvPath(cwd);
+		if (venvPath) {
+			const candidate = resolvePythonCandidateInVenv(venvPath);
+			if (fs.existsSync(candidate.pythonPath)) {
+				return runtimeFromVenv(candidate.venvPath, candidate.pythonPath, candidate.binDir, env);
+			}
+		}
+		await ensureWorkspaceManagedVenv(cwd, baseEnv, options.seedPackages ?? RLM_MANAGED_PYTHON_PACKAGES);
+	}
+	return resolvePythonRuntime(cwd, baseEnv, options);
 }

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -34,6 +34,10 @@ export interface BashExecutorOptions {
 	artifactId?: string;
 	/** Execute without retaining a native Shell in the persistent session registry. */
 	oneShot?: boolean;
+	/** Ignore user-configured shell command prefixes. Used by constrained read-only shells. */
+	ignoreShellPrefix?: boolean;
+	/** Skip sourced shell snapshots. Used by constrained read-only shells. */
+	disableShellSnapshot?: boolean;
 	/**
 	 * Invoked when the native minimizer rewrote the command's output, giving
 	 * the caller a chance to persist the lossless original capture (typically
@@ -119,15 +123,17 @@ export function buildMinimizerOptions(group: ShellMinimizerSettings): MinimizerO
 export async function executeBash(command: string, options?: BashExecutorOptions): Promise<BashResult> {
 	const settings = await Settings.init();
 	const { shell, env: shellEnv, prefix } = settings.getShellConfig();
-	const snapshotPath = shell.includes("bash") ? await getOrCreateSnapshot(shell, shellEnv) : null;
+	const configuredPrefix = options?.ignoreShellPrefix ? undefined : prefix;
+	const snapshotPath =
+		!options?.disableShellSnapshot && shell.includes("bash") ? await getOrCreateSnapshot(shell, shellEnv) : null;
 
 	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 
 	const commandCwd = await resolveShellCwd(options?.cwd);
 	const commandEnv = options?.env ? { ...NON_INTERACTIVE_ENV, ...options.env } : NON_INTERACTIVE_ENV;
 
-	// Apply command prefix if configured
-	const prefixedCommand = prefix ? `${prefix} ${command}` : command;
+	// Apply command prefix if configured and allowed for this execution.
+	const prefixedCommand = configuredPrefix ? `${configuredPrefix} ${command}` : command;
 	const finalCommand = prefixedCommand;
 
 	// Create output sink for truncation and artifact handling
@@ -160,7 +166,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	}
 
 	const usePersistentShell = options?.oneShot !== true;
-	const sessionKey = buildSessionKey(shell, prefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
+	const sessionKey = buildSessionKey(shell, configuredPrefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
 	const persistentSessionBroken = usePersistentShell && brokenShellSessions.has(sessionKey);
 
 	let shellSession = persistentSessionBroken || !usePersistentShell ? undefined : shellSessions.get(sessionKey);

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -180,6 +180,8 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	label: string;
 	/** If true, tool is strictly typed and validated against the parameters schema before execution */
 	strict?: boolean;
+	/** Tool scheduling mode; exclusive tools do not run in parallel with other tools in a model turn. */
+	concurrency?: "shared" | "exclusive";
 	/** Description for LLM */
 	description: string;
 	/** Parameter schema (Zod or TypeBox; TypeBox is auto-lifted to Zod at registration). */

--- a/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
@@ -15,6 +15,7 @@ export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = any
 	declare description: string;
 	declare parameters: TParams;
 	readonly strict: boolean | undefined;
+	readonly concurrency: "shared" | "exclusive" | undefined;
 
 	constructor(
 		private tool: CustomTool<TParams, TDetails>,
@@ -22,6 +23,7 @@ export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = any
 	) {
 		applyToolProxy(tool, this);
 		this.strict = tool.strict;
+		this.concurrency = tool.concurrency;
 	}
 
 	execute(

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -383,6 +383,8 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	description: string;
 	/** Parameter schema (Zod, or TypeBox for legacy/extension compat). */
 	parameters: TParams;
+	/** Tool scheduling mode; exclusive tools do not run in parallel with other tools in a model turn. */
+	concurrency?: "shared" | "exclusive";
 	/** If true, tool is excluded unless explicitly listed in --tools or agent's tools field */
 	hidden?: boolean;
 	/** If true, tool is registered but not auto-included in the initial active set.

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -17,6 +17,7 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 	declare parameters: any;
 	declare label: string;
 	declare strict: boolean;
+	declare concurrency: "shared" | "exclusive" | undefined;
 
 	renderCall?: (args: any, options: any, theme: any) => any;
 	renderResult?: (result: any, options: any, theme: any, args?: any) => any;

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -66,8 +66,15 @@ function buildGoalToolResult(op: GoalToolDetails["op"], response: GoalToolRespon
 	};
 }
 
+function assertGoalOperationAllowed(session: ToolSession, op: GoalToolInput["op"]): void {
+	const allowedOps = session.goalToolAllowedOps;
+	if (!allowedOps || allowedOps.includes(op)) return;
+	throw new ToolError(`Goal mode in this session only allows goal operations: ${allowedOps.join(", ")}.`);
+}
+
 async function executeGoalOperation(session: ToolSession, params: GoalToolInput): Promise<GoalToolResponse> {
 	rejectUnsupportedGoalArgs(params as Record<string, unknown>);
+	assertGoalOperationAllowed(session, params.op);
 	if (params.op === "get") {
 		const state = session.getGoalModeState?.();
 		return buildGoalToolResponse(state?.goal ?? null);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -721,6 +721,7 @@ interface RunRootCommandDependencies {
 	runAcpMode?: (createSession: AcpSessionFactory) => Promise<void>;
 	settings?: Settings;
 	rlmPreset?: RlmPreset;
+	suppressProcessExit?: boolean;
 }
 
 export async function runRootCommand(
@@ -1061,9 +1062,13 @@ export async function runRootCommand(
 			if ($env.PI_TIMING) {
 				logger.printTimings();
 			}
-			await session.dispose();
-			stopThemeWatcher();
-			await postmortem.quit(0);
+			if (!deps.suppressProcessExit) {
+				await session.dispose();
+				stopThemeWatcher();
+				await postmortem.quit(0);
+			} else {
+				stopThemeWatcher();
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/prompts/system/rlm-research.md
+++ b/packages/coding-agent/src/prompts/system/rlm-research.md
@@ -4,9 +4,9 @@ You are operating in **RLM research mode** — a Jupyter-notebook-style research
 
 - Drive the investigation with the `python` tool. The kernel is **persistent**: variables, imports, and loaded data survive across calls, exactly like notebook cells. Build up state incrementally instead of re-running everything each time.
 - Each `python` call is recorded as a notebook cell (code + output) in this session's `notebook.ipynb`. Write focused cells that each make one clear step of progress.
-- Prefer the scientific stack commonly available in research environments (`numpy`, `pandas`, `matplotlib`, `polars`). If a needed package is missing, say so plainly rather than guessing — managed-environment provisioning is out of scope for this mode.
+- Prefer the managed scientific stack (`numpy`, `pandas`, `matplotlib`, `polars`) when useful. If an additional package is missing, use the kernel's `%pip install ...` magic only when it is necessary for the investigation; that install cell is recorded in the notebook as provenance.
 - Use `read` to inspect local files, `web_search` to gather external facts, and read-only `bash` only for simple inspection commands where shell-native views are materially useful (`grep`, `rg`, `tree`, `ls`, `pwd`, `wc`, `du`, `file`, `stat`). The `bash` surface is restricted to a single command with no pipelines, redirects, env overrides, command substitution, shell expansion, or write-capable flags. You do **not** have file-editing or arbitrary-mutation tools in this mode by design: keep all work inside the Python kernel, read-only inspection, and the notebook/report artifacts.
-- RLM always runs under goal mode. Use `goal({"op":"get"})` to inspect the active research goal. When the research objective is actually satisfied and the report-worthy conclusions are grounded in notebook outputs, you must call `goal({"op":"complete"})`; do not present the session as complete without that tool call.
+- RLM always runs under goal mode. Use `goal({"op":"get"})` to inspect the active research goal. When the research objective is actually satisfied and the report-worthy conclusions are grounded in notebook outputs, call `goal({"op":"complete"})`, then call `complete_research` with a concise final summary. Do not present the session as complete without both tool calls.
 
 ## Evidence discipline
 

--- a/packages/coding-agent/src/prompts/system/rlm-research.md
+++ b/packages/coding-agent/src/prompts/system/rlm-research.md
@@ -5,7 +5,8 @@ You are operating in **RLM research mode** — a Jupyter-notebook-style research
 - Drive the investigation with the `python` tool. The kernel is **persistent**: variables, imports, and loaded data survive across calls, exactly like notebook cells. Build up state incrementally instead of re-running everything each time.
 - Each `python` call is recorded as a notebook cell (code + output) in this session's `notebook.ipynb`. Write focused cells that each make one clear step of progress.
 - Prefer the scientific stack commonly available in research environments (`numpy`, `pandas`, `matplotlib`, `polars`). If a needed package is missing, say so plainly rather than guessing — managed-environment provisioning is out of scope for this mode.
-- Use `read` to inspect local files and `web_search` to gather external facts. You do **not** have shell, file-editing, or arbitrary-mutation tools in this mode by design: keep all work inside the Python kernel and the notebook/report artifacts.
+- Use `read` to inspect local files, `web_search` to gather external facts, and read-only `bash` only for simple inspection commands where shell-native views are materially useful (`grep`, `rg`, `tree`, `ls`, `pwd`, `wc`, `du`, `file`, `stat`). The `bash` surface is restricted to a single command with no pipelines, redirects, env overrides, command substitution, shell expansion, or write-capable flags. You do **not** have file-editing or arbitrary-mutation tools in this mode by design: keep all work inside the Python kernel, read-only inspection, and the notebook/report artifacts.
+- RLM always runs under goal mode. Use `goal({"op":"get"})` to inspect the active research goal. When the research objective is actually satisfied and the report-worthy conclusions are grounded in notebook outputs, you must call `goal({"op":"complete"})`; do not present the session as complete without that tool call.
 
 ## Evidence discipline
 

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -2,27 +2,45 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 
 <instruction>
 - Use `cwd` to set working directory, not `cd dir && …`
+{{#when restrictionProfile "==" "read-only"}}
+- Do not pass `env` overrides or `pty: true`; read-only bash rejects both.
+- Shell control operators such as `;`, `|`, `&`, `<`, `>`, and command substitution are blocked.
+- Internal URIs (`agent://`, `artifact://`, `rule://`, `local://`) are auto-resolved to filesystem paths without creating parent directories.
+{{else}}
 - Prefer `env: { NAME: "…" }` for multiline, quote-heavy, or untrusted values; reference as `$NAME`
 - Quote variable expansions like `"$NAME"` to preserve exact content
 - PTY mode is opt-in: set `pty: true` only when the command needs a real terminal (e.g. `sudo`, `ssh` requiring user input); default is `false`
 - Use `;` only when later commands should run regardless of earlier failures
 - Internal URIs (`agent://`, `artifact://`, `rule://`, `local://`) are auto-resolved to filesystem paths
+{{/when}}
 {{#if asyncEnabled}}
 - Use `async: true` for long-running commands when you don't need immediate output; the call returns a background job ID and the result is delivered automatically as a follow-up.
 {{/if}}
 </instruction>
 {{#if restrictedAllowedPrefixes}}
-<restricted-role-agent-mode>
+<restricted-bash-mode>
+{{#when restrictionProfile "==" "read-only"}}
+This session's bash tool is read-only. It accepts only simple, single-command inspections beginning with:
+{{#each restrictedAllowedPrefixes}}
+- `{{this}}`
+{{/each}}
+Shell control operators, command substitution, env overrides, redirects, pipelines, glob expansion, and known write-capable flags are blocked before execution. Use it only when an inspection command is materially better than `read`, `search`, or `find`.
+{{else}}
 This session's bash tool is restricted. It only accepts commands beginning with:
 {{#each restrictedAllowedPrefixes}}
 - `{{this}}`
 {{/each}}
 Use it only for sanctioned GJC workflow CLI persistence or state read/write/contract operations; per-command env overrides and all other shell command shapes are blocked before execution.
-</restricted-role-agent-mode>
+{{/when}}
+</restricted-bash-mode>
 {{/if}}
 
 <critical>
+{{#when restrictionProfile "==" "read-only"}}
+- Use read-only bash only for approved inspection commands that are materially better than `read`, `search`, or `find`; the tool itself blocks non-approved commands and unsafe shell shapes.
+{{else}}
 - NEVER use Linux coreutils (`cat`, `head`, `tail`, `less`, `more`, `ls`, `grep`, `rg`, `awk`, `sed`, `find`, `fd`, etc.) when a dedicated tool suffices — ALWAYS prefer `read`, `search`, `find`, `edit`, `write`.
+{{/when}}
 - NEVER pipe through `| head -n N` or `| tail -n N` — output is already truncated with the full result available via `artifact://<id>`.
 - NEVER redirect with `2>&1` or `2>/dev/null` — stdout and stderr are already merged.
 </critical>

--- a/packages/coding-agent/src/rlm/artifacts.ts
+++ b/packages/coding-agent/src/rlm/artifacts.ts
@@ -3,6 +3,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { readNotebookDocument } from "../edit/notebook";
 import type { RlmArtifactPaths } from "./types";
 
 export const RLM_DIR_SEGMENT = path.join(".gjc", "rlm");
@@ -30,9 +31,30 @@ export function resolveRlmArtifactPaths(cwd: string, sessionId: string): RlmArti
 		notebookPath: path.join(dir, "notebook.ipynb"),
 		reportPath: path.join(dir, "report.md"),
 		metadataPath: path.join(dir, "metadata.json"),
+		agentSessionDir: path.join(dir, "agent-session"),
 	};
 }
 
 export async function ensureRlmSessionDir(paths: RlmArtifactPaths): Promise<void> {
 	await fs.mkdir(paths.dir, { recursive: true });
+}
+
+export async function rlmSessionExists(cwd: string, sessionId: string): Promise<boolean> {
+	const paths = resolveRlmArtifactPaths(cwd, sessionId);
+	try {
+		const stat = await fs.stat(paths.dir);
+		return stat.isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+export async function readRlmNotebookIfPresent(cwd: string, sessionId: string) {
+	const paths = resolveRlmArtifactPaths(cwd, sessionId);
+	try {
+		return await readNotebookDocument(paths.notebookPath, paths.notebookPath);
+	} catch (error) {
+		if (error instanceof Error && error.message.startsWith("File not found:")) return undefined;
+		throw error;
+	}
 }

--- a/packages/coding-agent/src/rlm/complete-research-tool.ts
+++ b/packages/coding-agent/src/rlm/complete-research-tool.ts
@@ -1,0 +1,163 @@
+/**
+ * RLM completion/report tool.
+ *
+ * This is the model-facing stop/report seam for autonomous research mode. It
+ * writes the deterministic report from the live notebook and, for final
+ * completion, marks the RLM controller complete so the existing agent loop can
+ * pause through CreateAgentSessionOptions.shouldPause.
+ */
+import * as z from "zod/v4";
+import type { NotebookCell, NotebookDocument } from "../edit/notebook";
+import type { CustomTool } from "../extensibility/custom-tools/types";
+import { ToolError } from "../tools/tool-errors";
+import type { RlmNotebookWriter } from "./notebook";
+import { synthesizeRlmReport } from "./report";
+import type { RlmArtifactPaths } from "./types";
+
+export const RLM_COMPLETE_RESEARCH_TOOL_NAME = "complete_research";
+
+const paramsSchema = z.object({
+	summary: z
+		.string()
+		.min(1)
+		.describe("Concise final report summary grounded in notebook outputs and cited observations."),
+	final: z
+		.boolean()
+		.optional()
+		.describe("Set false to synthesize a draft report without ending the research session."),
+});
+
+export interface RlmReportWriteInput {
+	paths: RlmArtifactPaths;
+	notebook: RlmNotebookWriter;
+	title: string;
+	summary?: string;
+	dataPath?: string | null;
+}
+
+export interface RlmCompleteResearchContext extends RlmReportWriteInput {
+	minSuccessfulRuns?: number;
+	getGoalStatus?: () => string | undefined;
+	markCompleted?: (summary: string) => void;
+}
+
+function cellText(value: string | string[] | undefined): string {
+	if (value === undefined) return "";
+	return Array.isArray(value) ? value.join("") : value;
+}
+
+function isErrorOutput(output: unknown): boolean {
+	if (!output || typeof output !== "object") return false;
+	const record = output as Record<string, unknown>;
+	return record.output_type === "error" || (record.output_type === "stream" && record.name === "stderr");
+}
+
+function hasAnyOutput(cell: NotebookCell): boolean {
+	return Array.isArray(cell.outputs) && cell.outputs.length > 0;
+}
+
+export function countSuccessfulNotebookRuns(notebook: NotebookDocument): number {
+	return notebook.cells.filter(cell => {
+		if (cell.cell_type !== "code") return false;
+		if (!hasAnyOutput(cell)) return true;
+		return !(cell.outputs ?? []).some(isErrorOutput);
+	}).length;
+}
+
+export function summarizeNotebookForReplay(notebook: NotebookDocument, maxChars: number = 12_000): string {
+	const parts: string[] = [];
+	let codeIndex = 0;
+	for (const cell of notebook.cells) {
+		if (cell.cell_type === "markdown") {
+			const text = cellText(cell.source).trim();
+			if (text.length > 0) parts.push(`Markdown:\n${text}`);
+			continue;
+		}
+		if (cell.cell_type !== "code") continue;
+		codeIndex += 1;
+		const source = cellText(cell.source).trimEnd();
+		const outputs = (cell.outputs ?? [])
+			.map(output => {
+				if (!output || typeof output !== "object") return "";
+				const record = output as Record<string, unknown>;
+				if (record.output_type === "stream")
+					return cellText(record.text as string | string[] | undefined).trimEnd();
+				if (record.output_type === "error") return [record.ename, record.evalue].filter(Boolean).join(": ");
+				return "";
+			})
+			.filter(Boolean)
+			.join("\n");
+		parts.push(
+			[`Cell ${codeIndex}:`, "```python", source, "```", outputs ? `Output:\n${outputs}` : undefined]
+				.filter(Boolean)
+				.join("\n"),
+		);
+	}
+	const text = parts.join("\n\n---\n\n");
+	return text.length > maxChars ? `${text.slice(0, maxChars)}\n\n...[prior notebook replay truncated]` : text;
+}
+
+export async function writeRlmReport(input: RlmReportWriteInput): Promise<string> {
+	await input.notebook.flush();
+	const report = synthesizeRlmReport({
+		title: input.title,
+		summary: input.summary,
+		notebook: input.notebook.document,
+		dataPath: input.dataPath,
+	});
+	await Bun.write(input.paths.reportPath, report);
+	return report;
+}
+
+export function createRlmCompleteResearchTool(context: RlmCompleteResearchContext): CustomTool<typeof paramsSchema> {
+	return {
+		name: RLM_COMPLETE_RESEARCH_TOOL_NAME,
+		label: "Complete Research",
+		description:
+			'Synthesize the RLM report from the live notebook. For final completion, call goal({op:"complete"}) first, then call this tool with final=true (default). Use final=false for a draft /report without ending the session.',
+		parameters: paramsSchema,
+		strict: true,
+		concurrency: "exclusive",
+		async execute(_toolCallId, params) {
+			const final = params.final ?? true;
+			const minRuns = Math.max(0, Math.floor(context.minSuccessfulRuns ?? 0));
+			const successfulRuns = countSuccessfulNotebookRuns(context.notebook.document);
+			if (final && minRuns > 0 && successfulRuns < minRuns) {
+				throw new ToolError(
+					`complete_research requires at least ${minRuns} successful Python run(s); current successful runs: ${successfulRuns}.`,
+				);
+			}
+
+			if (final) {
+				const goalStatus = context.getGoalStatus?.();
+				if (goalStatus !== undefined && goalStatus !== "complete") {
+					throw new ToolError(
+						`complete_research finalization requires goal({op:"complete"}) first; current RLM goal status is ${goalStatus}.`,
+					);
+				}
+			}
+
+			await writeRlmReport({
+				paths: context.paths,
+				notebook: context.notebook,
+				title: context.title,
+				summary: params.summary,
+				dataPath: context.dataPath,
+			});
+
+			if (final) {
+				context.markCompleted?.(params.summary);
+			}
+
+			const action = final ? "Final report synthesized" : "Draft report synthesized";
+			return {
+				content: [
+					{
+						type: "text",
+						text: `${action}: ${context.paths.reportPath}\nSuccessful Python runs: ${successfulRuns}`,
+					},
+				],
+			};
+		},
+	};
+}

--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -1,33 +1,77 @@
 /**
  * RLM (research) mode entry point.
  *
- * Composes an interactive research session over the existing agent/session loop
- * (python kernel + read + web_search + read-only bash), optional DATA.md
- * context, a live notebook.ipynb, and a synthesized report.md on session exit.
+ * Composes a research session over the existing agent/session loop (python
+ * kernel + read + web_search + read-only bash), optional DATA.md context, live
+ * notebook.ipynb, first-class complete_research report synthesis, autonomous
+ * goal-arg execution, and resumable .gjc/rlm/<session> artifacts.
  */
+import * as fs from "node:fs/promises";
 import { getProjectDir } from "@gajae-code/utils";
 import { parseArgs } from "../cli/args";
+import { disposeKernelSessionsByOwner } from "../eval/py/executor";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { type RlmPreset, runRootCommand } from "../main";
 import type { CreateAgentSessionOptions } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
-import { ensureRlmSessionDir, generateRlmSessionId, resolveRlmArtifactPaths } from "./artifacts";
+import {
+	ensureRlmSessionDir,
+	generateRlmSessionId,
+	readRlmNotebookIfPresent,
+	resolveRlmArtifactPaths,
+	rlmSessionExists,
+} from "./artifacts";
+import {
+	countSuccessfulNotebookRuns,
+	createRlmCompleteResearchTool,
+	summarizeNotebookForReplay,
+	writeRlmReport,
+} from "./complete-research-tool";
 import { loadRlmDataContext, type RlmDataContext } from "./data-context";
 import { RlmNotebookWriter } from "./notebook";
 import { assertRlmToolAllowlist, buildRlmSystemPrompt, isRlmToolAllowed, RLM_READ_ONLY_BASH_PREFIXES } from "./preset";
 import { createRlmPythonTool } from "./python-tool";
-import { synthesizeRlmReport } from "./report";
-import type { RlmSessionMetadata } from "./types";
+import type { RlmArtifactPaths, RlmSessionMetadata } from "./types";
 
-interface ExtractedDataFlag {
+interface ExtractedRlmFlags {
 	dataPath: string | undefined;
+	resumeSessionId: string | undefined;
+	minSuccessfulRuns: number;
 	rest: string[];
 }
 
-/** Pull `--data <path>` / `--data=<path>` out of argv; the remainder is forwarded to the root command. */
-export function extractDataFlag(argv: string[]): ExtractedDataFlag {
+export interface RlmPresetOptions {
+	dataContext: RlmDataContext | null;
+	pythonTool: CustomTool;
+	completeResearchTool?: CustomTool;
+	objective?: string;
+	resumeContext?: string;
+	onSessionReady?: (session: AgentSession) => void;
+}
+
+interface RlmRunController {
+	completed: boolean;
+	finalSummary: string | undefined;
+	session: AgentSession | undefined;
+}
+
+function parseNonNegativeIntegerFlag(name: string, value: string | undefined): number {
+	if (value === undefined || value.trim().length === 0) {
+		throw new Error(`${name} requires a non-negative integer value.`);
+	}
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		throw new Error(`${name} requires a non-negative integer value.`);
+	}
+	return parsed;
+}
+
+/** Pull RLM-owned flags out of argv; the remainder is forwarded to the root command. */
+export function extractRlmFlags(argv: string[]): ExtractedRlmFlags {
 	const rest: string[] = [];
 	let dataPath: string | undefined;
+	let resumeSessionId: string | undefined;
+	let minSuccessfulRuns = 0;
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--data") {
@@ -35,25 +79,48 @@ export function extractDataFlag(argv: string[]): ExtractedDataFlag {
 			i += 1;
 		} else if (arg.startsWith("--data=")) {
 			dataPath = arg.slice("--data=".length);
+		} else if (arg === "--resume" || arg === "-r") {
+			const next = argv[i + 1];
+			if (!next || next.startsWith("-")) throw new Error("gjc rlm --resume requires an RLM session id.");
+			resumeSessionId = next;
+			i += 1;
+		} else if (arg.startsWith("--resume=")) {
+			resumeSessionId = arg.slice("--resume=".length);
+		} else if (arg === "--min-successful-runs") {
+			minSuccessfulRuns = parseNonNegativeIntegerFlag(arg, argv[i + 1]);
+			i += 1;
+		} else if (arg.startsWith("--min-successful-runs=")) {
+			minSuccessfulRuns = parseNonNegativeIntegerFlag(
+				"--min-successful-runs",
+				arg.slice("--min-successful-runs=".length),
+			);
 		} else {
 			rest.push(arg);
 		}
 	}
+	return { dataPath, resumeSessionId, minSuccessfulRuns, rest };
+}
+
+/** @deprecated use extractRlmFlags; retained for tests and compatibility. */
+export function extractDataFlag(argv: string[]): { dataPath: string | undefined; rest: string[] } {
+	const { dataPath, rest } = extractRlmFlags(argv);
 	return { dataPath, rest };
 }
 
-export interface RlmPresetOptions {
-	dataContext: RlmDataContext | null;
-	pythonTool: CustomTool;
-	objective?: string;
-}
-
-export function createRlmPreset({ dataContext, pythonTool, objective }: RlmPresetOptions): RlmPreset {
+export function createRlmPreset({
+	dataContext,
+	pythonTool,
+	completeResearchTool,
+	objective,
+	resumeContext,
+	onSessionReady,
+}: RlmPresetOptions): RlmPreset {
 	const resolvedObjective = objective ?? buildRlmGoalObjective({ messages: [], dataContext });
+	const customTools = completeResearchTool ? [pythonTool, completeResearchTool] : [pythonTool];
 	return {
 		applyOptions: (options: CreateAgentSessionOptions, settings) => {
-			options.systemPrompt = buildRlmSystemPrompt(dataContext);
-			options.customTools = [pythonTool];
+			options.systemPrompt = buildRlmSystemPrompt(dataContext, resumeContext);
+			options.customTools = customTools;
 			options.toolNames = ["read", "web_search", "search_tool_bm25", "bash", "goal"];
 			options.requireYieldTool = false;
 			options.skills = [];
@@ -66,12 +133,23 @@ export function createRlmPreset({ dataContext, pythonTool, objective }: RlmPrese
 			options.bashRestrictionProfile = "read-only";
 			options.goalToolAllowedOps = ["get", "complete"];
 			options.discoverableToolAllowedNames = [];
+			options.slashCommands = [
+				...(options.slashCommands ?? []),
+				{
+					name: "report",
+					description: "Synthesize a draft RLM report from the current notebook",
+					content:
+						"Call complete_research with final=false and a concise summary of the current notebook-backed findings. Do not mark the goal complete unless the full research objective is satisfied.",
+					source: "rlm",
+				},
+			];
 			// RLM always runs in goal mode; recipe injection stays outside the research surface.
 			settings.override("goal.enabled", true);
 			settings.override("tools.discoveryMode", "all");
 			settings.override("recipe.enabled", false);
 		},
 		onSessionCreated: async (session: AgentSession) => {
+			onSessionReady?.(session);
 			await ensureRlmGoalMode(session, resolvedObjective);
 			// Hard boundary: fail launch if any non-allowlisted tool slipped into the active set.
 			assertRlmToolAllowlist(session.getActiveToolNames());
@@ -106,41 +184,143 @@ export function buildRlmGoalObjective(input: {
 	return "Complete this RLM research session, grounding conclusions in notebook outputs and finishing with a report.";
 }
 
+async function loadExistingMetadata(paths: RlmArtifactPaths): Promise<RlmSessionMetadata | undefined> {
+	try {
+		return (await Bun.file(paths.metadataPath).json()) as RlmSessionMetadata;
+	} catch {
+		return undefined;
+	}
+}
+
+async function writeRlmMetadata(input: {
+	paths: RlmArtifactPaths;
+	sessionId: string;
+	createdAt: string;
+	cwd: string;
+	dataPath: string | null;
+	cellCount: number;
+	mode: "interactive" | "autonomous";
+	resumedFrom: string | null;
+	completedAt: string | null;
+	finalSummary: string | null;
+	minSuccessfulRuns: number;
+	successfulRuns: number;
+}): Promise<void> {
+	const metadata: RlmSessionMetadata = {
+		sessionId: input.sessionId,
+		createdAt: input.createdAt,
+		cwd: input.cwd,
+		dataPath: input.dataPath,
+		cellCount: input.cellCount,
+		mode: input.mode,
+		resumedFrom: input.resumedFrom,
+		completedAt: input.completedAt,
+		finalSummary: input.finalSummary,
+		minSuccessfulRuns: input.minSuccessfulRuns,
+		successfulRuns: input.successfulRuns,
+	};
+	await Bun.write(input.paths.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
 export async function runRlmCommand(argv: string[]): Promise<void> {
 	const cwd = getProjectDir();
-	const { dataPath, rest } = extractDataFlag(argv);
+	const { dataPath, resumeSessionId, minSuccessfulRuns, rest } = extractRlmFlags(argv);
 	const dataContext = await loadRlmDataContext(cwd, dataPath);
 
-	const sessionId = generateRlmSessionId();
+	const sessionId = resumeSessionId ?? generateRlmSessionId();
 	const paths = resolveRlmArtifactPaths(cwd, sessionId);
+	if (resumeSessionId && !(await rlmSessionExists(cwd, resumeSessionId))) {
+		throw new Error(`RLM session not found: ${resumeSessionId}`);
+	}
 	await ensureRlmSessionDir(paths);
+	await fs.mkdir(paths.agentSessionDir, { recursive: true });
 
-	const notebook = new RlmNotebookWriter(paths.notebookPath);
-	const pythonTool = createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
+	const existingNotebook = resumeSessionId ? await readRlmNotebookIfPresent(cwd, sessionId) : undefined;
+	const existingMetadata = await loadExistingMetadata(paths);
+	const notebook = new RlmNotebookWriter(paths.notebookPath, existingNotebook);
+	const pythonTool = createRlmPythonTool({
+		cwd,
+		sessionId,
+		artifactsDir: paths.dir,
+		notebook,
+		managedWorkspaceVenv: true,
+	});
+	const controller: RlmRunController = { completed: false, finalSummary: undefined, session: undefined };
+	const reportTitle = `RLM research session ${sessionId}`;
+	const completeResearchTool = createRlmCompleteResearchTool({
+		paths,
+		notebook,
+		title: reportTitle,
+		dataPath: dataContext?.path ?? null,
+		minSuccessfulRuns,
+		getGoalStatus: () => controller.session?.getGoalModeState()?.goal.status,
+		markCompleted: summary => {
+			controller.completed = true;
+			controller.finalSummary = summary;
+		},
+	});
 
 	const parsed = parseArgs(rest);
+	parsed.sessionDir = paths.agentSessionDir;
+	if (resumeSessionId) {
+		parsed.continue = true;
+	}
+	const autonomous = parsed.print === true || parsed.mode !== undefined || parsed.messages.length > 0;
+	if (autonomous && parsed.mode === undefined) {
+		parsed.print = true;
+	}
+	const resumeContext = existingNotebook ? summarizeNotebookForReplay(existingNotebook) : undefined;
 	const preset = createRlmPreset({
 		dataContext,
 		pythonTool,
+		completeResearchTool,
 		objective: buildRlmGoalObjective({ messages: parsed.messages, dataContext }),
+		resumeContext,
+		onSessionReady: session => {
+			controller.session = session;
+		},
 	});
+	if (autonomous) {
+		preset.applyOptions = ((applyOptions: RlmPreset["applyOptions"]) => (options, settings) => {
+			applyOptions(options, settings);
+			options.shouldPause = () => controller.completed;
+		})(preset.applyOptions);
+	}
+
+	let runError: unknown;
 	try {
-		await runRootCommand(parsed, rest, { rlmPreset: preset });
+		await runRootCommand(parsed, rest, { rlmPreset: preset, suppressProcessExit: autonomous });
+	} catch (error) {
+		runError = error;
+		throw error;
 	} finally {
-		await notebook.flush();
-		const report = synthesizeRlmReport({
-			title: `RLM research session ${sessionId}`,
-			notebook: notebook.document,
+		// The RLM python tool owns a retained kernel keyed by `rlm:<sessionId>`; the
+		// session's own dispose targets a different owner id, so release it here so
+		// the persistent kernel subprocess is reaped on every exit path.
+		await disposeKernelSessionsByOwner(`rlm:${sessionId}`).catch(() => {});
+		await writeRlmReport({
+			paths,
+			notebook,
+			title: reportTitle,
+			summary: controller.finalSummary,
 			dataPath: dataContext?.path ?? null,
 		});
-		await Bun.write(paths.reportPath, report);
-		const metadata: RlmSessionMetadata = {
+		await writeRlmMetadata({
+			paths,
 			sessionId,
-			createdAt: new Date().toISOString(),
+			createdAt: existingMetadata?.createdAt ?? new Date().toISOString(),
 			cwd,
 			dataPath: dataContext?.path ?? null,
 			cellCount: notebook.cellCount,
-		};
-		await Bun.write(paths.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+			mode: autonomous ? "autonomous" : "interactive",
+			resumedFrom: resumeSessionId ?? null,
+			completedAt: controller.completed ? new Date().toISOString() : null,
+			finalSummary: controller.finalSummary ?? null,
+			minSuccessfulRuns,
+			successfulRuns: countSuccessfulNotebookRuns(notebook.document),
+		});
+	}
+	if (autonomous && !controller.completed && runError === undefined) {
+		throw new Error("RLM autonomous session ended before complete_research finalized the report.");
 	}
 }

--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -2,17 +2,19 @@
  * RLM (research) mode entry point.
  *
  * Composes an interactive research session over the existing agent/session loop
- * via a research preset: a distinct system prompt, a hard-gated research toolset
- * (python kernel + read + web_search), optional DATA.md context, a live
- * notebook.ipynb, and a synthesized report.md on session exit.
+ * (python kernel + read + web_search + read-only bash), optional DATA.md
+ * context, a live notebook.ipynb, and a synthesized report.md on session exit.
  */
 import { getProjectDir } from "@gajae-code/utils";
 import { parseArgs } from "../cli/args";
+import type { CustomTool } from "../extensibility/custom-tools/types";
 import { type RlmPreset, runRootCommand } from "../main";
+import type { CreateAgentSessionOptions } from "../sdk";
+import type { AgentSession } from "../session/agent-session";
 import { ensureRlmSessionDir, generateRlmSessionId, resolveRlmArtifactPaths } from "./artifacts";
-import { loadRlmDataContext } from "./data-context";
+import { loadRlmDataContext, type RlmDataContext } from "./data-context";
 import { RlmNotebookWriter } from "./notebook";
-import { assertRlmToolAllowlist, buildRlmSystemPrompt } from "./preset";
+import { assertRlmToolAllowlist, buildRlmSystemPrompt, isRlmToolAllowed, RLM_READ_ONLY_BASH_PREFIXES } from "./preset";
 import { createRlmPythonTool } from "./python-tool";
 import { synthesizeRlmReport } from "./report";
 import type { RlmSessionMetadata } from "./types";
@@ -40,6 +42,70 @@ export function extractDataFlag(argv: string[]): ExtractedDataFlag {
 	return { dataPath, rest };
 }
 
+export interface RlmPresetOptions {
+	dataContext: RlmDataContext | null;
+	pythonTool: CustomTool;
+	objective?: string;
+}
+
+export function createRlmPreset({ dataContext, pythonTool, objective }: RlmPresetOptions): RlmPreset {
+	const resolvedObjective = objective ?? buildRlmGoalObjective({ messages: [], dataContext });
+	return {
+		applyOptions: (options: CreateAgentSessionOptions, settings) => {
+			options.systemPrompt = buildRlmSystemPrompt(dataContext);
+			options.customTools = [pythonTool];
+			options.toolNames = ["read", "web_search", "search_tool_bm25", "bash", "goal"];
+			options.requireYieldTool = false;
+			options.skills = [];
+			options.rules = [];
+			options.disableExtensionDiscovery = true;
+			options.extensions = [];
+			options.additionalExtensionPaths = [];
+			options.preloadedExtensions = undefined;
+			options.bashAllowedPrefixes = [...RLM_READ_ONLY_BASH_PREFIXES];
+			options.bashRestrictionProfile = "read-only";
+			options.goalToolAllowedOps = ["get", "complete"];
+			options.discoverableToolAllowedNames = [];
+			// RLM always runs in goal mode; recipe injection stays outside the research surface.
+			settings.override("goal.enabled", true);
+			settings.override("tools.discoveryMode", "all");
+			settings.override("recipe.enabled", false);
+		},
+		onSessionCreated: async (session: AgentSession) => {
+			await ensureRlmGoalMode(session, resolvedObjective);
+			// Hard boundary: fail launch if any non-allowlisted tool slipped into the active set.
+			assertRlmToolAllowlist(session.getActiveToolNames());
+		},
+	};
+}
+
+async function ensureRlmGoalMode(session: AgentSession, objective: string): Promise<void> {
+	const current = session.getGoalModeState();
+	if (current?.goal && current.goal.status !== "complete" && current.goal.status !== "dropped") {
+		if (!current.enabled || current.goal.status === "paused") {
+			await session.goalRuntime.resumeGoal();
+		}
+	} else {
+		await session.goalRuntime.createGoal({ objective });
+	}
+	await session.setActiveToolsByName([...new Set([...session.getActiveToolNames().filter(isRlmToolAllowed), "goal"])]);
+}
+
+export function buildRlmGoalObjective(input: {
+	messages: readonly string[];
+	dataContext: RlmDataContext | null;
+}): string {
+	const prompt = input.messages
+		.map(message => message.trim())
+		.filter(Boolean)
+		.join("\n\n");
+	if (prompt.length > 0) return prompt;
+	if (input.dataContext) {
+		return `Complete an RLM research session using data context ${input.dataContext.path}, grounding conclusions in notebook outputs and finishing with a report.`;
+	}
+	return "Complete this RLM research session, grounding conclusions in notebook outputs and finishing with a report.";
+}
+
 export async function runRlmCommand(argv: string[]): Promise<void> {
 	const cwd = getProjectDir();
 	const { dataPath, rest } = extractDataFlag(argv);
@@ -52,25 +118,12 @@ export async function runRlmCommand(argv: string[]): Promise<void> {
 	const notebook = new RlmNotebookWriter(paths.notebookPath);
 	const pythonTool = createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
 
-	const preset: RlmPreset = {
-		applyOptions: (options, settings) => {
-			options.systemPrompt = buildRlmSystemPrompt(dataContext);
-			options.customTools = [pythonTool, ...(options.customTools ?? [])];
-			options.toolNames = ["read", "web_search"];
-			options.requireYieldTool = false;
-			options.skills = [];
-			options.rules = [];
-			options.disableExtensionDiscovery = true;
-			// Disable goal-mode tool injection so the research surface stays exactly the allowlist.
-			settings.override("goal.enabled", false);
-		},
-		onSessionCreated: session => {
-			// Hard boundary: fail launch if any non-allowlisted tool slipped into the active set.
-			assertRlmToolAllowlist(session.getActiveToolNames());
-		},
-	};
-
 	const parsed = parseArgs(rest);
+	const preset = createRlmPreset({
+		dataContext,
+		pythonTool,
+		objective: buildRlmGoalObjective({ messages: parsed.messages, dataContext }),
+	});
 	try {
 		await runRootCommand(parsed, rest, { rlmPreset: preset });
 	} finally {

--- a/packages/coding-agent/src/rlm/preset.ts
+++ b/packages/coding-agent/src/rlm/preset.ts
@@ -30,6 +30,7 @@ export const RLM_TOOL_ALLOWLIST: readonly string[] = [
 	"search_tool_bm25",
 	"bash",
 	"goal",
+	"complete_research",
 ];
 
 export function isRlmToolAllowed(name: string): boolean {
@@ -56,13 +57,19 @@ export const RLM_RESEARCH_PROMPT: string = rlmResearchPrompt;
 
 /**
  * Build the systemPrompt transform for createAgentSession: appends the research
- * prompt and (when present) the data-context block to the default blocks.
+ * prompt, data context, and prior-notebook replay context to the default blocks.
  */
-export function buildRlmSystemPrompt(dataContext: RlmDataContext | null): (defaultPrompt: string[]) => string[] {
+export function buildRlmSystemPrompt(
+	dataContext: RlmDataContext | null,
+	resumeContext?: string,
+): (defaultPrompt: string[]) => string[] {
 	return (defaultPrompt: string[]): string[] => {
 		const blocks = [...defaultPrompt, rlmResearchPrompt];
 		if (dataContext) {
 			blocks.push(`# Data context (from ${dataContext.path})\n\n${dataContext.content}`);
+		}
+		if (resumeContext && resumeContext.trim().length > 0) {
+			blocks.push(`# Prior notebook replay context\n\n${resumeContext}`);
 		}
 		return blocks;
 	};

--- a/packages/coding-agent/src/rlm/preset.ts
+++ b/packages/coding-agent/src/rlm/preset.ts
@@ -7,11 +7,30 @@ import rlmResearchPrompt from "../prompts/system/rlm-research.md" with { type: "
 import type { RlmDataContext } from "./data-context";
 
 /**
- * Tools the model may use in RLM mode. `python` is the RLM research execution
- * tool; `read` and `web_search` are the existing built-ins. Everything else
- * (bash, edit, write, goal, task, skill, browser, eval-js, ...) is excluded.
+ * tool; `read` and `web_search` are the existing built-ins. `bash` is exposed
+ * through the read-only restriction profile below for inspection commands only,
+ * and `goal` is required so RLM sessions cannot finish without explicit goal
+ * completion. Everything else (edit, write, task, skill, browser, eval-js, ...) is excluded.
  */
-export const RLM_TOOL_ALLOWLIST: readonly string[] = ["python", "read", "web_search", "search_tool_bm25"];
+export const RLM_READ_ONLY_BASH_PREFIXES: readonly string[] = [
+	"grep",
+	"rg",
+	"tree",
+	"ls",
+	"pwd",
+	"wc",
+	"du",
+	"file",
+	"stat",
+];
+export const RLM_TOOL_ALLOWLIST: readonly string[] = [
+	"python",
+	"read",
+	"web_search",
+	"search_tool_bm25",
+	"bash",
+	"goal",
+];
 
 export function isRlmToolAllowed(name: string): boolean {
 	return RLM_TOOL_ALLOWLIST.includes(name.toLowerCase());

--- a/packages/coding-agent/src/rlm/python-tool.ts
+++ b/packages/coding-agent/src/rlm/python-tool.ts
@@ -5,6 +5,7 @@
 import type { AgentToolResult } from "@gajae-code/agent-core";
 import { type Static, z } from "@gajae-code/ai";
 import { executePython } from "../eval/py/executor";
+import { RLM_MANAGED_PYTHON_PACKAGES } from "../eval/py/runtime";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { RlmNotebookWriter } from "./notebook";
 import type { RlmCellResult } from "./types";
@@ -16,6 +17,7 @@ export interface RlmPythonToolContext {
 	sessionId: string;
 	artifactsDir: string;
 	notebook: RlmNotebookWriter;
+	managedWorkspaceVenv?: boolean;
 }
 
 const paramsSchema = z.object({
@@ -31,6 +33,8 @@ export function createRlmPythonTool(rlm: RlmPythonToolContext): CustomTool<typeo
 		description:
 			"Execute Python in the persistent research kernel. Variables, imports, and loaded data persist across calls like notebook cells. Every call is recorded as a cell in the session notebook.",
 		parameters: paramsSchema,
+		strict: true,
+		concurrency: "exclusive",
 		async execute(
 			_toolCallId: string,
 			params: Static<typeof paramsSchema>,
@@ -44,6 +48,9 @@ export function createRlmPythonTool(rlm: RlmPythonToolContext): CustomTool<typeo
 				sessionId: `rlm:${rlm.sessionId}`,
 				kernelOwnerId: `rlm:${rlm.sessionId}`,
 				artifactsDir: rlm.artifactsDir,
+				runtimeOptions: rlm.managedWorkspaceVenv
+					? { managedWorkspaceVenv: true, seedPackages: RLM_MANAGED_PYTHON_PACKAGES }
+					: undefined,
 				signal,
 			});
 			const cell: RlmCellResult = {

--- a/packages/coding-agent/src/rlm/types.ts
+++ b/packages/coding-agent/src/rlm/types.ts
@@ -12,6 +12,8 @@ export interface RlmArtifactPaths {
 	reportPath: string;
 	/** Absolute path to the session metadata.json */
 	metadataPath: string;
+	/** Directory for the underlying GJC conversation session files. */
+	agentSessionDir: string;
 }
 
 /** Outcome of a single RLM python cell execution. */
@@ -29,4 +31,10 @@ export interface RlmSessionMetadata {
 	cwd: string;
 	dataPath: string | null;
 	cellCount: number;
+	mode?: "interactive" | "autonomous";
+	resumedFrom?: string | null;
+	completedAt?: string | null;
+	finalSummary?: string | null;
+	minSuccessfulRuns?: number;
+	successfulRuns?: number;
 }

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -626,6 +626,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		label: tool.label,
 		description: tool.description,
 		parameters: tool.parameters,
+		concurrency: tool.concurrency,
 		hidden: tool.hidden,
 		deferrable: tool.deferrable,
 		mcpServerName: tool.mcpServerName,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -47,6 +47,7 @@ import {
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { Settings, type SkillsSettings } from "./config/settings";
 import { CursorExecHandlers } from "./cursor";
+import type { BashRestrictionProfile } from "./tools/bash-allowed-prefixes";
 import "./discovery";
 import { resolveConfigValue } from "./config/resolve-config-value";
 import { getEmbeddedDefaultGjcSkills } from "./defaults/gjc-defaults";
@@ -310,6 +311,12 @@ export interface CreateAgentSessionOptions {
 	agentDisplayName?: string;
 	/** Optional restricted bash command prefixes for read-only role agents. */
 	bashAllowedPrefixes?: string[];
+	/** Restriction policy paired with bashAllowedPrefixes. */
+	bashRestrictionProfile?: BashRestrictionProfile;
+	/** Optional per-session restriction for goal tool operations. */
+	goalToolAllowedOps?: readonly ("create" | "get" | "complete" | "resume" | "drop")[];
+	/** Optional per-session allowlist for tools exposed through search_tool_bm25. */
+	discoverableToolAllowedNames?: readonly string[];
 	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
 	agentRegistry?: AgentRegistry;
 	/** Parent task ID prefix for nested artifact naming (e.g., "6-Extensions") */
@@ -1219,6 +1226,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			},
 			getAgentId: () => resolvedAgentId,
 			bashAllowedPrefixes: options.bashAllowedPrefixes,
+			bashRestrictionProfile: options.bashRestrictionProfile,
+			goalToolAllowedOps: options.goalToolAllowedOps,
+			discoverableToolAllowedNames: options.discoverableToolAllowedNames,
 			getToolByName: name => session?.getToolByName(name),
 			agentRegistry,
 			getSessionSpawns: () => options.spawns ?? "*",
@@ -2028,6 +2038,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			rebuildSystemPrompt,
 			reloadSshTool,
 			requestedToolNames: requestedToolNameSet,
+			discoverableToolAllowedNames: options.discoverableToolAllowedNames,
 			getMcpServerInstructions: mcpManager
 				? () => {
 						const raw = mcpManager.getServerInstructions();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -388,6 +388,8 @@ export interface AgentSessionConfig {
 	/** Rebuild the SSH tool from current capability discovery results. */
 	reloadSshTool?: () => Promise<AgentTool | null>;
 	requestedToolNames?: ReadonlySet<string>;
+	/** Optional per-session allowlist for tools exposed through search_tool_bm25. */
+	discoverableToolAllowedNames?: readonly string[];
 	/**
 	 * Optional accessor for live MCP server instructions. Read by the session's
 	 * `rebuildSystemPrompt`-skip optimization to detect server-side instruction
@@ -1016,6 +1018,7 @@ export class AgentSession {
 	// Generic tool discovery (covers built-in + MCP + extension when tools.discoveryMode === "all")
 	#discoverableToolSearchIndex: DiscoverableToolSearchIndex | null = null;
 	#selectedDiscoveredToolNames = new Set<string>();
+	#discoverableToolAllowedNames: ReadonlySet<string> | undefined;
 	#rpcHostToolNames = new Set<string>();
 	#gjcSubskillToolNames = new Set<string>();
 	#gjcSubskillToolSignature: string | undefined;
@@ -1224,6 +1227,9 @@ export class AgentSession {
 		this.#reloadSshTool = config.reloadSshTool;
 		this.#baseSystemPrompt = this.agent.state.systemPrompt;
 		this.#mcpDiscoveryEnabled = config.mcpDiscoveryEnabled ?? false;
+		this.#discoverableToolAllowedNames = config.discoverableToolAllowedNames
+			? new Set(config.discoverableToolAllowedNames.map(name => name.toLowerCase()))
+			: undefined;
 		this.#setDiscoverableMCPTools(this.#collectDiscoverableMCPToolsFromRegistry());
 		this.#selectedMCPToolNames = new Set(config.initialSelectedMCPToolNames ?? []);
 		this.#defaultSelectedMCPServerNames = new Set(config.defaultSelectedMCPServerNames ?? []);
@@ -3553,6 +3559,7 @@ export class AgentSession {
 		for (const tool of this.#toolRegistry.values()) {
 			if (tool.loadMode !== "discoverable") continue;
 			if (activeNames.has(tool.name)) continue;
+			if (this.#discoverableToolAllowedNames && !this.#discoverableToolAllowedNames.has(tool.name)) continue;
 			const collected = collectDiscoverableTools([tool], { source: "builtin" });
 			result.push(...collected);
 		}
@@ -3599,6 +3606,7 @@ export class AgentSession {
 			const currentActiveNames = new Set(this.getActiveToolNames());
 			const newlyAdded: string[] = [];
 			for (const name of nonMcpNames) {
+				if (this.#discoverableToolAllowedNames && !this.#discoverableToolAllowedNames.has(name)) continue;
 				if (this.#toolRegistry.has(name) && !currentActiveNames.has(name)) {
 					newlyAdded.push(name);
 					this.#selectedDiscoveredToolNames.add(name);

--- a/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
+++ b/packages/coding-agent/src/tools/bash-allowed-prefixes.ts
@@ -3,11 +3,18 @@ export interface BashAllowedPrefixesCheck {
 	reason?: string;
 }
 
+export type BashRestrictionProfile = "workflow" | "read-only";
+
+export interface BashRestrictionOptions {
+	profile?: BashRestrictionProfile;
+}
+
 const SHELL_CONTROL_CHARS = new Set([";", "|", "&", "<", ">", "(", ")"]);
 const UNSAFE_UNQUOTED_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
 const STATE_FLAGS_WITH_VALUES = new Set(["--input", "--mode", "--session-id", "--thread-id", "--turn-id", "--to"]);
 const STATE_ACTIONS = new Set(["read", "write", "clear", "contract", "handoff"]);
 const ALLOWED_STATE_ACTIONS = new Set(["read", "write", "contract"]);
+const READ_ONLY_COMMANDS = new Set(["grep", "rg", "tree", "ls", "pwd", "wc", "du", "file", "stat"]);
 
 function parseShellWords(command: string): { words: string[]; reason?: string } {
 	const words: string[] = [];
@@ -118,6 +125,59 @@ function parseStateAction(words: readonly string[]): string | undefined {
 	return third ? undefined : second;
 }
 
+function optionWords(words: readonly string[]): string[] {
+	const options: string[] = [];
+	for (const word of words.slice(1)) {
+		if (word === "--") break;
+		options.push(word);
+	}
+	return options;
+}
+
+function isLongOption(word: string, option: string): boolean {
+	return word === option || word.startsWith(`${option}=`);
+}
+
+function hasShortOption(word: string, option: string): boolean {
+	return word.startsWith("-") && !word.startsWith("--") && word.slice(1).includes(option);
+}
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function resolvedExternalCommand(command: string): string | undefined {
+	return Bun.which(command) ?? undefined;
+}
+
+function validateReadOnlyCommand(words: readonly string[]): BashAllowedPrefixesCheck {
+	const command = words[0];
+	if (!command || !READ_ONLY_COMMANDS.has(command)) {
+		return { allowed: false, reason: "read-only bash only allows approved inspection commands" };
+	}
+
+	const options = optionWords(words);
+	if (command === "rg") {
+		for (const option of options) {
+			if (isLongOption(option, "--pre") || isLongOption(option, "--pre-glob")) {
+				return { allowed: false, reason: "read-only bash does not allow ripgrep preprocessors" };
+			}
+			if (isLongOption(option, "--search-zip") || hasShortOption(option, "z")) {
+				return { allowed: false, reason: "read-only bash does not allow ripgrep compressed-file subprocesses" };
+			}
+		}
+	}
+
+	if (command === "tree") {
+		for (const option of options) {
+			if (isLongOption(option, "--output") || hasShortOption(option, "o")) {
+				return { allowed: false, reason: "read-only bash does not allow tree output-file writes" };
+			}
+		}
+	}
+
+	return { allowed: true };
+}
+
 function validateMatchedGjcCommand(words: readonly string[]): BashAllowedPrefixesCheck {
 	if (words[0] !== "gjc") return { allowed: true };
 
@@ -145,9 +205,29 @@ function validateMatchedGjcCommand(words: readonly string[]): BashAllowedPrefixe
 	return { allowed: true };
 }
 
+function commandAllowedPrefixesReason(normalizedPrefixes: readonly string[], options: BashRestrictionOptions): string {
+	const prefixList = normalizedPrefixes.join(", ");
+	return options.profile === "read-only"
+		? `read-only bash only allows commands starting with: ${prefixList}`
+		: `restricted role-agent bash only allows commands starting with: ${prefixList}`;
+}
+
+export function normalizeReadOnlyBashCommand(command: string): string | undefined {
+	const parsed = parseShellWords(command.trim());
+	if (parsed.reason || parsed.words.length === 0) return undefined;
+	const validation = validateReadOnlyCommand(parsed.words);
+	if (!validation.allowed) return undefined;
+	const [head, ...rest] = parsed.words;
+	if (!head) return undefined;
+	const resolvedHead = resolvedExternalCommand(head);
+	if (!resolvedHead) return undefined;
+	return [shellQuote(resolvedHead), ...rest.map(shellQuote)].join(" ");
+}
+
 export function checkBashAllowedPrefixes(
 	command: string,
 	allowedPrefixes: readonly string[] | undefined,
+	options: BashRestrictionOptions = {},
 ): BashAllowedPrefixesCheck {
 	const normalizedPrefixes = allowedPrefixes?.map(prefix => prefix.trim()).filter(Boolean) ?? [];
 	if (normalizedPrefixes.length === 0) return { allowed: true };
@@ -161,9 +241,12 @@ export function checkBashAllowedPrefixes(
 	if (!matched) {
 		return {
 			allowed: false,
-			reason: `restricted role-agent bash only allows commands starting with: ${normalizedPrefixes.join(", ")}`,
+			reason: commandAllowedPrefixesReason(normalizedPrefixes, options),
 		};
 	}
 
+	if (options.profile === "read-only") {
+		return validateReadOnlyCommand(parsed.words);
+	}
 	return validateMatchedGjcCommand(parsed.words);
 }

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -19,7 +19,7 @@ import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { getSixelLineMask } from "../utils/sixel";
 import type { ToolSession } from ".";
-import { checkBashAllowedPrefixes } from "./bash-allowed-prefixes";
+import { checkBashAllowedPrefixes, normalizeReadOnlyBashCommand } from "./bash-allowed-prefixes";
 import { applyBashFixups } from "./bash-command-fixup";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
@@ -36,6 +36,12 @@ export const BASH_DEFAULT_PREVIEW_LINES = 10;
 
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
+const READ_ONLY_BASH_ENV: Record<string, string> = {
+	GREP_OPTIONS: "",
+	GREP_COLOR: "",
+	GREP_COLORS: "",
+	RIPGREP_CONFIG_PATH: "",
+};
 
 export async function saveBashOriginalArtifactForTests(
 	session: ToolSession,
@@ -261,6 +267,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			hasSearch: this.session.settings.get("search.enabled"),
 			hasFind: this.session.settings.get("find.enabled"),
 			restrictedAllowedPrefixes: this.session.bashAllowedPrefixes,
+			restrictionProfile: this.session.bashRestrictionProfile,
 		});
 	}
 
@@ -381,6 +388,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						artifactPath,
 						artifactId,
 						oneShot: true,
+						ignoreShellPrefix: this.session.bashRestrictionProfile === "read-only",
+						disableShellSnapshot: this.session.bashRestrictionProfile === "read-only",
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							latestText = tailBuffer.text();
@@ -510,23 +519,37 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 
 		const rawCommand = input.command;
 		const allowedPrefixes = this.session.bashAllowedPrefixes;
+		if (
+			(this.session.bashRestrictionProfile === "read-only" || (allowedPrefixes && allowedPrefixes.length > 0)) &&
+			env &&
+			Object.keys(env).length > 0
+		) {
+			const mode = this.session.bashRestrictionProfile === "read-only" ? "Read-only" : "Restricted role-agent";
+			throw new ToolError(`${mode} bash does not allow per-command env overrides.`);
+		}
 		if (allowedPrefixes && allowedPrefixes.length > 0) {
-			if (env && Object.keys(env).length > 0) {
-				throw new ToolError("Restricted role-agent bash does not allow per-command env overrides.");
-			}
 			const commandsToCheck = rawCommand === command ? [command] : [rawCommand, command];
 			for (const commandToCheck of commandsToCheck) {
-				const allowlist = checkBashAllowedPrefixes(commandToCheck, allowedPrefixes);
+				const allowlist = checkBashAllowedPrefixes(commandToCheck, allowedPrefixes, {
+					profile: this.session.bashRestrictionProfile,
+				});
 				if (!allowlist.allowed) {
 					throw new ToolError(allowlist.reason ?? "Command blocked by restricted role-agent bash allowlist.");
 				}
 			}
 		}
+		if (this.session.bashRestrictionProfile === "read-only") {
+			const normalizedReadOnlyCommand = normalizeReadOnlyBashCommand(command);
+			if (!normalizedReadOnlyCommand) {
+				throw new ToolError("Read-only bash command could not be normalized safely.");
+			}
+			command = normalizedReadOnlyCommand;
+		}
 
 		// Check both the original command and the cwd-normalized command so
 		// leading `cd ... &&` wrappers do not hide either shell-navigation rules
 		// or the dedicated-tool command that follows the directory change.
-		if (this.session.settings.get("bashInterceptor.enabled")) {
+		if (this.session.bashRestrictionProfile !== "read-only" && this.session.settings.get("bashInterceptor.enabled")) {
 			const rules = this.session.settings.getBashInterceptorRules();
 			const commandsToCheck = rawCommand === command ? [command] : [rawCommand, command];
 			for (const commandToCheck of commandsToCheck) {
@@ -545,7 +568,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				getSessionId: this.session.getSessionId,
 			},
 		};
-		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
+		command = await expandInternalUrls(command, {
+			...internalUrlOptions,
+			ensureLocalParentDirs: this.session.bashRestrictionProfile !== "read-only",
+		});
 		const sessionFile = this.session.getSessionFile?.() ?? null;
 		const expandedEnv = env
 			? Object.fromEntries(
@@ -568,6 +594,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				cwd: this.session.cwd,
 			}),
 			...expandedEnv,
+			...(this.session.bashRestrictionProfile === "read-only" ? READ_ONLY_BASH_ENV : {}),
 			...(allowedPrefixes && allowedPrefixes.length > 0 ? { [GJC_RESTRICTED_ROLE_AGENT_BASH_ENV]: "1" } : {}),
 		};
 
@@ -682,6 +709,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						artifactPath,
 						artifactId,
 						oneShot: true,
+						ignoreShellPrefix: this.session.bashRestrictionProfile === "read-only",
+						disableShellSnapshot: this.session.bashRestrictionProfile === "read-only",
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							void reportProgress(tailBuffer.text(), {
@@ -729,6 +758,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		if (asyncRequested && !this.#asyncEnabled) {
 			throw new ToolError("Async bash execution is disabled. Enable async.enabled to use async mode.");
 		}
+		if (this.session.bashRestrictionProfile === "read-only" && pty) {
+			throw new ToolError("Read-only bash does not allow PTY mode.");
+		}
+
 		const prepared = await this.#prepareBashExecution(
 			{ command: rawCommand, env: rawEnv, timeout: rawTimeout, cwd },
 			ctx,
@@ -810,7 +843,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 
 		// Route through the client terminal when the client advertises the terminal capability.
 		// Skip when pty=true (PTY needs the local terminal UI).
-		const clientBridge = this.session.getClientBridge?.();
+		const clientBridge =
+			this.session.bashRestrictionProfile === "read-only" ? undefined : this.session.getClientBridge?.();
 		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
 			const handle = await clientBridge.createTerminal({
 				command,
@@ -983,7 +1017,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Allocate artifact for truncated output storage
 		const { path: artifactPath, id: artifactId } = (await this.session.allocateOutputArtifact?.("bash")) ?? {};
 
-		const interactiveUi = canUseInteractiveBashPty(pty, ctx) ? ctx?.ui : undefined;
+		const interactiveUi =
+			this.session.bashRestrictionProfile === "read-only"
+				? undefined
+				: canUseInteractiveBashPty(pty, ctx)
+					? ctx?.ui
+					: undefined;
 		const result: BashResult | BashInteractiveResult = interactiveUi
 			? await runInteractiveBashPty(interactiveUi, {
 					command,
@@ -997,6 +1036,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			: await executeBash(command, {
 					cwd: commandCwd,
 					sessionKey: this.session.getSessionId?.() ?? undefined,
+					oneShot: this.session.bashRestrictionProfile === "read-only",
 					timeout: timeoutMs,
 					signal,
 					env: resolvedEnv,
@@ -1004,6 +1044,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactId,
 					onChunk: streamTailUpdates(tailBuffer, onUpdate),
 					onMinimizedSave: originalText => saveBashOriginalArtifactForTests(this.session, originalText),
+					ignoreShellPrefix: this.session.bashRestrictionProfile === "read-only",
+					disableShellSnapshot: this.session.bashRestrictionProfile === "read-only",
 				});
 		if (result.cancelled) {
 			if (signal?.aborted) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -33,6 +33,7 @@ import { AskTool } from "./ask";
 import { AstEditTool } from "./ast-edit";
 import { AstGrepTool } from "./ast-grep";
 import { BashTool } from "./bash";
+import type { BashRestrictionProfile } from "./bash-allowed-prefixes";
 import { BrowserTool } from "./browser";
 import { CalculatorTool } from "./calculator";
 import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
@@ -173,8 +174,12 @@ export interface ToolSession {
 	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Agent registry for IRC routing across live sessions. */
 	agentRegistry?: AgentRegistry;
-	/** Optional restricted bash command prefixes for read-only role agents. */
+	/** Optional restricted bash command prefixes for read-only role agents and constrained modes. */
 	bashAllowedPrefixes?: string[];
+	/** Restriction policy for sessions that deliberately expose a narrow bash surface. */
+	bashRestrictionProfile?: BashRestrictionProfile;
+	/** Optional per-session allowlist for tools exposed through search_tool_bm25. */
+	discoverableToolAllowedNames?: readonly string[];
 	/** Get artifacts directory for artifact:// URLs */
 	getArtifactsDir?: () => string | null;
 	/** Get the ArtifactManager backing this session (shared across parent + subagents). */
@@ -203,6 +208,8 @@ export interface ToolSession {
 	getGoalModeState?: () => GoalModeState | undefined;
 	/** Unattended workflow-gate emitter (present only when unattended mode is negotiated). */
 	getWorkflowGateEmitter?: () => WorkflowGateEmitter | undefined;
+	/** Optional per-session restriction for goal tool operations. */
+	goalToolAllowedOps?: readonly ("create" | "get" | "complete" | "resume" | "drop")[];
 	/** Goal runtime for the active agent session. */
 	getGoalRuntime?: () => GoalRuntime | undefined;
 	/** Bridge to the connected client (e.g. ACP editor host). Tools should route fs/terminal/permission requests through this when available. */

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -107,6 +107,28 @@ describe("executeBash", () => {
 		expect(result.output.trim()).toBe("0:hello");
 	});
 
+	it("can ignore configured shell prefixes", async () => {
+		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+			shell: Bun.env.SHELL?.includes("bash") ? Bun.env.SHELL : "/bin/bash",
+			args: ["-l", "-c"],
+			env: {
+				PATH: Bun.env.PATH ?? "",
+				HOME: Bun.env.HOME ?? tempDir,
+			},
+			prefix: "false &&",
+		});
+
+		const blocked = await executeBash("echo prefixed", { cwd: tempDir, timeout: 5000 });
+		expect(blocked.exitCode).not.toBe(0);
+
+		const ignored = await executeBash("echo unprefixed", {
+			cwd: tempDir,
+			timeout: 5000,
+			ignoreShellPrefix: true,
+		});
+		expect(ignored.output.trim()).toBe("unprefixed");
+	});
+
 	it("invokes onChunk with command output", async () => {
 		let seenChunk: string | null = null;
 		const result = await executeBash("echo hello", {
@@ -472,6 +494,36 @@ describe("executeBash", () => {
 		await executeBash("true", { cwd: tempDir, timeout: 5000, sessionKey });
 		const result = await executeBash("echo $PI_SNAPSHOT_TEST", { cwd: tempDir, timeout: 5000, sessionKey });
 		expect(result.output.trim()).toBe("from_snapshot");
+	});
+
+	it("can disable shell snapshots", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+		const bashPath = Bun.env.SHELL?.includes("bash") ? Bun.env.SHELL : "/bin/bash";
+		if (!fs.existsSync(bashPath)) {
+			return;
+		}
+		const snapshotPath = path.join(tempDir, "disabled-snapshot.sh");
+		fs.writeFileSync(snapshotPath, "export PI_DISABLED_SNAPSHOT_TEST=from_snapshot\n");
+		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+			shell: bashPath,
+			args: ["-l", "-c"],
+			env: {
+				PATH: Bun.env.PATH ?? "",
+				HOME: Bun.env.HOME ?? tempDir,
+			},
+			prefix: undefined,
+		});
+		vi.spyOn(shellSnapshot, "getOrCreateSnapshot").mockResolvedValue(snapshotPath);
+
+		const result = await executeBash("printenv PI_DISABLED_SNAPSHOT_TEST || printf unset", {
+			cwd: tempDir,
+			timeout: 5000,
+			disableShellSnapshot: true,
+			sessionKey: "disabled-snapshot-test",
+		});
+		expect(result.output.trim()).toBe("unset");
 	});
 
 	it("sources large bash functions without base64 eval wrappers", async () => {

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -111,6 +111,28 @@ describe("GoalTool", () => {
 		expect(JSON.stringify(completed.details)).not.toContain("Budget");
 	});
 
+	it("honors per-session goal operation restrictions", async () => {
+		const harness = createRuntimeHarness({
+			enabled: true,
+			mode: "active",
+			goal: createGoal({ objective: "RLM analysis" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				goalToolAllowedOps: ["get", "complete"],
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const fetched = await tool.execute("call-get", { op: "get" });
+		expect(fetched.details?.op).toBe("get");
+		await expect(tool.execute("call-drop", { op: "drop" })).rejects.toThrow(
+			"only allows goal operations: get, complete",
+		);
+		expect(harness.getState()?.goal.status).toBe("active");
+	});
+
 	it("rejects unsupported token_budget before creating or mutating", async () => {
 		const harness = createRuntimeHarness();
 		const tool = new GoalTool(

--- a/packages/coding-agent/test/rlm-autonomous.test.ts
+++ b/packages/coding-agent/test/rlm-autonomous.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the autonomous / resumable / completion-gate RLM surface (G002-G005):
+ * flag extraction, the complete_research stop+report seam, the optional
+ * successful-run gate, and resume artifact helpers.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
+import type { CustomToolContext } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
+import {
+	ensureRlmSessionDir,
+	generateRlmSessionId,
+	readRlmNotebookIfPresent,
+	resolveRlmArtifactPaths,
+	rlmSessionExists,
+} from "@gajae-code/coding-agent/rlm/artifacts";
+import {
+	countSuccessfulNotebookRuns,
+	createRlmCompleteResearchTool,
+	summarizeNotebookForReplay,
+} from "@gajae-code/coding-agent/rlm/complete-research-tool";
+import { extractRlmFlags } from "@gajae-code/coding-agent/rlm/index";
+import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
+import type { RlmCellResult } from "@gajae-code/coding-agent/rlm/types";
+
+let tmp: string;
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-auto-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+const okCell = (output: string): RlmCellResult => ({
+	output,
+	exitCode: 0,
+	cancelled: false,
+	truncated: false,
+	displayOutputs: [],
+});
+
+const errCell = (output: string): RlmCellResult => ({
+	output,
+	exitCode: 1,
+	cancelled: false,
+	truncated: false,
+	displayOutputs: [],
+});
+
+const ctx = {} as unknown as CustomToolContext;
+
+describe("extractRlmFlags", () => {
+	test("pulls --data, --resume, and --min-successful-runs out of argv", () => {
+		const parsed = extractRlmFlags([
+			"--data",
+			"DATA.md",
+			"--resume",
+			"sess-1",
+			"--min-successful-runs",
+			"3",
+			"investigate the spike",
+		]);
+		expect(parsed.dataPath).toBe("DATA.md");
+		expect(parsed.resumeSessionId).toBe("sess-1");
+		expect(parsed.minSuccessfulRuns).toBe(3);
+		expect(parsed.rest).toEqual(["investigate the spike"]);
+	});
+
+	test("supports = syntax and the -r resume alias", () => {
+		const parsed = extractRlmFlags(["--data=custom.md", "-r", "sess-2", "--min-successful-runs=0"]);
+		expect(parsed.dataPath).toBe("custom.md");
+		expect(parsed.resumeSessionId).toBe("sess-2");
+		expect(parsed.minSuccessfulRuns).toBe(0);
+		expect(parsed.rest).toEqual([]);
+	});
+
+	test("defaults are empty and the min-successful-runs flag rejects non-integers", () => {
+		const parsed = extractRlmFlags(["just a goal"]);
+		expect(parsed.dataPath).toBeUndefined();
+		expect(parsed.resumeSessionId).toBeUndefined();
+		expect(parsed.minSuccessfulRuns).toBe(0);
+		expect(parsed.rest).toEqual(["just a goal"]);
+		expect(() => extractRlmFlags(["--min-successful-runs", "two"])).toThrow(/non-negative integer/);
+		expect(() => extractRlmFlags(["--resume"])).toThrow(/requires an RLM session id/);
+	});
+});
+
+describe("notebook run accounting", () => {
+	test("counts code cells without error output as successful", async () => {
+		const writer = new RlmNotebookWriter(path.join(tmp, "notebook.ipynb"));
+		await writer.appendMarkdown("# intro");
+		await writer.appendCode("x = 1", okCell("ok\n"));
+		await writer.appendCode("boom()", errCell("NameError\n"));
+		await writer.appendCode("y = 2", okCell(""));
+		await writer.flush();
+		expect(countSuccessfulNotebookRuns(writer.document)).toBe(2);
+	});
+
+	test("summarizes prior cells and outputs for replay context", async () => {
+		const writer = new RlmNotebookWriter(path.join(tmp, "notebook.ipynb"));
+		await writer.appendCode("print('total', 800)", okCell("total 800\n"));
+		await writer.flush();
+		const summary = summarizeNotebookForReplay(writer.document);
+		expect(summary).toContain("Cell 1");
+		expect(summary).toContain("print('total', 800)");
+		expect(summary).toContain("total 800");
+	});
+});
+
+describe("complete_research stop+report seam", () => {
+	function setup(options: { minSuccessfulRuns?: number; goalStatus?: string } = {}) {
+		const paths = resolveRlmArtifactPaths(tmp, "sess-complete");
+		const notebook = new RlmNotebookWriter(paths.notebookPath);
+		const completed: string[] = [];
+		const tool = createRlmCompleteResearchTool({
+			paths,
+			notebook,
+			title: "RLM session",
+			dataPath: null,
+			minSuccessfulRuns: options.minSuccessfulRuns,
+			getGoalStatus: () => options.goalStatus,
+			markCompleted: summary => completed.push(summary),
+		});
+		return { paths, notebook, completed, tool };
+	}
+
+	test("final completion requires goal completion first", async () => {
+		const { tool } = setup({ goalStatus: "active" });
+		await expect(tool.execute("c1", { summary: "done" }, undefined, ctx, undefined)).rejects.toThrow(
+			/requires goal\(\{op:"complete"\}\) first/,
+		);
+	});
+
+	test("final completion writes the report and marks the controller complete", async () => {
+		const { paths, notebook, completed, tool } = setup({ goalStatus: "complete" });
+		await notebook.appendCode("print('hi')", okCell("hi\n"));
+		const result = await tool.execute("c1", { summary: "Found the answer." }, undefined, ctx, undefined);
+		expect(result.content[0]?.type === "text" && result.content[0].text).toContain("Final report synthesized");
+		expect(completed).toEqual(["Found the answer."]);
+		const report = await Bun.file(paths.reportPath).text();
+		expect(report).toContain("Found the answer.");
+	});
+
+	test("draft mode never completes and ignores goal/gate state", async () => {
+		const { paths, completed, tool } = setup({ goalStatus: "active", minSuccessfulRuns: 5 });
+		const result = await tool.execute("c1", { summary: "interim", final: false }, undefined, ctx, undefined);
+		expect(result.content[0]?.type === "text" && result.content[0].text).toContain("Draft report synthesized");
+		expect(completed).toEqual([]);
+		expect(await Bun.file(paths.reportPath).text()).toContain("interim");
+	});
+
+	test("min-successful-runs gate blocks final completion until satisfied", async () => {
+		const { notebook, completed, tool } = setup({ goalStatus: "complete", minSuccessfulRuns: 2 });
+		await notebook.appendCode("x = 1", okCell("ok\n"));
+		await expect(tool.execute("c1", { summary: "too early" }, undefined, ctx, undefined)).rejects.toThrow(
+			/at least 2 successful Python run/,
+		);
+		await notebook.appendCode("y = 2", okCell("ok\n"));
+		await tool.execute("c2", { summary: "now grounded" }, undefined, ctx, undefined);
+		expect(completed).toEqual(["now grounded"]);
+	});
+});
+
+describe("resume artifact helpers", () => {
+	test("rlmSessionExists reflects on-disk session dirs", async () => {
+		const sessionId = generateRlmSessionId();
+		expect(await rlmSessionExists(tmp, sessionId)).toBe(false);
+		await ensureRlmSessionDir(resolveRlmArtifactPaths(tmp, sessionId));
+		expect(await rlmSessionExists(tmp, sessionId)).toBe(true);
+	});
+
+	test("readRlmNotebookIfPresent returns the prior notebook or undefined", async () => {
+		const sessionId = generateRlmSessionId();
+		expect(await readRlmNotebookIfPresent(tmp, sessionId)).toBeUndefined();
+		const paths = resolveRlmArtifactPaths(tmp, sessionId);
+		const writer = new RlmNotebookWriter(paths.notebookPath);
+		await writer.appendCode("z = 3", okCell("z\n"));
+		await writer.flush();
+		const restored = await readRlmNotebookIfPresent(tmp, sessionId);
+		expect(restored?.cells.length).toBe(1);
+		const reread = await readNotebookDocument(paths.notebookPath, paths.notebookPath);
+		expect(reread.cells.length).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/rlm-live-model-e2e.test.ts
+++ b/packages/coding-agent/test/rlm-live-model-e2e.test.ts
@@ -4,95 +4,106 @@
  * Gated behind GJC_RLM_LIVE=1 because it makes real LLM calls (creds + network)
  * and is therefore not part of the default CI suite. When enabled, it builds a
  * real RLM session via the same SDK path the `gjc rlm` command uses (research
- * preset: distinct system prompt + hard-gated python/read/web_search toolset),
+ * preset: distinct system prompt + hard-gated python/read/web_search/read-only bash/goal toolset),
  * lets the real model drive the `python` tool over a real CSV, and asserts the
  * notebook + report capture genuine, model-computed results.
  *
  * Run: GJC_RLM_LIVE=1 [RLM_MODEL=layofflabs/gpt-5.5] bun test test/rlm-live-model-e2e.test.ts
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
+import { disposeKernelSessionsByOwner } from "@gajae-code/coding-agent/eval/py/executor";
+import {
+	ensureRlmSessionDir,
+	generateRlmSessionId,
+	resolveRlmArtifactPaths,
+} from "@gajae-code/coding-agent/rlm/artifacts";
+import { loadRlmDataContext } from "@gajae-code/coding-agent/rlm/data-context";
+import { createRlmPreset } from "@gajae-code/coding-agent/rlm/index";
+import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
+import { assertRlmToolAllowlist } from "@gajae-code/coding-agent/rlm/preset";
+import { createRlmPythonTool } from "@gajae-code/coding-agent/rlm/python-tool";
+import { synthesizeRlmReport } from "@gajae-code/coding-agent/rlm/report";
+import { type CreateAgentSessionOptions, createAgentSession } from "@gajae-code/coding-agent/sdk";
 
 const LIVE = process.env.GJC_RLM_LIVE === "1";
 const SALES_CSV = "region,amount\nnorth,100\nnorth,150\nsouth,200\nsouth,50\neast,300\n";
+
+let cwd: string;
+let sessionId: string;
+
+beforeEach(async () => {
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-live-"));
+	sessionId = generateRlmSessionId();
+});
+
+afterEach(async () => {
+	await disposeKernelSessionsByOwner(`rlm:${sessionId}`);
+	await fs.rm(cwd, { recursive: true, force: true });
+});
 
 describe("rlm live model-driven e2e", () => {
 	test.skipIf(!LIVE)(
 		"real model drives the python tool and the report captures computed totals",
 		async () => {
-			const { Settings } = await import("@gajae-code/coding-agent/config/settings");
-			const { readNotebookDocument } = await import("@gajae-code/coding-agent/edit/notebook");
-			const { disposeKernelSessionsByOwner } = await import("@gajae-code/coding-agent/eval/py/executor");
-			const { ensureRlmSessionDir, generateRlmSessionId, resolveRlmArtifactPaths } = await import(
-				"@gajae-code/coding-agent/rlm/artifacts"
-			);
-			const { loadRlmDataContext } = await import("@gajae-code/coding-agent/rlm/data-context");
-			const { RlmNotebookWriter } = await import("@gajae-code/coding-agent/rlm/notebook");
-			const { assertRlmToolAllowlist, buildRlmSystemPrompt } = await import("@gajae-code/coding-agent/rlm/preset");
-			const { createRlmPythonTool } = await import("@gajae-code/coding-agent/rlm/python-tool");
-			const { synthesizeRlmReport } = await import("@gajae-code/coding-agent/rlm/report");
-			const { createAgentSession } = await import("@gajae-code/coding-agent/sdk");
+			await Bun.write(path.join(cwd, "data.csv"), SALES_CSV);
+			await Bun.write(path.join(cwd, "DATA.md"), "data.csv has columns region, amount with 5 rows.");
 
-			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-live-"));
-			const sessionId = generateRlmSessionId();
+			const paths = resolveRlmArtifactPaths(cwd, sessionId);
+			await ensureRlmSessionDir(paths);
+			const notebook = new RlmNotebookWriter(paths.notebookPath);
+			const tool = createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
+			const dataContext = await loadRlmDataContext(cwd, undefined);
+
+			const settings = await Settings.init({ cwd });
+			const preset = createRlmPreset({ dataContext, pythonTool: tool });
+			const options: CreateAgentSessionOptions = {
+				cwd,
+				modelPattern: process.env.RLM_MODEL ?? "layofflabs/gpt-5.5",
+				settings,
+				enableLsp: false,
+				skipPythonPreflight: true,
+			};
+			preset.applyOptions(options, settings);
+			const { session } = await createAgentSession(options);
+			await preset.onSessionCreated?.(session);
+
 			try {
-				await Bun.write(path.join(cwd, "data.csv"), SALES_CSV);
-				await Bun.write(path.join(cwd, "DATA.md"), "data.csv has columns region, amount with 5 rows.");
+				// Hard tool boundary holds against the real, fully-assembled registry.
+				assertRlmToolAllowlist(session.getActiveToolNames());
+				expect(session.getActiveToolNames().sort()).toEqual([
+					"bash",
+					"goal",
+					"python",
+					"read",
+					"search_tool_bm25",
+					"web_search",
+				]);
+				expect(session.getGoalModeState()?.goal.status).toBe("active");
 
-				const paths = resolveRlmArtifactPaths(cwd, sessionId);
-				await ensureRlmSessionDir(paths);
-				const notebook = new RlmNotebookWriter(paths.notebookPath);
-				const tool = createRlmPythonTool({ cwd, sessionId, artifactsDir: paths.dir, notebook });
-				const dataContext = await loadRlmDataContext(cwd, undefined);
+				await session.prompt(
+					"Using the python tool, load data.csv and compute the total and mean of amount and the total amount per region. State the numbers, then call the goal completion tool.",
+				);
 
-				const settings = await Settings.init({ cwd });
-				settings.override("goal.enabled", false);
+				await notebook.flush();
+				const doc = await readNotebookDocument(paths.notebookPath, paths.notebookPath);
+				const codeCells = doc.cells.filter(cell => cell.cell_type === "code");
+				expect(codeCells.length).toBeGreaterThanOrEqual(1);
 
-				const { session } = await createAgentSession({
-					cwd,
-					modelPattern: process.env.RLM_MODEL ?? "layofflabs/gpt-5.5",
-					settings,
-					systemPrompt: buildRlmSystemPrompt(dataContext),
-					customTools: [tool],
-					toolNames: ["read", "web_search"],
-					requireYieldTool: false,
-					skills: [],
-					rules: [],
-					disableExtensionDiscovery: true,
-					enableLsp: false,
-					skipPythonPreflight: true,
+				const report = synthesizeRlmReport({
+					title: "Live sales analysis",
+					notebook: doc,
+					dataPath: dataContext?.path ?? null,
 				});
-
-				try {
-					// Hard tool boundary holds against the real, fully-assembled registry.
-					assertRlmToolAllowlist(session.getActiveToolNames());
-					expect(session.getActiveToolNames().sort()).toEqual(["python", "read", "web_search"]);
-
-					await session.prompt(
-						"Using the python tool, load data.csv and compute the total and mean of amount and the total amount per region. State the numbers.",
-					);
-
-					await notebook.flush();
-					const doc = await readNotebookDocument(paths.notebookPath, paths.notebookPath);
-					const codeCells = doc.cells.filter(cell => cell.cell_type === "code");
-					expect(codeCells.length).toBeGreaterThanOrEqual(1);
-
-					const report = synthesizeRlmReport({
-						title: "Live sales analysis",
-						notebook: doc,
-						dataPath: dataContext?.path ?? null,
-					});
-					await Bun.write(paths.reportPath, report);
-					// The model computed the correct total (800) from the real data.
-					expect(report).toContain("800");
-				} finally {
-					await session.dispose();
-				}
+				await Bun.write(paths.reportPath, report);
+				// The model computed the correct total (800) from the real data.
+				expect(report).toContain("800");
 			} finally {
-				await disposeKernelSessionsByOwner(`rlm:${sessionId}`);
-				await fs.rm(cwd, { recursive: true, force: true });
+				await session.dispose();
 			}
 		},
 		300_000,

--- a/packages/coding-agent/test/rlm-managed-venv.test.ts
+++ b/packages/coding-agent/test/rlm-managed-venv.test.ts
@@ -1,0 +1,66 @@
+/**
+ * G004: managed per-workspace venv resolution.
+ *
+ * Verifies BYO (VIRTUAL_ENV / .venv) precedence and, absent a BYO env, that gjc
+ * auto-creates and uses a per-workspace venv under <cwd>/.gjc/python-env, with a
+ * sys.executable assertion proving the kernel interpreter is the managed one.
+ * Uses no network: the managed env is created with `python -m venv` and seeded
+ * with an empty package set.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ensurePythonRuntime } from "@gajae-code/coding-agent/eval/py/runtime";
+
+const PYTHON = Bun.which("python3") ?? Bun.which("python");
+const NO_AMBIENT_VENV = !process.env.VIRTUAL_ENV && !process.env.CONDA_PREFIX;
+const RUN = Boolean(PYTHON) && NO_AMBIENT_VENV;
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-venv-"));
+});
+
+afterEach(async () => {
+	await fs.rm(cwd, { recursive: true, force: true });
+});
+
+const baseEnv = (): Record<string, string | undefined> => ({ PATH: process.env.PATH, HOME: process.env.HOME });
+
+async function createVenv(target: string): Promise<void> {
+	const proc = Bun.spawn([PYTHON as string, "-m", "venv", target], { stdout: "pipe", stderr: "pipe" });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`venv create failed (${code}): ${await new Response(proc.stderr).text()}`);
+}
+
+describe.skipIf(!RUN)("RLM managed per-workspace venv", () => {
+	test("auto-creates <cwd>/.gjc/python-env and the kernel interpreter is that venv", async () => {
+		const runtime = await ensurePythonRuntime(cwd, baseEnv(), { managedWorkspaceVenv: true, seedPackages: [] });
+		const managedDir = path.join(cwd, ".gjc", "python-env");
+
+		expect(runtime.venvPath).toBe(managedDir);
+		expect(runtime.pythonPath.startsWith(managedDir)).toBe(true);
+		expect(await Bun.file(runtime.pythonPath).exists()).toBe(true);
+		expect(runtime.env.VIRTUAL_ENV).toBe(managedDir);
+
+		// sys.executable/prefix assertion: the resolved interpreter is rooted in the managed venv.
+		const probe = Bun.spawnSync([runtime.pythonPath, "-c", "import sys; print(sys.prefix)"]);
+		expect(probe.exitCode).toBe(0);
+		const reportedPrefix = await fs.realpath(probe.stdout.toString().trim());
+		const realManaged = await fs.realpath(managedDir);
+		expect(reportedPrefix).toBe(realManaged);
+	}, 120_000);
+
+	test("honors a BYO .venv and does not create the managed env", async () => {
+		const byo = path.join(cwd, ".venv");
+		await createVenv(byo);
+
+		const runtime = await ensurePythonRuntime(cwd, baseEnv(), { managedWorkspaceVenv: true, seedPackages: [] });
+		expect(runtime.venvPath).toBe(byo);
+		expect(runtime.pythonPath.startsWith(byo)).toBe(true);
+		// The managed env was never provisioned because a BYO venv took precedence.
+		expect(await Bun.file(path.join(cwd, ".gjc", "python-env")).exists()).toBe(false);
+	}, 120_000);
+});

--- a/packages/coding-agent/test/rlm.test.ts
+++ b/packages/coding-agent/test/rlm.test.ts
@@ -191,20 +191,37 @@ describe("rlm data context", () => {
 
 describe("rlm preset tool boundary", () => {
 	test("allowlist membership is exact, case-insensitive, and excludes mutation tools", () => {
-		expect(RLM_TOOL_ALLOWLIST).toEqual(["python", "read", "web_search", "search_tool_bm25", "bash", "goal"]);
+		expect(RLM_TOOL_ALLOWLIST).toEqual([
+			"python",
+			"read",
+			"web_search",
+			"search_tool_bm25",
+			"bash",
+			"goal",
+			"complete_research",
+		]);
 		expect(isRlmToolAllowed("python")).toBe(true);
 		expect(isRlmToolAllowed("READ")).toBe(true);
 		expect(isRlmToolAllowed("web_search")).toBe(true);
 		expect(isRlmToolAllowed("search_tool_bm25")).toBe(true);
 		expect(isRlmToolAllowed("bash")).toBe(true);
 		expect(isRlmToolAllowed("goal")).toBe(true);
+		expect(isRlmToolAllowed("complete_research")).toBe(true);
 		expect(isRlmToolAllowed("edit")).toBe(false);
 		expect(isRlmToolAllowed("write")).toBe(false);
 	});
 
 	test("assertRlmToolAllowlist passes for the RLM surface", () => {
 		expect(() =>
-			assertRlmToolAllowlist(["python", "read", "web_search", "search_tool_bm25", "bash", "goal"]),
+			assertRlmToolAllowlist([
+				"python",
+				"read",
+				"web_search",
+				"search_tool_bm25",
+				"bash",
+				"goal",
+				"complete_research",
+			]),
 		).not.toThrow();
 	});
 

--- a/packages/coding-agent/test/rlm.test.ts
+++ b/packages/coding-agent/test/rlm.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { createEmptyNotebook, readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
+import type { CustomTool } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
 import {
 	ensureRlmSessionDir,
 	generateRlmSessionId,
@@ -10,16 +13,26 @@ import {
 	resolveRlmArtifactPaths,
 } from "@gajae-code/coding-agent/rlm/artifacts";
 import { loadRlmDataContext } from "@gajae-code/coding-agent/rlm/data-context";
+import { buildRlmGoalObjective, createRlmPreset } from "@gajae-code/coding-agent/rlm/index";
 import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
 import {
 	assertRlmToolAllowlist,
 	buildRlmSystemPrompt,
 	isRlmToolAllowed,
+	RLM_READ_ONLY_BASH_PREFIXES,
 	RLM_RESEARCH_PROMPT,
 	RLM_TOOL_ALLOWLIST,
 } from "@gajae-code/coding-agent/rlm/preset";
 import { synthesizeRlmReport } from "@gajae-code/coding-agent/rlm/report";
 import type { RlmCellResult } from "@gajae-code/coding-agent/rlm/types";
+import { type CreateAgentSessionOptions, createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import {
+	checkBashAllowedPrefixes,
+	normalizeReadOnlyBashCommand,
+} from "@gajae-code/coding-agent/tools/bash-allowed-prefixes";
+import * as z from "zod/v4";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 let tmp: string;
 
@@ -177,23 +190,227 @@ describe("rlm data context", () => {
 });
 
 describe("rlm preset tool boundary", () => {
-	test("allowlist membership is case-insensitive and excludes dangerous tools", () => {
+	test("allowlist membership is exact, case-insensitive, and excludes mutation tools", () => {
+		expect(RLM_TOOL_ALLOWLIST).toEqual(["python", "read", "web_search", "search_tool_bm25", "bash", "goal"]);
 		expect(isRlmToolAllowed("python")).toBe(true);
 		expect(isRlmToolAllowed("READ")).toBe(true);
 		expect(isRlmToolAllowed("web_search")).toBe(true);
-		expect(isRlmToolAllowed("bash")).toBe(false);
+		expect(isRlmToolAllowed("search_tool_bm25")).toBe(true);
+		expect(isRlmToolAllowed("bash")).toBe(true);
+		expect(isRlmToolAllowed("goal")).toBe(true);
 		expect(isRlmToolAllowed("edit")).toBe(false);
-		expect(isRlmToolAllowed("goal")).toBe(false);
-		expect(RLM_TOOL_ALLOWLIST).not.toContain("bash");
+		expect(isRlmToolAllowed("write")).toBe(false);
 	});
 
-	test("assertRlmToolAllowlist passes for allowed sets", () => {
-		expect(() => assertRlmToolAllowlist(["python", "read", "web_search"])).not.toThrow();
+	test("assertRlmToolAllowlist passes for the RLM surface", () => {
+		expect(() =>
+			assertRlmToolAllowlist(["python", "read", "web_search", "search_tool_bm25", "bash", "goal"]),
+		).not.toThrow();
 	});
 
-	test("assertRlmToolAllowlist throws naming the leaked tools", () => {
-		expect(() => assertRlmToolAllowlist(["python", "bash", "edit"])).toThrow(/bash/);
-		expect(() => assertRlmToolAllowlist(["goal"])).toThrow(/goal/);
+	test("assertRlmToolAllowlist throws naming leaked mutation tools", () => {
+		expect(() => assertRlmToolAllowlist(["python", "bash", "edit"])).toThrow(/edit/);
+		expect(() => assertRlmToolAllowlist(["write"])).toThrow(/write/);
+	});
+
+	test("RLM preset wires read-only bash and required goal mode into session options", async () => {
+		const pythonTool = {
+			name: "python",
+			label: "Python",
+			description: "Execute Python",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+		} satisfies CustomTool;
+		const dataContext = { path: "/tmp/DATA.md", content: "schema: x" };
+		const preset = createRlmPreset({ dataContext, pythonTool, objective: "Analyze the schema" });
+		const options: CreateAgentSessionOptions = {
+			customTools: [{ ...pythonTool, name: "bash" }],
+			extensions: [(() => undefined) as never],
+		};
+		const settings = Settings.isolated({ "goal.enabled": false, "recipe.enabled": true });
+
+		preset.applyOptions(options, settings);
+
+		expect(options.toolNames).toEqual(["read", "web_search", "search_tool_bm25", "bash", "goal"]);
+		expect(options.customTools).toEqual([pythonTool]);
+		expect(options.skills).toEqual([]);
+		expect(options.extensions).toEqual([]);
+		expect(options.additionalExtensionPaths).toEqual([]);
+		expect(options.preloadedExtensions).toBeUndefined();
+		expect(options.rules).toEqual([]);
+		expect(options.disableExtensionDiscovery).toBe(true);
+		expect(options.bashAllowedPrefixes).toEqual([...RLM_READ_ONLY_BASH_PREFIXES]);
+		expect(options.bashRestrictionProfile).toBe("read-only");
+		expect(options.goalToolAllowedOps).toEqual(["get", "complete"]);
+		expect(options.discoverableToolAllowedNames).toEqual([]);
+		expect(settings.get("goal.enabled")).toBe(true);
+		expect(settings.get("goal.continuationModes")).toEqual(["interactive"]);
+		expect(settings.get("tools.discoveryMode")).toBe("all");
+		expect(settings.get("recipe.enabled")).toBe(false);
+		if (typeof options.systemPrompt !== "function")
+			throw new Error("RLM preset must install a system prompt builder");
+		expect(options.systemPrompt(["base"]).join("\n")).toContain("schema: x");
+
+		let activeToolNames = ["python", "read", "web_search", "search_tool_bm25", "bash"];
+		let createdObjective: string | undefined;
+		let goalState: unknown;
+		await preset.onSessionCreated?.({
+			getActiveToolNames: () => activeToolNames,
+			setActiveToolsByName: async (toolNames: string[]) => {
+				activeToolNames = toolNames;
+			},
+			getGoalModeState: () => goalState,
+			goalRuntime: {
+				createGoal: async ({ objective }: { objective: string }) => {
+					createdObjective = objective;
+					goalState = {
+						enabled: true,
+						mode: "active",
+						goal: {
+							id: "goal-1",
+							objective,
+							status: "active",
+							tokensUsed: 0,
+							timeUsedSeconds: 0,
+							createdAt: 0,
+							updatedAt: 0,
+						},
+					};
+					return goalState;
+				},
+				resumeGoal: async () => goalState,
+			},
+		} as never);
+		expect(createdObjective).toBe("Analyze the schema");
+		expect(activeToolNames).toEqual(["python", "read", "web_search", "search_tool_bm25", "bash", "goal"]);
+
+		await expect(
+			preset.onSessionCreated?.({
+				getActiveToolNames: () => ["python", "read", "bash", "goal", "edit"],
+				setActiveToolsByName: async () => {},
+				getGoalModeState: () => goalState,
+				goalRuntime: { createGoal: async () => goalState, resumeGoal: async () => goalState },
+			} as never),
+		).rejects.toThrow(/edit/);
+	});
+
+	test("RLM goal objective is derived from the user prompt before data fallback", () => {
+		expect(
+			buildRlmGoalObjective({
+				messages: ["", "Analyze DATA.md", "Find outliers"],
+				dataContext: { path: "/tmp/DATA.md", content: "schema" },
+			}),
+		).toBe("Analyze DATA.md\n\nFind outliers");
+		expect(
+			buildRlmGoalObjective({ messages: [], dataContext: { path: "/tmp/DATA.md", content: "schema" } }),
+		).toContain("/tmp/DATA.md");
+		expect(buildRlmGoalObjective({ messages: [], dataContext: null })).toContain("RLM research session");
+	});
+
+	test("RLM sessions start with an active goal and cannot stop cleanly before goal completion", async () => {
+		const pythonTool = {
+			name: "python",
+			label: "Python",
+			description: "Execute Python",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+		} satisfies CustomTool;
+		const settings = Settings.isolated({ "goal.enabled": false, "recipe.enabled": true, "todo.reminders": false });
+		const preset = createRlmPreset({ dataContext: null, pythonTool, objective: "Compute the RLM result" });
+		const options: CreateAgentSessionOptions = {
+			cwd: tmp,
+			agentDir: tmp,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		};
+		preset.applyOptions(options, settings);
+		const { session } = await createAgentSession(options);
+		try {
+			await preset.onSessionCreated?.(session);
+			expect(session.getGoalModeState()?.goal).toMatchObject({
+				objective: "Compute the RLM result",
+				status: "active",
+			});
+			expect(session.getActiveToolNames().sort()).toEqual([
+				"bash",
+				"goal",
+				"python",
+				"read",
+				"search_tool_bm25",
+				"web_search",
+			]);
+
+			const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+			const assistantMessage = { ...createAssistantMessage("Done without the goal tool."), timestamp: 101 };
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			for (let i = 0; i < 20; i++) await Promise.resolve();
+			await session.waitForIdle();
+			expect(continueSpy).toHaveBeenCalledTimes(1);
+			expect(
+				session.agent.state.messages.some(
+					message =>
+						message.role === "developer" && JSON.stringify(message.content).includes("active and uncleared"),
+				),
+			).toBe(true);
+
+			const goalTool = session.getToolByName("goal");
+			if (!goalTool) throw new Error("RLM session must register the goal tool");
+			await expect(goalTool.execute("call-drop", { op: "drop" } as never)).rejects.toThrow(
+				"only allows goal operations: get, complete",
+			);
+			await goalTool.execute("call-complete", { op: "complete" } as never);
+			expect(session.getGoalModeState()?.goal.status).toBe("complete");
+
+			const completedMessage = { ...createAssistantMessage("Done after the goal tool."), timestamp: 102 };
+			session.agent.emitExternalEvent({ type: "message_end", message: completedMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [completedMessage] });
+			for (let i = 0; i < 20; i++) await Promise.resolve();
+			await session.waitForIdle();
+			expect(continueSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("RLM read-only bash allows simple inspections and blocks unsafe shell shapes", () => {
+		expect(
+			checkBashAllowedPrefixes("rg sales DATA.md", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" }),
+		).toEqual({
+			allowed: true,
+		});
+		expect(checkBashAllowedPrefixes("ls -la .gjc", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" })).toEqual({
+			allowed: true,
+		});
+		expect(
+			checkBashAllowedPrefixes("rg foo | head", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" }).allowed,
+		).toBe(false);
+		expect(
+			checkBashAllowedPrefixes("rg --pre ./script foo", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" })
+				.allowed,
+		).toBe(false);
+		expect(
+			checkBashAllowedPrefixes("tree -o out.txt", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" }).allowed,
+		).toBe(false);
+		expect(
+			checkBashAllowedPrefixes("cat DATA.md", RLM_READ_ONLY_BASH_PREFIXES, { profile: "read-only" }).allowed,
+		).toBe(false);
+	});
+
+	test("RLM read-only bash normalizes through absolute binaries and quoted args", () => {
+		const normalized = normalizeReadOnlyBashCommand("ls 'dir name'");
+		expect(normalized).toContain("/ls'");
+		expect(normalized).toContain("'dir name'");
+		expect(normalizeReadOnlyBashCommand("rg foo | head")).toBeUndefined();
 	});
 
 	test("system prompt builder appends the research prompt and data context", () => {

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolContext } from "@gajae-code/agent-core";
 import { validateToolArguments } from "@gajae-code/ai/utils/validation";
+import { Settings } from "../../src/config/settings";
 import type { BashInterceptorRule } from "../../src/config/settings-schema";
+import { disposeAllShellSessions, getShellSessionCount } from "../../src/exec/bash-executor";
 import type { ToolSession } from "../../src/tools";
 import { BashTool, type BashToolInput } from "../../src/tools/bash";
+import * as shellSnapshot from "../../src/utils/shell-snapshot";
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await disposeAllShellSessions();
+});
 
 function createBashTool(rules: BashInterceptorRule[]): BashTool {
 	const session = {
@@ -126,12 +134,14 @@ describe("BashTool restricted role-agent allowlist", () => {
 	function createRestrictedBashTool(
 		cwd = process.cwd(),
 		bashAllowedPrefixes = ["gjc ralplan --write", "gjc state"],
+		bashRestrictionProfile?: ToolSession["bashRestrictionProfile"],
 	): BashTool {
 		const session = {
 			cwd,
 			getSessionFile: () => null,
 			getSessionId: () => undefined,
 			bashAllowedPrefixes,
+			bashRestrictionProfile,
 			settings: {
 				get(key: string) {
 					if (key === "bashInterceptor.enabled") return false;
@@ -163,6 +173,73 @@ describe("BashTool restricted role-agent allowlist", () => {
 		await expect(tool.execute("tool-call", { command: "echo should-not-run" })).rejects.toThrow(
 			"restricted role-agent bash only allows commands starting with",
 		);
+	});
+
+	it("surfaces read-only bash restrictions in the tool description", () => {
+		const tool = createRestrictedBashTool(process.cwd(), ["grep", "rg", "tree", "ls"], "read-only");
+
+		expect(tool.description).toContain("This session's bash tool is read-only");
+		expect(tool.description).toContain("grep");
+		expect(tool.description).toContain("ls");
+	});
+
+	it("allows read-only commands and still blocks env overrides or non-inspection commands", async () => {
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-read-only-bash-"));
+		try {
+			await fs.writeFile(path.join(root, "sample.txt"), "hello\n");
+			const tool = createRestrictedBashTool(root, ["ls", "grep"], "read-only");
+
+			const result = await tool.execute("tool-call", { command: "ls" });
+			expect(result.content.find(part => part.type === "text")?.text).toContain("sample.txt");
+
+			await expect(tool.execute("tool-call", { command: "touch nope" })).rejects.toThrow(
+				"read-only bash only allows commands starting with",
+			);
+			await expect(tool.execute("tool-call", { command: "ls", env: { PATH: "/tmp/fake" } })).rejects.toThrow(
+				"Read-only bash does not allow per-command env overrides",
+			);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runs read-only bash without PTY, configured prefixes, shell snapshots, or retained sessions", async () => {
+		if (process.platform === "win32") return;
+		const bashPath = Bun.env.SHELL?.includes("bash") ? Bun.env.SHELL : "/bin/bash";
+		try {
+			await fs.access(bashPath);
+		} catch {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-read-only-bash-hardening-"));
+		try {
+			await disposeAllShellSessions();
+			await fs.writeFile(path.join(root, "sample.txt"), "hello\n");
+			const snapshotPath = path.join(root, "snapshot.sh");
+			await fs.writeFile(snapshotPath, "export PI_READ_ONLY_SNAPSHOT=from_snapshot\n");
+			vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+				shell: bashPath,
+				args: ["-l", "-c"],
+				env: {
+					PATH: Bun.env.PATH ?? "",
+					HOME: root,
+				},
+				prefix: "false &&",
+			});
+			const snapshotSpy = vi.spyOn(shellSnapshot, "getOrCreateSnapshot").mockResolvedValue(snapshotPath);
+			const tool = createRestrictedBashTool(root, ["ls"], "read-only");
+
+			await expect(tool.execute("tool-call", { command: "ls", pty: true })).rejects.toThrow(
+				"Read-only bash does not allow PTY mode",
+			);
+
+			const result = await tool.execute("tool-call", { command: "ls" });
+			expect(result.content.find(part => part.type === "text")?.text).toContain("sample.txt");
+			expect(snapshotSpy).not.toHaveBeenCalled();
+			expect(getShellSessionCount()).toBe(0);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 
 	it("blocks ralplan invocations that are not artifact writes", async () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -287,26 +287,25 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		expect(testTask?.command).toEqual(["bun", "test", "packages/coding-agent/test/edit/foo.test.ts"]);
 	});
 
-	test("the live RLM e2e test stays a non-native single-file shard", () => {
+	test("the live RLM e2e test gets native artifacts for skipped import-time setup", () => {
 		const tasks = targeted(["packages/coding-agent/test/rlm-live-model-e2e.test.ts"]);
 		const keys = tasks.map(task => task.key);
 		expect(keys).toContain("test:packages/coding-agent/test/rlm-live-model-e2e.test.ts");
-		expect(keys).not.toContain("native-linux-x64");
-		expect(keys).not.toContain("native-build");
+		expect(keys.filter(key => key === "native-linux-x64" || key === "native-build")).toEqual(["native-linux-x64"]);
 		expect(keys).not.toContain("test:@gajae-code/coding-agent");
 		expect(keys).not.toContain("check:@gajae-code/coding-agent");
 
 		const entries = describeTasks(tasks);
-		expect(entries).toEqual([
-			{
-				key: "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts",
-				description: "Test packages/coding-agent/test/rlm-live-model-e2e.test.ts",
-				command: ["bun", "test", "packages/coding-agent/test/rlm-live-model-e2e.test.ts"],
-				native: false,
-				rust: false,
-				nativeBuild: false,
-			},
-		]);
+		const liveShard = entries.find(entry => entry.key === "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts");
+		expect(liveShard).toEqual({
+			key: "test:packages/coding-agent/test/rlm-live-model-e2e.test.ts",
+			description: "Test packages/coding-agent/test/rlm-live-model-e2e.test.ts",
+			command: ["bun", "test", "packages/coding-agent/test/rlm-live-model-e2e.test.ts"],
+			native: true,
+			rust: false,
+			nativeBuild: false,
+		});
+		expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
 	});
 
 	test("a source file with a directly-named test maps to exactly that test", () => {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -13,8 +13,6 @@ const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "
 // Declared here (before the top-level `await main()`) so it is initialized for
 // every CLI mode despite top-level await halting later module statements.
 const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-linux-x64"]);
-const NON_NATIVE_TEST_KEYS: ReadonlySet<string> = new Set(["test:packages/coding-agent/test/rlm-live-model-e2e.test.ts"]);
-
 export interface PackageManifest {
 	name?: string;
 	scripts?: Record<string, string>;
@@ -172,13 +170,7 @@ function isNativeBuildKey(key: string): boolean {
 // prebuilt `.node` present in `packages/natives/native/`. By construction (see
 // planTasks) every such task only appears in a plan that also includes a native
 // build task, so the shard can always download the artifact built once upstream.
-// The live RLM E2E is opt-in and must remain default-CI safe when skipped, so it
-// is classified as non-native while ordinary coding-agent test shards stay
-// conservatively native.
 function taskNeedsNative(key: string): boolean {
-	if (NON_NATIVE_TEST_KEYS.has(key)) {
-		return false;
-	}
 	return (
 		key === "root-test" ||
 		key === "cli-smoke" ||

--- a/scripts/verify-g002-gates.ts
+++ b/scripts/verify-g002-gates.ts
@@ -19,6 +19,7 @@ const ALLOWED_PUBLIC_PACKAGE_VERSIONS = new Map<string, string>();
 const ALLOWED_PRIVATE_PACKAGE_VERSIONS = new Map<string, string>([
 	["@gajae-code/orchestration-token-benchmark", "0.0.1"],
 	["@gajae-code/typescript-edit-benchmark", "0.0.1"],
+	["@gajae-code/telegram-remote", "0.0.1"],
 ]);
 const ALLOWED_UNSCOPED_PACKAGE_NAMES = new Set<string>(["gajae-code"]);
 const ALLOWED_PACKAGE_BINARIES = new Map<string, readonly string[]>([
@@ -26,6 +27,7 @@ const ALLOWED_PACKAGE_BINARIES = new Map<string, readonly string[]>([
 	["@gajae-code/coding-agent", ["gjc"]],
 	["gajae-code", ["gjc"]],
 	["@gajae-code/stats", ["gjc-stats"]],
+	["@gajae-code/telegram-remote", ["gjc-telegram-remote"]],
 	["@gajae-code/typescript-edit-benchmark", ["typescript-edit-benchmark"]],
 ]);
 const PUBLIC_DOC_FILES = ["README.md", "packages/coding-agent/README.md"] as const;


### PR DESCRIPTION
## Summary

Completes the deferred `gjc rlm` research-mode stories (G002–G005) on top of the merged interactive v1 (#778) and the read-only-bash goal-mode follow-up, all built over the existing GJC agent/session loop, the persistent Python kernel (`eval/py/kernel.ts`), and `.ipynb` handling (`edit/notebook.ts`). No bespoke loop, no second Python exec path.

- **G002 — Autonomous goal-arg mode**: `gjc rlm "<goal>"` runs to completion through the existing print-mode loop. A first-class `complete_research` tool synthesizes the report and pauses the loop via `CreateAgentSessionOptions.shouldPause`; `main` gains `suppressProcessExit` so RLM finalizes (report + metadata + kernel disposal) after the loop returns. `complete_research` finalization requires `goal({op:"complete"})` first.
- **G003 — Resumable sessions**: `gjc rlm --resume <session>` (`-r`) reopens `.gjc/rlm/<session>`, validates the session id, reuses a fresh kernel, and injects the prior notebook as replayable context (no live kernel-memory restore). Underlying conversation persists under `.gjc/rlm/<session>/agent-session`.
- **G004 — Managed per-workspace venv**: `ensurePythonRuntime` honors BYO precedence (`VIRTUAL_ENV` / `.venv` / conda) and otherwise provisions `<cwd>/.gjc/python-env` seeded with numpy/pandas/matplotlib/polars, threaded through `checkPythonKernelAvailability` / `PythonKernel.start` / `executePython`. Managed provisioning is opt-in (RLM python tool only); default Python execution is unchanged. On-demand installs use the kernel's existing `%pip` magic (recorded as notebook provenance).
- **G005 — Optional completion gate**: configurable `--min-successful-runs N` enforced in `complete_research`, off by default (0), layered with goal-mode/max-steps.

The RLM tool boundary stays hard-gated: allowlist adds only `complete_research` (notebook/report write); no edit/write/mutation tools.

## Tests
- New: `test/rlm-autonomous.test.ts` (flag extraction, `complete_research` final/draft + goal-status + min-run gate, resume helpers), `test/rlm-managed-venv.test.ts` (BYO precedence + managed-venv `sys.prefix` assertion).
- Updated: `test/rlm.test.ts` (allowlist now includes `complete_research`).
- Focused RLM suite: 106 pass / 1 skip (live-model e2e gated). Package check (biome + tsgo) clean. Default-surface gates pass. Python eval + agent-loop regression suites pass. Existing computer red-team fixtures still pass (7/7).

## Notes
- Adds an optional `concurrency` field to `CustomTool` / `ToolDefinition` (backward compatible; undefined → shared) so `python` and `complete_research` run exclusively.
- `scripts/verify-g002-gates.ts` allowlists the existing private `@gajae-code/telegram-remote` package (present on `dev`) so the default-surface gate passes.

Targets `dev`.
