### PR TITLE
Cover Cursor Composer version-style model ids

### DIFF
--- a/packages/ai/src/providers/composer-discipline.ts
+++ b/packages/ai/src/providers/composer-discipline.ts
@@ -23,8 +23,8 @@
  * system prompt on openai-completions, openai-responses, and cursor RPC paths.
  */
 
-/** Matches composer-harness model ids on any provider (xai grok-composer-*, cursor composer-*). */
-const COMPOSER_MODEL_ID_PATTERN = /(?:^|[/:._-])(?:grok-)?composer(?:[/:._-]|$)/i;
+/** Matches composer-harness model ids on any provider (xai grok-composer-*, cursor composer-* / composer2.*). */
+const COMPOSER_MODEL_ID_PATTERN = /(?:^|[/:._-])(?:grok-)?composer(?:[/:._-]|(?=\d)|$)/i;
 
 export function isComposerHarnessModel(modelId: string): boolean {
 	return COMPOSER_MODEL_ID_PATTERN.test(modelId);

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -95,6 +95,8 @@ describe("isComposerHarnessModel", () => {
 	it("matches composer ids on any provider, rejects others", () => {
 		expect(isComposerHarnessModel("grok-composer-2.5-fast")).toBe(true);
 		expect(isComposerHarnessModel("composer-1")).toBe(true);
+		expect(isComposerHarnessModel("composer2.5-fast")).toBe(true);
+		expect(isComposerHarnessModel("cursor/composer2.5-fast")).toBe(true);
 		expect(isComposerHarnessModel("Grok-Composer-Next")).toBe(true);
 		expect(isComposerHarnessModel("grok-4.3")).toBe(false);
 		expect(isComposerHarnessModel("gpt-5")).toBe(false);
@@ -102,6 +104,7 @@ describe("isComposerHarnessModel", () => {
 		expect(isComposerHarnessModel("composerish")).toBe(false);
 		expect(isComposerHarnessModel("decomposer-2.5")).toBe(false);
 		expect(isComposerHarnessModel("mycomposer-2.5-fast")).toBe(false);
+		expect(isComposerHarnessModel("mycomposer2.5-fast")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Extend Composer harness detection to cover Cursor-style version ids like `composer2.5-fast` and `cursor/composer2.5-fast`
- Keep false-positive guards for `decomposer`, `composerish`, and prefixed names like `mycomposer2.5-fast`

## Verification
- `mise x bun@1.3.14 -- bun test packages/ai/test/composer-discipline.test.ts`
- `mise x bun@1.3.14 -- bun --cwd=packages/ai run check:types`