### PR TITLE
Fix /copy quarantine Dev CI failure

### DIFF
--- a/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
+++ b/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
@@ -35,7 +35,6 @@ describe("GJC utility extensibility quarantine", () => {
 			"plan",
 			"share",
 			"browser",
-			"copy",
 			"todo",
 			"changelog",
 			"branch",


### PR DESCRIPTION
## Summary
- Update the utility extensibility quarantine test to allow the intentional builtin TUI /copy command from PR #818.
- Keep the implementation and registry metadata unchanged.

## Verification
- bun test packages/coding-agent/test/utility-extensibility-quarantine.test.ts -t "deletes approved non-critical slash command implementations"
- bun test packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/modes/controllers/copy-command.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/utility-extensibility-quarantine.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*