### PR TITLE
fix(rlm): finalize autonomous runs on print-mode error + classify piped stdin (follow-up to #816)

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1058,6 +1058,7 @@ export async function runRootCommand(
 				messages: parsedArgs.messages,
 				initialMessage,
 				initialImages,
+				suppressProcessExit: deps.suppressProcessExit,
 			});
 			if ($env.PI_TIMING) {
 				logger.printTimings();

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -23,6 +23,12 @@ export interface PrintModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
+	/**
+	 * When true, an assistant error/abort does not call process.exit(); print mode
+	 * returns instead so the caller (e.g. RLM autonomous mode) can run its own
+	 * finalization/cleanup before the process exits.
+	 */
+	suppressProcessExit?: boolean;
 }
 
 /**
@@ -84,10 +90,14 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			) {
 				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
 				const flushed = process.stderr.write(`${errorLine}\n`);
-				if (flushed) {
-					process.exit(1);
-				} else {
-					process.stderr.once("drain", () => process.exit(1));
+				// When the caller owns finalization (RLM autonomous), return instead of
+				// exiting so its cleanup runs; the caller surfaces a non-zero exit itself.
+				if (!options.suppressProcessExit) {
+					if (flushed) {
+						process.exit(1);
+					} else {
+						process.stderr.once("drain", () => process.exit(1));
+					}
 				}
 			}
 

--- a/packages/coding-agent/src/prompts/system/rlm-report-command.md
+++ b/packages/coding-agent/src/prompts/system/rlm-report-command.md
@@ -1,0 +1,1 @@
+Call complete_research with final=false and a concise summary of the current notebook-backed findings. Do not mark the goal complete unless the full research objective is satisfied.

--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -12,6 +12,7 @@ import { parseArgs } from "../cli/args";
 import { disposeKernelSessionsByOwner } from "../eval/py/executor";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { type RlmPreset, runRootCommand } from "../main";
+import rlmReportCommandPrompt from "../prompts/system/rlm-report-command.md" with { type: "text" };
 import type { CreateAgentSessionOptions } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import {
@@ -138,8 +139,7 @@ export function createRlmPreset({
 				{
 					name: "report",
 					description: "Synthesize a draft RLM report from the current notebook",
-					content:
-						"Call complete_research with final=false and a concise summary of the current notebook-backed findings. Do not mark the goal complete unless the full research objective is satisfied.",
+					content: rlmReportCommandPrompt,
 					source: "rlm",
 				},
 			];
@@ -265,7 +265,10 @@ export async function runRlmCommand(argv: string[]): Promise<void> {
 	if (resumeSessionId) {
 		parsed.continue = true;
 	}
-	const autonomous = parsed.print === true || parsed.mode !== undefined || parsed.messages.length > 0;
+	// Piped stdin (non-TTY) feeds an autonomous research prompt the same way an
+	// argv goal does, so it must get the shouldPause stop seam + completion gate.
+	const pipedStdin = process.stdin.isTTY === false;
+	const autonomous = parsed.print === true || parsed.mode !== undefined || parsed.messages.length > 0 || pipedStdin;
 	if (autonomous && parsed.mode === undefined) {
 		parsed.print = true;
 	}


### PR DESCRIPTION
## Summary

Follow-up to #816 (G002-G005 RLM autonomous mode), which was squash-merged from an earlier commit before the architect-review fixes landed. This PR brings those fixes into `dev`.

Without these, autonomous RLM (`gjc rlm "<goal>"`) has two defects:

- **Blocker — print-mode error bypasses RLM finalization**: `runPrintMode` called `process.exit(1)` on an assistant error/abort before returning, so an errored autonomous run skipped `runRlmCommand`'s `finally` (kernel disposal via `disposeKernelSessionsByOwner("rlm:<sessionId>")`, report, and metadata writes). Print mode now honors a `suppressProcessExit` option and returns to the caller for cleanup; the caller surfaces the non-zero exit itself.
- **Major — piped stdin not treated as autonomous**: `echo "<goal>" | gjc rlm` auto-enables print mode in `runRootCommand` but `runRlmCommand` did not classify it as autonomous, so it lacked the `shouldPause` stop seam and `complete_research` finalization enforcement. Piped (non-TTY) stdin is now classified autonomous.
- **Nit — static /report prompt**: the `/report` slash command content moved from an inline string into `src/prompts/system/rlm-report-command.md`, imported with `{ type: "text" }`, per the brief constraint that prompts live in static `.md`.

## Tests
- Type check (tsgo) clean; package check (biome) clean.
- Focused RLM suite (`rlm.test.ts`, `rlm-autonomous.test.ts`, `rlm-e2e.test.ts`) passes on the merged-`dev` base (33 pass).

Architect QA (re-verification) confirmed these three findings resolved: CLEAR / APPROVE / passed. Targets `dev`.
