### PR TITLE
Wire model selector thinking into session calls

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5812,9 +5812,9 @@ export class AgentSession {
 		);
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 
-		// Re-apply thinking for the newly selected model. Prefer the model's
-		// configured defaultLevel; otherwise preserve the current level.
-		this.setThinkingLevel(model.thinking?.defaultLevel ?? this.thinkingLevel);
+		// Apply the explicitly selected thinking level when the selector supplies one;
+		// otherwise prefer the model's configured defaultLevel, then preserve the current level.
+		this.setThinkingLevel(options?.thinkingLevel ?? model.thinking?.defaultLevel ?? this.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
 	}
 

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -174,6 +174,28 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(sessionSettings.getModelRole("default")).toBe(`${slowModel.provider}/${slowModel.id}:off`);
 	});
 
+	it("applies selected default role thinking to agent invocation state", async () => {
+		const initialModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const selectedModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: initialModel.id,
+			initialThinkingLevel: Effort.Low,
+			modelRoles: {
+				default: `${initialModel.provider}/${initialModel.id}:low`,
+			},
+		});
+
+		await session.setModel(selectedModel, "default", {
+			selector: `${selectedModel.provider}/${selectedModel.id}`,
+			thinkingLevel: Effort.High,
+		});
+
+		expect(session.thinkingLevel).toBe(Effort.High);
+		expect(sessionSettings.getModelRole("default")).toBe(`${selectedModel.provider}/${selectedModel.id}:high`);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.High);
+	});
+
 	it("clamps unsupported selections from model metadata", async () => {
 		const model = getAnthropicModelOrThrow("claude-sonnet-4-6");
 		const agent = new Agent({


### PR DESCRIPTION
## Summary
- Pass the model selector's explicit default-role thinking choice through `AgentSession.setModel()` into the active session thinking state.
- Keep existing fallback behavior for model metadata defaults and current thinking when no selector value is supplied.
- Add focused coverage proving selected default thinking reaches the agent invocation state (`agent.state.thinkingLevel`).

## Verification
- `bun install`
- `bun run build:native`
- `bun test packages/coding-agent/test/agent-session-role-thinking.test.ts` → 7 pass, 0 fail
- `bun run check:ts` → PASS; existing Biome warnings/infos only (`packages/tui/test/viewport-virtualization-redteam.test.ts`, `packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`, Biome config notices)

Terminal verdict: PASS

[repo owner's gaebal-gajae (clawdbot) 🦞]