### PR TITLE
Show current version in TUI status line

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -44,6 +44,10 @@ export interface StatusLineSettings {
 	sessionAccent?: boolean;
 }
 
+export interface StatusLineComponentOptions {
+	version?: string;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Per-message token cache
 // ═══════════════════════════════════════════════════════════════════════════
@@ -161,6 +165,7 @@ export class StatusLineComponent implements Component {
 	#skillHudEntries: SkillActiveEntry[] = [];
 	#skillHudLastFetch = 0;
 	#skillHudInFlight = false;
+	#version: string | undefined;
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
@@ -197,7 +202,10 @@ export class StatusLineComponent implements Component {
 	#nonMessageTokensCache: number | undefined;
 	#nonMessageInputsKey: string | undefined;
 
-	constructor(private readonly session: AgentSession) {
+	constructor(
+		private readonly session: AgentSession,
+		options: StatusLineComponentOptions = {},
+	) {
 		this.#settings = {
 			preset: settings.get("statusLine.preset"),
 			leftSegments: settings.get("statusLine.leftSegments"),
@@ -208,6 +216,7 @@ export class StatusLineComponent implements Component {
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 		};
+		this.#version = options.version?.trim() || undefined;
 	}
 
 	updateSettings(settings: StatusLineSettings): void {
@@ -700,6 +709,9 @@ export class StatusLineComponent implements Component {
 			const icon = theme.icon.agents ? `${theme.icon.agents} ` : "";
 			const label = `${formatCount("job", runningBackgroundJobs)} running`;
 			rightParts.push(theme.fg("statusLineSubagents", `${icon}${label}`));
+		}
+		if (this.#version) {
+			rightParts.push(theme.fg("dim", `v${this.#version}`));
 		}
 		const topFillWidth = Math.max(0, width);
 		const left = [...leftParts];

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -406,7 +406,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.hookWidgetContainerBelow = new Container();
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor);
-		this.statusLine = new StatusLineComponent(session);
+		this.statusLine = new StatusLineComponent(session, { version: this.#version });
 		this.statusLine.setAutoCompactEnabled(session.autoCompactionEnabled);
 
 		this.hideThinkingBlock = settings.get("hideThinkingBlock");

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -76,6 +76,7 @@ function createStatusLineSession(sessionName: string) {
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		getCurrentModel: () => undefined,
 		isFastModeEnabled: () => false,
+		isFastModeActive: () => false,
 		sessionManager: {
 			getSessionName: () => sessionName,
 			getUsageStatistics: () => ({
@@ -120,6 +121,35 @@ describe("status line session accent", () => {
 		// glyph) must not appear. The session_name segment may still emit the accent ANSI
 		// for its own text — we only care that the gap is not accent-painted.
 		expect(border).not.toContain(`${accentAnsi}${theme.boxRound.horizontal}`);
+	});
+});
+
+describe("status line version display", () => {
+	function buildComponent(widthVersion: string = "9.8.7") {
+		const component = new StatusLineComponent(createStatusLineSession("Version session"), { version: widthVersion });
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["gajae"],
+			rightSegments: ["model"],
+			separator: "powerline-thin",
+			showSkillHud: false,
+		});
+		return component;
+	}
+
+	it("shows the current version in the active status line", () => {
+		const lines = buildComponent().render(100);
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("v9.8.7");
+	});
+
+	it("drops the low-priority version before overflowing narrow terminals", () => {
+		const lines = buildComponent().render(12);
+
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(12);
+		expect(lines[0]).not.toContain("v9.8.7");
 	});
 });
 


### PR DESCRIPTION
## Summary
- display the current GJC version in the active TUI status line
- plumb the existing runtime version into StatusLineComponent
- keep the version low-priority so it drops before overflowing narrow terminals

Fixes #823

## Verification
- `cd packages/coding-agent && bun test test/status-line-overflow.test.ts`
- `cd packages/coding-agent && bun run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*