### PR TITLE
Expose retained output tails for background jobs

### DIFF
--- a/packages/coding-agent/src/prompts/tools/job.md
+++ b/packages/coding-agent/src/prompts/tools/job.md
@@ -1,11 +1,17 @@
 Inspects, waits, or cancels async jobs.
 
-Background job results are delivered automatically when complete. Reach for this tool only when you need to intervene.
+Background job results are delivered automatically when complete. Running job output stays quiet by default to avoid flooding the conversation; use `tail` when you explicitly want to show/reopen retained output. Reach for this tool only when you need to inspect or intervene.
 
 # Operations
 
 ## `list: true`
 Use to inspect what's running.
+
+## `tail: [id, …]`
+Show the retained output buffer for one or more background jobs without waiting.
+- Use this to reopen/tail a backgrounded long-running bash/tool output after folding it away.
+- Output is bounded by the manager retention window; stale cursors may report that only the retained tail is available.
+- Prefer `tail` over polling when you only need to peek at progress, so the conversation can continue without flooding the TUI.
 
 ## `poll: [id, …]`
 Block until the specified jobs finish or the wait window elapses.

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -26,6 +26,7 @@ const jobSchema = z.object({
 	poll: z.array(z.string()).optional().describe("job ids to wait for"),
 	cancel: z.array(z.string()).optional().describe("job ids to cancel"),
 	list: z.boolean().optional().describe("snapshot all jobs"),
+	tail: z.array(z.string()).optional().describe("job ids whose retained output should be shown without waiting"),
 });
 
 type JobParams = z.infer<typeof jobSchema>;
@@ -60,9 +61,19 @@ interface CancelOutcome {
 	message: string;
 }
 
+export interface JobOutputTail {
+	id: string;
+	status: AsyncJob["status"];
+	text: string;
+	startOffset: number;
+	nextOffset: number;
+	truncated: boolean;
+}
+
 export interface JobToolDetails {
 	jobs: JobSnapshot[];
 	cancelled?: { id: string; status: CancelStatus }[];
+	output?: JobOutputTail[];
 }
 
 export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
@@ -107,7 +118,21 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			if (params.cancel?.length || params.poll?.length) {
 				throw new ToolError("`list` cannot be combined with `poll` or `cancel`.");
 			}
-			return this.#buildResult(manager, manager.getAllJobs(ownerFilter), []);
+			return this.#buildResult(
+				manager,
+				manager.getAllJobs(ownerFilter),
+				[],
+				this.#readOutputTails(manager, params.tail, ownerFilter),
+			);
+		}
+
+		if (params.tail?.length && !params.poll?.length && !params.cancel?.length) {
+			return this.#buildResult(
+				manager,
+				this.#visibleJobs(manager, params.tail, ownerId),
+				[],
+				this.#readOutputTails(manager, params.tail, ownerFilter),
+			);
 		}
 
 		const cancelIds = params.cancel ?? [];
@@ -150,7 +175,12 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 
 		if (!shouldPoll) {
 			const cancelledJobs = this.#visibleJobs(manager, cancelIds, ownerId);
-			return this.#buildResult(manager, cancelledJobs, cancelOutcomes);
+			return this.#buildResult(
+				manager,
+				cancelledJobs,
+				cancelOutcomes,
+				this.#readOutputTails(manager, params.tail, ownerFilter),
+			);
 		}
 
 		// Resolve which jobs to watch.
@@ -163,7 +193,12 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 		if (jobsToWatch.length === 0) {
 			if (cancelOutcomes.length > 0) {
 				const cancelledJobs = this.#visibleJobs(manager, cancelIds, ownerId);
-				return this.#buildResult(manager, cancelledJobs, cancelOutcomes);
+				return this.#buildResult(
+					manager,
+					cancelledJobs,
+					cancelOutcomes,
+					this.#readOutputTails(manager, params.tail, ownerFilter),
+				);
 			}
 			const message = requestedPollIds?.length
 				? `No matching jobs found for IDs: ${requestedPollIds.join(", ")}`
@@ -178,7 +213,12 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 		const runningJobs = jobsToWatch.filter(j => j.status === "running");
 		if (runningJobs.length === 0) {
 			const cancelledJobs = cancelIds.map(id => manager.getJob(id)).filter(j => j != null);
-			return this.#buildResult(manager, [...cancelledJobs, ...jobsToWatch], cancelOutcomes);
+			return this.#buildResult(
+				manager,
+				[...cancelledJobs, ...jobsToWatch],
+				cancelOutcomes,
+				this.#readOutputTails(manager, params.tail, ownerFilter),
+			);
 		}
 
 		// Wait until at least one running job finishes, the wait duration elapses, or the call is aborted.
@@ -231,7 +271,12 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			if (progressTimer) clearInterval(progressTimer);
 		}
 
-		return this.#buildResult(manager, allTrackedJobs, cancelOutcomes);
+		return this.#buildResult(
+			manager,
+			allTrackedJobs,
+			cancelOutcomes,
+			this.#readOutputTails(manager, params.tail, ownerFilter),
+		);
 	}
 
 	/**
@@ -239,6 +284,28 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 	 * Drops missing ids and ids owned by other agents, so cross-agent inspection
 	 * via the `job` tool is impossible.
 	 */
+	#readOutputTails(
+		manager: AsyncJobManager,
+		ids: string[] | undefined,
+		ownerFilter: { ownerId: string } | undefined,
+	): JobOutputTail[] {
+		if (!ids?.length) return [];
+		const out: JobOutputTail[] = [];
+		for (const id of Array.from(new Set(ids.map(value => value.trim()).filter(Boolean)))) {
+			const slice = manager.readOutputSince(id, 0, ownerFilter);
+			if (!slice) continue;
+			out.push({
+				id: slice.jobId,
+				status: slice.status,
+				text: slice.text,
+				startOffset: slice.startOffset,
+				nextOffset: slice.nextOffset,
+				truncated: slice.truncated,
+			});
+		}
+		return out;
+	}
+
 	#visibleJobs(manager: AsyncJobManager, ids: string[], ownerId: string | undefined): AsyncJob[] {
 		const out: AsyncJob[] = [];
 		for (const id of ids) {
@@ -290,6 +357,7 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			errorText?: string;
 		}[],
 		cancelOutcomes: CancelOutcome[],
+		outputTails: JobOutputTail[] = [],
 	): AgentToolResult<JobToolDetails> {
 		// Deduplicate by id (cancelled jobs may also appear in the watched set).
 		const seen = new Set<string>();
@@ -335,11 +403,21 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			}
 		}
 
+		if (outputTails.length > 0) {
+			lines.push("", `## Retained Output (${outputTails.length})\n`);
+			for (const tail of outputTails) {
+				lines.push(`### ${tail.id} — ${tail.status}`);
+				if (tail.truncated) lines.push(`(showing retained tail from byte ${tail.startOffset})`);
+				lines.push("```", tail.text || "(no retained output yet)", "```", `cursor: ${tail.nextOffset}`, "");
+			}
+		}
+
 		return {
 			content: [{ type: "text", text: lines.join("\n").trimEnd() }],
 			details: {
 				jobs: jobResults,
 				...(cancelOutcomes.length ? { cancelled: cancelOutcomes.map(({ id, status }) => ({ id, status })) } : {}),
+				...(outputTails.length ? { output: outputTails } : {}),
 			},
 		};
 	}
@@ -352,6 +430,7 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 interface JobRenderArgs {
 	poll?: string[];
 	cancel?: string[];
+	tail?: string[];
 }
 
 const COLLAPSED_LIST_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
@@ -391,12 +470,16 @@ function statusToColor(status: JobSnapshot["status"]): ToolUIColor {
 function describeTarget(args: JobRenderArgs | undefined): string {
 	const poll = args?.poll ?? [];
 	const cancel = args?.cancel ?? [];
+	const tail = args?.tail ?? [];
 	const parts: string[] = [];
 	if (cancel.length > 0) {
 		parts.push(cancel.length === 1 ? `cancel ${cancel[0]}` : `cancel ${cancel.length} jobs`);
 	}
 	if (poll.length > 0) {
 		parts.push(poll.length === 1 ? `poll ${poll[0]}` : `poll ${poll.length} jobs`);
+	}
+	if (tail.length > 0) {
+		parts.push(tail.length === 1 ? `tail ${tail[0]}` : `tail ${tail.length} jobs`);
 	}
 	if (parts.length === 0) return "all running jobs";
 	return parts.join(", ");

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1349,6 +1349,82 @@ function b() {
 			// If it correctly acknowledged, the delivery is suppressed.
 			expect(manager.hasPendingDeliveries()).toBe(false);
 		});
+
+		it("should show retained output for a running job without waiting", async () => {
+			const manager = new AsyncJobManager({
+				onJobComplete: async () => {},
+			});
+			const session = createTestToolSession(testDir, Settings.isolated({ "bash.autoBackground.enabled": true }), {});
+			AsyncJobManager.setInstance(manager);
+			const jobTool = JobTool.createIf(session)!;
+
+			const jobId = manager.register("bash", "long job", async ({ signal }) => {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				return "done";
+			});
+			manager.appendOutput(jobId, "line one\n");
+			manager.appendOutput(jobId, "line two\n");
+
+			const result = await jobTool.execute("test-call-tail-1", { tail: [jobId] });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("Still Running");
+			expect(output).toContain("Retained Output");
+			expect(output).toContain("line one");
+			expect(output).toContain("line two");
+			expect(result.details?.output?.[0]).toMatchObject({
+				id: jobId,
+				text: "line one\nline two\n",
+				truncated: false,
+			});
+
+			manager.cancel(jobId);
+			await manager.dispose({ timeoutMs: 100 });
+		});
+
+		it("should scope retained output tails to the calling owner", async () => {
+			const manager = new AsyncJobManager({
+				onJobComplete: async () => {},
+			});
+			const ownerSession = createTestToolSession(
+				testDir,
+				Settings.isolated({ "bash.autoBackground.enabled": true }),
+				{
+					getAgentId: () => "0-Owner",
+				},
+			);
+			const otherSession = createTestToolSession(
+				testDir,
+				Settings.isolated({ "bash.autoBackground.enabled": true }),
+				{
+					getAgentId: () => "0-Other",
+				},
+			);
+			AsyncJobManager.setInstance(manager);
+			const ownerTool = JobTool.createIf(ownerSession)!;
+			const otherTool = JobTool.createIf(otherSession)!;
+
+			const jobId = manager.register(
+				"bash",
+				"private job",
+				async ({ signal }) => {
+					await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+					return "done";
+				},
+				{ ownerId: "0-Owner" },
+			);
+			manager.appendOutput(jobId, "owner-only\n");
+
+			const ownerResult = await ownerTool.execute("test-call-tail-owner", { tail: [jobId] });
+			const otherResult = await otherTool.execute("test-call-tail-other", { tail: [jobId] });
+
+			expect(ownerResult.details?.output?.[0]?.text).toBe("owner-only\n");
+			expect(otherResult.details?.output).toBeUndefined();
+			expect(getTextOutput(otherResult)).not.toContain("owner-only");
+
+			manager.cancel(jobId);
+			await manager.dispose({ timeoutMs: 100 });
+		});
 	});
 
 	describe("search tool", () => {


### PR DESCRIPTION
## Summary
- add `tail` support to the `job` tool so backgrounded jobs can reopen/show retained output without waiting
- keep background job output quiet by default to avoid conversation/TUI flooding
- document bounded retained output behavior and add owner-scoped tests

Addresses #824 as the safe first slice: output visibility/reopen is supported through `job.tail`; raw shell job control and full foreground reattach remain out of scope for this PR.

## Verification
- `cd packages/coding-agent && bun test test/tools.test.ts --test-name-pattern 'JobTool'`\n- `cd packages/coding-agent && bun test test/async-job-output.test.ts`\n- `cd packages/coding-agent && bun run check:types`\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*