### PR TITLE
Fix tmux window title labels

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -27,6 +27,7 @@ export {
 
 export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
+export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 
 type LaunchPolicy = "direct" | "tmux";
 
@@ -189,6 +190,82 @@ function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[])
 	return `exec env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
 }
 
+function visibleWidth(value: string): number {
+	return Bun.stringWidth(value);
+}
+
+function truncateVisible(value: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+	if (visibleWidth(value) <= maxWidth) return value;
+	if (maxWidth === 1) return "…";
+
+	let result = "";
+	for (const char of value) {
+		if (visibleWidth(`${result}${char}…`) > maxWidth) break;
+		result += char;
+	}
+
+	return `${result}…`;
+}
+
+export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
+	const project = path.basename(path.resolve(cwd)) || "gjc";
+	const trimmedBranch = branch?.trim();
+	if (!trimmedBranch) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+
+	const separatorWidth = visibleWidth(":");
+	const projectWidth = visibleWidth(project);
+	const fullTitle = `${project}:${trimmedBranch}`;
+	if (visibleWidth(fullTitle) <= GJC_TMUX_WINDOW_LABEL_MAX_WIDTH) return fullTitle;
+
+	const remainingBranchWidth = GJC_TMUX_WINDOW_LABEL_MAX_WIDTH - projectWidth - separatorWidth;
+	if (remainingBranchWidth <= 0) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+
+	return `${project}:${truncateVisible(trimmedBranch, remainingBranchWidth)}`;
+}
+
+function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
+	return target ? ["rename-window", "-t", target, title] : ["rename-window", title];
+}
+
+function renameTmuxWindow(
+	tmuxCommand: string,
+	title: string,
+	spawnSync: TmuxSpawnSync,
+	options: TmuxSpawnOptions,
+	target?: string,
+): void {
+	spawnSync(tmuxCommand, buildTmuxRenameWindowArgs(title, target), options);
+}
+
+function renameExistingTmuxWindowIfNeeded(context: TmuxLaunchContext): void {
+	const env = context.env ?? process.env;
+	if (!env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return;
+	if (parseLaunchPolicy(env) === "direct") return;
+
+	const platform = context.platform ?? process.platform;
+	if (platform === "win32") return;
+
+	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
+	if (!isInteractiveRootLaunch(context.parsed, tty)) return;
+
+	const tmuxCommand = resolveGjcTmuxCommand(env);
+	const tmuxAvailable = context.tmuxAvailable ?? Bun.which(tmuxCommand) !== null;
+	if (!tmuxAvailable) return;
+
+	const cwd = context.cwd ?? process.cwd();
+	const branch = context.worktreeBranch ?? context.currentBranch ?? readCurrentBranch(cwd);
+	const title = buildGjcTmuxWindowTitle(context.project ?? cwd, branch);
+	const spawnSync = context.spawnSync ?? defaultSpawnSync;
+	renameTmuxWindow(tmuxCommand, title, spawnSync, {
+		cwd,
+		env,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+}
+
 function readCurrentBranch(cwd: string): string | null {
 	try {
 		const result = Bun.spawnSync(["git", "symbolic-ref", "--quiet", "--short", "HEAD"], {
@@ -274,6 +351,8 @@ function defaultSpawnSync(command: string, args: string[], options: TmuxSpawnOpt
 }
 
 export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
+	renameExistingTmuxWindowIfNeeded(context);
+
 	const plan = buildDefaultTmuxLaunchPlan(context);
 	if (!plan) return false;
 	const env = context.env ?? process.env;
@@ -285,12 +364,22 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		stdout: "inherit",
 		stderr: "inherit",
 	};
+
 	if (plan.attachSessionName) {
 		const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.attachSessionName}`], options);
 		return attached.exitCode === 0;
 	}
+
 	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);
 	if (created.exitCode === 0) {
+		renameTmuxWindow(
+			plan.tmuxCommand,
+			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
+			spawnSync,
+			options,
+			`=${plan.sessionName}`,
+		);
+
 		const profile = applyGjcTmuxProfile({
 			tmuxCommand: plan.tmuxCommand,
 			target: plan.sessionName,

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -208,6 +208,20 @@ function truncateVisible(value: string, maxWidth: number): string {
 	return `${result}…`;
 }
 
+function truncateVisibleTail(value: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+	if (visibleWidth(value) <= maxWidth) return value;
+	if (maxWidth === 1) return "…";
+
+	let result = "";
+	for (const char of Array.from(value).reverse()) {
+		if (visibleWidth(`…${char}${result}`) > maxWidth) break;
+		result = `${char}${result}`;
+	}
+
+	return `…${result}`;
+}
+
 export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
 	const project = path.basename(path.resolve(cwd)) || "gjc";
 	const trimmedBranch = branch?.trim();
@@ -221,11 +235,11 @@ export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | und
 	const remainingBranchWidth = GJC_TMUX_WINDOW_LABEL_MAX_WIDTH - projectWidth - separatorWidth;
 	if (remainingBranchWidth <= 0) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
-	return `${project}:${truncateVisible(trimmedBranch, remainingBranchWidth)}`;
+	return `${project}:${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
-	return target ? ["rename-window", "-t", target, title] : ["rename-window", title];
+	return target ? ["rename-window", "-t", target, "--", title] : ["rename-window", "--", title];
 }
 
 function renameTmuxWindow(

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -4,6 +4,7 @@ import {
 	applyGjcTmuxProfile,
 	buildDefaultTmuxLaunchPlan,
 	buildGjcTmuxProfileCommands,
+	buildGjcTmuxWindowTitle,
 	GJC_TMUX_LAUNCHED_ENV,
 	GJC_TMUX_SESSION_PREFIX,
 	launchDefaultTmuxIfNeeded,
@@ -31,6 +32,28 @@ function stderrError(code: string): Error {
 describe("default GJC tmux launch", () => {
 	afterEach(() => {
 		process.stderr.write = originalStderrWrite;
+	});
+
+	it("builds project and branch tmux window titles", () => {
+		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("repo:feature/demo");
+		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("repo");
+		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("repo");
+	});
+
+	it("truncates long tmux window titles to 48 visible columns while preserving the project", () => {
+		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}`);
+
+		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
+		expect(title.startsWith("repo:feature/")).toBe(true);
+		expect(title.endsWith("…")).toBe(true);
+	});
+
+	it("truncates wide-character tmux window titles by visible width", () => {
+		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}`);
+
+		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
+		expect(title.startsWith("저장소:feature/")).toBe(true);
+		expect(title.endsWith("…")).toBe(true);
 	});
 
 	it("does not plan tmux for interactive root launch without --tmux", () => {
@@ -287,6 +310,135 @@ describe("default GJC tmux launch", () => {
 		).toBeUndefined();
 	});
 
+	it("renames the current window for direct interactive launches inside tmux", () => {
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"] }),
+			rawArgs: ["hello world"],
+			cwd: "/repo",
+			env: {
+				TMUX: "/tmp/tmux",
+			},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(false);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			command: "tmux",
+			args: ["rename-window", "repo:feature/demo"],
+		});
+	});
+
+	it("does not rename direct launches already inside a GJC-launched tmux wrapper", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"] }),
+			rawArgs: ["hello world"],
+			cwd: "/repo",
+			env: {
+				TMUX: "/tmp/tmux",
+				[GJC_TMUX_LAUNCHED_ENV]: "1",
+			},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(false);
+		expect(calls).toEqual([]);
+	});
+
+	it("skips direct tmux rename when guard conditions are not met", () => {
+		const cases = [
+			{
+				name: "non-interactive",
+				parsed: args({ print: true }),
+				env: { TMUX: "/tmp/tmux" },
+				tmuxAvailable: true,
+			},
+			{
+				name: "tmux unavailable",
+				parsed: args({ messages: ["hello world"] }),
+				env: { TMUX: "/tmp/tmux" },
+				tmuxAvailable: false,
+			},
+			{
+				name: "direct launch policy",
+				parsed: args({ messages: ["hello world"] }),
+				env: { TMUX: "/tmp/tmux", GJC_LAUNCH_POLICY: "direct" },
+				tmuxAvailable: true,
+			},
+		];
+
+		for (const testCase of cases) {
+			const calls: Array<{ command: string; args: string[] }> = [];
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: testCase.parsed,
+				rawArgs: ["hello world"],
+				cwd: "/repo",
+				env: testCase.env,
+				argv: ["/usr/local/bin/gjc"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: testCase.tmuxAvailable,
+				currentBranch: "feature/demo",
+				spawnSync: (command, spawnArgs) => {
+					calls.push({ command, args: spawnArgs });
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled, testCase.name).toBe(false);
+			expect(calls, testCase.name).toEqual([]);
+		}
+	});
+
+	it("renames managed tmux windows after creating the session", () => {
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		const newSessionIndex = calls.findIndex(call => call.args[0] === "new-session");
+		const renameIndex = calls.findIndex(call => call.args[0] === "rename-window");
+		const sessionName = calls[newSessionIndex]?.args[3] ?? "";
+
+		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
+		expect(renameIndex).toBeGreaterThan(newSessionIndex);
+		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "repo:feature/demo"]);
+	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const handled = launchDefaultTmuxIfNeeded({

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -40,20 +40,43 @@ describe("default GJC tmux launch", () => {
 		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("repo");
 	});
 
-	it("truncates long tmux window titles to 48 visible columns while preserving the project", () => {
-		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}`);
+	it("truncates long tmux window titles to 48 visible columns while preserving the project and branch tail", () => {
+		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}tail`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("repo:feature/")).toBe(true);
-		expect(title.endsWith("…")).toBe(true);
+		expect(title.startsWith("repo:…")).toBe(true);
+		expect(title.endsWith("tail")).toBe(true);
 	});
 
-	it("truncates wide-character tmux window titles by visible width", () => {
-		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}`);
+	it("truncates wide-character tmux window titles by visible width while preserving the branch tail", () => {
+		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}끝`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("저장소:feature/")).toBe(true);
-		expect(title.endsWith("…")).toBe(true);
+		expect(title.startsWith("저장소:…")).toBe(true);
+		expect(title.endsWith("끝")).toBe(true);
+	});
+
+	it("separates dash-leading tmux window titles from tmux options", () => {
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"] }),
+			rawArgs: ["hello world"],
+			cwd: "/tmp/-repo",
+			env: { TMUX: "/tmp/tmux" },
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(false);
+		expect(calls[0]?.args).toEqual(["rename-window", "--", "-repo:feature/demo"]);
 	});
 
 	it("does not plan tmux for interactive root launch without --tmux", () => {
@@ -335,7 +358,7 @@ describe("default GJC tmux launch", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]).toMatchObject({
 			command: "tmux",
-			args: ["rename-window", "repo:feature/demo"],
+			args: ["rename-window", "--", "repo:feature/demo"],
 		});
 	});
 
@@ -437,7 +460,7 @@ describe("default GJC tmux launch", () => {
 
 		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
 		expect(renameIndex).toBeGreaterThan(newSessionIndex);
-		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "repo:feature/demo"]);
+		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "--", "repo:feature/demo"]);
 	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];


### PR DESCRIPTION
## Summary
- Rename the current tmux window/status to `<project-folder>:<git-branch>` for direct `$TMUX` GJC runs and managed `gjc --tmux` sessions.
- Add 48-visible-column truncation that preserves the project folder and truncates the branch tail with `…`.
- Cover direct-run guards, managed-session target rename, fallback labels, and wide-character truncation in focused tests.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` — 26 pass / 0 fail
- `bun run check:ts` — touched tmux files clean; existing unrelated lint remains in `packages/tui/test/viewport-virtualization-redteam.test.ts` and `packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`
