### PR TITLE
fix(models): correct GLM-5.2 context window to 1M

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Corrected the bundled `zai/glm-5.2` context window from 200K to its true 1M (1,000,000-token) lossless window. GLM-5.2 was added in #579 by copying GLM-5.1's 200K entry, and that stale value survived every `generate-models` run because provider-scoped models bypass the models.dev refresh in `applyGlobalModelsDevFallback`. Added a regen-safe pin in `applyGeneratedModelPolicy` (mirroring the Bedrock-Opus-4.6 precedent) so the 1M value persists, and updated the bundled catalog entry. The wrong 200K tripped auto-compaction / context-cap thresholds ~5x early for GLM-5.2 sessions.
 
 ## [0.5.4] - 2026-06-17
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -397,6 +397,13 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 	if (parsedModel.family === "openai") {
 		applyOpenAICatalogPolicy(model, parsedModel);
 	}
+	// GLM-5.2 (Zhipu/ZAI): ships a 1M lossless context window, but the bundled
+	// catalog copied GLM-5.1's 200K and that stale value survives generate-models
+	// (provider-scoped models bypass the models.dev refresh in applyGlobalModelsDevFallback).
+	// Pin to the true 1M so context-cap / auto-compaction thresholds aren't tripped ~5x early.
+	if (model.provider === "zai" && model.id === "glm-5.2") {
+		model.contextWindow = 1_000_000;
+	}
 }
 
 function scrubGeneratedModelName(name: string): string {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -71628,7 +71628,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",

--- a/packages/ai/test/preset-catalog-models.test.ts
+++ b/packages/ai/test/preset-catalog-models.test.ts
@@ -22,7 +22,7 @@ describe("preset catalog model entries", () => {
 		expect(model.name).toBe("GLM-5.2");
 		expect(model.reasoning).toBe(true);
 		expect(model.input).toContain("text");
-		expect(model.contextWindow).toBe(200_000);
+		expect(model.contextWindow).toBe(1_000_000);
 		expect(model.maxTokens).toBe(131_072);
 		expect(model.thinking).toEqual({ mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh });
 	});


### PR DESCRIPTION
## Problem

`zai/glm-5.2` is bundled with a **200K** context window, but GLM-5.2 actually ships with a **1M** (1,000,000-token) lossless context window.

- Official Zhipu docs ([docs.bigmodel.cn — model overview](https://docs.bigmodel.cn/cn/guide/start/model-overview)): **GLM-5.2 → 1M context / 128K output**
- models.dev ([zhipuai/glm-5.2](https://models.dev/models/zhipuai/glm-5.2)): **1,000,000** context

The wrong 200K trips auto-compaction / context-cap thresholds ~5x too early for GLM-5.2 sessions.

## Root cause

GLM-5.2 was added to the catalog in #579 by copying the GLM-5.1 entry (200K). The stale value then survived every `generate-models` run: `applyGlobalModelsDevFallback` short-circuits any model whose `provider/id` exists in the models.dev data (returns it unchanged), so the stale fallback value is never refreshed from the (correct) models.dev reference.

## Fix

- **`packages/ai/src/model-thinking.ts`** — pin `zai/glm-5.2` to `1_000_000` in `applyGeneratedModelPolicy`, mirroring the existing Bedrock-Opus-4.6 precedent (`model.contextWindow = 1000000` with an "upstream metadata is stale" rationale). This runs after all fallback merges, so it wins and survives future regenerations.
- **`packages/ai/src/models.json`** — updated the bundled `glm-5.2` entry (the deterministic output of the pin). Focused single-line change, matching the surgical precedent of #579; no aggregator drift included.
- **`packages/ai/test/preset-catalog-models.test.ts`** — updated the regression assertion from `200_000` to `1_000_000`.
- **`packages/ai/CHANGELOG.md`** — `### Fixed` entry under `[Unreleased]`.

## Verification

- `bun --cwd=packages/ai run lint` -> clean (353 files)
- `bun --cwd=packages/ai run check:types` (tsgo) -> clean
- `bun --cwd=packages/ai run test` -> **1418 pass / 0 fail / 336 skip** (updated glm-5.2 test passes)
- Sibling GLM entries unchanged and consistent with models.dev: `glm-5.1`=200K, `glm-5`/`glm-5-turbo`/`glm-5v-turbo`=200K, `glm-4.6`/`glm-4.7`=204800. Only `glm-5.2` changed.
- `glm-5.2` `maxTokens` stays 131072 (128K), matching the official 128K output cap.

A full catalog `generate-models` run was intentionally **not** committed: 4 days of unrelated aggregator drift (OpenRouter/LiteLLM/Kilo/...) would have added ~3300 lines of noise unrelated to this fix. The generator pin guarantees the 1M value persists across future regenerations.