### PR TITLE
Support folding foreground bash into background jobs

### DIFF
--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -27,6 +27,7 @@ interface AppKeybindings {
 	"app.model.select": true;
 	"app.model.selectTemporary": true;
 	"app.tools.expand": true;
+	"app.tool.backgroundFold": true;
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.queue": true;
@@ -106,6 +107,10 @@ export const KEYBINDINGS = {
 	"app.tools.expand": {
 		defaultKeys: "ctrl+o",
 		description: "Expand tools",
+	},
+	"app.tool.backgroundFold": {
+		defaultKeys: "ctrl+b",
+		description: "Fold/background supported foreground tool",
 	},
 	"app.editor.external": {
 		defaultKeys: "ctrl+g",

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -90,7 +90,7 @@ export class CustomEditor extends Editor {
 	onCapsLock?: () => void;
 
 	/** Custom key handlers from extensions and non-built-in app actions. */
-	#customKeyHandlers = new Map<KeyId, () => void>();
+	#customKeyHandlers = new Map<KeyId, () => boolean | undefined>();
 	#actionKeys = new Map<ConfigurableEditorAction, KeyId[]>(
 		Object.entries(DEFAULT_ACTION_KEYS).map(([action, keys]) => [action as ConfigurableEditorAction, [...keys]]),
 	);
@@ -116,7 +116,7 @@ export class CustomEditor extends Editor {
 	/**
 	 * Register a custom key handler. Extensions use this for shortcuts.
 	 */
-	setCustomKeyHandler(key: KeyId, handler: () => void): void {
+	setCustomKeyHandler(key: KeyId, handler: () => boolean | undefined): void {
 		this.#customKeyHandlers.set(key, handler);
 	}
 
@@ -353,8 +353,7 @@ export class CustomEditor extends Editor {
 		// Check custom key handlers (extensions)
 		for (const [keyId, handler] of this.#customKeyHandlers) {
 			if (matchesKey(data, keyId)) {
-				handler();
-				return;
+				if (handler() !== false) return;
 			}
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -34,6 +34,8 @@ function isExpandable(obj: unknown): obj is Expandable {
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
+	#lastBackgroundFoldKeyTime = 0;
+
 	/** Set after a first Esc silently consumes a queued steer. Kept until the
 	 *  queued steer is either cancelled by a second Esc or drained by continuation,
 	 *  so abort cleanup going idle cannot turn the second Esc into an idle action. */
@@ -208,16 +210,22 @@ export class InputController {
 		}
 
 		for (const key of this.ctx.keybindings.getKeys("app.session.new")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.handleClearCommand());
+			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleClearCommand());
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.session.tree")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showTreeSelector());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.ctx.showTreeSelector();
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.session.fork")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showUserMessageSelector());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.ctx.showUserMessageSelector();
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.session.resume")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showSessionSelector());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.ctx.showSessionSelector();
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.message.followUp")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.handleFollowUp());
@@ -226,13 +234,22 @@ export class InputController {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.clipboard.copyLine")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyCurrentLine());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.handleCopyCurrentLine();
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.session.observe")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showSessionObserver());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.ctx.showSessionObserver();
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.jobs.open")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showJobsOverlay());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				this.ctx.showJobsOverlay();
+			});
+		}
+		for (const key of this.ctx.keybindings.getKeys("app.tool.backgroundFold")) {
+			this.ctx.editor.setCustomKeyHandler(key, () => this.handleForegroundToolBackgroundFold());
 		}
 
 		this.ctx.editor.onChange = (text: string) => {
@@ -695,6 +712,31 @@ export class InputController {
 		}
 
 		process.kill(0, "SIGTSTP");
+	}
+
+	handleForegroundToolBackgroundFold(): boolean {
+		if (!this.ctx.session.hasForegroundBashBackgroundRequestHandler?.()) {
+			this.#lastBackgroundFoldKeyTime = 0;
+			return false;
+		}
+
+		const now = Date.now();
+		if (now - this.#lastBackgroundFoldKeyTime > 750) {
+			this.#lastBackgroundFoldKeyTime = now;
+			this.ctx.showStatus("Press Ctrl+B again to fold supported foreground bash into a background job");
+			return true;
+		}
+		this.#lastBackgroundFoldKeyTime = 0;
+
+		if (!this.ctx.session.requestForegroundBashBackground?.()) {
+			this.ctx.showWarning(
+				"No supported foreground tool can be folded. Use managed async bash/auto-background; raw Ctrl+Z/bg is not supported inside the TUI.",
+			);
+			return true;
+		}
+
+		this.ctx.showStatus("Folding foreground bash into a quiet background job…");
+		return true;
 	}
 
 	handleTextPaste(text: string): boolean | Promise<boolean> {

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -46,6 +46,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.plan.toggle")}\` | Toggle plan mode |`,
 		`| \`${appKey(bindings, "app.history.search")}\` | Search prompt history |`,
 		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
+		`| \`${appKey(bindings, "app.tool.backgroundFold")}\` twice | Fold supported foreground bash into a background job |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
 		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
 		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image from clipboard |`,

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -16,6 +16,9 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 {{#if asyncEnabled}}
 - Use `async: true` for long-running commands when you don't need immediate output; the call returns a background job ID and the result is delivered automatically as a follow-up.
 {{/if}}
+{{#if autoBackgroundEnabled}}
+- In the interactive TUI, the user can press `Ctrl+B` twice while a supported managed foreground bash command is still running to fold it into a quiet background job. Do not instruct users to use raw shell `Ctrl+Z`/`bg` inside the GJC TUI; ownership and output routing are not safe there.
+{{/if}}
 </instruction>
 {{#if restrictedAllowedPrefixes}}
 <restricted-bash-mode>

--- a/packages/coding-agent/src/prompts/tools/job.md
+++ b/packages/coding-agent/src/prompts/tools/job.md
@@ -2,6 +2,8 @@ Inspects, waits, or cancels async jobs.
 
 Background job results are delivered automatically when complete. Running job output stays quiet by default to avoid flooding the conversation; use `tail` when you explicitly want to show/reopen retained output. Reach for this tool only when you need to inspect or intervene.
 
+In the interactive TUI, supported managed foreground bash can be folded into a background job by pressing `Ctrl+B` twice while it is running. Raw shell `Ctrl+Z`/`bg` is not the supported path inside GJC because it bypasses job ownership and output-routing contracts.
+
 # Operations
 
 ## `list: true`

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -946,6 +946,7 @@ export class AgentSession {
 	// Bash execution state
 	#bashAbortControllers = new Set<AbortController>();
 	#pendingBashMessages: BashExecutionMessage[] = [];
+	#foregroundBashBackgroundRequestHandler: (() => void) | undefined;
 
 	// Python execution state
 	#evalAbortControllers = new Set<AbortController>();
@@ -3433,6 +3434,42 @@ export class AgentSession {
 	 */
 	getToolByName(name: string): AgentTool | undefined {
 		return this.#toolRegistry.get(name);
+	}
+
+	/**
+	 * Register a UI/control-plane request handler for a currently foregrounded
+	 * managed bash execution. This is intentionally narrower than generic
+	 * process/job control: unsupported tool types simply do not register a
+	 * handler, so Ctrl+B-style folding fails closed instead of aborting or
+	 * shell-suspending arbitrary work.
+	 */
+	registerForegroundBashBackgroundRequestHandler(handler: () => void): () => void {
+		this.#foregroundBashBackgroundRequestHandler = handler;
+		return () => {
+			if (this.#foregroundBashBackgroundRequestHandler === handler) {
+				this.#foregroundBashBackgroundRequestHandler = undefined;
+			}
+		};
+	}
+
+	/**
+	 * Returns whether a managed foreground bash call is currently backgroundable.
+	 * UI key handlers use this to avoid consuming normal editor shortcuts when
+	 * no fold target exists.
+	 */
+	hasForegroundBashBackgroundRequestHandler(): boolean {
+		return this.#foregroundBashBackgroundRequestHandler !== undefined;
+	}
+
+	/**
+	 * Ask the active managed foreground bash call to return as a background job.
+	 * Returns false when no supported foreground tool is currently backgroundable.
+	 */
+	requestForegroundBashBackground(): boolean {
+		const handler = this.#foregroundBashBackgroundRequestHandler;
+		if (!handler) return false;
+		handler();
+		return true;
 	}
 
 	/**

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -370,6 +370,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const label = options.command.length > 120 ? `${options.command.slice(0, 117)}...` : options.command;
 		let latestText = "";
 		let backgrounded = options.startBackgrounded;
+		const runningDetails = (jobId: string): Record<string, unknown> | undefined =>
+			backgrounded ? { async: { state: "running", jobId, type: "bash" } } : undefined;
+		const completedDetails = (jobId: string): Record<string, unknown> | undefined =>
+			backgrounded ? { async: { state: "completed", jobId, type: "bash" } } : undefined;
+		const failedDetails = (jobId: string): Record<string, unknown> | undefined =>
+			backgrounded ? { async: { state: "failed", jobId, type: "bash" } } : undefined;
 		const completion = Promise.withResolvers<ManagedBashJobCompletion>();
 
 		const jobId = manager.register(
@@ -393,7 +399,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							latestText = tailBuffer.text();
-							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
+							void reportProgress(latestText, runningDetails(jobId));
 						},
 						onRawChunk: chunk => {
 							// Forward the unthrottled sanitized chunk to the async-job
@@ -411,13 +417,13 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					const finalText = this.#extractTextResult(finalResult);
 					latestText = finalText;
 					completion.resolve({ kind: "completed", result: finalResult });
-					await reportProgress(finalText, { async: { state: "completed", jobId, type: "bash" } });
+					await reportProgress(finalText, completedDetails(jobId));
 					return finalText;
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
 					latestText = message;
 					completion.resolve({ kind: "failed", error });
-					await reportProgress(message, { async: { state: "failed", jobId, type: "bash" } });
+					await reportProgress(message, failedDetails(jobId));
 					throw error;
 				}
 			},
@@ -448,6 +454,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		job: ManagedBashJobHandle,
 		thresholdMs: number,
 		signal?: AbortSignal,
+		backgroundRequest?: Promise<void>,
 	): Promise<ManagedBashJobCompletion | { kind: "running" } | { kind: "aborted" }> {
 		if (signal?.aborted) {
 			return { kind: "aborted" };
@@ -457,6 +464,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			job.completion,
 			Bun.sleep(thresholdMs).then(() => ({ kind: "running" as const })),
 		];
+		if (backgroundRequest) {
+			waiters.push(backgroundRequest.then(() => ({ kind: "running" as const })));
+		}
 
 		if (!signal) {
 			return await Promise.race(waiters);
@@ -820,7 +830,22 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					notices: pendingNotices,
 				});
 			}
-			const waitResult = await this.#waitForManagedBashJob(job, autoBackgroundWaitMs, signal);
+			const backgroundRequest = Promise.withResolvers<void>();
+			const unregisterBackgroundRequest = this.session.registerForegroundBashBackgroundRequestHandler?.(() => {
+				job.setBackgrounded(true);
+				backgroundRequest.resolve();
+			});
+			let waitResult: ManagedBashJobCompletion | { kind: "running" } | { kind: "aborted" };
+			try {
+				waitResult = await this.#waitForManagedBashJob(
+					job,
+					autoBackgroundWaitMs,
+					signal,
+					backgroundRequest.promise,
+				);
+			} finally {
+				unregisterBackgroundRequest?.();
+			}
 			if (waitResult.kind === "completed") {
 				autoBgManager.acknowledgeDeliveries([job.jobId]);
 				return waitResult.result;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -162,6 +162,12 @@ export interface ToolSession {
 	assertEvalExecutionAllowed?: () => void;
 	/** Track tool-owned eval work so session disposal can await/abort it like direct session eval runs. */
 	trackEvalExecution?<T>(execution: Promise<T>, abortController: AbortController): Promise<T>;
+	/** Register a safe request handler that asks a managed foreground bash call to fold into a background job. */
+	registerForegroundBashBackgroundRequestHandler?: (handler: () => void) => () => void;
+	/** Whether a managed foreground bash call is currently foldable into a background job. */
+	hasForegroundBashBackgroundRequestHandler?: () => boolean;
+	/** Request that the active managed foreground bash call fold into a background job, if supported. */
+	requestForegroundBashBackground?: () => boolean;
 	/** Get session ID */
 	getSessionId?: () => string | null;
 	/** Get Hindsight runtime state for this agent session. */

--- a/packages/coding-agent/test/custom-editor-keyhandlers.test.ts
+++ b/packages/coding-agent/test/custom-editor-keyhandlers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { defaultEditorTheme } from "../../tui/test/test-themes";
+import { CustomEditor } from "../src/modes/components/custom-editor";
+
+describe("CustomEditor custom key handlers", () => {
+	it("falls through to editor handling when a custom handler returns false", () => {
+		const editor = new CustomEditor(defaultEditorTheme);
+		let handled = 0;
+
+		editor.setText("abc");
+		editor.moveToLineEnd();
+		editor.setCustomKeyHandler("ctrl+b", () => {
+			handled += 1;
+			return false;
+		});
+		editor.handleInput("\x02");
+
+		expect(handled).toBe(1);
+		expect(editor.getCursor()).toEqual({ line: 0, col: 2 });
+	});
+
+	it("consumes editor handling when a custom handler returns true", () => {
+		const editor = new CustomEditor(defaultEditorTheme);
+		let handled = 0;
+
+		editor.setText("abc");
+		editor.moveToLineEnd();
+		editor.setCustomKeyHandler("ctrl+b", () => {
+			handled += 1;
+			return true;
+		});
+		editor.handleInput("\x02");
+
+		expect(handled).toBe(1);
+		expect(editor.getCursor()).toEqual({ line: 0, col: 3 });
+	});
+});

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1209,6 +1209,81 @@ function b() {
 			await asyncJobManager.dispose();
 		});
 
+		it("should fold a managed foreground command into a background job when requested", async () => {
+			const deliveries: Array<{ jobId: string; text: string }> = [];
+			const updates: Array<{ text: string; asyncState?: string }> = [];
+			const asyncJobManager = new AsyncJobManager({
+				onJobComplete: async (jobId, text) => {
+					deliveries.push({ jobId, text });
+				},
+			});
+			AsyncJobManager.setInstance(asyncJobManager);
+			let backgroundRequestHandler: (() => void) | undefined;
+			const autoBackgroundBashTool = wrapToolWithMetaNotice(
+				new BashTool(
+					createTestToolSession(
+						testDir,
+						Settings.isolated({
+							"bash.autoBackground.enabled": true,
+							"bash.autoBackground.thresholdMs": 30_000,
+						}),
+						{
+							getSessionId: () => "test-session",
+							registerForegroundBashBackgroundRequestHandler: handler => {
+								backgroundRequestHandler = handler;
+								return () => {
+									if (backgroundRequestHandler === handler) backgroundRequestHandler = undefined;
+								};
+							},
+						},
+					),
+				),
+			);
+
+			const resultPromise = autoBackgroundBashTool.execute(
+				"test-call-9-fold-foreground",
+				{
+					command: "printf 'start\\n'; sleep 0.05; printf 'after-fold\\n'; sleep 0.2; printf 'done\\n'",
+				},
+				undefined,
+				partialResult => {
+					updates.push({
+						text: getTextOutput(partialResult),
+						asyncState: partialResult.details?.async?.state,
+					});
+				},
+			);
+
+			for (let i = 0; i < 50 && !backgroundRequestHandler; i++) {
+				await Bun.sleep(10);
+			}
+			expect(backgroundRequestHandler).toBeDefined();
+			backgroundRequestHandler?.();
+
+			const result = await resultPromise;
+			expect(result.details?.async?.state).toBe("running");
+			expect(result.details?.async?.type).toBe("bash");
+			expect(getTextOutput(result)).toContain("Background job");
+			expect(getTextOutput(result)).toContain("start");
+			expect(backgroundRequestHandler).toBeUndefined();
+
+			const jobId = result.details?.async?.jobId;
+			if (!jobId) {
+				throw new Error("expected a folded background job id");
+			}
+			const runningJob = asyncJobManager.getJob(jobId);
+			expect(runningJob?.status).toBe("running");
+			await runningJob?.promise;
+			await asyncJobManager.drainDeliveries({ timeoutMs: 1 });
+			const postFoldProgress = updates.filter(update => update.text.includes("after-fold"));
+			expect(postFoldProgress.length).toBeGreaterThan(0);
+			expect(postFoldProgress.every(update => update.asyncState !== undefined)).toBe(true);
+			expect(deliveries).toHaveLength(1);
+			expect(deliveries[0]?.jobId).toBe(jobId);
+			expect(deliveries[0]?.text).toContain("done");
+			await asyncJobManager.dispose();
+		});
+
 		it("should background instead of timing out when auto-background wait exceeds the effective timeout", async () => {
 			const deliveries: Array<{ jobId: string; text: string }> = [];
 			const asyncJobManager = new AsyncJobManager({


### PR DESCRIPTION
## Summary
- add a safe `Ctrl+B` double-press path to fold a managed foreground bash command into a quiet background job
- preserve normal editor `Ctrl+B` cursor-left behavior when no foreground bash fold target is registered
- document the supported foreground-fold UX and explicitly avoid raw shell `Ctrl+Z`/`bg` inside the TUI

Fixes #824

## Verification
- `cd packages/coding-agent && bun test test/tools.test.ts --test-name-pattern 'fold a managed foreground command|JobTool|auto-background|Background job'`
- `cd packages/coding-agent && bun test test/async-job-output.test.ts`
- `cd packages/coding-agent && bun test test/custom-editor-keyhandlers.test.ts`
- `cd packages/coding-agent && bun run check:types`
- `cd packages/coding-agent && bun run check` (exit 0; only pre-existing Biome warnings outside this patch)

## Review
- `code-reviewer`: APPROVE, 0 issues
- `architect`: CLEAR
