### PR TITLE
fix(models): correct MiniMax-M3 context window to 1M

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Corrected the bundled `zai/glm-5.2` context window from 200K to its true 1M (1,000,000-token) lossless window. GLM-5.2 was added in #579 by copying GLM-5.1's 200K entry, and that stale value survived every `generate-models` run because provider-scoped models bypass the models.dev refresh in `applyGlobalModelsDevFallback`. Added a regen-safe pin in `applyGeneratedModelPolicy` (mirroring the Bedrock-Opus-4.6 precedent) so the 1M value persists, and updated the bundled catalog entry. The wrong 200K tripped auto-compaction / context-cap thresholds ~5x early for GLM-5.2 sessions.
+- Corrected the bundled `minimax-m3` context window from 512K to its true 1M (1,000,000-token) window per the official MiniMax docs (platform.minimax.io documents MiniMax-M3 as a 1M-context frontier coding model). All four provider copies (`minimax`, `minimax-cn`, `minimax-code`, `minimax-code-cn`) carried the stale 512K, which survived `generate-models` (provider-scoped models bypass the models.dev refresh in `applyGlobalModelsDevFallback`) and tripped auto-compaction / context-cap thresholds 2x early on MiniMax sessions. Added a regen-safe pin in `applyGeneratedModelPolicy` keyed on `model.id === "minimax-m3"` and updated the bundled entries. `minimax-v3` (an undocumented catalog alias) is intentionally left untouched.
 
 ## [0.5.4] - 2026-06-17
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -404,6 +404,14 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 	if (model.provider === "zai" && model.id === "glm-5.2") {
 		model.contextWindow = 1_000_000;
 	}
+	// MiniMax-M3: official MiniMax docs (platform.minimax.io/docs/guides/models-intro)
+	// document a 1M context window, but models.dev and the bundled catalog both report
+	// 512K. The stale 512K survives generate-models (provider-scoped models bypass the
+	// models.dev refresh in applyGlobalModelsDevFallback), tripping auto-compaction /
+	// context-cap thresholds 2x early on MiniMax sessions. Pin to the true 1M.
+	if (model.id === "minimax-m3") {
+		model.contextWindow = 1_000_000;
+	}
 }
 
 function scrubGeneratedModelName(name: string): string {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -34712,7 +34712,7 @@
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -34907,7 +34907,7 @@
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -35174,7 +35174,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
@@ -35478,7 +35478,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,

--- a/packages/ai/test/issue-385-minimax-m3.test.ts
+++ b/packages/ai/test/issue-385-minimax-m3.test.ts
@@ -11,7 +11,7 @@ describe("MiniMax M3 support (issue #385)", () => {
 
 			expect(model.id).toBe("minimax-m3");
 			expect(model.provider).toBe(provider);
-			expect(model.contextWindow).toBe(512_000);
+			expect(model.contextWindow).toBe(1_000_000);
 			expect(model.maxTokens).toBe(128_000);
 			expect(model.input).toContain("text");
 			expect(model.input).toContain("image");


### PR DESCRIPTION
## Problem

`minimax-m3` is bundled with a **512K** context window across all four first-class MiniMax providers, but MiniMax-M3 actually ships with a **1M** (1,000,000-token) context window.

- Official MiniMax docs ([platform.minimax.io — models overview](https://platform.minimax.io/docs/guides/models-intro)): **MiniMax-M3 → "Frontier multimodal coding model with 1M context window"**
- models.dev ([minimax/MiniMax-M3](https://models.dev/models/minimax/MiniMax-M3)): **512,000** ← stale; the generator's models.dev reference has not been updated for M3 yet, which is exactly why this slipped through.

The wrong 512K trips auto-compaction / context-cap thresholds **2× too early** on every MiniMax-M3 session.

## Root cause

Same regen-short-circuit class as the recently-merged glm-5.2 fix (#832). `applyGlobalModelsDevFallback` short-circuits any model whose `provider/id` exists in the models.dev data and returns it unchanged, so a stale bundled value is never refreshed from the (in this case also-stale) models.dev reference. Both data sources lag the official MiniMax docs here.

## Fix

- **`packages/ai/src/model-thinking.ts`** — pin `model.id === "minimax-m3"` to `1_000_000` in `applyGeneratedModelPolicy`, directly after the `zai/glm-5.2` pin (same pattern as that and the Bedrock-Opus-4.6 precedent). This runs after all fallback merges, so it wins and survives future regenerations.
- **`packages/ai/src/models.json`** — updated the bundled `minimax-m3` entries in all four provider copies (`minimax`, `minimax-cn`, `minimax-code`, `minimax-code-cn`) to the deterministic output of the pin. Focused 4-line change; no aggregator drift.
- **`packages/ai/test/issue-385-minimax-m3.test.ts`** — updated the existing regression assertion from `512_000` to `1_000_000`.
- **`packages/ai/CHANGELOG.md`** — `### Fixed` entry under `[Unreleased]`.

`minimax-v3` (an undocumented catalog alias, no official docs page) is intentionally **left untouched** — every change here is backed by the official MiniMax model reference.

## Verification

- `bun --cwd=packages/ai run lint` -> clean (354 files)
- `bun --cwd=packages/ai run check:types` (tsgo) -> clean
- `bun --cwd=packages/ai run test` -> **1433 pass / 0 fail / 336 skip** (issue-#385 minimax-m3 test updated and passing)
- `minimax-m3` now resolves to 1M across all four providers; `minimax-v3` unchanged at 512K.