### PR TITLE
fix(computer): stabilize Anthropic schema and hotkey liveness

### DIFF
--- a/crates/pi-natives/src/computer/hotkey.rs
+++ b/crates/pi-natives/src/computer/hotkey.rs
@@ -41,6 +41,9 @@ const LISTEN_ONLY: u32 = 1; // kCGEventTapOptionListenOnly
 const EVENT_KEY_DOWN: u32 = 10; // kCGEventKeyDown
 const KEYCODE_FIELD: u32 = 9; // kCGKeyboardEventKeycode
 const KEY_DOWN_MASK: u64 = 1 << EVENT_KEY_DOWN; // CGEventMaskBit(kCGEventKeyDown)
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(500);
+const RUN_LOOP_TIMED_OUT: i32 = 3;
+const RUN_LOOP_HANDLED_SOURCE: i32 = 4;
 
 // Default hotkey: Control+Option+Command+Escape — distinctive, unlikely to
 // collide.
@@ -61,6 +64,7 @@ unsafe extern "C" {
 		user_info: *mut c_void,
 	) -> CfMachPortRef;
 	fn CGEventTapEnable(tap: CfMachPortRef, enable: bool);
+	fn CGEventTapIsEnabled(tap: CfMachPortRef) -> bool;
 	fn CGEventGetIntegerValueField(event: CgEventRef, field: u32) -> i64;
 	fn CGEventGetFlags(event: CgEventRef) -> u64;
 }
@@ -68,6 +72,7 @@ unsafe extern "C" {
 #[link(name = "CoreFoundation", kind = "framework")]
 unsafe extern "C" {
 	static kCFRunLoopCommonModes: CfStringRef;
+	static kCFRunLoopDefaultMode: CfStringRef;
 	fn CFMachPortCreateRunLoopSource(
 		allocator: CfAllocatorRef,
 		port: CfMachPortRef,
@@ -75,8 +80,13 @@ unsafe extern "C" {
 	) -> CfRunLoopSourceRef;
 	fn CFRunLoopGetCurrent() -> CfRunLoopRef;
 	fn CFRunLoopAddSource(rl: CfRunLoopRef, source: CfRunLoopSourceRef, mode: CfStringRef);
-	fn CFRunLoopRun();
+	fn CFRunLoopRunInMode(mode: CfStringRef, seconds: f64, return_after_source_handled: bool)
+	-> i32;
 	fn CFRelease(cf: *const c_void);
+}
+
+const fn run_loop_result_allows_heartbeat(run_loop_result: i32) -> bool {
+	matches!(run_loop_result, RUN_LOOP_TIMED_OUT | RUN_LOOP_HANDLED_SOURCE)
 }
 
 const fn matches_hotkey(keycode: i64, flags: u64) -> bool {
@@ -122,9 +132,8 @@ pub fn start() -> bool {
 
 fn run_listener() {
 	// SAFETY: a listen-only key-down session tap; the returned mach port and
-	// run-loop source are added to this thread's run loop, which then runs for
-	// the process lifetime. Handles are released only on the (non-returning)
-	// teardown path below.
+	// run-loop source are added to this thread's run loop, which is stepped on a
+	// bounded interval so the listener owner can refresh liveness while idle.
 	unsafe {
 		let tap = CGEventTapCreate(
 			SESSION_EVENT_TAP,
@@ -146,13 +155,35 @@ fn run_listener() {
 		}
 		CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
 		CGEventTapEnable(tap, true);
+		if !CGEventTapIsEnabled(tap) {
+			Supervisor::global().set_hotkey_live(false);
+			CFRelease(source.cast_const());
+			CFRelease(tap.cast_const());
+			return;
+		}
 		Supervisor::global().set_hotkey_live(true);
-		CFRunLoopRun();
-		// Unreached in normal operation; if the run loop ever returns, fail closed.
+
+		loop {
+			let result =
+				CFRunLoopRunInMode(kCFRunLoopDefaultMode, HEARTBEAT_INTERVAL.as_secs_f64(), false);
+			if !listener_step_is_live(tap, result) {
+				break;
+			}
+			Supervisor::global().heartbeat();
+		}
+
+		// If the run loop exits, the tap is disabled/dead, or stepping returns an
+		// unexpected status, fail closed before releasing listener-owned handles.
 		Supervisor::global().set_hotkey_live(false);
 		CFRelease(source.cast_const());
 		CFRelease(tap.cast_const());
 	}
+}
+
+fn listener_step_is_live(tap: CfMachPortRef, run_loop_result: i32) -> bool {
+	run_loop_result_allows_heartbeat(run_loop_result) &&
+		// SAFETY: called only by the listener thread while it owns a valid event tap.
+		unsafe { CGEventTapIsEnabled(tap) }
 }
 
 fn wait_until_live(timeout: Duration) -> bool {
@@ -170,7 +201,11 @@ fn wait_until_live(timeout: Duration) -> bool {
 
 #[cfg(test)]
 mod tests {
-	use super::{HOTKEY_KEYCODE, HOTKEY_MODS, matches_hotkey};
+	use super::{
+		HEARTBEAT_INTERVAL, HOTKEY_KEYCODE, HOTKEY_MODS, RUN_LOOP_HANDLED_SOURCE, RUN_LOOP_TIMED_OUT,
+		matches_hotkey, run_loop_result_allows_heartbeat,
+	};
+	use crate::computer::supervisor::{HEARTBEAT_FRESH_MS, Supervisor};
 
 	#[test]
 	fn matches_only_the_full_hotkey_combo() {
@@ -179,6 +214,31 @@ mod tests {
 		assert!(!matches_hotkey(HOTKEY_KEYCODE, 0)); // no modifiers
 		assert!(!matches_hotkey(HOTKEY_KEYCODE, 0x0004_0000)); // only control
 		assert!(!matches_hotkey(0, HOTKEY_MODS)); // wrong key
+	}
+
+	#[test]
+	fn recurring_idle_heartbeat_keeps_supervisor_fresh_beyond_freshness_window() {
+		let interval_ms = u64::try_from(HEARTBEAT_INTERVAL.as_millis()).unwrap_or(u64::MAX);
+		assert!(interval_ms < HEARTBEAT_FRESH_MS);
+
+		let supervisor = Supervisor::new();
+		supervisor.set_hotkey_live(true);
+		let mut now_ms = 10_000;
+		let deadline_ms = now_ms + HEARTBEAT_FRESH_MS + interval_ms;
+		while now_ms <= deadline_ms {
+			supervisor.heartbeat_at(now_ms);
+			assert!(supervisor.status_at(now_ms).input_allowed());
+			now_ms += interval_ms;
+		}
+	}
+
+	#[test]
+	fn only_active_run_loop_steps_keep_listener_live() {
+		assert!(run_loop_result_allows_heartbeat(RUN_LOOP_TIMED_OUT));
+		assert!(run_loop_result_allows_heartbeat(RUN_LOOP_HANDLED_SOURCE));
+		assert!(!run_loop_result_allows_heartbeat(1)); // kCFRunLoopRunFinished
+		assert!(!run_loop_result_allows_heartbeat(2)); // kCFRunLoopRunStopped
+		assert!(!run_loop_result_allows_heartbeat(0)); // unexpected/unknown status
 	}
 }
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed Anthropic tool schema compatibility for discriminated-union tool inputs by flattening only the model-facing input-schema root, avoiding top-level `oneOf`/`anyOf`/`allOf` request rejections while preserving nested combinators and runtime validation authority.
+
 - Made the "No API key for provider" error from `stream`/`complete` actionable for OpenCode Go/Zen subscription providers in headless runs (#755). The subscription is itself an API key (`OPENCODE_API_KEY`, created at https://opencode.ai/auth), not a separate OAuth/session token; the new `formatProviderCredentialHint` helper (composed into `formatMissingApiKeyError`) names the env var GJC reads, warns that a project `.env` is intentionally ignored for provider credentials, and points OpenCode users at the one-time interactive `gjc auth-broker login <provider>` credential capture to run before headless/print mode. No auth behavior changed.
 
 ## [0.5.3] - 2026-06-16

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2573,6 +2573,99 @@ export function normalizeAnthropicToolSchema(schema: unknown): unknown {
 	return result;
 }
 
+function getRequiredNames(schema: Record<string, unknown>): Set<string> {
+	return new Set(
+		Array.isArray(schema.required)
+			? schema.required.filter((entry): entry is string => typeof entry === "string")
+			: [],
+	);
+}
+
+function getSingleLiteralValue(schema: unknown): unknown | undefined {
+	if (!isRecord(schema)) return undefined;
+	if (Object.hasOwn(schema, "const")) return schema.const;
+	if (Array.isArray(schema.enum) && schema.enum.length === 1) return schema.enum[0];
+	return undefined;
+}
+
+function describeAnthropicRootBranch(index: number, branch: Record<string, unknown>, action: unknown): string {
+	const required = [...getRequiredNames(branch)];
+	const parts = [`Branch ${index + 1}`];
+	if (typeof action === "string" || typeof action === "number" || typeof action === "boolean") {
+		parts.push(`action ${JSON.stringify(action)}`);
+	}
+	if (required.length > 0) parts.push(`branch-required fields: ${required.join(", ")}`);
+	if (typeof branch.description === "string" && branch.description.length > 0) parts.push(branch.description);
+	return parts.join("; ");
+}
+
+/**
+ * Anthropic rejects tool `input_schema` roots containing top-level oneOf/anyOf/allOf.
+ * Keep the generic normalizer schema-preserving, then flatten only provider-emitted
+ * tool roots into one object while leaving nested combinators untouched.
+ */
+export function normalizeAnthropicToolRootInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = { ...schema };
+	const rootCombinators = COMBINATOR_KEYS.filter(key => Array.isArray(result[key]));
+	if (rootCombinators.length === 0) return result;
+
+	const baseProperties = isRecord(result.properties) ? { ...result.properties } : {};
+	const flattenKey = rootCombinators.find(key => {
+		const variants = result[key];
+		return (
+			Array.isArray(variants) &&
+			variants.length > 0 &&
+			variants.every(variant => isRecord(variant) && isJsonSchemaObjectNode(variant))
+		);
+	});
+
+	result.type = "object";
+	result.properties = baseProperties;
+	result.additionalProperties = result.additionalProperties === undefined ? false : result.additionalProperties;
+
+	if (flattenKey !== undefined) {
+		const variants = result[flattenKey] as unknown[];
+		const commonRequired = variants.map(variant => getRequiredNames(variant as Record<string, unknown>));
+		const required =
+			commonRequired.length === 0
+				? []
+				: [...commonRequired[0]].filter(name => commonRequired.every(set => set.has(name)));
+		const actionValues: unknown[] = [];
+		const guidance: string[] = [];
+
+		for (const [index, variant] of variants.entries()) {
+			const branch = variant as Record<string, unknown>;
+			if (isRecord(branch.properties)) {
+				Object.assign(baseProperties, branch.properties);
+				const actionValue = getSingleLiteralValue(branch.properties.action);
+				if (actionValue !== undefined && !actionValues.includes(actionValue)) actionValues.push(actionValue);
+				guidance.push(describeAnthropicRootBranch(index, branch, actionValue));
+			} else {
+				guidance.push(describeAnthropicRootBranch(index, branch, undefined));
+			}
+		}
+
+		if (actionValues.length > 0) {
+			const existingAction = isRecord(baseProperties.action) ? { ...baseProperties.action } : {};
+			delete existingAction.const;
+			baseProperties.action = { ...existingAction, enum: actionValues };
+		}
+		result.required = required;
+		spillToDescription(result, [
+			["rootCombinatorGuidance", guidance],
+			...rootCombinators.filter(key => key !== flattenKey).map(key => [key, result[key]] as [string, unknown]),
+		]);
+	} else {
+		spillToDescription(
+			result,
+			rootCombinators.map(key => [key, result[key]]),
+		);
+	}
+
+	for (const key of COMBINATOR_KEYS) delete result[key];
+	return result;
+}
+
 type AnthropicToolInputSchema = Anthropic.Messages.Tool["input_schema"];
 
 type AnthropicToolSchemaPlan = {
@@ -2740,14 +2833,16 @@ function normalizeAnthropicStrictSchema(
 
 function buildAnthropicBaseToolInputSchema(tool: Tool): Record<string, unknown> {
 	const jsonSchema = toolWireSchema(tool);
-	return normalizeAnthropicToolSchema({
-		...jsonSchema,
-		type: "object",
-		properties: isRecord(jsonSchema.properties) ? jsonSchema.properties : {},
-		required: Array.isArray(jsonSchema.required)
-			? jsonSchema.required.filter((entry): entry is string => typeof entry === "string")
-			: [],
-	}) as Record<string, unknown>;
+	return normalizeAnthropicToolRootInputSchema(
+		normalizeAnthropicToolSchema({
+			...jsonSchema,
+			type: "object",
+			properties: isRecord(jsonSchema.properties) ? jsonSchema.properties : {},
+			required: Array.isArray(jsonSchema.required)
+				? jsonSchema.required.filter((entry): entry is string => typeof entry === "string")
+				: [],
+		}) as Record<string, unknown>,
+	);
 }
 
 function buildAnthropicToolSchemaPlans(tools: Tool[], disableStrictTools = false): AnthropicToolSchemaPlan[] {

--- a/packages/ai/test/anthropic-tool-schema.test.ts
+++ b/packages/ai/test/anthropic-tool-schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeAnthropicToolSchema } from "@gajae-code/ai/providers/anthropic";
+import {
+	normalizeAnthropicToolRootInputSchema,
+	normalizeAnthropicToolSchema,
+} from "@gajae-code/ai/providers/anthropic";
 
 describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 	describe("number / integer nodes", () => {
@@ -169,7 +172,7 @@ describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 			});
 		});
 
-		it("preserves universal keys: $ref, $defs, anyOf, enum, const, default, title", () => {
+		it("preserves universal keys: $ref, $defs, anyOf, oneOf, enum, const, default, title", () => {
 			const out = normalizeAnthropicToolSchema({
 				$defs: { Color: { type: "string", enum: ["r", "g", "b"] } },
 				type: "object",
@@ -177,6 +180,7 @@ describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 				properties: {
 					ref: { $ref: "#/$defs/Color" },
 					union: { anyOf: [{ type: "string" }, { type: "number" }] },
+					exclusive: { oneOf: [{ type: "string" }, { type: "number" }] },
 					choice: { const: "x" },
 					hint: { type: "string", default: "anon" },
 				},
@@ -185,9 +189,114 @@ describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 			expect(out.$defs).toEqual({ Color: { type: "string", enum: ["r", "g", "b"] } });
 			expect(out.properties.ref).toEqual({ $ref: "#/$defs/Color" });
 			expect(out.properties.union.anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+			expect(out.properties.exclusive.oneOf).toEqual([{ type: "string" }, { type: "number" }]);
 			expect(out.properties.choice).toEqual({ const: "x" });
 			expect(out.properties.hint).toEqual({ type: "string", default: "anon" });
 		});
+	});
+});
+
+describe("normalizeAnthropicToolRootInputSchema", () => {
+	it("removes root combinators, keeps common required fields only, derives action enum, and preserves nested combinators", () => {
+		const out = normalizeAnthropicToolRootInputSchema(
+			normalizeAnthropicToolSchema({
+				type: "object",
+				oneOf: [
+					{
+						type: "object",
+						description: "Move the cursor",
+						properties: {
+							action: { const: "move" },
+							x: { type: "integer" },
+							y: { type: "integer" },
+							button: { anyOf: [{ type: "string", enum: ["left"] }, { type: "null" }] },
+						},
+						required: ["action", "x", "y"],
+					},
+					{
+						type: "object",
+						description: "Type text",
+						properties: {
+							action: { enum: ["type"] },
+							text: { type: "string" },
+						},
+						required: ["action", "text"],
+					},
+				],
+			}) as Record<string, unknown>,
+		);
+
+		expect(out).not.toHaveProperty("oneOf");
+		expect(out).not.toHaveProperty("anyOf");
+		expect(out).not.toHaveProperty("allOf");
+		expect(out.type).toBe("object");
+		expect(out.required).toEqual(["action"]);
+
+		const properties = out.properties as Record<string, Record<string, unknown>>;
+		expect(properties.action.enum).toEqual(["move", "type"]);
+		expect(properties.button.anyOf).toEqual([{ type: "string", enum: ["left"] }, { type: "null" }]);
+		expect(out.description).toContain("rootCombinatorGuidance");
+		expect(out.description).toContain("Move the cursor");
+		expect(out.description).toContain("branch-required fields: action, x, y");
+	});
+
+	it("demotes unsafe root combinators into description without removing nested combinators", () => {
+		const out = normalizeAnthropicToolRootInputSchema(
+			normalizeAnthropicToolSchema({
+				type: "object",
+				properties: {
+					value: { anyOf: [{ type: "string" }, { type: "integer" }] },
+				},
+				anyOf: [{ type: "string" }, { type: "integer" }],
+			}) as Record<string, unknown>,
+		);
+
+		expect(out).not.toHaveProperty("anyOf");
+		expect(out.type).toBe("object");
+		expect(out.description).toContain("anyOf");
+		const properties = out.properties as Record<string, Record<string, unknown>>;
+		expect(properties.value.anyOf).toEqual([{ type: "string" }, { type: "integer" }]);
+	});
+
+	it("derives the complete computer action enum without globally requiring branch fields", () => {
+		const actions = [
+			{ action: "screenshot", required: ["action"] },
+			{ action: "click", required: ["action", "x", "y"] },
+			{ action: "double_click", required: ["action", "x", "y"] },
+			{ action: "move", required: ["action", "x", "y"] },
+			{ action: "drag", required: ["action", "x", "y", "to_x", "to_y"] },
+			{ action: "scroll", required: ["action", "x", "y", "scroll_x", "scroll_y"] },
+			{ action: "type", required: ["action", "text"] },
+			{ action: "keypress", required: ["action", "keys"] },
+			{ action: "wait", required: ["action", "ms"] },
+		];
+		const out = normalizeAnthropicToolRootInputSchema(
+			normalizeAnthropicToolSchema({
+				type: "object",
+				oneOf: actions.map(({ action, required }) => ({
+					type: "object",
+					properties: {
+						action: { const: action },
+						x: { type: "number" },
+						y: { type: "number" },
+						to_x: { type: "number" },
+						to_y: { type: "number" },
+						scroll_x: { type: "number" },
+						scroll_y: { type: "number" },
+						text: { type: "string" },
+						keys: { type: "array", items: { type: "string" }, minItems: 1 },
+						ms: { type: "integer" },
+					},
+					required,
+				})),
+			}) as Record<string, unknown>,
+		);
+
+		expect(out).not.toHaveProperty("oneOf");
+		expect(out.required).toEqual(["action"]);
+		const properties = out.properties as Record<string, Record<string, unknown>>;
+		expect(properties.action.enum).toEqual(actions.map(({ action }) => action));
+		expect(out.description).toContain("branch-required fields: action, x, y, to_x, to_y");
 	});
 });
 

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -62,6 +62,30 @@ describe("computer tool schema", () => {
 		expect(() => computerSchema.parse({ action: "scroll", x: 1, y: 2, scrollX: 0, scrollY: 1 })).toThrow();
 		expect(() => computerSchema.parse({ action: "screenshot", includeScreenshot: true })).toThrow();
 	});
+
+	it("keeps runtime validation authoritative for action-specific fields", () => {
+		expect(() => computerSchema.parse({ action: "screenshot", x: 1 })).toThrow();
+		expect(() => computerSchema.parse({ action: "screenshot", text: "ignored" })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "click", y: 2 })).toThrow();
+		expect(() => computerSchema.parse({ action: "click", x: 1 })).toThrow();
+		expect(() => computerSchema.parse({ action: "move", y: 2 })).toThrow();
+		expect(() => computerSchema.parse({ action: "move", x: 1 })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "drag", x: 1, y: 2, to_y: 4 })).toThrow();
+		expect(() => computerSchema.parse({ action: "drag", x: 1, y: 2, to_x: 3 })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "type" })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "keypress" })).toThrow();
+		expect(() => computerSchema.parse({ action: "keypress", keys: [] })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "wait" })).toThrow();
+		expect(() => computerSchema.parse({ action: "wait", ms: 1.5 })).toThrow();
+		expect(() => computerSchema.parse({ action: "wait", ms: -1 })).toThrow();
+
+		expect(() => computerSchema.parse({ action: "launch" })).toThrow();
+	});
 });
 
 describe("computer tool gating", () => {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed computer-use supervisor liveness on macOS by refreshing the kill-switch heartbeat from the live event-tap run loop while idle and clearing liveness on tap/run-loop failure or teardown, preventing false `COMPUTER_SUPERVISOR_NOT_LIVE` rejections without weakening fail-closed input gating.
+
 ## [0.5.3] - 2026-06-16
 
 ### Fixed


### PR DESCRIPTION
## Summary
- flatten Anthropic tool input-schema roots to avoid top-level combinator request rejections while preserving nested schemas
- keep computer runtime validation authoritative for action-specific fields
- refresh macOS computer-use hotkey supervisor heartbeat from the live event-tap run loop and fail closed on listener failure

## Verification
- bun test packages/ai/test/anthropic-tool-schema.test.ts packages/coding-agent/test/tools/computer.test.ts
- cargo test -p pi-natives computer::hotkey --lib
- bun run check (packages/ai)
- bunx biome check packages/ai/src/providers/anthropic.ts packages/ai/test/anthropic-tool-schema.test.ts packages/coding-agent/test/tools/computer.test.ts packages/ai/CHANGELOG.md packages/natives/CHANGELOG.md
- rustfmt --check crates/pi-natives/src/computer/hotkey.rs

Note: repo-wide bun run check:ts was attempted and fails on pre-existing source-linked worktree type identity issues under packages/coding-agent, unrelated to this change.