### PR TITLE
fix(ai): flatten nested Anthropic tool root combinators

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2598,6 +2598,25 @@ function describeAnthropicRootBranch(index: number, branch: Record<string, unkno
 	if (typeof branch.description === "string" && branch.description.length > 0) parts.push(branch.description);
 	return parts.join("; ");
 }
+function collectAnthropicRootObjectBranches(schema: unknown): Record<string, unknown>[] | undefined {
+	if (!isRecord(schema)) return undefined;
+	if (isJsonSchemaObjectNode(schema)) return [schema];
+
+	const combinatorKeys = COMBINATOR_KEYS.filter(key => Array.isArray(schema[key]));
+	if (combinatorKeys.length === 0) return undefined;
+
+	const branches: Record<string, unknown>[] = [];
+	for (const key of combinatorKeys) {
+		const variants = schema[key];
+		if (!Array.isArray(variants) || variants.length === 0) return undefined;
+		for (const variant of variants) {
+			const nestedBranches = collectAnthropicRootObjectBranches(variant);
+			if (nestedBranches === undefined) return undefined;
+			branches.push(...nestedBranches);
+		}
+	}
+	return branches;
+}
 
 /**
  * Anthropic rejects tool `input_schema` roots containing top-level oneOf/anyOf/allOf.
@@ -2610,31 +2629,22 @@ export function normalizeAnthropicToolRootInputSchema(schema: Record<string, unk
 	if (rootCombinators.length === 0) return result;
 
 	const baseProperties = isRecord(result.properties) ? { ...result.properties } : {};
-	const flattenKey = rootCombinators.find(key => {
-		const variants = result[key];
-		return (
-			Array.isArray(variants) &&
-			variants.length > 0 &&
-			variants.every(variant => isRecord(variant) && isJsonSchemaObjectNode(variant))
-		);
-	});
+	const flattenedBranches = rootCombinators
+		.map(key => ({ key, branches: collectAnthropicRootObjectBranches({ [key]: result[key] }) }))
+		.find(entry => entry.branches !== undefined && entry.branches.length > 0);
 
 	result.type = "object";
 	result.properties = baseProperties;
 	result.additionalProperties = result.additionalProperties === undefined ? false : result.additionalProperties;
 
-	if (flattenKey !== undefined) {
-		const variants = result[flattenKey] as unknown[];
-		const commonRequired = variants.map(variant => getRequiredNames(variant as Record<string, unknown>));
-		const required =
-			commonRequired.length === 0
-				? []
-				: [...commonRequired[0]].filter(name => commonRequired.every(set => set.has(name)));
+	if (flattenedBranches?.branches !== undefined) {
+		const variants = flattenedBranches.branches;
+		const commonRequired = variants.map(variant => getRequiredNames(variant));
+		const required = [...commonRequired[0]].filter(name => commonRequired.every(set => set.has(name)));
 		const actionValues: unknown[] = [];
 		const guidance: string[] = [];
 
-		for (const [index, variant] of variants.entries()) {
-			const branch = variant as Record<string, unknown>;
+		for (const [index, branch] of variants.entries()) {
 			if (isRecord(branch.properties)) {
 				Object.assign(baseProperties, branch.properties);
 				const actionValue = getSingleLiteralValue(branch.properties.action);
@@ -2653,7 +2663,9 @@ export function normalizeAnthropicToolRootInputSchema(schema: Record<string, unk
 		result.required = required;
 		spillToDescription(result, [
 			["rootCombinatorGuidance", guidance],
-			...rootCombinators.filter(key => key !== flattenKey).map(key => [key, result[key]] as [string, unknown]),
+			...rootCombinators
+				.filter(key => key !== flattenedBranches.key)
+				.map(key => [key, result[key]] as [string, unknown]),
 		]);
 	} else {
 		spillToDescription(

--- a/packages/ai/test/anthropic-tool-schema.test.ts
+++ b/packages/ai/test/anthropic-tool-schema.test.ts
@@ -298,6 +298,61 @@ describe("normalizeAnthropicToolRootInputSchema", () => {
 		expect(properties.action.enum).toEqual(actions.map(({ action }) => action));
 		expect(out.description).toContain("branch-required fields: action, x, y, to_x, to_y");
 	});
+
+	it("flattens nested root combinators from nullable discriminated unions", () => {
+		const leafActions = [
+			{ action: "screenshot", required: ["action"] },
+			{ action: "click", required: ["action", "x", "y"] },
+		];
+		const out = normalizeAnthropicToolRootInputSchema(
+			normalizeAnthropicToolSchema({
+				anyOf: [
+					{
+						oneOf: leafActions.map(({ action, required }) => ({
+							type: "object",
+							properties: {
+								action: { const: action },
+								x: { type: "number" },
+								y: { type: "number" },
+							},
+							required,
+							additionalProperties: false,
+						})),
+					},
+					{
+						type: "object",
+						properties: {
+							action: { const: "batch" },
+							actions: {
+								type: "array",
+								items: {
+									oneOf: leafActions.map(({ action }) => ({
+										type: "object",
+										properties: { action: { const: action } },
+									})),
+								},
+							},
+						},
+						required: ["action", "actions"],
+						additionalProperties: false,
+					},
+				],
+				properties: {},
+				required: [],
+				type: "object",
+				additionalProperties: false,
+			}) as Record<string, unknown>,
+		);
+
+		expect(out).not.toHaveProperty("anyOf");
+		expect(out).not.toHaveProperty("oneOf");
+		expect(out.required).toEqual(["action"]);
+		const properties = out.properties as Record<string, Record<string, unknown>>;
+		expect(properties.action.enum).toEqual(["screenshot", "click", "batch"]);
+		expect(properties.actions).toHaveProperty("items");
+		expect(JSON.stringify(properties.actions)).toContain("oneOf");
+		expect(out.description).toContain("branch-required fields: action, actions");
+	});
 });
 
 /**


### PR DESCRIPTION
## Summary
- flatten nested root combinators like anyOf -> oneOf at Anthropic tool input_schema roots
- preserve nested non-root combinators inside properties/items for runtime/tool guidance
- add regression coverage based on the reported computer tool schema 400

## Verification
- bun test packages/ai/test/anthropic-tool-schema.test.ts packages/coding-agent/test/tools/computer.test.ts
- bun run check (packages/ai)

Fixes the follow-up 400: input_schema does not support oneOf, allOf, or anyOf at the top level.