### PR TITLE
Fix Hangul terminal emission normalization

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalized canonically decomposed Hangul jamo at the terminal emission boundary so Korean text remains precomposed/stable in VS Code Remote and other terminal renderers that mishandle jamo clusters during repaint (#837).
+
 ## [0.5.3] - 2026-06-16
 
 ### Fixed

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -154,7 +154,6 @@ const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;
 const THAI_LAO_AM_GLOBAL_REGEX = /[\u0e33\u0eb3]/g;
 const HANGUL_JAMO_REGEX = /[\u1100-\u11ff\ua960-\ua97f\ud7b0-\ud7ff]/;
 
-
 /**
  * Normalize text for terminal output without changing logical editor content.
  * Some terminals render canonically decomposed Hangul jamo or precomposed
@@ -165,7 +164,9 @@ export function normalizeTerminalOutput(str: string): string {
 	let normalized = str;
 	if (HANGUL_JAMO_REGEX.test(normalized)) normalized = normalized.normalize("NFC");
 	if (!THAI_LAO_AM_REGEX.test(normalized)) return normalized;
-	return normalized.replaceAll(THAI_LAO_AM_GLOBAL_REGEX, char => (char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2"));
+	return normalized.replaceAll(THAI_LAO_AM_GLOBAL_REGEX, char =>
+		char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2",
+	);
 }
 
 const makeBoolArray = (chars: string): Uint8Array => {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -152,16 +152,20 @@ export function visibleWidth(str: string): number {
 
 const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;
 const THAI_LAO_AM_GLOBAL_REGEX = /[\u0e33\u0eb3]/g;
+const HANGUL_JAMO_REGEX = /[\u1100-\u11ff\ua960-\ua97f\ud7b0-\ud7ff]/;
+
 
 /**
  * Normalize text for terminal output without changing logical editor content.
- * Some terminals render precomposed Thai/Lao AM vowels inconsistently during
- * differential repaint. Their compatibility decompositions have the same cell
- * width but avoid stale-cell artifacts in terminal renderers.
+ * Some terminals render canonically decomposed Hangul jamo or precomposed
+ * Thai/Lao AM vowels inconsistently during differential repaint. Emit a stable
+ * terminal form while keeping the component/source strings unchanged.
  */
 export function normalizeTerminalOutput(str: string): string {
-	if (!THAI_LAO_AM_REGEX.test(str)) return str;
-	return str.replace(THAI_LAO_AM_GLOBAL_REGEX, char => (char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2"));
+	let normalized = str;
+	if (HANGUL_JAMO_REGEX.test(normalized)) normalized = normalized.normalize("NFC");
+	if (!THAI_LAO_AM_REGEX.test(normalized)) return normalized;
+	return normalized.replaceAll(THAI_LAO_AM_GLOBAL_REGEX, char => (char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2"));
 }
 
 const makeBoolArray = (chars: string): Uint8Array => {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -281,6 +281,26 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("normalizes decomposed Korean jamo before terminal emission", async () => {
+			const term = new VirtualTerminal(20, 6);
+			const tui = new TUI(term);
+			const decomposed = "한글 출력";
+			const component = new MutableLinesComponent([decomposed]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const viewport = visible(term);
+				expect(viewport[0]).toBe("한글 출력");
+				expect(viewport.join("\n")).not.toContain("ᄒ");
+				expect(viewport.join("\n")).not.toContain("\\u");
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("maintains exact viewport rows across repeated width reflow on sparse mixed content", async () => {
 			const term = new VirtualTerminal(80, 18);
 			const tui = new TUI(term);

--- a/packages/tui/test/viewport-virtualization-redteam.test.ts
+++ b/packages/tui/test/viewport-virtualization-redteam.test.ts
@@ -250,7 +250,7 @@ const scenarios: ScriptedScenario[] = [
 		width: 22,
 		initialLines: [
 			...makeRows(34),
-			"wide-ascii-" + "x".repeat(80),
+			`wide-ascii-${"x".repeat(80)}`,
 			"bang-fit-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
 			"wide-cjk-界".repeat(20),
 		],


### PR DESCRIPTION
## Summary
- Normalize canonically decomposed Hangul jamo at the TUI terminal emission boundary before diff/truncate writes.
- Add a virtual-terminal regression covering decomposed Korean output rendering as precomposed Hangul without visible `\u` fragments.
- Document the fix in the TUI changelog.

Fixes #837

## Verification
- `bun test packages/tui/test/render-regressions.test.ts`
- `bun --cwd=packages/tui run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*