### PR TITLE
Fix Korean Unicode leak detection

### DIFF
--- a/packages/agent/src/harmony-leak.ts
+++ b/packages/agent/src/harmony-leak.ts
@@ -31,10 +31,11 @@ const FAKE_RESULT_RE = /to=functions\.\w+[\s\S]{0,80}?code_output\s*\nCell\s+\d+
 
 const FENCE_RE = /^\s*(?:```+|~~~+)/;
 
-// Non-Latin scripts seen in the corpus: CJK + ext, Cyrillic, Thai, Georgian,
-// Armenian, Kannada, Telugu, Devanagari, Arabic, Malayalam.
+// Non-Latin scripts seen in the corpus: CJK + ext, Hangul + Jamo,
+// Cyrillic, Thai, Georgian, Armenian, Kannada, Telugu, Devanagari,
+// Arabic, Malayalam.
 const SCRIPT_CLASS =
-	"\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\u0400-\u04FF\u0E00-\u0E7F\u10A0-\u10FF\u0530-\u058F\u0C80-\u0CFF\u0C00-\u0C7F\u0900-\u097F\u0600-\u06FF\u0D00-\u0D7F";
+	"\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\u0400-\u04FF\u0E00-\u0E7F\u10A0-\u10FF\u0530-\u058F\u0C80-\u0CFF\u0C00-\u0C7F\u0900-\u097F\u0600-\u06FF\u0D00-\u0D7F";
 const SCRIPT_RUN_RE = new RegExp(`[${SCRIPT_CLASS}]{2,}`, "u");
 
 // Recovery registry. Each entry's parser must recognize the configured

--- a/packages/agent/test/harmony-leak.test.ts
+++ b/packages/agent/test/harmony-leak.test.ts
@@ -72,6 +72,11 @@ describe("detectHarmonyLeak — negative cases (must NOT trip)", () => {
 		expect(detectHarmonyLeak("...to=funct", "tool_arg")).toBeUndefined();
 		expect(detectHarmonyLeak("...to=functions.", "tool_arg")).toBeUndefined();
 	});
+
+	it("does not treat normal Korean prose as a leak", () => {
+		const korean = "추천 내용 이해 자체가 어렵네요. 다음 질문은 제약 조건을 명확히 합니다.";
+		expect(detectHarmonyLeak(korean, "assistant_text")).toBeUndefined();
+	});
 });
 
 describe("detectHarmonyLeak — positive corpus cases (must trip with co-signal)", () => {
@@ -90,6 +95,22 @@ describe("detectHarmonyLeak — positive corpus cases (must trip with co-signal)
 			}
 		});
 	}
+
+	it("trips script-mismatch recovery for Korean-adjacent leaked tool markers", () => {
+		const cases = [
+			{ name: "Hangul syllables", text: "추천 내용" },
+			{ name: "Hangul Jamo", text: "한글" },
+			{ name: "Hangul compatibility Jamo", text: "ㅎㅏㄴㄱㅡㄹ" },
+		];
+
+		for (const { name, text } of cases) {
+			const leaked = `${"ascii context ".repeat(20)}${text} to=functions.edit code \\ubcdef`;
+			const detection = detectHarmonyLeak(leaked, "assistant_text");
+
+			expect(detection, name).toBeDefined();
+			expect(signalListLabel(detection!.signals), name).toContain("S");
+		}
+	});
 });
 
 describe("recoverHarmonyToolCall — edit DSL", () => {

--- a/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
+++ b/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
@@ -85,4 +85,26 @@ describe("deep-interview assistant render middleware", () => {
 		expect(rendered).toContain("Status");
 		expect(rendered).toContain("Clarity threshold met! Ready to proceed.");
 	});
+
+	it("preserves Korean text literally in deep-interview progress rendering", () => {
+		const raw = [
+			"Round 5 complete.",
+			"",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.90 | 0.40 | 0.36 | Clear |",
+			"| Constraints | 0.70 | 0.30 | 0.21 | 추천 내용 이해 자체가 어렵네요 |",
+			"| Success Criteria | 0.60 | 0.30 | 0.18 | 한국어 출력이 리터럴로 보여야 합니다 |",
+			"| **Ambiguity** | | | **25%** | |",
+			"",
+			"**Next target:** 리뷰 UI / Success Criteria — 한국어 기준을 명확히 합니다",
+		].join("\n");
+
+		const rendered = renderAssistantText(raw);
+
+		expect(rendered).toContain("추천 내용 이해 자체가 어렵네요");
+		expect(rendered).toContain("한국어 출력이 리터럴로 보여야 합니다");
+		expect(rendered).toContain("한국어 기준을 명확히 합니다");
+		expect(rendered).not.toContain("\\u");
+	});
 });


### PR DESCRIPTION
## Summary
- Add Hangul syllable/Jamo ranges to harmony leak script-mismatch detection so Korean-adjacent tool/harmony marker leaks are caught instead of rendered.
- Add regression coverage for normal Korean prose, Hangul/Jamo/compatibility-Jamo leak detection, and deep-interview Korean rendering without \u escaping.

## Tests
- bun --cwd=packages/agent test test/harmony-leak.test.ts
- bun --cwd=packages/coding-agent test test/modes/components/deep-interview-render-middleware.test.ts
- bunx biome check packages/agent/src/harmony-leak.ts packages/agent/test/harmony-leak.test.ts packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*