### PR TITLE
Fix TUI render golden after Hangul normalization

### DIFF
--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/meta.json
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/meta.json
@@ -24,15 +24,15 @@
   "artifacts": {
     "viewport": {
       "file": "viewport.txt",
-      "sha256": "d7c2d3820bd42e49a4cfa152e3dc8a3d61e3f75f74f13b450384e1c8dabece32"
+      "sha256": "479295f08a5b215df4ce2295408db5f5c154f171e5b91dc1af6becb99cbf2ba5"
     },
     "scrollback": {
       "file": "scrollback.txt",
-      "sha256": "4b1772926f9e6e251e68c7257b3320d7d0909cdacea95a797e163ec0165a6fde"
+      "sha256": "a1772ae48ba458ea2acdb0a201ddd2b6e450e1c203b04c7dd325fc21fe024a3d"
     },
     "writelog": {
       "file": "writelog.bin",
-      "sha256": "42663eab43ab284c5953ab04832748b669525ab5d1f95622fff7bbd525314f40"
+      "sha256": "37ebbe53ebec5249449678b4c1286036d0da007f74217a41d42b13eb28f170d3"
     }
   }
 }

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/scrollback.txt
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/scrollback.txt
@@ -3,7 +3,7 @@
  │ Deterministic quote with link (https://example.test/golden).                     
                                                                                     
  - list alpha                                                                       
- - list beta with CJK 表示 and 한글 jamo 한                                         
+ - list beta with CJK 表示 and 한글 jamo 한                                         
                                                                                     
  +--------+------------+                                                            
  | Glyph  | Value      |                                                            

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/viewport.txt
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/viewport.txt
@@ -2,7 +2,7 @@
  │ Deterministic quote with link (https://example.test/golden).                     
                                                                                     
  - list alpha                                                                       
- - list beta with CJK 表示 and 한글 jamo 한                                         
+ - list beta with CJK 表示 and 한글 jamo 한                                         
                                                                                     
  +--------+------------+                                                            
  | Glyph  | Value      |                                                            

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/writelog.bin
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/writelog.bin
@@ -3,7 +3,7 @@
  [2m│ [22m[3m[3mDeterministic quote with ]8;;https://example.test/golden[34m[4mlink[24m[39m]8;;]8;;https://example.test/golden[2m (https://example.test/golden)[22m]8;;.[23m[3m[23m             [0m]8;;
                                                                             [0m
  [36m- [39mlist alpha                                                               [0m
- [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                 [0m
+ [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                 [0m
                                                                             [0m
  +--------+------------+                                                    [0m
  | [1mGlyph [22m | [1mValue     [22m |                                                    [0m
@@ -23,7 +23,7 @@
  [2m│ [22m[2;3m(https://example.test/golden)[22m]8;;.[23m[3m[23m                         [0m]8;;
                                                           [0m
  [36m- [39mlist alpha                                             [0m
- [36m- [39mlist beta with CJK 表示 and 한글 jamo 한               [0m
+ [36m- [39mlist beta with CJK 表示 and 한글 jamo 한               [0m
                                                           [0m
  +--------+------------+                                  [0m
  | [1mGlyph [22m | [1mValue     [22m |                                  [0m
@@ -42,7 +42,7 @@
  [2m│ [22m[3m[3mDeterministic quote with ]8;;https://example.test/golden[34m[4mlink[24m[39m]8;;]8;;https://example.test/golden[2m (https://example.test/golden)[22m]8;;.[23m[3m[23m                     [0m]8;;
                                                                                     [0m
  [36m- [39mlist alpha                                                                       [0m
- [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                         [0m
+ [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                         [0m
                                                                                     [0m
  +--------+------------+                                                            [0m
  | [1mGlyph [22m | [1mValue     [22m |                                                            [0m


### PR DESCRIPTION
Fixes dev CI failure after #840 by updating the `layout-resize-rich-text` render golden to match the intended terminal emission normalization for decomposed Hangul jamo.

Evidence:
- Reproduced `@gajae-code/tui/test` locally after `bun install` and `bun run @gajae-code/natives/build`: `test/render-goldens.test.ts` failed because expected golden text kept `한`, while runtime terminal output now emits NFC `한`.
- Updated only the affected golden fixture artifacts and hashes; reverted generated native loader churn.
- `bun test test/render-goldens.test.ts` — 6 pass.
- `bun test test/render-regressions.test.ts test/viewport-virtualization-redteam.test.ts test/visible-width-jamo.test.ts` — 63 pass.
- `bun run check` in `packages/tui` — pass.
- `bun run @gajae-code/tui/test` — 534 pass.

Do not merge until CI is green and operator review is complete.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*