### PR TITLE
Fix coding-agent dev CI after preset expansion merge

### DIFF
--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -159,6 +159,7 @@ describe("preset landing adversarial QA", () => {
 		const cancel = vi.fn();
 		const selector = createSelector({ onCancel: cancel });
 		await rendered(selector);
+		selector.handleInput("\x1b[C");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n"); // preview first expanded profile
 		selector.handleInput("\n"); // scope menu
@@ -186,6 +187,7 @@ describe("preset landing adversarial QA", () => {
 	test("printable input exits preview/scope menu into seeded model search", async () => {
 		const selector = createSelector();
 		await rendered(selector);
+		selector.handleInput("\x1b[C");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		selector.handleInput("\n");
@@ -234,7 +236,7 @@ describe("preset landing adversarial QA", () => {
 			},
 		});
 		await rendered(comboSelector);
-		comboSelector.handleInput("\n"); // expand CODEX so COMBOS is visible
+		comboSelector.handleInput("\x1b[C"); // expand CODEX so COMBOS is visible
 		comboSelector.handleInput("\x1b[B"); // codex-eco profile
 		comboSelector.handleInput("\x1b[B"); // MINIMAX group
 		comboSelector.handleInput("\x1b[B"); // COMBOS group
@@ -246,7 +248,7 @@ describe("preset landing adversarial QA", () => {
 
 		const miniSelector = createSelector({ authenticatedProviders: ["openai-codex", "anthropic", "provider-a"] });
 		await rendered(miniSelector);
-		for (let i = 0; i < 2; i++) miniSelector.handleInput("\x1b[B");
+		miniSelector.handleInput("\x1b[B");
 		miniSelector.handleInput("\n");
 		text = normalizeRenderedText(miniSelector.render(260).join("\n"));
 		expect(text).toContain("/login minimax-code");
@@ -271,6 +273,7 @@ describe("preset landing adversarial QA", () => {
 	test("preview clamps codex eco executor to low and omits suffix for suffixless selector", async () => {
 		const selector = createSelector();
 		await rendered(selector);
+		selector.handleInput("\x1b[C");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		let text = normalizeRenderedText(selector.render(260).join("\n"));
@@ -279,6 +282,7 @@ describe("preset landing adversarial QA", () => {
 
 		const suffixless = createSelector({ profiles: [noSuffixProfile] });
 		await rendered(suffixless);
+		suffixless.handleInput("\x1b[C");
 		suffixless.handleInput("\x1b[B");
 		suffixless.handleInput("\n");
 		text = normalizeRenderedText(suffixless.render(260).join("\n"));
@@ -292,6 +296,7 @@ describe("preset landing adversarial QA", () => {
 		// overshooting past the destination group header onto its first profile.
 		const selector = createSelector();
 		await rendered(selector);
+		selector.handleInput("\x1b[C"); // expand CODEX explicitly
 		selector.handleInput("\x1b[B"); // CODEX header -> Codex Eco profile
 		selector.handleInput("\x1b[B"); // cross boundary into MINIMAX group
 		const label = cursorRowLabel(selector);
@@ -305,6 +310,7 @@ describe("preset landing adversarial QA", () => {
 		// on the trailing Browse row.
 		const selector = createSelector({ profiles: [codexEco, codexMedium, codexPro, minimax] });
 		await rendered(selector);
+		selector.handleInput("\x1b[C"); // expand CODEX explicitly
 		selector.handleInput("\x1b[B"); // Codex Eco
 		selector.handleInput("\x1b[B"); // Codex Medium
 		selector.handleInput("\x1b[B"); // Codex Pro (last profile of CODEX)
@@ -314,7 +320,9 @@ describe("preset landing adversarial QA", () => {
 		expect(headerLabel).not.toContain("Browse all models");
 		expect(headerLabel).not.toContain("MiniMax Medium");
 
-		// Navigation continues correctly through the destination group.
+		// Navigation continues correctly through the destination group after
+		// explicit expansion; focus/up-down alone must not auto-expand.
+		selector.handleInput("\x1b[C");
 		selector.handleInput("\x1b[B"); // MINIMAX header -> MiniMax Medium profile
 		expect(cursorRowLabel(selector)).toContain("MiniMax Medium");
 	});

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -162,7 +162,9 @@ describe("model selector profile red-team", () => {
 		const builtinProfile: ModelProfileDefinition = { ...userProfile, source: "builtin" };
 		const overriddenProfile: ModelProfileDefinition = { ...userProfile, source: "user" };
 		const selector = createSelector(() => {}, { profiles: [builtinProfile, overriddenProfile] });
-		const rendered = await renderSelector(selector);
+		await renderSelector(selector);
+		selector.handleInput("\x1b[C");
+		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
 
 		expect(rendered.match(/profile-a/g) ?? []).toHaveLength(1);
 	});
@@ -173,6 +175,7 @@ describe("model selector profile red-team", () => {
 			selections.push(selection);
 		});
 		await renderSelector(applySelector);
+		applySelector.handleInput("\x1b[C");
 		applySelector.handleInput("\x1b[B");
 		applySelector.handleInput("\n");
 		applySelector.handleInput("\n");
@@ -182,6 +185,7 @@ describe("model selector profile red-team", () => {
 			selections.push(selection);
 		});
 		await renderSelector(defaultSelector);
+		defaultSelector.handleInput("\x1b[C");
 		defaultSelector.handleInput("\x1b[B");
 		defaultSelector.handleInput("\n");
 		defaultSelector.handleInput("\n");
@@ -232,7 +236,9 @@ describe("model selector profile red-team", () => {
 			name: "Team/Profile: β 🚀 [default] {x}|$",
 		};
 		const selector = createSelector(() => {}, { profiles: [weirdProfile] });
-		const rendered = await renderSelector(selector);
+		await renderSelector(selector);
+		selector.handleInput("\x1b[C");
+		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
 
 		expect(rendered).toContain("Model presets");
 		expect(rendered).toContain("Team/Profile: β 🚀 [default] {x}|$");
@@ -242,7 +248,6 @@ describe("model selector profile red-team", () => {
 	test("Browse all models switches to flat model rows", async () => {
 		const selector = createSelector(() => {});
 		await renderSelector(selector);
-		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		const rendered = normalizeRenderedText(selector.render(240).join("\n"));


### PR DESCRIPTION
## Summary
- Updates preset landing/model selector redteam tests to use the accepted #841 explicit expansion contract: Right expands provider groups, Left collapses, while focus/up/down does not auto-expand.
- Leaves production selector code untouched.

## Verification
- `bun run --cwd packages/coding-agent test model-selector-profiles-redteam.test.ts model-preset-landing-redteam-qa.test.ts` — 17 pass.
- `bun run --cwd packages/coding-agent check` — pass with existing Biome warnings in `ultragoal-runtime.ts`.

## Context
- Fixes red dev CI after #841: `Affected path validation / test:@gajae-code/coding-agent` failed at `model-selector-profiles-redteam.test.ts#167` because stale tests still assumed Enter/up-down expansion after #841 intentionally moved group expansion to Right.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*