### PR TITLE
docs: link multivendor setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ retry:
 
 `requestMaxRetries` applies before a stream is established. `streamMaxRetries` applies only to replay-safe transient stream failures. Invalid auth, unsupported models/providers, malformed requests, context overflow, user aborts, and permanent quota failures remain fail-fast.
 
+### Good to read together
+
+- [GJC multivendor setup guide](https://github.com/project820/gjc-multivendor-setup-guide) — a community guide for role-based provider/profile selection across Anthropic, OpenAI/Codex, Google/Gemini, xAI/Grok, and opencode-go. Treat its presets as user-level configuration guidance rather than bundled defaults; verify model availability and provider auth in your own environment before adopting them.
+
 ## TUI identity
 
 The default dark TUI identity is the GJC red-claw theme, while light-appearance terminals default to the bundled blue-crab theme. Three additional bundled migration themes — `claude-code`, `codex`, and `opencode` — mirror the look of those tools for easy eye-migration and are selectable from Settings or `/theme`. Explicit user theme settings still win.


### PR DESCRIPTION
## Summary
- Add the community GJC multivendor setup guide to the README as a related guide.
- Leave its presets as user-level configuration guidance instead of bundling them into defaults, because the model selectors and rankings are subscription- and time-sensitive.

## Verification
- `git diff --check -- README.md`
- `bun run check:tools` (completed; existing Biome config notices and unrelated warnings in `packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*