### PR TITLE
feat(ultragoal): add GJC_ULTRAGOAL_DIR to isolate per-session slots

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,10 @@
 - Interactive sessions no longer orphan the `browser` tool's headless/spawned Chrome (and the Python eval kernel) to PID 1 when killed by a signal. The interactive entry now registers a bounded, idempotent `postmortem` cleanup (`session-subprocess-teardown`) that runs `AgentSession.disposeChildSubprocesses()` on `SIGINT`/`SIGTERM`/`SIGHUP`, force-releasing the session's browser tabs (`kill:true`) and disposing its Python/JS kernels — the teardown the graceful `/quit` (`dispose()`) path already performs but that an external `kill`/terminal-close used to bypass. Headless `disposeBrowserHandle` now also SIGTERM/SIGKILLs the captured Chrome process tree as a fallback when forced, so a wedged renderer can't survive a bounded CDP `close()`; graceful release behavior is unchanged. The teardown is time-boxed (5s) so a stuck subprocess can't hang process exit (#698).
 - Added first-class xAI search provider support for the `web_search` tool and `gjc q`, including OAuth/API-key auth, web/X/combined search modes, xAI web/X filters, image/video options, citation controls, usage reporting, Settings provider selection, CLI flags, config schema wiring, and edge-case coverage.
 
+### Added
+
+- Added a `GJC_ULTRAGOAL_DIR` env var that overrides the durable ultragoal slot location (`brief.md`/`goals.json`/`ledger.jsonl`), mirroring `GJC_TEAM_STATE_ROOT` for team state. The slot is otherwise hardcoded to `<cwd>/.gjc/ultragoal`, so multiple GJC sessions that share one checkout (e.g. the same repo opened in several terminals) clobber a single `goals.json` and interleave one `ledger.jsonl`. Setting `GJC_ULTRAGOAL_DIR` to a per-session path keeps each session's ultragoal isolated while leaving `cwd` unchanged. An absolute value is used as-is; a relative value resolves against `cwd`; unset preserves the historical default. Both `getUltragoalPaths` and the goal-mode handoff path resolution honor it.
+
 ## [0.5.3] - 2026-06-16
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
+++ b/packages/coding-agent/src/gjc-runtime/goal-mode-request.ts
@@ -53,7 +53,11 @@ function requestPath(cwd: string): string {
 }
 
 function ultragoalGoalsPath(cwd: string): string {
-	return path.join(cwd, ".gjc", "ultragoal", "goals.json");
+	// Mirror getUltragoalPaths: honor GJC_ULTRAGOAL_DIR so the goal-mode handoff
+	// resolves the same per-session slot the runtime uses.
+	const override = process.env.GJC_ULTRAGOAL_DIR?.trim();
+	const dir = override ? path.resolve(cwd, override) : path.join(cwd, ".gjc", "ultragoal");
+	return path.join(dir, "goals.json");
 }
 
 function isCreateGoalsArg(value: string): boolean {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -163,7 +163,14 @@ export function hashStructuredValue(value: unknown): string {
 }
 
 export function getUltragoalPaths(cwd: string): UltragoalPaths {
-	const dir = path.join(cwd, ".gjc", "ultragoal");
+	// GJC_ULTRAGOAL_DIR overrides the durable ultragoal slot location, mirroring
+	// GJC_TEAM_STATE_ROOT for team state. It lets several sessions that share one
+	// cwd (e.g. a single repo checkout opened in multiple terminals) keep isolated
+	// ultragoal slots instead of clobbering one .gjc/ultragoal. An absolute value
+	// is used as-is; a relative value resolves against cwd. Unset preserves the
+	// historical default (cwd/.gjc/ultragoal).
+	const override = process.env.GJC_ULTRAGOAL_DIR?.trim();
+	const dir = override ? path.resolve(cwd, override) : path.join(cwd, ".gjc", "ultragoal");
 	return {
 		dir,
 		briefPath: path.join(dir, "brief.md"),

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -13,6 +13,7 @@ import {
 	buildUltragoalHudSummary,
 	checkpointUltragoalGoal,
 	createUltragoalPlan,
+	getUltragoalPaths,
 	getUltragoalStatus,
 	readUltragoalLedger,
 	readUltragoalPlan,
@@ -3045,5 +3046,42 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 			const ledger = await Bun.file(path.join(root, ".gjc", "ultragoal", "ledger.jsonl")).text();
 			expect(ledger).toContain("reconcile_failed");
 		});
+	});
+});
+
+describe("getUltragoalPaths GJC_ULTRAGOAL_DIR override", () => {
+	let saved: string | undefined;
+	beforeEach(() => {
+		saved = process.env.GJC_ULTRAGOAL_DIR;
+		delete process.env.GJC_ULTRAGOAL_DIR;
+	});
+	afterEach(() => {
+		if (saved === undefined) delete process.env.GJC_ULTRAGOAL_DIR;
+		else process.env.GJC_ULTRAGOAL_DIR = saved;
+	});
+
+	it("defaults to <cwd>/.gjc/ultragoal when unset", () => {
+		const paths = getUltragoalPaths("/work/repo");
+		expect(paths.dir).toBe(path.join("/work/repo", ".gjc", "ultragoal"));
+		expect(paths.goalsPath).toBe(path.join("/work/repo", ".gjc", "ultragoal", "goals.json"));
+	});
+
+	it("uses an absolute GJC_ULTRAGOAL_DIR as-is, ignoring cwd", () => {
+		process.env.GJC_ULTRAGOAL_DIR = "/slots/session-a";
+		const paths = getUltragoalPaths("/work/repo");
+		expect(paths.dir).toBe("/slots/session-a");
+		expect(paths.ledgerPath).toBe(path.join("/slots/session-a", "ledger.jsonl"));
+	});
+
+	it("resolves a relative GJC_ULTRAGOAL_DIR against cwd", () => {
+		process.env.GJC_ULTRAGOAL_DIR = "slots/a";
+		const paths = getUltragoalPaths("/work/repo");
+		expect(paths.dir).toBe(path.join("/work/repo", "slots/a"));
+	});
+
+	it("trims and ignores a whitespace-only override", () => {
+		process.env.GJC_ULTRAGOAL_DIR = "   ";
+		const paths = getUltragoalPaths("/work/repo");
+		expect(paths.dir).toBe(path.join("/work/repo", ".gjc", "ultragoal"));
 	});
 });


### PR DESCRIPTION
## Problem

`getUltragoalPaths` hardcodes the durable ultragoal slot to `<cwd>/.gjc/ultragoal`. GJC goal mode is one-active-goal-per-session and the ledger/plan live at a single fixed path, so when several GJC sessions share one checkout — the common case for users who keep one working root open in multiple terminals — they all resolve the same `goals.json` / `ledger.jsonl`. The result is last-writer-wins clobbering of the active plan and interleaved audit trails. The goal-mode handoff path resolver hardcodes the same location.

## Change

Add a `GJC_ULTRAGOAL_DIR` env var that overrides the slot directory, mirroring the existing `GJC_TEAM_STATE_ROOT` pattern for team state:

- absolute value → used as-is (ignores `cwd`)
- relative value → resolved against `cwd`
- unset → historical default `<cwd>/.gjc/ultragoal` (fully backward compatible)

A launcher can set `GJC_ULTRAGOAL_DIR` to a per-session path to give each session an isolated ultragoal slot while leaving `cwd` unchanged, so file work and rule/context discovery are unaffected. Both `getUltragoalPaths` (the hub used across the runtime and the ultragoal guard) and `ultragoalGoalsPath` (goal-mode handoff) honor it.

## Tests

`bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts -t "GJC_ULTRAGOAL_DIR"` — 4 cases (unset default / absolute / relative / whitespace-only). All pass.

## Notes

- No behavior change when the env var is unset.
- Team integration that reads the fixed `.gjc/ultragoal/goals.json` is unaffected unless the env is explicitly set for the session.
