### PR TITLE
test(telegram-remote): wait for async event bridge sends

### DIFF
--- a/packages/telegram-remote/test/rpc-event-bridge.test.ts
+++ b/packages/telegram-remote/test/rpc-event-bridge.test.ts
@@ -26,7 +26,14 @@ async function storeWith(attachment: Partial<AttachmentRecord> = {}) {
 	return store;
 }
 
-function outbound(failAt: number[] = []) {
+type OutboundCapture = {
+	sent: Array<{ chatId: string; reply: ChatReply }>;
+	port: {
+		send(message: { chatId: string; reply: ChatReply }): Promise<{ ok: boolean; retryAfterMs?: number }>;
+	};
+};
+
+function outbound(failAt: number[] = []): OutboundCapture {
 	const sent: Array<{ chatId: string; reply: ChatReply }> = [];
 	let calls = 0;
 	return {
@@ -67,12 +74,16 @@ async function flush() {
 	}
 }
 
-async function waitForSent(out: ReturnType<typeof outbound>, count: number) {
+async function waitForCondition(predicate: () => boolean) {
 	for (let index = 0; index < 25; index += 1) {
-		if (out.sent.length >= count) return;
+		if (predicate()) return;
 		await Promise.resolve();
 		await new Promise(resolve => setTimeout(resolve, 0));
 	}
+}
+
+async function waitForSent(out: OutboundCapture, count: number) {
+	await waitForCondition(() => out.sent.length >= count);
 }
 
 describe("RpcEventBridge", () => {
@@ -96,6 +107,7 @@ describe("RpcEventBridge", () => {
 		expect(out.sent.map(item => item.reply.text)).toEqual(expected);
 		expect(out.sent.every(item => item.reply.text.length <= 4096)).toBe(true);
 		expect(out.sent.join(" ")).not.toContain("<");
+		await waitForCondition(() => store.get()?.deliveryIdentities.length === 1);
 		expect(store.get()?.deliveryIdentities).toHaveLength(1);
 	});
 
@@ -231,6 +243,7 @@ describe("RpcEventBridge", () => {
 		backend.emitEvent({ type: "session_exit" });
 		backend.emitEvent({ type: "agent_dead" });
 		await flush();
+		await waitForSent(out, 1);
 		expect(out.sent.map(item => item.reply.text)).toEqual([formatExitAlert()]);
 		expect(store.get()?.stale).toBe(true);
 


### PR DESCRIPTION
## Summary
- harden RpcEventBridge tests by waiting for async outbound sends/store identity persistence before assertions
- covers the post-merge Dev CI failure from #847 where telegram-remote tests observed zero sends before the async bridge delivery completed

## Validation
- `bun test packages/telegram-remote/test/rpc-event-bridge.test.ts -t 'turn_end delivers|session-exit event'` — pass\n- `cd packages/telegram-remote && bun run test` — 216 pass\n- `cd packages/telegram-remote && bun run check` — pass\n\nFollow-up for post-merge Dev CI failure: https://github.com/Yeachan-Heo/gajae-code/actions/runs/27739123151