### PR TITLE
feat(ai): opt-in session-identity headers for openai-completions

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -701,6 +701,7 @@ Request shaping:
 
 - `supportsStore` — emit `store: false` on requests. Default: auto (off for non-standard endpoints).
 - `supportsDeveloperRole` — use the `developer` system role for reasoning models instead of `system`. Default: auto.
+- `sendSessionHeaders` — forward the agent session id as `session_id` and `x-session-id` request headers so OpenAI-compatible relays/proxies can do session-affinity routing and reuse a server-side prompt cache. Default: `false`. Caller-set `headers`/`requestTransform` values are never overwritten.
 - `supportsUsageInStreaming` — send `stream_options: { include_usage: true }` to receive token usage on streaming responses. Default: `true`.
 - `maxTokensField` — `"max_completion_tokens"` or `"max_tokens"`. Default: auto.
 - `supportsToolChoice` — emit the `tool_choice` parameter when the caller forces a specific tool. Default: `true`. Set `false` for endpoints that 400 on `tool_choice` (e.g. DeepSeek when reasoning is on).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added opt-in `compat.sendSessionHeaders` for the `openai-completions` provider. When enabled (default off), the agent session id is forwarded as vendor-neutral `session_id` and `x-session-id` request headers to any OpenAI-compatible endpoint, letting relays/proxies do session-affinity routing and reuse a server-side prompt cache keyed by the session. Previously only the `openai-responses` provider injected session headers, and only against a first-party OpenAI base URL. Injection runs after the caller's `headers`/`extraHeaders` are merged and before `requestTransform`, and uses `??=` so any header the caller already set always wins; it is skipped entirely when the flag is off or no session id is available, leaving existing provider behavior byte-identical. The first-party `openai-responses` gating is unchanged.
 
 ## [0.6.0] - 2026-06-18
 ### Fixed

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -778,6 +778,7 @@ The `openai-completions` API is implemented by many providers with minor differe
 interface OpenAICompat {
 	supportsStore?: boolean; // Whether provider supports the `store` field (default: true)
 	supportsDeveloperRole?: boolean; // Whether provider supports `developer` role vs `system` (default: true)
+	sendSessionHeaders?: boolean; // Forward the session id as `session_id`/`x-session-id` headers for relay session-affinity & prompt-cache reuse (default: false)
 	supportsReasoningEffort?: boolean; // Whether provider supports `reasoning_effort` (default: true)
 	maxTokensField?: "max_completion_tokens" | "max_tokens"; // Which field name to use (default: max_completion_tokens)
 	extraBody?: Record<string, unknown>; // Extra request-body fields for custom proxy routing or provider-specific options

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -189,6 +189,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 	return {
 		supportsStore: !isNonStandard,
 		supportsDeveloperRole: !isNonStandard,
+		sendSessionHeaders: false,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
@@ -254,6 +255,7 @@ export function resolveOpenAICompat(
 	return {
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
+		sendSessionHeaders: model.compat.sendSessionHeaders ?? detected.sendSessionHeaders,
 		supportsMultipleSystemMessages:
 			model.compat.supportsMultipleSystemMessages ?? detected.supportsMultipleSystemMessages,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -453,6 +453,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				options?.streamFirstEventTimeoutMs,
 				options?.authCredentialType,
 				options?.requestMaxRetries,
+				options?.sessionId,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			getCapturedErrorResponse = captureErrorResponse;
@@ -943,6 +944,7 @@ async function createClient(
 	streamFirstEventTimeoutOverride?: number,
 	authCredentialType?: OpenAICompletionsOptions["authCredentialType"],
 	requestMaxRetries?: number,
+	sessionId?: string,
 ): Promise<{
 	client: OpenAI;
 	copilotPremiumRequests: number | undefined;
@@ -981,6 +983,14 @@ async function createClient(
 		headers["X-OpenRouter-Cache-TTL"] = "3600";
 	}
 	Object.assign(headers, extraHeaders);
+	if (sessionId && resolveOpenAICompat(model).sendSessionHeaders) {
+		// Forward the agent session id as vendor-neutral session-identity headers so
+		// OpenAI-compatible proxies/relays can do session-affinity routing and reuse a
+		// server-side prompt cache. Opt-in via `compat.sendSessionHeaders`; never
+		// overwrite a header the caller already set (model.headers / requestTransform).
+		headers.session_id ??= sessionId;
+		headers["x-session-id"] ??= sessionId;
+	}
 	if (model.provider === "kimi-code") {
 		headers = { ...getKimiCommonHeaders(), ...headers };
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -743,6 +743,17 @@ export interface OpenAICompat extends ToolChoiceCompat {
 	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
 	supportsDeveloperRole?: boolean;
 	/**
+	 * Whether to forward the agent session id as vendor-neutral session-identity
+	 * headers (`session_id`, `x-session-id`) on every chat-completions request.
+	 * Off by default. Opt in for OpenAI-compatible proxies/relays that route on
+	 * session affinity or reuse a server-side prompt cache keyed by session.
+	 * First-party OpenAI does not need this (it has its own gated injection in
+	 * the openai-responses provider). Headers are only added when a non-empty
+	 * session id is available and are never allowed to overwrite a header the
+	 * caller already set via `headers`/`requestTransform`.
+	 */
+	sendSessionHeaders?: boolean;
+	/**
 	 * Whether the provider's chat-completions endpoint accepts multiple
 	 * leading `system`/`developer` messages. When false, ordered system
 	 * prompts are coalesced into a single message joined by `\n\n` so

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -14,6 +14,7 @@ import type { Context, Model, OpenAICompat } from "@gajae-code/ai/types";
 const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: false,
+	sendSessionHeaders: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: false,
 	reasoningEffortMap: {},

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -22,6 +22,7 @@ const emptyUsage: Usage = {
 const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
+	sendSessionHeaders: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -70,6 +70,7 @@ describe("openai-completions compatibility", () => {
 		const compat = {
 			supportsStore: true,
 			supportsDeveloperRole: true,
+			sendSessionHeaders: false,
 			supportsMultipleSystemMessages: true,
 			supportsReasoningEffort: true,
 			reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-session-headers.test.ts
+++ b/packages/ai/test/openai-completions-session-headers.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import { detectOpenAICompat, resolveOpenAICompat } from "../src/providers/openai-completions-compat";
+import type { Context, Model } from "../src/types";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+// ── Wire-capture fetch ───────────────────────────────────────────────────────
+// The session-header injection lives in createClient(), which sets the OpenAI
+// SDK client's `defaultHeaders`. The SDK then merges those into the real fetch
+// `init.headers`. Capturing the outgoing headers here therefore proves the
+// header is actually transmitted on the wire, not just stored on an object.
+
+interface CapturedRequest {
+	url: string;
+	headers: Record<string, string>;
+}
+
+function createCapturingFetch(captured: CapturedRequest[]): typeof fetch {
+	async function capturingFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+		const headers: Record<string, string> = {};
+		// Headers can arrive as a Headers instance, a plain record, or on a Request.
+		const merge = (h: ConstructorParameters<typeof Headers>[0] | undefined): void => {
+			if (!h) return;
+			new Headers(h).forEach((value, key) => {
+				headers[key.toLowerCase()] = value;
+			});
+		};
+		if (input instanceof Request) merge(input.headers);
+		merge(init?.headers);
+		captured.push({
+			url: input instanceof Request ? input.url : String(input),
+			headers,
+		});
+		const payload = `data: ${JSON.stringify({
+			id: "chatcmpl-test",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "claude-opus-4-8",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		})}\n\ndata: [DONE]\n\n`;
+		return new Response(payload, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	}
+	return Object.assign(capturingFetch, { preconnect: originalFetch.preconnect });
+}
+
+function baseContext(): Context {
+	return {
+		messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+	};
+}
+
+// A custom OpenAI-compatible relay model (NOT first-party OpenAI).
+function relayModel(compat?: Model<"openai-completions">["compat"]): Model<"openai-completions"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		provider: "relay",
+		id: "claude-opus-4-8",
+		api: "openai-completions",
+		baseUrl: "https://api.relay.example.com/v1",
+		...(compat ? { compat } : {}),
+	};
+}
+
+// ── compat resolution ────────────────────────────────────────────────────────
+
+describe("sendSessionHeaders compat resolution", () => {
+	it("defaults to false for a custom relay base URL", () => {
+		const detected = detectOpenAICompat(relayModel());
+		expect(detected.sendSessionHeaders).toBe(false);
+	});
+
+	it("defaults to false for first-party OpenAI", () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+		};
+		expect(detectOpenAICompat(model).sendSessionHeaders).toBe(false);
+	});
+
+	it("is enabled when models.yml compat opts in", () => {
+		const resolved = resolveOpenAICompat(relayModel({ sendSessionHeaders: true }));
+		expect(resolved.sendSessionHeaders).toBe(true);
+	});
+
+	it("stays false when compat is present but omits the flag", () => {
+		const resolved = resolveOpenAICompat(relayModel({ supportsDeveloperRole: false }));
+		expect(resolved.sendSessionHeaders).toBe(false);
+	});
+});
+
+// ── end-to-end wire transmission ─────────────────────────────────────────────
+
+describe("session headers on the wire (streamOpenAICompletions)", () => {
+	it("transmits session_id + x-session-id when flag is ON and sessionId is present", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(relayModel({ sendSessionHeaders: true }), baseContext(), {
+			apiKey: "test-key",
+			sessionId: "conv-abc-123",
+			fetch: createCapturingFetch(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].headers.session_id).toBe("conv-abc-123");
+		expect(captured[0].headers["x-session-id"]).toBe("conv-abc-123");
+	});
+
+	it("omits session headers when flag is OFF (default behavior unchanged)", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(relayModel(), baseContext(), {
+			apiKey: "test-key",
+			sessionId: "conv-abc-123",
+			fetch: createCapturingFetch(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].headers.session_id).toBeUndefined();
+		expect(captured[0].headers["x-session-id"]).toBeUndefined();
+	});
+
+	it("omits session headers when flag is ON but sessionId is empty", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(relayModel({ sendSessionHeaders: true }), baseContext(), {
+			apiKey: "test-key",
+			sessionId: "",
+			fetch: createCapturingFetch(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].headers.session_id).toBeUndefined();
+		expect(captured[0].headers["x-session-id"]).toBeUndefined();
+	});
+
+	it("does not overwrite a caller-supplied session_id header (options.headers precedence)", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(relayModel({ sendSessionHeaders: true }), baseContext(), {
+			apiKey: "test-key",
+			sessionId: "derived-session",
+			headers: { session_id: "user-pinned" },
+			fetch: createCapturingFetch(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		// User-supplied header wins; the auto-injected x-session-id still fills the gap.
+		expect(captured[0].headers.session_id).toBe("user-pinned");
+		expect(captured[0].headers["x-session-id"]).toBe("derived-session");
+	});
+
+	it("does not overwrite a session_id baked into model.headers (models.yml headers precedence)", async () => {
+		const captured: CapturedRequest[] = [];
+		const model = relayModel({ sendSessionHeaders: true });
+		model.headers = { session_id: "config-pinned" };
+		await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			sessionId: "derived-session",
+			fetch: createCapturingFetch(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].headers.session_id).toBe("config-pinned");
+		expect(captured[0].headers["x-session-id"]).toBe("derived-session");
+	});
+});

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -15,6 +15,7 @@ const emptyUsage: Usage = {
 const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
+	sendSessionHeaders: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -22,6 +22,7 @@ const ReasoningEffortMapSchema = z.object({
 export const OpenAICompatSchema = z.object({
 	supportsStore: z.boolean().optional(),
 	supportsDeveloperRole: z.boolean().optional(),
+	sendSessionHeaders: z.boolean().optional(),
 	supportsMultipleSystemMessages: z.boolean().optional(),
 	supportsReasoningEffort: z.boolean().optional(),
 	reasoningEffortMap: ReasoningEffortMapSchema.optional(),

--- a/packages/coding-agent/test/models-config-send-session-headers.test.ts
+++ b/packages/coding-agent/test/models-config-send-session-headers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { ModelsConfigSchema } from "@gajae-code/coding-agent/config/models-config-schema";
+
+describe("models config sendSessionHeaders", () => {
+	test("accepts sendSessionHeaders in provider and model compat", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-completions",
+					compat: { sendSessionHeaders: true },
+					models: [
+						{
+							id: "relay-model",
+							name: "Relay",
+							contextWindow: 128000,
+							maxTokens: 8192,
+							compat: { sendSessionHeaders: false },
+						},
+					],
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a non-boolean sendSessionHeaders value", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-completions",
+					compat: { sendSessionHeaders: "yes" },
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("generated JSON schema exposes the sendSessionHeaders field", async () => {
+		const schema = (await import("../../../schemas/models.schema.json")) as Record<string, unknown>;
+		const text = JSON.stringify(schema);
+		expect(text).toContain('"sendSessionHeaders"');
+	});
+});

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -59,6 +59,9 @@
 							"supportsDeveloperRole": {
 								"type": "boolean"
 							},
+							"sendSessionHeaders": {
+								"type": "boolean"
+							},
 							"supportsMultipleSystemMessages": {
 								"type": "boolean"
 							},
@@ -469,6 +472,9 @@
 										"supportsDeveloperRole": {
 											"type": "boolean"
 										},
+										"sendSessionHeaders": {
+											"type": "boolean"
+										},
 										"supportsMultipleSystemMessages": {
 											"type": "boolean"
 										},
@@ -836,6 +842,9 @@
 											"type": "boolean"
 										},
 										"supportsDeveloperRole": {
+											"type": "boolean"
+										},
+										"sendSessionHeaders": {
 											"type": "boolean"
 										},
 										"supportsMultipleSystemMessages": {


### PR DESCRIPTION
## What

Add an opt-in `compat.sendSessionHeaders` flag (default **off**) to the `openai-completions` provider. When enabled, the agent session id is forwarded as vendor-neutral `session_id` and `x-session-id` request headers to **any** OpenAI-compatible endpoint.

## Why

Today only the `openai-responses` provider injects session-identity headers, and only when targeting a first-party OpenAI base URL (`openai-responses.ts:438-440`). The `openai-completions` path has no injection at all.

That leaves OpenAI-compatible relays/proxies unable to identify a conversation: the `/v1/chat/completions` wire is stateless and gajae-code's stable per-conversation `sessionId` (already available as `StreamOptions.sessionId`) never reaches the endpoint. Such relays then fall back to fragile request-body hashing for session-affinity ("sticky") routing and server-side prompt-cache reuse.

These header names (`session_id`, `x-session-id`) are already part of gajae-code's own auth-gateway session-identity allow-list (`packages/ai/src/auth-gateway/http.ts`), so the choice is consistent with existing conventions.

## Testing

- `bun --cwd packages/ai run check` — biome + tsgo clean.
- New `packages/ai/test/openai-completions-session-headers.test.ts` (9 tests). The e2e cases wrap `fetch` and assert the **real outgoing `init.headers`** captured at dispatch (proving wire transmission, not object state):
  - flag ON + non-empty sessionId → `session_id` + `x-session-id` present
  - flag OFF (default) → neither header present
  - flag ON + empty sessionId → neither header present
  - caller `options.headers` and `model.headers` both take precedence over the auto-injected value
  - compat default/merge resolution unit tests
- Adversarial pass (covered by the suite + manual red-team): weird sessionId chars transmit without throwing; `openrouter` with the flag OFF still emits its other injected headers but no session headers.
- Existing `Required<OpenAICompat>` test fixtures updated for the new field.

### Design notes

- **Default OFF.** With the flag unset, behavior is byte-identical for every provider — the whole block is skipped.
- **Caller precedence.** Injection uses `??=` and runs *after* the caller's `headers`/`extraHeaders` merge and *before* `requestTransform`, so anything the caller set via `model.headers`/`requestTransform` still wins.
- **First-party untouched.** The `openai-responses` gating is unchanged.

Enable via `models.yml`:

```yaml
providers:
  relay:
    baseUrl: https://relay.example.com/v1
    api: openai-completions
    compat:
      sendSessionHeaders: true
```

---

- [x] `bun check` passes (TS-only change: `bun --cwd packages/ai run check` clean; biome + tsgo)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
