### PR TITLE
feat(coding-agent): steer by default while agent is busy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 
-- Queued ordinary chat messages by default while the agent is busy: Enter now routes normal prompts into the next-turn queue unless `busyPromptMode` is explicitly set to `steer`, pending normal messages render as `Queued:`, and existing steer/cancel plus explicit queue/dequeue controls remain separate (#829).
+- Restored steer-by-default while the agent is busy: `busyPromptMode` now defaults to `steer`, so Enter on a normal prompt interrupts the active turn. Queueing for the next turn is reserved for the explicit Ctrl+Enter follow-up keystroke (or `busyPromptMode: "queue"`); existing steer/cancel plus explicit queue/dequeue controls remain separate (#829).
 
 ### Added
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -995,7 +995,7 @@ export const SETTINGS_SCHEMA = {
 	busyPromptMode: {
 		type: "enum",
 		values: ["steer", "queue"] as const,
-		default: "queue",
+		default: "steer",
 		ui: {
 			tab: "interaction",
 			label: "Busy Prompt Mode",

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -90,7 +90,7 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue" }) {
 		settings: {
 			get(path: string) {
 				if (path === "images.autoResize") return false;
-				if (path === "busyPromptMode") return options?.busyPromptMode;
+				if (path === "busyPromptMode") return options?.busyPromptMode ?? "steer";
 				return undefined;
 			},
 		} as unknown as InteractiveModeContext["settings"],
@@ -202,19 +202,19 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
-	it("queues streaming Enter submissions by default", async () => {
+	it("steers streaming Enter submissions by default", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isStreaming: boolean };
 		session.isStreaming = true;
-		editor.setText("queue by default while busy");
+		editor.setText("steer by default while busy");
 		const controller = new InputController(ctx);
 		controller.setupEditorSubmitHandler();
 
-		await editor.onSubmit?.("queue by default while busy");
+		await editor.onSubmit?.("steer by default while busy");
 
-		expect(ctx.locallySubmittedUserSignatures.has("queue by default while busy\u00000")).toBe(true);
-		expect(spies.prompt).toHaveBeenCalledWith("queue by default while busy", {
-			streamingBehavior: "followUp",
+		expect(ctx.locallySubmittedUserSignatures.has("steer by default while busy\u00000")).toBe(true);
+		expect(spies.prompt).toHaveBeenCalledWith("steer by default while busy", {
+			streamingBehavior: "steer",
 			images: undefined,
 		});
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -663,7 +663,7 @@
 				"queue"
 			],
 			"description": "What a submitted prompt does while the agent is busy: queue normal chat for the next turn, or steer to interrupt the active turn",
-			"default": "queue"
+			"default": "steer"
 		},
 		"doubleEscapeAction": {
 			"type": "string",


### PR DESCRIPTION
## Summary

Flips the `busyPromptMode` default from `queue` → `steer`. The during-streaming behavior was off (queueing) by default; now Enter on a normal prompt while the agent is busy steers (interrupts) the active turn.

Queueing for the next turn is reserved for the explicit Ctrl+Enter follow-up keystroke (or setting `busyPromptMode: "queue"`).

## Changes
- `settings-schema.ts` — `busyPromptMode` default `queue` → `steer`
- `schemas/config.schema.json` — regenerated to match
- `CHANGELOG.md` — revised #829 entry
- `input-controller-keybindings.test.ts` — stub default + "by default" test now assert `steer`

## Verification
- `bun test input-controller-keybindings input-controller-skill-queue` → 29 pass
- `check:schemas` clean

Refs #829