### PR TITLE
docs: model selection guide with cross-vendor profiles

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -175,6 +175,8 @@ Presets only write `models.yml` entries that reference documented environment va
 
 Model profiles are optional top-level `profiles:` entries in `~/.gjc/agent/models.yml`. A profile can require provider credentials before activation and can map one or more model roles; omitted roles inherit from the active defaults.
 
+> See also: [Cross-vendor role-based profiles](./multi-vendor-profiles.md) — a curated multi-vendor `profiles:` recipe and verified selector notes that build on the mechanism described here.
+
 ```yaml
 profiles:
   team-standard:

--- a/docs/multi-vendor-profiles.md
+++ b/docs/multi-vendor-profiles.md
@@ -1,0 +1,104 @@
+# Choosing models in GJC: role-based profiles
+
+A practical guide to picking models for GJC's roles, for every subscription situation — one vendor, two vendors, or the full multi-vendor set. It adds curated cross-vendor `profiles:` for `~/.gjc/agent/models.yml` and verified selector notes on top of the mechanism in [Model profiles](./models.md#model-profiles---mpreset). Everything here is **user config**; it complements the built-in `--mpreset` presets and overrides a built-in only when it shares its exact name.
+
+> Selectors, prices, and "axis leaders" are catalog- and time-sensitive (observed 2026-06 on the current bundled catalog). Re-verify any selector with `gjc -p --no-session --no-tools --model <selector> "Reply OK"`.
+
+## The five roles
+
+`default` runs the main loop and most turns; `executor` / `architect` / `planner` / `critic` are the four bundled task agents, delegated only when the work calls for it.
+
+| Role | What it optimizes for |
+| --- | --- |
+| `default` | tool-calling reliability + honesty (it routes — its quality bounds the whole system) |
+| `executor` | real coding (SWE-bench Verified) |
+| `planner` | reasoning + sequencing (GPQA / ARC-AGI-2) |
+| `architect` | large-context + multimodal review |
+| `critic` | independent adversarial review (different family from what it reviews) |
+
+## Pick by what you subscribe to
+
+| You have | Use |
+| --- | --- |
+| **One vendor** | the built-in preset for that vendor — `claude-opus` (Anthropic), `codex-{eco,medium,pro}` (OpenAI/Codex), `opencodego` (OpenCode Go), or a single-vendor flagship tier (`zai/glm-5.2`, `kimi-code/...`, `xiaomi/...`, `xai/grok-4.3`, `minimax-code/...`). These already map all five roles inside one vendor. |
+| **Claude + Codex** | the built-in `opus-codex` (Claude main loop + Codex support roles), or `codex-opencodego`. |
+| **Three or more / all five** | the cross-vendor profiles below — each role on its axis leader, `critic` kept cross-family. |
+
+The single guiding rule across all of these: **keep `default` on the strongest router you have** (Anthropic Opus when available). A weak `default` caps quality regardless of the delegated models.
+
+## Cross-vendor profiles (3+ vendors)
+
+No single vendor leads every axis, so these put each role on its axis leader and keep `critic` on a different family from the `executor` it reviews.
+
+```yaml
+profiles:
+
+  daily:                 # everyday balance
+    required_providers: [anthropic, openai-codex, google-antigravity, xai]
+    model_mapping:
+      default:   anthropic/claude-opus-4-8:medium
+      executor:  openai-codex/gpt-5.4:high
+      planner:   google-antigravity/gemini-3.1-pro-low:high
+      architect: google-antigravity/gemini-3.1-pro-low:high
+      critic:    xai/grok-4.3:medium
+
+  ultimate:              # cost-no-object, best per role
+    required_providers: [anthropic, openai-codex, google-antigravity, xai]
+    model_mapping:
+      default:   anthropic/claude-opus-4-8:high
+      executor:  anthropic/claude-opus-4-8:max
+      planner:   openai-codex/gpt-5.5:xhigh
+      architect: google-antigravity/gemini-3.1-pro-low:high
+      critic:    xai/grok-4.3:high
+
+  eco:                   # cheapest delegated work; main loop stays on Opus
+    required_providers: [anthropic, opencode-go, google-antigravity, xai]
+    model_mapping:
+      default:   anthropic/claude-opus-4-8:low
+      executor:  opencode-go/deepseek-v4-flash
+      planner:   xai/grok-4-1-fast:high
+      architect: google-antigravity/gemini-3.1-pro-low
+      critic:    google-antigravity/gemini-3.5-flash
+
+  monorepo:              # huge codebases (openai-codex excluded: 272k context cap)
+    required_providers: [anthropic, google-antigravity, opencode-go]
+    model_mapping:
+      default:   anthropic/claude-opus-4-8:medium
+      executor:  anthropic/claude-opus-4-8:high
+      planner:   google-antigravity/gemini-3.1-pro-low:high
+      architect: anthropic/claude-opus-4-8:high
+      critic:    opencode-go/glm-5.2
+```
+
+## Model cheatsheet (by need)
+
+Current axis leaders and the cheaper second option, with metered price ($/1M in/out; Gemini via Antigravity runs on the Google AI subscription):
+
+| Need | First pick | Cheaper option |
+| --- | --- | --- |
+| Router / tool-calling (`default`) | `anthropic/claude-opus-4-8` (5/25) | `anthropic/claude-sonnet-4-6` (3/15) |
+| Coding (`executor`) | `anthropic/claude-opus-4-8` — SWE-bench Verified ~88.6 (5/25) | `openai-codex/gpt-5.4` (2.5/15) · `opencode-go/deepseek-v4-flash` (0.14/0.28) |
+| Reasoning (`planner`) | `openai-codex/gpt-5.5` (ARC-AGI-2) / `google-antigravity/gemini-3.1-pro-low:high` (GPQA) | `xai/grok-4-1-fast` (0.2/0.5) |
+| Large context (`architect`) | `anthropic/claude-opus-4-8` (effective long-context) | `xai/grok-4-fast` (2M nominal, 0.2/0.5) |
+| Multimodal review (`architect`) | `google-antigravity/gemini-3.1-pro-low:high` | `google-antigravity/gemini-3.5-flash` |
+| Independent critic | `xai/grok-4.3` (1.25/2.5) | `opencode-go/glm-5.2` · `google-antigravity/gemini-3.5-flash` |
+
+On standard tasks, all current frontier models in the catalog are accurate; **pick by cost, latency, and role fit, not by raw accuracy on easy prompts.** As an indicative GJC-routed latency reference (`gjc -p`, identical coding + reasoning prompts, all correct): `grok-4.3` and `glm-5.2` ≈ 2–3s, `deepseek-v4-pro` ≈ 3–4s, `claude-opus-4-8` / `gpt-5.5` ≈ 4–7s, `gemini-3.1-pro-low:high` ≈ 7s.
+
+## Verified selector notes (current catalog)
+
+Observed via live `gjc -p` calls; useful when wiring the profiles above:
+
+- **Antigravity Gemini, high reasoning** → use `google-antigravity/gemini-3.1-pro-low:high`. The id `gemini-3.1-pro-high` returns HTTP 400 (no matching backend model); `thinkingLevel` is a per-request parameter, so raising it on `gemini-3.1-pro-low` invokes the model's native high-reasoning mode rather than a degraded one.
+- **openai-codex on a ChatGPT account** serves base GPT only (`gpt-5.5`, `gpt-5.4`). Standalone `-codex` variants (`gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max` / `-mini`) return `not supported when using Codex with a ChatGPT account`.
+- **Single-message input limit is separate from the context window.** `claude-opus-4-8` runs with a 1M window via multi-turn accumulation, but a single `@file` message above ~400k tokens returns 400 on `anthropic` / `google-antigravity`; `xai` / `opencode-go` accept larger single messages. Chunk very large inputs across turns instead of pasting one block.
+- **`opencode-go` and `google-antigravity` resolve models from a live catalog fetched after `/login`.** Their runtime model lists include ids newer than any bundled snapshot — e.g. `opencode-go/glm-5.2` (current open-weight leader by AA Index) and `google-antigravity/gemini-3.5-flash`. Because each profile's `required_providers` gates activation on those credentials, the live catalog (carrying these ids) is always present by the time the profile runs. Both confirmed via `gjc -p`.
+
+## Activation
+
+```bash
+gjc --mpreset daily               # this session only
+gjc --mpreset ultimate --default  # persist as the startup default (config.yml)
+```
+
+Activation hard-blocks when any provider in `required_providers` lacks credentials, so log in first: `/login anthropic`, `/login openai-codex`, `/login google-antigravity`, `/login xai` (and `opencode-go` via `OPENCODE_API_KEY`).


### PR DESCRIPTION
> Reopened against `dev` per maintainer policy (previous #858 targeted `main`). Docs-only; selector verification evidence included below.

## What

Adds `docs/multi-vendor-profiles.md` — a guide to choosing models for GJC's five roles across subscription situations (single-vendor → built-in presets; Claude+Codex → `opus-codex`; 3+ vendors → curated cross-vendor profiles), with a model cheatsheet by need and verified selector notes. Linked from `docs/models.md` → Model profiles.

## Why

`docs/models.md` documents the profile *mechanism* (`profiles:`, `--mpreset`, built-in presets) thoroughly, but there is no curated cross-vendor role recipe, no "which model for which need" cheatsheet, and no record of the operational selector gotchas that come up when wiring real multi-vendor profiles:

- Antigravity high reasoning is `gemini-3.1-pro-low:high` (the `gemini-3.1-pro-high` id returns 400).
- ChatGPT-account `openai-codex` serves base GPT only (`-codex` variants return "not supported").
- A single `@file` message has a ~400k input limit that is separate from the 1M context window — chunk large inputs.

Single-vendor users are pointed to the existing built-in presets (`claude-opus`, `codex-*`, `opencodego`, single-vendor flagships) rather than duplicating them. Everything is user config — no new bundled defaults and no workflow skills.

## Testing — selector verification evidence

Every selector that appears in a profile or cheatsheet was confirmed via live `gjc -p --no-session --no-tools --model <selector> "Reply OK"` on the current bundled catalog (2026-06). Profiles use only selectors that are **present in the bundled catalog** and **resolve at runtime**.

Verified working (used in profiles/cheatsheet):

| Selector | Result |
| --- | --- |
| `anthropic/claude-opus-4-8` (low/medium/high/max) | OK |
| `openai-codex/gpt-5.5:high` · `openai-codex/gpt-5.4:high` | OK |
| `google-antigravity/gemini-3.1-pro-low` · `gemini-3.1-pro-low:high` | OK |
| `xai/grok-4.3` · `xai/grok-4-1-fast:high` · `xai/grok-4-fast:high` | OK |
| `opencode-go/deepseek-v4-flash` · `deepseek-v4-pro` | OK |

Rejections documented in the "Verified selector notes" section (reproduced, not guessed):

| Selector | Result |
| --- | --- |
| `google-antigravity/gemini-3.1-pro-high` | HTTP 400 (no matching backend model) → use `gemini-3.1-pro-low:high` |
| `openai-codex/gpt-5.3-codex`, `gpt-5.2-codex` (ChatGPT account) | "not supported when using Codex with a ChatGPT account" |
| single `@file` > ~400k tokens on `anthropic` / `google-antigravity` | 400 (separate from the 1M context window) |

Long-context limits were probed with multi-needle `@file` inputs (350k/476k/857k); the latency reference uses identical coding + reasoning prompts across candidate models.

Docs-only: no source, schema, or config files touched.

---

- [ ] `bun check` — n/a (docs-only; no source/config changed, build not run here)
- [x] Tested locally — selectors verified via `gjc -p` (see table above)
- [ ] CHANGELOG — n/a (no CHANGELOG.md in repo; docs-only, not user-facing behavior)
