### PR TITLE
fix(rlm): keep seeded text interactive

### DIFF
--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -8,7 +8,7 @@
  */
 import * as fs from "node:fs/promises";
 import { getProjectDir } from "@gajae-code/utils";
-import { parseArgs } from "../cli/args";
+import { type Args, parseArgs } from "../cli/args";
 import { disposeKernelSessionsByOwner } from "../eval/py/executor";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { type RlmPreset, runRootCommand } from "../main";
@@ -183,6 +183,17 @@ export function buildRlmGoalObjective(input: {
 	}
 	return "Complete this RLM research session, grounding conclusions in notebook outputs and finishing with a report.";
 }
+export function isRlmAutonomousRun(parsed: Pick<Args, "print" | "mode" | "messages">, pipedStdin: boolean): boolean {
+	return parsed.print === true || parsed.mode !== undefined || pipedStdin;
+}
+
+export function prepareRlmLaunchMode(parsed: Args, pipedStdin: boolean): boolean {
+	const autonomous = isRlmAutonomousRun(parsed, pipedStdin);
+	if (autonomous && parsed.mode === undefined) {
+		parsed.print = true;
+	}
+	return autonomous;
+}
 
 async function loadExistingMetadata(paths: RlmArtifactPaths): Promise<RlmSessionMetadata | undefined> {
 	try {
@@ -265,13 +276,12 @@ export async function runRlmCommand(argv: string[]): Promise<void> {
 	if (resumeSessionId) {
 		parsed.continue = true;
 	}
-	// Piped stdin (non-TTY) feeds an autonomous research prompt the same way an
-	// argv goal does, so it must get the shouldPause stop seam + completion gate.
+	// Piped stdin (non-TTY), explicit --print, and explicit --mode run as autonomous
+	// research. Positional argv messages seed the interactive RLM shell, so
+	// `gjc rlm "question"` still loads the TUI instead of being coerced into
+	// print mode.
 	const pipedStdin = process.stdin.isTTY === false;
-	const autonomous = parsed.print === true || parsed.mode !== undefined || parsed.messages.length > 0 || pipedStdin;
-	if (autonomous && parsed.mode === undefined) {
-		parsed.print = true;
-	}
+	const autonomous = prepareRlmLaunchMode(parsed, pipedStdin);
 	const resumeContext = existingNotebook ? summarizeNotebookForReplay(existingNotebook) : undefined;
 	const preset = createRlmPreset({
 		dataContext,

--- a/packages/coding-agent/test/rlm-autonomous.test.ts
+++ b/packages/coding-agent/test/rlm-autonomous.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { parseArgs } from "@gajae-code/coding-agent/cli/args";
 import { readNotebookDocument } from "@gajae-code/coding-agent/edit/notebook";
 import type { CustomToolContext } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
 import {
@@ -21,7 +22,7 @@ import {
 	createRlmCompleteResearchTool,
 	summarizeNotebookForReplay,
 } from "@gajae-code/coding-agent/rlm/complete-research-tool";
-import { extractRlmFlags } from "@gajae-code/coding-agent/rlm/index";
+import { extractRlmFlags, isRlmAutonomousRun, prepareRlmLaunchMode } from "@gajae-code/coding-agent/rlm/index";
 import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
 import type { RlmCellResult } from "@gajae-code/coding-agent/rlm/types";
 
@@ -86,6 +87,41 @@ describe("extractRlmFlags", () => {
 		expect(parsed.rest).toEqual(["just a goal"]);
 		expect(() => extractRlmFlags(["--min-successful-runs", "two"])).toThrow(/non-negative integer/);
 		expect(() => extractRlmFlags(["--resume"])).toThrow(/requires an RLM session id/);
+	});
+});
+
+describe("RLM launch mode detection", () => {
+	test("plain positional text seeds interactive RLM instead of forcing print mode", () => {
+		expect(isRlmAutonomousRun({ messages: ["text"] }, false)).toBe(false);
+	});
+
+	test("explicit print, explicit mode, and piped stdin remain autonomous", () => {
+		expect(isRlmAutonomousRun({ messages: [], print: true }, false)).toBe(true);
+		expect(isRlmAutonomousRun({ messages: [], mode: "json" }, false)).toBe(true);
+		expect(isRlmAutonomousRun({ messages: [] }, true)).toBe(true);
+	});
+
+	test("launch preparation keeps positional text interactive and preserves the seed message", () => {
+		const parsed = parseArgs(["text"]);
+		expect(prepareRlmLaunchMode(parsed, false)).toBe(false);
+		expect(parsed.print).toBeUndefined();
+		expect(parsed.mode).toBeUndefined();
+		expect(parsed.messages).toEqual(["text"]);
+	});
+
+	test("launch preparation coerces only autonomous text mode to print", () => {
+		const printed = parseArgs(["--print", "text"]);
+		expect(prepareRlmLaunchMode(printed, false)).toBe(true);
+		expect(printed.print).toBe(true);
+
+		const jsonMode = parseArgs(["--mode", "json", "text"]);
+		expect(prepareRlmLaunchMode(jsonMode, false)).toBe(true);
+		expect(jsonMode.print).toBeUndefined();
+		expect(jsonMode.mode).toBe("json");
+
+		const piped = parseArgs([]);
+		expect(prepareRlmLaunchMode(piped, true)).toBe(true);
+		expect(piped.print).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary
- keep `gjc rlm "text"` on the interactive RLM shell instead of coercing positional text into autonomous print mode
- preserve explicit autonomous entrypoints: `--print`, `--mode`, and piped stdin
- add launch-mode regression tests around parser/preparation behavior

## Verification
- `bun test packages/coding-agent/test/rlm-autonomous.test.ts`
- `bun run check:ts`