### PR TITLE
fix(ai): flatten union-root tool schemas for all providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Generalized tool `input_schema` root-combinator flattening across providers so discriminated-union tool inputs (e.g. the `computer` tool, a `z.union`) no longer ship a bare top-level `anyOf`/`oneOf`/`allOf` root that strict validators reject. The Anthropic-only fix from 0.5.4 is now the shared, provider-agnostic `flattenToolRootCombinators` (in `utils/schema`) and is applied by Amazon Bedrock, OpenAI Chat Completions / Responses / Codex-Responses / Azure-Responses, Ollama, and Cursor. Previously only Anthropic flattened the root, so those providers forwarded the union root verbatim and a union-root tool failed upstream — Bedrock Converse (including via Kiro/CodeWhisperer relays) returned `400 TOOL_SCHEMA_INVALID: The value at toolConfig.tools.N.toolSpec.inputSchema.json.type must be one of the following: object`. Anthropic behavior is unchanged (it now calls the shared util), Google / Cloud Code Assist keep their own object-merge, and object-root tools, nested combinators, and runtime Zod validation are all untouched.
+
 ## [0.6.0] - 2026-06-18
 ### Fixed
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -33,7 +33,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { appendRawHttpRequestDumpFor400, type RawHttpRequestDump, withHttpStatus } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { toolWireSchema } from "../utils/schema/wire";
+import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import {
 	isForcedToolChoiceUnsupportedError,
 	markToolChoiceIncapability,
@@ -808,7 +808,7 @@ export function convertToolConfig(
 		toolSpec: {
 			name: tool.name,
 			description: tool.description || "",
-			inputSchema: { json: toolWireSchema(tool) },
+			inputSchema: { json: flattenToolRootCombinators(toolWireSchema(tool)) },
 		},
 	}));
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -62,7 +62,13 @@ import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { isCopilotTransientModelError } from "../utils/retry";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
+import {
+	COMBINATOR_KEYS,
+	flattenToolRootCombinators,
+	isJsonSchemaObjectNode,
+	NO_STRICT,
+	toolWireSchema,
+} from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
 import { notifyRawSseEvent, wrapFetchForSseDebug } from "../utils/sse-debug";
 import {
@@ -2406,22 +2412,6 @@ const MAX_ANTHROPIC_STRICT_TOOLS = 20;
 const MAX_ANTHROPIC_STRICT_OPTIONAL_PARAMETERS = 24;
 const MAX_ANTHROPIC_STRICT_UNION_PARAMETERS = 16;
 
-/** `minItems` / `maxItems` apply to arrays; Anthropic rejects them on `type: "object"` (including `minItems: 0`/`1`). */
-function isJsonSchemaArrayNode(schema: Record<string, unknown>): boolean {
-	const t = schema.type;
-	if (t === "array") return true;
-	if (Array.isArray(t) && t.includes("array") && !t.includes("object")) return true;
-	return false;
-}
-
-function isJsonSchemaObjectNode(schema: Record<string, unknown>): boolean {
-	if (isJsonSchemaArrayNode(schema)) return false;
-	if (schema.type === "object") return true;
-	if (Array.isArray(schema.type) && schema.type.includes("object")) return true;
-	if (isRecord(schema.properties)) return true;
-	return false;
-}
-
 /**
  * Pick the principal non-null scalar type from a `type` keyword. Anthropic accepts
  * `type` as either a single string or an array (e.g. `["number", "null"]` for a
@@ -2570,111 +2560,6 @@ export function normalizeAnthropicToolSchema(schema: unknown): unknown {
 	}
 
 	spillToDescription(result, spill);
-	return result;
-}
-
-function getRequiredNames(schema: Record<string, unknown>): Set<string> {
-	return new Set(
-		Array.isArray(schema.required)
-			? schema.required.filter((entry): entry is string => typeof entry === "string")
-			: [],
-	);
-}
-
-function getSingleLiteralValue(schema: unknown): unknown | undefined {
-	if (!isRecord(schema)) return undefined;
-	if (Object.hasOwn(schema, "const")) return schema.const;
-	if (Array.isArray(schema.enum) && schema.enum.length === 1) return schema.enum[0];
-	return undefined;
-}
-
-function describeAnthropicRootBranch(index: number, branch: Record<string, unknown>, action: unknown): string {
-	const required = [...getRequiredNames(branch)];
-	const parts = [`Branch ${index + 1}`];
-	if (typeof action === "string" || typeof action === "number" || typeof action === "boolean") {
-		parts.push(`action ${JSON.stringify(action)}`);
-	}
-	if (required.length > 0) parts.push(`branch-required fields: ${required.join(", ")}`);
-	if (typeof branch.description === "string" && branch.description.length > 0) parts.push(branch.description);
-	return parts.join("; ");
-}
-function collectAnthropicRootObjectBranches(schema: unknown): Record<string, unknown>[] | undefined {
-	if (!isRecord(schema)) return undefined;
-	if (isJsonSchemaObjectNode(schema)) return [schema];
-
-	const combinatorKeys = COMBINATOR_KEYS.filter(key => Array.isArray(schema[key]));
-	if (combinatorKeys.length === 0) return undefined;
-
-	const branches: Record<string, unknown>[] = [];
-	for (const key of combinatorKeys) {
-		const variants = schema[key];
-		if (!Array.isArray(variants) || variants.length === 0) return undefined;
-		for (const variant of variants) {
-			const nestedBranches = collectAnthropicRootObjectBranches(variant);
-			if (nestedBranches === undefined) return undefined;
-			branches.push(...nestedBranches);
-		}
-	}
-	return branches;
-}
-
-/**
- * Anthropic rejects tool `input_schema` roots containing top-level oneOf/anyOf/allOf.
- * Keep the generic normalizer schema-preserving, then flatten only provider-emitted
- * tool roots into one object while leaving nested combinators untouched.
- */
-export function normalizeAnthropicToolRootInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
-	const result: Record<string, unknown> = { ...schema };
-	const rootCombinators = COMBINATOR_KEYS.filter(key => Array.isArray(result[key]));
-	if (rootCombinators.length === 0) return result;
-
-	const baseProperties = isRecord(result.properties) ? { ...result.properties } : {};
-	const flattenedBranches = rootCombinators
-		.map(key => ({ key, branches: collectAnthropicRootObjectBranches({ [key]: result[key] }) }))
-		.find(entry => entry.branches !== undefined && entry.branches.length > 0);
-
-	result.type = "object";
-	result.properties = baseProperties;
-	result.additionalProperties = result.additionalProperties === undefined ? false : result.additionalProperties;
-
-	if (flattenedBranches?.branches !== undefined) {
-		const variants = flattenedBranches.branches;
-		const commonRequired = variants.map(variant => getRequiredNames(variant));
-		const required = [...commonRequired[0]].filter(name => commonRequired.every(set => set.has(name)));
-		const actionValues: unknown[] = [];
-		const guidance: string[] = [];
-
-		for (const [index, branch] of variants.entries()) {
-			if (isRecord(branch.properties)) {
-				Object.assign(baseProperties, branch.properties);
-				const actionValue = getSingleLiteralValue(branch.properties.action);
-				if (actionValue !== undefined && !actionValues.includes(actionValue)) actionValues.push(actionValue);
-				guidance.push(describeAnthropicRootBranch(index, branch, actionValue));
-			} else {
-				guidance.push(describeAnthropicRootBranch(index, branch, undefined));
-			}
-		}
-
-		if (actionValues.length > 0) {
-			const existingAction = isRecord(baseProperties.action) ? { ...baseProperties.action } : {};
-			delete existingAction.const;
-			baseProperties.action = { ...existingAction, enum: actionValues };
-		}
-		result.required = required;
-		spillToDescription(result, [
-			["rootCombinatorGuidance", guidance],
-			...rootCombinators
-				.filter(key => key !== flattenedBranches.key)
-				.map(key => [key, result[key]] as [string, unknown]),
-		]);
-	} else {
-		spillToDescription(
-			result,
-			rootCombinators.map(key => [key, result[key]]),
-		);
-	}
-
-	for (const key of COMBINATOR_KEYS) delete result[key];
 	return result;
 }
 
@@ -2845,7 +2730,7 @@ function normalizeAnthropicStrictSchema(
 
 function buildAnthropicBaseToolInputSchema(tool: Tool): Record<string, unknown> {
 	const jsonSchema = toolWireSchema(tool);
-	return normalizeAnthropicToolRootInputSchema(
+	return flattenToolRootCombinators(
 		normalizeAnthropicToolSchema({
 			...jsonSchema,
 			type: "object",

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -27,7 +27,7 @@ import {
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
+import { flattenToolRootCombinators, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
 import { mapToOpenAIResponsesToolChoice } from "../utils/tool-choice";
 import {
@@ -373,7 +373,7 @@ function convertTools(tools: Tool[]): OpenAITool[] {
 		type: "function",
 		name: tool.name,
 		description: tool.description || "",
-		parameters: sanitizeSchemaForOpenAIResponses(toolWireSchema(tool)),
+		parameters: sanitizeSchemaForOpenAIResponses(flattenToolRootCombinators(toolWireSchema(tool))),
 		strict: false,
 	}));
 }

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -29,7 +29,7 @@ import { normalizeSystemPrompts } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseStreamingJson } from "../utils/json-parse";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
-import { toolWireSchema } from "../utils/schema/wire";
+import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
 import type { McpToolDefinition } from "./cursor/gen/agent_pb";
 import {
@@ -2183,7 +2183,7 @@ function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[]
 	}
 
 	return advertisedTools.map(tool => {
-		const jsonSchema = toolWireSchema(tool);
+		const jsonSchema = flattenToolRootCombinators(toolWireSchema(tool));
 		const schemaValue: JsonValue =
 			jsonSchema && typeof jsonSchema === "object"
 				? (jsonSchema as JsonValue)

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -19,7 +19,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { toolWireSchema } from "../utils/schema/wire";
+import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import {
 	isForcedToolChoiceUnsupportedError,
 	markToolChoiceIncapability,
@@ -253,7 +253,7 @@ function convertTools(tools: Tool[] | undefined): OllamaFunctionTool[] | undefin
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: toolWireSchema(tool),
+			parameters: flattenToolRootCombinators(toolWireSchema(tool)),
 		},
 	}));
 }

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -50,7 +50,13 @@ import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-ins
 import { getOpenAIStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
+import {
+	adaptSchemaForStrict,
+	flattenToolRootCombinators,
+	NO_STRICT,
+	sanitizeSchemaForOpenAIResponses,
+	toolWireSchema,
+} from "../utils/schema";
 import {
 	isForcedToolChoiceUnsupportedError,
 	markToolChoiceIncapability,
@@ -2658,7 +2664,7 @@ export function convertOpenAICodexResponsesTools(
 			};
 		}
 		const strict = !!(!NO_STRICT && tool.strict);
-		const baseParameters = sanitizeSchemaForOpenAIResponses(toolWireSchema(tool));
+		const baseParameters = sanitizeSchemaForOpenAIResponses(flattenToolRootCombinators(toolWireSchema(tool)));
 		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(baseParameters, strict);
 		return {
 			type: "function",

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -57,7 +57,7 @@ import { getKimiCommonHeaders } from "../utils/oauth/kimi";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema";
+import { adaptSchemaForStrict, flattenToolRootCombinators, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
 import { type HealedToolCall, modelMayLeakKimiToolCalls, ToolCallHealer } from "../utils/tool-call-healing";
 import { isForcedToolChoice, mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
@@ -1832,7 +1832,7 @@ function convertTools(
 ): BuiltOpenAICompletionTools {
 	const adaptedTools = tools.map(tool => {
 		const strict = !NO_STRICT && compat.supportsStrictMode !== false && tool.strict !== false;
-		const baseParameters = toolWireSchema(tool);
+		const baseParameters = flattenToolRootCombinators(toolWireSchema(tool));
 		const adapted = adaptSchemaForStrict(baseParameters, strict);
 		return {
 			tool,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -50,7 +50,13 @@ import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import { resolveRetryBudget } from "../utils/retry-budget";
-import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
+import {
+	adaptSchemaForStrict,
+	flattenToolRootCombinators,
+	NO_STRICT,
+	sanitizeSchemaForOpenAIResponses,
+	toolWireSchema,
+} from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
 import { mapToOpenAIResponsesToolChoice, type OpenAIResponsesToolChoice } from "../utils/tool-choice";
 import {
@@ -724,7 +730,7 @@ export function convertTools(tools: Tool[], strictMode: boolean, model: Model<"o
 			} as unknown as OpenAITool;
 		}
 		const strict = !NO_STRICT && strictMode && tool.strict !== false;
-		const baseParameters = toolWireSchema(tool);
+		const baseParameters = flattenToolRootCombinators(toolWireSchema(tool));
 		const responseParameters = sanitizeSchemaForOpenAIResponses(baseParameters);
 		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(responseParameters, strict);
 		return {

--- a/packages/ai/src/utils/schema/index.ts
+++ b/packages/ai/src/utils/schema/index.ts
@@ -7,6 +7,7 @@ export * from "./fields";
 export * from "./json-schema-validator";
 export * from "./meta-validator";
 export * from "./normalize";
+export * from "./root-combinator";
 export * from "./spill";
 export * from "./types";
 export * from "./wire";

--- a/packages/ai/src/utils/schema/root-combinator.ts
+++ b/packages/ai/src/utils/schema/root-combinator.ts
@@ -1,0 +1,143 @@
+/**
+ * Tool `input_schema` root flattening.
+ *
+ * Tool/function-calling `input_schema` roots MUST be a single JSON Schema object.
+ * Bedrock Converse (`toolConfig.tools[*].toolSpec.inputSchema.json.type must be
+ * one of the following: object`), OpenAI strict mode, Gemini, and Anthropic all
+ * reject roots whose top level is a bare `oneOf`/`anyOf`/`allOf` combinator (the
+ * validators require `type: "object"`).
+ *
+ * Zod `z.union(...)` / `z.discriminatedUnion(...)` tool parameters serialize to
+ * exactly such a combinator root, so this normalization is provider-agnostic and
+ * runs inside the shared wire pipeline (`toolWireSchema`).
+ */
+import { isRecord } from "@gajae-code/utils";
+import { COMBINATOR_KEYS } from "./fields";
+import { spillToDescription } from "./spill";
+
+/** `minItems` / `maxItems` apply to arrays; some validators reject them on `type: "object"`. */
+function isJsonSchemaArrayNode(schema: Record<string, unknown>): boolean {
+	const t = schema.type;
+	if (t === "array") return true;
+	if (Array.isArray(t) && t.includes("array") && !t.includes("object")) return true;
+	return false;
+}
+
+/** True when a JSON Schema node describes an object (explicit `type` or `properties`). */
+export function isJsonSchemaObjectNode(schema: Record<string, unknown>): boolean {
+	if (isJsonSchemaArrayNode(schema)) return false;
+	if (schema.type === "object") return true;
+	if (Array.isArray(schema.type) && schema.type.includes("object")) return true;
+	if (isRecord(schema.properties)) return true;
+	return false;
+}
+
+function getRequiredNames(schema: Record<string, unknown>): Set<string> {
+	return new Set(
+		Array.isArray(schema.required)
+			? schema.required.filter((entry): entry is string => typeof entry === "string")
+			: [],
+	);
+}
+
+function getSingleLiteralValue(schema: unknown): unknown | undefined {
+	if (!isRecord(schema)) return undefined;
+	if (Object.hasOwn(schema, "const")) return schema.const;
+	if (Array.isArray(schema.enum) && schema.enum.length === 1) return schema.enum[0];
+	return undefined;
+}
+
+function describeRootBranch(index: number, branch: Record<string, unknown>, action: unknown): string {
+	const required = [...getRequiredNames(branch)];
+	const parts = [`Branch ${index + 1}`];
+	if (typeof action === "string" || typeof action === "number" || typeof action === "boolean") {
+		parts.push(`action ${JSON.stringify(action)}`);
+	}
+	if (required.length > 0) parts.push(`branch-required fields: ${required.join(", ")}`);
+	if (typeof branch.description === "string" && branch.description.length > 0) parts.push(branch.description);
+	return parts.join("; ");
+}
+
+function collectRootObjectBranches(schema: unknown): Record<string, unknown>[] | undefined {
+	if (!isRecord(schema)) return undefined;
+	if (isJsonSchemaObjectNode(schema)) return [schema];
+
+	const combinatorKeys = COMBINATOR_KEYS.filter(key => Array.isArray(schema[key]));
+	if (combinatorKeys.length === 0) return undefined;
+
+	const branches: Record<string, unknown>[] = [];
+	for (const key of combinatorKeys) {
+		const variants = schema[key];
+		if (!Array.isArray(variants) || variants.length === 0) return undefined;
+		for (const variant of variants) {
+			const nestedBranches = collectRootObjectBranches(variant);
+			if (nestedBranches === undefined) return undefined;
+			branches.push(...nestedBranches);
+		}
+	}
+	return branches;
+}
+
+/**
+ * Flatten a provider-emitted tool ROOT whose top level is a `oneOf`/`anyOf`/`allOf`
+ * combinator into one `type: "object"` schema: merge object-branch properties,
+ * derive the discriminant (`action`) enum, keep the common required set, and demote
+ * leftover combinators plus per-branch guidance into the description. Nested
+ * combinators (inside individual properties) are left untouched.
+ *
+ * Idempotent: a root that already lacks top-level combinators is returned unchanged.
+ */
+export function flattenToolRootCombinators(schema: Record<string, unknown>): Record<string, unknown> {
+	const rootCombinators = COMBINATOR_KEYS.filter(key => Array.isArray(schema[key]));
+	if (rootCombinators.length === 0) return schema;
+	const result: Record<string, unknown> = { ...schema };
+
+	const baseProperties = isRecord(result.properties) ? { ...result.properties } : {};
+	const flattenedBranches = rootCombinators
+		.map(key => ({ key, branches: collectRootObjectBranches({ [key]: result[key] }) }))
+		.find(entry => entry.branches !== undefined && entry.branches.length > 0);
+
+	result.type = "object";
+	result.properties = baseProperties;
+	result.additionalProperties = result.additionalProperties === undefined ? false : result.additionalProperties;
+
+	if (flattenedBranches?.branches !== undefined) {
+		const variants = flattenedBranches.branches;
+		const commonRequired = variants.map(variant => getRequiredNames(variant));
+		const required = [...commonRequired[0]].filter(name => commonRequired.every(set => set.has(name)));
+		const actionValues: unknown[] = [];
+		const guidance: string[] = [];
+
+		for (const [index, branch] of variants.entries()) {
+			if (isRecord(branch.properties)) {
+				Object.assign(baseProperties, branch.properties);
+				const actionValue = getSingleLiteralValue(branch.properties.action);
+				if (actionValue !== undefined && !actionValues.includes(actionValue)) actionValues.push(actionValue);
+				guidance.push(describeRootBranch(index, branch, actionValue));
+			} else {
+				guidance.push(describeRootBranch(index, branch, undefined));
+			}
+		}
+
+		if (actionValues.length > 0) {
+			const existingAction = isRecord(baseProperties.action) ? { ...baseProperties.action } : {};
+			delete existingAction.const;
+			baseProperties.action = { ...existingAction, enum: actionValues };
+		}
+		result.required = required;
+		spillToDescription(result, [
+			["rootCombinatorGuidance", guidance],
+			...rootCombinators
+				.filter(key => key !== flattenedBranches.key)
+				.map(key => [key, result[key]] as [string, unknown]),
+		]);
+	} else {
+		spillToDescription(
+			result,
+			rootCombinators.map(key => [key, result[key]]),
+		);
+	}
+
+	for (const key of COMBINATOR_KEYS) delete result[key];
+	return result;
+}

--- a/packages/ai/test/anthropic-tool-schema.test.ts
+++ b/packages/ai/test/anthropic-tool-schema.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import {
-	normalizeAnthropicToolRootInputSchema,
-	normalizeAnthropicToolSchema,
-} from "@gajae-code/ai/providers/anthropic";
+import { normalizeAnthropicToolSchema } from "@gajae-code/ai/providers/anthropic";
+import { flattenToolRootCombinators } from "@gajae-code/ai/utils/schema";
 
 describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 	describe("number / integer nodes", () => {
@@ -196,9 +194,9 @@ describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
 	});
 });
 
-describe("normalizeAnthropicToolRootInputSchema", () => {
+describe("flattenToolRootCombinators", () => {
 	it("removes root combinators, keeps common required fields only, derives action enum, and preserves nested combinators", () => {
-		const out = normalizeAnthropicToolRootInputSchema(
+		const out = flattenToolRootCombinators(
 			normalizeAnthropicToolSchema({
 				type: "object",
 				oneOf: [
@@ -241,7 +239,7 @@ describe("normalizeAnthropicToolRootInputSchema", () => {
 	});
 
 	it("demotes unsafe root combinators into description without removing nested combinators", () => {
-		const out = normalizeAnthropicToolRootInputSchema(
+		const out = flattenToolRootCombinators(
 			normalizeAnthropicToolSchema({
 				type: "object",
 				properties: {
@@ -270,7 +268,7 @@ describe("normalizeAnthropicToolRootInputSchema", () => {
 			{ action: "keypress", required: ["action", "keys"] },
 			{ action: "wait", required: ["action", "ms"] },
 		];
-		const out = normalizeAnthropicToolRootInputSchema(
+		const out = flattenToolRootCombinators(
 			normalizeAnthropicToolSchema({
 				type: "object",
 				oneOf: actions.map(({ action, required }) => ({
@@ -304,7 +302,7 @@ describe("normalizeAnthropicToolRootInputSchema", () => {
 			{ action: "screenshot", required: ["action"] },
 			{ action: "click", required: ["action", "x", "y"] },
 		];
-		const out = normalizeAnthropicToolRootInputSchema(
+		const out = flattenToolRootCombinators(
 			normalizeAnthropicToolSchema({
 				anyOf: [
 					{

--- a/packages/ai/test/bedrock-tool-choice.test.ts
+++ b/packages/ai/test/bedrock-tool-choice.test.ts
@@ -87,3 +87,45 @@ describe("Bedrock tool choice", () => {
 		).toBeUndefined();
 	});
 });
+
+describe("Bedrock tool schema root", () => {
+	// Regression: a union-root tool (e.g. `computer`, a z.union) serialized to
+	// { anyOf: [...] } with no root `type`, which Bedrock Converse rejects with
+	// TOOL_SCHEMA_INVALID: inputSchema.json.type must be one of the following: object.
+	const unionTool: Tool = {
+		name: "computer",
+		description: "Union-root tool",
+		parameters: {
+			anyOf: [
+				{
+					type: "object",
+					properties: { action: { const: "screenshot" } },
+					required: ["action"],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: { action: { const: "click" }, x: { type: "number" }, y: { type: "number" } },
+					required: ["action", "x", "y"],
+					additionalProperties: false,
+				},
+			],
+		} as unknown as Tool["parameters"],
+	};
+
+	it("flattens a union root to type:object so Bedrock accepts it", () => {
+		const config = convertToolConfig([unionTool], "auto");
+		const json = config?.tools[0]?.toolSpec.inputSchema.json as Record<string, unknown>;
+		expect(json.type).toBe("object");
+		expect(json).not.toHaveProperty("anyOf");
+		expect(json).not.toHaveProperty("oneOf");
+		expect((json.properties as Record<string, unknown>).action).toBeDefined();
+	});
+
+	it("leaves an object-root tool's schema unchanged", () => {
+		const config = convertToolConfig([tool], "auto");
+		const json = config?.tools[0]?.toolSpec.inputSchema.json as Record<string, unknown>;
+		expect(json.type).toBe("object");
+		expect(json).not.toHaveProperty("anyOf");
+	});
+});

--- a/packages/ai/test/schema-wire.test.ts
+++ b/packages/ai/test/schema-wire.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { normalizeAnthropicToolSchema } from "@gajae-code/ai/providers/anthropic";
 import type { Tool } from "@gajae-code/ai/types";
 import {
+	flattenToolRootCombinators,
 	isZodSchema,
 	normalizeEmptySchemas,
 	normalizeSchemaForCCA,
@@ -189,5 +190,95 @@ describe("provider normalizers on normalized open-record schemas", () => {
 		const out = normalizeSchemaForCCA(wire) as Record<string, unknown>;
 		const extra = (out.properties as Record<string, unknown>).extra as Record<string, unknown>;
 		expect(extra).not.toHaveProperty("additionalProperties");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// toolWireSchema — root combinator flattening
+// Regression: Bedrock Converse / OpenAI strict / Gemini reject tool input_schema
+// roots whose top level is a bare anyOf/oneOf/allOf. A `z.union(...)` tool (e.g.
+// `computer`) serialized to `{ anyOf: [...] }` and hit
+// `TOOL_SCHEMA_INVALID: ...inputSchema.json.type must be one of the following: object`.
+// ---------------------------------------------------------------------------
+
+describe("flattenToolRootCombinators over toolWireSchema output", () => {
+	function mkZod(parameters: z.ZodType): Tool {
+		return { name: "t", description: "", parameters, async execute() {} } as unknown as Tool;
+	}
+	function mkJson(parameters: Record<string, unknown>): Tool {
+		return { name: "t", description: "", parameters, async execute() {} } as unknown as Tool;
+	}
+	const wireOf = (tool: Tool) => flattenToolRootCombinators(toolWireSchema(tool));
+
+	it("flattens a z.union root into a single type:object schema", () => {
+		const wire = wireOf(
+			mkZod(
+				z.union([
+					z.object({ action: z.literal("screenshot") }).strict(),
+					z.object({ action: z.literal("click"), x: z.number(), y: z.number() }).strict(),
+				]),
+			),
+		);
+		expect(wire.type).toBe("object");
+		expect(wire).not.toHaveProperty("anyOf");
+		expect(wire).not.toHaveProperty("oneOf");
+		const properties = wire.properties as Record<string, unknown>;
+		// Branch properties are merged and the discriminant becomes an enum.
+		expect(properties.action).toBeDefined();
+		expect((properties.action as Record<string, unknown>).enum).toEqual(["screenshot", "click"]);
+		expect(properties.x).toBeDefined();
+		expect(properties.y).toBeDefined();
+	});
+
+	it("flattens a z.discriminatedUnion root", () => {
+		const wire = wireOf(
+			mkZod(
+				z.discriminatedUnion("action", [
+					z.object({ action: z.literal("a"), foo: z.string() }).strict(),
+					z.object({ action: z.literal("b"), bar: z.number() }).strict(),
+				]),
+			),
+		);
+		expect(wire.type).toBe("object");
+		expect(wire).not.toHaveProperty("anyOf");
+		expect(wire).not.toHaveProperty("oneOf");
+	});
+
+	it("flattens a raw JSON-Schema anyOf root carrying an injected intent (_i) field", () => {
+		// Mirrors the real intent-injected wire shape: agent-loop injects `_i` onto a
+		// union root, producing { anyOf, properties:{_i}, required:[_i] } with no root type.
+		const wire = wireOf(
+			mkJson({
+				anyOf: [
+					{
+						type: "object",
+						properties: { action: { const: "a" }, x: { type: "number" } },
+						required: ["action", "x"],
+						additionalProperties: false,
+					},
+					{
+						type: "object",
+						properties: { action: { const: "b" } },
+						required: ["action"],
+						additionalProperties: false,
+					},
+				],
+				properties: { _i: { type: "string" } },
+				required: ["_i"],
+			}),
+		);
+		expect(wire.type).toBe("object");
+		expect(wire).not.toHaveProperty("anyOf");
+		const properties = wire.properties as Record<string, unknown>;
+		expect(properties._i).toEqual({ type: "string" });
+		expect(properties.action).toBeDefined();
+		expect(properties.x).toBeDefined();
+	});
+
+	it("leaves a plain object-root tool unchanged", () => {
+		const wire = wireOf(mkZod(z.object({ path: z.string() }).strict()));
+		expect(wire.type).toBe("object");
+		expect(wire).not.toHaveProperty("anyOf");
+		expect((wire.properties as Record<string, unknown>).path).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary

Tool `input_schema` roots must be a single `type: "object"` schema. Bedrock Converse, OpenAI strict mode, and Gemini all reject a bare top-level `anyOf`/`oneOf`/`allOf` root. A `z.union` / `z.discriminatedUnion` tool — notably the `computer` tool (shipped + enabled-by-default on Apple Silicon in 0.6.0) — serializes to `{ anyOf: [...] }` with **no root `type`**, so against Bedrock (including via Kiro/CodeWhisperer relays) the request fails:

```
400 TOOL_SCHEMA_INVALID: The value at toolConfig.tools.N.toolSpec.inputSchema.json.type
must be one of the following: object.
```

Every other tool is a plain `z.object` (object root) and is accepted; only the union-root tool breaks.

## Root cause

The root-combinator flattening added in 0.5.4 lived **only in the Anthropic provider** (`normalizeAnthropicToolRootInputSchema`). The shared `toolWireSchema` produces the union root, and every non-Anthropic provider forwarded it verbatim:

- `amazon-bedrock` → `inputSchema: { json: toolWireSchema(tool) }` (so gjc's **native** Bedrock path is identically broken, relay or not)
- `openai-completions` / `openai-responses` / `openai-codex-responses` / `azure-openai-responses`
- `ollama`, `cursor`

Anthropic flattened it (works); Google / Cloud Code Assist have their own object-merge (works). The OpenAI-compatible path is what the relay receives, so the union root reached Bedrock untouched.

## Fix

Generalize the Anthropic-only logic into a shared, provider-agnostic `flattenToolRootCombinators` in `utils/schema` and apply it at the tool-serialization boundary of the providers that previously shipped the raw root:

- Bedrock, OpenAI Completions/Responses/Codex-Responses/Azure-Responses, Ollama, Cursor.
- Anthropic now calls the shared util (behavior unchanged; its local helpers are removed/deduped).
- Google / Cloud Code Assist are untouched (they keep their own object-merge — folding the shared flatten in front of them would leak `rootCombinatorGuidance`/internal stamps into their clean merged output).

The flatten is a no-op (returns the input unchanged) when the root has no top-level combinator, so object-root tools, nested combinators, and runtime Zod validation are all untouched.

## Tests

- `packages/ai/test/schema-wire.test.ts` — `flattenToolRootCombinators` over `toolWireSchema` output for `z.union`, `z.discriminatedUnion`, the real intent-injected `{ anyOf, properties:{_i}, required:[_i] }` wire shape, and an object-root no-op.
- `packages/ai/test/bedrock-tool-choice.test.ts` — `convertToolConfig` yields `toolSpec.inputSchema.json.type === "object"` (no `anyOf`) for a union-root tool; object-root tools unchanged.
- `packages/ai/test/anthropic-tool-schema.test.ts` — existing root-flatten cases repointed at the shared util.
- `bun test packages/ai/test` green (the only failures are pre-existing, env-related `auth-storage-*` cases that also fail on `dev` because a real Anthropic key is present locally). `bun run check:ts` passes.

## Scope / risk

Only the previously-broken provider paths change. The shared util is the exact 0.5.4 Anthropic logic, lifted to `utils/schema` and reused.
