### PR TITLE
Suppress optional rust-analyzer startup warning

### DIFF
--- a/packages/coding-agent/src/lsp/startup-events.ts
+++ b/packages/coding-agent/src/lsp/startup-events.ts
@@ -11,3 +11,27 @@ export type LspStartupEvent =
 			type: "failed";
 			error: string;
 	  };
+const OPTIONAL_STARTUP_FAILURE_SERVERS = new Set(["rust-analyzer"]);
+
+function isOptionalStartupFailure(server: LspStartupServerInfo): boolean {
+	return server.status === "error" && OPTIONAL_STARTUP_FAILURE_SERVERS.has(server.name);
+}
+
+export function getLspStartupWarningMessage(event: LspStartupEvent): string | null {
+	if (event.type === "failed") {
+		return "LSP startup failed. It will retry lazily on write.";
+	}
+
+	const failedServers = event.servers.filter(server => server.status === "error" && !isOptionalStartupFailure(server));
+
+	if (failedServers.length === 1) {
+		return `LSP startup failed for ${failedServers[0].name}. It will retry lazily on write.`;
+	}
+
+	if (failedServers.length > 1) {
+		const failedNames = failedServers.map(server => server.name).join(", ");
+		return `LSP startup failed for ${failedNames}. It will retry lazily on write.`;
+	}
+
+	return null;
+}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -44,7 +44,7 @@ import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slas
 import { consumePendingGoalModeRequest } from "../gjc-runtime/goal-mode-request";
 import { type Goal, type GoalModeState, normalizeGoal } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
-import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
+import { getLspStartupWarningMessage, LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import {
 	humanizePlanTitle,
 	type PlanApprovalDetails,
@@ -71,6 +71,7 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { type ResolveToolDetails, runResolveInvocation } from "../tools/resolve";
 import { formatPhaseDisplayName } from "../tools/todo-write";
 import { ToolError } from "../tools/tool-errors";
+
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
@@ -2061,23 +2062,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	#handleLspStartupEvent(event: LspStartupEvent): void {
 		this.#updateWelcomeLspServers();
 
-		if (event.type === "failed") {
-			this.showWarning(`LSP startup failed: ${event.error}. It will retry lazily on write.`);
-			return;
-		}
-
-		const failedServers = event.servers.filter(server => server.status === "error");
-
-		if (failedServers.length === 1) {
-			const failedServer = failedServers[0];
-			const detail = failedServer.error ? `: ${failedServer.error}` : "";
-			this.showWarning(`LSP startup failed for ${failedServer.name}${detail}. It will retry lazily on write.`);
-			return;
-		}
-
-		if (failedServers.length > 1) {
-			const failedNames = failedServers.map(server => server.name).join(", ");
-			this.showWarning(`LSP startup failed for ${failedNames}. It will retry lazily on write.`);
+		const warningMessage = getLspStartupWarningMessage(event);
+		if (warningMessage) {
+			this.showWarning(warningMessage);
 		}
 	}
 

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../src/lsp/startup-events";
+import {
+	getLspStartupWarningMessage,
+	LSP_STARTUP_EVENT_CHANNEL,
+	type LspStartupEvent,
+} from "../src/lsp/startup-events";
 import { EventBus } from "../src/utils/event-bus";
 
 describe("InteractiveMode LSP startup events", () => {
@@ -15,5 +19,38 @@ describe("InteractiveMode LSP startup events", () => {
 		eventBus.emit(LSP_STARTUP_EVENT_CHANNEL, event);
 
 		expect(received).toEqual([event]);
+	});
+	it("does not warn for optional rust-analyzer startup failures", () => {
+		const event: LspStartupEvent = {
+			type: "completed",
+			servers: [
+				{
+					name: "rust-analyzer",
+					status: "error",
+					fileTypes: [".rs"],
+					error: "LSP server exited (code 1): error: Unknown binary 'rust-analyzer' in official toolchain 'stable-x86_64-unknown-linux-gnu'.",
+				},
+			],
+		};
+
+		expect(getLspStartupWarningMessage(event)).toBeNull();
+	});
+
+	it("still warns for non-optional startup failures without leaking raw error detail", () => {
+		const event: LspStartupEvent = {
+			type: "completed",
+			servers: [
+				{
+					name: "typescript-language-server",
+					status: "error",
+					fileTypes: [".ts"],
+					error: "private path /home/alice/project failed",
+				},
+			],
+		};
+
+		expect(getLspStartupWarningMessage(event)).toBe(
+			"LSP startup failed for typescript-language-server. It will retry lazily on write.",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- suppresses normal-startup warnings for optional `rust-analyzer` warmup failures
- keeps non-optional LSP startup failures visible with sanitized, server-name-only warnings
- adds regression coverage for optional rust-analyzer and sanitized non-optional failures

Fixes #870.

## Verification
- `bun test packages/coding-agent/test/interactive-mode-lsp-startup.test.ts`
- `bun run build:native` (needed local native addon before full TS checks)
- `bun run check:ts`