### PR TITLE
fix(ai): correct openai-codex/gpt-5.5 context window to 272K

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -53332,7 +53332,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 9,

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -16,8 +16,10 @@ describe("OpenAI Codex defaults", () => {
 			maxLevel: Effort.XHigh,
 			defaultLevel: Effort.XHigh,
 		});
-		// gpt-5.5 is a 400K-context model and must not demote to the smaller gpt-5.4.
-		expect(model.contextWindow).toBe(400000);
-		expect(model.contextPromotionTarget).toBeUndefined();
+		// gpt-5.5 exposes a 272K context window, matching the rest of the codex family and
+		// the live discovery API (`context_window`/`max_context_window` both 272000).
+		// Whether it promotes to a larger model on overflow is governed by the Auto-Promote
+		// Context option, not pinned here.
+		expect(model.contextWindow).toBe(272000);
 	});
 });


### PR DESCRIPTION
## Summary

`openai-codex/gpt-5.5` was bundled in `models.json` with `contextWindow: 400000`, but the real OpenAI codex backend caps it at **272K**. Since `contextWindow` is the input budget that drives overflow detection / auto-compaction, the inflated value let a session keep appending input past the actual ceiling and then fail hard with `context_length_exceeded` at ~68% (272K / 400K) instead of compacting in time.

This PR sets `openai-codex/gpt-5.5` `contextWindow` to `272000`, matching the rest of the codex family and the live discovery API.

## Evidence

Called the same endpoint `fetchCodexModels` uses — `GET https://chatgpt.com/backend-api/codex/models?client_version=0.141.0` with valid codex OAuth (headers: `OpenAI-Beta: responses=experimental`, `originator: pi`, `chatgpt-account-id`). **HTTP 200.** The `gpt-5.5` entry:

```json
{
  "slug": "gpt-5.5",
  "context_window": 272000,
  "max_context_window": 272000,
  "minimal_client_version": "0.124.0",
  "supported_in_api": true,
  "priority": 9
}
```

`context_window` for every model the API returned:

| model | context_window |
|---|---|
| gpt-5.5 | **272000** |
| gpt-5.4 | 272000 |
| gpt-5.4-mini | 272000 |
| gpt-5.3-codex-spark | 128000 |
| codex-auto-review | 272000 |

So the bundled `400000` was a **stale snapshot value**, not what discovery returns. `normalizeCodexModelEntry` reads `payload.context_window` directly (`packages/ai/src/utils/discovery/codex.ts:261`), so a fresh `bun run generate-models` now produces `272000` on its own — **no generator override is needed**, and this change won't be clobbered on the next regeneration.

The whole bundled codex family is already `272000` (except `gpt-5`/`gpt-5.1`, left untouched here as they're a separate question), so `gpt-5.5` was the lone outlier.

## Changes

- `packages/ai/src/models.json` — `openai-codex/gpt-5.5` `contextWindow`: `400000 → 272000`.
- `packages/ai/test/openai-codex-default.test.ts` — assert `272000`; drop the `contextPromotionTarget === undefined` assertion. The old test framed gpt-5.5 as "must not demote to gpt-5.4," but promotion is governed by the **Auto-Promote Context** option, not a pinned model property — so when that option is on, promoting on overflow is the intended behavior.

<img width="1381" height="191" alt="image (4)" src="https://github.com/user-attachments/assets/26b5ffa6-09d7-4f72-a957-0f299f92f28d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)