### PR TITLE
Fix workflow stage precedence

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -298,8 +298,28 @@ function flattenActiveSubskills(entries: SkillActiveEntry[]): ActiveSubskillEntr
 	return [...deduped.values()];
 }
 
+const CANONICAL_PIPELINE_RANK = new Map<string, number>([
+	["deep-interview", 0],
+	["ralplan", 1],
+	["ultragoal", 2],
+]);
+
+function canonicalPipelineRank(skill: string): number | undefined {
+	return CANONICAL_PIPELINE_RANK.get(skill);
+}
+
+function compareActiveEntryPrimary(a: SkillActiveEntry, b: SkillActiveEntry): number {
+	const aRank = canonicalPipelineRank(a.skill);
+	const bRank = canonicalPipelineRank(b.skill);
+	if (aRank !== undefined || bRank !== undefined) return (bRank ?? -1) - (aRank ?? -1);
+	const aTime = Date.parse(safeString(a.updated_at));
+	const bTime = Date.parse(safeString(b.updated_at));
+	if (Number.isFinite(aTime) || Number.isFinite(bTime)) return (bTime || 0) - (aTime || 0);
+	return 0;
+}
+
 function buildActiveSnapshot(entries: SkillActiveEntry[]): SkillActiveState {
-	const visible = entries.filter(entry => entry.active !== false);
+	const visible = entries.filter(entry => entry.active !== false).toSorted(compareActiveEntryPrimary);
 	const primary = visible[0];
 	return {
 		version: 1,

--- a/packages/coding-agent/src/skill-state/active-state.ts
+++ b/packages/coding-agent/src/skill-state/active-state.ts
@@ -559,39 +559,44 @@ function dedupeVisibleBySkill(entries: SkillActiveEntry[], sessionId?: string): 
 
 /**
  * The planning pipeline advances one stage at a time: `deep-interview →
- * ralplan → ultragoal`. Each stage is activated through its own command path
- * (`gjc deep-interview`, `gjc ralplan`, `gjc ultragoal`), and those activations
- * do not demote the previous stage's row — only the explicit `handoff` verb
- * does. Without this collapse, activating ultragoal while ralplan is still
- * `active:true` would render both stages and keep showing a workflow that has
- * already handed control forward. Keep only the most recently updated pipeline
- * stage so the HUD reflects the single current workflow. `team` is intentionally
- * excluded — it runs alongside ultragoal — and every non-pipeline skill is left
- * untouched.
- *
- * This is a HUD-display policy only. It is applied by the skill HUD renderer and
- * deliberately NOT folded into `readVisibleSkillActiveState`, whose callers (the
- * deep-interview mutation guard and handoff caller inference) must keep seeing
- * every genuinely-active skill rather than the single most-recent pipeline stage.
+ * ralplan → ultragoal`. Activating a downstream stage supersedes upstream
+ * stages so stale rows cannot keep owning the HUD, gate, or primary active
+ * snapshot. `team` is intentionally excluded — it runs alongside ultragoal —
+ * and every non-pipeline skill is left untouched.
  */
 const PLANNING_PIPELINE_SKILLS = new Set<string>(["deep-interview", "ralplan", "ultragoal"]);
+const PLANNING_PIPELINE_RANK = new Map<string, number>([
+	["deep-interview", 0],
+	["ralplan", 1],
+	["ultragoal", 2],
+]);
+
+function planningPipelineRank(skill: string): number | undefined {
+	return PLANNING_PIPELINE_RANK.get(skill);
+}
+
+function comparePipelineEntry(a: SkillActiveEntry, b: SkillActiveEntry): number {
+	const aRank = planningPipelineRank(a.skill);
+	const bRank = planningPipelineRank(b.skill);
+	if (aRank !== undefined || bRank !== undefined) return (bRank ?? -1) - (aRank ?? -1);
+	const aRecency = entryRecency(a);
+	const bRecency = entryRecency(b);
+	if (Number.isFinite(aRecency) || Number.isFinite(bRecency)) return (bRecency || 0) - (aRecency || 0);
+	return 0;
+}
+
+function upstreamPlanningPipelineSkills(skill: string): string[] {
+	const rank = planningPipelineRank(skill);
+	if (rank === undefined) return [];
+	return [...PLANNING_PIPELINE_RANK.entries()]
+		.filter(([, candidateRank]) => candidateRank < rank)
+		.map(([candidate]) => candidate);
+}
 
 export function collapsePlanningPipeline(entries: readonly SkillActiveEntry[]): SkillActiveEntry[] {
 	const pipeline = entries.filter(entry => PLANNING_PIPELINE_SKILLS.has(entry.skill));
 	if (pipeline.length <= 1) return [...entries];
-	let current = pipeline[0];
-	let currentRecency = entryRecency(current);
-	for (const entry of pipeline) {
-		const recency = entryRecency(entry);
-		// Prefer a strictly-newer valid timestamp; a valid timestamp also beats a
-		// missing/unparseable one. Ties (or all-invalid) keep the first stage
-		// deterministically rather than letting an unknown-recency row win.
-		const better = Number.isFinite(recency) && (!Number.isFinite(currentRecency) || recency > currentRecency);
-		if (better) {
-			current = entry;
-			currentRecency = recency;
-		}
-	}
+	const current = pipeline.toSorted(comparePipelineEntry)[0];
 	return entries.filter(entry => !PLANNING_PIPELINE_SKILLS.has(entry.skill) || entry === current);
 }
 
@@ -618,9 +623,11 @@ async function mergeVisibleEntries(
 		merged.set(entryKey(entry), entry);
 	}
 	const canonicalRalplanPhase = await readModeStatePhase(cwd, sessionId, "ralplan");
-	return dedupeVisibleBySkill([...merged.values()], sessionId)
-		.filter(entry => entry.active !== false)
-		.map(entry => withCanonicalRalplanPhase(entry, canonicalRalplanPhase));
+	return collapsePlanningPipeline(
+		dedupeVisibleBySkill([...merged.values()], sessionId)
+			.filter(entry => entry.active !== false)
+			.map(entry => withCanonicalRalplanPhase(entry, canonicalRalplanPhase)),
+	);
 }
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveState | null> {
@@ -682,6 +689,20 @@ async function rebuildActiveState(cwd: string, sessionScope?: ActiveSessionScope
 	await rebuildActiveSnapshot(cwd, sessionScope, { cwd, audit: activeStateWriterAudit("rebuild-active-snapshot") });
 }
 
+async function removeSupersededPlanningPipelineEntries(
+	cwd: string,
+	sessionScope: ActiveSessionScope | undefined,
+	entry: SkillActiveEntry,
+): Promise<void> {
+	if (entry.active === false) return;
+	for (const skill of upstreamPlanningPipelineSkills(entry.skill)) {
+		await removeActiveEntry(cwd, sessionScope, skill, {
+			cwd,
+			audit: activeStateWriterAudit("remove-superseded-pipeline-entry"),
+		});
+	}
+}
+
 async function activeSubskillsForExistingEntry(
 	cwd: string,
 	sessionId: string | undefined,
@@ -725,11 +746,13 @@ export async function syncSkillActiveState(options: SyncSkillActiveStateOptions)
 				? { active_subskills: preservedActiveSubskills }
 				: {}),
 	};
+	await removeSupersededPlanningPipelineEntries(options.cwd, undefined, entry);
 	await persistActiveEntry(options.cwd, undefined, entry);
 	await rebuildActiveState(options.cwd);
 
 	if (!options.sessionId) return;
 	const sessionScope = { sessionId: options.sessionId };
+	await removeSupersededPlanningPipelineEntries(options.cwd, sessionScope, entry);
 	await persistActiveEntry(options.cwd, sessionScope, entry);
 	await rebuildActiveState(options.cwd, sessionScope);
 }

--- a/packages/coding-agent/test/skill-active-state.test.ts
+++ b/packages/coding-agent/test/skill-active-state.test.ts
@@ -268,32 +268,49 @@ describe("GJC skill-active state", () => {
 		});
 	});
 
-	it("keeps every active pipeline skill at the read layer (HUD pipeline collapse is render-only)", async () => {
+	it("enforces canonical pipeline precedence when downstream stages activate", async () => {
 		await withTempCwd(async cwd => {
-			// `gjc ralplan` then `gjc ultragoal` each activate their own row without
-			// demoting the other. The shared read keeps both so blocking consumers
-			// (deep-interview mutation guard, handoff caller inference) still see the
-			// true active set; collapsing to the current stage is the HUD renderer's
-			// job, covered in skill-hud-bar.test.ts.
 			await syncSkillActiveState({
 				cwd,
-				skill: "ralplan",
-				phase: "final",
+				skill: "deep-interview",
+				phase: "handoff",
 				active: true,
-				source: "gjc-ralplan-native",
+				source: "gjc-deep-interview",
 				nowIso: "2026-01-01T00:00:00.000Z",
 			});
 			await syncSkillActiveState({
 				cwd,
-				skill: "ultragoal",
-				phase: "executing",
+				skill: "ralplan",
+				phase: "planner",
 				active: true,
-				source: "gjc-ultragoal",
+				source: "gjc-ralplan-native",
 				nowIso: "2026-01-01T00:05:00.000Z",
 			});
 
-			const visible = await readVisibleSkillActiveState(cwd);
-			expect(visible?.active_skills?.map(entry => entry.skill).sort()).toEqual(["ralplan", "ultragoal"]);
+			let visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.skill).toBe("ralplan");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ralplan"]);
+
+			await syncSkillActiveState({
+				cwd,
+				skill: "deep-interview",
+				phase: "interviewing",
+				active: true,
+				source: "stale-upstream",
+				nowIso: "2026-01-01T00:10:00.000Z",
+			});
+			await syncSkillActiveState({
+				cwd,
+				skill: "ultragoal",
+				phase: "goal-planning",
+				active: true,
+				source: "gjc-ultragoal",
+				nowIso: "2026-01-01T00:15:00.000Z",
+			});
+
+			visible = await readVisibleSkillActiveState(cwd);
+			expect(visible?.skill).toBe("ultragoal");
+			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["ultragoal"]);
 		});
 	});
 
@@ -375,6 +392,33 @@ describe("GJC skill-active state", () => {
 			const visible = await readVisibleSkillActiveState(cwd);
 			expect(visible?.active_skills?.map(entry => entry.skill)).toEqual(["deep-interview"]);
 			expect(visible?.active_skills?.[0]?.phase).toBe("intent-first");
+		});
+	});
+
+	it("chooses the most advanced active pipeline stage as snapshot primary regardless of file order", async () => {
+		await withTempCwd(async cwd => {
+			const activeDir = path.join(cwd, ".gjc", "state", "active");
+			await fs.mkdir(activeDir, { recursive: true });
+			await fs.writeFile(
+				path.join(activeDir, "deep-interview.json"),
+				JSON.stringify({ skill: "deep-interview", phase: "interviewing", active: true }),
+			);
+			await fs.writeFile(
+				path.join(activeDir, "ralplan.json"),
+				JSON.stringify({ skill: "ralplan", phase: "planner", active: true }),
+			);
+			await fs.writeFile(
+				path.join(activeDir, "ultragoal.json"),
+				JSON.stringify({ skill: "ultragoal", phase: "goal-planning", active: true }),
+			);
+
+			await syncSkillActiveState({ cwd, skill: "team", phase: "running", active: true });
+
+			const snapshot = JSON.parse(
+				await fs.readFile(path.join(cwd, ".gjc", "state", "skill-active-state.json"), "utf-8"),
+			);
+			expect(snapshot.skill).toBe("ultragoal");
+			expect(snapshot.phase).toBe("goal-planning");
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Enforce canonical workflow precedence for `deep-interview -> ralplan -> ultragoal` when downstream stages activate.
- Make active snapshot primary selection choose the most advanced active canonical stage instead of entry array order.
- Keep visible active-state reads defensive so lingering upstream `handoff` rows do not own HUD/gate state after downstream activation.
- Add focused regressions for #877.

Fixes #877.

## Tests
- `bun test packages/coding-agent/test/skill-active-state.test.ts packages/coding-agent/test/gjc-runtime/state-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*