### PR TITLE
fix: respect session env in state doctor

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -297,12 +297,26 @@ async function resolveSelectors(
 	}
 	if (mode) assertKnownMode(mode);
 
+	const sessionId = resolveSessionIdFromArgs(args, payload);
+
+	const threadId = flagValue(args, "--thread-id")?.trim() || undefined;
+	if (threadId) assertSafePathComponent(threadId, "thread-id");
+	const turnId = flagValue(args, "--turn-id")?.trim() || undefined;
+	if (turnId) assertSafePathComponent(turnId, "turn-id");
+
+	return { mode: mode as CanonicalGjcWorkflowSkill | undefined, sessionId, threadId, turnId, payload };
+}
+
+// Session-id resolution order: explicit --session-id flag, then payload
+// session_id, then GJC_SESSION_ID env var (set by AgentSession.sdk for
+// agent-initiated CLI invocations). The env-var default keeps shell
+// snippets in skill docs short while still routing state commands to the
+// caller's session-scoped state files.
+function resolveSessionIdFromArgs(
+	args: readonly string[],
+	payload: Record<string, unknown> | undefined,
+): string | undefined {
 	const explicitSessionId = flagValue(args, "--session-id");
-	// Session-id resolution order: explicit --session-id flag, then payload
-	// session_id, then GJC_SESSION_ID env var (set by AgentSession.sdk for
-	// agent-initiated CLI invocations). The env-var default keeps shell
-	// snippets in skill docs short while still routing writes/reads to the
-	// caller's session-scoped state files.
 	let sessionId = explicitSessionId !== undefined ? explicitSessionId.trim() || undefined : undefined;
 	if (!sessionId && payload && typeof payload.session_id === "string") {
 		sessionId = payload.session_id.trim() || undefined;
@@ -312,13 +326,7 @@ async function resolveSelectors(
 		if (envSessionId) sessionId = envSessionId;
 	}
 	if (sessionId) assertSafePathComponent(sessionId, "session-id");
-
-	const threadId = flagValue(args, "--thread-id")?.trim() || undefined;
-	if (threadId) assertSafePathComponent(threadId, "thread-id");
-	const turnId = flagValue(args, "--turn-id")?.trim() || undefined;
-	if (turnId) assertSafePathComponent(turnId, "turn-id");
-
-	return { mode: mode as CanonicalGjcWorkflowSkill | undefined, sessionId, threadId, turnId, payload };
+	return sessionId;
 }
 
 async function inferModeFromActiveState(
@@ -718,8 +726,8 @@ async function handleDoctor(
 ): Promise<StateCommandResult> {
 	const rawSkill = flagValue(args, "--skill")?.trim() || flagValue(args, "--mode")?.trim() || positionalSkill?.trim();
 	if (rawSkill) assertKnownMode(rawSkill);
-	const sessionId = flagValue(args, "--session-id")?.trim() || undefined;
-	if (sessionId) assertSafePathComponent(sessionId, "session-id");
+	const payload = await readInputJson(flagValue(args, "--input"), cwd);
+	const sessionId = resolveSessionIdFromArgs(args, payload);
 	const summary = await collectDoctorSummary(cwd, rawSkill as CanonicalGjcWorkflowSkill | undefined, sessionId);
 	return {
 		status: summary.ok ? 0 : 1,

--- a/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-doctor.test.ts
@@ -109,6 +109,48 @@ describe("gjc state doctor", () => {
 		});
 	});
 
+	it("uses GJC_SESSION_ID for session-scoped active state when --session-id is absent", async () => {
+		const root = await tempDir();
+		const sessionId = "doctor-env-default";
+		const write = await runNativeStateCommand(
+			[
+				"write",
+				"--mode",
+				"deep-interview",
+				"--session-id",
+				sessionId,
+				"--input",
+				JSON.stringify({ current_phase: "interviewing" }),
+				"--json",
+			],
+			root,
+		);
+		expect(write.status).toBe(0);
+		const handoff = await runNativeStateCommand(
+			["handoff", "--mode", "deep-interview", "--to", "ralplan", "--session-id", sessionId, "--json"],
+			root,
+		);
+		expect(handoff.status).toBe(0);
+
+		const prior = process.env.GJC_SESSION_ID;
+		process.env.GJC_SESSION_ID = sessionId;
+		try {
+			const result = await runDoctorUnchanged(root, ["doctor", "--json"]);
+			expect(result.status).toBe(0);
+			const parsed = JSON.parse(result.stdout ?? "{}");
+			expect(parsed.ok).toBe(true);
+			expect(parsed.summary.by_kind.stale_active_state).toBe(0);
+			expect(parsed.problems).toEqual([]);
+			expect(parsed.problems).not.toEqual(
+				expect.arrayContaining([expect.objectContaining({ type: "stale_active_state" })]),
+			);
+			expect(result.stdout).not.toContain("gjc state ralplan clear");
+		} finally {
+			if (prior === undefined) delete process.env.GJC_SESSION_ID;
+			else process.env.GJC_SESSION_ID = prior;
+		}
+	});
+
 	it("detects orphan transaction journals and prints the hard prune fix command", async () => {
 		const root = await tempDir();
 		const journalPath = path.join(root, ".gjc", "state", "transactions", "orphan.json");


### PR DESCRIPTION
## Summary
- Reuses the shared state-runtime session-id resolver for `gjc state doctor`, preserving explicit `--session-id`, payload `session_id`, then `GJC_SESSION_ID` precedence.
- Adds focused regression coverage for session-scoped deep-interview → ralplan active state so a sessionless doctor invocation does not report false `stale_active_state` or suggest `gjc state ralplan clear`.

Fixes #876.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/state-doctor.test.ts packages/coding-agent/test/gjc-runtime/state-runtime.test.ts packages/coding-agent/test/gjc-runtime/state-handoff.test.ts` → 43 pass / 0 fail
- `bun --cwd=packages/coding-agent run check:types` → pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*