### PR TITLE
feat(dist): minified npm bundle production path (follow-up to #879)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
            run: |
               hash=$(find crates Cargo.toml Cargo.lock rust-toolchain.toml \
                       packages/natives/scripts packages/natives/package.json \
-                      scripts/ci-build-native.ts scripts/host-detect.ts \
+                      packages/coding-agent/package.json packages/coding-agent/scripts/build-npm-bin.ts \
+                      scripts/ci-build-native.ts scripts/ci-release-build-binaries.ts scripts/ci-release-publish.ts scripts/host-detect.ts \
                       -type f -print0 \
                     | sort -z \
                     | xargs -0 sha256sum \
@@ -527,6 +528,8 @@ jobs:
               pattern: pi-natives-*-h${{ needs.rust-hash.outputs.hash }}
               path: packages/natives/native
               merge-multiple: true
+         - name: Package install smoke (dry run)
+           run: bun run ci:test:install-methods
          - name: Configure npm auth
            env:
               NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: packages/natives/native/pi_natives.*.node
-          key: dev-affected-native-${{ runner.os }}-${{ steps.native-host.outputs.glibc }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'scripts/ci-build-native.ts', 'scripts/host-detect.ts') }}
+          key: dev-affected-native-${{ runner.os }}-${{ steps.native-host.outputs.glibc }}-${{ hashFiles('crates/**/*.rs', 'crates/**/Cargo.toml', 'crates/pi-natives/src/tokens.rs', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'packages/natives/scripts/**', 'packages/natives/package.json', 'packages/coding-agent/package.json', 'packages/coding-agent/scripts/build-npm-bin.ts', 'scripts/ci-build-native.ts', 'scripts/ci-release-build-binaries.ts', 'scripts/ci-release-publish.ts', 'scripts/host-detect.ts') }}
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
         if: steps.native-cache.outputs.cache-hit != 'true'
         with:

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -28,10 +28,11 @@
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
 	"bin": {
-		"gjc": "src/cli.ts"
+		"gjc": "dist/cli.js"
 	},
 	"scripts": {
 		"build": "bun scripts/build-binary.ts",
+		"build:npm-bin": "bun scripts/build-npm-bin.ts",
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
@@ -80,6 +81,7 @@
 	},
 	"files": [
 		"src",
+		"dist",
 		"scripts",
 		"examples",
 		"README.md",

--- a/packages/coding-agent/scripts/build-npm-bin.ts
+++ b/packages/coding-agent/scripts/build-npm-bin.ts
@@ -1,10 +1,31 @@
 #!/usr/bin/env bun
 
+import { chmodSync } from "node:fs";
 import * as path from "node:path";
 
 const packageDir = path.join(import.meta.dir, "..");
 const outputPath = path.join(packageDir, "dist", "cli.js");
 const shebang = "#!/usr/bin/env bun";
+
+// Keep platform/native and lazy-loaded heavy modules out of the JS bundle:
+// `@gajae-code/natives` resolves its platform `.node` relative to its own
+// installed location (only correct when loaded from node_modules at runtime),
+// and `mupdf` is a large WASM PDF engine loaded on demand.
+// Also externalize the relative `../../natives/native/index.js` imports (used
+// by cli/hashline/edit warmup probes) and any `.node` addon so the native
+// loader runs from its installed location instead of being inlined here.
+const externals = ["mupdf", "@gajae-code/natives", "*natives/native/index.js", "*.node"];
+
+// Worker entrypoints. Unlike the compiled binary (which lists these as
+// `--compile` additional entries), the JS bundle spawns them via
+// `new Worker(new URL("./<name>.ts", import.meta.url))`. Bundled into
+// `dist/cli.js`, every spawn site's `import.meta.url` is the bundle, so each
+// URL resolves to `dist/<name>.ts`. We must emit a bundle at exactly that path.
+const workers: { entry: string; outfile: string }[] = [
+	{ entry: "../stats/src/sync-worker.ts", outfile: "dist/sync-worker.ts" },
+	{ entry: "./src/tools/browser/tab-worker-entry.ts", outfile: "dist/tab-worker-entry.ts" },
+	{ entry: "./src/eval/js/worker-entry.ts", outfile: "dist/worker-entry.ts" },
+];
 
 async function runCommand(command: string[], env: NodeJS.ProcessEnv = Bun.env): Promise<void> {
 	const proc = Bun.spawn(command, {
@@ -19,29 +40,32 @@ async function runCommand(command: string[], env: NodeJS.ProcessEnv = Bun.env): 
 	}
 }
 
+function buildArgs(entry: string, outfile: string): string[] {
+	const args = ["bun", "build", entry, "--minify", "--keep-names", "--target=bun"];
+	for (const external of externals) args.push("--external", external);
+	args.push("--outfile", outfile);
+	return args;
+}
+
 async function ensureShebang(): Promise<void> {
 	const output = await Bun.file(outputPath).text();
-	if (output.startsWith(`${shebang}\n`)) return;
-	const withoutExistingShebang = output.startsWith("#!") ? output.replace(/^#!.*(?:\r?\n|$)/u, "") : output;
-	await Bun.write(outputPath, `${shebang}\n${withoutExistingShebang}`);
+	if (!output.startsWith(`${shebang}\n`)) {
+		const withoutExistingShebang = output.startsWith("#!") ? output.replace(/^#!.*(?:\r?\n|$)/u, "") : output;
+		await Bun.write(outputPath, `${shebang}\n${withoutExistingShebang}`);
+	}
+	// Mark the bin executable so it runs directly (matches how npm/bun set +x on
+	// install) for the bundle install-smoke and any direct invocation.
+	chmodSync(outputPath, 0o755);
 }
 
 async function main(): Promise<void> {
 	await runCommand(["bun", "--cwd=../stats", "scripts/generate-client-bundle.ts", "--generate"]);
 	try {
-		await runCommand([
-			"bun",
-			"build",
-			"./src/cli.ts",
-			"--minify",
-			"--keep-names",
-			"--target=bun",
-			"--external",
-			"mupdf",
-			"--outfile",
-			"dist/cli.js",
-		]);
+		await runCommand(buildArgs("./src/cli.ts", "dist/cli.js"));
 		await ensureShebang();
+		for (const worker of workers) {
+			await runCommand(buildArgs(worker.entry, worker.outfile));
+		}
 	} finally {
 		await runCommand(["bun", "--cwd=../stats", "scripts/generate-client-bundle.ts", "--reset"]);
 	}

--- a/packages/coding-agent/scripts/build-npm-bin.ts
+++ b/packages/coding-agent/scripts/build-npm-bin.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+
+import * as path from "node:path";
+
+const packageDir = path.join(import.meta.dir, "..");
+const outputPath = path.join(packageDir, "dist", "cli.js");
+const shebang = "#!/usr/bin/env bun";
+
+async function runCommand(command: string[], env: NodeJS.ProcessEnv = Bun.env): Promise<void> {
+	const proc = Bun.spawn(command, {
+		cwd: packageDir,
+		env,
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		throw new Error(`Command failed with exit code ${exitCode}: ${command.join(" ")}`);
+	}
+}
+
+async function ensureShebang(): Promise<void> {
+	const output = await Bun.file(outputPath).text();
+	if (output.startsWith(`${shebang}\n`)) return;
+	const withoutExistingShebang = output.startsWith("#!") ? output.replace(/^#!.*(?:\r?\n|$)/u, "") : output;
+	await Bun.write(outputPath, `${shebang}\n${withoutExistingShebang}`);
+}
+
+async function main(): Promise<void> {
+	await runCommand(["bun", "--cwd=../stats", "scripts/generate-client-bundle.ts", "--generate"]);
+	try {
+		await runCommand([
+			"bun",
+			"build",
+			"./src/cli.ts",
+			"--minify",
+			"--keep-names",
+			"--target=bun",
+			"--external",
+			"mupdf",
+			"--outfile",
+			"dist/cli.js",
+		]);
+		await ensureShebang();
+	} finally {
+		await runCommand(["bun", "--cwd=../stats", "scripts/generate-client-bundle.ts", "--reset"]);
+	}
+}
+
+await main();

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -14,12 +14,6 @@ interface BinaryTarget {
 const repoRoot = path.join(import.meta.dir, "..");
 const binariesDir = path.join(repoRoot, "packages", "coding-agent", "binaries");
 const entrypoint = "./packages/coding-agent/src/cli.ts";
-// Lazy native tokenizer entrypoint. `agent-core/compaction` loads this from
-// the explicit native entrypoint instead of a package-name dynamic require of
-// `@gajae-code/natives`, because those fail inside Bun standalone `$bunfs`.
-// Listing the module here makes the absolute target path exist in the compiled
-// bunfs.
-const nativeTokenizerEntrypoint = "./packages/natives/native/index.js";
 // Worker entrypoints. Bun's `--compile` static analyzer discovers the
 // literal in `new Worker("…", …)` at each spawn site, but only actually
 // emits the worker into the bunfs root when it is also listed here as an
@@ -136,8 +130,8 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		const compileEntrypoints = [...workerEntrypoints, nativeTokenizerEntrypoint].join(" ");
-		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --keep-names --define process.env.PI_COMPILED="true" --root . --external mupdf --target=${target.target} ${entrypoint} ${compileEntrypoints} --outfile ${target.outfile}`);
+		const compileEntrypoints = workerEntrypoints.join(" ");
+		console.log(`DRY RUN bun build --compile --minify --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --keep-names --define process.env.PI_COMPILED="true" --root . --external mupdf --target=${target.target} ${entrypoint} ${compileEntrypoints} --outfile ${target.outfile}`);
 		return;
 	}
 
@@ -149,6 +143,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 			"bun",
 			"build",
 			"--compile",
+			"--minify",
 			"--no-compile-autoload-bunfig",
 			"--no-compile-autoload-dotenv",
 			"--no-compile-autoload-tsconfig",
@@ -164,7 +159,6 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 			target.target,
 			entrypoint,
 			...workerEntrypoints,
-			nativeTokenizerEntrypoint,
 			"--outfile",
 			target.outfile,
 		],

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -28,6 +28,9 @@ interface PublishPackage {
 	extraFiles?: readonly string[];
 	/** Extra tsgo invocations beyond `tsconfig.publish.json`. */
 	extraTypeConfigs?: readonly string[];
+	/** Per-export condition overrides applied after the src→dist types rewrite
+	 *  (e.g. repoint a published `./cli` import/default at the bundled JS). */
+	exportOverrides?: Readonly<Record<string, Readonly<Record<string, string>>>>;
 }
 
 type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
@@ -59,7 +62,11 @@ export const packages: PublishPackage[] = [
 		dir: "packages/coding-agent",
 		kind: "typescript",
 		preBuild: [["bun", "run", "build:npm-bin"]],
-		extraFiles: ["dist/cli.js"],
+		extraFiles: ["dist/cli.js", "dist/sync-worker.ts", "dist/tab-worker-entry.ts", "dist/worker-entry.ts"],
+		// Published consumers (incl. the `gajae-code` wrapper that imports
+		// `@gajae-code/coding-agent/cli`) must hit the minified bundle, not the
+		// `./src/cli.ts` source the on-repo manifest keeps for local dev.
+		exportOverrides: { "./cli": { import: "./dist/cli.js", default: "./dist/cli.js" } },
 	},
 	{ dir: "packages/bridge-client", kind: "typescript" },
 	{ dir: "packages/gajae-code", kind: "manifest" },
@@ -173,7 +180,11 @@ function rewriteExports(exports: JsonValue): JsonValue {
 	return out;
 }
 
-async function rewriteManifest(pkgDir: string, extraFiles: readonly string[]): Promise<PackageManifest> {
+async function rewriteManifest(
+	pkgDir: string,
+	extraFiles: readonly string[],
+	exportOverrides?: Readonly<Record<string, Readonly<Record<string, string>>>>,
+): Promise<PackageManifest> {
 	const manifestPath = path.join(pkgDir, "package.json");
 	const manifest = (await Bun.file(manifestPath).json()) as PackageManifest;
 	await rewriteDependencyFields(manifest);
@@ -181,6 +192,14 @@ async function rewriteManifest(pkgDir: string, extraFiles: readonly string[]): P
 		manifest.types = rewriteSrcPath(manifest.types);
 	}
 	if (manifest.exports !== undefined) manifest.exports = rewriteExports(manifest.exports);
+	if (exportOverrides && manifest.exports !== null && typeof manifest.exports === "object" && !Array.isArray(manifest.exports)) {
+		const exportsObj = manifest.exports as JsonObject;
+		for (const [key, conditions] of Object.entries(exportOverrides)) {
+			const existing = exportsObj[key];
+			const base = existing !== null && typeof existing === "object" && !Array.isArray(existing) ? (existing as JsonObject) : {};
+			exportsObj[key] = { ...base, ...conditions };
+		}
+	}
 	const files = Array.isArray(manifest.files) ? [...manifest.files] : [];
 	const hasDist = files.includes("dist");
 	if (!hasDist && !files.includes("dist/types")) files.push("dist/types");
@@ -212,7 +231,7 @@ async function preparePackage(pkg: PublishPackage): Promise<PackageManifest> {
 	for (const cfg of pkg.extraTypeConfigs ?? []) {
 		await $`bun x tsgo -p ${cfg}`.cwd(pkgDir);
 	}
-	return rewriteManifest(pkgDir, pkg.extraFiles ?? []);
+	return rewriteManifest(pkgDir, pkg.extraFiles ?? [], pkg.exportOverrides);
 }
 
 async function publishPackage(pkg: PublishPackage): Promise<void> {

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -55,7 +55,12 @@ export const packages: PublishPackage[] = [
 		extraTypeConfigs: ["tsconfig.publish.client.json"],
 	},
 	{ dir: "packages/agent", kind: "typescript" },
-	{ dir: "packages/coding-agent", kind: "typescript" },
+	{
+		dir: "packages/coding-agent",
+		kind: "typescript",
+		preBuild: [["bun", "run", "build:npm-bin"]],
+		extraFiles: ["dist/cli.js"],
+	},
 	{ dir: "packages/bridge-client", kind: "typescript" },
 	{ dir: "packages/gajae-code", kind: "manifest" },
 ];

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -54,6 +54,15 @@ mkdir -p "$BINARY_DIR"
 cp packages/coding-agent/dist/gjc "$BINARY_DIR/gjc"
 smoke_cli "$BINARY_DIR/gjc"
 
+section "Bundle (npm bin) smoke"
+# Build and exercise the prebuilt minified JS bundle that npm ships as `bin.gjc`
+# (bun build --minify, not --compile). Proves the bundle resolves the external
+# native addon from node_modules and that the stats/browser/eval workers, which
+# the bundle spawns via `new Worker(new URL("./<name>.ts", import.meta.url))`,
+# are emitted next to dist/cli.js and load successfully.
+bun --cwd=packages/coding-agent run build:npm-bin
+smoke_cli "$ROOT_DIR/packages/coding-agent/dist/cli.js"
+
 section "Source install smoke"
 SOURCE_BUN_HOME="$WORK_DIR/bun-source"
 (


### PR DESCRIPTION
## Summary (follow-up to #879)

Makes the **minified compiled binary** gjc's production path.

**Measured (darwin-arm64):** npm bundle `dist/cli.js` `--help` RSS ~**120 MB** vs ~**302 MB** from source. `dist/cli.js --smoke-test` passes (native addon + stats/browser/eval workers all resolve).

## Changes
- npm `bin.gjc` → prebuilt minified `dist/cli.js`; `scripts/build-npm-bin.ts` (`bun build --minify --target=bun`, no `--compile`).
- **Native external:** `@gajae-code/natives` + the relative `../natives/native/index.js` loader + `*.node` are kept external so the addon loads from node_modules at runtime (bundling it inlined the loader and broke `.node` resolution from `dist/`).
- **Workers emitted:** the bundle spawns workers via `new Worker(new URL("./<name>.ts", import.meta.url))`; build-npm-bin emits `dist/{sync-worker,tab-worker-entry,worker-entry}.ts` so they resolve next to `dist/cli.js`.
- **Wrapper fix:** `ci-release-publish.ts` gains per-package `exportOverrides`; published coding-agent `./cli` import/default → `./dist/cli.js`, so the `gajae-code` wrapper (`import "@gajae-code/coding-agent/cli"`) runs the bundle, not `src/cli.ts`.
- Release compiled binaries gain `--minify`; CI/dev-ci workflows wired; `scripts/install-tests/run-ci.sh` adds a Bundle (npm bin) smoke.

## Validation
- ✅ Locally: `dist/cli.js --version` (`gjc/0.6.1`), `--help`, `stats --help`, `--smoke-test` (workers + native) all pass against the executable bundle.
- ⏳ CI-only (can't run here): the publish `exportOverrides` rewrite + tarball/wrapper install (`bun pm pack` uses the on-repo manifest, so the rewrite is exercised only by `ci-release-publish`) and the full cross-platform release matrix. The new run-ci.sh bundle-smoke + tarball-install sections cover these in CI.

Stacks on #879 (G001) until that merges.
