### PR TITLE
Fix native Windows tmux launch

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -160,7 +160,8 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
 	);
 	const invocation = ["&", ...command.map(powershellQuote), ...rawArgs.map(powershellQuote)].join(" ");
-	const script = [...envLines, invocation, "exit $LASTEXITCODE"].join("\n");
+	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
+	const script = [...envLines, invocation, exitLine].join("\n");
 	const encodedCommand = Buffer.from(script, "utf16le").toString("base64");
 	return `pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
 }

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import * as path from "node:path";
 import { safeStderrWrite } from "@gajae-code/utils";
 import type { Args } from "../cli/args";
@@ -107,6 +108,7 @@ interface CommandResolutionContext {
 	argv: string[];
 	execPath: string;
 	extraEnv?: Record<string, string>;
+	platform?: NodeJS.Platform;
 }
 
 function parseLaunchPolicy(env: NodeJS.ProcessEnv): LaunchPolicy {
@@ -148,6 +150,20 @@ function buildEnvAssignments(values: Record<string, string> | undefined): string
 	const entries = Object.entries(values ?? {});
 	return entries.length === 0 ? "" : ` ${entries.map(([key, value]) => `${key}=${shellQuote(value)}`).join(" ")}`;
 }
+function powershellQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
+	const command = resolveCurrentGjcCommand(context);
+	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(context.extraEnv ?? {}) }).map(
+		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
+	);
+	const invocation = ["&", ...command.map(powershellQuote), ...rawArgs.map(powershellQuote)].join(" ");
+	const script = [...envLines, invocation, "exit $LASTEXITCODE"].join("\n");
+	const encodedCommand = Buffer.from(script, "utf16le").toString("base64");
+	return `pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
+}
 
 export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProfileResult {
 	const env = context.env ?? process.env;
@@ -177,14 +193,24 @@ function resolveCurrentGjcCommand(context: CommandResolutionContext): string[] {
 	if (isBunVirtualPath(entrypoint)) {
 		return isBunVirtualPath(context.execPath) ? ["gjc"] : [context.execPath];
 	}
-	const resolvedEntrypoint = path.isAbsolute(entrypoint) ? entrypoint : path.resolve(context.cwd, entrypoint);
+	const pathModule = pathModuleForPlatform(context.platform);
+	const resolvedEntrypoint = pathModule.isAbsolute(entrypoint)
+		? entrypoint
+		: pathModule.resolve(context.cwd, entrypoint);
 	if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs")) {
 		return [context.execPath, resolvedEntrypoint];
 	}
 	return [resolvedEntrypoint];
 }
+function isWindowsPlatform(platform: NodeJS.Platform | undefined): boolean {
+	return platform === "win32";
+}
+function pathModuleForPlatform(platform: NodeJS.Platform | undefined): typeof path.win32 | typeof path {
+	return isWindowsPlatform(platform) ? path.win32 : path;
+}
 
 function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
+	if (isWindowsPlatform(context.platform)) return buildWindowsPowerShellInnerCommand(context, rawArgs);
 	const command = resolveCurrentGjcCommand(context);
 	const quoted = [...command, ...rawArgs].map(shellQuote).join(" ");
 	return `exec env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
@@ -305,7 +331,6 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 	if (!context.parsed.tmux || policy === "direct") return undefined;
 	if (env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return undefined;
 	const platform = context.platform ?? process.platform;
-	if (platform === "win32") return undefined;
 	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
 	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
 
@@ -335,6 +360,7 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 				[GJC_COORDINATOR_SESSION_ID_ENV]: sessionId,
 				[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: sessionStateFile,
 			},
+			platform,
 		},
 		context.rawArgs,
 	);

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -137,6 +137,8 @@ function listRawTmuxSessionNames(env: NodeJS.ProcessEnv = process.env): string[]
 export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus[] {
 	return listSessionLines(env)
 		.map(parseSessionLine)
+		.filter((session): session is GjcTmuxSessionStatus => session != null)
+		.map(session => hydrateSessionFromExactOptions(session, env))
 		.filter((session): session is GjcTmuxSessionStatus => session?.profile === GJC_TMUX_PROFILE_VALUE)
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -145,7 +147,8 @@ export function listGjcTmuxSessions(env: NodeJS.ProcessEnv = process.env): GjcTm
 export function listTmuxSessionsForGc(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionsForGc {
 	const sessions = listSessionLines(env)
 		.map(parseSessionLine)
-		.filter((session): session is GjcTmuxSessionStatus => session != null);
+		.filter((session): session is GjcTmuxSessionStatus => session != null)
+		.map(session => hydrateSessionFromExactOptions(session, env));
 	const tagged = sessions
 		.filter(session => session.profile === GJC_TMUX_PROFILE_VALUE)
 		.sort((a, b) => a.name.localeCompare(b.name));
@@ -225,6 +228,22 @@ function readExactOptionForGc(sessionName: string, option: string, env: NodeJS.P
 	} catch {
 		return undefined;
 	}
+}
+
+function hydrateSessionFromExactOptions(session: GjcTmuxSessionStatus, env: NodeJS.ProcessEnv): GjcTmuxSessionStatus {
+	if (session.profile === GJC_TMUX_PROFILE_VALUE) return session;
+	const profile = readExactOptionForGc(session.name, GJC_TMUX_PROFILE_OPTION, env);
+	if (profile !== GJC_TMUX_PROFILE_VALUE) return session;
+	return {
+		...session,
+		profile,
+		branch: session.branch ?? readExactOptionForGc(session.name, GJC_TMUX_BRANCH_OPTION, env),
+		branchSlug: session.branchSlug ?? readExactOptionForGc(session.name, GJC_TMUX_BRANCH_SLUG_OPTION, env),
+		project: session.project ?? readExactOptionForGc(session.name, GJC_TMUX_PROJECT_OPTION, env),
+		sessionId: session.sessionId ?? readExactOptionForGc(session.name, GJC_TMUX_SESSION_ID_OPTION, env),
+		sessionStateFile:
+			session.sessionStateFile ?? readExactOptionForGc(session.name, GJC_TMUX_SESSION_STATE_FILE_OPTION, env),
+	};
 }
 
 /** @internal */

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { Buffer } from "node:buffer";
 import type { Args } from "@gajae-code/coding-agent/cli/args";
 import {
 	applyGjcTmuxProfile,
@@ -21,6 +22,12 @@ function args(overrides: Partial<Args> = {}): Args {
 }
 
 const interactiveTty = { stdin: true, stdout: true };
+function decodePowerShellEncodedCommand(command: string): string {
+	const match = command.match(/ -EncodedCommand (?<encoded>[A-Za-z0-9+/=]+)$/);
+	if (!match?.groups?.encoded) throw new Error(`missing encoded command: ${command}`);
+	return Buffer.from(match.groups.encoded, "base64").toString("utf16le");
+}
+
 const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
 function stderrError(code: string): Error {
@@ -120,6 +127,55 @@ describe("default GJC tmux launch", () => {
 		);
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_ID=");
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
+	});
+
+	it("plans native Windows --tmux launches when tmux is available", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "C:\\repo",
+			env: {},
+			argv: ["C:\\Program Files\\GJC\\gjc.exe"],
+			execPath: "C:\\Program Files\\GJC\\gjc.exe",
+			platform: "win32",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+
+		expect(plan.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", plan.sessionName, "-c", "C:\\repo"]);
+		expect(plan.innerCommand).toStartWith(
+			"pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ",
+		);
+		expect(plan.innerCommand).not.toContain("exec env");
+		expect(decodePowerShellEncodedCommand(plan.innerCommand)).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
+	});
+
+	it("builds a PowerShell-safe Windows tmux bootstrap command", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["say it's ok"], tmux: true }),
+			rawArgs: ["--tmux", "say it's ok"],
+			cwd: "C:\\repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "C:\\Program Files\\Bun\\bun.exe",
+			platform: "win32",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+
+		const script = decodePowerShellEncodedCommand(plan.innerCommand);
+		expect(script).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
+		expect(script).toContain(`$env:GJC_COORDINATOR_SESSION_ID = '${plan.sessionId}'`);
+		expect(script).toContain(
+			"& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' '--tmux' 'say it''s ok'",
+		);
+		expect(script).toEndWith("exit $LASTEXITCODE");
 	});
 	it("uses a host command for compiled Bun virtual entrypoints", () => {
 		const plan = buildDefaultTmuxLaunchPlan({

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -175,7 +175,7 @@ describe("default GJC tmux launch", () => {
 		expect(script).toContain(
 			"& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' '--tmux' 'say it''s ok'",
 		);
-		expect(script).toEndWith("exit $LASTEXITCODE");
+		expect(script).toEndWith("if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }");
 	});
 	it("uses a host command for compiled Bun virtual entrypoints", () => {
 		const plan = buildDefaultTmuxLaunchPlan({

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -114,6 +114,31 @@ describe("GJC tmux session management", () => {
 		expect(() => statusGjcTmuxSession("psmux_session", { GJC_TMUX_COMMAND: "psmux" })).toThrow(/not fully supported/);
 	});
 
+	it("hydrates native Windows tmux sessions from exact option reads when list-sessions omits user options", () => {
+		const calls: string[][] = [];
+		const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+		spawnSyncSpy.mockImplementation((cmd: string[]) => {
+			calls.push(cmd);
+			if (cmd.includes("list-sessions")) {
+				return spawnResult(0, "win_session\t1\t0\t1770000000\t\troot\t1\t12345\t\t\t\t\t\n");
+			}
+			if (cmd.includes("show-options")) {
+				const option = cmd.at(-1);
+				if (option === "@gjc-profile") return spawnResult(0, "1\n");
+				if (option === "@gjc-branch") return spawnResult(0, "issue-882-windows-tmux\n");
+				return spawnResult(0, "\n");
+			}
+			return spawnResult(0, "");
+		});
+
+		const session = statusGjcTmuxSession("win_session", { GJC_TMUX_COMMAND: "tmux" });
+
+		expect(session.name).toBe("win_session");
+		expect(session.profile).toBe("1");
+		expect(session.branch).toBe("issue-882-windows-tmux");
+		expect(calls).toContainEqual(["tmux", "show-options", "-qv", "-t", "=win_session:", "@gjc-profile"]);
+	});
+
 	it("still reports plain not-found when the multiplexer does not list the session", () => {
 		spyOn(Bun, "spawnSync").mockReturnValue(spawnResult(0, ""));
 


### PR DESCRIPTION
## Summary
- allow `gjc --tmux` to plan a tmux launch on native Windows when tmux is available
- use a PowerShell `-EncodedCommand` bootstrap on Windows instead of POSIX `exec env ...`
- add unit coverage for win32 launch planning and PowerShell-safe command generation

Closes #882

## Verification
- `bun --filter @gajae-code/coding-agent test test/gjc-runtime/launch-tmux.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*