### PR TITLE
Fix tmux GC test fixture after exact tag hydration

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
@@ -99,7 +99,10 @@ describe("tmux GC safety", () => {
 					].join("\n"),
 				);
 			}
-			if (cmd.includes("show-options")) return spawnResult(0, cmd.at(-1) === "@gjc-profile" ? "1\n" : "\n");
+			if (cmd.includes("show-options")) {
+				const target = cmd[cmd.indexOf("-t") + 1] ?? "";
+				return spawnResult(0, cmd.at(-1) === "@gjc-profile" && target.includes("gajae_code_orphan") ? "1\n" : "\n");
+			}
 			return spawnResult(0, "");
 		});
 


### PR DESCRIPTION
## Summary
- keep the tmux GC unrelated-session fixture untagged under exact show-options reads
- align the test with the Windows exact-option tag hydration added in #884

## Verification
- bun --filter @gajae-code/coding-agent test test/gjc-runtime/tmux-gc.test.ts

Follow-up for post-#886 Dev CI failure: the production behavior was correct, but the fixture mocked @gjc-profile=1 for every exact option read, including the unrelated session.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*