### PR TITLE
Fix Windows welcome banner fallback

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1065,6 +1065,22 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"startup.welcomeBannerMode": {
+		type: "enum",
+		values: ["auto", "unicode", "ascii"] as const,
+		default: "auto",
+		ui: {
+			tab: "interaction",
+			label: "Welcome Banner Mode",
+			description: "Logo style for the startup welcome screen",
+			options: [
+				{ value: "auto", label: "Auto", description: "Use a terminal-compatible logo" },
+				{ value: "unicode", label: "Unicode", description: "Force the rounded Unicode logo" },
+				{ value: "ascii", label: "ASCII", description: "Force the ASCII-safe logo" },
+			],
+		},
+	},
+
 	"startup.checkUpdate": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -13,6 +13,8 @@ export interface LspServerInfo {
 	fileTypes: string[];
 }
 
+export type WelcomeLogoMode = "unicode" | "ascii";
+
 /**
  * GJC-native launch surface with compact command affordances, project
  * signals, and a claw/talon mark without copying another agent shell.
@@ -27,6 +29,7 @@ export class WelcomeComponent implements Component {
 		private providerName: string,
 		private recentSessions: RecentSession[] = [],
 		private lspServers: LspServerInfo[] = [],
+		private readonly logoMode: WelcomeLogoMode = "unicode",
 	) {}
 
 	invalidate(): void {}
@@ -83,7 +86,8 @@ export class WelcomeComponent implements Component {
 		const minRightCol = 20;
 		const modelPill = this.#pill(theme.icon.model || "model", this.modelName, "statusLineModel");
 		const providerPill = this.#pill(theme.icon.package || "provider", this.providerName, "statusLinePath");
-		const logoMinWidth = Math.max(...RED_CLAW_LOGO.map(line => visibleWidth(line)));
+		const logoLines = this.#logoLines();
+		const logoMinWidth = Math.max(...logoLines.map(line => visibleWidth(line)));
 		const leftMinContentWidth = Math.max(
 			minLeftCol,
 			logoMinWidth,
@@ -102,8 +106,7 @@ export class WelcomeComponent implements Component {
 		const leftCol = showRightColumn ? dualLeftCol : boxWidth - 2;
 		const rightCol = showRightColumn ? dualRightCol : 0;
 
-		// Logo: pick a frame from the intro animation if active, else the resting frame.
-		const logoColored = this.#currentLogoFrame();
+		const logoColored = this.#currentLogoFrame(logoLines);
 
 		// Left column - centered content
 		const leftLines = [
@@ -258,10 +261,10 @@ export class WelcomeComponent implements Component {
 	}
 
 	/** Pick the logo frame for the current intro phase, or the resting frame. */
-	#currentLogoFrame(): readonly string[] {
-		if (this.#animStart == null) return REST_FRAME;
+	#currentLogoFrame(logoLines: readonly string[]): readonly string[] {
+		if (this.#animStart == null) return REST_FRAMES[this.logoMode];
 		const elapsed = performance.now() - this.#animStart;
-		if (elapsed >= INTRO_MS) return REST_FRAME;
+		if (elapsed >= INTRO_MS) return REST_FRAMES[this.logoMode];
 		// Ease-out cubic so the spin decelerates into the resting state.
 		const progress = elapsed / INTRO_MS;
 		const eased = 1 - (1 - progress) ** 3;
@@ -273,7 +276,11 @@ export class WelcomeComponent implements Component {
 		// the same ease-out curve so the highlight is gone by the resting frame.
 		const shinePos = (((progress * INTRO_SHINE_TRAVERSALS) % 1) + 1) % 1;
 		const shineStrength = (1 - eased) ** 1.5;
-		return gradientLogo(RED_CLAW_LOGO, phase, { strength: shineStrength, pos: shinePos });
+		return gradientLogo(logoLines, phase, { strength: shineStrength, pos: shinePos });
+	}
+
+	#logoLines(): readonly string[] {
+		return this.logoMode === "ascii" ? ASCII_CLAW_LOGO : RED_CLAW_LOGO;
 	}
 }
 
@@ -285,6 +292,16 @@ const RED_CLAW_LOGO = [
 	"       ╭──────╮    ╰───╮  ╰──╮      ",
 	"╭──────╯      ╰──╮     ╰──╮  ╰─────╮",
 	"╰────────────────╯        ╰────────╯",
+];
+
+// biome-ignore format: preserve ASCII art layout
+const ASCII_CLAW_LOGO = [
+	"+----------------+        +--------+",
+	"+------+      +--+     +--+  +-----+",
+	"       +------+    +---+  +--+      ",
+	"       +------+    +---+  +--+      ",
+	"+------+      +--+     +--+  +-----+",
+	"+----------------+        +--------+",
 ];
 
 /** Multi-stop palette for the red-claw diagonal gradient. */
@@ -385,5 +402,8 @@ const INTRO_SWEEPS = 2.5;
 /** Number of times the shine highlight crosses the diagonal across the intro. */
 const INTRO_SHINE_TRAVERSALS = 3;
 
-/** Resting gradient frame, cached for re-renders outside of the intro. */
-const REST_FRAME = gradientLogo(RED_CLAW_LOGO, 0);
+/** Resting gradient frames, cached for re-renders outside of the intro. */
+const REST_FRAMES: Record<WelcomeLogoMode, readonly string[]> = {
+	unicode: gradientLogo(RED_CLAW_LOGO, 0),
+	ascii: gradientLogo(ASCII_CLAW_LOGO, 0),
+};

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -86,7 +86,11 @@ import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
-import { WelcomeComponent, type LspServerInfo as WelcomeLspServerInfo } from "./components/welcome";
+import {
+	WelcomeComponent,
+	type WelcomeLogoMode,
+	type LspServerInfo as WelcomeLspServerInfo,
+} from "./components/welcome";
 import { BtwController } from "./controllers/btw-controller";
 import { CommandController } from "./controllers/command-controller";
 import { EventController } from "./controllers/event-controller";
@@ -216,6 +220,18 @@ function parseGoalSubcommand(args: string): { sub: GoalSubcommand | undefined; r
 		return { sub: first as GoalSubcommand, rest: match[2]?.trim() ?? "" };
 	}
 	return { sub: undefined, rest: trimmed };
+}
+
+type WelcomeBannerSettingMode = "auto" | "unicode" | "ascii";
+
+export function resolveWelcomeLogoMode(
+	mode: WelcomeBannerSettingMode,
+	env: Record<string, string | undefined> = Bun.env,
+	platform: NodeJS.Platform = process.platform,
+): WelcomeLogoMode {
+	if (mode === "unicode") return "unicode";
+	if (mode === "ascii") return "ascii";
+	return platform === "win32" && env.WT_SESSION ? "ascii" : "unicode";
 }
 
 /** Options for creating an InteractiveMode instance (for future API use) */
@@ -479,6 +495,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 
 		const startupQuiet = settings.get("startup.quiet");
+		const welcomeLogoMode = resolveWelcomeLogoMode(settings.get("startup.welcomeBannerMode"));
 		this.#welcomeComponent = undefined;
 
 		for (const warning of this.session.configWarnings) {
@@ -494,6 +511,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				providerName,
 				recentSessions,
 				this.#getWelcomeLspServers(),
+				welcomeLogoMode,
 			);
 
 			// Setup UI layout

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -9,6 +9,7 @@ import { FooterComponent } from "@gajae-code/coding-agent/modes/components/foote
 import { STATUS_LINE_PRESETS } from "@gajae-code/coding-agent/modes/components/status-line/presets";
 import { UserMessageComponent } from "@gajae-code/coding-agent/modes/components/user-message";
 import { WelcomeComponent } from "@gajae-code/coding-agent/modes/components/welcome";
+import { resolveWelcomeLogoMode } from "@gajae-code/coding-agent/modes/interactive-mode";
 import { getEditorTheme, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { type TUI, visibleWidth } from "@gajae-code/tui";
@@ -110,6 +111,27 @@ describe("redesigned interactive shell chrome", () => {
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(54);
 		}
+	});
+
+	it("renders an ASCII-safe welcome logo when requested", () => {
+		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai", [], [], "ascii");
+		const lines = component.render(54);
+		const rendered = Bun.stripANSI(lines.join("\n"));
+
+		expect(rendered).toContain("+----------------+        +--------+");
+		expect(rendered).toContain("+------+      +--+     +--+  +-----+");
+		expect(rendered).not.toContain("╭────────────────╮");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(54);
+		}
+	});
+
+	it("resolves welcome banner auto mode for native Windows Terminal only", () => {
+		expect(resolveWelcomeLogoMode("auto", { WT_SESSION: "session-id" }, "win32")).toBe("ascii");
+		expect(resolveWelcomeLogoMode("auto", { WT_SESSION: "session-id" }, "linux")).toBe("unicode");
+		expect(resolveWelcomeLogoMode("auto", {}, "win32")).toBe("unicode");
+		expect(resolveWelcomeLogoMode("unicode", { WT_SESSION: "session-id" }, "win32")).toBe("unicode");
+		expect(resolveWelcomeLogoMode("ascii", {}, "linux")).toBe("ascii");
 	});
 
 	it("renders the live composer as a borderless opencode-style prompt", () => {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -705,6 +705,16 @@
 					"description": "Skip welcome screen and startup status messages",
 					"default": false
 				},
+				"welcomeBannerMode": {
+					"type": "string",
+					"enum": [
+						"auto",
+						"unicode",
+						"ascii"
+					],
+					"description": "Logo style for the startup welcome screen",
+					"default": "auto"
+				},
 				"checkUpdate": {
 					"type": "boolean",
 					"description": "If false, skip update check",


### PR DESCRIPTION
## Summary
- add `startup.welcomeBannerMode` (`auto` | `unicode` | `ascii`) with default `auto`
- resolve Windows Terminal native startup to an ASCII-safe welcome logo in auto mode
- keep `WelcomeComponent` pure by passing the resolved logo mode from interactive mode
- cover quiet/auto/unicode/ascii behavior in welcome rendering tests

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun run check:schemas`
- `bun test packages/coding-agent/test/modes/components/redesigned-shell.test.ts`

Fixes #888

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*