### PR TITLE
fix(ai): correct Responses API multi-tool-call stream correlation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed argument mis-attribution in the OpenAI-compatible Responses API streaming decoder when a single response emits multiple tool-call items. The decoder buffered streamed argument deltas against a single most-recent item/block slot, so interleaved or back-to-back `function_call`/`custom_tool_call` argument deltas could be applied to the wrong item — finalizing a tool call with another call's arguments (e.g. one tool's payload landing on a different tool's schema and tripping validation). Streamed deltas now accumulate against a per-item buffer keyed on stable item identity (`item_id` primary; positional `output_index` only when finite), each block records its content index at registration time, and finalization writes onto the same block stored in the message content while reading only the matching item's buffer. Single-tool-call streams, reasoning/text streaming, and the Chat Completions path are unchanged.
+
 ## [0.6.2] - 2026-06-19
 ### Added
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -370,15 +370,57 @@ export async function processResponsesStream<TApi extends Api>(
 	model: Model<TApi>,
 	options?: ProcessResponsesStreamOptions,
 ): Promise<void> {
-	let currentItem:
-		| ResponseReasoningItem
-		| ResponseOutputMessage
-		| ResponseFunctionToolCall
-		| ResponseCustomToolCall
-		| null = null;
-	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
-	const blocks = output.content;
-	const blockIndex = () => blocks.length - 1;
+	type StreamItem = ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | ResponseCustomToolCall;
+	type StreamBlock = ThinkingContent | TextContent | (ToolCall & { partialJson: string });
+	interface ItemEntry {
+		item: StreamItem;
+		block: StreamBlock;
+		blockContentIndex: number;
+	}
+	// Per-item argument buffer keyed on stable item identity. Multiple tool-call
+	// items can stream interleaved argument deltas in one response, so a single
+	// most-recent slot would mis-attribute deltas to the wrong item.
+	const items = new Map<string, ItemEntry>();
+	let lastKey: string | null = null;
+	const idKey = (id: string) => `id:${id}`;
+	const idxKey = (n: number) => `idx:${n}`;
+	const hasIndex = (n: number | undefined): n is number => typeof n === "number" && Number.isFinite(n);
+	const resolveEntry = (
+		itemId: string | undefined,
+		outputIndex: number | undefined,
+		allowLastKey: boolean,
+	): ItemEntry | undefined => {
+		if (itemId) {
+			const byId = items.get(idKey(itemId));
+			if (byId) return byId;
+		}
+		if (hasIndex(outputIndex)) {
+			const byIdx = items.get(idxKey(outputIndex));
+			if (byIdx) return byIdx;
+		}
+		if (allowLastKey && lastKey) return items.get(lastKey);
+		return undefined;
+	};
+	const registerEntry = (item: StreamItem, block: StreamBlock, outputIndex: number | undefined): ItemEntry => {
+		output.content.push(block);
+		const entry: ItemEntry = { item, block, blockContentIndex: output.content.length - 1 };
+		// Primary key prefers the stable item id; if the wire omits it, fall back to
+		// the positional index. A synthetic key keeps the entry addressable as lastKey
+		// for continuation-style non-tool events even when neither is present.
+		const key = item.id ? idKey(item.id) : hasIndex(outputIndex) ? idxKey(outputIndex) : `seq:${items.size}`;
+		items.set(key, entry);
+		if (item.id && hasIndex(outputIndex)) items.set(idxKey(outputIndex), entry);
+		lastKey = key;
+		return entry;
+	};
+	const dropEntry = (itemId: string | undefined, outputIndex: number | undefined): void => {
+		const key = itemId ? idKey(itemId) : hasIndex(outputIndex) ? idxKey(outputIndex) : null;
+		if (key) {
+			items.delete(key);
+			if (lastKey === key) lastKey = null;
+		}
+		if (itemId && hasIndex(outputIndex)) items.delete(idxKey(outputIndex));
+	};
 	let sawFirstToken = false;
 
 	for await (const event of openaiStream) {
@@ -390,30 +432,27 @@ export async function processResponsesStream<TApi extends Api>(
 				options?.onFirstToken?.();
 			}
 			const item = event.item;
+			const outputIndex = event.output_index;
 			if (item.type === "reasoning") {
-				currentItem = item;
-				currentBlock = { type: "thinking", thinking: "", itemId: item.id };
-				output.content.push(currentBlock);
-				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+				const block: ThinkingContent = { type: "thinking", thinking: "", itemId: item.id };
+				const entry = registerEntry(item, block, outputIndex);
+				stream.push({ type: "thinking_start", contentIndex: entry.blockContentIndex, partial: output });
 			} else if (item.type === "message") {
-				currentItem = item;
-				currentBlock = { type: "text", text: "" };
-				output.content.push(currentBlock);
-				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+				const block: TextContent = { type: "text", text: "" };
+				const entry = registerEntry(item, block, outputIndex);
+				stream.push({ type: "text_start", contentIndex: entry.blockContentIndex, partial: output });
 			} else if (item.type === "function_call") {
-				currentItem = item;
-				currentBlock = {
+				const block: ToolCall & { partialJson: string } = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					name: item.name,
 					arguments: {},
 					partialJson: item.arguments || "",
 				};
-				output.content.push(currentBlock);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+				const entry = registerEntry(item, block, outputIndex);
+				stream.push({ type: "toolcall_start", contentIndex: entry.blockContentIndex, partial: output });
 			} else if (item.type === "custom_tool_call") {
-				currentItem = item;
-				currentBlock = {
+				const block: ToolCall & { partialJson: string } = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					// Preserve the raw wire name (e.g. `apply_patch`). The agent-loop
@@ -427,39 +466,42 @@ export async function processResponsesStream<TApi extends Api>(
 					// accumulation buffer so later code that inspects the field still works.
 					partialJson: item.input ?? "",
 				};
-				output.content.push(currentBlock);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+				const entry = registerEntry(item, block, outputIndex);
+				stream.push({ type: "toolcall_start", contentIndex: entry.blockContentIndex, partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
-			if (currentItem?.type === "reasoning") {
-				currentItem.summary = currentItem.summary || [];
-				currentItem.summary.push(event.part);
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "reasoning") {
+				entry.item.summary = entry.item.summary || [];
+				entry.item.summary.push(event.part);
 			}
 		} else if (event.type === "response.reasoning_summary_text.delta") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.item.summary = entry.item.summary || [];
+				const lastPart = entry.item.summary[entry.item.summary.length - 1];
 				if (lastPart) {
-					currentBlock.thinking += event.delta;
+					entry.block.thinking += event.delta;
 					lastPart.text += event.delta;
 					stream.push({
 						type: "thinking_delta",
-						contentIndex: blockIndex(),
+						contentIndex: entry.blockContentIndex,
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.reasoning_summary_part.done") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.item.summary = entry.item.summary || [];
+				const lastPart = entry.item.summary[entry.item.summary.length - 1];
 				if (lastPart) {
-					currentBlock.thinking += "\n\n";
+					entry.block.thinking += "\n\n";
 					lastPart.text += "\n\n";
 					stream.push({
 						type: "thinking_delta",
-						contentIndex: blockIndex(),
+						contentIndex: entry.blockContentIndex,
 						delta: "\n\n",
 						partial: output,
 					});
@@ -468,85 +510,94 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "response.reasoning_text.delta") {
 			// Raw reasoning text delta from local providers that stream thinking
 			// directly rather than via the OpenAI summary tracking protocol.
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentBlock.thinking += event.delta;
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.block.thinking += event.delta;
 				stream.push({
 					type: "thinking_delta",
-					contentIndex: blockIndex(),
+					contentIndex: entry.blockContentIndex,
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.content_part.added") {
-			if (currentItem?.type === "message") {
-				currentItem.content = currentItem.content || [];
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "message") {
+				entry.item.content = entry.item.content || [];
 				if (event.part.type === "output_text" || event.part.type === "refusal") {
-					currentItem.content.push(event.part);
+					entry.item.content.push(event.part);
 				}
 			}
 		} else if (event.type === "response.output_text.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				const lastPart = currentItem.content?.[currentItem.content.length - 1];
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "message" && entry.block.type === "text") {
+				const lastPart = entry.item.content?.[entry.item.content.length - 1];
 				if (lastPart?.type === "output_text") {
-					currentBlock.text += event.delta;
+					entry.block.text += event.delta;
 					lastPart.text += event.delta;
 					stream.push({
 						type: "text_delta",
-						contentIndex: blockIndex(),
+						contentIndex: entry.blockContentIndex,
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.refusal.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				const lastPart = currentItem.content?.[currentItem.content.length - 1];
+			const entry = resolveEntry(event.item_id, event.output_index, true);
+			if (entry?.item.type === "message" && entry.block.type === "text") {
+				const lastPart = entry.item.content?.[entry.item.content.length - 1];
 				if (lastPart?.type === "refusal") {
-					currentBlock.text += event.delta;
+					entry.block.text += event.delta;
 					lastPart.refusal += event.delta;
 					stream.push({
 						type: "text_delta",
-						contentIndex: blockIndex(),
+						contentIndex: entry.blockContentIndex,
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.function_call_arguments.delta") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+			const entry = resolveEntry(event.item_id, event.output_index, false);
+			if (entry?.item.type === "function_call" && entry.block.type === "toolCall") {
+				entry.block.partialJson += event.delta;
+				entry.block.arguments = parseStreamingJson(entry.block.partialJson);
 				stream.push({
 					type: "toolcall_delta",
-					contentIndex: blockIndex(),
+					contentIndex: entry.blockContentIndex,
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.function_call_arguments.done") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson = event.arguments;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+			const entry = resolveEntry(event.item_id, event.output_index, false);
+			if (entry?.item.type === "function_call" && entry.block.type === "toolCall") {
+				entry.block.partialJson = event.arguments;
+				entry.block.arguments = parseStreamingJson(entry.block.partialJson);
 			}
 		} else if (event.type === "response.custom_tool_call_input.delta") {
-			if (currentItem?.type === "custom_tool_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = { input: currentBlock.partialJson };
+			const entry = resolveEntry(event.item_id, event.output_index, false);
+			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
+				entry.block.partialJson += event.delta;
+				entry.block.arguments = { input: entry.block.partialJson };
 				stream.push({
 					type: "toolcall_delta",
-					contentIndex: blockIndex(),
+					contentIndex: entry.blockContentIndex,
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.custom_tool_call_input.done") {
-			if (currentItem?.type === "custom_tool_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson = event.input;
-				currentBlock.arguments = { input: event.input };
+			const entry = resolveEntry(event.item_id, event.output_index, false);
+			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
+				entry.block.partialJson = event.input;
+				entry.block.arguments = { input: event.input };
 			}
 		} else if (event.type === "response.output_item.done") {
 			const item = structuredCloneJSON(event.item);
 			options?.onOutputItemDone?.(item);
+			const entry = resolveEntry(item.id, event.output_index, false);
 			if (item.type === "reasoning") {
 				const thinking =
 					item.summary?.length > 0
@@ -554,13 +605,17 @@ export async function processResponsesStream<TApi extends Api>(
 						: item.content?.[0]?.type === "reasoning_text"
 							? (item.content[0].text ?? "")
 							: "";
-				const reasoningBlock = output.content.find(
-					b => b.type === "thinking" && (b as ThinkingContent).itemId === item.id,
-				) as ThinkingContent | undefined;
+				const reasoningBlock =
+					entry?.block.type === "thinking"
+						? entry.block
+						: (output.content.find(b => b.type === "thinking" && (b as ThinkingContent).itemId === item.id) as
+								| ThinkingContent
+								| undefined);
 				if (reasoningBlock) {
 					reasoningBlock.thinking = thinking;
 					reasoningBlock.thinkingSignature = JSON.stringify(item);
-					const reasoningBlockIndex = output.content.indexOf(reasoningBlock);
+					const reasoningBlockIndex =
+						entry?.block === reasoningBlock ? entry.blockContentIndex : output.content.indexOf(reasoningBlock);
 					stream.push({
 						type: "thinking_end",
 						contentIndex: reasoningBlockIndex,
@@ -568,23 +623,27 @@ export async function processResponsesStream<TApi extends Api>(
 						partial: output,
 					});
 				}
-				if ((currentBlock as ThinkingContent | null)?.itemId === item.id) currentBlock = null;
-			} else if (item.type === "message" && currentBlock?.type === "text") {
-				currentBlock.text = item.content
+				dropEntry(item.id, event.output_index);
+			} else if (item.type === "message" && entry?.block.type === "text") {
+				const block = entry.block;
+				block.text = item.content
 					.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))
 					.join("");
-				currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+				block.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
 				stream.push({
 					type: "text_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.text,
+					contentIndex: entry.blockContentIndex,
+					content: block.text,
 					partial: output,
 				});
-				currentBlock = null;
+				dropEntry(item.id, event.output_index);
 			} else if (item.type === "function_call") {
+				// Finalize onto the same block object stored in output.content, reading
+				// the matching entry's buffered partialJson first and only then the done
+				// item's arguments — never an adjacent item's buffer.
 				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
+					entry?.block.type === "toolCall" && entry.block.partialJson
+						? parseStreamingJson(entry.block.partialJson)
 						: parseStreamingJson(item.arguments || "{}");
 				const toolCall: ToolCall = {
 					type: "toolCall",
@@ -592,12 +651,18 @@ export async function processResponsesStream<TApi extends Api>(
 					name: item.name,
 					arguments: args,
 				};
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				if (entry?.block.type === "toolCall") {
+					entry.block.id = toolCall.id;
+					entry.block.name = toolCall.name;
+					entry.block.arguments = args;
+				}
+				const contentIndex = entry?.blockContentIndex ?? output.content.length - 1;
+				dropEntry(item.id, event.output_index);
+				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			} else if (item.type === "custom_tool_call") {
 				const rawInput =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? currentBlock.partialJson
+					entry?.block.type === "toolCall" && entry.block.partialJson
+						? entry.block.partialJson
 						: (item.input ?? "");
 				const toolCall: ToolCall = {
 					type: "toolCall",
@@ -606,8 +671,14 @@ export async function processResponsesStream<TApi extends Api>(
 					arguments: { input: rawInput },
 					customWireName: item.name,
 				};
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				if (entry?.block.type === "toolCall") {
+					entry.block.id = toolCall.id;
+					entry.block.name = toolCall.name;
+					entry.block.arguments = { input: rawInput };
+				}
+				const contentIndex = entry?.blockContentIndex ?? output.content.length - 1;
+				dropEntry(item.id, event.output_index);
+				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;

--- a/packages/ai/test/openai-responses-multi-toolcall-stream-adversarial.test.ts
+++ b/packages/ai/test/openai-responses-multi-toolcall-stream-adversarial.test.ts
@@ -1,0 +1,590 @@
+import { describe, expect, test } from "bun:test";
+import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
+import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai/types";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+
+// Adversarial red-team tests designed to expose cross-attribution bugs and
+// content-index drift in the per-item correlation fix of processResponsesStream.
+// Tool names are generic placeholders throughout.
+
+async function* makeStream(events: unknown[]): AsyncIterable<ResponseStreamEvent> {
+	for (const e of events) yield e as ResponseStreamEvent;
+}
+
+function makeModel(): Model<"openai-responses"> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "openai-responses",
+		provider: "test-provider",
+		baseUrl: "https://example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		timestamp: Date.now(),
+		provider: "test-provider",
+		model: "test-model",
+		api: "openai-responses",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+interface ToolCallEndEvent {
+	type: "toolcall_end";
+	contentIndex: number;
+	toolCall: ToolCall;
+}
+
+function makeCapture() {
+	const emitted: Array<Record<string, unknown>> = [];
+	const stream = {
+		push: (e: Record<string, unknown>) => emitted.push(e),
+		end: () => {},
+	} as never;
+	return { emitted, stream };
+}
+
+function toolCallEnds(emitted: Array<Record<string, unknown>>): ToolCallEndEvent[] {
+	return emitted.filter(e => e.type === "toolcall_end") as unknown as ToolCallEndEvent[];
+}
+
+function toolBlocks(output: AssistantMessage): Array<ToolCall & { partialJson?: string }> {
+	return output.content.filter(b => b.type === "toolCall") as Array<ToolCall & { partialJson?: string }>;
+}
+
+describe("Adversarial Responses stream red-team", () => {
+	// -----------------------------------------------------------------------
+	// Case (a): THREE function_call items added in order; argument deltas
+	// delivered in REVERSE/SHUFFLED item order with chunk boundaries that
+	// split JSON mid-key.  Assert each finalized toolCall.arguments equals
+	// its OWN intended object — no cross-item content leak.
+	// -----------------------------------------------------------------------
+	test("(a) three items, reversed/shuffled delta order with mid-key splits", async () => {
+		const events = [
+			// All three items added first (output_index 0, 1, 2).
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_alpha", call_id: "call_alpha", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_bravo", call_id: "call_bravo", name: "bravo_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 2,
+				item: {
+					type: "function_call",
+					id: "fc_charlie",
+					call_id: "call_charlie",
+					name: "charlie_tool",
+					arguments: "",
+				},
+			},
+			// Deltas for C first, then A, then B — all interleaved, mid-key splits.
+			// charlie_tool target: {"mode":"strict","limit":5}
+			{ type: "response.function_call_arguments.delta", item_id: "fc_charlie", output_index: 2, delta: '{"mo' },
+			// alpha_tool target: {"command":"echo hello"}
+			{ type: "response.function_call_arguments.delta", item_id: "fc_alpha", output_index: 0, delta: '{"com' },
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_charlie",
+				output_index: 2,
+				delta: 'de":"strict',
+			},
+			// bravo_tool target: {"path":"/var/log"}
+			{ type: "response.function_call_arguments.delta", item_id: "fc_bravo", output_index: 1, delta: '{"pat' },
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_alpha",
+				output_index: 0,
+				delta: 'mand":"echo hello"}',
+			},
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_charlie",
+				output_index: 2,
+				delta: '","limit":5}',
+			},
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_bravo",
+				output_index: 1,
+				delta: 'h":"/var/log"}',
+			},
+			// done events
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_charlie",
+				output_index: 2,
+				arguments: '{"mode":"strict","limit":5}',
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_alpha",
+				output_index: 0,
+				arguments: '{"command":"echo hello"}',
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_bravo",
+				output_index: 1,
+				arguments: '{"path":"/var/log"}',
+			},
+			// output_item.done in original order
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_alpha",
+					call_id: "call_alpha",
+					name: "alpha_tool",
+					arguments: '{"command":"echo hello"}',
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc_bravo",
+					call_id: "call_bravo",
+					name: "bravo_tool",
+					arguments: '{"path":"/var/log"}',
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 2,
+				item: {
+					type: "function_call",
+					id: "fc_charlie",
+					call_id: "call_charlie",
+					name: "charlie_tool",
+					arguments: '{"mode":"strict","limit":5}',
+				},
+			},
+		];
+
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// --- output.content assertions ---
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(3);
+
+		const byName = new Map(blocks.map(b => [b.name, b.arguments as Record<string, unknown>]));
+		// Each item must carry only its own args.
+		expect(byName.get("alpha_tool")).toEqual({ command: "echo hello" });
+		expect(byName.get("bravo_tool")).toEqual({ path: "/var/log" });
+		expect(byName.get("charlie_tool")).toEqual({ mode: "strict", limit: 5 });
+		// Anti-leak: no foreign keys
+		expect(byName.get("alpha_tool")?.path).toBeUndefined();
+		expect(byName.get("alpha_tool")?.mode).toBeUndefined();
+		expect(byName.get("bravo_tool")?.command).toBeUndefined();
+		expect(byName.get("bravo_tool")?.mode).toBeUndefined();
+		expect(byName.get("charlie_tool")?.command).toBeUndefined();
+		expect(byName.get("charlie_tool")?.path).toBeUndefined();
+
+		// --- emitted toolcall_end assertions ---
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(3);
+		const endByName = new Map(ends.map(e => [e.toolCall.name, e.toolCall.arguments as Record<string, unknown>]));
+		expect(endByName.get("alpha_tool")).toEqual({ command: "echo hello" });
+		expect(endByName.get("bravo_tool")).toEqual({ path: "/var/log" });
+		expect(endByName.get("charlie_tool")).toEqual({ mode: "strict", limit: 5 });
+		// Content indices must be distinct 0/1/2.
+		const ciByName = new Map(ends.map(e => [e.toolCall.name, e.contentIndex]));
+		expect(ciByName.get("alpha_tool")).toBe(0);
+		expect(ciByName.get("bravo_tool")).toBe(1);
+		expect(ciByName.get("charlie_tool")).toBe(2);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case (b): function_call_arguments.done is ABSENT; finalization happens
+	// only via output_item.done.  The accumulated per-item partialJson buffer
+	// (from deltas) must supply the arguments, not another item's buffer.
+	// -----------------------------------------------------------------------
+	test("(b) no function_call_arguments.done — output_item.done finalizes from per-item buffer", async () => {
+		// Two items so we can verify the delta buffer of item 1 does NOT pollute item 2.
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_delta_only", call_id: "c_delta", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_control", call_id: "c_ctrl", name: "bravo_tool", arguments: "" },
+			},
+			// Deltas for item 0 only — split mid-value
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_delta_only",
+				output_index: 0,
+				delta: '{"result"',
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_delta_only", output_index: 0, delta: ':"ok"}' },
+			// NO function_call_arguments.done for fc_delta_only
+			// Control item gets its done event
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_control",
+				output_index: 1,
+				arguments: '{"ctrl":true}',
+			},
+			// output_item.done carries the canonical arguments (which should agree with per-item buffer)
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_delta_only",
+					call_id: "c_delta",
+					name: "alpha_tool",
+					arguments: '{"result":"ok"}',
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc_control",
+					call_id: "c_ctrl",
+					name: "bravo_tool",
+					arguments: '{"ctrl":true}',
+				},
+			},
+		];
+
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// output.content blocks
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		const alpha = blocks.find(b => b.name === "alpha_tool");
+		const bravo = blocks.find(b => b.name === "bravo_tool");
+		// alpha_tool must have its own accumulated args — not bravo's
+		expect(alpha?.arguments).toEqual({ result: "ok" });
+		expect(bravo?.arguments).toEqual({ ctrl: true });
+		// Anti-leak
+		expect((alpha?.arguments as Record<string, unknown>)?.ctrl).toBeUndefined();
+		expect((bravo?.arguments as Record<string, unknown>)?.result).toBeUndefined();
+
+		// Emitted toolcall_end events
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(2);
+		const alphaEnd = ends.find(e => e.toolCall.name === "alpha_tool");
+		const bravoEnd = ends.find(e => e.toolCall.name === "bravo_tool");
+		expect(alphaEnd?.toolCall.arguments).toEqual({ result: "ok" });
+		expect(bravoEnd?.toolCall.arguments).toEqual({ ctrl: true });
+		// The stored block and emitted event must agree for item 0
+		expect(alpha?.arguments).toEqual(alphaEnd?.toolCall.arguments);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case (c): Ghost event — item_id matches NO known item AND output_index
+	// is undefined/non-finite.  Must be silently ignored: no new block
+	// created, existing blocks unchanged.
+	// -----------------------------------------------------------------------
+	test("(c) ghost event with unknown item_id and no output_index is ignored", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_real", call_id: "c_real", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_real", output_index: 0, delta: '{"x":42}' },
+			// GHOST delta: item_id unknown, output_index undefined
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "ghost",
+				output_index: undefined,
+				delta: '{"injected":"POISON"}',
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_real",
+				output_index: 0,
+				arguments: '{"x":42}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_real",
+					call_id: "c_real",
+					name: "alpha_tool",
+					arguments: '{"x":42}',
+				},
+			},
+		];
+
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// Only the real item should exist
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]?.name).toBe("alpha_tool");
+		expect(blocks[0]?.arguments).toEqual({ x: 42 });
+		// No injected poison
+		expect((blocks[0]?.arguments as Record<string, unknown>)?.injected).toBeUndefined();
+
+		// Emitted: only one toolcall_end for the real item
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(1);
+		expect(ends[0]?.toolCall.name).toBe("alpha_tool");
+		expect(ends[0]?.toolCall.arguments).toEqual({ x: 42 });
+		// No ghost toolcall_start or toolcall_end was emitted
+		const ghostStarts = emitted.filter(
+			e => e.type === "toolcall_start" && (e as Record<string, unknown>).contentIndex !== 0,
+		);
+		expect(ghostStarts).toHaveLength(0);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case (d): output_index REUSE — two sequential items occupy the same
+	// output_index (0), i.e. item 1 is done/dropped before item 2 is added.
+	// Assert that no entry from item 1 bleeds into item 2 after the lifecycle
+	// boundary.
+	// -----------------------------------------------------------------------
+	test("(d) output_index reuse: item 2 at same index does not inherit item 1 state", async () => {
+		const events = [
+			// --- Item 1 lifecycle: output_index 0 ---
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_first", call_id: "c_first", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_first", output_index: 0, delta: '{"seq":1}' },
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_first",
+				output_index: 0,
+				arguments: '{"seq":1}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_first",
+					call_id: "c_first",
+					name: "alpha_tool",
+					arguments: '{"seq":1}',
+				},
+			},
+			// --- Item 2 lifecycle: SAME output_index 0 (reused) ---
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_second", call_id: "c_second", name: "bravo_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_second", output_index: 0, delta: '{"seq":2}' },
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_second",
+				output_index: 0,
+				arguments: '{"seq":2}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_second",
+					call_id: "c_second",
+					name: "bravo_tool",
+					arguments: '{"seq":2}',
+				},
+			},
+		];
+
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// Both blocks must be recorded
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		const first = blocks.find(b => b.name === "alpha_tool");
+		const second = blocks.find(b => b.name === "bravo_tool");
+		expect(first?.arguments).toEqual({ seq: 1 });
+		expect(second?.arguments).toEqual({ seq: 2 });
+		// Anti-bleed
+		expect((first?.arguments as Record<string, unknown>)?.seq).toBe(1);
+		expect((second?.arguments as Record<string, unknown>)?.seq).toBe(2);
+
+		// Two distinct toolcall_end events
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(2);
+		const e1 = ends.find(e => e.toolCall.name === "alpha_tool");
+		const e2 = ends.find(e => e.toolCall.name === "bravo_tool");
+		expect(e1?.toolCall.arguments).toEqual({ seq: 1 });
+		expect(e2?.toolCall.arguments).toEqual({ seq: 2 });
+	});
+
+	// -----------------------------------------------------------------------
+	// Case (e): A text/message item interleaved between two tool-call items.
+	// A late output_text.delta must land on the message block's recorded
+	// content index, NOT on either tool block.
+	// -----------------------------------------------------------------------
+	test("(e) late text delta targets message block, not adjacent tool blocks", async () => {
+		const events = [
+			// tool item at index 0
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_pre", call_id: "c_pre", name: "alpha_tool", arguments: "" },
+			},
+			// message item at index 1 (interleaved)
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: {
+					type: "message",
+					id: "msg_mid",
+					role: "assistant",
+					content: [],
+					status: "in_progress",
+				},
+			},
+			// content_part added to the message so the text-delta path works
+			{
+				type: "response.content_part.added",
+				item_id: "msg_mid",
+				output_index: 1,
+				content_index: 0,
+				part: { type: "output_text", text: "" },
+			},
+			// tool item at index 2
+			{
+				type: "response.output_item.added",
+				output_index: 2,
+				item: { type: "function_call", id: "fc_post", call_id: "c_post", name: "bravo_tool", arguments: "" },
+			},
+			// pre-tool deltas
+			{ type: "response.function_call_arguments.delta", item_id: "fc_pre", output_index: 0, delta: '{"pre":1}' },
+			// LATE text delta — arrives after both tool items are already registered
+			{
+				type: "response.output_text.delta",
+				item_id: "msg_mid",
+				output_index: 1,
+				content_index: 0,
+				delta: "hello world",
+			},
+			// post-tool deltas
+			{ type: "response.function_call_arguments.delta", item_id: "fc_post", output_index: 2, delta: '{"post":2}' },
+			// finalize tools
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_pre",
+				output_index: 0,
+				arguments: '{"pre":1}',
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_post",
+				output_index: 2,
+				arguments: '{"post":2}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_pre", call_id: "c_pre", name: "alpha_tool", arguments: '{"pre":1}' },
+			},
+			// finalize message
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "message",
+					id: "msg_mid",
+					role: "assistant",
+					content: [{ type: "output_text", text: "hello world" }],
+					status: "completed",
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 2,
+				item: {
+					type: "function_call",
+					id: "fc_post",
+					call_id: "c_post",
+					name: "bravo_tool",
+					arguments: '{"post":2}',
+				},
+			},
+		];
+
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// output.content: [toolCall(alpha), text(msg), toolCall(bravo)]
+		expect(output.content).toHaveLength(3);
+		expect(output.content[0]?.type).toBe("toolCall");
+		expect(output.content[1]?.type).toBe("text");
+		expect(output.content[2]?.type).toBe("toolCall");
+
+		// Text block must carry the interleaved delta
+		const textBlock = output.content[1] as { type: "text"; text: string };
+		expect(textBlock.text).toBe("hello world");
+
+		// Tool blocks must NOT have text content
+		const preTool = output.content[0] as ToolCall;
+		const postTool = output.content[2] as ToolCall;
+		expect(preTool.arguments).toEqual({ pre: 1 });
+		expect(postTool.arguments).toEqual({ post: 2 });
+
+		// text_delta event must target contentIndex 1 (the message block)
+		const textDeltas = emitted.filter(e => e.type === "text_delta");
+		expect(textDeltas.length).toBeGreaterThan(0);
+		for (const td of textDeltas) {
+			expect(td.contentIndex).toBe(1);
+		}
+
+		// toolcall_end events must have their correct content indices
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(2);
+		const preEnd = ends.find(e => e.toolCall.name === "alpha_tool");
+		const postEnd = ends.find(e => e.toolCall.name === "bravo_tool");
+		expect(preEnd?.contentIndex).toBe(0);
+		expect(postEnd?.contentIndex).toBe(2);
+		expect(preEnd?.toolCall.arguments).toEqual({ pre: 1 });
+		expect(postEnd?.toolCall.arguments).toEqual({ post: 2 });
+
+		// Verify text delta did NOT mutate any tool block
+		expect((preTool.arguments as Record<string, unknown>).text).toBeUndefined();
+		expect((postTool.arguments as Record<string, unknown>).text).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-responses-multi-toolcall-stream.test.ts
+++ b/packages/ai/test/openai-responses-multi-toolcall-stream.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, test } from "bun:test";
+import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
+import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai/types";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+
+// Regression coverage for multi-tool-call stream correlation: when a single
+// Responses API stream emits multiple tool-call items, each item's streamed
+// argument deltas must accumulate against its own identity and never leak into
+// an adjacent tool call. Tool names below are generic placeholders.
+
+async function* makeStream(events: unknown[]): AsyncIterable<ResponseStreamEvent> {
+	for (const e of events) yield e as ResponseStreamEvent;
+}
+
+function makeModel(): Model<"openai-responses"> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "openai-responses",
+		provider: "test-provider",
+		baseUrl: "https://example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		timestamp: Date.now(),
+		provider: "test-provider",
+		model: "test-model",
+		api: "openai-responses",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+interface ToolCallEndEvent {
+	type: "toolcall_end";
+	contentIndex: number;
+	toolCall: ToolCall;
+}
+
+interface ThinkingEndEvent {
+	type: "thinking_end";
+	contentIndex: number;
+	content: string;
+}
+
+function makeCapture() {
+	const emitted: Array<Record<string, unknown>> = [];
+	const stream = {
+		push: (e: Record<string, unknown>) => emitted.push(e),
+		end: () => {},
+	} as never;
+	return { emitted, stream };
+}
+
+function toolCallEnds(emitted: Array<Record<string, unknown>>): ToolCallEndEvent[] {
+	return emitted.filter(e => e.type === "toolcall_end") as unknown as ToolCallEndEvent[];
+}
+
+function toolBlocks(output: AssistantMessage): Array<ToolCall & { partialJson?: string }> {
+	return output.content.filter(b => b.type === "toolCall") as Array<ToolCall & { partialJson?: string }>;
+}
+
+describe("Responses multi-tool-call stream correlation", () => {
+	test("interleaved argument deltas stay isolated per tool call", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "beta_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_a", output_index: 0, delta: '{"command"' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_b", output_index: 1, delta: '{"path"' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_a", output_index: 0, delta: ':"ls -la"}' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_b", output_index: 1, delta: ':"/etc/hosts"}' },
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_a",
+				output_index: 0,
+				arguments: '{"command":"ls -la"}',
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_b",
+				output_index: 1,
+				arguments: '{"path":"/etc/hosts"}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_a",
+					call_id: "call_a",
+					name: "alpha_tool",
+					arguments: '{"command":"ls -la"}',
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc_b",
+					call_id: "call_b",
+					name: "beta_tool",
+					arguments: '{"path":"/etc/hosts"}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		expect(blocks[0]?.name).toBe("alpha_tool");
+		expect(blocks[0]?.arguments).toEqual({ command: "ls -la" });
+		expect(blocks[1]?.name).toBe("beta_tool");
+		expect(blocks[1]?.arguments).toEqual({ path: "/etc/hosts" });
+
+		const ends = toolCallEnds(emitted);
+		const alpha = ends.find(e => e.toolCall.name === "alpha_tool");
+		const beta = ends.find(e => e.toolCall.name === "beta_tool");
+		expect(alpha?.toolCall.arguments).toEqual({ command: "ls -la" });
+		expect(beta?.toolCall.arguments).toEqual({ path: "/etc/hosts" });
+		expect(alpha?.contentIndex).toBe(0);
+		expect(beta?.contentIndex).toBe(1);
+	});
+
+	test("back-to-back items finalize in order with per-item arguments", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_2", call_id: "call_2", name: "beta_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_1", output_index: 0, delta: '{"x":1}' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_2", output_index: 1, delta: '{"y":2}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "alpha_tool", arguments: '{"x":1}' },
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_2", call_id: "call_2", name: "beta_tool", arguments: '{"y":2}' },
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks.map(b => b.name)).toEqual(["alpha_tool", "beta_tool"]);
+		expect(blocks[0]?.arguments).toEqual({ x: 1 });
+		expect(blocks[1]?.arguments).toEqual({ y: 2 });
+		const ends = toolCallEnds(emitted);
+		expect(ends.map(e => e.toolCall.name)).toEqual(["alpha_tool", "beta_tool"]);
+	});
+
+	test("each tool shape keeps its own fields with zero cross-leak", async () => {
+		const specs = [
+			{ id: "fc_bash", call: "c_bash", name: "bash_tool", args: { command: "echo hi" } },
+			{ id: "fc_read", call: "c_read", name: "read_tool", args: { path: "/tmp/file.txt" } },
+			{ id: "fc_search", call: "c_search", name: "search_tool", args: { pattern: "TODO", paths: ["src"] } },
+			{ id: "fc_gh", call: "c_gh", name: "gh_tool", args: { op: "search_issues", query: "is:open" } },
+		];
+		const added = specs.map((s, i) => ({
+			type: "response.output_item.added",
+			output_index: i,
+			item: { type: "function_call", id: s.id, call_id: s.call, name: s.name, arguments: "" },
+		}));
+		// Interleave the argument deltas across all four items.
+		const deltas = specs.map((s, i) => ({
+			type: "response.function_call_arguments.delta",
+			item_id: s.id,
+			output_index: i,
+			delta: JSON.stringify(s.args),
+		}));
+		const dones = specs.map((s, i) => ({
+			type: "response.output_item.done",
+			output_index: i,
+			item: { type: "function_call", id: s.id, call_id: s.call, name: s.name, arguments: JSON.stringify(s.args) },
+		}));
+		const events = [...added, ...deltas, ...dones];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const byName = new Map(toolBlocks(output).map(b => [b.name, b.arguments]));
+		expect(byName.get("bash_tool")).toEqual({ command: "echo hi" });
+		expect(byName.get("read_tool")).toEqual({ path: "/tmp/file.txt" });
+		expect(byName.get("search_tool")).toEqual({ pattern: "TODO", paths: ["src"] });
+		expect(byName.get("gh_tool")).toEqual({ op: "search_issues", query: "is:open" });
+		// Explicit anti-leak assertions.
+		expect((byName.get("bash_tool") as Record<string, unknown>).path).toBeUndefined();
+		expect((byName.get("read_tool") as Record<string, unknown>).command).toBeUndefined();
+		expect((byName.get("search_tool") as Record<string, unknown>).command).toBeUndefined();
+		expect((byName.get("gh_tool") as Record<string, unknown>).pattern).toBeUndefined();
+	});
+
+	test("custom_tool_call interleaved with function_call keeps input and arguments separate", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "custom_tool_call", id: "ctc", call_id: "c_custom", name: "apply_patch", input: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc", call_id: "c_fn", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.custom_tool_call_input.delta", item_id: "ctc", output_index: 0, delta: "*** Begin" },
+			{ type: "response.function_call_arguments.delta", item_id: "fc", output_index: 1, delta: '{"command"' },
+			{ type: "response.custom_tool_call_input.delta", item_id: "ctc", output_index: 0, delta: " Patch ***" },
+			{ type: "response.function_call_arguments.delta", item_id: "fc", output_index: 1, delta: ':"go"}' },
+			{
+				type: "response.custom_tool_call_input.done",
+				item_id: "ctc",
+				output_index: 0,
+				input: "*** Begin Patch ***",
+			},
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc",
+				output_index: 1,
+				arguments: '{"command":"go"}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "custom_tool_call",
+					id: "ctc",
+					call_id: "c_custom",
+					name: "apply_patch",
+					input: "*** Begin Patch ***",
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc",
+					call_id: "c_fn",
+					name: "alpha_tool",
+					arguments: '{"command":"go"}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		const custom = blocks.find(b => b.name === "apply_patch");
+		const fn = blocks.find(b => b.name === "alpha_tool");
+		expect(custom?.arguments).toEqual({ input: "*** Begin Patch ***" });
+		expect(fn?.arguments).toEqual({ command: "go" });
+	});
+
+	test("single tool call streams unchanged with stable content index", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_only", call_id: "call_only", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_only", output_index: 0, delta: '{"a"' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_only", output_index: 0, delta: ":1}" },
+			{ type: "response.function_call_arguments.done", item_id: "fc_only", output_index: 0, arguments: '{"a":1}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_only",
+					call_id: "call_only",
+					name: "alpha_tool",
+					arguments: '{"a":1}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]?.arguments).toEqual({ a: 1 });
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(1);
+		expect(ends[0]?.contentIndex).toBe(0);
+		expect(ends[0]?.toolCall.arguments).toEqual({ a: 1 });
+	});
+
+	test("late reasoning delta after a tool-call block targets the reasoning block", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "reasoning", id: "r1", summary: [] },
+			},
+			{
+				type: "response.reasoning_summary_part.added",
+				item_id: "r1",
+				output_index: 0,
+				part: { type: "summary_text", text: "" },
+			},
+			// A tool-call block opens AFTER the reasoning block, so output.content[1] exists.
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_late", call_id: "call_late", name: "alpha_tool", arguments: "" },
+			},
+			// Late reasoning delta for the FIRST item must still target content index 0.
+			{ type: "response.reasoning_summary_text.delta", item_id: "r1", output_index: 0, delta: "thinking..." },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "reasoning", id: "r1", summary: [{ type: "summary_text", text: "thinking..." }] },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_late", output_index: 1, delta: '{"z":9}' },
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc_late",
+					call_id: "call_late",
+					name: "alpha_tool",
+					arguments: '{"z":9}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// The reasoning delta and end must reference content index 0, not the tool block at index 1.
+		const thinkingDeltas = emitted.filter(e => e.type === "thinking_delta");
+		expect(thinkingDeltas.length).toBeGreaterThan(0);
+		for (const d of thinkingDeltas) {
+			expect(d.contentIndex).toBe(0);
+		}
+		const thinkingEnd = emitted.find(e => e.type === "thinking_end") as ThinkingEndEvent | undefined;
+		expect(thinkingEnd?.contentIndex).toBe(0);
+		expect(thinkingEnd?.content).toBe("thinking...");
+
+		// output.content agrees: reasoning content landed on the reasoning block, tool args on the tool block.
+		expect(output.content[0]?.type).toBe("thinking");
+		expect((output.content[0] as { thinking: string }).thinking).toBe("thinking...");
+		expect(output.content[1]?.type).toBe("toolCall");
+		expect((output.content[1] as ToolCall).arguments).toEqual({ z: 9 });
+	});
+
+	test("tool-call deltas with no resolvable key are ignored without phantom blocks", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_real", call_id: "call_real", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_real", output_index: 0, delta: '{"ok":1}' },
+			// Unresolvable: unknown item_id AND non-finite output_index. Must be ignored.
+			{ type: "response.function_call_arguments.delta", item_id: "ghost", delta: '{"leak":true}' },
+			{ type: "response.function_call_arguments.done", item_id: "ghost", arguments: '{"leak":true}' },
+			{ type: "response.custom_tool_call_input.delta", item_id: "ghost", delta: "noise" },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_real",
+					call_id: "call_real",
+					name: "alpha_tool",
+					arguments: '{"ok":1}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		// Only the real tool call exists; the ghost events created no block and leaked nothing.
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(1);
+		expect(output.content).toHaveLength(1);
+		expect(blocks[0]?.name).toBe("alpha_tool");
+		expect(blocks[0]?.arguments).toEqual({ ok: 1 });
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(1);
+		expect(ends[0]?.toolCall.arguments).toEqual({ ok: 1 });
+	});
+});


### PR DESCRIPTION
## What

Fixes argument mis-attribution in the OpenAI-compatible Responses API streaming decoder when a single response emits multiple tool-call items. Streamed argument deltas now accumulate against a per-item buffer keyed on stable item identity instead of a single shared most-recent slot.

## Why

The Responses API streaming decoder tracked one current item and one current block. When a response contained multiple tool-call items, interleaved or back-to-back `function_call` / `custom_tool_call` argument deltas could be applied to the wrong item, so a finalized tool call could carry another call's arguments (e.g. one tool's payload landing on a different tool's schema and tripping validation). The Chat Completions path was not affected.

## Testing

- `bun test test/openai-responses-multi-toolcall-stream.test.ts` (cwd `packages/ai`) — 7 regression cases
- `bun test test/openai-responses-multi-toolcall-stream-adversarial.test.ts` (cwd `packages/ai`) — 5 adversarial red-team cases
- `bun run check:types` (packages/ai) and `bun run check:ts` (repo) pass
- 12 tests / 100 assertions pass

### Change detail

Replaced the single-slot buffer with a per-item map keyed on stable item identity (`item_id` primary; positional `output_index` only when finite). Each block records its content index at registration time and every contentIndex-emitting handler uses that recorded index; finalization writes onto the same block stored in the message content and reads only the matching item's buffer. Unresolvable tool-call deltas are ignored without creating phantom blocks. Single-tool-call streams, reasoning/text streaming, and the Chat Completions path are unchanged.

---

- [x] `bun check` passes (`check:ts` clean; pre-existing unrelated `check:rs` rustfmt diffs in vendored crates only — no Rust files changed here)
- [x] Tested locally
- [x] CHANGELOG updated (packages/ai)