### PR TITLE
Fix bash cancellation descendant cleanup race

### DIFF
--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -66,9 +66,9 @@ export interface BashResult {
 const shellSessions = new Map<string, Shell>();
 const brokenShellSessions = new Set<string>();
 const retiringShellSessions = new Set<Shell>();
-// Match pi-shell's bounded cancellation grace so executeBash does not return
-// before native descendant kill waves finish on slow CI runners.
-const CANCEL_CLEANUP_WAIT_MS = 2_500;
+// Cover pi-shell's normal cancellation kill waves without turning a stalled
+// native cleanup into a multi-second JavaScript tool stall.
+const CANCEL_CLEANUP_WAIT_MS = 400;
 
 /** Number of persistent shell sessions currently retained (owner gauge). */
 export function getShellSessionCount(): number {

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -66,7 +66,9 @@ export interface BashResult {
 const shellSessions = new Map<string, Shell>();
 const brokenShellSessions = new Set<string>();
 const retiringShellSessions = new Set<Shell>();
-const CANCEL_CLEANUP_WAIT_MS = 250;
+// Match pi-shell's bounded cancellation grace so executeBash does not return
+// before native descendant kill waves finish on slow CI runners.
+const CANCEL_CLEANUP_WAIT_MS = 2_500;
 
 /** Number of persistent shell sessions currently retained (owner gauge). */
 export function getShellSessionCount(): number {


### PR DESCRIPTION
## Summary
- Keep cancelled persistent bash shells in bounded cleanup long enough for pi-shell descendant kill waves to finish.
- Preserve lifecycle safety: owned descendants are reaped before `executeBash` returns while unrelated sibling processes remain outside the kill set.

## Verification
- `bun test packages/coding-agent/test/tools/bash-resource-lifecycle.test.ts`
- `bun test packages/coding-agent/test/tools/bash-resource-lifecycle.redteam.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes; Biome prints existing informational schema/deprecation notices for `src/defaults/gjc/extensions/grok-cli-vendor/biome.json`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
