### PR TITLE
fix(coding-agent): harden Windows tmux root launch

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -153,13 +153,16 @@ function buildEnvAssignments(values: Record<string, string> | undefined): string
 function powershellQuote(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
+function stripRootTmuxFlag(rawArgs: string[]): string[] {
+	return rawArgs.filter(arg => arg !== "--tmux");
+}
 
 function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
 	const command = resolveCurrentGjcCommand(context);
 	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(context.extraEnv ?? {}) }).map(
 		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
 	);
-	const invocation = ["&", ...command.map(powershellQuote), ...rawArgs.map(powershellQuote)].join(" ");
+	const invocation = ["&", ...command.map(powershellQuote), ...stripRootTmuxFlag(rawArgs).map(powershellQuote)].join(" ");
 	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
 	const script = [...envLines, invocation, exitLine].join("\n");
 	const encodedCommand = Buffer.from(script, "utf16le").toString("base64");
@@ -213,7 +216,7 @@ function pathModuleForPlatform(platform: NodeJS.Platform | undefined): typeof pa
 function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
 	if (isWindowsPlatform(context.platform)) return buildWindowsPowerShellInnerCommand(context, rawArgs);
 	const command = resolveCurrentGjcCommand(context);
-	const quoted = [...command, ...rawArgs].map(shellQuote).join(" ");
+	const quoted = [...command, ...stripRootTmuxFlag(rawArgs)].map(shellQuote).join(" ");
 	return `exec env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
 }
 
@@ -432,12 +435,11 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			sessionId: plan.sessionId ?? null,
 			sessionStateFile: plan.sessionStateFile ?? null,
 		});
-		if (profile.failures.length > 0) {
+		const ownershipFailure = profile.failures.find(item => item.command.args.includes("@gjc-profile"));
+		if (ownershipFailure) {
 			cleanupCreatedTmuxSession(plan, spawnSync, options);
-			const failure =
-				profile.failures.find(item => item.command.args.includes("@gjc-profile")) ?? profile.failures[0];
 			(context.diagnosticWriter ?? safeStderrWrite)(
-				formatTmuxLaunchDiagnostic("profile tagging failed", failure?.stderr),
+				formatTmuxLaunchDiagnostic("profile tagging failed", ownershipFailure.stderr),
 			);
 			return true;
 		}

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -121,10 +121,8 @@ describe("default GJC tmux launch", () => {
 		expect(plan.sessionName.startsWith(GJC_TMUX_SESSION_PREFIX)).toBe(true);
 		expect(plan.tmuxCommand).toBe("tmux");
 		expect(plan.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", plan.sessionName, "-c", "/repo"]);
-		expect(plan?.innerCommand).toContain(`${GJC_TMUX_LAUNCHED_ENV}=1`);
-		expect(plan?.innerCommand).toContain(
-			"'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' '--tmux' 'hello world'",
-		);
+		expect(plan?.innerCommand).toContain("'/bin/bun' '/repo/packages/coding-agent/src/cli.ts' 'hello world'");
+		expect(plan?.innerCommand).not.toContain("'--tmux'");
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_ID=");
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
 	});
@@ -172,9 +170,8 @@ describe("default GJC tmux launch", () => {
 		const script = decodePowerShellEncodedCommand(plan.innerCommand);
 		expect(script).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
 		expect(script).toContain(`$env:GJC_COORDINATOR_SESSION_ID = '${plan.sessionId}'`);
-		expect(script).toContain(
-			"& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' '--tmux' 'say it''s ok'",
-		);
+		expect(script).toContain("& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' 'say it''s ok'");
+		expect(script).not.toContain("'--tmux'");
 		expect(script).toEndWith("if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }");
 	});
 	it("uses a host command for compiled Bun virtual entrypoints", () => {
@@ -195,7 +192,7 @@ describe("default GJC tmux launch", () => {
 
 		expect(plan.innerCommand).not.toContain("$bunfs");
 		expect(plan.innerCommand).toContain(`${GJC_TMUX_LAUNCHED_ENV}=1`);
-		expect(plan.innerCommand).toContain("'/home/me/.local/bin/gjc' '--tmux' 'hello world'");
+		expect(plan.innerCommand).toContain("'/home/me/.local/bin/gjc' 'hello world'");
 	});
 
 	it("falls back to gjc when compiled Bun virtual entrypoint has no host exec path", () => {
@@ -212,7 +209,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(plan?.innerCommand).not.toContain("$bunfs");
-		expect(plan?.innerCommand).toContain("'gjc' '--tmux'");
+		expect(plan?.innerCommand).toContain("'gjc'");
 	});
 
 	it("attaches existing tagged session for matching worktree branch", () => {
@@ -568,6 +565,37 @@ describe("default GJC tmux launch", () => {
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: profile tagging failed.");
 		expect(diagnostics[0].length).toBeLessThan(320);
+	});
+
+	it("continues root launch when non-ownership metadata tagging fails", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "win32",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "issue-882",
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs.includes("@gjc-branch")) return { exitCode: 1, stderr: "psmux: connection timed out" };
+				if (spawnArgs[0] === "attach-session") return { exitCode: 0 };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.map(call => call.args)).toContainEqual(["set-option", "-t", expect.any(String), "@gjc-profile", "1"]);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(diagnostics).toEqual([]);
 	});
 
 	it("handles and reports partial launch when attach fails after profile succeeds", () => {


### PR DESCRIPTION
## Summary
- strip root `--tmux` from the child command launched inside managed tmux sessions so Windows root launch does not recursively re-enter tmux mode
- keep `@gjc-profile` ownership tagging fatal, but treat later branch/project/session metadata tag writes as best-effort during root launch
- add focused launch regression coverage for Windows child bootstrap args and psmux-style metadata tagging failures

## Verification
- `bun --cwd=packages/natives run build` (produced local linux-x64 native addon; long-running wrapper was stale after build output)
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` (30 pass)

Fixes #882.
