### PR TITLE
style(coding-agent): format Windows tmux launch fix

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -162,7 +162,9 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(context.extraEnv ?? {}) }).map(
 		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
 	);
-	const invocation = ["&", ...command.map(powershellQuote), ...stripRootTmuxFlag(rawArgs).map(powershellQuote)].join(" ");
+	const invocation = ["&", ...command.map(powershellQuote), ...stripRootTmuxFlag(rawArgs).map(powershellQuote)].join(
+		" ",
+	);
 	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
 	const script = [...envLines, invocation, exitLine].join("\n");
 	const encodedCommand = Buffer.from(script, "utf16le").toString("base64");

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -170,7 +170,9 @@ describe("default GJC tmux launch", () => {
 		const script = decodePowerShellEncodedCommand(plan.innerCommand);
 		expect(script).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
 		expect(script).toContain(`$env:GJC_COORDINATOR_SESSION_ID = '${plan.sessionId}'`);
-		expect(script).toContain("& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' 'say it''s ok'");
+		expect(script).toContain(
+			"& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' 'say it''s ok'",
+		);
 		expect(script).not.toContain("'--tmux'");
 		expect(script).toEndWith("if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }");
 	});
@@ -592,7 +594,13 @@ describe("default GJC tmux launch", () => {
 
 		expect(handled).toBe(true);
 		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
-		expect(calls.map(call => call.args)).toContainEqual(["set-option", "-t", expect.any(String), "@gjc-profile", "1"]);
+		expect(calls.map(call => call.args)).toContainEqual([
+			"set-option",
+			"-t",
+			expect.any(String),
+			"@gjc-profile",
+			"1",
+		]);
 		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
 		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
 		expect(diagnostics).toEqual([]);


### PR DESCRIPTION
## Summary
- apply the Biome formatting required by post-merge Dev CI for the #895 Windows tmux root-launch fix
- no behavior changes beyond formatting of the two files touched by #895

## Verification
- `git diff --check`

Follow-up for #895 / #882 post-merge CI failure.
