### PR TITLE
Improve skill migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ And four bundled role agents:
 
 No sprawling default skill zoo: GJC improves by making this small method better.
 
+### Skill migration and bundled skill inspection
+
+When moving a workflow into GJC, inspect the bundled defaults before installing or overwriting anything:
+
+```sh
+gjc skills list
+gjc skills read ralplan
+gjc setup defaults --check
+```
+
+`gjc setup defaults` installs the four bundled GJC workflow skills into your user `.gjc` directory and preserves existing local files by default. If `--check` reports missing or different files, compare the embedded copy with `gjc skills read <name>` first; use `gjc setup defaults --force` only when you intentionally want to replace local default workflow skill files.
+
 ## Works beside your existing agent or bot
 
 | Tool or bot | Recommended GJC command | Boundary |

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -374,6 +374,7 @@ async function handleHooksSetup(flags: { json?: boolean; check?: boolean }): Pro
 async function handleDefaultsSetup(flags: { json?: boolean; check?: boolean; force?: boolean }): Promise<void> {
 	const result = await installDefaultGjcDefinitions({ check: flags.check, force: flags.force });
 	const hasCheckFailure = result.missing > 0 || result.different > 0;
+	const inspectGuidance = `Inspect bundled skills with: ${APP_NAME} skills list; read one with: ${APP_NAME} skills read ralplan`;
 
 	if (flags.json) {
 		console.log(JSON.stringify(result, null, 2));
@@ -388,18 +389,28 @@ async function handleDefaultsSetup(flags: { json?: boolean; check?: boolean; for
 			console.error(
 				chalk.dim(`Missing: ${result.missing}; different: ${result.different}; matching: ${result.matching}`),
 			);
+			console.error(chalk.dim(inspectGuidance));
+			console.error(
+				chalk.dim(`Compare embedded defaults before overwriting local files with: ${APP_NAME} setup defaults --force`),
+			);
 			process.exit(1);
 		}
 		console.log(chalk.green(`${theme.status.success} Default GJC workflow skills are installed`));
 		console.log(chalk.dim(`Target: ${result.targetRoot}`));
+		console.log(chalk.dim(inspectGuidance));
 		return;
 	}
 
 	console.log(chalk.green(`${theme.status.success} Default GJC workflow skills installed`));
 	console.log(chalk.dim(`Target: ${result.targetRoot}`));
 	console.log(chalk.dim(`Written: ${result.written}; skipped: ${result.skipped}`));
+	console.log(chalk.dim(inspectGuidance));
 	if (result.skipped > 0 && !flags.force) {
-		console.log(chalk.dim("Use --force to overwrite existing default workflow skill files."));
+		console.log(
+			chalk.dim(
+				`Existing local default workflow skill files were preserved. Use ${APP_NAME} setup defaults --force to overwrite them intentionally.`,
+			),
+		);
 	}
 }
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -455,6 +455,66 @@ Project executor override body.
 			);
 		});
 	});
+	it("prints skill inspection guidance for setup defaults without changing JSON output", async () => {
+		const externalRoot = await makeTempRoot();
+		const home = await makeTempRoot();
+		const env = {
+			...process.env,
+			HOME: home,
+			PI_NO_TITLE: "1",
+			NO_COLOR: "1",
+			FORCE_COLOR: undefined,
+		};
+
+		const installProc = Bun.spawn(
+			[process.execPath, path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"), "setup", "defaults"],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env,
+			},
+		);
+		const installStdout = await new Response(installProc.stdout).text();
+		const installStderr = await new Response(installProc.stderr).text();
+		expect(await installProc.exited).toBe(0);
+		expect(installStderr).toBe("");
+		expect(installStdout).toContain("gjc skills list");
+		expect(installStdout).toContain("gjc skills read ralplan");
+
+		const skippedProc = Bun.spawn(
+			[process.execPath, path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"), "setup", "defaults"],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env,
+			},
+		);
+		const skippedStdout = await new Response(skippedProc.stdout).text();
+		const skippedStderr = await new Response(skippedProc.stderr).text();
+		expect(await skippedProc.exited).toBe(0);
+		expect(skippedStderr).toBe("");
+		expect(skippedStdout).toContain("gjc skills list");
+		expect(skippedStdout).toContain("gjc setup defaults --force");
+
+		const jsonProc = Bun.spawn(
+			[process.execPath, path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"), "setup", "defaults", "--json"],
+			{
+				cwd: externalRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env,
+			},
+		);
+		const jsonStdout = await new Response(jsonProc.stdout).text();
+		const jsonStderr = await new Response(jsonProc.stderr).text();
+		expect(await jsonProc.exited).toBe(0);
+		expect(jsonStderr).toBe("");
+		expect(jsonStdout).not.toContain("gjc skills list");
+		expect(JSON.parse(jsonStdout) as { skipped: number }).toMatchObject({ skipped: 8 });
+	});
+
 });
 
 describe("bundled skills CLI", () => {


### PR DESCRIPTION
Fixes #897.

## Summary
- Added README guidance for inspecting bundled workflow skills before installing or overwriting defaults.
- Added human-only `gjc setup defaults` guidance pointing to `gjc skills list`, `gjc skills read ralplan`, and explicit `gjc setup defaults --force` overwrite behavior.
- Added focused coverage that setup guidance appears in human output while JSON output remains machine-readable.

## Verification
- `bun install` (to restore workspace dependencies in this worktree)
- `bun run build:native` (to build the local native addon required by this test file)
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts` → 21 pass, 0 fail, 196 expect() calls

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*