### PR TITLE
Improve image paste input discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ gjc --tmux --worktree my-task-branch
 cd ../my-task-worktree && gjc --tmux
 ```
 
+### Image input
+
+GJC accepts images in two ways:
+
+- **CLI startup**: prefix a local image path with `@`, for example `gjc @screenshot.png "What should I change?"`.
+- **Interactive TUI**: copy an image to the system clipboard and use the configured **Paste image from clipboard** key (Ctrl+V on Linux/macOS, Alt+V on Windows), or type `#paste-image` and choose the prompt action. When the clipboard is unavailable, paste or pass the image file path with `@path/to/image.png` instead.
+
 Inside a GJC session, use the public workflow surface:
 
 ```text

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 - Added `startup.welcomeBannerMode = "square"` for a square-corner Unicode welcome-logo fallback, and stopped treating Windows Terminal (`WT_SESSION`) as an automatic ASCII downgrade; `auto` now preserves the rounded Unicode logo while `unicode`, `square`, and `ascii` remain explicit overrides.
 
+- Improved image input discoverability by adding an interactive `#paste-image` prompt action and clearer clipboard fallback guidance when no image is available.
+
 ### Documentation
 
 - Documented Windows Terminal welcome-logo troubleshooting with Cascadia Mono / Cascadia Mono Nerd Font and the profile `fontFace` setting.
+- Documented CLI `@image` attachments and interactive TUI clipboard image paste fallbacks in the root README.
 
 ## [0.6.3] - 2026-06-19
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -824,8 +824,9 @@ export class InputController {
 				this.ctx.ui.requestRender();
 				return true;
 			}
-			// No image in clipboard - show hint
-			this.ctx.showStatus("No image in clipboard (use terminal paste for text)");
+			this.ctx.showStatus(
+				"No image in clipboard. Use #paste-image, paste a copied image, or attach an image file with @path/to/image.png.",
+			);
 			return false;
 		} catch {
 			this.ctx.showStatus("Failed to read clipboard");
@@ -840,6 +841,7 @@ export class InputController {
 			keybindings: this.ctx.keybindings,
 			copyCurrentLine: () => this.handleCopyCurrentLine(),
 			copyPrompt: () => this.handleCopyPrompt(),
+			pasteImage: () => void this.handleImagePaste(),
 			undo: prefix => this.ctx.editor.undoPastTransientText(prefix),
 			moveCursorToMessageEnd: () => this.ctx.editor.moveToMessageEnd(),
 			moveCursorToMessageStart: () => this.ctx.editor.moveToMessageStart(),

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -28,6 +28,7 @@ interface PromptActionAutocompleteOptions {
 	keybindings: KeybindingsManager;
 	copyCurrentLine: () => void;
 	copyPrompt: () => void;
+	pasteImage: () => void;
 	undo: (prefix: string) => void;
 	moveCursorToMessageEnd: () => void;
 	moveCursorToMessageStart: () => void;
@@ -190,7 +191,9 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			const query = promptActionPrefix.slice(1).toLowerCase();
 			const items = this.#actions
 				.map(action => {
-					const searchable = [action.label, action.description, ...action.keywords].join(" ").toLowerCase();
+					const searchable = [action.id, action.label, action.description, ...action.keywords]
+						.join(" ")
+						.toLowerCase();
 					if (!fuzzyMatch(query, searchable)) return null;
 					return {
 						value: action.label,
@@ -367,6 +370,13 @@ export function createPromptActionAutocompleteProvider(
 			description: formatKeyHints(options.keybindings.getKeys("app.clipboard.copyPrompt")),
 			keywords: ["copy", "prompt", "clipboard", "message"],
 			execute: options.copyPrompt,
+		},
+		{
+			id: "paste-image",
+			label: "Paste image from clipboard",
+			description: formatKeyHints(options.keybindings.getKeys("app.clipboard.pasteImage")),
+			keywords: ["paste", "image", "clipboard", "screenshot", "attach", "vision"],
+			execute: options.pasteImage,
 		},
 		{
 			id: "undo",

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -25,9 +25,11 @@ describe("prompt action autocomplete", () => {
 			keybindings: AppKeybindingsManager.inMemory({
 				"app.clipboard.copyLine": "ctrl+shift+l",
 				"app.clipboard.copyPrompt": ["alt+shift+c", "ctrl+shift+c"],
+				"app.clipboard.pasteImage": "ctrl+i",
 			}),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
+			pasteImage: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -41,6 +43,7 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.items.map(item => item.label)).toEqual([
 			"Copy current line",
 			"Copy whole prompt",
+			"Paste image from clipboard",
 			"Undo",
 			"Move cursor to end of message",
 			"Move cursor to beginning of message",
@@ -51,6 +54,7 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.items.find(item => item.label === "Copy whole prompt")?.description).toBe(
 			"Alt+Shift+C/Ctrl+Shift+C",
 		);
+		expect(suggestions?.items.find(item => item.label === "Paste image from clipboard")?.description).toBe("Ctrl+I");
 		expect(suggestions?.items.find(item => item.label === "Move cursor to beginning of line")?.description).toBe(
 			"Home/F6",
 		);
@@ -67,6 +71,7 @@ describe("prompt action autocomplete", () => {
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
+			pasteImage: () => {},
 			undo: prefix => {
 				undoCalls += 1;
 				undoPrefix = prefix;
@@ -93,6 +98,41 @@ describe("prompt action autocomplete", () => {
 		expect(undoPrefix).toBe("#undo");
 	});
 
+	it("runs image paste from the prompt action menu", async () => {
+		let pasteCalls = 0;
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory({
+				"app.clipboard.pasteImage": "ctrl+i",
+			}),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			pasteImage: () => {
+				pasteCalls += 1;
+			},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const suggestions = await provider.getSuggestions(["please #paste-image"], 0, 19);
+		const item = suggestions?.items.find(entry => entry.label === "Paste image from clipboard");
+		expect(item).toBeDefined();
+		if (!item || !suggestions) {
+			throw new Error("expected paste image suggestion");
+		}
+
+		const result = provider.applyCompletion(["please #paste-image"], 0, 19, item, suggestions.prefix);
+		expect(result.lines).toEqual(["please "]);
+		expect(result.cursorLine).toBe(0);
+		expect(result.cursorCol).toBe(7);
+		result.onApplied?.();
+		expect(pasteCalls).toBe(1);
+	});
+
 	it("falls back to normal typing for literal hashtags with no matching action", async () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [],
@@ -100,6 +140,7 @@ describe("prompt action autocomplete", () => {
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
+			pasteImage: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -118,6 +159,7 @@ describe("prompt action autocomplete", () => {
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
+			pasteImage: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -137,6 +179,7 @@ describe("prompt action autocomplete", () => {
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
+			pasteImage: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -18,6 +18,7 @@ function createProvider() {
 		keybindings: { getKeys: () => [] } as unknown as KeybindingsManager,
 		copyCurrentLine: () => {},
 		copyPrompt: () => {},
+		pasteImage: () => {},
 		undo: () => {},
 		moveCursorToMessageEnd: () => {},
 		moveCursorToMessageStart: () => {},


### PR DESCRIPTION
## Summary
- Add a `#paste-image` prompt action that triggers the existing TUI clipboard image paste flow.
- Improve the no-image clipboard status message with a concrete `@path/to/image.png` fallback.
- Document CLI `@image` attachments and interactive clipboard image paste fallback guidance.

Fixes #898.

## Verification
- `bun --cwd=packages/natives run build` — passed
- `bun test test/prompt-action-autocomplete.test.ts test/prompt-action-skill-autocomplete.test.ts test/input-controller-keybindings.test.ts test/utils/clipboard.test.ts` — 32 pass, 0 fail
- `bun run check:ts` — passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*