### PR TITLE
style(coding-agent): format skill migration guidance

### DIFF
--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -391,7 +391,9 @@ async function handleDefaultsSetup(flags: { json?: boolean; check?: boolean; for
 			);
 			console.error(chalk.dim(inspectGuidance));
 			console.error(
-				chalk.dim(`Compare embedded defaults before overwriting local files with: ${APP_NAME} setup defaults --force`),
+				chalk.dim(
+					`Compare embedded defaults before overwriting local files with: ${APP_NAME} setup defaults --force`,
+				),
 			);
 			process.exit(1);
 		}

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -499,7 +499,13 @@ Project executor override body.
 		expect(skippedStdout).toContain("gjc setup defaults --force");
 
 		const jsonProc = Bun.spawn(
-			[process.execPath, path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"), "setup", "defaults", "--json"],
+			[
+				process.execPath,
+				path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts"),
+				"setup",
+				"defaults",
+				"--json",
+			],
 			{
 				cwd: externalRoot,
 				stdout: "pipe",
@@ -514,7 +520,6 @@ Project executor override body.
 		expect(jsonStdout).not.toContain("gjc skills list");
 		expect(JSON.parse(jsonStdout) as { skipped: number }).toMatchObject({ skipped: 8 });
 	});
-
 });
 
 describe("bundled skills CLI", () => {


### PR DESCRIPTION
## Summary
- apply Biome formatting required by post-merge Dev CI for the #899 skill migration guidance changes
- formatting-only follow-up for #897 / #899

## Verification
- `bun install --frozen-lockfile`
- `./node_modules/.bin/biome check --write packages/coding-agent/src/cli/setup-cli.ts packages/coding-agent/test/default-gjc-definitions.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
