### PR TITLE
Document lifecycle notification hooks

### DIFF
--- a/docs/bot-integration.md
+++ b/docs/bot-integration.md
@@ -192,6 +192,48 @@ When the work is done, your bot must call `gjc_coordinator_report_status` with t
 Use `status: "failed"` plus `blocker` for provider failures, unrecoverable tool failures, missing credentials, policy denial, or task blockers.
 Use `status: "cancelled"` when the coordinator policy intentionally stops tracking an active turn, for example after an operator abort or a bot-side shutdown decision. This records the turn as terminal in coordinator state; it does not kill the underlying tmux process. To supersede one active turn with replacement work, send the replacement prompt with `force: true` and preserve the superseded turn id in your audit trail.
 
+### Forward finish/stop lifecycle notifications
+
+Discord, Hermes, Clawhip, and similar external notifiers should be opt-in and should forward only the public lifecycle surface. Use one of these supported paths:
+
+- Coordinator controllers: watch or poll turn state with `gjc_coordinator_watch_events`, `gjc_coordinator_await_turn`, or `gjc_coordinator_read_turn`, then notify from the terminal turn status your controller records with `gjc_coordinator_report_status`.
+- In-process extensions or hooks: subscribe to the public lifecycle events `turn_end` and `agent_end` from the shared hook/extension event contract.
+
+Recommended notification mapping:
+
+| Notification intent | Public surface | Safe meaning |
+| --- | --- | --- |
+| Turn finished | `turn_end` or terminal coordinator turn status `completed` | One LLM turn produced its final assistant message. |
+| Agent stopped / finished | `agent_end` | The agent loop ended for the submitted prompt. |
+| Waiting for user | Coordinator turn status `waiting_for_answer` | The agent is blocked on a structured question. |
+| Failed or blocked | Coordinator status `failed` with a public `blocker` summary | The controller recorded a terminal failure. |
+| Cancelled / superseded | Coordinator status `cancelled` or `superseded` | The controller intentionally stopped tracking or replaced the turn. |
+
+Do not forward raw prompts, transcripts, tool outputs, hidden instructions, private configs, host paths, channel ids, webhook URLs, or tokens. If your notifier needs a human-readable sentence, create a caller-supplied sanitized summary and keep provider/tool details out of the payload.
+
+Example public-safe extension event payloads:
+
+```json
+{ "type": "turn_end", "turnIndex": 2, "summary": "Turn finished; review the local GJC session for details." }
+```
+
+```json
+{ "type": "agent_end", "summary": "Agent loop ended; no raw transcript is included." }
+```
+
+Example opt-in forwarding policy:
+
+```json
+{
+  "enabled": true,
+  "events": ["turn_end", "agent_end"],
+  "destination": "external-notifier-profile",
+  "redaction": "metadata-only"
+}
+```
+
+GJC does not currently expose a structured stop-reason field on `agent_end`; integrators that need `waiting_for_answer`, `failed`, `cancelled`, or `superseded` should prefer the Coordinator MCP turn status because it is explicit, terminal-state oriented, and safe to relay after controller-side redaction.
+
 ### Answer structured questions
 
 List pending questions:

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -11,6 +11,66 @@ Package-specific references:
 - [DEVELOPMENT](./DEVELOPMENT.md)
 - [RenderMermaid guide](../../docs/render-mermaid.md)
 
+## External lifecycle notifications
+
+GJC already exposes public lifecycle events through the extension/hook event contract. External notification integrations for Discord, Hermes, clawhip, or similar channels should be opt-in and subscribe to these events instead of scraping transcripts or logs:
+
+- `turn_end` — a model/tool turn finished. The public payload is `{ type: "turn_end", turnIndex, message, toolResults }`.
+- `agent_end` — the agent loop for a submitted prompt reached a terminal boundary. The public payload is `{ type: "agent_end", messages }`.
+
+Recommended external mapping:
+
+| Notification | Public event | Status guidance |
+|---|---|---|
+| Turn finished | `turn_end` | Use the handler's own sanitized status such as `"finished"`. |
+| Agent stopped/finished | `agent_end` | Treat as terminal for the prompt. |
+| Waiting/blocked/failed | `agent_end` plus a caller-supplied safe summary | Current lifecycle events do not expose a separate structured waiting/blocked reason; inspect only public-safe, integration-owned state. |
+
+Forward only a minimal, caller-sanitized payload. Do not include raw prompts, assistant transcripts, hidden prompts, tool outputs, raw logs, host paths, private config, webhook URLs, channel IDs, tokens, or secrets. A safe notification payload should be built by the extension/hook itself, for example:
+
+```ts
+import type { ExtensionAPI } from "@gajae-code/coding-agent";
+
+type PublicLifecycleNotification = {
+	type: "turn_end" | "agent_end";
+	status: "finished" | "stopped" | "failed" | "blocked" | "waiting";
+	turnIndex?: number;
+	timestamp: string;
+	summary: string;
+};
+
+export default function lifecycleNotifier(pi: ExtensionAPI) {
+	const enabled = process.env.GJC_LIFECYCLE_NOTIFY === "1";
+	if (!enabled) return;
+
+	const send = async (payload: PublicLifecycleNotification) => {
+		// POST to Discord/Hermes/clawhip here. Keep target URLs and channel IDs in
+		// private config or environment variables; never include them in payloads.
+	};
+
+	pi.on("turn_end", event =>
+		send({
+			type: "turn_end",
+			status: "finished",
+			turnIndex: event.turnIndex,
+			timestamp: new Date().toISOString(),
+			summary: "GJC turn finished",
+		}),
+	);
+
+	pi.on("agent_end", () =>
+		send({
+			type: "agent_end",
+			status: "stopped",
+			timestamp: new Date().toISOString(),
+			summary: "GJC prompt reached a terminal lifecycle boundary",
+		}),
+	);
+}
+```
+
+This is the supported repo-native lifecycle notification path. It is not Claude Code hook compatibility, and it remains disabled unless the user configures an extension/hook handler and private delivery target.
+
 ## Memory backends
 
 The agent supports three mutually-exclusive memory backends, selected via the `memory.backend` setting (Settings → Memory tab, or `~/.gjc/agent/config.yml`):

--- a/packages/coding-agent/test/bot-integration-docs.test.ts
+++ b/packages/coding-agent/test/bot-integration-docs.test.ts
@@ -113,6 +113,22 @@ describe("external controller integration docs", () => {
 		}
 	});
 
+	it("documents public-safe lifecycle notification forwarding", async () => {
+		const guide = await readRepoFile("docs", "bot-integration.md");
+
+		expect(guide).toContain("Forward finish/stop lifecycle notifications");
+		expect(guide).toContain("turn_end");
+		expect(guide).toContain("agent_end");
+		expect(guide).toContain("gjc_coordinator_watch_events");
+		expect(guide).toContain("waiting_for_answer");
+		expect(guide).toContain("metadata-only");
+		expect(guide).toContain("caller-supplied sanitized summary");
+		expect(guide).toContain("does not currently expose a structured stop-reason field on `agent_end`");
+		expect(guide).toContain("Do not forward raw prompts, transcripts, tool outputs");
+		expect(guide).not.toContain("webhook.site");
+		expect(guide).not.toContain("discord.com/api/webhooks");
+	});
+
 	it("keeps bot integration docs free of local-only operator details", async () => {
 		const docs = [
 			await readRepoFile("README.md"),

--- a/packages/coding-agent/test/lifecycle-notification-docs.test.ts
+++ b/packages/coding-agent/test/lifecycle-notification-docs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+
+async function readRepoFile(...segments: string[]): Promise<string> {
+	return await Bun.file(path.join(repoRoot, ...segments)).text();
+}
+
+describe("lifecycle notification docs", () => {
+	it("documents the public opt-in lifecycle notification surface", async () => {
+		const readme = await readRepoFile("packages", "coding-agent", "README.md");
+
+		expect(readme).toContain("## External lifecycle notifications");
+		expect(readme).toContain("`turn_end` — a model/tool turn finished");
+		expect(readme).toContain("`agent_end` — the agent loop for a submitted prompt reached a terminal boundary");
+		expect(readme).toContain('type: "turn_end"');
+		expect(readme).toContain('type: "agent_end"');
+		expect(readme).toContain('status: "finished" | "stopped" | "failed" | "blocked" | "waiting"');
+		expect(readme).toContain("Current lifecycle events do not expose a separate structured waiting/blocked reason");
+		expect(readme).toContain("Discord/Hermes/clawhip");
+		expect(readme).toContain("opt-in");
+		expect(readme).toContain("disabled unless the user configures an extension/hook handler");
+	});
+
+	it("keeps lifecycle notification guidance public-safe", async () => {
+		const readme = await readRepoFile("packages", "coding-agent", "README.md");
+		const section = readme.slice(readme.indexOf("## External lifecycle notifications"), readme.indexOf("## Memory backends"));
+
+		expect(section).toContain("Do not include raw prompts");
+		expect(section).toContain("assistant transcripts");
+		expect(section).toContain("hidden prompts");
+		expect(section).toContain("tool outputs");
+		expect(section).toContain("raw logs");
+		expect(section).toContain("host paths");
+		expect(section).toContain("webhook URLs");
+		expect(section).toContain("channel IDs");
+		expect(section).toContain("tokens, or secrets");
+		expect(section).toContain("summary: string");
+		expect(section).not.toContain("https://discord.com/api/webhooks/");
+		expect(section).not.toContain("WEBHOOK_URL=");
+		expect(section).not.toContain("channel_id");
+	});
+});


### PR DESCRIPTION
## Summary
- documents the repo-native opt-in lifecycle notification path using public `turn_end` and `agent_end` extension/hook events
- adds Discord/Hermes/clawhip-safe payload guidance without raw prompts, transcripts, logs, secrets, webhook URLs, channel IDs, or host paths
- adds focused docs tests for the supported surface and redaction guidance

## Verification
- `bun test packages/coding-agent/test/lifecycle-notification-docs.test.ts`
- `bun run test packages/coding-agent/test/lifecycle-notification-docs.test.ts` was attempted but the workspace test script ignored the path and ran the broader suite, failing on unrelated missing dependency/module issues (`@gajae-code/utils`, `linkedom`, `zod/v4`) in other tests.

Closes #902