### PR TITLE
style(coding-agent): format lifecycle notification docs test

### DIFF
--- a/packages/coding-agent/test/lifecycle-notification-docs.test.ts
+++ b/packages/coding-agent/test/lifecycle-notification-docs.test.ts
@@ -25,7 +25,10 @@ describe("lifecycle notification docs", () => {
 
 	it("keeps lifecycle notification guidance public-safe", async () => {
 		const readme = await readRepoFile("packages", "coding-agent", "README.md");
-		const section = readme.slice(readme.indexOf("## External lifecycle notifications"), readme.indexOf("## Memory backends"));
+		const section = readme.slice(
+			readme.indexOf("## External lifecycle notifications"),
+			readme.indexOf("## Memory backends"),
+		);
 
 		expect(section).toContain("Do not include raw prompts");
 		expect(section).toContain("assistant transcripts");


### PR DESCRIPTION
## Summary
- apply Biome formatting required by post-merge Dev CI for the #903 lifecycle notification docs test
- formatting-only follow-up for #902 / #903

## Verification
- `./node_modules/.bin/biome check --write packages/coding-agent/test/lifecycle-notification-docs.test.ts`
- `bun test packages/coding-agent/test/lifecycle-notification-docs.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
