### PR TITLE
Fix Windows tmux launch and input regressions

### DIFF
--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -169,7 +169,7 @@ export default class Index extends Command {
 				rawArgs: launch.args,
 				cwd: launch.cwd,
 				worktreeBranch: launch.worktree.enabled && !launch.worktree.detached ? launch.worktree.branchName : null,
-				project: launch.worktree.enabled ? launch.worktree.repoRoot : launch.cwd,
+				project: launch.cwd,
 			})
 		)
 			return;

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -15,7 +15,7 @@ import {
 	type GjcTmuxProfileCommand,
 	resolveGjcTmuxCommand,
 } from "./tmux-common";
-import { findGjcTmuxSessionByBranch } from "./tmux-sessions";
+import { findGjcTmuxSessionByName, findGjcTmuxSessionByScope } from "./tmux-sessions";
 
 export {
 	buildGjcTmuxProfileCommands,
@@ -82,6 +82,20 @@ export interface TmuxLaunchPlan {
 	project?: string | null;
 	sessionId?: string | null;
 	sessionStateFile?: string | null;
+}
+
+function explicitTmuxSessionName(env: NodeJS.ProcessEnv): string | undefined {
+	return env.GJC_TMUX_SESSION?.trim() || undefined;
+}
+
+function findExistingSessionForLaunch(context: {
+	env: NodeJS.ProcessEnv;
+	project: string;
+	branch?: string | null;
+}): string | undefined {
+	const explicit = explicitTmuxSessionName(context.env);
+	if (explicit) return findGjcTmuxSessionByName(explicit, context.env)?.name;
+	return findGjcTmuxSessionByScope(context.project, context.branch, context.env)?.name;
 }
 
 export interface GjcTmuxProfileResult {
@@ -351,12 +365,14 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		path.join(cwd, ".gjc", "runtime", "tmux-sessions", `${buildGjcTmuxSessionSlug(sessionName)}.json`);
 	const tmuxAvailable = context.tmuxAvailable ?? Bun.which(tmuxCommand) !== null;
 	if (!tmuxAvailable) return undefined;
-	const existingBranchSessionName =
+	const existingSessionName =
 		"existingBranchSessionName" in context
 			? (context.existingBranchSessionName ?? undefined)
-			: context.worktreeBranch
-				? findGjcTmuxSessionByBranch(context.worktreeBranch, env, project)?.name
-				: undefined;
+			: findExistingSessionForLaunch({
+					env,
+					project,
+					branch,
+				});
 	const innerCommand = buildInnerCommand(
 		{
 			cwd,
@@ -380,7 +396,7 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		project,
 		sessionId,
 		sessionStateFile,
-		attachSessionName: existingBranchSessionName,
+		attachSessionName: existingSessionName,
 	};
 }
 
@@ -447,8 +463,9 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		}
 	}
 	if (created.exitCode !== 0) return false;
-	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", plan.sessionName], options);
+	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], options);
 	if (attached.exitCode === 0) return true;
+	cleanupCreatedTmuxSession(plan, spawnSync, options);
 	(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach failed", attached.stderr));
 	return true;
 }

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -182,6 +182,22 @@ export function findGjcTmuxSessionByBranch(
 	);
 }
 
+export function findGjcTmuxSessionByName(
+	sessionName: string,
+	env: NodeJS.ProcessEnv = process.env,
+): GjcTmuxSessionStatus | undefined {
+	return listGjcTmuxSessions(env).find(session => session.name === sessionName);
+}
+
+export function findGjcTmuxSessionByScope(
+	project: string,
+	branch: string | null | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): GjcTmuxSessionStatus | undefined {
+	return listGjcTmuxSessions(env).find(
+		session => session.project === project && (branch ? session.branch === branch : session.branch === undefined),
+	);
+}
 export function statusGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {
 	const session = listGjcTmuxSessions(env).find(candidate => candidate.name === sessionName);
 	if (session) return session;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -199,6 +199,9 @@ export class InputController {
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
+		this.ctx.editor.onTabDeclined = () => {
+			if (this.ctx.session.isStreaming) void this.handleQueueSubmit();
+		};
 
 		this.ctx.editor.clearCustomKeyHandlers();
 		// Wire up extension shortcuts

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import { Buffer } from "node:buffer";
 import type { Args } from "@gajae-code/coding-agent/cli/args";
 import {
@@ -22,6 +22,15 @@ function args(overrides: Partial<Args> = {}): Args {
 }
 
 const interactiveTty = { stdin: true, stdout: true };
+type SpawnSyncResult = Bun.SyncSubprocess<"pipe", "pipe">;
+
+function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncResult {
+	return {
+		exitCode,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+	} as SpawnSyncResult;
+}
 function decodePowerShellEncodedCommand(command: string): string {
 	const match = command.match(/ -EncodedCommand (?<encoded>[A-Za-z0-9+/=]+)$/);
 	if (!match?.groups?.encoded) throw new Error(`missing encoded command: ${command}`);
@@ -39,6 +48,7 @@ function stderrError(code: string): Error {
 describe("default GJC tmux launch", () => {
 	afterEach(() => {
 		process.stderr.write = originalStderrWrite;
+		vi.restoreAllMocks();
 	});
 
 	it("builds project and branch tmux window titles", () => {
@@ -75,6 +85,7 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 			currentBranch: "feature/demo",
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -97,9 +108,31 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeUndefined();
+	});
+
+	it("does not invoke tmux session listing when existing session lookup is injected", () => {
+		const spawnSyncSpy = spyOn(Bun, "spawnSync");
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan).toBeDefined();
+		expect(spawnSyncSpy).not.toHaveBeenCalled();
 	});
 
 	it("plans an interactive --tmux root launch inside a new GJC tmux session", () => {
@@ -113,6 +146,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeDefined();
@@ -138,6 +173,8 @@ describe("default GJC tmux launch", () => {
 			platform: "win32",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeDefined();
@@ -162,6 +199,8 @@ describe("default GJC tmux launch", () => {
 			platform: "win32",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeDefined();
@@ -187,6 +226,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeDefined();
@@ -208,6 +249,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan?.innerCommand).not.toContain("$bunfs");
@@ -261,6 +304,9 @@ describe("default GJC tmux launch", () => {
 	});
 
 	it("honors an explicit GJC_TMUX_SESSION override", () => {
+		spyOn(Bun, "spawnSync").mockReturnValue(
+			spawnResult(0, "custom-gjc\t1\t0\t1770000000\t1\troot\t1\t12345\tfeature/demo\tfeature-demo\t/repo"),
+		);
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),
 			rawArgs: ["--tmux", "hello world"],
@@ -271,9 +317,11 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
 		});
 
 		expect(plan?.sessionName).toBe("custom-gjc");
+		expect(plan?.attachSessionName).toBe("custom-gjc");
 		expect(plan?.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", "custom-gjc", "-c", "/repo"]);
 	});
 
@@ -311,6 +359,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -381,6 +431,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 		});
 
 		expect(plan).toBeDefined();
@@ -451,6 +503,7 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 			currentBranch: "feature/demo",
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -481,6 +534,7 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 			currentBranch: "feature/demo",
 			spawnSync: (command, spawnArgs) => {
 				calls.push({ command, args: spawnArgs });
@@ -550,6 +604,7 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 			currentBranch: "feature/demo",
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -578,6 +633,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
 				return { exitCode: 1 };
@@ -602,6 +659,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -631,6 +690,7 @@ describe("default GJC tmux launch", () => {
 			platform: "win32",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 			currentBranch: "issue-882",
 			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (command, spawnArgs, options) => {
@@ -668,6 +728,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
@@ -702,6 +764,8 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			spawnSync: (_command, spawnArgs) => {
 				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
 				return { exitCode: 0 };
@@ -741,6 +805,8 @@ describe("default GJC tmux launch", () => {
 			platform: "linux",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
 				return { exitCode: 0 };
@@ -771,6 +837,8 @@ describe("default GJC tmux launch", () => {
 			platform: "linux",
 			tty: interactiveTty,
 			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
 			spawnSync: (command, spawnArgs, options) => {
 				calls.push({ command, args: spawnArgs, options });
 				return { exitCode: 0 };

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -277,6 +277,55 @@ describe("default GJC tmux launch", () => {
 		expect(plan?.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", "custom-gjc", "-c", "/repo"]);
 	});
 
+	it("does not reuse a same-branch session from another worktree path in the same project", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo/worktree-b",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			project: "/repo/worktree-b",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan?.attachSessionName).toBeUndefined();
+		expect(plan?.branch).toBe("feature/demo");
+		expect(plan?.project).toBe("/repo/worktree-b");
+	});
+
+	it("cleans up a newly created managed session when attach fails", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+	});
+
 	it("builds a session-scoped tmux profile without global tmux mutation", () => {
 		const commands = buildGjcTmuxProfileCommands("gjc-session:0", {});
 		const args = commands.map(command => command.args);
@@ -630,7 +679,7 @@ describe("default GJC tmux launch", () => {
 		expect(handled).toBe(true);
 		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
 		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
-		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
 		expect(diagnostics[0].length).toBeLessThan(320);

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -26,6 +26,7 @@ type FakeEditor = {
 	onQueue?: () => void | Promise<void>;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => void | Promise<void>;
+	onTabDeclined?: (text: string) => void;
 	setText(text: string): void;
 	getText(): string;
 	insertText(text: string): void;
@@ -197,6 +198,23 @@ describe("InputController keybinding setup", () => {
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.message.queue", ["alt+enter"]);
 		expect(ctx.locallySubmittedUserSignatures.has("queue after current response\u00000")).toBe(true);
 		expect(spies.prompt).toHaveBeenCalledWith("queue after current response", {
+			streamingBehavior: "followUp",
+		});
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues streaming Tab only after editor tab completion declines", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		editor.setText("queue after declined tab completion");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onTabDeclined?.(editor.getText());
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue after declined tab completion", {
 			streamingBehavior: "followUp",
 		});
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -447,6 +447,7 @@ export class Editor implements Component, Focusable {
 	onAltEnter?: (text: string) => void;
 	onChange?: (text: string) => void;
 	onAutocompleteCancel?: () => void;
+	onTabDeclined?: (text: string) => void;
 	disableSubmit: boolean = false;
 
 	// Custom top border (for status line integration)
@@ -1248,7 +1249,7 @@ export class Editor implements Component, Focusable {
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
 			(data.length > 1 && data.includes("\x1b") && data.includes("\r")) ||
-			(data === "\n" && data.length === 1) // Shift+Enter from iTerm2 mapping
+			(data === "\n" && data.length === 1 && process.platform !== "win32") // Shift+Enter from iTerm2 mapping
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
 				this.#handleBackspace();
@@ -2612,6 +2613,9 @@ export class Editor implements Component, Focusable {
 
 	// Autocomplete methods
 	async #tryTriggerAutocomplete(explicitTab: boolean = false): Promise<void> {
+		const declineExplicitTab = (): void => {
+			if (explicitTab) this.onTabDeclined?.(this.getText());
+		};
 		if (!this.#autocompleteProvider) return;
 		// Check if we should trigger file completion on Tab
 		if (explicitTab) {
@@ -2620,6 +2624,7 @@ export class Editor implements Component, Focusable {
 				!provider.shouldTriggerFileCompletion ||
 				provider.shouldTriggerFileCompletion(this.#state.lines, this.#state.cursorLine, this.#state.cursorCol);
 			if (!shouldTrigger) {
+				declineExplicitTab();
 				return;
 			}
 		}
@@ -2641,6 +2646,7 @@ export class Editor implements Component, Focusable {
 		} else {
 			this.#cancelAutocomplete();
 			this.onAutocompleteUpdate?.();
+			declineExplicitTab();
 		}
 	}
 	#createAutocompleteList(
@@ -2655,7 +2661,10 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleTabCompletion(): void {
-		if (!this.#autocompleteProvider) return;
+		if (!this.#autocompleteProvider) {
+			this.onTabDeclined?.(this.getText());
+			return;
+		}
 
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
@@ -2726,6 +2735,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		} else {
 			this.#cancelAutocomplete();
 			this.onAutocompleteUpdate?.();
+			if (explicitTab) this.onTabDeclined?.(this.getText());
 		}
 	}
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -506,6 +506,26 @@ describe("Editor component", () => {
 			}
 		});
 
+		it("submits raw LF as Enter on Windows instead of inserting newline", () => {
+			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+			Object.defineProperty(process, "platform", { value: "win32" });
+			try {
+				const editor = new Editor(defaultEditorTheme);
+				let submitted = "";
+				editor.onSubmit = text => {
+					submitted = text;
+				};
+
+				editor.handleInput("a");
+				editor.handleInput("\n");
+
+				expect(submitted).toBe("a");
+				expect(editor.getText()).toBe("");
+			} finally {
+				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+			}
+		});
+
 		it("deletes single-code-unit unicode characters (umlauts) with Backspace", () => {
 			const editor = new Editor(defaultEditorTheme);
 


### PR DESCRIPTION
## Summary
- Fix `gjc --tmux` reuse to prefer exact explicit `GJC_TMUX_SESSION` and project/path scoped managed sessions instead of same-branch sessions from another worktree.
- Clean up only newly-created managed tmux sessions on profile/attach failure, with exact tmux targets.
- Preserve non-Windows raw LF newline behavior while making Windows raw LF submit, and queue streaming Tab only after editor autocomplete declines.

Fixes #905.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/tui/test/editor.test.ts` — 167 pass, 0 fail.
- `bun run check:ts` — passed; existing Biome config informational deprecation/schema notices only.
- Architect review lanes: CLEAR/CLEAR/CLEAR, APPROVE, no blockers.
- QA/red-team lane: focused tests passed; no blocking defects found.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*