### PR TITLE
Fix launch worktree tmux test isolation

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -231,6 +231,7 @@ describe("default launch worktrees", () => {
 			platform: "darwin",
 			tty: { stdin: true, stdout: true },
 			tmuxAvailable: true,
+			existingBranchSessionName: null,
 		});
 
 		expect(plan?.cwd).toBe(launch.cwd);


### PR DESCRIPTION
Repairs post-merge Dev CI run 27850005904 (`Affected path validation / test:@gajae-code/coding-agent`, job 82427138664).

## Summary
- Injects the existing-session seam in `launch-worktree.test.ts` so the worktree tmux planning test does not query the host tmux server.
- Matches the isolation pattern already used by `launch-tmux.test.ts` after PR #906.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun run test test/gjc-runtime/launch-worktree.test.ts` from `packages/coding-agent` — passed (9 tests).
- Attempted full CI shard command with `AFFECTED_TASK_KEY=test:@gajae-code/coding-agent GITHUB_EVENT_NAME=push CI_DEV_CHANGED_PATHS=packages/coding-agent/src/gjc-runtime/launch-tmux.ts bun scripts/ci-dev-affected.ts --task=test:@gajae-code/coding-agent`; it reached unrelated package failures in `test/tools/image-gen.test.ts` and `test/gjc-runtime/ralplan-runtime.test.ts` before timing out locally.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*