### PR TITLE
fix(skill-state): stop fd-dup redirects (2>&1) from trapping planning phases

### DIFF
--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -38,6 +38,14 @@ const VIM_FILE_SWITCH_RE = /^\s*:(?:e|e!|edit|edit!)(?:\s+([^<\r\n]+))?(?:<CR>|\
 const BASH_TOKEN_RE = /'[^']*'|"(?:\\.|[^"\\])*"|\S+/g;
 const BASH_REDIRECT_RE = /^(?:\d*)>>?$/;
 const BASH_HEREDOC_RE = /^(?:\d*)<<-?$/;
+// A file-descriptor duplication / move / close redirect target (`2>&1`, `>&2`,
+// `1>&-`, `&-`). These rewire a file descriptor — they NEVER name a filesystem
+// path, so they must not be recorded as write targets. Without this carve-out
+// the `&1` of a benign `... 2>&1` resolves to an in-project path and falsely
+// trips the planning phase-boundary block — which traps `gjc … --write … 2>&1`,
+// the very escape/finalize command this guard instructs the agent to run. A real
+// `>&file` (word, not a digit) still falls through and is recorded.
+const BASH_FD_DUP_TARGET_RE = /^&(?:\d+-?|-)$/;
 // Shell command-list / redirection / substitution operators. Includes `\r` and
 // `\n` because the shell treats a newline as a command separator and tool command
 // strings can be multiline (e.g. heredocs).
@@ -362,13 +370,16 @@ function extractBashTargets(args: unknown): ExtractedTargets {
 	for (let index = 0; index < tokens.length; index++) {
 		const token = tokens[index] ?? "";
 		if (BASH_REDIRECT_RE.test(token)) {
-			addPath(targets, tokens[index + 1]);
+			// `2>` `&1` split form: a following fd-dup word is not a path target.
+			const next = tokens[index + 1] ?? "";
+			if (!BASH_FD_DUP_TARGET_RE.test(next)) addPath(targets, next);
 			index++;
 			continue;
 		}
 		const redirectMatch = token.match(/^(?:\d*)>>?(.+)$/);
 		if (redirectMatch?.[1]) {
-			addPath(targets, redirectMatch[1]);
+			// Skip fd duplication/close (`2>&1`, `>&2`, `1>&-`); record real files.
+			if (!BASH_FD_DUP_TARGET_RE.test(redirectMatch[1])) addPath(targets, redirectMatch[1]);
 			continue;
 		}
 		// A heredoc delimiter (`<<EOF`) is a here-document word, NOT a filesystem

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -255,6 +255,47 @@ describe("deep-interview mutation guard", () => {
 		}
 	});
 
+	it("allows fd-duplication redirects (2>&1, >&2) and the gjc escape command wrapped in them", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			// fd duplication / close is never a filesystem path → no phantom target.
+			"git status 2>&1",
+			"bun test 1>&2",
+			"ls -la >&-",
+			// The exact escape/finalize command an agent reaches for, wrapped in the
+			// near-universal `2>&1 || echo` defensive shell. This MUST stay allowed or
+			// deep-interview becomes an inescapable trap (the guard's own message tells
+			// the agent to run `gjc deep-interview --write --stage final`).
+			'gjc deep-interview --write --stage final --slug x --spec /tmp/x.md --json 2>&1 || echo "EXIT:$?"',
+			"gjc state deep-interview handoff --to ralplan --json 2>&1",
+		]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(false);
+			expect(decision.targets).toEqual([]);
+		}
+	});
+
+	it("still blocks a real file redirect even alongside an fd-duplication redirect", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of ["gjc state read 2>&1 > .gjc/state/foo.json", "build 2>&1 | tee src/product.ts"]) {
+			const decision = await getDeepInterviewMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+		}
+	});
 	it("blocks mutating bash that targets .gjc during active deep-interview", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);


### PR DESCRIPTION
## Summary

The planning phase-boundary guard (`deep-interview` / `ralplan` / `ultragoal`) can trap a session **with no way out**, because its own documented escape command gets blocked by a redirect-parsing bug.

When `deep-interview` is active, the guard blocks the `bash` tool unless the command extracts no in-project write target. To let agents finalize/escape, the block message says to run:

```
gjc deep-interview --write --stage final ...
```

But `extractBashTargets()` mis-parses a file-descriptor duplication redirect as a filesystem path:

- redirect regex `^(?:\d*)>>?(.+)$` matches the token `2>&1` and captures `&1`
- `&1` is recorded as a write target, resolves to `<cwd>/&1` (inside the project, not neutral temp), and trips the block

Since `2>&1` / `|| echo "EXIT:$?"` defensive wrapping is near-universal, **every** attempt to run the escape command with normal shell habits is blocked. The skill only releases via a *perfectly bare* command with zero shell operators — which an agent rarely guesses, so it stays trapped. (Discovered live: a deep-interview session could not finalize, hand off, or run any `bash` for many turns.)

## Reproduction

```js
// command: gjc deep-interview --write --stage final --slug x --spec /tmp/x.md --json 2>&1 || echo "EXIT:$?"
// extractBashTargets → phantom target ["&1"] → resolves in-project → BLOCKED
```

## Fix

A redirect target that is an fd duplication/move/close (`&N`, `&N-`, `&-`) never names a file, so it must not be recorded as a write target. A real `>&file` (a word, not a digit) still falls through and is recorded, and genuine mutations alongside an fd-dup stay blocked:

- `... 2>&1 > .gjc/state/x` → still blocked (real `>` target)
- `... 2>&1 | tee src/x` → still blocked (`tee` target)
- `gjc ... --write ... 2>&1 || echo` → now allowed (only fd-dup, no real target)

## Tests

`packages/coding-agent/test/deep-interview-mutation-guard.test.ts`:
- allows fd-dup redirects (`2>&1`, `1>&2`, `>&-`) and the wrapped `gjc` escape command
- still blocks a real file redirect / `tee` next to an fd-dup

```
bun test test/deep-interview-mutation-guard.test.ts   # 25 pass
# adjacent guards: deep-interview-gate-redteam + workflow-gates + state-redteam = 32 pass
```

## Notes / follow-ups (not in this PR)

- The always-on `.gjc/**` block also scans **heredoc body lines** as live tokens, so a `git commit <<EOF`/message containing a literal `> .gjc/...` is falsely blocked. Same class of "treat shell-inert text as a target" issue; worth a separate fix.
- Considered improving the block message to warn "run bare, no shell operators", but removing the false positive is the correct fix rather than documenting around it.
