### PR TITLE
fix(coding-agent): record first /goal set in input history

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -250,11 +250,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[objective]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
-			const hadArgs = !!command.args;
-			// Capture state BEFORE the call (see /plan above for rationale).
-			const wasGoalModeEnabled = runtime.ctx.goalModeEnabled;
+			// The goal command always consumes the typed input: it either submits
+			// the bare objective (never the literal `/goal …` text the user typed)
+			// or shows a warning, so the normal submission path never records it in
+			// input history. Preserve the typed command whenever args were supplied
+			// — including the first-time `/goal set <objective>` case where goal
+			// mode was not yet active. A previous `wasGoalModeEnabled` guard dropped
+			// that first-time case from history (up/down-arrow recall).
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
-			if (hadArgs && wasGoalModeEnabled) {
+			if (command.args) {
 				runtime.ctx.editor.addToHistory(command.text);
 			}
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -69,3 +69,51 @@ describe("builtin /copy slash command", () => {
 		expect(setText).toHaveBeenCalledWith("");
 	});
 });
+
+function createGoalTuiRuntime(goalModeEnabled: boolean) {
+	const handleGoalModeCommand = vi.fn(async () => {});
+	const addToHistory = vi.fn();
+	const setText = vi.fn();
+	const ctx = {
+		goalModeEnabled,
+		handleGoalModeCommand,
+		editor: { addToHistory, setText },
+	} as unknown as InteractiveModeContext;
+
+	return {
+		runtime: { ctx, handleBackgroundCommand: () => undefined },
+		handleGoalModeCommand,
+		addToHistory,
+		setText,
+	};
+}
+
+describe("builtin /goal slash command", () => {
+	it("records the first-time /goal set in input history even when goal mode was inactive", async () => {
+		const { runtime, handleGoalModeCommand, addToHistory } = createGoalTuiRuntime(false);
+
+		const result = await executeBuiltinSlashCommand("/goal set Ship the release", runtime);
+
+		expect(result).toBe(true);
+		expect(handleGoalModeCommand).toHaveBeenCalledWith("set Ship the release");
+		expect(addToHistory).toHaveBeenCalledWith("/goal set Ship the release");
+	});
+
+	it("records a replacement /goal set in input history when goal mode is active", async () => {
+		const { runtime, addToHistory } = createGoalTuiRuntime(true);
+
+		const result = await executeBuiltinSlashCommand("/goal set Replace the objective", runtime);
+
+		expect(result).toBe(true);
+		expect(addToHistory).toHaveBeenCalledWith("/goal set Replace the objective");
+	});
+
+	it("does not record an argument-less /goal in input history", async () => {
+		const { runtime, addToHistory } = createGoalTuiRuntime(false);
+
+		const result = await executeBuiltinSlashCommand("/goal", runtime);
+
+		expect(result).toBe(true);
+		expect(addToHistory).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Problem

After `/goal set <objective>` set a goal for the first time, the typed command did not appear in the editor's input history (up/down-arrow recall). Setting a *replacement* goal while goal mode was already active worked fine, so the omission only hit the first goal of a session.

## Root cause

The `/goal` TUI handler in `builtin-registry.ts` recorded the typed command only when goal mode was already active:

```ts
const wasGoalModeEnabled = runtime.ctx.goalModeEnabled;
await runtime.ctx.handleGoalModeCommand(command.args || undefined);
if (hadArgs && wasGoalModeEnabled) {
    runtime.ctx.editor.addToHistory(command.text);
}
```

The first-time path (`handleGoalModeCommand` → `#startGoalFromObjective`) runs with goal mode off and submits only the **bare objective** through `startPendingSubmission`, which never calls `addToHistory`. The slash handler is therefore the only place that can preserve the literal `/goal …` text, but the `wasGoalModeEnabled` guard skipped it precisely in the first-time case.

## Fix

Record the typed command whenever args are supplied, regardless of prior goal-mode state. No duplicate is introduced because the submission path enqueues only the bare objective, not the `/goal …` text.

## Tests

Added regression tests in `slash-command-builtin-registry.test.ts` covering:
- first-time `/goal set` while goal mode is inactive (now recorded)
- replacement `/goal set` while goal mode is active (still recorded)
- argument-less `/goal` (not recorded)

`bun test` for the registry and goal-mode integration suites pass; `check:ts` (typecheck + biome) is clean.