### PR TITLE
fix(tui): handle ctrl-shift-enter newline

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1245,6 +1245,7 @@ export class Editor implements Component, Focusable {
 		else if (
 			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
 			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
+			matchesKey(data, "ctrl+shift+enter") || // Ctrl+Shift+Enter (Kitty/modifyOtherKeys combined modifier)
 			data === "\x1b\r" || // Option+Enter in some terminals (legacy)
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -506,6 +506,20 @@ describe("Editor component", () => {
 			}
 		});
 
+		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~"];
+
+			for (const [index, variant] of variants.entries()) {
+				const editor = new Editor(defaultEditorTheme);
+				const prefix = index === 0 ? "alpha" : "beta";
+
+				editor.setText(prefix);
+				editor.handleInput(variant);
+
+				expect(editor.getText()).toBe(`${prefix}\n`);
+			}
+		});
+
 		it("submits raw LF as Enter on Windows instead of inserting newline", () => {
 			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 			Object.defineProperty(process, "platform", { value: "win32" });

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -57,6 +57,13 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
+	it("matches Ctrl+Shift+Enter terminal protocol variants", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b[13;6u", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[27;6;13~", "ctrl+shift+enter")).toBe(true);
+		setKittyProtocolActive(false);
+	});
+
 	it("preserves keypad navigation matches when NumLock is on but modifiers are held", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[57400;133u", "ctrl+end")).toBe(true);
@@ -98,6 +105,13 @@ describe("parseKey", () => {
 		setKittyProtocolActive(true);
 		expect(parseKey("\x1b[57410u")).toBe("/");
 		expect(parseKey("\x1b[57413;5u")).toBe("ctrl++");
+		setKittyProtocolActive(false);
+	});
+
+	it("parses Ctrl+Shift+Enter terminal protocol variants", () => {
+		setKittyProtocolActive(true);
+		expect(parseKey("\x1b[13;6u")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[27;6;13~")).toBe("shift+ctrl+enter");
 		setKittyProtocolActive(false);
 	});
 


### PR DESCRIPTION
## Summary
- Add explicit `ctrl+shift+enter` newline handling in the TUI editor modified-Enter branch
- Cover Kitty/CSI-u and modifyOtherKeys `Ctrl+Shift+Enter` sequences in key parsing/matching tests
- Cover `Editor.handleInput` newline insertion for both downstream-reported sequences

Fixes #905

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts`
- `bun --cwd=packages/tui run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*