### PR TITLE
fix(coding-agent): let idle ctrl-enter insert newline

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -231,7 +231,11 @@ export class InputController {
 			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.message.followUp")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.handleFollowUp());
+			this.ctx.editor.setCustomKeyHandler(key, () => {
+				if (!this.#isFollowUpShortcutActive()) return false;
+				void this.handleFollowUp();
+				return true;
+			});
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
@@ -504,6 +508,15 @@ export class InputController {
 	 */
 	#busyStreamingBehavior(): "steer" | "followUp" {
 		return this.ctx.settings.get("busyPromptMode") === "steer" ? "steer" : "followUp";
+	}
+
+	#isFollowUpShortcutActive(): boolean {
+		return (
+			this.ctx.session.isStreaming ||
+			this.ctx.session.isCompacting ||
+			this.ctx.session.isBashRunning ||
+			this.ctx.session.isEvalRunning
+		);
 	}
 
 	/**

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -32,7 +32,7 @@ type FakeEditor = {
 	insertText(text: string): void;
 	addToHistory(text: string): void;
 	setActionKeys(action: string, keys: string[]): void;
-	setCustomKeyHandler(key: string, handler: () => void): void;
+	setCustomKeyHandler(key: string, handler: () => boolean | undefined): void;
 	clearCustomKeyHandlers(): void;
 };
 
@@ -42,6 +42,7 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue" }) {
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["ctrl+l"],
 		"app.message.queue": ["alt+enter"],
+		"app.message.followUp": ["ctrl+enter"],
 	};
 	const setActionKeys = vi.fn();
 	const showModelSelector = vi.fn();
@@ -201,6 +202,41 @@ describe("InputController keybinding setup", () => {
 			streamingBehavior: "followUp",
 		});
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets idle Ctrl+Enter fall through to editor newline handling", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const followUpRegistration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "ctrl+enter",
+		);
+		expect(followUpRegistration).toBeDefined();
+		const handler = followUpRegistration?.[1] as () => boolean | undefined;
+
+		expect(handler()).toBe(false);
+		expect(spies.prompt).not.toHaveBeenCalled();
+	});
+
+	it("consumes Ctrl+Enter as follow-up while streaming", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		editor.setText("follow up from shortcut");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const followUpRegistration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "ctrl+enter",
+		);
+		const handler = followUpRegistration?.[1] as () => boolean | undefined;
+
+		expect(handler()).toBe(true);
+		await Bun.sleep(0);
+		expect(spies.prompt).toHaveBeenCalledWith("follow up from shortcut", {
+			streamingBehavior: "followUp",
+		});
 	});
 
 	it("queues streaming Tab only after editor tab completion declines", async () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1245,6 +1245,7 @@ export class Editor implements Component, Focusable {
 		else if (
 			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
 			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
+			matchesKey(data, "ctrl+shift+enter") || // Ctrl+Shift+Enter (Kitty/modifyOtherKeys combined modifier)
 			data === "\x1b\r" || // Option+Enter in some terminals (legacy)
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -506,6 +506,20 @@ describe("Editor component", () => {
 			}
 		});
 
+		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~"];
+
+			for (const [index, variant] of variants.entries()) {
+				const editor = new Editor(defaultEditorTheme);
+				const prefix = index === 0 ? "alpha" : "beta";
+
+				editor.setText(prefix);
+				editor.handleInput(variant);
+
+				expect(editor.getText()).toBe(`${prefix}\n`);
+			}
+		});
+
 		it("submits raw LF as Enter on Windows instead of inserting newline", () => {
 			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 			Object.defineProperty(process, "platform", { value: "win32" });

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -57,6 +57,13 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
+	it("matches Ctrl+Shift+Enter terminal protocol variants", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b[13;6u", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[27;6;13~", "ctrl+shift+enter")).toBe(true);
+		setKittyProtocolActive(false);
+	});
+
 	it("preserves keypad navigation matches when NumLock is on but modifiers are held", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[57400;133u", "ctrl+end")).toBe(true);
@@ -98,6 +105,13 @@ describe("parseKey", () => {
 		setKittyProtocolActive(true);
 		expect(parseKey("\x1b[57410u")).toBe("/");
 		expect(parseKey("\x1b[57413;5u")).toBe("ctrl++");
+		setKittyProtocolActive(false);
+	});
+
+	it("parses Ctrl+Shift+Enter terminal protocol variants", () => {
+		setKittyProtocolActive(true);
+		expect(parseKey("\x1b[13;6u")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[27;6;13~")).toBe("shift+ctrl+enter");
 		setKittyProtocolActive(false);
 	});
 


### PR DESCRIPTION
## Summary
- Keep Ctrl+Enter as a busy-session follow-up shortcut only when the session is actually busy
- Let idle Ctrl+Enter fall through to the TUI editor newline path, preserving live `gjc --tmux` multiline composition
- Add controller coverage for idle fallthrough vs streaming follow-up consumption

## Verification
- `bun test packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts`
- `(cd packages/coding-agent && bun run check)`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*