### PR TITLE
fix(tui): handle psmux ctrl-shift-enter sequence

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -305,6 +305,7 @@ const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
+const CSI_ENTER_MODIFIER_PATTERN = /^\x1b\[13;(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
 	57411: "*",
@@ -520,7 +521,33 @@ export function decodePrintableKey(data: string): string | undefined {
  * @param data - Raw input data from terminal
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
+function parseCsiEnterModifierKey(data: string): string | undefined {
+	const match = data.match(CSI_ENTER_MODIFIER_PATTERN);
+	if (!match) return undefined;
+	const modValue = Number.parseInt(match[1] ?? "", 10);
+	if (!Number.isFinite(modValue)) return undefined;
+	const modifier = (modValue - 1) & ~KITTY_LOCK_MASK;
+	const modifiers: string[] = [];
+	if (modifier & KITTY_MOD_SHIFT) modifiers.push("shift");
+	if (modifier & KITTY_MOD_CTRL) modifiers.push("ctrl");
+	if (modifier & KITTY_MOD_ALT) modifiers.push("alt");
+	if (modifier & KITTY_MOD_SUPER) modifiers.push("super");
+	const supportedModifierMask = KITTY_MOD_SHIFT | KITTY_MOD_CTRL | KITTY_MOD_ALT | KITTY_MOD_SUPER;
+	if (modifier & ~supportedModifierMask) return undefined;
+	return [...modifiers, "enter"].join("+");
+}
+
+function keyIdMatchesParsedKey(keyId: KeyId, parsed: string): boolean {
+	if (keyId === parsed) return true;
+	const expectedParts = keyId.split("+");
+	const parsedParts = parsed.split("+");
+	if (expectedParts.at(-1) !== parsedParts.at(-1)) return false;
+	return expectedParts.slice(0, -1).sort().join("+") === parsedParts.slice(0, -1).sort().join("+");
+}
+
 export function matchesKey(data: string, keyId: KeyId): boolean {
+	const parsed = parseCsiEnterModifierKey(data);
+	if (parsed !== undefined && keyIdMatchesParsedKey(keyId, parsed)) return true;
 	return matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
@@ -533,5 +560,5 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
-	return parseKeyNative(data, kittyProtocolActive) ?? undefined;
+	return parseCsiEnterModifierKey(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -507,7 +507,7 @@ describe("Editor component", () => {
 		});
 
 		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
-			const variants = ["\x1b[13;6u", "\x1b[27;6;13~"];
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~"];
 
 			for (const [index, variant] of variants.entries()) {
 				const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -61,6 +61,8 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[13;6u", "ctrl+shift+enter")).toBe(true);
 		expect(matchesKey("\x1b[27;6;13~", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;6~", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;2~", "shift+enter")).toBe(true);
 		setKittyProtocolActive(false);
 	});
 
@@ -112,6 +114,8 @@ describe("parseKey", () => {
 		setKittyProtocolActive(true);
 		expect(parseKey("\x1b[13;6u")).toBe("shift+ctrl+enter");
 		expect(parseKey("\x1b[27;6;13~")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[13;6~")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[13;2~")).toBe("shift+enter");
 		setKittyProtocolActive(false);
 	});
 


### PR DESCRIPTION
## Summary
- recognize the psmux / Windows tmux `CSI 13;6~` sequence as Ctrl+Shift+Enter before the native parser can classify it as F3
- recognize `CSI 13;2~` as Shift+Enter for the same modifier form
- extend key parser and editor newline regression coverage for the new Windows-native sequence

Fixes #916

## Verification
- `bun --cwd=packages/tui run check`
- `bun test packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
