### PR TITLE
fix(tui): parse psmux modified enter sequences

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -305,6 +305,7 @@ const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
+const PSMUX_MODIFIED_ENTER_PATTERN = /^\x1b\[13;(2|6)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
 	57411: "*",
@@ -376,6 +377,20 @@ export function parseKittySequence(data: string): ParsedKittySequence | null {
 		modifier: result.modifier,
 		eventType: result.eventType,
 	};
+}
+
+function parsePsmuxModifiedEnter(data: string): string | undefined {
+	const match = data.match(PSMUX_MODIFIED_ENTER_PATTERN);
+	if (!match) return undefined;
+	return match[1] === "6" ? "shift+ctrl+enter" : "shift+enter";
+}
+
+function matchesPsmuxModifiedEnter(data: string, keyId: KeyId): boolean {
+	const parsed = parsePsmuxModifiedEnter(data);
+	if (!parsed) return false;
+	const expected = String(keyId);
+	if (parsed === expected) return true;
+	return parsed === "shift+ctrl+enter" && expected === "ctrl+shift+enter";
 }
 
 function hasControlChars(data: string): boolean {
@@ -521,7 +536,7 @@ export function decodePrintableKey(data: string): string | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
-	return matchesKeyNative(data, keyId, kittyProtocolActive);
+	return matchesPsmuxModifiedEnter(data, keyId) || matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
 /**
@@ -533,5 +548,5 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
-	return parseKeyNative(data, kittyProtocolActive) ?? undefined;
+	return parsePsmuxModifiedEnter(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -507,7 +507,7 @@ describe("Editor component", () => {
 		});
 
 		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
-			const variants = ["\x1b[13;6u", "\x1b[27;6;13~"];
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~"];
 
 			for (const [index, variant] of variants.entries()) {
 				const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -61,6 +61,8 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(true);
 		expect(matchesKey("\x1b[13;6u", "ctrl+shift+enter")).toBe(true);
 		expect(matchesKey("\x1b[27;6;13~", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;6~", "ctrl+shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;2~", "shift+enter")).toBe(true);
 		setKittyProtocolActive(false);
 	});
 
@@ -112,6 +114,8 @@ describe("parseKey", () => {
 		setKittyProtocolActive(true);
 		expect(parseKey("\x1b[13;6u")).toBe("shift+ctrl+enter");
 		expect(parseKey("\x1b[27;6;13~")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[13;6~")).toBe("shift+ctrl+enter");
+		expect(parseKey("\x1b[13;2~")).toBe("shift+enter");
 		setKittyProtocolActive(false);
 	});
 


### PR DESCRIPTION
## Summary
- recognize psmux/Windows tmux modified Enter sequences (`CSI 13;6~`, `CSI 13;2~`) before native parser fallback
- keep Ctrl+Shift+Enter and Shift+Enter newline behavior working in the editor
- add focused key parser/editor coverage for the new psmux forms

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts`
- `bunx biome check packages/tui/src/keys.ts packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts`

Fixes #916