### PR TITLE
feat(keybindings): pasteImage SSOT + default-collision diagnostics (Phase 1 partial)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -46,3 +46,16 @@ Set an action to an empty array to disable it:
 | `app.stt.toggle` | `Alt+H` | Toggle speech-to-text recording |
 
 Older unqualified action names are migrated when `keybindings.json` is loaded, but new docs and new configs should use the namespaced action IDs above.
+
+## Auditing default-key collisions
+
+Some default chords are intentionally reused across different UI contexts, where the focused component disambiguates them at dispatch time. For example `Enter` maps to both input submit and selection confirm, and `Ctrl+C` maps to both input copy and selection cancel. These are not conflicts — only one context is active at a time.
+
+To audit the registry for keys whose default binding is claimed by more than one action, use `detectDefaultKeyCollisions(definitions)` from `@gajae-code/tui/keybindings`. It returns one entry per colliding key with the list of claiming action IDs, which is useful when adding new defaults or reviewing the surface. User-remap conflicts (multiple actions bound to the same chord in `keybindings.json`) continue to be reported separately by `KeybindingsManager.getConflicts()`.
+
+Two audit clarifications for the current surface:
+
+- `app.clipboard.copyLine` is registry-backed and dispatched through the input controller's custom key handlers, not hardcoded.
+- `tui.input.copy` is declared in the registry but is not currently dispatched by `Editor.handleInput`.
+
+The editor's configurable action defaults (including the platform-aware `app.clipboard.pasteImage` default) are derived directly from the central `KEYBINDINGS` registry, so there is a single source of truth for those defaults.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -59,3 +59,103 @@ Two audit clarifications for the current surface:
 - `tui.input.copy` is declared in the registry but is not currently dispatched by `Editor.handleInput`.
 
 The editor's configurable action defaults (including the platform-aware `app.clipboard.pasteImage` default) are derived directly from the central `KEYBINDINGS` registry, so there is a single source of truth for those defaults.
+
+## Current surface audit
+
+Authoritative inventory of the keybinding registry, one row per action. Generated from `TUI_KEYBINDINGS` (`packages/tui/src/keybindings.ts`) and `KEYBINDINGS` (`packages/coding-agent/src/config/keybindings.ts`). Every action ID below is remappable via `~/.gjc/agent/keybindings.json` unless noted. A drift test (`packages/coding-agent/test/keybindings-audit.test.ts`) asserts every registry action ID appears in this table.
+
+### Editor context (`tui.editor.*`)
+
+| Action ID | Default | Notes |
+| --- | --- | --- |
+| `tui.editor.cursorUp` | `up` | |
+| `tui.editor.cursorDown` | `down` | |
+| `tui.editor.cursorLeft` | `left`, `ctrl+b` | `ctrl+b` also `app.tool.backgroundFold` (other context) |
+| `tui.editor.cursorRight` | `right`, `ctrl+f` | |
+| `tui.editor.cursorWordLeft` | `alt+left`, `ctrl+left`, `alt+b` | `ctrl+left` also `app.tree.foldOrUp` |
+| `tui.editor.cursorWordRight` | `alt+right`, `ctrl+right`, `alt+f` | `ctrl+right` also `app.tree.unfoldOrDown` |
+| `tui.editor.cursorLineStart` | `home`, `ctrl+a` | |
+| `tui.editor.cursorLineEnd` | `end`, `ctrl+e` | |
+| `tui.editor.jumpForward` | `ctrl+]` | |
+| `tui.editor.jumpBackward` | `ctrl+alt+]` | |
+| `tui.editor.pageUp` | `pageUp` | |
+| `tui.editor.pageDown` | `pageDown` | |
+| `tui.editor.deleteCharBackward` | `backspace` | |
+| `tui.editor.deleteCharForward` | `delete`, `ctrl+d` | `ctrl+d` also `app.exit` / `app.session.delete` |
+| `tui.editor.deleteWordBackward` | `ctrl+w`, `alt+backspace`, `ctrl+backspace` | |
+| `tui.editor.deleteWordForward` | `alt+delete`, `alt+d` | |
+| `tui.editor.deleteToLineStart` | `ctrl+u` | |
+| `tui.editor.deleteToLineEnd` | `ctrl+k` | |
+| `tui.editor.yank` | `ctrl+y` | |
+| `tui.editor.yankPop` | `alt+y` | |
+| `tui.editor.undo` | `ctrl+-`, `ctrl+_` | |
+
+### Input context (`tui.input.*`)
+
+| Action ID | Default | Notes |
+| --- | --- | --- |
+| `tui.input.newLine` | `shift+enter` | |
+| `tui.input.submit` | `enter` | also `tui.select.confirm` (other context) |
+| `tui.input.tab` | `tab` | |
+| `tui.input.copy` | `ctrl+c` | declared but not dispatched by `Editor.handleInput` |
+
+### Selection context (`tui.select.*`)
+
+| Action ID | Default | Notes |
+| --- | --- | --- |
+| `tui.select.up` | `up` | |
+| `tui.select.down` | `down` | |
+| `tui.select.pageUp` | `pageUp` | |
+| `tui.select.pageDown` | `pageDown` | |
+| `tui.select.confirm` | `enter` | |
+| `tui.select.cancel` | `escape`, `ctrl+c` | `escape` also `app.interrupt` |
+
+### Application context (`app.*`)
+
+| Action ID | Default | Notes |
+| --- | --- | --- |
+| `app.interrupt` | `escape` | |
+| `app.clear` | `ctrl+c` | |
+| `app.exit` | `ctrl+d` | |
+| `app.suspend` | `ctrl+z` | |
+| `app.thinking.cycle` | `shift+tab` | |
+| `app.thinking.toggle` | `ctrl+t` | |
+| `app.model.cycleForward` | `ctrl+p` | also `app.session.togglePath` (session list) |
+| `app.model.cycleBackward` | `shift+ctrl+p` | |
+| `app.model.select` | `ctrl+l` | |
+| `app.model.selectTemporary` | `alt+p` | |
+| `app.tools.expand` | `ctrl+o` | |
+| `app.tool.backgroundFold` | `ctrl+b` | |
+| `app.editor.external` | `ctrl+g` | |
+| `app.message.followUp` | `ctrl+enter` | |
+| `app.message.queue` | `alt+enter` | |
+| `app.message.dequeue` | `alt+up` | |
+| `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on win32) | platform-aware; single source of truth in `KEYBINDINGS` |
+| `app.clipboard.copyLine` | `alt+shift+l` | registry-backed via input-controller custom handler |
+| `app.clipboard.copyPrompt` | `alt+shift+c` | |
+| `app.session.new` | _(none)_ | command-driven; empty default |
+| `app.session.tree` | _(none)_ | command-driven; empty default |
+| `app.session.fork` | _(none)_ | command-driven; empty default |
+| `app.session.resume` | _(none)_ | command-driven; empty default |
+| `app.session.observe` | `ctrl+s` | also `app.session.toggleSort` (session list) |
+| `app.jobs.open` | `alt+j` | |
+| `app.session.togglePath` | `ctrl+p` | session-list context |
+| `app.session.toggleSort` | `ctrl+s` | session-list context |
+| `app.session.rename` | `ctrl+r` | also `app.history.search` |
+| `app.session.delete` | `ctrl+d` | session-list context |
+| `app.session.deleteNoninvasive` | `ctrl+backspace` | |
+| `app.tree.foldOrUp` | `ctrl+left`, `alt+left` | |
+| `app.tree.unfoldOrDown` | `ctrl+right`, `alt+right` | |
+| `app.plan.toggle` | `alt+shift+p` | |
+| `app.history.search` | `ctrl+r` | |
+| `app.stt.toggle` | `alt+h` | |
+
+Cross-context default reuse (`ctrl+p`, `ctrl+s`, `ctrl+r`, `ctrl+d`, `ctrl+b`, `ctrl+left`/`ctrl+right`, `enter`, `escape`, `ctrl+c`) is intentional: each pair is active in a different focused context and is disambiguated at dispatch time. Use `detectDefaultKeyCollisions()` (above) to re-derive this list from the registry.
+
+### Not yet registry-managed
+
+A few contexts still match chords directly instead of resolving through the registry, and are tracked for a later phase:
+
+- Tree selector (`tree-selector.ts`): up/down/left/right/enter, `ctrl+c`, filter cycling (`ctrl+o` / `ctrl+shift+o`), filter modes (`alt+d/t/u/l/a`), label edit (`shift+l`).
+- Global debug overlay: `shift+ctrl+d` (`tui.ts`).
+- Parts of the model selector.

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,6 +1,6 @@
 import { Editor, type KeyId, matchesKey, parseKittySequence } from "@gajae-code/tui";
 import { BracketedPasteHandler } from "@gajae-code/tui/bracketed-paste";
-import type { AppKeybinding } from "../../config/keybindings";
+import { type AppKeybinding, KEYBINDINGS } from "../../config/keybindings";
 
 type ConfigurableEditorAction = Extract<
 	AppKeybinding,
@@ -23,25 +23,35 @@ type ConfigurableEditorAction = Extract<
 	| "app.clipboard.copyPrompt"
 >;
 
-const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
-	"app.interrupt": ["escape"],
-	"app.clear": ["ctrl+c"],
-	"app.exit": ["ctrl+d"],
-	"app.suspend": ["ctrl+z"],
-	"app.thinking.cycle": ["shift+tab"],
-	"app.model.cycleForward": ["ctrl+p"],
-	"app.model.cycleBackward": ["shift+ctrl+p"],
-	"app.model.select": ["ctrl+l"],
-	"app.model.selectTemporary": ["alt+p"],
-	"app.tools.expand": ["ctrl+o"],
-	"app.thinking.toggle": ["ctrl+t"],
-	"app.editor.external": ["ctrl+g"],
-	"app.history.search": ["ctrl+r"],
-	"app.message.queue": ["alt+enter"],
-	"app.message.dequeue": ["alt+up"],
-	"app.clipboard.pasteImage": ["ctrl+v"],
-	"app.clipboard.copyPrompt": ["alt+shift+c"],
-};
+// Editor-configurable app actions. Defaults are derived from the central
+// KEYBINDINGS registry so there is a single source of truth (e.g. the
+// platform-aware app.clipboard.pasteImage default is not duplicated here).
+const CONFIGURABLE_EDITOR_ACTIONS = [
+	"app.interrupt",
+	"app.clear",
+	"app.exit",
+	"app.suspend",
+	"app.thinking.cycle",
+	"app.model.cycleForward",
+	"app.model.cycleBackward",
+	"app.model.select",
+	"app.model.selectTemporary",
+	"app.tools.expand",
+	"app.thinking.toggle",
+	"app.editor.external",
+	"app.history.search",
+	"app.message.queue",
+	"app.message.dequeue",
+	"app.clipboard.pasteImage",
+	"app.clipboard.copyPrompt",
+] as const satisfies readonly ConfigurableEditorAction[];
+
+const DEFAULT_ACTION_KEYS = Object.fromEntries(
+	CONFIGURABLE_EDITOR_ACTIONS.map(action => {
+		const defaultKeys = KEYBINDINGS[action].defaultKeys;
+		return [action, Array.isArray(defaultKeys) ? [...defaultKeys] : [defaultKeys]];
+	}),
+) as Record<ConfigurableEditorAction, KeyId[]>;
 
 const PASTE_DECISION_TIMEOUT_MS = 5_000;
 const PENDING_PASTE_INPUT_MAX = 64;

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
+import { KEYBINDINGS } from "../src/config/keybindings";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 
 function ctrl(key: string): string {
@@ -65,6 +66,22 @@ describe("CustomEditor queue keybinding", () => {
 
 		editor.handleInput("\x1bq");
 		expect(onQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("CustomEditor pasteImage default sourced from KEYBINDINGS", () => {
+	it("intercepts the registry's platform-aware pasteImage default (single source of truth)", () => {
+		const editor = createEditor();
+		const onPasteImage = vi.fn();
+		editor.onPasteImage = onPasteImage;
+
+		const def = KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys;
+		const key = Array.isArray(def) ? def[0]! : def;
+		// ctrl+v on most platforms, alt+v on win32 — both come from the registry now.
+		const data = key === "alt+v" ? "\x1bv" : ctrl("v");
+
+		editor.handleInput(data);
+		expect(onPasteImage).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/coding-agent/test/keybindings-audit.test.ts
+++ b/packages/coding-agent/test/keybindings-audit.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { KEYBINDINGS } from "../src/config/keybindings";
+
+const DOC_PATH = join(import.meta.dir, "../../../docs/keybindings.md");
+
+describe("docs/keybindings.md current-surface audit", () => {
+	it("documents every registry action ID (no drift)", () => {
+		const doc = readFileSync(DOC_PATH, "utf8");
+		const missing = Object.keys(KEYBINDINGS).filter(id => !doc.includes(`\`${id}\``));
+		expect(missing).toEqual([]);
+	});
+});

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -265,6 +265,30 @@ export class KeybindingsManager {
 	}
 }
 
+/**
+ * Detect default-key collisions across the registry: keys whose default
+ * binding is claimed by more than one action. Cross-context collisions are
+ * often intentional (the dispatch context disambiguates them), so this is a
+ * diagnostics aid for auditing the surface, not an error by itself.
+ */
+export function detectDefaultKeyCollisions(definitions: KeybindingDefinitions): KeybindingConflict[] {
+	const claims = new Map<KeyId, Set<Keybinding>>();
+	for (const [id, definition] of Object.entries(definitions)) {
+		for (const key of normalizeKeys(definition.defaultKeys)) {
+			const claimants = claims.get(key) ?? new Set<Keybinding>();
+			claimants.add(id as Keybinding);
+			claims.set(key, claimants);
+		}
+	}
+	const collisions: KeybindingConflict[] = [];
+	for (const [key, keybindings] of claims) {
+		if (keybindings.size > 1) {
+			collisions.push({ key, keybindings: [...keybindings] });
+		}
+	}
+	return collisions;
+}
+
 let globalKeybindings: KeybindingsManager | null = null;
 
 export function setKeybindings(keybindings: KeybindingsManager): void {

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { KeybindingsManager, TUI_KEYBINDINGS } from "@gajae-code/tui/keybindings";
+import { detectDefaultKeyCollisions, KeybindingsManager, TUI_KEYBINDINGS } from "@gajae-code/tui/keybindings";
 
 describe("KeybindingsManager", () => {
 	it("does not evict selector confirm when input submit is rebound", () => {
@@ -33,5 +33,34 @@ describe("KeybindingsManager", () => {
 			},
 		]);
 		expect(keybindings.getKeys("tui.editor.cursorLeft")).toEqual(["left", "ctrl+b"]);
+	});
+});
+
+describe("detectDefaultKeyCollisions", () => {
+	it("reports keys whose default binding is claimed by more than one action", () => {
+		const collisions = detectDefaultKeyCollisions({
+			"tui.input.submit": { defaultKeys: "enter", description: "Submit" },
+			"tui.select.confirm": { defaultKeys: "enter", description: "Confirm" },
+			"tui.editor.cursorUp": { defaultKeys: "up", description: "Up" },
+		});
+
+		expect(collisions).toEqual([{ key: "enter", keybindings: ["tui.input.submit", "tui.select.confirm"] }]);
+	});
+
+	it("returns no collisions when every default key is unique", () => {
+		expect(
+			detectDefaultKeyCollisions({
+				"a.one": { defaultKeys: "ctrl+a", description: "" },
+				"a.two": { defaultKeys: ["ctrl+b", "alt+b"], description: "" },
+			}),
+		).toEqual([]);
+	});
+
+	it("flags the known cross-context default reuse in TUI_KEYBINDINGS", () => {
+		const byKey = new Map(detectDefaultKeyCollisions(TUI_KEYBINDINGS).map(c => [c.key, c.keybindings]));
+		// enter is intentionally shared by submit + confirm (context-disambiguated).
+		expect(byKey.get("enter")).toEqual(expect.arrayContaining(["tui.input.submit", "tui.select.confirm"]));
+		// ctrl+c is shared by input copy + select cancel.
+		expect(byKey.get("ctrl+c")).toEqual(expect.arrayContaining(["tui.input.copy", "tui.select.cancel"]));
 	});
 });


### PR DESCRIPTION
## Keybindings reconciliation — Phase 1 (partial)

First increment of the phased keybindings reconciliation toward peer parity
(Claude Code / Codex / opencode / oh-my-pi). Produced via deep-interview →
ralplan consensus → ultragoal execution.

- Spec: `.gjc/specs/deep-interview-keybindings-reconciliation.md`
- Plan: `.gjc/plans/ralplan/2026-06-20-1443-c6e9/pending-approval.md`

### What's in this PR
- **pasteImage single source of truth.** `CustomEditor` previously kept its own
  `DEFAULT_ACTION_KEYS` table with a hardcoded `ctrl+v` pasteImage default,
  which diverged from the registry's platform-aware default (`alt+v` on win32).
  Defaults are now derived from the central `KEYBINDINGS` registry, eliminating
  the divergence and the duplicate table.
- **Default-collision diagnostics.** New `detectDefaultKeyCollisions(definitions)`
  in `@gajae-code/tui/keybindings` reports keys whose default binding is claimed
  by more than one action (cross-context reuse is often intentional; this is an
  audit aid). User-remap conflicts remain reported by `getConflicts()`.
- **Docs.** `docs/keybindings.md` gains a collision-auditing section and corrects
  two audit classifications (`app.clipboard.copyLine` is registry-backed;
  `tui.input.copy` is declared but not dispatched by `Editor.handleInput`).
- **Tests** for both changes.

### Verification
- `bun test` on the touched keybindings/editor suites: pass (26 tests).
- `tsc --noEmit` clean for `packages/tui` and `packages/coding-agent`.
- `biome check` clean.

### Backward compatibility
No changes to default chords or to the `~/.gjc/agent/keybindings.json` format.
No migration required for this increment.

### Follow-ups (remaining phases — separate PRs)
1. **Phase 1 completion:** resolve/annotate the cross-context default collisions
   (ctrl+p, ctrl+s, ctrl+r, ctrl+d, ctrl+b, ctrl+left/right), close remaining
   remap gaps, regenerate the full current-surface audit table (all
   `tui.editor.*` and `app.*` actions; split grouped rows), wire diagnostics
   into a user-facing surface.
2. **Phase 2:** define context adapter/dispatch semantics, then migrate the
   hardcoded contexts (tree-selector, Shift+Ctrl+D debug, model-selector) into
   the registry while preserving selector search fallthrough + global debug
   precedence.
3. **Phase 3:** presets (readline/emacs-lite + cleaned classic/default).
4. **Phase 4:** in-TUI Codex `/keymap`-style interactive remap panel.
5. **Phase 5:** vim modal mode.
