### PR TITLE
test(coding-agent): set session ids for scoped state tests

### DIFF
--- a/packages/coding-agent/test/coordinator-mcp-policy.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-policy.test.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
 
 describe("Hermes MCP safety policy", () => {
 	it("defaults to read-only with no implicit global namespace", () => {
-		const config = buildCoordinatorMcpConfig({});
+		const config = buildCoordinatorMcpConfig({ GJC_SESSION_ID: "coordinator-policy-test-session" });
 
 		expect(config.mutationClasses.size).toBe(0);
 		expect(config.namespace.profile).toBeNull();
@@ -32,7 +32,10 @@ describe("Hermes MCP safety policy", () => {
 	});
 
 	it("requires startup mutation opt-in and per-call allow_mutation", () => {
-		const config = buildCoordinatorMcpConfig({ GJC_COORDINATOR_MCP_MUTATIONS: "sessions,reports" });
+		const config = buildCoordinatorMcpConfig({
+			GJC_SESSION_ID: "coordinator-policy-test-session",
+			GJC_COORDINATOR_MCP_MUTATIONS: "sessions,reports",
+		});
 
 		expect(() => requireCoordinatorMutation(config, "sessions", { allow_mutation: false })).toThrow(
 			"coordinator_mutation_call_not_allowed",
@@ -46,7 +49,10 @@ describe("Hermes MCP safety policy", () => {
 	it("rejects workdirs outside canonical allowlisted roots", async () => {
 		const root = await tempRoot();
 		const outside = await tempRoot();
-		const config = buildCoordinatorMcpConfig({ GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root });
+		const config = buildCoordinatorMcpConfig({
+			GJC_SESSION_ID: "coordinator-policy-test-session",
+			GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+		});
 
 		await expect(assertCoordinatorWorkdir(config, path.join(root, "child"))).resolves.toBe(path.join(root, "child"));
 		await expect(assertCoordinatorWorkdir(config, outside)).rejects.toThrow(
@@ -66,6 +72,7 @@ describe("Hermes MCP safety policy", () => {
 		await Bun.write(path.join(outside, "secret.txt"), "secret");
 		await fs.symlink(path.join(outside, "secret.txt"), escapedLink);
 		const config = buildCoordinatorMcpConfig({
+			GJC_SESSION_ID: "coordinator-policy-test-session",
 			GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
 			GJC_COORDINATOR_MCP_ARTIFACT_BYTE_CAP: "3",
 		});

--- a/packages/coding-agent/test/rlm-autonomous.test.ts
+++ b/packages/coding-agent/test/rlm-autonomous.test.ts
@@ -27,12 +27,20 @@ import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
 import type { RlmCellResult } from "@gajae-code/coding-agent/rlm/types";
 
 let tmp: string;
+let previousGjcSessionId: string | undefined;
 
 beforeEach(async () => {
 	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-auto-"));
+	previousGjcSessionId = process.env.GJC_SESSION_ID;
+	process.env.GJC_SESSION_ID = "rlm-autonomous-test-session";
 });
 
 afterEach(async () => {
+	if (previousGjcSessionId === undefined) {
+		delete process.env.GJC_SESSION_ID;
+	} else {
+		process.env.GJC_SESSION_ID = previousGjcSessionId;
+	}
 	await fs.rm(tmp, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/rlm-e2e.test.ts
+++ b/packages/coding-agent/test/rlm-e2e.test.ts
@@ -34,14 +34,22 @@ east,300
 
 let cwd: string;
 let sessionId: string;
+let previousGjcSessionId: string | undefined;
 
 beforeEach(async () => {
 	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "rlm-e2e-"));
 	sessionId = generateRlmSessionId();
+	previousGjcSessionId = process.env.GJC_SESSION_ID;
+	process.env.GJC_SESSION_ID = "rlm-e2e-test-session";
 });
 
 afterEach(async () => {
 	await disposeKernelSessionsByOwner(`rlm:${sessionId}`);
+	if (previousGjcSessionId === undefined) {
+		delete process.env.GJC_SESSION_ID;
+	} else {
+		process.env.GJC_SESSION_ID = previousGjcSessionId;
+	}
 	await fs.rm(cwd, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/unattended-session-redteam.test.ts
+++ b/packages/coding-agent/test/unattended-session-redteam.test.ts
@@ -179,28 +179,38 @@ describe("UnattendedSessionControlPlane red-team G011", () => {
 
 describe("AskTool unattended gate red-team G011", () => {
 	it("decodes a multi-select gate answer to multiple selectedOptions", async () => {
-		const emitter = new StubEmitter(() => ({ selected: ["JWT", "OAuth2"], other: false }));
-		const tool = new AskTool(createSession(emitter));
+		const previousGjcSessionId = process.env.GJC_SESSION_ID;
+		process.env.GJC_SESSION_ID = "unattended-redteam-ask-test-session";
+		try {
+			const emitter = new StubEmitter(() => ({ selected: ["JWT", "OAuth2"], other: false }));
+			const tool = new AskTool(createSession(emitter));
 
-		const result = await tool.execute(
-			"call-redteam-multi",
-			{
-				questions: [
-					{
-						id: "auth",
-						question: "Which auth methods?",
-						options: [{ label: "JWT" }, { label: "OAuth2" }, { label: "Passkeys" }],
-						multi: true,
-					},
-				],
-			},
-			undefined,
-			undefined,
-			createContext(),
-		);
+			const result = await tool.execute(
+				"call-redteam-multi",
+				{
+					questions: [
+						{
+							id: "auth",
+							question: "Which auth methods?",
+							options: [{ label: "JWT" }, { label: "OAuth2" }, { label: "Passkeys" }],
+							multi: true,
+						},
+					],
+				},
+				undefined,
+				undefined,
+				createContext(),
+			);
 
-		expect(emitter.received).toHaveLength(1);
-		expect(emitter.received[0]).toMatchObject({ stage: "deep-interview", kind: "question" });
-		expect(result.details).toMatchObject({ selectedOptions: ["JWT", "OAuth2"] });
+			expect(emitter.received).toHaveLength(1);
+			expect(emitter.received[0]).toMatchObject({ stage: "deep-interview", kind: "question" });
+			expect(result.details).toMatchObject({ selectedOptions: ["JWT", "OAuth2"] });
+		} finally {
+			if (previousGjcSessionId === undefined) {
+				delete process.env.GJC_SESSION_ID;
+			} else {
+				process.env.GJC_SESSION_ID = previousGjcSessionId;
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- set explicit `GJC_SESSION_ID` values in tests that now exercise session-scoped runtime/artifact state after #924
- cover RLM e2e/autonomous helpers, coordinator MCP policy config, and AskTool ultragoal-guard path
- leave product code unchanged

## Verification
- `HOME=/tmp/gjc-devci-repro-home bun test packages/coding-agent/test/rlm-autonomous.test.ts packages/coding-agent/test/rlm-e2e.test.ts packages/coding-agent/test/coordinator-mcp-policy.test.ts packages/coding-agent/test/rlm.test.ts --timeout 120000` ✅
- `HOME=/tmp/gjc-devci-repro-home bun test packages/coding-agent/test/unattended-session-redteam.test.ts packages/coding-agent/test/rlm-autonomous.test.ts packages/coding-agent/test/rlm-e2e.test.ts packages/coding-agent/test/coordinator-mcp-policy.test.ts --timeout 120000` ✅
- `HOME=$(mktemp -d /tmp/gjc-test-home.XXXXXX) bun test packages/coding-agent/test/agent-session-auto-compaction-x-initiator.test.ts --timeout 120000` ✅
- `HOME=/tmp/gjc-devci-repro-home bun --cwd=packages/coding-agent run test` progressed through the original #926 failures; one local run hit temp-HOME auth contamination in `agent-session-auto-compaction-x-initiator.test.ts`, then the test passed in a fresh HOME (listed above).

Closes #926
