### PR TITLE
test(setup): isolate Hermes smoke state root

### DIFF
--- a/packages/coding-agent/src/setup/hermes-setup.ts
+++ b/packages/coding-agent/src/setup/hermes-setup.ts
@@ -404,7 +404,7 @@ async function installConfig(spec: CoordinatorSetupSpec, force: boolean): Promis
 
 async function runSmoke(spec: CoordinatorSetupSpec): Promise<HermesSetupResult["smoke"]> {
 	const requiredTools = [...COORDINATOR_MCP_TOOL_NAMES];
-	const server = createCoordinatorMcpServer({ env: {} });
+	const server = createCoordinatorMcpServer({ env: renderHermesServerBlock(spec).env as NodeJS.ProcessEnv });
 	const listed = await server.handleJsonRpc({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
 	const listedResult = isRecord(listed.result) ? listed.result : {};
 	const tools = Array.isArray(listedResult.tools) ? listedResult.tools : [];

--- a/packages/coding-agent/test/setup-cli.test.ts
+++ b/packages/coding-agent/test/setup-cli.test.ts
@@ -4,7 +4,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { YAML } from "bun";
 import { parseSetupArgs, runSetupCommand } from "../src/cli/setup-cli";
-import { runHermesSetup } from "../src/setup/hermes-setup";
 import { addApiCompatibleProvider } from "../src/setup/provider-onboarding";
 
 let tempRoot: string | undefined;
@@ -65,7 +64,11 @@ describe("setup CLI parsing", () => {
 			stdout: "pipe",
 			stderr: "pipe",
 		});
-		const [exitCode, stdout, stderr] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
 
 		expect({ exitCode, stdout, stderr }).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
 	});

--- a/packages/coding-agent/test/setup-cli.test.ts
+++ b/packages/coding-agent/test/setup-cli.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { YAML } from "bun";
 import { parseSetupArgs, runSetupCommand } from "../src/cli/setup-cli";
+import { runHermesSetup } from "../src/setup/hermes-setup";
+import { addApiCompatibleProvider } from "../src/setup/provider-onboarding";
 
 let tempRoot: string | undefined;
 
@@ -37,14 +39,35 @@ describe("setup CLI parsing", () => {
 		});
 	});
 
-	it("rejects provider flags unless provider setup is explicit", () => {
-		vi.spyOn(console, "error").mockImplementation(() => {});
-		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
-			throw new Error("exit");
-		}) as (code?: string | number | null | undefined) => never);
+	it("rejects provider flags unless provider setup is explicit", async () => {
+		const proc = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"-e",
+				`import { parseSetupArgs } from "./src/cli/setup-cli";
+				const errors = [];
+				const realExit = process.exit;
+				console.error = (...args) => errors.push(args.join(" "));
+				process.exit = code => { throw new Error("exit " + code); };
+				try {
+					parseSetupArgs(["setup", "--provider", "proxy", "--compat", "openai"]);
+					process.exit(2);
+				} catch (error) {
+					if (String(error?.message ?? error) === "exit 1" && errors.some(error => error.includes("Provider setup flags require the explicit"))) {
+						process.stdout.write("ok");
+						realExit(0);
+					}
+					process.stderr.write(String(error?.stack ?? error));
+					realExit(1);
+				}`,
+			],
+			cwd: path.join(import.meta.dir, ".."),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 
-		expect(() => parseSetupArgs(["setup", "--provider", "proxy", "--compat", "openai"])).toThrow("exit");
-		expect(exit).toHaveBeenCalledWith(1);
+		expect({ exitCode, stdout, stderr }).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
 	});
 
 	it("allows provider flags for explicit provider setup", () => {
@@ -57,49 +80,29 @@ describe("setup CLI parsing", () => {
 	it("rejects preset provider setup with arbitrary CLI base URL, model, or API key env", async () => {
 		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-setup-cli-"));
 		const modelsPath = path.join(tempRoot, "models.yml");
-		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-		vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined): never => {
-			throw new Error(`exit ${code}`);
-		});
 
 		await expect(
-			runSetupCommand({
-				component: "provider",
-				flags: {
-					json: true,
-					preset: "minimax",
-					baseUrl: "https://example.invalid/v1",
-					modelsPath,
-				},
+			addApiCompatibleProvider({
+				preset: "minimax",
+				baseUrl: "https://example.invalid/v1",
+				modelsPath,
 			}),
-		).rejects.toThrow("exit 1");
+		).rejects.toThrow("fixed base URL");
 		await expect(
-			runSetupCommand({
-				component: "provider",
-				flags: {
-					json: true,
-					preset: "minimax",
-					model: ["custom-model"],
-					modelsPath,
-				},
+			addApiCompatibleProvider({
+				preset: "minimax",
+				models: ["custom-model"],
+				modelsPath,
 			}),
-		).rejects.toThrow("exit 1");
+		).rejects.toThrow("fixed model ids");
 		await expect(
-			runSetupCommand({
-				component: "provider",
-				flags: {
-					json: true,
-					preset: "minimax",
-					apiKeyEnv: "CUSTOM_KEY",
-					modelsPath,
-				},
+			addApiCompatibleProvider({
+				preset: "minimax",
+				apiKeyEnv: "CUSTOM_KEY",
+				modelsPath,
 			}),
-		).rejects.toThrow("exit 1");
+		).rejects.toThrow("MINIMAX_CODE_API_KEY");
 
-		const errors = stdout.mock.calls.map(call => String(call[0])).join("\n");
-		expect(errors).toContain("fixed base URL");
-		expect(errors).toContain("fixed model ids");
-		expect(errors).toContain("MINIMAX_CODE_API_KEY");
 		expect(await Bun.file(modelsPath).exists()).toBe(false);
 	});
 
@@ -290,22 +293,32 @@ describe("setup CLI parsing", () => {
 					},
 				}),
 			);
-			vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-			vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined): never => {
-				throw new Error(`exit ${code}`);
+			const proc = Bun.spawn({
+				cmd: [
+					process.execPath,
+					"-e",
+					`import { runHermesSetup } from "./src/setup/hermes-setup";
+					try {
+						await runHermesSetup({ json: true, install: true, root: [${JSON.stringify(tempRoot)}], target: ${JSON.stringify(configPath)} });
+						process.exit(1);
+					} catch (error) {
+						const message = String(error?.message ?? error);
+						if (error?.name === "HermesSetupError" && message.includes("already exists and is not managed by GJC")) {
+							process.stdout.write("ok");
+							process.exit(0);
+						}
+						process.stderr.write(String(error?.stack ?? error));
+						process.exit(1);
+					}`,
+				],
+				cwd: path.join(import.meta.dir, ".."),
+				stdout: "pipe",
+				stderr: "pipe",
 			});
+			const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
 
-			await expect(
-				runSetupCommand({
-					component: "hermes",
-					flags: {
-						json: true,
-						install: true,
-						root: [tempRoot],
-						target: configPath,
-					},
-				}),
-			).rejects.toThrow("exit 3");
+			expect(exitCode).toBe(0);
+			expect(stdout).toBe("ok");
 		});
 
 		it("smoke checks the current Hermes MCP tool contract without provider credentials", async () => {
@@ -318,6 +331,7 @@ describe("setup CLI parsing", () => {
 					json: true,
 					smoke: true,
 					root: [tempRoot],
+					stateRoot: path.join(tempRoot, "state"),
 				},
 			});
 


### PR DESCRIPTION
## Summary
- make Hermes setup smoke use the generated coordinator MCP env so explicit setup state roots are honored
- give the setup CLI smoke test a temp state root instead of relying on GJC_SESSION_ID
- avoid parent test-process exit contamination in negative setup-path checks

## Verification
- bun --cwd=packages/natives run build
- bun test packages/coding-agent/test/setup-cli.test.ts --timeout 120000
- bun test packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/keybindings-audit.test.ts packages/coding-agent/test/setup-cli.test.ts --timeout 120000

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*