### PR TITLE
fix(coding-agent): tolerate missing session env in guard reads

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/policy.ts
+++ b/packages/coding-agent/src/coordinator-mcp/policy.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { coordinatorMcpStateRoot } from "../gjc-runtime/session-layout";
+import { coordinatorMcpStateRoot, gjcRoot } from "../gjc-runtime/session-layout";
 
 export type CoordinatorMutationClass = "sessions" | "questions" | "reports";
 
@@ -74,11 +74,16 @@ function cleanScope(value: string | undefined): string | null {
 	return trimmed.replace(/[^a-zA-Z0-9_.-]+/g, "-").slice(0, 100) || null;
 }
 
+function defaultCoordinatorMcpStateRoot(cwd: string, gjcSessionId?: string): string {
+	return gjcSessionId
+		? coordinatorMcpStateRoot(cwd, gjcSessionId)
+		: path.join(gjcRoot(cwd), "state", "coordinator-mcp");
+}
+
 export function buildCoordinatorMcpConfig(env: NodeJS.ProcessEnv = process.env): CoordinatorMcpConfig {
 	const stateRootOverride = env.GJC_COORDINATOR_MCP_STATE_ROOT?.trim();
 	const gjcSessionId = env.GJC_SESSION_ID?.trim();
-	const stateRoot = stateRootOverride || (gjcSessionId ? coordinatorMcpStateRoot(process.cwd(), gjcSessionId) : null);
-	if (!stateRoot) throw new Error("GJC_SESSION_ID is required for default coordinator MCP state root");
+	const stateRoot = stateRootOverride || defaultCoordinatorMcpStateRoot(process.cwd(), gjcSessionId);
 	return {
 		allowedRoots: parseRootList(env.GJC_COORDINATOR_MCP_WORKDIR_ROOTS).map(root => path.resolve(root)),
 		mutationClasses: parseMutationClasses(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
 import {
 	computeUltragoalPlanGeneration,
 	getUltragoalPaths,
@@ -10,6 +11,7 @@ import {
 	type UltragoalCompletionVerification,
 	type UltragoalGoal,
 	type UltragoalLedgerEvent,
+	type UltragoalPaths,
 	type UltragoalPlan,
 	type UltragoalReceiptKind,
 } from "./ultragoal-runtime";
@@ -63,9 +65,30 @@ function isKnownUltragoalObjective(currentObjective: string): boolean {
 	);
 }
 
-async function hasDurableUltragoalState(cwd: string): Promise<boolean> {
+async function ultragoalReadPaths(cwd: string): Promise<UltragoalPaths> {
+	const envSessionId = process.env.GJC_SESSION_ID?.trim();
+	if (envSessionId) return getUltragoalPaths(cwd, envSessionId);
 	try {
-		await fs.stat(getUltragoalPaths(cwd, process.env.GJC_SESSION_ID).dir);
+		const session = await resolveGjcSessionForRead(cwd, { envSessionId: process.env.GJC_SESSION_ID });
+		return getUltragoalPaths(cwd, session.gjcSessionId);
+	} catch (error) {
+		if (error instanceof SessionResolutionError && error.code === "no_session") {
+			return getUltragoalPaths(cwd, null);
+		}
+		throw error;
+	}
+}
+
+async function hasDurableUltragoalState(cwd: string): Promise<boolean> {
+	let paths: UltragoalPaths;
+	try {
+		paths = await ultragoalReadPaths(cwd);
+	} catch (error) {
+		if (error instanceof SessionResolutionError) return true;
+		throw error;
+	}
+	try {
+		await fs.stat(paths.dir);
 		return true;
 	} catch (error) {
 		if (
@@ -331,7 +354,15 @@ export async function readUltragoalVerificationState(input: {
 }
 
 export async function isUltragoalAskBlocked(cwd: string): Promise<UltragoalAskBlockDiagnostic> {
-	const paths = getUltragoalPaths(cwd, process.env.GJC_SESSION_ID);
+	let paths: UltragoalPaths;
+	try {
+		paths = await ultragoalReadPaths(cwd);
+	} catch (error) {
+		return activeAskDiagnostic({
+			reason: `Unable to resolve durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,
+			source: "durable_state_unreadable",
+		});
+	}
 	try {
 		await fs.stat(paths.dir);
 	} catch (error) {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -7,7 +7,7 @@ import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "..
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { latestUltragoalLedgerEventFromText } from "./ledger-event-renderer";
-import { sessionUltragoalDir } from "./session-layout";
+import { gjcRoot, sessionUltragoalDir } from "./session-layout";
 import { resolveGjcSessionForRead, resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
 import { reconcileWorkflowSkillState } from "./state-runtime";
@@ -170,8 +170,7 @@ export function hashStructuredValue(value: unknown): string {
 
 export function getUltragoalPaths(cwd: string, sessionId?: string | null): UltragoalPaths {
 	const explicitSessionId = sessionId?.trim() || process.env.GJC_SESSION_ID?.trim();
-	if (!explicitSessionId) throw new Error("ultragoal paths require a session id");
-	const dir = sessionUltragoalDir(cwd, explicitSessionId);
+	const dir = explicitSessionId ? sessionUltragoalDir(cwd, explicitSessionId) : path.join(gjcRoot(cwd), "ultragoal");
 	return {
 		dir,
 		briefPath: path.join(dir, "brief.md"),

--- a/packages/coding-agent/test/coordinator-mcp-policy.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-policy.test.ts
@@ -22,9 +22,22 @@ afterEach(async () => {
 });
 
 describe("Hermes MCP safety policy", () => {
-	it("defaults to read-only with no implicit global namespace", () => {
+	it("defaults to read-only with a deterministic local state root when no session env exists", () => {
+		const config = buildCoordinatorMcpConfig({});
+
+		expect(config.stateRoot).toBe(path.join(process.cwd(), ".gjc", "state", "coordinator-mcp"));
+		expect(config.mutationClasses.size).toBe(0);
+		expect(config.namespace.profile).toBeNull();
+		expect(config.namespace.repo).toBeNull();
+		expect(config.artifactByteCap).toBe(65536);
+	});
+
+	it("scopes the default state root to GJC_SESSION_ID when present", () => {
 		const config = buildCoordinatorMcpConfig({ GJC_SESSION_ID: "coordinator-policy-test-session" });
 
+		expect(config.stateRoot).toContain(
+			path.join(".gjc", "_session-coordinator-policy-test-session", "state", "coordinator-mcp"),
+		);
 		expect(config.mutationClasses.size).toBe(0);
 		expect(config.namespace.profile).toBeNull();
 		expect(config.namespace.repo).toBeNull();

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -15,6 +15,8 @@ import { AskTool } from "@gajae-code/coding-agent/tools/ask";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
 import { guardToolForUltragoalAsk } from "@gajae-code/coding-agent/tools/ultragoal-ask-guard";
 
+const TEST_SESSION_ID = "ultragoal-ask-guard-test-session";
+const ORIGINAL_GJC_SESSION_ID = process.env.GJC_SESSION_ID;
 const tempRoots: string[] = [];
 
 async function tempDir(): Promise<string> {
@@ -24,6 +26,8 @@ async function tempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+	if (ORIGINAL_GJC_SESSION_ID === undefined) delete process.env.GJC_SESSION_ID;
+	else process.env.GJC_SESSION_ID = ORIGINAL_GJC_SESSION_ID;
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -83,15 +87,24 @@ class StubExtensionWrappedAskTool {
 }
 
 describe("ultragoal ask guard", () => {
-	it("allows ask when durable ultragoal state is absent", async () => {
+	it("allows ask when durable ultragoal state is absent without requiring ambient GJC_SESSION_ID", async () => {
 		const cwd = await tempDir();
-		const diagnostic = await isUltragoalAskBlocked(cwd);
-		expect(diagnostic.active).toBe(false);
-		expect(diagnostic.source).toBe("absent");
+		const previousSessionId = process.env.GJC_SESSION_ID;
+		delete process.env.GJC_SESSION_ID;
+		try {
+			const diagnostic = await isUltragoalAskBlocked(cwd);
+			expect(diagnostic.active).toBe(false);
+			expect(diagnostic.source).toBe("absent");
+			expect(diagnostic.goalsPath).toBe(path.join(cwd, ".gjc", "ultragoal", "goals.json"));
+		} finally {
+			if (previousSessionId === undefined) delete process.env.GJC_SESSION_ID;
+			else process.env.GJC_SESSION_ID = previousSessionId;
+		}
 	});
 
 	it("blocks SDK-initial-path style wrapped ask while ultragoal is active", async () => {
 		const cwd = await tempDir();
+		process.env.GJC_SESSION_ID = TEST_SESSION_ID;
 		await createUltragoalPlan({ cwd, brief: "Implement the story" });
 		const execute = vi.fn(async () => {});
 		const guarded = guardToolForUltragoalAsk(stubAskTool(execute), () => cwd);
@@ -117,6 +130,7 @@ describe("ultragoal ask guard", () => {
 
 	it("blocks an unwrapped AskTool before prompting while ultragoal is active", async () => {
 		const cwd = await tempDir();
+		process.env.GJC_SESSION_ID = TEST_SESSION_ID;
 		await createUltragoalPlan({ cwd, brief: "Implement the story" });
 		const select = vi.fn(async () => "Yes");
 		const tool = new AskTool(createSession(cwd));
@@ -135,6 +149,7 @@ describe("ultragoal ask guard", () => {
 
 	it("allows ask when the ultragoal run is verified complete", async () => {
 		const cwd = await tempDir();
+		process.env.GJC_SESSION_ID = TEST_SESSION_ID;
 		await createUltragoalPlan({ cwd, brief: "Implement the story" });
 		const paths = getUltragoalPaths(cwd);
 		const now = new Date().toISOString();

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -102,6 +102,20 @@ describe("ultragoal ask guard", () => {
 		}
 	});
 
+	it("blocks latest session-scoped ultragoal ask when GJC_SESSION_ID is absent", async () => {
+		const cwd = await tempDir();
+		process.env.GJC_SESSION_ID = TEST_SESSION_ID;
+		await createUltragoalPlan({ cwd, brief: "Implement the story" });
+		delete process.env.GJC_SESSION_ID;
+
+		const diagnostic = await isUltragoalAskBlocked(cwd);
+
+		expect(diagnostic.active).toBe(true);
+		expect(diagnostic.source).toBe("goals_json");
+		expect(diagnostic.goalsPath).toBe(getUltragoalPaths(cwd, TEST_SESSION_ID).goalsPath);
+		expect(diagnostic.message).toContain("record-review-blockers");
+	});
+
 	it("blocks SDK-initial-path style wrapped ask while ultragoal is active", async () => {
 		const cwd = await tempDir();
 		process.env.GJC_SESSION_ID = TEST_SESSION_ID;


### PR DESCRIPTION
Fixes #929.

## Summary
- make ultragoal read-paths fall back to a deterministic local `.gjc/ultragoal` directory when no `GJC_SESSION_ID` exists
- make coordinator MCP default to a deterministic local state root without opening mutation classes or namespaces
- add regression coverage for no ambient session env plus the session-scoped path when env is present

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts packages/coding-agent/test/coordinator-mcp-policy.test.ts packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*