### PR TITLE
test(coding-agent): scope plugin activation state tests to sessions

### DIFF
--- a/packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts
@@ -93,15 +93,17 @@ describe("GJC sub-skill activation dispatch", () => {
 		const result = await resolveSubskillActivationForSkillInvocation({ cwd, skillName: "ralplan", args: "--design" });
 		expect(result.activation).toBeDefined();
 
+		const sessionId = "activation-pack-session";
 		await syncSkillActiveState({
 			cwd,
+			sessionId,
 			skill: "ralplan",
 			active: true,
 			phase: result.activation!.phase,
 			active_subskills: result.activeSubskillsToPersist.map(toActiveSubskillEntry),
 		});
 
-		const executorSubskills = await readActiveSubskillsForParent({ cwd, parent: "executor", phase: "prompt" });
+		const executorSubskills = await readActiveSubskillsForParent({ cwd, sessionId, parent: "executor", phase: "prompt" });
 		expect(executorSubskills).toHaveLength(1);
 		expect(executorSubskills[0]).toMatchObject({
 			plugin: "combined-pack",
@@ -180,15 +182,17 @@ describe("GJC sub-skill activation dispatch", () => {
 		const result = await resolveSubskillActivationForSkillInvocation({ cwd, skillName: "ralplan", args: "--design" });
 		expect(result.activation).toBeDefined();
 
+		const sessionId = "active-subskill-writer-session";
 		await syncSkillActiveState({
 			cwd,
+			sessionId,
 			skill: "ralplan",
 			active: true,
 			phase: "planner",
 			active_subskills: result.activeSubskillsToPersist.map(toActiveSubskillEntry),
 		});
 
-		const persisted = await readActiveSubskillsForParent({ cwd, parent: "ralplan", phase: "planner" });
+		const persisted = await readActiveSubskillsForParent({ cwd, sessionId, parent: "ralplan", phase: "planner" });
 		expect(persisted).toHaveLength(1);
 		expect(persisted[0]).toMatchObject({
 			plugin: "valid-skill-plugin",
@@ -198,12 +202,13 @@ describe("GJC sub-skill activation dispatch", () => {
 
 		await syncSkillActiveState({
 			cwd,
+			sessionId,
 			skill: "ralplan",
 			active: true,
 			phase: "planner",
 		});
 
-		const preserved = await readActiveSubskillsForParent({ cwd, parent: "ralplan", phase: "planner" });
+		const preserved = await readActiveSubskillsForParent({ cwd, sessionId, parent: "ralplan", phase: "planner" });
 		expect(preserved).toHaveLength(1);
 		expect(preserved[0]).toMatchObject({
 			plugin: "valid-skill-plugin",
@@ -213,13 +218,14 @@ describe("GJC sub-skill activation dispatch", () => {
 
 		await syncSkillActiveState({
 			cwd,
+			sessionId,
 			skill: "ralplan",
 			active: true,
 			phase: "planner",
 			active_subskills: [],
 		});
 
-		const cleared = await readActiveSubskillsForParent({ cwd, parent: "ralplan", phase: "planner" });
+		const cleared = await readActiveSubskillsForParent({ cwd, sessionId, parent: "ralplan", phase: "planner" });
 		expect(cleared).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
Fixes #929.

## Summary
- Update the plugin activation dispatch tests that still exercised sessionless active-state persistence.
- Pass explicit `sessionId` through `syncSkillActiveState` and `readActiveSubskillsForParent` so the tests match the current session-scoped state-writer contract.

## Verification
- `bun test packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts`
- `HOME=$(mktemp -d /tmp/gajae-code-929-home.XXXXXX) bun test packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts`

## CI context
- Dev CI run <https://github.com/Yeachan-Heo/gajae-code/actions/runs/27884303960> failed `Affected path validation / test:@gajae-code/coding-agent` on `gjc-plugin-activation-dispatch.test.ts` because two tests expected active subskills from a sessionless read path.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
