### PR TITLE
feat(coding-agent): add research plan ledger spike

### DIFF
--- a/docs/research-plan-ledger.md
+++ b/docs/research-plan-ledger.md
@@ -1,0 +1,92 @@
+# Research plan items and evidence ledger
+
+Research/deep-research workflows need a planning contract that is stronger than an execution-order checklist. A plan item should name the claim under investigation, the uncertainty around it, what evidence is required, what counterexamples would falsify it, and how a verifier should handle source conflicts.
+
+This document defines the public product-facing spike for issue #932. It intentionally avoids private operator, session, channel, and routing internals.
+
+## Research plan item schema
+
+```ts
+type ResearchPlanConfidence = "low" | "medium" | "high";
+
+type ResearchPlanItem = {
+  claim: string;
+  confidence: ResearchPlanConfidence;
+  unknowns: string[];
+  evidenceNeeded: string[];
+  counterexampleQueries: string[];
+  sourceConflictPolicy: string;
+  dropCondition: string;
+  verifierChecks: string[];
+};
+```
+
+Field intent:
+
+- `claim`: The smallest claim that can survive or fail verification.
+- `confidence`: Planner's initial confidence before evidence collection.
+- `unknowns`: Known gaps the final answer must resolve or explicitly carry forward.
+- `evidenceNeeded`: Evidence workers must collect before the claim can be accepted.
+- `counterexampleQueries`: Directed search prompts for evidence that would weaken or falsify the claim.
+- `sourceConflictPolicy`: How the verifier treats conflicting sources, stale sources, or mismatched methodology.
+- `dropCondition`: The explicit condition that removes this claim from the final answer.
+- `verifierChecks`: Checklist the verifier applies before accepting the claim.
+
+## Evidence ledger schema
+
+```ts
+type ResearchEvidenceVerdict = "support" | "contradict" | "uncertain";
+
+type ResearchEvidenceEntry = {
+  claim: string;
+  source: string;
+  confidence: ResearchPlanConfidence;
+  verdict: ResearchEvidenceVerdict;
+  notes?: string;
+};
+
+type ResearchLedgerVerdict = {
+  claim: string;
+  finalVerdict: "accepted" | "rejected" | "uncertain";
+  survivingSources: ResearchEvidenceEntry[];
+  rejectReason?: string;
+  unresolvedUnknowns: string[];
+};
+```
+
+The ledger is claim-centric. Workers add evidence entries against plan-item claims; the verifier reduces those entries into a final verdict. Accepted claims can be cited in the final answer. Rejected claims are named with `rejectReason`. Uncertain claims are either excluded or marked explicitly as unresolved.
+
+## Ralplan/research workflow shape
+
+1. Planner emits `ResearchPlanItem[]` alongside the normal plan narrative when the task is research-heavy.
+2. Workers gather independent evidence for each item, including counterexample-oriented searches.
+3. Verifier checks contradictions, source quality, stale information, and unresolved uncertainty using the item's `verifierChecks`, `sourceConflictPolicy`, and `dropCondition`.
+4. The final answer cites accepted claims, lists rejected claims with reasons, and marks any surviving uncertainty.
+
+## Example
+
+```ts
+const item: ResearchPlanItem = {
+  claim: "Model X reduces latency by 30% on production-like workloads",
+  confidence: "medium",
+  unknowns: ["production workload mix"],
+  evidenceNeeded: ["benchmark with production-like fixture", "baseline comparison"],
+  counterexampleQueries: ["regression on long-context workload", "cold-start latency increase"],
+  sourceConflictPolicy: "Reject the claim when any credible counterexample contradicts the benchmark.",
+  dropCondition: "Drop if a counterexample contradicts the claim or key unknowns remain unresolved.",
+  verifierChecks: ["check source freshness", "compare benchmark harness", "inspect counterexample evidence"],
+};
+```
+
+If the ledger contains a supporting benchmark and a credible long-context counterexample, the verifier rejects the broad claim instead of letting a plausible summary survive by vibes.
+
+## Current spike
+
+The first implementation spike lives in `packages/coding-agent/src/research-plan/ledger.ts` and provides:
+
+- TypeScript interfaces for research plan items, evidence entries, and final verdicts.
+- Validators for product-facing plan/evidence objects.
+- A deterministic verifier helper that rejects plausible claims when counterexample/source-conflict/drop-condition evidence applies.
+- Regression tests in `packages/coding-agent/test/research-plan-ledger.test.ts`.
+
+Future runtime integration can make `/skill:ralplan` emit these structures as a fenced JSON block or structured sidecar in the persisted ralplan artifact. The spike keeps the schema independent from private session state so it can be exposed in docs and tests safely.

--- a/packages/coding-agent/src/research-plan/index.ts
+++ b/packages/coding-agent/src/research-plan/index.ts
@@ -1,0 +1,1 @@
+export * from "./ledger";

--- a/packages/coding-agent/src/research-plan/ledger.ts
+++ b/packages/coding-agent/src/research-plan/ledger.ts
@@ -1,0 +1,169 @@
+export type ResearchPlanConfidence = "low" | "medium" | "high";
+
+export type ResearchEvidenceVerdict = "support" | "contradict" | "uncertain";
+
+export interface ResearchPlanItem {
+	claim: string;
+	confidence: ResearchPlanConfidence;
+	unknowns: string[];
+	evidenceNeeded: string[];
+	counterexampleQueries: string[];
+	sourceConflictPolicy: string;
+	dropCondition: string;
+	verifierChecks: string[];
+}
+
+export interface ResearchEvidenceEntry {
+	claim: string;
+	source: string;
+	confidence: ResearchPlanConfidence;
+	verdict: ResearchEvidenceVerdict;
+	notes?: string;
+}
+
+export interface ResearchLedgerVerdict {
+	claim: string;
+	finalVerdict: "accepted" | "rejected" | "uncertain";
+	survivingSources: ResearchEvidenceEntry[];
+	rejectReason?: string;
+	unresolvedUnknowns: string[];
+}
+
+export interface ResearchPlanValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+const CONFIDENCE_VALUES = new Set<ResearchPlanConfidence>(["low", "medium", "high"]);
+const EVIDENCE_VERDICTS = new Set<ResearchEvidenceVerdict>(["support", "contradict", "uncertain"]);
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateStringArray(value: unknown, field: string, minLength = 1): string[] {
+	if (!Array.isArray(value)) return [`${field} must be an array`];
+	if (value.length < minLength) return [`${field} must contain at least ${minLength} item(s)`];
+	return value.flatMap((item, index) =>
+		isNonEmptyString(item) ? [] : [`${field}[${index}] must be a non-empty string`],
+	);
+}
+
+export function validateResearchPlanItem(item: Partial<ResearchPlanItem>): ResearchPlanValidationResult {
+	const errors: string[] = [];
+	if (!isNonEmptyString(item.claim)) errors.push("claim must be a non-empty string");
+	if (!item.confidence || !CONFIDENCE_VALUES.has(item.confidence)) {
+		errors.push("confidence must be one of: low, medium, high");
+	}
+	errors.push(...validateStringArray(item.unknowns, "unknowns", 0));
+	errors.push(...validateStringArray(item.evidenceNeeded, "evidenceNeeded"));
+	errors.push(...validateStringArray(item.counterexampleQueries, "counterexampleQueries"));
+	if (!isNonEmptyString(item.sourceConflictPolicy)) errors.push("sourceConflictPolicy must be a non-empty string");
+	if (!isNonEmptyString(item.dropCondition)) errors.push("dropCondition must be a non-empty string");
+	errors.push(...validateStringArray(item.verifierChecks, "verifierChecks"));
+	return { valid: errors.length === 0, errors };
+}
+
+export function validateResearchEvidenceEntry(entry: Partial<ResearchEvidenceEntry>): ResearchPlanValidationResult {
+	const errors: string[] = [];
+	if (!isNonEmptyString(entry.claim)) errors.push("claim must be a non-empty string");
+	if (!isNonEmptyString(entry.source)) errors.push("source must be a non-empty string");
+	if (!entry.confidence || !CONFIDENCE_VALUES.has(entry.confidence)) {
+		errors.push("confidence must be one of: low, medium, high");
+	}
+	if (!entry.verdict || !EVIDENCE_VERDICTS.has(entry.verdict)) {
+		errors.push("verdict must be one of: support, contradict, uncertain");
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+function lower(value: string): string {
+	return value.toLowerCase();
+}
+
+function matchesDropCondition(item: ResearchPlanItem, evidence: ResearchEvidenceEntry[]): string | undefined {
+	const condition = lower(item.dropCondition);
+	const contradiction = evidence.find(entry => entry.verdict === "contradict");
+	if (contradiction && /(counterexample|contradict|conflict|falsif)/.test(condition)) {
+		return `dropCondition matched by contradictory source: ${contradiction.source}`;
+	}
+	const unresolved = evidence.find(entry => entry.verdict === "uncertain");
+	if (unresolved && /(unknown|unresolved|uncertain)/.test(condition)) {
+		return `dropCondition matched by unresolved evidence: ${unresolved.source}`;
+	}
+	return undefined;
+}
+
+function sourceConflictReason(item: ResearchPlanItem, evidence: ResearchEvidenceEntry[]): string | undefined {
+	const supporting = evidence.filter(entry => entry.verdict === "support");
+	const contradicting = evidence.filter(entry => entry.verdict === "contradict");
+	if (supporting.length === 0 || contradicting.length === 0) return undefined;
+	const policy = lower(item.sourceConflictPolicy);
+	if (/(reject|drop|do not accept|prefer contradiction|requires resolution)/.test(policy)) {
+		return `sourceConflictPolicy rejected mixed support/contradiction (${supporting.length} support, ${contradicting.length} contradict)`;
+	}
+	return "source conflict remains unresolved";
+}
+
+export function evaluateResearchLedger(
+	item: ResearchPlanItem,
+	evidence: readonly ResearchEvidenceEntry[],
+): ResearchLedgerVerdict {
+	const relevantEvidence = evidence.filter(entry => entry.claim === item.claim);
+	const invalidItem = validateResearchPlanItem(item);
+	if (!invalidItem.valid) {
+		return {
+			claim: item.claim,
+			finalVerdict: "rejected",
+			survivingSources: [],
+			rejectReason: `invalid research plan item: ${invalidItem.errors.join("; ")}`,
+			unresolvedUnknowns: item.unknowns,
+		};
+	}
+	const invalidEvidence = relevantEvidence.flatMap(entry => validateResearchEvidenceEntry(entry).errors);
+	if (invalidEvidence.length > 0) {
+		return {
+			claim: item.claim,
+			finalVerdict: "rejected",
+			survivingSources: [],
+			rejectReason: `invalid evidence entry: ${invalidEvidence.join("; ")}`,
+			unresolvedUnknowns: item.unknowns,
+		};
+	}
+	if (relevantEvidence.length === 0) {
+		return {
+			claim: item.claim,
+			finalVerdict: "uncertain",
+			survivingSources: [],
+			rejectReason: "no evidence collected for claim",
+			unresolvedUnknowns: item.unknowns,
+		};
+	}
+	const dropReason = matchesDropCondition(item, relevantEvidence) ?? sourceConflictReason(item, relevantEvidence);
+	if (dropReason) {
+		return {
+			claim: item.claim,
+			finalVerdict: "rejected",
+			survivingSources: relevantEvidence.filter(entry => entry.verdict === "support"),
+			rejectReason: dropReason,
+			unresolvedUnknowns: item.unknowns,
+		};
+	}
+	const uncertain = relevantEvidence.some(entry => entry.verdict === "uncertain");
+	const supporting = relevantEvidence.filter(entry => entry.verdict === "support");
+	if (uncertain || supporting.length === 0) {
+		return {
+			claim: item.claim,
+			finalVerdict: "uncertain",
+			survivingSources: supporting,
+			rejectReason: uncertain ? "unresolved uncertainty remains" : "no supporting evidence survived verification",
+			unresolvedUnknowns: item.unknowns,
+		};
+	}
+	return {
+		claim: item.claim,
+		finalVerdict: "accepted",
+		survivingSources: supporting,
+		unresolvedUnknowns: [],
+	};
+}

--- a/packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-activation-dispatch.test.ts
@@ -103,7 +103,12 @@ describe("GJC sub-skill activation dispatch", () => {
 			active_subskills: result.activeSubskillsToPersist.map(toActiveSubskillEntry),
 		});
 
-		const executorSubskills = await readActiveSubskillsForParent({ cwd, sessionId, parent: "executor", phase: "prompt" });
+		const executorSubskills = await readActiveSubskillsForParent({
+			cwd,
+			sessionId,
+			parent: "executor",
+			phase: "prompt",
+		});
 		expect(executorSubskills).toHaveLength(1);
 		expect(executorSubskills[0]).toMatchObject({
 			plugin: "combined-pack",

--- a/packages/coding-agent/test/research-plan-ledger.test.ts
+++ b/packages/coding-agent/test/research-plan-ledger.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+	evaluateResearchLedger,
+	type ResearchEvidenceEntry,
+	type ResearchPlanItem,
+	validateResearchPlanItem,
+} from "../src/research-plan";
+
+function makePlanItem(partial: Partial<ResearchPlanItem> = {}): ResearchPlanItem {
+	return {
+		claim: "Model X reduces latency by 30% on production-like workloads",
+		confidence: "medium",
+		unknowns: ["production workload mix"],
+		evidenceNeeded: ["benchmark with production-like fixture", "baseline comparison"],
+		counterexampleQueries: ["regression on long-context workload", "cold-start latency increase"],
+		sourceConflictPolicy: "Reject the claim when any credible counterexample contradicts the benchmark.",
+		dropCondition: "Drop if a counterexample contradicts the claim or key unknowns remain unresolved.",
+		verifierChecks: ["check source freshness", "compare benchmark harness", "inspect counterexample evidence"],
+		...partial,
+	};
+}
+
+describe("research plan ledger", () => {
+	it("validates the product-facing research plan item contract", () => {
+		const result = validateResearchPlanItem(makePlanItem());
+		expect(result).toEqual({ valid: true, errors: [] });
+	});
+
+	it("rejects incomplete plan items before workers collect evidence", () => {
+		const result = validateResearchPlanItem({
+			claim: " ",
+			confidence: "medium",
+			unknowns: [],
+			evidenceNeeded: [],
+			counterexampleQueries: [],
+			sourceConflictPolicy: "",
+			dropCondition: "",
+			verifierChecks: [],
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("claim must be a non-empty string");
+		expect(result.errors).toContain("evidenceNeeded must contain at least 1 item(s)");
+		expect(result.errors).toContain("counterexampleQueries must contain at least 1 item(s)");
+		expect(result.errors).toContain("sourceConflictPolicy must be a non-empty string");
+		expect(result.errors).toContain("dropCondition must be a non-empty string");
+		expect(result.errors).toContain("verifierChecks must contain at least 1 item(s)");
+	});
+
+	it("accepts a claim only when supporting evidence survives verification", () => {
+		const item = makePlanItem();
+		const evidence: ResearchEvidenceEntry[] = [
+			{
+				claim: item.claim,
+				source: "benchmarks/latency-prod-fixture.md",
+				confidence: "high",
+				verdict: "support",
+			},
+		];
+
+		const verdict = evaluateResearchLedger(item, evidence);
+		expect(verdict).toMatchObject({
+			claim: item.claim,
+			finalVerdict: "accepted",
+			unresolvedUnknowns: [],
+		});
+		expect(verdict.rejectReason).toBeUndefined();
+	});
+
+	it("rejects a plausible claim when counterexample evidence triggers the drop condition", () => {
+		const item = makePlanItem();
+		const evidence: ResearchEvidenceEntry[] = [
+			{
+				claim: item.claim,
+				source: "benchmarks/latency-prod-fixture.md",
+				confidence: "high",
+				verdict: "support",
+			},
+			{
+				claim: item.claim,
+				source: "counterexamples/long-context-regression.md",
+				confidence: "high",
+				verdict: "contradict",
+				notes: "Long-context p95 latency regressed by 18%, contradicting the broad latency-reduction claim.",
+			},
+		];
+
+		const verdict = evaluateResearchLedger(item, evidence);
+		expect(verdict.finalVerdict).toBe("rejected");
+		expect(verdict.rejectReason).toContain("contradictory source");
+		expect(verdict.rejectReason).toContain("counterexamples/long-context-regression.md");
+	});
+
+	it("marks claims uncertain when evidence collection never covers the plan item", () => {
+		const item = makePlanItem();
+		expect(evaluateResearchLedger(item, [])).toMatchObject({
+			claim: item.claim,
+			finalVerdict: "uncertain",
+			rejectReason: "no evidence collected for claim",
+			unresolvedUnknowns: ["production workload mix"],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements a narrow product-facing spike for #932:

- adds `ResearchPlanItem`, evidence entry, and ledger verdict types
- adds validators for research plan/evidence objects
- adds deterministic verifier helper that rejects plausible claims when counterexample/source-conflict/drop-condition evidence applies
- documents the public schema in `docs/research-plan-ledger.md`
- adds regression coverage for accepting supported claims, rejecting counterexample conflicts, and marking uncovered claims uncertain

## Verification

- `bun test packages/coding-agent/test/research-plan-ledger.test.ts` → 5 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` → pass

## Harness note

Attempted the clawhip-visible GJC tmux lane first. Global `gjc` resolved through a stale release worktree and failed to import `@gajae-code/utils/cli`; repo-local GJC loaded after native build but model call failed with `401 Invalid API key`. Because this repo allows owner-delegated direct non-main work when GJC is unavailable, I kept the patch narrow and test-backed.

Closes #932

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
