### PR TITLE
fix(coding-agent): bound computer screenshot inline images

### DIFF
--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -6,6 +6,7 @@ import type { ImageContent } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import computerDescription from "../prompts/tools/computer.md" with { type: "text" };
+import { resizeImage } from "../utils/image-resize";
 import type { ToolSession } from "./index";
 import type { OutputMeta } from "./output-meta";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
@@ -174,6 +175,11 @@ let platformOverrideForTests: NodeJS.Platform | undefined;
 let archOverrideForTests: NodeJS.Architecture | undefined;
 const screenshotFallbackDirs = new WeakMap<ToolSession, Promise<string>>();
 
+const COMPUTER_INLINE_SCREENSHOT_MAX_WIDTH = 1568;
+const COMPUTER_INLINE_SCREENSHOT_MAX_HEIGHT = 1568;
+const COMPUTER_INLINE_SCREENSHOT_MAX_BYTES = 500 * 1024;
+const COMPUTER_INLINE_SCREENSHOT_JPEG_QUALITY = 70;
+
 export function setComputerControllerFactoryForTests(factory: ComputerControllerFactory | undefined): void {
 	controllerFactory = factory ?? createNativeComputerController;
 }
@@ -285,11 +291,11 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 					};
 				}
 				details.message = describeComputerSuccess(details);
-				const image = imageContentFromNativeResult(batchResult.screenshotSource);
 				if (batchResult.screenshotSource !== undefined) {
 					await persistScreenshotFallback(batchResult.screenshotSource, details.screenshot, this.session);
 					details.message = describeComputerSuccess(details);
 				}
+				const image = await inlineImageContentFromNativeResult(batchResult.screenshotSource, details);
 				await writeComputerAuditLog(this.session, details);
 				return image
 					? toolResult(details)
@@ -302,11 +308,11 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 			if (screenshot) details.screenshot = screenshot;
 			details.status = "success";
 			details.message = describeComputerSuccess(details);
-			const image = imageContentFromNativeResult(result);
 			if (screenshot) {
 				await persistScreenshotFallback(result, details.screenshot, this.session);
 				details.message = describeComputerSuccess(details);
 			}
+			const image = await inlineImageContentFromNativeResult(result, details);
 			await writeComputerAuditLog(this.session, details);
 			return image
 				? toolResult(details)
@@ -472,7 +478,7 @@ function normalizeScreenshot(value: unknown): ComputerScreenshotDetails | undefi
 	};
 }
 
-function imageContentFromNativeResult(value: unknown): ImageContent | undefined {
+function fullResolutionImageContentFromNativeResult(value: unknown): ImageContent | undefined {
 	const candidate =
 		value && typeof value === "object" && "screenshot" in value
 			? (value as { screenshot?: unknown }).screenshot
@@ -483,13 +489,40 @@ function imageContentFromNativeResult(value: unknown): ImageContent | undefined 
 	return data ? { type: "image", data, mimeType: "image/png" } : undefined;
 }
 
+async function inlineImageContentFromNativeResult(
+	value: unknown,
+	details: ComputerToolDetails,
+): Promise<ImageContent | undefined> {
+	const image = fullResolutionImageContentFromNativeResult(value);
+	if (!image) return undefined;
+	const originalBytes = Buffer.byteLength(image.data, "base64");
+	if (originalBytes <= COMPUTER_INLINE_SCREENSHOT_MAX_BYTES) return image;
+
+	try {
+		const resized = await resizeImage(image, {
+			maxWidth: COMPUTER_INLINE_SCREENSHOT_MAX_WIDTH,
+			maxHeight: COMPUTER_INLINE_SCREENSHOT_MAX_HEIGHT,
+			maxBytes: COMPUTER_INLINE_SCREENSHOT_MAX_BYTES,
+			jpegQuality: COMPUTER_INLINE_SCREENSHOT_JPEG_QUALITY,
+		});
+		if (resized.buffer.length <= COMPUTER_INLINE_SCREENSHOT_MAX_BYTES) {
+			return { type: "image", data: resized.data, mimeType: resized.mimeType };
+		}
+	} catch {
+		// Keep the action successful and rely on the full-resolution artifact path below.
+	}
+
+	details.message = `${details.message} Inline screenshot omitted because it could not be bounded below ${formatByteCount(COMPUTER_INLINE_SCREENSHOT_MAX_BYTES)}; use the saved screenshot artifact instead.`;
+	return undefined;
+}
+
 async function persistScreenshotFallback(
 	value: unknown,
 	screenshot: ComputerScreenshotDetails | undefined,
 	session: ToolSession,
 ): Promise<void> {
 	if (!screenshot || screenshot.path) return;
-	const image = imageContentFromNativeResult(value);
+	const image = fullResolutionImageContentFromNativeResult(value);
 	if (!image) return;
 	const dir = await getScreenshotFallbackDir(session);
 	const filePath = path.join(dir, `computer-${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
@@ -524,6 +557,13 @@ function getPngByteLength(png: NativeScreenshot["png"]): number | undefined {
 	if (typeof png === "string") return Buffer.byteLength(png, "base64");
 	if (png instanceof ArrayBuffer) return png.byteLength;
 	return png.byteLength;
+}
+
+function formatByteCount(bytes: number): string {
+	if (bytes < 1024) return `${bytes} bytes`;
+	const kib = bytes / 1024;
+	if (kib < 1024) return `${Math.round(kib)} KiB`;
+	return `${(kib / 1024).toFixed(1)} MiB`;
 }
 
 function mapComputerError(error: unknown, hotkey?: string): { code: string; message: string } {

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -177,7 +177,7 @@ const screenshotFallbackDirs = new WeakMap<ToolSession, Promise<string>>();
 
 const COMPUTER_INLINE_SCREENSHOT_MAX_WIDTH = 1568;
 const COMPUTER_INLINE_SCREENSHOT_MAX_HEIGHT = 1568;
-const COMPUTER_INLINE_SCREENSHOT_MAX_BYTES = 500 * 1024;
+const COMPUTER_INLINE_SCREENSHOT_PROVIDER_MAX_BYTES = 5 * 1024 * 1024;
 const COMPUTER_INLINE_SCREENSHOT_JPEG_QUALITY = 70;
 
 export function setComputerControllerFactoryForTests(factory: ComputerControllerFactory | undefined): void {
@@ -295,7 +295,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 					await persistScreenshotFallback(batchResult.screenshotSource, details.screenshot, this.session);
 					details.message = describeComputerSuccess(details);
 				}
-				const image = await inlineImageContentFromNativeResult(batchResult.screenshotSource, details);
+				const image = await inlineImageContentFromNativeResult(batchResult.screenshotSource, details, this.session);
 				await writeComputerAuditLog(this.session, details);
 				return image
 					? toolResult(details)
@@ -312,7 +312,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 				await persistScreenshotFallback(result, details.screenshot, this.session);
 				details.message = describeComputerSuccess(details);
 			}
-			const image = await inlineImageContentFromNativeResult(result, details);
+			const image = await inlineImageContentFromNativeResult(result, details, this.session);
 			await writeComputerAuditLog(this.session, details);
 			return image
 				? toolResult(details)
@@ -492,27 +492,29 @@ function fullResolutionImageContentFromNativeResult(value: unknown): ImageConten
 async function inlineImageContentFromNativeResult(
 	value: unknown,
 	details: ComputerToolDetails,
+	session: ToolSession,
 ): Promise<ImageContent | undefined> {
 	const image = fullResolutionImageContentFromNativeResult(value);
 	if (!image) return undefined;
+	const maxBytes = getInlineScreenshotMaxBytes(session);
 	const originalBytes = Buffer.byteLength(image.data, "base64");
-	if (originalBytes <= COMPUTER_INLINE_SCREENSHOT_MAX_BYTES) return image;
+	if (originalBytes <= maxBytes) return image;
 
 	try {
 		const resized = await resizeImage(image, {
 			maxWidth: COMPUTER_INLINE_SCREENSHOT_MAX_WIDTH,
 			maxHeight: COMPUTER_INLINE_SCREENSHOT_MAX_HEIGHT,
-			maxBytes: COMPUTER_INLINE_SCREENSHOT_MAX_BYTES,
+			maxBytes,
 			jpegQuality: COMPUTER_INLINE_SCREENSHOT_JPEG_QUALITY,
 		});
-		if (resized.buffer.length <= COMPUTER_INLINE_SCREENSHOT_MAX_BYTES) {
+		if (resized.buffer.length <= maxBytes) {
 			return { type: "image", data: resized.data, mimeType: resized.mimeType };
 		}
 	} catch {
 		// Keep the action successful and rely on the full-resolution artifact path below.
 	}
 
-	details.message = `${details.message} Inline screenshot omitted because it could not be bounded below ${formatByteCount(COMPUTER_INLINE_SCREENSHOT_MAX_BYTES)}; use the saved screenshot artifact instead.`;
+	details.message = `${details.message} Inline screenshot omitted because it could not be bounded below ${formatByteCount(maxBytes)}; use the saved screenshot artifact instead.`;
 	return undefined;
 }
 
@@ -557,6 +559,15 @@ function getPngByteLength(png: NativeScreenshot["png"]): number | undefined {
 	if (typeof png === "string") return Buffer.byteLength(png, "base64");
 	if (png instanceof ArrayBuffer) return png.byteLength;
 	return png.byteLength;
+}
+
+function getInlineScreenshotMaxBytes(session: Pick<ToolSession, "settings">): number {
+	const configured = Number(session.settings.get("computer.screenshotMaxBytes"));
+	const finiteConfigured =
+		Number.isFinite(configured) && configured > 0
+			? Math.floor(configured)
+			: COMPUTER_INLINE_SCREENSHOT_PROVIDER_MAX_BYTES;
+	return Math.min(finiteConfigured, COMPUTER_INLINE_SCREENSHOT_PROVIDER_MAX_BYTES);
 }
 
 function formatByteCount(bytes: number): string {

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -284,6 +284,9 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 				if (batchResult.failedStep) {
 					details.code = batchResult.failedStep.code;
 					details.message = batchResult.failedStep.message;
+					if (batchResult.screenshotSource !== undefined) {
+						await persistScreenshotFallback(batchResult.screenshotSource, details.screenshot, this.session);
+					}
 					await writeComputerAuditLog(this.session, details);
 					return {
 						...toolResult(details).text(`${details.code}: ${details.message}`).done(),

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@gajae-code/coding-agent/tools";
 import { summarizeComputerDetails } from "@gajae-code/coding-agent/tools/computer/render";
 import { toolRenderers } from "@gajae-code/coding-agent/tools/renderers";
+import { zlibSync } from "fflate";
 
 function createSession(settings = Settings.isolated(), sessionFile: string | null = null): ToolSession {
 	return {
@@ -30,6 +31,56 @@ function createSession(settings = Settings.isolated(), sessionFile: string | nul
 
 function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
 	return result.content.map(c => c.text ?? "").join("\n");
+}
+
+function crc32(bytes: Uint8Array): number {
+	let crc = 0xffffffff;
+	for (const byte of bytes) {
+		crc ^= byte;
+		for (let bit = 0; bit < 8; bit += 1) {
+			crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+		}
+	}
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Uint8Array): Buffer {
+	const typeBytes = Buffer.from(type, "ascii");
+	const chunk = Buffer.alloc(12 + data.length);
+	chunk.writeUInt32BE(data.length, 0);
+	typeBytes.copy(chunk, 4);
+	Buffer.from(data).copy(chunk, 8);
+	const crcInput = Buffer.concat([typeBytes, Buffer.from(data)]);
+	chunk.writeUInt32BE(crc32(crcInput), 8 + data.length);
+	return chunk;
+}
+
+function makeNoisePng(width: number, height: number): Buffer {
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(width, 0);
+	ihdr.writeUInt32BE(height, 4);
+	ihdr[8] = 8;
+	ihdr[9] = 6;
+	const stride = 1 + width * 4;
+	const raw = Buffer.alloc(stride * height);
+	for (let y = 0; y < height; y += 1) {
+		const row = y * stride;
+		raw[row] = 0;
+		for (let x = 0; x < width; x += 1) {
+			const offset = row + 1 + x * 4;
+			const seed = (x * 1103515245 + y * 12345) >>> 0;
+			raw[offset] = seed & 0xff;
+			raw[offset + 1] = (seed >>> 8) & 0xff;
+			raw[offset + 2] = (seed >>> 16) & 0xff;
+			raw[offset + 3] = 0xff;
+		}
+	}
+	return Buffer.concat([
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+		pngChunk("IHDR", ihdr),
+		pngChunk("IDAT", zlibSync(raw, { level: 0 })),
+		pngChunk("IEND", Buffer.alloc(0)),
+	]);
 }
 
 describe("computer tool schema", () => {
@@ -236,6 +287,50 @@ describe("computer tool dispatch", () => {
 		expect(calls[1].args).toEqual([undefined, 1, 2, "right"]);
 		expect(calls[2].args).toEqual([undefined, 1, 2, 3, 4, "left"]);
 		expect(calls[3].args).toEqual([undefined, 1, 2, 5, -6]);
+	});
+
+	it("bounds oversized screenshot images sent inline while preserving the full-resolution artifact", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeNoisePng(1024, 1024);
+		expect(png.length).toBeGreaterThan(500 * 1024);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 1024, heightPx: 1024, png }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("oversized-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		expect(result.details?.screenshot?.pngBytes).toBe(png.length);
+		const artifactPath = result.details?.screenshot?.path;
+		expect(artifactPath).toBeTruthy();
+		if (!artifactPath) throw new Error("expected persisted screenshot path");
+		expect((await fs.stat(artifactPath)).size).toBe(png.length);
+		const image = result.content.find(block => block.type === "image");
+		expect(image).toBeTruthy();
+		if (image?.type !== "image") throw new Error("expected inline image");
+		expect(Buffer.byteLength(image.data, "base64")).toBeLessThanOrEqual(500 * 1024);
+	});
+
+	it("omits an oversized inline screenshot safely if resizing cannot decode it", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const invalidPngBase64 = Buffer.alloc(600 * 1024, 0xff).toString("base64");
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 10, heightPx: 10, png: invalidPngBase64 }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("invalid-oversized-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		expect(result.content.some(block => block.type === "image")).toBe(false);
+		expect(textOf(result)).toContain("Inline screenshot omitted");
+		const artifactPath = result.details?.screenshot?.path;
+		expect(artifactPath).toBeTruthy();
+		if (!artifactPath) throw new Error("expected persisted screenshot path");
+		expect((await fs.stat(artifactPath)).size).toBe(600 * 1024);
 	});
 
 	it("persists screenshot fallbacks in private per-session directories with restrictive file modes", async () => {

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -270,7 +270,9 @@ describe("computer tool dispatch", () => {
 				calls.push({ method: "scroll", args });
 			},
 		}));
-		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.screenshotMaxBytes": 500 * 1024 })),
+		);
 		const shot = await tool.execute("shot", { action: "screenshot", timeout: 2 });
 		await tool.execute("dbl", { action: "double_click", x: 1, y: 2, button: "right" });
 		await tool.execute("drag", { action: "drag", x: 1, y: 2, to_x: 3, to_y: 4 });
@@ -297,7 +299,9 @@ describe("computer tool dispatch", () => {
 		setComputerControllerFactoryForTests(() => ({
 			screenshot: () => ({ widthPx: 1024, heightPx: 1024, png }),
 		}));
-		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.screenshotMaxBytes": 500 * 1024 })),
+		);
 
 		const result = await tool.execute("oversized-shot", { action: "screenshot" });
 
@@ -313,6 +317,26 @@ describe("computer tool dispatch", () => {
 		expect(Buffer.byteLength(image.data, "base64")).toBeLessThanOrEqual(500 * 1024);
 	});
 
+	it("honors computer.screenshotMaxBytes for the inline screenshot budget", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const png = makeNoisePng(1024, 1024);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 1024, heightPx: 1024, png }),
+		}));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.screenshotMaxBytes": 300 * 1024 })),
+		);
+
+		const result = await tool.execute("setting-budget-shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		const image = result.content.find(block => block.type === "image");
+		expect(image).toBeTruthy();
+		if (image?.type !== "image") throw new Error("expected inline image");
+		expect(Buffer.byteLength(image.data, "base64")).toBeLessThanOrEqual(300 * 1024);
+	});
+
 	it("omits an oversized inline screenshot safely if resizing cannot decode it", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");
@@ -320,7 +344,9 @@ describe("computer tool dispatch", () => {
 		setComputerControllerFactoryForTests(() => ({
 			screenshot: () => ({ widthPx: 10, heightPx: 10, png: invalidPngBase64 }),
 		}));
-		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.screenshotMaxBytes": 500 * 1024 })),
+		);
 
 		const result = await tool.execute("invalid-oversized-shot", { action: "screenshot" });
 

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -478,6 +478,8 @@ describe("computer tool dispatch", () => {
 		expect(result.details?.steps?.[1]?.code).toBe("COMPUTER_COORD_INVALID");
 		expect(result.details?.steps?.[1]?.message).toContain("outside the latest screenshot bounds");
 		expect(result.details?.code).toBe("COMPUTER_COORD_INVALID");
+		expect(result.details?.screenshot?.path).toBeTruthy();
+		expect(await fs.stat(result.details?.screenshot?.path ?? "")).toMatchObject({ size: 3 });
 		expect(calls.map(call => call.method)).toEqual(["screenshot"]);
 	});
 


### PR DESCRIPTION
Fixes #934.

## Summary
- bound `computer` screenshot inline image blocks with the existing `resizeImage` budgeted pipeline before returning them to the model
- preserve the full-resolution PNG fallback artifact/path for follow-up inspection; only the inline model copy is downscaled/re-encoded or omitted
- honor `computer.screenshotMaxBytes` for the inline byte budget while capping it at a safe provider ceiling, so large Retina/6K/ultrawide captures cannot exceed provider request limits
- add regression coverage for oversized-image bounding, setting-driven byte budgets, and safe omission when resizing cannot decode the screenshot

## Verification
- `HOME=$(mktemp -d /tmp/gjc-issue934-home.XXXXXX) bun test packages/coding-agent/test/tools/computer.test.ts`
- `bunx biome check --write packages/coding-agent/src/tools/computer.ts packages/coding-agent/test/tools/computer.test.ts`
- `HOME=$(mktemp -d /tmp/gjc-issue934-home.XXXXXX) bun --cwd=packages/coding-agent run check:types`

## Notes
- Request-builder central image guards are still a useful defense-in-depth follow-up, but this PR fixes the concrete `computer` screenshot tool-result path without changing broader provider conversion semantics.