### PR TITLE
fix(computer): bound inline screenshot to the provider image limit (#934)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded the `computer` tool's inline screenshot so a single high-resolution capture (Retina/6K/ultrawide) can no longer exceed the provider's per-image limit and 400 the whole request; the model-facing image is downscaled/recompressed through the shared image-resize path while the full-resolution PNG is still persisted to disk for `inspect_image`/`read` (#934).
+
 ## [0.6.4] - 2026-06-20
 
 ### Changed

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -6,6 +6,7 @@ import type { ImageContent } from "@gajae-code/ai";
 import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import computerDescription from "../prompts/tools/computer.md" with { type: "text" };
+import { resizeImage } from "../utils/image-resize";
 import type { ToolSession } from "./index";
 import type { OutputMeta } from "./output-meta";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
@@ -285,7 +286,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 					};
 				}
 				details.message = describeComputerSuccess(details);
-				const image = imageContentFromNativeResult(batchResult.screenshotSource);
+				const image = await inlineImageFromNativeResult(batchResult.screenshotSource);
 				if (batchResult.screenshotSource !== undefined) {
 					await persistScreenshotFallback(batchResult.screenshotSource, details.screenshot, this.session);
 					details.message = describeComputerSuccess(details);
@@ -302,7 +303,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 			if (screenshot) details.screenshot = screenshot;
 			details.status = "success";
 			details.message = describeComputerSuccess(details);
-			const image = imageContentFromNativeResult(result);
+			const image = await inlineImageFromNativeResult(result);
 			if (screenshot) {
 				await persistScreenshotFallback(result, details.screenshot, this.session);
 				details.message = describeComputerSuccess(details);
@@ -472,15 +473,63 @@ function normalizeScreenshot(value: unknown): ComputerScreenshotDetails | undefi
 	};
 }
 
-function imageContentFromNativeResult(value: unknown): ImageContent | undefined {
+function nativeScreenshot(value: unknown): NativeScreenshot | undefined {
 	const candidate =
 		value && typeof value === "object" && "screenshot" in value
 			? (value as { screenshot?: unknown }).screenshot
 			: value;
 	if (!candidate || typeof candidate !== "object") return undefined;
-	const png = (candidate as NativeScreenshot).png;
-	const data = pngToBase64(png);
+	return candidate as NativeScreenshot;
+}
+
+function imageContentFromNativeResult(value: unknown): ImageContent | undefined {
+	const data = pngToBase64(nativeScreenshot(value)?.png);
 	return data ? { type: "image", data, mimeType: "image/png" } : undefined;
+}
+
+// Raw screenshot bytes for disk persistence — avoids round-tripping the full-resolution
+// PNG through base64 just to decode it back before writing.
+function pngBufferFromNativeResult(value: unknown): Uint8Array | undefined {
+	const png = nativeScreenshot(value)?.png;
+	if (png === undefined) return undefined;
+	if (typeof png === "string") return Buffer.from(png, "base64");
+	if (png instanceof ArrayBuffer) return new Uint8Array(png);
+	return png;
+}
+
+// The model-facing screenshot is bounded so a single capture can never exceed the
+// provider's per-image limit; an oversized image block 400s the whole request and wedges
+// the session. 1568px is Anthropic's internal vision threshold, so clamping to it is
+// effectively lossless for the model while keeping the payload small. The full-resolution
+// PNG is still persisted to disk (persistScreenshotFallback) for inspect_image/read.
+const SCREENSHOT_INLINE_MAX_EDGE = 1568;
+const SCREENSHOT_INLINE_MAX_BYTES = 3 * 1024 * 1024;
+// Hard ceiling on the base64 payload, matching the strictest provider per-image limit.
+// If a capture still exceeds this after resizing (e.g. it could not be decoded), omit the
+// inline image rather than send a block that would be rejected.
+const SCREENSHOT_INLINE_MAX_BASE64_BYTES = 5 * 1024 * 1024;
+
+async function inlineImageFromNativeResult(value: unknown): Promise<ImageContent | undefined> {
+	const raw = imageContentFromNativeResult(value);
+	if (!raw) return undefined;
+	const inline = await resizeForInline(raw);
+	if (Buffer.byteLength(inline.data, "utf8") > SCREENSHOT_INLINE_MAX_BASE64_BYTES) return undefined;
+	return inline;
+}
+
+async function resizeForInline(raw: ImageContent): Promise<ImageContent> {
+	try {
+		const resized = await resizeImage(raw, {
+			maxWidth: SCREENSHOT_INLINE_MAX_EDGE,
+			maxHeight: SCREENSHOT_INLINE_MAX_EDGE,
+			maxBytes: SCREENSHOT_INLINE_MAX_BYTES,
+		});
+		return { type: "image", data: resized.data, mimeType: resized.mimeType };
+	} catch {
+		// Could not re-encode (e.g. an undecodable capture); fall back to the raw image and
+		// let the base64 ceiling guard in the caller drop it if it is still too large.
+		return raw;
+	}
 }
 
 async function persistScreenshotFallback(
@@ -489,11 +538,11 @@ async function persistScreenshotFallback(
 	session: ToolSession,
 ): Promise<void> {
 	if (!screenshot || screenshot.path) return;
-	const image = imageContentFromNativeResult(value);
-	if (!image) return;
+	const buffer = pngBufferFromNativeResult(value);
+	if (!buffer) return;
 	const dir = await getScreenshotFallbackDir(session);
 	const filePath = path.join(dir, `computer-${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
-	await fs.writeFile(filePath, Buffer.from(image.data, "base64"), { mode: 0o600 });
+	await fs.writeFile(filePath, buffer, { mode: 0o600 });
 	screenshot.path = filePath;
 }
 

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -411,6 +411,68 @@ describe("computer tool dispatch", () => {
 		expect(result.details?.code).toBe("COMPUTER_SUPERVISOR_NOT_LIVE");
 		expect(textOf(result)).toContain("supervisor is not live");
 	});
+
+	it("downscales the inline screenshot while persisting the full-resolution capture", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		// 1x1 transparent PNG seed, upscaled to a real, decodable capture larger than the inline edge cap.
+		const seed = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+		const fullRes = await new Bun.Image(Buffer.from(seed, "base64")).resize(2000, 1400).png().bytes();
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 2000, heightPx: 1400, png: fullRes }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+		const result = await tool.execute("shot", { action: "screenshot" });
+
+		// Coordinate frame stays at native resolution.
+		expect(result.details?.screenshot).toMatchObject({ widthPx: 2000, heightPx: 1400 });
+
+		const image = result.content.find(block => block.type === "image") as { data: string } | undefined;
+		expect(image).toBeDefined();
+		const inlineMeta = await new Bun.Image(Buffer.from(image?.data ?? "", "base64")).metadata();
+		expect(inlineMeta.width).toBeLessThanOrEqual(1568);
+		expect(inlineMeta.height).toBeLessThanOrEqual(1568);
+		expect(inlineMeta.width).toBeLessThan(2000);
+
+		// Disk fallback keeps the full-resolution PNG.
+		const savedPath = result.details?.screenshot?.path;
+		expect(savedPath).toBeTruthy();
+		try {
+			const saved = await fs.readFile(savedPath ?? "");
+			expect(saved.length).toBe(fullRes.length);
+			const savedMeta = await new Bun.Image(saved).metadata();
+			expect(savedMeta.width).toBe(2000);
+			expect(savedMeta.height).toBe(1400);
+		} finally {
+			if (savedPath) await fs.rm(path.dirname(savedPath), { recursive: true, force: true });
+		}
+	});
+
+	it("omits the inline screenshot when it cannot be bounded, keeping the disk fallback", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		// An undecodable 6 MB capture: resizeImage cannot shrink it, so the oversized inline
+		// image block must be dropped rather than sent (it would 400 the request).
+		const oversized = new Uint8Array(6 * 1024 * 1024);
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => ({ widthPx: 6000, heightPx: 3400, png: oversized }),
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+		const result = await tool.execute("shot", { action: "screenshot" });
+
+		expect(result.isError).not.toBe(true);
+		expect(result.details?.status).toBe("success");
+		expect(result.content.some(block => block.type === "image")).toBe(false);
+
+		const savedPath = result.details?.screenshot?.path;
+		expect(savedPath).toBeTruthy();
+		try {
+			expect((await fs.stat(savedPath ?? "")).size).toBe(oversized.length);
+			expect(textOf(result)).toContain("saved");
+		} finally {
+			if (savedPath) await fs.rm(path.dirname(savedPath), { recursive: true, force: true });
+		}
+	});
 });
 
 describe("computer renderer", () => {


### PR DESCRIPTION
## What

Bound the `computer` tool's model-facing screenshot so a single capture can never exceed the provider's per-image limit.

- The inline image is now downscaled/recompressed through the shared `resizeImage` util (1568px longest edge, ~3 MB encoded budget), exactly like the `browser`/`fetch`/`read`/`inspect_image` tools already do.
- A hard base64 ceiling (5 MB) omits the inline image entirely if it still can't be bounded (e.g. an undecodable capture), instead of sending a block that would be rejected.
- The **full-resolution PNG is still persisted to disk** (`persistScreenshotFallback`) and its path is returned, so the model can `inspect_image`/`read` the original at full fidelity.
- The native coordinate frame (`details.screenshot.widthPx/heightPx`) is intentionally unchanged.
- Disk persistence now writes the raw native buffer directly instead of round-tripping the full-res PNG through base64.

## Why

The `computer` screenshot returned the native full-resolution PNG as an inline image block with **no size clamp**. On a Retina/6K/ultrawide display the base64 payload exceeds the Anthropic per-image limit, so the API returns `400 invalid_request_error` (`image exceeds 10 MB maximum: 12504100 bytes > 10485760 bytes`) and the session dies — the oversized `tool_result` stays in context and replays the same 400 on every retry.

`computer` was the only image-producing tool that did not route through `resizeImage`. Anthropic already downsizes images >1568px server-side for vision, so clamping to 1568px client-side is effectively lossless for the model while keeping the upload small — no coordinate drift.

Fixes #934

## Testing

- `bun test packages/coding-agent/test/tools/computer.test.ts` → 23 pass / 0 fail (2 new regression tests: a decodable 2000×1400 capture is downscaled to ≤1568px inline while the full-res PNG is persisted to disk; an undecodable 6 MB capture drops the inline block but still persists the file and reports the saved path).
- `bunx biome check packages/coding-agent/src/tools/computer.ts packages/coding-agent/test/tools/computer.test.ts` → clean.
- `bun run check:types` (packages/coding-agent, tsgo) → exit 0.
- `bun run check` (packages/coding-agent) → biome + types clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
