### PR TITLE
fix(coding-agent): isolate session-scoped test state

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -599,6 +599,7 @@ export async function createUltragoalPlan(input: {
 	cwd: string;
 	brief: string;
 	gjcGoalMode?: UltragoalGjcGoalMode;
+	sessionId?: string | null;
 }): Promise<UltragoalPlan> {
 	const brief = input.brief.trim();
 	if (!brief) throw new Error("ultragoal brief is required");
@@ -623,8 +624,8 @@ export async function createUltragoalPlan(input: {
 		createdAt: now,
 		updatedAt: now,
 	};
-	await writePlan(input.cwd, plan);
-	await appendLedger(input.cwd, { event: "plan_created", goalIds: plan.goals.map(goal => goal.id) });
+	await writePlan(input.cwd, plan, input.sessionId);
+	await appendLedger(input.cwd, { event: "plan_created", goalIds: plan.goals.map(goal => goal.id) }, input.sessionId);
 	return plan;
 }
 
@@ -661,12 +662,16 @@ export function getUltragoalRunCompletionState(
 	};
 }
 
-export async function startNextUltragoalGoal(input: { cwd: string; retryFailed?: boolean }): Promise<{
+export async function startNextUltragoalGoal(input: {
+	cwd: string;
+	retryFailed?: boolean;
+	sessionId?: string | null;
+}): Promise<{
 	plan: UltragoalPlan;
 	goal?: UltragoalGoal;
 	allComplete: boolean;
 }> {
-	const plan = await readUltragoalPlan(input.cwd);
+	const plan = await readUltragoalPlan(input.cwd, input.sessionId);
 	if (!plan) throw new Error("No ultragoal plan found. Run `gjc ultragoal create-goals --brief ...` first.");
 	const goal = chooseNextGoal(plan, input.retryFailed === true);
 	if (!goal) return { plan, allComplete: getUltragoalRunCompletionState(plan).allComplete };
@@ -676,8 +681,8 @@ export async function startNextUltragoalGoal(input: { cwd: string; retryFailed?:
 		goal.startedAt = goal.startedAt ?? now;
 		goal.updatedAt = now;
 		plan.updatedAt = now;
-		await writePlan(input.cwd, plan);
-		await appendLedger(input.cwd, { event: "goal_started", goalId: goal.id });
+		await writePlan(input.cwd, plan, input.sessionId);
+		await appendLedger(input.cwd, { event: "goal_started", goalId: goal.id }, input.sessionId);
 	}
 	return { plan, goal, allComplete: false };
 }

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -230,7 +230,7 @@ async function getActivePlanningSkill(
 	threadId?: string,
 ): Promise<ActivePlanningSkill | null> {
 	const resolvedSessionId = await resolveBoundarySessionId(cwd, sessionId);
-	if (!resolvedSessionId) return { skill: "deep-interview", phase: "unresolved-session" };
+	if (!resolvedSessionId) return null;
 	const skillState = await readVisibleSkillActiveState(cwd, resolvedSessionId);
 	if (!skillState) return null;
 	const activeEntries = listActiveSkills(skillState).filter(entry =>

--- a/packages/coding-agent/test/gjc-plugin-tools.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-tools.test.ts
@@ -37,9 +37,12 @@ export default factory;
 	return toolPath;
 }
 
+const TEST_SESSION_ID = "gjc-plugin-tools-test";
+
 async function writeActiveSubskill(cwd: string, toolPaths: string[]): Promise<void> {
 	await syncSkillActiveState({
 		cwd,
+		sessionId: TEST_SESSION_ID,
 		skill: "ralplan",
 		active: true,
 		phase: "planner",
@@ -70,11 +73,17 @@ describe("GJC plugin sub-skill tools", () => {
 		const toolPath = await writeTool(cwd, "domain-note.ts", "domain_note");
 		await writeActiveSubskill(cwd, [toolPath]);
 
-		const loaded = await loadActiveSubskillTools({ cwd, parent: "ralplan", phase: "planner" });
+		const loaded = await loadActiveSubskillTools({
+			cwd,
+			sessionId: TEST_SESSION_ID,
+			parent: "ralplan",
+			phase: "planner",
+		});
 		expect(loaded.map(tool => tool.name)).toEqual(["domain_note"]);
 
 		const reserved = await loadActiveSubskillTools({
 			cwd,
+			sessionId: TEST_SESSION_ID,
 			parent: "ralplan",
 			phase: "planner",
 			reservedToolNames: ["domain_note"],
@@ -89,6 +98,7 @@ describe("GJC plugin sub-skill tools", () => {
 
 		const loaded = await loadActiveSubskillTools({
 			cwd,
+			sessionId: TEST_SESSION_ID,
 			parent: "ralplan",
 			phase: "planner",
 			reservedToolNames: ["read"],
@@ -102,7 +112,12 @@ describe("GJC plugin sub-skill tools", () => {
 		const toolPath = await writeTool(cwd, "domain-note.ts", "domain_note");
 		await writeActiveSubskill(cwd, [toolPath]);
 
-		const loaded = await loadActiveSubskillTools({ cwd, parent: "team", phase: "planner" });
+		const loaded = await loadActiveSubskillTools({
+			cwd,
+			sessionId: TEST_SESSION_ID,
+			parent: "team",
+			phase: "planner",
+		});
 
 		expect(loaded).toEqual([]);
 	});

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -255,8 +255,9 @@ describe("GoalTool", () => {
 	it("blocks direct unified goal completion for active ultragoal objectives without verification receipt", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-goal-ultragoal-"));
 		try {
-			const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
-			await startNextUltragoalGoal({ cwd: root });
+			const sessionId = "goal-tool-ultragoal-test";
+			const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal", sessionId });
+			await startNextUltragoalGoal({ cwd: root, sessionId });
 			const harness = createRuntimeHarness({
 				enabled: true,
 				mode: "active",
@@ -265,6 +266,7 @@ describe("GoalTool", () => {
 			const tool = new GoalTool(
 				createToolSession({
 					cwd: root,
+					getSessionId: () => sessionId,
 					getGoalRuntime: () => harness.runtime,
 					getGoalModeState: () => harness.getState(),
 				}),

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolContext } from "@gajae-code/agent-core";
 import { validateToolArguments } from "@gajae-code/ai/utils/validation";
+import { sessionDirName } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { Settings } from "../../src/config/settings";
 import type { BashInterceptorRule } from "../../src/config/settings-schema";
 import { disposeAllShellSessions, getShellSessionCount } from "../../src/exec/bash-executor";
@@ -139,7 +140,7 @@ describe("BashTool restricted role-agent allowlist", () => {
 		const session = {
 			cwd,
 			getSessionFile: () => null,
-			getSessionId: () => undefined,
+			getSessionId: () => "restricted-bash-test",
 			bashAllowedPrefixes,
 			bashRestrictionProfile,
 			settings: {
@@ -270,13 +271,21 @@ describe("BashTool restricted role-agent allowlist", () => {
 			const bunPath = process.execPath;
 			const tool = createRestrictedBashTool(root, [`${bunPath} ${cliPath} ralplan --write`]);
 			const result = await tool.execute("tool-call", {
-				command: `${bunPath} ${cliPath} ralplan --write --stage architect --stage_n 1 --artifact ${artifactPath} --run-id bash-marker`,
+				command: `${bunPath} ${cliPath} ralplan --write --stage architect --stage_n 1 --artifact ${artifactPath} --run-id bash-marker --session-id restricted-bash-test`,
 				timeout: 30,
 			});
 
 			expect(result.content.find(part => part.type === "text")?.text).toContain("stage-01-architect.md");
 			const persisted = await fs.readFile(
-				path.join(root, ".gjc", "plans", "ralplan", "bash-marker", "stage-01-architect.md"),
+				path.join(
+					root,
+					".gjc",
+					sessionDirName("restricted-bash-test"),
+					"plans",
+					"ralplan",
+					"bash-marker",
+					"stage-01-architect.md",
+				),
 				"utf-8",
 			);
 			expect(persisted).toBe(`${artifactPath}\n`);

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -13,6 +13,8 @@ import {
 
 const originalFetch = global.fetch;
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
+const originalGeminiKey = Bun.env.GEMINI_API_KEY;
+const originalGoogleKey = Bun.env.GOOGLE_API_KEY;
 const originalOpenAIBaseUrl = Bun.env.OPENAI_BASE_URL;
 const generatedImagePaths: string[] = [];
 
@@ -29,8 +31,24 @@ afterEach(async () => {
 	} else {
 		Bun.env.OPENAI_BASE_URL = originalOpenAIBaseUrl;
 	}
+	if (originalGeminiKey === undefined) {
+		delete Bun.env.GEMINI_API_KEY;
+	} else {
+		Bun.env.GEMINI_API_KEY = originalGeminiKey;
+	}
+	if (originalGoogleKey === undefined) {
+		delete Bun.env.GOOGLE_API_KEY;
+	} else {
+		Bun.env.GOOGLE_API_KEY = originalGoogleKey;
+	}
 	setPreferredImageProvider("auto");
 });
+
+function clearFallbackImageProviderEnv(): void {
+	delete Bun.env.OPENROUTER_API_KEY;
+	delete Bun.env.GEMINI_API_KEY;
+	delete Bun.env.GOOGLE_API_KEY;
+}
 
 describe("imageGenTool", () => {
 	it("e2e writes OpenAI Responses image_generation WebP output to a temp file", async () => {
@@ -313,6 +331,7 @@ describe("imageGenTool antigravity provider", () => {
 
 	it("does not register for malformed JSON credentials without a token field", async () => {
 		setPreferredImageProvider("antigravity");
+		clearFallbackImageProviderEnv();
 
 		const modelRegistry = {
 			authStorage: {
@@ -327,6 +346,7 @@ describe("imageGenTool antigravity provider", () => {
 
 	it("does not register for empty or whitespace antigravity credentials", async () => {
 		setPreferredImageProvider("antigravity");
+		clearFallbackImageProviderEnv();
 
 		for (const credential of ["", "   \n\t  "]) {
 			const modelRegistry = {

--- a/packages/coding-agent/test/unattended-audit-redteam.test.ts
+++ b/packages/coding-agent/test/unattended-audit-redteam.test.ts
@@ -214,8 +214,18 @@ describe("UnattendedAuditLog red-team coverage", () => {
 		const root = tempDir();
 		const auditPath = defaultAuditPath("../run with/slashes and spaces", root);
 		const relative = path.relative(root, auditPath);
-		expect(relative).toBe(path.join(".gjc", "audit", "unattended", ".._run_with_slashes_and_spaces.jsonl"));
-		expect(path.dirname(auditPath)).toBe(path.join(root, ".gjc", "audit", "unattended"));
+		expect(relative).toBe(
+			path.join(
+				".gjc",
+				"_session-%2E%2E%2Frun%20with%2Fslashes%20and%20spaces",
+				"audit",
+				"unattended",
+				".._run_with_slashes_and_spaces.jsonl",
+			),
+		);
+		expect(path.dirname(auditPath)).toBe(
+			path.join(root, ".gjc", "_session-%2E%2E%2Frun%20with%2Fslashes%20and%20spaces", "audit", "unattended"),
+		);
 		expect(path.basename(auditPath)).not.toContain("/");
 		expect(path.basename(auditPath)).not.toContain(" ");
 	});


### PR DESCRIPTION
## Summary
- pass session ids through ultragoal plan/start helpers so session-scoped state is read/written consistently
- make planning mutation guard tolerate unresolved session boundaries instead of assuming an active deep-interview guard
- update affected tests to use explicit session ids and isolate image provider fallback env

## Verification
- `bun --cwd packages/coding-agent test test/gjc-plugin-tools.test.ts test/unattended-audit-redteam.test.ts test/goals/goal-tool.test.ts test/tools/root-path-alias.test.ts test/tools/search-path-lists.test.ts test/tools/bash-interceptor.test.ts test/tools/action-pending.test.ts test/tools/search-and-replace.test.ts test/tools/image-gen.test.ts`
- `cd packages/coding-agent && bun run check`

Fixes #936
