### PR TITLE
feat(keybindings): registry migration — global debug shortcut (Phase 2.1)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -150,6 +150,12 @@ Authoritative inventory of the keybinding registry, one row per action. Generate
 | `app.history.search` | `ctrl+r` | |
 | `app.stt.toggle` | `alt+h` | |
 
+### Global engine context (`tui.global.*`)
+
+| Action ID | Default | Notes |
+| --- | --- | --- |
+| `tui.global.debug` | `shift+ctrl+d` | Toggle debug overlay; resolved through the registry in `tui.ts` |
+
 Cross-context default reuse (`ctrl+p`, `ctrl+s`, `ctrl+r`, `ctrl+d`, `ctrl+b`, `ctrl+left`/`ctrl+right`, `enter`, `escape`, `ctrl+c`) is intentional: each pair is active in a different focused context and is disambiguated at dispatch time. Use `detectDefaultKeyCollisions()` (above) to re-derive this list from the registry.
 
 ### Not yet registry-managed
@@ -157,5 +163,4 @@ Cross-context default reuse (`ctrl+p`, `ctrl+s`, `ctrl+r`, `ctrl+d`, `ctrl+b`, `
 A few contexts still match chords directly instead of resolving through the registry, and are tracked for a later phase:
 
 - Tree selector (`tree-selector.ts`): up/down/left/right/enter, `ctrl+c`, filter cycling (`ctrl+o` / `ctrl+shift+o`), filter modes (`alt+d/t/u/l/a`), label edit (`shift+l`).
-- Global debug overlay: `shift+ctrl+d` (`tui.ts`).
 - Parts of the model selector.

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -39,6 +39,8 @@ export interface Keybindings {
 	"tui.select.pageDown": true;
 	"tui.select.confirm": true;
 	"tui.select.cancel": true;
+	// Global engine actions
+	"tui.global.debug": true;
 }
 
 export type Keybinding = keyof Keybindings;
@@ -133,6 +135,10 @@ export const TUI_KEYBINDINGS = {
 	"tui.select.cancel": {
 		defaultKeys: ["escape", "ctrl+c"],
 		description: "Cancel selection",
+	},
+	"tui.global.debug": {
+		defaultKeys: "shift+ctrl+d",
+		description: "Toggle debug overlay",
 	},
 } as const satisfies KeybindingDefinitions;
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -5,7 +5,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { $flag, getDebugLogPath } from "@gajae-code/utils";
-import { isKeyRelease, matchesKey } from "./keys";
+import { getKeybindings } from "./keybindings";
+import { isKeyRelease } from "./keys";
 import { renderMetrics } from "./metrics";
 import type { Terminal } from "./terminal";
 import { ImageProtocol, setCellDimensions, setTerminalImageProtocol, TERMINAL } from "./terminal-capabilities";
@@ -842,8 +843,8 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Global debug key handler (Shift+Ctrl+D)
-		if (matchesKey(data, "shift+ctrl+d") && this.onDebug) {
+		// Global debug key handler (registry: tui.global.debug, default Shift+Ctrl+D)
+		if (getKeybindings().matches(data, "tui.global.debug") && this.onDebug) {
 			this.onDebug();
 			return;
 		}

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -64,3 +64,21 @@ describe("detectDefaultKeyCollisions", () => {
 		expect(byKey.get("ctrl+c")).toEqual(expect.arrayContaining(["tui.input.copy", "tui.select.cancel"]));
 	});
 });
+
+describe("tui.global.debug registry action", () => {
+	it("resolves to the default Shift+Ctrl+D chord", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+		expect(keybindings.getKeys("tui.global.debug")).toEqual(["shift+ctrl+d"]);
+		expect(keybindings.matches("\x1b[100;6u", "tui.global.debug")).toBe(true);
+		expect(keybindings.matches("\x04", "tui.global.debug")).toBe(false);
+	});
+
+	it("is remappable like any other registry action", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.global.debug": "ctrl+alt+d",
+		});
+		expect(keybindings.getKeys("tui.global.debug")).toEqual(["ctrl+alt+d"]);
+		expect(keybindings.matches("\x1b[100;7u", "tui.global.debug")).toBe(true);
+		expect(keybindings.matches("\x1b[100;6u", "tui.global.debug")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Keybindings reconciliation — Phase 2 (registry migration), increment 1

First slice of Phase 2: bring hardcoded key-handling contexts into the
data-driven registry so they are remappable and appear in the audit/diagnostics.

**Stacked on #925 (Phase 1).** Base is `feat/key-customization`; retarget to
`dev` once #925 merges.

### This increment
- New registry action `tui.global.debug` (default `shift+ctrl+d`) added to the
  `Keybindings` interface and `TUI_KEYBINDINGS`.
- `tui.ts` now resolves the debug-overlay shortcut via
  `getKeybindings().matches("tui.global.debug")` instead of a hardcoded
  `matchesKey(data, "shift+ctrl+d")`. Behavior is unchanged (same default chord);
  the shortcut is now user-remappable and auditable.
- Removed the unused `matchesKey` import from `tui.ts`.
- `docs/keybindings.md` audit updated (new `tui.global.*` row; removed debug
  overlay from "not yet registry-managed").
- Tests: registry resolution + remap.

### Verification
- Full `packages/tui` suite: 543 pass, 0 fail.
- `tsc --noEmit` clean for `packages/tui` and `packages/coding-agent`.
- `biome` clean.

### Backward compatibility
No default chord changes; no migration required.

### Remaining Phase 2 (follow-up increments)
- Tree selector (`tree-selector.ts`): migrate up/down/left/right/enter, filter
  cycling/modes, label edit while preserving text-search fallthrough.
- Model selector hardcoded paths.
- Requires defining the context adapter/dispatch-priority semantics from the
  plan before the riskier selector migrations.
