### PR TITLE
feat(migrate): `gjc migrate` for skills + MCPs + collision-aware upsertMCPServer

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -43,6 +43,7 @@ const commands: CommandEntry[] = [
 		load: () => import("./commands/contribution-prep").then(m => m.default),
 	},
 	{ name: "deep-interview", load: () => import("./commands/deep-interview").then(m => m.default) },
+	{ name: "migrate", load: () => import("./commands/migrate").then(m => m.default) },
 	{ name: "rlm", load: () => import("./commands/rlm").then(m => m.default) },
 	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },

--- a/packages/coding-agent/src/cli/migrate-cli.ts
+++ b/packages/coding-agent/src/cli/migrate-cli.ts
@@ -1,0 +1,106 @@
+/**
+ * `gjc migrate` — import MCP servers and skills from other coding agents.
+ */
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getMCPConfigPath, getProjectAgentDir, getProjectDir } from "@gajae-code/utils";
+import { planMigration } from "../migrate/action-planner";
+import { getAdapter } from "../migrate/adapters/index";
+import { executeActions } from "../migrate/executor";
+import { buildReport, renderHuman } from "../migrate/report";
+import {
+	type AdapterResult,
+	CANONICAL_SOURCE_ORDER,
+	MIGRATE_SOURCES,
+	type MigrateDestinations,
+	type MigrateReport,
+	type MigrateSource,
+} from "../migrate/types";
+
+export interface MigrateCommandArgs {
+	from: string[];
+	project: boolean;
+	force: boolean;
+	dryRun: boolean;
+	json: boolean;
+	/** Test seam: override home dir for source discovery. */
+	homeDir?: string;
+	/** Test seam: override cwd for project-scope destinations. */
+	cwd?: string;
+}
+
+export class MigrateArgsError extends Error {}
+
+/** Expand `all`/repeated `--from`, validate, and return sources in canonical order. */
+export function resolveSources(from: string[]): MigrateSource[] {
+	if (from.length === 0) {
+		throw new MigrateArgsError("No source selected. Use --from <claude-code|codex|opencode|all> (repeatable).");
+	}
+	const selected = new Set<MigrateSource>();
+	for (const raw of from) {
+		const value = raw.trim().toLowerCase();
+		if (value === "all") {
+			for (const s of MIGRATE_SOURCES) selected.add(s);
+			continue;
+		}
+		if (!(MIGRATE_SOURCES as readonly string[]).includes(value)) {
+			throw new MigrateArgsError(`Unknown source "${raw}". Valid: ${MIGRATE_SOURCES.join(", ")}, all.`);
+		}
+		selected.add(value as MigrateSource);
+	}
+	return CANONICAL_SOURCE_ORDER.filter(s => selected.has(s));
+}
+
+function resolveDestinations(project: boolean, cwd: string): MigrateDestinations {
+	const scope = project ? "project" : "user";
+	const skillsDir = project ? path.join(getProjectAgentDir(cwd), "skills") : path.join(getAgentDir(), "skills");
+	return { mcpConfigPath: getMCPConfigPath(scope, cwd), skillsDir };
+}
+
+/** Run the migration and return the report (does not set process.exitCode). */
+export async function runMigrate(args: MigrateCommandArgs): Promise<MigrateReport> {
+	const sources = resolveSources(args.from);
+	const cwd = args.cwd ?? getProjectDir();
+	const homeDir = args.homeDir ?? os.homedir();
+	const destinations = resolveDestinations(args.project, cwd);
+
+	const results: AdapterResult[] = [];
+	for (const source of sources) {
+		results.push(await getAdapter(source).collect({ homeDir }));
+	}
+
+	const { actions, warnings } = await planMigration({ results, destinations, force: args.force });
+	const finalActions = args.dryRun ? actions : await executeActions(actions);
+
+	return buildReport({
+		actions: finalActions,
+		warnings,
+		sources,
+		destinations,
+		dryRun: args.dryRun,
+		project: args.project,
+		force: args.force,
+	});
+}
+
+/** CLI entry: run, render, and set the process exit code. */
+export async function runMigrateCommand(args: MigrateCommandArgs): Promise<void> {
+	let report: MigrateReport;
+	try {
+		report = await runMigrate(args);
+	} catch (error) {
+		if (error instanceof MigrateArgsError) {
+			process.stderr.write(`${error.message}\n`);
+			process.exitCode = 2;
+			return;
+		}
+		throw error;
+	}
+
+	if (args.json) {
+		process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+	} else {
+		process.stdout.write(`${renderHuman(report)}\n`);
+	}
+	process.exitCode = report.ok ? 0 : 1;
+}

--- a/packages/coding-agent/src/commands/migrate.ts
+++ b/packages/coding-agent/src/commands/migrate.ts
@@ -1,0 +1,46 @@
+/**
+ * Import MCP servers and skills from other coding agents into GJC.
+ */
+import { Command, Flags } from "@gajae-code/utils/cli";
+import { type MigrateCommandArgs, runMigrateCommand } from "../cli/migrate-cli";
+
+export default class Migrate extends Command {
+	static description = "Import MCP servers and skills from Claude Code, Codex, or OpenCode";
+
+	static examples = [
+		"gjc migrate --from claude-code",
+		"gjc migrate --from codex --from opencode",
+		"gjc migrate --from all --dry-run --json",
+		"gjc migrate --from claude-code --project --force",
+	];
+
+	static flags = {
+		from: Flags.string({
+			description: "Source agent to import from (repeatable): claude-code | codex | opencode | all",
+			multiple: true,
+			required: true,
+		}),
+		project: Flags.boolean({
+			description: "Write to the project scope (./.gjc) instead of the user scope (~/.gjc)",
+			default: false,
+		}),
+		force: Flags.boolean({
+			description: "Overwrite existing skills/MCP servers instead of skipping them",
+			default: false,
+		}),
+		"dry-run": Flags.boolean({ description: "Preview the migration without writing anything", default: false }),
+		json: Flags.boolean({ char: "j", description: "Emit a machine-readable JSON report", default: false }),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(Migrate);
+		const cmd: MigrateCommandArgs = {
+			from: flags.from ?? [],
+			project: flags.project,
+			force: flags.force,
+			dryRun: flags["dry-run"],
+			json: flags.json,
+		};
+		await runMigrateCommand(cmd);
+	}
+}

--- a/packages/coding-agent/src/migrate/action-planner.ts
+++ b/packages/coding-agent/src/migrate/action-planner.ts
@@ -1,0 +1,289 @@
+/**
+ * Central migration action planner.
+ *
+ * Reads destination state ONCE and produces an immutable list of actions that
+ * both dry-run and live execution consume unchanged. This is the single place
+ * that decides add/update/skip/fail, destinations, and warnings, guaranteeing
+ * dry-run/live parity.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, parseFrontmatter } from "@gajae-code/utils";
+import { readMCPConfigFile, validateServerName } from "../runtime-mcp/config-writer";
+import { mapMcpEntry } from "./mcp-mapper";
+import { slugify } from "./skill-normalizer";
+import type { AdapterResult, MigrateAction, MigrateDestinations, MigrateWarning } from "./types";
+
+export interface PlanInput {
+	results: AdapterResult[];
+	destinations: MigrateDestinations;
+	force: boolean;
+}
+
+export interface PlanOutput {
+	actions: MigrateAction[];
+	warnings: MigrateWarning[];
+}
+
+interface DestSkillIndex {
+	/** slug -> kind of existing destination entry. */
+	slugs: Map<string, "dir-with-skill" | "stale-dir" | "file">;
+	/** effective loaded name -> owning slug. */
+	effectiveNames: Map<string, string>;
+}
+
+async function indexDestinationSkills(skillsDir: string): Promise<DestSkillIndex> {
+	const index: DestSkillIndex = { slugs: new Map(), effectiveNames: new Map() };
+	const entries = await fs.readdir(skillsDir, { withFileTypes: true }).catch((error: unknown) => {
+		if (isEnoent(error)) return null;
+		throw error;
+	});
+	if (!entries) return index;
+	for (const entry of entries) {
+		const name = String(entry.name);
+		if (entry.isFile()) {
+			index.slugs.set(name, "file");
+			continue;
+		}
+		if (!entry.isDirectory()) continue;
+		const slug = name;
+		const skillFile = path.join(skillsDir, slug, "SKILL.md");
+		let content: string | undefined;
+		try {
+			content = await fs.readFile(skillFile, "utf-8");
+		} catch (error) {
+			if (isEnoent(error)) {
+				index.slugs.set(slug, "stale-dir");
+				continue;
+			}
+			throw error;
+		}
+		index.slugs.set(slug, "dir-with-skill");
+		const { frontmatter } = parseFrontmatter(content, { level: "off" });
+		const effective =
+			typeof frontmatter.name === "string" && frontmatter.name.trim() ? slugify(frontmatter.name) : slug;
+		index.effectiveNames.set(effective, slug);
+	}
+	return index;
+}
+
+export async function planMigration(input: PlanInput): Promise<PlanOutput> {
+	const actions: MigrateAction[] = [];
+	const warnings: MigrateWarning[] = [];
+
+	// 1. Source-level diagnostics become `source`-typed actions.
+	for (const result of input.results) {
+		for (const diag of result.diagnostics) {
+			actions.push({
+				source: diag.source,
+				type: "source",
+				operation: diag.status.startsWith("failed") ? "fail" : "skip",
+				status: diag.status,
+				reason: diag.message,
+			});
+		}
+	}
+
+	// 2. MCP actions — read the destination config once.
+	const existingConfig = await readMCPConfigFile(input.destinations.mcpConfigPath).catch(() => null);
+	const mcpInvalid = existingConfig === null;
+	const existingServers = new Set(Object.keys(existingConfig?.mcpServers ?? {}));
+	const disabledServers = new Set(existingConfig?.disabledServers ?? []);
+
+	for (const result of input.results) {
+		for (const candidate of result.mcpCandidates) {
+			const nameError = validateServerName(candidate.name);
+			if (nameError) {
+				actions.push({
+					source: candidate.source,
+					type: "mcp",
+					name: candidate.name,
+					operation: "fail",
+					status: "failed_invalid_source",
+					reason: nameError,
+				});
+				continue;
+			}
+			const mapped = mapMcpEntry(candidate.source, candidate.name, candidate.raw);
+			if (!mapped.ok) {
+				actions.push({
+					source: candidate.source,
+					type: "mcp",
+					name: candidate.name,
+					operation: mapped.status.startsWith("failed") ? "fail" : "skip",
+					status: mapped.status,
+					reason: mapped.reason,
+				});
+				continue;
+			}
+			for (const w of mapped.warnings)
+				warnings.push({ source: candidate.source, type: "mcp", name: candidate.name, message: w });
+
+			if (mcpInvalid) {
+				actions.push({
+					source: candidate.source,
+					type: "mcp",
+					name: candidate.name,
+					destination: input.destinations.mcpConfigPath,
+					operation: "fail",
+					status: "failed_invalid_destination",
+					reason: "destination mcp.json is malformed",
+				});
+				continue;
+			}
+
+			const exists = existingServers.has(candidate.name);
+			if (exists && !input.force) {
+				actions.push({
+					source: candidate.source,
+					type: "mcp",
+					name: candidate.name,
+					destination: input.destinations.mcpConfigPath,
+					operation: "skip",
+					status: "skipped_exists",
+				});
+				continue;
+			}
+			const actionWarnings = [...mapped.warnings];
+			if (exists && disabledServers.has(candidate.name)) {
+				const msg = `disabled MCP state preserved for "${candidate.name}"`;
+				actionWarnings.push(msg);
+				warnings.push({ source: candidate.source, type: "mcp", name: candidate.name, message: msg });
+			}
+			actions.push({
+				source: candidate.source,
+				type: "mcp",
+				name: candidate.name,
+				destination: input.destinations.mcpConfigPath,
+				operation: exists ? "update" : "create",
+				status: exists ? "updated" : "imported",
+				warnings: actionWarnings.length > 0 ? actionWarnings : undefined,
+				mcp: { config: mapped.config, force: input.force },
+			});
+			// Track so an intra-run duplicate of the same name doesn't double-write.
+			existingServers.add(candidate.name);
+		}
+	}
+
+	// 3. Skill actions — index the destination skills tree once.
+	const destIndex = await indexDestinationSkills(input.destinations.skillsDir);
+	const plannedSlugs = new Map<string, string>(); // slug -> source (intra-run)
+	const plannedEffective = new Map<string, string>(); // effective -> slug (intra-run)
+
+	for (const result of input.results) {
+		for (const candidate of result.skillCandidates) {
+			for (const w of candidate.warnings) {
+				warnings.push({ source: candidate.source, type: "skill", name: candidate.slug, message: w });
+			}
+			const slug = candidate.slug;
+			const destination = path.join(input.destinations.skillsDir, slug, "SKILL.md");
+			const base = {
+				source: candidate.source,
+				type: "skill" as const,
+				name: slug,
+				effectiveName: slug,
+				destination,
+			};
+
+			// Intra-run duplicate slug / effective name. Since effective name == slug, a
+			// duplicate always targets the same destination: skip by default; with --force
+			// the later (canonical-order) source overwrites the same destination.
+			if (plannedSlugs.has(slug) || plannedEffective.has(slug)) {
+				if (input.force) {
+					actions.push({
+						...base,
+						operation: "update",
+						status: "updated",
+						reason: "duplicate within this run (overwritten under --force)",
+						skill: { content: candidate.content },
+					});
+				} else {
+					actions.push({
+						...base,
+						operation: "skip",
+						status: "skipped_exists",
+						reason: "duplicate within this run",
+					});
+				}
+				continue;
+			}
+
+			const existingKind = destIndex.slugs.get(slug);
+			const effectiveOwner = destIndex.effectiveNames.get(slug);
+
+			// Effective-name collision with a different existing destination skill.
+			if (effectiveOwner && effectiveOwner !== slug) {
+				if (!input.force) {
+					actions.push({
+						...base,
+						operation: "skip",
+						status: "skipped_exists",
+						reason: `effective name collides with "${effectiveOwner}"`,
+					});
+				} else {
+					actions.push({
+						...base,
+						operation: "fail",
+						status: "failed_invalid_destination",
+						reason: `effective name collides with "${effectiveOwner}"`,
+					});
+				}
+				continue;
+			}
+
+			if (existingKind === "file") {
+				if (!input.force) {
+					actions.push({
+						...base,
+						operation: "skip",
+						status: "skipped_exists",
+						reason: "a file occupies the destination path",
+					});
+				} else {
+					actions.push({
+						...base,
+						operation: "fail",
+						status: "failed_invalid_destination",
+						reason: "a file occupies the destination path; refusing to delete",
+					});
+				}
+				continue;
+			}
+
+			if (existingKind === "dir-with-skill") {
+				if (!input.force) {
+					actions.push({ ...base, operation: "skip", status: "skipped_exists" });
+				} else {
+					actions.push({ ...base, operation: "update", status: "updated", skill: { content: candidate.content } });
+				}
+				plannedSlugs.set(slug, candidate.source);
+				plannedEffective.set(slug, slug);
+				continue;
+			}
+
+			if (existingKind === "stale-dir") {
+				if (!input.force) {
+					actions.push({ ...base, operation: "skip", status: "skipped_exists", reason: "stale skill directory" });
+				} else {
+					actions.push({
+						...base,
+						operation: "update",
+						status: "updated",
+						reason: "stale skill directory reused",
+						skill: { content: candidate.content },
+					});
+				}
+				plannedSlugs.set(slug, candidate.source);
+				plannedEffective.set(slug, slug);
+				continue;
+			}
+
+			// Fresh import.
+			actions.push({ ...base, operation: "create", status: "imported", skill: { content: candidate.content } });
+			plannedSlugs.set(slug, candidate.source);
+			plannedEffective.set(slug, slug);
+		}
+	}
+
+	return { actions, warnings };
+}

--- a/packages/coding-agent/src/migrate/action-planner.ts
+++ b/packages/coding-agent/src/migrate/action-planner.ts
@@ -27,29 +27,39 @@ export interface PlanOutput {
 
 interface DestSkillIndex {
 	/** slug -> kind of existing destination entry. */
-	slugs: Map<string, "dir-with-skill" | "stale-dir" | "file">;
+	slugs: Map<string, "dir-with-skill" | "stale-dir" | "occupied">;
 	/** effective loaded name -> owning slug. */
 	effectiveNames: Map<string, string>;
+	/** The skills root exists but is unsafe to write through. */
+	rootUnsafe?: boolean;
 }
 
 async function indexDestinationSkills(skillsDir: string): Promise<DestSkillIndex> {
 	const index: DestSkillIndex = { slugs: new Map(), effectiveNames: new Map() };
-	const entries = await fs.readdir(skillsDir, { withFileTypes: true }).catch((error: unknown) => {
-		if (isEnoent(error)) return null;
+	let rootStat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		rootStat = await fs.lstat(skillsDir);
+	} catch (error) {
+		if (isEnoent(error)) return index;
 		throw error;
-	});
-	if (!entries) return index;
+	}
+	if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return { ...index, rootUnsafe: true };
+	const entries = await fs.readdir(skillsDir, { withFileTypes: true });
 	for (const entry of entries) {
 		const name = String(entry.name);
-		if (entry.isFile()) {
-			index.slugs.set(name, "file");
+		if (!entry.isDirectory() || entry.isSymbolicLink()) {
+			index.slugs.set(name, "occupied");
 			continue;
 		}
-		if (!entry.isDirectory()) continue;
 		const slug = name;
 		const skillFile = path.join(skillsDir, slug, "SKILL.md");
 		let content: string | undefined;
 		try {
+			const skillFileStat = await fs.lstat(skillFile);
+			if (!skillFileStat.isFile() || skillFileStat.isSymbolicLink()) {
+				index.slugs.set(slug, "occupied");
+				continue;
+			}
 			content = await fs.readFile(skillFile, "utf-8");
 		} catch (error) {
 			if (isEnoent(error)) {
@@ -211,6 +221,25 @@ export async function planMigration(input: PlanInput): Promise<PlanOutput> {
 			const existingKind = destIndex.slugs.get(slug);
 			const effectiveOwner = destIndex.effectiveNames.get(slug);
 
+			if (destIndex.rootUnsafe) {
+				if (!input.force) {
+					actions.push({
+						...base,
+						operation: "skip",
+						status: "skipped_exists",
+						reason: "skills destination root is not a real directory",
+					});
+				} else {
+					actions.push({
+						...base,
+						operation: "fail",
+						status: "failed_invalid_destination",
+						reason: "skills destination root is not a real directory; refusing to write",
+					});
+				}
+				continue;
+			}
+
 			// Effective-name collision with a different existing destination skill.
 			if (effectiveOwner && effectiveOwner !== slug) {
 				if (!input.force) {
@@ -231,20 +260,20 @@ export async function planMigration(input: PlanInput): Promise<PlanOutput> {
 				continue;
 			}
 
-			if (existingKind === "file") {
+			if (existingKind === "occupied") {
 				if (!input.force) {
 					actions.push({
 						...base,
 						operation: "skip",
 						status: "skipped_exists",
-						reason: "a file occupies the destination path",
+						reason: "a non-directory or unsafe file occupies the destination path",
 					});
 				} else {
 					actions.push({
 						...base,
 						operation: "fail",
 						status: "failed_invalid_destination",
-						reason: "a file occupies the destination path; refusing to delete",
+						reason: "a non-directory or unsafe file occupies the destination path; refusing to delete",
 					});
 				}
 				continue;

--- a/packages/coding-agent/src/migrate/adapters/claude-code.ts
+++ b/packages/coding-agent/src/migrate/adapters/claude-code.ts
@@ -1,0 +1,39 @@
+/**
+ * Claude Code adapter: reads `~/.claude.json` (mcpServers) and `~/.claude/skills`.
+ */
+import * as path from "node:path";
+import type { AdapterResult, McpCandidate } from "../types";
+import { type Adapter, type AdapterOptions, collectSkillDir, parseSourceJson, readSourceText } from "./index";
+
+const SOURCE = "claude-code" as const;
+
+export const claudeCodeAdapter: Adapter = {
+	source: SOURCE,
+	async collect({ homeDir }: AdapterOptions): Promise<AdapterResult> {
+		const result: AdapterResult = { mcpCandidates: [], skillCandidates: [], diagnostics: [] };
+
+		const configPath = path.join(homeDir, ".claude.json");
+		const read = await readSourceText(configPath, SOURCE, "mcp");
+		if ("diagnostic" in read) {
+			result.diagnostics.push(read.diagnostic);
+		} else {
+			const parsed = parseSourceJson(read.text, configPath, SOURCE, "mcp");
+			if ("diagnostic" in parsed) {
+				result.diagnostics.push(parsed.diagnostic);
+			} else {
+				const servers = parsed.data.mcpServers;
+				if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+					for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+						result.mcpCandidates.push({ source: SOURCE, name, raw } satisfies McpCandidate);
+					}
+				}
+			}
+		}
+
+		const skills = await collectSkillDir(path.join(homeDir, ".claude", "skills"), SOURCE);
+		result.skillCandidates.push(...skills.candidates);
+		result.diagnostics.push(...skills.diagnostics);
+
+		return result;
+	},
+};

--- a/packages/coding-agent/src/migrate/adapters/codex.ts
+++ b/packages/coding-agent/src/migrate/adapters/codex.ts
@@ -1,0 +1,70 @@
+/**
+ * Codex adapter: reads `~/.codex/config.toml` ([mcp_servers]) and `~/.codex/prompts`.
+ */
+
+import * as path from "node:path";
+import { TOML } from "bun";
+import type { AdapterResult, McpCandidate, SourceDiagnostic } from "../types";
+import { type Adapter, type AdapterOptions, collectMarkdownPrompts, readSourceText } from "./index";
+
+const SOURCE = "codex" as const;
+
+function parseToml(
+	text: string,
+	filePath: string,
+): { data: Record<string, unknown> } | { diagnostic: SourceDiagnostic } {
+	try {
+		const data = TOML.parse(text) as unknown;
+		if (typeof data !== "object" || data === null) {
+			return {
+				diagnostic: {
+					source: SOURCE,
+					type: "mcp",
+					status: "failed_invalid_source",
+					message: `${filePath} is not a TOML table`,
+				},
+			};
+		}
+		return { data: data as Record<string, unknown> };
+	} catch (error) {
+		return {
+			diagnostic: {
+				source: SOURCE,
+				type: "mcp",
+				status: "failed_invalid_source",
+				message: `invalid TOML in ${filePath}: ${(error as Error).message}`,
+			},
+		};
+	}
+}
+
+export const codexAdapter: Adapter = {
+	source: SOURCE,
+	async collect({ homeDir }: AdapterOptions): Promise<AdapterResult> {
+		const result: AdapterResult = { mcpCandidates: [], skillCandidates: [], diagnostics: [] };
+
+		const configPath = path.join(homeDir, ".codex", "config.toml");
+		const read = await readSourceText(configPath, SOURCE, "mcp");
+		if ("diagnostic" in read) {
+			result.diagnostics.push(read.diagnostic);
+		} else {
+			const parsed = parseToml(read.text, configPath);
+			if ("diagnostic" in parsed) {
+				result.diagnostics.push(parsed.diagnostic);
+			} else {
+				const servers = parsed.data.mcp_servers;
+				if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+					for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+						result.mcpCandidates.push({ source: SOURCE, name, raw } satisfies McpCandidate);
+					}
+				}
+			}
+		}
+
+		const prompts = await collectMarkdownPrompts(path.join(homeDir, ".codex", "prompts"), SOURCE);
+		result.skillCandidates.push(...prompts.candidates);
+		result.diagnostics.push(...prompts.diagnostics);
+
+		return result;
+	},
+};

--- a/packages/coding-agent/src/migrate/adapters/index.ts
+++ b/packages/coding-agent/src/migrate/adapters/index.ts
@@ -1,0 +1,277 @@
+/**
+ * Source adapters for `gjc migrate`.
+ *
+ * Each adapter reads GLOBAL/home config for one source agent and returns
+ * normalized MCP + skill candidates plus source-level diagnostics. Adapters never
+ * read project-level config and never connect to anything.
+ */
+import * as fs from "node:fs/promises";
+import { isEnoent } from "@gajae-code/utils";
+import { normalizeSkill } from "../skill-normalizer";
+import type { AdapterResult, MigrateSource, SkillCandidate, SourceDiagnostic } from "../types";
+import { claudeCodeAdapter } from "./claude-code";
+import { codexAdapter } from "./codex";
+import { opencodeAdapter } from "./opencode";
+
+export interface AdapterOptions {
+	/** Home directory root; overridable for tests. */
+	homeDir: string;
+}
+
+export interface Adapter {
+	source: MigrateSource;
+	collect(options: AdapterOptions): Promise<AdapterResult>;
+}
+
+const ADAPTERS: Record<MigrateSource, Adapter> = {
+	"claude-code": claudeCodeAdapter,
+	codex: codexAdapter,
+	opencode: opencodeAdapter,
+};
+
+export function getAdapter(source: MigrateSource): Adapter {
+	return ADAPTERS[source];
+}
+
+/** Read a text file, classifying absence/IO errors into source diagnostics. */
+export async function readSourceText(
+	filePath: string,
+	source: MigrateSource,
+	type: SourceDiagnostic["type"],
+): Promise<{ text: string } | { diagnostic: SourceDiagnostic }> {
+	try {
+		return { text: await fs.readFile(filePath, "utf-8") };
+	} catch (error) {
+		if (isEnoent(error)) {
+			return {
+				diagnostic: { source, type, status: "skipped_absent_source", message: `no ${type} config at ${filePath}` },
+			};
+		}
+		return {
+			diagnostic: {
+				source,
+				type,
+				status: "failed_io",
+				message: `failed to read ${filePath}: ${(error as Error).message}`,
+			},
+		};
+	}
+}
+
+/** Parse JSON text, classifying parse errors into a `failed_invalid_source` diagnostic. */
+export function parseSourceJson(
+	text: string,
+	filePath: string,
+	source: MigrateSource,
+	type: SourceDiagnostic["type"],
+): { data: Record<string, unknown> } | { diagnostic: SourceDiagnostic } {
+	try {
+		const data = JSON.parse(text) as unknown;
+		if (typeof data !== "object" || data === null) {
+			return {
+				diagnostic: { source, type, status: "failed_invalid_source", message: `${filePath} is not a JSON object` },
+			};
+		}
+		return { data: data as Record<string, unknown> };
+	} catch (error) {
+		return {
+			diagnostic: {
+				source,
+				type,
+				status: "failed_invalid_source",
+				message: `invalid JSON in ${filePath}: ${(error as Error).message}`,
+			},
+		};
+	}
+}
+
+/**
+ * Collect skill candidates from a directory of `<name>/SKILL.md` entries.
+ * A missing directory yields a `skipped_absent_source` diagnostic.
+ */
+export async function collectSkillDir(
+	dir: string,
+	source: MigrateSource,
+): Promise<{ candidates: SkillCandidate[]; diagnostics: SourceDiagnostic[] }> {
+	const candidates: SkillCandidate[] = [];
+	const diagnostics: SourceDiagnostic[] = [];
+	let entries: string[];
+	try {
+		const dirents = await fs.readdir(dir, { withFileTypes: true });
+		entries = dirents.filter(d => d.isDirectory()).map(d => d.name);
+	} catch (error) {
+		if (isEnoent(error)) {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "skipped_absent_source",
+				message: `no skills dir at ${dir}`,
+			});
+		} else {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_io",
+				message: `failed to read ${dir}: ${(error as Error).message}`,
+			});
+		}
+		return { candidates, diagnostics };
+	}
+
+	for (const name of entries.sort()) {
+		const skillFile = `${dir}/${name}/SKILL.md`;
+		const read = await readSourceText(skillFile, source, "skill");
+		if ("diagnostic" in read) {
+			// A subdir without SKILL.md is simply not a skill; only surface non-absent errors.
+			if (read.diagnostic.status !== "skipped_absent_source") diagnostics.push(read.diagnostic);
+			continue;
+		}
+		try {
+			const normalized = normalizeSkill({ rawName: name, content: read.text });
+			candidates.push({ source, slug: normalized.slug, content: normalized.content, warnings: normalized.warnings });
+		} catch (error) {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_invalid_source",
+				message: `failed to normalize skill ${skillFile}: ${(error as Error).message}`,
+			});
+		}
+	}
+	return { candidates, diagnostics };
+}
+
+/**
+ * Collect skill candidates from a flat directory of `*.md` prompt/command files.
+ */
+export async function collectMarkdownPrompts(
+	dir: string,
+	source: MigrateSource,
+): Promise<{ candidates: SkillCandidate[]; diagnostics: SourceDiagnostic[] }> {
+	const candidates: SkillCandidate[] = [];
+	const diagnostics: SourceDiagnostic[] = [];
+	let files: string[];
+	try {
+		const dirents = await fs.readdir(dir, { withFileTypes: true });
+		files = dirents.filter(d => d.isFile() && d.name.endsWith(".md")).map(d => d.name);
+	} catch (error) {
+		if (isEnoent(error)) {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "skipped_absent_source",
+				message: `no prompts dir at ${dir}`,
+			});
+		} else {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_io",
+				message: `failed to read ${dir}: ${(error as Error).message}`,
+			});
+		}
+		return { candidates, diagnostics };
+	}
+
+	for (const file of files.sort()) {
+		const promptFile = `${dir}/${file}`;
+		const read = await readSourceText(promptFile, source, "skill");
+		if ("diagnostic" in read) {
+			diagnostics.push(read.diagnostic);
+			continue;
+		}
+		const rawName = file.replace(/\.md$/, "");
+		try {
+			const normalized = normalizeSkill({ rawName, content: read.text });
+			candidates.push({ source, slug: normalized.slug, content: normalized.content, warnings: normalized.warnings });
+		} catch (error) {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_invalid_source",
+				message: `failed to convert prompt ${promptFile}: ${(error as Error).message}`,
+			});
+		}
+	}
+	return { candidates, diagnostics };
+}
+
+/**
+ * Recursively collect skill candidates from any `**​/SKILL.md` under `root`.
+ * The slug derives from the directory that directly contains the `SKILL.md`.
+ */
+export async function collectSkillTree(
+	root: string,
+	source: MigrateSource,
+): Promise<{ candidates: SkillCandidate[]; diagnostics: SourceDiagnostic[] }> {
+	const candidates: SkillCandidate[] = [];
+	const diagnostics: SourceDiagnostic[] = [];
+
+	async function walk(dir: string): Promise<void> {
+		const entries = await fs.readdir(dir, { withFileTypes: true }).catch((error: unknown) => {
+			if (isEnoent(error)) return null;
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_io",
+				message: `failed to read ${dir}: ${(error as Error).message}`,
+			});
+			return null;
+		});
+		if (!entries) return;
+
+		const hasSkill = entries.some(e => e.isFile() && String(e.name) === "SKILL.md");
+		if (hasSkill) {
+			const skillFile = `${dir}/SKILL.md`;
+			const read = await readSourceText(skillFile, source, "skill");
+			if ("diagnostic" in read) {
+				if (read.diagnostic.status !== "skipped_absent_source") diagnostics.push(read.diagnostic);
+			} else {
+				try {
+					const rawName = dir.split("/").pop() ?? dir;
+					const normalized = normalizeSkill({ rawName, content: read.text });
+					candidates.push({
+						source,
+						slug: normalized.slug,
+						content: normalized.content,
+						warnings: normalized.warnings,
+					});
+				} catch (error) {
+					diagnostics.push({
+						source,
+						type: "skill",
+						status: "failed_invalid_source",
+						message: `failed to normalize skill ${skillFile}: ${(error as Error).message}`,
+					});
+				}
+			}
+		}
+
+		for (const entry of entries) {
+			if (entry.isDirectory()) await walk(`${dir}/${String(entry.name)}`);
+		}
+	}
+
+	// Surface an absent root the same way the flat collectors do.
+	const rootEntries = await fs.readdir(root).catch((error: unknown) => {
+		if (isEnoent(error)) {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "skipped_absent_source",
+				message: `no skills dir at ${root}`,
+			});
+		} else {
+			diagnostics.push({
+				source,
+				type: "skill",
+				status: "failed_io",
+				message: `failed to read ${root}: ${(error as Error).message}`,
+			});
+		}
+		return null;
+	});
+	if (rootEntries) await walk(root);
+
+	return { candidates, diagnostics };
+}

--- a/packages/coding-agent/src/migrate/adapters/opencode.ts
+++ b/packages/coding-agent/src/migrate/adapters/opencode.ts
@@ -1,0 +1,52 @@
+/**
+ * OpenCode adapter: reads `~/.config/opencode/opencode.json` (mcp), plus
+ * `~/.config/opencode/skills` and `~/.config/opencode/commands`.
+ */
+import * as path from "node:path";
+import type { AdapterResult, McpCandidate } from "../types";
+import {
+	type Adapter,
+	type AdapterOptions,
+	collectMarkdownPrompts,
+	collectSkillTree,
+	parseSourceJson,
+	readSourceText,
+} from "./index";
+
+const SOURCE = "opencode" as const;
+
+export const opencodeAdapter: Adapter = {
+	source: SOURCE,
+	async collect({ homeDir }: AdapterOptions): Promise<AdapterResult> {
+		const result: AdapterResult = { mcpCandidates: [], skillCandidates: [], diagnostics: [] };
+		const baseDir = path.join(homeDir, ".config", "opencode");
+
+		const configPath = path.join(baseDir, "opencode.json");
+		const read = await readSourceText(configPath, SOURCE, "mcp");
+		if ("diagnostic" in read) {
+			result.diagnostics.push(read.diagnostic);
+		} else {
+			const parsed = parseSourceJson(read.text, configPath, SOURCE, "mcp");
+			if ("diagnostic" in parsed) {
+				result.diagnostics.push(parsed.diagnostic);
+			} else {
+				const servers = parsed.data.mcp;
+				if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+					for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+						result.mcpCandidates.push({ source: SOURCE, name, raw } satisfies McpCandidate);
+					}
+				}
+			}
+		}
+
+		const skills = await collectSkillTree(path.join(baseDir, "skills"), SOURCE);
+		result.skillCandidates.push(...skills.candidates);
+		result.diagnostics.push(...skills.diagnostics);
+
+		const commands = await collectMarkdownPrompts(path.join(baseDir, "commands"), SOURCE);
+		result.skillCandidates.push(...commands.candidates);
+		result.diagnostics.push(...commands.diagnostics);
+
+		return result;
+	},
+};

--- a/packages/coding-agent/src/migrate/executor.ts
+++ b/packages/coding-agent/src/migrate/executor.ts
@@ -1,0 +1,44 @@
+/**
+ * Execute planned migration actions.
+ *
+ * Consumes the planner's actions unchanged and performs only `create`/`update`
+ * operations. It never re-plans. Writes are not transactional: on a write error
+ * the offending action flips to `failed_io`, already-written actions remain, and
+ * remaining actions still run (no rollback). Dry-run never calls this.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { upsertMCPServer } from "../runtime-mcp/config-writer";
+import type { MigrateAction } from "./types";
+
+export async function executeActions(actions: MigrateAction[]): Promise<MigrateAction[]> {
+	const out: MigrateAction[] = [];
+	for (const action of actions) {
+		if (action.operation !== "create" && action.operation !== "update") {
+			out.push(action);
+			continue;
+		}
+		try {
+			if (action.type === "mcp" && action.mcp && action.name && action.destination) {
+				await upsertMCPServer(action.destination, action.name, action.mcp.config, {
+					force: action.operation === "update",
+				});
+				out.push(action);
+			} else if (action.type === "skill" && action.skill && action.destination) {
+				await fs.mkdir(path.dirname(action.destination), { recursive: true });
+				await fs.writeFile(action.destination, action.skill.content, "utf-8");
+				out.push(action);
+			} else {
+				out.push(action);
+			}
+		} catch (error) {
+			out.push({
+				...action,
+				operation: "fail",
+				status: "failed_io",
+				reason: `write failed: ${(error as Error).message}`,
+			});
+		}
+	}
+	return out;
+}

--- a/packages/coding-agent/src/migrate/executor.ts
+++ b/packages/coding-agent/src/migrate/executor.ts
@@ -6,10 +6,48 @@
  * the offending action flips to `failed_io`, already-written actions remain, and
  * remaining actions still run (no rollback). Dry-run never calls this.
  */
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { upsertMCPServer } from "../runtime-mcp/config-writer";
 import type { MigrateAction } from "./types";
+
+async function ensureRealDirectoryPathNoFollow(directory: string): Promise<void> {
+	const resolved = path.resolve(directory);
+	const parsed = path.parse(resolved);
+	let current = parsed.root;
+	for (const part of resolved.slice(parsed.root.length).split(path.sep).filter(Boolean)) {
+		current = path.join(current, part);
+		try {
+			const stat = await fs.lstat(current);
+			if (!stat.isDirectory() || stat.isSymbolicLink()) {
+				throw new Error(`skill destination ancestor is not a real directory: ${current}`);
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			await fs.mkdir(current);
+			const stat = await fs.lstat(current);
+			if (!stat.isDirectory() || stat.isSymbolicLink()) {
+				throw new Error(`skill destination ancestor is not a real directory: ${current}`);
+			}
+		}
+	}
+}
+
+async function writeSkillFileNoFollow(destination: string, content: string): Promise<void> {
+	const skillDir = path.dirname(destination);
+	await ensureRealDirectoryPathNoFollow(skillDir);
+	const handle = await fs.open(
+		destination,
+		fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_TRUNC | fsSync.constants.O_NOFOLLOW,
+		0o666,
+	);
+	try {
+		await handle.writeFile(content, "utf-8");
+	} finally {
+		await handle.close();
+	}
+}
 
 export async function executeActions(actions: MigrateAction[]): Promise<MigrateAction[]> {
 	const out: MigrateAction[] = [];
@@ -25,8 +63,7 @@ export async function executeActions(actions: MigrateAction[]): Promise<MigrateA
 				});
 				out.push(action);
 			} else if (action.type === "skill" && action.skill && action.destination) {
-				await fs.mkdir(path.dirname(action.destination), { recursive: true });
-				await fs.writeFile(action.destination, action.skill.content, "utf-8");
+				await writeSkillFileNoFollow(action.destination, action.skill.content);
 				out.push(action);
 			} else {
 				out.push(action);

--- a/packages/coding-agent/src/migrate/mcp-mapper.ts
+++ b/packages/coding-agent/src/migrate/mcp-mapper.ts
@@ -1,0 +1,152 @@
+/**
+ * Map raw source MCP server entries onto GJC `MCPServerConfig`.
+ *
+ * Implements the source-schema compatibility matrix from the consensus plan:
+ * preserved (P), transformed (T), omitted-with-warning (OW), skipped (S,
+ * `skipped_unmappable`), and failed (F, `failed_invalid_source`). Secret-indirection
+ * fields are always omitted-with-warning; their values are never read or emitted.
+ */
+import type { MCPServerConfig } from "../runtime-mcp/types";
+import type { MigrateSource } from "./types";
+
+export type McpMapOutcome =
+	| { ok: true; config: MCPServerConfig; warnings: string[] }
+	| { ok: false; status: "skipped_unmappable" | "failed_invalid_source"; reason: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] | undefined | "invalid" {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value) || !value.every(v => typeof v === "string")) return "invalid";
+	return value as string[];
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined | "invalid" {
+	if (value === undefined) return undefined;
+	if (!isRecord(value) || !Object.values(value).every(v => typeof v === "string")) return "invalid";
+	return value as Record<string, string>;
+}
+
+/** Secret-indirection fields per source: always omitted-with-warning, never read. */
+const SECRET_INDIRECTION_FIELDS: Record<MigrateSource, string[]> = {
+	"claude-code": [],
+	codex: ["env_vars", "env_http_headers", "bearer_token_env_var"],
+	opencode: [],
+};
+
+/** Fields recognized for a source (handled or intentionally omitted). Anything else is omitted-with-warning. */
+const RECOGNIZED_FIELDS: Record<MigrateSource, ReadonlySet<string>> = {
+	"claude-code": new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
+	codex: new Set([
+		"type",
+		"command",
+		"args",
+		"env",
+		"url",
+		"http_headers",
+		"cwd",
+		"enabled",
+		"timeout",
+		"tool_timeout_sec",
+		// omitted-with-warning fields are still "recognized" (handled below):
+		"env_vars",
+		"env_http_headers",
+		"bearer_token_env_var",
+		"startup_timeout_sec",
+		"enabled_tools",
+		"disabled_tools",
+	]),
+	opencode: new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
+};
+
+/** Fields with no GJC equivalent: omitted-with-warning (named explicitly so the warning is precise). */
+const OMITTED_FIELDS: Record<MigrateSource, string[]> = {
+	"claude-code": [],
+	codex: ["startup_timeout_sec", "enabled_tools", "disabled_tools"],
+	opencode: [],
+};
+
+export function mapMcpEntry(source: MigrateSource, name: string, raw: unknown): McpMapOutcome {
+	if (!isRecord(raw)) {
+		return { ok: false, status: "failed_invalid_source", reason: `server "${name}" is not an object` };
+	}
+
+	const warnings: string[] = [];
+	for (const field of SECRET_INDIRECTION_FIELDS[source]) {
+		if (field in raw) warnings.push(`omitted secret-indirection field "${field}" for "${name}" (value not read)`);
+	}
+	for (const field of OMITTED_FIELDS[source]) {
+		if (field in raw) warnings.push(`omitted unsupported field "${field}" for "${name}"`);
+	}
+	// Unknown/unrecognized fields: omit-with-warning (never copy their values).
+	for (const field of Object.keys(raw)) {
+		if (!RECOGNIZED_FIELDS[source].has(field)) {
+			warnings.push(`omitted unknown field "${field}" for "${name}"`);
+		}
+	}
+
+	const rawType = typeof raw.type === "string" ? raw.type : undefined;
+	const command = typeof raw.command === "string" ? raw.command : undefined;
+	const url = typeof raw.url === "string" ? raw.url : undefined;
+
+	const base: { enabled?: boolean; timeout?: number } = {};
+	if (typeof raw.enabled === "boolean") base.enabled = raw.enabled;
+	if (typeof raw.timeout === "number") base.timeout = raw.timeout;
+	// Codex tool_timeout_sec -> timeout (ms).
+	if (source === "codex" && typeof raw.tool_timeout_sec === "number") {
+		base.timeout = raw.tool_timeout_sec * 1000;
+	}
+
+	const wantsStdio =
+		source === "opencode" ? rawType === "local" || (!rawType && !!command) : !!command || rawType === "stdio";
+	const wantsHttp =
+		source === "opencode"
+			? rawType === "remote" || rawType === "sse"
+			: rawType === "http" || rawType === "sse" || (!command && !!url);
+
+	if (wantsStdio) {
+		if (!command) {
+			return {
+				ok: false,
+				status: "skipped_unmappable",
+				reason: `server "${name}" has no command for stdio transport`,
+			};
+		}
+		const args = asStringArray(raw.args);
+		if (args === "invalid") {
+			return { ok: false, status: "failed_invalid_source", reason: `server "${name}" has invalid "args"` };
+		}
+		const env = asStringRecord(raw.env);
+		if (env === "invalid") {
+			return { ok: false, status: "failed_invalid_source", reason: `server "${name}" has invalid "env"` };
+		}
+		const config: MCPServerConfig = { type: "stdio", command, ...base };
+		if (args) config.args = args;
+		if (env) config.env = env;
+		if (typeof raw.cwd === "string") config.cwd = raw.cwd;
+		return { ok: true, config, warnings };
+	}
+
+	if (wantsHttp) {
+		if (!url) {
+			return {
+				ok: false,
+				status: "skipped_unmappable",
+				reason: `server "${name}" has no url for http/sse transport`,
+			};
+		}
+		const headerSource = source === "codex" ? raw.http_headers : raw.headers;
+		const headers = asStringRecord(headerSource);
+		if (headers === "invalid") {
+			return { ok: false, status: "failed_invalid_source", reason: `server "${name}" has invalid headers` };
+		}
+		const type = rawType === "sse" ? "sse" : "http";
+		const config = { type, url, ...base } as MCPServerConfig;
+		if (headers) (config as { headers?: Record<string, string> }).headers = headers;
+		return { ok: true, config, warnings };
+	}
+
+	return { ok: false, status: "skipped_unmappable", reason: `server "${name}" has neither a usable command nor url` };
+}

--- a/packages/coding-agent/src/migrate/report.ts
+++ b/packages/coding-agent/src/migrate/report.ts
@@ -1,0 +1,104 @@
+/**
+ * Build the human-readable and `--json` reports for `gjc migrate`.
+ *
+ * Secret values are never read upstream, so the report only ever contains field
+ * names in warnings — but rendering still treats action/warning text as opaque.
+ */
+import {
+	emptyStatusCounts,
+	isFailureStatus,
+	type MigrateAction,
+	type MigrateDestinations,
+	type MigrateReport,
+	type MigrateSource,
+	type MigrateWarning,
+	type StatusCounts,
+} from "./types";
+
+export interface BuildReportInput {
+	actions: MigrateAction[];
+	warnings: MigrateWarning[];
+	sources: MigrateSource[];
+	destinations: MigrateDestinations;
+	dryRun: boolean;
+	project: boolean;
+	force: boolean;
+}
+
+export function buildReport(input: BuildReportInput): MigrateReport {
+	const total = emptyStatusCounts();
+	const byType = { mcp: emptyStatusCounts(), skill: emptyStatusCounts(), source: emptyStatusCounts() };
+	const bySource = {} as Record<MigrateSource, StatusCounts>;
+	for (const source of input.sources) bySource[source] = emptyStatusCounts();
+
+	let ok = true;
+	for (const action of input.actions) {
+		total[action.status] += 1;
+		byType[action.type][action.status] += 1;
+		if (bySource[action.source]) bySource[action.source][action.status] += 1;
+		if (isFailureStatus(action.status)) ok = false;
+	}
+
+	return {
+		ok,
+		dryRun: input.dryRun,
+		project: input.project,
+		force: input.force,
+		sources: input.sources,
+		destinations: input.destinations,
+		summary: { total, byType, bySource },
+		actions: input.actions.map(action => ({
+			source: action.source,
+			type: action.type,
+			name: action.name,
+			effectiveName: action.effectiveName,
+			destination: action.destination,
+			operation: action.operation,
+			status: action.status,
+			reason: action.reason,
+			warnings: action.warnings,
+		})),
+		warnings: input.warnings,
+	};
+}
+
+function summarizeCounts(counts: StatusCounts): string {
+	const parts: string[] = [];
+	for (const [status, count] of Object.entries(counts)) {
+		if (count > 0) parts.push(`${status}=${count}`);
+	}
+	return parts.length > 0 ? parts.join(", ") : "nothing";
+}
+
+export function renderHuman(report: MigrateReport): string {
+	const lines: string[] = [];
+	const mode = report.dryRun ? " (dry-run)" : "";
+	lines.push(`gjc migrate${mode}: ${report.ok ? "ok" : "completed with failures"}`);
+	lines.push(`Sources: ${report.sources.join(", ") || "none"}`);
+	lines.push(`Destination: mcp=${report.destinations.mcpConfigPath} skills=${report.destinations.skillsDir}`);
+	lines.push("");
+	lines.push(`MCP:    ${summarizeCounts(report.summary.byType.mcp)}`);
+	lines.push(`Skills: ${summarizeCounts(report.summary.byType.skill)}`);
+	if (Object.values(report.summary.byType.source).some(n => n > 0)) {
+		lines.push(`Source: ${summarizeCounts(report.summary.byType.source)}`);
+	}
+
+	const failures = report.actions.filter(a => isFailureStatus(a.status));
+	if (failures.length > 0) {
+		lines.push("");
+		lines.push("Failures:");
+		for (const f of failures) {
+			lines.push(`  - [${f.source}] ${f.type} ${f.name ?? ""}: ${f.status}${f.reason ? ` (${f.reason})` : ""}`);
+		}
+	}
+
+	if (report.warnings.length > 0) {
+		lines.push("");
+		lines.push("Warnings:");
+		for (const w of report.warnings) {
+			lines.push(`  - [${w.source}] ${w.type} ${w.name ?? ""}: ${w.message}`);
+		}
+	}
+
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/migrate/skill-normalizer.ts
+++ b/packages/coding-agent/src/migrate/skill-normalizer.ts
@@ -1,0 +1,80 @@
+/**
+ * Normalize a skill from another agent into a native GJC `SKILL.md`.
+ *
+ * GJC derives a skill's loaded name from its directory (`<slug>/SKILL.md`) when no
+ * frontmatter `name` is present, and requires a `description`. To guarantee the
+ * effective loaded name equals the lowercase-hyphen slug, we drop any frontmatter
+ * `name` and place the file at `<slug>/SKILL.md`, synthesizing a `description`
+ * when the source lacks one.
+ */
+
+import { parseFrontmatter } from "@gajae-code/utils";
+import { YAML } from "bun";
+
+export interface NormalizeSkillInput {
+	/** Raw name from the source (filename stem, frontmatter name, etc.). */
+	rawName: string;
+	/** Full source markdown (may or may not have frontmatter). */
+	content: string;
+}
+
+export interface NormalizedSkill {
+	slug: string;
+	content: string;
+	warnings: string[];
+}
+
+/** Convert an arbitrary name into a lowercase-hyphen slug. */
+export function slugify(name: string): string {
+	const slug = name
+		.normalize("NFKD")
+		.replace(/[^\w\s-]/g, "")
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug;
+}
+
+function firstNonEmptyLine(body: string): string | undefined {
+	for (const raw of body.split("\n")) {
+		const line = raw.replace(/^#+\s*/, "").trim();
+		if (line) return line;
+	}
+	return undefined;
+}
+
+/**
+ * Produce a `{ slug, content }` pair whose effective GJC-loaded name equals `slug`.
+ * Throws only on an unusable name (cannot produce a slug).
+ */
+export function normalizeSkill(input: NormalizeSkillInput): NormalizedSkill {
+	const warnings: string[] = [];
+	const { frontmatter, body } = parseFrontmatter(input.content, { level: "off" });
+
+	const sourceName =
+		typeof frontmatter.name === "string" && frontmatter.name.trim() ? frontmatter.name : input.rawName;
+	const slug = slugify(sourceName);
+	if (!slug) {
+		throw new Error(`cannot derive a valid slug from skill name "${input.rawName}"`);
+	}
+	if (slugify(input.rawName) !== slug && typeof frontmatter.name === "string") {
+		warnings.push(`renamed skill "${input.rawName}" to slug "${slug}"`);
+	}
+
+	// Build the destination frontmatter: drop `name` (loaded name comes from the dir),
+	// keep other fields, and ensure a non-empty description.
+	const { name: _droppedName, description: rawDescription, ...rest } = frontmatter;
+	let description = typeof rawDescription === "string" ? rawDescription.trim() : "";
+	if (!description) {
+		description = firstNonEmptyLine(body) ?? `Imported ${slug} skill.`;
+		warnings.push(`synthesized description for skill "${slug}"`);
+	}
+
+	const fm: Record<string, unknown> = { description, ...rest };
+	const yaml = YAML.stringify(fm).trimEnd();
+	const content = `---\n${yaml}\n---\n\n${body.trim()}\n`;
+
+	return { slug, content, warnings };
+}

--- a/packages/coding-agent/src/migrate/types.ts
+++ b/packages/coding-agent/src/migrate/types.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared types for `gjc migrate`.
+ *
+ * Imports MCP servers and skills from other coding agents (Claude Code, Codex,
+ * OpenCode) into native GJC config. See the consensus plan under
+ * `.gjc/plans/ralplan/` for the full taxonomy and force/collision semantics.
+ */
+import type { MCPServerConfig } from "../runtime-mcp/types";
+
+/** Supported migration sources. */
+export type MigrateSource = "claude-code" | "codex" | "opencode";
+
+export const MIGRATE_SOURCES: readonly MigrateSource[] = ["claude-code", "codex", "opencode"];
+
+/** Canonical, deterministic ordering used when expanding `--from all` / repeated `--from`. */
+export const CANONICAL_SOURCE_ORDER: readonly MigrateSource[] = MIGRATE_SOURCES;
+
+/** What kind of thing an action/coverage row is about. */
+export type MigrateItemType = "mcp" | "skill" | "source";
+
+/**
+ * Per-item outcome taxonomy.
+ *
+ * `skipped_*` outcomes are non-fatal (exit 0). Any `failed_*` outcome sets
+ * `ok=false` and a non-zero process exit code.
+ */
+export type MigrationStatus =
+	| "imported"
+	| "updated"
+	| "skipped_exists"
+	| "skipped_absent_source"
+	| "skipped_unmappable"
+	| "failed_invalid_source"
+	| "failed_invalid_destination"
+	| "failed_io";
+
+export const MIGRATION_STATUSES: readonly MigrationStatus[] = [
+	"imported",
+	"updated",
+	"skipped_exists",
+	"skipped_absent_source",
+	"skipped_unmappable",
+	"failed_invalid_source",
+	"failed_invalid_destination",
+	"failed_io",
+];
+
+/** Statuses that represent a hard failure (drive `ok=false` + non-zero exit). */
+export const FAILURE_STATUSES: ReadonlySet<MigrationStatus> = new Set<MigrationStatus>([
+	"failed_invalid_source",
+	"failed_invalid_destination",
+	"failed_io",
+]);
+
+export function isFailureStatus(status: MigrationStatus): boolean {
+	return FAILURE_STATUSES.has(status);
+}
+
+/** Operation the planner decided for an item. */
+export type MigrateOperation = "create" | "update" | "skip" | "fail";
+
+/** A raw MCP server candidate parsed from a source, before mapping/destination planning. */
+export interface McpCandidate {
+	source: MigrateSource;
+	name: string;
+	/** The raw, unmapped server entry from the source config (mapped by the planner). */
+	raw: unknown;
+}
+
+/** A raw skill candidate parsed from a source, before normalization/destination planning. */
+export interface SkillCandidate {
+	source: MigrateSource;
+	/** Slug used as the destination directory and effective loaded name. */
+	slug: string;
+	/** Full SKILL.md content (frontmatter already normalized so loaded name == slug). */
+	content: string;
+	warnings: string[];
+}
+
+/**
+ * Source-level diagnostic for a single source/type pair (e.g. "codex mcp config
+ * was malformed"). Distinct from per-item actions so absent/unreadable sources
+ * are reported once instead of per item.
+ */
+export interface SourceDiagnostic {
+	source: MigrateSource;
+	type: Exclude<MigrateItemType, "source"> | "source";
+	status: Extract<MigrationStatus, "skipped_absent_source" | "failed_invalid_source" | "failed_io">;
+	message: string;
+}
+
+/** Normalized candidates + diagnostics returned by an adapter. */
+export interface AdapterResult {
+	mcpCandidates: McpCandidate[];
+	skillCandidates: SkillCandidate[];
+	diagnostics: SourceDiagnostic[];
+}
+
+/** A single planned action consumed identically by dry-run and live execution. */
+export interface MigrateAction {
+	source: MigrateSource;
+	type: MigrateItemType;
+	name?: string;
+	/** For skills: the effective GJC-loaded name (== slug). */
+	effectiveName?: string;
+	/** Absolute destination path (mcp.json for MCP, <skillsDir>/<slug>/SKILL.md for skills). */
+	destination?: string;
+	operation: MigrateOperation;
+	status: MigrationStatus;
+	reason?: string;
+	warnings?: string[];
+	/** Resolved payload the executor needs; never serialized to the report. */
+	mcp?: { config: MCPServerConfig; force: boolean };
+	skill?: { content: string };
+}
+
+export interface MigrateWarning {
+	source: MigrateSource;
+	type: string;
+	name?: string;
+	message: string;
+}
+
+export type StatusCounts = Record<MigrationStatus, number>;
+
+export interface MigrateDestinations {
+	mcpConfigPath: string;
+	skillsDir: string;
+}
+
+/** The full machine-readable report emitted with `--json`. */
+export interface MigrateReport {
+	ok: boolean;
+	dryRun: boolean;
+	project: boolean;
+	force: boolean;
+	sources: MigrateSource[];
+	destinations: MigrateDestinations;
+	summary: {
+		total: StatusCounts;
+		byType: { mcp: StatusCounts; skill: StatusCounts; source: StatusCounts };
+		bySource: Record<MigrateSource, StatusCounts>;
+	};
+	actions: Array<{
+		source: MigrateSource;
+		type: MigrateItemType;
+		name?: string;
+		effectiveName?: string;
+		destination?: string;
+		operation: MigrateOperation;
+		status: MigrationStatus;
+		reason?: string;
+		warnings?: string[];
+	}>;
+	warnings: MigrateWarning[];
+}
+
+/** Create a zeroed status-count record. */
+export function emptyStatusCounts(): StatusCounts {
+	const counts = {} as StatusCounts;
+	for (const status of MIGRATION_STATUSES) counts[status] = 0;
+	return counts;
+}

--- a/packages/coding-agent/src/runtime-mcp/config-writer.ts
+++ b/packages/coding-agent/src/runtime-mcp/config-writer.ts
@@ -150,6 +150,52 @@ export async function updateMCPServer(filePath: string, name: string, config: MC
 }
 
 /**
+ * Result of an {@link upsertMCPServer} call.
+ * - `added`: server did not exist and was written.
+ * - `updated`: server existed and was overwritten because `force` was set.
+ * - `skipped`: server existed and `force` was not set, so nothing was written.
+ */
+export type UpsertMCPServerResult =
+	| { status: "added" }
+	| { status: "updated" }
+	| { status: "skipped"; reason: "exists" };
+
+/**
+ * Add an MCP server, or overwrite an existing one only when `force` is set.
+ *
+ * Collision-aware wrapper over {@link addMCPServer} / {@link updateMCPServer} used by
+ * `gjc migrate`. Never connects to the server. Reuses the underlying writers so the
+ * rest of the config file (including `disabledServers`) is preserved on update.
+ *
+ * @throws Error if the server name or config is invalid (validated before any write).
+ */
+export async function upsertMCPServer(
+	filePath: string,
+	name: string,
+	config: MCPServerConfig,
+	options: { force?: boolean } = {},
+): Promise<UpsertMCPServerResult> {
+	// Validate name up front so an invalid name fails regardless of collision state.
+	const nameError = validateServerName(name);
+	if (nameError) {
+		throw new Error(nameError);
+	}
+
+	const existing = await getMCPServer(filePath, name);
+	if (existing) {
+		if (!options.force) {
+			return { status: "skipped", reason: "exists" };
+		}
+		// updateMCPServer preserves the rest of MCPConfigFile, incl. disabledServers.
+		await updateMCPServer(filePath, name, config);
+		return { status: "updated" };
+	}
+
+	await addMCPServer(filePath, name, config);
+	return { status: "added" };
+}
+
+/**
  * Remove an MCP server from a config file.
  *
  * @throws Error if server doesn't exist

--- a/packages/coding-agent/test/migrate-action-planner.test.ts
+++ b/packages/coding-agent/test/migrate-action-planner.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { planMigration } from "../src/migrate/action-planner";
+import type { AdapterResult, McpCandidate, MigrateDestinations, SkillCandidate } from "../src/migrate/types";
+
+let tmp: string;
+let dest: MigrateDestinations;
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-planner-"));
+	dest = { mcpConfigPath: path.join(tmp, "mcp.json"), skillsDir: path.join(tmp, "skills") };
+});
+
+afterEach(async () => {
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function mcp(name: string, raw: unknown): McpCandidate {
+	return { source: "claude-code", name, raw };
+}
+function skill(slug: string, content = `---\ndescription: d\n---\nbody`): SkillCandidate {
+	return { source: "claude-code", slug, content, warnings: [] };
+}
+function result(partial: Partial<AdapterResult>): AdapterResult {
+	return { mcpCandidates: [], skillCandidates: [], diagnostics: [], ...partial };
+}
+
+async function writeMcpConfig(servers: Record<string, unknown>): Promise<void> {
+	await fs.writeFile(dest.mcpConfigPath, JSON.stringify({ mcpServers: servers }), "utf-8");
+}
+async function writeDestSkill(slug: string, frontmatter: string): Promise<void> {
+	const dir = path.join(dest.skillsDir, slug);
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(path.join(dir, "SKILL.md"), `---\n${frontmatter}\n---\nbody`, "utf-8");
+}
+
+describe("planMigration — MCP", () => {
+	test("fresh import is `imported`", async () => {
+		const { actions } = await planMigration({
+			results: [result({ mcpCandidates: [mcp("srv", { command: "bin" })] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions).toHaveLength(1);
+		expect(actions[0]).toMatchObject({ type: "mcp", name: "srv", operation: "create", status: "imported" });
+	});
+
+	test("existing server: skip without force, update with force", async () => {
+		await writeMcpConfig({ srv: { command: "old" } });
+		const candidate = result({ mcpCandidates: [mcp("srv", { command: "new" })] });
+		const skipped = await planMigration({ results: [candidate], destinations: dest, force: false });
+		expect(skipped.actions[0]).toMatchObject({ status: "skipped_exists", operation: "skip" });
+		const forced = await planMigration({ results: [candidate], destinations: dest, force: true });
+		expect(forced.actions[0]).toMatchObject({ status: "updated", operation: "update" });
+	});
+
+	test("invalid server name -> failed_invalid_source", async () => {
+		const { actions } = await planMigration({
+			results: [result({ mcpCandidates: [mcp("bad name", { command: "bin" })] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({ status: "failed_invalid_source", operation: "fail" });
+	});
+
+	test("unmappable entry -> skipped_unmappable", async () => {
+		const { actions } = await planMigration({
+			results: [result({ mcpCandidates: [mcp("srv", { foo: "bar" })] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({ status: "skipped_unmappable" });
+	});
+
+	test("malformed destination mcp.json -> failed_invalid_destination", async () => {
+		await fs.writeFile(dest.mcpConfigPath, "{ not json", "utf-8");
+		const { actions } = await planMigration({
+			results: [result({ mcpCandidates: [mcp("srv", { command: "bin" })] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({ status: "failed_invalid_destination" });
+	});
+
+	test("force update of a disabled server preserves state and warns", async () => {
+		await fs.writeFile(
+			dest.mcpConfigPath,
+			JSON.stringify({ mcpServers: { srv: { command: "old" } }, disabledServers: ["srv"] }),
+			"utf-8",
+		);
+		const { actions, warnings } = await planMigration({
+			results: [result({ mcpCandidates: [mcp("srv", { command: "new" })] })],
+			destinations: dest,
+			force: true,
+		});
+		expect(actions[0]).toMatchObject({ status: "updated" });
+		expect(actions[0].warnings?.some(w => w.includes("disabled MCP state preserved"))).toBe(true);
+		expect(warnings.some(w => w.message.includes("disabled MCP state preserved"))).toBe(true);
+	});
+});
+
+describe("planMigration — skills", () => {
+	test("fresh import is `imported`", async () => {
+		const { actions } = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha")] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({
+			type: "skill",
+			name: "alpha",
+			effectiveName: "alpha",
+			operation: "create",
+			status: "imported",
+		});
+	});
+
+	test("existing skill: skip without force, update with force", async () => {
+		await writeDestSkill("alpha", "description: existing");
+		const cand = result({ skillCandidates: [skill("alpha")] });
+		const skipped = await planMigration({ results: [cand], destinations: dest, force: false });
+		expect(skipped.actions[0]).toMatchObject({ status: "skipped_exists" });
+		const forced = await planMigration({ results: [cand], destinations: dest, force: true });
+		expect(forced.actions[0]).toMatchObject({ status: "updated", operation: "update" });
+	});
+
+	test("stale dir (no SKILL.md): force reuses with warning reason", async () => {
+		await fs.mkdir(path.join(dest.skillsDir, "alpha"), { recursive: true });
+		const forced = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha")] })],
+			destinations: dest,
+			force: true,
+		});
+		expect(forced.actions[0]).toMatchObject({ status: "updated", reason: "stale skill directory reused" });
+	});
+
+	test("file at destination path: skip default, fail on force (no delete)", async () => {
+		await fs.mkdir(dest.skillsDir, { recursive: true });
+		await fs.writeFile(path.join(dest.skillsDir, "alpha"), "x", "utf-8");
+		const skipped = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha")] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(skipped.actions[0]).toMatchObject({ status: "skipped_exists" });
+		const forced = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha")] })],
+			destinations: dest,
+			force: true,
+		});
+		expect(forced.actions[0]).toMatchObject({ status: "failed_invalid_destination" });
+	});
+
+	test("effective-name collision across dirs: fail on force", async () => {
+		// Existing dir "other" whose frontmatter name slugifies to "target".
+		await writeDestSkill("other", "name: Target\ndescription: d");
+		const forced = await planMigration({
+			results: [result({ skillCandidates: [skill("target")] })],
+			destinations: dest,
+			force: true,
+		});
+		expect(forced.actions[0]).toMatchObject({ status: "failed_invalid_destination" });
+	});
+
+	test("intra-run duplicate slug -> second skipped_exists", async () => {
+		const { actions } = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha"), skill("alpha")] })],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({ status: "imported" });
+		expect(actions[1]).toMatchObject({ status: "skipped_exists", reason: "duplicate within this run" });
+	});
+
+	test("intra-run duplicate slug with --force: second overwrites same destination", async () => {
+		const { actions } = await planMigration({
+			results: [result({ skillCandidates: [skill("alpha"), skill("alpha")] })],
+			destinations: dest,
+			force: true,
+		});
+		expect(actions[0]).toMatchObject({ status: "imported" });
+		expect(actions[1]).toMatchObject({ status: "updated", operation: "update" });
+	});
+});
+
+describe("planMigration — diagnostics", () => {
+	test("source diagnostics become source actions", async () => {
+		const { actions } = await planMigration({
+			results: [
+				result({
+					diagnostics: [{ source: "codex", type: "mcp", status: "failed_invalid_source", message: "bad toml" }],
+				}),
+			],
+			destinations: dest,
+			force: false,
+		});
+		expect(actions[0]).toMatchObject({ type: "source", status: "failed_invalid_source", operation: "fail" });
+	});
+});

--- a/packages/coding-agent/test/migrate-action-planner.test.ts
+++ b/packages/coding-agent/test/migrate-action-planner.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { planMigration } from "../src/migrate/action-planner";
+import { executeActions } from "../src/migrate/executor";
 import type { AdapterResult, McpCandidate, MigrateDestinations, SkillCandidate } from "../src/migrate/types";
 
 let tmp: string;
@@ -153,6 +154,61 @@ describe("planMigration — skills", () => {
 		expect(forced.actions[0]).toMatchObject({ status: "failed_invalid_destination" });
 	});
 
+	test("skills root symlink: skip default, fail on force", async () => {
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-planner-root-outside-"));
+		try {
+			await fs.symlink(outside, dest.skillsDir, "dir");
+			const skipped = await planMigration({
+				results: [result({ skillCandidates: [skill("alpha")] })],
+				destinations: dest,
+				force: false,
+			});
+			expect(skipped.actions[0]).toMatchObject({
+				operation: "skip",
+				status: "skipped_exists",
+			});
+			const forced = await planMigration({
+				results: [result({ skillCandidates: [skill("alpha")] })],
+				destinations: dest,
+				force: true,
+			});
+			expect(forced.actions[0]).toMatchObject({
+				operation: "fail",
+				status: "failed_invalid_destination",
+			});
+		} finally {
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
+
+	test("symlink at destination path: skip default, fail on force (no follow)", async () => {
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-planner-outside-"));
+		try {
+			await fs.mkdir(dest.skillsDir, { recursive: true });
+			await fs.symlink(outside, path.join(dest.skillsDir, "alpha"), "dir");
+			const skipped = await planMigration({
+				results: [result({ skillCandidates: [skill("alpha")] })],
+				destinations: dest,
+				force: false,
+			});
+			expect(skipped.actions[0]).toMatchObject({
+				operation: "skip",
+				status: "skipped_exists",
+			});
+			const forced = await planMigration({
+				results: [result({ skillCandidates: [skill("alpha")] })],
+				destinations: dest,
+				force: true,
+			});
+			expect(forced.actions[0]).toMatchObject({
+				operation: "fail",
+				status: "failed_invalid_destination",
+			});
+		} finally {
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
+
 	test("effective-name collision across dirs: fail on force", async () => {
 		// Existing dir "other" whose frontmatter name slugifies to "target".
 		await writeDestSkill("other", "name: Target\ndescription: d");
@@ -197,5 +253,37 @@ describe("planMigration — diagnostics", () => {
 			force: false,
 		});
 		expect(actions[0]).toMatchObject({ type: "source", status: "failed_invalid_source", operation: "fail" });
+	});
+});
+
+describe("executeActions — skill destination safety", () => {
+	test("does not follow a symlinked ancestor while creating a skill", async () => {
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-executor-outside-"));
+		try {
+			const agentRoot = path.join(tmp, ".gjc");
+			await fs.symlink(outside, agentRoot, "dir");
+			const [action] = await executeActions([
+				{
+					source: "claude-code",
+					type: "skill",
+					name: "alpha",
+					effectiveName: "alpha",
+					destination: path.join(agentRoot, "skills", "alpha", "SKILL.md"),
+					operation: "create",
+					status: "imported",
+					skill: { content: "---\ndescription: a\n---\nbody" },
+				},
+			]);
+
+			expect(action).toMatchObject({ operation: "fail", status: "failed_io" });
+			expect(
+				await fs.access(path.join(outside, "skills", "alpha", "SKILL.md")).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+		} finally {
+			await fs.rm(outside, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/migrate-adapters.test.ts
+++ b/packages/coding-agent/test/migrate-adapters.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAdapter } from "../src/migrate/adapters/index";
+
+let home: string;
+
+async function writeFile(rel: string, content: string): Promise<void> {
+	const full = path.join(home, rel);
+	await fs.mkdir(path.dirname(full), { recursive: true });
+	await fs.writeFile(full, content, "utf-8");
+}
+
+beforeEach(async () => {
+	home = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-adapters-"));
+});
+
+afterEach(async () => {
+	await fs.rm(home, { recursive: true, force: true });
+});
+
+describe("claude-code adapter", () => {
+	test("absent config yields skipped_absent_source diagnostics, no candidates", async () => {
+		const result = await getAdapter("claude-code").collect({ homeDir: home });
+		expect(result.mcpCandidates).toHaveLength(0);
+		expect(result.skillCandidates).toHaveLength(0);
+		expect(result.diagnostics.every(d => d.status === "skipped_absent_source")).toBe(true);
+	});
+
+	test("reads mcpServers and skills", async () => {
+		await writeFile(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "bin" } } }));
+		await writeFile(".claude/skills/My Skill/SKILL.md", "---\nname: My Skill\ndescription: does things\n---\nBody");
+		const result = await getAdapter("claude-code").collect({ homeDir: home });
+		expect(result.mcpCandidates).toEqual([{ source: "claude-code", name: "srv", raw: { command: "bin" } }]);
+		expect(result.skillCandidates).toHaveLength(1);
+		expect(result.skillCandidates[0].slug).toBe("my-skill");
+		expect(result.skillCandidates[0].content).toContain("description: does things");
+		// `name` is dropped so the loaded name comes from the slug directory.
+		expect(result.skillCandidates[0].content).not.toContain("name: My Skill");
+	});
+
+	test("malformed mcp config yields failed_invalid_source", async () => {
+		await writeFile(".claude.json", "{ not json");
+		const result = await getAdapter("claude-code").collect({ homeDir: home });
+		expect(result.diagnostics.some(d => d.status === "failed_invalid_source")).toBe(true);
+	});
+});
+
+describe("codex adapter", () => {
+	test("reads TOML mcp_servers and prompt skills", async () => {
+		await writeFile(".codex/config.toml", '[mcp_servers.srv]\ncommand = "bin"\nargs = ["--x"]\n');
+		await writeFile(".codex/prompts/review.md", "Review the code carefully.");
+		const result = await getAdapter("codex").collect({ homeDir: home });
+		expect(result.mcpCandidates).toHaveLength(1);
+		expect(result.mcpCandidates[0]).toMatchObject({ source: "codex", name: "srv" });
+		expect(result.skillCandidates).toHaveLength(1);
+		expect(result.skillCandidates[0].slug).toBe("review");
+		// Description synthesized from the body.
+		expect(result.skillCandidates[0].content).toContain("description:");
+	});
+
+	test("malformed TOML yields failed_invalid_source", async () => {
+		await writeFile(".codex/config.toml", "this is = = not toml ][");
+		const result = await getAdapter("codex").collect({ homeDir: home });
+		expect(result.diagnostics.some(d => d.status === "failed_invalid_source")).toBe(true);
+	});
+});
+
+describe("opencode adapter", () => {
+	test("reads mcp, skills, and command conversions", async () => {
+		await writeFile(
+			".config/opencode/opencode.json",
+			JSON.stringify({ mcp: { srv: { type: "local", command: "bin" } } }),
+		);
+		await writeFile(".config/opencode/skills/helper/SKILL.md", "---\ndescription: helps\n---\nHelp body");
+		await writeFile(".config/opencode/commands/deploy.md", "Deploy the service.");
+		const result = await getAdapter("opencode").collect({ homeDir: home });
+		expect(result.mcpCandidates).toHaveLength(1);
+		expect(result.skillCandidates.map(c => c.slug).sort()).toEqual(["deploy", "helper"]);
+	});
+
+	test("discovers nested skills/**/SKILL.md recursively", async () => {
+		await writeFile(".config/opencode/opencode.json", JSON.stringify({ mcp: {} }));
+		await writeFile(".config/opencode/skills/group/nested/SKILL.md", "---\ndescription: deep\n---\nbody");
+		const result = await getAdapter("opencode").collect({ homeDir: home });
+		expect(result.skillCandidates.map(c => c.slug)).toContain("nested");
+	});
+});

--- a/packages/coding-agent/test/migrate-cli.test.ts
+++ b/packages/coding-agent/test/migrate-cli.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { setAgentDir } from "@gajae-code/utils";
+import { MigrateArgsError, resolveSources, runMigrate } from "../src/cli/migrate-cli";
+
+let home: string;
+let cwd: string;
+
+async function write(rel: string, content: string): Promise<void> {
+	const full = path.join(home, rel);
+	await fs.mkdir(path.dirname(full), { recursive: true });
+	await fs.writeFile(full, content, "utf-8");
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await fs.stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+beforeEach(async () => {
+	home = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-cli-home-"));
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-cli-cwd-"));
+	await write(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "bin" } } }));
+	await write(".claude/skills/alpha/SKILL.md", "---\ndescription: a\n---\nbody");
+});
+
+afterEach(async () => {
+	await fs.rm(home, { recursive: true, force: true });
+	await fs.rm(cwd, { recursive: true, force: true });
+});
+
+describe("resolveSources", () => {
+	test("expands all", () => {
+		expect(resolveSources(["all"])).toEqual(["claude-code", "codex", "opencode"]);
+	});
+	test("dedupes and returns canonical order regardless of input order", () => {
+		expect(resolveSources(["opencode", "claude-code", "opencode"])).toEqual(["claude-code", "opencode"]);
+	});
+	test("rejects unknown source", () => {
+		expect(() => resolveSources(["bogus"])).toThrow(MigrateArgsError);
+	});
+	test("rejects empty selection", () => {
+		expect(() => resolveSources([])).toThrow(MigrateArgsError);
+	});
+});
+
+describe("runMigrate", () => {
+	test("--dry-run writes nothing", async () => {
+		const report = await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			homeDir: home,
+			cwd,
+		});
+		expect(report.dryRun).toBe(true);
+		expect(report.actions.length).toBeGreaterThan(0);
+		expect(await exists(path.join(cwd, ".gjc", "mcp.json"))).toBe(false);
+		expect(await exists(path.join(cwd, ".gjc", "skills"))).toBe(false);
+	});
+
+	test("--json report carries taxonomy counts by total/type/source", async () => {
+		const report = await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			homeDir: home,
+			cwd,
+		});
+		expect(report.summary.total).toHaveProperty("imported");
+		expect(report.summary.byType).toHaveProperty("mcp");
+		expect(report.summary.byType).toHaveProperty("skill");
+		expect(report.summary.bySource).toHaveProperty("claude-code");
+	});
+
+	test("--project writes under cwd/.gjc", async () => {
+		await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: false,
+			json: false,
+			homeDir: home,
+			cwd,
+		});
+		expect(await exists(path.join(cwd, ".gjc", "mcp.json"))).toBe(true);
+		expect(await exists(path.join(cwd, ".gjc", "skills", "alpha", "SKILL.md"))).toBe(true);
+	});
+
+	test("user scope writes under the agent dir", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-agent-"));
+		setAgentDir(agentDir);
+		try {
+			await runMigrate({
+				from: ["claude-code"],
+				project: false,
+				force: false,
+				dryRun: false,
+				json: false,
+				homeDir: home,
+				cwd,
+			});
+			expect(await exists(path.join(agentDir, "mcp.json"))).toBe(true);
+			expect(await exists(path.join(agentDir, "skills", "alpha", "SKILL.md"))).toBe(true);
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("failure status makes report.ok false (malformed source)", async () => {
+		await write(".claude.json", "{ not json");
+		const report = await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			homeDir: home,
+			cwd,
+		});
+		expect(report.ok).toBe(false);
+	});
+
+	test("--from all and repeated --from load every selected source once", async () => {
+		const report = await runMigrate({
+			from: ["opencode", "claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			homeDir: home,
+			cwd,
+		});
+		expect(report.sources).toEqual(["claude-code", "opencode"]);
+	});
+});

--- a/packages/coding-agent/test/migrate-import.test.ts
+++ b/packages/coding-agent/test/migrate-import.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runMigrate } from "../src/cli/migrate-cli";
+import { readMCPConfigFile } from "../src/runtime-mcp/config-writer";
+
+let home: string;
+let cwd: string;
+
+async function write(rel: string, content: string): Promise<void> {
+	const full = path.join(home, rel);
+	await fs.mkdir(path.dirname(full), { recursive: true });
+	await fs.writeFile(full, content, "utf-8");
+}
+
+beforeEach(async () => {
+	home = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-import-home-"));
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-import-cwd-"));
+});
+
+afterEach(async () => {
+	await fs.rm(home, { recursive: true, force: true });
+	await fs.rm(cwd, { recursive: true, force: true });
+});
+
+const opts = (over: Partial<Parameters<typeof runMigrate>[0]>) => ({
+	from: ["all"] as string[],
+	project: true,
+	force: false,
+	dryRun: false,
+	json: true,
+	homeDir: home,
+	cwd,
+	...over,
+});
+
+describe("end-to-end import", () => {
+	test("claude-code imports MCP + skill", async () => {
+		await write(".claude.json", JSON.stringify({ mcpServers: { claudeSrv: { command: "cbin" } } }));
+		await write(".claude/skills/alpha/SKILL.md", "---\ndescription: a\n---\nbody");
+		const report = await runMigrate(opts({ from: ["claude-code"] }));
+		const config = await readMCPConfigFile(path.join(cwd, ".gjc", "mcp.json"));
+		expect(config.mcpServers?.claudeSrv).toMatchObject({ command: "cbin" });
+		expect(await fs.readFile(path.join(cwd, ".gjc", "skills", "alpha", "SKILL.md"), "utf-8")).toContain(
+			"description: a",
+		);
+		expect(report.ok).toBe(true);
+	});
+
+	test("codex imports TOML MCP + converted prompt", async () => {
+		await write(".codex/config.toml", '[mcp_servers.codexSrv]\ncommand = "cdx"\n');
+		await write(".codex/prompts/review.md", "Review carefully.");
+		await runMigrate(opts({ from: ["codex"] }));
+		const config = await readMCPConfigFile(path.join(cwd, ".gjc", "mcp.json"));
+		expect(config.mcpServers?.codexSrv).toMatchObject({ type: "stdio", command: "cdx" });
+		expect(await fs.readFile(path.join(cwd, ".gjc", "skills", "review", "SKILL.md"), "utf-8")).toContain(
+			"description:",
+		);
+	});
+
+	test("opencode imports MCP + skill + command", async () => {
+		await write(
+			".config/opencode/opencode.json",
+			JSON.stringify({ mcp: { ocSrv: { type: "local", command: "ocb" } } }),
+		);
+		await write(".config/opencode/commands/deploy.md", "Deploy it.");
+		await runMigrate(opts({ from: ["opencode"] }));
+		const config = await readMCPConfigFile(path.join(cwd, ".gjc", "mcp.json"));
+		expect(config.mcpServers?.ocSrv).toMatchObject({ type: "stdio", command: "ocb" });
+		expect(await fs.readFile(path.join(cwd, ".gjc", "skills", "deploy", "SKILL.md"), "utf-8")).toContain(
+			"description:",
+		);
+	});
+
+	test("default rerun is idempotent (all skipped)", async () => {
+		await write(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "bin" } } }));
+		await write(".claude/skills/alpha/SKILL.md", "---\ndescription: a\n---\nbody");
+		await runMigrate(opts({ from: ["claude-code"] }));
+		const second = await runMigrate(opts({ from: ["claude-code"] }));
+		const statuses = second.actions.filter(a => a.type !== "source").map(a => a.status);
+		expect(statuses.length).toBeGreaterThan(0);
+		expect(statuses.every(s => s === "skipped_exists")).toBe(true);
+		expect(second.ok).toBe(true);
+	});
+
+	test("force overwrites existing MCP server", async () => {
+		await write(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "v1" } } }));
+		await runMigrate(opts({ from: ["claude-code"] }));
+		await write(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "v2" } } }));
+		await runMigrate(opts({ from: ["claude-code"], force: true }));
+		const config = await readMCPConfigFile(path.join(cwd, ".gjc", "mcp.json"));
+		expect(config.mcpServers?.srv).toMatchObject({ command: "v2" });
+	});
+});

--- a/packages/coding-agent/test/migrate-import.test.ts
+++ b/packages/coding-agent/test/migrate-import.test.ts
@@ -84,6 +84,29 @@ describe("end-to-end import", () => {
 		expect(second.ok).toBe(true);
 	});
 
+	test("pre-existing skill destination symlink is reported as a conflict and not followed", async () => {
+		await write(".claude/skills/alpha/SKILL.md", "---\ndescription: a\n---\nbody");
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-import-outside-"));
+		try {
+			await fs.mkdir(path.join(cwd, ".gjc", "skills"), { recursive: true });
+			await fs.symlink(outside, path.join(cwd, ".gjc", "skills", "alpha"), "dir");
+
+			const report = await runMigrate(opts({ from: ["claude-code"] }));
+			const alphaAction = report.actions.find(action => action.type === "skill" && action.name === "alpha");
+
+			expect(alphaAction).toMatchObject({ operation: "skip", status: "skipped_exists" });
+			expect(report.ok).toBe(true);
+			expect(
+				await fs.access(path.join(outside, "SKILL.md")).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+		} finally {
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
+
 	test("force overwrites existing MCP server", async () => {
 		await write(".claude.json", JSON.stringify({ mcpServers: { srv: { command: "v1" } } }));
 		await runMigrate(opts({ from: ["claude-code"] }));

--- a/packages/coding-agent/test/migrate-schema-matrix.test.ts
+++ b/packages/coding-agent/test/migrate-schema-matrix.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { mapMcpEntry } from "../src/migrate/mcp-mapper";
+
+describe("mapMcpEntry — Claude Code", () => {
+	test("preserves stdio command/args/env", () => {
+		const out = mapMcpEntry("claude-code", "a", { command: "bin", args: ["--x"], env: { K: "v" } });
+		expect(out).toEqual({
+			ok: true,
+			config: { type: "stdio", command: "bin", args: ["--x"], env: { K: "v" } },
+			warnings: [],
+		});
+	});
+
+	test("preserves http url + headers", () => {
+		const out = mapMcpEntry("claude-code", "a", { type: "http", url: "https://x", headers: { A: "b" } });
+		expect(out).toEqual({ ok: true, config: { type: "http", url: "https://x", headers: { A: "b" } }, warnings: [] });
+	});
+
+	test("maps sse transport", () => {
+		const out = mapMcpEntry("claude-code", "a", { type: "sse", url: "https://x" });
+		expect(out.ok && out.config.type).toBe("sse");
+	});
+
+	test("fails on invalid args type", () => {
+		const out = mapMcpEntry("claude-code", "a", { command: "bin", args: "nope" });
+		expect(out).toMatchObject({ ok: false, status: "failed_invalid_source" });
+	});
+
+	test("fails on invalid env type", () => {
+		const out = mapMcpEntry("claude-code", "a", { command: "bin", env: { K: 1 } });
+		expect(out).toMatchObject({ ok: false, status: "failed_invalid_source" });
+	});
+
+	test("skips entry with neither command nor url", () => {
+		const out = mapMcpEntry("claude-code", "a", { foo: "bar" });
+		expect(out).toMatchObject({ ok: false, status: "skipped_unmappable" });
+	});
+});
+
+describe("mapMcpEntry — Codex", () => {
+	test("transforms tool_timeout_sec to timeout ms and preserves cwd", () => {
+		const out = mapMcpEntry("codex", "a", { command: "bin", cwd: "/w", tool_timeout_sec: 5 });
+		expect(out).toMatchObject({ ok: true, config: { type: "stdio", command: "bin", cwd: "/w", timeout: 5000 } });
+	});
+
+	test("omits secret-indirection fields with warning and never echoes value", () => {
+		const out = mapMcpEntry("codex", "a", {
+			command: "bin",
+			env_vars: { SECRET: "super-secret-value" },
+			bearer_token_env_var: "MY_TOKEN",
+		});
+		expect(out.ok).toBe(true);
+		if (!out.ok) throw new Error("expected ok");
+		const joined = out.warnings.join(" | ");
+		expect(joined).toContain("env_vars");
+		expect(joined).toContain("bearer_token_env_var");
+		expect(joined).not.toContain("super-secret-value");
+		expect(JSON.stringify(out.config)).not.toContain("super-secret-value");
+	});
+
+	test("omits startup_timeout_sec and enabled_tools with warning", () => {
+		const out = mapMcpEntry("codex", "a", { command: "bin", startup_timeout_sec: 10, enabled_tools: ["x"] });
+		expect(out.ok).toBe(true);
+		if (!out.ok) throw new Error("expected ok");
+		expect(out.warnings.join(" ")).toContain("startup_timeout_sec");
+		expect(out.warnings.join(" ")).toContain("enabled_tools");
+	});
+
+	test("maps http with http_headers", () => {
+		const out = mapMcpEntry("codex", "a", { url: "https://x", http_headers: { A: "b" } });
+		expect(out).toMatchObject({ ok: true, config: { type: "http", url: "https://x", headers: { A: "b" } } });
+	});
+
+	test("fails on malformed-typed args", () => {
+		const out = mapMcpEntry("codex", "a", { command: "bin", args: [1, 2] });
+		expect(out).toMatchObject({ ok: false, status: "failed_invalid_source" });
+	});
+});
+
+describe("mapMcpEntry — OpenCode", () => {
+	test("type:local transforms to stdio", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "local", command: "bin", enabled: false });
+		expect(out).toMatchObject({ ok: true, config: { type: "stdio", command: "bin", enabled: false } });
+	});
+
+	test("type:remote transforms to http", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "remote", url: "https://x" });
+		expect(out).toMatchObject({ ok: true, config: { type: "http", url: "https://x" } });
+	});
+
+	test("type:local without command is skipped", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "local" });
+		expect(out).toMatchObject({ ok: false, status: "skipped_unmappable" });
+	});
+
+	test("type:remote without url is skipped", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "remote" });
+		expect(out).toMatchObject({ ok: false, status: "skipped_unmappable" });
+	});
+
+	test("non-object entry fails", () => {
+		const out = mapMcpEntry("opencode", "a", "nope");
+		expect(out).toMatchObject({ ok: false, status: "failed_invalid_source" });
+	});
+
+	test("type:sse with url is preserved as sse", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "sse", url: "https://x" });
+		expect(out).toMatchObject({ ok: true, config: { type: "sse", url: "https://x" } });
+	});
+
+	test("unknown fields are omitted with a warning (not copied)", () => {
+		const out = mapMcpEntry("opencode", "a", { type: "local", command: "bin", mystery: "drop-me" });
+		expect(out.ok).toBe(true);
+		if (!out.ok) throw new Error("expected ok");
+		expect(out.warnings.join(" ")).toContain('omitted unknown field "mystery"');
+		expect(JSON.stringify(out.config)).not.toContain("drop-me");
+	});
+});

--- a/packages/coding-agent/test/migrate.redteam.test.ts
+++ b/packages/coding-agent/test/migrate.redteam.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Red-team / adversarial tests for `gjc migrate`. These try to break the feature:
+ * secret leakage, path traversal, all-malformed input, and cross-source collisions.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runMigrate } from "../src/cli/migrate-cli";
+
+let home: string;
+let cwd: string;
+
+async function write(rel: string, content: string): Promise<void> {
+	const full = path.join(home, rel);
+	await fs.mkdir(path.dirname(full), { recursive: true });
+	await fs.writeFile(full, content, "utf-8");
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await fs.stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+beforeEach(async () => {
+	home = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-redteam-home-"));
+	cwd = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-redteam-cwd-"));
+});
+
+afterEach(async () => {
+	await fs.rm(home, { recursive: true, force: true });
+	await fs.rm(cwd, { recursive: true, force: true });
+});
+
+const base = (over: Partial<Parameters<typeof runMigrate>[0]>) => ({
+	from: ["all"] as string[],
+	project: true,
+	force: false,
+	dryRun: false,
+	json: true,
+	homeDir: home,
+	cwd,
+	...over,
+});
+
+describe("red-team: secret leakage", () => {
+	test("codex env_vars / bearer_token values never appear in the report", async () => {
+		await write(
+			".codex/config.toml",
+			'[mcp_servers.srv]\ncommand = "bin"\nbearer_token_env_var = "TOKEN_ENV"\n\n[mcp_servers.srv.env_vars]\nSECRET = "TOPSECRET-LEAK-CANARY"\n',
+		);
+		const report = await runMigrate(base({ from: ["codex"], dryRun: true }));
+		const serialized = JSON.stringify(report);
+		expect(serialized).not.toContain("TOPSECRET-LEAK-CANARY");
+		// The field name may be referenced in a warning, but never the value.
+		expect(serialized.includes("env_vars") || serialized.includes("bearer_token_env_var")).toBe(true);
+	});
+});
+
+describe("red-team: path traversal", () => {
+	test("a malicious skill name cannot escape the skills dir", async () => {
+		await write(".claude/skills/..evil/SKILL.md", "---\ndescription: x\n---\nbody");
+		await runMigrate(base({ from: ["claude-code"] }));
+		// Slugified to a safe name; nothing written outside the project skills dir.
+		const escaped = path.join(cwd, "evil");
+		const escaped2 = path.join(path.dirname(cwd), "evil");
+		expect(await exists(escaped)).toBe(false);
+		expect(await exists(escaped2)).toBe(false);
+		const skillsDir = path.join(cwd, ".gjc", "skills");
+		const entries = await fs.readdir(skillsDir).catch(() => []);
+		for (const e of entries) expect(e.includes("..")).toBe(false);
+	});
+});
+
+describe("red-team: all-malformed input", () => {
+	test("every source malformed -> ok=false, no partial MCP writes", async () => {
+		await write(".claude.json", "{ broken");
+		await write(".codex/config.toml", "= = broken ][");
+		await write(".config/opencode/opencode.json", "{ broken");
+		const report = await runMigrate(base({}));
+		expect(report.ok).toBe(false);
+		expect(await exists(path.join(cwd, ".gjc", "mcp.json"))).toBe(false);
+	});
+});
+
+describe("red-team: cross-source slug collision", () => {
+	test("same skill slug from two sources: first imported, second skipped (no silent clobber)", async () => {
+		await write(".claude/skills/shared/SKILL.md", "---\ndescription: from-claude\n---\nbody");
+		await write(".config/opencode/skills/shared/SKILL.md", "---\ndescription: from-opencode\n---\nbody");
+		const report = await runMigrate(base({ from: ["claude-code", "opencode"] }));
+		const skillActions = report.actions.filter(a => a.type === "skill" && a.name === "shared");
+		expect(skillActions).toHaveLength(2);
+		expect(skillActions[0].status).toBe("imported");
+		expect(skillActions[1].status).toBe("skipped_exists");
+		// The first (canonical-order: claude-code) wins on disk.
+		const written = await fs.readFile(path.join(cwd, ".gjc", "skills", "shared", "SKILL.md"), "utf-8");
+		expect(written).toContain("from-claude");
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	getMCPServer,
+	readDisabledServers,
+	setServerDisabled,
+	upsertMCPServer,
+} from "../../src/runtime-mcp/config-writer";
+import type { MCPServerConfig } from "../../src/runtime-mcp/types";
+
+let tmpDir: string;
+let configPath: string;
+
+const stdio = (command: string): MCPServerConfig => ({ command });
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-config-writer-"));
+	configPath = path.join(tmpDir, "mcp.json");
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("upsertMCPServer", () => {
+	test("adds a server that does not exist", async () => {
+		const result = await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+		expect(result).toEqual({ status: "added" });
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
+	});
+
+	test("skips an existing server without force and does not overwrite", async () => {
+		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"));
+		expect(result).toEqual({ status: "skipped", reason: "exists" });
+		// Original config is untouched.
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
+	});
+
+	test("updates an existing server with force", async () => {
+		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"), { force: true });
+		expect(result).toEqual({ status: "updated" });
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("changed-bin"));
+	});
+
+	test("throws on an invalid server name", async () => {
+		await expect(upsertMCPServer(configPath, "has spaces", stdio("bin"))).rejects.toThrow();
+		// Nothing was written.
+		expect(await getMCPServer(configPath, "has spaces")).toBeUndefined();
+	});
+
+	test("throws on an invalid server config", async () => {
+		// Missing `command`/`url` is not a valid MCP server config.
+		await expect(upsertMCPServer(configPath, "alpha", {} as MCPServerConfig)).rejects.toThrow();
+		expect(await getMCPServer(configPath, "alpha")).toBeUndefined();
+	});
+
+	test("preserves disabledServers when force-updating a disabled server", async () => {
+		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+		await setServerDisabled(configPath, "alpha", true);
+		expect(await readDisabledServers(configPath)).toEqual(["alpha"]);
+
+		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"), { force: true });
+		expect(result).toEqual({ status: "updated" });
+		// The server is updated but its disabled state is preserved.
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("changed-bin"));
+		expect(await readDisabledServers(configPath)).toEqual(["alpha"]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds `gjc migrate --from <claude-code|codex|opencode|all> [--project] [--force] [--dry-run] [--json]` to import **MCP servers and skills** from other coding agents into native GJC config, plus a new collision-aware `upsertMCPServer` in `runtime-mcp/config-writer.ts`.

Planned via **deep-interview → ralplan consensus** (Planner/Architect/Critic) and executed via **ultragoal**; spec at `.gjc/specs/deep-interview-mcp-skill-migration.md`, plan at `.gjc/plans/ralplan/2026-06-20-1455-3cb2/`.

## What's included

- **`upsertMCPServer(filePath, name, config, {force})`** — `added` / `skipped(exists)` / `updated`; reuses existing `add`/`update`/`get` primitives; preserves `disabledServers`; never connects to a server.
- **`src/migrate/`**
  - per-source **adapters** (`claude-code`, `codex`, `opencode`) — read global/home config only; `absent → skipped_absent_source`, `malformed → failed_invalid_source`, `unreadable → failed_io`; recursive OpenCode `skills/**/SKILL.md`.
  - **mcp-mapper** — source-schema compatibility matrix (P/T/OW/S/F); secret-indirection fields omitted-with-warning (values never read); SSE preserved; unknown fields omitted-with-warning.
  - **skill-normalizer** — effective GJC-loaded name == lowercase-hyphen slug; `description` synthesized when missing.
  - **action-planner** — reads destination state **once**; dry-run and live execution consume the same actions; full force/collision semantics (stale dir, file-at-path, effective-name collision, intra-run duplicate, malformed destination).
  - **executor** — performs only planned create/update; `failed_io` on write error; no rollback (documented).
  - **report** — human + `--json`; secret redaction.
- **Taxonomy / exit codes** — 8 statuses; `skipped_*` → exit 0, any `failed_*` → `ok=false` + exit 1.

## Verification

- **64 tests pass** across 7 files: `config-writer`, `migrate-schema-matrix`, `migrate-adapters`, `migrate-action-planner`, `migrate-cli`, `migrate-import`, and adversarial `migrate.redteam` (secret-leak, path-traversal, all-malformed, cross-source collision).
- `bun --cwd packages/coding-agent run check:types` clean; biome clean.
- Independent **architect review**: initial pass found 5 spec-conformance gaps → all fixed + test-covered → re-review **CLEAR / APPROVE** on architecture, product, and code lanes.

## Non-goals

- No live-session MCP re-registration (config is picked up next session).
- No connection/OAuth validation during migrate (use `/mcp test`).
- No project-level source-config reading.

## Notes

The `gjc migrate` command is a thin argv wrapper over `runMigrate`; all behavior is covered at the package surface. Local `.gjc/` runtime state is intentionally not committed.
