### PR TITLE
fix(research-plan): reject counterexample-only claims regardless of dropCondition wording (#941)

### DIFF
--- a/packages/coding-agent/src/research-plan/ledger.ts
+++ b/packages/coding-agent/src/research-plan/ledger.ts
@@ -139,18 +139,26 @@ export function evaluateResearchLedger(
 			unresolvedUnknowns: item.unknowns,
 		};
 	}
-	const dropReason = matchesDropCondition(item, relevantEvidence) ?? sourceConflictReason(item, relevantEvidence);
+	const supporting = relevantEvidence.filter(entry => entry.verdict === "support");
+	const firstContradiction = relevantEvidence.find(entry => entry.verdict === "contradict");
+	let dropReason = matchesDropCondition(item, relevantEvidence) ?? sourceConflictReason(item, relevantEvidence);
+	// A counterexample with no surviving support falsifies the claim regardless of how the
+	// dropCondition / sourceConflictPolicy prose is worded. Without this, a purely contradicted
+	// claim would slip through as "uncertain" and reopen the hallucination survival path the
+	// evidence ledger exists to close (a contested claim already rejects via sourceConflictReason).
+	if (!dropReason && firstContradiction && supporting.length === 0) {
+		dropReason = `claim contradicted by counterexample with no supporting evidence: ${firstContradiction.source}`;
+	}
 	if (dropReason) {
 		return {
 			claim: item.claim,
 			finalVerdict: "rejected",
-			survivingSources: relevantEvidence.filter(entry => entry.verdict === "support"),
+			survivingSources: supporting,
 			rejectReason: dropReason,
 			unresolvedUnknowns: item.unknowns,
 		};
 	}
 	const uncertain = relevantEvidence.some(entry => entry.verdict === "uncertain");
-	const supporting = relevantEvidence.filter(entry => entry.verdict === "support");
 	if (uncertain || supporting.length === 0) {
 		return {
 			claim: item.claim,

--- a/packages/coding-agent/test/research-plan-ledger.test.ts
+++ b/packages/coding-agent/test/research-plan-ledger.test.ts
@@ -99,4 +99,69 @@ describe("research plan ledger", () => {
 			unresolvedUnknowns: ["production workload mix"],
 		});
 	});
+
+	it("rejects a counterexample-only claim even when the dropCondition wording lacks trigger keywords", () => {
+		const item = makePlanItem({
+			dropCondition: "Remove the claim if the benchmarks disagree.",
+			sourceConflictPolicy: "Prefer the newest source.",
+		});
+		const evidence: ResearchEvidenceEntry[] = [
+			{
+				claim: item.claim,
+				source: "counterexamples/long-context-regression.md",
+				confidence: "high",
+				verdict: "contradict",
+			},
+		];
+
+		const verdict = evaluateResearchLedger(item, evidence);
+		expect(verdict.finalVerdict).toBe("rejected");
+		expect(verdict.rejectReason).toContain("no supporting evidence");
+		expect(verdict.rejectReason).toContain("counterexamples/long-context-regression.md");
+		expect(verdict.survivingSources).toEqual([]);
+	});
+
+	it("rejects when a counterexample coexists with unresolved evidence and no support", () => {
+		const item = makePlanItem({
+			dropCondition: "Remove the claim if the benchmarks disagree.",
+			sourceConflictPolicy: "Prefer the newest source.",
+		});
+		const evidence: ResearchEvidenceEntry[] = [
+			{ claim: item.claim, source: "src/contra.md", confidence: "high", verdict: "contradict" },
+			{ claim: item.claim, source: "src/unsure.md", confidence: "low", verdict: "uncertain" },
+		];
+
+		expect(evaluateResearchLedger(item, evidence).finalVerdict).toBe("rejected");
+	});
+
+	it("rejects mixed support and contradiction even when the dropCondition wording does not match", () => {
+		const item = makePlanItem({
+			dropCondition: "Remove the claim if the benchmarks disagree.",
+			sourceConflictPolicy: "Prefer the newest source.",
+		});
+		const evidence: ResearchEvidenceEntry[] = [
+			{ claim: item.claim, source: "src/support.md", confidence: "high", verdict: "support" },
+			{ claim: item.claim, source: "src/contra.md", confidence: "high", verdict: "contradict" },
+		];
+
+		expect(evaluateResearchLedger(item, evidence)).toMatchObject({
+			finalVerdict: "rejected",
+			rejectReason: "source conflict remains unresolved",
+		});
+	});
+
+	it("ignores evidence recorded against a different claim", () => {
+		const item = makePlanItem({
+			dropCondition: "Remove the claim if the benchmarks disagree.",
+			sourceConflictPolicy: "Prefer the newest source.",
+		});
+		const evidence: ResearchEvidenceEntry[] = [
+			{ claim: "an unrelated claim", source: "src/other.md", confidence: "high", verdict: "contradict" },
+		];
+
+		expect(evaluateResearchLedger(item, evidence)).toMatchObject({
+			finalVerdict: "uncertain",
+			rejectReason: "no evidence collected for claim",
+		});
+	});
 });


### PR DESCRIPTION
## What

Make `evaluateResearchLedger` reject a claim whose only evidence is a counterexample (a `contradict` entry with no surviving support), regardless of how the `dropCondition` / `sourceConflictPolicy` prose is worded.

## Why

Trying out the research-plan evidence ledger from #933, a claim with only a contradicting source returned `finalVerdict: "uncertain"` instead of `"rejected"`. The reject path depended on the `dropCondition` string matching a hardcoded regex (`/counterexample|contradict|conflict|falsif/`), and `sourceConflictReason` only rejects when both support and contradiction exist. So a pure counterexample (the strongest falsification) slipped through as `uncertain` unless the policy prose happened to contain the right keywords — while a *contested* `support`+`contradict` claim always rejected.

That reopens the hallucination survival path the ledger exists to close (#932: "Verifier checks contradictions"; `docs/research-plan-ledger.md`: "rejects the broad claim instead of letting a plausible summary survive by vibes").

Fix: a counterexample with no surviving support is treated as a falsification and rejected, independent of wording. The `accept` / `uncertain` paths and the three existing tests are unchanged. (Option considered and rejected: rejecting on *any* contradiction would override the natural-language `dropCondition`/`sourceConflictPolicy` the design intentionally exposes for the mixed-evidence case.)

Out of scope (left for follow-up): the verifier currently ignores `entry.confidence`, and `accepted` verdicts always report `unresolvedUnknowns: []`.

Fixes #941

## Testing

- `bun test packages/coding-agent/test/research-plan-ledger.test.ts` → 8 pass / 0 fail (3 new: counterexample-only rejection with non-keyword dropCondition, counterexample+uncertain rejection, claim-mismatch filtering).
- `bunx biome check packages/coding-agent/src/research-plan/ledger.ts packages/coding-agent/test/research-plan-ledger.test.ts` → clean.
- `bun run check:types` (packages/coding-agent, tsgo) → exit 0.
- `bun run check` (packages/coding-agent) → biome + types clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — N/A: internal research-plan spike (#933), not yet wired to a user-facing surface, no user-visible behavior change.
