### PR TITLE
test(coding-agent): include migrate in CLI surface golden

### DIFF
--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -33,6 +33,7 @@ describe("GJC public CLI command surface", () => {
 			"mcp-serve",
 			"contribute-pr",
 			"deep-interview",
+			"migrate",
 			"rlm",
 			"update",
 			"launch",


### PR DESCRIPTION
## Summary
- Update the public CLI command surface golden test to include the newly registered `migrate` command from PR #940.

## Verification
- `bun --cwd=packages/coding-agent test test/cli-command-surface.test.ts`

## Context
Dev CI on `dev` failed after #940 because the command was intentionally registered but the golden command-surface expectation was not updated.