### PR TITLE
fix(coding-agent): keep combo preset main model on resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Documented lifecycle notification hooks (#903).
 - Added a routed GJC session guide for Clawhip/Hermes/OpenClaw visible routed sessions and linked it from the Hermes docs and operator instructions.
 
+### Fixed
+
+- Fixed combo/cross-provider model presets flipping the main provider on resume. A profile's main model was applied through `setModelTemporary`, which records the session `model_change` with `role: "temporary"`; on resume the session restored `models.default` (the stale pre-profile base model), so an "Apply for this session" combo like `opus-codex` came back on the base default (e.g. `openai-codex/gpt-5.5`) instead of the profile's main model (`anthropic/claude-opus-4-8`). Profile activation now records its main model as the session default (without writing global settings), while transient retry/fallback/context-promotion/plan-mode switches keep `role: "temporary"` so the issue #849 protection is preserved.
+
 ## [0.6.3] - 2026-06-19
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -209,7 +209,9 @@ export async function applyPreparedModelProfileActivation(
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel);
+			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel, {
+				persistAsSessionDefault: true,
+			});
 			modelChanged = true;
 		}
 		if (Object.keys(prepared.agentModelOverrides).length > 0) {
@@ -234,7 +236,9 @@ export async function applyPreparedModelProfileActivation(
 		}
 		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 		if (modelChanged && previousModel) {
-			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel, {
+				persistAsSessionDefault: true,
+			});
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5859,9 +5859,21 @@ export class AgentSession {
 	/**
 	 * Set model temporarily (for this session only).
 	 * Validates API key, saves to session log but NOT to settings.
+	 *
+	 * The change is recorded in the session log as `role: "temporary"` by
+	 * default, which means it is NOT restored as the session default on resume —
+	 * transient retry/fallback/context-promotion/plan switches must not clobber
+	 * the user's explicit pick (issue #849). Model-profile activation passes
+	 * `persistAsSessionDefault: true` so the profile's main model becomes the
+	 * session default and survives resume, while still not being written to
+	 * global settings (new sessions keep the global default).
 	 * @throws Error if no API key available for the model
 	 */
-	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+	async setModelTemporary(
+		model: Model,
+		thinkingLevel?: ThinkingLevel,
+		options?: { persistAsSessionDefault?: boolean },
+	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -5870,7 +5882,10 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
-		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
+		this.sessionManager.appendModelChange(
+			`${model.provider}/${model.id}`,
+			options?.persistAsSessionDefault ? "default" : "temporary",
+		);
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 
 		// Apply explicit thinking level if given; otherwise prefer the model's

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+// Regression coverage for the combo-preset resume bug: activating a model
+// profile (e.g. opus-codex) whose main model differs from the startup base
+// model used to record the main model with role="temporary". On resume the
+// session restored `models.default` (the stale pre-profile base model, e.g.
+// openai-codex/gpt-5.5), flipping the main provider away from the profile's
+// intended main model. Profile activation now records its main model as the
+// session default via `persistAsSessionDefault`, while transient switches
+// (retry/fallback/context-promotion/plan mode) stay role="temporary".
+describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-profile-resume-default-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+		}
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function makeSession(startModel: Model): AgentSession {
+		const agent = new Agent({
+			initialState: {
+				model: startModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	}
+
+	function resolveModels(): { base: Model; profileMain: Model } {
+		const base = modelRegistry.find("openai-codex", "gpt-5.5");
+		const profileMain = modelRegistry.find("anthropic", "claude-opus-4-8");
+		if (!base || !profileMain) {
+			throw new Error("Expected codex and anthropic opus models to exist");
+		}
+		return { base, profileMain };
+	}
+
+	it("records the profile main model as the resume default without touching global settings", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+
+		// Session start records the base default model.
+		await session.setModel(base);
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+		const globalDefaultBefore = session.settings.getModelRole("default");
+
+		// Combo-profile activation applies the main model for this session only.
+		await session.setModelTemporary(profileMain, undefined, { persistAsSessionDefault: true });
+
+		// The default that resume restores is now the profile's main model.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("anthropic/claude-opus-4-8");
+		// Global default setting is untouched (apply-for-this-session semantics).
+		expect(session.settings.getModelRole("default")).toBe(globalDefaultBefore);
+	});
+
+	it("keeps a transient switch as role=temporary so resume does not adopt it", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+
+		await session.setModel(base);
+		// No persistAsSessionDefault: simulates a retry/fallback/plan-mode switch.
+		await session.setModelTemporary(profileMain);
+
+		expect(session.model?.provider).toBe("anthropic");
+		expect(session.model?.id).toBe("claude-opus-4-8");
+		// Resume still restores the explicit base default, not the transient model.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+	});
+});


### PR DESCRIPTION
## What

Combo / cross-provider model presets (e.g. `opus-codex`) no longer flip the **main provider** to the base default model on resume.

## Why

When a model profile is activated, its **main** model is applied through `AgentSession.setModelTemporary()`, which records the session `model_change` with `role: "temporary"`. At session start the *base* model (the global default, often `openai-codex/gpt-5.5`) is recorded with `role: "default"`.

On resume, the session restores `sessionContext.models.default` — i.e. the stale **pre-profile base model**, not the profile's main model. So:

- `opus-codex` (main = `anthropic/claude-opus-4-8`, sub-agents = `gpt-5.5`) is selected via **"Apply for this session"**.
- You work the whole session with Opus as the main model.
- After `/resume` (or `gjc -r`), the main provider silently flips to `openai-codex/gpt-5.5`.

Root cause confirmed from real session logs:

```jsonl
{"type":"model_change","model":"openai-codex/gpt-5.5"}                          // role defaults to "default"
{"type":"model_change","model":"anthropic/claude-opus-4-8","role":"temporary"} // profile activation
```

`models.default` resolves to `openai-codex/gpt-5.5`, which `agent-session.ts` restores on resume. The in-memory `#activeModelProfile` is also lost on resume, and `modelProfile.default` isn't persisted for "Apply for this session", so nothing re-applies the profile.

## Fix

- Add an opt-in `persistAsSessionDefault` option to `setModelTemporary`. When set, the session `model_change` is recorded with `role: "default"` so resume restores it — while still **not** writing to global settings (`modelRoles.default`), preserving "apply for this session" semantics.
- Profile activation (`applyPreparedModelProfileActivation`) passes `persistAsSessionDefault: true` for the profile's main model and its rollback restore.
- Transient switches (retry/fallback, context-promotion, plan-mode, manual temporary `/model`) keep `role: "temporary"`, so the issue #849 protection (transient fallback models must not clobber the user's pick on resume) is fully preserved.

Scope note: this restores the **main model** on both in-app `/resume` and CLI `gjc -r`. In-app resume keeps the sub-agent overrides (they live in the in-process runtime settings); restoring sub-agent overrides for an "apply for this session" preset across a cold CLI restart is a separate, lower-severity gap (sub-agents fall back to the restored main model, not the wrong base default) and is intentionally out of scope here.

## Testing

- New `test/agent-session-profile-resume-default.test.ts` builds a real `AgentSession` and asserts:
  - with `persistAsSessionDefault`, `buildSessionContext().models.default` becomes the profile's main model and global `modelRoles.default` is untouched;
  - without it, a transient switch stays `role: "temporary"` and resume keeps the explicit base default.
- Ran the profile / model-selector / resume suites green (73 tests), plus the openai-responses replay model-restore suite (17 tests).
- `biome check` and `tsgo --noEmit` clean on the changed files.

---

- [x] `bun check` passes (biome + tsgo on changed files; targeted test suites green)
- [x] Tested locally
- [x] CHANGELOG updated



---

Recreated against `dev` per review on #908 (original PR was closed because it targeted `main`).