### PR TITLE
fix(coding-agent): keep combo preset main model on resume (rollback-hardened)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Documented lifecycle notification hooks (#903).
 - Added a routed GJC session guide for Clawhip/Hermes/OpenClaw visible routed sessions and linked it from the Hermes docs and operator instructions.
 
+### Fixed
+
+- Fixed combo/cross-provider model presets flipping the main provider on resume. A profile's main model was applied through `setModelTemporary`, which records the session `model_change` with `role: "temporary"`; on resume the session restored `models.default` (the stale pre-profile base model), so an "Apply for this session" combo like `opus-codex` came back on the base default (e.g. `openai-codex/gpt-5.5`) instead of the profile's main model (`anthropic/claude-opus-4-8`). Profile activation now records its main model as the session default (without writing global settings), while transient retry/fallback/context-promotion/plan-mode switches keep `role: "temporary"` so the issue #849 protection is preserved.
+
 ## [0.6.3] - 2026-06-19
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Fixed combo/cross-provider model presets flipping the main provider on resume. A profile's main model was applied through `setModelTemporary`, which records the session `model_change` with `role: "temporary"`; on resume the session restored `models.default` (the stale pre-profile base model), so an "Apply for this session" combo like `opus-codex` came back on the base default (e.g. `openai-codex/gpt-5.5`) instead of the profile's main model (`anthropic/claude-opus-4-8`). Profile activation now records its main model as the session default (without writing global settings), while transient retry/fallback/context-promotion/plan-mode switches keep `role: "temporary"` so the issue #849 protection is preserved.
+- Hardened the model-profile activation rollback so a failed activation no longer poisons the resume default. The rollback previously restored the pre-activation *live* model as the session default (`role: "default"`); if the user was on a transient retry/fallback/context-promotion/plan switch when activation failed, that transient model was promoted to the resume default and weakened the issue #849 protection. Activation now snapshots the pre-activation resume default separately from the live model and re-asserts it on rollback, while the runtime live model still rolls back as a transient switch (`role: "temporary"`).
 
 ## [0.6.3] - 2026-06-19
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -17,6 +17,8 @@ type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel
 	setModelTemporary?: AgentSession["setModelTemporary"];
 	setActiveModelProfile?: (name: string | undefined) => void;
 	getActiveModelProfile?: () => string | undefined;
+	getSessionDefaultModelSelector?: () => string | undefined;
+	recordResumeDefaultModel?: (selector: string) => void;
 };
 
 export interface PrepareModelProfileActivationOptions {
@@ -47,6 +49,14 @@ export interface PreparedModelProfileActivation {
 	defaultThinkingLevel: ThinkingLevel | undefined;
 	agentModelOverrides: Record<string, string>;
 	previousActiveModelProfile: string | undefined;
+	/**
+	 * The session resume default ("provider/id") captured BEFORE activation —
+	 * the model resume would restore prior to this profile. Snapshotted
+	 * separately from `previousModel` (the live runtime model, which may be a
+	 * transient switch) so a failed-activation rollback restores the correct
+	 * resume default without promoting a transient model to it.
+	 */
+	previousSessionDefaultModel: string | undefined;
 }
 
 export function formatModelProfileCredentialError(profileName: string, providers: readonly string[]): string {
@@ -191,6 +201,7 @@ export async function prepareModelProfileActivation(
 		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
 		agentModelOverrides,
 		previousActiveModelProfile: options.session.getActiveModelProfile?.(),
+		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
 	};
 }
 
@@ -203,6 +214,7 @@ export async function applyPreparedModelProfileActivation(
 	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
 	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
+	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
 	let modelChanged = false;
 	let overridesChanged = false;
 	let defaultChanged = false;
@@ -235,10 +247,25 @@ export async function applyPreparedModelProfileActivation(
 			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
 		}
 		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
-		if (modelChanged && previousModel) {
-			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel, {
-				persistAsSessionDefault: true,
-			});
+		if (modelChanged) {
+			// Runtime rolls back to the pre-activation live model. That model may
+			// itself be a transient retry/fallback/context-promotion/plan switch,
+			// so it is recorded as role:"temporary" (NOT the resume default) to
+			// preserve the issue #849 protection.
+			if (previousModel) {
+				await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+			}
+			// The happy path already appended the profile main model as the resume
+			// default (role:"default"). Re-assert the pre-activation resume default
+			// so a failed activation does not poison future resume. Fall back to the
+			// live model only when there was no explicit pre-activation default
+			// (nothing to protect). Append-only — never touches the runtime model.
+			const restoreDefaultSelector =
+				previousSessionDefaultModel ??
+				(previousModel ? `${previousModel.provider}/${previousModel.id}` : undefined);
+			if (restoreDefaultSelector) {
+				prepared.session.recordResumeDefaultModel?.(restoreDefaultSelector);
+			}
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -209,7 +209,9 @@ export async function applyPreparedModelProfileActivation(
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel);
+			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel, {
+				persistAsSessionDefault: true,
+			});
 			modelChanged = true;
 		}
 		if (Object.keys(prepared.agentModelOverrides).length > 0) {
@@ -234,7 +236,9 @@ export async function applyPreparedModelProfileActivation(
 		}
 		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 		if (modelChanged && previousModel) {
-			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel, {
+				persistAsSessionDefault: true,
+			});
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5857,6 +5857,28 @@ export class AgentSession {
 	}
 
 	/**
+	 * The model selector ("provider/id") that resume restores as the session
+	 * default — the latest session-log `model_change` with role="default".
+	 * Model-profile activation snapshots this before mutating the session so a
+	 * failed-activation rollback can restore the pre-activation resume default
+	 * instead of promoting a transient runtime model to the resume default.
+	 */
+	getSessionDefaultModelSelector(): string | undefined {
+		return this.sessionManager.buildSessionContext().models.default;
+	}
+
+	/**
+	 * Re-assert the session resume default ("provider/id") in the session log
+	 * WITHOUT touching the live runtime model. Appends a `model_change` with
+	 * role="default"; never writes to global settings (apply-for-this-session
+	 * semantics). Used by model-profile activation rollback to neutralize the
+	 * profile main model the failed activation already recorded as the default.
+	 */
+	recordResumeDefaultModel(selector: string): void {
+		this.sessionManager.appendModelChange(selector, "default");
+	}
+
+	/**
 	 * Set model temporarily (for this session only).
 	 * Validates API key, saves to session log but NOT to settings.
 	 *

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5859,9 +5859,21 @@ export class AgentSession {
 	/**
 	 * Set model temporarily (for this session only).
 	 * Validates API key, saves to session log but NOT to settings.
+	 *
+	 * The change is recorded in the session log as `role: "temporary"` by
+	 * default, which means it is NOT restored as the session default on resume —
+	 * transient retry/fallback/context-promotion/plan switches must not clobber
+	 * the user's explicit pick (issue #849). Model-profile activation passes
+	 * `persistAsSessionDefault: true` so the profile's main model becomes the
+	 * session default and survives resume, while still not being written to
+	 * global settings (new sessions keep the global default).
 	 * @throws Error if no API key available for the model
 	 */
-	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+	async setModelTemporary(
+		model: Model,
+		thinkingLevel?: ThinkingLevel,
+		options?: { persistAsSessionDefault?: boolean },
+	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -5870,7 +5882,10 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
-		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
+		this.sessionManager.appendModelChange(
+			`${model.provider}/${model.id}`,
+			options?.persistAsSessionDefault ? "default" : "temporary",
+		);
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 
 		// Apply explicit thinking level if given; otherwise prefer the model's

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+// Regression coverage for the combo-preset resume bug: activating a model
+// profile (e.g. opus-codex) whose main model differs from the startup base
+// model used to record the main model with role="temporary". On resume the
+// session restored `models.default` (the stale pre-profile base model, e.g.
+// openai-codex/gpt-5.5), flipping the main provider away from the profile's
+// intended main model. Profile activation now records its main model as the
+// session default via `persistAsSessionDefault`, while transient switches
+// (retry/fallback/context-promotion/plan mode) stay role="temporary".
+describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-profile-resume-default-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+		}
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function makeSession(startModel: Model): AgentSession {
+		const agent = new Agent({
+			initialState: {
+				model: startModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	}
+
+	function resolveModels(): { base: Model; profileMain: Model } {
+		const base = modelRegistry.find("openai-codex", "gpt-5.5");
+		const profileMain = modelRegistry.find("anthropic", "claude-opus-4-8");
+		if (!base || !profileMain) {
+			throw new Error("Expected codex and anthropic opus models to exist");
+		}
+		return { base, profileMain };
+	}
+
+	it("records the profile main model as the resume default without touching global settings", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+
+		// Session start records the base default model.
+		await session.setModel(base);
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+		const globalDefaultBefore = session.settings.getModelRole("default");
+
+		// Combo-profile activation applies the main model for this session only.
+		await session.setModelTemporary(profileMain, undefined, { persistAsSessionDefault: true });
+
+		// The default that resume restores is now the profile's main model.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("anthropic/claude-opus-4-8");
+		// Global default setting is untouched (apply-for-this-session semantics).
+		expect(session.settings.getModelRole("default")).toBe(globalDefaultBefore);
+	});
+
+	it("keeps a transient switch as role=temporary so resume does not adopt it", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+
+		await session.setModel(base);
+		// No persistAsSessionDefault: simulates a retry/fallback/plan-mode switch.
+		await session.setModelTemporary(profileMain);
+
+		expect(session.model?.provider).toBe("anthropic");
+		expect(session.model?.id).toBe("claude-opus-4-8");
+		// Resume still restores the explicit base default, not the transient model.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+	});
+});

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import {
+	applyPreparedModelProfileActivation,
+	prepareModelProfileActivation,
+} from "@gajae-code/coding-agent/config/model-profile-activation";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
@@ -95,5 +99,65 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 		expect(session.model?.id).toBe("claude-opus-4-8");
 		// Resume still restores the explicit base default, not the transient model.
 		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+	});
+
+	it("rollback of a failed activation restores the pre-activation resume default, not the transient live model", async () => {
+		// A = persisted resume default, B = transient live model (e.g. retry/
+		// fallback/plan switch), profileMain = the profile's main model the failed
+		// activation already recorded as the session default before throwing.
+		const base = modelRegistry.find("openai-codex", "gpt-5.5");
+		const transient = modelRegistry.find("anthropic", "claude-sonnet-4-6");
+		const profileMain = modelRegistry.find("anthropic", "claude-opus-4-8");
+		if (!base || !transient || !profileMain) {
+			throw new Error("Expected codex gpt-5.5 + anthropic sonnet/opus models to exist");
+		}
+		session = makeSession(base);
+
+		// Persisted resume default A.
+		await session.setModel(base);
+		// Transient switch to B (role=temporary): resume default stays A (#849).
+		await session.setModelTemporary(transient);
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+		expect(session.model?.id).toBe("claude-sonnet-4-6");
+		const globalProfileDefaultBefore = session.settings.get("modelProfile.default");
+
+		// Prepare snapshots the pre-activation state: the live model is B, but the
+		// resume default is A — captured separately.
+		const prepared = await prepareModelProfileActivation({
+			session,
+			modelRegistry,
+			settings: session.settings,
+			profileName: "opus-codex",
+		});
+		expect(prepared.previousModel?.id).toBe("claude-sonnet-4-6");
+		expect(prepared.previousSessionDefaultModel).toBe("openai-codex/gpt-5.5");
+		expect(prepared.defaultModel?.id).toBe("claude-opus-4-8");
+
+		// Force the activation to fail AFTER the profile main model is recorded as
+		// the session default: the agent-model-override step throws.
+		prepared.settings = new Proxy(session.settings, {
+			get(target, prop, receiver) {
+				if (prop === "override") {
+					return () => {
+						throw new Error("simulated activation failure after model change");
+					};
+				}
+				const value = Reflect.get(target, prop, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		}) as typeof prepared.settings;
+
+		await expect(applyPreparedModelProfileActivation(prepared)).rejects.toThrow(
+			"simulated activation failure after model change",
+		);
+
+		// Resume default remains A: the failed profile main model did not poison it,
+		// and the transient live model B was NOT promoted to the resume default.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+		// Runtime rollback is intentional: the live model returns to B as temporary.
+		expect(session.model?.id).toBe("claude-sonnet-4-6");
+		expect(session.sessionManager.buildSessionContext().models.temporary).toBe("anthropic/claude-sonnet-4-6");
+		// Apply-for-this-session setting untouched.
+		expect(session.settings.get("modelProfile.default")).toBe(globalProfileDefaultBefore);
 	});
 });


### PR DESCRIPTION
## What

Recreates the closed PR **#945** (`fix(coding-agent): keep combo preset main model on resume`) with the blocking rollback/resume-default concern from the maintainer red-team review fixed and covered by a regression test.

Two parts:

1. **Original fix (unchanged from #945, MERGE_READY in review 4539434220):** combo / cross-provider model presets (e.g. `opus-codex`) no longer flip the **main provider** to the base default model on resume. Profile activation records its main model as the session default via a new opt-in `setModelTemporary(..., { persistAsSessionDefault: true })`, while still **not** writing global settings. Transient retry/fallback/context-promotion/plan switches keep `role: "temporary"`, preserving the #849 protection.

2. **New: rollback hardening** (addresses review 4539437417 `REQUEST_CHANGES`).

## The blocking concern (from #945 review)

`applyPreparedModelProfileActivation`'s failed-activation rollback restored the pre-activation **live** model as the session default:

```ts
setModelTemporary(previousModel, ..., { persistAsSessionDefault: true })
```

This conflated the pre-activation **live model** with the pre-activation **resume default**. If the user was on a transient retry/fallback/context-promotion/plan switch (model **B**) before activating a profile, and activation failed **after** the profile main model was already appended as the session default, rollback promoted **B** to `role: "default"`. `buildSessionContext()` resolves the resume default from the latest `model_change` with `role === "default"`, so this silently poisoned future resume and weakened the issue #849 protection.

## Fix

- Snapshot the pre-activation resume default (`previousSessionDefaultModel`) **separately** from the live model in `prepareModelProfileActivation`, via the new `AgentSession.getSessionDefaultModelSelector()`.
- On rollback:
  - restore the live runtime model as a transient switch (`role: "temporary"`, **no** `persistAsSessionDefault`) so it does **not** become the resume default, then
  - re-assert the snapshotted resume default through the new `AgentSession.recordResumeDefaultModel()` — append-only, never touches the runtime model, never writes global settings.
  - Falls back to the live model only when there was **no** explicit pre-activation default (nothing to protect).

Net rollback semantics: runtime live model returns to **B** (intentional), resume default returns to **A** (the pre-activation default), global settings untouched.

## Testing

`test/agent-session-profile-resume-default.test.ts` adds the requested regression case on a real `AgentSession`:

- persisted default **A** (`openai-codex/gpt-5.5`) -> temporary model **B** (`anthropic/claude-sonnet-4-6`) -> `opus-codex` activation fails **after** the profile main model (`anthropic/claude-opus-4-8`) is recorded as the default ->
  - `buildSessionContext().models.default` remains **A**;
  - runtime live model rolls back to **B** (`role: "temporary"`);
  - `modelProfile.default` (apply-for-this-session) untouched.
- Also asserts `prepared.previousSessionDefaultModel === A` and `prepared.previousModel === B` (snapshotted separately).

Verified the regression test **fails** against the old rollback (`models.default` became `anthropic/claude-sonnet-4-6`) and **passes** with the fix.

Suites run green in this worktree:
- `agent-session-profile-resume-default.test.ts` — 3/3
- `model-profile-activation.test.ts` — 17/17
- `model-profile-activation-redteam` / `model-selector-profiles` (+ redteam) / `model-profile-legacy-alias` / `repro-issue-1022-disabled-default-model` — 48/48 together
- `agent-session-openai-responses-replay.test.ts` (model-restore) — 17/17
- `biome check` clean on changed files; `tsgo -p tsconfig.json --noEmit` clean.

---

Supersedes #945. Recreated against `dev`.
