### PR TITLE
fix(coding-agent): restore active model profile model on session resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session resume reverting the model to a fallback (e.g. `claude-3-5-sonnet`) when a model profile is active and no `modelRoles.default` is configured. Model-profile activation and explicit `--model` startup now record the session's effective model under the `default` role so `--continue`/`--resume` restores it, while runtime temporary switches (Ctrl+P cycling, retry fallback, context promotion) still stay session-local (#947).
+
 ## [0.6.4] - 2026-06-20
 
 ### Changed

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -209,7 +209,9 @@ export async function applyPreparedModelProfileActivation(
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel);
+			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel, {
+				recordedRole: "default",
+			});
 			modelChanged = true;
 		}
 		if (Object.keys(prepared.agentModelOverrides).length > 0) {
@@ -234,7 +236,7 @@ export async function applyPreparedModelProfileActivation(
 		}
 		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 		if (modelChanged && previousModel) {
-			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+			await prepared.session.setModelTemporary(previousModel, previousThinkingLevel, { recordedRole: "default" });
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -229,9 +229,13 @@ export async function applyStartupModelProfiles(args: {
 		await applyProfile(args.parsedArgs.mpreset, args.parsedArgs.default === true);
 	}
 
-	// Explicit CLI --model/--thinking must win over any activated profile.
+	// Explicit CLI --model/--thinking must win over any activated profile. Record
+	// it under the "default" role so resume restores the explicit model rather than
+	// a model profile's default (which is applied earlier in this function).
 	if (explicitModel) {
-		await args.session.setModelTemporary(explicitModel, args.startupThinkingLevel ?? args.parsedArgs.thinking);
+		await args.session.setModelTemporary(explicitModel, args.startupThinkingLevel ?? args.parsedArgs.thinking, {
+			recordedRole: "default",
+		});
 	} else if (args.parsedArgs.thinking && args.session.model) {
 		await args.session.setModelTemporary(args.session.model, args.parsedArgs.thinking);
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5863,11 +5863,22 @@ export class AgentSession {
 	}
 
 	/**
-	 * Set model temporarily (for this session only).
-	 * Validates API key, saves to session log but NOT to settings.
+	 * Set the model for this session only.
+	 * Validates API key, saves to the session log but NOT to settings (modelRoles).
+	 *
+	 * By default the change is logged under the "temporary" role, which session
+	 * resume intentionally drops (Ctrl+P cycling, retry fallback, context
+	 * promotion). Pass `recordedRole: "default"` when the model is the session's
+	 * effective default — model-profile activation and explicit `--model` startup —
+	 * so `--continue`/`--resume` restores it instead of the pre-activation fallback
+	 * model recorded at session creation.
 	 * @throws Error if no API key available for the model
 	 */
-	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+	async setModelTemporary(
+		model: Model,
+		thinkingLevel?: ThinkingLevel,
+		options?: { recordedRole?: string },
+	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -5876,7 +5887,7 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
-		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
+		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, options?.recordedRole ?? "temporary");
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 
 		// Apply explicit thinking level if given; otherwise prefer the model's

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -79,9 +79,9 @@ function fakeSession(initial = model("provider-a", "initial")) {
 		model: initial as Model | undefined,
 		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
 		sessionId: "session-1",
-		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
-		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
-			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel; recordedRole?: string }>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel, options?: { recordedRole?: string }) {
+			this.setModelTemporaryCalls.push({ model: next, thinkingLevel, recordedRole: options?.recordedRole });
 			this.model = next;
 			this.thinkingLevel = thinkingLevel;
 		},
@@ -180,6 +180,23 @@ describe("model profile activation", () => {
 		expect(setCalls).toEqual([]);
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(session.getActiveModelProfile()).toBe("profile-a");
+	});
+
+	test("activation records the profile default model under the default role for resume", async () => {
+		const session = fakeSession();
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry(),
+			settings: Settings.isolated(),
+			profileName: "profile-a",
+		});
+
+		// The profile's default model must be logged under the "default" role so
+		// `--continue`/`--resume` restores it. Recording it as "temporary" (the old
+		// behavior) made resume revert to the pre-activation fallback model.
+		expect(session.setModelTemporaryCalls).toHaveLength(1);
+		expect(session.setModelTemporaryCalls[0].model.id).toBe("default");
+		expect(session.setModelTemporaryCalls[0].recordedRole).toBe("default");
 	});
 
 	test("--default persists only modelProfile.default and flushes", async () => {

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -60,6 +60,23 @@ function modelChange(id: string, parentId: string | null, provider: string, mode
 	return { type: "model_change", id, parentId, timestamp: "2025-01-01T00:00:00Z", model: `${provider}/${modelId}` };
 }
 
+function modelChangeRole(
+	id: string,
+	parentId: string | null,
+	provider: string,
+	modelId: string,
+	role: string,
+): ModelChangeEntry {
+	return {
+		type: "model_change",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		model: `${provider}/${modelId}`,
+		role,
+	};
+}
+
 describe("buildSessionContext", () => {
 	describe("trivial cases", () => {
 		it("empty entries returns empty context", () => {
@@ -156,6 +173,30 @@ describe("buildSessionContext", () => {
 			// different model id. Temporary fallbacks and provider-side
 			// downgrades both produce such mismatched messages.
 			expect(ctx.models.default).toBe("openai/gpt-4");
+		});
+
+		it("restores the last default-role model on resume (model profile activation)", () => {
+			// Model-profile activation records its default model under the "default"
+			// role, so the most recent default wins on resume even when an earlier
+			// fallback default was recorded at session creation.
+			const entries: SessionEntry[] = [
+				modelChange("1", null, "anthropic", "claude-3-5-sonnet-20240620"),
+				modelChangeRole("2", "1", "anthropic", "claude-opus-4-8", "default"),
+			];
+			expect(buildSessionContext(entries).models.default).toBe("anthropic/claude-opus-4-8");
+		});
+
+		it("does not restore a temporary-role model as the session default", () => {
+			// Regression guard for the resume-reverts-to-Sonnet bug: a "temporary"
+			// model change (Ctrl+P cycle, retry fallback, context promotion) must not
+			// become the restored default; the prior default is kept instead.
+			const entries: SessionEntry[] = [
+				modelChange("1", null, "anthropic", "claude-3-5-sonnet-20240620"),
+				modelChangeRole("2", "1", "anthropic", "claude-opus-4-8", "temporary"),
+			];
+			const ctx = buildSessionContext(entries);
+			expect(ctx.models.default).toBe("anthropic/claude-3-5-sonnet-20240620");
+			expect(ctx.models.temporary).toBe("anthropic/claude-opus-4-8");
 		});
 	});
 


### PR DESCRIPTION
## What

Resuming a session reverted the active model to a fallback (e.g. `anthropic/claude-3-5-sonnet-20240620`) instead of the model the session was actually using, whenever a model profile was active and `modelRoles.default` was unset.

Model-profile activation (and the explicit `--model` startup path) now record the session's effective model under the `default` role, so `--continue`/`--resume` (and the interactive session picker) restore it. Runtime temporary switches (Ctrl+P cycling, retry fallback, context promotion, plan mode) keep recording `temporary` and remain session-local.

## Why

Fixes #947.

At session creation, `createAgentSession` writes the initial **default**-role `model_change` for the model it resolves; with no `modelRoles.default`, that is the first credentialed catalog model (e.g. Sonnet 3.5). The active profile is then applied via `applyPreparedModelProfileActivation` → `setModelTemporary()`, which records `role: "temporary"`. On resume, `buildSessionContext()` restores only the `default` role and intentionally drops `temporary` (correct for Ctrl+P / retry fallback / context promotion, see #849) — so the profile's real model was lost and the pre-profile fallback won.

Observed session JSONL at startup:

```jsonl
{"type":"model_change","model":"anthropic/claude-3-5-sonnet-20240620"}            // role omitted => "default"
{"type":"model_change","model":"anthropic/claude-opus-4-8","role":"temporary"}    // the model actually in use
```

## How

- `setModelTemporary()` gains an optional `options.recordedRole` (default `"temporary"`); the recorded `model_change` role is `options?.recordedRole ?? "temporary"`. No behavior change for existing callers.
- `applyPreparedModelProfileActivation()` records the profile's default model (and the error-path rollback model) with `recordedRole: "default"`.
- `applyStartupModelProfiles()` records the explicit `--model` startup model with `recordedRole: "default"` so an explicit `--model` still wins over an activated profile on resume (it is applied after the profile, and last-default-wins in `buildSessionContext`).

This keeps the fix at the recording layer, so it works for every resume path (`--continue`, `--resume`, interactive picker).

## Testing

- `bun test test/model-profile-activation.test.ts test/session-manager/build-context.test.ts` — added:
  - profile activation records its default model with `recordedRole: "default"` (verified failing before the fix: `Received: undefined`),
  - `buildSessionContext` restores the last `default`-role model, and does **not** restore a `temporary`-role model as the session default (regression guard).
- `bun test` across 21 related profile/model/session-manager suites — 174 pass, 0 fail.
- `bun run check:types` (tsgo) — clean.
- `biome check` on changed files — clean.

---

- [x] `bun check` passes (typecheck + biome on changed files)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
