### PR TITLE
Fix Windows Shift+Enter LF newline handling

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1250,7 +1250,7 @@ export class Editor implements Component, Focusable {
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
 			(data.length > 1 && data.includes("\x1b") && data.includes("\r")) ||
-			(data === "\n" && data.length === 1 && process.platform !== "win32") // Shift+Enter from iTerm2 mapping
+			(data === "\n" && data.length === 1) // Shift+Enter from terminal sendInput mapping
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
 				this.#handleBackspace();

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -520,7 +520,7 @@ describe("Editor component", () => {
 			}
 		});
 
-		it("submits raw LF as Enter on Windows instead of inserting newline", () => {
+		it("inserts a newline for raw LF on Windows terminal sendInput mappings", () => {
 			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 			Object.defineProperty(process, "platform", { value: "win32" });
 			try {
@@ -532,6 +532,27 @@ describe("Editor component", () => {
 
 				editor.handleInput("a");
 				editor.handleInput("\n");
+				editor.handleInput("b");
+
+				expect(submitted).toBe("");
+				expect(editor.getText()).toBe("a\nb");
+			} finally {
+				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+			}
+		});
+
+		it("still submits plain CR Enter on Windows", () => {
+			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+			Object.defineProperty(process, "platform", { value: "win32" });
+			try {
+				const editor = new Editor(defaultEditorTheme);
+				let submitted = "";
+				editor.onSubmit = text => {
+					submitted = text;
+				};
+
+				editor.handleInput("a");
+				editor.handleInput("\r");
 
 				expect(submitted).toBe("a");
 				expect(editor.getText()).toBe("");


### PR DESCRIPTION
## Summary
- treat a bare LF (`\n`) as editor newline on Windows too, covering Windows Terminal Shift+Enter `sendInput "\n"` mappings
- keep plain Windows Enter submit behavior covered through CR (`\r`)
- update focused editor regression coverage for issue #958

## Verification
- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/editor.test.ts packages/tui/test/keys.test.ts` — 146 pass, 0 fail
- `bun --cwd=packages/tui run check` — pass

Fixes #958

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*