### PR TITLE
fix(coding-agent): render ask dump payloads readably

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -134,6 +134,7 @@
 
 ### Fixed
 
+- Rendered `/dump` tool-call parameters with readable structured bodies, XML-safe text, and decoded Unicode escape sequences so `ask`/`proxy_ask` deep-interview payloads no longer show dense `questions` JSON or literal Korean `\u...` escapes.
 - Prevented `gjc --tmux` partial-launch diagnostics from throwing when stderr is already closed during shutdown.
 - Fixed v0.5.1-style macOS/Linux standalone binaries crashing before the first model request with `Cannot find module '@gajae-code/natives' from '/$bunfs/root/gjc-*'` when pre-prompt context maintenance invokes the native tokenizer.
 - Mapped the retired `codex-standard` model profile name to `codex-medium` during profile activation, **as a fallback only** so a user-defined profile literally named `codex-standard` is never shadowed, letting stale `modelProfile.default: codex-standard` configs reach activation instead of blocking startup after the rebuilt profile catalog.

--- a/packages/coding-agent/src/session/session-dump-format.ts
+++ b/packages/coding-agent/src/session/session-dump-format.ts
@@ -47,13 +47,49 @@ function stripTypeBoxFields(obj: unknown): unknown {
 	return obj;
 }
 
+function escapeXmlAttribute(input: string): string {
+	return input.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeXmlText(input: string): string {
+	return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function decodeCodePoint(hex: string): string {
+	const codePoint = Number.parseInt(hex, 16);
+	if (!Number.isFinite(codePoint) || codePoint < 0x20 || codePoint === 0x7f) {
+		return `\\u${hex}`;
+	}
+	return String.fromCharCode(codePoint);
+}
+
+function decodeUnicodeEscapeText(input: string): string {
+	return input
+		.replace(/\\\\u([0-9a-fA-F]{4})/g, (_match, hex: string) => decodeCodePoint(hex))
+		.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex: string) => decodeCodePoint(hex));
+}
+
+function formatParameterValue(value: unknown): string {
+	const raw = typeof value === "string" ? value : (JSON.stringify(value, null, "\t") ?? "null");
+	return escapeXmlText(decodeUnicodeEscapeText(raw));
+}
+
 /** Serialize an object as XML parameter elements, one per key. */
 function formatArgsAsXml(args: Record<string, unknown>, indent = "\t"): string {
 	const parts: string[] = [];
 	for (const [key, value] of Object.entries(args)) {
 		if (key === INTENT_FIELD) continue;
-		const text = typeof value === "string" ? value : JSON.stringify(value);
-		parts.push(`${indent}<parameter name="${key}">${text}</parameter>`);
+		const escapedKey = escapeXmlAttribute(key);
+		const text = formatParameterValue(value);
+		if (text.includes("\n")) {
+			const indentedText = text
+				.split("\n")
+				.map(line => `${indent}\t${line}`)
+				.join("\n");
+			parts.push(`${indent}<parameter name="${escapedKey}">\n${indentedText}\n${indent}</parameter>`);
+		} else {
+			parts.push(`${indent}<parameter name="${escapedKey}">${text}</parameter>`);
+		}
 	}
 	return parts.join("\n");
 }

--- a/packages/coding-agent/src/session/session-dump-format.ts
+++ b/packages/coding-agent/src/session/session-dump-format.ts
@@ -57,7 +57,12 @@ function escapeXmlText(input: string): string {
 
 function decodeCodePoint(hex: string): string {
 	const codePoint = Number.parseInt(hex, 16);
-	if (!Number.isFinite(codePoint) || codePoint < 0x20 || codePoint === 0x7f) {
+	if (
+		!Number.isFinite(codePoint) ||
+		codePoint < 0x20 ||
+		(codePoint >= 0x7f && codePoint <= 0x9f) ||
+		(codePoint >= 0xd800 && codePoint <= 0xdfff)
+	) {
 		return `\\u${hex}`;
 	}
 	return String.fromCharCode(codePoint);

--- a/packages/coding-agent/test/session-dump-format.test.ts
+++ b/packages/coding-agent/test/session-dump-format.test.ts
@@ -72,7 +72,7 @@ describe("formatSessionDumpText tool calls", () => {
 		expect(dumped).toContain('"deepInterview": {\n');
 	});
 
-	it("keeps escaped control codes structural instead of injecting raw control text", () => {
+	it("keeps escaped control and surrogate codes structural instead of injecting raw control text", () => {
 		const dumped = formatSessionDumpText({
 			messages: [
 				{
@@ -83,7 +83,7 @@ describe("formatSessionDumpText tool calls", () => {
 							id: "ask-2",
 							name: "proxy_ask",
 							arguments: {
-								note: "literal control marker: \\u000a",
+								note: "literal control marker: \\u000a, c1 marker: \\u0085, surrogate marker: \\ud800",
 							},
 						},
 					],
@@ -94,5 +94,33 @@ describe("formatSessionDumpText tool calls", () => {
 		});
 
 		expect(dumped).toContain("literal control marker: \\u000a");
+		expect(dumped).toContain("c1 marker: \\u0085");
+		expect(dumped).toContain("surrogate marker: \\ud800");
+	});
+
+	it("applies XML escaping after decoding readable Unicode escapes", () => {
+		const dumped = formatSessionDumpText({
+			messages: [
+				{
+					...assistantWithProxyAsk(),
+					content: [
+						{
+							type: "toolCall",
+							id: "ask-3",
+							name: "proxy_ask",
+							arguments: {
+								"unsafe<key": "readable Korean: \\ud55c\\uae00 & raw <tag>",
+							},
+						},
+					],
+				},
+			],
+			model: null,
+			thinkingLevel: null,
+		});
+
+		expect(dumped).toContain('name="unsafe&lt;key"');
+		expect(dumped).toContain("readable Korean: 한글 &amp; raw &lt;tag&gt;");
+		expect(dumped).not.toContain("\\ud55c");
 	});
 });

--- a/packages/coding-agent/test/session-dump-format.test.ts
+++ b/packages/coding-agent/test/session-dump-format.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantMessage, Usage } from "@gajae-code/ai";
+import { formatSessionDumpText } from "@gajae-code/coding-agent/session/session-dump-format";
+
+const zeroUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+	},
+};
+
+function assistantWithProxyAsk(): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude",
+		usage: zeroUsage,
+		stopReason: "toolUse",
+		timestamp: 0,
+		content: [
+			{
+				type: "toolCall",
+				id: "ask-1",
+				name: "proxy_ask",
+				arguments: {
+					_i: "Deciding guardrail package",
+					questions: [
+						{
+							id: "r6_guardrails",
+							question:
+								"\\uac8c\\uc774\\ubc0d \\uac00\\ub4dc + \\uce21\\uc815 \\uacbd\\uacc4 \\ud328\\ud0a4\\uc9c0\\ub97c \\uace8\\ub77c\\uc918.",
+							options: [
+								{ label: "A) \\uad8c\\uc7a5 \\uac00\\ub4dc \\ud328\\ud0a4\\uc9c0 \\uadf8\\ub300\\ub85c" },
+							],
+							recommended: 0,
+							deepInterview: {
+								round: 6,
+								component: "scoring-model",
+								dimension: "constraints",
+								ambiguity: 0.41,
+							},
+						},
+					],
+				},
+			},
+		],
+	};
+}
+
+describe("formatSessionDumpText tool calls", () => {
+	it("renders structured ask payloads readably when question text contains escaped Korean", () => {
+		const dumped = formatSessionDumpText({
+			messages: [assistantWithProxyAsk()],
+			model: null,
+			thinkingLevel: null,
+		});
+
+		expect(dumped).toContain('<invoke name="proxy_ask">');
+		expect(dumped).toContain('<parameter name="questions">');
+		expect(dumped).toContain("게이밍 가드 + 측정 경계 패키지를 골라줘.");
+		expect(dumped).toContain("A) 권장 가드 패키지 그대로");
+		expect(dumped).not.toContain("\\uac8c");
+		expect(dumped).toContain('"deepInterview": {\n');
+	});
+
+	it("keeps escaped control codes structural instead of injecting raw control text", () => {
+		const dumped = formatSessionDumpText({
+			messages: [
+				{
+					...assistantWithProxyAsk(),
+					content: [
+						{
+							type: "toolCall",
+							id: "ask-2",
+							name: "proxy_ask",
+							arguments: {
+								note: "literal control marker: \\u000a",
+							},
+						},
+					],
+				},
+			],
+			model: null,
+			thinkingLevel: null,
+		});
+
+		expect(dumped).toContain("literal control marker: \\u000a");
+	});
+});


### PR DESCRIPTION
## Summary
- Pretty-print structured tool-call parameters in `/dump` output instead of compact JSON blobs
- Decode readable Unicode escape sequences so Korean `ask`/`proxy_ask` payloads are human-readable
- Keep C0/C1 controls and surrogate escapes escaped to preserve the structured dump boundary
- XML-escape parameter text/attributes after the readability transform

## Review response
- Addresses maintainer requested changes on #957.
- Added focused coverage for `\u0085` C1 controls, lone surrogate escapes, normal Korean BMP text, and XML escaping after decoding.

## Verification
- `bun test packages/coding-agent/test/session-dump-format.test.ts`
- `bun --cwd=packages/coding-agent run check`