### PR TITLE
Fix notify CI test expectations

### DIFF
--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -29,6 +29,7 @@ describe("GJC public CLI command surface", () => {
 			"gc",
 			"ralplan",
 			"config",
+			"notify",
 			"web-search",
 			"mcp-serve",
 			"contribute-pr",

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { daemonPaths } from "../src/notifications/telegram-daemon";
 
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+
 describe("compiled daemon smoke coverage", () => {
 	function tempDir(prefix: string): string {
 		return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -14,7 +16,7 @@ describe("compiled daemon smoke coverage", () => {
 		const cwd = tempDir("gjc-compiled-daemon-cwd-");
 		const token = "123456:super-secret-token";
 		const proc = Bun.spawn(
-			["bun", "run", path.resolve("packages/coding-agent/src/cli.ts"), "notify", "daemon-internal", "--smoke"],
+			["bun", "run", path.join(repoRoot, "packages/coding-agent/src/cli.ts"), "notify", "daemon-internal", "--smoke"],
 			{
 				cwd,
 				env: {
@@ -44,7 +46,7 @@ describe("compiled daemon smoke coverage", () => {
 	});
 
 	test("build script preserves the dynamic daemon entrypoint for compiled binaries", () => {
-		const buildScript = fs.readFileSync(path.resolve("packages/coding-agent/scripts/build-binary.ts"), "utf8");
+		const buildScript = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts"), "utf8");
 		expect(buildScript).toContain("telegram-daemon-cli.ts");
 	});
 });


### PR DESCRIPTION
Fixes #960.\n\n## Summary\n- add the new notify command to the public CLI command-surface expectation\n- make compiled notify daemon smoke tests resolve repo-root paths instead of depending on the test runner cwd\n\n## Verification\n- bun test packages/coding-agent/test/cli-command-surface.test.ts -t "registers launch plus retained workflow/runtime utility endpoints"\n- bun test packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts -t "build script preserves the dynamic daemon entrypoint for compiled binaries"\n- bun test packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts -t "hidden daemon CLI smoke creates and removes its temp lock without leaking tokens"\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*