### PR TITLE
Fix notification daemon smoke test formatting

### DIFF
--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -16,7 +16,14 @@ describe("compiled daemon smoke coverage", () => {
 		const cwd = tempDir("gjc-compiled-daemon-cwd-");
 		const token = "123456:super-secret-token";
 		const proc = Bun.spawn(
-			["bun", "run", path.join(repoRoot, "packages/coding-agent/src/cli.ts"), "notify", "daemon-internal", "--smoke"],
+			[
+				"bun",
+				"run",
+				path.join(repoRoot, "packages/coding-agent/src/cli.ts"),
+				"notify",
+				"daemon-internal",
+				"--smoke",
+			],
 			{
 				cwd,
 				env: {


### PR DESCRIPTION
## Summary
- Split the compiled notification daemon smoke test spawn argv array into Biome multi-line format
- Keep the change limited to packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts

Fixes #963

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent test test/notifications-compiled-daemon-smoke.test.ts` (blocked locally by missing native bindings in this worktree; PR #962 CI already proved smoke/native-build green)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*