### PR TITLE
Add Gemini 3.5 Flash to Gemini CLI models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the bundled `google-gemini-cli/gemini-3.5-flash` model entry so Gemini CLI users can select the model from the static registry (#965).
+
 ## [0.6.4] - 2026-06-20
 
 ### Fixed

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -10486,6 +10486,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "google-gemini-cli",
+			"provider": "google-gemini-cli",
+			"baseUrl": "https://cloudcode-pa.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
 			"name": "Gemini 3 Flash Preview",

--- a/packages/ai/test/preset-catalog-models.test.ts
+++ b/packages/ai/test/preset-catalog-models.test.ts
@@ -27,6 +27,21 @@ describe("preset catalog model entries", () => {
 		expect(model.thinking).toEqual({ mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh });
 	});
 
+	test("bundles google-gemini-cli/gemini-3.5-flash", () => {
+		const model = getBundledModel("google-gemini-cli", "gemini-3.5-flash");
+
+		expect(model.id).toBe("gemini-3.5-flash");
+		expect(model.provider).toBe("google-gemini-cli");
+		expect(model.api).toBe("google-gemini-cli");
+		expect(model.baseUrl).toBe("https://cloudcode-pa.googleapis.com");
+		expect(model.name).toBe("Gemini 3.5 Flash");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toContain("image");
+		expect(model.contextWindow).toBe(1_048_576);
+		expect(model.maxTokens).toBe(65_536);
+		expect(model.thinking).toEqual({ mode: "google-level", minLevel: Effort.Minimal, maxLevel: Effort.High });
+	});
+
 	test("bundles minimax-code/minimax-v3", () => {
 		const model = getBundledModel("minimax-code", "minimax-v3");
 


### PR DESCRIPTION
Closes #965

## Summary
- Add `gemini-3.5-flash` to the bundled `google-gemini-cli` model registry.
- Cover the bundled model entry in preset catalog tests.
- Add a minimal Unreleased changelog note.

## Verification
- `cd packages/ai && bun test test/preset-catalog-models.test.ts` (4 tests, 31 expects)
- `cd packages/ai && bun run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*