### PR TITLE
fix(ai): restore Codex GPT-5.5 context window

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -455,10 +455,13 @@ function inferGeneratedApplyPatchToolType(
 }
 
 function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
-	// gpt-5.5 is a 400K-context model. OpenAI code backend discovery can omit the
-	// context window, falling back to the 272K default, which incorrectly trips
-	// context-cap / auto-promote thresholds (a ~272K session would look over-cap
-	// and demote to gpt-5.4). Pin gpt-5.5 to its true 400K window.
+	// OpenAI Codex reports GPT-5.5 with a 272K prompt budget. Keep the generated
+	// bundle aligned with the backend limit so compaction fires before the prompt
+	// crosses the usable Codex window instead of trusting stale 400K snapshots.
+	if (model.provider === "openai-codex" && parsedModel.variant === "base" && semverEqual(parsedModel.version, "5.5")) {
+		model.contextWindow = 272000;
+		return true;
+	}
 	if (parsedModel.variant === "base" && semverEqual(parsedModel.version, "5.5")) {
 		model.contextWindow = 400000;
 		return true;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -56310,7 +56310,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 9,

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -285,7 +285,7 @@ describe("generated model policies", () => {
 		expect(models[1]?.contextPromotionTarget).toBeUndefined();
 	});
 
-	it("treats gpt-5.5 as a 400K-context model so it is not over-cap at ~272K", () => {
+	it("keeps Codex gpt-5.5 at the 272K prompt budget so compaction fires before the backend cap", () => {
 		const models: Model<Api>[] = [
 			{
 				...createModel({
@@ -301,7 +301,7 @@ describe("generated model policies", () => {
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(400000);
+		expect(models[0]?.contextWindow).toBe(272000);
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -16,8 +16,8 @@ describe("OpenAI Codex defaults", () => {
 			maxLevel: Effort.XHigh,
 			defaultLevel: Effort.XHigh,
 		});
-		// gpt-5.5 is pinned to its true 400K context window so long sessions do not
-		// incorrectly look over-cap at the stale 272K discovery fallback.
-		expect(model.contextWindow).toBe(400000);
+		// Codex discovery reports GPT-5.5 at 272K; bundled metadata must not
+		// drift back to a stale 400K snapshot or compaction fires too late.
+		expect(model.contextWindow).toBe(272000);
 	});
 });


### PR DESCRIPTION
## Summary
- Restores `openai-codex/gpt-5.5` `contextWindow` to `272000` after the latest model metadata regeneration brought back the stale 400K value.
- Updates the OpenAI Codex default test so future regenerations fail if this regresses again.

## Context
PR #873 fixed this exact Codex backend limit. PR #915 regenerated model metadata afterward and overwrote the bundled value back to 400K, which makes compaction fire too late for gpt-5.5 sessions.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/ai/test/openai-codex-default.test.ts`
- `bun --cwd=packages/ai run check`
