### PR TITLE
fix(ultragoal): scope checkpoint changeset to the nearest integration base

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2944,11 +2944,33 @@ async function spawnText(
 	}
 }
 
-async function resolveGitBase(cwd: string, branch?: string): Promise<string> {
-	const candidates = branch ? [branch] : ["origin/main", "origin/master", "main", "master"];
-	for (const candidate of candidates) {
-		const exists = await spawnText(["git", "rev-parse", "--verify", candidate], { cwd, timeoutMs: 3000 });
-		if (exists.ok) return candidate;
+export async function resolveGitBase(cwd: string, branch?: string): Promise<string> {
+	if (branch) {
+		const exists = await spawnText(["git", "rev-parse", "--verify", branch], { cwd, timeoutMs: 3000 });
+		if (exists.ok) return branch;
+	} else {
+		// Prefer the NEAREST integration base (the branch this work actually forks
+		// from) rather than always `main`. A branch opened against `dev` must be
+		// scoped to `dev`; using a stale `main` sweeps in unrelated trunk history
+		// and mis-attributes other people's changes to this story (e.g. falsely
+		// tripping change-scoped gates). Among existing candidates, pick the one
+		// whose merge-base with HEAD is closest to HEAD (fewest commits ahead).
+		const candidates = ["origin/dev", "dev", "origin/main", "origin/master", "main", "master"];
+		let best: { ref: string; ahead: number } | undefined;
+		for (const candidate of candidates) {
+			const exists = await spawnText(["git", "rev-parse", "--verify", candidate], { cwd, timeoutMs: 3000 });
+			if (!exists.ok) continue;
+			const mergeBase = await spawnText(["git", "merge-base", "HEAD", candidate], { cwd, timeoutMs: 3000 });
+			if (!mergeBase.ok || !mergeBase.stdout.trim()) continue;
+			const count = await spawnText(
+				["git", "rev-list", "--count", `${mergeBase.stdout.trim()}..HEAD`],
+				{ cwd, timeoutMs: 3000 },
+			);
+			const ahead = Number.parseInt(count.stdout.trim(), 10);
+			if (!Number.isFinite(ahead)) continue;
+			if (!best || ahead < best.ahead) best = { ref: candidate, ahead };
+		}
+		if (best) return best.ref;
 	}
 	const mergeBase = await spawnText(["git", "merge-base", "HEAD", "origin/main"], { cwd, timeoutMs: 3000 });
 	if (mergeBase.ok && mergeBase.stdout.trim()) return mergeBase.stdout.trim();

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -22,6 +22,7 @@ import {
 	getUltragoalStatus,
 	readUltragoalLedger,
 	readUltragoalPlan,
+	resolveGitBase,
 	runNativeUltragoalCommand,
 	startNextUltragoalGoal,
 	validateExecutorQaRedTeamEvidenceForReview,
@@ -3198,5 +3199,57 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 			const ledger = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text();
 			expect(ledger).toContain("reconcile_failed");
 		});
+	});
+});
+
+describe("resolveGitBase nearest integration base", () => {
+	async function git(cwd: string, args: string[]): Promise<void> {
+		const proc = Bun.spawn(["git", ...args], {
+			cwd,
+			env: {
+				...process.env,
+				GIT_AUTHOR_NAME: "T",
+				GIT_AUTHOR_EMAIL: "t@example.com",
+				GIT_COMMITTER_NAME: "T",
+				GIT_COMMITTER_EMAIL: "t@example.com",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		if (proc.exitCode !== 0) {
+			throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+		}
+	}
+
+	async function commit(cwd: string, file: string, message: string): Promise<void> {
+		await fs.writeFile(path.join(cwd, file), `${message}\n`);
+		await git(cwd, ["add", "."]);
+		await git(cwd, ["commit", "-m", message]);
+	}
+
+	it("scopes a dev-forked branch to dev, not a stale main", async () => {
+		const dir = await tempDir();
+		await git(dir, ["init", "-q"]);
+		await git(dir, ["checkout", "-q", "-b", "main"]);
+		await commit(dir, "base.txt", "base");
+		await git(dir, ["checkout", "-q", "-b", "dev"]);
+		await commit(dir, "dev.txt", "dev work");
+		await git(dir, ["checkout", "-q", "-b", "feature/x"]);
+		await commit(dir, "feature.txt", "feature work");
+
+		// dev is the nearest base (1 commit ahead) vs main (2 commits ahead).
+		expect(await resolveGitBase(dir)).toBe("dev");
+	});
+
+	it("honors an explicit branch argument", async () => {
+		const dir = await tempDir();
+		await git(dir, ["init", "-q"]);
+		await git(dir, ["checkout", "-q", "-b", "main"]);
+		await commit(dir, "base.txt", "base");
+		await git(dir, ["checkout", "-q", "-b", "feature/y"]);
+		await commit(dir, "feature.txt", "feature work");
+
+		expect(await resolveGitBase(dir, "main")).toBe("main");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the ultragoal completion checkpoint mis-scoping its changeset on branches opened against `dev`.

`computeCheckpointChangeSet` computed the diff as `resolveGitBase(cwd)...HEAD`, and `resolveGitBase` always preferred `main`. For a branch forked from `dev` (which has diverged from `main`), this swept in **all** of dev's unrelated trunk history — mis-attributing other people's changes to the current story and **falsely tripping change-scoped gates**. Concretely, the mandatory computer-use red-team suite (`kill-switch-bypass`, …) fired on a change that ships no computer surface, purely because dev's diff vs main happens to touch `tools/index.ts` / `config/settings-schema.ts`.

## Fix

`resolveGitBase` now selects the **nearest** existing integration base among `origin/dev`, `dev`, `origin/main`, `origin/master`, `main`, `master` — the candidate whose merge-base with HEAD is closest to HEAD (fewest commits ahead). A dev-forked branch resolves to `dev`; a main-forked branch still resolves to `main`. Explicit `--branch` (review mode) is unchanged. Falls back to the previous `merge-base HEAD origin/main` / `HEAD~1` behavior when no candidate resolves.

## Tests

`resolveGitBase` is now exported and covered in `test/gjc-runtime/ultragoal-runtime.test.ts`:
- a `main → dev → feature` repo resolves to `dev` (nearest), not the stale `main`;
- an explicit `--branch` argument is honored.

typecheck + lint clean.

🤖 Generated with Claude Code.
