### PR TITLE
fix(ai): cap MiniMax M3 default context at 512K

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -404,13 +404,11 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 	if (model.provider === "zai" && model.id === "glm-5.2") {
 		model.contextWindow = 1_000_000;
 	}
-	// MiniMax-M3: official MiniMax docs (platform.minimax.io/docs/guides/models-intro)
-	// document a 1M context window, but models.dev and the bundled catalog both report
-	// 512K. The stale 512K survives generate-models (provider-scoped models bypass the
-	// models.dev refresh in applyGlobalModelsDevFallback), tripping auto-compaction /
-	// context-cap thresholds 2x early on MiniMax sessions. Pin to the true 1M.
+	// MiniMax-M3: MiniMax exposes a 1M context tier, but usage beyond 512K is
+	// billed separately. Keep bundled/default metadata at the billing-safe 512K
+	// unless an explicit paid-tier contract is added.
 	if (model.provider !== "opencode-go" && model.id === "minimax-m3") {
-		model.contextWindow = 1_000_000;
+		model.contextWindow = 512_000;
 	}
 }
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -37478,7 +37478,7 @@
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -37698,7 +37698,7 @@
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -37990,7 +37990,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
@@ -38325,7 +38325,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
@@ -68532,7 +68532,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"compat": {
 				"supportsUsageInStreaming": false

--- a/packages/ai/test/issue-385-minimax-m3.test.ts
+++ b/packages/ai/test/issue-385-minimax-m3.test.ts
@@ -11,7 +11,7 @@ describe("MiniMax M3 support (issue #385)", () => {
 
 			expect(model.id).toBe("minimax-m3");
 			expect(model.provider).toBe(provider);
-			expect(model.contextWindow).toBe(1_000_000);
+			expect(model.contextWindow).toBe(512_000);
 			expect(model.maxTokens).toBe(128_000);
 			expect(model.input).toContain("text");
 			expect(model.input).toContain("image");


### PR DESCRIPTION
## Summary
- restore MiniMax M3 bundled/default context-window metadata to the billing-safe 512K tier
- keep the explicit 1M capability out of default routing/catalog behavior until a paid-tier opt-in contract exists
- update the MiniMax M3 regression test to assert the 512K default

Closes #974.

## Verification
- `biome check packages/ai/src/models.json packages/ai/src/model-thinking.ts packages/ai/test/issue-385-minimax-m3.test.ts`
- `bun test packages/ai/test/issue-385-minimax-m3.test.ts --timeout 15000`
- `bun test packages/ai/test/issue-887-repro.test.ts --timeout 15000`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
