### PR TITLE
fix(coding-agent): format ultragoal runtime dev CI

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2962,10 +2962,10 @@ export async function resolveGitBase(cwd: string, branch?: string): Promise<stri
 			if (!exists.ok) continue;
 			const mergeBase = await spawnText(["git", "merge-base", "HEAD", candidate], { cwd, timeoutMs: 3000 });
 			if (!mergeBase.ok || !mergeBase.stdout.trim()) continue;
-			const count = await spawnText(
-				["git", "rev-list", "--count", `${mergeBase.stdout.trim()}..HEAD`],
-				{ cwd, timeoutMs: 3000 },
-			);
+			const count = await spawnText(["git", "rev-list", "--count", `${mergeBase.stdout.trim()}..HEAD`], {
+				cwd,
+				timeoutMs: 3000,
+			});
 			const ahead = Number.parseInt(count.stdout.trim(), 10);
 			if (!Number.isFinite(ahead)) continue;
 			if (!best || ahead < best.ahead) best = { ref: candidate, ahead };


### PR DESCRIPTION
## Summary
- repair the post-merge dev CI failure from #976 by applying the missing Biome formatting in `ultragoal-runtime.ts`
- keep the notification behavior from #970 intact; no runtime logic changes

Closes #976.

## Verification
- `biome check packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
