### PR TITLE
fix(ai): strip computer call actions from responses replay

### DIFF
--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -98,13 +98,22 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 ): OpenAIResponsesReplayItem | undefined {
 	if (item.type === "item_reference") return undefined;
 
-	// providerPayload stores raw output items; replay strips item ids and keeps only normalized call_id.
-	const { id: _id, ...sanitizedItem } = item;
+	// providerPayload stores raw output items; replay strips fields that are output-only.
+	const { id: _id, ...itemWithoutId } = item;
+	const sanitizedItem =
+		item.type === "computer_call" ? sanitizeComputerCallForResponsesInput(itemWithoutId) : itemWithoutId;
 	if (typeof item.call_id === "string") {
 		sanitizedItem.call_id = normalizeReplayedResponsesHistoryCallId(item.call_id, normalizedCallIds);
 	}
 
 	return sanitizedItem as unknown as OpenAIResponsesReplayItem;
+}
+
+function sanitizeComputerCallForResponsesInput(item: Record<string, unknown>): Record<string, unknown> {
+	// The Responses stream includes the performed computer action on output items,
+	// but the create input accepts only the call identity/status fields on replay.
+	const { action: _action, actions: _actions, ...inputSafeItem } = item;
+	return inputSafeItem;
 }
 
 function normalizeReplayedResponsesHistoryCallId(value: string, normalizedValues: Map<string, string>): string {

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -223,6 +223,18 @@ const incrementalItems2 = [
 	},
 ];
 
+const computerCallHistoryItems = [
+	{
+		type: "computer_call",
+		id: "cu_1",
+		call_id: "call_computer_1",
+		status: "completed",
+		pending_safety_checks: [],
+		action: { type: "screenshot" },
+		actions: [{ type: "screenshot" }],
+	},
+];
+
 function makeAssistantMessage(
 	items: Record<string, unknown>[],
 	incremental = false,
@@ -475,6 +487,28 @@ describe("OpenAI responses history payload", () => {
 			{ role: "user", content: [{ type: "input_text", text: "second question" }] },
 			...incrementalItems2.map(({ id: _id, ...item }) => item),
 			{ role: "user", content: [{ type: "input_text", text: "third question" }] },
+		]);
+	});
+
+	it("strips computer_call actions from replayed native history", async () => {
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const payload = (await captureResponsesPayload(model, {
+			messages: [
+				{ role: "user", content: "inspect", timestamp: Date.now() },
+				makeAssistantMessage(computerCallHistoryItems, true),
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		})) as { input?: unknown[] };
+
+		expect(payload.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "inspect" }] },
+			{
+				type: "computer_call",
+				call_id: "call_computer_1",
+				status: "completed",
+				pending_safety_checks: [],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "continue" }] },
 		]);
 	});
 


### PR DESCRIPTION
## Summary
- fix OpenAI Responses native-history replay for `computer_call` output items by projecting them into an input-safe shape before sending the next request
- strip the output-only `action` / `actions` fields while preserving call identity, status, safety checks, and existing call-id normalization
- add a regression test covering the exact `input[n].action` 400 failure mode

## Context
A long-running Responses session can store raw provider output items in `providerPayload` and replay them as future `input[]` history. `computer_call` stream output may include the performed computer action, but the Responses create input rejects that field during replay. When such an item survives into the next request, OpenAI returns errors like:

```text
400 Unknown parameter: 'input[447].action'
```

## Fix
`sanitizeOpenAIResponsesHistoryItemForReplay` now routes `computer_call` items through a small `sanitizeComputerCallForResponsesInput` projection. This keeps the existing generic native-history replay behavior intact for other item types, including web search actions, and only removes fields that are specific to computer-call output payloads.

## Side effects / compatibility
- No behavior change for normal message, reasoning, function-call, custom-tool, web-search, compaction, or non-computer native history replay.
- No loss of dispatch data for GJC tools: the removed fields describe the already-performed computer action and are not valid create-input replay fields.
- The change is intentionally narrower than a full typed whitelist migration to avoid broad replay compatibility risk.
- Existing persisted sessions containing `computer_call.action` can recover on the next request once this sanitizer is used.

## Verification
- `bun test packages/ai/test/openai-responses-history-payload.test.ts`
- `bun run check:ts`

—
*[gajae-code fix branch: `fix/openai-responses-computer-call-replay`]*