### PR TITLE
fix(notifications): topic reuse race, title with session name, thread-reply injection

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -72,7 +72,10 @@ function readGitBranch(cwd: string): string | undefined {
 }
 
 /** Build the one-time identity header fields for a session thread. */
-function buildIdentity(cwd: string): {
+function buildIdentity(
+	cwd: string,
+	sessionName?: string,
+): {
 	repo: string;
 	branch: string;
 	machine: string;
@@ -80,7 +83,11 @@ function buildIdentity(cwd: string): {
 } {
 	const repo = path.basename(cwd) || cwd;
 	const branch = readGitBranch(cwd) ?? "(detached)";
-	return { repo, branch, machine: os.hostname(), title: `${repo} · ${branch}` };
+	// Topic title: "{repo}/{branch}" before the session title is auto-generated,
+	// then "{repo}/{branch} - {session title}" once it exists.
+	const base = `${repo}/${branch}`;
+	const title = sessionName ? `${base} - ${sessionName}` : base;
+	return { repo, branch, machine: os.hostname(), title };
 }
 
 const execFileAsync = promisify(execFile);
@@ -356,7 +363,13 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			// One-time identity header (repo/branch/machine/session) pinned at the top
 			// of the session thread by the daemon.
 			try {
-				server.pushFrame(JSON.stringify({ type: "identity_header", sessionId: id, ...buildIdentity(ctx.cwd) }));
+				server.pushFrame(
+					JSON.stringify({
+						type: "identity_header",
+						sessionId: id,
+						...buildIdentity(ctx.cwd, ctx.sessionManager.getSessionName()),
+					}),
+				);
 			} catch (e) {
 				logger.warn(`notifications: identity_header failed: ${String(e)}`);
 			}
@@ -475,6 +488,18 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const rt = runtimes.get(id);
 		if (!rt) return;
 		const seq = rt.idleSeq++;
+		// Re-assert the identity header so the daemon renames the topic once the
+		// session title has been auto-generated ("{repo}/{branch} - {title}"). The
+		// daemon only renames when the title actually changed.
+		try {
+			rt.server.pushFrame(
+				JSON.stringify({
+					type: "identity_header",
+					sessionId: id,
+					...buildIdentity(ctx.cwd, ctx.sessionManager.getSessionName()),
+				}),
+			);
+		} catch {}
 		try {
 			rt.server.noteIdle(
 				JSON.stringify(

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -511,6 +511,7 @@ export class TelegramNotificationDaemon {
 				},
 				this.opts.now,
 			);
+			this.topics.applyName(sessionId, name);
 			await this.persistTopics();
 			return rec.topicId;
 		} catch {
@@ -598,6 +599,20 @@ export class TelegramNotificationDaemon {
 			});
 			await this.flushPool();
 			if (send.identity) {
+				// Rename the topic if the title changed (e.g. the session title was
+				// auto-generated after the topic was first created).
+				const name = this.topicNameFor(session.sessionId, msg);
+				if (this.topics.applyName(session.sessionId, name)) {
+					try {
+						await this.botApi.call("editForumTopic", {
+							chat_id: this.opts.chatId,
+							message_thread_id: Number(topicId),
+							name,
+						});
+					} catch {
+						// Best-effort rename; never block delivery.
+					}
+				}
 				this.topics.markIdentitySent(session.sessionId);
 				await this.persistTopics();
 			}
@@ -666,9 +681,16 @@ export class TelegramNotificationDaemon {
 		// update_id dedupe are all enforced by decideThreadedInbound.
 		const raw = update as {
 			callback_query?: unknown;
-			message?: { reply_to_message?: unknown };
+			message?: { reply_to_message?: { message_id?: unknown } };
 		};
-		if (!raw.callback_query && !raw.message?.reply_to_message) {
+		// A reply to a known ask message routes to that ask (below). Any OTHER
+		// message in a topic (plain text, or a reply to a non-ask message) is a
+		// free-text injection. Previously replies bypassed injection entirely.
+		const replyTo = raw.message?.reply_to_message?.message_id;
+		const isAskReply =
+			replyTo !== undefined &&
+			(this.messageRoutes.has(String(replyTo)) || this.messageRoutes.has(Number(replyTo)));
+		if (!raw.callback_query && !isAskReply) {
 			const inbound = decideThreadedInbound(update as never, {
 				pairedChatId: this.opts.chatId,
 				topicToSession: t => this.topics.sessionForTopic(t),

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -21,6 +21,8 @@ export interface TopicRecord {
 	identitySent: boolean;
 	/** Creation timestamp (ms epoch). */
 	createdAt: number;
+	/** Last applied topic title (for rename detection). */
+	name?: string;
 }
 
 /** Serialisable shape persisted to disk. */
@@ -42,6 +44,8 @@ export class TopicRegistry {
 	private readonly topics: Map<string, TopicRecord>;
 	/** Maps topicId -> sessionId for fast inbound routing. */
 	private readonly byTopic = new Map<string, string>();
+	/** In-flight create promises, keyed by session, to dedupe concurrent creates. */
+	private readonly inflight = new Map<string, Promise<TopicRecord>>();
 
 	constructor(state: TopicRegistryState = emptyTopicRegistryState()) {
 		this.topics = new Map(Object.entries(state.topics ?? {}));
@@ -70,11 +74,25 @@ export class TopicRegistry {
 	): Promise<TopicRecord> {
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing;
-		const topicId = await create();
-		const record: TopicRecord = { topicId, identitySent: false, createdAt: now() };
-		this.topics.set(sessionId, record);
-		this.byTopic.set(topicId, sessionId);
-		return record;
+		// Concurrency guard: many session frames (identity/idle/turn/ask) can race
+		// to first-use the same session. Without this, each call passes the
+		// `existing` check before `create()` resolves and creates a DUPLICATE
+		// forum topic. Share a single in-flight create per session id.
+		const pending = this.inflight.get(sessionId);
+		if (pending) return pending;
+		const promise = (async () => {
+			const topicId = await create();
+			const record: TopicRecord = { topicId, identitySent: false, createdAt: now() };
+			this.topics.set(sessionId, record);
+			this.byTopic.set(topicId, sessionId);
+			return record;
+		})();
+		this.inflight.set(sessionId, promise);
+		try {
+			return await promise;
+		} finally {
+			this.inflight.delete(sessionId);
+		}
 	}
 
 	/** Mark the identity header as sent for a session. Idempotent. */
@@ -87,6 +105,17 @@ export class TopicRegistry {
 	needsIdentity(sessionId: string): boolean {
 		const record = this.topics.get(sessionId);
 		return record ? !record.identitySent : true;
+	}
+
+	/**
+	 * Record the topic's applied title. Returns `true` when it changed (so the
+	 * caller should `editForumTopic`), `false` when already current or unknown.
+	 */
+	applyName(sessionId: string, name: string): boolean {
+		const record = this.topics.get(sessionId);
+		if (!record || record.name === name) return false;
+		record.name = name;
+		return true;
 	}
 
 	/** Serialise for atomic persistence beside the daemon state. */

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -60,4 +60,23 @@ describe("TopicRegistry", () => {
 		expect(reloaded.needsIdentity("s1")).toBe(false);
 		expect(reloaded.sessionForTopic("t1")).toBe("s1");
 	});
+	test("concurrent getOrCreateTopic for one session creates exactly one topic (no race)", async () => {
+		const reg = new TopicRegistry();
+		let creates = 0;
+		const create = async () => {
+			creates++;
+			await new Promise(r => setTimeout(r, 5));
+			return `topic-${creates}`;
+		};
+		// identity + idle + turn frames all first-touch the session concurrently.
+		const results = await Promise.all([
+			reg.getOrCreateTopic("s1", create),
+			reg.getOrCreateTopic("s1", create),
+			reg.getOrCreateTopic("s1", create),
+		]);
+		expect(creates).toBe(1);
+		expect(results.map(r => r.topicId)).toEqual(["topic-1", "topic-1", "topic-1"]);
+		expect(reg.sessionForTopic("topic-1")).toBe("s1");
+	});
+
 });


### PR DESCRIPTION
Fixes three live-integration bugs found QA'ing the threaded notification surface (#970).

## 1. Duplicate threads (race)
`TopicRegistry.getOrCreateTopic` had no in-flight guard — concurrent session frames (identity/idle/turn/ask) all passed the `existing` check before `createForumTopic` resolved, each creating a topic. Now a single in-flight create is shared per session id → exactly one topic. New concurrency test proves create is called once for 3 racing calls.

## 2. Thread title was just the session id
Identity was pushed ephemerally at session start, but the daemon connects later (scanRoots) and missed it → the topic got created by a later frame with the default `GJC <sessionId>` name. Now:
- Topic title is `{repo}/{branch}`, becoming `{repo}/{branch} - {session title}` once the session title auto-generates.
- Host emits identity at session start **and re-emits on `agent_end`** with `getSessionName()`.
- Daemon renames the topic via `editForumTopic` when the title changed (`TopicRecord.name` + `applyName`).

## 3. Replying in a thread did nothing
`handleTelegramUpdate` skipped injection for **any** message with `reply_to_message`. Now it only skips injection for a reply to a **known ask** message; any other thread message (plain text, or a reply to a non-ask message) injects a user turn.

## Tests
topic-registry (6, incl. concurrency), helpers, daemon (17) green; typecheck clean. TS-only — no native rebuild.

Note: live Telegram round-trip verification is the reviewer's step (needs a real bot + forum DM).

🤖 Generated with Claude Code