### PR TITLE
Fix Windows PowerShell newline chords

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-editor.ts
+++ b/packages/coding-agent/src/modes/components/hook-editor.ts
@@ -17,6 +17,10 @@ export interface HookEditorOptions {
 	promptStyle?: boolean;
 }
 
+function isWindowsRawLfNewlineInput(keyData: string): boolean {
+	return process.platform === "win32" && keyData === "\n";
+}
+
 export class HookEditorComponent extends Container {
 	#editor: Editor;
 	#onSubmitCallback: (value: string) => void;
@@ -92,8 +96,9 @@ export class HookEditorComponent extends Container {
 			return;
 		}
 
-		// Submit on any plain Enter encoding, including terminals that report unmodified Enter as LF.
-		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return")) {
+		// Submit on plain Enter encodings. On Windows, raw LF is reserved for terminal
+		// newline mappings (Shift+Enter/Ctrl+J/Ctrl+Enter); plain Enter reports CR.
+		if (!isWindowsRawLfNewlineInput(keyData) && (matchesKey(keyData, "enter") || matchesKey(keyData, "return"))) {
 			this.#onSubmitCallback(this.#editor.getText());
 			return;
 		}

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -177,19 +177,48 @@ describe("HookEditorComponent prompt-style mode", () => {
 		expect(onCancel).not.toHaveBeenCalled();
 	});
 
-	it("submits when a terminal reports plain Enter as LF", () => {
-		const onSubmit = vi.fn();
-		const onCancel = vi.fn();
-		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
-			promptStyle: true,
-		});
+	it("submits when a non-Windows terminal reports plain Enter as LF", () => {
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: "linux" });
+		try {
+			const onSubmit = vi.fn();
+			const onCancel = vi.fn();
+			const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
+				promptStyle: true,
+			});
 
-		component.handleInput("a");
-		component.handleInput("\n");
+			component.handleInput("a");
+			component.handleInput("\n");
 
-		expect(onSubmit).toHaveBeenCalledTimes(1);
-		expect(onSubmit).toHaveBeenCalledWith("a");
-		expect(onCancel).not.toHaveBeenCalled();
+			expect(onSubmit).toHaveBeenCalledTimes(1);
+			expect(onSubmit).toHaveBeenCalledWith("a");
+			expect(onCancel).not.toHaveBeenCalled();
+		} finally {
+			if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+		}
+	});
+
+	it("inserts newline for Windows PowerShell raw LF newline chords", () => {
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: "win32" });
+		try {
+			const onSubmit = vi.fn();
+			const onCancel = vi.fn();
+			const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
+				promptStyle: true,
+			});
+
+			component.handleInput("a");
+			component.handleInput("\n");
+			component.handleInput("b");
+			component.handleInput("\r");
+
+			expect(onSubmit).toHaveBeenCalledTimes(1);
+			expect(onSubmit).toHaveBeenCalledWith("a\nb");
+			expect(onCancel).not.toHaveBeenCalled();
+		} finally {
+			if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+		}
 	});
 
 	it("inserts newline on Shift+Enter instead of submitting", () => {


### PR DESCRIPTION
## Summary
- Treat raw LF as a Windows prompt-style newline input instead of submitting immediately
- Preserve CR/plain Enter submit behavior and non-Windows LF submit behavior
- Add focused HookEditor regression coverage for Windows PowerShell raw LF newline chords

## Verification
- `bun test packages/coding-agent/test/hook-editor.test.ts packages/tui/test/editor.test.ts packages/tui/test/keys.test.ts` — 164 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — blocked after rebase by pre-existing formatting issues in `src/notifications/telegram-daemon.ts` and `test/notifications-topic-registry.test.ts` from current `origin/dev`, outside this PR
- `bunx biome check packages/coding-agent/src/modes/components/hook-editor.ts packages/coding-agent/test/hook-editor.test.ts` — pass
- `bun --cwd=packages/coding-agent run check:types` — pass
- `bun --cwd=packages/tui run check:types` — pass

Fixes #972

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*