### PR TITLE
fix(notifications): identity bullets once + de-duplicate idle output

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -40,7 +40,7 @@ import {
 	imageAttachmentsFromMessage,
 	notificationActionPayload,
 	summaryFromMessage,
-	summaryFromMessages,
+
 } from "./helpers";
 import { ensureTelegramDaemonRunning } from "./telegram-daemon";
 
@@ -508,7 +508,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 							id: `idle:${id}#${seq}`,
 							kind: "idle",
 							sessionId: id,
-							summary: summaryFromMessages(event.messages),
+							summary: undefined,
 						},
 						{ redact: rt.redact, sessionTag: rt.sessionTag },
 					),
@@ -518,10 +518,10 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			logger.warn(`notifications: noteIdle failed: ${String(e)}`);
 		}
 
-		// On idle, also stream a context update (last message + working-tree diff
-		// stat) unless redaction is on. Best-effort + async; never blocks.
+		// On idle, stream a context update with metadata (token/model usage +
+		// working-tree diff) unless redaction is on. The agent's last message is
+		// NOT repeated here — it is already streamed once via `turn_stream`.
 		if (!rt.redact) {
-			const last = summaryFromMessages(event.messages, 600);
 			const usage = (
 				ctx as { getContextUsage?: () => { tokens: number | null; contextWindow: number } | undefined }
 			).getContextUsage?.();
@@ -529,13 +529,12 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			const tokenUsage = usage && usage.tokens != null ? `${usage.tokens}/${usage.contextWindow}` : undefined;
 			const modelId = model?.id;
 			void readGitDiffStat(ctx.cwd).then(diff => {
-				if (!last && !diff && !tokenUsage && !modelId) return;
+				if (!diff && !tokenUsage && !modelId) return;
 				try {
 					rt.server.pushFrame(
 						JSON.stringify({
 							type: "context_update",
 							sessionId: id,
-							lastMessage: last,
 							tokenUsage,
 							model: modelId,
 							diff,

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -591,16 +591,10 @@ export class TelegramNotificationDaemon {
 			if (!send) return;
 			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
 			if (!topicId) return;
-			this.pool.submit({
-				sessionId: session.sessionId,
-				lane: send.lane,
-				coalesceKey: send.coalesceKey,
-				payload: { send, topicId },
-			});
-			await this.flushPool();
 			if (send.identity) {
 				// Rename the topic if the title changed (e.g. the session title was
-				// auto-generated after the topic was first created).
+				// auto-generated after the topic was first created). This runs on
+				// every identity frame, but does NOT re-send the bulleted message.
 				const name = this.topicNameFor(session.sessionId, msg);
 				if (this.topics.applyName(session.sessionId, name)) {
 					try {
@@ -613,9 +607,27 @@ export class TelegramNotificationDaemon {
 						// Best-effort rename; never block delivery.
 					}
 				}
-				this.topics.markIdentitySent(session.sessionId);
+				// Send the full bulleted identity header EXACTLY ONCE per topic.
+				if (this.topics.needsIdentity(session.sessionId)) {
+					this.pool.submit({
+						sessionId: session.sessionId,
+						lane: send.lane,
+						coalesceKey: send.coalesceKey,
+						payload: { send, topicId },
+					});
+					await this.flushPool();
+					this.topics.markIdentitySent(session.sessionId);
+				}
 				await this.persistTopics();
+				return;
 			}
+			this.pool.submit({
+				sessionId: session.sessionId,
+				lane: send.lane,
+				coalesceKey: send.coalesceKey,
+				payload: { send, topicId },
+			});
+			await this.flushPool();
 			return;
 		}
 		if (msg.type === "action_needed" && msg.id) {

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -122,7 +122,7 @@ export function buildActionMessage(action: {
 	summary?: string;
 }): RenderedMessage {
 	if (action.kind === "idle") {
-		return { text: `🟢 Agent idle\n${action.summary ?? "(no summary)"}` };
+		return { text: action.summary ? `🟢 Agent idle\n${action.summary}` : "🟢 Agent idle" };
 	}
 	const text = `❓ ${action.question ?? "Question"}`;
 	const options = action.options ?? [];


### PR DESCRIPTION
Follow-up to #970/#979 from live QA.

- **Identity bullets re-emitted every idle** → now sent exactly once per topic (host re-emits identity on agent_end only to drive topic rename; daemon gates the bulleted message on `needsIdentity` and otherwise just `editForumTopic`-renames).
- **Agent outcome tripled on idle** (turn_stream finalized + idle summary + context_update lastMessage) → outcome streams once via `turn_stream`; idle is a marker; context_update is metadata-only (token/model + diff).

Tests: topic-registry/helpers/reference (29) + daemon (17) green; typecheck clean. TS-only.

🤖 Generated with Claude Code