### PR TITLE
fix: support explicit vision fallback handoff

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -45,8 +45,10 @@ export interface PreparedModelProfileActivation {
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
 	previousAgentModelOverrides: Record<string, string>;
+	previousModelRoles: Record<string, string>;
 	defaultModel: Model<Api> | undefined;
 	defaultThinkingLevel: ThinkingLevel | undefined;
+	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
 	previousActiveModelProfile: string | undefined;
 	/**
@@ -97,14 +99,24 @@ function rewriteSelectorProvider(
 }
 
 function rewriteBindingsProviders(
-	bindings: { defaultSelector?: string; agentModelOverrides: Record<string, string> },
+	bindings: {
+		defaultSelector?: string;
+		modelRoles: Record<string, string>;
+		agentModelOverrides: Record<string, string>;
+	},
 	authenticatedProviders: ReadonlySet<string>,
 	alternativeGroups: readonly (readonly string[])[],
-): { defaultSelector?: string; agentModelOverrides: Record<string, string> } {
+): { defaultSelector?: string; modelRoles: Record<string, string>; agentModelOverrides: Record<string, string> } {
 	return {
 		defaultSelector: bindings.defaultSelector
 			? rewriteSelectorProvider(bindings.defaultSelector, authenticatedProviders, alternativeGroups)
 			: undefined,
+		modelRoles: Object.fromEntries(
+			Object.entries(bindings.modelRoles).map(([role, sel]) => [
+				role,
+				rewriteSelectorProvider(sel, authenticatedProviders, alternativeGroups),
+			]),
+		),
 		agentModelOverrides: Object.fromEntries(
 			Object.entries(bindings.agentModelOverrides).map(([role, sel]) => [
 				role,
@@ -175,6 +187,18 @@ export async function prepareModelProfileActivation(
 		);
 	}
 
+	const modelRoles: Record<string, string> = {};
+	for (const [role, selector] of Object.entries(bindings.modelRoles) as [GjcModelAssignmentTargetId, string][]) {
+		const resolved = resolveModelRoleValue(selector, availableModels, {
+			settings: options.settings as Settings,
+			modelRegistry: options.modelRegistry,
+		});
+		if (!resolved.model) {
+			throw new Error(`Model profile "${options.profileName}" ${role} selector did not resolve: ${selector}`);
+		}
+		modelRoles[role] = formatClampedModelSelector(selector, resolved.model);
+	}
+
 	const agentModelOverrides: Record<string, string> = {};
 	for (const [role, selector] of Object.entries(bindings.agentModelOverrides) as [
 		GjcModelAssignmentTargetId,
@@ -197,8 +221,10 @@ export async function prepareModelProfileActivation(
 		previousModel: options.session.model,
 		previousThinkingLevel: options.session.thinkingLevel,
 		previousAgentModelOverrides: { ...options.settings.get("task.agentModelOverrides") },
+		previousModelRoles: { ...options.settings.get("modelRoles") },
 		defaultModel: resolvedDefault?.model,
 		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
+		modelRoles,
 		agentModelOverrides,
 		previousActiveModelProfile: options.session.getActiveModelProfile?.(),
 		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
@@ -212,12 +238,14 @@ export async function applyPreparedModelProfileActivation(
 	const previousModel = prepared.previousModel;
 	const previousThinkingLevel = prepared.previousThinkingLevel;
 	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
+	const previousModelRoles = prepared.previousModelRoles;
 	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
 	let modelChanged = false;
 	let overridesChanged = false;
 	let defaultChanged = false;
+	let modelRolesChanged = false;
 
 	try {
 		if (prepared.defaultModel) {
@@ -225,6 +253,13 @@ export async function applyPreparedModelProfileActivation(
 				persistAsSessionDefault: true,
 			});
 			modelChanged = true;
+		}
+		if (Object.keys(prepared.modelRoles).length > 0) {
+			prepared.settings.override("modelRoles", {
+				...prepared.settings.get("modelRoles"),
+				...prepared.modelRoles,
+			});
+			modelRolesChanged = true;
 		}
 		if (Object.keys(prepared.agentModelOverrides).length > 0) {
 			prepared.settings.override("task.agentModelOverrides", {
@@ -242,6 +277,9 @@ export async function applyPreparedModelProfileActivation(
 	} catch (error) {
 		if (defaultChanged) {
 			prepared.settings.set("modelProfile.default", previousPersistedDefault);
+		}
+		if (modelRolesChanged) {
+			prepared.settings.override("modelRoles", previousModelRoles);
 		}
 		if (overridesChanged) {
 			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -23,7 +23,8 @@ export interface ModelProfileDefinition {
 
 export interface ResolvedProfileBinding {
 	defaultSelector?: string;
-	agentModelOverrides: Partial<Record<Exclude<ModelProfileRole, "default">, string>>;
+	modelRoles: Partial<Record<"vision", string>>;
+	agentModelOverrides: Partial<Record<Exclude<ModelProfileRole, "default" | "vision">, string>>;
 }
 
 function parseModelSelectorProvider(selector: string): string | undefined {
@@ -56,7 +57,7 @@ export function aggregateModelProfileRequiredProviders(
 const profile = (
 	name: string,
 	requiredProviders: string[],
-	modelMapping: Record<ModelProfileRole, string>,
+	modelMapping: Partial<Record<ModelProfileRole, string>>,
 	alternativeProviderGroups?: readonly (readonly string[])[],
 ): ModelProfileDefinition => ({
 	name,
@@ -382,13 +383,15 @@ export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map
 }
 
 export function resolveProfileBindings(definition: ModelProfileDefinition): ResolvedProfileBinding {
-	const { default: defaultSelector, executor, architect, planner, critic } = definition.modelMapping;
+	const { default: defaultSelector, vision, executor, architect, planner, critic } = definition.modelMapping;
+	const modelRoles: ResolvedProfileBinding["modelRoles"] = {};
+	if (vision !== undefined) modelRoles.vision = vision;
 	const agentModelOverrides: ResolvedProfileBinding["agentModelOverrides"] = {};
 	if (executor !== undefined) agentModelOverrides.executor = executor;
 	if (architect !== undefined) agentModelOverrides.architect = architect;
 	if (planner !== undefined) agentModelOverrides.planner = planner;
 	if (critic !== undefined) agentModelOverrides.critic = critic;
-	return { defaultSelector, agentModelOverrides };
+	return { defaultSelector, modelRoles, agentModelOverrides };
 }
 
 export function formatAvailableProfileNames(profiles: ReadonlyMap<string, ModelProfileDefinition>): string {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -70,7 +70,7 @@ export function isAuthenticated(apiKey: string | undefined | null): apiKey is st
 	return Boolean(apiKey) && apiKey !== kNoAuth;
 }
 
-export type ModelRole = "default";
+export type ModelRole = "default" | "vision";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -80,11 +80,12 @@ export interface ModelRoleInfo {
 
 export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	default: { tag: "DEFAULT", name: "Default", color: "success" },
+	vision: { tag: "VISION", name: "Vision", color: "accent" },
 };
 
-export const MODEL_ROLE_IDS: ModelRole[] = ["default"];
+export const MODEL_ROLE_IDS: ModelRole[] = ["default", "vision"];
 
-export type GjcModelAssignmentTargetId = "default" | "executor" | "architect" | "planner" | "critic";
+export type GjcModelAssignmentTargetId = "default" | "vision" | "executor" | "architect" | "planner" | "critic";
 
 export interface GjcModelAssignmentTargetInfo extends ModelRoleInfo {
 	id: GjcModelAssignmentTargetId;
@@ -93,6 +94,7 @@ export interface GjcModelAssignmentTargetInfo extends ModelRoleInfo {
 
 export const GJC_MODEL_ASSIGNMENT_TARGET_IDS: GjcModelAssignmentTargetId[] = [
 	"default",
+	"vision",
 	"executor",
 	"architect",
 	"planner",
@@ -101,6 +103,7 @@ export const GJC_MODEL_ASSIGNMENT_TARGET_IDS: GjcModelAssignmentTargetId[] = [
 
 export const GJC_MODEL_ASSIGNMENT_TARGETS: Record<GjcModelAssignmentTargetId, GjcModelAssignmentTargetInfo> = {
 	default: { id: "default", tag: "DEFAULT", name: "Default", color: "success", settingsPath: "modelRoles" },
+	vision: { id: "vision", tag: "VISION", name: "Vision", color: "accent", settingsPath: "modelRoles" },
 	executor: {
 		id: "executor",
 		tag: "EXECUTOR",

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -81,7 +81,7 @@ const ModelBindingsSchema = z.object({
 	modelRoles: z.record(z.string(), z.string().min(1)).optional(),
 	agentModelOverrides: z.record(z.string(), z.string().min(1)).optional(),
 });
-export const ProfileRoleSchema = z.enum(["default", "executor", "architect", "planner", "critic"]);
+export const ProfileRoleSchema = z.enum(["default", "vision", "executor", "architect", "planner", "critic"]);
 
 function isValidProfileModelSelector(value: string): boolean {
 	if (value.includes(",")) return false;

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -78,21 +78,26 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 		};
 
 		const activeModelPattern = this.session.getActiveModelString?.() ?? this.session.getModelString?.();
-		let model = resolvePattern("pi/default") ?? resolvePattern(activeModelPattern) ?? availableModels[0];
+		const configuredVisionPattern = this.session.settings.getModelRole("vision")?.trim();
+		const configuredVisionModel = configuredVisionPattern ? resolvePattern("pi/vision") : undefined;
+		if (configuredVisionPattern && !configuredVisionModel) {
+			throw new ToolError(
+				`Configured modelRoles.vision (${configuredVisionPattern}) did not resolve to an available model. Configure modelRoles.vision with a vision-capable model.`,
+			);
+		}
+		const model = configuredVisionModel ?? resolvePattern("pi/default") ?? resolvePattern(activeModelPattern);
 		if (!model) {
-			throw new ToolError("Unable to resolve a model for inspect_image.");
+			throw new ToolError(
+				"Unable to resolve a model for inspect_image. Configure modelRoles.vision with a vision-capable model or select a vision-capable active/default model.",
+			);
 		}
 
-		// inspect_image requires image input; if the resolved model is text-only,
-		// fall back to any available vision-capable model before failing.
+		// inspect_image requires image input. A text-only selected model must be
+		// paired with an explicit vision role so the model/cost boundary is visible.
 		if (!model.input.includes("image")) {
-			const visionModel = availableModels.find(candidate => candidate.input.includes("image"));
-			if (!visionModel) {
-				throw new ToolError(
-					`Resolved model ${model.provider}/${model.id} does not support image input, and no vision-capable model is available. Configure a vision-capable model.`,
-				);
-			}
-			model = visionModel;
+			throw new ToolError(
+				`Resolved model ${model.provider}/${model.id} does not support image input. Configure modelRoles.vision with a vision-capable model.`,
+			);
 		}
 
 		const apiKey = await modelRegistry.getApiKey(model);

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -190,10 +190,18 @@ describe("default GJC definitions", () => {
 		});
 	});
 
-	it("exposes only default plus four GJC role agents as model assignment targets", () => {
-		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS).toEqual(["default", "executor", "architect", "planner", "critic"]);
+	it("exposes default, vision, and four GJC role agents as model assignment targets", () => {
+		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS).toEqual([
+			"default",
+			"vision",
+			"executor",
+			"architect",
+			"planner",
+			"critic",
+		]);
 		expect(GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => GJC_MODEL_ASSIGNMENT_TARGETS[id].tag)).toEqual([
 			"DEFAULT",
+			"VISION",
 			"EXECUTOR",
 			"ARCHITECT",
 			"PLANNER",

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -34,6 +34,7 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 				default: "provider-a/default:high",
 				executor: "provider-b/executor",
 				architect: "provider-a/architect",
+				vision: "provider-a/architect",
 			},
 			source: "user" as const,
 		},
@@ -106,6 +107,9 @@ describe("model profile activation", () => {
 		expect(prepared.defaultModel?.provider).toBe("provider-a");
 		expect(prepared.defaultModel?.id).toBe("default");
 		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.High);
+		expect(prepared.modelRoles).toEqual({
+			vision: "provider-a/architect",
+		});
 		expect(prepared.agentModelOverrides).toEqual({
 			executor: "provider-b/executor",
 			architect: "provider-a/architect",
@@ -172,6 +176,9 @@ describe("model profile activation", () => {
 
 		expect(session.setModelTemporaryCalls).toHaveLength(1);
 		expect(session.model?.id).toBe("default");
+		expect(settings.get("modelRoles")).toEqual({
+			vision: "provider-a/architect",
+		});
 		expect(settings.get("task.agentModelOverrides")).toEqual({
 			critic: "provider-a/old",
 			executor: "provider-b/executor",

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -448,6 +448,7 @@ describe("built-in model profile catalog", () => {
 		});
 		expect(resolveProfileBindings(profile as ModelProfileDefinition)).toEqual({
 			defaultSelector: "custom/model",
+			modelRoles: {},
 			agentModelOverrides: {},
 		});
 	});

--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -136,7 +136,7 @@ describe("model profile red-team schema and catalog cases", () => {
 			source: "user",
 		});
 
-		expect(resolved).toEqual({ defaultSelector: "provider/model", agentModelOverrides: {} });
+		expect(resolved).toEqual({ defaultSelector: "provider/model", modelRoles: {}, agentModelOverrides: {} });
 	});
 
 	test("resolveProfileBindings preserves effort suffixes verbatim", () => {
@@ -146,11 +146,13 @@ describe("model profile red-team schema and catalog cases", () => {
 			modelMapping: {
 				default: "provider/default:medium",
 				executor: "provider/executor:high",
+				vision: "provider/vision",
 			},
 			source: "user",
 		});
 
 		expect(resolved.defaultSelector).toBe("provider/default:medium");
+		expect(resolved.modelRoles).toEqual({ vision: "provider/vision" });
 		expect(resolved.agentModelOverrides).toEqual({ executor: "provider/executor:high" });
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -10,8 +10,8 @@ import { addApiCompatibleProvider } from "@gajae-code/coding-agent/setup/provide
 import { $credentialEnv, hookFetch, Snowflake } from "@gajae-code/utils";
 
 describe("model roles", () => {
-	test("only the default role remains after legacy role cleanup", () => {
-		expect(MODEL_ROLE_IDS).toEqual(["default"]);
+	test("default and vision are built-in model roles", () => {
+		expect(MODEL_ROLE_IDS).toEqual(["default", "vision"]);
 	});
 });
 

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -905,9 +905,15 @@ describe("expandRoleAlias", () => {
 		expect(expandRoleAlias("pi/default", settings)).toBe("openai/gpt-4o");
 	});
 
-	test("keeps an unknown role alias unchanged", () => {
+	test("expands pi/vision to the configured vision role", () => {
 		const settings = Settings.isolated();
-		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
+		settings.setModelRole("vision", "openai/gpt-4o");
+
+		expect(expandRoleAlias("pi/vision", settings)).toBe("openai/gpt-4o");
+	});
+
+	test("keeps an unconfigured known role alias unchanged", () => {
+		const settings = Settings.isolated();
 
 		expect(expandRoleAlias("pi/vision", settings)).toBe("pi/vision");
 	});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -219,6 +219,7 @@ describe("ModelSelector canonical model selection", () => {
 
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
 		const selectedAfterEnter = selected;
@@ -298,6 +299,7 @@ describe("ModelSelector canonical model selection", () => {
 
 		selector.handleInput("\t");
 		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
@@ -450,6 +452,7 @@ describe("ModelSelector canonical model selection", () => {
 		installTestTheme();
 
 		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 

--- a/packages/coding-agent/test/tools/inspect-image.test.ts
+++ b/packages/coding-agent/test/tools/inspect-image.test.ts
@@ -219,7 +219,7 @@ describe("InspectImageTool", () => {
 		expect(stub.calls).toHaveLength(0);
 	});
 
-	it("falls back to pi/default when vision role is unset", async () => {
+	it("uses pi/default when vision role is unset and default supports images", async () => {
 		const imagePath = path.join(testDir, "screen.png");
 		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
 
@@ -237,6 +237,100 @@ describe("InspectImageTool", () => {
 		);
 
 		const result = await tool.execute("call-1c", { path: imagePath, question: "What text is visible?" });
+		expect(result.details?.model).toBe("openai/gpt-4o");
+		expect(stub.calls).toHaveLength(1);
+		const selectedModel = stub.calls[0]?.[0] as { id?: string } | undefined;
+		expect(selectedModel?.id).toBe("gpt-4o");
+	});
+
+	it("does not fall back to an arbitrary vision model when vision role is unset", async () => {
+		const imagePath = path.join(testDir, "screen.png");
+		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", `${textOnlyModel.provider}/${textOnlyModel.id}`);
+
+		const stub = createCompleteSimpleForbiddenStub();
+		const tool = new InspectImageTool(
+			createSession(testDir, textOnlyModel, "test-key", settings, {
+				configureVisionRole: false,
+				availableModels: [textOnlyModel, visionModel],
+				activeModel: textOnlyModel,
+			}),
+			stub.fn,
+		);
+
+		await expect(
+			tool.execute("call-no-roulette", { path: imagePath, question: "What text is visible?" }),
+		).rejects.toThrow(/modelRoles\.vision/);
+		expect(stub.calls).toHaveLength(0);
+	});
+
+	it("fails when configured vision role does not resolve", async () => {
+		const imagePath = path.join(testDir, "screen.png");
+		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+		const settings = Settings.isolated();
+		settings.setModelRole("vision", "openai/missing-vision-model");
+
+		const stub = createCompleteSimpleForbiddenStub();
+		const tool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", settings, {
+				configureVisionRole: false,
+				availableModels: [visionModel],
+				activeModel: visionModel,
+			}),
+			stub.fn,
+		);
+
+		await expect(
+			tool.execute("call-missing-vision-role", { path: imagePath, question: "What text is visible?" }),
+		).rejects.toThrow(/Configured modelRoles\.vision .* did not resolve/);
+		expect(stub.calls).toHaveLength(0);
+	});
+
+	it("does not use registry-order fallback when no configured or selected model resolves", async () => {
+		const imagePath = path.join(testDir, "screen.png");
+		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+		const settings = Settings.isolated();
+		const stub = createCompleteSimpleForbiddenStub();
+		const tool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", settings, {
+				configureVisionRole: false,
+				availableModels: [visionModel],
+				activeModel: textOnlyModel,
+			}),
+			stub.fn,
+		);
+
+		await expect(
+			tool.execute("call-no-registry-order-fallback", { path: imagePath, question: "What text is visible?" }),
+		).rejects.toThrow(/Unable to resolve a model for inspect_image/);
+		expect(stub.calls).toHaveLength(0);
+	});
+
+	it("uses configured vision role when active model is text-only", async () => {
+		const imagePath = path.join(testDir, "screen.png");
+		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", `${textOnlyModel.provider}/${textOnlyModel.id}`);
+		settings.setModelRole("vision", `${visionModel.provider}/${visionModel.id}`);
+
+		const stub = createCompleteSimpleSuccessStub("Configured vision fallback used");
+		const tool = new InspectImageTool(
+			createSession(testDir, visionModel, "test-key", settings, {
+				configureVisionRole: false,
+				availableModels: [textOnlyModel, visionModel],
+				activeModel: textOnlyModel,
+			}),
+			stub.fn,
+		);
+
+		const result = await tool.execute("call-vision-role", { path: imagePath, question: "What text is visible?" });
+		expect(result.content).toEqual([{ type: "text", text: "Configured vision fallback used" }]);
+		expect((result.content as Array<{ type: string }>).some(c => c.type === "image")).toBe(false);
 		expect(result.details?.model).toBe("openai/gpt-4o");
 		expect(stub.calls).toHaveLength(1);
 		const selectedModel = stub.calls[0]?.[0] as { id?: string } | undefined;

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -49,6 +49,10 @@
 					"type": "boolean",
 					"default": false
 				},
+				"verbosity": {
+					"type": "string",
+					"default": "lean"
+				},
 				"daemon": {
 					"type": "object",
 					"properties": {

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -1160,6 +1160,7 @@
 							"type": "string",
 							"enum": [
 								"default",
+								"vision",
 								"executor",
 								"architect",
 								"planner",


### PR DESCRIPTION
## Summary

- Add an explicit built-in `vision` model role / assignment target (`modelRoles.vision`, `pi/vision`).
- Route `inspect_image` through configured `pi/vision` first, then existing default/active model resolution; text-only selections now fail with an actionable `modelRoles.vision` message instead of choosing an arbitrary vision model.
- Wire profile `model_mapping.vision` into `modelRoles.vision` and keep executor/architect/planner/critic mappings in `task.agentModelOverrides`.
- Keep `inspect_image` results compact and text-only while reporting the actual fallback model in details.

## Verification

- `bun test packages/coding-agent/test/tools/inspect-image.test.ts packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/model-profiles-redteam.test.ts packages/coding-agent/test/model-profiles-catalog.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` → 268 pass, 0 fail, 3314 expect calls.
- `bun run check:ts` → pass (Biome emitted existing deprecated `recommended` config infos only).

## Notes

- Rebased onto current `origin/dev` before implementation.
- `gjc ultragoal checkpoint` could not be completed because `gjc goal get --json` hung in this session and handcrafted goal snapshots are rejected by the runtime checkpoint validator; the active `goal` tool state remained active and all verification gates were run manually.

Closes #971

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
