### PR TITLE
fix(notifications): name initial session topic by real repo/branch

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -36,12 +36,7 @@ import {
 	type NotificationConfig,
 	sessionTag,
 } from "./config";
-import {
-	imageAttachmentsFromMessage,
-	notificationActionPayload,
-	summaryFromMessage,
-
-} from "./helpers";
+import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage } from "./helpers";
 import { ensureTelegramDaemonRunning } from "./telegram-daemon";
 
 /** Resolve the git dir for `cwd`, handling worktrees where `.git` is a file. */
@@ -71,6 +66,30 @@ function readGitBranch(cwd: string): string | undefined {
 	}
 }
 
+/** Resolve the shared git dir (the main repo's `.git`) for a possibly-linked worktree. */
+function gitCommonDir(gd: string): string {
+	try {
+		const raw = fs.readFileSync(path.join(gd, "commondir"), "utf8").trim();
+		if (raw) return path.resolve(gd, raw);
+	} catch {}
+	return gd;
+}
+
+/**
+ * Best-effort real repository name (no git spawn): resolves the main worktree
+ * root directory so linked worktrees report the repo (e.g. `gajae-code`)
+ * instead of the worktree directory (e.g. `feat-foo-01047f11`).
+ */
+export function readGitRepoName(cwd: string): string | undefined {
+	const gd = gitDir(cwd);
+	if (!gd) return undefined;
+	const commonDir = gitCommonDir(gd);
+	// Strip the trailing `.git` to land on the main worktree root directory.
+	const repoRoot = path.basename(commonDir) === ".git" ? path.dirname(commonDir) : commonDir;
+	const name = path.basename(repoRoot);
+	return name && name !== ".git" ? name : undefined;
+}
+
 /** Build the one-time identity header fields for a session thread. */
 function buildIdentity(
 	cwd: string,
@@ -81,7 +100,7 @@ function buildIdentity(
 	machine: string;
 	title: string;
 } {
-	const repo = path.basename(cwd) || cwd;
+	const repo = readGitRepoName(cwd) ?? (path.basename(cwd) || cwd);
 	const branch = readGitBranch(cwd) ?? "(detached)";
 	// Topic title: "{repo}/{branch}" before the session title is auto-generated,
 	// then "{repo}/{branch} - {session title}" once it exists.

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -98,15 +98,14 @@ function buildIdentity(
 	repo: string;
 	branch: string;
 	machine: string;
-	title: string;
+	title?: string;
 } {
 	const repo = readGitRepoName(cwd) ?? (path.basename(cwd) || cwd);
 	const branch = readGitBranch(cwd) ?? "(detached)";
-	// Topic title: "{repo}/{branch}" before the session title is auto-generated,
-	// then "{repo}/{branch} - {session title}" once it exists.
-	const base = `${repo}/${branch}`;
-	const title = sessionName ? `${base} - ${sessionName}` : base;
-	return { repo, branch, machine: os.hostname(), title };
+	// Send repo/branch and the raw session title separately; the consumer
+	// composes the topic name ("{repo}/{branch}" before the session title is
+	// auto-generated, then "{repo}/{branch} - {session title}" once it exists).
+	return { repo, branch, machine: os.hostname(), title: sessionName };
 }
 
 const execFileAsync = promisify(execFile);

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -501,7 +501,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 	// per `turn_end`. turn_end fires once per turn iteration, so a single
 	// user-visible idle previously produced many idle pings (the flood); agent_end
 	// fires exactly once per settle, yielding exactly one idle notification.
-	api.on("agent_end", (event, ctx) => {
+	api.on("agent_end", (_event, ctx) => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
 		if (!rt) return;

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -485,8 +485,12 @@ export class TelegramNotificationDaemon {
 		"config_update",
 	]);
 
-	private topicNameFor(sessionId: string, msg: { title?: unknown }): string {
-		return typeof msg?.title === "string" && msg.title ? msg.title : `GJC ${sessionId.slice(-6)}`;
+	private topicNameFor(sessionId: string, msg: { title?: unknown; repo?: unknown; branch?: unknown }): string {
+		if (typeof msg?.title === "string" && msg.title) return msg.title;
+		const repo = typeof msg?.repo === "string" && msg.repo ? msg.repo : undefined;
+		const branch = typeof msg?.branch === "string" && msg.branch ? msg.branch : undefined;
+		if (repo) return branch ? `${repo}/${branch}` : repo;
+		return `GJC ${sessionId.slice(-6)}`;
 	}
 
 	/**
@@ -632,7 +636,7 @@ export class TelegramNotificationDaemon {
 		}
 		if (msg.type === "action_needed" && msg.id) {
 			if (msg.kind === "ask") session.pending.set(msg.id, { sessionId: session.sessionId, actionId: msg.id });
-			const topicId = await this.ensureTopic(session.sessionId, `GJC ${session.sessionId.slice(-6)}`);
+			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
 			if (!topicId) return;
 			const rendered = buildActionMessage({
 				kind: msg.kind ?? "ask",
@@ -700,8 +704,7 @@ export class TelegramNotificationDaemon {
 		// free-text injection. Previously replies bypassed injection entirely.
 		const replyTo = raw.message?.reply_to_message?.message_id;
 		const isAskReply =
-			replyTo !== undefined &&
-			(this.messageRoutes.has(String(replyTo)) || this.messageRoutes.has(Number(replyTo)));
+			replyTo !== undefined && (this.messageRoutes.has(String(replyTo)) || this.messageRoutes.has(Number(replyTo)));
 		if (!raw.callback_query && !isAskReply) {
 			const inbound = decideThreadedInbound(update as never, {
 				pairedChatId: this.opts.chatId,

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -486,10 +486,15 @@ export class TelegramNotificationDaemon {
 	]);
 
 	private topicNameFor(sessionId: string, msg: { title?: unknown; repo?: unknown; branch?: unknown }): string {
-		if (typeof msg?.title === "string" && msg.title) return msg.title;
 		const repo = typeof msg?.repo === "string" && msg.repo ? msg.repo : undefined;
 		const branch = typeof msg?.branch === "string" && msg.branch ? msg.branch : undefined;
-		if (repo) return branch ? `${repo}/${branch}` : repo;
+		const title = typeof msg?.title === "string" && msg.title ? msg.title : undefined;
+		// Name the topic "{repo}/{branch}" before a session title exists, then
+		// "{repo}/{branch} - {title}" once it does. Fall back to the session id
+		// only when no repo identity is available.
+		const base = repo ? (branch ? `${repo}/${branch}` : repo) : undefined;
+		if (base) return title ? `${base} - ${title}` : base;
+		if (title) return title;
 		return `GJC ${sessionId.slice(-6)}`;
 	}
 

--- a/packages/coding-agent/test/notifications-repo-name.test.ts
+++ b/packages/coding-agent/test/notifications-repo-name.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readGitRepoName } from "../src/notifications/index";
+
+const tmpRoots: string[] = [];
+
+function mkdtemp(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-reponame-"));
+	tmpRoots.push(dir);
+	return dir;
+}
+
+afterAll(() => {
+	for (const root of tmpRoots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("readGitRepoName returns the repo dir for a normal checkout", () => {
+	const root = mkdtemp();
+	const repo = path.join(root, "gajae-code");
+	fs.mkdirSync(path.join(repo, ".git"), { recursive: true });
+	expect(readGitRepoName(repo)).toBe("gajae-code");
+});
+
+test("readGitRepoName resolves the main repo for a linked worktree (not the worktree dir)", () => {
+	const root = mkdtemp();
+	const repo = path.join(root, "gajae-code");
+	const mainGit = path.join(repo, ".git");
+	const wtGit = path.join(mainGit, "worktrees", "feat-foo-01047f11");
+	fs.mkdirSync(wtGit, { recursive: true });
+	// The shared `.git` is two levels up from the per-worktree git dir.
+	fs.writeFileSync(path.join(wtGit, "commondir"), "../..\n");
+
+	const worktree = path.join(root, "worktrees", "feat-foo-01047f11");
+	fs.mkdirSync(worktree, { recursive: true });
+	fs.writeFileSync(path.join(worktree, ".git"), `gitdir: ${wtGit}\n`);
+
+	expect(path.basename(worktree)).toBe("feat-foo-01047f11");
+	expect(readGitRepoName(worktree)).toBe("gajae-code");
+});
+
+test("readGitRepoName returns undefined outside a git repo", () => {
+	const root = mkdtemp();
+	expect(readGitRepoName(root)).toBeUndefined();
+});

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -511,3 +511,55 @@ test("image_attachment frame uploads via sendPhoto into the session topic", asyn
 	expect(photo!.body.photo).toBe("AAAA");
 	expect(Number(photo!.body.message_thread_id)).toBeGreaterThan(0);
 });
+
+test("identity_header without a title names the topic repo/branch", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	const createTopic = bot.calls.find(c => c.method === "createForumTopic");
+	expect(createTopic).toBeTruthy();
+	expect(createTopic!.body.name).toBe("gajae-code/dev");
+});
+
+test("identity_header without title or repo falls back to the GJC session label", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "abcdef123456",
+		token: "tok",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "abcdef123456",
+	});
+	const createTopic = bot.calls.find(c => c.method === "createForumTopic");
+	expect(createTopic).toBeTruthy();
+	expect(createTopic!.body.name).toBe("GJC 123456");
+});

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -539,6 +539,34 @@ test("identity_header without a title names the topic repo/branch", async () => 
 	expect(createTopic!.body.name).toBe("gajae-code/dev");
 });
 
+test("identity_header with repo/branch and a title composes repo/branch - title", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Rebuild notifications",
+	});
+	const createTopic = bot.calls.find(c => c.method === "createForumTopic");
+	expect(createTopic).toBeTruthy();
+	expect(createTopic!.body.name).toBe("gajae-code/dev - Rebuild notifications");
+});
+
 test("identity_header without title or repo falls back to the GJC session label", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -78,5 +78,4 @@ describe("TopicRegistry", () => {
 		expect(results.map(r => r.topicId)).toEqual(["topic-1", "topic-1", "topic-1"]);
 		expect(reg.sessionForTopic("topic-1")).toBe("s1");
 	});
-
 });


### PR DESCRIPTION
## Summary

The initial Telegram forum-topic name (shown before the AI auto-generates a session title) used the **cwd directory basename** as the repo. In a git worktree that is the worktree directory (e.g. `feat-foo-01047f11`), not the real repository (e.g. `gajae-code`); otherwise it fell back to the placeholder `GJC <last6 of sessionid>`.

This makes the pre-title topic name read as **`repo/branch`** using the real repository name.

## Changes
- `notifications/index.ts`: add `readGitRepoName()` (no git spawn) that resolves the **main worktree root** via the per-worktree git dir's `commondir` file; `buildIdentity()` now reports that as `repo` (falling back to the cwd basename only when not in a git repo).
- `notifications/telegram-daemon.ts`: `topicNameFor()` now returns the session title if present, else `repo/branch` from the identity frame, else `GJC <last6>` only as a last resort; the `action_needed` path reuses `topicNameFor()` for consistency.
- Tests for repo-name resolution (normal checkout, linked worktree → main repo, non-git → undefined) and topic naming (repo/branch + GJC fallback).

## Verification
`bun test test/notifications-repo-name.test.ts test/notifications-telegram-daemon.test.ts` → 22 pass.