### PR TITLE
feat(notifications): pretty HTML formatting for Telegram daemon output

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -1,0 +1,267 @@
+/**
+ * Telegram HTML formatting helpers for the notifications SDK.
+ *
+ * All notifications-SDK Telegram output is sent with `parse_mode: "HTML"`. This
+ * module is the single source of truth for: escaping dynamic text, converting a
+ * bounded markdown subset into Telegram HTML, safely truncating a finished
+ * message to Telegram's 4096-char limit without breaking tags/entities, and
+ * laying out inline-keyboard buttons as a numbered grid.
+ *
+ * Discipline: escape first, tag second. Telegram only parses a small tag set
+ * (b, i, u, s, code, pre, a, blockquote, tg-spoiler); a stray `<` or unbalanced
+ * tag can make Telegram reject the whole message, so dynamic text is always
+ * escaped before any tag is emitted.
+ */
+
+export const TELEGRAM_PARSE_MODE = "HTML" as const;
+export const TELEGRAM_MESSAGE_LIMIT = 4096;
+
+/** Tags Telegram parses in HTML mode (used by the truncation guard). */
+const ALLOWED_TAGS = new Set(["b", "i", "u", "s", "code", "pre", "a", "blockquote", "tg-spoiler"]);
+
+/** Escape text for Telegram HTML body content (`& < >`). */
+export function escapeHtml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Escape a value for use inside a double-quoted HTML attribute. */
+function escapeAttr(value: string): string {
+	return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+/** Wrap already-escaped text in a Telegram tag. */
+function tag(name: string, escaped: string): string {
+	return `<${name}>${escaped}</${name}>`;
+}
+
+/** Bold the given raw text (escaped internally). */
+export function bold(raw: string): string {
+	return tag("b", escapeHtml(raw));
+}
+
+/** Italicize the given raw text (escaped internally). */
+export function italic(raw: string): string {
+	return tag("i", escapeHtml(raw));
+}
+
+/** Render the given raw text as inline code (escaped internally). */
+export function code(raw: string): string {
+	return tag("code", escapeHtml(raw));
+}
+
+/** Render the given raw text as a preformatted block (escaped internally). */
+export function pre(raw: string): string {
+	return tag("pre", escapeHtml(raw));
+}
+
+const PLACEHOLDER_PREFIX = "\u0000ph";
+const PLACEHOLDER_SUFFIX = "\u0000";
+
+/** Only http(s) and mailto links are emitted; anything else stays literal. */
+function isSafeUrl(url: string): boolean {
+	return /^(https?:\/\/|mailto:)/i.test(url);
+}
+
+/**
+ * Convert a bounded markdown subset into Telegram HTML. Supported: fenced code,
+ * inline code, `**bold**`, `*italic*`, `[text](url)` (safe schemes only),
+ * `#` headers, and `>` blockquotes. Unsupported or malformed markdown is left as
+ * escaped literal text — never emitted as unbalanced tags.
+ */
+export function markdownToTelegramHtml(markdown: string): string {
+	const placeholders: string[] = [];
+	const stash = (html: string): string => {
+		const token = `${PLACEHOLDER_PREFIX}${placeholders.length}${PLACEHOLDER_SUFFIX}`;
+		placeholders.push(html);
+		return token;
+	};
+
+	let text = markdown;
+
+	// 1. Fenced code blocks (protect literal content before any other transform).
+	text = text.replace(/```[^\n]*\n?([\s\S]*?)```/g, (_m, body: string) => stash(pre(body)));
+
+	// 2. Inline code.
+	text = text.replace(/`([^`\n]+)`/g, (_m, body: string) => stash(code(body)));
+
+	// 3. Links (capture raw URL before escaping). Unsafe/malformed links stay literal.
+	text = text.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/g, (whole, label: string, url: string) => {
+		if (!isSafeUrl(url)) return whole;
+		return stash(`<a href="${escapeAttr(url)}">${escapeHtml(label)}</a>`);
+	});
+
+	// 4. Escape everything that remains (placeholders contain no escapable chars).
+	text = escapeHtml(text);
+
+	// 5. Line-level transforms on escaped text: headers and merged blockquotes.
+	const lines = text.split("\n");
+	const out: string[] = [];
+	let quoteBuffer: string[] | null = null;
+	const flushQuote = () => {
+		if (quoteBuffer) {
+			out.push(tag("blockquote", quoteBuffer.join("\n")));
+			quoteBuffer = null;
+		}
+	};
+	for (const line of lines) {
+		const quote = /^&gt;\s?(.*)$/.exec(line);
+		if (quote) {
+			(quoteBuffer ??= []).push(quote[1] ?? "");
+			continue;
+		}
+		flushQuote();
+		const header = /^(#{1,6})\s+(.*)$/.exec(line);
+		out.push(header ? tag("b", header[2] ?? "") : line);
+	}
+	flushQuote();
+	text = out.join("\n");
+
+	// 6. Inline emphasis (bold before italic; unbalanced markers stay literal).
+	text = text.replace(/\*\*([^*\n]+)\*\*/g, (_m, body: string) => tag("b", body));
+	text = text.replace(/\*([^*\n]+)\*/g, (_m, body: string) => tag("i", body));
+
+	// 7. Restore protected placeholders.
+	text = text.replace(new RegExp(`${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, "g"), (_m, i: string) =>
+		placeholders[Number(i)] ?? "",
+	);
+
+	return text;
+}
+
+interface Token {
+	value: string;
+	/** Tag name if this token opens a tag, else undefined. */
+	open?: string;
+	/** Tag name if this token closes a tag, else undefined. */
+	close?: string;
+}
+
+/** Tokenize HTML into tags, entities, and single characters (never splits them). */
+function tokenize(html: string): Token[] {
+	const tokens: Token[] = [];
+	let i = 0;
+	while (i < html.length) {
+		const ch = html[i]!;
+		if (ch === "<") {
+			const end = html.indexOf(">", i);
+			if (end !== -1) {
+				const raw = html.slice(i, end + 1);
+				const close = /^<\/([a-z-]+)>$/i.exec(raw);
+				const openMatch = /^<([a-z-]+)(?:\s[^>]*)?>$/i.exec(raw);
+				const token: Token = { value: raw };
+				if (close && ALLOWED_TAGS.has(close[1]!.toLowerCase())) token.close = close[1]!.toLowerCase();
+				else if (openMatch && ALLOWED_TAGS.has(openMatch[1]!.toLowerCase())) token.open = openMatch[1]!.toLowerCase();
+				tokens.push(token);
+				i = end + 1;
+				continue;
+			}
+		}
+		if (ch === "&") {
+			const end = html.indexOf(";", i);
+			if (end !== -1 && end - i <= 10) {
+				tokens.push({ value: html.slice(i, end + 1) });
+				i = end + 1;
+				continue;
+			}
+		}
+		tokens.push({ value: ch });
+		i++;
+	}
+	return tokens;
+}
+
+/**
+ * Truncate a finished Telegram HTML message to at most `max` chars without
+ * splitting a tag or entity, closing any still-open allowed tags and appending
+ * `marker`. The final string is guaranteed to be <= `max`.
+ */
+export function truncateTelegramHtml(
+	message: string,
+	max = TELEGRAM_MESSAGE_LIMIT,
+	marker = "… [truncated]",
+): string {
+	if (message.length <= max) return message;
+
+	// When `max` is too small to even hold the marker, drop it so the hard
+	// length guarantee (output.length <= max) still holds.
+	const effectiveMarker = marker.length <= max ? marker : "";
+
+	const tokens = tokenize(message);
+	const stack: string[] = [];
+	let out = "";
+
+	const closersFor = (s: string[]): string => s.map(t => `</${t}>`).reverse().join("");
+
+	for (const token of tokens) {
+		// Simulate accepting this token, then ensure we can still close + mark.
+		const nextStack = [...stack];
+		if (token.open) nextStack.push(token.open);
+		else if (token.close) {
+			const idx = nextStack.lastIndexOf(token.close);
+			if (idx !== -1) nextStack.splice(idx, 1);
+		}
+		const projected = out.length + token.value.length + closersFor(nextStack).length + effectiveMarker.length;
+		if (projected > max) break;
+		out += token.value;
+		if (token.open) stack.push(token.open);
+		else if (token.close) {
+			const idx = stack.lastIndexOf(token.close);
+			if (idx !== -1) stack.splice(idx, 1);
+		}
+	}
+
+	return out + closersFor(stack) + effectiveMarker;
+}
+
+/** Finalize an optional message: undefined passthrough, else safe-truncate. */
+export function finalizeTelegramHtml(message?: string): string | undefined {
+	if (message === undefined) return undefined;
+	return truncateTelegramHtml(message);
+}
+
+/** One-based, plain-text button label (Telegram does not parse HTML in labels). */
+export function buttonLabel(label: string, index: number): string {
+	return `${index + 1}. ${label}`;
+}
+
+export interface InlineButton {
+	text: string;
+	callback_data: string;
+}
+
+/** A prefixed button label is "long" when it is wide or contains a newline. */
+function isLongLabel(label: string): boolean {
+	return label.length > 18 || /[\r\n]/.test(label);
+}
+
+/**
+ * Lay out option labels as a numbered button grid. Long buttons take a
+ * full-width row; runs of short buttons are packed into rows of up to 3. The
+ * callback value comes from `callbackForIndex(i)` using the original zero-based
+ * option index — layout never changes callback semantics.
+ */
+export function buildButtonGrid(
+	labels: string[],
+	callbackForIndex: (index: number) => string,
+): InlineButton[][] {
+	const rows: InlineButton[][] = [];
+	let run: InlineButton[] = [];
+	const flush = () => {
+		if (run.length) {
+			rows.push(run);
+			run = [];
+		}
+	};
+	labels.forEach((label, i) => {
+		const button: InlineButton = { text: buttonLabel(label, i), callback_data: callbackForIndex(i) };
+		if (isLongLabel(button.text)) {
+			flush();
+			rows.push([button]);
+			return;
+		}
+		run.push(button);
+		if (run.length === 3) flush();
+	});
+	flush();
+	return rows;
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -6,6 +6,7 @@ import type { Settings } from "../config/settings";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { RateLimitPool } from "./rate-limit-pool";
+import { buildButtonGrid, TELEGRAM_PARSE_MODE } from "./html-format";
 import {
 	type AliasTable,
 	buildActionMessage,
@@ -411,11 +412,13 @@ export class TelegramNotificationDaemon {
 						photo: string;
 						mime?: string;
 						caption?: string;
+						parse_mode?: string;
 					};
 					const form = new FormData();
 					form.set("chat_id", String(b.chat_id));
 					if (b.message_thread_id !== undefined) form.set("message_thread_id", String(b.message_thread_id));
 					if (b.caption) form.set("caption", b.caption);
+					if (b.parse_mode) form.set("parse_mode", String(b.parse_mode));
 					form.set("photo", new Blob([Buffer.from(b.photo, "base64")], { type: b.mime ?? "image/png" }), "image");
 					const res = await fetchImpl(url, { method: "POST", body: form });
 					return res.json();
@@ -555,12 +558,14 @@ export class TelegramNotificationDaemon {
 						photo: send.photoBase64,
 						mime: send.mime,
 						caption: send.text,
+						parse_mode: TELEGRAM_PARSE_MODE,
 					});
 				} else if (send.text) {
 					await this.botApi.call("sendMessage", {
 						chat_id: this.opts.chatId,
 						message_thread_id: thread,
 						text: send.text,
+						parse_mode: TELEGRAM_PARSE_MODE,
 					});
 				}
 			} catch {
@@ -642,16 +647,16 @@ export class TelegramNotificationDaemon {
 				summary: msg.summary,
 			});
 			const options = Array.isArray(msg.options) ? msg.options : [];
-			const inline_keyboard = options.map((label: string, i: number) => [
-				{
-					text: label,
-					callback_data: this.aliasTable.put({ sessionId: session.sessionId, actionId: msg.id, answer: i }),
-				},
-			]);
+			// Daemon keyboards MUST use alias callback data (not reference encodeCallbackData).
+			// Labels show one-based numbers; the stored alias answer stays zero-based.
+			const inline_keyboard = buildButtonGrid(options, (i: number) =>
+				this.aliasTable.put({ sessionId: session.sessionId, actionId: msg.id, answer: i }),
+			);
 			const result = (await this.botApi.call("sendMessage", {
 				chat_id: this.opts.chatId,
 				message_thread_id: Number(topicId),
 				text: rendered.text,
+				parse_mode: TELEGRAM_PARSE_MODE,
 				...(inline_keyboard.length ? { reply_markup: { inline_keyboard } } : {}),
 			})) as { result?: { message_id?: number } };
 			const messageId = result.result?.message_id;
@@ -683,6 +688,7 @@ export class TelegramNotificationDaemon {
 		await this.botApi.call("sendMessage", {
 			chat_id: this.opts.chatId,
 			text: "This button is stale after notification daemon restart. Please answer locally in the GJC session or wait for a fresh notification.",
+			parse_mode: TELEGRAM_PARSE_MODE,
 		});
 	}
 

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -15,6 +15,13 @@
  */
 
 import * as fs from "node:fs";
+import {
+	bold,
+	buildButtonGrid,
+	escapeHtml,
+	TELEGRAM_PARSE_MODE,
+	truncateTelegramHtml,
+} from "./html-format";
 import { renderThreadedFrame } from "./threaded-render";
 
 /** One inline-keyboard button. */
@@ -122,15 +129,14 @@ export function buildActionMessage(action: {
 	summary?: string;
 }): RenderedMessage {
 	if (action.kind === "idle") {
-		return { text: action.summary ? `🟢 Agent idle\n${action.summary}` : "🟢 Agent idle" };
+		const text = action.summary ? `🟢 Agent idle\n${escapeHtml(action.summary)}` : "🟢 Agent idle";
+		return { text: truncateTelegramHtml(text) };
 	}
-	const text = `❓ ${action.question ?? "Question"}`;
+	const text = `❓ ${bold(action.question ?? "Question")}`;
 	const options = action.options ?? [];
-	if (options.length === 0) return { text: `${text}\n\n(reply with text)` };
-	const inline_keyboard = options.map((label, i) => [
-		{ text: label, callback_data: encodeCallbackData(action.id, i) },
-	]);
-	return { text, inline_keyboard };
+	if (options.length === 0) return { text: truncateTelegramHtml(`${text}\n\n(reply with text)`) };
+	const inline_keyboard = buildButtonGrid(options, i => encodeCallbackData(action.id, i));
+	return { text: truncateTelegramHtml(text), inline_keyboard };
 }
 
 /** A protocol `reply` frame the client should send to the server. */
@@ -296,6 +302,7 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 			void send("sendMessage", {
 				chat_id: opts.chatId,
 				text: rendered.text,
+				parse_mode: TELEGRAM_PARSE_MODE,
 				...(rendered.inline_keyboard ? { reply_markup: { inline_keyboard: rendered.inline_keyboard } } : {}),
 			});
 		} else if (msg.type === "action_resolved" && msg.id === latestPendingAskId) {
@@ -306,7 +313,7 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 			// session's forum topic; this reference shows the minimal handling.
 			const threaded = renderThreadedFrame(msg as never);
 			if (threaded?.text) {
-				void send("sendMessage", { chat_id: opts.chatId, text: threaded.text });
+				void send("sendMessage", { chat_id: opts.chatId, text: threaded.text, parse_mode: TELEGRAM_PARSE_MODE });
 			}
 		}
 	});

--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -10,6 +10,15 @@
  */
 
 import { truncate } from "./helpers";
+import {
+	bold,
+	code,
+	escapeHtml,
+	finalizeTelegramHtml,
+	italic,
+	markdownToTelegramHtml,
+	pre,
+} from "./html-format";
 import type { RateLimitLane } from "./rate-limit-pool";
 
 /** A Telegram send derived from a threaded frame (topic id is applied by the daemon). */
@@ -72,28 +81,28 @@ export function formatIdentityHeader(frame: {
 }): string {
 	const title = str(frame.title) ?? "GJC session";
 	const bullets = [
-		`• repo: ${str(frame.repo) ?? "?"}`,
-		`• branch: ${str(frame.branch) ?? "?"}`,
-		`• machine: ${str(frame.machine) ?? "?"}`,
-		`• session: ${str(frame.sessionId) ?? "?"}`,
+		`• repo: ${code(str(frame.repo) ?? "?")}`,
+		`• branch: ${code(str(frame.branch) ?? "?")}`,
+		`• machine: ${code(str(frame.machine) ?? "?")}`,
+		`• session: ${code(str(frame.sessionId) ?? "?")}`,
 	];
-	return `${title}\n${bullets.join("\n")}`;
+	return `${bold(title)}\n${bullets.join("\n")}`;
 }
 
 /** Format a streamed context update into a compact block (omitting empty fields). */
 export function formatContextUpdate(frame: ThreadedFrame): string | undefined {
 	const lines: string[] = [];
 	const last = str(frame.lastMessage);
-	if (last) lines.push(truncate(last, 600));
+	if (last) lines.push(escapeHtml(truncate(last, 600)));
 	const task = str(frame.task);
-	if (task) lines.push(`task: ${task}`);
+	if (task) lines.push(`${italic("task:")} ${escapeHtml(task)}`);
 	const goal = str(frame.goal);
-	if (goal) lines.push(`goal: ${goal}`);
+	if (goal) lines.push(`${italic("goal:")} ${escapeHtml(goal)}`);
 	const usage = str(frame.tokenUsage);
 	const model = str(frame.model);
-	if (usage || model) lines.push(`ctx: ${[usage, model].filter(Boolean).join(" · ")}`);
+	if (usage || model) lines.push(`ctx: ${code([usage, model].filter(Boolean).join(" · "))}`);
 	const diff = str(frame.diff);
-	if (diff) lines.push(`diff:\n${truncate(diff, 1200)}`);
+	if (diff) lines.push(`diff:\n${pre(truncate(diff, 1200))}`);
 	return lines.length ? lines.join("\n") : undefined;
 }
 
@@ -104,16 +113,22 @@ export function formatContextUpdate(frame: ThreadedFrame): string | undefined {
 export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefined {
 	switch (frame.type) {
 		case "identity_header":
-			return { method: "sendMessage", lane: "finalized", text: formatIdentityHeader(frame), identity: true };
+			return {
+				method: "sendMessage",
+				lane: "finalized",
+				text: finalizeTelegramHtml(formatIdentityHeader(frame)),
+				identity: true,
+			};
 		case "context_update": {
-			const text = formatContextUpdate(frame);
+			const text = finalizeTelegramHtml(formatContextUpdate(frame));
 			return text
 				? { method: "sendMessage", lane: "live", text, coalesceKey: `ctx:${str(frame.sessionId) ?? ""}` }
 				: undefined;
 		}
 		case "turn_stream": {
-			const text = str(frame.text);
-			if (!text) return undefined;
+			const raw = str(frame.text);
+			if (!raw) return undefined;
+			const text = finalizeTelegramHtml(markdownToTelegramHtml(raw));
 			const finalized = frame.phase === "finalized";
 			return {
 				method: "sendMessage",
@@ -125,19 +140,22 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 		case "image_attachment": {
 			const data = str(frame.data);
 			if (!data) return undefined;
+			const caption = str(frame.caption);
 			return {
 				method: "sendPhoto",
 				lane: "finalized",
 				photoBase64: data,
 				mime: str(frame.mime),
-				text: str(frame.caption),
+				text: finalizeTelegramHtml(caption === undefined ? undefined : escapeHtml(caption)),
 			};
 		}
 		case "config_update": {
 			const verbosity = str(frame.verbosity);
 			const redact = typeof frame.redact === "boolean" ? `redact ${frame.redact ? "on" : "off"}` : undefined;
 			const parts = [verbosity ? `verbosity ${verbosity}` : undefined, redact].filter(Boolean);
-			return parts.length ? { method: "sendMessage", lane: "idle", text: `⚙ ${parts.join(", ")}` } : undefined;
+			return parts.length
+				? { method: "sendMessage", lane: "idle", text: finalizeTelegramHtml(`⚙ ${escapeHtml(parts.join(", "))}`) }
+				: undefined;
 		}
 		default:
 			return undefined;

--- a/packages/coding-agent/test/notifications-html-format-redteam.test.ts
+++ b/packages/coding-agent/test/notifications-html-format-redteam.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import {
+	finalizeTelegramHtml,
+	markdownToTelegramHtml,
+	truncateTelegramHtml,
+} from "../src/notifications/html-format";
+
+const allowedTags = new Set(["b", "i", "u", "s", "code", "pre", "a", "blockquote", "tg-spoiler"]);
+const allowedTagPattern = /<\/?(?:b|i|u|s|code|pre|blockquote|tg-spoiler)>|<a\s+href="[^"]*">|<\/a>/gi;
+
+function pseudoRandom(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+		return state / 0x100000000;
+	};
+}
+
+function randomString(seed: number): string {
+	const rand = pseudoRandom(seed);
+	const atoms = [
+		"<",
+		">",
+		"&",
+		"*",
+		"`",
+		"#",
+		"</b>",
+		"<b>",
+		"<script>",
+		"</pre>",
+		"&amp;",
+		"&lt",
+		"&notanentity",
+		"[x](javascript:alert(1))",
+		"[ok](https://example.com/a?b=1&c=2)",
+		"```ts\nconst x = '<tag>';&amp;\n```",
+		"a".repeat(256),
+		"<unterminated" + "x".repeat(32),
+		"&amp" + "x".repeat(32),
+		"plain text ",
+	];
+	const pieces: string[] = [];
+	const count = 1 + Math.floor(rand() * 40);
+	for (let i = 0; i < count; i++) {
+		pieces.push(atoms[Math.floor(rand() * atoms.length)] ?? "");
+		if (rand() < 0.2) pieces.push(String.fromCharCode(32 + Math.floor(rand() * 95)));
+	}
+	return pieces.join("");
+}
+
+function stripAllowedTags(html: string): string {
+	return html.replace(allowedTagPattern, "");
+}
+
+function assertNoStrayAngles(html: string): void {
+	const stripped = stripAllowedTags(html);
+	expect(stripped, html).not.toContain("<");
+	expect(stripped, html).not.toContain(">");
+}
+
+function tagBalance(html: string): Map<string, number> {
+	const balance = new Map<string, number>();
+	const tagPattern = /<\/?([a-z-]+)(?:\s+href="[^"]*")?>/gi;
+	for (const match of html.matchAll(tagPattern)) {
+		const whole = match[0] ?? "";
+		const name = (match[1] ?? "").toLowerCase();
+		if (!allowedTags.has(name)) continue;
+		balance.set(name, (balance.get(name) ?? 0) + (whole.startsWith("</") ? -1 : 1));
+	}
+	return balance;
+}
+
+function assertBalancedAllowedTags(html: string): void {
+	const stack: string[] = [];
+	const tagPattern = /<\/?([a-z-]+)(?:\s+href="[^"]*")?>/gi;
+	for (const match of html.matchAll(tagPattern)) {
+		const whole = match[0] ?? "";
+		const name = (match[1] ?? "").toLowerCase();
+		if (!allowedTags.has(name)) continue;
+		if (whole.startsWith("</")) {
+			expect(stack.pop(), html).toBe(name);
+		} else {
+			stack.push(name);
+		}
+	}
+	expect(stack, html).toEqual([]);
+	for (const [name, count] of tagBalance(html)) {
+		expect(count, `${name}: ${html}`).toBe(0);
+	}
+}
+
+function assertNoTrailingEntityOrTagFragment(html: string): void {
+	expect(html).not.toMatch(/&(a(m(p?)?)?|l(t?)?|g(t?)?|q(u(o(t?)?)?)?)?$/);
+	expect(html).not.toMatch(/<[^>]*$/);
+}
+
+describe("red-team truncateTelegramHtml properties", () => {
+	test("converted HTML stays within max and never ends mid-token", () => {
+		const maxValues = [5, 16, 64, 4096];
+		for (let seed = 1; seed <= 520; seed++) {
+			// truncateTelegramHtml's contract is "finished Telegram HTML": in
+			// production turn_stream is converted first, then truncated. Feed it
+			// valid converted HTML for the mid-token property.
+			const html = markdownToTelegramHtml(randomString(seed));
+			for (const max of maxValues) {
+				const out = truncateTelegramHtml(html, max);
+				expect(out.length, `seed=${seed} max=${max} out=${JSON.stringify(out)}`).toBeLessThanOrEqual(max);
+				assertNoTrailingEntityOrTagFragment(out);
+			}
+		}
+	});
+
+	test("length guarantee holds for arbitrary raw input regardless of validity", () => {
+		const maxValues = [5, 16, 64, 4096];
+		for (let seed = 1; seed <= 520; seed++) {
+			const sample = randomString(seed);
+			for (const max of maxValues) {
+				expect(
+					truncateTelegramHtml(sample, max).length,
+					`seed=${seed} max=${max}`,
+				).toBeLessThanOrEqual(max);
+			}
+		}
+	});
+});
+
+describe("red-team markdownToTelegramHtml escaping property", () => {
+	test("dynamic angle brackets are escaped except allowed Telegram tags", () => {
+		for (let seed = 1000; seed < 1550; seed++) {
+			const out = markdownToTelegramHtml(randomString(seed));
+			assertNoStrayAngles(out);
+		}
+	});
+});
+
+describe("red-team adversarial links", () => {
+	const unsafeLinks = [
+		"[x](data:text/html,<b>x</b>)",
+		"[x](javascript:alert(1))",
+		"[x](file:///etc/passwd)",
+		"[x](vbscript:msgbox(1))",
+		"[x](http://a b)",
+	];
+
+	test.each(unsafeLinks)("%s stays literal/escaped and does not emit an anchor", input => {
+		const out = markdownToTelegramHtml(input);
+		expect(out).not.toContain("<a ");
+		expect(out).not.toContain("</a>");
+		assertNoStrayAngles(out);
+	});
+});
+
+describe("red-team adversarial markdown balance", () => {
+	const cases = [
+		"***x***",
+		"**a*b**",
+		"unclosed `code",
+		"```\nliteral </pre> text and <b>fake</b>\n```",
+		"[**bold label**](https://example.com)",
+	];
+
+	test.each(cases)("%s emits only balanced allowed tags", input => {
+		const out = markdownToTelegramHtml(input);
+		assertNoStrayAngles(out);
+		assertBalancedAllowedTags(out);
+	});
+});
+
+describe("red-team huge turn_stream-like input", () => {
+	test("50k-char markdown converts and finalizes to Telegram limit", () => {
+		const chunk = "# Heading <unsafe> & stuff\n> quoted **bold** `code <x>` [bad](javascript:1) [ok](https://example.com?a=1&b=2)\n";
+		const huge = chunk.repeat(Math.ceil(50_000 / chunk.length)).slice(0, 50_000);
+		const finalized = finalizeTelegramHtml(markdownToTelegramHtml(huge));
+		expect(finalized).toBeDefined();
+		expect(finalized!.length).toBeLessThanOrEqual(4096);
+		assertNoTrailingEntityOrTagFragment(finalized!);
+		assertNoStrayAngles(finalized!);
+		assertBalancedAllowedTags(finalized!);
+	});
+});

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "../src/config/settings";
+import {
+	bold,
+	buildButtonGrid,
+	buttonLabel,
+	code,
+	escapeHtml,
+	markdownToTelegramHtml,
+	TELEGRAM_MESSAGE_LIMIT,
+	TELEGRAM_PARSE_MODE,
+	truncateTelegramHtml,
+} from "../src/notifications/html-format";
+import { buildActionMessage } from "../src/notifications/telegram-reference";
+import { TelegramNotificationDaemon } from "../src/notifications/telegram-daemon";
+import { formatIdentityHeader, renderThreadedFrame } from "../src/notifications/threaded-render";
+
+describe("escapeHtml (AC2)", () => {
+	test("escapes & < > and escapes & first", () => {
+		expect(escapeHtml(`<b>a & b > c</b>`)).toBe("&lt;b&gt;a &amp; b &gt; c&lt;/b&gt;");
+		expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+	});
+});
+
+describe("markdownToTelegramHtml (AC5)", () => {
+	test("bold and italic", () => {
+		expect(markdownToTelegramHtml("**hi**")).toBe("<b>hi</b>");
+		expect(markdownToTelegramHtml("*hi*")).toBe("<i>hi</i>");
+	});
+
+	test("inline and fenced code escape their contents and are not re-parsed", () => {
+		expect(markdownToTelegramHtml("`a<b>`" )).toBe("<code>a&lt;b&gt;</code>");
+		expect(markdownToTelegramHtml("```ts\nconst x = a < b && c > d;\n```")).toBe(
+			"<pre>const x = a &lt; b &amp;&amp; c &gt; d;\n</pre>",
+		);
+		// markdown markers inside code are literal
+		expect(markdownToTelegramHtml("`**not bold**`")).toBe("<code>**not bold**</code>");
+	});
+
+	test("safe links render <a>, unsafe and malformed links stay escaped literal", () => {
+		expect(markdownToTelegramHtml("[site](https://example.com/a?x=1&y=2)")).toBe(
+			`<a href="https://example.com/a?x=1&amp;y=2">site</a>`,
+		);
+		expect(markdownToTelegramHtml("[x](javascript:alert(1))")).toBe("[x](javascript:alert(1))");
+		expect(markdownToTelegramHtml("[mail](mailto:a@b.com)")).toBe(`<a href="mailto:a@b.com">mail</a>`);
+	});
+
+	test("headers become bold and quotes become a merged blockquote", () => {
+		expect(markdownToTelegramHtml("# Title")).toBe("<b>Title</b>");
+		expect(markdownToTelegramHtml("> one\n> two")).toBe("<blockquote>one\ntwo</blockquote>");
+	});
+
+	test("unbalanced markers remain literal, never unbalanced tags", () => {
+		expect(markdownToTelegramHtml("**oops")).toBe("**oops");
+		expect(markdownToTelegramHtml("a < b")).toBe("a &lt; b");
+	});
+});
+
+describe("truncateTelegramHtml (AC7)", () => {
+	test("short messages pass through unchanged", () => {
+		expect(truncateTelegramHtml("hello")).toBe("hello");
+	});
+
+	test("long plain text is truncated within the limit with a marker", () => {
+		const out = truncateTelegramHtml("a".repeat(5000), TELEGRAM_MESSAGE_LIMIT, "…");
+		expect(out.length).toBeLessThanOrEqual(TELEGRAM_MESSAGE_LIMIT);
+		expect(out.endsWith("…")).toBe(true);
+	});
+
+	test("does not split an open tag and closes it", () => {
+		const msg = `<b>${"x".repeat(40)}</b>`;
+		const out = truncateTelegramHtml(msg, 20, "…");
+		expect(out.length).toBeLessThanOrEqual(20);
+		// Tag was opened then auto-closed; never a dangling "<b" fragment.
+		expect(out).toContain("<b>");
+		expect(out.endsWith("</b>…")).toBe(true);
+		expect(out).not.toMatch(/<b$/);
+	});
+
+	test("never splits an entity", () => {
+		const msg = `${"a".repeat(15)}&amp;tail`;
+		const out = truncateTelegramHtml(msg, 18, "…");
+		expect(out.length).toBeLessThanOrEqual(18);
+		expect(out).not.toMatch(/&amp$/);
+		expect(out).not.toMatch(/&$/);
+	});
+});
+
+describe("button grid (AC6)", () => {
+	test("buttonLabel is one-based plain text", () => {
+		expect(buttonLabel("Yes", 0)).toBe("1. Yes");
+		expect(buttonLabel("No", 1)).toBe("2. No");
+	});
+
+	test("short options pack into rows of three; callback index stays zero-based", () => {
+		const grid = buildButtonGrid(["Yes", "No", "Maybe", "Later"], i => `cb:${i}`);
+		expect(grid).toEqual([
+			[
+				{ text: "1. Yes", callback_data: "cb:0" },
+				{ text: "2. No", callback_data: "cb:1" },
+				{ text: "3. Maybe", callback_data: "cb:2" },
+			],
+			[{ text: "4. Later", callback_data: "cb:3" }],
+		]);
+	});
+
+	test("long or newline labels take a full-width row", () => {
+		const grid = buildButtonGrid(["Yes", "This is a very long option label", "No"], i => `cb:${i}`);
+		expect(grid).toEqual([
+			[{ text: "1. Yes", callback_data: "cb:0" }],
+			[{ text: "2. This is a very long option label", callback_data: "cb:1" }],
+			[{ text: "3. No", callback_data: "cb:2" }],
+		]);
+	});
+});
+
+describe("buildActionMessage (AC6)", () => {
+	test("ask bolds the escaped question, keeps emoji, and grids numbered options", () => {
+		const rendered = buildActionMessage({ kind: "ask", id: "a1", question: "Pick <one>", options: ["Yes", "No"] });
+		expect(rendered.text).toBe(`❓ ${bold("Pick <one>")}`);
+		expect(rendered.inline_keyboard?.[0]?.[0]?.text).toBe("1. Yes");
+		expect(rendered.inline_keyboard?.[0]?.[1]?.text).toBe("2. No");
+	});
+
+	test("idle escapes the summary and keeps the emoji", () => {
+		const rendered = buildActionMessage({ kind: "idle", id: "i1", summary: "done <ok>" });
+		expect(rendered.text).toBe("🟢 Agent idle\ndone &lt;ok&gt;");
+	});
+});
+
+describe("threaded-render HTML treatment (AC3/AC5)", () => {
+	test("identity header bolds title and wraps fields in code", () => {
+		expect(formatIdentityHeader({ title: "Sess", repo: "r", branch: "b", machine: "m", sessionId: "s" })).toBe(
+			`${bold("Sess")}\n• repo: ${code("r")}\n• branch: ${code("b")}\n• machine: ${code("m")}\n• session: ${code("s")}`,
+		);
+	});
+
+	test("turn_stream converts markdown to Telegram HTML", () => {
+		const send = renderThreadedFrame({ type: "turn_stream", sessionId: "s", phase: "finalized", text: "**bold** and `code`" });
+		expect(send?.text).toBe("<b>bold</b> and <code>code</code>");
+	});
+});
+
+// --- Daemon send-site coverage (AC1) ---
+
+function isolatedSettings(agentDir: string): Settings {
+	const s = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": "tok",
+		"notifications.telegram.chatId": "42",
+	}) as Settings;
+	return new Proxy(s, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as Settings;
+}
+
+class CapturingBotApi {
+	calls: Array<{ method: string; body: any }> = [];
+	async call(method: string, body: unknown): Promise<unknown> {
+		this.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
+		return { ok: true, result: true };
+	}
+}
+
+function makeDaemon(bot: CapturingBotApi, agentDir: string): TelegramNotificationDaemon {
+	return new TelegramNotificationDaemon({
+		settings: isolatedSettings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot as any,
+	});
+}
+
+const fakeSession = () => ({ sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() });
+
+describe("daemon send sites force parse_mode HTML (AC1)", () => {
+	test("turn_stream sendMessage sets parse_mode", async () => {
+		const agentDir = Bun.env.TMPDIR ?? "/tmp";
+		const bot = new CapturingBotApi();
+		const daemon = makeDaemon(bot, agentDir);
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: "hi",
+		});
+		const send = bot.calls.find(c => c.method === "sendMessage");
+		expect(send?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
+	});
+
+	test("image_attachment sendPhoto sets parse_mode", async () => {
+		const bot = new CapturingBotApi();
+		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "image_attachment",
+			sessionId: "S",
+			mime: "image/png",
+			data: "AAAA",
+			caption: "shot",
+		});
+		const photo = bot.calls.find(c => c.method === "sendPhoto");
+		expect(photo?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
+	});
+
+	test("action_needed sendMessage sets parse_mode and grid alias answers stay zero-based", async () => {
+		const bot = new CapturingBotApi();
+		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "action_needed",
+			kind: "ask",
+			id: "act-1",
+			question: "Pick",
+			options: ["Yes", "No"],
+		});
+		const send = bot.calls.find(c => c.method === "sendMessage");
+		expect(send?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
+		const keyboard = send?.body.reply_markup?.inline_keyboard as Array<Array<{ text: string; callback_data: string }>>;
+		expect(keyboard[0]?.[0]?.text).toBe("1. Yes");
+		// The first button's alias must resolve to zero-based answer 0.
+		const alias = keyboard[0]?.[0]?.callback_data as string;
+		expect(daemon.aliasTable.get(alias)?.answer).toBe(0);
+	});
+
+	test("stale guidance sendMessage sets parse_mode", async () => {
+		const bot = new CapturingBotApi();
+		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
+		await (daemon as any).sendStaleGuidance("cb-1");
+		const send = bot.calls.find(c => c.method === "sendMessage");
+		expect(send?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
+	});
+});
+
+describe("default multipart sendPhoto forwards parse_mode (AC1 amendment)", () => {
+	test("FormData includes parse_mode for base64 photo uploads", async () => {
+		let captured: FormData | undefined;
+		const fetchImpl = (async (_url: string, init: any) => {
+			captured = init.body as FormData;
+			return { json: async () => ({ ok: true, result: {} }) };
+		}) as unknown as typeof fetch;
+		const daemon = new TelegramNotificationDaemon({
+			settings: isolatedSettings(Bun.env.TMPDIR ?? "/tmp"),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			fetchImpl,
+		});
+		await (daemon as any).botApi.call("sendPhoto", {
+			chat_id: "42",
+			photo: Buffer.from("img").toString("base64"),
+			mime: "image/png",
+			caption: "cap",
+			parse_mode: TELEGRAM_PARSE_MODE,
+		});
+		expect(captured).toBeInstanceOf(FormData);
+		expect(captured?.get("parse_mode")).toBe(TELEGRAM_PARSE_MODE);
+		expect(captured?.get("caption")).toBe("cap");
+	});
+});

--- a/packages/coding-agent/test/notifications-telegram-reference.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-reference.test.ts
@@ -108,8 +108,9 @@ describe("telegram reference client helpers", () => {
 	test("buildActionMessage renders ask with an inline keyboard", () => {
 		const m = buildActionMessage({ kind: "ask", id: "a1", question: "Proceed?", options: ["Yes", "No"] });
 		expect(m.text).toContain("Proceed?");
-		expect(m.inline_keyboard).toHaveLength(2);
-		expect(m.inline_keyboard?.[0]?.[0]?.text).toBe("Yes");
+		expect(m.inline_keyboard).toHaveLength(1);
+		expect(m.inline_keyboard?.[0]?.[0]?.text).toBe("1. Yes");
+		expect(m.inline_keyboard?.[0]?.[1]?.text).toBe("2. No");
 		expect(decodeCallbackData(m.inline_keyboard![0]![0]!.callback_data)).toEqual({ id: "a1", index: 0 });
 	});
 

--- a/packages/coding-agent/test/notifications-threaded-render.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-render.test.ts
@@ -14,11 +14,11 @@ describe("renderThreadedFrame", () => {
 		expect(send?.method).toBe("sendMessage");
 		expect(send?.identity).toBe(true);
 		expect(send?.lane).toBe("finalized");
-		expect(send?.text).toContain("Rebuild notifications");
-		expect(send?.text).toContain("• repo: gajae-code");
-		expect(send?.text).toContain("• branch: feat/notification-surface");
-		expect(send?.text).toContain("• machine: mac-studio");
-		expect(send?.text).toContain("• session: sess-1");
+		expect(send?.text).toContain("<b>Rebuild notifications</b>");
+		expect(send?.text).toContain("• repo: <code>gajae-code</code>");
+		expect(send?.text).toContain("• branch: <code>feat/notification-surface</code>");
+		expect(send?.text).toContain("• machine: <code>mac-studio</code>");
+		expect(send?.text).toContain("• session: <code>sess-1</code>");
 	});
 
 	test("finalized turn_stream is finalized lane with no coalesce key", () => {
@@ -49,7 +49,7 @@ describe("renderThreadedFrame", () => {
 		});
 		expect(send?.lane).toBe("live");
 		expect(send?.coalesceKey).toBe("ctx:s");
-		expect(send?.text).toContain("ctx: 12k/200k · opus");
+		expect(send?.text).toContain("ctx: <code>12k/200k · opus</code>");
 	});
 
 	test("image_attachment renders a sendPhoto with caption", () => {
@@ -87,6 +87,6 @@ describe("renderThreadedFrame", () => {
 	});
 
 	test("formatIdentityHeader tolerates missing fields", () => {
-		expect(formatIdentityHeader({ sessionId: "s" })).toContain("• repo: ?");
+		expect(formatIdentityHeader({ sessionId: "s" })).toContain("• repo: <code>?</code>");
 	});
 });


### PR DESCRIPTION
## Summary
Renders all notifications-SDK Telegram output as escaped HTML (`parse_mode=HTML`) with structured visual treatment across every event and text. Produced via deep-interview → ralplan consensus → ultragoal execution.

## Changes
- **New** `packages/coding-agent/src/notifications/html-format.ts` — single source of truth: `escapeHtml`, tag helpers, `markdownToTelegramHtml` (fenced→`<pre>`, inline→`<code>`, `**bold**`→`<b>`, `*italic*`→`<i>`, `[t](url)`→`<a>` with http/https/mailto allowlist + escaped href, `#`→`<b>`, `>`→`<blockquote>`; malformed/unsafe left as escaped literal), `truncateTelegramHtml`/`finalizeTelegramHtml` (4096 guard that never splits tags/entities and closes open tags), `buttonLabel`, `buildButtonGrid`.
- `threaded-render.ts` — bold identity title + `<code>` fields; italic context labels, `<code>` ctx, `<pre>` diff; `turn_stream` markdown→HTML; escaped config/image captions; emoji retained.
- `telegram-reference.ts` — bold ask question + numbered grid keyboard; `parse_mode` on send sites.
- `telegram-daemon.ts` — `parse_mode` at all six content send sites, daemon alias keyboard grid (zero-based callback answers preserved), and **multipart `sendPhoto` `FormData` now forwards `parse_mode`** (otherwise HTML captions render as raw tags in production).

## Constraints honored
Escape-first; Telegram tag set only; emoji/coalesce keys/rate-limit lanes/topic routing/redaction unchanged; truncation (not splitting); no WS protocol changes.

## Tests
`bun test` on the 5 notifications test files: **73 pass / 0 fail**. Covers AC1–AC8 unit cases, the multipart `FormData` `parse_mode` test, and an adversarial red-team suite (length guarantee incl. tiny `max`, mid-token safety, escaping, unsafe-link rejection, tag balance, 50k input).

> Note: `notifications-e2e.test.ts` failure is a pre-existing missing native addon (`pi_natives`) environment issue, unrelated to this change.