### PR TITLE
fix(session): restore --worktree branch in HUD on --continue/--resume

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -904,6 +904,24 @@ export async function runRootCommand(
 		sessionManager = await SessionManager.open(selectedPath);
 	}
 
+	// Restore the resumed session's working directory so the HUD branch, the
+	// project path, and the agent's tools all match where the session was
+	// created. A `--worktree` session lives in a linked worktree whose path
+	// differs from where `--continue`/`--resume` is invoked, which would
+	// otherwise leave the HUD pinned to the main checkout's branch.
+	if (sessionManager && !parsedArgs.cwd) {
+		const sessionCwd = sessionManager.getCwd();
+		if (sessionCwd && normalizePathForComparison(sessionCwd) !== normalizePathForComparison(getProjectDir())) {
+			try {
+				if ((await fs.stat(sessionCwd)).isDirectory()) {
+					setProjectDir(sessionCwd);
+				}
+			} catch {
+				// Session cwd no longer exists (e.g. worktree removed); keep current dir.
+			}
+		}
+	}
+
 	const { options: sessionOptions } = await logger.time(
 		"buildSessionOptions",
 		buildSessionOptions,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -28,6 +28,7 @@ import {
 	toError,
 } from "@gajae-code/utils";
 import { writeTextAtomic } from "../gjc-runtime/state-writer";
+import * as git from "../utils/git";
 import { ArtifactManager } from "./artifacts";
 import {
 	type BlobPutResult,
@@ -792,6 +793,25 @@ function writeTerminalBreadcrumb(cwd: string, sessionFile: string): void {
 }
 
 /**
+ * Two paths belong to linked worktrees of the same repository when they share a
+ * git common dir but resolve to different git dirs (i.e. one is a `git worktree`
+ * of the other). `--worktree` sessions run from such a linked worktree, so a
+ * `--continue` from the main checkout should still resolve their breadcrumb.
+ */
+function isLinkedWorktreePeer(a: string, b: string): boolean {
+	const ra = git.repo.resolveSync(a);
+	const rb = git.repo.resolveSync(b);
+	if (ra === null || rb === null) return false;
+	// Canonicalize: a worktree's commondir is stored as an absolute path that may
+	// differ from the main checkout only by a symlink prefix (e.g. macOS
+	// /tmp -> /private/tmp), so compare resolved-equivalent paths.
+	return (
+		resolveEquivalentPath(ra.commonDir) === resolveEquivalentPath(rb.commonDir) &&
+		resolveEquivalentPath(ra.gitDir) !== resolveEquivalentPath(rb.gitDir)
+	);
+}
+
+/**
  * Read the terminal breadcrumb for the current terminal, scoped to a cwd.
  * Returns the session file path if it exists and matches the cwd, null otherwise.
  */
@@ -808,8 +828,12 @@ async function readTerminalBreadcrumb(cwd: string): Promise<string | null> {
 		const breadcrumbCwd = lines[0];
 		const sessionFile = lines[1];
 
-		// Only return if cwd matches (user might have cd'd)
-		if (path.resolve(breadcrumbCwd) !== path.resolve(cwd)) return null;
+		// Honor the breadcrumb when the cwd matches, or when it points to a linked
+		// worktree of the same repository (e.g. a `--worktree` session resumed from
+		// the main checkout). A genuinely different project is still ignored.
+		if (path.resolve(breadcrumbCwd) !== path.resolve(cwd) && !isLinkedWorktreePeer(breadcrumbCwd, cwd)) {
+			return null;
+		}
 
 		// Verify the session file still exists
 		const stat = fs.statSync(sessionFile, { throwIfNoEntry: false });
@@ -4010,12 +4034,22 @@ export class SessionManager {
 		// Prefer terminal-scoped breadcrumb (handles concurrent sessions correctly)
 		const terminalSession = await readTerminalBreadcrumb(cwd);
 		const mostRecent = terminalSession ?? (await findMostRecentSession(dir, storage));
-		const manager = new SessionManager(cwd, dir, true, storage);
 		if (mostRecent) {
+			// Adopt the resumed session's recorded cwd and its own directory. A
+			// `--worktree` session lives in a linked worktree whose path differs from
+			// the invocation cwd; binding the manager (and HUD) to `cwd` would leave
+			// it on the main checkout instead of the worktree it was created in.
+			const header = (await loadEntriesFromFile(mostRecent, storage)).find(e => e.type === "session") as
+				| SessionHeader
+				| undefined;
+			const resumeCwd = header?.cwd || cwd;
+			const resumeDir = sessionDir ?? path.resolve(mostRecent, "..");
+			const manager = new SessionManager(resumeCwd, resumeDir, true, storage);
 			await manager.#initSessionFile(mostRecent);
-		} else {
-			manager.#initNewSession();
+			return manager;
 		}
+		const manager = new SessionManager(cwd, dir, true, storage);
+		manager.#initNewSession();
 		return manager;
 	}
 

--- a/packages/coding-agent/test/session-manager/worktree-continue.test.ts
+++ b/packages/coding-agent/test/session-manager/worktree-continue.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getSessionsDir, getTerminalSessionsDir, Snowflake, setAgentDir } from "@gajae-code/utils";
+
+function git(cwd: string, ...args: string[]): string {
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+	}
+	return result.stdout.toString().trim();
+}
+
+function initRepo(dir: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	git(dir, "init", "-q");
+	git(dir, "config", "user.email", "test@example.com");
+	git(dir, "config", "user.name", "test");
+	git(dir, "commit", "-q", "--allow-empty", "-m", "init");
+}
+
+function writeSession(cwd: string, sessionId: string): string {
+	const sessionDir = path.join(getSessionsDir(), sessionId);
+	fs.mkdirSync(sessionDir, { recursive: true });
+	const sessionFile = path.join(sessionDir, `${sessionId}.jsonl`);
+	const header = { type: "session", id: sessionId, timestamp: "2025-01-01T00:00:00Z", cwd, version: 3 };
+	const message = {
+		type: "message",
+		id: "1",
+		parentId: null,
+		timestamp: "2025-01-01T00:00:01Z",
+		message: { role: "user", content: "hi", timestamp: 1 },
+	};
+	fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`);
+	return sessionFile;
+}
+
+function writeBreadcrumb(crumbCwd: string, sessionFile: string): void {
+	const dir = getTerminalSessionsDir();
+	fs.mkdirSync(dir, { recursive: true });
+	const terminalId = `tmux-${process.env.TMUX_PANE}`;
+	fs.writeFileSync(path.join(dir, terminalId), `${crumbCwd}\n${sessionFile}\n`);
+}
+
+describe("continueRecent with --worktree sessions", () => {
+	let root: string;
+	let repo: string;
+	let worktree: string;
+	const prevTmux = process.env.TMUX;
+	const prevPane = process.env.TMUX_PANE;
+
+	beforeEach(() => {
+		root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "wt-continue-")));
+		setAgentDir(path.join(root, "agent"));
+		repo = path.join(root, "repo");
+		initRepo(repo);
+		worktree = path.join(root, "repo-worktrees", "feat");
+		git(repo, "worktree", "add", "-q", "-b", "feat", worktree, "HEAD");
+		process.env.TMUX = "/tmp/fake,1,0";
+		process.env.TMUX_PANE = `%wt-${Snowflake.next()}`;
+	});
+
+	afterEach(() => {
+		if (prevTmux === undefined) delete process.env.TMUX;
+		else process.env.TMUX = prevTmux;
+		if (prevPane === undefined) delete process.env.TMUX_PANE;
+		else process.env.TMUX_PANE = prevPane;
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("resumes a worktree session from the main checkout and adopts its cwd", async () => {
+		const sessionFile = writeSession(worktree, "worktree-session");
+		// Breadcrumb cwd is the linked worktree; `--continue` runs from the main repo.
+		writeBreadcrumb(worktree, sessionFile);
+
+		const resumed = await SessionManager.continueRecent(repo);
+		try {
+			expect(resumed.getSessionFile()).toBe(sessionFile);
+			// The HUD/branch and the agent's tools read getCwd(); it must be the
+			// worktree, not the main checkout where `--continue` was invoked.
+			expect(path.resolve(resumed.getCwd())).toBe(path.resolve(worktree));
+		} finally {
+			await resumed.close();
+		}
+	});
+
+	it("ignores a breadcrumb that points to an unrelated repository", async () => {
+		const other = path.join(root, "other");
+		initRepo(other);
+		const sessionFile = writeSession(other, "other-session");
+		writeBreadcrumb(other, sessionFile);
+
+		// Continuing from `repo` must not hijack an unrelated project's session.
+		const resumed = await SessionManager.continueRecent(repo);
+		try {
+			expect(resumed.getSessionFile()).not.toBe(sessionFile);
+		} finally {
+			await resumed.close();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Starting a session with `--worktree <branch>` runs gjc inside a linked git worktree, and the HUD correctly shows that worktree's branch (e.g. `⑂ feat`). But resuming the session afterwards with `gjc --continue` (or `gjc --resume <id>`) showed the **main checkout's** branch (`⑂ main`) instead — and `--continue` from the main checkout silently started a brand-new `main` session rather than recovering the worktree one.

### Reproduction
```
gjc --worktree feat      # HUD shows ⑂ feat, work happens in the worktree
# ...exit...
gjc --continue           # HUD shows ⑂ main  ❌ (and the worktree session is not recovered)
```

## Root cause

1. **`continueRecent()` ignored the session's recorded cwd.** It bound the `SessionManager` (and thus the HUD, which reads `getProjectDir()`) to the invocation cwd, unlike `SessionManager.open()` which adopts the header's `cwd`.
2. **The terminal breadcrumb required an exact cwd match.** `--worktree` moves the *gjc process* into the worktree while the *shell* stays in the main checkout, so on `--continue` the breadcrumb's cwd (worktree) never matched the invocation cwd (main checkout) and was discarded.
3. **Nothing restored the resumed session's working directory**, so even an explicitly resumed worktree session (`--resume <id>`) rendered the main checkout's branch.

## Fix

- `continueRecent()` now adopts the resumed session header's `cwd` and its own directory (mirrors `open()`).
- `readTerminalBreadcrumb()` now also honors a breadcrumb that points to a **linked worktree of the same repository** (same git common dir, different git dir), using symlink-safe path comparison. Genuinely different projects are still ignored.
- `runRootCommand()` restores the resumed session's working directory via `setProjectDir()` (guarded by existence — a removed worktree keeps the current dir) so the HUD branch, project path, and the agent's tools all match the worktree the session was created in.

## Result
```
gjc --worktree feat
# ...exit...
gjc --continue           # HUD shows ⑂ feat ✅ and the prior conversation is recovered
```
Normal (non-worktree) `--continue` is unchanged, and an unrelated project's breadcrumb is never picked up.

## Tests
- `packages/coding-agent/test/session-manager/worktree-continue.test.ts`: resuming a worktree session from the main checkout adopts its cwd; a breadcrumb from an unrelated repository is ignored.
- Verified end-to-end with the real CLI + tmux: `--worktree` → `--continue` now shows the worktree branch and recovers the session; plain `main` `--continue` still recovers the `main` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)